### PR TITLE
chore(apple): ignore benign keychain errors

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -73,7 +73,6 @@ enum IPCClient {
     let _ = try await sendProviderMessage(session: session, message: message)
   }
 
-
   // MARK: - Low-level IPC operations
 
   @MainActor

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -325,14 +325,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       } catch let error as KeychainError {
         // macOS 13 and below have a bug that raises an error when a root proc (such as our system extension) tries
         // to add an item to the system keychain. We can safely ignore this.
-        if #available(macOS 14.0, *) {
-          Log.error(error)
+        if #unavailable(macOS 14.0), case .appleSecError("SecItemAdd", 100001) = error {
+          // ignore
         } else {
-          if case .appleSecError("SecItemAdd", 100001) = error { // Operation not permitted
-            // ignore
-          } else {
-            Log.error(error)
-          }
+          Log.error(error)
         }
       } catch {
         Log.error(error)

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -78,11 +78,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       // If we don't have a token, we can't continue.
       guard let token = loadAndSaveToken(from: options)
       else {
-        throw PacketTunnelProviderError.tokenNotFoundInKeychain
+        return completionHandler(PacketTunnelProviderError.tokenNotFoundInKeychain)
       }
 
       // Try to save the token back to the Keychain but continue if we can't
-      do { try token.save() } catch { Log.error(error) }
+      handleTokenSave(token)
 
       // The firezone id should be initialized by now
       guard let id = UserDefaults.standard.string(forKey: "firezoneId")
@@ -123,7 +123,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       self.adapter = adapter
 
     } catch {
-
       Log.error(error)
       completionHandler(error)
     }
@@ -318,6 +317,34 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // 3. Generate and save new one
     defaults.set(UUID().uuidString, forKey: key)
   }
+
+  #if os(macOS)
+    private func handleTokenSave(_ token: Token) {
+      do {
+        try token.save()
+      } catch let error as KeychainError {
+        // macOS 13 and below have a bug that raises an error when a root proc (such as our system extension) tries
+        // to add an item to the system keychain. We can safely ignore this.
+        if #available(macOS 14.0, *) {
+          Log.error(error)
+        } else {
+          if case .appleSecError("SecItemAdd", 100001) = error { // Operation not permitted
+            // ignore
+          } else {
+            Log.error(error)
+          }
+        }
+      } catch {
+        Log.error(error)
+      }
+    }
+  #endif
+
+  #if os(iOS)
+    private func handleTokenSave(_ token: Token) {
+      do { try token.save() } catch { Log.error(error) }
+    }
+  #endif
 }
 
 // Increase usefulness of TunnelConfiguration now that we're over the IPC barrier


### PR DESCRIPTION
* macOS 13 and below has a known bug that prevents us from saving the token on the system keychain. To avoid Sentry noise, we ignore this specific error and continue to log other errors that aren't an exact match.
* Relatedly, if we try to start the tunnel and a token is not found, it's not necessarily an error. This happens when the user signs out and then tries to activate the VPN from system settings, for example.