### PR TITLE
fix(apple): Restore favorites UI updates on iOS

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -64,6 +64,13 @@ public final class Store: ObservableObject {
       }
     }
 
+    // Forward favourites changes to Store's objectWillChange so SwiftUI views observing Store get notified
+    self.favorites.objectWillChange
+      .sink { [weak self] _ in
+        self?.objectWillChange.send()
+      }
+      .store(in: &cancellables)
+
     // We monitor for any configuration changes and tell the tunnel service about them
     self.configuration.objectWillChange
       .receive(on: DispatchQueue.main)


### PR DESCRIPTION
Recent refactors uncovered a latent bug where we never properly subscribed to favorites updates.

The underlying data was being saved correctly to UserDefaults, but the view wouldn't redraw to reflect the change.

The fix forwards Favourites.objectWillChange to Store.objectWillChange, matching the existing pattern for configuration changes and the pattern used by MenuBar on macOS.

Relevant information:
- Favourites is a nested ObservableObject inside Store
- SwiftUI views observe Store via @EnvironmentObject
- Nested ObservableObject changes don't automatically propagate through @Published properties

Fixes #10906 