### PR TITLE
fix(clients): avoid packet loops when uploading Sentry logs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1309,6 +1309,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit-breaker"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7826,6 +7826,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socket-factory",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2508,6 +2508,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_variant",
+ "socket-factory",
  "specta",
  "specta-typescript",
  "strum",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7820,9 +7820,14 @@ name = "telemetry"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
+ "bytes",
+ "circuit-breaker",
  "flume",
  "futures",
  "hex",
+ "http 1.3.1",
+ "http-client",
+ "httpdate",
  "ip-packet",
  "moka",
  "opentelemetry",
@@ -7836,6 +7841,7 @@ dependencies = [
  "socket-factory",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "libs/anyhow-ext",
     "libs/bin-shared",
     "libs/client-shared",
+    "libs/circuit-breaker",
     "libs/connlib/bufferpool",
     "libs/connlib/dns-over-tcp",
     "libs/connlib/dns-types",
@@ -80,6 +81,7 @@ dns-lookup = "3.0"
 dns-over-tcp = { path = "libs/connlib/dns-over-tcp" }
 dns-types = { path = "libs/connlib/dns-types" }
 ebpf-shared = { path = "relay/ebpf-shared" }
+circuit-breaker = { path = "circuit-breaker" }
 either = "1"
 etherparse = { version = "0.19", default-features = false }
 etherparse-ext = { path = "libs/connlib/etherparse-ext" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,8 +8,8 @@ members = [
     "headless-client",
     "libs/anyhow-ext",
     "libs/bin-shared",
-    "libs/client-shared",
     "libs/circuit-breaker",
+    "libs/client-shared",
     "libs/connlib/bufferpool",
     "libs/connlib/dns-over-tcp",
     "libs/connlib/dns-types",
@@ -68,6 +68,7 @@ bytecodec = "0.5.0"
 bytes = { version = "1.9.0", default-features = false }
 caps = "0.5.6"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
+circuit-breaker = { path = "libs/circuit-breaker" }
 clap = "4.5.50"
 client-shared = { path = "libs/client-shared" }
 connlib-model = { path = "libs/connlib/model" }
@@ -81,7 +82,6 @@ dns-lookup = "3.0"
 dns-over-tcp = { path = "libs/connlib/dns-over-tcp" }
 dns-types = { path = "libs/connlib/dns-types" }
 ebpf-shared = { path = "relay/ebpf-shared" }
-circuit-breaker = { path = "circuit-breaker" }
 either = "1"
 etherparse = { version = "0.19", default-features = false }
 etherparse-ext = { path = "libs/connlib/etherparse-ext" }
@@ -100,6 +100,7 @@ hmac = "0.12.1"
 http = "1.3.1"
 http-body-util = "0.1.3"
 http-client = { path = "libs/http-client" }
+httpdate = "1.0.3"
 humantime = "2.3"
 hyper = "1.7.0"
 hyper-util = "0.1.17"

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -476,6 +476,7 @@ fn connect(
         .context("Failed to create tokio runtime")?;
 
     let mut telemetry = Telemetry::new();
+    telemetry.set_tcp_socket_factory(tcp_socket_factory.clone());
     runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN, device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_variant = { workspace = true }
+socket-factory = { workspace = true }
 specta = { workspace = true, features = ["url"] }
 specta-typescript = { workspace = true }
 strum = { workspace = true }

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::process::ExitCode;
+use std::{process::ExitCode, sync::Arc};
 
 use anyhow::{Context as _, ErrorExt, Result, bail};
 use clap::{Args, Parser};
@@ -82,6 +82,9 @@ fn try_main(
     let id = bin_shared::device_id::get_client().context("Failed to get device ID")?;
 
     if cli.is_telemetry_allowed() {
+        telemetry
+            .set_tcp_socket_factory(Arc::new(firezone_bin_shared::platform::tcp_socket_factory));
+
         rt.block_on(telemetry.start(
             &api_url,
             firezone_gui_client::RELEASE,

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -82,8 +82,7 @@ fn try_main(
     let id = bin_shared::device_id::get_client().context("Failed to get device ID")?;
 
     if cli.is_telemetry_allowed() {
-        telemetry
-            .set_tcp_socket_factory(Arc::new(firezone_bin_shared::platform::tcp_socket_factory));
+        telemetry.set_tcp_socket_factory(Arc::new(bin_shared::platform::tcp_socket_factory));
 
         rt.block_on(telemetry.start(
             &api_url,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -22,6 +22,7 @@ use futures::{
 use logging::{FilterReloadHandle, err_with_src};
 use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, get_user_agent};
 use secrecy::{ExposeSecret, SecretBox, SecretString};
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     io::{self, Write},
     mem,
@@ -184,6 +185,9 @@ struct Handler<'a> {
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
     network_notifier: BoxStream<'static, Result<()>>,
+
+    tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+    udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
 }
 
 #[derive(Default, Debug)]
@@ -322,6 +326,8 @@ impl<'a> Handler<'a> {
             tun_device,
             dns_notifier,
             network_notifier,
+            tcp_socket_factory: Arc::new(tcp_socket_factory),
+            udp_socket_factory: Arc::new(UdpSocketFactory::default()),
         })
     }
 
@@ -658,14 +664,14 @@ impl<'a> Handler<'a> {
                     .with_max_elapsed_time(Some(Duration::from_secs(60 * 60 * 24 * 30)))
                     .build()
             },
-            Arc::new(tcp_socket_factory),
+            self.tcp_socket_factory.clone(),
         )?;
 
         // Read the resolvers before starting connlib, in case connlib's startup interferes.
         let dns = self.dns_controller.system_resolvers();
         let (connlib, event_stream) = client_shared::Session::connect(
-            Arc::new(tcp_socket_factory),
-            Arc::new(UdpSocketFactory::default()),
+            self.tcp_socket_factory.clone(),
+            self.udp_socket_factory.clone(),
             portal,
             is_internet_resource_active,
             tokio::runtime::Handle::current(),

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -610,6 +610,8 @@ impl<'a> Handler<'a> {
 
                 if !no_telemetry {
                     self.telemetry
+                        .set_tcp_socket_factory(self.tcp_socket_factory.clone());
+                    self.telemetry
                         .start(
                             &environment,
                             &release,

--- a/rust/libs/circuit-breaker/Cargo.toml
+++ b/rust/libs/circuit-breaker/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "circuit-breaker"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/circuit-breaker/src/lib.rs
+++ b/rust/libs/circuit-breaker/src/lib.rs
@@ -1,0 +1,320 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::time::{Duration, Instant};
+
+pub struct CircuitBreaker {
+    name: String,
+    state: State,
+    failure_threshold: u32,
+    success_threshold: u32,
+    timeout: Duration,
+}
+
+pub struct Token<'a> {
+    cb: &'a mut CircuitBreaker,
+}
+
+impl<'a> Token<'a> {
+    pub fn success(self, now: Instant) {
+        self.cb.handle_success(now);
+    }
+
+    pub fn failure(self, now: Instant) {
+        self.cb.handle_failure(now);
+    }
+}
+
+impl CircuitBreaker {
+    pub fn new(
+        name: impl Into<String>,
+        failure_threshold: u32,
+        success_threshold: u32,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            state: State::Closed { failure_count: 0 },
+            failure_threshold,
+            success_threshold,
+            timeout,
+        }
+    }
+
+    pub fn request_token(&mut self, now: Instant) -> Result<Token<'_>, Rejected> {
+        self.update_state(now);
+
+        match &mut self.state {
+            State::Closed { .. } => Ok(Token { cb: self }),
+            State::HalfOpen { attempts, .. } => {
+                if *attempts < self.success_threshold {
+                    *attempts += 1;
+                    Ok(Token { cb: self })
+                } else {
+                    Err(Rejected {
+                        retry_after: Duration::ZERO,
+                    })
+                }
+            }
+            State::Open { last_failure_time } => {
+                let elapsed = now.duration_since(*last_failure_time);
+                let retry_after = if elapsed >= self.timeout {
+                    Duration::ZERO
+                } else {
+                    self.timeout - elapsed
+                };
+                Err(Rejected { retry_after })
+            }
+        }
+    }
+
+    fn handle_success(&mut self, now: Instant) {
+        self.update_state(now);
+
+        match &mut self.state {
+            State::Closed { failure_count } => {
+                *failure_count = 0;
+            }
+            State::HalfOpen { success_count, .. } => {
+                *success_count += 1;
+                if *success_count >= self.success_threshold {
+                    self.transition_to_closed();
+                }
+            }
+            State::Open { .. } => {}
+        }
+    }
+
+    fn handle_failure(&mut self, now: Instant) {
+        self.update_state(now);
+
+        match &mut self.state {
+            State::Closed { failure_count } => {
+                *failure_count += 1;
+                if *failure_count >= self.failure_threshold {
+                    self.transition_to_open(now);
+                }
+            }
+            State::HalfOpen { .. } => {
+                self.transition_to_open(now);
+            }
+            State::Open { last_failure_time } => {
+                *last_failure_time = now;
+            }
+        }
+    }
+
+    fn update_state(&mut self, now: Instant) {
+        if let State::Open { last_failure_time } = self.state
+            && now.duration_since(last_failure_time) >= self.timeout
+        {
+            self.transition_to_half_open();
+        }
+    }
+
+    fn transition_to_closed(&mut self) {
+        tracing::debug!(name = %self.name, "Transitioning to Closed");
+
+        self.state = State::Closed { failure_count: 0 };
+    }
+
+    fn transition_to_open(&mut self, now: Instant) {
+        tracing::debug!(name = %self.name, "Transitioning to Open");
+
+        self.state = State::Open {
+            last_failure_time: now,
+        };
+    }
+
+    fn transition_to_half_open(&mut self) {
+        tracing::debug!(name = %self.name, "Transitioning to HalfOpen");
+
+        self.state = State::HalfOpen {
+            success_count: 0,
+            attempts: 0,
+        };
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rejected {
+    pub retry_after: Duration,
+}
+
+impl std::fmt::Display for Rejected {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "circuit breaker rejected request, retry after {:?}",
+            self.retry_after
+        )
+    }
+}
+
+impl std::error::Error for Rejected {}
+
+impl<'a> std::fmt::Debug for Token<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Token").finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum State {
+    Closed { failure_count: u32 },
+    Open { last_failure_time: Instant },
+    HalfOpen { success_count: u32, attempts: u32 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_request_when_closed() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let now = Instant::now();
+
+        assert!(cb.request_token(now).is_ok());
+    }
+
+    #[test]
+    fn opens_after_threshold_failures() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+
+        let t3 = cb.request_token(now).unwrap();
+        t3.failure(now);
+
+        let err = cb.request_token(now).unwrap_err();
+        assert_eq!(err.retry_after, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn success_resets_failure_count_when_closed() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+
+        let t3 = cb.request_token(now).unwrap();
+        t3.success(now);
+
+        let t4 = cb.request_token(now).unwrap();
+        t4.failure(now);
+        let t5 = cb.request_token(now).unwrap();
+        t5.failure(now);
+
+        assert!(cb.request_token(now).is_ok());
+    }
+
+    #[test]
+    fn transitions_to_half_open_after_timeout() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let mut now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+        let t3 = cb.request_token(now).unwrap();
+        t3.failure(now);
+
+        now += Duration::from_secs(11);
+        assert!(cb.request_token(now).is_ok());
+    }
+
+    #[test]
+    fn half_open_limits_concurrent_requests() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let mut now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+        let t3 = cb.request_token(now).unwrap();
+        t3.failure(now);
+
+        now += Duration::from_secs(11);
+        let _token1 = cb.request_token(now).unwrap();
+        let _token2 = cb.request_token(now).unwrap();
+
+        let err = cb.request_token(now).unwrap_err();
+        assert_eq!(err.retry_after, Duration::ZERO);
+    }
+
+    #[test]
+    fn half_open_closes_after_success_threshold() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let mut now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+        let t3 = cb.request_token(now).unwrap();
+        t3.failure(now);
+
+        now += Duration::from_secs(11);
+        let t4 = cb.request_token(now).unwrap();
+        t4.success(now);
+
+        let t5 = cb.request_token(now).unwrap();
+        t5.success(now);
+
+        assert!(cb.request_token(now).is_ok());
+    }
+
+    #[test]
+    fn half_open_reopens_on_failure() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let mut now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+        let t3 = cb.request_token(now).unwrap();
+        t3.failure(now);
+
+        now += Duration::from_secs(11);
+        let t4 = cb.request_token(now).unwrap();
+
+        t4.failure(now);
+        let err = cb.request_token(now).unwrap_err();
+        assert_eq!(err.retry_after, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn retry_after_decreases_over_time() {
+        let mut cb = CircuitBreaker::new("test", 3, 2, Duration::from_secs(10));
+        let mut now = Instant::now();
+
+        let t1 = cb.request_token(now).unwrap();
+        t1.failure(now);
+        let t2 = cb.request_token(now).unwrap();
+        t2.failure(now);
+        let t3 = cb.request_token(now).unwrap();
+        t3.failure(now);
+
+        let err = cb.request_token(now).unwrap_err();
+        assert_eq!(err.retry_after, Duration::from_secs(10));
+
+        now += Duration::from_secs(3);
+        let err = cb.request_token(now).unwrap_err();
+        assert_eq!(err.retry_after, Duration::from_secs(7));
+
+        now += Duration::from_secs(6);
+        let err = cb.request_token(now).unwrap_err();
+        assert_eq!(err.retry_after, Duration::from_secs(1));
+    }
+}

--- a/rust/libs/circuit-breaker/src/lib.rs
+++ b/rust/libs/circuit-breaker/src/lib.rs
@@ -15,6 +15,15 @@ pub struct Token<'a> {
 }
 
 impl<'a> Token<'a> {
+    pub fn result<T, E>(self, result: Result<T, E>, now: Instant) -> Result<T, E> {
+        match &result {
+            Ok(_) => self.success(now),
+            Err(_) => self.failure(now),
+        }
+
+        result
+    }
+
     pub fn success(self, now: Instant) {
         self.cb.handle_success(now);
     }

--- a/rust/libs/circuit-breaker/src/lib.rs
+++ b/rust/libs/circuit-breaker/src/lib.rs
@@ -27,12 +27,12 @@ impl<'a> Token<'a> {
         result
     }
 
-    /// Consme the token and report success of the IO operation.
+    /// Consume the token and report success of the IO operation.
     pub fn success(self, now: Instant) {
         self.cb.handle_success(now);
     }
 
-    /// Consme the token and report failure of the IO operation.
+    /// Consume the token and report failure of the IO operation.
     pub fn failure(self, now: Instant) {
         self.cb.handle_failure(now);
     }

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -19,6 +19,7 @@ sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+socket-factory = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -6,9 +6,14 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = { workspace = true }
+circuit-breaker = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+http = { workspace = true }
+http-client = { workspace = true }
+httpdate = { workspace = true }
 ip-packet = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
@@ -21,6 +26,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 socket-factory = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -4,18 +4,18 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     fmt, mem,
-    net::{SocketAddr, ToSocketAddrs as _},
+    net::{IpAddr, ToSocketAddrs as _},
     str::FromStr,
     sync::Arc,
     time::Duration,
 };
 
+use crate::{sentry_http_client::SentryHttpClient, sentry_vendor::TransportThread};
 use anyhow::{Context, Result, anyhow, bail};
 use api_url::ApiUrl;
 use sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, SessionStatus},
-    transports::ReqwestHttpTransport,
 };
 use sha2::Digest as _;
 use socket_factory::{SocketFactory, TcpSocket};
@@ -28,6 +28,8 @@ mod api_url;
 mod maybe_push_metrics_exporter;
 mod noop_push_metrics_exporter;
 mod posthog;
+mod sentry_http_client;
+mod sentry_vendor;
 
 pub use maybe_push_metrics_exporter::MaybePushMetricsExporter;
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
@@ -438,7 +440,7 @@ fn set_current_user(user: Option<sentry::User>) {
 
 #[derive(Clone)]
 pub struct TransportFactory {
-    ingest_domain_addresses: Vec<SocketAddr>,
+    ingest_domain_addresses: Vec<IpAddr>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 }
 
@@ -447,6 +449,7 @@ impl TransportFactory {
         let resolved_addresses = (INGEST_HOST, 443u16)
             .to_socket_addrs()
             .with_context(|| format!("Failed to resolve {INGEST_HOST}"))?
+            .map(|s| s.ip())
             .collect();
 
         tracing::debug!(host = %INGEST_HOST, addresses = ?resolved_addresses, "Resolved ingest host IPs");
@@ -467,21 +470,75 @@ impl TransportFactory {
 
 impl sentry::TransportFactory for TransportFactory {
     fn create_transport(&self, options: &sentry::ClientOptions) -> Arc<dyn sentry::Transport> {
-        let mut builder = reqwest::ClientBuilder::new()
-            .http2_prior_knowledge()
-            .http2_keep_alive_while_idle(true)
-            .http2_keep_alive_timeout(Duration::from_secs(1))
-            .http2_keep_alive_interval(Duration::from_secs(5)); // Ensure we detect broken connections, i.e. when enabling / disabling the Internet Resource.
+        Arc::new(Transport::new(
+            options,
+            self.ingest_domain_addresses.clone(),
+            self.tcp_socket_factory.clone(),
+        ))
+    }
+}
 
-        if !self.ingest_domain_addresses.is_empty() {
-            builder = builder.resolve_to_addrs(INGEST_HOST, &self.ingest_domain_addresses);
-        } else {
-            tracing::debug!(host = %INGEST_HOST, "No addresses were pre-resolved for ingest host");
-        }
+struct Transport {
+    thread: TransportThread,
+}
 
-        let client = builder.build().expect("Failed to build HTTP client");
+impl Transport {
+    fn new(
+        options: &sentry::ClientOptions,
+        addresses: Vec<IpAddr>,
+        sf: Arc<dyn SocketFactory<TcpSocket>>,
+    ) -> Self {
+        let client = SentryHttpClient::new(options, addresses, sf);
 
-        Arc::new(ReqwestHttpTransport::with_client(options, client))
+        let thread = TransportThread::new(client, move |mut client, envelope, mut rl| async move {
+            let response = match client.send(envelope).await {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::debug!("{e:#}");
+                    return (client, rl);
+                }
+            };
+
+            if let Some(sentry_header) = response
+                .headers()
+                .get("x-sentry-rate-limits")
+                .and_then(|x| x.to_str().ok())
+            {
+                rl.update_from_sentry_header(sentry_header);
+
+                return (client, rl);
+            }
+
+            if let Some(retry_after) = response
+                .headers()
+                .get(http::header::RETRY_AFTER)
+                .and_then(|x| x.to_str().ok())
+            {
+                rl.update_from_retry_after(retry_after);
+
+                return (client, rl);
+            }
+
+            if response.status() == http::StatusCode::TOO_MANY_REQUESTS {
+                rl.update_from_429();
+
+                return (client, rl);
+            }
+
+            (client, rl)
+        });
+
+        Self { thread }
+    }
+}
+
+impl sentry::Transport for Transport {
+    fn send_envelope(&self, envelope: sentry::Envelope) {
+        self.thread.send(envelope);
+    }
+
+    fn flush(&self, timeout: Duration) -> bool {
+        self.thread.flush(timeout)
     }
 }
 

--- a/rust/libs/telemetry/src/sentry_http_client.rs
+++ b/rust/libs/telemetry/src/sentry_http_client.rs
@@ -1,0 +1,98 @@
+use std::{
+    net::IpAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, ErrorExt as _, Result};
+use bytes::{BufMut as _, Bytes, BytesMut};
+use circuit_breaker::CircuitBreaker;
+use http_client::HttpClient;
+use sentry::Envelope;
+use socket_factory::{SocketFactory, TcpSocket};
+
+use crate::INGEST_HOST;
+
+pub struct SentryHttpClient {
+    cb: CircuitBreaker,
+    maybe_client: Option<HttpClient>,
+    options: sentry::ClientOptions,
+    addresses: Vec<IpAddr>,
+    sf: Arc<dyn SocketFactory<TcpSocket>>,
+}
+
+impl SentryHttpClient {
+    pub fn new(
+        options: &sentry::ClientOptions,
+        addresses: Vec<IpAddr>,
+        sf: Arc<dyn SocketFactory<TcpSocket>>,
+    ) -> Self {
+        Self {
+            cb: CircuitBreaker::new("Sentry HTTP transport", 5, 2, Duration::from_secs(10)),
+            maybe_client: None,
+            options: options.clone(),
+            addresses,
+            sf,
+        }
+    }
+
+    pub async fn send(&mut self, envelope: Envelope) -> Result<http::Response<Bytes>> {
+        let dsn = self.options.dsn.as_ref().expect("DSN must be set");
+        let user_agent = self.options.user_agent.clone();
+        let url = dsn.envelope_api_url().to_string();
+        let auth = dsn.to_auth(Some(&user_agent)).to_string();
+
+        let client = match self.maybe_client.as_ref() {
+            Some(c) => c,
+            None => loop {
+                match self.cb.request_token(Instant::now()) {
+                    Ok(token) => {
+                        let result = HttpClient::new(
+                            INGEST_HOST.to_owned(),
+                            self.addresses.clone(),
+                            self.sf.clone(),
+                        )
+                        .await;
+
+                        let client = token
+                            .result(result, Instant::now())
+                            .context("Failed to create Sentry transport HTTP client")?;
+
+                        break self.maybe_client.get_or_insert(client);
+                    }
+                    Err(e) => tokio::time::sleep(e.retry_after).await,
+                };
+            },
+        };
+
+        let mut body = BytesMut::new().writer();
+        envelope
+            .to_writer(&mut body)
+            .context("Failed to write envelope to buffer")?;
+
+        let req = http::Request::builder()
+            .uri(url.clone())
+            .method(http::Method::POST)
+            .header("X-Sentry-Auth", &auth)
+            .body(body.into_inner().freeze())
+            .context("Failed to create HTTP request from Sentry envelope")?;
+
+        let token = loop {
+            match self.cb.request_token(Instant::now()) {
+                Ok(t) => break t,
+                Err(e) => tokio::time::sleep(e.retry_after).await,
+            }
+        };
+
+        let response = token
+            .result(client.send_request(req), Instant::now())
+            .inspect_err(|e| {
+                if e.any_is::<http_client::Closed>() {
+                    self.maybe_client = None;
+                }
+            })?
+            .await?;
+
+        Ok(response)
+    }
+}

--- a/rust/libs/telemetry/src/sentry_vendor/mod.rs
+++ b/rust/libs/telemetry/src/sentry_vendor/mod.rs
@@ -1,0 +1,9 @@
+//! Copied from https://github.com/getsentry/sentry-rust/blob/master/sentry/src/transports
+//!
+//! See https://github.com/getsentry/sentry-rust/issues/941 for discussion on how to properly reuse this.
+
+mod sentry_rate_limiter;
+mod tokio_thread;
+
+pub use sentry_rate_limiter::{RateLimiter, RateLimitingCategory};
+pub use tokio_thread::TransportThread;

--- a/rust/libs/telemetry/src/sentry_vendor/sentry_rate_limiter.rs
+++ b/rust/libs/telemetry/src/sentry_vendor/sentry_rate_limiter.rs
@@ -1,0 +1,206 @@
+use httpdate::parse_http_date;
+use std::time::{Duration, SystemTime};
+
+use sentry::Envelope;
+use sentry::protocol::EnvelopeItem;
+use sentry::protocol::ItemContainer;
+
+/// A Utility that helps with rate limiting sentry requests.
+#[derive(Debug, Default)]
+pub struct RateLimiter {
+    global: Option<SystemTime>,
+    error: Option<SystemTime>,
+    session: Option<SystemTime>,
+    transaction: Option<SystemTime>,
+    attachment: Option<SystemTime>,
+    log_item: Option<SystemTime>,
+}
+
+impl RateLimiter {
+    /// Create a new RateLimiter.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Updates the RateLimiter with information from a `Retry-After` header.
+    pub fn update_from_retry_after(&mut self, header: &str) {
+        let new_time = if let Ok(value) = header.parse::<f64>() {
+            SystemTime::now() + Duration::from_secs(value.ceil() as u64)
+        } else if let Ok(value) = parse_http_date(header) {
+            value
+        } else {
+            SystemTime::now() + Duration::from_secs(60)
+        };
+
+        self.global = Some(new_time);
+    }
+
+    /// Updates the RateLimiter with information from a `X-Sentry-Rate-Limits` header.
+    pub fn update_from_sentry_header(&mut self, header: &str) {
+        // <rate-limit> = (<group>,)+
+        // <group> = <time>:(<category>;)+:<scope>(:<reason>)?
+
+        let mut parse_group = |group: &str| {
+            let mut splits = group.split(':');
+            let seconds = splits.next()?.parse::<f64>().ok()?;
+            let categories = splits.next()?;
+            let _scope = splits.next()?;
+
+            let new_time = Some(SystemTime::now() + Duration::from_secs(seconds.ceil() as u64));
+
+            if categories.is_empty() {
+                self.global = new_time;
+            }
+
+            for category in categories.split(';') {
+                match category {
+                    "error" => self.error = new_time,
+                    "session" => self.session = new_time,
+                    "transaction" => self.transaction = new_time,
+                    "attachment" => self.attachment = new_time,
+                    "log_item" => self.log_item = new_time,
+                    _ => {}
+                }
+            }
+            Some(())
+        };
+
+        for group in header.split(',') {
+            parse_group(group.trim());
+        }
+    }
+
+    /// Updates the RateLimiter in response to a `429` status code.
+    pub fn update_from_429(&mut self) {
+        self.global = Some(SystemTime::now() + Duration::from_secs(60));
+    }
+
+    /// Query the RateLimiter if a certain category of event is currently rate limited.
+    ///
+    /// If the given category is rate limited, it will return the remaining
+    /// [`Duration`] for which it is.
+    pub fn is_disabled(&self, category: RateLimitingCategory) -> Option<Duration> {
+        if let Some(ts) = self.global {
+            let time_left = ts.duration_since(SystemTime::now()).ok();
+            if time_left.is_some() {
+                return time_left;
+            }
+        }
+        let time_left = match category {
+            RateLimitingCategory::Any => self.global,
+            RateLimitingCategory::Error => self.error,
+            RateLimitingCategory::Session => self.session,
+            RateLimitingCategory::Transaction => self.transaction,
+            RateLimitingCategory::Attachment => self.attachment,
+            RateLimitingCategory::LogItem => self.log_item,
+        }?;
+        time_left.duration_since(SystemTime::now()).ok()
+    }
+
+    /// Query the RateLimiter for a certain category of event.
+    ///
+    /// Returns `true` if the category is *not* rate limited and should be sent.
+    pub fn is_enabled(&self, category: RateLimitingCategory) -> bool {
+        self.is_disabled(category).is_none()
+    }
+
+    /// Filters the [`Envelope`] according to the current rate limits.
+    ///
+    /// Returns [`None`] if all the envelope items were filtered out.
+    pub fn filter_envelope(&self, envelope: Envelope) -> Option<Envelope> {
+        envelope.filter(|item| {
+            self.is_enabled(match item {
+                EnvelopeItem::Event(_) => RateLimitingCategory::Error,
+                EnvelopeItem::SessionUpdate(_) | EnvelopeItem::SessionAggregates(_) => {
+                    RateLimitingCategory::Session
+                }
+                EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
+                EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
+                EnvelopeItem::ItemContainer(ItemContainer::Logs(_)) => {
+                    RateLimitingCategory::LogItem
+                }
+                EnvelopeItem::MonitorCheckIn(_)
+                | EnvelopeItem::ItemContainer(_)
+                | EnvelopeItem::Raw
+                | _ => RateLimitingCategory::Any,
+            })
+        })
+    }
+}
+
+/// The Category of payload that a Rate Limit refers to.
+#[non_exhaustive]
+pub enum RateLimitingCategory {
+    /// Rate Limit for any kind of payload.
+    Any,
+    /// Rate Limit pertaining to Errors.
+    Error,
+    /// Rate Limit pertaining to Sessions.
+    Session,
+    /// Rate Limit pertaining to Transactions.
+    Transaction,
+    /// Rate Limit pertaining to Attachments.
+    Attachment,
+    /// Rate Limit pertaining to Log Items.
+    LogItem,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sentry_header() {
+        let mut rl = RateLimiter::new();
+        rl.update_from_sentry_header("120:error:project:reason, 60:session:foo");
+
+        assert!(rl.is_disabled(RateLimitingCategory::Error).unwrap() <= Duration::from_secs(120));
+        assert!(rl.is_disabled(RateLimitingCategory::Session).unwrap() <= Duration::from_secs(60));
+        assert!(rl.is_disabled(RateLimitingCategory::Transaction).is_none());
+        assert!(rl.is_disabled(RateLimitingCategory::LogItem).is_none());
+        assert!(rl.is_disabled(RateLimitingCategory::Any).is_none());
+
+        rl.update_from_sentry_header(
+            r#"
+                30::bar,
+                120:invalid:invalid,
+                4711:foo;bar;baz;security:project
+            "#,
+        );
+
+        assert!(
+            rl.is_disabled(RateLimitingCategory::Transaction).unwrap() <= Duration::from_secs(30)
+        );
+        assert!(rl.is_disabled(RateLimitingCategory::Any).unwrap() <= Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_sentry_header_no_categories() {
+        let mut rl = RateLimiter::new();
+        rl.update_from_sentry_header("120::bar");
+
+        assert!(rl.is_disabled(RateLimitingCategory::Error).unwrap() <= Duration::from_secs(120));
+        assert!(rl.is_disabled(RateLimitingCategory::Session).unwrap() <= Duration::from_secs(120));
+        assert!(
+            rl.is_disabled(RateLimitingCategory::Transaction).unwrap() <= Duration::from_secs(120)
+        );
+        assert!(rl.is_disabled(RateLimitingCategory::LogItem).unwrap() <= Duration::from_secs(120));
+        assert!(
+            rl.is_disabled(RateLimitingCategory::Attachment).unwrap() <= Duration::from_secs(120)
+        );
+        assert!(rl.is_disabled(RateLimitingCategory::Any).unwrap() <= Duration::from_secs(120));
+    }
+
+    #[test]
+    fn test_retry_after() {
+        let mut rl = RateLimiter::new();
+        rl.update_from_retry_after("60");
+
+        assert!(rl.is_disabled(RateLimitingCategory::Error).unwrap() <= Duration::from_secs(60));
+        assert!(rl.is_disabled(RateLimitingCategory::Session).unwrap() <= Duration::from_secs(60));
+        assert!(
+            rl.is_disabled(RateLimitingCategory::Transaction).unwrap() <= Duration::from_secs(60)
+        );
+        assert!(rl.is_disabled(RateLimitingCategory::Any).unwrap() <= Duration::from_secs(60));
+    }
+}

--- a/rust/libs/telemetry/src/sentry_vendor/tokio_thread.rs
+++ b/rust/libs/telemetry/src/sentry_vendor/tokio_thread.rs
@@ -64,7 +64,7 @@ impl TransportThread {
                             }
                         };
 
-                        if let Some(time_left) =  rl.is_disabled(RateLimitingCategory::Any) {
+                        if let Some(time_left) = rl.is_disabled(RateLimitingCategory::Any) {
                             sentry_debug!(
                                 "Skipping event send because we're disabled due to rate limits for {}s",
                                 time_left.as_secs()

--- a/rust/libs/telemetry/src/sentry_vendor/tokio_thread.rs
+++ b/rust/libs/telemetry/src/sentry_vendor/tokio_thread.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use sentry::{Envelope, sentry_debug};
+
+use crate::sentry_vendor::{RateLimiter, RateLimitingCategory};
+
+#[expect(
+    clippy::large_enum_variant,
+    reason = "In normal usage this is usually SendEnvelope, the other variants are only used when \
+    the user manually calls transport.flush() or when the transport is shut down."
+)]
+enum Task {
+    SendEnvelope(Envelope),
+    Flush(SyncSender<()>),
+    Shutdown,
+}
+
+pub struct TransportThread {
+    sender: SyncSender<Task>,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl TransportThread {
+    pub fn new<S, SendFn, SendFuture>(mut state: S, mut send: SendFn) -> Self
+    where
+        SendFn: FnMut(S, Envelope, RateLimiter) -> SendFuture + Send + 'static,
+        // NOTE: returning RateLimiter here, otherwise we are in borrow hell
+        SendFuture: std::future::Future<Output = (S, RateLimiter)>,
+        S: Send + 'static,
+    {
+        let (sender, receiver) = sync_channel(30);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_worker = shutdown.clone();
+        let handle = thread::Builder::new()
+            .name("sentry-transport".into())
+            .spawn(move || {
+                // create a runtime on the transport thread
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("Should be able to create a runtime");
+
+                let mut rl = RateLimiter::new();
+
+                // and block on an async fn in this runtime/thread
+                rt.block_on(async move {
+                    for task in receiver.into_iter() {
+                        if shutdown_worker.load(Ordering::SeqCst) {
+                            return;
+                        }
+                        let envelope = match task {
+                            Task::SendEnvelope(envelope) => envelope,
+                            Task::Flush(sender) => {
+                                sender.send(()).ok();
+                                continue;
+                            }
+                            Task::Shutdown => {
+                                return;
+                            }
+                        };
+
+                        if let Some(time_left) =  rl.is_disabled(RateLimitingCategory::Any) {
+                            sentry_debug!(
+                                "Skipping event send because we're disabled due to rate limits for {}s",
+                                time_left.as_secs()
+                            );
+                            continue;
+                        }
+                        match rl.filter_envelope(envelope) {
+                            Some(envelope) => {
+                                let (new_state, new_rl) = send(state, envelope, rl).await;
+
+                                state = new_state;
+                                rl = new_rl;
+                            },
+                            None => {
+                                sentry_debug!("Envelope was discarded due to per-item rate limits");
+                            },
+                        };
+                    }
+                })
+            })
+            .ok();
+
+        Self {
+            sender,
+            shutdown,
+            handle,
+        }
+    }
+
+    pub fn send(&self, envelope: Envelope) {
+        // Using send here would mean that when the channel fills up for whatever
+        // reason, trying to send an envelope would block everything. We'd rather
+        // drop the envelope in that case.
+        if let Err(e) = self.sender.try_send(Task::SendEnvelope(envelope)) {
+            sentry_debug!("envelope dropped: {e}");
+        }
+    }
+
+    pub fn flush(&self, timeout: Duration) -> bool {
+        let (sender, receiver) = sync_channel(1);
+        let _ = self.sender.send(Task::Flush(sender));
+        receiver.recv_timeout(timeout).is_ok()
+    }
+}
+
+impl Drop for TransportThread {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.sender.send(Task::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}


### PR DESCRIPTION
Our "stream logs to Sentry" feature currently relies on Sentry's internal HTTP client. That client has no idea that it is running within the context of a VPN and therefore doesn't take the necessary measures to avoid routing loops. On MacOS, that isn't an issue because the OS automatically takes care of that for us.

On all other operating systems, a user with the Internet Resource and log streaming enabled will currently have all of their Sentry traffic routed through the tunnel as well. This is not ideal as it generates unnecessary traffic that connlib needs to process. Most likely, log-streaming is only enabled for the customer because they are having some kind of issues. Forcing additional traffic through their tunnels thus may only exacerbate the problem.

To fix this, we build on top of the HTTP2 client that we already had to introduce for DoH. To create sockets that don't cause routing loops, we need to thread-through the `SocketFactory` to the `Telemetry` instance on every platform. This HTTP client is designed around a single connection. If the connection breaks, the Client needs to be re-created. To do this in a robust way, we attempt to re-create the connection on every "Envelope" that we are meant to send to Sentry. Doing this naively would likely result in a retries. Thus, we also add a sans-IO circuit breaker crate that ensures we only retry a number of times before stopping for a bit.

Resolves: #10272