### PR TITLE
chore: modularize `.tool-versions`

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -7,6 +7,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
+      with:
+        path: kotlin/android/.tool-versions
+
     - uses: ./.github/actions/setup-rust
       with:
         targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android

--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -17,6 +17,8 @@ runs:
     - name: Tool Versions
       id: versions
       uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
+      with:
+        path: elixir/.tool-versions
     - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
       id: setup-beam
       with:

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -67,7 +67,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
-      - uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
       - uses: ./.github/actions/setup-android
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,19 +1,6 @@
-# These are used for the dev environment.
-# This should match the versions used in the built product.
-nodejs 22.20.0
-elixir 1.18.4-otp-27
-erlang 27.3.4.1
-
 # Used for static analysis
 python 3.11.14
 shfmt 3.9.0
 
 # Used to lint Bash scripts
 shellcheck 0.9.0
-
-# GUI client
-pnpm 10.18.3
-
-# Android app
-java openjdk-17
-ktlint 1.7.1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -141,7 +141,7 @@ setup properly.
 
 The versions for most tools and SDKs required for working on Firezone are managed
 via `.tool-versions` files in the respective directories, i.e. Elixir tools in
-[elixir/.tool-versions](elixir/.tool-versions) etc.
+[elixir/.tool-versions](../elixir/.tool-versions) etc.
 
 You can use any `.tool-versions`-compatible version manager for installing them.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -143,7 +143,7 @@ The versions for most tools and SDKs required for working on Firezone are manage
 via `.tool-versions` files in the respective directories, i.e. Elixir tools in
 [elixir/.tool-versions](elixir/.tool-versions) etc.
 
-You can use any `.tool-versions` compatible version manager for installing them.
+You can use any `.tool-versions`-compatible version manager for installing them.
 
 - Note: For a fresh install of `asdf` you will need to install some
   [asdf-plugins](https://asdf-vm.com/manage/plugins.html). e.g. `asdf plugin add nodejs && asdf install nodejs` to set up the NodeJS plugin and package.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -137,11 +137,13 @@ environment setup. If you have not read the Docker Setup instructions we
 recommend following the directions listed there to get your Docker environment
 setup properly.
 
-### asdf-vm Setup
+### Developer tools
 
-We use [asdf-vm](https://asdf-vm.com) to manage language versions for Firezone.
-Install the language runtimes defined in the [.tool-versions](../.tool-versions)
-file by running `asdf install` from the project root.
+The versions for most tools and SDKs required for working on Firezone are managed
+via `.tool-versions` files in the respective directories, i.e. Elixir tools in
+[elixir/.tool-versions](elixir/.tool-versions) etc.
+
+You can use any `.tool-versions` compatible version manager for installing them.
 
 - Note: For a fresh install of `asdf` you will need to install some
   [asdf-plugins](https://asdf-vm.com/manage/plugins.html). e.g. `asdf plugin add nodejs && asdf install nodejs` to set up the NodeJS plugin and package.

--- a/elixir/.tool-versions
+++ b/elixir/.tool-versions
@@ -1,0 +1,5 @@
+# These are used for the dev environment.
+# This should match the versions used in the built product.
+nodejs 22.20.0
+elixir 1.18.4-otp-27
+erlang 27.3.4.1

--- a/kotlin/android/.tool-versions
+++ b/kotlin/android/.tool-versions
@@ -1,0 +1,2 @@
+java openjdk-17
+ktlint 1.7.1

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,0 +1,2 @@
+# GUI client
+pnpm 10.18.3


### PR DESCRIPTION
Not all tools are needed for all parts of the codebase. In order to avoid installing all tools, we create nested `.tool-versions` files that list the specific dev-tools needed for a certain part of the product.