### PR TITLE
chore(elixir): manage Chrome & driver via `.tool-versions`

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -175,7 +175,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-postgres
-      - uses: nanasess/setup-chromedriver@e93e57b843c0c92788f22483f1a31af8ee48db25 # v2.3.0
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &

--- a/elixir/.tool-versions
+++ b/elixir/.tool-versions
@@ -4,3 +4,4 @@ nodejs       22.20.0
 elixir       1.18.4-otp-27
 erlang       27.3.4.1
 chromedriver 144.0.7534.0
+chrome       144.0.7534.0 # https://github.com/weizhliu/asdf-chrome.git

--- a/elixir/.tool-versions
+++ b/elixir/.tool-versions
@@ -1,5 +1,6 @@
 # These are used for the dev environment.
 # This should match the versions used in the built product.
-nodejs 22.20.0
-elixir 1.18.4-otp-27
-erlang 27.3.4.1
+nodejs       22.20.0
+elixir       1.18.4-otp-27
+erlang       27.3.4.1
+chromedriver 144.0.7534.0

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -143,7 +143,10 @@ config :wallaby,
   # TODO: Contribute to Wallaby to make this configurable on the per-process level,
   # along with buffer to write logs only on process failure
   js_logger: false,
-  hackney_options: [timeout: 10_000, recv_timeout: 10_000]
+  hackney_options: [timeout: 10_000, recv_timeout: 10_000],
+  chromedriver: [
+    binary: System.find_executable("chrome"),
+  ]
 
 ex_unit_config =
   [

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -145,7 +145,7 @@ config :wallaby,
   js_logger: false,
   hackney_options: [timeout: 10_000, recv_timeout: 10_000],
   chromedriver: [
-    binary: System.find_executable("chrome"),
+    binary: System.find_executable("chrome")
   ]
 
 ex_unit_config =


### PR DESCRIPTION
In order to run the LiveView tests, we need chromedriver and Chrome in matching versions.