### PR TITLE
ci: run more Rust tests on all platforms

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -26,7 +26,7 @@ outputs:
     description: Testable packages for the current OS
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
-      (runner.os == 'macOS' && '--workspace') ||
+      (runner.os == 'macOS' && '--workspace --exclude firezone-bin-shared --exclude firezone-gui-client') ||
       (runner.os == 'Windows' && '--workspace') }}
   nightly_version:
     description: The nightly version of Rust

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -27,7 +27,7 @@ outputs:
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '--workspace --exclude firezone-bin-shared --exclude firezone-gui-client') ||
-      (runner.os == 'Windows' && '--workspace') }}
+      (runner.os == 'Windows' && '--workspace --exclude client-ffi') }}
   nightly_version:
     description: The nightly version of Rust
     value: ${{ steps.nightly.outputs.nightly }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -26,8 +26,8 @@ outputs:
     description: Testable packages for the current OS
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
-      (runner.os == 'macOS' && '-p client-ffi -p client-shared -p firezone-tunnel -p snownet') ||
-      (runner.os == 'Windows' && '-p client-shared -p connlib-model -p firezone-bin-shared -p firezone-gui-client -p firezone-headless-client -p firezone-logging -p firezone-telemetry -p firezone-tunnel -p gui-smoke-test -p http-test-server -p ip-packet -p phoenix-channel -p snownet -p socket-factory -p tun') }}
+      (runner.os == 'macOS' && '--workspace') ||
+      (runner.os == 'Windows' && '--workspace') }}
   nightly_version:
     description: The nightly version of Rust
     value: ${{ steps.nightly.outputs.nightly }}

--- a/rust/connlib/bufferpool/lib.rs
+++ b/rust/connlib/bufferpool/lib.rs
@@ -350,7 +350,7 @@ mod tests {
         let buffer2 = pool.pull_initialised(b"hello world");
         let buffer3 = pool.pull_initialised(b"hello world");
 
-        tokio::time::sleep(Duration::from_millis(10)).await; // Wait for metrics to be exported.
+        tokio::time::sleep(Duration::from_millis(100)).await; // Wait for metrics to be exported.
 
         assert_eq!(get_num_buffers(&exporter), 3);
 
@@ -359,7 +359,7 @@ mod tests {
         drop(buffer2);
         drop(buffer3);
 
-        tokio::time::sleep(Duration::from_millis(10)).await; // Wait for metrics to be exported.
+        tokio::time::sleep(Duration::from_millis(100)).await; // Wait for metrics to be exported.
 
         assert_eq!(get_num_buffers(&exporter), 0);
     }

--- a/rust/connlib/dns-over-tcp/Cargo.toml
+++ b/rust/connlib/dns-over-tcp/Cargo.toml
@@ -15,10 +15,12 @@ rand = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-firezone-bin-shared = { workspace = true }
 futures = { workspace = true }
-ip_network = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt", "macros"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dev-dependencies]
+firezone-bin-shared = { workspace = true }
+ip_network = { workspace = true }
 tun = { workspace = true }
 
 [lints]

--- a/rust/connlib/dns-over-tcp/Cargo.toml
+++ b/rust/connlib/dns-over-tcp/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt", "macros"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 firezone-bin-shared = { workspace = true }
 ip_network = { workspace = true }
 tun = { workspace = true }

--- a/rust/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unwrap_used)]
-#![cfg(not(any(target_os = "macos", target_os = "windows")))]
+#![cfg(not(any(target_os = "macos", target_os = "windows")))] // The DNS-over-TCP server is sans-IO so it doesn't matter where the IP packets come from. Testing it only on Linux is therefore fine.
 
 use std::{
     collections::BTreeSet,

--- a/rust/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unwrap_used)]
-#![cfg(not(target_os = "macos"))]
+#![cfg(not(any(target_os = "macos", target_os = "windows")))]
 
 use std::{
     collections::BTreeSet,

--- a/rust/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used)]
+#![cfg(not(target_os = "macos"))]
 
 use std::{
     collections::BTreeSet,

--- a/rust/connlib/l4-tcp-dns-server/lib.rs
+++ b/rust/connlib/l4-tcp-dns-server/lib.rs
@@ -196,7 +196,7 @@ mod tests {
     async fn smoke_ipv4() {
         let mut server = Server::default();
 
-        let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 127), 8080));
+        let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080));
 
         let server_task = tokio::spawn(async move {
             server.rebind(socket).unwrap();

--- a/rust/connlib/l4-udp-dns-server/lib.rs
+++ b/rust/connlib/l4-udp-dns-server/lib.rs
@@ -183,7 +183,7 @@ mod tests {
     async fn smoke_ipv4() {
         let mut server = Server::default();
 
-        let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 127), 8080));
+        let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080));
 
         let server_task = tokio::spawn(async move {
             server.rebind(socket).unwrap();


### PR DESCRIPTION
Running only the unit-tests of select crates on some platforms is problematic. We are unlikely to update this list of crates as we introduce new ones. It is a better default to run the tests of all crates on all platforms and selectively exclude the ones that can't run because they are unsupported.