### PR TITLE
fix(connlib): override query ID of DoH response

### DIFF
--- a/rust/connlib/dns-types/lib.rs
+++ b/rust/connlib/dns-types/lib.rs
@@ -225,6 +225,12 @@ impl Response {
         Self::parse(response.body())
     }
 
+    pub fn with_id(mut self, id: u16) -> Self {
+        self.inner.header_mut().set_id(id);
+
+        self
+    }
+
     pub fn id(&self) -> u16 {
         self.inner.header().id()
     }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -534,6 +534,10 @@ impl ClientState {
             }
         };
 
+        // Ensure the response we are sending back has the original query ID.
+        // Recursive DoH queries set the ID to 0.
+        let message = message.with_id(qid);
+
         self.dns_cache.insert(domain, &message, now);
 
         match response.transport {

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -554,8 +554,13 @@ impl TunnelTest {
                 let server = query.server;
                 let transport = query.transport;
 
+                // DoH queries are always sent with an ID of 0, simulate that in the tests.
+                let message = matches!(server, dns::Upstream::DoH { .. })
+                    .then_some(query.message.clone().with_id(0))
+                    .unwrap_or(query.message.clone());
+
                 let response =
-                    self.on_recursive_dns_query(&query.message, &ref_state.global_dns_records, now);
+                    self.on_recursive_dns_query(&message, &ref_state.global_dns_records, now);
                 self.client.exec_mut(|c| {
                     c.sut.handle_dns_response(
                         dns::RecursiveResponse {


### PR DESCRIPTION
As per the RFC, queries to DoH servers should always set their query ID to 0. This is more cache-friendly because two queries for the same domain end up being byte-for-byte equivalent in the HTTP request. When transported over HTTP, the query ID is obsolete because the response can be unambiguously mapped back to the request already.

Connlib's DoH feature zeros out the query ID in the IO layer. To correctly test this functionality, we therefore extend the test-suite to do the same and restore the original query ID before sending back the response on the original transport.

This fixes a bug where all DNS queries that were forwarded to a DoH server incorrectly had their query ID set to 0.