### PR TITLE
ci: install dotnet v10

### DIFF
--- a/.github/actions/setup-azure-sign-tool/action.yml
+++ b/.github/actions/setup-azure-sign-tool/action.yml
@@ -1,0 +1,13 @@
+name: "Setup AzureSignTool"
+description: "Installs the AzureSignTool"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+      if: ${{ runner.os == 'Windows' }}
+      with:
+        dotnet-version: "10.0.x"
+    - name: Install AzureSignTool
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: dotnet tool install --global AzureSignTool

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -139,6 +139,9 @@ jobs:
 
           cargo build $PROFILE -p ${{ matrix.package }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe "$ARTIFACT_PATH"
+      - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: "10.0.x"
       - name: Install AzureSignTool
         shell: bash
         run: dotnet tool install --global AzureSignTool

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -139,12 +139,7 @@ jobs:
 
           cargo build $PROFILE -p ${{ matrix.package }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe "$ARTIFACT_PATH"
-      - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
-        with:
-          dotnet-version: "10.0.x"
-      - name: Install AzureSignTool
-        shell: bash
-        run: dotnet tool install --global AzureSignTool
+      - uses: ./.github/actions/setup-azure-sign-tool
       - name: Sign the binary
         shell: bash
         env:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -151,6 +151,10 @@ jobs:
           organization: firezone-inc
       - name: Install pnpm deps
         run: pnpm install
+      - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          dotnet-version: "10.0.x"
       - name: Install AzureSignTool
         if: ${{ runner.os == 'Windows' }}
         shell: bash

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -151,14 +151,7 @@ jobs:
           organization: firezone-inc
       - name: Install pnpm deps
         run: pnpm install
-      - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          dotnet-version: "10.0.x"
-      - name: Install AzureSignTool
-        if: ${{ runner.os == 'Windows' }}
-        shell: bash
-        run: dotnet tool install --global AzureSignTool
+      - uses: ./.github/actions/setup-azure-sign-tool
       - name: Build release exe and MSI / deb
         env:
           CARGO_PROFILE_RELEASE_LTO: thin # Fat LTO is getting too slow / RAM-hungry on Tauri builds


### PR DESCRIPTION
A new version of the `AzureSignTool` appears to require a dotnet version that is not yet installed on the GitHub runners. Ideally we would be managing this via `.tool-versions` but that needs a bit more work, see the CI failures in #10936.