### PR TITLE
ci(apt): import packages one by one

### DIFF
--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -77,20 +77,11 @@ for DISTRIBUTION in "stable" "preview"; do
 
                 # Construct the proper filename
                 NORMALIZED_NAME="${PACKAGE}_${VERSION}_${ARCH}.deb"
-                NORMALIZED_PATH="${IMPORT_DIR}/${NORMALIZED_NAME}"
 
-                # Rename if needed
-                if [ "$(basename "$deb")" == "$NORMALIZED_NAME" ]; then
-                    continue
-                fi
-
-                echo "Renaming $(basename "$deb") → $NORMALIZED_NAME"
-                mv "$deb" "$NORMALIZED_PATH"
+                echo "Importing $(basename "$deb") as ${NORMALIZED_NAME}"
+                mv --force "$deb" "${POOL_DIR}/${NORMALIZED_NAME}"
             fi
         done
-
-        echo "Importing new packages..."
-        mv --force --target-directory="${POOL_DIR}/" "${IMPORT_DIR}"/**/*.deb
     fi
 
     if [ -z "$(ls -A "${POOL_DIR}")" ]; then


### PR DESCRIPTION
When importing packages into the APT repository, we need to do so one-by-one. Moving packages using a glob-pattern confuses the CLI because it wants to overwrite files it just created.

Current main: https://github.com/firezone/firezone/actions/runs/19619491316/job/56177170625
This PR: https://github.com/firezone/firezone/actions/runs/19619725967/job/56177805109