### PR TITLE
fix(connlib): fail connection upsert early

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -305,6 +305,8 @@ where
             return Ok(());
         }
 
+        let selected_relay = self.sample_relay()?;
+
         let existing = self.connections.remove_established(&cid, now);
         let index = self.index.next();
 
@@ -314,8 +316,6 @@ where
         } else {
             tracing::info!(local = ?local_creds, remote = ?remote_creds, %index, "Creating new connection");
         }
-
-        let selected_relay = self.sample_relay()?;
 
         let mut agent = match self.role.kind() {
             RoleKind::Client => new_client_agent(),

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -535,12 +535,18 @@ impl TunnelTest {
             if let Some(event) = self.client.exec_mut(|c| c.sut.poll_event()) {
                 match self.on_client_event(self.client.inner().id, event, &ref_state.portal) {
                     Ok(()) => {}
-                    Err(AuthorizeFlowError::Client(_)) => {
+                    Err(AuthorizeFlowError::Client(e)) => {
+                        tracing::debug!("Failed to handle ClientEvent: {e}");
+
+                        // Simulate WebSocket reconnect ...
                         self.client.exec_mut(|c| {
                             c.update_relays(iter::empty(), self.relays.iter(), now);
                         });
                     }
-                    Err(AuthorizeFlowError::Gateway(_)) => {
+                    Err(AuthorizeFlowError::Gateway(e)) => {
+                        tracing::debug!("Failed to handle GatewayEvent: {e}");
+
+                        // Simulate WebSocket reconnect ...
                         for gateway in self.gateways.values_mut() {
                             gateway.exec_mut(|g| {
                                 g.update_relays(iter::empty(), self.relays.iter(), now)


### PR DESCRIPTION
When upserting a connection, we need to sample one of our relays to use as a fallback. If we don't have any relays (because they all got disconnected), we cannot create the connection.

Right now, we perform this sampling a bit too late in the function and thus wrongly print "Creating new connection" even though we never make it that for.

To avoid that, move the `sample_relay` call higher up to avoid making any state modifications if we cannot proceed.