### PR TITLE
fix(connlib): retry sending packet on ENOBUFS

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7030,7 +7030,6 @@ dependencies = [
  "opentelemetry",
  "quinn-udp",
  "socket2 0.6.1",
- "telemetry",
  "tokio",
  "tracing",
 ]

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -23,7 +23,7 @@ libc = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 libc = { workspace = true }
 
 [dev-dependencies]

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -25,7 +25,6 @@ libc = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = { workspace = true }
-telemetry = { workspace = true }
 
 [dev-dependencies]
 derive_more = { workspace = true, features = ["deref"] }

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -14,7 +14,7 @@ ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net", "time"] }
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -17,13 +17,13 @@ socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net", "time"] }
 tracing = { workspace = true }
 
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(target_os = "android")'.dependencies]
 libc = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = { workspace = true }
-
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 libc = { workspace = true }
 
 [dev-dependencies]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -27,8 +27,8 @@ pub const SEND_BUFFER_SIZE: usize = 16 * ONE_MB;
 pub const RECV_BUFFER_SIZE: usize = 128 * ONE_MB;
 const ONE_MB: usize = 1024 * 1024;
 
-#[cfg(any(target_os = "macos", test))]
 /// How many times we at most try to re-send a packet if we encounter ENOBUFS.
+#[cfg(any(target_os = "macos", test))]
 const MAX_ENOBUFS_RETRIES: u32 = 24;
 
 impl<F, S> SocketFactory<S> for F

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -504,6 +504,10 @@ fn is_equal_modulo_scope_for_ipv6_link_local(expected: SocketAddr, actual: Socke
     }
 }
 
+#[cfg_attr(
+    not(any(target_os = "linux", target_os = "android", target_os = "macos")),
+    expect(unused_variables, reason = "No backoff strategy for other platforms")
+)]
 fn backoff(e: &anyhow::Error, attempts: u32) -> Option<Duration> {
     let raw_os_error = e.any_downcast_ref::<io::Error>()?.raw_os_error()?;
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -766,7 +766,7 @@ mod tests {
     }
 
     #[test]
-    // #[cfg(target_os = "macos")]
+    #[cfg(target_os = "macos")]
     fn at_most_24_retries_of_enobufs() {
         let err = anyhow::Error::new(io::Error::from_raw_os_error(libc::ENOBUFS));
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -319,7 +319,7 @@ impl UdpSocket {
                 Err(e) => {
                     let backoff = backoff(&e, attempt).ok_or(e)?; // Attempt to get a backoff value or otherwise bail with error.
 
-                    tracing::debug!("Re");
+                    tracing::debug!(?backoff, dst = %datagram.dst, len = %datagram.packet.len(), "Retrying packet");
 
                     tokio::time::sleep(backoff).await;
                 }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -48,7 +48,7 @@ export default function Apple() {
           dropped.
         </ChangeItem>
         <ChangeItem pull="10965">
-          Fixes an issue where some packets would get dropped on high-througput.
+          Fixes an issue where some packets would get dropped under high throughput scenarios.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-10-20")}>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -47,6 +47,9 @@ export default function Apple() {
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
+        <ChangeItem pull="10965">
+          Fixes an issue where some packets would get dropped on high-througput.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-10-20")}>
         <ChangeItem pull="10603">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -48,7 +48,8 @@ export default function Apple() {
           dropped.
         </ChangeItem>
         <ChangeItem pull="10965">
-          Fixes an issue where some packets would get dropped under high throughput scenarios.
+          Fixes an issue where some packets would get dropped under high
+          throughput scenarios.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-10-20")}>


### PR DESCRIPTION
In #9798, we added a check to map `ENOBUFS` to `WOUDLBLOCK` on MacOS. More experimentation on that front revealed that this was actually incorrect and the UDP sending task will hang as the OS does **not** notify us once there are new buffers available.

This may explain some random connection hangs that some users have recently complained about. I've already disabled the feature flag in production, this PR therefore only removes code that is now inactive.

In order to make this as robust as possible, we implement a retry loop with an exponential backoff, starting a 2ns. At most, we will be retrying such a packet for 16ms. Local experiments on my Macbook have shown that most of the time, new buffer space is available within 1ms. The exponential backoff ensures we retry very quickly on faster machines but still successfully send the packet on slower machines.

According to the linked mailing list, the link-speed of the attached network has nothing to do with this which makes sense. UDP has no congestion control so sending packets is merely a function of how fast the CPU can process them.

Related: https://lists.freebsd.org/pipermail/freebsd-hackers/2004-January/005369.html