### PR TITLE
ci: consolidate static-analysis triggers long description on purpose 

### DIFF
--- a/.github/workflows/_rerun-on-edit.yml
+++ b/.github/workflows/_rerun-on-edit.yml
@@ -1,0 +1,44 @@
+name: Re-run PR Lint on Edit
+on:
+  pull_request:
+    types: [edited]
+
+jobs:
+  rerun-pr-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run static-analysis jobs in CI run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # Find the latest CI workflow run for this PR's head SHA
+          run_id=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow "Continuous Integration" \
+            --branch "$HEAD_REF" \
+            --json databaseId,headSha \
+            --jq ".[] | select(.headSha == \"${{ github.event.pull_request.head.sha }}\") | .databaseId" \
+            | head -1)
+
+          if [ -z "$run_id" ]; then
+            echo "No CI run found for this commit"
+            exit 0
+          fi
+
+          echo "Found CI run: $run_id"
+
+          # Get static-analysis job IDs (pr-lint, global-linter, etc.)
+          job_ids=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id/jobs" \
+            --jq '.jobs[] | select(.name | contains("static-analysis")) | .id')
+
+          if [ -z "$job_ids" ]; then
+            echo "No static-analysis jobs found"
+            exit 0
+          fi
+
+          # Re-run each static-analysis job
+          for job_id in $job_ids; do
+            echo "Re-running job $job_id"
+            gh api --method POST "repos/${{ github.repository }}/actions/jobs/$job_id/rerun"
+          done

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -1,8 +1,6 @@
 name: Static Analysis
 on:
   workflow_call:
-  pull_request:
-    types: [edited]
 
 jobs:
   pr-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Continuous Integration
 run-name: Triggered by ${{ github.actor }} on ${{ github.event_name }}
 on:
   pull_request:
-    # Default types + edited (for static analysis, with early exit)
-    types: [opened, synchronize, reopened, edited]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -34,13 +32,6 @@ jobs:
           set -e
 
           jobs="static-analysis,elixir,rust,tauri,kotlin,swift,codeql,control-plane,data-plane,data-plane-perf";
-
-          # For PR edits (title/description changes), only run static-analysis
-          if [ "${{ github.event.action }}" = "edited" ]; then
-            echo "jobs_to_run=static-analysis" >> "$GITHUB_OUTPUT"
-
-            exit 0;
-          fi
 
           # For workflow_dispatch or workflow_call, run all jobs
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Continuous Integration
 run-name: Triggered by ${{ github.actor }} on ${{ github.event_name }}
 on:
   pull_request:
+    # Default types + edited (for static analysis, with early exit)
+    types: [opened, synchronize, reopened, edited]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -32,6 +34,13 @@ jobs:
           set -e
 
           jobs="static-analysis,elixir,rust,tauri,kotlin,swift,codeql,control-plane,data-plane,data-plane-perf";
+
+          # For PR edits (title/description changes), only run static-analysis
+          if [ "${{ github.event.action }}" = "edited" ]; then
+            echo "jobs_to_run=static-analysis" >> "$GITHUB_OUTPUT"
+
+            exit 0;
+          fi
 
           # For workflow_dispatch or workflow_call, run all jobs
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then


### PR DESCRIPTION
Previously, _static-analysis.yml had both workflow_call (for ci.yml) and pull_request[edited] triggers, causing duplicate GitHub checks:
- "Continuous Integration / static-analysis / *"
- "Static Analysis / *"

When PR title/description was edited, only the standalone check re-ran, leaving the CI version stale and required-check unable to update.

Now ci.yml handles the edited event directly and runs only static-analysis jobs, so required-check updates correctly when PR lint issues are fixed.