### PR TITLE
refactor(swift): replace @unchecked Sendable

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -27,6 +27,7 @@ import System
       case invalidFileHandle
     }
 
+    @MainActor
     static func export(
       to archiveURL: URL,
       session: NETunnelProviderSession


### PR DESCRIPTION
VPNConfigurationManager now uses `@MainActor` isolation instead of `@unchecked Sendable`. This aligns with Apple's documented behaviour where NEVPNManager callbacks arrive on the main thread.

- Made `VPNConfigurationManager` final and `@MainActor`
- Added `@MainActor` to `LogExporter.export(to:session:)` on macOS
- Marked `legacyConfiguration()` as `nonisolated` (pure function, called from network extension)
- Removed redundant `@MainActor` from `maybeMigrateConfiguration()`