### PR TITLE
test(connlib): cover more ground with determinism tests

### DIFF
--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -4,6 +4,8 @@
 //! [Tunnel] is the main entry-point for this crate.
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::print_stdout))]
+#![cfg_attr(test, allow(clippy::print_stderr))]
 
 use anyhow::{Context as _, ErrorExt as _, Result};
 use chrono::Utc;

--- a/rust/libs/connlib/tunnel/src/tests.rs
+++ b/rust/libs/connlib/tunnel/src/tests.rs
@@ -38,7 +38,6 @@ mod transition;
 type QueryId = u16;
 
 #[test]
-#[expect(clippy::print_stdout, clippy::print_stderr)]
 fn tunnel_test() {
     let config = Config {
         source_file: Some(file!()),

--- a/rust/libs/connlib/tunnel/src/tests.rs
+++ b/rust/libs/connlib/tunnel/src/tests.rs
@@ -138,27 +138,36 @@ fn tunnel_test() {
 }
 
 #[test]
-fn reference_state_is_deterministic() {
+fn transitions_and_state_are_deterministic() {
     let now = Instant::now();
 
     for n in 0..1000 {
-        let state1 = sample_from_strategy(n, ReferenceState::initial_state(now));
-        let state2 = sample_from_strategy(n, ReferenceState::initial_state(now));
+        println!("Checking seed {n}");
+
+        let mut state1 = sample_from_strategy(n, ReferenceState::initial_state(now));
+        let mut state2 = sample_from_strategy(n, ReferenceState::initial_state(now));
 
         assert_eq!(format!("{state1:?}"), format!("{state2:?}"));
-    }
-}
 
-#[test]
-fn transitions_are_deterministic() {
-    let now = Instant::now();
+        let num_transitions = sample_from_strategy(n, 5..=15);
 
-    for n in 0..1000 {
-        let state = sample_from_strategy(n, ReferenceState::initial_state(now));
-        let transitions1 = sample_from_strategy(n, ReferenceState::transitions(&state, now));
-        let transitions2 = sample_from_strategy(n, ReferenceState::transitions(&state, now));
+        for _ in 0..num_transitions {
+            let transition1 = sample_from_strategy(n, ReferenceState::transitions(&state1, now));
+            let transition2 = sample_from_strategy(n, ReferenceState::transitions(&state2, now));
 
-        assert_eq!(format!("{transitions1:?}"), format!("{transitions2:?}"));
+            assert_eq!(format!("{transition1:?}"), format!("{transition2:?}"));
+
+            if !ReferenceState::is_valid_transition(&state1, &transition1)
+                || !ReferenceState::is_valid_transition(&state2, &transition2)
+            {
+                continue;
+            }
+
+            state1 = ReferenceState::apply(state1, &transition1, now);
+            state2 = ReferenceState::apply(state2, &transition2, now);
+
+            assert_eq!(format!("{state1:?}"), format!("{state2:?}"));
+        }
     }
 }
 


### PR DESCRIPTION
In order for the `tunnel_test` test-suite to be useful, we need to ensure that they are deterministic based off the seed. We have unit-tests for those but those only check a single `Transition` for a few hard-coded seeds.

To ensure we don't have some hidden non-determinism somewhere, we convert that into a proptest and also create a series of transitions the same way `tunnel_test` does.