### PR TITLE
refactor(apple): Make Adapter an actor

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -34,8 +34,6 @@
 		8DCC022A28D512AE007E12D2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8DCC022928D512AE007E12D2 /* Preview Assets.xcassets */; };
 		8DE452A82CE6C194004CEDF9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5047E82CE6A8F4009802E9 /* main.swift */; };
 		8DFDEAC72D2CEBA500615095 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8DA12C322BB7DA04007D91EB /* PrivacyInfo.xcprivacy */; };
-		A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */; };
-		A1B2C3D4E5F6A78901234569 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */; };
 		C1892134991C462C8E137DE3 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09DC14A4A04715A37BC04C /* Channel.swift */; };
 		C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */; };
 		CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2847ACC9D73EA6F356F2DEE1 /* connlib.swift */; };
@@ -116,7 +114,6 @@
 		8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = xcconfig/config.xcconfig; sourceTree = "<group>"; };
 		8DE1077A2D2313EB00DB5A45 /* Info.iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.iOS.plist; sourceTree = "<group>"; };
 		8DE1077B2D2313EB00DB5A45 /* Info.macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.macOS.plist; sourceTree = "<group>"; };
-		A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathUpdates.swift; sourceTree = "<group>"; };
 		E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionEventLoop.swift; sourceTree = "<group>"; };
 		8D0000012D41000000A2 /* NetworkPathUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathUpdates.swift; sourceTree = "<group>"; };
 		8D0000012D41000000B1 /* ProviderCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderCommand.swift; sourceTree = "<group>"; };
@@ -170,7 +167,6 @@
 				177FB893F19457A113042247 /* Adapter.swift */,
 				05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */,
 				8D41B9A42D15DD6800D16065 /* TunnelLogArchive.swift */,
-				A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */,
 				6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */,
 			);
 			path = FirezoneNetworkExtension;
@@ -513,7 +509,6 @@
 				8D0000012D4100000003 /* NetworkPathUpdates.swift in Sources */,
 				8D0000012D4100000005 /* ProviderCommand.swift in Sources */,
 				C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */,
-				A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,7 +526,6 @@
 				6571861AB9324D6A9395BDB3 /* SessionEventLoop.swift in Sources */,
 				858AA13A09A55E3B1DD5DEDA /* Adapter.swift in Sources */,
 				CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */,
-				A1B2C3D4E5F6A78901234569 /* NetworkPathUpdates.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -39,6 +39,10 @@
 		C1892134991C462C8E137DE3 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09DC14A4A04715A37BC04C /* Channel.swift */; };
 		C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */; };
 		CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2847ACC9D73EA6F356F2DEE1 /* connlib.swift */; };
+		8D0000012D4100000003 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0000012D41000000A2 /* NetworkPathUpdates.swift */; };
+		8D0000012D4100000004 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0000012D41000000A2 /* NetworkPathUpdates.swift */; };
+		8D0000012D4100000005 /* ProviderCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0000012D41000000B1 /* ProviderCommand.swift */; };
+		8D0000012D4100000006 /* ProviderCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0000012D41000000B1 /* ProviderCommand.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -114,6 +118,8 @@
 		8DE1077B2D2313EB00DB5A45 /* Info.macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.macOS.plist; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathUpdates.swift; sourceTree = "<group>"; };
 		E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionEventLoop.swift; sourceTree = "<group>"; };
+		8D0000012D41000000A2 /* NetworkPathUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathUpdates.swift; sourceTree = "<group>"; };
+		8D0000012D41000000B1 /* ProviderCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderCommand.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +162,8 @@
 				8DE1077A2D2313EB00DB5A45 /* Info.iOS.plist */,
 				8DE1077B2D2313EB00DB5A45 /* Info.macOS.plist */,
 				6C09DC14A4A04715A37BC04C /* Channel.swift */,
+				8D0000012D41000000A2 /* NetworkPathUpdates.swift */,
+				8D0000012D41000000B1 /* ProviderCommand.swift */,
 				E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */,
 				05CF1CF6290B1CEE00CF4755 /* FirezoneNetworkExtension.entitlements */,
 				8D5047E82CE6A8F4009802E9 /* main.swift */,
@@ -502,6 +510,8 @@
 				8D41B9A52D15DD6800D16065 /* TunnelLogArchive.swift in Sources */,
 				05CF1D17290B1FE700CF4755 /* PacketTunnelProvider.swift in Sources */,
 				146C8E809FF744D18C053A79 /* Channel.swift in Sources */,
+				8D0000012D4100000003 /* NetworkPathUpdates.swift in Sources */,
+				8D0000012D4100000005 /* ProviderCommand.swift in Sources */,
 				C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */,
 				A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */,
 			);
@@ -516,6 +526,8 @@
 				8D5047FB2CE6AA37009802E9 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */,
 				8D5047FE2CE6AA54009802E9 /* PacketTunnelProvider.swift in Sources */,
 				C1892134991C462C8E137DE3 /* Channel.swift in Sources */,
+				8D0000012D4100000004 /* NetworkPathUpdates.swift in Sources */,
+				8D0000012D4100000006 /* ProviderCommand.swift in Sources */,
 				6571861AB9324D6A9395BDB3 /* SessionEventLoop.swift in Sources */,
 				858AA13A09A55E3B1DD5DEDA /* Adapter.swift in Sources */,
 				CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/NetworkSettings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/NetworkSettings.swift
@@ -7,30 +7,112 @@ import Foundation
 import NetworkExtension
 import os.log
 
-public struct NetworkSettings: Equatable {
+public struct NetworkSettings: Equatable, Sendable {
   private var tunnelAddressIPv4: String?
   private var tunnelAddressIPv6: String?
   private var dnsServers: [String] = []
-  private var routes4: [NEIPv4Route] = []
-  private var routes6: [NEIPv6Route] = []
+  private var routes4: [Cidr] = []
+  private var routes6: [Cidr] = []
   private var dnsResources: [String] = []
   private var matchDomains: [String] = [""]
   private var searchDomain: String?
 
   public init() {}
 
+  // MARK: - Payload
+
+  /// A Sendable snapshot of network settings that can cross actor boundaries.
+  ///
+  /// This type exists to solve two conflicting requirements:
+  /// 1. **Sendable safety**: We need to pass settings from the Adapter actor to PacketTunnelProvider
+  ///    without using `@unchecked Sendable` on non-Sendable `NEPacketTunnelNetworkSettings`.
+  /// 2. **Test invariant**: Settings should only be built when they actually change. Making
+  ///    `buildNetworkSettings()` public would allow arbitrary calls, breaking this guarantee.
+  ///
+  /// The `fileprivate init` ensures only `NetworkSettings` update methods can create a `Payload`.
+  /// Possession of a `Payload` proves you went through an update method that detected a change.
+  /// The actual `NEPacketTunnelNetworkSettings` is built via `build()` on the receiving side.
+  public struct Payload: Sendable {
+    fileprivate let tunnelAddressIPv4: String
+    fileprivate let tunnelAddressIPv6: String
+    fileprivate let dnsServers: [String]
+    fileprivate let routes4: [Cidr]
+    fileprivate let routes6: [Cidr]
+    fileprivate let matchDomains: [String]
+    fileprivate let searchDomain: String?
+
+    fileprivate init(
+      tunnelAddressIPv4: String,
+      tunnelAddressIPv6: String,
+      dnsServers: [String],
+      routes4: [Cidr],
+      routes6: [Cidr],
+      matchDomains: [String],
+      searchDomain: String?
+    ) {
+      self.tunnelAddressIPv4 = tunnelAddressIPv4
+      self.tunnelAddressIPv6 = tunnelAddressIPv6
+      self.dnsServers = dnsServers
+      self.routes4 = routes4
+      self.routes6 = routes6
+      self.matchDomains = matchDomains
+      self.searchDomain = searchDomain
+    }
+
+    /// Build NEPacketTunnelNetworkSettings from this payload.
+    public func build() -> NEPacketTunnelNetworkSettings {
+      // Set tunnel addresses and routes
+      let ipv4Settings = NEIPv4Settings(
+        addresses: [tunnelAddressIPv4], subnetMasks: ["255.255.255.255"])
+      let validRoutes4 = routes4.compactMap { $0.asNEIPv4Route }
+      if validRoutes4.count != routes4.count {
+        Log.warning("Dropped \(routes4.count - validRoutes4.count) invalid IPv4 routes")
+      }
+      ipv4Settings.includedRoutes = validRoutes4
+
+      // This is a hack since macos routing table ignores, for full route, any prefix smaller than 120.
+      // Without this, adding a full route, remove the previous default route and leaves the system with none,
+      // completely breaking IPv6 on the user's system.
+      let ipv6Settings = NEIPv6Settings(
+        addresses: [tunnelAddressIPv6], networkPrefixLengths: [120])
+      let validRoutes6 = routes6.compactMap { $0.asNEIPv6Route }
+      if validRoutes6.count != routes6.count {
+        Log.warning("Dropped \(routes6.count - validRoutes6.count) invalid IPv6 routes")
+      }
+      ipv6Settings.includedRoutes = validRoutes6
+
+      let dnsSettings = NEDNSSettings(servers: dnsServers)
+      dnsSettings.matchDomains = matchDomains
+      dnsSettings.searchDomains = searchDomain.map { [$0] } ?? [""]
+      dnsSettings.matchDomainsNoSearch = false
+
+      // We don't really know the connlib gateway IP address at this point, but just using 127.0.0.1 is okay
+      // because the OS doesn't really need this IP address.
+      // NEPacketTunnelNetworkSettings taking in tunnelRemoteAddress is probably a bad abstraction caused by
+      // NEPacketTunnelNetworkSettings inheriting from NETunnelNetworkSettings.
+      let tunnelNetworkSettings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
+
+      tunnelNetworkSettings.ipv4Settings = ipv4Settings
+      tunnelNetworkSettings.ipv6Settings = ipv6Settings
+      tunnelNetworkSettings.dnsSettings = dnsSettings
+      tunnelNetworkSettings.mtu = 1280
+
+      return tunnelNetworkSettings
+    }
+  }
+
   // MARK: - Mutable update functions
 
   /// Update tunnel interface configuration
-  /// Returns NEPacketTunnelNetworkSettings if settings changed, nil if unchanged or build fails
+  /// Returns Payload if settings changed, nil if unchanged or missing required fields
   public mutating func updateTunInterface(
     ipv4: String?,
     ipv6: String?,
     dnsServers: [String],
     searchDomain: String?,
-    routes4: [NEIPv4Route],
-    routes6: [NEIPv6Route]
-  ) -> NEPacketTunnelNetworkSettings? {
+    routes4: [Cidr],
+    routes6: [Cidr]
+  ) -> Payload? {
     let oldSelf = self
 
     // Update values
@@ -39,30 +121,23 @@ public struct NetworkSettings: Equatable {
     self.dnsServers = dnsServers
     self.searchDomain = searchDomain
     self.matchDomains = searchDomain.map { ["", $0] } ?? [""]
-    self.routes4 = routes4.sorted {
-      ($0.destinationAddress, $0.destinationSubnetMask) < (
-        $1.destinationAddress, $1.destinationSubnetMask
-      )
-    }
-    self.routes6 = routes6.sorted {
-      ($0.destinationAddress, $0.destinationNetworkPrefixLength.intValue)
-        < ($1.destinationAddress, $1.destinationNetworkPrefixLength.intValue)
-    }
+    self.routes4 = routes4.sorted { ($0.address, $0.prefix) < ($1.address, $1.prefix) }
+    self.routes6 = routes6.sorted { ($0.address, $0.prefix) < ($1.address, $1.prefix) }
 
     // Check if anything actually changed
     if oldSelf == self {
       return nil
     }
 
-    return buildNetworkSettings()
+    return makePayload()
   }
 
   /// Update DNS resource addresses
   /// Used to trigger network settings apply when DNS resources change,
   /// which flushes the DNS cache so new DNS resources are immediately resolvable
-  /// Returns NEPacketTunnelNetworkSettings if settings changed, nil if unchanged or build fails
+  /// Returns Payload if settings changed, nil if unchanged or missing required fields
   public mutating func updateDnsResources(newDnsResources: [String])
-    -> NEPacketTunnelNetworkSettings?
+    -> Payload?
   {
     let oldSelf = self
 
@@ -74,30 +149,29 @@ public struct NetworkSettings: Equatable {
       return nil
     }
 
-    return buildNetworkSettings()
+    return makePayload()
   }
 
-  public mutating func setDummyMatchDomain() -> NEPacketTunnelNetworkSettings? {
+  public mutating func setDummyMatchDomain() -> Payload? {
     self.matchDomains = ["firezone-fd0020211111"]
 
-    return buildNetworkSettings()
+    return makePayload()
   }
 
-  public mutating func clearDummyMatchDomain() -> NEPacketTunnelNetworkSettings? {
+  public mutating func clearDummyMatchDomain() -> Payload? {
     if let searchDomain = self.searchDomain {
       self.matchDomains = ["", searchDomain]
     } else {
       self.matchDomains = [""]
     }
 
-    return buildNetworkSettings()
+    return makePayload()
   }
 
-  // MARK: - NEPacketTunnelNetworkSettings Builder
+  // MARK: - Private Helpers
 
-  /// Build NEPacketTunnelNetworkSettings from current state
-  private func buildNetworkSettings() -> NEPacketTunnelNetworkSettings? {
-    // Validate we have required fields
+  /// Create a Payload from current state, if tunnel addresses are present.
+  private func makePayload() -> Payload? {
     guard let tunnelAddressIPv4 = tunnelAddressIPv4,
       let tunnelAddressIPv6 = tunnelAddressIPv6
     else {
@@ -105,64 +179,15 @@ public struct NetworkSettings: Equatable {
       return nil
     }
 
-    // Set tunnel addresses and routes
-    let ipv4Settings = NEIPv4Settings(
-      addresses: [tunnelAddressIPv4], subnetMasks: ["255.255.255.255"])
-    ipv4Settings.includedRoutes = routes4
-
-    // This is a hack since macos routing table ignores, for full route, any prefix smaller than 120.
-    // Without this, adding a full route, remove the previous default route and leaves the system with none,
-    // completely breaking IPv6 on the user's system.
-    let ipv6Settings = NEIPv6Settings(
-      addresses: [tunnelAddressIPv6], networkPrefixLengths: [120])
-    ipv6Settings.includedRoutes = routes6
-
-    let dnsSettings = NEDNSSettings(servers: dnsServers)
-    dnsSettings.matchDomains = matchDomains
-    dnsSettings.searchDomains = searchDomain.map { [$0] } ?? [""]
-    dnsSettings.matchDomainsNoSearch = false
-
-    // We don't really know the connlib gateway IP address at this point, but just using 127.0.0.1 is okay
-    // because the OS doesn't really need this IP address.
-    // NEPacketTunnelNetworkSettings taking in tunnelRemoteAddress is probably a bad abstraction caused by
-    // NEPacketTunnelNetworkSettings inheriting from NETunnelNetworkSettings.
-    let tunnelNetworkSettings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
-
-    tunnelNetworkSettings.ipv4Settings = ipv4Settings
-    tunnelNetworkSettings.ipv6Settings = ipv6Settings
-    tunnelNetworkSettings.dnsSettings = dnsSettings
-    tunnelNetworkSettings.mtu = 1280
-
-    return tunnelNetworkSettings
-  }
-
-  // MARK: - Equatable Conformance
-
-  public static func == (lhs: NetworkSettings, rhs: NetworkSettings) -> Bool {
-    return lhs.tunnelAddressIPv4 == rhs.tunnelAddressIPv4
-      && lhs.tunnelAddressIPv6 == rhs.tunnelAddressIPv6
-      && lhs.dnsServers == rhs.dnsServers
-      && lhs.matchDomains == rhs.matchDomains
-      && lhs.searchDomain == rhs.searchDomain
-      && lhs.dnsResources == rhs.dnsResources
-      && compareRoutes4(lhs.routes4, rhs.routes4)
-      && compareRoutes6(lhs.routes6, rhs.routes6)
-  }
-
-  private static func compareRoutes4(_ lhs: [NEIPv4Route], _ rhs: [NEIPv4Route]) -> Bool {
-    guard lhs.count == rhs.count else { return false }
-    return zip(lhs, rhs).allSatisfy {
-      $0.destinationAddress == $1.destinationAddress
-        && $0.destinationSubnetMask == $1.destinationSubnetMask
-    }
-  }
-
-  private static func compareRoutes6(_ lhs: [NEIPv6Route], _ rhs: [NEIPv6Route]) -> Bool {
-    guard lhs.count == rhs.count else { return false }
-    return zip(lhs, rhs).allSatisfy {
-      $0.destinationAddress == $1.destinationAddress
-        && $0.destinationNetworkPrefixLength == $1.destinationNetworkPrefixLength
-    }
+    return Payload(
+      tunnelAddressIPv4: tunnelAddressIPv4,
+      tunnelAddressIPv6: tunnelAddressIPv6,
+      dnsServers: dnsServers,
+      routes4: routes4,
+      routes6: routes6,
+      matchDomains: matchDomains,
+      searchDomain: searchDomain
+    )
   }
 }
 
@@ -210,7 +235,7 @@ enum IPv4SubnetMaskLookup {
 // MARK: - Route Convenience Helpers
 
 extension NetworkSettings {
-  public struct Cidr {
+  public struct Cidr: Equatable, Sendable {
     public let address: String
     public let prefix: Int
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/NetworkSettings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/NetworkSettings.swift
@@ -39,25 +39,9 @@ public struct NetworkSettings: Equatable, Sendable {
     fileprivate let routes4: [Cidr]
     fileprivate let routes6: [Cidr]
     fileprivate let matchDomains: [String]
+    // All properties are fileprivate, so Swift synthesizes a fileprivate memberwise init.
+    // This enforces that Payload can only be created within this file (via NetworkSettings methods).
     fileprivate let searchDomain: String?
-
-    fileprivate init(
-      tunnelAddressIPv4: String,
-      tunnelAddressIPv6: String,
-      dnsServers: [String],
-      routes4: [Cidr],
-      routes6: [Cidr],
-      matchDomains: [String],
-      searchDomain: String?
-    ) {
-      self.tunnelAddressIPv4 = tunnelAddressIPv4
-      self.tunnelAddressIPv6 = tunnelAddressIPv6
-      self.dnsServers = dnsServers
-      self.routes4 = routes4
-      self.routes6 = routes6
-      self.matchDomains = matchDomains
-      self.searchDomain = searchDomain
-    }
 
     /// Build NEPacketTunnelNetworkSettings from this payload.
     public func build() -> NEPacketTunnelNetworkSettings {

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/NetworkSettingsTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/NetworkSettingsTests.swift
@@ -427,6 +427,26 @@ struct NetworkSettingsTests {
     #expect(cidr256.asNEIPv6Route == nil, "Very large prefix should return nil")
   }
 
+  // MARK: - Payload Encapsulation Tests
+
+  @Test("Payload cannot be constructed directly - only via NetworkSettings methods")
+  func payloadEncapsulation() {
+    // Uncomment to verify fileprivate encapsulation (should fail to compile):
+    // let _ = NetworkSettings.Payload(tunnelAddressIPv4: "", tunnelAddressIPv6: "", dnsServers: [], routes4: [], routes6: [], matchDomains: [], searchDomain: nil)
+
+    // The only way to get a Payload is through NetworkSettings methods
+    var settings = NetworkSettings()
+    let payload = settings.updateTunInterface(
+      ipv4: "10.0.0.1",
+      ipv6: "fd00::1",
+      dnsServers: ["1.1.1.1"],
+      searchDomain: nil,
+      routes4: [],
+      routes6: []
+    )
+    #expect(payload != nil, "Payload should only be obtainable via update methods")
+  }
+
   @Test("Invalid routes are dropped during build")
   func invalidRoutesDroppedDuringBuild() {
     var settings = NetworkSettings()

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -142,6 +142,9 @@ actor Adapter {
     self.internetResourceEnabled = internetResourceEnabled
     self.providerCommandSender = providerCommandSender
     self.systemConfigurationResolvers = try SystemConfigurationResolvers()
+
+    // Start log cleanup immediately - doesn't depend on tunnel being connected
+    providerCommandSender.send(.startLogCleanupTask)
   }
 
   func start() async throws {
@@ -396,7 +399,6 @@ actor Adapter {
       if firstStart {
         if applySucceeded {
           resumeStartContinuation()
-          providerCommandSender.send(.startLogCleanupTask)
         } else {
           // Settings failed to apply on first start - signal error
           Log.warning("Failed to apply network settings on first start")

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -434,6 +434,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   #endif
 
   /// Handle commands from the Adapter via channel.
+  ///
+  /// **Must be called on the main thread.** NEPacketTunnelProvider's properties and methods
+  /// have undocumented main-thread requirements:
+  /// - `reasserting`: Reading/writing from background threads silently returns stale values
+  /// - `cancelTunnelWithError(_:)`: May not properly signal the system from background threads
+  /// - `setTunnelNetworkSettings(_:completionHandler:)`: Works from any thread but we keep
+  ///   it consistent with other calls
+  ///
+  /// The caller (`PacketTunnelProviderActorBridge.handle`) dispatches to main before calling.
   private func handleProviderCommand(_ command: ProviderCommand) {
     switch command {
     case .cancelWithError(let sendableError):

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -357,11 +357,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // Hardcoded 100MB limit for log cleanup
     let maxSizeMb: UInt32 = 100
 
-    // Run cleanup immediately at startup
-    Self.performLogCleanup(maxSizeMb: maxSizeMb)
-
-    // Schedule hourly cleanup
+    // Run cleanup in background task - both immediately and hourly
     logCleanupTask = CancellableTask {
+      Self.performLogCleanup(maxSizeMb: maxSizeMb)
+
       while !Task.isCancelled {
         try? await Task.sleep(nanoseconds: 3600 * 1_000_000_000)
         guard !Task.isCancelled else { break }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -443,7 +443,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   ///   it consistent with other calls
   ///
   /// The caller (`PacketTunnelProviderActorBridge.handle`) dispatches to main before calling.
-  private func handleProviderCommand(_ command: ProviderCommand) {
+  fileprivate func handleProviderCommand(_ command: ProviderCommand) {
     switch command {
     case .cancelWithError(let sendableError):
       if let sendableError {

--- a/swift/apple/FirezoneNetworkExtension/ProviderCommand.swift
+++ b/swift/apple/FirezoneNetworkExtension/ProviderCommand.swift
@@ -1,0 +1,36 @@
+import FirezoneKit
+import Foundation
+
+/// Commands sent from Adapter to PacketTunnelProvider.
+///
+/// All cases and associated values are Sendable, enabling compiler-verified
+/// thread-safe communication without @unchecked Sendable.
+enum ProviderCommand: Sendable {
+  /// Cancel the tunnel with an optional error.
+  case cancelWithError(SendableError?)
+
+  /// Set the reasserting state (network transition indicator).
+  case setReasserting(Bool)
+
+  /// Get the current reasserting state. Response sent via the provided channel.
+  case getReasserting(Sender<Bool>)
+
+  /// Start the log cleanup task after successful tunnel startup.
+  case startLogCleanupTask
+
+  /// Apply network settings. Error message (nil on success) sent via the provided channel.
+  case applyNetworkSettings(NetworkSettings.Payload, Sender<String?>)
+}
+
+/// Sendable wrapper for Error since Error itself is not Sendable.
+///
+/// Captures the essential error information needed for tunnel cancellation.
+struct SendableError: Sendable {
+  let message: String
+  let isAuthenticationError: Bool
+
+  init(_ message: String, isAuthenticationError: Bool = false) {
+    self.message = message
+    self.isAuthenticationError = isAuthenticationError
+  }
+}


### PR DESCRIPTION
 Convert the Apple client's Adapter from a class to a Swift actor, gaining compiler-verified thread safety.

  Changes:
  - Convert Adapter from `class: @unchecked Sendable` to actor
  - Replace DispatchQueue and LockedState<T> with actor isolation
  - Replace semaphore patterns with async/await and CheckedContinuation
  - Add RAII wrappers (CancellableTask, NetworkPathUpdates) that clean up resources automatically
  - Confine `@unchecked Sendable` to a 15-line TunnelCallbacks struct
  - Guard against missing tunnel addresses in NetworkSettings.apply()

  Unfortunately, `TunnelCallbacks` uses `@unchecked Sendable`, below are the reasons:
  NEPacketTunnelProvider predates Swift concurrency; its override methods are nonisolated. `@MainActor` isolation
  would not work. The struct's documentation explains why the annotation is safe.

Fixes #10895 