### PR TITLE
chore(connlib): check for non-resources early

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -395,6 +395,10 @@ impl ClientState {
             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
         }
 
+        if is_definitely_not_a_resource(packet.destination()) {
+            return None;
+        }
+
         let tun_config = self.tun_config.as_ref()?;
 
         if !tun_config.ip.is_ip(packet.source()) {
@@ -560,10 +564,6 @@ impl ClientState {
 
     fn encapsulate(&mut self, mut packet: IpPacket, now: Instant) -> Option<snownet::Transmit> {
         let dst = packet.destination();
-
-        if is_definitely_not_a_resource(dst) {
-            return None;
-        }
 
         let peer = if is_peer(dst) {
             let Some(peer) = self.peers.peer_by_ip_mut(dst) else {


### PR DESCRIPTION
Avoids log-spam in the form of:

```
Dropping packet with bad source IP packet=Packet { src: fe80::223:a4ff:fe06:88c8, dst: ff02::16, protocol: "IPv6-ICMP", icmp_type: Unknown { type_u8: 143, code_u8: 0, bytes5to8: [0, 0, 0, 1] } }
```