### PR TITLE
fix(apple): Use a single keychain label

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -8,16 +8,9 @@
 import Foundation
 
 public struct Token: CustomStringConvertible {
-  // Debug builds can't write to release build Keychain items, so keep them separate
-  #if DEBUG
-    private static let label = "Firezone token (debug)"
-  #else
-    private static let label = "Firezone token"
-  #endif
-
   private static var query: [CFString: Any] {
     [
-      kSecAttrLabel: label,
+      kSecAttrLabel: "Firezone token",
       kSecAttrAccount: "1",
       kSecAttrService: BundleHelper.appGroupId,
       kSecAttrDescription: "Firezone access token",


### PR DESCRIPTION
Previous attempt to split the Keychain item between between Debug and Release versions caused issues - we could not save things in the keychain in Debug.

Revert the problematic change. No changelog entry as it only affected unreleased debug versions.