### PR TITLE
chore(connlib): capture more data for unroutable packets

### DIFF
--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -1238,9 +1238,9 @@ mod tests {
         let error = error.any_downcast_ref::<UnroutablePacket>().unwrap();
 
         assert_eq!(error.to_string(), "Unroutable packet: OutboundIcmpError");
-        assert_eq!(error.source().to_string(), "unknown");
-        assert_eq!(error.destination().to_string(), "unknown");
-        assert_eq!(error.proto().to_string(), "unknown");
+        assert_eq!(error.source().to_string(), "100.64.0.1");
+        assert_eq!(error.destination().to_string(), "100.96.0.1");
+        assert_eq!(error.proto().to_string(), "ICMP");
     }
 
     fn foo_dns_resource() -> crate::messages::gateway::ResourceDescription {

--- a/rust/libs/connlib/tunnel/src/gateway/unroutable_packet.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/unroutable_packet.rs
@@ -3,7 +3,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use ip_packet::{IpPacket, Protocol};
+use ip_packet::{IpNumber, IpPacket, Protocol};
 
 #[derive(Debug, thiserror::Error)]
 #[error("Unroutable packet: {error}")]
@@ -90,8 +90,8 @@ enum MaybeProto {
     Udp,
     #[display("ICMP")]
     Icmp,
-    #[display("unknown")]
-    Unknown,
+    #[display("{_0:?}")]
+    Other(IpNumber),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -127,7 +127,7 @@ impl FiveTuple {
             _ => Self {
                 src: MaybeIpOrSocket::Unknown,
                 dst: MaybeIpOrSocket::Unknown,
-                proto: MaybeProto::Unknown,
+                proto: MaybeProto::Other(p.next_header()),
             },
         }
     }

--- a/rust/libs/connlib/tunnel/src/gateway/unroutable_packet.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/unroutable_packet.rs
@@ -73,13 +73,11 @@ impl UnroutablePacket {
 }
 
 #[derive(Debug, derive_more::Display, Clone, Copy)]
-enum MaybeIpOrSocket {
+enum IpOrSocket {
     #[display("{_0}")]
     Ip(IpAddr),
     #[display("{_0}")]
     Socket(SocketAddr),
-    #[display("unknown")]
-    Unknown,
 }
 
 #[derive(Debug, derive_more::Display, Clone, Copy)]
@@ -96,8 +94,8 @@ enum MaybeProto {
 
 #[derive(Debug, Clone, Copy)]
 struct FiveTuple {
-    src: MaybeIpOrSocket,
-    dst: MaybeIpOrSocket,
+    src: IpOrSocket,
+    dst: IpOrSocket,
     proto: MaybeProto,
 }
 
@@ -110,23 +108,23 @@ impl FiveTuple {
 
         match (src_proto, dst_proto) {
             (Ok(Protocol::Tcp(src_port)), Ok(Protocol::Tcp(dst_port))) => Self {
-                src: MaybeIpOrSocket::Socket(SocketAddr::new(src_ip, src_port)),
-                dst: MaybeIpOrSocket::Socket(SocketAddr::new(dst_ip, dst_port)),
+                src: IpOrSocket::Socket(SocketAddr::new(src_ip, src_port)),
+                dst: IpOrSocket::Socket(SocketAddr::new(dst_ip, dst_port)),
                 proto: MaybeProto::Tcp,
             },
             (Ok(Protocol::Udp(src_port)), Ok(Protocol::Udp(dst_port))) => Self {
-                src: MaybeIpOrSocket::Socket(SocketAddr::new(src_ip, src_port)),
-                dst: MaybeIpOrSocket::Socket(SocketAddr::new(dst_ip, dst_port)),
+                src: IpOrSocket::Socket(SocketAddr::new(src_ip, src_port)),
+                dst: IpOrSocket::Socket(SocketAddr::new(dst_ip, dst_port)),
                 proto: MaybeProto::Udp,
             },
             (Ok(Protocol::IcmpEcho(_)), Ok(Protocol::IcmpEcho(_))) => Self {
-                src: MaybeIpOrSocket::Ip(src_ip),
-                dst: MaybeIpOrSocket::Ip(dst_ip),
+                src: IpOrSocket::Ip(src_ip),
+                dst: IpOrSocket::Ip(dst_ip),
                 proto: MaybeProto::Icmp,
             },
             _ => Self {
-                src: MaybeIpOrSocket::Unknown,
-                dst: MaybeIpOrSocket::Unknown,
+                src: IpOrSocket::Ip(src_ip),
+                dst: IpOrSocket::Ip(dst_ip),
                 proto: MaybeProto::Other(p.next_header()),
             },
         }


### PR DESCRIPTION
Certain packets cannot be routed by the Gateway. For those, we emit an `UnroutablePacket` error. Right now, the information in those is rendered as "unknown" if we cannot parse the L4 protocol from it. In order to make the logs more useful, we extend this to capture at least the IP addresses and the L4 protocol number.