### PR TITLE
fix(gateway): don't route outbound ICMP errors

### DIFF
--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -300,6 +300,10 @@ impl ClientOnGateway {
         packet: IpPacket,
         now: Instant,
     ) -> anyhow::Result<TranslateOutboundResult> {
+        if packet.icmp_error().is_ok_and(|e| e.is_some()) {
+            bail!(UnroutablePacket::outbound_icmp_error(&packet))
+        }
+
         // Filtering a packet is not an error.
         if let Err(e) = self.ensure_allowed_outbound(&packet) {
             tracing::debug!(filtered_packet = ?packet, "{e:#}");

--- a/rust/libs/connlib/tunnel/src/gateway/unroutable_packet.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/unroutable_packet.rs
@@ -48,6 +48,13 @@ impl UnroutablePacket {
         }
     }
 
+    pub fn outbound_icmp_error(packet: &IpPacket) -> Self {
+        Self {
+            five_tuple: FiveTuple::for_packet(packet),
+            error: RoutingError::OutboundIcmpError,
+        }
+    }
+
     pub fn reason(&self) -> RoutingError {
         self.error
     }
@@ -138,6 +145,8 @@ pub enum RoutingError {
     NoPeerState,
     #[display("No connection")]
     NotConnected,
+    #[display("OutboundIcmpError")]
+    OutboundIcmpError,
     #[display("Other")]
     Other,
 }
@@ -150,6 +159,7 @@ impl From<RoutingError> for opentelemetry::Value {
             RoutingError::NotAPeer => opentelemetry::Value::from("NotAPeer"),
             RoutingError::NoPeerState => opentelemetry::Value::from("NoPeerState"),
             RoutingError::NotConnected => opentelemetry::Value::from("NotConnected"),
+            RoutingError::OutboundIcmpError => opentelemetry::Value::from("OutboundIcmpError"),
             RoutingError::Other => opentelemetry::Value::from("Other"),
         }
     }


### PR DESCRIPTION
ICMP errors like "Destination unreachable" can be sent by both ends of a network connection. For DNS resources, handling these packets requires special care as we also need to translate the failed packet embedded within these ICMP messages such that the recipient can correctly relate them to the network socket that has sent the original packet.

We do this for inbound ICMP errors already to alert the Client of e.g. unreachable paths such as unreachable IPv6 networks. Outbound ICMP errors, that is, ICMP errors generated by the Client for a packet sent by a resource are currently not handled and result in warnings such as:

> Failed to translate outbound packet: Unsupported ICMPv4 type: DestinationUnreachable(Port)

Whilst it is possible to correctly handle and translate these packets, doing so requires a fair amount of work and changes to a very critical part of the Gateway. As such, we simply drop these packets for now as "unroutable packets" which downgrades their log level to DEBUG.

Resolves: #10983