### PR TITLE
fix(apple): store debug token in separate keychain item

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -8,12 +8,22 @@
 import Foundation
 
 public struct Token: CustomStringConvertible {
+  #if DEBUG
+    private static let label = "Firezone token (debug)"
+    private static let account = "1 (debug)"
+    private static let description = "Firezone access token (debug)"
+  #else
+    private static let label = "Firezone token"
+    private static let account = "1"
+    private static let description = "Firezone access token"
+  #endif
+
   private static var query: [CFString: Any] {
     [
-      kSecAttrLabel: "Firezone token",
-      kSecAttrAccount: "1",
+      kSecAttrLabel: label,
+      kSecAttrAccount: account,
       kSecAttrService: BundleHelper.appGroupId,
-      kSecAttrDescription: "Firezone access token",
+      kSecAttrDescription: description,
     ]
   }
 


### PR DESCRIPTION
When building / testing for debug, it's helpful to have the token stick around so that we can test autoconnect and toggling the VPN on/off from system settings.

To facilitate this we need to ensure the release and debug keychain items do not conflict. There was a previous attempt at handling this, however, not enough of the keys were differentiated to ensure this worked correctly.

To store these as separate items, it appears the `account` attribute should be differentiated as well.

Related: #10986