### PR TITLE
feat(portal): add banner support

### DIFF
--- a/elixir/apps/domain/lib/domain/banner.ex
+++ b/elixir/apps/domain/lib/domain/banner.ex
@@ -1,0 +1,14 @@
+defmodule Domain.Banner do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "banners" do
+    field :message, :string
+  end
+
+  def changeset(changeset) do
+    changeset
+    |> validate_required([:message])
+  end
+end

--- a/elixir/apps/domain/lib/domain/banner.ex
+++ b/elixir/apps/domain/lib/domain/banner.ex
@@ -7,8 +7,9 @@ defmodule Domain.Banner do
     field :message, :string
   end
 
-  def changeset(changeset) do
-    changeset
+  def changeset(changeset_or_struct, attrs \\ %{}) do
+    changeset_or_struct
+    |> change(attrs)
     |> validate_required([:message])
   end
 end

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -1,5 +1,4 @@
 defmodule Domain.Ops do
-  import Ecto.Changeset
   alias __MODULE__.DB
   alias Domain.Banner
 
@@ -123,7 +122,10 @@ defmodule Domain.Ops do
   end
 
   def set_banner(message) do
-    cast(%Banner{}, %{message: message}, [:message])
+    clear_banner()
+
+    %Banner{}
+    |> Banner.changeset(message: message)
     |> DB.insert()
   end
 

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -1,4 +1,8 @@
 defmodule Domain.Ops do
+  import Ecto.Changeset
+  alias __MODULE__.DB
+  alias Domain.Banner
+
   def create_and_provision_account(opts) do
     %{
       name: account_name,
@@ -116,5 +120,29 @@ defmodule Domain.Ops do
     |> Domain.Repo.delete(timeout: :infinity)
 
     :ok
+  end
+
+  def set_banner(message) do
+    cast(%Banner{}, %{message: message}, [:message])
+    |> DB.insert()
+  end
+
+  def clear_banner do
+    DB.delete_all(Banner)
+  end
+
+  defmodule DB do
+    import Ecto.Query
+    alias Domain.Repo
+
+    def insert(changeset) do
+      changeset
+      |> Repo.insert()
+    end
+
+    def delete_all(schema) do
+      from(s in schema)
+      |> Repo.delete_all()
+    end
   end
 end

--- a/elixir/apps/domain/priv/repo/migrations/20251202165550_create_banners_table.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251202165550_create_banners_table.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.CreateBannersTable do
+  use Ecto.Migration
+
+  def change do
+    create(table(:banners, primary_key: false)) do
+      add(:message, :text, null: false)
+    end
+  end
+end

--- a/elixir/apps/domain/test/support/fixtures/banners.ex
+++ b/elixir/apps/domain/test/support/fixtures/banners.ex
@@ -1,0 +1,9 @@
+defmodule Domain.Fixtures.Banners do
+  import Ecto.Changeset
+  use Domain.Fixture
+
+  def create_banner(attrs \\ %{}) do
+    cast(%Domain.Banner{}, Enum.into(attrs, %{}), [:message])
+    |> Domain.Repo.insert!()
+  end
+end

--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -99,6 +99,14 @@
 </.sidebar>
 
 <main class="lg:ml-64 h-auto pt-14">
+  <% banner = Domain.Repo.one(Domain.Banner) %>
+  <div
+    :if={banner}
+    id="banner"
+    class="bg-yellow-100 border-b border-yellow-400 text-neutral-900 px-4 py-3 text-center -mt-14 mb-4"
+  >
+    {Phoenix.HTML.raw(banner.message)}
+  </div>
   <.flash :if={@account.warning} kind={:warning} class="m-1">
     {@account.warning}.
     <span :if={Domain.Billing.account_provisioned?(@account)}>

--- a/elixir/apps/web/test/web/banner_test.exs
+++ b/elixir/apps/web/test/web/banner_test.exs
@@ -1,0 +1,45 @@
+defmodule Web.BannerTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity
+    }
+  end
+
+  test "shows banner when one exists", %{
+    conn: conn,
+    account: account,
+    identity: identity
+  } do
+    banner = Fixtures.Banners.create_banner(message: "Test Banner Message")
+
+    {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/sites")
+
+    assert html
+           |> Floki.parse_fragment!()
+           |> Floki.find("div#banner")
+           |> Floki.text()
+           |> String.contains?(banner.message)
+  end
+
+  test "does not show banner when none exists", %{
+    conn: conn,
+    account: account,
+    identity: identity
+  } do
+    {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/sites")
+
+    assert Enum.empty?(
+             html
+             |> Floki.parse_fragment!()
+             |> Floki.find("div#banner")
+           )
+  end
+end


### PR DESCRIPTION
Set the banner with `Domain.Ops.set_banner("raw HTML string to display")`.
Clear with `Domain.Ops.clear_banner()`.



<img width="1676" height="675" alt="Screenshot 2025-12-02 at 9 40 05 AM" src="https://github.com/user-attachments/assets/0fa21233-0482-44f6-a11f-a49b6b8a1fd4" />


Fixes #5462