### PR TITLE
chore: add dist dir for rust analyzer

### DIFF
--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -75,7 +75,3 @@ runs:
       # Currently the MSI does this and it's a little janky.
       run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
       shell: pwsh
-      # Otherwise one of the Tauri macros panics in static analysis
-    - name: Create `rust/gui-client/dist`
-      run: mkdir "$GITHUB_WORKSPACE/rust/gui-client/dist"
-      shell: bash

--- a/rust/gui-client/.gitignore
+++ b/rust/gui-client/.gitignore
@@ -30,6 +30,7 @@ src/**/*.js
 
 # Vite output
 dist
+!dist/.gitkeep
 
 # Some new generated files in Tauri v2
 src-tauri/gen

--- a/rust/gui-client/vite.config.ts
+++ b/rust/gui-client/vite.config.ts
@@ -1,9 +1,22 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, Plugin } from "vite";
 import flowbiteReact from "flowbite-react/plugin/vite";
 import typescript from "vite-plugin-typescript";
 import { execSync } from "child_process";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+// Plugin to recreate .gitkeep after build (Vite's emptyOutDir deletes it)
+function preserveGitkeep(): Plugin {
+  return {
+    name: "preserve-gitkeep",
+    writeBundle(options) {
+      const outDir = options.dir ?? "dist";
+      writeFileSync(join(outDir, ".gitkeep"), "");
+    },
+  };
+}
 
 const host = process.env.TAURI_DEV_HOST;
 const gitVersion =
@@ -11,7 +24,13 @@ const gitVersion =
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), flowbiteReact(), tailwindcss(), typescript()],
+  plugins: [
+    react(),
+    flowbiteReact(),
+    tailwindcss(),
+    typescript(),
+    preserveGitkeep(),
+  ],
 
   define: {
     // mark:next-gui-version


### PR DESCRIPTION
Makes rust-analyzer work nicely where tauri is not built (new worktree or macOS, where tauri doesn't get built).
Removes a CI workaround for this issue.