### PR TITLE
ci: upload preview .msi to Azure blob storage

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -216,6 +216,18 @@ jobs:
             --no-progress \
             --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
+      - name: Upload to preview repository
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
+        shell: bash
+        run: |
+          az storage blob upload \
+            --container-name binaries \
+            --name "windows-gui-client/preview/${{ matrix.arch.shortname }}" \
+            --file "${{ env.ARTIFACT_SRC }}.msi" \
+            --overwrite true \
+            --no-progress \
+            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+
   regenerate-apt-index:
     needs: build-gui
     if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -222,7 +222,7 @@ jobs:
         run: |
           az storage blob upload \
             --container-name binaries \
-            --name "windows-gui-client/preview/${{ matrix.arch.shortname }}" \
+            --name "windows-gui-client/preview/${{ matrix.arch }}" \
             --file "${{ env.ARTIFACT_SRC }}.msi" \
             --overwrite true \
             --no-progress \


### PR DESCRIPTION
In order to install these on test VMs, we need to move them over to Azure. For Linux, these are moved to a `preview` APT repository. Right now, we don't have our own WinGet repository but if we decide to host one, we can upload preview builds there.