### PR TITLE
ci: create dedicated `loadtest.yml` workflow

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -238,10 +238,7 @@ jobs:
           - package: http-test-server
             artifact: http-test-server
             image_name: http-test-server
-          - package: firezone-loadtest
-            artifact: firezone-loadtest
-            image_name: loadtest
-            skip_docker: true
+
     env:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}_${{ matrix.name.version }}_${{ matrix.arch.shortname }}
       SENTRY_ENVIRONMENT: "production"
@@ -320,25 +317,7 @@ jobs:
             --overwrite true \
             --no-progress \
             --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
-      - name: Copy loadtest to Azure Storage
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-loadtest' }}
-        run: |
-          set -e
-          az storage blob upload \
-            --container-name binaries \
-            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
-            --file "${{ matrix.name.package }}" \
-            --overwrite true \
-            --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
-          az storage blob upload \
-            --container-name binaries \
-            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
-            --file "${{ matrix.name.package }}.sha256sum.txt" \
-            --overwrite true \
-            --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
       - name: Create Firezone Gateway .deb package
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
         run: |
@@ -404,7 +383,7 @@ jobs:
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       # PRs & non-main branches: read-only cache
       - name: Build Docker images (read-only cache)
-        if: ${{ github.ref != 'refs/heads/main' && !matrix.name.skip_docker }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         id: build_ro
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -421,7 +400,7 @@ jobs:
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       # main: read/write cache
       - name: Build Docker images (read/write cache)
-        if: ${{ github.ref == 'refs/heads/main' && !matrix.name.skip_docker }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         id: build_rw
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -438,13 +417,11 @@ jobs:
           target: ${{ matrix.stage }}
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
-        if: ${{ !matrix.name.skip_docker }}
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
           digest="${{ github.ref == 'refs/heads/main' && steps.build_rw.outputs.digest || steps.build_ro.outputs.digest }}"
           touch "/tmp/digests/${{ matrix.name.image_name }}/${digest#sha256:}"
       - name: Upload digest artifact
-        if: ${{ !matrix.name.skip_docker }}
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           overwrite: true
@@ -453,7 +430,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: Output image name
-        if: ${{ !matrix.name.skip_docker }}
         id: image-name
         run: echo "${{ matrix.name.image_name }}_image=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -1,0 +1,102 @@
+name: Build and upload loadtest binaries
+run-name: Triggered from ${{ github.event_name }} by ${{ github.actor }}
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  loadtest:
+    name: loadtest-${{ matrix.os }}-${{ matrix.artifact_name }}
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: rust
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            binary: firezone-loadtest
+            artifact_name: x86_64
+          - os: windows
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+            binary: firezone-loadtest.exe
+            artifact_name: x86_64.exe
+          - os: macos
+            runner: macos-26
+            target: aarch64-apple-darwin
+            binary: firezone-loadtest
+            artifact_name: aarch64
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.sha }}
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+
+      - name: Install dependencies (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Install Azure CLI (macOS)
+        if: matrix.os == 'macos'
+        run: brew update && brew install azure-cli
+
+      - name: Build loadtest binary
+        shell: bash
+        run: |
+          set -e
+          cargo build \
+            --profile release \
+            --target ${{ matrix.target }} \
+            --package firezone-loadtest
+
+          cp target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.binary }}
+
+      - name: Generate checksum (Linux/Windows)
+        if: matrix.os != 'macos'
+        shell: bash
+        run: sha256sum ${{ matrix.binary }} > ${{ matrix.binary }}.sha256sum.txt
+
+      - name: Generate checksum (macOS)
+        if: matrix.os == 'macos'
+        run: shasum -a 256 ${{ matrix.binary }} > ${{ matrix.binary }}.sha256sum.txt
+
+      - name: Upload to Azure Storage
+        shell: bash
+        run: |
+          set -e
+          az storage blob upload \
+            --container-name binaries \
+            --name "loadtest/${{ matrix.os }}/${{ inputs.sha }}/${{ matrix.artifact_name }}" \
+            --file "${{ matrix.binary }}" \
+            --overwrite true \
+            --no-progress \
+            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+
+          az storage blob upload \
+            --container-name binaries \
+            --name "loadtest/${{ matrix.os }}/${{ inputs.sha }}/${{ matrix.artifact_name }}.sha256sum.txt" \
+            --file "${{ matrix.binary }}.sha256sum.txt" \
+            --overwrite true \
+            --no-progress \
+            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,10 @@ jobs:
     uses: ./.github/workflows/_control-plane.yml
     secrets: inherit
 
+  build-loadtest:
+    uses: ./.github/workflows/_loadtest.yml
+    secrets: inherit
+
   # Re-run CI checks to make sure everything's green, since "Merging as administrator"
   # won't trigger these in the merge group.
   ci:


### PR DESCRIPTION
Building the loadtest binaries has nothing to do with our dataplane really. To build it more easily across multiple operating systems, it is easier to split this out into a dedicated workflow.

Resolves: #11029