### PR TITLE
fix(portal): extract nested email param for sign in

### DIFF
--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -404,7 +404,8 @@ defmodule Domain.Repo.Seeds do
         account_id: account.id,
         type: :account_user,
         name: "Firezone Unprivileged",
-        email: unprivileged_actor_email
+        email: unprivileged_actor_email,
+        allow_email_otp_sign_in: true
       }
       |> Repo.insert()
 
@@ -430,7 +431,8 @@ defmodule Domain.Repo.Seeds do
         account_id: account.id,
         type: :account_admin_user,
         name: "Firezone Admin",
-        email: admin_actor_email
+        email: admin_actor_email,
+        allow_email_otp_sign_in: true
       })
 
     {:ok, service_account_actor} =

--- a/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
@@ -35,7 +35,7 @@ defmodule Web.EmailOTPController do
         %{
           "account_id_or_slug" => account_id_or_slug,
           "auth_provider_id" => auth_provider_id,
-          "email" => email
+          "email" => %{"email" => email}
         } = params
       )
       when is_binary(email) do


### PR DESCRIPTION
- Fixes an issue introduced as a result of #10505 where the `email` nested param was lost because the form name is also `email`.
- Updates seeds to set `allow_email_otp_sign_in` to true to align with how the development environment with seeds behaved before.

Fixes #11047 