### PR TITLE
refactor(portal): reduce sentry false-positive logs

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/event_handler.ex
+++ b/elixir/apps/domain/lib/domain/billing/event_handler.ex
@@ -40,14 +40,6 @@ defmodule Domain.Billing.EventHandler do
         )
 
         {:error, reason}
-
-      error ->
-        Logger.error("Unknown failure processing stripe event",
-          customer_id: customer_id,
-          reason: inspect(error)
-        )
-
-        {:error, :unknown_failure}
     end
   end
 

--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -3,7 +3,10 @@ defmodule Domain.Telemetry.Sentry do
     # This happens when libcluster loses connection to a node, which is normal during deploys.
     # We have threshold-based error logging in Domain.Cluster.GoogleComputeLabelsStrategy to report those.
     "Node ~p not responding **~n** Removing (timedout) connection",
-    "[libcluster:default] unable to connect to"
+    "[libcluster:default] unable to connect to",
+
+    # These occur under normal operation whenever a particular account or resource can't be found in the DB.
+    "Ecto.NoResultsError: expected at least one result but got none in query:"
   ]
 
   def before_send(%{original_exception: %{skip_sentry: skip_sentry}}) when skip_sentry do

--- a/elixir/apps/web/lib/web/live/settings/authentication.ex
+++ b/elixir/apps/web/lib/web/live/settings/authentication.ex
@@ -181,7 +181,7 @@ defmodule Web.Settings.Authentication do
            |> push_patch(to: ~p"/#{socket.assigns.account}/settings/authentication")}
 
         {:error, reason} ->
-          Logger.warning("Failed to delete authentication provider", reason: reason)
+          Logger.info("Failed to delete authentication provider", reason: reason)
           {:noreply, put_flash(socket, :error, "Failed to delete authentication provider.")}
       end
     else
@@ -219,7 +219,7 @@ defmodule Web.Settings.Authentication do
          |> put_flash(:success, "Authentication provider #{action} successfully.")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        Logger.error("Failed to toggle authentication provider",
+        Logger.info("Failed to toggle authentication provider",
           errors: inspect(changeset.errors),
           changes: inspect(changeset.changes)
         )
@@ -240,7 +240,7 @@ defmodule Web.Settings.Authentication do
         {:noreply, put_flash(socket, :error, error_message)}
 
       {:error, reason} ->
-        Logger.error("Failed to toggle authentication provider: #{inspect(reason)}")
+        Logger.info("Failed to toggle authentication provider: #{inspect(reason)}")
         {:noreply, put_flash(socket, :error, "Failed to update authentication provider.")}
     end
   end
@@ -1073,7 +1073,7 @@ defmodule Web.Settings.Authentication do
   end
 
   defp handle_verification_setup_error({:error, reason}, field, socket) do
-    Logger.warning(
+    Logger.info(
       "Unexpected error during OIDC verification setup",
       subject: socket.assigns.subject,
       reason: reason
@@ -1114,7 +1114,7 @@ defmodule Web.Settings.Authentication do
         {:noreply, socket}
 
       error ->
-        Logger.warning("Failed to set default auth provider",
+        Logger.info("Failed to set default auth provider",
           error: inspect(error)
         )
 
@@ -1139,7 +1139,7 @@ defmodule Web.Settings.Authentication do
       {:noreply, socket}
     else
       error ->
-        Logger.warning("Failed to clear default auth provider",
+        Logger.info("Failed to clear default auth provider",
           error: inspect(error)
         )
 


### PR DESCRIPTION
- Reduces Sentry noise by moving routine errors to use `Logger.info`
- Refactors sync scheduler logic to be simpler and provider-agnostic

Related: #11040 