### PR TITLE
chore(gui-client): clarify panic message if XDG dir missing

### DIFF
--- a/rust/gui-client/src-tauri/src/ipc/linux.rs
+++ b/rust/gui-client/src-tauri/src/ipc/linux.rs
@@ -101,11 +101,11 @@ fn ipc_path(id: SocketId) -> PathBuf {
     match id {
         SocketId::Tunnel => PathBuf::from("/run").join(BUNDLE_ID).join("tunnel.sock"),
         SocketId::Gui => bin_shared::known_dirs::runtime()
-            .expect("`known_dirs::runtime()` should always work")
+            .expect("$XDG_RUNTIME_DIR not set")
             .join("gui.sock"),
         #[cfg(test)]
         SocketId::Test(id) => bin_shared::known_dirs::runtime()
-            .expect("`known_dirs::runtime()` should always work")
+            .expect("$XDG_RUNTIME_DIR not set")
             .join(format!("ipc_test_{id}.sock")),
     }
 }


### PR DESCRIPTION
When the $XDG_RUNTIME_DIR is missing, the user must have misconfigured their system. We need a well-known place to put our socket in order for the GUI and service processes to communicate so our only option here is to abort.

To make it clear, why we are failing, clarify the panic message.