### PR TITLE
fix(gui-client): don't panic if `$XDG_RUNTIME_DIR` is not set

### DIFF
--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -244,14 +244,7 @@ pub fn run(
 ) -> Result<()> {
     tauri::async_runtime::set(rt.handle().clone());
 
-    let gui_ipc = match rt.block_on(create_gui_ipc_server()) {
-        Ok(gui_ipc) => gui_ipc,
-        Err(e) => {
-            tracing::debug!("{e:#}");
-
-            return Err(anyhow::Error::new(AlreadyRunning));
-        }
-    };
+    let gui_ipc = rt.block_on(create_gui_ipc_server())?;
 
     let (general_settings, advanced_settings) =
         rt.block_on(settings::migrate_legacy_settings(advanced_settings));
@@ -600,7 +593,7 @@ async fn create_gui_ipc_server() -> Result<ipc::Server> {
 
     // If we managed to send the IPC message then another instance of Firezone is already running.
 
-    bail!("Successfully handshaked with existing instance of Firezone GUI")
+    bail!(AlreadyRunning)
 }
 
 async fn new_instance_handshake(

--- a/rust/gui-client/src-tauri/src/ipc/linux.rs
+++ b/rust/gui-client/src-tauri/src/ipc/linux.rs
@@ -101,11 +101,11 @@ fn ipc_path(id: SocketId) -> PathBuf {
     match id {
         SocketId::Tunnel => PathBuf::from("/run").join(BUNDLE_ID).join("tunnel.sock"),
         SocketId::Gui => bin_shared::known_dirs::runtime()
-            .expect("`known_dirs::runtime()` should always work")
+            .expect("$XDG_RUNTIME_DIR not set")
             .join("gui.sock"),
         #[cfg(test)]
         SocketId::Test(id) => bin_shared::known_dirs::runtime()
-            .expect("`known_dirs::runtime()` should always work")
+            .expect("$XDG_RUNTIME_DIR not set")
             .join(format!("ipc_test_{id}.sock")),
     }
 }

--- a/rust/gui-client/src-tauri/src/ipc/linux.rs
+++ b/rust/gui-client/src-tauri/src/ipc/linux.rs
@@ -11,7 +11,9 @@ pub(crate) struct Server {
 
 impl Drop for Server {
     fn drop(&mut self) {
-        let path = ipc_path(self.id);
+        let Ok(path) = ipc_path(self.id) else {
+            return;
+        };
 
         if let Err(e) = std::fs::remove_file(&path) {
             tracing::debug!(path = %path.display(), "Failed to delete IPC socket: {e}");
@@ -30,7 +32,7 @@ pub(crate) type ServerStream = UnixStream;
 /// Connect to the Tunnel service
 #[expect(clippy::wildcard_enum_match_arm)]
 pub async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
-    let path = ipc_path(id);
+    let path = ipc_path(id)?;
     let stream = UnixStream::connect(&path)
         .await
         .map_err(|error| match error.kind() {
@@ -53,7 +55,7 @@ pub async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
 impl Server {
     /// Platform-specific setup
     pub(crate) fn new(id: SocketId) -> Result<Self> {
-        let sock_path = ipc_path(id);
+        let sock_path = ipc_path(id)?;
 
         tracing::debug!(socket = %sock_path.display(), "Creating new IPC server");
 
@@ -97,15 +99,15 @@ impl Server {
 /// Also systemd can create this dir with the `RuntimeDir=` directive which is nice.
 ///
 /// Test sockets live in e.g. `/run/user/1000/dev.firezone.client/data/`
-fn ipc_path(id: SocketId) -> PathBuf {
-    match id {
+fn ipc_path(id: SocketId) -> Result<PathBuf> {
+    Ok(match id {
         SocketId::Tunnel => PathBuf::from("/run").join(BUNDLE_ID).join("tunnel.sock"),
         SocketId::Gui => bin_shared::known_dirs::runtime()
-            .expect("$XDG_RUNTIME_DIR not set")
+            .context("$XDG_RUNTIME_DIR not set")?
             .join("gui.sock"),
         #[cfg(test)]
         SocketId::Test(id) => bin_shared::known_dirs::runtime()
-            .expect("$XDG_RUNTIME_DIR not set")
+            .context("$XDG_RUNTIME_DIR not set")?
             .join(format!("ipc_test_{id}.sock")),
-    }
+    })
 }


### PR DESCRIPTION
It appears that on some systems, the `$XDG_RUNTIME_DIR` is not set. In that case, the GUI cannot function because we don't have a well-known place to put our IPC sockets.

Instead of panicking, we now return an error from the `ipc_path` function.

Whilst investigating the behaviour around these errors, I noticed that we are currently always assuming that the GUI is already running if creating the GUI IPC server creation fails. That is not correct. We fix this by forwarding all errors from the GUI IPC server and return `AlreadyRunning` only in the case when we successfully handshaked with the existing session.