### PR TITLE
feat(logging): add Windows Event Log support

### DIFF
--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -97,6 +97,7 @@ jobs:
             rust/${{ matrix.binary }}.sha256sum.txt
 
       - name: Upload to Azure Storage
+        if: github.ref == 'refs/heads/main'
         shell: bash
         run: |
           set -e

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -88,6 +88,14 @@ jobs:
         if: matrix.os == 'macos'
         run: shasum -a 256 ${{ matrix.binary }} > ${{ matrix.binary }}.sha256sum.txt
 
+      - name: Upload artifact to GitHub
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: firezone-loadtest-${{ matrix.os }}-${{ matrix.artifact_name }}
+          path: |
+            rust/${{ matrix.binary }}
+            rust/${{ matrix.binary }}.sha256sum.txt
+
       - name: Upload to Azure Storage
         shell: bash
         run: |

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -61,6 +61,13 @@ jobs:
         if: matrix.os == 'macos'
         run: brew update && brew install azure-cli
 
+      - name: Register Event Log source (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          New-EventLog -LogName Application -Source "Firezone-Loadtest" -ErrorAction SilentlyContinue
+          Write-Host "Event Log source 'Firezone-Loadtest' registered (or already exists)"
+
       - name: Build loadtest binary
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -e
 
-          jobs="static-analysis,elixir,rust,tauri,kotlin,swift,codeql,control-plane,data-plane,data-plane-perf";
+          jobs="static-analysis,elixir,rust,tauri,kotlin,swift,codeql,control-plane,data-plane,data-plane-perf,loadtest";
 
           # For workflow_dispatch or workflow_call, run all jobs
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
@@ -84,7 +84,7 @@ jobs:
           jobs="static-analysis" # Always run static-analysis
 
           if grep -q '^rust/' changed_files.txt; then
-            jobs="${jobs},rust,kotlin,swift,control-plane,data-plane,data-plane-perf"
+            jobs="${jobs},rust,kotlin,swift,control-plane,data-plane,data-plane-perf,loadtest"
           fi
           if grep -q '^rust/gui-client/' changed_files.txt; then
             jobs="${jobs},tauri"
@@ -209,6 +209,12 @@ jobs:
       image_prefix: "perf"
       profile: "release"
       stage: "debug" # Only the debug images have perf tooling
+
+  loadtest:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'loadtest')
+    uses: ./.github/workflows/_loadtest.yml
+    secrets: inherit
 
   integration-tests:
     uses: ./.github/workflows/_integration_tests.yml

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2657,9 +2657,12 @@ name = "firezone-loadtest"
 version = "0.1.0"
 dependencies = [
  "goose",
+ "logging",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4429,6 +4432,7 @@ dependencies = [
  "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
+ "windows",
 ]
 
 [[package]]

--- a/rust/libs/bin-shared/src/network_changes/windows.rs
+++ b/rust/libs/bin-shared/src/network_changes/windows.rs
@@ -743,7 +743,7 @@ mod async_dns {
             let notify_flags = Registry::REG_NOTIFY_CHANGE_NAME
                 | Registry::REG_NOTIFY_CHANGE_LAST_SET
                 | Registry::REG_NOTIFY_THREAD_AGNOSTIC;
-            let key_handle = Registry::HKEY(key.raw_handle() as *mut c_void);
+            let key_handle = Registry::HKEY(key.raw_handle());
             unsafe {
                 Registry::RegNotifyChangeKeyValue(key_handle, true, notify_flags, Some(event), true)
             }

--- a/rust/libs/logging/Cargo.toml
+++ b/rust/libs/logging/Cargo.toml
@@ -21,6 +21,10 @@ tracing-appender = { workspace = true }
 tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
+[target.'cfg(windows)'.dependencies]
+thiserror = { workspace = true }
+windows = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_System_EventLog", "Win32_System_Registry"] }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -9,6 +9,8 @@ mod capturing_writer;
 mod display_btree_set;
 mod err_with_sources;
 mod event_message_contains_filter;
+#[cfg(windows)]
+pub mod windows_event_log;
 
 use std::sync::Arc;
 

--- a/rust/libs/logging/src/windows_event_log.rs
+++ b/rust/libs/logging/src/windows_event_log.rs
@@ -1,0 +1,816 @@
+//! Windows Event Log layer for tracing.
+//!
+//! Provides a `tracing` layer that writes events to the Windows Event Log.
+//!
+//! Inspired by the [`tracing-layer-win-eventlog`](https://github.com/itsscb/tracing-layer-win-eventlog)
+//! crate (MIT licensed).
+//!
+//! # Level Filtering
+//!
+//! The layer supports independent filtering via the `EVENTLOG_DIRECTIVES` environment
+//! variable. This allows controlling what gets written to the Windows Event Log
+//! separately from `RUST_LOG`:
+//!
+//! ```ignore
+//! // Set in environment:
+//! // RUST_LOG=debug              # Console gets debug logs
+//! // EVENTLOG_DIRECTIVES=warn    # Event Log only gets warn and above
+//!
+//! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+//!
+//! tracing_subscriber::registry()
+//!     .with(logging::windows_event_log::filtered_layer("MyApp")?)
+//!     .init();
+//! ```
+//!
+//! If `EVENTLOG_DIRECTIVES` is not set, it defaults to `info`.
+//!
+//! # Event IDs
+//!
+//! Different log levels map to distinct Event IDs for filtering in Event Viewer:
+//! - ERROR: Event ID 1
+//! - WARN:  Event ID 2
+//! - INFO:  Event ID 3
+//! - DEBUG: Event ID 4
+//! - TRACE: Event ID 5
+//!
+//! # Event Source Registration
+//!
+//! The layer attempts to auto-register the event source on creation.
+//! This requires administrator privileges. If registration fails (no admin),
+//! it falls back gracefully - the layer will still work if the source was
+//! previously registered.
+//!
+//! To manually register a source (as admin):
+//! ```powershell
+//! New-EventLog -LogName Application -Source "MyApp"
+//! ```
+
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::span::Attributes;
+use tracing::{Event, Id, Level, Subscriber};
+use tracing_subscriber::filter::Filtered;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{EnvFilter, Layer};
+
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::EventLog::{
+    DeregisterEventSource, EVENTLOG_ERROR_TYPE, EVENTLOG_INFORMATION_TYPE, EVENTLOG_WARNING_TYPE,
+    REPORT_EVENT_TYPE, RegisterEventSourceW, ReportEventW,
+};
+use windows::Win32::System::Registry::{
+    HKEY_LOCAL_MACHINE, KEY_WRITE, REG_DWORD, REG_EXPAND_SZ, REG_OPTION_NON_VOLATILE, RegCloseKey,
+    RegCreateKeyExW, RegSetValueExW,
+};
+use windows::core::{PCWSTR, w};
+
+const EVENT_ID_ERROR: u32 = 1;
+const EVENT_ID_WARNING: u32 = 2;
+const EVENT_ID_INFO: u32 = 3;
+const EVENT_ID_DEBUG: u32 = 4;
+const EVENT_ID_TRACE: u32 = 5;
+
+/// Registry value for supported event types (Error | Warning | Information).
+const TYPES_SUPPORTED: u32 = 0x07;
+
+/// A thread-safe wrapper around the Windows Event Log handle.
+struct EventSourceHandle {
+    // Windows Event Log handles are NOT inherently thread-safe, so we use a
+    // `Mutex` to serialize access. The handle is wrapped in an `Option` to
+    // allow taking ownership during `Drop`.
+    handle: Mutex<Option<HANDLE>>,
+}
+
+// SAFETY: EventSourceHandle is thread-safe because:
+// 1. The HANDLE is protected by a Mutex, ensuring exclusive access
+// 2. Windows Event Log handles can be used from any thread as long as access is serialised
+// 3. The Mutex ensures only one thread accesses the handle at a time
+unsafe impl Send for EventSourceHandle {}
+unsafe impl Sync for EventSourceHandle {}
+
+/// Environment variable for controlling Windows Event Log filtering.
+///
+/// Supports the same directive syntax as `RUST_LOG`.
+pub const ENV_EVENTLOG_DIRECTIVES: &str = "EVENTLOG_DIRECTIVES";
+
+/// Default filter directives when `EVENTLOG_DIRECTIVES` is not set.
+const DEFAULT_DIRECTIVES: &str = "info";
+
+impl EventSourceHandle {
+    fn new(handle: HANDLE) -> Self {
+        Self {
+            handle: Mutex::new(Some(handle)),
+        }
+    }
+
+    /// Reports an event to the Windows Event Log.
+    fn report_event(&self, event_type: REPORT_EVENT_TYPE, event_id: u32, message: &str) {
+        let message_wide = to_wide_string(message);
+        let message_ptr = PCWSTR(message_wide.as_ptr());
+        let messages = [message_ptr];
+
+        let Ok(guard) = self.handle.lock() else {
+            // Mutex is poisoned, skip logging
+            #[cfg(debug_assertions)]
+            eprintln!("Event Log handle mutex poisoned, skipping log");
+            return;
+        };
+
+        let Some(handle) = *guard else {
+            #[cfg(debug_assertions)]
+            eprintln!("Event Log handle is not available, skipping log");
+            return;
+        };
+
+        // SAFETY: We hold the mutex lock ensuring exclusive access to the handle.
+        // The handle is valid (checked above) and message pointers are valid for
+        // the duration of this call.
+        unsafe {
+            if let Err(_e) = ReportEventW(
+                handle,
+                event_type,
+                0, // category
+                event_id,
+                None,            // user SID
+                0,               // raw data size
+                Some(&messages), // strings
+                None,            // raw data
+            ) {
+                // Only log in debug builds to avoid noise in production.
+                #[cfg(debug_assertions)]
+                eprintln!("Failed to write to Windows Event Log: {_e}");
+            }
+        }
+    }
+}
+
+impl Drop for EventSourceHandle {
+    fn drop(&mut self) {
+        // No need to lock - we have &mut self, so we're the only accessor
+        if let Some(handle) = self.handle.get_mut().expect("not to be poisoned").take() {
+            // SAFETY: We own the handle and only drop it once (ensured by `take()`).
+            unsafe {
+                let _ = DeregisterEventSource(handle);
+            }
+        }
+    }
+}
+
+/// A [`tracing`] layer that writes events to the Windows Event Log.
+pub struct WindowsEventLogLayer {
+    handle: Arc<EventSourceHandle>,
+}
+
+impl WindowsEventLogLayer {
+    /// Creates a new Event Log layer for the given source.
+    ///
+    /// Attempts to auto-register the source first (requires admin).
+    /// Returns an error if the source cannot be opened.
+    pub fn new(source: &str) -> Result<Self, Error> {
+        // Try to register the source (may fail without admin - that's OK)
+        if let Err(e) = try_register_source(source) {
+            tracing::debug!(
+                source,
+                error = %e,
+                "Could not register Event Log source (requires admin)"
+            );
+        }
+
+        let source_wide = to_wide_string(source);
+        // SAFETY: We pass valid pointers and the source string is null-terminated.
+        let handle = unsafe { RegisterEventSourceW(PCWSTR::null(), PCWSTR(source_wide.as_ptr())) }
+            .map_err(|e| Error::OpenSource {
+                source: source.to_owned(),
+                error: e,
+            })?;
+
+        Ok(Self {
+            handle: Arc::new(EventSourceHandle::new(handle)),
+        })
+    }
+}
+
+/// Storage for span fields, attached to spans via extensions.
+#[derive(Default)]
+struct SpanFields {
+    fields: Vec<(String, String)>,
+}
+
+/// Visitor for recording span fields into SpanFields storage.
+struct SpanFieldVisitor<'a> {
+    fields: &'a mut SpanFields,
+}
+
+impl Visit for SpanFieldVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), format!("{value:?}")));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_owned()));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.fields
+            .fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+}
+
+impl<S> Layer<S> for WindowsEventLogLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        let mut fields = SpanFields::default();
+        attrs.record(&mut SpanFieldVisitor {
+            fields: &mut fields,
+        });
+        span.extensions_mut().insert(fields);
+    }
+
+    fn on_record(&self, id: &Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        let mut extensions = span.extensions_mut();
+        if let Some(fields) = extensions.get_mut::<SpanFields>() {
+            values.record(&mut SpanFieldVisitor { fields });
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level = metadata.level();
+
+        let (event_type, event_id) = match *level {
+            Level::ERROR => (EVENTLOG_ERROR_TYPE, EVENT_ID_ERROR),
+            Level::WARN => (EVENTLOG_WARNING_TYPE, EVENT_ID_WARNING),
+            Level::INFO => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_INFO),
+            Level::DEBUG => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_DEBUG),
+            Level::TRACE => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_TRACE),
+        };
+
+        // Build plain text message
+        let mut visitor = EventVisitor::new();
+        event.record(&mut visitor);
+
+        // Collect span context with fields
+        let span_context: Vec<SpanInfo> = ctx
+            .event_scope(event)
+            .map(|scope| {
+                scope
+                    .from_root()
+                    .map(|span| {
+                        let name = span.name().to_owned();
+                        let fields = span
+                            .extensions()
+                            .get::<SpanFields>()
+                            .map(|f| f.fields.clone())
+                            .unwrap_or_default();
+                        SpanInfo { name, fields }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let message = visitor.into_message(&span_context);
+        self.handle.report_event(event_type, event_id, &message);
+    }
+}
+
+/// Information about a span including its name and fields.
+struct SpanInfo {
+    name: String,
+    fields: Vec<(String, String)>,
+}
+
+/// Visitor that collects fields into a plain text message.
+///
+/// Output format:
+/// ```text
+/// <message>
+/// span: <span1(field=value) / span2(field=value) / ...>
+/// <field1>: <value1>
+/// <field2>: <value2>
+/// ```
+struct EventVisitor {
+    message: Option<String>,
+    fields: Vec<(String, String)>,
+}
+
+impl EventVisitor {
+    fn new() -> Self {
+        Self {
+            message: None,
+            fields: Vec::new(),
+        }
+    }
+
+    fn into_message(self, spans: &[SpanInfo]) -> String {
+        let mut output = String::new();
+
+        // Message first
+        if let Some(msg) = &self.message {
+            output.push_str(msg);
+        }
+
+        // Span context with fields
+        if !spans.is_empty() {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            let span_str = spans
+                .iter()
+                .map(|s| {
+                    if s.fields.is_empty() {
+                        s.name.clone()
+                    } else {
+                        let fields_str = s
+                            .fields
+                            .iter()
+                            .map(|(k, v)| format!("{k}={v}"))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("{}({})", s.name, fields_str)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" / ");
+            let _ = write!(output, "span: {span_str}");
+        }
+
+        // Event fields
+        for (key, value) in &self.fields {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            let _ = write!(output, "{key}: {value}");
+        }
+
+        output
+    }
+}
+
+impl Visit for EventVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let value_str = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = Some(value_str);
+        } else {
+            self.fields.push((field.name().to_owned(), value_str));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_owned());
+        } else {
+            self.fields
+                .push((field.name().to_owned(), value.to_owned()));
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.fields
+            .push((field.name().to_owned(), value.to_string()));
+    }
+}
+
+/// Attempts to register an Event Log source.
+///
+/// This requires administrator privileges. If the source already exists,
+/// this is a no-op.
+fn try_register_source(source: &str) -> Result<(), Error> {
+    let key_path = format!("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\{source}");
+    let key_path_wide = to_wide_string(&key_path);
+
+    let mut hkey = windows::Win32::System::Registry::HKEY::default();
+
+    // SAFETY: We pass valid pointers and handle the result.
+    unsafe {
+        RegCreateKeyExW(
+            HKEY_LOCAL_MACHINE,
+            PCWSTR(key_path_wide.as_ptr()),
+            Some(0),
+            PCWSTR::null(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_WRITE,
+            None,
+            &mut hkey,
+            None,
+        )
+        .ok()
+        .map_err(|e| Error::CreateRegistryKey { error: e })?;
+
+        // Set TypesSupported (required for event types to work)
+        let result = (|| {
+            RegSetValueExW(
+                hkey,
+                w!("TypesSupported"),
+                Some(0),
+                REG_DWORD,
+                Some(TYPES_SUPPORTED.to_le_bytes().as_slice()),
+            )
+            .ok()
+            .map_err(|e| Error::SetRegistryValue { error: e })?;
+
+            // Set EventMessageFile to a default message file
+            // Using the system's default which handles %1 style messages
+            let message_file = "%SystemRoot%\\System32\\EventCreate.exe";
+            let message_file_wide = to_wide_string(message_file);
+            let message_file_bytes: Vec<u8> = message_file_wide
+                .iter()
+                .flat_map(|&word| word.to_le_bytes())
+                .collect();
+
+            RegSetValueExW(
+                hkey,
+                w!("EventMessageFile"),
+                Some(0),
+                REG_EXPAND_SZ,
+                Some(&message_file_bytes),
+            )
+            .ok()
+            .map_err(|e| Error::SetRegistryValue { error: e })?;
+
+            Ok(())
+        })();
+
+        // Always close the registry key
+        let _ = RegCloseKey(hkey);
+
+        result
+    }
+}
+
+/// Converts a Rust string to a null-terminated wide string (UTF-16).
+fn to_wide_string(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// Creates a new Windows Event Log layer without filtering.
+///
+/// Attempts to auto-register the source (requires admin privileges).
+/// Falls back gracefully if registration fails but the source exists.
+///
+/// **Note:** This layer logs all events regardless of level. For independent
+/// filtering, use [`filtered_layer`] instead.
+///
+/// # Errors
+///
+/// Returns an error if the event source cannot be opened. This typically
+/// means the source was never registered. Register it manually with:
+///
+/// ```powershell
+/// New-EventLog -LogName Application -Source "YourSourceName"
+/// ```
+pub fn layer(source: &str) -> Result<WindowsEventLogLayer, Error> {
+    WindowsEventLogLayer::new(source)
+}
+
+/// Creates a Windows Event Log layer with filtering from `EVENTLOG_DIRECTIVES`.
+///
+/// This allows independent control of what gets logged to the Windows Event Log,
+/// separate from the `RUST_LOG` environment variable.
+///
+/// # Environment Variable
+///
+/// Set `EVENTLOG_DIRECTIVES` to control filtering:
+/// - `warn` - only warnings and errors
+/// - `info` - info, warnings, and errors (default)
+/// - `debug` - debug and above
+/// - `mymodule=debug,warn` - debug for mymodule, warn for everything else
+///
+/// If not set, defaults to `info`.
+///
+/// # Errors
+///
+/// Returns an error if the event source cannot be opened or if the filter
+/// directives are invalid.
+pub fn filtered_layer<S>(
+    source: &str,
+) -> Result<Filtered<WindowsEventLogLayer, EnvFilter, S>, Error>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let directives =
+        std::env::var(ENV_EVENTLOG_DIRECTIVES).unwrap_or_else(|_| DEFAULT_DIRECTIVES.to_owned());
+
+    filtered_layer_with_directives(source, &directives)
+}
+
+/// Creates a Windows Event Log layer with custom filter directives.
+///
+/// Use this when you want to specify directives programmatically rather than
+/// via environment variable.
+///
+/// # Errors
+///
+/// Returns an error if the event source cannot be opened or if the filter
+/// directives are invalid.
+pub fn filtered_layer_with_directives<S>(
+    source: &str,
+    directives: &str,
+) -> Result<Filtered<WindowsEventLogLayer, EnvFilter, S>, Error>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let layer = WindowsEventLogLayer::new(source)?;
+    let filter = EnvFilter::try_new(directives).map_err(|error| Error::InvalidDirectives {
+        directives: directives.to_owned(),
+        error: error.to_string(),
+    })?;
+
+    Ok(layer.with_filter(filter))
+}
+
+/// Errors that can occur when working with the Windows Event Log.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failed to open the event source.
+    #[error(
+        "Failed to open Event Log source '{source}': {error}. \
+        Run as admin once or use: New-EventLog -LogName Application -Source \"{source}\""
+    )]
+    OpenSource {
+        source: String,
+        #[source]
+        error: windows::core::Error,
+    },
+
+    /// Failed to create registry key (requires admin).
+    #[error("Failed to create registry key (requires admin): {error}")]
+    CreateRegistryKey {
+        #[source]
+        error: windows::core::Error,
+    },
+
+    /// Failed to set registry value.
+    #[error("Failed to set registry value: {error}")]
+    SetRegistryValue {
+        #[source]
+        error: windows::core::Error,
+    },
+
+    /// Invalid filter directives.
+    #[error("Invalid filter directives '{directives}': {error}")]
+    InvalidDirectives { directives: String, error: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_visitor_builds_message_with_fields() {
+        let mut visitor = EventVisitor::new();
+        visitor.message = Some("test message".to_owned());
+        visitor.fields.push(("count".to_owned(), "42".to_owned()));
+        visitor.fields.push(("name".to_owned(), "test".to_owned()));
+
+        let spans = vec![
+            SpanInfo {
+                name: "span1".to_owned(),
+                fields: vec![("id".to_owned(), "123".to_owned())],
+            },
+            SpanInfo {
+                name: "span2".to_owned(),
+                fields: vec![],
+            },
+        ];
+
+        let output = visitor.into_message(&spans);
+
+        assert!(output.contains("test message"));
+        assert!(output.contains("span: span1(id=123) / span2"));
+        assert!(output.contains("count: 42"));
+        assert!(output.contains("name: test"));
+    }
+
+    #[test]
+    fn event_visitor_handles_empty_spans() {
+        let mut visitor = EventVisitor::new();
+        visitor.message = Some("test".to_owned());
+
+        let output = visitor.into_message(&[]);
+
+        assert_eq!(output, "test");
+        assert!(!output.contains("span:"));
+    }
+
+    #[test]
+    fn event_visitor_handles_no_message() {
+        let mut visitor = EventVisitor::new();
+        visitor.fields.push(("key".to_owned(), "value".to_owned()));
+
+        let output = visitor.into_message(&[]);
+
+        assert_eq!(output, "key: value");
+    }
+
+    #[test]
+    fn to_wide_string_includes_null_terminator() {
+        let wide = to_wide_string("test");
+        assert_eq!(wide.len(), 5); // 4 chars + null
+        assert_eq!(wide[4], 0);
+    }
+
+    #[test]
+    fn to_wide_string_handles_unicode() {
+        // Test various Unicode characters
+        let wide = to_wide_string("héllo wörld 日本語 🔥");
+        assert_eq!(*wide.last().unwrap(), 0, "Should be null-terminated");
+
+        // Verify it round-trips correctly
+        let without_null = &wide[..wide.len() - 1];
+        let back = String::from_utf16(without_null).unwrap();
+        assert_eq!(back, "héllo wörld 日本語 🔥");
+    }
+
+    #[test]
+    fn to_wide_string_handles_empty() {
+        let wide = to_wide_string("");
+        assert_eq!(wide.len(), 1); // Just null terminator
+        assert_eq!(wide[0], 0);
+    }
+
+    #[test]
+    fn event_visitor_spans_without_message() {
+        let visitor = EventVisitor::new();
+        let spans = vec![SpanInfo {
+            name: "outer".to_owned(),
+            fields: vec![("id".to_owned(), "1".to_owned())],
+        }];
+
+        let output = visitor.into_message(&spans);
+
+        assert_eq!(output, "span: outer(id=1)");
+    }
+
+    #[test]
+    fn event_visitor_nested_spans() {
+        let visitor = EventVisitor::new();
+        let spans = vec![
+            SpanInfo {
+                name: "root".to_owned(),
+                fields: vec![],
+            },
+            SpanInfo {
+                name: "middle".to_owned(),
+                fields: vec![("a".to_owned(), "1".to_owned())],
+            },
+            SpanInfo {
+                name: "leaf".to_owned(),
+                fields: vec![
+                    ("b".to_owned(), "2".to_owned()),
+                    ("c".to_owned(), "3".to_owned()),
+                ],
+            },
+        ];
+
+        let output = visitor.into_message(&spans);
+
+        assert_eq!(output, "span: root / middle(a=1) / leaf(b=2, c=3)");
+    }
+
+    #[test]
+    fn event_visitor_record_primitives() {
+        use tracing::field::Field;
+
+        let mut visitor = EventVisitor::new();
+
+        // Create a fake field for testing
+        struct FakeField(&'static str);
+        impl FakeField {
+            fn as_field(&self) -> Field {
+                // Get field from the test metadata's field set
+                METADATA.fields().field(self.0).unwrap()
+            }
+        }
+
+        struct TestCallsite;
+        static CALLSITE: TestCallsite = TestCallsite;
+
+        impl tracing::Callsite for TestCallsite {
+            fn set_interest(&self, _: tracing::subscriber::Interest) {}
+            fn metadata(&self) -> &tracing::Metadata<'_> {
+                &METADATA
+            }
+        }
+
+        static METADATA: tracing::Metadata<'static> = tracing::Metadata::new(
+            "test",
+            "test",
+            tracing::Level::INFO,
+            Some(file!()),
+            Some(line!()),
+            Some(module_path!()),
+            tracing::field::FieldSet::new(
+                &["i64_field", "u64_field", "bool_field", "f64_field"],
+                tracing::callsite::Identifier(&CALLSITE),
+            ),
+            tracing::metadata::Kind::EVENT,
+        );
+
+        visitor.record_i64(&FakeField("i64_field").as_field(), -42);
+        visitor.record_u64(&FakeField("u64_field").as_field(), 123);
+        visitor.record_bool(&FakeField("bool_field").as_field(), true);
+        visitor.record_f64(&FakeField("f64_field").as_field(), 2.88);
+
+        let output = visitor.into_message(&[]);
+
+        assert!(output.contains("i64_field: -42"), "got: {output}");
+        assert!(output.contains("u64_field: 123"), "got: {output}");
+        assert!(output.contains("bool_field: true"), "got: {output}");
+        assert!(output.contains("f64_field: 2.88"), "got: {output}");
+    }
+
+    #[test]
+    fn error_display_messages() {
+        let err = Error::InvalidDirectives {
+            directives: "invalid[".to_owned(),
+            error: "parse error".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("invalid["), "got: {msg}");
+        assert!(msg.contains("parse error"), "got: {msg}");
+    }
+}

--- a/rust/libs/logging/src/windows_event_log.rs
+++ b/rust/libs/logging/src/windows_event_log.rs
@@ -4,42 +4,17 @@
 //!
 //! Inspired by the [`tracing-layer-win-eventlog`](https://github.com/itsscb/tracing-layer-win-eventlog)
 //! crate (MIT licensed).
-//!
-//! # Level Filtering
-//!
-//! The layer filters events via the `EVENTLOG_DIRECTIVES` environment variable,
-//! defaulting to `info`. This allows controlling what gets written to the Windows
-//! Event Log separately from `RUST_LOG`:
+//! Filters via `EVENTLOG_DIRECTIVES` env var (default: `info`), independent of `RUST_LOG`.
 //!
 //! ```ignore
-//! // Set in environment:
-//! // RUST_LOG=debug              # Console gets debug logs
-//! // EVENTLOG_DIRECTIVES=info    # Event Log gets info and above
-//!
-//! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-//!
 //! tracing_subscriber::registry()
 //!     .with(logging::windows_event_log::layer("MyApp")?)
 //!     .init();
 //! ```
 //!
-//! If `EVENTLOG_DIRECTIVES` is not set, it defaults to `info`.
+//! Event IDs: ERROR=1, WARN=2, INFO/DEBUG/TRACE=3 (supported by `EventCreate.exe`).
 //!
-//! # Event IDs
-//!
-//! Log levels map to Event IDs supported by `EventCreate.exe`:
-//! - ERROR: Event ID 1
-//! - WARN:  Event ID 2
-//! - INFO/DEBUG/TRACE: Event ID 3
-//!
-//! # Event Source Registration
-//!
-//! The layer attempts to auto-register the event source on creation.
-//! This requires administrator privileges. If registration fails (no admin),
-//! it falls back gracefully - the layer will still work if the source was
-//! previously registered.
-//!
-//! To manually register a source (as admin):
+//! Auto-registers the source on creation (requires admin). To register manually:
 //! ```powershell
 //! New-EventLog -LogName Application -Source "MyApp"
 //! ```
@@ -66,37 +41,23 @@ use windows::Win32::System::Registry::{
 };
 use windows::core::{PCWSTR, w};
 
-// Event IDs 1-3 are defined in EventCreate.exe's message table
-// with the "%1" format string for custom messages.
 const EVENT_ID_ERROR: u32 = 1;
 const EVENT_ID_WARNING: u32 = 2;
 const EVENT_ID_INFO: u32 = 3;
+const TYPES_SUPPORTED: u32 = 0x07; // Error | Warning | Information
 
-/// Registry value for supported event types (Error | Warning | Information).
-const TYPES_SUPPORTED: u32 = 0x07;
+/// Environment variable for controlling Windows Event Log filtering.
+pub const ENV_EVENTLOG_DIRECTIVES: &str = "EVENTLOG_DIRECTIVES";
+const DEFAULT_DIRECTIVES: &str = "info";
 
-/// A thread-safe wrapper around the Windows Event Log handle.
+/// Thread-safe wrapper around the Windows Event Log handle.
 struct EventSourceHandle {
-    // Windows Event Log handles are NOT inherently thread-safe, so we use a
-    // `Mutex` to serialize access. The handle is wrapped in an `Option` to
-    // allow taking ownership during `Drop`.
     handle: Mutex<Option<HANDLE>>,
 }
 
-// SAFETY: EventSourceHandle is thread-safe because:
-// 1. The HANDLE is protected by a Mutex, ensuring exclusive access
-// 2. Windows Event Log handles can be used from any thread as long as access is serialised
-// 3. The Mutex ensures only one thread accesses the handle at a time
+// SAFETY: Access is serialized via Mutex.
 unsafe impl Send for EventSourceHandle {}
 unsafe impl Sync for EventSourceHandle {}
-
-/// Environment variable for controlling Windows Event Log filtering.
-///
-/// Supports the same directive syntax as `RUST_LOG`.
-pub const ENV_EVENTLOG_DIRECTIVES: &str = "EVENTLOG_DIRECTIVES";
-
-/// Default filter directives when `EVENTLOG_DIRECTIVES` is not set.
-const DEFAULT_DIRECTIVES: &str = "info";
 
 impl EventSourceHandle {
     fn new(handle: HANDLE) -> Self {
@@ -105,52 +66,37 @@ impl EventSourceHandle {
         }
     }
 
-    /// Reports an event to the Windows Event Log.
     fn report_event(&self, event_type: REPORT_EVENT_TYPE, event_id: u32, message: &str) {
         let message_wide = to_wide_string(message);
-        let message_ptr = PCWSTR(message_wide.as_ptr());
-        let messages = [message_ptr];
+        let messages = [PCWSTR(message_wide.as_ptr())];
 
         let Ok(guard) = self.handle.lock() else {
-            // Mutex is poisoned, skip logging
-            #[cfg(debug_assertions)]
-            eprintln!("Event Log handle mutex poisoned, skipping log");
             return;
         };
-
         let Some(handle) = *guard else {
-            #[cfg(debug_assertions)]
-            eprintln!("Event Log handle is not available, skipping log");
             return;
         };
 
-        // SAFETY: We hold the mutex lock ensuring exclusive access to the handle.
-        // The handle is valid (checked above) and message pointers are valid for
-        // the duration of this call.
+        // SAFETY: Handle is valid and protected by mutex.
         unsafe {
-            if let Err(_e) = ReportEventW(
+            let _ = ReportEventW(
                 handle,
                 event_type,
-                0, // category
+                0,
                 event_id,
-                None,            // user SID
-                0,               // raw data size
-                Some(&messages), // strings
-                None,            // raw data
-            ) {
-                // Only log in debug builds to avoid noise in production.
-                #[cfg(debug_assertions)]
-                eprintln!("Failed to write to Windows Event Log: {_e}");
-            }
+                None,
+                0,
+                Some(&messages),
+                None,
+            );
         }
     }
 }
 
 impl Drop for EventSourceHandle {
     fn drop(&mut self) {
-        // No need to lock - we have &mut self, so we're the only accessor
-        if let Some(handle) = self.handle.get_mut().expect("not to be poisoned").take() {
-            // SAFETY: We own the handle and only drop it once (ensured by `take()`).
+        if let Some(handle) = self.handle.get_mut().expect("not poisoned").take() {
+            // SAFETY: We own the handle.
             unsafe {
                 let _ = DeregisterEventSource(handle);
             }
@@ -158,28 +104,16 @@ impl Drop for EventSourceHandle {
     }
 }
 
-/// A [`tracing`] layer that writes events to the Windows Event Log.
+/// A tracing layer that writes events to the Windows Event Log.
 pub struct WindowsEventLogLayer {
     handle: Arc<EventSourceHandle>,
 }
 
 impl WindowsEventLogLayer {
-    /// Creates a new Event Log layer for the given source.
-    ///
-    /// Attempts to auto-register the source first (requires admin).
-    /// Returns an error if the source cannot be opened.
-    pub fn new(source: &str) -> Result<Self, Error> {
-        // Try to register the source (may fail without admin - that's OK)
-        if let Err(e) = try_register_source(source) {
-            tracing::debug!(
-                source,
-                error = %e,
-                "Could not register Event Log source (requires admin)"
-            );
-        }
+    fn new(source: &str) -> Result<Self, Error> {
+        let _ = try_register_source(source);
 
         let source_wide = to_wide_string(source);
-        // SAFETY: We pass valid pointers and the source string is null-terminated.
         let handle = unsafe { RegisterEventSourceW(PCWSTR::null(), PCWSTR(source_wide.as_ptr())) }
             .map_err(|e| Error::OpenSource {
                 source: source.to_owned(),
@@ -192,71 +126,10 @@ impl WindowsEventLogLayer {
     }
 }
 
-/// Storage for span fields, attached to spans via extensions.
+/// Storage for span fields.
 #[derive(Default)]
 struct SpanFields {
     fields: Vec<(String, String)>,
-}
-
-/// Visitor for recording span fields into SpanFields storage.
-struct SpanFieldVisitor<'a> {
-    fields: &'a mut SpanFields,
-}
-
-impl Visit for SpanFieldVisitor<'_> {
-    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), format!("{value:?}")));
-    }
-
-    fn record_str(&mut self, field: &Field, value: &str) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_owned()));
-    }
-
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_u64(&mut self, field: &Field, value: u64) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_i128(&mut self, field: &Field, value: i128) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_u128(&mut self, field: &Field, value: u128) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_f64(&mut self, field: &Field, value: f64) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.fields
-            .fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
 }
 
 impl<S> Layer<S> for WindowsEventLogLayer
@@ -264,29 +137,24 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        let Some(span) = ctx.span(id) else {
-            return;
-        };
-        let mut fields = SpanFields::default();
-        attrs.record(&mut SpanFieldVisitor {
-            fields: &mut fields,
-        });
-        span.extensions_mut().insert(fields);
+        if let Some(span) = ctx.span(id) {
+            let mut fields = SpanFields::default();
+            attrs.record(&mut FieldVisitor(&mut fields.fields));
+            span.extensions_mut().insert(fields);
+        }
     }
 
     fn on_record(&self, id: &Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
-        let Some(span) = ctx.span(id) else {
-            return;
-        };
-        let mut extensions = span.extensions_mut();
-        if let Some(fields) = extensions.get_mut::<SpanFields>() {
-            values.record(&mut SpanFieldVisitor { fields });
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(fields) = extensions.get_mut::<SpanFields>() {
+                values.record(&mut FieldVisitor(&mut fields.fields));
+            }
         }
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
-        let metadata = event.metadata();
-        let level = metadata.level();
+        let level = event.metadata().level();
 
         let (event_type, event_id) = match *level {
             Level::ERROR => (EVENTLOG_ERROR_TYPE, EVENT_ID_ERROR),
@@ -294,173 +162,124 @@ where
             _ => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_INFO),
         };
 
-        // Build plain text message
-        let mut visitor = EventVisitor::new();
-        event.record(&mut visitor);
+        let mut message = None;
+        let mut fields = Vec::new();
+        event.record(&mut EventVisitor {
+            message: &mut message,
+            fields: &mut fields,
+        });
 
-        // Collect span context with fields
-        let span_context: Vec<SpanInfo> = ctx
+        let spans: Vec<_> = ctx
             .event_scope(event)
             .map(|scope| {
                 scope
                     .from_root()
                     .map(|span| {
-                        let name = span.name().to_owned();
+                        let name = span.name();
                         let fields = span
                             .extensions()
                             .get::<SpanFields>()
                             .map(|f| f.fields.clone())
                             .unwrap_or_default();
-                        SpanInfo { name, fields }
+                        (name, fields)
                     })
                     .collect()
             })
             .unwrap_or_default();
 
-        let message = visitor.into_message(&span_context);
-        self.handle.report_event(event_type, event_id, &message);
+        let output = format_message(message.as_deref(), &spans, &fields);
+        self.handle.report_event(event_type, event_id, &output);
     }
 }
 
-/// Information about a span including its name and fields.
-struct SpanInfo {
-    name: String,
-    fields: Vec<(String, String)>,
-}
+/// Visitor for recording fields as key-value pairs.
+struct FieldVisitor<'a>(&'a mut Vec<(String, String)>);
 
-/// Visitor that collects fields into a plain text message.
-///
-/// Output format:
-/// ```text
-/// <message>
-/// span: <span1(field=value) / span2(field=value) / ...>
-/// <field1>: <value1>
-/// <field2>: <value2>
-/// ```
-struct EventVisitor {
-    message: Option<String>,
-    fields: Vec<(String, String)>,
-}
-
-impl EventVisitor {
-    fn new() -> Self {
-        Self {
-            message: None,
-            fields: Vec::new(),
-        }
-    }
-
-    fn into_message(self, spans: &[SpanInfo]) -> String {
-        let mut output = String::new();
-
-        // Message first
-        if let Some(msg) = &self.message {
-            output.push_str(msg);
-        }
-
-        // Span context with fields
-        if !spans.is_empty() {
-            if !output.is_empty() {
-                output.push('\n');
-            }
-            let span_str = spans
-                .iter()
-                .map(|s| {
-                    if s.fields.is_empty() {
-                        s.name.clone()
-                    } else {
-                        let fields_str = s
-                            .fields
-                            .iter()
-                            .map(|(k, v)| format!("{k}={v}"))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        format!("{}({})", s.name, fields_str)
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(" / ");
-            let _ = write!(output, "span: {span_str}");
-        }
-
-        // Event fields
-        for (key, value) in &self.fields {
-            if !output.is_empty() {
-                output.push('\n');
-            }
-            let _ = write!(output, "{key}: {value}");
-        }
-
-        output
-    }
-}
-
-impl Visit for EventVisitor {
+impl Visit for FieldVisitor<'_> {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        let value_str = format!("{value:?}");
+        self.0.push((field.name().to_owned(), format!("{value:?}")));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.push((field.name().to_owned(), value.to_owned()));
+    }
+}
+
+/// Visitor for recording event fields, with special handling for "message".
+struct EventVisitor<'a> {
+    message: &'a mut Option<String>,
+    fields: &'a mut Vec<(String, String)>,
+}
+
+impl Visit for EventVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let s = format!("{value:?}");
         if field.name() == "message" {
-            self.message = Some(value_str);
+            *self.message = Some(s);
         } else {
-            self.fields.push((field.name().to_owned(), value_str));
+            self.fields.push((field.name().to_owned(), s));
         }
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
         if field.name() == "message" {
-            self.message = Some(value.to_owned());
+            *self.message = Some(value.to_owned());
         } else {
             self.fields
                 .push((field.name().to_owned(), value.to_owned()));
         }
     }
-
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_u64(&mut self, field: &Field, value: u64) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_i128(&mut self, field: &Field, value: i128) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_u128(&mut self, field: &Field, value: u128) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_f64(&mut self, field: &Field, value: f64) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
-
-    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.fields
-            .push((field.name().to_owned(), value.to_string()));
-    }
 }
 
-/// Attempts to register an Event Log source.
-///
-/// This requires administrator privileges. If the source already exists,
-/// this is a no-op.
+fn format_message(
+    message: Option<&str>,
+    spans: &[(&str, Vec<(String, String)>)],
+    fields: &[(String, String)],
+) -> String {
+    let mut output = String::new();
+
+    if let Some(msg) = message {
+        output.push_str(msg);
+    }
+
+    if !spans.is_empty() {
+        if !output.is_empty() {
+            output.push('\n');
+        }
+        let span_str = spans
+            .iter()
+            .map(|(name, fields)| {
+                if fields.is_empty() {
+                    (*name).to_owned()
+                } else {
+                    let fields_str = fields
+                        .iter()
+                        .map(|(k, v)| format!("{k}={v}"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{name}({fields_str})")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" / ");
+        let _ = write!(output, "span: {span_str}");
+    }
+
+    for (key, value) in fields {
+        if !output.is_empty() {
+            output.push('\n');
+        }
+        let _ = write!(output, "{key}: {value}");
+    }
+
+    output
+}
+
 fn try_register_source(source: &str) -> Result<(), Error> {
     let key_path = format!("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\{source}");
     let key_path_wide = to_wide_string(&key_path);
-
     let mut hkey = windows::Win32::System::Registry::HKEY::default();
 
-    // SAFETY: We pass valid pointers and handle the result.
     unsafe {
         RegCreateKeyExW(
             HKEY_LOCAL_MACHINE,
@@ -476,7 +295,6 @@ fn try_register_source(source: &str) -> Result<(), Error> {
         .ok()
         .map_err(|e| Error::CreateRegistryKey { error: e })?;
 
-        // Set TypesSupported (required for event types to work)
         let result = (|| {
             RegSetValueExW(
                 hkey,
@@ -488,8 +306,6 @@ fn try_register_source(source: &str) -> Result<(), Error> {
             .ok()
             .map_err(|e| Error::SetRegistryValue { error: e })?;
 
-            // Set EventMessageFile to a default message file
-            // Using the system's default which handles %1 style messages
             let message_file = "%SystemRoot%\\System32\\EventCreate.exe";
             let message_file_wide = to_wide_string(message_file);
             let message_file_bytes: Vec<u8> = message_file_wide
@@ -510,56 +326,26 @@ fn try_register_source(source: &str) -> Result<(), Error> {
             Ok(())
         })();
 
-        // Always close the registry key
         let _ = RegCloseKey(hkey);
-
         result
     }
 }
 
-/// Converts a Rust string to a null-terminated wide string (UTF-16).
 fn to_wide_string(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
-/// Creates a Windows Event Log layer with default filtering.
-///
-/// Filtering is controlled by the `EVENTLOG_DIRECTIVES` environment variable,
-/// defaulting to `info`. This allows independent control of Event Log verbosity
-/// separate from `RUST_LOG`.
-///
-/// # Environment Variable
-///
-/// Set `EVENTLOG_DIRECTIVES` to control filtering:
-/// - `error` - only errors
-/// - `warn` - warnings and errors
-/// - `info` - info, warnings, and errors (default)
-/// - `debug` - debug and above
-/// - `mymodule=debug,warn` - debug for mymodule, warn for everything else
-///
-/// # Errors
-///
-/// Returns an error if the event source cannot be opened or if the filter
-/// directives are invalid.
+/// Creates a Windows Event Log layer with filtering from `EVENTLOG_DIRECTIVES` (default: `info`).
 pub fn layer<S>(source: &str) -> Result<Filtered<WindowsEventLogLayer, EnvFilter, S>, Error>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     let directives =
         std::env::var(ENV_EVENTLOG_DIRECTIVES).unwrap_or_else(|_| DEFAULT_DIRECTIVES.to_owned());
-
     layer_with_directives(source, &directives)
 }
 
 /// Creates a Windows Event Log layer with custom filter directives.
-///
-/// Use this when you want to specify directives programmatically rather than
-/// via environment variable.
-///
-/// # Errors
-///
-/// Returns an error if the event source cannot be opened or if the filter
-/// directives are invalid.
 pub fn layer_with_directives<S>(
     source: &str,
     directives: &str,
@@ -572,51 +358,29 @@ where
         directives: directives.to_owned(),
         error: error.to_string(),
     })?;
-
     Ok(layer.with_filter(filter))
 }
 
-/// Creates an unfiltered Windows Event Log layer.
-///
-/// **Warning:** This logs ALL events regardless of level, which can be very
-/// verbose. Prefer [`layer`] for production use.
-///
-/// # Errors
-///
-/// Returns an error if the event source cannot be opened.
-pub fn unfiltered_layer(source: &str) -> Result<WindowsEventLogLayer, Error> {
-    WindowsEventLogLayer::new(source)
-}
-
-/// Errors that can occur when working with the Windows Event Log.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Failed to open the event source.
     #[error(
-        "Failed to open Event Log source '{source}': {error}. \
-        Run as admin once or use: New-EventLog -LogName Application -Source \"{source}\""
+        "Failed to open Event Log source '{source}': {error}. Run as admin or use: New-EventLog -LogName Application -Source \"{source}\""
     )]
     OpenSource {
         source: String,
         #[source]
         error: windows::core::Error,
     },
-
-    /// Failed to create registry key (requires admin).
-    #[error("Failed to create registry key (requires admin): {error}")]
+    #[error("Failed to create registry key: {error}")]
     CreateRegistryKey {
         #[source]
         error: windows::core::Error,
     },
-
-    /// Failed to set registry value.
     #[error("Failed to set registry value: {error}")]
     SetRegistryValue {
         #[source]
         error: windows::core::Error,
     },
-
-    /// Invalid filter directives.
     #[error("Invalid filter directives '{directives}': {error}")]
     InvalidDirectives { directives: String, error: String },
 }
@@ -626,24 +390,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn event_visitor_builds_message_with_fields() {
-        let mut visitor = EventVisitor::new();
-        visitor.message = Some("test message".to_owned());
-        visitor.fields.push(("count".to_owned(), "42".to_owned()));
-        visitor.fields.push(("name".to_owned(), "test".to_owned()));
-
+    fn format_message_with_all_parts() {
         let spans = vec![
-            SpanInfo {
-                name: "span1".to_owned(),
-                fields: vec![("id".to_owned(), "123".to_owned())],
-            },
-            SpanInfo {
-                name: "span2".to_owned(),
-                fields: vec![],
-            },
+            ("span1", vec![("id".to_owned(), "123".to_owned())]),
+            ("span2", vec![]),
+        ];
+        let fields = vec![
+            ("count".to_owned(), "42".to_owned()),
+            ("name".to_owned(), "test".to_owned()),
         ];
 
-        let output = visitor.into_message(&spans);
+        let output = format_message(Some("test message"), &spans, &fields);
 
         assert!(output.contains("test message"));
         assert!(output.contains("span: span1(id=123) / span2"));
@@ -652,151 +409,48 @@ mod tests {
     }
 
     #[test]
-    fn event_visitor_handles_empty_spans() {
-        let mut visitor = EventVisitor::new();
-        visitor.message = Some("test".to_owned());
-
-        let output = visitor.into_message(&[]);
-
+    fn format_message_without_spans() {
+        let output = format_message(Some("test"), &[], &[]);
         assert_eq!(output, "test");
-        assert!(!output.contains("span:"));
     }
 
     #[test]
-    fn event_visitor_handles_no_message() {
-        let mut visitor = EventVisitor::new();
-        visitor.fields.push(("key".to_owned(), "value".to_owned()));
-
-        let output = visitor.into_message(&[]);
-
+    fn format_message_without_message() {
+        let fields = vec![("key".to_owned(), "value".to_owned())];
+        let output = format_message(None, &[], &fields);
         assert_eq!(output, "key: value");
     }
 
     #[test]
-    fn to_wide_string_includes_null_terminator() {
-        let wide = to_wide_string("test");
-        assert_eq!(wide.len(), 5); // 4 chars + null
-        assert_eq!(wide[4], 0);
-    }
-
-    #[test]
-    fn to_wide_string_handles_unicode() {
-        // Test various Unicode characters
-        let wide = to_wide_string("héllo wörld 日本語 🔥");
-        assert_eq!(*wide.last().unwrap(), 0, "Should be null-terminated");
-
-        // Verify it round-trips correctly
-        let without_null = &wide[..wide.len() - 1];
-        let back = String::from_utf16(without_null).unwrap();
-        assert_eq!(back, "héllo wörld 日本語 🔥");
-    }
-
-    #[test]
-    fn to_wide_string_handles_empty() {
-        let wide = to_wide_string("");
-        assert_eq!(wide.len(), 1); // Just null terminator
-        assert_eq!(wide[0], 0);
-    }
-
-    #[test]
-    fn event_visitor_spans_without_message() {
-        let visitor = EventVisitor::new();
-        let spans = vec![SpanInfo {
-            name: "outer".to_owned(),
-            fields: vec![("id".to_owned(), "1".to_owned())],
-        }];
-
-        let output = visitor.into_message(&spans);
-
-        assert_eq!(output, "span: outer(id=1)");
-    }
-
-    #[test]
-    fn event_visitor_nested_spans() {
-        let visitor = EventVisitor::new();
+    fn format_message_nested_spans() {
         let spans = vec![
-            SpanInfo {
-                name: "root".to_owned(),
-                fields: vec![],
-            },
-            SpanInfo {
-                name: "middle".to_owned(),
-                fields: vec![("a".to_owned(), "1".to_owned())],
-            },
-            SpanInfo {
-                name: "leaf".to_owned(),
-                fields: vec![
+            ("root", vec![]),
+            ("middle", vec![("a".to_owned(), "1".to_owned())]),
+            (
+                "leaf",
+                vec![
                     ("b".to_owned(), "2".to_owned()),
                     ("c".to_owned(), "3".to_owned()),
                 ],
-            },
+            ),
         ];
 
-        let output = visitor.into_message(&spans);
-
+        let output = format_message(None, &spans, &[]);
         assert_eq!(output, "span: root / middle(a=1) / leaf(b=2, c=3)");
     }
 
     #[test]
-    fn event_visitor_record_primitives() {
-        use tracing::field::Field;
-
-        let mut visitor = EventVisitor::new();
-
-        // Create a fake field for testing
-        struct FakeField(&'static str);
-        impl FakeField {
-            fn as_field(&self) -> Field {
-                // Get field from the test metadata's field set
-                METADATA.fields().field(self.0).unwrap()
-            }
-        }
-
-        struct TestCallsite;
-        static CALLSITE: TestCallsite = TestCallsite;
-
-        impl tracing::Callsite for TestCallsite {
-            fn set_interest(&self, _: tracing::subscriber::Interest) {}
-            fn metadata(&self) -> &tracing::Metadata<'_> {
-                &METADATA
-            }
-        }
-
-        static METADATA: tracing::Metadata<'static> = tracing::Metadata::new(
-            "test",
-            "test",
-            tracing::Level::INFO,
-            Some(file!()),
-            Some(line!()),
-            Some(module_path!()),
-            tracing::field::FieldSet::new(
-                &["i64_field", "u64_field", "bool_field", "f64_field"],
-                tracing::callsite::Identifier(&CALLSITE),
-            ),
-            tracing::metadata::Kind::EVENT,
-        );
-
-        visitor.record_i64(&FakeField("i64_field").as_field(), -42);
-        visitor.record_u64(&FakeField("u64_field").as_field(), 123);
-        visitor.record_bool(&FakeField("bool_field").as_field(), true);
-        visitor.record_f64(&FakeField("f64_field").as_field(), 2.88);
-
-        let output = visitor.into_message(&[]);
-
-        assert!(output.contains("i64_field: -42"), "got: {output}");
-        assert!(output.contains("u64_field: 123"), "got: {output}");
-        assert!(output.contains("bool_field: true"), "got: {output}");
-        assert!(output.contains("f64_field: 2.88"), "got: {output}");
+    fn to_wide_string_null_terminated() {
+        let wide = to_wide_string("test");
+        assert_eq!(wide.len(), 5);
+        assert_eq!(wide[4], 0);
     }
 
     #[test]
-    fn error_display_messages() {
-        let err = Error::InvalidDirectives {
-            directives: "invalid[".to_owned(),
-            error: "parse error".to_owned(),
-        };
-        let msg = err.to_string();
-        assert!(msg.contains("invalid["), "got: {msg}");
-        assert!(msg.contains("parse error"), "got: {msg}");
+    fn to_wide_string_unicode() {
+        let wide = to_wide_string("héllo 日本語");
+        assert_eq!(*wide.last().unwrap(), 0);
+        let back = String::from_utf16(&wide[..wide.len() - 1]).unwrap();
+        assert_eq!(back, "héllo 日本語");
     }
 }

--- a/rust/libs/logging/src/windows_event_log.rs
+++ b/rust/libs/logging/src/windows_event_log.rs
@@ -68,11 +68,11 @@ use windows::Win32::System::Registry::{
 };
 use windows::core::{PCWSTR, w};
 
+// Event IDs 1-3 are defined in EventCreate.exe's message table
+// with the "%1" format string for custom messages.
 const EVENT_ID_ERROR: u32 = 1;
 const EVENT_ID_WARNING: u32 = 2;
 const EVENT_ID_INFO: u32 = 3;
-const EVENT_ID_DEBUG: u32 = 4;
-const EVENT_ID_TRACE: u32 = 5;
 
 /// Registry value for supported event types (Error | Warning | Information).
 const TYPES_SUPPORTED: u32 = 0x07;
@@ -293,9 +293,7 @@ where
         let (event_type, event_id) = match *level {
             Level::ERROR => (EVENTLOG_ERROR_TYPE, EVENT_ID_ERROR),
             Level::WARN => (EVENTLOG_WARNING_TYPE, EVENT_ID_WARNING),
-            Level::INFO => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_INFO),
-            Level::DEBUG => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_DEBUG),
-            Level::TRACE => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_TRACE),
+            _ => (EVENTLOG_INFORMATION_TYPE, EVENT_ID_INFO),
         };
 
         // Build plain text message

--- a/rust/libs/logging/tests/windows_event_log_integration.rs
+++ b/rust/libs/logging/tests/windows_event_log_integration.rs
@@ -11,8 +11,10 @@ use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
 /// Unique source name for testing to avoid conflicts.
-fn test_source() -> String {
-    format!("Firezone-Test-{}", std::process::id())
+///
+/// Uses process ID and a unique suffix to ensure each test has its own source.
+fn test_source(suffix: &str) -> String {
+    format!("Firezone-Test-{}-{suffix}", std::process::id())
 }
 
 /// Guard that removes the Event Log source on drop.
@@ -80,7 +82,7 @@ fn read_latest_event(source: &str) -> Option<String> {
 #[test]
 #[ignore = "Requires Windows and may need admin privileges"]
 fn writes_event_to_event_log() {
-    let source = test_source();
+    let source = test_source("writes");
     let _cleanup = SourceGuard(source.clone());
 
     // Clean up any previous test runs
@@ -121,7 +123,7 @@ fn writes_event_to_event_log() {
 #[test]
 #[ignore = "Requires Windows and may need admin privileges"]
 fn maps_log_levels_correctly() {
-    let source = test_source();
+    let source = test_source("levels");
     let _cleanup = SourceGuard(source.clone());
 
     remove_source(&source);
@@ -170,7 +172,7 @@ fn maps_log_levels_correctly() {
 #[test]
 #[ignore = "Requires Windows and may need admin privileges"]
 fn captures_span_fields() {
-    let source = test_source();
+    let source = test_source("spans");
     let _cleanup = SourceGuard(source.clone());
 
     remove_source(&source);

--- a/rust/libs/logging/tests/windows_event_log_integration.rs
+++ b/rust/libs/logging/tests/windows_event_log_integration.rs
@@ -1,0 +1,203 @@
+//! Integration tests for Windows Event Log layer.
+//!
+//! These tests require Windows and write to the actual Event Log.
+//! Run with: `cargo test --test windows_event_log_integration -- --include-ignored`
+
+#![cfg(windows)]
+
+use std::process::Command;
+
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+
+/// Unique source name for testing to avoid conflicts.
+fn test_source() -> String {
+    format!("Firezone-Test-{}", std::process::id())
+}
+
+/// Guard that removes the Event Log source on drop.
+///
+/// Ensures cleanup happens even if a test panics.
+struct SourceGuard(String);
+
+impl Drop for SourceGuard {
+    fn drop(&mut self) {
+        remove_source(&self.0);
+    }
+}
+
+/// Registers an Event Log source using PowerShell.
+fn register_source(source: &str) -> bool {
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "New-EventLog -LogName Application -Source '{}' -ErrorAction SilentlyContinue",
+                source
+            ),
+        ])
+        .output();
+
+    output.is_ok_and(|o| o.status.success() || o.stderr.is_empty())
+}
+
+/// Removes an Event Log source using PowerShell.
+fn remove_source(source: &str) {
+    let _ = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "Remove-EventLog -Source '{}' -ErrorAction SilentlyContinue",
+                source
+            ),
+        ])
+        .output();
+}
+
+/// Reads the most recent event from the specified source.
+fn read_latest_event(source: &str) -> Option<String> {
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "Get-WinEvent -LogName Application -FilterXPath \"*[System[Provider[@Name='{}']]]\" -MaxEvents 1 | Select-Object -ExpandProperty Message",
+                source
+            ),
+        ])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+#[test]
+#[ignore = "Requires Windows and may need admin privileges"]
+fn writes_event_to_event_log() {
+    let source = test_source();
+    let _cleanup = SourceGuard(source.clone());
+
+    // Clean up any previous test runs
+    remove_source(&source);
+
+    // Register the source (may fail without admin - that's OK, auto-registration may work)
+    let _ = register_source(&source);
+
+    // Create the layer
+    let layer = logging::windows_event_log::layer(&source)
+        .expect("Failed to create Event Log layer (need admin?)");
+
+    // Set up tracing with our layer
+    let _subscriber = tracing_subscriber::registry().with(layer).set_default();
+
+    // Write a test event
+    let test_message = format!("Integration test event {}", std::process::id());
+    tracing::info!(test_field = "test_value", number = 42, "{test_message}");
+
+    // Give Windows a moment to process the event
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Read it back
+    let event_content = read_latest_event(&source);
+
+    // Verify (cleanup happens via SourceGuard on drop)
+    let content = event_content.expect("Should have read an event");
+    assert!(
+        content.contains(&test_message) || content.contains("Integration test event"),
+        "Event should contain our message, got: {content}"
+    );
+    assert!(
+        content.contains("test_field") || content.contains("test_value"),
+        "Event should contain our field, got: {content}"
+    );
+}
+
+#[test]
+#[ignore = "Requires Windows and may need admin privileges"]
+fn maps_log_levels_correctly() {
+    let source = test_source();
+    let _cleanup = SourceGuard(source.clone());
+
+    remove_source(&source);
+    let _ = register_source(&source);
+
+    let layer =
+        logging::windows_event_log::layer(&source).expect("Failed to create Event Log layer");
+
+    let _subscriber = tracing_subscriber::registry().with(layer).set_default();
+
+    // Write events at different levels
+    tracing::error!("error level test");
+    tracing::warn!("warn level test");
+    tracing::info!("info level test");
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Read events and check they exist
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "Get-WinEvent -LogName Application -FilterXPath \"*[System[Provider[@Name='{}']]]\" -MaxEvents 3 | Select-Object Level, Message | ConvertTo-Json",
+                source
+            ),
+        ])
+        .output()
+        .expect("PowerShell should run");
+
+    assert!(
+        output.status.success(),
+        "Should read events: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let events = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        events.contains("error level test"),
+        "Should have error event"
+    );
+    assert!(events.contains("warn level test"), "Should have warn event");
+    assert!(events.contains("info level test"), "Should have info event");
+}
+
+#[test]
+#[ignore = "Requires Windows and may need admin privileges"]
+fn captures_span_fields() {
+    let source = test_source();
+    let _cleanup = SourceGuard(source.clone());
+
+    remove_source(&source);
+    let _ = register_source(&source);
+
+    let layer =
+        logging::windows_event_log::layer(&source).expect("Failed to create Event Log layer");
+
+    let _subscriber = tracing_subscriber::registry().with(layer).set_default();
+
+    // Create a span with fields and emit an event inside it
+    let span = tracing::info_span!("request", method = "GET", path = "/api/test");
+    let _enter = span.enter();
+
+    tracing::info!("handling request");
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let event_content = read_latest_event(&source);
+
+    let content = event_content.expect("Should have read an event");
+    assert!(
+        content.contains("handling request"),
+        "Event should contain our message, got: {content}"
+    );
+    assert!(
+        content.contains("request") && content.contains("method=GET"),
+        "Event should contain span name and fields, got: {content}"
+    );
+}

--- a/rust/tests/loadtest/Cargo.toml
+++ b/rust/tests/loadtest/Cargo.toml
@@ -14,6 +14,11 @@ goose = { version = "0.18", default-features = false, features = ["rustls-tls"] 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+logging = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Add a tracing layer that writes events to the Windows Event Log, enabling centralised log collection via Windows Event Forwarding.

use it in the firezone-loadtest.

Features:
- Maps tracing levels to Event Log types (Error/Warning/Information)
- Assigns distinct Event IDs per level for filtering in Event Viewer
- Captures span context with field values in log messages
- Auto-registers event source (requires admin, falls back gracefully)
- Independent filtering via EVENTLOG_DIRECTIVES env var (defaults to info)

Usage:
  EVENTLOG_DIRECTIVES=warn  # Only warnings and errors to Event Log
  RUST_LOG=debug            # Debug to console (independent)

Event IDs: ERROR=1, WARN=2, {INFO,DEBUG,TRACE}=3


  On your Windows machine, you need to run (as admin) once:
  `New-EventLog -LogName Application -Source "Firezone-Loadtest"`


here it is in action: 
<img width="826" height="307" alt="image" src="https://github.com/user-attachments/assets/69c74687-cc21-4e78-a912-f13cc78b4efe" />
