### PR TITLE
fix(android): only select apps that are browsable

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -42,10 +42,6 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
         viewModel.actionLiveData.observe(this) { action ->
             when (action) {
                 is AuthViewModel.ViewAction.LaunchAuthFlow -> setupWebView(action.url)
-                is AuthViewModel.ViewAction.NavigateToSignIn -> {
-                    navigateToSignIn()
-                }
-                is AuthViewModel.ViewAction.ShowError -> showError()
                 else -> {}
             }
         }
@@ -77,18 +73,5 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
             Intent(this, MainActivity::class.java),
         )
         finish()
-    }
-
-    private fun showError() {
-        AlertDialog
-            .Builder(this)
-            .setTitle(R.string.error_dialog_title)
-            .setMessage(R.string.error_dialog_message)
-            .setPositiveButton(
-                R.string.error_dialog_button_text,
-            ) { _, _ ->
-                this@AuthActivity.finish()
-            }.setIcon(R.drawable.ic_firezone_logo)
-            .show()
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -67,6 +67,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
             // Fallback to default browser if Custom Tabs unavailable
             val intent = Intent(Intent.ACTION_VIEW, url)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.addCategory(Intent.CATEGORY_BROWSABLE)
             startActivity(intent)
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -49,23 +50,38 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
 
     private fun setupWebView(url: String) {
         hasLaunchedCustomTab = true
-        val customTabsIntent =
-            CustomTabsIntent
-                .Builder()
-                .setShowTitle(true)
-                .build()
+
         val url = Uri.parse(url)
 
         // Try to use Custom Tabs with the default browser first
         try {
-            customTabsIntent.launchUrl(this, url)
+            launchCustomTabsIntent(url);
+            return
         } catch (e: ActivityNotFoundException) {
-            // Fallback to default browser if Custom Tabs unavailable
-            val intent = Intent(Intent.ACTION_VIEW, url)
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            intent.addCategory(Intent.CATEGORY_BROWSABLE)
-            startActivity(intent)
+            Log.d(TAG, "CustomTabs don't appear to be available, falling back to ACTION_VIEW intent")
         }
+
+        // Fallback to default browser if Custom Tabs unavailable
+        try {
+            launchActionViewIntent(url)
+        } catch (e: ActivityNotFoundException) {
+            showBrowserRequiredError()
+        }
+    }
+
+    private fun launchCustomTabsIntent(uri: Uri) {
+            CustomTabsIntent
+                .Builder()
+                .setShowTitle(true)
+                .build()
+                .launchUrl(this, uri)
+    }
+
+    private fun launchActionViewIntent(uri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.addCategory(Intent.CATEGORY_BROWSABLE)
+        startActivity(intent)
     }
 
     private fun navigateToSignIn() {
@@ -73,5 +89,22 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
             Intent(this, MainActivity::class.java),
         )
         finish()
+    }
+
+    private fun showBrowserRequiredError() {
+        AlertDialog
+            .Builder(this)
+            .setTitle(R.string.error_dialog_title)
+            .setMessage(R.string.error_dialog_message_browser_required)
+            .setPositiveButton(
+                R.string.error_dialog_button_text,
+            ) { _, _ ->
+                this@AuthActivity.finish()
+            }.setIcon(R.drawable.ic_firezone_logo)
+            .show()
+    }
+
+    companion object {
+        private const val TAG = "AuthActivity"
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -55,7 +55,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
 
         // Try to use Custom Tabs with the default browser first
         try {
-            launchCustomTabsIntent(url);
+            launchCustomTabsIntent(url)
             return
         } catch (e: ActivityNotFoundException) {
             Log.d(TAG, "CustomTabs don't appear to be available, falling back to ACTION_VIEW intent")
@@ -70,11 +70,11 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
     }
 
     private fun launchCustomTabsIntent(uri: Uri) {
-            CustomTabsIntent
-                .Builder()
-                .setShowTitle(true)
-                .build()
-                .launchUrl(this, uri)
+        CustomTabsIntent
+            .Builder()
+            .setShowTitle(true)
+            .build()
+            .launchUrl(this, uri)
     }
 
     private fun launchActionViewIntent(uri: Uri) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -45,10 +45,6 @@ internal class AuthViewModel
             data class LaunchAuthFlow(
                 val url: String,
             ) : ViewAction()
-
-            object NavigateToSignIn : ViewAction()
-
-            object ShowError : ViewAction()
         }
 
         internal companion object {

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -38,6 +38,11 @@
 	<string name="launching_auth_flow">Launching Browser to sign in…</string>
 
 	<!-- Error Dialog -->
+	<string name="error_dialog_title">Error</string>
+	<string name="error_dialog_message_browser_required">
+		Please install a browser to sign in to Firezone.
+	</string>
+	<string name="error_dialog_button_text">Ok</string>
 	<string name="enable_vpn_permission">Enable VPN Permission</string>
 	<string name="vpn_permission_description">
 		Firezone requires the VPN permission in order to route packets from your device to protected

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -51,7 +51,6 @@
 		the button below.
 	</string>
 	<string name="request_permission">Request Permission</string>
-	<string name="signing_in_requires_chrome_browser">Signing in requires Chrome browser</string>
 
 	<!-- Managed Configuration -->
 	<string name="config_token_title">Token</string>

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
 	<string name="sign_out">Sign Out</string>
 
 	<!-- Auth -->
-	<string name="launching_auth_flow">Launching Chrome to sign in…</string>
+	<string name="launching_auth_flow">Launching Browser to sign in…</string>
 
 	<!-- Error Dialog -->
 	<string name="error_dialog_title">Error</string>

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -38,11 +38,6 @@
 	<string name="launching_auth_flow">Launching Browser to sign in…</string>
 
 	<!-- Error Dialog -->
-	<string name="error_dialog_title">Error</string>
-	<string name="error_dialog_message">
-		Oops! Something went wrong. Contact your admin if this issue persists.
-	</string>
-	<string name="error_dialog_button_text">Ok</string>
 	<string name="enable_vpn_permission">Enable VPN Permission</string>
 	<string name="vpn_permission_description">
 		Firezone requires the VPN permission in order to route packets from your device to protected

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11077">
+          Fixes an issue where the authentication link would not open in the
+          correct app.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.7" date={new Date("2025-12-05")}>
         <ChangeItem pull="10752">
           Fixes an issue where the reported client version was out of date.


### PR DESCRIPTION
When a user has a browser installed that doesn't support custom tabs, we fallback to just opening the Auth URL via an `ACTION_VIEW` intent. This can select non-browser apps if they are registered to handle HTTP links. To fix this, we need to restrict the intent to apps in the "browsable" category.

While testing this, I noticed that we will still crash if there is no browser available. Hence, I've also added a check for that and removed some dead code in the module.

Source: https://stackoverflow.com/a/67485825