### PR TITLE
fix(portal): handle already-exists `unaccent` extension

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20240301170517_enable_unnacent.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240301170517_enable_unnacent.exs
@@ -3,7 +3,7 @@ defmodule Domain.Repo.Migrations.EnableUnnacent do
 
   def change do
     execute("""
-    CREATE EXTENSION unaccent;
+    CREATE EXTENSION IF NOT EXISTS unaccent;
     """)
   end
 end


### PR DESCRIPTION
The migration was fixed because it did not take place in a managed cloud postgresql, in which extensions are installed through the infrastructure