### PR TITLE
fix(portal): don't encode tokens in session cookies

### DIFF
--- a/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
@@ -256,16 +256,14 @@ defmodule Web.EmailOTPController do
       expires_at: DateTime.add(DateTime.utc_now(), session_lifetime_secs, :second)
     }
 
-    with {:ok, token} <- Auth.create_token(attrs) do
-      {:ok, Auth.encode_fragment!(token)}
-    end
+    Auth.create_token(attrs)
   end
 
   # Context: :browser
   # Store session cookie and redirect to portal or redirect_to parameter
   defp signed_in(conn, :browser, account, _actor, token, params) do
     conn
-    |> Web.Session.Cookie.put_account_cookie(account.id, token)
+    |> Web.Session.Cookie.put_account_cookie(account.id, token.id)
     |> Redirector.portal_signed_in(account, params)
   end
 

--- a/elixir/apps/web/lib/web/controllers/oidc_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/oidc_controller.ex
@@ -259,16 +259,14 @@ defmodule Web.OIDCController do
       expires_at: DateTime.add(DateTime.utc_now(), session_lifetime_secs, :second)
     }
 
-    with {:ok, token} <- Domain.Auth.create_token(attrs) do
-      {:ok, Domain.Auth.encode_fragment!(token)}
-    end
+    Domain.Auth.create_token(attrs)
   end
 
   # Context: :browser
   # Store session cookie and redirect to portal or redirect_to parameter
   defp signed_in(conn, :browser, account, _identity, token, _provider, _tokens, params) do
     conn
-    |> Web.Session.Cookie.put_account_cookie(account.id, token)
+    |> Web.Session.Cookie.put_account_cookie(account.id, token.id)
     |> Redirector.portal_signed_in(account, params)
   end
 

--- a/elixir/apps/web/lib/web/controllers/userpass_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/userpass_controller.ex
@@ -91,16 +91,14 @@ defmodule Web.UserpassController do
       expires_at: DateTime.add(DateTime.utc_now(), session_lifetime_secs, :second)
     }
 
-    with {:ok, token} <- Domain.Auth.create_token(attrs) do
-      {:ok, Domain.Auth.encode_fragment!(token)}
-    end
+    Domain.Auth.create_token(attrs)
   end
 
   # Context: :browser
   # Store session cookie and redirect to portal or redirect_to parameter
   defp signed_in(conn, :browser, account, _actor, token, params) do
     conn
-    |> Web.Session.Cookie.put_account_cookie(account.id, token)
+    |> Web.Session.Cookie.put_account_cookie(account.id, token.id)
     |> Redirector.portal_signed_in(account, params)
   end
 

--- a/elixir/apps/web/lib/web/session/redirector.ex
+++ b/elixir/apps/web/lib/web/session/redirector.ex
@@ -9,6 +9,7 @@ defmodule Web.Session.Redirector do
   """
   use Web, :verified_routes
 
+  alias Domain.Token
   alias __MODULE__.DB
 
   @doc """
@@ -55,7 +56,16 @@ defmodule Web.Session.Redirector do
   Sets a cookie with client auth data and renders the client_redirect.html page
   which handles the platform-specific redirect.
   """
-  def client_signed_in(%Plug.Conn{} = conn, account, actor_name, identifier, fragment, state) do
+  def client_signed_in(
+        %Plug.Conn{} = conn,
+        account,
+        actor_name,
+        identifier,
+        %Token{} = token,
+        state
+      ) do
+    fragment = Domain.Auth.encode_fragment!(token)
+
     client_auth_data = %{
       actor_name: actor_name,
       fragment: fragment,


### PR DESCRIPTION
This is completely unnecessary and only increases the spaghettification of our codebase.

Fixes #11086 