### PR TITLE
chore: consistent ktlint

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ spotless {
         ktlint()
         target("**/*.kt")
         targetExclude("**/generated/*")
-        licenseHeader("/* Licensed under Apache 2.0 (C) \$YEAR Firezone, Inc. */", "^(package |import |@file)")
+        licenseHeader("// Licensed under Apache 2.0 (C) \$YEAR Firezone, Inc.", "^(package |import |@file)")
     }
     kotlinGradle {
         ktlint()

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/HiltTestRunner.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/HiltTestRunner.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core
 
 import android.app.Application

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/ViewActions.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/ViewActions.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core
 
 import android.view.View

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestRuntimeModule.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/di/TestRuntimeModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import dagger.Module

--- a/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/presentation/MainActivityTest.kt
+++ b/kotlin/android/app/src/androidTest/java/dev/firezone/android/core/presentation/MainActivityTest.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.presentation
 
 import android.content.Context

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/ApplicationMode.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/ApplicationMode.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core
 
 enum class ApplicationMode {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/BootReceiver.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/BootReceiver.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2025 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2025 Firezone, Inc.
 package dev.firezone.android.core
 
 import android.content.BroadcastReceiver

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/FirezoneApp.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core
 
 import android.app.Application

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/UrlInterceptor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/UrlInterceptor.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core
 
 import android.content.SharedPreferences

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.data
 
 import android.content.Context

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/Config.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/Config.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.data.model
 
 data class Config(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfigStatus.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/ManagedConfigStatus.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.data.model
 
 data class ManagedConfigStatus(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/AppModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/AppModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import android.app.Application

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/CoroutinesQualifiers.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/CoroutinesQualifiers.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import javax.inject.Qualifier

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/CoroutinesScopeModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/CoroutinesScopeModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import dagger.Module

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DataModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DataModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import android.content.Context

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DispatcherModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/DispatcherModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import dagger.Module

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/NetworkModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/NetworkModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import android.content.SharedPreferences

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/RuntimeModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/RuntimeModule.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.di
 
 import dagger.Module

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.presentation
 
 import android.content.Context

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/utils/ClipboardUtils.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/utils/ClipboardUtils.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core.utils
 
 import android.content.ClipData

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.auth.ui
 
 import android.content.ActivityNotFoundException

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.auth.ui
 
 import androidx.lifecycle.LiveData

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/notifications/CustomUriNotification.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/notifications/CustomUriNotification.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.customuri.notifications
 
 import android.app.NotificationChannel

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/ui/CustomUriHandlerActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/ui/CustomUriHandlerActivity.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.customuri.ui
 
 import android.app.NotificationManager

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/ui/CustomUriViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/customuri/ui/CustomUriViewModel.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.customuri.ui
 
 import android.content.Intent

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/permission/vpn/ui/VpnPermissionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/permission/vpn/ui/VpnPermissionActivity.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.permission.vpn.ui
 
 import android.app.Activity

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.session.ui
 
 import android.content.ClipData

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.session.ui
 
 import dev.firezone.android.core.data.ResourceState

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.session.ui
 
 import android.view.LayoutInflater

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.session.ui
 
 import android.content.ComponentName

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.session.ui
 
 import android.view.View

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.settings.ui
 
 import android.os.Bundle

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/GeneralSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/GeneralSettingsFragment.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.settings.ui
 
 import android.os.Bundle

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/LogSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/LogSettingsFragment.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.settings.ui
 
 import android.os.Bundle

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.settings.ui
 
 import android.os.Bundle

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.settings.ui
 
 import android.content.Context

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInFragment.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.signin.ui
 
 import android.content.Intent

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.splash.ui
 
 import android.content.Intent

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.features.splash.ui
 
 import android.content.Context

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.Network

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.Network

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.tunnel
 
 import DisconnectMonitor

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelStatusNotification.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelStatusNotification.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.tunnel
 
 import android.app.Notification

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Cidr.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Cidr.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.tunnel.model
 
 import android.os.Parcelable

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.tunnel.model
 
 import android.os.Parcelable

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Site.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Site.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.tunnel.model
 
 import android.os.Parcelable

--- a/kotlin/android/app/src/test/java/dev/firezone/android/core/SampleTest.kt
+++ b/kotlin/android/app/src/test/java/dev/firezone/android/core/SampleTest.kt
@@ -1,4 +1,4 @@
-/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
 package dev.firezone.android.core
 
 import org.junit.Assert.assertTrue


### PR DESCRIPTION
Makes it easier to run `ktlint` standalone - otherwise, it's a wrong comment format and it tries to reformat it every time.