### PR TITLE
refactor(portal): move relay tokens to separate table

### DIFF
--- a/elixir/apps/domain/lib/domain/changes/hooks/relay_tokens.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/relay_tokens.ex
@@ -1,0 +1,30 @@
+defmodule Domain.Changes.Hooks.RelayTokens do
+  @behaviour Domain.Changes.Hooks
+  alias Domain.PubSub
+  import Domain.SchemaHelpers
+
+  @impl true
+  def on_insert(_lsn, _data), do: :ok
+
+  @impl true
+  def on_update(_lsn, _old_data, _new_data), do: :ok
+
+  @impl true
+  def on_delete(_lsn, old_data) do
+    token = struct_from_params(Domain.Token, old_data)
+
+    # We don't need to broadcast deleted tokens since the disconnect_socket/1
+    # function will handle any disconnects for us directly.
+
+    # Disconnect all sockets using this token
+    disconnect_socket(token)
+  end
+
+  # This is a special message that disconnects all sockets using this token,
+  # such as for LiveViews.
+  defp disconnect_socket(token) do
+    topic = Domain.Auth.socket_id(token.id)
+    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
+    PubSub.broadcast(topic, payload)
+  end
+end

--- a/elixir/apps/domain/lib/domain/changes/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/changes/replication_connection.ex
@@ -20,7 +20,8 @@ defmodule Domain.Changes.ReplicationConnection do
     "userpass_auth_providers" => Hooks.AuthProviders,
     "entra_directories" => Hooks.Directories,
     "okta_directories" => Hooks.Directories,
-    "google_directories" => Hooks.Directories
+    "google_directories" => Hooks.Directories,
+    "relay_tokens" => Hooks.RelayTokens
   }
 
   def on_write(state, lsn, op, table, old_data, data) do

--- a/elixir/apps/domain/lib/domain/relay_token.ex
+++ b/elixir/apps/domain/lib/domain/relay_token.ex
@@ -1,0 +1,20 @@
+defmodule Domain.RelayToken do
+  use Ecto.Schema
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "relay_tokens" do
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    field :secret_hash, :string, redact: true
+    field :secret_salt, :string, redact: true
+
+    # Used only during creation
+    field :secret_fragment, :string, virtual: true, redact: true
+    field :secret_nonce, :string, virtual: true, redact: true
+
+    timestamps(updated_at: false)
+  end
+end

--- a/elixir/apps/domain/lib/domain/token.ex
+++ b/elixir/apps/domain/lib/domain/token.ex
@@ -16,7 +16,6 @@ defmodule Domain.Token do
         :browser,
         :client,
         :api_client,
-        :relay,
         :site,
         :email
       ]

--- a/elixir/apps/domain/priv/repo/migrations/20251210043454_move_relay_tokens_to_dedicated_table.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251210043454_move_relay_tokens_to_dedicated_table.exs
@@ -1,0 +1,45 @@
+defmodule Domain.Repo.Migrations.MoveRelayTokensToDedicatedTable do
+  use Ecto.Migration
+
+  def change do
+    # Create the new relay_tokens table
+    create table(:relay_tokens, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:secret_salt, :string, null: false)
+      add(:secret_hash, :string, null: false)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    # Migrate existing relay tokens from tokens table
+    execute(
+      """
+      INSERT INTO relay_tokens (id, secret_salt, secret_hash, inserted_at)
+      SELECT id, secret_salt, secret_hash, inserted_at
+      FROM tokens
+      WHERE type = 'relay'
+      """,
+      """
+      INSERT INTO tokens (id, type, secret_salt, secret_hash, inserted_at, updated_at)
+      SELECT id, 'relay', secret_salt, secret_hash, inserted_at, inserted_at
+      FROM relay_tokens
+      """
+    )
+
+    # Delete relay tokens from the tokens table
+    execute(
+      "DELETE FROM tokens WHERE type = 'relay'",
+      # No-op on rollback
+      ""
+    )
+
+    # Update the type constraint to remove 'relay'
+    drop(constraint(:tokens, :type_must_be_valid))
+
+    create(
+      constraint(:tokens, :type_must_be_valid,
+        check: "type IN ('browser', 'client', 'api_client', 'site', 'email')"
+      )
+    )
+  end
+end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -122,6 +122,7 @@ config :domain, Domain.Changes.ReplicationConnection,
     entra_directories
     okta_directories
     google_directories
+    relay_tokens
   ],
   # Allow up to 60 seconds of lag before alerting
   warning_threshold: :timer.seconds(60),


### PR DESCRIPTION
Moves the relay token type to a dedicated table, preserving all existing tokens in the process.

All fields unused / unneeded by relay tokens are removed for simplicity / clarity.

Additionally a `create_relay_token/0` helper is added to Domain.Auth to make it easy to create these for deployments if needed.

Fixes #11094