### PR TITLE
refactor(portal): move gateway tokens to dedicated table

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -38,6 +38,7 @@ jobs:
           mix test apps/api/test/api/relay/channel_test.exs
           mix test apps/api/test/api/controllers
           mix test apps/domain/test/domain/auth_test.exs
+          mix test apps/domain/test/domain/gateway_token_test.exs
           # mix_test="mix test --warnings-as-errors --exclude flaky:true --exclude acceptance:true"
           # $mix_test || $mix_test --failed
       - name: Test Report

--- a/elixir/apps/api/lib/api/controllers/gateway_token_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/gateway_token_controller.ex
@@ -1,0 +1,134 @@
+defmodule API.GatewayTokenController do
+  use API, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias Domain.{Auth, Safe}
+  alias __MODULE__.DB
+
+  action_fallback API.FallbackController
+
+  tags ["Gateway Tokens"]
+
+  operation :create,
+    summary: "Create a Gateway Token",
+    parameters: [
+      site_id: [
+        in: :path,
+        description: "Site ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
+    responses: [
+      ok: {"New Token Response", "application/json", API.Schemas.GatewayToken.Response}
+    ]
+
+  def create(conn, %{"site_id" => site_id}) do
+    subject = conn.assigns.subject
+
+    with {:ok, site} <- DB.fetch_site(site_id, subject),
+         {:ok, token} <- Auth.create_gateway_token(site, subject) do
+      conn
+      |> put_status(:created)
+      |> render(:show, token: token, encoded_token: Auth.encode_fragment!(token))
+    end
+  end
+
+  operation :delete,
+    summary: "Delete a Gateway Token",
+    parameters: [
+      site_id: [
+        in: :path,
+        description: "Site ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ],
+      id: [
+        in: :path,
+        description: "Token ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
+    responses: [
+      ok: {"Deleted Token Response", "application/json", API.Schemas.GatewayToken.DeletedResponse}
+    ]
+
+  def delete(conn, %{"site_id" => _site_id, "id" => token_id}) do
+    subject = conn.assigns.subject
+
+    with {:ok, token} <- DB.fetch_token(token_id, subject),
+         {:ok, deleted_token} <- DB.delete_token(token, subject) do
+      render(conn, :deleted, token: deleted_token)
+    end
+  end
+
+  operation :delete_all,
+    summary: "Delete all Gateway Tokens for a Site",
+    parameters: [
+      site_id: [
+        in: :path,
+        description: "Site ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
+    responses: [
+      ok:
+        {"Deleted Tokens Response", "application/json",
+         API.Schemas.GatewayToken.DeletedAllResponse}
+    ]
+
+  def delete_all(conn, %{"site_id" => site_id}) do
+    subject = conn.assigns.subject
+
+    with {:ok, site} <- DB.fetch_site(site_id, subject),
+         {deleted_count, _} <- DB.delete_all_tokens(site, subject) do
+      render(conn, :deleted_all, count: deleted_count)
+    end
+  end
+
+  defmodule DB do
+    import Ecto.Query
+    alias Domain.Safe
+    alias Domain.{Site, GatewayToken}
+
+    def fetch_site(id, subject) do
+      result =
+        from(s in Site, as: :sites)
+        |> where([sites: s], s.id == ^id)
+        |> Safe.scoped(subject)
+        |> Safe.one()
+
+      case result do
+        nil -> {:error, :not_found}
+        {:error, :unauthorized} -> {:error, :unauthorized}
+        site -> {:ok, site}
+      end
+    end
+
+    def fetch_token(id, subject) do
+      result =
+        from(t in GatewayToken, where: t.id == ^id)
+        |> Safe.scoped(subject)
+        |> Safe.one()
+
+      case result do
+        nil -> {:error, :not_found}
+        {:error, :unauthorized} -> {:error, :unauthorized}
+        token -> {:ok, token}
+      end
+    end
+
+    def delete_token(token, subject) do
+      token
+      |> Safe.scoped(subject)
+      |> Safe.delete()
+    end
+
+    def delete_all_tokens(site, subject) do
+      from(t in GatewayToken, where: t.site_id == ^site.id)
+      |> Safe.scoped(subject)
+      |> Safe.delete_all()
+    end
+  end
+end

--- a/elixir/apps/api/lib/api/controllers/gateway_token_json.ex
+++ b/elixir/apps/api/lib/api/controllers/gateway_token_json.ex
@@ -1,0 +1,26 @@
+defmodule API.GatewayTokenJSON do
+  def show(%{token: token, encoded_token: encoded_token}) do
+    %{
+      data: %{
+        id: token.id,
+        token: encoded_token
+      }
+    }
+  end
+
+  def deleted(%{token: token}) do
+    %{
+      data: %{
+        id: token.id
+      }
+    }
+  end
+
+  def deleted_all(%{count: count}) do
+    %{
+      data: %{
+        deleted_count: count
+      }
+    }
+  end
+end

--- a/elixir/apps/api/lib/api/controllers/site_json.ex
+++ b/elixir/apps/api/lib/api/controllers/site_json.ex
@@ -18,36 +18,6 @@ defmodule API.SiteJSON do
     %{data: data(site)}
   end
 
-  @doc """
-  Render a Site Token
-  """
-  def token(%{token: token, encoded_token: encoded_token}) do
-    %{
-      data: %{
-        id: token.id,
-        token: encoded_token
-      }
-    }
-  end
-
-  @doc """
-  Render a deleted Site Token
-  """
-  def deleted_token(%{token: token}) do
-    %{
-      data: %{
-        id: token.id
-      }
-    }
-  end
-
-  @doc """
-  Render all deleted Site Tokens
-  """
-  def deleted_tokens(%{count: count}) do
-    %{data: %{deleted_count: count}}
-  end
-
   defp data(%Domain.Site{} = site) do
     %{
       id: site.id,

--- a/elixir/apps/api/lib/api/router.ex
+++ b/elixir/apps/api/lib/api/router.ex
@@ -51,9 +51,9 @@ defmodule API.Router do
     resources "/policies", PolicyController, except: [:new, :edit]
 
     resources "/sites", SiteController, except: [:new, :edit] do
-      post "/tokens", SiteController, :create_token
-      delete "/tokens", SiteController, :delete_all_tokens
-      delete "/tokens/:id", SiteController, :delete_token
+      post "/gateway_tokens", GatewayTokenController, :create
+      delete "/gateway_tokens", GatewayTokenController, :delete_all
+      delete "/gateway_tokens/:id", GatewayTokenController, :delete
       resources "/gateways", GatewayController, except: [:new, :edit, :create, :update]
     end
 

--- a/elixir/apps/api/lib/api/schemas/gateway_token_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/gateway_token_schema.ex
@@ -1,4 +1,4 @@
-defmodule API.Schemas.SiteToken do
+defmodule API.Schemas.GatewayToken do
   alias OpenApiSpex.Schema
 
   defmodule Schema do
@@ -6,12 +6,12 @@ defmodule API.Schemas.SiteToken do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "SiteToken",
-      description: "Site Token",
+      title: "GatewayToken",
+      description: "Gateway Token",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Site Token ID"},
-        token: %Schema{type: :string, description: "Site Token"}
+        id: %Schema{type: :string, description: "Gateway Token ID"},
+        token: %Schema{type: :string, description: "Gateway Token"}
       },
       required: [:id, :token],
       example: %{
@@ -21,17 +21,16 @@ defmodule API.Schemas.SiteToken do
     })
   end
 
-  defmodule NewToken do
+  defmodule Response do
     require OpenApiSpex
-    alias OpenApiSpex.Schema
-    alias API.Schemas.SiteToken
+    alias API.Schemas.GatewayToken
 
     OpenApiSpex.schema(%{
-      title: "NewSiteTokenResponse",
-      description: "Response schema for a new Site Token",
+      title: "GatewayTokenResponse",
+      description: "Response schema for a new Gateway Token",
       type: :object,
       properties: %{
-        data: SiteToken.Schema
+        data: GatewayToken.Schema
       },
       example: %{
         "data" => %{
@@ -42,17 +41,22 @@ defmodule API.Schemas.SiteToken do
     })
   end
 
-  defmodule DeletedToken do
+  defmodule DeletedResponse do
     require OpenApiSpex
     alias OpenApiSpex.Schema
-    alias API.Schemas.SiteToken
 
     OpenApiSpex.schema(%{
-      title: "DeletedSiteTokenResponse",
-      description: "Response schema for a new Site Token",
+      title: "DeletedGatewayTokenResponse",
+      description: "Response schema for a deleted Gateway Token",
       type: :object,
       properties: %{
-        data: SiteToken.Schema
+        data: %Schema{
+          type: :object,
+          properties: %{
+            id: %Schema{type: :string, description: "Gateway Token ID"}
+          },
+          required: [:id]
+        }
       },
       example: %{
         "data" => %{
@@ -62,13 +66,13 @@ defmodule API.Schemas.SiteToken do
     })
   end
 
-  defmodule DeletedTokens do
+  defmodule DeletedAllResponse do
     require OpenApiSpex
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "DeletedSiteTokenListResponse",
-      description: "Response schema for deleted Site Tokens",
+      title: "DeletedGatewayTokensResponse",
+      description: "Response schema for deleted Gateway Tokens",
       type: :object,
       properties: %{
         data: %Schema{

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -60,13 +60,13 @@ defmodule API.Client.ChannelTest do
     client = client_fixture(account: account, actor: actor)
 
     site = site_fixture(account: account)
-    site_token = site_token_fixture(account: account, site: site)
+    gateway_token = gateway_token_fixture(account: account, site: site)
     gateway = gateway_fixture(account: account, site: site)
 
     internet_site = internet_site_fixture(account: account)
 
-    internet_site_token =
-      site_token_fixture(account: account, site: internet_site)
+    internet_gateway_token =
+      gateway_token_fixture(account: account, site: internet_site)
 
     internet_gateway =
       gateway_fixture(account: account, site: internet_site)
@@ -188,12 +188,12 @@ defmodule API.Client.ChannelTest do
       identity: identity,
       subject: subject,
       client: client,
-      site_token: site_token,
+      gateway_token: gateway_token,
       site: site,
       membership: membership,
       gateway: gateway,
       internet_site: internet_site,
-      internet_site_token: internet_site_token,
+      internet_gateway_token: internet_gateway_token,
       internet_gateway: internet_gateway,
       dns_resource: dns_resource,
       cidr_resource: cidr_resource,
@@ -1956,8 +1956,8 @@ defmodule API.Client.ChannelTest do
       resource = resource_fixture(account: account)
 
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       attrs = %{
         "resource_id" => resource.id,
@@ -2027,8 +2027,8 @@ defmodule API.Client.ChannelTest do
       }
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       push(socket, "create_flow", attrs)
 
@@ -2048,8 +2048,8 @@ defmodule API.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2069,7 +2069,7 @@ defmodule API.Client.ChannelTest do
       dns_resource_policy: policy,
       membership: membership,
       client: client,
-      site_token: site_token,
+      gateway_token: gateway_token,
       gateway: gateway,
       global_relay: global_relay,
       global_relay_token: global_relay_token,
@@ -2084,8 +2084,8 @@ defmodule API.Client.ChannelTest do
       )
 
       :ok = PubSub.Account.subscribe(gateway.account_id)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      :ok = PubSub.subscribe(Auth.socket_id(site_token.id))
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      :ok = PubSub.subscribe(Auth.socket_id(gateway_token.id))
 
       # Prime cache
       send(socket.channel_pid, {:created, resource})
@@ -2144,9 +2144,9 @@ defmodule API.Client.ChannelTest do
       )
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      PubSub.subscribe(Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      PubSub.subscribe(Auth.socket_id(gateway_token.id))
 
       send(socket.channel_pid, {:created, resource})
       send(socket.channel_pid, {:created, policy})
@@ -2180,7 +2180,7 @@ defmodule API.Client.ChannelTest do
       dns_resource_policy: policy,
       membership: membership,
       client: client,
-      site_token: site_token,
+      gateway_token: gateway_token,
       gateway: gateway,
       subject: subject,
       global_relay: global_relay,
@@ -2199,8 +2199,8 @@ defmodule API.Client.ChannelTest do
         last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
       )
 
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      PubSub.subscribe(Auth.socket_id(site_token.id))
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      PubSub.subscribe(Auth.socket_id(gateway_token.id))
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2308,9 +2308,9 @@ defmodule API.Client.ChannelTest do
       )
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      PubSub.subscribe(Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      PubSub.subscribe(Auth.socket_id(gateway_token.id))
 
       :ok = PubSub.Account.subscribe(account.id)
 
@@ -2358,8 +2358,8 @@ defmodule API.Client.ChannelTest do
         )
         |> Repo.preload(:site)
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       :ok = PubSub.Account.subscribe(account.id)
 
@@ -2392,8 +2392,8 @@ defmodule API.Client.ChannelTest do
         )
         |> Repo.preload(:site)
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2432,9 +2432,9 @@ defmodule API.Client.ChannelTest do
         )
         |> Repo.preload(:site)
 
-      site_token = site_token_fixture(account: account, site: gateway1.site)
+      gateway_token = gateway_token_fixture(account: account, site: gateway1.site)
 
-      :ok = Presence.Gateways.connect(gateway1, site_token.id)
+      :ok = Presence.Gateways.connect(gateway1, gateway_token.id)
 
       gateway2 =
         gateway_fixture(
@@ -2442,7 +2442,7 @@ defmodule API.Client.ChannelTest do
           site: site
         )
 
-      :ok = Presence.Gateways.connect(gateway2, site_token.id)
+      :ok = Presence.Gateways.connect(gateway2, gateway_token.id)
 
       :ok = PubSub.Account.subscribe(account.id)
 
@@ -2518,8 +2518,8 @@ defmodule API.Client.ChannelTest do
       resource = resource_fixture(account: account)
 
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       attrs = %{
         "resource_id" => resource.id
@@ -2537,8 +2537,8 @@ defmodule API.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
       assert_reply ref, :error, %{reason: :offline}
@@ -2562,8 +2562,8 @@ defmodule API.Client.ChannelTest do
       )
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
       resource_id = resource.id
@@ -2587,8 +2587,8 @@ defmodule API.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => dns_resource.id})
       assert_reply ref, :error, %{reason: :offline}
@@ -2639,8 +2639,8 @@ defmodule API.Client.ChannelTest do
           resource: resource
         )
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
       resource_id = resource.id
@@ -2660,8 +2660,8 @@ defmodule API.Client.ChannelTest do
         last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
       )
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
       :ok = PubSub.Account.subscribe(account.id)
 
       send(socket.channel_pid, %Changes.Change{
@@ -2728,8 +2728,8 @@ defmodule API.Client.ChannelTest do
         )
         |> Repo.preload(:site)
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
       resource_id = resource.id
@@ -2749,8 +2749,8 @@ defmodule API.Client.ChannelTest do
         last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
       )
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
 
@@ -2795,8 +2795,8 @@ defmodule API.Client.ChannelTest do
       )
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
 
@@ -2830,8 +2830,8 @@ defmodule API.Client.ChannelTest do
         )
         |> Repo.preload(:site)
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       {:ok, _reply, socket} =
         API.Client.Socket
@@ -2854,8 +2854,8 @@ defmodule API.Client.ChannelTest do
         )
         |> Repo.preload(:site)
 
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
 
@@ -2906,8 +2906,8 @@ defmodule API.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       attrs = %{
         "resource_id" => resource.id,
@@ -2957,8 +2957,8 @@ defmodule API.Client.ChannelTest do
       }
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
       :ok = PubSub.Account.subscribe(account.id)
 
       send(socket.channel_pid, {:created, resource})
@@ -2981,8 +2981,8 @@ defmodule API.Client.ChannelTest do
       resource = resource_fixture(account: account)
 
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       attrs = %{
         "resource_id" => resource.id,
@@ -3027,8 +3027,8 @@ defmodule API.Client.ChannelTest do
       client_id = client.id
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
       :ok = PubSub.Account.subscribe(resource.account_id)
 
       send(socket.channel_pid, %Changes.Change{
@@ -3109,9 +3109,9 @@ defmodule API.Client.ChannelTest do
         |> subscribe_and_join(API.Client.Channel, "client")
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      Phoenix.PubSub.subscribe(PubSub, Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      Phoenix.PubSub.subscribe(PubSub, Auth.socket_id(gateway_token.id))
 
       :ok = PubSub.Account.subscribe(account.id)
 
@@ -3176,8 +3176,8 @@ defmodule API.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       attrs = %{
         "resource_id" => resource.id,
@@ -3199,8 +3199,8 @@ defmodule API.Client.ChannelTest do
       resource = resource_fixture(account: account)
 
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       attrs = %{
         "resource_id" => resource.id,
@@ -3252,8 +3252,8 @@ defmodule API.Client.ChannelTest do
       }
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
 
       :ok = PubSub.Account.subscribe(account.id)
 
@@ -3314,9 +3314,9 @@ defmodule API.Client.ChannelTest do
       client_id = client.id
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      PubSub.subscribe(Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      PubSub.subscribe(Auth.socket_id(gateway_token.id))
 
       :ok = PubSub.Account.subscribe(resource.account_id)
 
@@ -3381,9 +3381,9 @@ defmodule API.Client.ChannelTest do
         |> subscribe_and_join(API.Client.Channel, "client")
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      Phoenix.PubSub.subscribe(PubSub, Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      Phoenix.PubSub.subscribe(PubSub, Auth.socket_id(gateway_token.id))
 
       :ok = PubSub.Account.subscribe(account.id)
 
@@ -3432,9 +3432,9 @@ defmodule API.Client.ChannelTest do
       }
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      PubSub.subscribe(Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      PubSub.subscribe(Auth.socket_id(gateway_token.id))
 
       :ok = PubSub.Account.subscribe(client.account_id)
 
@@ -3479,9 +3479,9 @@ defmodule API.Client.ChannelTest do
       }
 
       gateway = Repo.preload(gateway, :site)
-      site_token = site_token_fixture(account: account, site: gateway.site)
-      :ok = Presence.Gateways.connect(gateway, site_token.id)
-      :ok = PubSub.subscribe(Auth.socket_id(site_token.id))
+      gateway_token = gateway_token_fixture(account: account, site: gateway.site)
+      :ok = Presence.Gateways.connect(gateway, gateway_token.id)
+      :ok = PubSub.subscribe(Auth.socket_id(gateway_token.id))
       :ok = PubSub.Account.subscribe(client.account_id)
 
       push(socket, "broadcast_invalidated_ice_candidates", attrs)

--- a/elixir/apps/api/test/api/controllers/gateway_token_controller_test.exs
+++ b/elixir/apps/api/test/api/controllers/gateway_token_controller_test.exs
@@ -1,0 +1,96 @@
+defmodule API.GatewayTokenControllerTest do
+  use API.ConnCase, async: true
+  alias Domain.GatewayToken
+
+  import Domain.AccountFixtures
+  import Domain.ActorFixtures
+  import Domain.SiteFixtures
+  import Domain.TokenFixtures
+
+  setup do
+    account = account_fixture()
+    actor = actor_fixture(type: :api_client, account: account)
+
+    %{
+      account: account,
+      actor: actor
+    }
+  end
+
+  describe "create/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      site = site_fixture(%{account: account})
+      conn = post(conn, "/sites/#{site.id}/gateway_tokens")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "creates a gateway token", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(%{account: account})
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/sites/#{site.id}/gateway_tokens")
+
+      assert %{"data" => %{"id" => _id, "token" => _token}} = json_response(conn, 201)
+    end
+  end
+
+  describe "delete/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      site = site_fixture(%{account: account})
+      token = gateway_token_fixture(account: account, site: site)
+      conn = delete(conn, "/sites/#{site.id}/gateway_tokens/#{token.id}")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "deletes gateway token", %{conn: conn, account: account, actor: actor} do
+      site = site_fixture(%{account: account})
+      token = gateway_token_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> delete("/sites/#{site.id}/gateway_tokens/#{token.id}")
+
+      assert %{"data" => %{"id" => _id}} = json_response(conn, 200)
+
+      refute Repo.get_by(GatewayToken, id: token.id, account_id: token.account_id)
+    end
+  end
+
+  describe "delete_all/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      site = site_fixture(%{account: account})
+      conn = delete(conn, "/sites/#{site.id}/gateway_tokens")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "deletes all gateway tokens", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+
+      tokens = for _ <- 1..3, do: gateway_token_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> delete("/sites/#{site.id}/gateway_tokens")
+
+      assert %{"data" => %{"deleted_count" => 3}} = json_response(conn, 200)
+
+      Enum.each(tokens, fn token ->
+        refute Repo.get_by(GatewayToken, id: token.id, account_id: token.account_id)
+      end)
+    end
+  end
+end

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -38,7 +38,7 @@ defmodule API.Gateway.ChannelTest do
 
     policy = policy_fixture(account: account, group: group, resource: resource)
 
-    token = site_token_fixture(site: site, account: account)
+    token = gateway_token_fixture(site: site, account: account)
 
     {:ok, _, socket} =
       API.Gateway.Socket

--- a/elixir/apps/domain/lib/domain/account.ex
+++ b/elixir/apps/domain/lib/domain/account.ex
@@ -43,6 +43,7 @@ defmodule Domain.Account do
     has_many :sites, Domain.Site
 
     has_many :tokens, Domain.Token
+    has_many :gateway_tokens, Domain.GatewayToken
 
     has_many :google_directories, Domain.Google.Directory
     has_many :google_auth_providers, Domain.Google.AuthProvider

--- a/elixir/apps/domain/lib/domain/billing/event_handler.ex
+++ b/elixir/apps/domain/lib/domain/billing/event_handler.ex
@@ -477,7 +477,7 @@ defmodule Domain.Billing.EventHandler do
     %Domain.Site{
       account_id: account.id,
       managed_by: :account,
-      tokens: []
+      gateway_tokens: []
     }
     |> cast(attrs, [:name])
     |> validate_required([:name])

--- a/elixir/apps/domain/lib/domain/changes/hooks/gateway_tokens.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/gateway_tokens.ex
@@ -1,0 +1,25 @@
+defmodule Domain.Changes.Hooks.GatewayTokens do
+  @behaviour Domain.Changes.Hooks
+  alias Domain.PubSub
+  import Domain.SchemaHelpers
+
+  @impl true
+  def on_insert(_lsn, _data), do: :ok
+
+  @impl true
+  def on_update(_lsn, _old_data, _new_data), do: :ok
+
+  @impl true
+  def on_delete(_lsn, old_data) do
+    token = struct_from_params(Domain.GatewayToken, old_data)
+
+    # Disconnect all sockets using this token
+    disconnect_socket(token)
+  end
+
+  defp disconnect_socket(token) do
+    topic = Domain.Auth.socket_id(token.id)
+    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
+    PubSub.broadcast(topic, payload)
+  end
+end

--- a/elixir/apps/domain/lib/domain/changes/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/changes/replication_connection.ex
@@ -8,6 +8,7 @@ defmodule Domain.Changes.ReplicationConnection do
     "clients" => Hooks.Clients,
     "policy_authorizations" => Hooks.PolicyAuthorizations,
     "gateways" => Hooks.Gateways,
+    "gateway_tokens" => Hooks.GatewayTokens,
     "sites" => Hooks.Sites,
     "policies" => Hooks.Policies,
     "resources" => Hooks.Resources,

--- a/elixir/apps/domain/lib/domain/gateway_token.ex
+++ b/elixir/apps/domain/lib/domain/gateway_token.ex
@@ -1,0 +1,30 @@
+defmodule Domain.GatewayToken do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "gateway_tokens" do
+    belongs_to :account, Domain.Account, primary_key: true
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    belongs_to :site, Domain.Site
+
+    field :secret_hash, :string, redact: true
+    field :secret_salt, :string, redact: true
+
+    # Used only during creation
+    field :secret_fragment, :string, virtual: true, redact: true
+    field :secret_nonce, :string, virtual: true, redact: true
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:site)
+  end
+end

--- a/elixir/apps/domain/lib/domain/safe.ex
+++ b/elixir/apps/domain/lib/domain/safe.ex
@@ -665,6 +665,10 @@ defmodule Domain.Safe do
   def permit(_action, Domain.Site, :api_client), do: :ok
   def permit(:read, Domain.Site, _), do: :ok
 
+  # GatewayToken permissions
+  def permit(_action, Domain.GatewayToken, :account_admin_user), do: :ok
+  def permit(_action, Domain.GatewayToken, :api_client), do: :ok
+
   # Resource permissions
   def permit(_action, Domain.Resource, :account_admin_user), do: :ok
   def permit(_action, Domain.Resource, :api_client), do: :ok

--- a/elixir/apps/domain/lib/domain/site.ex
+++ b/elixir/apps/domain/lib/domain/site.ex
@@ -21,10 +21,10 @@ defmodule Domain.Site do
 
     field :name, :string
 
-    field :managed_by, Ecto.Enum, values: ~w[account system]a, defauilt: :account
+    field :managed_by, Ecto.Enum, values: ~w[account system]a, default: :account
 
     has_many :gateways, Domain.Gateway, references: :id
-    has_many :tokens, Domain.Token, references: :id
+    has_many :gateway_tokens, Domain.GatewayToken, references: :id
     has_many :resources, Domain.Resource, references: :id
 
     timestamps()

--- a/elixir/apps/domain/lib/domain/token.ex
+++ b/elixir/apps/domain/lib/domain/token.ex
@@ -16,7 +16,6 @@ defmodule Domain.Token do
         :browser,
         :client,
         :api_client,
-        :site,
         :email
       ]
 
@@ -27,8 +26,6 @@ defmodule Domain.Token do
 
     # set for browser and client tokens
     belongs_to :actor, Domain.Actor
-    # set for gateway tokens
-    belongs_to :site, Domain.Site
 
     # we store just hash(nonce+fragment+salt)
     field :secret_nonce, :string, virtual: true, redact: true
@@ -59,7 +56,6 @@ defmodule Domain.Token do
     |> assoc_constraint(:account)
     |> assoc_constraint(:actor)
     |> assoc_constraint(:auth_provider)
-    |> assoc_constraint(:site)
     |> check_constraint(:type, name: :type_must_be_valid)
     |> unique_constraint(:secret_hash)
   end

--- a/elixir/apps/domain/priv/repo/migrations/20251210055333_move_gateway_tokens_to_dedicated_table.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251210055333_move_gateway_tokens_to_dedicated_table.exs
@@ -1,0 +1,63 @@
+defmodule Domain.Repo.Migrations.MoveGatewayTokensToDedicatedTable do
+  use Ecto.Migration
+
+  def change do
+    # Create the new gateway_tokens table
+    create table(:gateway_tokens, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id), primary_key: true, null: false)
+      add(:id, :uuid, primary_key: true)
+      add(:site_id, :binary_id, null: false)
+      add(:secret_salt, :string, null: false)
+      add(:secret_hash, :string, null: false)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    # Composite foreign key for (account_id, site_id) -> sites(account_id, id)
+    execute(
+      """
+      ALTER TABLE gateway_tokens
+      ADD CONSTRAINT gateway_tokens_site_id_fkey
+      FOREIGN KEY (account_id, site_id) REFERENCES sites(account_id, id) ON DELETE CASCADE
+      """,
+      "ALTER TABLE gateway_tokens DROP CONSTRAINT gateway_tokens_site_id_fkey"
+    )
+
+    create(index(:gateway_tokens, [:site_id]))
+
+    # Migrate existing site tokens from tokens table
+    execute(
+      """
+      INSERT INTO gateway_tokens (account_id, id, site_id, secret_salt, secret_hash, inserted_at)
+      SELECT account_id, id, site_id, secret_salt, secret_hash, inserted_at
+      FROM tokens
+      WHERE type = 'site'
+      """,
+      """
+      INSERT INTO tokens (account_id, id, type, site_id, secret_salt, secret_hash, inserted_at, updated_at)
+      SELECT account_id, id, 'site', site_id, secret_salt, secret_hash, inserted_at, inserted_at
+      FROM gateway_tokens
+      """
+    )
+
+    # Delete site tokens from the tokens table
+    execute(
+      "DELETE FROM tokens WHERE type = 'site'",
+      "SELECT 1"
+    )
+
+    # Update the type constraint to remove 'site'
+    drop(constraint(:tokens, :type_must_be_valid))
+
+    create(
+      constraint(:tokens, :type_must_be_valid,
+        check: "type IN ('browser', 'client', 'api_client', 'email')"
+      )
+    )
+
+    # Drop the site_id column from tokens table (also drops FK constraint and index)
+    alter table(:tokens) do
+      remove(:site_id, references(:sites, type: :binary_id))
+    end
+  end
+end

--- a/elixir/apps/domain/test/domain/gateway_token_test.exs
+++ b/elixir/apps/domain/test/domain/gateway_token_test.exs
@@ -1,0 +1,53 @@
+defmodule Domain.GatewayTokenTest do
+  use Domain.DataCase, async: true
+  import Ecto.Changeset
+  import Domain.AccountFixtures
+  import Domain.SiteFixtures
+
+  alias Domain.GatewayToken
+
+  describe "changeset/1" do
+    test "returns error when account does not exist" do
+      attrs = attrs(%{account_id: Ecto.UUID.generate(), site_id: Ecto.UUID.generate()})
+
+      changeset =
+        %GatewayToken{}
+        |> change(attrs)
+        |> GatewayToken.changeset()
+
+      assert {:error, changeset} = Repo.insert(changeset)
+      assert {:account, {"does not exist", _}} = hd(changeset.errors)
+    end
+
+    test "returns error when site does not exist" do
+      account = account_fixture()
+      attrs = attrs(%{account_id: account.id, site_id: Ecto.UUID.generate()})
+
+      changeset =
+        %GatewayToken{}
+        |> change(attrs)
+        |> GatewayToken.changeset()
+
+      assert {:error, changeset} = Repo.insert(changeset)
+      assert {:site, {"does not exist", _}} = hd(changeset.errors)
+    end
+
+    test "inserts successfully with valid associations" do
+      site = site_fixture()
+      attrs = attrs(%{account_id: site.account_id, site_id: site.id})
+
+      changeset =
+        %GatewayToken{}
+        |> change(attrs)
+        |> GatewayToken.changeset()
+
+      assert {:ok, token} = Repo.insert(changeset)
+      assert token.account_id == site.account_id
+      assert token.site_id == site.id
+    end
+  end
+
+  defp attrs(overrides) do
+    Map.merge(%{secret_hash: "test_hash", secret_salt: "test_salt"}, overrides)
+  end
+end

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -476,7 +476,7 @@ defmodule Web.SignUp do
     %Domain.Site{
       account_id: account.id,
       managed_by: :account,
-      tokens: []
+      gateway_tokens: []
     }
     |> cast(attrs, [:name])
     |> validate_required([:name])
@@ -489,7 +489,7 @@ defmodule Web.SignUp do
     %Domain.Site{
       account_id: account.id,
       managed_by: :system,
-      tokens: []
+      gateway_tokens: []
     }
     |> cast(%{name: "Internet", managed_by: :system}, [:name, :managed_by])
     |> validate_required([:name, :managed_by])

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -522,7 +522,7 @@ defmodule Web.Sites.Show do
     end
 
     def delete_tokens_for_site(site, subject) do
-      from(t in Domain.Token, where: t.site_id == ^site.id)
+      from(t in Domain.GatewayToken, where: t.site_id == ^site.id)
       |> Safe.scoped(subject)
       |> Safe.delete_all()
     end
@@ -583,7 +583,7 @@ defmodule Web.Sites.Show do
         |> Safe.aggregate(:count)
 
       tokens =
-        from(t in Domain.Token, where: t.site_id == ^site.id)
+        from(t in Domain.GatewayToken, where: t.site_id == ^site.id)
         |> Safe.scoped(subject)
         |> Safe.aggregate(:count)
 

--- a/elixir/apps/web/test/web/live/gateways/show_test.exs
+++ b/elixir/apps/web/test/web/live/gateways/show_test.exs
@@ -100,8 +100,8 @@ defmodule Web.Live.Gateways.ShowTest do
     identity: identity,
     conn: conn
   } do
-    site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
-    :ok = Domain.Presence.Gateways.connect(gateway, site_token.id)
+    gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+    :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
 
     {:ok, lv, _html} =
       conn
@@ -149,8 +149,8 @@ defmodule Web.Live.Gateways.ShowTest do
       |> live(~p"/#{account}/gateways/#{gateway}")
 
     :ok = Domain.Presence.Gateways.Site.subscribe(gateway.site.id)
-    site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
-    :ok = Domain.Presence.Gateways.connect(gateway, site_token.id)
+    gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+    :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
     assert_receive %{topic: "presences:sites:" <> _}
 
     table =

--- a/elixir/apps/web/test/web/live/sites/show_test.exs
+++ b/elixir/apps/web/test/web/live/sites/show_test.exs
@@ -140,8 +140,8 @@ defmodule Web.Live.Sites.ShowTest do
       gateway: gateway,
       conn: conn
     } do
-      site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
-      :ok = Domain.Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+      :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
       Fixtures.Gateways.create_gateway(account: account, site: site)
 
       {:ok, lv, _html} =
@@ -377,8 +377,8 @@ defmodule Web.Live.Sites.ShowTest do
       gateway: gateway,
       conn: conn
     } do
-      site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
-      :ok = Domain.Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+      :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
       Fixtures.Gateways.create_gateway(account: account, site: site)
 
       {:ok, lv, _html} =
@@ -415,8 +415,8 @@ defmodule Web.Live.Sites.ShowTest do
         |> live(~p"/#{account}/sites/#{site}")
 
       :ok = Domain.Presence.Gateways.Site.subscribe(site.id)
-      site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
-      :ok = Domain.Presence.Gateways.connect(gateway, site_token.id)
+      gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+      :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
       assert_receive %Phoenix.Socket.Broadcast{topic: "presences:sites:#{gateway.site.id}"}
 
       wait_for(fn ->
@@ -602,7 +602,7 @@ defmodule Web.Live.Sites.ShowTest do
       gateway: gateway,
       conn: conn
     } do
-      site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+      gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
       :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
       Fixtures.Gateways.create_gateway(account: account, site: site)
 
@@ -640,7 +640,7 @@ defmodule Web.Live.Sites.ShowTest do
         |> live(~p"/#{account}/sites/#{site}")
 
       :ok = Domain.Presence.Gateways.Site.subscribe(site.id)
-      site_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
+      gateway_token = Fixtures.Sites.create_token(site: gateway.site, account: account)
       :ok = Domain.Presence.Gateways.connect(gateway, gateway_token.id)
       assert_receive %Phoenix.Socket.Broadcast{topic: "presences:sites:#{gateway.site.id}"}
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -68,6 +68,7 @@ config :domain, Domain.ChangeLogs.ReplicationConnection,
     clients
     sites
     gateways
+    gateway_tokens
     policies
     resources
     tokens
@@ -109,6 +110,7 @@ config :domain, Domain.Changes.ReplicationConnection,
     clients
     policy_authorizations
     gateways
+    gateway_tokens
     sites
     policies
     resources


### PR DESCRIPTION
Moves the gateway token type to its own dedicated table and updates views and controllers to use the new semantics. This is done to simplify / clarify tokens and authentication in general for better maintainability.

Fixes #11096 