### PR TITLE
refactor(portal): move email tokens to `one_time_passcodes`

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -39,6 +39,9 @@ jobs:
           mix test apps/api/test/api/controllers
           mix test apps/domain/test/domain/auth_test.exs
           mix test apps/domain/test/domain/gateway_token_test.exs
+          mix test apps/web/test/web/email_otp_test.exs
+          mix test apps/web/test/web/controllers/email_otp_controller_test.exs
+
           # mix_test="mix test --warnings-as-errors --exclude flaky:true --exclude acceptance:true"
           # $mix_test || $mix_test --failed
       - name: Test Report

--- a/elixir/apps/domain/lib/domain/account.ex
+++ b/elixir/apps/domain/lib/domain/account.ex
@@ -44,6 +44,7 @@ defmodule Domain.Account do
 
     has_many :tokens, Domain.Token
     has_many :gateway_tokens, Domain.GatewayToken
+    has_many :one_time_passcodes, Domain.OneTimePasscode
 
     has_many :google_directories, Domain.Google.Directory
     has_many :google_auth_providers, Domain.Google.AuthProvider

--- a/elixir/apps/domain/lib/domain/actor.ex
+++ b/elixir/apps/domain/lib/domain/actor.ex
@@ -23,6 +23,7 @@ defmodule Domain.Actor do
     has_many :identities, Domain.ExternalIdentity, references: :id
     has_many :clients, Domain.Client, preload_order: [desc: :last_seen_at], references: :id
     has_many :tokens, Domain.Token, references: :id
+    has_many :one_time_passcodes, Domain.OneTimePasscode, references: :id
     has_many :memberships, Domain.Membership, on_replace: :delete, references: :id
     has_many :groups, through: [:memberships, :group]
 

--- a/elixir/apps/domain/lib/domain/changes/hooks/tokens.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/tokens.ex
@@ -7,7 +7,6 @@ defmodule Domain.Changes.Hooks.Tokens do
   def on_insert(_lsn, _data), do: :ok
 
   @impl true
-  # updates for email and relay tokens have no side effects
   def on_update(_lsn, _old_data, _new_data), do: :ok
 
   @impl true

--- a/elixir/apps/domain/lib/domain/mailer/auth_email.ex
+++ b/elixir/apps/domain/lib/domain/mailer/auth_email.ex
@@ -50,7 +50,7 @@ defmodule Domain.Mailer.AuthEmail do
     |> to(actor.email)
     |> render_body(__MODULE__, :sign_in_link,
       account: actor.account,
-      client_platform: params["client_platform"],
+      client_sign_in: params["as"] == "client",
       sign_in_token_created_at: token_created_at,
       secret: secret,
       sign_in_url: sign_in_url,

--- a/elixir/apps/domain/lib/domain/mailer/auth_email/sign_in_link.html.eex
+++ b/elixir/apps/domain/lib/domain/mailer/auth_email/sign_in_link.html.eex
@@ -102,6 +102,7 @@
                     <p style="border-radius: 4px; border: 1px solid #e7e7e7; padding: 8px; text-align: center; font-size: 30px">
                       <code><%= @secret %></code>
                     </p>
+                    <%= unless @client_sign_in do %>
                     <p style="margin: 0; line-height: 24px;">
                       Or click the button below
                     </p>
@@ -124,6 +125,7 @@
                       </a>
                     </div>
                     <div role="separator" style="line-height: 16px">&zwj;</div>
+                    <% end %>
                     <p style="margin: 0; font-size: 12px; font-style: italic; line-height: 24px">
                       This email will only be valid for 15 minutes
                     </p>

--- a/elixir/apps/domain/lib/domain/mailer/auth_email/sign_in_link.text.eex
+++ b/elixir/apps/domain/lib/domain/mailer/auth_email/sign_in_link.text.eex
@@ -3,11 +3,11 @@ Finish Signing In!
 Copy and paste the following token into the Sign In form
 
 <%= @secret %>
-
+<%= unless @client_sign_in do %>
 or click on the following link if you are on the same device where you are trying to sign in:
 
 <%= @sign_in_url %>
-
+<% end %>
 This email is valid for 15 minutes.
 
 If you did not request this action and have received this email in error, you can safely ignore

--- a/elixir/apps/domain/lib/domain/one_time_passcode.ex
+++ b/elixir/apps/domain/lib/domain/one_time_passcode.ex
@@ -1,0 +1,21 @@
+defmodule Domain.OneTimePasscode do
+  use Ecto.Schema
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "one_time_passcodes" do
+    belongs_to :account, Domain.Account, primary_key: true
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    belongs_to :actor, Domain.Actor
+
+    field :code_hash, :string, redact: true
+    field :code, :string, virtual: true, redact: true
+
+    field :expires_at, :utc_datetime_usec
+
+    timestamps()
+  end
+end

--- a/elixir/apps/domain/lib/domain/token.ex
+++ b/elixir/apps/domain/lib/domain/token.ex
@@ -15,8 +15,7 @@ defmodule Domain.Token do
       values: [
         :browser,
         :client,
-        :api_client,
-        :email
+        :api_client
       ]
 
     field :name, :string

--- a/elixir/apps/domain/lib/domain/workers/delete_expired_one_time_passcodes.ex
+++ b/elixir/apps/domain/lib/domain/workers/delete_expired_one_time_passcodes.ex
@@ -1,0 +1,36 @@
+defmodule Domain.Workers.DeleteExpiredOneTimePasscodes do
+  @moduledoc """
+  Oban worker that deletes expired one-time passcodes.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: :infinity]
+
+  alias __MODULE__.DB
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    {count, _} = DB.delete_expired_passcodes()
+
+    Logger.info("Deleted #{count} expired one-time passcodes")
+
+    :ok
+  end
+
+  defmodule DB do
+    import Ecto.Query
+    alias Domain.OneTimePasscode
+    alias Domain.Safe
+
+    def delete_expired_passcodes do
+      from(p in OneTimePasscode, as: :passcodes)
+      |> where([passcodes: p], p.expires_at <= ^DateTime.utc_now())
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20251210163508_create_one_time_passcodes.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251210163508_create_one_time_passcodes.exs
@@ -25,6 +25,7 @@ defmodule Domain.Repo.Migrations.CreateOneTimePasscodes do
     )
 
     create(index(:one_time_passcodes, [:actor_id]))
+    create(index(:one_time_passcodes, [:expires_at]))
 
     # Delete all email tokens from the tokens table - these are short-lived, so should not cause
     # any real disruption

--- a/elixir/apps/domain/priv/repo/migrations/20251210163508_create_one_time_passcodes.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251210163508_create_one_time_passcodes.exs
@@ -1,0 +1,45 @@
+defmodule Domain.Repo.Migrations.CreateOneTimePasscodes do
+  use Ecto.Migration
+
+  def change do
+    create table(:one_time_passcodes, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id), primary_key: true, null: false)
+      add(:id, :uuid, primary_key: true)
+      add(:actor_id, :binary_id, null: false)
+
+      add(:code_hash, :string, null: false)
+
+      add(:expires_at, :utc_datetime_usec, null: false)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Composite foreign key for (account_id, actor_id) -> actors(account_id, id)
+    execute(
+      """
+      ALTER TABLE one_time_passcodes
+      ADD CONSTRAINT one_time_passcodes_actor_id_fkey
+      FOREIGN KEY (account_id, actor_id) REFERENCES actors(account_id, id) ON DELETE CASCADE
+      """,
+      "ALTER TABLE one_time_passcodes DROP CONSTRAINT one_time_passcodes_actor_id_fkey"
+    )
+
+    create(index(:one_time_passcodes, [:actor_id]))
+
+    # Delete all email tokens from the tokens table - these are short-lived, so should not cause
+    # any real disruption
+    execute(
+      "DELETE FROM tokens WHERE type = 'email'",
+      ""
+    )
+
+    # Update the type constraint to remove 'email'
+    drop(constraint(:tokens, :type_must_be_valid))
+
+    create(
+      constraint(:tokens, :type_must_be_valid,
+        check: "type IN ('browser', 'client', 'api_client')"
+      )
+    )
+  end
+end

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -734,12 +734,12 @@ defmodule Domain.AuthTest do
 
     test "verifies a valid one-time passcode" do
       account = account_fixture()
-      actor = actor_fixture(account: account)
+      actor = actor_fixture(account: account, allow_email_otp_sign_in: true)
 
       {:ok, passcode} = create_one_time_passcode(account, actor)
 
       assert {:ok, verified_passcode} =
-               verify_one_time_passcode(account.id, passcode.id, passcode.code)
+               verify_one_time_passcode(account.id, actor.id, passcode.id, passcode.code)
 
       assert verified_passcode.id == passcode.id
       assert verified_passcode.actor_id == actor.id
@@ -752,7 +752,7 @@ defmodule Domain.AuthTest do
       {:ok, passcode} = create_one_time_passcode(account, actor)
 
       assert {:error, :invalid_code} =
-               verify_one_time_passcode(account.id, passcode.id, "wrong")
+               verify_one_time_passcode(account.id, actor.id, passcode.id, "wrong")
     end
 
     test "fails to verify one-time passcode with wrong passcode_id" do
@@ -762,34 +762,50 @@ defmodule Domain.AuthTest do
       {:ok, passcode} = create_one_time_passcode(account, actor)
 
       assert {:error, :invalid_code} =
-               verify_one_time_passcode(account.id, Ecto.UUID.generate(), passcode.code)
+               verify_one_time_passcode(account.id, actor.id, Ecto.UUID.generate(), passcode.code)
     end
 
-    test "one-time passcode can only be used once" do
+    test "fails to verify one-time passcode with wrong actor_id" do
       account = account_fixture()
       actor = actor_fixture(account: account)
 
       {:ok, passcode} = create_one_time_passcode(account, actor)
 
-      assert {:ok, _} = verify_one_time_passcode(account.id, passcode.id, passcode.code)
+      assert {:error, :invalid_code} =
+               verify_one_time_passcode(
+                 account.id,
+                 Ecto.UUID.generate(),
+                 passcode.id,
+                 passcode.code
+               )
+    end
+
+    test "one-time passcode can only be used once" do
+      account = account_fixture()
+      actor = actor_fixture(account: account, allow_email_otp_sign_in: true)
+
+      {:ok, passcode} = create_one_time_passcode(account, actor)
+
+      assert {:ok, _} = verify_one_time_passcode(account.id, actor.id, passcode.id, passcode.code)
 
       assert {:error, :invalid_code} =
-               verify_one_time_passcode(account.id, passcode.id, passcode.code)
+               verify_one_time_passcode(account.id, actor.id, passcode.id, passcode.code)
     end
 
     test "creating a new passcode deletes existing passcodes for the actor" do
       account = account_fixture()
-      actor = actor_fixture(account: account)
+      actor = actor_fixture(account: account, allow_email_otp_sign_in: true)
 
       {:ok, passcode1} = create_one_time_passcode(account, actor)
       {:ok, passcode2} = create_one_time_passcode(account, actor)
 
       # First passcode should no longer be valid
       assert {:error, :invalid_code} =
-               verify_one_time_passcode(account.id, passcode1.id, passcode1.code)
+               verify_one_time_passcode(account.id, actor.id, passcode1.id, passcode1.code)
 
       # Second passcode should still be valid
-      assert {:ok, _} = verify_one_time_passcode(account.id, passcode2.id, passcode2.code)
+      assert {:ok, _} =
+               verify_one_time_passcode(account.id, actor.id, passcode2.id, passcode2.code)
     end
 
     test "fails to create token without type" do

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -718,49 +718,78 @@ defmodule Domain.AuthTest do
       assert {:error, :unauthorized} = create_gateway_token(site, subject)
     end
 
-    test "creates an email token with all required fields" do
+    test "creates a one-time passcode" do
       account = account_fixture()
       actor = actor_fixture(account: account)
 
-      attrs = %{
-        type: :email,
-        account_id: account.id,
-        actor_id: actor.id,
-        secret_fragment: Domain.Crypto.random_token(32, encoder: :hex32),
-        expires_at: DateTime.add(DateTime.utc_now(), 15, :minute)
-      }
-
-      assert {:ok, token} = create_token(attrs)
-      assert token.type == :email
+      assert {:ok, passcode} = create_one_time_passcode(account, actor)
+      assert passcode.id != nil
+      assert passcode.account_id == account.id
+      assert passcode.actor_id == actor.id
+      assert passcode.code != nil
+      assert String.length(passcode.code) == 5
+      assert passcode.code_hash != nil
+      assert passcode.expires_at != nil
     end
 
-    test "fails to create email token without expires_at" do
+    test "verifies a valid one-time passcode" do
       account = account_fixture()
       actor = actor_fixture(account: account)
 
-      attrs = %{
-        type: :email,
-        account_id: account.id,
-        actor_id: actor.id,
-        secret_fragment: Domain.Crypto.random_token(32, encoder: :hex32)
-      }
+      {:ok, passcode} = create_one_time_passcode(account, actor)
 
-      assert {:error, changeset} = create_token(attrs)
-      assert "can't be blank" in errors_on(changeset).expires_at
+      assert {:ok, verified_passcode} =
+               verify_one_time_passcode(account.id, passcode.id, passcode.code)
+
+      assert verified_passcode.id == passcode.id
+      assert verified_passcode.actor_id == actor.id
     end
 
-    test "fails to create email token without actor_id" do
+    test "fails to verify one-time passcode with wrong code" do
       account = account_fixture()
+      actor = actor_fixture(account: account)
 
-      attrs = %{
-        type: :email,
-        account_id: account.id,
-        secret_fragment: Domain.Crypto.random_token(32, encoder: :hex32),
-        expires_at: DateTime.add(DateTime.utc_now(), 15, :minute)
-      }
+      {:ok, passcode} = create_one_time_passcode(account, actor)
 
-      assert {:error, changeset} = create_token(attrs)
-      assert "can't be blank" in errors_on(changeset).actor_id
+      assert {:error, :invalid_code} =
+               verify_one_time_passcode(account.id, passcode.id, "wrong")
+    end
+
+    test "fails to verify one-time passcode with wrong passcode_id" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      {:ok, passcode} = create_one_time_passcode(account, actor)
+
+      assert {:error, :invalid_code} =
+               verify_one_time_passcode(account.id, Ecto.UUID.generate(), passcode.code)
+    end
+
+    test "one-time passcode can only be used once" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      {:ok, passcode} = create_one_time_passcode(account, actor)
+
+      assert {:ok, _} = verify_one_time_passcode(account.id, passcode.id, passcode.code)
+
+      assert {:error, :invalid_code} =
+               verify_one_time_passcode(account.id, passcode.id, passcode.code)
+    end
+
+    test "creating a new passcode deletes existing passcodes for the actor" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      {:ok, passcode1} = create_one_time_passcode(account, actor)
+      {:ok, passcode2} = create_one_time_passcode(account, actor)
+
+      # First passcode should no longer be valid
+      assert {:error, :invalid_code} =
+               verify_one_time_passcode(account.id, passcode1.id, passcode1.code)
+
+      # Second passcode should still be valid
+      assert {:ok, _} = verify_one_time_passcode(account.id, passcode2.id, passcode2.code)
     end
 
     test "fails to create token without type" do

--- a/elixir/apps/domain/test/domain/workers/delete_expired_one_time_passcodes_test.exs
+++ b/elixir/apps/domain/test/domain/workers/delete_expired_one_time_passcodes_test.exs
@@ -1,0 +1,67 @@
+defmodule Domain.Workers.DeleteExpiredOneTimePasscodesTest do
+  use Domain.DataCase, async: true
+  use Oban.Testing, repo: Domain.Repo
+
+  import Domain.AccountFixtures
+  import Domain.ActorFixtures
+
+  alias Domain.Auth
+  alias Domain.OneTimePasscode
+  alias Domain.Workers.DeleteExpiredOneTimePasscodes
+
+  describe "perform/1" do
+    test "deletes expired one-time passcodes" do
+      account = account_fixture()
+      actor = actor_fixture(account: account, type: :account_admin_user)
+
+      # Create a passcode and manually expire it
+      {:ok, passcode} = Auth.create_one_time_passcode(account, actor)
+
+      passcode
+      |> Ecto.Changeset.change(expires_at: DateTime.utc_now() |> DateTime.add(-1, :minute))
+      |> Repo.update!()
+
+      assert Repo.get_by(OneTimePasscode, id: passcode.id)
+
+      assert :ok = perform_job(DeleteExpiredOneTimePasscodes, %{})
+
+      refute Repo.get_by(OneTimePasscode, id: passcode.id)
+    end
+
+    test "does not delete non-expired one-time passcodes" do
+      account = account_fixture()
+      actor = actor_fixture(account: account, type: :account_admin_user)
+
+      {:ok, passcode} = Auth.create_one_time_passcode(account, actor)
+
+      assert Repo.get_by(OneTimePasscode, id: passcode.id)
+
+      assert :ok = perform_job(DeleteExpiredOneTimePasscodes, %{})
+
+      assert Repo.get_by(OneTimePasscode, id: passcode.id)
+    end
+
+    test "deletes multiple expired passcodes across accounts" do
+      account1 = account_fixture()
+      actor1 = actor_fixture(account: account1, type: :account_admin_user)
+
+      account2 = account_fixture()
+      actor2 = actor_fixture(account: account2, type: :account_admin_user)
+
+      {:ok, passcode1} = Auth.create_one_time_passcode(account1, actor1)
+      {:ok, passcode2} = Auth.create_one_time_passcode(account2, actor2)
+
+      # Expire both passcodes
+      for passcode <- [passcode1, passcode2] do
+        passcode
+        |> Ecto.Changeset.change(expires_at: DateTime.utc_now() |> DateTime.add(-1, :minute))
+        |> Repo.update!()
+      end
+
+      assert :ok = perform_job(DeleteExpiredOneTimePasscodes, %{})
+
+      refute Repo.get_by(OneTimePasscode, id: passcode1.id)
+      refute Repo.get_by(OneTimePasscode, id: passcode2.id)
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -90,44 +90,6 @@ defmodule Web.Auth do
   end
 
   @doc """
-  Attempts to execute a callback in the given constant time.
-
-  If the time it takes to execute the callback is less than the timeout,
-  the function will sleep for the remaining time. Otherwise, the function
-  returns immediately.
-  """
-  def execute_with_constant_time(callback, constant_time) do
-    start_time = System.monotonic_time(:millisecond)
-    result = callback.()
-    end_time = System.monotonic_time(:millisecond)
-
-    elapsed_time = end_time - start_time
-    remaining_time = max(0, constant_time - elapsed_time)
-
-    if remaining_time > 0 do
-      :timer.sleep(remaining_time)
-    else
-      log_constant_time_exceeded(constant_time, elapsed_time, remaining_time)
-    end
-
-    result
-  end
-
-  if Mix.env() in [:dev, :test] do
-    def log_constant_time_exceeded(_constant_time, _elapsed_time, _remaining_time) do
-      :ok
-    end
-  else
-    def log_constant_time_exceeded(constant_time, elapsed_time, remaining_time) do
-      Logger.error("Execution took longer than the given constant time",
-        constant_time: constant_time,
-        elapsed_time: elapsed_time,
-        remaining_time: remaining_time
-      )
-    end
-  end
-
-  @doc """
   Returns non-empty parameters that should be persisted during sign in flow.
   """
   def take_sign_in_params(params) do

--- a/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
@@ -65,14 +65,14 @@ defmodule Web.EmailOTPController do
     %{"account_id_or_slug" => account_id_or_slug, "auth_provider_id" => auth_provider_id} = params
     context_type = context_type(params)
 
-    with {:ok, passcode_id, email} <- fetch_state(conn),
+    with {:ok, actor_id, passcode_id, email} <- fetch_state(conn),
          {:ok, account} <- DB.fetch_account_by_id_or_slug(account_id_or_slug),
          {:ok, provider} <- DB.fetch_provider_by_id(account, auth_provider_id),
-         {:ok, passcode} <- Auth.verify_one_time_passcode(account.id, passcode_id, entered_code),
-         {:ok, actor} <- DB.fetch_actor_by_id(account, passcode.actor_id),
-         :ok <- check_admin(actor, context_type),
-         {:ok, token} <- create_token(conn, actor, provider, params) do
-      {:ok, %{account: account, actor: actor, token: token, email: email}}
+         {:ok, passcode} <-
+           Auth.verify_one_time_passcode(account.id, actor_id, passcode_id, entered_code),
+         :ok <- check_admin(passcode.actor, context_type),
+         {:ok, token} <- create_token(conn, passcode.actor, provider, params) do
+      {:ok, %{account: account, actor: passcode.actor, token: token, email: email}}
     end
   end
 
@@ -89,8 +89,8 @@ defmodule Web.EmailOTPController do
 
   defp fetch_state(conn) do
     case Web.EmailOTP.fetch_state(conn) do
-      %{"one_time_passcode_id" => passcode_id, "email" => email} ->
-        {:ok, passcode_id, email}
+      %{"actor_id" => actor_id, "one_time_passcode_id" => passcode_id, "email" => email} ->
+        {:ok, actor_id, passcode_id, email}
 
       _ ->
         :error
@@ -98,26 +98,26 @@ defmodule Web.EmailOTPController do
   end
 
   defp maybe_send_email_otp(conn, account, email, params, auth_provider_id) do
-    {passcode_id, error} =
+    {actor_id, passcode_id, error} =
       execute_with_constant_time(
         fn ->
           with {:ok, actor} <- DB.fetch_actor_by_email(account, email),
                {:ok, otp} <- Auth.create_one_time_passcode(account, actor),
                {:ok, _} <- send_email_otp(conn, actor, otp.code, auth_provider_id, params) do
-            {otp.id, nil}
+            {actor.id, otp.id, nil}
           else
             {:error, :rate_limited} ->
-              {Ecto.UUID.generate(), :rate_limited}
+              {Ecto.UUID.generate(), Ecto.UUID.generate(), :rate_limited}
 
             _ ->
-              # Generate dummy ID to prevent oracle attacks
-              {Ecto.UUID.generate(), nil}
+              # Generate dummy IDs to prevent oracle attacks
+              {Ecto.UUID.generate(), Ecto.UUID.generate(), nil}
           end
         end,
         @constant_execution_time
       )
 
-    conn = Web.EmailOTP.put_state(conn, auth_provider_id, passcode_id, email)
+    conn = Web.EmailOTP.put_state(conn, auth_provider_id, actor_id, passcode_id, email)
 
     case error do
       :rate_limited ->
@@ -329,20 +329,6 @@ defmodule Web.EmailOTPController do
       from(a in Actor,
         where:
           a.email == ^email and
-            a.account_id == ^account.id and
-            is_nil(a.disabled_at) and
-            a.allow_email_otp_sign_in == true
-      )
-      |> preload(:account)
-      |> Safe.unscoped()
-      |> Safe.one()
-      |> handle_nil()
-    end
-
-    def fetch_actor_by_id(account, actor_id) do
-      from(a in Actor,
-        where:
-          a.id == ^actor_id and
             a.account_id == ^account.id and
             is_nil(a.disabled_at) and
             a.allow_email_otp_sign_in == true

--- a/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
@@ -4,7 +4,8 @@ defmodule Web.EmailOTPController do
   """
   use Web, :controller
 
-  alias Domain.{Auth, EmailOTP}
+  alias Domain.Auth
+  alias Domain.EmailOTP
   alias __MODULE__.DB
   alias Web.Session.Redirector
 

--- a/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
@@ -4,27 +4,11 @@ defmodule Web.EmailOTPController do
   """
   use Web, :controller
 
-  alias Domain.{
-    Actor,
-    Auth,
-    EmailOTP,
-    Token
-  }
-
+  alias Domain.{Auth, EmailOTP}
   alias __MODULE__.DB
   alias Web.Session.Redirector
 
   require Logger
-
-  # For persisting state across the email OTP flow
-  @cookie_key "email_otp"
-  @cookie_options [
-    encrypt: true,
-    max_age: 30 * 60,
-    same_site: "Lax",
-    secure: true,
-    http_only: true
-  ]
 
   @constant_execution_time Application.compile_env(:web, :constant_execution_time, 2000)
 
@@ -39,17 +23,11 @@ defmodule Web.EmailOTPController do
         } = params
       )
       when is_binary(email) do
-    with %Domain.Account{} = account <- DB.get_account_by_id_or_slug(account_id_or_slug),
-         %EmailOTP.AuthProvider{} <- DB.get_provider(account, auth_provider_id) do
+    with {:ok, account} <- DB.fetch_account_by_id_or_slug(account_id_or_slug),
+         {:ok, _provider} <- DB.fetch_provider_by_id(account, auth_provider_id) do
       conn = maybe_send_email_otp(conn, account, email, params, auth_provider_id)
 
-      signed_email =
-        Plug.Crypto.sign(conn.secret_key_base, "signed_email", email)
-
-      redirect_params =
-        params
-        |> sanitize()
-        |> Map.put("signed_email", signed_email)
+      redirect_params = sanitize(params)
 
       conn
       |> maybe_put_resent_flash(params)
@@ -63,93 +41,82 @@ defmodule Web.EmailOTPController do
   end
 
   def sign_in(conn, params) do
-    Logger.warning("Invalid request parameters", params: params)
+    Logger.info("Invalid request parameters", params: params)
     handle_error(conn, :invalid_params, params)
   end
 
-  def verify(
-        conn,
-        %{
-          "account_id_or_slug" => account_id_or_slug,
-          "auth_provider_id" => auth_provider_id,
-          "secret" => nonce
-        } = params
-      ) do
-    cookie_key = state_cookie_key(auth_provider_id)
-    conn = fetch_cookies(conn, encrypted: [cookie_key])
-    context_type = context_type(params)
+  def verify(conn, %{"secret" => entered_code} = params) do
+    result =
+      execute_with_constant_time(
+        fn -> do_verify(conn, params, String.downcase(entered_code)) end,
+        @constant_execution_time
+      )
 
-    with {:ok, cookie_binary} <- Map.fetch(conn.cookies, cookie_key),
-         {fragment, email, _stored_params} <- :erlang.binary_to_term(cookie_binary),
-         conn = delete_resp_cookie(conn, cookie_key),
-         %Domain.Account{} = account <- DB.get_account_by_id_or_slug(account_id_or_slug),
-         %EmailOTP.AuthProvider{} = provider <- DB.get_provider(account, auth_provider_id),
-         %Domain.Actor{} = actor <- DB.get_actor(account, email),
-         :ok <- check_admin(actor, context_type),
-         secret = String.downcase(nonce) <> fragment,
-         {:ok, actor, _expires_at} <- verify_secret(actor, secret, conn),
-         {:ok, token} <- create_token(conn, actor, provider, params) do
-      :ok = Domain.Mailer.RateLimiter.reset_rate_limit({:sign_in_link, actor.id})
-      signed_in(conn, context_type, account, actor, token, params)
-    else
-      error ->
-        handle_error(conn, error, params)
-    end
+    handle_verify_result(conn, result, params)
   end
 
   def verify(conn, params) do
-    Logger.warning("Invalid request parameters", params: params)
+    Logger.info("Invalid request parameters", params: params)
     handle_error(conn, :invalid_params, params)
   end
 
-  defp maybe_send_email_otp(conn, account, email, params, auth_provider_id) do
+  defp do_verify(conn, params, entered_code) do
+    %{"account_id_or_slug" => account_id_or_slug, "auth_provider_id" => auth_provider_id} = params
     context_type = context_type(params)
-    context = auth_context(conn, context_type)
 
-    {fragment, error} =
-      Web.Auth.execute_with_constant_time(
+    with {:ok, passcode_id, email} <- fetch_state(conn),
+         {:ok, account} <- DB.fetch_account_by_id_or_slug(account_id_or_slug),
+         {:ok, provider} <- DB.fetch_provider_by_id(account, auth_provider_id),
+         {:ok, passcode} <- Auth.verify_one_time_passcode(account.id, passcode_id, entered_code),
+         {:ok, actor} <- DB.fetch_actor_by_id(account, passcode.actor_id),
+         :ok <- check_admin(actor, context_type),
+         {:ok, token} <- create_token(conn, actor, provider, params) do
+      {:ok, %{account: account, actor: actor, token: token, email: email}}
+    end
+  end
+
+  defp handle_verify_result(conn, {:ok, result}, params) do
+    context_type = context_type(params)
+    conn = Web.EmailOTP.delete_state(conn, params["auth_provider_id"])
+    :ok = Domain.Mailer.RateLimiter.reset_rate_limit({:sign_in_link, result.email})
+    signed_in(conn, context_type, result.account, result.actor, result.token, params)
+  end
+
+  defp handle_verify_result(conn, error, params) do
+    handle_error(conn, error, params)
+  end
+
+  defp fetch_state(conn) do
+    case Web.EmailOTP.fetch_state(conn) do
+      %{"one_time_passcode_id" => passcode_id, "email" => email} ->
+        {:ok, passcode_id, email}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp maybe_send_email_otp(conn, account, email, params, auth_provider_id) do
+    {passcode_id, error} =
+      execute_with_constant_time(
         fn ->
-          with %Domain.Actor{} = actor <- DB.get_actor(account, email),
-               {:ok, actor, fragment, nonce} <- request_sign_in_token(actor, context),
-               {:ok, fragment} <-
-                 send_email_otp(conn, actor, fragment, nonce, auth_provider_id, params) do
-            {fragment, nil}
+          with {:ok, actor} <- DB.fetch_actor_by_email(account, email),
+               {:ok, otp} <- Auth.create_one_time_passcode(account, actor),
+               {:ok, _} <- send_email_otp(conn, actor, otp.code, auth_provider_id, params) do
+            {otp.id, nil}
           else
             {:error, :rate_limited} ->
-              # Generate fake fragment but track the error
-              fake_fragment =
-                Auth.encode_fragment!(%Token{
-                  type: :email,
-                  secret_nonce: Domain.Crypto.random_token(5, encoder: :user_friendly),
-                  secret_fragment: Domain.Crypto.random_token(27, encoder: :hex32),
-                  account_id: Ecto.UUID.generate(),
-                  actor_id: Ecto.UUID.generate(),
-                  id: Ecto.UUID.generate(),
-                  expires_at: DateTime.utc_now()
-                })
-
-              {fake_fragment, :rate_limited}
+              {Ecto.UUID.generate(), :rate_limited}
 
             _ ->
-              # We generate a fake fragment to prevent information leakage
-              fake_fragment =
-                Auth.encode_fragment!(%Token{
-                  type: :email,
-                  secret_nonce: Domain.Crypto.random_token(5, encoder: :user_friendly),
-                  secret_fragment: Domain.Crypto.random_token(27, encoder: :hex32),
-                  account_id: Ecto.UUID.generate(),
-                  actor_id: Ecto.UUID.generate(),
-                  id: Ecto.UUID.generate(),
-                  expires_at: DateTime.utc_now()
-                })
-
-              {fake_fragment, nil}
+              # Generate dummy ID to prevent oracle attacks
+              {Ecto.UUID.generate(), nil}
           end
         end,
         @constant_execution_time
       )
 
-    conn = put_auth_state(conn, auth_provider_id, {fragment, email, sanitize(params)})
+    conn = Web.EmailOTP.put_state(conn, auth_provider_id, passcode_id, email)
 
     case error do
       :rate_limited ->
@@ -164,62 +131,21 @@ defmodule Web.EmailOTPController do
     end
   end
 
-  defp request_sign_in_token(actor, _context) do
-    # Token expiration: 30 minutes
-    sign_in_token_expiration_seconds = 30 * 60
-
-    nonce = String.downcase(Domain.Crypto.random_token(5, encoder: :user_friendly))
-    expires_at = DateTime.utc_now() |> DateTime.add(sign_in_token_expiration_seconds, :second)
-
-    # Delete all existing email tokens for this actor
-    {:ok, _count} = DB.delete_all_email_tokens_for_actor(actor)
-
-    {:ok, token} =
-      Auth.create_token(%{
-        type: :email,
-        secret_fragment: Domain.Crypto.random_token(27),
-        secret_nonce: nonce,
-        account_id: actor.account_id,
-        actor_id: actor.id,
-        expires_at: expires_at
-      })
-
-    fragment = Auth.encode_fragment!(token)
-
-    {:ok, actor, fragment, nonce}
-  end
-
-  defp send_email_otp(conn, actor, fragment, nonce, auth_provider_id, params) do
+  defp send_email_otp(conn, actor, code, auth_provider_id, params) do
     Domain.Mailer.AuthEmail.sign_in_link_email(
       actor,
       DateTime.utc_now(),
       auth_provider_id,
-      nonce,
+      code,
       conn.assigns.user_agent,
       conn.remote_ip,
       sanitize(params)
     )
     |> Domain.Mailer.deliver_with_rate_limit(
-      rate_limit_key: {:sign_in_link, actor.id},
+      rate_limit_key: {:sign_in_link, actor.email},
       rate_limit: 3,
       rate_limit_interval: :timer.minutes(5)
     )
-    |> case do
-      {:ok, _} -> {:ok, fragment}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp verify_secret(actor, encoded_token, conn) do
-    # Email tokens are always of type :email
-    context = auth_context(conn, :browser)
-    email_context = %{context | type: :email}
-
-    with {:ok, token} <- Auth.use_token(encoded_token, email_context),
-         true <- token.actor_id == actor.id do
-      {:ok, _count} = DB.delete_all_email_tokens_for_actor(actor)
-      {:ok, actor, nil}
-    end
   end
 
   defp check_admin(%Domain.Actor{type: :account_admin_user}, _context_type), do: :ok
@@ -280,21 +206,11 @@ defmodule Web.EmailOTPController do
     )
   end
 
-  defp put_auth_state(conn, provider_id, state) do
-    key = state_cookie_key(provider_id)
-    value = :erlang.term_to_binary(state)
-    put_resp_cookie(conn, key, value, @cookie_options)
-  end
-
-  defp maybe_put_resent_flash(%Plug.Conn{state: :unset} = conn, %{"resend" => "true"}),
+  defp maybe_put_resent_flash(%Plug.Conn{} = conn, %{"resend" => "true"}),
     do: put_flash(conn, :success_inline, "Email was resent.")
 
   defp maybe_put_resent_flash(conn, _params),
     do: conn
-
-  defp state_cookie_key(provider_id) do
-    @cookie_key <> "_" <> provider_id
-  end
 
   defp handle_error(conn, {:error, :not_found}, params) do
     error = "You may not use this method to sign in."
@@ -308,30 +224,10 @@ defmodule Web.EmailOTPController do
     redirect_for_error(conn, error, path)
   end
 
-  defp handle_error(conn, {:error, :invalid_secret}, params) do
-    cookie_key = state_cookie_key(params["auth_provider_id"])
-    conn = fetch_cookies(conn, encrypted: [cookie_key])
-
-    {_fragment, email, _stored_params} =
-      case Map.get(conn.cookies, cookie_key) do
-        binary when is_binary(binary) -> :erlang.binary_to_term(binary)
-        _ -> {"", "", %{}}
-      end
-
-    signed_email =
-      Plug.Crypto.sign(
-        conn.secret_key_base,
-        "signed_email",
-        email
-      )
-
-    redirect_params =
-      params
-      |> sanitize()
-      |> Map.put("signed_email", signed_email)
-
+  defp handle_error(conn, {:error, :invalid_code}, params) do
     auth_provider_id = params["auth_provider_id"]
-    error = "The sign in token is invalid or expired."
+    redirect_params = sanitize(params)
+    error = "The sign in code is invalid or expired."
 
     path =
       ~p"/#{params["account_id_or_slug"]}/sign_in/email_otp/#{auth_provider_id}?#{redirect_params}"
@@ -340,7 +236,7 @@ defmodule Web.EmailOTPController do
   end
 
   defp handle_error(conn, :error, params) do
-    error = "The sign in token is missing or expired. Please try again."
+    error = "The sign in code is missing or expired. Please try again."
     path = ~p"/#{params["account_id_or_slug"]}?#{sanitize(params)}"
     redirect_for_error(conn, error, path)
   end
@@ -352,7 +248,7 @@ defmodule Web.EmailOTPController do
   end
 
   defp handle_error(conn, error, params) do
-    Logger.warning("Email OTP sign in error: #{inspect(error)}")
+    Logger.info("Email OTP sign in error", error: error)
     error = "An unexpected error occurred while signing you in. Please try again."
     path = ~p"/#{params["account_id_or_slug"]}?#{sanitize(params)}"
     redirect_for_error(conn, error, path)
@@ -372,59 +268,91 @@ defmodule Web.EmailOTPController do
   defp context_type(%{"as" => "client"}), do: :client
   defp context_type(_), do: :browser
 
-  defp auth_context(conn, context_type) do
-    remote_ip = conn.remote_ip
-    user_agent = conn.assigns[:user_agent]
-    headers = conn.req_headers
+  # Executes a callback in constant time to prevent timing attacks.
+  # If execution is faster than constant_time, sleeps for the remainder.
+  defp execute_with_constant_time(callback, constant_time) do
+    start_time = System.monotonic_time(:millisecond)
+    result = callback.()
+    end_time = System.monotonic_time(:millisecond)
 
-    Domain.Auth.Context.build(remote_ip, user_agent, headers, context_type)
+    elapsed_time = end_time - start_time
+    remaining_time = max(0, constant_time - elapsed_time)
+
+    if remaining_time > 0 do
+      :timer.sleep(remaining_time)
+    else
+      log_constant_time_exceeded(constant_time, elapsed_time)
+    end
+
+    result
+  end
+
+  if Mix.env() in [:dev, :test] do
+    defp log_constant_time_exceeded(_constant_time, _elapsed_time), do: :ok
+  else
+    defp log_constant_time_exceeded(constant_time, elapsed_time) do
+      Logger.error("Execution took longer than the given constant time",
+        constant_time: constant_time,
+        elapsed_time: elapsed_time
+      )
+    end
   end
 
   defmodule DB do
     import Ecto.Query
     alias Domain.Safe
-    alias Domain.{Account, Actor, EmailOTP, Token}
+    alias Domain.{Account, Actor, EmailOTP}
 
-    def get_account_by_id_or_slug(id_or_slug) do
+    def fetch_account_by_id_or_slug(id_or_slug) do
       query =
         if Domain.Repo.valid_uuid?(id_or_slug),
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one()
+      query
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> handle_nil()
     end
 
-    def get_provider(account, id) do
+    def fetch_provider_by_id(account, id) do
       from(p in EmailOTP.AuthProvider,
         where: p.account_id == ^account.id and p.id == ^id and not p.is_disabled
       )
       |> Safe.unscoped()
       |> Safe.one()
+      |> handle_nil()
     end
 
-    def get_actor(account, email) do
+    def fetch_actor_by_email(account, email) do
       from(a in Actor,
         where:
           a.email == ^email and
             a.account_id == ^account.id and
             is_nil(a.disabled_at) and
-            a.allow_email_otp_sign_in == true,
-        preload: [:account]
+            a.allow_email_otp_sign_in == true
       )
+      |> preload(:account)
       |> Safe.unscoped()
       |> Safe.one()
+      |> handle_nil()
     end
 
-    def delete_all_email_tokens_for_actor(actor) do
-      query =
-        from(t in Token,
-          where:
-            t.type == :email and t.account_id == ^actor.account_id and t.actor_id == ^actor.id
-        )
-
-      {num_deleted, _} = query |> Safe.unscoped() |> Safe.delete_all()
-
-      {:ok, num_deleted}
+    def fetch_actor_by_id(account, actor_id) do
+      from(a in Actor,
+        where:
+          a.id == ^actor_id and
+            a.account_id == ^account.id and
+            is_nil(a.disabled_at) and
+            a.allow_email_otp_sign_in == true
+      )
+      |> preload(:account)
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> handle_nil()
     end
+
+    defp handle_nil(nil), do: {:error, :not_found}
+    defp handle_nil(result), do: {:ok, result}
   end
 end

--- a/elixir/apps/web/lib/web/email_otp.ex
+++ b/elixir/apps/web/lib/web/email_otp.ex
@@ -1,0 +1,41 @@
+defmodule Web.EmailOTP do
+  @moduledoc """
+  Helpers for email OTP authentication state management.
+  """
+
+  @cookie_key_prefix "email_otp_"
+  @cookie_options [
+    encrypt: true,
+    max_age: 15 * 60,
+    same_site: "Strict",
+    secure: true,
+    http_only: true
+  ]
+
+  def put_state(conn, provider_id, passcode_id, email) do
+    key = cookie_key(provider_id)
+    value = %{"one_time_passcode_id" => passcode_id, "email" => email}
+    Plug.Conn.put_resp_cookie(conn, key, value, @cookie_options)
+  end
+
+  def delete_state(conn, provider_id) do
+    key = cookie_key(provider_id)
+    Plug.Conn.delete_resp_cookie(conn, key)
+  end
+
+  @doc """
+  Fetches email OTP state from the encrypted cookie.
+  Used as a session function for the email_otp_verify live_session.
+  """
+  def fetch_state(%{path_params: %{"auth_provider_id" => provider_id}} = conn) do
+    key = cookie_key(provider_id)
+    conn = Plug.Conn.fetch_cookies(conn, encrypted: [key])
+    conn.cookies[key] || %{}
+  end
+
+  def fetch_state(_conn), do: %{}
+
+  defp cookie_key(provider_id) do
+    @cookie_key_prefix <> provider_id
+  end
+end

--- a/elixir/apps/web/lib/web/email_otp.ex
+++ b/elixir/apps/web/lib/web/email_otp.ex
@@ -12,9 +12,9 @@ defmodule Web.EmailOTP do
     http_only: true
   ]
 
-  def put_state(conn, provider_id, passcode_id, email) do
+  def put_state(conn, provider_id, actor_id, passcode_id, email) do
     key = cookie_key(provider_id)
-    value = %{"one_time_passcode_id" => passcode_id, "email" => email}
+    value = %{"actor_id" => actor_id, "one_time_passcode_id" => passcode_id, "email" => email}
     Plug.Conn.put_resp_cookie(conn, key, value, @cookie_options)
   end
 

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -5,25 +5,18 @@ defmodule Web.SignIn.Email do
   def mount(
         %{
           "account_id_or_slug" => account_id_or_slug,
-          "auth_provider_id" => provider_id,
-          "signed_email" => signed_email
+          "auth_provider_id" => provider_id
         } = params,
-        _session,
+        session,
         socket
       ) do
     redirect_params = Web.Auth.take_sign_in_params(params)
-    secret_key_base = socket.endpoint.config(:secret_key_base)
 
     account = DB.get_account_by_id_or_slug(account_id_or_slug)
+    email = session["email"]
 
     with %Domain.Account{} = account <- account,
-         {:ok, email} <-
-           Plug.Crypto.verify(
-             secret_key_base,
-             "signed_email",
-             signed_email,
-             max_age: 3600
-           ) do
+         email when is_binary(email) and email != "" <- email do
       form = to_form(%{"secret" => nil})
 
       verify_action = ~p"/#{account_id_or_slug}/sign_in/email_otp/#{provider_id}/verify"
@@ -83,13 +76,14 @@ defmodule Web.SignIn.Email do
 
             <div>
               <p>
-                If <strong>{@email}</strong> is registered, a sign-in token has been sent.
+                If <strong>{@email}</strong> is registered, a sign-in code has been sent.
               </p>
               <form
                 id="verify-sign-in-token"
                 action={@verify_action}
                 method="post"
                 class="my-4 flex"
+                phx-update="ignore"
                 phx-hook="AttachDisableSubmit"
                 phx-submit={JS.dispatch("form:disable_and_submit", to: "#verify-sign-in-token")}
               >
@@ -111,7 +105,7 @@ defmodule Web.SignIn.Email do
                     "rounded-l border-neutral-300"
                   ]}
                   required
-                  placeholder="Enter token from email"
+                  placeholder="Enter code from email"
                 />
 
                 <button

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -13,10 +13,9 @@ defmodule Web.SignIn.Email do
     redirect_params = Web.Auth.take_sign_in_params(params)
 
     account = DB.get_account_by_id_or_slug(account_id_or_slug)
-    email = session["email"]
 
     with %Domain.Account{} = account <- account,
-         email when is_binary(email) and email != "" <- email do
+         {:ok, email} <- Map.fetch(session, "email") do
       form = to_form(%{"secret" => nil})
 
       verify_action = ~p"/#{account_id_or_slug}/sign_in/email_otp/#{provider_id}/verify"

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -89,6 +89,7 @@ defmodule Web.Router do
 
     # Email auth entry point
     post "/sign_in/email_otp/:auth_provider_id", EmailOTPController, :sign_in
+    get "/sign_in/email_otp/:auth_provider_id/verify", EmailOTPController, :verify
     post "/sign_in/email_otp/:auth_provider_id/verify", EmailOTPController, :verify
 
     # Userpass auth entry point
@@ -102,6 +103,16 @@ defmodule Web.Router do
         Web.LiveHooks.RedirectIfAuthenticated
       ] do
       live "/", SignIn
+    end
+
+    live_session :email_otp_verify,
+      session: {Web.EmailOTP, :fetch_state, []},
+      on_mount: [
+        Web.LiveHooks.AllowEctoSandbox,
+        Web.LiveHooks.FetchAccount,
+        Web.LiveHooks.FetchSubject,
+        Web.LiveHooks.RedirectIfAuthenticated
+      ] do
       live "/sign_in/email_otp/:auth_provider_id", SignIn.Email
     end
 

--- a/elixir/apps/web/test/web/controllers/email_otp_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/email_otp_controller_test.exs
@@ -1,0 +1,687 @@
+defmodule Web.EmailOTPControllerTest do
+  use Web.ConnCase, async: true
+
+  import Domain.AccountFixtures
+  import Domain.ActorFixtures
+  import Domain.AuthProviderFixtures
+
+  alias Web.EmailOTP
+
+  setup do
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
+    account = account_fixture()
+    provider = email_otp_provider_fixture(account: account)
+
+    {:ok, account: account, provider: provider}
+  end
+
+  defp get_cookie_state(conn, provider_id) do
+    cookie_key = "email_otp_#{provider_id}"
+
+    conn
+    |> then(&Plug.Test.recycle_cookies(build_conn(), &1))
+    |> Map.put(:path_params, %{"auth_provider_id" => provider_id})
+    |> Map.put(:secret_key_base, Web.Endpoint.config(:secret_key_base))
+    |> Plug.Conn.fetch_cookies(encrypted: [cookie_key])
+    |> EmailOTP.fetch_state()
+  end
+
+  describe "sign_in/2" do
+    test "redirects with error when account does not exist", %{conn: conn} do
+      conn =
+        post(conn, ~p"/nonexistent-account/sign_in/email_otp/#{Ecto.UUID.generate()}", %{
+          "email" => %{"email" => "test@example.com"}
+        })
+
+      assert redirected_to(conn) == ~p"/nonexistent-account"
+      assert flash(conn, :error) =~ "You may not use this method to sign in"
+    end
+
+    test "redirects with error when provider does not exist", %{
+      conn: conn,
+      account: account
+    } do
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{Ecto.UUID.generate()}", %{
+          "email" => %{"email" => "test@example.com"}
+        })
+
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) =~ "You may not use this method to sign in"
+    end
+
+    test "redirects with error when provider is disabled", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      provider
+      |> Ecto.Changeset.change(is_disabled: true)
+      |> Domain.Repo.update!()
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => "test@example.com"}
+        })
+
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) =~ "You may not use this method to sign in"
+    end
+
+    test "sets cookie with dummy passcode_id when email does not exist", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      nonexistent_email = "nonexistent@example.com"
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => nonexistent_email}
+        })
+
+      # Should still redirect to verify page (no oracle)
+      assert redirected_to(conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      # Cookie should be set with email and dummy passcode_id (no oracle)
+      state = get_cookie_state(conn, provider.id)
+      assert state["email"] == nonexistent_email
+      assert state["one_time_passcode_id"] != nil
+    end
+
+    test "sets cookie with real passcode_id when email exists", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Should redirect to verify page
+      assert redirected_to(conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      # Verify the cookie contains the email and a real passcode_id
+      state = get_cookie_state(conn, provider.id)
+      assert state["email"] == actor.email
+      assert state["one_time_passcode_id"] != nil
+
+      # Email should have been sent
+      assert_received {:email, email}
+      assert email.to == [{"", actor.email}]
+    end
+
+    test "sends email for account_user with allow_email_otp_sign_in", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      assert redirected_to(conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      # Cookie should be set with real passcode_id
+      state = get_cookie_state(conn, provider.id)
+      assert state["email"] == actor.email
+      assert state["one_time_passcode_id"] != nil
+
+      # Email should have been sent
+      assert_received {:email, email}
+      assert email.to == [{"", actor.email}]
+    end
+
+    # Note: This scenario shouldn't be possible in practice because a DB constraint
+    # prevents api_client actors from having emails, but we test for defense in depth.
+    test "does not send email for api_client actor type", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor = actor_fixture(type: :api_client, account: account)
+      email = "api_client_#{actor.id}@example.com"
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => email}
+        })
+
+      # Should still redirect to verify page (no oracle)
+      assert redirected_to(conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      # Cookie should still be set with dummy passcode_id (no oracle)
+      state = get_cookie_state(conn, provider.id)
+      assert state["email"] == email
+      assert state["one_time_passcode_id"] != nil
+
+      # No email should have been sent
+      refute_received {:email, _}
+    end
+
+    # Note: This scenario shouldn't be possible in practice because a DB constraint
+    # prevents service_account actors from having emails, but we test for defense in depth.
+    test "does not send email for service_account actor type", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor = actor_fixture(type: :service_account, account: account)
+      email = "service_account_#{actor.id}@example.com"
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => email}
+        })
+
+      # Should still redirect to verify page (no oracle)
+      assert redirected_to(conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      # Cookie should still be set with dummy passcode_id (no oracle)
+      state = get_cookie_state(conn, provider.id)
+      assert state["email"] == email
+      assert state["one_time_passcode_id"] != nil
+
+      # No email should have been sent
+      refute_received {:email, _}
+    end
+
+    test "does not send email for actor without allow_email_otp_sign_in", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: false
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Should still redirect to verify page (no oracle)
+      assert redirected_to(conn) =~
+               ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+
+      # Cookie should still be set with dummy passcode_id (no oracle)
+      state = get_cookie_state(conn, provider.id)
+      assert state["email"] == actor.email
+      assert state["one_time_passcode_id"] != nil
+
+      # No email should have been sent
+      refute_received {:email, _}
+    end
+  end
+
+  describe "verify/2 POST" do
+    test "redirects with error when cookie is missing", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => "123456"
+        })
+
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) =~ "missing or expired"
+    end
+
+    test "redirects with error when code is invalid", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # First, initiate sign-in to get a valid cookie
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Now try to verify with wrong code
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => "wrong1"
+        })
+
+      assert redirected_to(conn) =~ ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+      assert flash(conn, :error) =~ "invalid or expired"
+    end
+
+    test "redirects with error when passcode_id does not exist", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      # Set up cookie with a fake passcode_id
+      conn =
+        conn
+        |> EmailOTP.put_state(provider.id, Ecto.UUID.generate(), "test@example.com")
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => "123456"
+        })
+
+      assert redirected_to(conn) =~ ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+      assert flash(conn, :error) =~ "invalid or expired"
+    end
+
+    test "redirects with error when actor is disabled", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in to get a valid cookie and passcode
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Disable the actor
+      actor
+      |> Ecto.Changeset.change(disabled_at: DateTime.utc_now())
+      |> Domain.Repo.update!()
+
+      # Try to verify
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      assert redirected_to(conn) =~ ~p"/#{account.id}"
+      # Actor no longer has allow_email_otp_sign_in (due to being disabled)
+      assert flash(conn, :error) =~ "You may not use this method to sign in"
+    end
+
+    test "redirects with error when actor no longer has allow_email_otp_sign_in", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in to get a valid cookie and passcode
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Remove allow_email_otp_sign_in
+      actor
+      |> Ecto.Changeset.change(allow_email_otp_sign_in: false)
+      |> Domain.Repo.update!()
+
+      # Try to verify
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      assert redirected_to(conn) =~ ~p"/#{account.id}"
+      # Actor no longer allowed to use email OTP sign-in
+      assert flash(conn, :error) =~ "You may not use this method to sign in"
+    end
+
+    test "redirects with error when provider is disabled", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in to get a valid cookie and passcode
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Disable the provider
+      provider
+      |> Ecto.Changeset.change(is_disabled: true)
+      |> Domain.Repo.update!()
+
+      # Try to verify
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) =~ "You may not use this method to sign in"
+    end
+
+    test "redirects with error when code is already used", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in to get a valid cookie and passcode
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # First verification should succeed
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      # Should redirect to portal (browser context) - goes to sites page
+      assert redirected_to(conn) =~ "/sites"
+
+      # The cookie should have been deleted after successful verification
+      state = get_cookie_state(conn, provider.id)
+      assert state == %{}
+    end
+
+    test "successfully authenticates admin user in browser context", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Verify
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      # Should redirect to portal - goes to sites page
+      assert redirected_to(conn) =~ "/sites"
+
+      # Cookie should be cleared after successful verification
+      state = get_cookie_state(conn, provider.id)
+      assert state == %{}
+    end
+
+    test "successfully authenticates account_user in client context", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in with client context
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email},
+          "as" => "client",
+          "state" => "test-state",
+          "nonce" => "test-nonce"
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Verify with client context
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code,
+          "as" => "client",
+          "state" => "test-state",
+          "nonce" => "test-nonce"
+        })
+
+      # Client context renders the client_redirect page (200) with a meta redirect
+      assert conn.status == 200
+      assert conn.resp_body =~ "client_redirect"
+
+      # Email OTP cookie should be cleared
+      state = get_cookie_state(conn, provider.id)
+      assert state == %{}
+    end
+
+    test "rejects account_user in browser context (portal requires admin)", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in in browser context (no as=client)
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Verify in browser context
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      # Should be rejected - account_user can't access portal
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) =~ "admin privileges"
+    end
+  end
+
+  describe "verify/2 GET" do
+    test "redirects with error when cookie is missing", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      conn =
+        get(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => "123456"
+        })
+
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) =~ "missing or expired"
+    end
+
+    test "successfully authenticates via GET with valid code", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Get the code from the email
+      assert_received {:email, email}
+      code = extract_code_from_email(email)
+
+      # Verify via GET (as if clicking link in email)
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> get(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => code
+        })
+
+      # Should redirect to portal - goes to sites page
+      assert redirected_to(conn) =~ "/sites"
+    end
+
+    test "redirects with error when code is invalid via GET", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      actor =
+        actor_fixture(
+          type: :account_admin_user,
+          account: account,
+          allow_email_otp_sign_in: true
+        )
+
+      # Initiate sign-in
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/email_otp/#{provider.id}", %{
+          "email" => %{"email" => actor.email}
+        })
+
+      # Verify via GET with wrong code
+      conn =
+        conn
+        |> recycle_with_cookie(provider.id)
+        |> get(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
+          "secret" => "wrong1"
+        })
+
+      assert redirected_to(conn) =~ ~p"/#{account.id}/sign_in/email_otp/#{provider.id}"
+      assert flash(conn, :error) =~ "invalid or expired"
+    end
+  end
+
+  # Helper to recycle cookies for a given provider
+  defp recycle_with_cookie(conn, provider_id) do
+    cookie_key = "email_otp_#{provider_id}"
+
+    # Ensure response is sent before recycling cookies
+    conn =
+      if conn.state == :sent do
+        conn
+      else
+        Plug.Conn.send_resp(conn, 200, "")
+      end
+
+    conn
+    |> then(&Plug.Test.recycle_cookies(build_conn(), &1))
+    |> Map.put(:secret_key_base, Web.Endpoint.config(:secret_key_base))
+    |> Plug.Conn.fetch_cookies(encrypted: [cookie_key])
+  end
+
+  # Helper to extract the OTP code from the email
+  defp extract_code_from_email(email) do
+    # The code is on its own line after "Copy and paste..."
+    # It's 5 characters, URL-friendly (lowercase alphanumeric)
+    case Regex.run(~r/\n([a-z0-9]{5})\n/, email.text_body) do
+      [_, code] -> code
+      _ -> raise "Could not extract code from email: #{email.text_body}"
+    end
+  end
+end

--- a/elixir/apps/web/test/web/controllers/email_otp_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/email_otp_controller_test.exs
@@ -288,10 +288,15 @@ defmodule Web.EmailOTPControllerTest do
       account: account,
       provider: provider
     } do
-      # Set up cookie with a fake passcode_id
+      # Set up cookie with a fake passcode_id and actor_id
       conn =
         conn
-        |> EmailOTP.put_state(provider.id, Ecto.UUID.generate(), "test@example.com")
+        |> EmailOTP.put_state(
+          provider.id,
+          Ecto.UUID.generate(),
+          Ecto.UUID.generate(),
+          "test@example.com"
+        )
         |> recycle_with_cookie(provider.id)
         |> post(~p"/#{account.id}/sign_in/email_otp/#{provider.id}/verify", %{
           "secret" => "123456"
@@ -338,7 +343,7 @@ defmodule Web.EmailOTPControllerTest do
 
       assert redirected_to(conn) =~ ~p"/#{account.id}"
       # Actor no longer has allow_email_otp_sign_in (due to being disabled)
-      assert flash(conn, :error) =~ "You may not use this method to sign in"
+      assert flash(conn, :error) =~ "The sign in code is invalid or expired."
     end
 
     test "redirects with error when actor no longer has allow_email_otp_sign_in", %{
@@ -378,7 +383,7 @@ defmodule Web.EmailOTPControllerTest do
 
       assert redirected_to(conn) =~ ~p"/#{account.id}"
       # Actor no longer allowed to use email OTP sign-in
-      assert flash(conn, :error) =~ "You may not use this method to sign in"
+      assert flash(conn, :error) =~ "The sign in code is invalid or expired."
     end
 
     test "redirects with error when provider is disabled", %{

--- a/elixir/apps/web/test/web/email_otp_test.exs
+++ b/elixir/apps/web/test/web/email_otp_test.exs
@@ -3,13 +3,14 @@ defmodule Web.EmailOTPTest do
 
   alias Web.EmailOTP
 
-  describe "put_state/4" do
+  describe "put_state/5" do
     test "sets encrypted cookie with correct options", %{conn: conn} do
       provider_id = Ecto.UUID.generate()
+      actor_id = Ecto.UUID.generate()
       passcode_id = Ecto.UUID.generate()
       email = "test@example.com"
 
-      conn = EmailOTP.put_state(conn, provider_id, passcode_id, email)
+      conn = EmailOTP.put_state(conn, provider_id, actor_id, passcode_id, email)
 
       cookie_key = "email_otp_#{provider_id}"
       assert %{^cookie_key => cookie} = conn.resp_cookies
@@ -36,6 +37,7 @@ defmodule Web.EmailOTPTest do
   describe "fetch_state/1" do
     test "returns state from cookie when provider_id is in path_params", %{conn: conn} do
       provider_id = Ecto.UUID.generate()
+      actor_id = Ecto.UUID.generate()
       passcode_id = Ecto.UUID.generate()
       email = "test@example.com"
 
@@ -43,7 +45,7 @@ defmodule Web.EmailOTPTest do
 
       conn =
         conn
-        |> EmailOTP.put_state(provider_id, passcode_id, email)
+        |> EmailOTP.put_state(provider_id, actor_id, passcode_id, email)
         |> Plug.Conn.send_resp(200, "")
         |> then(&Plug.Test.recycle_cookies(build_conn(), &1))
         |> Map.put(:path_params, %{"auth_provider_id" => provider_id})
@@ -51,6 +53,7 @@ defmodule Web.EmailOTPTest do
         |> Plug.Conn.fetch_cookies(encrypted: [cookie_key])
 
       assert EmailOTP.fetch_state(conn) == %{
+               "actor_id" => actor_id,
                "one_time_passcode_id" => passcode_id,
                "email" => email
              }

--- a/elixir/apps/web/test/web/email_otp_test.exs
+++ b/elixir/apps/web/test/web/email_otp_test.exs
@@ -1,0 +1,70 @@
+defmodule Web.EmailOTPTest do
+  use Web.ConnCase, async: true
+
+  alias Web.EmailOTP
+
+  describe "put_state/4" do
+    test "sets encrypted cookie with correct options", %{conn: conn} do
+      provider_id = Ecto.UUID.generate()
+      passcode_id = Ecto.UUID.generate()
+      email = "test@example.com"
+
+      conn = EmailOTP.put_state(conn, provider_id, passcode_id, email)
+
+      cookie_key = "email_otp_#{provider_id}"
+      assert %{^cookie_key => cookie} = conn.resp_cookies
+
+      assert cookie.max_age == 15 * 60
+      assert cookie.same_site == "Strict"
+      assert cookie.secure == true
+      assert cookie.http_only == true
+    end
+  end
+
+  describe "delete_state/2" do
+    test "deletes the cookie for the provider", %{conn: conn} do
+      provider_id = Ecto.UUID.generate()
+
+      conn = EmailOTP.delete_state(conn, provider_id)
+
+      cookie_key = "email_otp_#{provider_id}"
+      assert %{^cookie_key => cookie} = conn.resp_cookies
+      assert cookie.max_age == 0
+    end
+  end
+
+  describe "fetch_state/1" do
+    test "returns state from cookie when provider_id is in path_params", %{conn: conn} do
+      provider_id = Ecto.UUID.generate()
+      passcode_id = Ecto.UUID.generate()
+      email = "test@example.com"
+
+      cookie_key = "email_otp_#{provider_id}"
+
+      conn =
+        conn
+        |> EmailOTP.put_state(provider_id, passcode_id, email)
+        |> Plug.Conn.send_resp(200, "")
+        |> then(&Plug.Test.recycle_cookies(build_conn(), &1))
+        |> Map.put(:path_params, %{"auth_provider_id" => provider_id})
+        |> Map.put(:secret_key_base, Web.Endpoint.config(:secret_key_base))
+        |> Plug.Conn.fetch_cookies(encrypted: [cookie_key])
+
+      assert EmailOTP.fetch_state(conn) == %{
+               "one_time_passcode_id" => passcode_id,
+               "email" => email
+             }
+    end
+
+    test "returns empty map when provider_id is not in path_params", %{conn: conn} do
+      conn = Map.put(conn, :path_params, %{})
+      assert EmailOTP.fetch_state(conn) == %{}
+    end
+
+    test "returns empty map when cookie is not present", %{conn: conn} do
+      provider_id = Ecto.UUID.generate()
+      conn = Map.put(conn, :path_params, %{"auth_provider_id" => provider_id})
+      assert EmailOTP.fetch_state(conn) == %{}
+    end
+  end
+end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -72,6 +72,7 @@ config :domain, Domain.ChangeLogs.ReplicationConnection,
     policies
     resources
     tokens
+    one_time_passcodes
   ],
   # Allow up to 5 minutes of processing lag before alerting. This needs to be able to survive
   # deploys without alerting.

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -60,7 +60,8 @@ config :domain, Oban,
        {worker_dev_schedule, Domain.Workers.DeleteExpiredPolicyAuthorizations},
        {worker_dev_schedule, Domain.Workers.CheckAccountLimits},
        {worker_dev_schedule, Domain.Workers.OutdatedGateways},
-       {worker_dev_schedule, Domain.Workers.DeleteExpiredTokens}
+       {worker_dev_schedule, Domain.Workers.DeleteExpiredTokens},
+       {worker_dev_schedule, Domain.Workers.DeleteExpiredOneTimePasscodes}
      ]}
   ],
   queues: [

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -196,7 +196,10 @@ if config_env() == :prod do
          {"0 9 * * 0", Domain.Workers.OutdatedGateways},
 
          # Delete expired tokens every 5 minutes
-         {"*/5 * * * *", Domain.Workers.DeleteExpiredTokens}
+         {"*/5 * * * *", Domain.Workers.DeleteExpiredTokens},
+
+         # Delete expired one-time passcodes every 5 minutes
+         {"*/5 * * * *", Domain.Workers.DeleteExpiredOneTimePasscodes}
        ]}
     ],
     queues:


### PR DESCRIPTION
Further removes overloading of the `tokens` table by implementing a purpose-built system for handling `one_time_passcodes`:

- Updates the way passcodes are requested and passed to the input form page so that the code_id (if exists) and email are stored in a short-lived auth state cookie. Before, we used a signed param to store the email (for display in the LiveView).
- Uses `argon2` for the hashing, eliminating the need for a separate salt
- Adds the `one_time_passcodes` table with an account-scoped foreign key constraint to actors
- Fixes the email otp sign in email which included a broken "Complete Sign In" when signing in from a client

Fixes #11098 
Fixes #8535