### PR TITLE
ci: upload code coverage for Rust unit tests

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -52,7 +52,7 @@ runs:
       id: toolchain
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-        components: rustfmt,clippy
+        components: rustfmt,clippy,llvm-tools-preview
         target: ${{ inputs.targets }}
         cache: false # We explicitly configure the cache below because it doesn't forward `cache-targets`.
 

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Finalize coverage upload
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -143,7 +143,7 @@ jobs:
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "libs/connlib/tunnel/testcases"
 
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/lcov.info

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -148,7 +148,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/lcov.info
           format: lcov
-          flag-name: ${{ matrix.runs-on }}
+          flag-name: rust-${{ matrix.runs-on }}
           parallel: true
 
   coverage-finish:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -96,12 +96,7 @@ jobs:
 
           set -x
 
-          # First, run all tests with coverage instrumentation.
-          if [ "${{ runner.os }}" = "Linux" ] && [ "${{ matrix.runs-on }}" = "ubuntu-24.04" ]; then
-            cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture
-          else
-            cargo test --all-features ${{ steps.setup-rust.outputs.test-packages }} -- --include-ignored --nocapture
-          fi
+          cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture
 
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
           patterns=(
@@ -148,13 +143,24 @@ jobs:
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "libs/connlib/tunnel/testcases"
 
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
-        if: ${{ runner.os == 'Linux' && matrix.runs-on == 'ubuntu-24.04' }}
+      - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/lcov.info
           format: lcov
+          flag-name: ${{ matrix.runs-on }}
+          parallel: true
+
+  coverage-finish:
+    name: coverage-finish
+    needs: test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Finalize coverage upload
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
   fuzz:
     name: fuzz

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tool: ripgrep
+          tool: ripgrep,cargo-llvm-cov
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
         if: ${{ runner.os == 'Linux' }}
         env:
@@ -96,8 +96,12 @@ jobs:
 
           set -x
 
-          # First, run all tests.
-          cargo test --all-features ${{ steps.setup-rust.outputs.test-packages }} -- --include-ignored --nocapture
+          # First, run all tests with coverage instrumentation.
+          if [ "${{ runner.os }}" = "Linux" ] && [ "${{ matrix.runs-on }}" = "ubuntu-24.04" ]; then
+            cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture
+          else
+            cargo test --all-features ${{ steps.setup-rust.outputs.test-packages }} -- --include-ignored --nocapture
+          fi
 
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
           patterns=(
@@ -143,6 +147,14 @@ jobs:
           PROPTEST_CASES: ${{ runner.os == 'Windows' && '0' || '256' }} # Default is only 256. Windows is very slow in GitHub Actions, so only run the regression cases there.
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "libs/connlib/tunnel/testcases"
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        if: ${{ runner.os == 'Linux' && matrix.runs-on == 'ubuntu-24.04' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: rust/lcov.info
+          format: lcov
 
   fuzz:
     name: fuzz


### PR DESCRIPTION
This uploads the coverage of our Rust unit tests to our coveralls account.