### PR TITLE
fix(phoenix-channel): try all addresses in parallel

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -25,6 +25,10 @@ export default function Android() {
           Fixes an issue where the authentication link would not open in the
           correct app.
         </ChangeItem>
+        <ChangeItem pull="11115">
+          Fixes an issue where Firezone would not connect if an IPv6 interface
+          is present but not routable.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.7" date={new Date("2025-12-05")}>
         <ChangeItem pull="10752">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11115">
+          Fixes an issue where Firezone would not connect if an IPv6 interface
+          is present but not routable.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.10" date={new Date("2025-12-04")}>
         <ChangeItem pull="10986">
           Fixes a minor race condition that could arise on sign out.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -30,6 +30,10 @@ export default function GUI({ os }: { os: OS }) {
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
+        <ChangeItem pull="11115">
+          Fixes an issue where Firezone would not connect if an IPv6 interface
+          is present but not routable.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-10-16")}>
         <ChangeItem pull="10509">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -26,6 +26,10 @@ export default function Gateway() {
         <ChangeItem pull="10972">
           Fixes an issue where IPv6-only DNS resources could not be reached.
         </ChangeItem>
+        <ChangeItem pull="11115">
+          Fixes an issue where Firezone would not connect if an IPv6 interface
+          is present but not routable.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.18" date={new Date("2025-11-10")}>
         <ChangeItem pull="10620">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -24,6 +24,10 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
+        <ChangeItem pull="11115">
+          Fixes an issue where Firezone would not connect if an IPv6 interface
+          is present but not routable.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.4" date={new Date("2025-10-16")}>
         <ChangeItem pull="10533">


### PR DESCRIPTION
Some systems may report IPv6 connectivity without actually being able to route IPv6 packets. Normally, such situations result in ICMP messages which then fail the `connect` operation with an IO error. If that doesn't happen, the `connect` operation may hang and run into our 5s timeout for making a connection without ever trying the other addresses.

To fix this, we implement happy eyeballs for the WebSocket connection which attempts all addresses in parallel, picking the one which resolves first and dropping the other sockets.

This ensures we are able to create a socket connection even if some paths are entirely non-responsive.