### PR TITLE
refactor(portal): move browser tokens to portal_sessions

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -58,7 +58,7 @@ defmodule API.Client.Channel do
     socket = Presence.Relays.Debouncer.cache_stamp_secrets(socket, relays)
 
     # Track client's presence
-    :ok = Presence.Clients.connect(socket.assigns.client, socket.assigns.subject.token_id)
+    :ok = Presence.Clients.connect(socket.assigns.client, socket.assigns.subject.auth_ref.id)
 
     # Subscribe to all account updates
     :ok = PubSub.Account.subscribe(socket.assigns.client.account_id)
@@ -1075,7 +1075,7 @@ defmodule API.Client.Channel do
          %Auth.Subject{
            account: %{id: account_id},
            actor: %{id: actor_id},
-           token_id: token_id,
+           auth_ref: %{id: token_id},
            context: %Auth.Context{
              remote_ip: client_remote_ip,
              user_agent: client_user_agent

--- a/elixir/apps/api/lib/api/gateway/socket.ex
+++ b/elixir/apps/api/lib/api/gateway/socket.ex
@@ -57,7 +57,7 @@ defmodule API.Gateway.Socket do
   end
 
   @impl true
-  def id(socket), do: Domain.Auth.socket_id(socket.assigns.token_id)
+  def id(socket), do: Domain.Sockets.socket_id(socket.assigns.token_id)
 
   defp upsert_changeset(site, attrs, context) do
     upsert_fields = ~w[external_id name public_key

--- a/elixir/apps/api/lib/api/relay/socket.ex
+++ b/elixir/apps/api/lib/api/relay/socket.ex
@@ -52,7 +52,7 @@ defmodule API.Relay.Socket do
   end
 
   @impl true
-  def id(socket), do: Auth.socket_id(socket.assigns.token_id)
+  def id(socket), do: Domain.Sockets.socket_id(socket.assigns.token_id)
 
   defp upsert_relay(attrs, %Auth.Context{} = context) do
     changeset = upsert_changeset(attrs, context)

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -1,6 +1,7 @@
 defmodule API.Gateway.ChannelTest do
   use API.ChannelCase, async: true
-  alias Domain.{Changes, PubSub}
+  alias Domain.Changes
+  alias Domain.PubSub
   import Domain.Cache.Cacheable, only: [to_cache: 1]
   import ExUnit.CaptureLog
 
@@ -24,7 +25,7 @@ defmodule API.Gateway.ChannelTest do
     group = group_fixture(account: account)
     membership = membership_fixture(account: account, actor: actor, group: group)
 
-    subject = subject_fixture(account: account, actor: actor)
+    subject = subject_fixture(account: account, actor: actor, type: :client)
     client = client_fixture(account: account, actor: actor)
 
     site = site_fixture(account: account)
@@ -338,8 +339,8 @@ defmodule API.Gateway.ChannelTest do
       # Consume the init message from join
       assert_push "init", _init_payload
 
-      # Subscribe to the token's socket topic (Domain.Auth.socket_id returns "tokens:#{id}")
-      socket_topic = Domain.Auth.socket_id(token.id)
+      # Subscribe to the token's socket topic (Domain.Sockets.socket_id returns "tokens:#{id}")
+      socket_topic = Domain.Sockets.socket_id(token.id)
       :ok = PubSub.subscribe(socket_topic)
 
       data = %{
@@ -1949,7 +1950,7 @@ defmodule API.Gateway.ChannelTest do
         )
 
       :ok = Domain.Presence.Clients.connect(client, client_token.id)
-      PubSub.subscribe(Domain.Auth.socket_id(subject.token_id))
+      PubSub.subscribe(Domain.Sockets.socket_id(subject.auth_ref.id))
       :ok = PubSub.Account.subscribe(gateway.account_id)
 
       push(socket, "broadcast_ice_candidates", attrs)
@@ -2003,7 +2004,7 @@ defmodule API.Gateway.ChannelTest do
         )
 
       :ok = Domain.Presence.Clients.connect(client, client_token.id)
-      PubSub.subscribe(Domain.Auth.socket_id(subject.token_id))
+      PubSub.subscribe(Domain.Sockets.socket_id(subject.auth_ref.id))
 
       push(socket, "broadcast_invalidated_ice_candidates", attrs)
 

--- a/elixir/apps/domain/lib/domain/auth/context.ex
+++ b/elixir/apps/domain/lib/domain/auth/context.ex
@@ -6,7 +6,7 @@ defmodule Domain.Auth.Context do
   the client and IP address used to perform the action.
   """
   @type t :: %__MODULE__{
-          type: :browser | :client | :relay | :gateway | :api_client,
+          type: :portal | :client | :relay | :gateway | :api_client,
           remote_ip: :inet.ip_address(),
           remote_ip_location_region: String.t(),
           remote_ip_location_city: String.t(),

--- a/elixir/apps/domain/lib/domain/auth/subject.ex
+++ b/elixir/apps/domain/lib/domain/auth/subject.ex
@@ -3,19 +3,21 @@ defmodule Domain.Auth.Subject do
 
   @type actor :: %Domain.Actor{}
 
+  @type auth_ref :: %{type: :portal_session | :token, id: Ecto.UUID.t()}
+
   @type t :: %__MODULE__{
           actor: actor(),
           account: %Domain.Account{},
-          token_id: Ecto.UUID.t(),
+          auth_ref: auth_ref(),
           auth_provider_id: Ecto.UUID.t() | nil,
           expires_at: DateTime.t(),
           context: Context.t()
         }
 
-  @enforce_keys [:actor, :account, :token_id, :expires_at, :context]
+  @enforce_keys [:actor, :account, :auth_ref, :expires_at, :context]
   defstruct actor: nil,
             account: nil,
-            token_id: nil,
+            auth_ref: nil,
             auth_provider_id: nil,
             expires_at: nil,
             context: nil

--- a/elixir/apps/domain/lib/domain/changes/hooks/gateway_tokens.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/gateway_tokens.ex
@@ -18,7 +18,7 @@ defmodule Domain.Changes.Hooks.GatewayTokens do
   end
 
   defp disconnect_socket(token) do
-    topic = Domain.Auth.socket_id(token.id)
+    topic = Domain.Sockets.socket_id(token.id)
     payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
     PubSub.broadcast(topic, payload)
   end

--- a/elixir/apps/domain/lib/domain/changes/hooks/portal_sessions.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/portal_sessions.ex
@@ -1,0 +1,27 @@
+defmodule Domain.Changes.Hooks.PortalSessions do
+  @behaviour Domain.Changes.Hooks
+  alias Domain.PubSub
+  import Domain.SchemaHelpers
+
+  @impl true
+  def on_insert(_lsn, _data), do: :ok
+
+  @impl true
+  def on_update(_lsn, _old_data, _new_data), do: :ok
+
+  @impl true
+  def on_delete(_lsn, old_data) do
+    session = struct_from_params(Domain.PortalSession, old_data)
+
+    # Disconnect all sockets using this portal session
+    disconnect_socket(session)
+  end
+
+  # This is a special message that disconnects all sockets using this session,
+  # such as for LiveViews.
+  defp disconnect_socket(session) do
+    topic = Domain.Sockets.socket_id(session.id)
+    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
+    PubSub.broadcast(topic, payload)
+  end
+end

--- a/elixir/apps/domain/lib/domain/changes/hooks/relay_tokens.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/relay_tokens.ex
@@ -11,7 +11,7 @@ defmodule Domain.Changes.Hooks.RelayTokens do
 
   @impl true
   def on_delete(_lsn, old_data) do
-    token = struct_from_params(Domain.Token, old_data)
+    token = struct_from_params(Domain.RelayToken, old_data)
 
     # We don't need to broadcast deleted tokens since the disconnect_socket/1
     # function will handle any disconnects for us directly.
@@ -23,7 +23,7 @@ defmodule Domain.Changes.Hooks.RelayTokens do
   # This is a special message that disconnects all sockets using this token,
   # such as for LiveViews.
   defp disconnect_socket(token) do
-    topic = Domain.Auth.socket_id(token.id)
+    topic = Domain.Sockets.socket_id(token.id)
     payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
     PubSub.broadcast(topic, payload)
   end

--- a/elixir/apps/domain/lib/domain/changes/hooks/tokens.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/tokens.ex
@@ -23,7 +23,7 @@ defmodule Domain.Changes.Hooks.Tokens do
   # This is a special message that disconnects all sockets using this token,
   # such as for LiveViews.
   defp disconnect_socket(token) do
-    topic = Domain.Auth.socket_id(token.id)
+    topic = Domain.Sockets.socket_id(token.id)
     payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
     PubSub.broadcast(topic, payload)
   end

--- a/elixir/apps/domain/lib/domain/changes/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/changes/replication_connection.ex
@@ -13,6 +13,7 @@ defmodule Domain.Changes.ReplicationConnection do
     "policies" => Hooks.Policies,
     "resources" => Hooks.Resources,
     "tokens" => Hooks.Tokens,
+    "portal_sessions" => Hooks.PortalSessions,
     "google_auth_providers" => Hooks.AuthProviders,
     "okta_auth_providers" => Hooks.AuthProviders,
     "entra_auth_providers" => Hooks.AuthProviders,

--- a/elixir/apps/domain/lib/domain/portal_session.ex
+++ b/elixir/apps/domain/lib/domain/portal_session.ex
@@ -1,0 +1,30 @@
+defmodule Domain.PortalSession do
+  use Ecto.Schema
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "portal_sessions" do
+    belongs_to :account, Domain.Account, primary_key: true
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    belongs_to :actor, Domain.Actor
+    belongs_to :auth_provider, Domain.AuthProvider
+
+    field :user_agent, :string
+    field :remote_ip, Domain.Types.IP
+    field :remote_ip_location_region, :string
+    field :remote_ip_location_city, :string
+    field :remote_ip_location_lat, :float
+    field :remote_ip_location_lon, :float
+
+    field :expires_at, :utc_datetime_usec
+
+    # Allows for convenient mapping of the corresponding auth provider for display
+    field :auth_provider_name, :string, virtual: true
+    field :auth_provider_type, :string, virtual: true
+
+    timestamps(updated_at: false)
+  end
+end

--- a/elixir/apps/domain/lib/domain/safe.ex
+++ b/elixir/apps/domain/lib/domain/safe.ex
@@ -638,6 +638,8 @@ defmodule Domain.Safe do
   def permit(_action, Domain.Okta.Directory, :account_admin_user), do: :ok
   def permit(:read, Domain.Okta.Directory, :api_client), do: :ok
 
+  def permit(_action, Domain.PortalSession, :account_admin_user), do: :ok
+
   # Oban.Job permissions - admin only
   def permit(:read, Oban.Job, :account_admin_user), do: :ok
 

--- a/elixir/apps/domain/lib/domain/sockets.ex
+++ b/elixir/apps/domain/lib/domain/sockets.ex
@@ -1,0 +1,11 @@
+defmodule Domain.Sockets do
+  @moduledoc """
+    Keeps our socket ID format in one place.
+  """
+
+  @typedoc ~s|A socket identifier in the format "socket:<uuid>"|
+  @type socket_id :: String.t()
+
+  @spec socket_id(Ecto.UUID.t()) :: socket_id()
+  def socket_id(id) when is_binary(id), do: "socket:#{id}"
+end

--- a/elixir/apps/domain/lib/domain/token.ex
+++ b/elixir/apps/domain/lib/domain/token.ex
@@ -13,7 +13,6 @@ defmodule Domain.Token do
 
     field :type, Ecto.Enum,
       values: [
-        :browser,
         :client,
         :api_client
       ]

--- a/elixir/apps/domain/lib/domain/workers/delete_expired_portal_sessions.ex
+++ b/elixir/apps/domain/lib/domain/workers/delete_expired_portal_sessions.ex
@@ -1,0 +1,36 @@
+defmodule Domain.Workers.DeleteExpiredPortalSessions do
+  @moduledoc """
+  Oban worker that deletes expired portal sessions.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
+
+  alias __MODULE__.DB
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    {count, _} = DB.delete_expired_sessions()
+
+    Logger.info("Deleted #{count} expired portal sessions")
+
+    :ok
+  end
+
+  defmodule DB do
+    import Ecto.Query
+    alias Domain.PortalSession
+    alias Domain.Safe
+
+    def delete_expired_sessions do
+      from(s in PortalSession, as: :sessions)
+      |> where([sessions: s], s.expires_at <= ^DateTime.utc_now())
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20251211193852_create_portal_sessions.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251211193852_create_portal_sessions.exs
@@ -1,0 +1,58 @@
+defmodule Domain.Repo.Migrations.CreatePortalSessions do
+  use Ecto.Migration
+
+  def change do
+    create table(:portal_sessions, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id), primary_key: true, null: false)
+      add(:id, :uuid, primary_key: true)
+      add(:actor_id, :binary_id, null: false)
+      add(:auth_provider_id, :binary_id, null: false)
+
+      add(:user_agent, :string, size: 2000)
+      add(:remote_ip, :inet)
+      add(:remote_ip_location_region, :string)
+      add(:remote_ip_location_city, :string)
+      add(:remote_ip_location_lat, :float)
+      add(:remote_ip_location_lon, :float)
+
+      add(:expires_at, :utc_datetime_usec, null: false)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    # Composite foreign key for (account_id, actor_id) -> actors(account_id, id)
+    execute(
+      """
+      ALTER TABLE portal_sessions
+      ADD CONSTRAINT portal_sessions_actor_id_fkey
+      FOREIGN KEY (account_id, actor_id) REFERENCES actors(account_id, id) ON DELETE CASCADE
+      """,
+      "ALTER TABLE portal_sessions DROP CONSTRAINT portal_sessions_actor_id_fkey"
+    )
+
+    # Composite foreign key for (account_id, auth_provider_id) -> auth_providers(account_id, id)
+    execute(
+      """
+      ALTER TABLE portal_sessions
+      ADD CONSTRAINT portal_sessions_auth_provider_id_fkey
+      FOREIGN KEY (account_id, auth_provider_id) REFERENCES auth_providers(account_id, id) ON DELETE CASCADE
+      """,
+      "ALTER TABLE portal_sessions DROP CONSTRAINT portal_sessions_auth_provider_id_fkey"
+    )
+
+    create(index(:portal_sessions, [:actor_id]))
+    create(index(:portal_sessions, [:auth_provider_id]))
+    create(index(:portal_sessions, [:expires_at]))
+
+    # Delete all browser tokens from the tokens table - these will be migrated to portal_sessions
+    execute(
+      "DELETE FROM tokens WHERE type = 'browser'",
+      ""
+    )
+
+    # Update the type constraint to remove 'browser'
+    drop(constraint(:tokens, :type_must_be_valid))
+
+    create(constraint(:tokens, :type_must_be_valid, check: "type IN ('client', 'api_client')"))
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -332,10 +332,10 @@ defmodule Domain.Repo.Seeds do
     system_subject = %Auth.Subject{
       account: account,
       actor: %Actor{type: :system, id: Ecto.UUID.generate(), name: "System"},
-      token_id: Ecto.UUID.generate(),
+      auth_ref: %{type: :client, id: Ecto.UUID.generate()},
       auth_provider_id: nil,
       expires_at: DateTime.utc_now() |> DateTime.add(1, :hour),
-      context: %Auth.Context{type: :browser, remote_ip: {127, 0, 0, 1}, user_agent: "seeds/1"}
+      context: %Auth.Context{type: :client, remote_ip: {127, 0, 0, 1}, user_agent: "seeds/1"}
     }
 
     {:ok, _email_provider} =
@@ -391,10 +391,10 @@ defmodule Domain.Repo.Seeds do
     other_system_subject = %Auth.Subject{
       account: other_account,
       actor: %Actor{type: :system, id: Ecto.UUID.generate(), name: "System"},
-      token_id: Ecto.UUID.generate(),
+      auth_ref: %{type: :portal_session, id: Ecto.UUID.generate()},
       auth_provider_id: nil,
       expires_at: DateTime.utc_now() |> DateTime.add(1, :hour),
-      context: %Auth.Context{type: :browser, remote_ip: {127, 0, 0, 1}, user_agent: "seeds/1"}
+      context: %Auth.Context{type: :portal, remote_ip: {127, 0, 0, 1}, user_agent: "seeds/1"}
     }
 
     {:ok, _other_email_provider} =
@@ -505,7 +505,7 @@ defmodule Domain.Repo.Seeds do
         })
 
       context = %Auth.Context{
-        type: :browser,
+        type: :client,
         user_agent: "Windows/10.0.22631 seeds/1",
         remote_ip: {172, 28, 0, 100},
         remote_ip_location_region: "UA",
@@ -516,7 +516,7 @@ defmodule Domain.Repo.Seeds do
 
       {:ok, token} =
         Repo.insert(%Token{
-          type: :browser,
+          type: :client,
           account_id: account.id,
           actor_id: identity.actor_id,
           expires_at: DateTime.utc_now() |> DateTime.add(90, :day),
@@ -597,7 +597,7 @@ defmodule Domain.Repo.Seeds do
       |> Repo.update!()
 
     _unprivileged_actor_context = %Auth.Context{
-      type: :browser,
+      type: :client,
       user_agent: "iOS/18.1.0 connlib/1.3.5",
       remote_ip: {172, 28, 0, 100},
       remote_ip_location_region: "UA",
@@ -624,11 +624,11 @@ defmodule Domain.Repo.Seeds do
     admin_subject = %Auth.Subject{
       account: account,
       actor: admin_actor,
-      token_id: Ecto.UUID.generate(),
+      auth_ref: %{type: :portal_session, id: Ecto.UUID.generate()},
       auth_provider_id: nil,
       expires_at: DateTime.utc_now() |> DateTime.add(1, :hour),
       context: %Auth.Context{
-        type: :browser,
+        type: :portal,
         remote_ip: {127, 0, 0, 1},
         user_agent: "seeds/1"
       }
@@ -637,11 +637,11 @@ defmodule Domain.Repo.Seeds do
     unprivileged_subject = %Auth.Subject{
       account: account,
       actor: unprivileged_actor,
-      token_id: unprivileged_client_token.id,
+      auth_ref: %{type: :client, id: unprivileged_client_token.id},
       auth_provider_id: nil,
       expires_at: unprivileged_client_token.expires_at,
       context: %Auth.Context{
-        type: :browser,
+        type: :client,
         remote_ip: {127, 0, 0, 1},
         user_agent: "seeds/1"
       }
@@ -1491,7 +1491,7 @@ defmodule Domain.Repo.Seeds do
         policy_id: policy.id,
         membership_id: membership.id,
         account_id: unprivileged_subject.account.id,
-        token_id: unprivileged_subject.token_id,
+        token_id: unprivileged_subject.auth_ref.id,
         client_remote_ip: {127, 0, 0, 1},
         client_user_agent: "iOS/12.7 (iPhone) connlib/0.7.412",
         gateway_remote_ip: %Postgrex.INET{address: {189, 172, 73, 153}, netmask: nil},

--- a/elixir/apps/domain/test/domain/changes/hooks/portal_sessions_test.exs
+++ b/elixir/apps/domain/test/domain/changes/hooks/portal_sessions_test.exs
@@ -1,0 +1,41 @@
+defmodule Domain.Changes.Hooks.PortalSessionsTest do
+  use Domain.DataCase, async: true
+  import Domain.Changes.Hooks.PortalSessions
+  import Domain.PortalSessionFixtures
+  alias Domain.PubSub
+
+  describe "on_insert/2" do
+    test "returns :ok" do
+      assert :ok == on_insert(0, %{})
+    end
+  end
+
+  describe "on_update/3" do
+    test "returns :ok" do
+      assert :ok == on_update(0, %{}, %{})
+    end
+  end
+
+  describe "on_delete/2" do
+    test "broadcasts disconnect message" do
+      session = portal_session_fixture()
+
+      topic = Domain.Sockets.socket_id(session.id)
+      :ok = PubSub.subscribe(topic)
+
+      old_data = %{
+        "id" => session.id,
+        "account_id" => session.account_id
+      }
+
+      assert :ok == on_delete(0, old_data)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "disconnect"
+      }
+
+      assert topic == "socket:#{session.id}"
+    end
+  end
+end

--- a/elixir/apps/domain/test/domain/workers/delete_expired_portal_sessions_test.exs
+++ b/elixir/apps/domain/test/domain/workers/delete_expired_portal_sessions_test.exs
@@ -1,0 +1,51 @@
+defmodule Domain.Workers.DeleteExpiredPortalSessionsTest do
+  use Domain.DataCase, async: true
+  use Oban.Testing, repo: Domain.Repo
+
+  import Domain.PortalSessionFixtures
+
+  alias Domain.PortalSession
+  alias Domain.Workers.DeleteExpiredPortalSessions
+
+  describe "perform/1" do
+    test "deletes expired portal sessions" do
+      session = portal_session_fixture()
+
+      session
+      |> Ecto.Changeset.change(expires_at: DateTime.utc_now() |> DateTime.add(-1, :minute))
+      |> Repo.update!()
+
+      assert Repo.get_by(PortalSession, id: session.id)
+
+      assert :ok = perform_job(DeleteExpiredPortalSessions, %{})
+
+      refute Repo.get_by(PortalSession, id: session.id)
+    end
+
+    test "does not delete non-expired portal sessions" do
+      session = portal_session_fixture()
+
+      assert Repo.get_by(PortalSession, id: session.id)
+
+      assert :ok = perform_job(DeleteExpiredPortalSessions, %{})
+
+      assert Repo.get_by(PortalSession, id: session.id)
+    end
+
+    test "deletes multiple expired sessions across accounts" do
+      session1 = portal_session_fixture()
+      session2 = portal_session_fixture()
+
+      for session <- [session1, session2] do
+        session
+        |> Ecto.Changeset.change(expires_at: DateTime.utc_now() |> DateTime.add(-1, :minute))
+        |> Repo.update!()
+      end
+
+      assert :ok = perform_job(DeleteExpiredPortalSessions, %{})
+
+      refute Repo.get_by(PortalSession, id: session1.id)
+      refute Repo.get_by(PortalSession, id: session2.id)
+    end
+  end
+end

--- a/elixir/apps/domain/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/auth_provider_fixtures.ex
@@ -63,16 +63,11 @@ defmodule Domain.AuthProviderFixtures do
     # Get or create account
     account = Map.get(attrs, :account) || account_fixture()
 
-    # Create base auth provider
-    auth_provider_id = Ecto.UUID.generate()
-
-    {:ok, _base_provider} =
-      %Domain.AuthProvider{}
-      |> Ecto.Changeset.cast(%{type: :email_otp}, [:type])
-      |> Ecto.Changeset.put_change(:id, auth_provider_id)
-      |> Ecto.Changeset.put_assoc(:account, account)
-      |> Domain.AuthProvider.changeset()
-      |> Domain.Repo.insert()
+    # Get or create base auth provider
+    auth_provider =
+      Map.get_lazy(attrs, :auth_provider, fn ->
+        auth_provider_fixture(type: :email_otp, account: account)
+      end)
 
     # Create email OTP provider
     email_otp_attrs =
@@ -91,8 +86,9 @@ defmodule Domain.AuthProviderFixtures do
         :client_session_lifetime_secs,
         :portal_session_lifetime_secs
       ])
-      |> Ecto.Changeset.put_change(:id, auth_provider_id)
+      |> Ecto.Changeset.put_change(:id, auth_provider.id)
       |> Ecto.Changeset.put_assoc(:account, account)
+      |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)
       |> Domain.EmailOTP.AuthProvider.changeset()
       |> Domain.Repo.insert()
 
@@ -111,16 +107,11 @@ defmodule Domain.AuthProviderFixtures do
     # Get or create account
     account = Map.get(attrs, :account) || account_fixture()
 
-    # Create base auth provider
-    auth_provider_id = Ecto.UUID.generate()
-
-    {:ok, _base_provider} =
-      %Domain.AuthProvider{}
-      |> Ecto.Changeset.cast(%{type: :userpass}, [:type])
-      |> Ecto.Changeset.put_change(:id, auth_provider_id)
-      |> Ecto.Changeset.put_assoc(:account, account)
-      |> Domain.AuthProvider.changeset()
-      |> Domain.Repo.insert()
+    # Get or create base auth provider
+    auth_provider =
+      Map.get_lazy(attrs, :auth_provider, fn ->
+        auth_provider_fixture(type: :userpass, account: account)
+      end)
 
     # Create userpass provider
     userpass_attrs =
@@ -139,7 +130,8 @@ defmodule Domain.AuthProviderFixtures do
         :client_session_lifetime_secs,
         :portal_session_lifetime_secs
       ])
-      |> Ecto.Changeset.put_change(:id, auth_provider_id)
+      |> Ecto.Changeset.put_change(:id, auth_provider.id)
+      |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)
       |> Ecto.Changeset.put_assoc(:account, account)
       |> Domain.Userpass.AuthProvider.changeset()
       |> Domain.Repo.insert()
@@ -166,16 +158,11 @@ defmodule Domain.AuthProviderFixtures do
     # Get or create account
     account = Map.get(attrs, :account) || account_fixture()
 
-    # Create base auth provider
-    auth_provider_id = Ecto.UUID.generate()
-
-    {:ok, _base_provider} =
-      %Domain.AuthProvider{}
-      |> Ecto.Changeset.cast(%{type: :oidc}, [:type])
-      |> Ecto.Changeset.put_change(:id, auth_provider_id)
-      |> Ecto.Changeset.put_assoc(:account, account)
-      |> Domain.AuthProvider.changeset()
-      |> Domain.Repo.insert()
+    # Get or create base auth provider
+    auth_provider =
+      Map.get_lazy(attrs, :auth_provider, fn ->
+        auth_provider_fixture(type: :oidc, account: account)
+      end)
 
     # Create OIDC provider
     oidc_attrs =
@@ -207,7 +194,8 @@ defmodule Domain.AuthProviderFixtures do
         :issuer,
         :is_verified
       ])
-      |> Ecto.Changeset.put_change(:id, auth_provider_id)
+      |> Ecto.Changeset.put_change(:id, auth_provider.id)
+      |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)
       |> Ecto.Changeset.put_assoc(:account, account)
       |> Domain.OIDC.AuthProvider.changeset()
       |> Domain.Repo.insert()

--- a/elixir/apps/domain/test/support/fixtures/portal_session_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/portal_session_fixtures.ex
@@ -1,0 +1,44 @@
+defmodule Domain.PortalSessionFixtures do
+  @moduledoc """
+  Test helpers for building portal sessions.
+  """
+
+  import Ecto.Changeset
+  import Domain.AccountFixtures
+  import Domain.ActorFixtures
+  import Domain.AuthProviderFixtures
+
+  def valid_portal_session_attrs do
+    %{
+      user_agent: "Mozilla/5.0",
+      remote_ip: %Postgrex.INET{address: {100, 64, 0, 1}},
+      remote_ip_location_region: "US",
+      remote_ip_location_city: "San Francisco",
+      remote_ip_location_lat: 37.7749,
+      remote_ip_location_lon: -122.4194,
+      expires_at: DateTime.utc_now() |> DateTime.add(86400, :second)
+    }
+  end
+
+  @doc """
+  Build a portal session with sensible defaults.
+  """
+  def portal_session_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, valid_portal_session_attrs())
+
+    account = Map.get_lazy(attrs, :account, fn -> account_fixture() end)
+    actor = Map.get_lazy(attrs, :actor, fn -> actor_fixture(account: account) end)
+
+    auth_provider =
+      Map.get_lazy(attrs, :auth_provider, fn ->
+        email_otp_provider_fixture(account: account).auth_provider
+      end)
+
+    %Domain.PortalSession{}
+    |> change(attrs)
+    |> put_assoc(:account, account)
+    |> put_assoc(:actor, actor)
+    |> put_assoc(:auth_provider, auth_provider)
+    |> Domain.Repo.insert!()
+  end
+end

--- a/elixir/apps/domain/test/support/fixtures/token_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/token_fixtures.ex
@@ -13,7 +13,7 @@ defmodule Domain.TokenFixtures do
   def valid_token_attrs(attrs \\ %{}) do
     attrs =
       Enum.into(attrs, %{
-        type: :browser,
+        type: :client,
         name: "Token #{System.unique_integer([:positive, :monotonic])}",
         secret_nonce: "",
         secret_fragment: generate_secret_fragment(),
@@ -68,9 +68,9 @@ defmodule Domain.TokenFixtures do
 
     changeset = Ecto.Changeset.put_assoc(changeset, :account, account)
 
-    # Associate with actor for browser/client/api_client/email tokens
+    # Associate with actor for client/api_client tokens
     changeset =
-      if type in [:browser, :client, :api_client, :email] do
+      if type in [:client, :api_client] do
         actor = Map.get(attrs, :actor) || actor_fixture(account: account)
         Ecto.Changeset.put_assoc(changeset, :actor, actor)
       else
@@ -86,13 +86,6 @@ defmodule Domain.TokenFixtures do
       end
 
     Domain.Repo.insert!(changeset)
-  end
-
-  @doc """
-  Generate a browser token (default type).
-  """
-  def browser_token_fixture(attrs \\ %{}) do
-    attrs |> Enum.into(%{}) |> Map.put(:type, :browser) |> token_fixture()
   end
 
   @doc """
@@ -147,16 +140,6 @@ defmodule Domain.TokenFixtures do
     Map.put_new_lazy(attrs, :secret_hash, fn ->
       compute_secret_hash(attrs.secret_nonce, attrs.secret_fragment, attrs.secret_salt)
     end)
-  end
-
-  @doc """
-  Generate an email token.
-  """
-  def email_token_fixture(attrs \\ %{}) do
-    attrs
-    |> Enum.into(%{})
-    |> Map.put(:type, :email)
-    |> token_fixture()
   end
 
   @doc """

--- a/elixir/apps/web/lib/web/live_hooks/fetch_subject.ex
+++ b/elixir/apps/web/lib/web/live_hooks/fetch_subject.ex
@@ -1,19 +1,19 @@
 defmodule Web.LiveHooks.FetchSubject do
   import Phoenix.LiveView
   alias Domain.Account
+  alias Domain.Auth
 
-  def on_mount(:default, params, session, %{assigns: %{account: %Account{} = account}} = socket) do
+  def on_mount(:default, _params, session, %{assigns: %{account: %Account{} = account}} = socket) do
     socket =
       Phoenix.Component.assign_new(socket, :subject, fn ->
-        context_type = context_type(params)
         user_agent = get_connect_info(socket, :user_agent)
         real_ip = Web.Auth.real_ip(socket)
         x_headers = get_connect_info(socket, :x_headers)
-        context = Domain.Auth.Context.build(real_ip, user_agent, x_headers, context_type)
+        context = Auth.Context.build(real_ip, user_agent, x_headers, :portal)
 
-        with {:ok, token_id} <- Map.fetch(session, "token_id"),
-             {:ok, token} <- Domain.Auth.fetch_token(account.id, token_id, context_type),
-             {:ok, subject} <- Domain.Auth.build_subject(token, context) do
+        with {:ok, session_id} <- Map.fetch(session, "portal_session_id"),
+             {:ok, portal_session} <- Auth.fetch_portal_session(account.id, session_id),
+             {:ok, subject} <- Auth.build_subject(portal_session, context) do
           subject
         else
           _ -> nil
@@ -26,7 +26,4 @@ defmodule Web.LiveHooks.FetchSubject do
   def on_mount(:default, _params, _session, socket) do
     {:cont, socket}
   end
-
-  defp context_type(%{"as" => "client"}), do: :client
-  defp context_type(_), do: :browser
 end

--- a/elixir/apps/web/lib/web/plugs/fetch_subject.ex
+++ b/elixir/apps/web/lib/web/plugs/fetch_subject.ex
@@ -3,6 +3,7 @@ defmodule Web.Plugs.FetchSubject do
 
   import Plug.Conn
   alias Domain.Account
+  alias Domain.Auth
 
   require Logger
 
@@ -11,31 +12,19 @@ defmodule Web.Plugs.FetchSubject do
 
   @impl true
   def call(%Plug.Conn{assigns: %{account: %Account{} = account}} = conn, _opts) do
-    context_type = context_type(conn.params)
     user_agent = conn.assigns[:user_agent]
     remote_ip = conn.remote_ip
-    context = Domain.Auth.Context.build(remote_ip, user_agent, conn.req_headers, context_type)
+    context = Auth.Context.build(remote_ip, user_agent, conn.req_headers, :portal)
 
-    with {:ok, token_id} <- Web.Session.Cookie.fetch_account_cookie(conn, account.id),
-         {:ok, token} <- Domain.Auth.fetch_token(account.id, token_id, context_type),
-         {:ok, subject} <- Domain.Auth.build_subject(token, context) do
+    with {:ok, session_id} <- Web.Session.Cookie.fetch_account_cookie(conn, account.id),
+         {:ok, session} <- Auth.fetch_portal_session(account.id, session_id),
+         {:ok, subject} <- Auth.build_subject(session, context) do
       conn
-      |> put_session(:live_socket_id, Domain.Auth.socket_id(token.id))
-      # We re-fetch the token in the fetch_subject live hook
-      |> put_session(:token_id, token.id)
+      |> put_session(:live_socket_id, Domain.Sockets.socket_id(session.id))
+      |> put_session(:portal_session_id, session.id)
       |> assign(:subject, subject)
     else
-      error ->
-        trace = Process.info(self(), :current_stacktrace)
-
-        Logger.info("Failed to fetch subject",
-          error: error,
-          stacktrace: trace,
-          account_id: account.id
-        )
-
-        conn
-        |> delete_account_session(account)
+      _ -> delete_account_session(conn, account)
     end
   end
 
@@ -44,10 +33,7 @@ defmodule Web.Plugs.FetchSubject do
   defp delete_account_session(conn, %Account{} = account) do
     conn
     |> delete_session(:live_socket_id)
-    |> delete_session(:token_id)
+    |> delete_session(:portal_session_id)
     |> Web.Session.Cookie.delete_account_cookie(account.id)
   end
-
-  defp context_type(%{"as" => "client"}), do: :client
-  defp context_type(_), do: :browser
 end

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -124,16 +124,24 @@ defmodule Web.Router do
     get "/sign_in/:auth_provider_type/:auth_provider_id", OIDCController, :sign_in
   end
 
-  # Sign in / out routes
+  # Client auth redirect routes (don't need portal session)
+  scope "/:account_id_or_slug", Web do
+    pipe_through [
+      :public,
+      Web.Plugs.FetchAccount
+    ]
+
+    get "/sign_in/client_redirect", SignInController, :client_redirect
+    get "/sign_in/client_auth_error", SignInController, :client_auth_error
+  end
+
+  # Sign out route (needs portal session)
   scope "/:account_id_or_slug", Web do
     pipe_through [
       :public,
       Web.Plugs.FetchAccount,
       Web.Plugs.FetchSubject
     ]
-
-    get "/sign_in/client_redirect", SignInController, :client_redirect
-    get "/sign_in/client_auth_error", SignInController, :client_auth_error
 
     post "/sign_out", SignOutController, :sign_out
   end

--- a/elixir/apps/web/lib/web/session/cookie.ex
+++ b/elixir/apps/web/lib/web/session/cookie.ex
@@ -33,23 +33,23 @@ defmodule Web.Session.Cookie do
   @doc """
   Puts account session data into a per-account cookie.
   """
-  def put_account_cookie(conn, account_id, token_id) do
+  def put_account_cookie(conn, account_id, session_id) do
     cookie_name = cookie_name(account_id)
-    cookie_data = %{"token_id" => token_id}
+    cookie_data = %{"session_id" => session_id}
 
     Plug.Conn.put_resp_cookie(conn, cookie_name, cookie_data, cookie_options())
   end
 
   @doc """
   Fetches account session data from a per-account cookie.
-  Returns `{:ok, token_id}` or `:error`.
+  Returns `{:ok, session_id}` or `:error`.
   """
   def fetch_account_cookie(conn, account_id) do
     cookie_name = cookie_name(account_id)
     conn = Plug.Conn.fetch_cookies(conn, encrypted: [cookie_name])
 
-    with {:ok, %{"token_id" => token_id}} <- Map.fetch(conn.cookies, cookie_name) do
-      {:ok, token_id}
+    with {:ok, %{"session_id" => session_id}} <- Map.fetch(conn.cookies, cookie_name) do
+      {:ok, session_id}
     end
   end
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -73,6 +73,7 @@ config :domain, Domain.ChangeLogs.ReplicationConnection,
     resources
     tokens
     one_time_passcodes
+    portal_sessions
   ],
   # Allow up to 5 minutes of processing lag before alerting. This needs to be able to survive
   # deploys without alerting.
@@ -126,6 +127,7 @@ config :domain, Domain.Changes.ReplicationConnection,
     okta_directories
     google_directories
     relay_tokens
+    portal_sessions
   ],
   # Allow up to 60 seconds of lag before alerting
   warning_threshold: :timer.seconds(60),

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -61,7 +61,8 @@ config :domain, Oban,
        {worker_dev_schedule, Domain.Workers.CheckAccountLimits},
        {worker_dev_schedule, Domain.Workers.OutdatedGateways},
        {worker_dev_schedule, Domain.Workers.DeleteExpiredTokens},
-       {worker_dev_schedule, Domain.Workers.DeleteExpiredOneTimePasscodes}
+       {worker_dev_schedule, Domain.Workers.DeleteExpiredOneTimePasscodes},
+       {worker_dev_schedule, Domain.Workers.DeleteExpiredPortalSessions}
      ]}
   ],
   queues: [

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -199,7 +199,10 @@ if config_env() == :prod do
          {"*/5 * * * *", Domain.Workers.DeleteExpiredTokens},
 
          # Delete expired one-time passcodes every 5 minutes
-         {"*/5 * * * *", Domain.Workers.DeleteExpiredOneTimePasscodes}
+         {"*/5 * * * *", Domain.Workers.DeleteExpiredOneTimePasscodes},
+
+         # Delete expired portal sessions every 5 minutes
+         {"*/5 * * * *", Domain.Workers.DeleteExpiredPortalSessions}
        ]}
     ],
     queues:


### PR DESCRIPTION
Moves the `browser` token type to a new table, `portal_sessions` and updates all references.

These are added to the change_log for now to ensure if we want them in there in the future, we'll have them retroactively.

Updates associated tests that have already been created, but does not create new controller test files just yet.

Related: #11056
Fixes: #11100 