### PR TITLE
fix(portal): use worker states to allow subsequent runs

### DIFF
--- a/elixir/apps/domain/lib/domain/workers/check_account_limits.ex
+++ b/elixir/apps/domain/lib/domain/workers/check_account_limits.ex
@@ -7,7 +7,7 @@ defmodule Domain.Workers.CheckAccountLimits do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: 300]
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
 
   alias Domain.Billing
   alias __MODULE__.DB

--- a/elixir/apps/domain/lib/domain/workers/delete_expired_one_time_passcodes.ex
+++ b/elixir/apps/domain/lib/domain/workers/delete_expired_one_time_passcodes.ex
@@ -6,7 +6,7 @@ defmodule Domain.Workers.DeleteExpiredOneTimePasscodes do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: :infinity]
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
 
   alias __MODULE__.DB
 

--- a/elixir/apps/domain/lib/domain/workers/delete_expired_policy_authorizations.ex
+++ b/elixir/apps/domain/lib/domain/workers/delete_expired_policy_authorizations.ex
@@ -6,7 +6,7 @@ defmodule Domain.Workers.DeleteExpiredPolicyAuthorizations do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: :infinity]
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
 
   alias __MODULE__.DB
 

--- a/elixir/apps/domain/lib/domain/workers/delete_expired_tokens.ex
+++ b/elixir/apps/domain/lib/domain/workers/delete_expired_tokens.ex
@@ -6,7 +6,7 @@ defmodule Domain.Workers.DeleteExpiredTokens do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: :infinity]
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
 
   alias __MODULE__.DB
 

--- a/elixir/apps/domain/lib/domain/workers/outdated_gateways.ex
+++ b/elixir/apps/domain/lib/domain/workers/outdated_gateways.ex
@@ -7,7 +7,7 @@ defmodule Domain.Workers.OutdatedGateways do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: 86_400]
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
 
   require Logger
   require OpenTelemetry.Tracer

--- a/elixir/apps/domain/lib/domain/workers/sync_error_notification.ex
+++ b/elixir/apps/domain/lib/domain/workers/sync_error_notification.ex
@@ -13,7 +13,7 @@ defmodule Domain.Workers.SyncErrorNotification do
   use Oban.Worker,
     queue: :sync_error_notifications,
     max_attempts: 3,
-    unique: [period: 3600]
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
 
   alias Domain.{Entra, Google, Mailer}
   alias __MODULE__.DB


### PR DESCRIPTION
Since the introduction of the [lifeline](https://hexdocs.pm/oban/2.9.1/lifeline.html) plugin, we have a hard cap of 2 hours before jobs stuck in the `executing` state are "rescued" and available for running again.

This means that we should effectively allow a uniqueness period of `:infinity` for jobs in the executable states. Otherwise, a job could be started again after the `period` even if it is already executing.