### PR TITLE
fix(apple): don't apply unchanged network settings

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -402,9 +402,15 @@ class Adapter: @unchecked Sendable {
       return
     }
 
+    guard let provider = packetTunnelProvider else {
+      Log.error(AdapterError.invalidSession(nil))
+      completionHandler?()
+      return
+    }
+
     Log.log("Applying network settings; settings changed")
     lastAppliedSettings = settings
-    settings.apply(completionHandler: completionHandler)
+    settings.apply(to: provider, completionHandler: completionHandler)
   }
 
   // MARK: - Event handling
@@ -425,15 +431,9 @@ class Adapter: @unchecked Sendable {
         NetworkSettings.Cidr(address: cidr.address, prefix: Int(cidr.prefix)).asNEIPv6Route
       }
 
-      // All decoding succeeded - now apply settings atomically
-      guard let provider = packetTunnelProvider else {
-        Log.error(AdapterError.invalidSession(nil))
-        return
-      }
-
       Log.log("Setting interface config")
 
-      let networkSettings = NetworkSettings(packetTunnelProvider: provider)
+      var networkSettings = NetworkSettings()
       networkSettings.tunnelAddressIPv4 = ipv4
       networkSettings.tunnelAddressIPv6 = ipv6
       networkSettings.dnsAddresses = dns
@@ -457,9 +457,11 @@ class Adapter: @unchecked Sendable {
         self.resources = resourceList
       }
 
-      // Apply network settings to flush DNS cache when resources change
-      // This ensures new DNS resources are immediately resolvable
-      if let networkSettings = networkSettings {
+      // Update DNS resource addresses to trigger network settings apply when they change
+      // This flushes the DNS cache so new DNS resources are immediately resolvable
+      if var networkSettings = networkSettings {
+        networkSettings.setDnsResourceAddresses(from: resourceList)
+        self.networkSettings = networkSettings
         applyNetworkSettingsIfChanged(networkSettings)
       }
 
@@ -616,7 +618,8 @@ class Adapter: @unchecked Sendable {
     // If matchDomains is an empty string, /etc/resolv.conf will contain connlib's
     // sentinel, which isn't helpful to us.
     private func resetToSystemDNSGettingBindResolvers() -> [String] {
-      guard let networkSettings = networkSettings
+      guard var networkSettings = networkSettings,
+        let provider = packetTunnelProvider
       else {
         // Network Settings hasn't been applied yet, so our sentinel isn't
         // the system's resolver and we can grab the system resolvers directly.
@@ -636,17 +639,24 @@ class Adapter: @unchecked Sendable {
 
       // Set tunnel's matchDomains to a dummy string that will never match any name
       networkSettings.setDummyMatchDomain()
+      self.networkSettings = networkSettings
 
       // Call apply to populate /etc/resolv.conf with the system's default resolvers
-      networkSettings.apply {
-        guard let networkSettings = self.networkSettings else { return }
+      networkSettings.apply(to: provider) {
+        guard var networkSettings = self.networkSettings,
+          let provider = self.packetTunnelProvider
+        else {
+          semaphore.signal()
+          return
+        }
 
         // Only now can we get the system resolvers
         resolversBox.value = BindResolvers.getServers()
 
         // Restore connlib's DNS resolvers
         networkSettings.clearDummyMatchDomain()
-        networkSettings.apply { semaphore.signal() }
+        self.networkSettings = networkSettings
+        networkSettings.apply(to: provider) { semaphore.signal() }
       }
 
       semaphore.wait()

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,11 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11141">
+          Fixes an issue where spurious resource updates would result in
+          perceived network interruptions resulting in errors like{" "}
+          <code>ERR_NETWORK_CHANGED</code> in Google Chrome.
+        </ChangeItem>
         <ChangeItem pull="11115">
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.


### PR DESCRIPTION
Connlib sends various updates via the `onResourcesUpdated` event to the app in order to both update network settings (for route changes) and the UI (for site online / offline status).

We were blindly applying these updates without first determining if they had any network-related changes. Combined with a bug in connlib that emitted this event even when nothing changed, it had the potential to cause very noticeable network disruptions during something like a `flow_creation_failed` event. This is because updates like those are emitted at the rate we retry resource connections, every 2s.

When network settings are applied, apps like Google Chrome detect this and immediately cut all in-flight browser requests with an `ERR_NETWORK_CHANGED` error.

With this change in place, these should happen much less frequently in day to day operation.

Fixes #11120