### PR TITLE
ci: report combined coverage from Elixir and Rust tests

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -50,9 +50,25 @@ jobs:
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: elixir/cover/lcov.info
+          file: elixir/apps/api/cover/lcov.info
           format: lcov
-          flag-name: elixir
+          flag-name: elixir-api
+          parallel: true
+
+      - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: elixir/apps/web/cover/lcov.info
+          format: lcov
+          flag-name: elixir-web
+          parallel: true
+
+      - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: elixir/apps/domain/cover/lcov.info
+          format: lcov
+          flag-name: elixir-domain
           parallel: true
 
   type-check:

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: elixir/cover/excoveralls.lcov
+          file: elixir/cover/lcov.info
           format: lcov
           flag-name: elixir
           parallel: true

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -36,8 +36,8 @@ jobs:
           CI_ASSERT_RECEIVE_TIMEOUT_MS: 250
         run: |
           # TODO: IDP-REFACTOR make sure to re-enable the --warnings-as-errors flag
-          mix coveralls.github --exclude flaky:true --exclude acceptance:true || \
-          mix coveralls.github --exclude flaky:true --exclude acceptance:true --failed
+          mix coveralls.github --parallel --flagname elixir --exclude flaky:true --exclude acceptance:true || \
+          mix coveralls.github --parallel --flagname elixir --exclude flaky:true --exclude acceptance:true --failed
 
       - name: Test Report
         if: github.event.pull_request.head.repo.full_name == github.repository && (success() || failure())

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -36,8 +36,8 @@ jobs:
           CI_ASSERT_RECEIVE_TIMEOUT_MS: 250
         run: |
           # TODO: IDP-REFACTOR make sure to re-enable the --warnings-as-errors flag
-          mix coveralls.github --parallel --flagname elixir --exclude flaky:true --exclude acceptance:true || \
-          mix coveralls.github --parallel --flagname elixir --exclude flaky:true --exclude acceptance:true --failed
+          mix coveralls.lcov --exclude flaky:true --exclude acceptance:true || \
+          mix coveralls.lcov --exclude flaky:true --exclude acceptance:true --failed
 
       - name: Test Report
         if: github.event.pull_request.head.repo.full_name == github.repository && (success() || failure())
@@ -46,6 +46,14 @@ jobs:
           name: Elixir Unit Test Report
           path: elixir/_build/test/lib/*/test-junit-report.xml
           reporter: java-junit
+
+      - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: elixir/cover/excoveralls.lcov
+          format: lcov
+          flag-name: elixir
+          parallel: true
 
   type-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -151,17 +151,6 @@ jobs:
           flag-name: rust-${{ matrix.runs-on }}
           parallel: true
 
-  coverage-finish:
-    name: coverage-finish
-    needs: test
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Finalize coverage upload
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
-
   fuzz:
     name: fuzz
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,7 @@ jobs:
   coverage-finish:
     name: coverage-finish
     needs: [elixir, rust]
-    if: always()
+    if: needs.elixir.result != 'skipped' || needs.rust.result != 'skipped'
     runs-on: ubuntu-24.04
     steps:
       - name: Finalize coverage upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,3 +407,15 @@ jobs:
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
           BRANCH: "${{ github.head_ref || github.ref_name }}"
+
+  coverage-finish:
+    name: coverage-finish
+    needs: [elixir, rust]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Finalize coverage upload
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
In order to correctly report the coverage stats, we need to report the coverage of all 3 Elixir apps separately and only "finish" the job after the Rust and Elixir workflows have both finished.