### PR TITLE
feat(portal): expose tun ips for clients and gateways

### DIFF
--- a/elixir/apps/domain/test/support/fixtures/client_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/client_fixtures.ex
@@ -24,7 +24,10 @@ defmodule Domain.ClientFixtures do
       last_seen_remote_ip: {100, 64, 0, 1},
       last_seen_remote_ip_location_region: "US",
       last_seen_version: "1.3.0",
-      last_seen_at: DateTime.utc_now()
+      last_seen_at: DateTime.utc_now(),
+      device_serial: "SN#{unique_num}",
+      device_uuid: "UUID-#{unique_num}",
+      firebase_installation_id: "firebase_#{unique_num}"
     })
   end
 

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -128,6 +128,14 @@ defmodule Web.Clients.Show do
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
+            <:label>Tunnel Interface IPv4 Address</:label>
+            <:value>{@client.ipv4}</:value>
+          </.vertical_table_row>
+          <.vertical_table_row>
+            <:label>Tunnel Interface IPv6 Address</:label>
+            <:value>{@client.ipv6}</:value>
+          </.vertical_table_row>
+          <.vertical_table_row>
             <:label>Created</:label>
             <:value>
               <.relative_datetime datetime={@client.inserted_at} />

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -94,12 +94,14 @@ defmodule Web.Gateways.Show do
               {@gateway.last_seen_user_agent}
             </:value>
           </.vertical_table_row>
-          <!--
-        <.vertical_table_row>
-          <:label>Deployment Method</:label>
-          <:value>TODO: Docker</:value>
-        </.vertical_table_row>
-        -->
+          <.vertical_table_row>
+            <:label>Tunnel Interface IPv4 Address</:label>
+            <:value>{@gateway.ipv4}</:value>
+          </.vertical_table_row>
+          <.vertical_table_row>
+            <:label>Tunnel Interface IPv6 Address</:label>
+            <:value>{@gateway.ipv6}</:value>
+          </.vertical_table_row>
         </.vertical_table>
       </:content>
     </.section>

--- a/elixir/apps/web/test/support/conn_case.ex
+++ b/elixir/apps/web/test/support/conn_case.ex
@@ -50,8 +50,17 @@ defmodule Web.ConnCase do
     Phoenix.Flash.get(conn.assigns.flash, key)
   end
 
-  def authorize_conn(conn, %Domain.ExternalIdentity{} = identity) do
-    expires_in = DateTime.utc_now() |> DateTime.add(300, :second)
+  def authorize_conn(conn, %Domain.Actor{} = actor) do
+    {:ok, token} =
+      Domain.Auth.create_token(%{
+        type: :browser,
+        account_id: actor.account_id,
+        actor_id: actor.id,
+        expires_at: DateTime.add(DateTime.utc_now(), 300, :second),
+        secret_fragment: Domain.Crypto.random_token(32),
+        secret_nonce: ""
+      })
+
     {"user-agent", user_agent} = List.keyfind(conn.req_headers, "user-agent", 0, "FooBar 1.1")
 
     context = %Domain.Auth.Context{
@@ -64,13 +73,16 @@ defmodule Web.ConnCase do
       remote_ip: conn.remote_ip
     }
 
-    nonce = "nonce"
-    {:ok, token} = Domain.Auth.create_token(identity, context, nonce, expires_in)
-    encoded_fragment = Domain.Crypto.encode_token_fragment!(token)
     {:ok, subject} = Domain.Auth.build_subject(token, context)
 
+    # Set the cookie. We need to set it as a response cookie first,
+    # then transfer to request cookies for subsequent requests.
+    conn = Web.Session.Cookie.put_account_cookie(conn, actor.account_id, token.id)
+    cookie_name = Web.Session.Cookie.cookie_name(actor.account_id)
+    cookie_value = conn.resp_cookies[cookie_name].value
+
     conn
-    |> Web.Auth.put_account_session(context.type, identity.account_id, nonce <> encoded_fragment)
+    |> put_req_cookie(cookie_name, cookie_value)
     |> Plug.Conn.assign(:account, subject.account)
     |> Plug.Conn.assign(:subject, subject)
   end


### PR DESCRIPTION
This feature was requested for a pilot.

- Exposes the client and gateway tun interface ipv4 / ipv6
- Updates the fixtures to ensure these are generated
- Fixes the relevant Web live view tests so that they now pass
- Updates the `conn_case` so that we are set up to start enabling the other LiveView tests

Related: #11056 
Fixes #8300 