### PR TITLE
fix(portal): disallow nulls in client/gateway tun ips

### DIFF
--- a/elixir/apps/api/test/api/client/socket_test.exs
+++ b/elixir/apps/api/test/api/client/socket_test.exs
@@ -153,6 +153,30 @@ defmodule API.Client.SocketTest do
       assert client.last_seen_remote_ip_location_lon == 30.5167
     end
 
+    test "preserves ipv4 and ipv6 addresses on reconnection" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      # Create existing client with specific IPs
+      existing_client = client_fixture(account: account, actor: actor)
+      original_ipv4 = existing_client.ipv4
+      original_ipv6 = existing_client.ipv6
+
+      # Create a new token for same actor
+      token = client_token_fixture(account: account, actor: actor)
+      encoded_token = encode_token(token)
+
+      attrs = connect_attrs(token: encoded_token, external_id: existing_client.external_id)
+
+      # Reconnect
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: @connect_info)
+      assert client = socket.assigns.client
+
+      # Verify IPs are preserved
+      assert client.ipv4 == original_ipv4
+      assert client.ipv6 == original_ipv6
+    end
+
     test "uses region code to put default coordinates" do
       account = account_fixture()
       actor = actor_fixture(account: account)

--- a/elixir/apps/domain/priv/repo/migrations/20251213172923_disallow_clients_gateways_ipv4_ipv6_null.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251213172923_disallow_clients_gateways_ipv4_ipv6_null.exs
@@ -1,0 +1,15 @@
+defmodule Domain.Repo.Migrations.DisallowClientsGatewaysIpv4Ipv6Null do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clients) do
+      modify(:ipv4, :inet, null: false, from: {:inet, null: true})
+      modify(:ipv6, :inet, null: false, from: {:inet, null: true})
+    end
+
+    alter table(:gateways) do
+      modify(:ipv4, :inet, null: false, from: {:inet, null: true})
+      modify(:ipv6, :inet, null: false, from: {:inet, null: true})
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -143,9 +143,6 @@ defmodule Domain.Repo.Seeds do
     # Create tunnel IPs in CGNAT range (100.64.0.0/10) and fd00:2021:1111::/48
     {ipv4, ipv6} = create_tunnel_ips(site.account_id, external_id)
 
-    # Create tunnel IPs in CGNAT range (100.64.0.0/10) and fd00:2021:1111::/48
-    {ipv4, ipv6} = create_tunnel_ips(site.account_id)
-
     gateway =
       %Gateway{
         site_id: site_id,

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -143,6 +143,9 @@ defmodule Domain.Repo.Seeds do
     # Create tunnel IPs in CGNAT range (100.64.0.0/10) and fd00:2021:1111::/48
     {ipv4, ipv6} = create_tunnel_ips(site.account_id, external_id)
 
+    # Create tunnel IPs in CGNAT range (100.64.0.0/10) and fd00:2021:1111::/48
+    {ipv4, ipv6} = create_tunnel_ips(site.account_id)
+
     gateway =
       %Gateway{
         site_id: site_id,


### PR DESCRIPTION
These should never be allowed to be null otherwise Firezone will not work. I did check both staging and prod at the time of this PR and we don't have any data that violates this constraint, so we should be ok to send this migration out.