### PR TITLE
fix(loadtest): don't use dashes in log source

### DIFF
--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -65,8 +65,8 @@ jobs:
         if: matrix.os == 'windows'
         shell: pwsh
         run: |
-          New-EventLog -LogName Application -Source "Firezone-Loadtest" -ErrorAction SilentlyContinue
-          Write-Host "Event Log source 'Firezone-Loadtest' registered (or already exists)"
+          New-EventLog -LogName Application -Source "FirezoneLoadtest" -ErrorAction SilentlyContinue
+          Write-Host "Event Log source 'FirezoneLoadtest' registered (or already exists)"
 
       - name: Build loadtest binary
         shell: bash

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -41,7 +41,7 @@
 //! On Windows, events are logged to the Application Event Log under source
 //! "Firezone-Loadtest". Register the source (as admin) with:
 //! ```powershell
-//! New-EventLog -LogName Application -Source "Firezone-Loadtest"
+//! New-EventLog -LogName Application -Source "FirezoneLoadtest"
 //! ```
 
 mod cli;
@@ -230,7 +230,7 @@ fn init_logging() {
         use tracing_subscriber::layer::SubscriberExt as _;
         use tracing_subscriber::util::SubscriberInitExt as _;
 
-        match logging::windows_event_log::layer("Firezone-Loadtest") {
+        match logging::windows_event_log::layer("FirezoneLoadtest") {
             Ok(layer) => {
                 tracing_subscriber::registry().with(layer).init();
             }

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -39,7 +39,7 @@
 //! # Windows Event Log
 //!
 //! On Windows, events are logged to the Application Event Log under source
-//! "Firezone-Loadtest". Register the source (as admin) with:
+//! "FirezoneLoadtest". Register the source (as admin) with:
 //! ```powershell
 //! New-EventLog -LogName Application -Source "FirezoneLoadtest"
 //! ```


### PR DESCRIPTION
The use of dashes in Windows Event Log source names appears to cause some problems.