### PR TITLE
chore: remove `mutants` dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -870,7 +870,6 @@ dependencies = [
  "known-folders",
  "libc",
  "logging",
- "mutants",
  "netlink-packet-core",
  "netlink-packet-route",
  "nix 0.30.1",
@@ -4648,12 +4647,6 @@ dependencies = [
  "thiserror 2.0.17",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "mutants"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "nanorand"

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -83,9 +83,6 @@ bytes = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
 
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` testing
-
 [target.'cfg(windows)'.dev-dependencies]
 ip-packet = { workspace = true }
 tokio = { workspace = true, features = ["net", "time"] }

--- a/rust/libs/bin-shared/src/dns_control/linux/etc_resolv_conf.rs
+++ b/rust/libs/bin-shared/src/dns_control/linux/etc_resolv_conf.rs
@@ -35,7 +35,6 @@ impl Default for ResolvPaths {
 ///
 /// This is async because it's called in a Tokio context and it's nice to use their
 /// `fs` module
-#[cfg_attr(test, mutants::skip)] // Would modify system-wide `/etc/resolv.conf`
 pub(crate) fn configure(dns_config: &[IpAddr], search_domain: Option<DomainName>) -> Result<()> {
     configure_at_paths(dns_config, search_domain, &ResolvPaths::default())
 }
@@ -43,7 +42,6 @@ pub(crate) fn configure(dns_config: &[IpAddr], search_domain: Option<DomainName>
 /// Revert changes Firezone made to `/etc/resolv.conf`
 ///
 /// Must be sync because it's called in `Drop` impls
-#[cfg_attr(test, mutants::skip)] // Would modify system-wide `/etc/resolv.conf`
 pub(crate) fn revert() -> Result<()> {
     revert_at_paths(&ResolvPaths::default())
 }


### PR DESCRIPTION
We no longer run any mutation tests so this is unnecessary.