### PR TITLE
fix(loadtest): output CLI error via `tracing`

### DIFF
--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -114,7 +114,10 @@ async fn main() {
 
     match try_main().await {
         Ok(()) => {}
-        Err(e) => tracing::error!("{e:#}"),
+        Err(e) => {
+            tracing::error!("{e:#}");
+            std::process::exit(1);
+        }
     }
 }
 

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -109,8 +109,16 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
     init_logging();
+
+    match try_main().await {
+        Ok(()) => {}
+        Err(e) => tracing::error!("{e:#}"),
+    }
+}
+
+async fn try_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     if cli.dump_config {


### PR DESCRIPTION
This ensures any startup failures are logged to Windows Event Log.