### PR TITLE
refactor(loadtest): simplify WebSocket test

### DIFF
--- a/rust/tests/loadtest/loadtest.example.toml
+++ b/rust/tests/loadtest/loadtest.example.toml
@@ -55,18 +55,8 @@ addresses = [
 concurrent = "5..50"
 # How long to hold connections (seconds)
 duration_secs = "30..300"
-# Connection timeout (seconds)
-timeout_secs = "5..30"
-# Ping interval (seconds) - ignored if echo_mode is true
-ping_interval_secs = "5..15"
-# Enable echo mode for round-trip verification
-echo_mode = false
-# Payload size for echo messages (bytes)
-echo_payload_size = "64..64"
-# Interval between echo messages (seconds)
-echo_interval_secs = "1..1"
-# Timeout for echo responses (seconds)
-echo_read_timeout_secs = "5..5"
+# How long to at most wait between messages. Zero means we won't send any messages.
+max_echo_interval_secs = 10
 
 # ICMP ping testing
 # Note: Requires elevated privileges on Linux/macOS (root or CAP_NET_RAW)

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -162,10 +162,6 @@ pub struct WebsocketConfig {
     pub duration_secs: Range,
     /// Connection timeout in seconds.
     pub timeout_secs: Range,
-    /// Ping interval in seconds. Ignored in echo mode.
-    pub ping_interval_secs: Range,
-    /// Enable echo mode for payload verification.
-    pub echo_mode: bool,
     /// Echo payload size in bytes.
     pub echo_payload_size: Range,
     /// Interval between echo messages in seconds.

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -162,8 +162,6 @@ pub struct WebsocketConfig {
     pub duration_secs: Range,
     /// Connection timeout in seconds.
     pub timeout_secs: Range,
-    /// Echo payload size in bytes.
-    pub echo_payload_size: Range,
     /// Interval between echo messages in seconds.
     pub echo_interval_secs: Range,
 }

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -160,8 +160,8 @@ pub struct WebsocketConfig {
     pub concurrent: Range,
     /// How long to hold connections in seconds.
     pub duration_secs: Range,
-    /// Interval between echo messages in seconds.
-    pub echo_interval_secs: Range,
+    /// How long to at most wait between messages. Zero means we won't send any messages.
+    pub max_echo_interval_secs: u64,
 }
 
 impl WebsocketConfig {

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -160,8 +160,6 @@ pub struct WebsocketConfig {
     pub concurrent: Range,
     /// How long to hold connections in seconds.
     pub duration_secs: Range,
-    /// Connection timeout in seconds.
-    pub timeout_secs: Range,
     /// Interval between echo messages in seconds.
     pub echo_interval_secs: Range,
 }

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -166,8 +166,6 @@ pub struct WebsocketConfig {
     pub echo_payload_size: Range,
     /// Interval between echo messages in seconds.
     pub echo_interval_secs: Range,
-    /// Timeout for reading echo responses in seconds.
-    pub echo_read_timeout_secs: Range,
 }
 
 impl WebsocketConfig {

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -301,15 +301,12 @@ impl TestSelector {
 
         let concurrent = self.rng.gen_range(config.concurrent) as usize;
         let duration = Duration::from_secs(self.rng.gen_range(config.duration_secs));
-        let echo_interval = Some(Duration::from_secs(
-            self.rng.gen_range(config.echo_interval_secs),
-        ));
 
         websocket::TestConfig {
             url: address,
             concurrent,
             hold_duration: duration,
-            echo_interval,
+            max_echo_interval: Duration::from_secs(config.max_echo_interval_secs),
         }
     }
 

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -302,10 +302,6 @@ impl TestSelector {
         let concurrent = self.rng.gen_range(config.concurrent) as usize;
         let duration = Duration::from_secs(self.rng.gen_range(config.duration_secs));
         let timeout = Duration::from_secs(self.rng.gen_range(config.timeout_secs));
-        let ping_interval = Some(Duration::from_secs(
-            self.rng.gen_range(config.ping_interval_secs),
-        ));
-        let echo_mode = config.echo_mode;
         let echo_payload_size = self.rng.gen_range(config.echo_payload_size) as usize;
         let echo_interval = Some(Duration::from_secs(
             self.rng.gen_range(config.echo_interval_secs),
@@ -318,8 +314,6 @@ impl TestSelector {
             concurrent,
             hold_duration: duration,
             connect_timeout: timeout,
-            ping_interval,
-            echo_mode,
             echo_payload_size,
             echo_interval,
             echo_read_timeout,

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -301,7 +301,6 @@ impl TestSelector {
 
         let concurrent = self.rng.gen_range(config.concurrent) as usize;
         let duration = Duration::from_secs(self.rng.gen_range(config.duration_secs));
-        let timeout = Duration::from_secs(self.rng.gen_range(config.timeout_secs));
         let echo_interval = Some(Duration::from_secs(
             self.rng.gen_range(config.echo_interval_secs),
         ));
@@ -310,7 +309,6 @@ impl TestSelector {
             url: address,
             concurrent,
             hold_duration: duration,
-            connect_timeout: timeout,
             echo_interval,
         }
     }

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -306,8 +306,6 @@ impl TestSelector {
         let echo_interval = Some(Duration::from_secs(
             self.rng.gen_range(config.echo_interval_secs),
         ));
-        let echo_read_timeout =
-            Duration::from_secs(self.rng.gen_range(config.echo_read_timeout_secs));
 
         websocket::TestConfig {
             url: address,
@@ -316,7 +314,6 @@ impl TestSelector {
             connect_timeout: timeout,
             echo_payload_size,
             echo_interval,
-            echo_read_timeout,
         }
     }
 

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -302,7 +302,6 @@ impl TestSelector {
         let concurrent = self.rng.gen_range(config.concurrent) as usize;
         let duration = Duration::from_secs(self.rng.gen_range(config.duration_secs));
         let timeout = Duration::from_secs(self.rng.gen_range(config.timeout_secs));
-        let echo_payload_size = self.rng.gen_range(config.echo_payload_size) as usize;
         let echo_interval = Some(Duration::from_secs(
             self.rng.gen_range(config.echo_interval_secs),
         ));
@@ -312,7 +311,6 @@ impl TestSelector {
             concurrent,
             hold_duration: duration,
             connect_timeout: timeout,
-            echo_payload_size,
             echo_interval,
         }
     }

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -1,8 +1,3 @@
-//! WebSocket connection load testing.
-//!
-//! Tests WebSocket connection establishment and hold time.
-//! Optionally verifies echo responses when connected to an echo server.
-
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -188,6 +188,8 @@ async fn run_echo_loop(
 
         let interval = rand::thread_rng().gen_range(Duration::ZERO..config.max_echo_interval);
 
+        tracing::trace!("Next message in {interval:?}");
+
         tokio::time::sleep(interval).await;
     }
 

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -178,7 +178,7 @@ async fn run_single_connection(connection_id: usize, config: TestConfig) -> Resu
     tracing::debug!(?connect_latency, "WebSocket connection established");
 
     let echo_stats = if config.echo_mode {
-        run_echo_loop(connection_id, ws, &config).await
+        run_echo_loop(connection_id, ws, &config).await?
     } else {
         run_ping_loop(ws, &config).await?;
 
@@ -240,7 +240,7 @@ async fn run_echo_loop(
     connection_id: usize,
     mut ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
     config: &TestConfig,
-) -> EchoStats {
+) -> Result<EchoStats> {
     let mut stats = EchoStats::default();
     let hold_start = Instant::now();
     let echo_interval = config.echo_interval.unwrap_or(Duration::from_secs(1));
@@ -337,9 +337,9 @@ async fn run_echo_loop(
     }
 
     // Graceful close
-    let _ = ws.close(None).await;
+    ws.close(None).await?;
 
-    stats
+    Ok(stats)
 }
 
 /// Configuration for WebSocket echo server.

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -3,18 +3,14 @@
 //! Tests WebSocket connection establishment and hold time.
 //! Optionally verifies echo responses when connected to an echo server.
 
+use crate::DEFAULT_ECHO_PAYLOAD_SIZE;
 use crate::echo_payload::{self, EchoPayload};
-use crate::util::{EchoStats, StreamingStats, saturating_usize_to_u32};
-use crate::{DEFAULT_ECHO_PAYLOAD_SIZE, WithSeed};
-use anyhow::Result;
+use crate::util::EchoStats;
+use anyhow::{Context, Result};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
-use serde::Serialize;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
@@ -91,58 +87,6 @@ pub struct Args {
     echo_read_timeout: Duration,
 }
 
-/// Result of a WebSocket connection attempt.
-struct ConnectionResult {
-    success: bool,
-    messages_sent: usize,
-    messages_received: usize,
-    connect_latency: Duration,
-    held_duration: Duration,
-    /// Echo mode statistics
-    echo_stats: EchoStats,
-}
-
-/// Summary of WebSocket load test results.
-///
-/// # Echo Mode Semantics
-///
-/// When `echo_mode` is `true`, the `failed_connections` count includes connections
-/// that had any echo verification failures (mismatches), not just connection failures.
-/// A connection is considered successful only if it both connected successfully AND
-/// had zero echo mismatches during the test duration.
-#[derive(Debug, Serialize)]
-pub struct WebsocketTestSummary {
-    pub test_type: &'static str,
-    pub url: String,
-    pub concurrent_connections: usize,
-    pub hold_duration_secs: u64,
-    pub total_connections: usize,
-    pub successful_connections: usize,
-    pub failed_connections: usize,
-    /// Peak number of connections that were simultaneously active.
-    pub peak_active_connections: usize,
-    pub total_messages_sent: usize,
-    pub total_messages_received: usize,
-    pub min_connect_latency_ms: u64,
-    pub max_connect_latency_ms: u64,
-    pub avg_connect_latency_ms: u64,
-    pub avg_held_duration_ms: u64,
-    // Echo mode fields
-    pub echo_mode: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub echo_messages_sent: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub echo_messages_verified: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub echo_mismatches: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_echo_latency_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_echo_latency_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub avg_echo_latency_ms: Option<u64>,
-}
-
 /// Run WebSocket test with manual CLI args.
 pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
     if args.server {
@@ -167,11 +111,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
             echo_read_timeout: args.echo_read_timeout,
         };
 
-        let summary = run(config, 0).await?;
-        println!(
-            "{}",
-            serde_json::to_string(&summary).expect("Failed to serialize metrics")
-        );
+        run(config, 0).await?;
     }
 
     Ok(())
@@ -179,12 +119,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
 
 /// Run WebSocket test from resolved config.
 pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()> {
-    let summary = run(config, seed).await?;
-
-    println!(
-        "{}",
-        serde_json::to_string(&WithSeed::new(seed, summary)).expect("Failed to serialize metrics")
-    );
+    run(config, seed).await?;
 
     Ok(())
 }
@@ -194,11 +129,7 @@ pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()
 /// Establishes `concurrent` connections and holds each open for `hold_duration`.
 /// In echo mode, sends timestamped payloads and verifies responses.
 /// Otherwise, optionally sends periodic ping messages to keep connections alive.
-async fn run(config: TestConfig, seed: u64) -> Result<WebsocketTestSummary> {
-    let (tx, mut rx) = mpsc::channel::<ConnectionResult>(config.concurrent);
-    let active_connections = Arc::new(AtomicUsize::new(0));
-    let peak_active = Arc::new(AtomicUsize::new(0));
-
+async fn run(config: TestConfig, seed: u64) -> Result<()> {
     if config.echo_mode && config.ping_interval.is_some() {
         tracing::warn!("ping_interval is ignored when echo_mode is enabled");
     }
@@ -212,192 +143,50 @@ async fn run(config: TestConfig, seed: u64) -> Result<WebsocketTestSummary> {
         "Starting WebSocket connection test"
     );
 
+    let mut connections = tokio::task::JoinSet::new();
+
     // Spawn one task per concurrent connection
     for i in 0..config.concurrent {
-        let tx = tx.clone();
-        let config = config.clone();
-        let active = Arc::clone(&active_connections);
-        let peak = Arc::clone(&peak_active);
-
-        tokio::spawn(async move {
-            let result = run_single_connection(i, &config, &active, &peak).await;
-            let _ = tx.send(result).await;
-        });
+        connections.spawn(run_single_connection(i, config.clone()));
     }
 
-    // Drop our sender so rx completes when all workers finish
-    drop(tx);
+    connections
+        .join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
 
-    // Collect results
-    let mut total = 0usize;
-    let mut successful = 0usize;
-    let mut failed = 0usize;
-    let mut total_sent = 0usize;
-    let mut total_received = 0usize;
-    let mut min_latency = Duration::MAX;
-    let mut max_latency = Duration::ZERO;
-    let mut total_latency = Duration::ZERO;
-    let mut total_held = Duration::ZERO;
-
-    // Echo mode aggregates
-    let mut total_echo_sent = 0usize;
-    let mut total_echo_verified = 0usize;
-    let mut total_echo_mismatches = 0usize;
-    let mut echo_latencies = StreamingStats::new();
-
-    while let Some(result) = rx.recv().await {
-        total += 1;
-        if result.success {
-            successful += 1;
-            total_sent += result.messages_sent;
-            total_received += result.messages_received;
-            min_latency = min_latency.min(result.connect_latency);
-            max_latency = max_latency.max(result.connect_latency);
-            total_latency += result.connect_latency;
-            total_held += result.held_duration;
-
-            // Aggregate echo stats
-            total_echo_sent += result.echo_stats.messages_sent;
-            total_echo_verified += result.echo_stats.messages_verified;
-            total_echo_mismatches += result.echo_stats.mismatches;
-            echo_latencies.merge(&result.echo_stats.latencies);
-        } else {
-            failed += 1;
-        }
-    }
-
-    let avg_latency = if successful > 0 {
-        total_latency / saturating_usize_to_u32(successful)
-    } else {
-        Duration::ZERO
-    };
-
-    let avg_held = if successful > 0 {
-        total_held / saturating_usize_to_u32(successful)
-    } else {
-        Duration::ZERO
-    };
-
-    // Calculate echo latency stats
-    let (min_echo_latency, max_echo_latency, avg_echo_latency) =
-        if config.echo_mode && echo_latencies.count() > 0 {
-            (
-                echo_latencies.min().map(|d| d.as_millis() as u64),
-                echo_latencies.max().map(|d| d.as_millis() as u64),
-                echo_latencies.avg().map(|d| d.as_millis() as u64),
-            )
-        } else {
-            (None, None, None)
-        };
-
-    let has_errors = failed > 0 || total_echo_mismatches > 0;
-    crate::log_test_result!(
-        has_errors,
-        successful,
-        failed,
-        total_sent,
-        total_received,
-        avg_connect_latency_ms = avg_latency.as_millis(),
-        echo_verified = total_echo_verified,
-        echo_mismatches = total_echo_mismatches,
-        "WebSocket connection test complete"
-    );
-
-    Ok(WebsocketTestSummary {
-        test_type: "websocket",
-        url: config.url.to_string(),
-        concurrent_connections: config.concurrent,
-        hold_duration_secs: config.hold_duration.as_secs(),
-        total_connections: total,
-        successful_connections: successful,
-        failed_connections: failed,
-        peak_active_connections: peak_active.load(Ordering::SeqCst),
-        total_messages_sent: total_sent,
-        total_messages_received: total_received,
-        min_connect_latency_ms: if min_latency == Duration::MAX {
-            0
-        } else {
-            min_latency.as_millis() as u64
-        },
-        max_connect_latency_ms: max_latency.as_millis() as u64,
-        avg_connect_latency_ms: avg_latency.as_millis() as u64,
-        avg_held_duration_ms: avg_held.as_millis() as u64,
-        echo_mode: config.echo_mode,
-        echo_messages_sent: config.echo_mode.then_some(total_echo_sent),
-        echo_messages_verified: config.echo_mode.then_some(total_echo_verified),
-        echo_mismatches: config.echo_mode.then_some(total_echo_mismatches),
-        min_echo_latency_ms: min_echo_latency,
-        max_echo_latency_ms: max_echo_latency,
-        avg_echo_latency_ms: avg_echo_latency,
-    })
+    Ok(())
 }
 
 /// Run a single WebSocket connection test.
-async fn run_single_connection(
-    connection_id: usize,
-    config: &TestConfig,
-    active: &AtomicUsize,
-    peak: &AtomicUsize,
-) -> ConnectionResult {
+async fn run_single_connection(connection_id: usize, config: TestConfig) -> Result<()> {
     let connect_start = Instant::now();
 
-    match timeout(config.connect_timeout, connect_async(config.url.as_str())).await {
-        Ok(Ok((ws, _response))) => {
-            let connect_latency = connect_start.elapsed();
-            let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-            // Update peak if this is a new high water mark
-            peak.fetch_max(current, Ordering::SeqCst);
-            tracing::trace!(connection = connection_id, url = %config.url, ?connect_latency, "WebSocket connection established");
+    let (ws, _response) = timeout(config.connect_timeout, connect_async(config.url.as_str()))
+        .await
+        .context("Connection timed out")?
+        .context("Connection failed")?;
 
-            let hold_start = Instant::now();
+    let connect_latency = connect_start.elapsed();
+    tracing::trace!(connection = connection_id, url = %config.url, ?connect_latency, "WebSocket connection established");
 
-            let (messages_sent, messages_received, echo_stats) = if config.echo_mode {
-                let stats = run_echo_loop(connection_id, ws, config).await;
-                (stats.messages_sent, stats.messages_verified, stats)
-            } else {
-                let (sent, received) = run_ping_loop(connection_id, ws, config).await;
-                (sent, received, EchoStats::default())
-            };
+    let hold_start = Instant::now();
 
-            let held_duration = hold_start.elapsed();
-            active.fetch_sub(1, Ordering::SeqCst);
-            tracing::trace!(connection = connection_id, url = %config.url, ?held_duration, "WebSocket connection closed");
+    let (_, _, echo_stats) = if config.echo_mode {
+        let stats = run_echo_loop(connection_id, ws, &config).await;
+        (stats.messages_sent, stats.messages_verified, stats)
+    } else {
+        let (sent, received) = run_ping_loop(connection_id, ws, &config).await;
+        (sent, received, EchoStats::default())
+    };
 
-            // A connection is only successful if there were no echo mismatches
-            let success = echo_stats.mismatches == 0;
+    let held_duration = hold_start.elapsed();
+    tracing::trace!(connection = connection_id, url = %config.url, ?held_duration, "WebSocket connection closed");
 
-            ConnectionResult {
-                success,
-                messages_sent,
-                messages_received,
-                connect_latency,
-                held_duration,
-                echo_stats,
-            }
-        }
-        Ok(Err(e)) => {
-            tracing::debug!(connection = connection_id, url = %config.url, error = %e, "WebSocket connection failed");
-            ConnectionResult {
-                success: false,
-                messages_sent: 0,
-                messages_received: 0,
-                connect_latency: connect_start.elapsed(),
-                held_duration: Duration::ZERO,
-                echo_stats: EchoStats::default(),
-            }
-        }
-        Err(_) => {
-            tracing::debug!(connection = connection_id, url = %config.url, "WebSocket connection timed out");
-            ConnectionResult {
-                success: false,
-                messages_sent: 0,
-                messages_received: 0,
-                connect_latency: connect_start.elapsed(),
-                held_duration: Duration::ZERO,
-                echo_stats: EchoStats::default(),
-            }
-        }
-    }
+    anyhow::ensure!(echo_stats.mismatches == 0, "State mismatches on connection");
+
+    Ok(())
 }
 
 /// Run the ping/pong loop for a connection (non-echo mode).

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -160,6 +160,8 @@ async fn run(config: TestConfig, seed: u64) -> Result<()> {
         .into_iter()
         .collect::<Result<Vec<_>>>()?;
 
+    tracing::info!("WebSocket connection test complete");
+
     Ok(())
 }
 

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -177,8 +177,6 @@ async fn run_single_connection(connection_id: usize, config: TestConfig) -> Resu
     let connect_latency = connect_start.elapsed();
     tracing::debug!(?connect_latency, "WebSocket connection established");
 
-    let hold_start = Instant::now();
-
     let echo_stats = if config.echo_mode {
         run_echo_loop(connection_id, ws, &config).await
     } else {
@@ -187,8 +185,7 @@ async fn run_single_connection(connection_id: usize, config: TestConfig) -> Resu
         EchoStats::default()
     };
 
-    let held_duration = hold_start.elapsed();
-    tracing::debug!(?held_duration, "WebSocket connection closed");
+    tracing::debug!("WebSocket connection closed");
 
     anyhow::ensure!(echo_stats.mismatches == 0, "State mismatches on connection");
 

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -267,19 +267,7 @@ async fn run_echo_loop(
                     );
                 }
             }
-            Message::Text(text) => {
-                // Try to verify as text (some servers echo back as text)
-                let received = echo_payload::verify_echo(&payload, text.as_bytes())
-                    .context("Failed to verify text echo data")?;
-
-                if let Some(latency) = received.round_trip_latency() {
-                    tracing::trace!(
-                        connection = connection_id,
-                        latency_ms = latency.as_millis(),
-                        "Echo verified (text)"
-                    );
-                }
-            }
+            Message::Text(_) => anyhow::bail!("Unexpected `Text` message"),
             Message::Close(_) => anyhow::bail!("WebSocket closed by server"),
             Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
         }

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -87,11 +87,7 @@ pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()
     Ok(())
 }
 
-/// Run the WebSocket connection load test.
-///
-/// Establishes `concurrent` connections and holds each open for `hold_duration`.
-/// In echo mode, sends timestamped payloads and verifies responses.
-/// Otherwise, optionally sends periodic ping messages to keep connections alive.
+/// Sends random binary data over each connection and verifies echo responses.
 async fn run(config: TestConfig, seed: u64) -> Result<()> {
     tracing::info!(
         url = %config.url,

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -229,8 +229,7 @@ async fn run_ping_loop(
         tokio::time::sleep(config.hold_duration).await;
     }
 
-    // Graceful close
-    let _ = ws.close(None).await;
+    ws.close(None).await.context("Failed to close connection")?;
 
     Ok(())
 }

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -205,9 +205,11 @@ async fn run_ping_loop(
     if let Some(interval) = config.ping_interval {
         // Send periodic pings while holding
         while hold_start.elapsed() < config.hold_duration {
-            if ws.send(Message::Ping(vec![].into())).await.is_ok() {
-                tracing::trace!("Sent ping");
-            }
+            ws.send(Message::Ping(vec![].into()))
+                .await
+                .context("Failed to sent ping")?;
+
+            tracing::trace!("Sent ping");
 
             // Wait for pong or timeout
             #[expect(


### PR DESCRIPTION
This PR simplifies the WebSocket part of `loadtest` down to its essentials. Most notably, almost all configuration options are removed except for the number of connections, how long to hold them open for and how often to send messages. Timeouts and message sizes have been inlined into the code.

The `echo` mode is now the default and the ping-only loop has been removed. From an IP layer PoV, it doesn't matter whether we send WebSocket ping/pong messages or other binary data, so having both is redundant.

The delay between messages as well as their size is now randomised between each message. This ensures we exercise a more varied load on the tunnel.

Finally, all stats have been removed and the error handling has been simplified. Any form of error now aborts the connection and if any of the connections fail, we consider the entire test a failure by returning an error.

Related: #11134
Related: #11155