### PR TITLE
chore(loadtest): remove redundant log

### DIFF
--- a/rust/tests/loadtest/src/http.rs
+++ b/rust/tests/loadtest/src/http.rs
@@ -216,6 +216,14 @@ pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()
         "-qq",
     ];
 
+    tracing::info!(
+        address = %config.address,
+        concurrent = config.users,
+        hold_duration = ?config.run_time,
+        %seed,
+        "Starting HTTP connection test"
+    );
+
     let goose_args_ref: Vec<&str> = goose_args.to_vec();
     let goose_config = GooseConfiguration::parse_args_default(&goose_args_ref)
         .map_err(|e| anyhow::anyhow!("Failed to parse Goose arguments: {e}"))?;

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -152,57 +152,10 @@ async fn run_random(config_path: Option<PathBuf>, seed: Option<u64>) -> anyhow::
     info!(seed, enabled_types = ?config.enabled_types(), "Selecting random test");
 
     match selector.select(&config) {
-        AnyTestConfig::Http(http) => {
-            info!(
-                test_type = "http",
-                seed,
-                address = %http.address,
-                http_version = http.http_version,
-                users = http.users,
-                duration_secs = http.run_time.as_secs(),
-                "Starting HTTP test"
-            );
-
-            http::run_with_config(http, seed).await
-        }
-        AnyTestConfig::Tcp(tcp) => {
-            info!(
-                test_type = "tcp",
-                seed,
-                address = %tcp.target,
-                concurrent = tcp.concurrent,
-                duration_secs = tcp.hold_duration.as_secs(),
-                echo_mode = tcp.echo_mode,
-                "Starting TCP test"
-            );
-
-            tcp::run_with_config(tcp, seed).await
-        }
-        AnyTestConfig::Websocket(ws) => {
-            info!(
-                test_type = "websocket",
-                seed,
-                url = %ws.url,
-                concurrent = ws.concurrent,
-                duration_secs = ws.hold_duration.as_secs(),
-                echo_mode = ws.echo_mode,
-                "Starting WebSocket test"
-            );
-
-            websocket::run_with_config(ws, seed).await
-        }
-        AnyTestConfig::Ping(ping) => {
-            info!(
-                test_type = "ping",
-                seed,
-                targets = ?ping.targets,
-                count = ping.count,
-                interval_ms = ping.interval.as_millis() as u64,
-                "Starting ping test"
-            );
-
-            ping::run_with_config(ping, seed).await
-        }
+        AnyTestConfig::Http(http) => http::run_with_config(http, seed).await,
+        AnyTestConfig::Tcp(tcp) => tcp::run_with_config(tcp, seed).await,
+        AnyTestConfig::Websocket(ws) => websocket::run_with_config(ws, seed).await,
+        AnyTestConfig::Ping(ping) => ping::run_with_config(ping, seed).await,
     }
 }
 

--- a/rust/tests/loadtest/src/ping.rs
+++ b/rust/tests/loadtest/src/ping.rs
@@ -120,7 +120,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
         payload_size: args.payload_size,
     };
 
-    let summary = run(config).await?;
+    let summary = run(config, 0).await?;
 
     println!(
         "{}",
@@ -132,7 +132,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
 
 /// Run ping test from resolved config.
 pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()> {
-    let summary = run(config).await?;
+    let summary = run(config, seed).await?;
 
     println!(
         "{}",
@@ -143,7 +143,7 @@ pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()
 }
 
 /// Run the ICMP ping test.
-async fn run(config: TestConfig) -> Result<PingTestSummary> {
+async fn run(config: TestConfig, seed: u64) -> Result<PingTestSummary> {
     // Validate payload size
     if config.payload_size > MAX_ICMP_PAYLOAD_SIZE {
         bail!(
@@ -158,6 +158,7 @@ async fn run(config: TestConfig) -> Result<PingTestSummary> {
         duration = ?config.duration,
         interval = ?config.interval,
         payload_size = config.payload_size,
+        %seed,
         "Starting ICMP ping test"
     );
 

--- a/rust/tests/loadtest/src/tcp.rs
+++ b/rust/tests/loadtest/src/tcp.rs
@@ -155,7 +155,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
             echo_read_timeout: args.echo_read_timeout,
         };
 
-        let summary = run(config).await?;
+        let summary = run(config, 0).await?;
 
         println!(
             "{}",
@@ -168,7 +168,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
 
 /// Run TCP test from resolved config.
 pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()> {
-    let summary = run(config).await?;
+    let summary = run(config, seed).await?;
 
     println!(
         "{}",
@@ -178,7 +178,7 @@ pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()
     Ok(())
 }
 
-async fn run(config: TestConfig) -> Result<TcpTestSummary> {
+async fn run(config: TestConfig, seed: u64) -> Result<TcpTestSummary> {
     let (tx, mut rx) = mpsc::channel::<ConnectionResult>(config.concurrent);
     let active_connections = Arc::new(AtomicUsize::new(0));
     let peak_active = Arc::new(AtomicUsize::new(0));
@@ -188,6 +188,7 @@ async fn run(config: TestConfig) -> Result<TcpTestSummary> {
         concurrent = config.concurrent,
         hold_duration = ?config.hold_duration,
         echo_mode = config.echo_mode,
+        %seed,
         "Starting TCP connection test"
     );
 

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -168,7 +168,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
             echo_read_timeout: args.echo_read_timeout,
         };
 
-        let summary = run(config).await?;
+        let summary = run(config, 0).await?;
         println!(
             "{}",
             serde_json::to_string(&summary).expect("Failed to serialize metrics")
@@ -180,7 +180,7 @@ pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
 
 /// Run WebSocket test from resolved config.
 pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()> {
-    let summary = run(config).await?;
+    let summary = run(config, seed).await?;
 
     println!(
         "{}",
@@ -195,7 +195,7 @@ pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()
 /// Establishes `concurrent` connections and holds each open for `hold_duration`.
 /// In echo mode, sends timestamped payloads and verifies responses.
 /// Otherwise, optionally sends periodic ping messages to keep connections alive.
-async fn run(config: TestConfig) -> Result<WebsocketTestSummary> {
+async fn run(config: TestConfig, seed: u64) -> Result<WebsocketTestSummary> {
     let (tx, mut rx) = mpsc::channel::<ConnectionResult>(config.concurrent);
     let active_connections = Arc::new(AtomicUsize::new(0));
     let peak_active = Arc::new(AtomicUsize::new(0));
@@ -209,6 +209,7 @@ async fn run(config: TestConfig) -> Result<WebsocketTestSummary> {
         concurrent = config.concurrent,
         hold_duration = ?config.hold_duration,
         echo_mode = config.echo_mode,
+        %seed,
         "Starting WebSocket connection test"
     );
 


### PR DESCRIPTION
The test internally already logs this so doing this again one layer up before is redundant.