### PR TITLE
fix(portal): add missing ON DELETE CASCADE

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20251215054647_add_cascade_delete_to_auth_tables.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251215054647_add_cascade_delete_to_auth_tables.exs
@@ -1,0 +1,39 @@
+defmodule Domain.Repo.Migrations.AddCascadeDeleteToAuthTables do
+  use Ecto.Migration
+
+  @tables [:portal_sessions, :one_time_passcodes, :gateway_tokens]
+
+  def up do
+    for table <- @tables do
+      execute("""
+      ALTER TABLE #{table}
+      DROP CONSTRAINT IF EXISTS #{table}_account_id_fkey
+      """)
+
+      execute("""
+      ALTER TABLE #{table}
+      ADD CONSTRAINT #{table}_account_id_fkey
+      FOREIGN KEY (account_id)
+      REFERENCES accounts(id)
+      ON DELETE CASCADE
+      """)
+    end
+  end
+
+  def down do
+    for table <- @tables do
+      execute("""
+      ALTER TABLE #{table}
+      DROP CONSTRAINT IF EXISTS #{table}_account_id_fkey
+      """)
+
+      execute("""
+      ALTER TABLE #{table}
+      ADD CONSTRAINT #{table}_account_id_fkey
+      FOREIGN KEY (account_id)
+      REFERENCES accounts(id)
+      ON DELETE NO ACTION
+      """)
+    end
+  end
+end

--- a/elixir/apps/domain/test/domain/gateway_token_test.exs
+++ b/elixir/apps/domain/test/domain/gateway_token_test.exs
@@ -7,8 +7,9 @@ defmodule Domain.GatewayTokenTest do
   alias Domain.GatewayToken
 
   describe "changeset/1" do
-    test "returns error when account does not exist" do
-      attrs = attrs(%{account_id: Ecto.UUID.generate(), site_id: Ecto.UUID.generate()})
+    test "returns error when account_id does not match site's account" do
+      site = site_fixture()
+      attrs = attrs(%{account_id: Ecto.UUID.generate(), site_id: site.id})
 
       changeset =
         %GatewayToken{}
@@ -16,7 +17,10 @@ defmodule Domain.GatewayTokenTest do
         |> GatewayToken.changeset()
 
       assert {:error, changeset} = Repo.insert(changeset)
-      assert {:account, {"does not exist", _}} = hd(changeset.errors)
+
+      # The composite FK (account_id, site_id) -> sites(account_id, id) ensures
+      # the account_id must match the site's account
+      assert {:site, {"does not exist", _}} = hd(changeset.errors)
     end
 
     test "returns error when site does not exist" do


### PR DESCRIPTION
These were inadvertently left out in recent refactors.