### PR TITLE
fix(connlib): handle tun updates before resource ones

### DIFF
--- a/rust/libs/client-shared/src/lib.rs
+++ b/rust/libs/client-shared/src/lib.rs
@@ -135,12 +135,12 @@ impl EventStream {
             Poll::Pending => {}
         }
 
-        if let Poll::Ready(Some(resources)) = self.resource_list_receiver.poll_next_unpin(cx) {
-            return Poll::Ready(Some(Event::ResourcesUpdated(resources)));
-        }
-
         if let Poll::Ready(Some(Some(config))) = self.tun_config_receiver.poll_next_unpin(cx) {
             return Poll::Ready(Some(Event::TunInterfaceUpdated(config)));
+        }
+
+        if let Poll::Ready(Some(resources)) = self.resource_list_receiver.poll_next_unpin(cx) {
+            return Poll::Ready(Some(Event::ResourcesUpdated(resources)));
         }
 
         Poll::Pending


### PR DESCRIPTION
When polling for updates to process and emit events for, we were processing the `resource_list_receiver` before `tun_config_receiver`. This meant that upon startup, if both receivers had items in the queue, we would emit the `resourcesUpdated` event before `tunInterfaceUpdated`.

Unfortunately this can cause issues on some platforms (e.g. Apple) which expects to have the tunnel interface configured before resources are added to the routing table.

Since we rely on event ordering to compute meaningful diffs now, it's important these remain correct and consistent with what the portal is sending. We have strong guarantees over ordering there due to the nature of the replication connection.

Fixes #11185 