### PR TITLE
refactor(apple): use AsyncStream for network path

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		05CF1CF1290B1CEE00CF4755 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */; };
 		05CF1D17290B1FE700CF4755 /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */; };
+		A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */; };
+		A1B2C3D4E5F6A78901234569 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */; };
+		B1C2D3E4F5A6B78901234568 /* CancellableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */; };
+		B1C2D3E4F5A6B78901234569 /* CancellableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */; };
 		05D3BB2128FDE9C000BC3727 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */; };
 		146C8E809FF744D18C053A79 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09DC14A4A04715A37BC04C /* Channel.swift */; };
 		6571861AB9324D6A9395BDB3 /* SessionEventLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */; };
@@ -85,6 +89,8 @@
 
 /* Begin PBXFileReference section */
 		05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathUpdates.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellableTask.swift; sourceTree = "<group>"; };
 		05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "dev.firezone.firezone.network-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		05CF1CF6290B1CEE00CF4755 /* FirezoneNetworkExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FirezoneNetworkExtension.entitlements; sourceTree = "<group>"; };
 		05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
@@ -165,6 +171,8 @@
 				177FB893F19457A113042247 /* Adapter.swift */,
 				05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */,
 				8D41B9A42D15DD6800D16065 /* TunnelLogArchive.swift */,
+				A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */,
+				B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */,
 				6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */,
 			);
 			path = FirezoneNetworkExtension;
@@ -505,6 +513,8 @@
 				8D69392C2BA24FE600AF4396 /* BindResolvers.swift in Sources */,
 				146C8E809FF744D18C053A79 /* Channel.swift in Sources */,
 				C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */,
+				A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */,
+				B1C2D3E4F5A6B78901234568 /* CancellableTask.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -521,6 +531,8 @@
 				6571861AB9324D6A9395BDB3 /* SessionEventLoop.swift in Sources */,
 				858AA13A09A55E3B1DD5DEDA /* Adapter.swift in Sources */,
 				CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */,
+				A1B2C3D4E5F6A78901234569 /* NetworkPathUpdates.swift in Sources */,
+				B1C2D3E4F5A6B78901234569 /* CancellableTask.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -11,8 +11,6 @@
 		05CF1D17290B1FE700CF4755 /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */; };
 		A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */; };
 		A1B2C3D4E5F6A78901234569 /* NetworkPathUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */; };
-		B1C2D3E4F5A6B78901234568 /* CancellableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */; };
-		B1C2D3E4F5A6B78901234569 /* CancellableTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */; };
 		05D3BB2128FDE9C000BC3727 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */; };
 		146C8E809FF744D18C053A79 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09DC14A4A04715A37BC04C /* Channel.swift */; };
 		6571861AB9324D6A9395BDB3 /* SessionEventLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */; };
@@ -90,7 +88,6 @@
 /* Begin PBXFileReference section */
 		05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathUpdates.swift; sourceTree = "<group>"; };
-		B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellableTask.swift; sourceTree = "<group>"; };
 		05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "dev.firezone.firezone.network-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		05CF1CF6290B1CEE00CF4755 /* FirezoneNetworkExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FirezoneNetworkExtension.entitlements; sourceTree = "<group>"; };
 		05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
@@ -172,7 +169,6 @@
 				05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */,
 				8D41B9A42D15DD6800D16065 /* TunnelLogArchive.swift */,
 				A1B2C3D4E5F6A78901234567 /* NetworkPathUpdates.swift */,
-				B1C2D3E4F5A6B78901234567 /* CancellableTask.swift */,
 				6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */,
 			);
 			path = FirezoneNetworkExtension;
@@ -514,7 +510,6 @@
 				146C8E809FF744D18C053A79 /* Channel.swift in Sources */,
 				C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */,
 				A1B2C3D4E5F6A78901234568 /* NetworkPathUpdates.swift in Sources */,
-				B1C2D3E4F5A6B78901234568 /* CancellableTask.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -532,7 +527,6 @@
 				858AA13A09A55E3B1DD5DEDA /* Adapter.swift in Sources */,
 				CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */,
 				A1B2C3D4E5F6A78901234569 /* NetworkPathUpdates.swift in Sources */,
-				B1C2D3E4F5A6B78901234569 /* CancellableTask.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift/apple/FirezoneKit/Package.resolved
+++ b/swift/apple/FirezoneKit/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "a4daf15fa8480d038e9127ba1366f82ecdbf2242355d2bd1ee3fcb6dbc7e5426",
   "pins" : [
     {
       "identity" : "sentry-cocoa",
@@ -10,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/CancellableTask.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/CancellableTask.swift
@@ -7,10 +7,10 @@ import Foundation
 /// when the property is set to nil or the owner is deallocated (via ARC releasing the wrapper).
 ///
 /// Fully Sendable because Task<Void, Never> is Sendable and the property is immutable.
-final class CancellableTask: Sendable {
+public final class CancellableTask: Sendable {
   private let task: Task<Void, Never>
 
-  init(_ operation: @escaping @Sendable () async -> Void) {
+  public init(_ operation: @escaping @Sendable () async -> Void) {
     self.task = Task(operation: operation)
   }
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+@testable import FirezoneKit
+
+/// Thread-safe flag for testing
+private actor Flag {
+  var value: Bool = false
+
+  func set(_ newValue: Bool) {
+    value = newValue
+  }
+
+  func get() -> Bool {
+    value
+  }
+}
+
+@Suite("CancellableTask Tests")
+struct CancellableTaskTests {
+
+  @Test("Task executes its operation")
+  func taskExecutesOperation() async {
+    let executed = Flag()
+
+    let task = CancellableTask {
+      await executed.set(true)
+    }
+
+    // Give the task time to execute
+    try? await Task.sleep(for: .milliseconds(50))
+
+    let wasExecuted = await executed.get()
+    #expect(wasExecuted == true)
+
+    // Keep task alive until assertion
+    _ = task
+  }
+
+  @Test("Task is cancelled when CancellableTask is deallocated")
+  func taskCancelledOnDealloc() async {
+    let wasCancelled = Flag()
+
+    do {
+      let _ = CancellableTask {
+        // Wait long enough that we can dealloc the wrapper
+        // When the CancellableTask is deallocated and calls cancel(),
+        // Task.sleep throws CancellationError and aborts immediately (no need to wait 10 seconds)
+        // The try? suppresses the error since CancellableTask requires a non-throwing closure
+        try? await Task.sleep(for: .seconds(10))
+
+        // After cancellation, Task.isCancelled will be true
+        if Task.isCancelled {
+          await wasCancelled.set(true)
+        }
+      }
+      // CancellableTask goes out of scope here, triggering deinit -> cancel
+    }
+
+    // Give the cancelled task time to handle the cancellation
+    try? await Task.sleep(for: .milliseconds(50))
+
+    let taskWasCancelled = await wasCancelled.get()
+    #expect(taskWasCancelled == true)
+  }
+
+  @Test("Setting to nil cancels the task")
+  func settingToNilCancelsTask() async {
+    let wasCancelled = Flag()
+
+    var task: CancellableTask? = CancellableTask {
+      // Task.sleep throws CancellationError when cancelled
+      // The try? suppresses the error since CancellableTask requires a non-throwing closure
+      try? await Task.sleep(for: .seconds(10))
+
+      // After cancellation, Task.isCancelled will be true
+      if Task.isCancelled {
+        await wasCancelled.set(true)
+      }
+    }
+
+    // Set to nil, triggering cancellation
+    task = nil
+
+    // Give the cancelled task time to check its cancellation status
+    try? await Task.sleep(for: .milliseconds(50))
+
+    let taskWasCancelled = await wasCancelled.get()
+    #expect(taskWasCancelled == true)
+
+    // Silence unused variable warning
+    _ = task
+  }
+}

--- a/swift/apple/FirezoneNetworkExtension/CancellableTask.swift
+++ b/swift/apple/FirezoneNetworkExtension/CancellableTask.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// RAII wrapper that cancels its task on deallocation.
+///
+/// This enables classes to manage task lifecycles cleanly.
+/// When stored as a property, the task is automatically cancelled
+/// when the property is set to nil or the owner is deallocated (via ARC releasing the wrapper).
+///
+/// Fully Sendable because Task<Void, Never> is Sendable and the property is immutable.
+final class CancellableTask: Sendable {
+  private let task: Task<Void, Never>
+
+  init(_ operation: @escaping @Sendable () async -> Void) {
+    self.task = Task(operation: operation)
+  }
+
+  deinit {
+    task.cancel()
+  }
+}

--- a/swift/apple/FirezoneNetworkExtension/NetworkPathUpdates.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkPathUpdates.swift
@@ -1,0 +1,25 @@
+import Network
+
+/// Creates an AsyncStream that emits NWPath updates.
+///
+/// Cancels the monitor via `onTermination` when the consuming Task is cancelled.
+/// This enables actors to manage NWPathMonitor lifecycle without needing
+/// `nonisolated(unsafe)` or `@unchecked Sendable`.
+///
+/// - Parameter queue: The dispatch queue on which to execute the monitor's path update handler.
+///   Defaults to a global concurrent queue.
+func networkPathUpdates(queue: DispatchQueue = .global()) -> AsyncStream<Network.NWPath> {
+  let (stream, continuation) = AsyncStream.makeStream(of: Network.NWPath.self)
+  let monitor = NWPathMonitor()
+  monitor.pathUpdateHandler = { path in
+    continuation.yield(path)
+  }
+  monitor.start(queue: queue)
+
+  // Cancel monitor when stream terminates (Task cancelled or finished)
+  continuation.onTermination = { _ in
+    monitor.cancel()
+  }
+
+  return stream
+}

--- a/swift/apple/Makefile
+++ b/swift/apple/Makefile
@@ -97,6 +97,11 @@ install:
 	@echo "Launching Firezone..."
 	@open /Applications/Firezone.app
 
+.PHONY: test
+test:
+	@echo "Running FirezoneKit tests..."
+	@cd FirezoneKit && swift test
+
 .PHONY: clean
 clean:
 	@echo "Cleaning Xcode build"


### PR DESCRIPTION
Replace closure-based NWPathMonitor handler with AsyncStream pattern:

- Add NetworkPathUpdates.swift: AsyncStream wrapper for NWPathMonitor
  with RAII cleanup via onTermination callback
- Add CancellableTask.swift: RAII wrapper that cancels Task on dealloc
- Refactor Adapter to use CancellableTask consuming networkPathUpdates()
- Remove networkMonitor property and pathUpdateHandler lazy var