### PR TITLE
chore(apple): fix install and build number include

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -430,10 +430,11 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/Firezone/xcconfig/dynamic_build_number.xcconfig",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Set the project (build) version to the current epoch so that it monotonically increases\nseconds_since_epoch=$(date +%s)\necho \"CURRENT_PROJECT_VERSION = $seconds_since_epoch\" > Firezone/xcconfig/dynamic_build_number.xcconfig\n";
+			shellScript = "# Set the project (build) version to the current epoch so that it monotonically increases\nseconds_since_epoch=$(date +%s)\necho \"CURRENT_PROJECT_VERSION = $seconds_since_epoch\" > \"${SRCROOT}/Firezone/xcconfig/dynamic_build_number.xcconfig\"\n";
 		};
 		8D70FAE62D4971E900216473 /* Static Analysis */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/swift/apple/Makefile
+++ b/swift/apple/Makefile
@@ -92,8 +92,19 @@ install:
 	@-sudo systemextensionsctl uninstall 47R2M6779T dev.firezone.firezone.network-extension 2>/dev/null || true
 	@-sudo systemextensionsctl uninstall 47R2M6779T dev.firezone.firezone.network-extension-systemextension 2>/dev/null || true
 	@sleep 2
-	@echo "Copying app to /Applications..."
-	@sudo cp -R ~/Library/Developer/Xcode/DerivedData/Firezone-*/Build/Products/$(CONFIGURATION)/Firezone.app /Applications/
+	@echo "Finding build location..."
+	@PRODUCTS_DIR=$$(xcodebuild -project Firezone.xcodeproj -scheme Firezone -configuration $(CONFIGURATION) -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR = ' | sed 's/.*= //'); \
+	if [ -z "$$PRODUCTS_DIR" ]; then \
+		echo "Error: Could not determine build products directory"; \
+		exit 1; \
+	fi; \
+	if [ ! -d "$$PRODUCTS_DIR/Firezone.app" ]; then \
+		echo "Error: Firezone.app not found at $$PRODUCTS_DIR"; \
+		echo "Run 'make build' first"; \
+		exit 1; \
+	fi; \
+	echo "Copying app from $$PRODUCTS_DIR to /Applications..."; \
+	sudo cp -R "$$PRODUCTS_DIR/Firezone.app" /Applications/
 	@echo "Launching Firezone..."
 	@open /Applications/Firezone.app
 

--- a/swift/apple/Makefile
+++ b/swift/apple/Makefile
@@ -70,6 +70,10 @@ build: $(GENERATED_DIR)/connlib.swift $(GENERATED_DIR)/connlibFFI.h
 		echo "buildServer.json not found, generating LSP configuration..."; \
 		$(MAKE) lsp; \
 	fi
+	@# Ensure dynamic_build_number.xcconfig exists before Xcode parses the project
+	@if [ ! -f Firezone/xcconfig/dynamic_build_number.xcconfig ]; then \
+		echo "CURRENT_PROJECT_VERSION = $$(date +%s)" > Firezone/xcconfig/dynamic_build_number.xcconfig; \
+	fi
 	@echo "Building Xcode project for ${PLATFORM}, ${ARCH}"
 	@echo "Git SHA: ${GIT_SHA}"
 	@xcodebuild build \


### PR DESCRIPTION
  - Fix make install to reliably find the built app using xcodebuild -showBuildSettings instead of fragile glob
  patterns
  - Ensure dynamic build number is always generated by specifying output path in Xcode build phase
  - Make dynamic build number include mandatory
  
  
  context:
----------
  On macOS 26.1, I can no longer just hit "play" - have to resort to install step from Makefile to make the network extension run without disabling SIP. It turned out that I was sometimes deploying the wrong thing, due to naive approach used earlier.

As for build number, I would hit occasionally this error after a clean build, as we used to optionally include it - and it would sometimes be missing. making it explicitly required by xcode and code prevents this error.