### PR TITLE
fix(portal): add horizontal spacing to authorized group badges

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -1231,7 +1231,7 @@ defmodule Web.CoreComponents do
 
     ~H"""
     <span
-      class={["inline-flex items-center rounded border border-neutral-200 overflow-hidden", @class]}
+      class={["inline-flex items-center rounded border border-neutral-200 overflow-hidden mr-1", @class]}
       data-group-id={@group.id}
     >
       <span class={~w[

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -1231,7 +1231,10 @@ defmodule Web.CoreComponents do
 
     ~H"""
     <span
-      class={["inline-flex items-center rounded border border-neutral-200 overflow-hidden mr-1", @class]}
+      class={[
+        "inline-flex items-center rounded border border-neutral-200 overflow-hidden mr-1",
+        @class
+      ]}
       data-group-id={@group.id}
     >
       <span class={~w[


### PR DESCRIPTION
Noticed that the group badges in the "Authorized Groups" column don't have horizontal spacing:

<img width="3788" height="1187" alt="Screenshot From 2025-12-16 15-22-52" src="https://github.com/user-attachments/assets/264bbc44-ae22-4fd0-a76d-5e8ce45e5a10" />

Now corrected to:

<img width="3788" height="1187" alt="Screenshot From 2025-12-16 15-22-40" src="https://github.com/user-attachments/assets/d9ed88b9-0dec-46ee-a189-fdce5f61c2bb" />
