### PR TITLE
chore: Add Rust lint to pre-commit

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -48,11 +48,14 @@ repos:
           - '^(?!((chore|feat|feature|bug|fix|build|ci|docs|style|refactor|perf|test|revert)\/[@a-zA-Z0-9\-\.\/]+)$).*'
 
   # Third party pre-commit hooks
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+  - repo: local
     hooks:
       - id: shellcheck
+        name: ShellCheck
+        entry: shellcheck
         args: ["--severity=warning"]
+        language: system
+        types: [shell]
         exclude: ^.*/gradlew$
   - repo: https://github.com/pecigonzalo/pre-commit-shfmt
     rev: v2.2.0

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: no-tracing-macro-imports
         name: "rust: no direct tracing macro imports"
-        entry: "bash -c 'if grep -E \"use tracing::(trace|debug|info|warn|error)[^_]|use tracing::\\{[^}]*(trace|debug|info|warn|error)[^_]\" \"$@\"; then echo \"Error: Do not import tracing macros directly\"; exit 1; fi' --"
+        entry: "bash -c 'if grep -E \"use tracing::(trace|debug|info|warn|error)[^_]|use tracing::\\{[^}]*(trace|debug|info|warn|error)[^_]\" \"$@\"; then echo \"Error: Do not import tracing macros\"; exit 1; fi' --"
         language: system
         types: [rust]
       - id: codespell

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -14,19 +14,7 @@ repos:
         pass_filenames: false
       - id: prettier
         name: Prettier
-        entry: pnpm
-        args:
-          [
-            "--dir",
-            ".github",
-            "exec",
-            "prettier",
-            "--ignore-path",
-            "../.prettierignore",
-            "--check",
-            "--ignore-unknown",
-            "../",
-          ]
+        entry: bash -c 'cd .github && git -C .. ls-files "*.md" "*.json" "*.yaml" "*.yml" "*.css" "*.js" "*.ts" "*.tsx" | sed "s|^|../|" | xargs pnpm exec prettier --ignore-path ../.prettierignore --check --ignore-unknown --no-error-on-unmatched-pattern'
         language: system
         pass_filenames: false
 

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
   - repo: local
     hooks:
+      - id: no-tracing-macro-imports
+        name: "rust: no direct tracing macro imports"
+        entry: "bash -c 'if grep -E \"use tracing::(trace|debug|info|warn|error)[^_]|use tracing::\\{[^}]*(trace|debug|info|warn|error)[^_]\" \"$@\"; then echo \"Error: Do not import tracing macros directly\"; exit 1; fi' --"
+        language: system
+        types: [rust]
       - id: codespell
         name: "python: codespell"
         args: [--config=.github/codespellrc]

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y shfmt
+          sudo apt-get install -y shfmt shellcheck
           pnpm i --frozen-lockfile --dir ./.github
       - name: Run pre-commit
         run: |

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -59,7 +59,6 @@ use serde::Serialize;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
-use tracing::info;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer as _;
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -154,13 +153,13 @@ async fn run_random(config_path: Option<PathBuf>, seed: Option<u64>) -> anyhow::
         );
     }
 
-    info!(config = %config_path.display(), "Loading config");
+    tracing::info!(config = %config_path.display(), "Loading config");
 
     let config = LoadTestConfig::load(&config_path)?;
     let mut selector = TestSelector::new(seed);
     let seed = selector.seed();
 
-    info!(seed, enabled_types = ?config.enabled_types(), "Selecting random test");
+    tracing::info!(seed, enabled_types = ?config.enabled_types(), "Selecting random test");
 
     match selector.select(&config) {
         AnyTestConfig::Http(http) => http::run_with_config(http, seed).await,

--- a/rust/tests/loadtest/src/ping.rs
+++ b/rust/tests/loadtest/src/ping.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use surge_ping::{Client, Config, ICMP, PingIdentifier, PingSequence};
 use tokio::sync::mpsc;
-use tracing::{debug, info, trace};
 
 /// Maximum ICMP payload size in bytes.
 ///
@@ -152,7 +151,7 @@ async fn run(config: TestConfig, seed: u64) -> Result<PingTestSummary> {
         );
     }
 
-    info!(
+    tracing::info!(
         targets = ?config.targets,
         count = ?config.count,
         duration = ?config.duration,
@@ -240,10 +239,10 @@ async fn ping_target(
             Ok((_packet, rtt)) => {
                 packets_received += 1;
                 rtts.record(rtt);
-                trace!(target = %target, seq, rtt_ms = rtt.as_secs_f64() * 1000.0, "Ping reply");
+                tracing::trace!(target = %target, seq, rtt_ms = rtt.as_secs_f64() * 1000.0, "Ping reply");
             }
             Err(e) => {
-                debug!(target = %target, seq, error = %e, "Ping failed");
+                tracing::debug!(target = %target, seq, error = %e, "Ping failed");
             }
         }
 

--- a/rust/tests/loadtest/src/tcp.rs
+++ b/rust/tests/loadtest/src/tcp.rs
@@ -16,7 +16,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
-use tracing::{debug, info, trace, warn};
 
 /// Configuration for TCP connection load testing.
 #[derive(Debug, Clone)]
@@ -183,7 +182,7 @@ async fn run(config: TestConfig, seed: u64) -> Result<TcpTestSummary> {
     let active_connections = Arc::new(AtomicUsize::new(0));
     let peak_active = Arc::new(AtomicUsize::new(0));
 
-    info!(
+    tracing::info!(
         target = %config.target,
         concurrent = config.concurrent,
         hold_duration = ?config.hold_duration,
@@ -321,7 +320,7 @@ async fn run_single_connection(
             let current = active.fetch_add(1, Ordering::SeqCst) + 1;
             // Update peak if this is a new high water mark
             peak.fetch_max(current, Ordering::SeqCst);
-            trace!(connection = connection_id, target = %config.target, ?connect_latency, "TCP connection established");
+            tracing::trace!(connection = connection_id, target = %config.target, ?connect_latency, "TCP connection established");
 
             let hold_start = Instant::now();
             let echo_stats = if config.echo_mode {
@@ -334,7 +333,7 @@ async fn run_single_connection(
             let held_duration = hold_start.elapsed();
 
             active.fetch_sub(1, Ordering::SeqCst);
-            trace!(connection = connection_id, target = %config.target, ?held_duration, "TCP connection closed");
+            tracing::trace!(connection = connection_id, target = %config.target, ?held_duration, "TCP connection closed");
 
             // A connection is only successful if there were no echo mismatches
             let success = echo_stats.mismatches == 0;
@@ -347,7 +346,7 @@ async fn run_single_connection(
             }
         }
         Ok(Err(e)) => {
-            debug!(connection = connection_id, target = %config.target, error = %e, "TCP connection failed");
+            tracing::debug!(connection = connection_id, target = %config.target, error = %e, "TCP connection failed");
             ConnectionResult {
                 success: false,
                 connect_latency: connect_start.elapsed(),
@@ -356,7 +355,7 @@ async fn run_single_connection(
             }
         }
         Err(_) => {
-            debug!(connection = connection_id, target = %config.target, "TCP connection timed out");
+            tracing::debug!(connection = connection_id, target = %config.target, "TCP connection timed out");
             ConnectionResult {
                 success: false,
                 connect_latency: connect_start.elapsed(),
@@ -383,12 +382,12 @@ async fn run_echo_loop(
         let bytes = payload.to_bytes();
 
         if let Err(e) = stream.write_all(&bytes).await {
-            warn!(connection = connection_id, error = %e, "Failed to send echo payload");
+            tracing::warn!(connection = connection_id, error = %e, "Failed to send echo payload");
             stats.mismatches += 1;
             break;
         }
         if let Err(e) = stream.flush().await {
-            warn!(connection = connection_id, error = %e, "Failed to flush echo payload");
+            tracing::warn!(connection = connection_id, error = %e, "Failed to flush echo payload");
             stats.mismatches += 1;
             break;
         }
@@ -402,7 +401,7 @@ async fn run_echo_loop(
                     stats.messages_verified += 1;
                     if let Some(latency) = received.round_trip_latency() {
                         stats.latencies.record(latency);
-                        trace!(
+                        tracing::trace!(
                             connection = connection_id,
                             latency_ms = latency.as_millis(),
                             "Echo verified"
@@ -410,17 +409,17 @@ async fn run_echo_loop(
                     }
                 }
                 Err(e) => {
-                    warn!(connection = connection_id, error = %e, "Echo verification failed");
+                    tracing::warn!(connection = connection_id, error = %e, "Echo verification failed");
                     stats.mismatches += 1;
                 }
             },
             Ok(Err(e)) => {
-                warn!(connection = connection_id, error = %e, "Failed to read echo response");
+                tracing::warn!(connection = connection_id, error = %e, "Failed to read echo response");
                 stats.mismatches += 1;
                 break;
             }
             Err(_) => {
-                warn!(connection = connection_id, "Echo response timed out");
+                tracing::warn!(connection = connection_id, "Echo response timed out");
                 stats.mismatches += 1;
             }
         }
@@ -453,17 +452,17 @@ async fn run_server(config: TcpServerConfig) -> anyhow::Result<()> {
     use tokio::net::TcpListener;
 
     let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, config.port)).await?;
-    info!(port = config.port, "TCP echo server listening");
+    tracing::info!(port = config.port, "TCP echo server listening");
 
     loop {
         let (stream, addr) = listener.accept().await?;
-        debug!(%addr, "TCP connection accepted");
+        tracing::debug!(%addr, "TCP connection accepted");
 
         tokio::spawn(async move {
             if let Err(e) = handle_echo_connection(stream).await {
-                debug!(%addr, error = %e, "TCP connection error");
+                tracing::debug!(%addr, error = %e, "TCP connection error");
             }
-            trace!(%addr, "TCP connection closed");
+            tracing::trace!(%addr, "TCP connection closed");
         });
     }
 }
@@ -481,7 +480,7 @@ async fn handle_echo_connection(mut stream: TcpStream) -> anyhow::Result<()> {
 
         stream.write_all(&buf[..n]).await?;
         stream.flush().await?;
-        trace!(bytes = n, "TCP echoed");
+        tracing::trace!(bytes = n, "TCP echoed");
     }
 
     Ok(())


### PR DESCRIPTION
Start linting custom Rust rules with pre-commit.

In Rust, we favour using `tracing::` prefix instead of importing the macros.
Add a custom rule and fix the errors as part of this changeset.

Also, as part of development of the rule, and to make it more useful for other devs, improve pre-commit configuration to:
1. Only check files tracked by git with prettier (avoids failing on local markdown notes etc)
2. Use shellcheck directly (it's already specified by .tool-versions) instead of via Docker container - matters on macOS, where Docker is not as lightweight.