### PR TITLE
refactor(loadtest): remove `goose`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1513,27 +1513,8 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "percent-encoding",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -1694,17 +1675,6 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
-dependencies = [
- "dispatch2",
- "nix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2110,15 +2080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "domain"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,12 +2105,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dpi"
@@ -2604,8 +2559,6 @@ dependencies = [
  "axum",
  "clap",
  "futures",
- "goose",
- "gumdrop",
  "logging",
  "rand 0.8.5",
  "reqwest",
@@ -2614,7 +2567,7 @@ dependencies = [
  "surge-ping",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "toml 0.9.6",
  "tracing",
  "tracing-subscriber",
@@ -3191,38 +3144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goose"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5e77ce04d5086ca6659396f81b5d63c9c0c4453c05b7fa38fcc83ea1b2b8e7"
-dependencies = [
- "async-trait",
- "chrono",
- "ctrlc",
- "downcast-rs",
- "flume",
- "futures",
- "gumdrop",
- "http 1.4.0",
- "itertools",
- "lazy_static",
- "log",
- "num-format",
- "rand 0.9.1",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "simplelog",
- "strum",
- "strum_macros",
- "tokio",
- "tokio-tungstenite 0.27.0",
- "tungstenite 0.27.0",
- "url",
-]
-
-[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3283,26 +3204,6 @@ dependencies = [
  "subprocess",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "gumdrop"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
-dependencies = [
- "gumdrop_derive",
-]
-
-[[package]]
-name = "gumdrop_derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4323,12 +4224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "local-channel"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,16 +4688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
-name = "num-format"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
-dependencies = [
- "arrayvec",
- "itoa",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4861,15 +4746,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -5542,7 +5418,7 @@ dependencies = [
  "socket-factory",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "url",
  "uuid",
@@ -5884,22 +5760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "publicsuffix"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
-dependencies = [
- "idna",
- "psl-types",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6206,8 +6066,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "cookie",
- "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -7050,17 +6908,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -8002,15 +7849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8134,9 +7972,7 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8237,19 +8073,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "tokio",
- "tungstenite 0.27.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -8261,7 +8084,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.28.0",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -8650,23 +8473,6 @@ dependencies = [
  "libc",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.1",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -269,11 +269,9 @@ skip = [
     "syn",
     "thiserror",
     "thiserror-impl",
-    "tokio-tungstenite",  # goose uses 0.27.0, phoenix-channel uses 0.28.0
     "toml",
     "toml_datetime",
     "toml_edit",
-    "tungstenite",        # goose uses 0.27.0, phoenix-channel uses 0.28.0
     "wasi",
     "webpki-roots",
     "which",

--- a/rust/tests/loadtest/Cargo.toml
+++ b/rust/tests/loadtest/Cargo.toml
@@ -14,8 +14,6 @@ anyhow = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio", "ws"] }
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
-goose = { version = "0.18", default-features = false, features = ["rustls-tls"] }
-gumdrop = "0.8"
 logging = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls", "gzip", "http2"] }

--- a/rust/tests/loadtest/loadtest.example.toml
+++ b/rust/tests/loadtest/loadtest.example.toml
@@ -19,10 +19,8 @@ addresses = [
 ]
 # HTTP versions: 1 (HTTP/1.1) or 2 (HTTP/2)
 http_version = [1, 2]
-# Number of concurrent users (random value from range)
-users = "10..100"
-# Test duration in seconds
-run_time_secs = "30..120"
+# Number of max concurrent connections
+max_connections = 100
 
 # TCP connection testing
 [tcp]

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -90,10 +90,8 @@ pub struct HttpConfig {
     pub addresses: Vec<String>,
     /// HTTP versions to choose from (1 or 2).
     pub http_version: Vec<u8>,
-    /// Number of concurrent users.
-    pub users: Range,
-    /// Test duration in seconds.
-    pub run_time_secs: Range,
+    /// Maximum number of concurrent connections.
+    pub max_connections: u64,
 }
 
 impl HttpConfig {

--- a/rust/tests/loadtest/src/http.rs
+++ b/rust/tests/loadtest/src/http.rs
@@ -112,6 +112,7 @@ async fn run(config: TestConfig, seed: u64) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument(err)]
 async fn run_single_connection(client: reqwest::Client, address: String) -> Result<()> {
     tracing::trace!("Sending GET request");
 

--- a/rust/tests/loadtest/src/http.rs
+++ b/rust/tests/loadtest/src/http.rs
@@ -81,7 +81,7 @@ async fn run(config: TestConfig, seed: u64) -> Result<()> {
     let client = build_client(&config)?;
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
 
-    let num_connections = rng.gen_range(0..=config.max_connections);
+    let num_connections = rng.gen_range(1..=config.max_connections);
 
     tracing::info!(
         url = %config.address,

--- a/rust/tests/loadtest/src/http.rs
+++ b/rust/tests/loadtest/src/http.rs
@@ -1,151 +1,47 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+
 use clap::Parser;
 use clap::ValueEnum;
-use goose::config::GooseConfiguration;
-use goose::prelude::*;
-use gumdrop::Options as _;
-use std::sync::OnceLock;
-use std::time::Duration;
-use url::Url;
+use rand::Rng;
+use rand::SeedableRng as _;
+use tracing::Instrument;
 
-/// Global HTTP version configuration set from CLI args.
-///
-/// Goose transactions are static functions, so we use a global to pass configuration.
-static HTTP_VERSION: OnceLock<HttpVersion> = OnceLock::new();
-
-/// Default request timeout in seconds.
-const DEFAULT_TIMEOUT_SECS: u64 = 60;
-
-/// Goose options help text appended to HTTP subcommand help.
-const GOOSE_HELP: &str = r#"
-GOOSE OPTIONS (forwarded):
-  -H, --host <HOST>        Target host URL
-  -u, --users <N>          Concurrent users (default: 10)
-  -t, --run-time <TIME>    Duration (e.g., 30s, 5m, 1h)
-  --report-file <FILE>     Generate report (.html, .json, .md)
-  --no-print-metrics       Suppress human-readable metrics output
-  -q                       Quiet mode (-qq, -qqq for less)
-
-See: https://book.goose.rs/getting-started/runtime-options.html
-"#;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Parser)]
-#[command(after_long_help = GOOSE_HELP)]
 pub struct Args {
     /// HTTP version to use (1 or 2)
     #[arg(long, default_value = "1", value_name = "VERSION")]
-    pub http_version: HttpVersion,
+    http_version: HttpVersion,
 
-    /// Arguments passed to Goose
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub goose_args: Vec<String>,
+    /// The address to GET.
+    #[arg(long)]
+    address: String,
+
+    /// The maximum number of concurrent connections.
+    #[arg(long, default_value_t = 10)]
+    max_connections: u64,
 }
 
 /// HTTP protocol version to use for load testing.
 #[derive(Debug, Clone, Copy, ValueEnum, Default, PartialEq, Eq)]
-pub enum HttpVersion {
-    /// HTTP/1.1 - widely supported, connection-per-request
+enum HttpVersion {
     #[default]
     #[value(name = "1", alias = "1.1", alias = "http1")]
     Http1,
 
-    /// HTTP/2 - multiplexed streams, header compression
     #[value(name = "2", alias = "http2")]
     Http2,
 }
 
-impl HttpVersion {
-    /// Configure a reqwest `ClientBuilder` for this HTTP version.
-    pub fn configure_client(self, timeout: Duration) -> reqwest::ClientBuilder {
-        let builder = reqwest::ClientBuilder::new()
-            .timeout(timeout)
-            .gzip(true)
-            .cookie_store(true);
-
-        match self {
-            Self::Http1 => builder.http1_only(),
-            Self::Http2 => builder.http2_prior_knowledge(),
-        }
-    }
-
-    /// Returns display name for metrics output.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Http1 => "HTTP/1.1",
-            Self::Http2 => "HTTP/2",
-        }
-    }
-}
-
 impl std::fmt::Display for HttpVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Simplified metrics summary for Azure log ingestion.
-#[derive(serde::Serialize)]
-struct HttpTestSummary {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    seed: Option<u64>,
-    test_type: &'static str,
-    http_version: String,
-    target_host: String,
-    duration_secs: usize,
-    total_requests: usize,
-    successful_requests: usize,
-    failed_requests: usize,
-    min_response_time_ms: usize,
-    max_response_time_ms: usize,
-    avg_response_time_ms: usize,
-}
-
-impl HttpTestSummary {
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "Iterating to find our single endpoint"
-    )]
-    fn from_metrics(metrics: &GooseMetrics, http_version: HttpVersion, seed: Option<u64>) -> Self {
-        let (total_requests, successful_requests, failed_requests, min_time, max_time, avg_time) =
-            metrics
-                .requests
-                .values()
-                .next()
-                .map(|r| {
-                    let avg = if r.raw_data.counter > 0 {
-                        r.raw_data.total_time / r.raw_data.counter
-                    } else {
-                        0
-                    };
-                    (
-                        r.raw_data.counter,
-                        r.success_count,
-                        r.fail_count,
-                        r.raw_data.minimum_time,
-                        r.raw_data.maximum_time,
-                        avg,
-                    )
-                })
-                .unwrap_or_default();
-
-        let target_host = metrics
-            .hosts
-            .iter()
-            .next()
-            .cloned()
-            .unwrap_or_else(|| "unknown".to_string());
-
-        Self {
-            seed,
-            test_type: "http",
-            http_version: http_version.to_string(),
-            target_host,
-            duration_secs: metrics.duration,
-            total_requests,
-            successful_requests,
-            failed_requests,
-            min_response_time_ms: min_time,
-            max_response_time_ms: max_time,
-            avg_response_time_ms: avg_time,
+        match self {
+            Self::Http1 => "HTTP/1.1".fmt(f),
+            Self::Http2 => "HTTP/2".fmt(f),
         }
     }
 }
@@ -153,130 +49,100 @@ impl HttpTestSummary {
 /// Resolved HTTP test parameters (ready to execute).
 #[derive(Debug)]
 pub struct TestConfig {
-    pub address: Url,
+    pub address: String,
+    pub max_connections: u64,
     pub http_version: u8,
-    pub users: u64,
-    pub run_time: Duration,
 }
 
 /// Run HTTP test with manual CLI args.
-pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
-    HTTP_VERSION
-        .set(args.http_version)
-        .expect("HTTP_VERSION already set");
+pub async fn run_with_cli_args(args: Args) -> Result<()> {
+    let config = TestConfig {
+        address: args.address,
+        max_connections: args.max_connections,
+        http_version: match args.http_version {
+            HttpVersion::Http1 => 1,
+            HttpVersion::Http2 => 2,
+        },
+    };
 
-    // Parse Goose configuration from forwarded args
-    let goose_args: Vec<&str> = args.goose_args.iter().map(String::as_str).collect();
-    let config = GooseConfiguration::parse_args_default(&goose_args)
-        .map_err(|e| anyhow::anyhow!("Failed to parse Goose arguments: {e}"))?;
-
-    let metrics = GooseAttack::initialize_with_config(config)?
-        .register_scenario(
-            scenario!("LoadTest")
-                .register_transaction(transaction!(setup_http_client).set_on_start())
-                .register_transaction(transaction!(load_test_request)),
-        )
-        .execute()
-        .await?;
-
-    let http_version = HTTP_VERSION.get().copied().unwrap_or_default();
-    let summary = HttpTestSummary::from_metrics(&metrics, http_version, None);
-    println!(
-        "{}",
-        serde_json::to_string(&summary).expect("Failed to serialize metrics")
-    );
+    run(config, 0).await?;
 
     Ok(())
 }
 
 /// Run HTTP test from resolved config.
-pub async fn run_with_config(config: TestConfig, seed: u64) -> anyhow::Result<()> {
-    let http_version = match config.http_version {
-        1 => HttpVersion::Http1,
-        2 => HttpVersion::Http2,
-        _ => HttpVersion::Http1,
-    };
+pub async fn run_with_config(config: TestConfig, seed: u64) -> Result<()> {
+    run(config, seed).await?;
 
-    // Ignore if already set (can happen in tests)
-    let _ = HTTP_VERSION.set(http_version);
+    Ok(())
+}
 
-    // Build Goose args from resolved config
-    let run_time_secs = config.run_time.as_secs();
-    let address = config.address.to_string();
-    let users = config.users.to_string();
-    let run_time = format!("{run_time_secs}s");
-    let goose_args: &[&str] = &[
-        "--host",
-        &address,
-        "--users",
-        &users,
-        "--run-time",
-        &run_time,
-        "--no-print-metrics",
-        "-qq",
-    ];
+async fn run(config: TestConfig, seed: u64) -> Result<()> {
+    let client = build_client(&config)?;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let num_connections = rng.gen_range(0..=config.max_connections);
 
     tracing::info!(
-        address = %config.address,
-        concurrent = config.users,
-        hold_duration = ?config.run_time,
+        url = %config.address,
+        max_connections = %config.max_connections,
+        http_version = %config.http_version,
+        %num_connections,
         %seed,
         "Starting HTTP connection test"
     );
 
-    let goose_args_ref: Vec<&str> = goose_args.to_vec();
-    let goose_config = GooseConfiguration::parse_args_default(&goose_args_ref)
-        .map_err(|e| anyhow::anyhow!("Failed to parse Goose arguments: {e}"))?;
+    let mut connections = tokio::task::JoinSet::new();
 
-    let metrics = GooseAttack::initialize_with_config(goose_config)?
-        .register_scenario(
-            scenario!("LoadTest")
-                .register_transaction(transaction!(setup_http_client).set_on_start())
-                .register_transaction(transaction!(load_test_request)),
-        )
-        .execute()
-        .await?;
-
-    let summary = HttpTestSummary::from_metrics(&metrics, http_version, Some(seed));
-    println!(
-        "{}",
-        serde_json::to_string(&summary).expect("Failed to serialize metrics")
-    );
-
-    Ok(())
-}
-
-/// Configure the HTTP client with the specified HTTP version.
-///
-/// This runs once per user at startup via `set_on_start()`.
-async fn setup_http_client(user: &mut GooseUser) -> TransactionResult {
-    let http_version = HTTP_VERSION.get().copied().unwrap_or_default();
-    let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);
-
-    let builder = http_version.configure_client(timeout);
-    user.set_client_builder(builder).await?;
-
-    Ok(())
-}
-
-/// Performs an HTTP GET request and validates the response.
-async fn load_test_request(user: &mut GooseUser) -> TransactionResult {
-    let mut goose = user.get("/").await?;
-
-    if let Ok(response) = goose.response
-        && !response.status().is_success()
-    {
-        let status = response.status();
-        let url = user.base_url.as_str();
-
-        tracing::warn!(
-            status = %status,
-            url = %url,
-            "request failed"
+    for id in 0..num_connections {
+        connections.spawn(
+            run_single_connection(client.clone(), config.address.clone())
+                .instrument(tracing::info_span!("connection", %id)),
         );
-
-        return user.set_failure(&format!("{status}"), &mut goose.request, None, None);
     }
 
+    connections
+        .join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+
+    tracing::info!("HTTP connection test complete");
+
     Ok(())
+}
+
+async fn run_single_connection(client: reqwest::Client, address: String) -> Result<()> {
+    tracing::trace!("Sending GET request");
+
+    let response = client
+        .get(address)
+        .send()
+        .await
+        .context("Failed to send request")?;
+
+    let status = response.status();
+
+    // Finish all the IO.
+    let _text = response.text().await?;
+
+    // TODO: If text/html, crawl for further links.
+
+    tracing::trace!(%status, "Response received");
+
+    Ok(())
+}
+
+fn build_client(config: &TestConfig) -> Result<reqwest::Client> {
+    let builder = reqwest::ClientBuilder::new()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .connection_verbose(true);
+    let builder = match config.http_version {
+        1 => builder.http1_only(),
+        2 => builder.http2_prior_knowledge(),
+        other => anyhow::bail!("Unsupported HTTP version: {other}"),
+    };
+    let client = builder.build().context("Failed to build HTTP client")?;
+
+    Ok(client)
 }

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -253,17 +253,17 @@ impl TestSelector {
         let address = config
             .addresses
             .choose(&mut self.rng)
-            .expect("should have at least one address");
-        let address = Url::parse(address).expect("URL validated during config load");
-        let http_version = config.http_version[self.rng.gen_range(0..config.http_version.len())];
-        let users = self.rng.gen_range(config.users);
-        let run_time = Duration::from_secs(self.rng.gen_range(config.run_time_secs));
+            .expect("should have at least one address")
+            .clone();
+        let http_version = config
+            .http_version
+            .choose(&mut self.rng)
+            .expect("should have at least one HTTP version");
 
         http::TestConfig {
             address,
-            http_version,
-            users,
-            run_time,
+            http_version: *http_version,
+            max_connections: config.max_connections,
         }
     }
 


### PR DESCRIPTION
Instead of pulling in all of `goose`, we can instead make HTTP calls ourselves using `reqwest`. In later iterations, we can then extend this by e.g. crawling the host further if the response is `text/html`. For now, a single request per host is enough.

Resolves: #11130