### PR TITLE
fix(portal): don't redirect authenticated for as=client

### DIFF
--- a/elixir/apps/web/lib/web/live_hooks/redirect_if_authenticated.ex
+++ b/elixir/apps/web/lib/web/live_hooks/redirect_if_authenticated.ex
@@ -1,7 +1,23 @@
 defmodule Web.LiveHooks.RedirectIfAuthenticated do
+  @moduledoc """
+  Redirects authenticated users to the portal when accessing sign-in pages.
+
+  When `as=client` is specified in the params, this hook does NOT redirect,
+  allowing client sign-in flows to proceed even when a portal session exists.
+  """
   alias Domain.Account
   alias Domain.Auth.Subject
   alias Web.Session.Redirector
+
+  def on_mount(
+        :default,
+        %{"as" => "client"},
+        _session,
+        %{assigns: %{account: %Account{}, subject: %Subject{}}} = socket
+      ) do
+    # Client sign-in flow should proceed even if user has a portal session
+    {:cont, socket}
+  end
 
   def on_mount(
         :default,

--- a/elixir/apps/web/lib/web/plugs/redirect_if_authenticated.ex
+++ b/elixir/apps/web/lib/web/plugs/redirect_if_authenticated.ex
@@ -1,4 +1,10 @@
 defmodule Web.Plugs.RedirectIfAuthenticated do
+  @moduledoc """
+  Redirects authenticated users to the portal when accessing sign-in pages.
+
+  When `as=client` is specified in the params, this plug does NOT redirect,
+  allowing client sign-in flows to proceed even when a portal session exists.
+  """
   @behaviour Plug
 
   alias Domain.Account
@@ -9,6 +15,17 @@ defmodule Web.Plugs.RedirectIfAuthenticated do
   def init(opts), do: opts
 
   @impl true
+  def call(
+        %Plug.Conn{
+          params: %{"as" => "client"},
+          assigns: %{account: %Account{}, subject: %Subject{}}
+        } = conn,
+        _opts
+      ) do
+    # Client sign-in flow should proceed even if user has a portal session
+    conn
+  end
+
   def call(
         %Plug.Conn{
           assigns: %{account: %Account{} = account, subject: %Subject{}}

--- a/elixir/apps/web/test/web/live_hooks/redirect_if_authenticated_test.exs
+++ b/elixir/apps/web/test/web/live_hooks/redirect_if_authenticated_test.exs
@@ -1,0 +1,65 @@
+defmodule Web.LiveHooks.RedirectIfAuthenticatedTest do
+  use Web.ConnCase, async: true
+
+  import Domain.AccountFixtures
+  import Domain.SubjectFixtures
+
+  alias Web.LiveHooks.RedirectIfAuthenticated
+
+  setup do
+    account = account_fixture()
+
+    {:ok, account: account}
+  end
+
+  defp build_socket(assigns) do
+    %Phoenix.LiveView.Socket{
+      assigns: Map.merge(%{__changed__: %{}}, assigns)
+    }
+  end
+
+  describe "on_mount/4" do
+    test "halts and redirects authenticated user when not signing in as client", %{
+      account: account
+    } do
+      subject = admin_subject_fixture(account: account)
+      socket = build_socket(%{account: account, subject: subject})
+
+      assert {:halt, redirected_socket} =
+               RedirectIfAuthenticated.on_mount(:default, %{}, %{}, socket)
+
+      expected_path = "/#{account.id}/sites"
+      assert {:redirect, %{to: ^expected_path}} = redirected_socket.redirected
+    end
+
+    test "continues when as=client param is set even with authenticated user", %{
+      account: account
+    } do
+      subject = admin_subject_fixture(account: account)
+      socket = build_socket(%{account: account, subject: subject})
+
+      assert {:cont, returned_socket} =
+               RedirectIfAuthenticated.on_mount(:default, %{"as" => "client"}, %{}, socket)
+
+      assert is_nil(returned_socket.redirected)
+    end
+
+    test "continues when user is not authenticated", %{account: account} do
+      socket = build_socket(%{account: account})
+
+      assert {:cont, returned_socket} =
+               RedirectIfAuthenticated.on_mount(:default, %{}, %{}, socket)
+
+      assert is_nil(returned_socket.redirected)
+    end
+
+    test "continues when no account is assigned" do
+      socket = build_socket(%{})
+
+      assert {:cont, returned_socket} =
+               RedirectIfAuthenticated.on_mount(:default, %{}, %{}, socket)
+
+      assert is_nil(returned_socket.redirected)
+    end
+  end
+end

--- a/elixir/apps/web/test/web/plugs/redirect_if_authenticated_test.exs
+++ b/elixir/apps/web/test/web/plugs/redirect_if_authenticated_test.exs
@@ -1,0 +1,67 @@
+defmodule Web.Plugs.RedirectIfAuthenticatedTest do
+  use Web.ConnCase, async: true
+
+  import Domain.AccountFixtures
+  import Domain.ActorFixtures
+
+  alias Web.Plugs.RedirectIfAuthenticated
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+
+    {:ok, account: account, actor: actor}
+  end
+
+  describe "call/2" do
+    test "redirects authenticated user to portal when not signing in as client", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> Map.put(:params, %{})
+        |> RedirectIfAuthenticated.call([])
+
+      assert conn.halted
+      assert redirected_to(conn) == ~p"/#{account.id}/sites"
+    end
+
+    test "does not redirect authenticated user when as=client param is set", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> Map.put(:params, %{"as" => "client"})
+        |> RedirectIfAuthenticated.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect unauthenticated user", %{
+      conn: conn,
+      account: account
+    } do
+      conn =
+        conn
+        |> Plug.Conn.assign(:account, account)
+        |> Map.put(:params, %{})
+        |> RedirectIfAuthenticated.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect when no account is assigned", %{conn: conn} do
+      conn =
+        conn
+        |> Map.put(:params, %{})
+        |> RedirectIfAuthenticated.call([])
+
+      refute conn.halted
+    end
+  end
+end


### PR DESCRIPTION
When determining whether to redirect a sign-in flow based on whether we're already authenticated, we weren't taking into account whether the flow was for a client. If we already had an active session to the portal opened in the same browser, we would land straight into the portal when authenticating as a client.

Fixes #11203