### PR TITLE
fix(gateway): retry binding DNS servers on TUN interface

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -167,6 +167,7 @@ jobs:
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Start docker compose in the background
+        if: ${{ steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure' }} # Run if version checks succeed or are skipped
         run: |
           set -xe
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -128,6 +128,7 @@ jobs:
           - name: download-ipv4-only
             script: download
             gateway_disable_ipv6: 1
+            min_gateway_version: 1.4.19
           - script: download-packet-loss
             rust_log: debug
           - script: download-roaming-network

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -237,6 +237,7 @@ jobs:
           # Disabling checksum offloading causes one or two "I/O error (os error 5)" warnings
           docker compose logs gateway | \
             grep --invert "I/O error (os error 5)" | \
+            ${{ matrix.test.gateway_disable_ipv6 == 1 && 'grep --invert "Failed to add route: Received a netlink error message Permission denied (os error 13) route=fd00:2021:1111::/107" |' || '' }} \
             grep "WARN" && exit 1 || exit 0
       - name: Show Gateway logs
         if: "!cancelled()"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -147,6 +147,9 @@ jobs:
           ACTUAL_VERSION=$(docker run --privileged ${{ inputs.client_image }}:${{ inputs.client_tag }} firezone-headless-client --version | awk '{print $2}')
           MIN_VERSION="${{ matrix.test.min_client_version }}"
 
+          echo "ACTUAL_VERSION=${ACTUAL_VERSION}"
+          echo "MIN_VERSION=${MIN_VERSION}"
+
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
       - name: Check minimum gateway version
         id: gateway_version_check
@@ -155,6 +158,9 @@ jobs:
         run: |
           ACTUAL_VERSION=$(docker run --privileged ${{ inputs.gateway_image }}:${{ inputs.gateway_tag }} firezone-gateway --version | awk '{print $2}')
           MIN_VERSION="${{ matrix.test.min_gateway_version }}"
+
+          echo "ACTUAL_VERSION=${ACTUAL_VERSION}"
+          echo "MIN_VERSION=${MIN_VERSION}"
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
       - uses: ./.github/actions/setup-docker

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -125,6 +125,9 @@ jobs:
             rust_log: debug,flow_logs=trace
             single_relay: true # Force single relay
             min_gateway_version: 1.4.18
+          - name: download-ipv4-only
+            script: download
+            gateway_disable_ipv6: 1
           - script: download-packet-loss
             rust_log: debug
           - script: download-roaming-network
@@ -170,6 +173,10 @@ jobs:
 
           if [[ -n "${{ matrix.test.gateway_masquerade }}" ]]; then
             export GATEWAY_MASQUERADE="${{ matrix.test.gateway_masquerade }}"
+          fi
+
+          if [[ -n "${{ matrix.test.gateway_disable_ipv6 }}" ]]; then
+            export GATEWAY_DISABLE_IPV6="${{ matrix.test.gateway_disable_ipv6 }}"
           fi
 
           docker compose build client-router gateway-router relay-1-router relay-2-router api-router

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -144,7 +144,7 @@ jobs:
         if: ${{ matrix.test.min_client_version }}
         continue-on-error: true
         run: |
-          ACTUAL_VERSION=$(docker run ${{ inputs.client_image }}:${{ inputs.client_tag }} firezone-headless-client --version | awk '{print $2}')
+          ACTUAL_VERSION=$(docker run --privileged ${{ inputs.client_image }}:${{ inputs.client_tag }} firezone-headless-client --version | awk '{print $2}')
           MIN_VERSION="${{ matrix.test.min_client_version }}"
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
@@ -153,7 +153,7 @@ jobs:
         if: ${{ matrix.test.min_gateway_version }}
         continue-on-error: true
         run: |
-          ACTUAL_VERSION=$(docker run ${{ inputs.gateway_image }}:${{ inputs.gateway_tag }} firezone-gateway --version | awk '{print $2}')
+          ACTUAL_VERSION=$(docker run --privileged ${{ inputs.gateway_image }}:${{ inputs.gateway_tag }} firezone-gateway --version | awk '{print $2}')
           MIN_VERSION="${{ matrix.test.min_gateway_version }}"
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -255,7 +255,7 @@ jobs:
         run: docker compose logs api
 
       - name: Ensure no eBPF checksum errors on relay-1
-        if: "!cancelled()"
+        if: "!cancelled() && steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure'"
         run: |
           set -xe
 
@@ -272,7 +272,7 @@ jobs:
           path: ./relay-1-packets.pcap
 
       - name: Ensure no eBPF checksum errors on relay-2
-        if: "!cancelled() && !matrix.test.single_relay"
+        if: "!cancelled() && !matrix.test.single_relay && steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure'"
         run: |
           set -xe
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,7 +256,7 @@ services:
 
         # Add static route to internet subnet via router
         ip -4 route add 203.0.113.0/24 via 172.31.0.254
-        ip -6 route add 203:0:113::/64 via 172:31:0::254
+        ip -6 route add 203:0:113::/64 via 172:31:0::254 || true
 
         # Disable checksum offloading so that checksums are correct when they reach the relay
         apk add --no-cache ethtool iproute2
@@ -281,8 +281,8 @@ services:
       - NET_ADMIN
     sysctls:
       - net.ipv4.ip_forward=1
-      - net.ipv6.conf.all.disable_ipv6=0
-      - net.ipv6.conf.default.disable_ipv6=0
+      - net.ipv6.conf.all.disable_ipv6=${GATEWAY_DISABLE_IPV6:-0}
+      - net.ipv6.conf.default.disable_ipv6=${GATEWAY_DISABLE_IPV6:-0}
       - net.ipv6.conf.all.forwarding=1
       - net.ipv6.conf.default.forwarding=1
     devices:

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -499,7 +499,9 @@ impl Eventloop {
                 let ipv6_socket = SocketAddr::V6(SocketAddrV6::new(interface.ipv6, 53535, 0, 0));
 
                 let mut attempts = [
-                    // First attempt with both sockets.
+                    // 3 attempts with both sockets.
+                    vec![ipv4_socket, ipv6_socket],
+                    vec![ipv4_socket, ipv6_socket],
                     vec![ipv4_socket, ipv6_socket],
                     // If IPv6 is not available, try with just the IPv4 address.
                     vec![ipv4_socket],

--- a/rust/libs/bin-shared/src/lib.rs
+++ b/rust/libs/bin-shared/src/lib.rs
@@ -55,4 +55,4 @@ pub const FIREZONE_MARK: u32 = 0xfd002021;
 
 pub use dns_control::{DnsControlMethod, DnsController};
 pub use network_changes::{new_dns_notifier, new_network_notifier};
-pub use tun_device_manager::TunDeviceManager;
+pub use tun_device_manager::{TunDeviceManager, TunIpStack};

--- a/rust/libs/bin-shared/src/tun_device_manager.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager.rs
@@ -2,6 +2,8 @@
 
 #[cfg(target_os = "linux")]
 pub mod linux;
+use std::fmt;
+
 #[cfg(target_os = "linux")]
 pub use linux as platform;
 
@@ -23,4 +25,14 @@ pub enum TunIpStack {
     V4Only,
     V6Only,
     Dual,
+}
+
+impl fmt::Display for TunIpStack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TunIpStack::V4Only => write!(f, "V4Only"),
+            TunIpStack::V6Only => write!(f, "V6Only"),
+            TunIpStack::Dual => write!(f, "Dual"),
+        }
+    }
 }

--- a/rust/libs/bin-shared/src/tun_device_manager.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager.rs
@@ -16,3 +16,11 @@ pub mod macos;
 pub use macos as platform;
 
 pub use platform::TunDeviceManager;
+
+/// The supported IP stack of the TUN device
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunIpStack {
+    V4Only,
+    V6Only,
+    Dual,
+}

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -152,6 +152,8 @@ impl TunDeviceManager {
             .await
             .context("Failed to set default MTU")?;
 
+        tracing::debug!(%ipv4, %ipv6, "Setting tunnel interface IPs");
+
         let res_v4 = handle.address().add(index, ipv4.into(), 32).execute().await;
         let res_v6 = handle
             .address()

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -1,6 +1,6 @@
 //! Virtual network interface
 
-use crate::FIREZONE_MARK;
+use crate::{FIREZONE_MARK, tun_device_manager::TunIpStack};
 use anyhow::{Context as _, Result};
 use futures::{
     SinkExt, StreamExt, TryStreamExt,
@@ -131,7 +131,7 @@ impl TunDeviceManager {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    pub async fn set_ips(&mut self, ipv4: Ipv4Addr, ipv6: Ipv6Addr) -> Result<()> {
+    pub async fn set_ips(&mut self, ipv4: Ipv4Addr, ipv6: Ipv6Addr) -> Result<TunIpStack> {
         let handle = &self.connection.handle;
         let index = tun_device_index(handle).await?;
 
@@ -192,9 +192,24 @@ impl TunDeviceManager {
             }
         }
 
-        res_v4.or(res_v6)?;
+        let tun_ip_stack = match (res_v4, res_v6) {
+            (Ok(()), Ok(())) => TunIpStack::Dual,
+            (Ok(()), Err(e)) => {
+                tracing::debug!("Failed to set IPv6 address on TUN device: {e}");
 
-        Ok(())
+                TunIpStack::V4Only
+            }
+            (Err(e), Ok(())) => {
+                tracing::debug!("Failed to set IPv4 address on TUN device: {e}");
+
+                TunIpStack::V6Only
+            }
+            (Err(e_v4), Err(e_v6)) => {
+                anyhow::bail!("Failed to set IPv4 and IPv6 address on TUN device: {e_v4} | {e_v6}")
+            }
+        };
+
+        Ok(tun_ip_stack)
     }
 
     pub async fn set_routes(

--- a/rust/libs/bin-shared/src/tun_device_manager/macos.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/macos.rs
@@ -4,6 +4,8 @@ use anyhow::{Result, bail};
 use ip_network::{Ipv4Network, Ipv6Network};
 use tun::Tun;
 
+use crate::tun_device_manager::TunIpStack;
+
 pub struct TunDeviceManager {}
 
 impl TunDeviceManager {
@@ -19,7 +21,7 @@ impl TunDeviceManager {
         clippy::unused_async,
         reason = "Signture must match other operating systems"
     )]
-    pub async fn set_ips(&mut self, _ipv4: Ipv4Addr, _ipv6: Ipv6Addr) -> Result<()> {
+    pub async fn set_ips(&mut self, _ipv4: Ipv4Addr, _ipv6: Ipv6Addr) -> Result<TunIpStack> {
         bail!("Not implemented")
     }
 

--- a/rust/libs/connlib/l4-tcp-dns-server/lib.rs
+++ b/rust/libs/connlib/l4-tcp-dns-server/lib.rs
@@ -9,7 +9,7 @@ use futures::{
 use std::{
     collections::HashMap,
     io,
-    net::{SocketAddr, ToSocketAddrs},
+    net::SocketAddr,
     task::{Context, Poll},
 };
 use tokio::{
@@ -171,9 +171,9 @@ pub struct Query {
     pub message: dns_types::Query,
 }
 
-fn make_tcp_listener(socket: impl ToSocketAddrs) -> Result<TcpListener> {
-    let tcp_listener =
-        std::net::TcpListener::bind(socket).context("Failed to bind TCP listener")?;
+fn make_tcp_listener(socket: SocketAddr) -> Result<TcpListener> {
+    let tcp_listener = std::net::TcpListener::bind(socket)
+        .with_context(|| format!("Failed to bind TCP listener on {socket}"))?;
     tcp_listener
         .set_nonblocking(true)
         .context("Failed to set listener to non-blocking")?;

--- a/rust/libs/connlib/l4-udp-dns-server/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-server/lib.rs
@@ -11,7 +11,7 @@ use futures::{
 };
 use std::{
     io,
-    net::{SocketAddr, ToSocketAddrs},
+    net::SocketAddr,
     sync::{Arc, Weak},
     task::{Context, Poll},
 };
@@ -148,8 +148,9 @@ pub struct Query {
     pub message: dns_types::Query,
 }
 
-fn make_udp_socket(socket: impl ToSocketAddrs) -> Result<UdpSocket> {
-    let udp_socket = std::net::UdpSocket::bind(socket).context("Failed to bind UDP socket")?;
+fn make_udp_socket(socket: SocketAddr) -> Result<UdpSocket> {
+    let udp_socket = std::net::UdpSocket::bind(socket)
+        .with_context(|| format!("Failed to bind UDP socket on {socket}"))?;
     udp_socket
         .set_nonblocking(true)
         .context("Failed to set socket as non-blocking")?;

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -211,15 +211,22 @@ impl Io {
             let mut udp = l4_udp_dns_server::Server::default();
             let mut tcp = l4_tcp_dns_server::Server::default();
 
-            if let Err(e) = udp.rebind(socket) {
-                error.push(e);
+            match udp.rebind(socket) {
+                Ok(()) => {
+                    self.udp_dns_server.insert(socket, udp);
+                }
+                Err(e) => {
+                    error.push(e);
+                }
             };
-            if let Err(e) = tcp.rebind(socket) {
-                error.push(e);
+            match tcp.rebind(socket) {
+                Ok(()) => {
+                    self.tcp_dns_server.insert(socket, tcp);
+                }
+                Err(e) => {
+                    error.push(e);
+                }
             };
-
-            self.udp_dns_server.insert(socket, udp);
-            self.tcp_dns_server.insert(socket, tcp);
         }
 
         if !error.is_empty() {

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -722,7 +722,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)] // Windows has different error messages.
     #[tokio::test]
     async fn rebind_dns_clears_all_servers_on_failure() {
         let _guard = logging::test("debug");
@@ -738,11 +737,11 @@ mod tests {
             result
                 .unwrap_err()
                 .drain()
-                .map(|e| format!("{e:#}"))
+                .map(|e| e.to_string())
                 .collect::<Vec<_>>(),
             vec![
-                "Failed to bind UDP socket on 1.1.1.1:40000: Cannot assign requested address (os error 99)",
-                "Failed to bind TCP listener on 1.1.1.1:40000: Cannot assign requested address (os error 99)"
+                "Failed to bind UDP socket on 1.1.1.1:40000",
+                "Failed to bind TCP listener on 1.1.1.1:40000"
             ]
         );
         assert!(io.udp_dns_server.is_empty());

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -730,8 +730,8 @@ mod tests {
         let mut io = Io::for_test();
 
         let result = io.rebind_dns(vec![
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 55555), // This one will almost definitely work.
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 55555), // This one will fail.
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000), // This one will almost definitely work.
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 40000), // This one will fail.
         ]);
 
         assert_eq!(
@@ -741,8 +741,8 @@ mod tests {
                 .map(|e| format!("{e:#}"))
                 .collect::<Vec<_>>(),
             vec![
-                "Failed to bind UDP socket on 1.1.1.1:55555: Cannot assign requested address (os error 99)",
-                "Failed to bind TCP listener on 1.1.1.1:55555: Cannot assign requested address (os error 99)"
+                "Failed to bind UDP socket on 1.1.1.1:40000: Cannot assign requested address (os error 99)",
+                "Failed to bind TCP listener on 1.1.1.1:40000: Cannot assign requested address (os error 99)"
             ]
         );
         assert!(io.udp_dns_server.is_empty());

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -103,7 +103,7 @@ impl<TRoleState> Tunnel<TRoleState> {
         self.io.set_tun(tun);
     }
 
-    pub fn rebind_dns(&mut self, sockets: Vec<SocketAddr>) -> Result<()> {
+    pub fn rebind_dns(&mut self, sockets: Vec<SocketAddr>) -> Result<(), TunnelError> {
         self.io.rebind_dns(sockets)
     }
 }

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -30,6 +30,10 @@ export default function Gateway() {
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
+        <ChangeItem pull="11208">
+          Fixes an issue where the Gateway would not boot up if IPv6 was
+          disabled on the system.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.18" date={new Date("2025-11-10")}>
         <ChangeItem pull="10620">


### PR DESCRIPTION
We currently have a bug where the Gateway may restart if the WebSocket gets cut and we need to rebind the DNS servers on the TUN interface. The sockets may not have been fully dropped or the interface may not be fully available yet. Additionally, the last release introduced a regression where the Gateway would not start up if IPv6 was completely disabled on the machine.

To fix this, we now return a `TunIpStack` enum from `TunDeviceManager::set_ips` which allows us to further inform, which operations we want to make and only try to bind DNS servers on the IPs that worked. We retry this 3 times in case the previous sockets haven't been fully cleared yet.