### PR TITLE
chore(apple): format swift

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/NetworkSettings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/NetworkSettings.swift
@@ -38,7 +38,7 @@ public struct NetworkSettings: Equatable {
     self.tunnelAddressIPv6 = ipv6
     self.dnsServers = dnsServers
     self.searchDomain = searchDomain
-    self.matchDomains = searchDomain.map{ ["", $0] } ?? [""]
+    self.matchDomains = searchDomain.map { ["", $0] } ?? [""]
     self.routes4 = routes4.sorted {
       ($0.destinationAddress, $0.destinationSubnetMask) < (
         $1.destinationAddress, $1.destinationSubnetMask

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/CancellableTaskTests.swift
@@ -46,7 +46,7 @@ struct CancellableTaskTests {
           try await Task.sleep(for: .seconds(10))
         } catch is CancellationError {
           await wasCancelled.set(true)
-        } catch { }
+        } catch {}
       }
       // CancellableTask goes out of scope here, triggering deinit -> cancel
     }
@@ -67,7 +67,7 @@ struct CancellableTaskTests {
         try await Task.sleep(for: .seconds(10))
       } catch is CancellationError {
         await wasCancelled.set(true)
-      } catch { }
+      } catch {}
     }
 
     // Set to nil, triggering cancellation

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -472,7 +472,8 @@ class Adapter: @unchecked Sendable {
           }
           return nil
         }
-        let tunnelNetworkSettings = self.networkSettings.updateDnsResources(newDnsResources: dnsAddresses)
+        let tunnelNetworkSettings = self.networkSettings.updateDnsResources(
+          newDnsResources: dnsAddresses)
         self.applyNetworkSettings(tunnelNetworkSettings)
       }
 


### PR DESCRIPTION
Not sure how the style lint got broken for Swift code. This fixes the violations introduced in #11191.