### PR TITLE
chore: Check Swift formatting on CI

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -33,6 +33,17 @@ jobs:
       - run: swift test
         working-directory: swift/apple/FirezoneKit
 
+  static-analysis:
+    runs-on: macos-15
+    env:
+      XCODE_VERSION: "26.0"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - run: sudo xcode-select --switch "$(find /Applications -maxdepth 1 -name "Xcode*${XCODE_VERSION}*.app" | sort -V | tail -n 1)"
+      - name: Check Swift formatting
+        run: make format-check
+        working-directory: swift/apple
+
   build:
     name: ${{ matrix.job_name }}
     needs: update-release-draft

--- a/swift/apple/Makefile
+++ b/swift/apple/Makefile
@@ -134,7 +134,10 @@ clean:
 format:
 	@echo "Formatting Swift code..."
 	@find . -name "*.swift" -not -path "./FirezoneNetworkExtension/Connlib/Generated/*" -not -path "./FirezoneKit/.build/*" | xargs swift format format --in-place --parallel
-	@echo "Linting Swift code..."
+
+.PHONY: format-check
+format-check:
+	@echo "Checking Swift formatting..."
 	@find . -name "*.swift" -not -path "./FirezoneNetworkExtension/Connlib/Generated/*" -not -path "./FirezoneKit/.build/*" | xargs swift format lint --parallel --strict
 
 .PHONY: setup


### PR DESCRIPTION
Linting in `swift format` is only "checking formatting".

We used to only check it *after* fixing the formatting, so it was never
triggered...move "checking" into a separate task so it can be
independently run on CI.
