### PR TITLE
fix(portal): don't double-prepend nonce

### DIFF
--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -174,8 +174,8 @@ defmodule Domain.Auth do
   The token is encoded as a tuple of {account_id, token_id, secret_fragment}
   which is then signed using Plug.Crypto to ensure it can't be tampered with.
   """
-  def encode_fragment!(%Token{type: :client, secret_nonce: nonce} = token),
-    do: encode_token(token.account_id, token.id, token.secret_fragment, "client", nonce)
+  def encode_fragment!(%Token{type: :client} = token),
+    do: encode_token(token.account_id, token.id, token.secret_fragment, "client")
 
   def encode_fragment!(%Domain.RelayToken{} = token),
     do: encode_token(nil, token.id, token.secret_fragment, "relay")
@@ -186,12 +186,12 @@ defmodule Domain.Auth do
   def encode_fragment!(%Domain.APIToken{} = token),
     do: encode_token(token.account_id, token.id, token.secret_fragment, "api_client")
 
-  defp encode_token(account_id, id, fragment, type, nonce \\ "") do
+  defp encode_token(account_id, id, fragment, type) do
     body = {account_id, id, fragment}
     config = fetch_config!()
     key_base = Keyword.fetch!(config, :key_base)
     salt = Keyword.fetch!(config, :salt)
-    nonce <> "." <> Plug.Crypto.sign(key_base, salt <> type, body)
+    "." <> Plug.Crypto.sign(key_base, salt <> type, body)
   end
 
   def verify_relay_token(encoded_token) when is_binary(encoded_token) do


### PR DESCRIPTION
In #11166 we made a subtle yet breaking change to prepend the `nonce <> "."` to the signed output in `encode_fragment!`.

The encoded fragment should be the signed portion of the token without the nonce prepended. Clients receiving tokens via insecure channels (i.e. GUI clients) receive this signed fragment and then prepend their nonce to it, forming the full token.

The `secret_hash` contains the hashed nonce and is verified upon token use when a nonce is provided.

A test is also added to ensure this regression doesn't resurface.