### PR TITLE
chore(ci): use GHA cache with increased size

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -1,9 +1,6 @@
 # From https://tauri.app/v1/guides/getting-started/prerequisites
 name: "Setup Android"
 description: "Sets up the dependencies for building our Android app"
-inputs:
-  sccache_azure_connection_string:
-    description: "Azure connection string for sccache"
 runs:
   using: "composite"
   steps:
@@ -14,7 +11,6 @@ runs:
     - uses: ./.github/actions/setup-rust
       with:
         targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android
-        sccache_azure_connection_string: ${{ inputs.sccache_azure_connection_string }}
 
     - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -2,8 +2,6 @@
 name: "Setup Rust"
 description: "Sets up the correct Rust version and caching via sccache and a GCP backend"
 inputs:
-  sccache_azure_connection_string:
-    description: "Azure connection string for sccache"
   targets:
     description: "Additional targets to install"
     required: false
@@ -63,15 +61,10 @@ runs:
         cache-targets: false # Don't cache `target` directory, we use sccache for that.
         save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main
 
-    # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).
-    # For this to work, you need an Azure Storage account and a blob container named `sccache`.
-    # The connection string here can be found under Storage Account -> Settings -> Security + networking -> Access keys.
     - name: Configure sccache
       shell: bash
       run: |
-        echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
-        echo "SCCACHE_AZURE_CONNECTION_STRING=${{ inputs.sccache_azure_connection_string }}" >> $GITHUB_ENV
-        echo "SCCACHE_AZURE_BLOB_CONTAINER=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
 
     - name: Install nightly Rust to use for certain tools (fuzzing, cargo-udeps)

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -125,7 +125,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - name: Build binaries
         shell: bash
         run: |
@@ -258,7 +257,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.arch.target }}
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - name: Install dependencies
         run: ${{ matrix.arch.install_dependencies }}
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-android
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - name: Run linter
         run: ./gradlew spotlessCheck
 
@@ -68,8 +66,6 @@ jobs:
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-android
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - name: Build the release package
         env:
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
@@ -126,8 +122,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-android
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - name: Build debug APK
         run: |
           ./gradlew assembleDebug

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -49,7 +49,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'linux'

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -27,8 +27,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-rust
         id: setup-rust
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
         timeout-minutes: 15
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
@@ -76,8 +74,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-rust
         id: setup-rust
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
         env:
@@ -162,8 +158,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-rust
         id: setup-rust
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -189,8 +183,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-rust
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
         timeout-minutes: 15
       - run: scripts/tests/${{ matrix.test }}

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -77,7 +77,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.rust-targets }}
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - run: ${{ matrix.build-script }}
         env:
           IOS_APP_PROVISIONING_PROFILE: "${{ secrets.APPLE_IOS_APP_PROVISIONING_PROFILE }}"

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -69,8 +69,6 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
           lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
         timeout-minutes: 15
         with:
@@ -140,8 +138,6 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
           lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust
-        with:
-          sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15


### PR DESCRIPTION
Apparently GitHub allows increasing the cache size to an obscene size and ours was set (for no good reason) to the default of 10 GB.

I've since bumped this up to 1000 GB which should allow us to use the GHA cache over the Azure blob storage to save on cost.