### PR TITLE
fix(portal): sync org units from google

### DIFF
--- a/elixir/apps/domain/lib/domain/google/api_client.ex
+++ b/elixir/apps/domain/lib/domain/google/api_client.ex
@@ -97,6 +97,20 @@ defmodule Domain.Google.APIClient do
     stream_pages(path, query, access_token, "members")
   end
 
+  @doc """
+  Streams organization units from the Google Workspace directory.
+  Returns a stream that yields pages of organization units.
+  """
+  def stream_organization_units(access_token) do
+    query =
+      URI.encode_query(%{
+        "type" => "all"
+      })
+
+    path = "/admin/directory/v1/customer/my_customer/orgunits"
+    stream_pages(path, query, access_token, "organizationUnits")
+  end
+
   defp get(path, access_token) do
     config = Domain.Config.fetch_env!(:domain, __MODULE__)
 


### PR DESCRIPTION
This was an oversight and should have been included in #10505.

Simply adds org unit fetching and inserting similar to how we do groups, except we set the `entity_type` to `org_unit`.

Fixes #11218 