### PR TITLE
fix(portal): use consistent callback url for verification

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/directory_sync.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_sync.ex
@@ -1266,8 +1266,8 @@ defmodule Web.Settings.DirectorySync do
     config = Domain.Config.fetch_env!(:domain, Entra.APIClient)
     client_id = config[:client_id]
 
-    # Build admin consent URL
-    redirect_uri = url(~p"/verification")
+    # Build admin consent URL - route through /auth/oidc/callback so admins only need one redirect URI
+    redirect_uri = url(~p"/auth/oidc/callback")
 
     # Use .default scope to request all configured application permissions
     params = %{

--- a/elixir/apps/web/lib/web/oidc.ex
+++ b/elixir/apps/web/lib/web/oidc.ex
@@ -171,14 +171,15 @@ defmodule Web.OIDC do
   """
   def setup_verification("entra", opts) do
     # For Entra, use admin consent endpoint to pre-check organization-wide consent
+    # We route through /auth/oidc/callback so admins only need to configure one redirect URI
     token = Domain.Crypto.random_token(32)
     state = "entra-verification:#{token}"
 
     config = verification_config_for_type("entra", opts)
     client_id = config[:client_id]
 
-    # Build admin consent URL pointing to our unified verification handler
-    redirect_uri = url(~p"/verification")
+    # Build admin consent URL pointing to our unified OIDC callback
+    redirect_uri = callback_url()
     scope = "openid email profile"
 
     params = %{


### PR DESCRIPTION
When verifying Entra auth and sync configurations, we were using a different callback URI, `/verification` since Entra handles things using a special OIDC flow dubbed "admin consent".

This is actually a flavor of OIDC under the covers, so rather than have a special handler for Entra, we now handle it in the `/auth/oidc/callback` handler like other verifications.

Furthermore, we simplify the key that the verification session data is stored under to be a single `verification` key such that only one verification can be in flight at a time.

Fixes #11189