### PR TITLE
perf(ci): parallelise DMG and PKG notarisation

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
@@ -3,7 +3,6 @@
 //  (c) 2024 Firezone, Inc.
 //  LICENSE: Apache-2.0
 //
-//
 // Reads system resolvers from libresolv, similar to reading /etc/resolv.conf but this also works on iOS
 
 import FirezoneKit


### PR DESCRIPTION
Submit both artifacts to Apple's notary service concurrently instead of sequentially. Each notarisation can take a few minutes, so this roughly halves the notarisation wait time for standalone macOS releases.