### PR TITLE
fix(portal): migrate existing google sync key

### DIFF
--- a/elixir/apps/domain/lib/domain/google/api_client.ex
+++ b/elixir/apps/domain/lib/domain/google/api_client.ex
@@ -1,8 +1,7 @@
 defmodule Domain.Google.APIClient do
-  def get_access_token(impersonation_email) do
+  def get_access_token(impersonation_email, key) do
     config = Domain.Config.fetch_env!(:domain, __MODULE__)
     token_endpoint = config[:token_endpoint]
-    key = config[:service_account_key] |> JSON.decode!()
     iss = key["client_email"]
     private_key = key["private_key"]
 

--- a/elixir/apps/domain/lib/domain/google/directory.ex
+++ b/elixir/apps/domain/lib/domain/google/directory.ex
@@ -26,6 +26,7 @@ defmodule Domain.Google.Directory do
     field :error_message, :string
     field :error_email_count, :integer, default: 0, read_after_writes: true
     field :is_verified, :boolean, default: false, read_after_writes: true
+    field :legacy_service_account_key, :map
 
     timestamps()
   end

--- a/elixir/apps/domain/priv/repo/migrations/20251025120000_create_google_directories.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251025120000_create_google_directories.exs
@@ -20,6 +20,7 @@ defmodule Domain.Repo.Migrations.CreateGoogleDirectories do
       add(:error_message, :text)
       add(:error_email_count, :integer, default: 0, null: false)
       add(:is_verified, :boolean, default: false, null: false)
+      add(:legacy_service_account_key, :map)
 
       add(:created_by, :string, null: false)
       add(:created_by_subject, :map)

--- a/elixir/apps/domain/priv/repo/migrations/20251104130000_migrate_to_new_auth_system.sql
+++ b/elixir/apps/domain/priv/repo/migrations/20251104130000_migrate_to_new_auth_system.sql
@@ -469,6 +469,50 @@ BEGIN
       AND p.adapter = 'google_workspace'
     ON CONFLICT (id) DO NOTHING;
 
+    -- Step 9d2: Migrate Google Workspace providers with service_account_json_key to google_directories
+    -- First, create the parent Directory record
+    INSERT INTO directories (account_id, id, type)
+    SELECT
+      p.account_id,
+      gen_random_uuid(),
+      'google'
+    FROM legacy_auth_providers p
+    WHERE p.account_id = v_account_id
+      AND p.adapter = 'google_workspace'
+      AND p.adapter_config->>'service_account_json_key' IS NOT NULL
+    ON CONFLICT DO NOTHING;
+
+    -- Then, create the google_directories record with the same id
+    INSERT INTO google_directories (
+      id,
+      account_id,
+      domain,
+      name,
+      impersonation_email,
+      is_verified,
+      legacy_service_account_key,
+      created_by,
+      inserted_at,
+      updated_at
+    )
+    SELECT
+      d.id,
+      p.account_id,
+      COALESCE(p.adapter_state->'claims'->>'hd', ''),
+      COALESCE(p.name || ' Directory', 'Google Directory'),
+      COALESCE(p.adapter_state->'userinfo'->>'email', ''),
+      false,
+      (p.adapter_config->>'service_account_json_key')::jsonb,
+      'system',
+      NOW(),
+      NOW()
+    FROM legacy_auth_providers p
+    JOIN directories d ON d.account_id = p.account_id AND d.type = 'google'
+    WHERE p.account_id = v_account_id
+      AND p.adapter = 'google_workspace'
+      AND p.adapter_config->>'service_account_json_key' IS NOT NULL
+    ON CONFLICT (id) DO NOTHING;
+
     -- Step 9e: Migrate Microsoft Entra providers as OIDC providers
     INSERT INTO auth_providers (id, account_id, type)
     SELECT p.id, p.account_id, 'oidc'

--- a/elixir/apps/web/lib/web/live/settings/directory_sync.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_sync.ex
@@ -89,6 +89,10 @@ defmodule Web.Settings.DirectorySync do
         nil
       end
 
+    # Check if this is a legacy Google directory (has legacy_service_account_key)
+    is_legacy =
+      type == "google" && directory.legacy_service_account_key != nil
+
     {:noreply,
      assign(socket,
        directory: directory,
@@ -96,7 +100,8 @@ defmodule Web.Settings.DirectorySync do
        verifying: false,
        type: type,
        form: to_form(changeset),
-       public_jwk: public_jwk
+       public_jwk: public_jwk,
+       is_legacy: is_legacy
      )}
   end
 
@@ -353,6 +358,7 @@ defmodule Web.Settings.DirectorySync do
                 account={@account}
                 directory={directory}
                 subject={@subject}
+                is_legacy={directory.is_legacy}
               />
             <% end %>
           </div>
@@ -525,10 +531,21 @@ defmodule Web.Settings.DirectorySync do
       :if={@live_action == :edit}
       id="edit-directory-modal"
       on_close="close_modal"
-      confirm_disabled={not @form.source.valid? or Enum.empty?(@form.source.changes)}
+      confirm_disabled={
+        not @form.source.valid? or Enum.empty?(@form.source.changes) or not verified?(@form)
+      }
     >
       <:title icon={@type}>Edit {@directory_name}</:title>
       <:body>
+        <.flash :if={assigns[:is_legacy]} kind={:warning_inline}>
+          This directory uses legacy credentials and needs to be updated to use Firezone's shared service account.
+          <.website_link path="/kb/">
+            Read the docs
+          </.website_link>
+          to setup domain-wide delegation, then click <strong>Verify Now</strong>
+          and <strong>Save</strong>
+          below.
+        </.flash>
         <.directory_form
           verification_error={@verification_error}
           verifying={assigns[:verifying] || false}
@@ -552,6 +569,7 @@ defmodule Web.Settings.DirectorySync do
   attr :account, :any, required: true
   attr :directory, :any, required: true
   attr :subject, :any, required: true
+  attr :is_legacy, :boolean, default: false
 
   defp directory_card(assigns) do
     # Determine if toggle should be disabled (when directory is disabled and account lacks feature)
@@ -564,9 +582,12 @@ defmodule Web.Settings.DirectorySync do
         <div class="flex items-center flex-1 min-w-0">
           <.provider_icon type={@type} class="w-7 h-7 mr-2 flex-shrink-0" />
           <div class="flex flex-col min-w-0">
-            <span class="font-medium text-xl truncate" title={@directory.name}>
-              {@directory.name}
-            </span>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-xl truncate" title={@directory.name}>
+                {@directory.name}
+              </span>
+              <.badge :if={@is_legacy} type="warning">LEGACY</.badge>
+            </div>
             <span class="text-xs text-neutral-500 font-mono">
               ID: {@directory.id}
             </span>
@@ -1018,6 +1039,11 @@ defmodule Web.Settings.DirectorySync do
     end
   end
 
+  attr :id, :string, required: true
+  attr :form, :any, required: true
+  attr :verifying, :boolean, required: true
+  attr :type, :string, required: true
+
   defp verification_status_badge(assigns) do
     # Entra opens a new window, so show the arrow icon and use OpenURL hook
     # Google/Okta are server-side only, no icon or hook needed
@@ -1199,6 +1225,14 @@ defmodule Web.Settings.DirectorySync do
         changeset
       end
 
+    # Clear legacy_service_account_key for Google directories on save
+    changeset =
+      if changeset.data.__struct__ == Google.Directory do
+        put_change(changeset, :legacy_service_account_key, nil)
+      else
+        changeset
+      end
+
     changeset
     |> DB.update_directory(socket.assigns.subject)
     |> handle_submit(socket)
@@ -1228,9 +1262,11 @@ defmodule Web.Settings.DirectorySync do
   defp start_verification(%{assigns: %{type: "google"}} = socket) do
     changeset = socket.assigns.form.source
     impersonation_email = get_field(changeset, :impersonation_email)
+    config = Domain.Config.fetch_env!(:domain, Google.APIClient)
+    key = config[:service_account_key] |> JSON.decode!()
 
     with {:ok, %Req.Response{status: 200, body: %{"access_token" => access_token}}} <-
-           Google.APIClient.get_access_token(impersonation_email),
+           Google.APIClient.get_access_token(impersonation_email, key),
          {:ok, %Req.Response{status: 200, body: body}} <-
            Google.APIClient.get_customer(access_token) do
       changeset =
@@ -1737,9 +1773,11 @@ defmodule Web.Settings.DirectorySync do
         end)
         |> Map.new()
 
-      # Add has_active_job field to each directory
+      # Add has_active_job and is_legacy fields to each directory
       Enum.map(directories, fn dir ->
-        Map.put(dir, :has_active_job, Map.has_key?(active_jobs, dir.id))
+        dir
+        |> Map.put(:has_active_job, Map.has_key?(active_jobs, dir.id))
+        |> Map.put(:is_legacy, Map.get(dir, :legacy_service_account_key) != nil)
       end)
     end
   end


### PR DESCRIPTION
Updates the migration script to pull over the existing information needed to keep Google directory sync intact from the previous provider.

<img width="524" height="348" alt="Screenshot 2025-12-16 at 9 38 42 PM" src="https://github.com/user-attachments/assets/ec009373-e0ea-424d-9f0c-ac2b6b62018c" />




Fixes #11071 