### PR TITLE
ci(rust): only run tests on 1 version per OS

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -61,16 +61,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on:
-          [
-            ubuntu-22.04,
-            ubuntu-24.04,
-            macos-14,
-            macos-15,
-            macos-26,
-            windows-2022,
-            windows-2025,
-          ]
+        runs-on: [ubuntu-24.04, macos-26, windows-2025]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Our Rust code is primarily cross-platform and for the platform-specific bits, we don't have many tests. The biggest part here is our UDP socket which is already very well-tested in the upstream `quinn` repository. As such, running all of our Rust tests on several versions of each operating system is just a waste in CI resources, especially because we only have 5 macos runners across the entire organization.