### PR TITLE
ci(portal): always seed deterministically

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -55,10 +55,10 @@ Prerequisites:
 
 Steps:
 
-- Use static seeds to provision account ID that corresponds to staging setup on Stripe:
+- Reset and seed the database (seeds use static IDs that correspond to staging setup on Stripe):
 
   ```
-  STATIC_SEEDS=true mix do ecto.reset, ecto.seed
+  mix do ecto.reset, ecto.seed
   ```
 
 - Start Stripe CLI webhook proxy:

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -66,8 +66,6 @@ services:
       FEATURE_IDP_SYNC_ENABLED: "true"
       FEATURE_REST_API_ENABLED: "true"
       FEATURE_INTERNET_RESOURCE_ENABLED: "true"
-      # Seeds
-      STATIC_SEEDS: "true"
       ## Warning: The token is for the blackhole Postmark server created in a separate isolated account,
       ## that WILL NOT send any actual emails, but you can see and debug them in the Postmark dashboard.
       OUTBOUND_EMAIL_ADAPTER_OPTS: '{"api_key":"7da7d1cd-111c-44a7-b5ac-4027b9d230e5"}'


### PR DESCRIPTION
This removes a few more variables from all of the variables we need to worry about when building Firezone - seed data.

In this PR we remove the `STATIC_SEEDS` conditional and instead always:

- generate static deterministic tokens that work with the hard-coded dev values in docker compose
- always use a consistent random number generator seed