### PR TITLE
fix(portal): show `unknown` for migrated groups

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -1489,10 +1489,12 @@ defmodule Web.CoreComponents do
   end
 
   @doc """
-  Helper function to get provider type from group
-  Groups now have directory_type field that indicates the provider
+  Helper function to get provider type from group.
+  Groups have a directory_type field that indicates the provider.
+  If the group has idp_id but no directory_type, it's synced but we can't determine the provider.
   """
   def provider_type_from_group(%{directory_type: type}) when not is_nil(type), do: to_string(type)
+  def provider_type_from_group(%{idp_id: idp_id}) when not is_nil(idp_id), do: "unknown"
   def provider_type_from_group(_), do: "firezone"
 
   @doc """
@@ -1556,6 +1558,12 @@ defmodule Web.CoreComponents do
   def provider_icon(%{type: "userpass"} = assigns) do
     ~H"""
     <.icon name="hero-key" {@rest} />
+    """
+  end
+
+  def provider_icon(%{type: "unknown"} = assigns) do
+    ~H"""
+    <.icon name="hero-question-mark-circle" {@rest} />
     """
   end
 

--- a/elixir/apps/web/lib/web/live/groups.ex
+++ b/elixir/apps/web/lib/web/live/groups.ex
@@ -429,8 +429,8 @@ defmodule Web.Groups do
               </div>
               <div>
                 <p class="text-xs font-medium text-neutral-500 uppercase">Directory</p>
-                <p class="text-sm text-neutral-900 truncate" title={@group.directory_name}>
-                  {@group.directory_name}
+                <p class="text-sm text-neutral-900 truncate" title={directory_display_name(@group)}>
+                  {directory_display_name(@group)}
                 </p>
               </div>
               <div>
@@ -704,11 +704,15 @@ defmodule Web.Groups do
   end
 
   defp editable_group?(%{type: :managed, name: "Everyone"}), do: false
-  defp editable_group?(%{directory_id: nil}), do: true
+  defp editable_group?(%{idp_id: nil}), do: true
   defp editable_group?(_group), do: false
 
   defp deletable_group?(%{name: "Everyone"}), do: false
   defp deletable_group?(_group), do: true
+
+  defp directory_display_name(%{directory_name: name}) when not is_nil(name), do: name
+  defp directory_display_name(%{idp_id: idp_id}) when not is_nil(idp_id), do: "Unknown"
+  defp directory_display_name(_), do: "Firezone"
 
   defp get_idp_id(nil), do: nil
 
@@ -1084,7 +1088,7 @@ defmodule Web.Groups do
           %{
             directory_name:
               fragment(
-                "COALESCE(?, ?, ?, 'Firezone')",
+                "COALESCE(?, ?, ?)",
                 gd.name,
                 ed.name,
                 od.name

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -310,7 +310,7 @@ defmodule Web.Policies.Edit do
           %{
             directory_name:
               fragment(
-                "COALESCE(?, ?, ?, 'Firezone')",
+                "COALESCE(?, ?, ?)",
                 gd.name,
                 ed.name,
                 od.name
@@ -345,7 +345,7 @@ defmodule Web.Policies.Edit do
           %{
             directory_name:
               fragment(
-                "COALESCE(?, ?, ?, 'Firezone')",
+                "COALESCE(?, ?, ?)",
                 gd.name,
                 ed.name,
                 od.name
@@ -390,7 +390,7 @@ defmodule Web.Policies.Edit do
 
       label =
         cond do
-          group_synced?(group) -> "Synced from #{group.directory_name}"
+          group_synced?(group) -> "Synced from #{directory_display_name(group)}"
           group_managed?(group) -> "Managed by Firezone"
           true -> "Manually managed"
         end
@@ -399,7 +399,10 @@ defmodule Web.Policies.Edit do
     end
 
     defp group_option(group), do: {group.id, group.name, group}
-    defp group_synced?(group), do: not is_nil(group.directory_id)
+    defp group_synced?(group), do: not is_nil(group.idp_id)
     defp group_managed?(group), do: group.type == :managed
+
+    defp directory_display_name(%{directory_name: name}) when not is_nil(name), do: name
+    defp directory_display_name(_), do: "Unknown"
   end
 end

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -331,7 +331,7 @@ defmodule Web.Policies.New do
           %{
             directory_name:
               fragment(
-                "COALESCE(?, ?, ?, 'Firezone')",
+                "COALESCE(?, ?, ?)",
                 gd.name,
                 ed.name,
                 od.name
@@ -366,7 +366,7 @@ defmodule Web.Policies.New do
           %{
             directory_name:
               fragment(
-                "COALESCE(?, ?, ?, 'Firezone')",
+                "COALESCE(?, ?, ?)",
                 gd.name,
                 ed.name,
                 od.name
@@ -411,7 +411,7 @@ defmodule Web.Policies.New do
 
       label =
         cond do
-          group_synced?(group) -> "Synced from #{group.directory_name}"
+          group_synced?(group) -> "Synced from #{directory_display_name(group)}"
           group_managed?(group) -> "Managed by Firezone"
           true -> "Manually managed"
         end
@@ -420,7 +420,10 @@ defmodule Web.Policies.New do
     end
 
     defp group_option(group), do: {group.id, group.name, group}
-    defp group_synced?(group), do: not is_nil(group.directory_id)
+    defp group_synced?(group), do: not is_nil(group.idp_id)
     defp group_managed?(group), do: group.type == :managed
+
+    defp directory_display_name(%{directory_name: name}) when not is_nil(name), do: name
+    defp directory_display_name(_), do: "Unknown"
   end
 end


### PR DESCRIPTION
Post-migration, before the directory sync has been re-setup, existing groups and identities will have nil directory_id's. This shouldn't cause an issue, but we currently display these as "Firezone" entities when in fact they should be "Unknown" until the sync is connected and we link them up.

<img width="1369" height="841" alt="Screenshot 2025-12-16 at 11 28 41 PM" src="https://github.com/user-attachments/assets/5476e609-bba9-4960-9d85-602b34c41b03" />


Fixes #11119