### PR TITLE
fix(portal): consistently use slug in path param

### DIFF
--- a/elixir/apps/web/lib/web/controllers/oidc_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/oidc_controller.ex
@@ -101,6 +101,7 @@ defmodule Web.OIDCController do
           "auth_provider_type" => params["auth_provider_type"],
           "auth_provider_id" => params["auth_provider_id"],
           "account_id" => account.id,
+          "account_slug" => account.slug,
           "state" => state,
           "verifier" => verifier,
           "params" => sanitize(params)
@@ -301,30 +302,30 @@ defmodule Web.OIDCController do
 
   defp handle_error(conn, {:error, :not_admin}, params) do
     cookie = conn.cookies[cookie_key(params["state"])] || %{}
-    account_id = cookie["account_id"] || ""
+    account_slug = cookie["account_slug"] || ""
     original_params = cookie["params"] || %{}
     error = "This action requires admin privileges."
-    path = ~p"/#{account_id}?#{sanitize(original_params)}"
+    path = ~p"/#{account_slug}?#{sanitize(original_params)}"
 
     redirect_for_error(conn, error, path)
   end
 
   defp handle_error(conn, {:error, :actor_not_found}, params) do
     cookie = conn.cookies[cookie_key(params["state"])] || %{}
-    account_id = cookie["account_id"] || ""
+    account_slug = cookie["account_slug"] || ""
     original_params = cookie["params"] || %{}
     error = "Unable to sign you in. Please contact your administrator."
-    path = ~p"/#{account_id}?#{sanitize(original_params)}"
+    path = ~p"/#{account_slug}?#{sanitize(original_params)}"
 
     redirect_for_error(conn, error, path)
   end
 
   defp handle_error(conn, {:error, :email_not_verified}, params) do
     cookie = conn.cookies[cookie_key(params["state"])] || %{}
-    account_id = cookie["account_id"] || ""
+    account_slug = cookie["account_slug"] || ""
     original_params = cookie["params"] || %{}
     error = "Your email address must be verified before signing in."
-    path = ~p"/#{account_id}?#{sanitize(original_params)}"
+    path = ~p"/#{account_slug}?#{sanitize(original_params)}"
 
     redirect_for_error(conn, error, path)
   end
@@ -332,10 +333,10 @@ defmodule Web.OIDCController do
   defp handle_error(conn, error, params) do
     Logger.warning("OIDC sign-in error: #{inspect(error)}")
     cookie = conn.cookies[cookie_key(params["state"])] || %{}
-    account_id = cookie["account_id"] || ""
+    account_slug = cookie["account_slug"] || ""
     original_params = cookie["params"] || %{}
     error = "An unexpected error occurred while signing you in. Please try again."
-    path = ~p"/#{account_id}?#{sanitize(original_params)}"
+    path = ~p"/#{account_slug}?#{sanitize(original_params)}"
 
     redirect_for_error(conn, error, path)
   end

--- a/elixir/apps/web/lib/web/session/redirector.ex
+++ b/elixir/apps/web/lib/web/session/redirector.ex
@@ -127,6 +127,6 @@ defmodule Web.Session.Redirector do
   end
 
   defp default_portal_path(%Domain.Account{} = account) do
-    ~p"/#{account.id}/sites"
+    ~p"/#{account}/sites"
   end
 end

--- a/elixir/apps/web/test/web/live_hooks/redirect_if_authenticated_test.exs
+++ b/elixir/apps/web/test/web/live_hooks/redirect_if_authenticated_test.exs
@@ -28,7 +28,7 @@ defmodule Web.LiveHooks.RedirectIfAuthenticatedTest do
       assert {:halt, redirected_socket} =
                RedirectIfAuthenticated.on_mount(:default, %{}, %{}, socket)
 
-      expected_path = "/#{account.id}/sites"
+      expected_path = "/#{account.slug}/sites"
       assert {:redirect, %{to: ^expected_path}} = redirected_socket.redirected
     end
 

--- a/elixir/apps/web/test/web/plugs/redirect_if_authenticated_test.exs
+++ b/elixir/apps/web/test/web/plugs/redirect_if_authenticated_test.exs
@@ -26,7 +26,7 @@ defmodule Web.Plugs.RedirectIfAuthenticatedTest do
         |> RedirectIfAuthenticated.call([])
 
       assert conn.halted
-      assert redirected_to(conn) == ~p"/#{account.id}/sites"
+      assert redirected_to(conn) == ~p"/#{account.slug}/sites"
     end
 
     test "does not redirect authenticated user when as=client param is set", %{


### PR DESCRIPTION
In a few places, we were writing the account ID when the user originally visited the page by account slug. This fixes that.

Notably, we keep the account ID for the legacy OIDC redirect URIs because those need to remain consistent.

Fixes: #11057