### PR TITLE
feat(portal): expose all group fields

### DIFF
--- a/elixir/apps/api/lib/api/controllers/group_json.ex
+++ b/elixir/apps/api/lib/api/controllers/group_json.ex
@@ -22,7 +22,13 @@ defmodule API.GroupJSON do
   defp data(%Group{} = group) do
     %{
       id: group.id,
-      name: group.name
+      name: group.name,
+      entity_type: group.entity_type,
+      directory_id: group.directory_id,
+      idp_id: group.idp_id,
+      last_synced_at: group.last_synced_at,
+      inserted_at: group.inserted_at,
+      updated_at: group.updated_at
     }
   end
 end

--- a/elixir/apps/api/lib/api/schemas/group_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/group_schema.ex
@@ -11,12 +11,49 @@ defmodule API.Schemas.Group do
       type: :object,
       properties: %{
         id: %Schema{type: :string, description: "Group ID"},
-        name: %Schema{type: :string, description: "Group Name"}
+        name: %Schema{type: :string, description: "Group Name"},
+        entity_type: %Schema{
+          type: :string,
+          enum: ["group", "org_unit"],
+          description: "Entity type"
+        },
+        directory_id: %Schema{
+          type: :string,
+          description: "Directory ID this group belongs to",
+          nullable: true
+        },
+        idp_id: %Schema{
+          type: :string,
+          description: "Identity provider ID for synced groups",
+          nullable: true
+        },
+        last_synced_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Last sync timestamp for synced groups",
+          nullable: true
+        },
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Last update timestamp"
+        }
       },
-      required: [:id, :name],
+      required: [:id, :name, :entity_type, :inserted_at, :updated_at],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-        "name" => "Engineering"
+        "name" => "Engineering",
+        "entity_type" => "group",
+        "directory_id" => nil,
+        "idp_id" => nil,
+        "last_synced_at" => nil,
+        "inserted_at" => "2024-01-15T10:30:00Z",
+        "updated_at" => "2024-01-15T10:30:00Z"
       }
     })
   end
@@ -57,7 +94,13 @@ defmodule API.Schemas.Group do
       example: %{
         "data" => %{
           "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-          "name" => "Engineering"
+          "name" => "Engineering",
+          "entity_type" => "group",
+          "directory_id" => nil,
+          "idp_id" => nil,
+          "last_synced_at" => nil,
+          "inserted_at" => "2024-01-15T10:30:00Z",
+          "updated_at" => "2024-01-15T10:30:00Z"
         }
       }
     })
@@ -80,11 +123,23 @@ defmodule API.Schemas.Group do
         "data" => [
           %{
             "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
-            "name" => "Engineering"
+            "name" => "Engineering",
+            "entity_type" => "group",
+            "directory_id" => nil,
+            "idp_id" => nil,
+            "last_synced_at" => nil,
+            "inserted_at" => "2024-01-15T10:30:00Z",
+            "updated_at" => "2024-01-15T10:30:00Z"
           },
           %{
             "id" => "4ae929a7-1973-43f2-a1a8-9221b91a4c0e",
-            "name" => "Finance"
+            "name" => "Finance",
+            "entity_type" => "group",
+            "directory_id" => "6b4e3a2c-1234-5678-9abc-def012345678",
+            "idp_id" => "google-workspace-group-123",
+            "last_synced_at" => "2024-01-14T16:00:00Z",
+            "inserted_at" => "2024-01-10T08:15:00Z",
+            "updated_at" => "2024-01-14T16:45:00Z"
           }
         ],
         "metadata" => %{

--- a/elixir/apps/web/lib/web/live/groups.ex
+++ b/elixir/apps/web/lib/web/live/groups.ex
@@ -270,7 +270,16 @@ defmodule Web.Groups do
             <.provider_icon type={provider_type_from_group(group)} class="w-8 h-8" />
           </:col>
           <:col :let={group} field={{:groups, :name}} label="group" class="w-3/12">
-            {group.name}
+            <span class="flex items-center gap-2">
+              {group.name}
+              <span
+                :if={group.entity_type == :org_unit}
+                class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-neutral-100 text-neutral-600"
+                title="Organizational Unit"
+              >
+                OU
+              </span>
+            </span>
           </:col>
           <:col :let={group} field={{:member_counts, :count}} label="members">
             {group.member_count}
@@ -419,6 +428,12 @@ defmodule Web.Groups do
                 <p class="text-xs font-medium text-neutral-500 uppercase">ID</p>
                 <p class="text-sm text-neutral-900 font-mono truncate" title={@group.id}>
                   {@group.id}
+                </p>
+              </div>
+              <div :if={@group.entity_type == :org_unit}>
+                <p class="text-xs font-medium text-neutral-500 uppercase">Type</p>
+                <p class="text-sm text-neutral-900">
+                  Org Unit
                 </p>
               </div>
               <div>


### PR DESCRIPTION
When viewing groups in the UI, we weren't displaying any indication whether the group was an org_unit or not. Since 99% of all groups are going to be `group`s and not org_units, we add an indication in both the index view and the modal only when this is set to `org_unit`.

Additionally, all fields except the internal `type` field have been added to the REST API, and we clean up the check that determines what's a synced group based off `idp_id`. This field will be set for migrated groups that are not yet re-attached to a directory, so we don't want to allow modifying these either.

<img width="1056" height="684" alt="Screenshot 2025-12-17 at 8 17 05 AM" src="https://github.com/user-attachments/assets/687f0256-c4c0-4435-a751-98f54d86e855" />
<img width="709" height="749" alt="Screenshot 2025-12-17 at 8 17 15 AM" src="https://github.com/user-attachments/assets/15d1efa4-f00b-4fd5-8c0b-dcf590cdd160" />


Fixes #11220 