### PR TITLE
fix(portal): increase identity count overlay size

### DIFF
--- a/elixir/apps/web/lib/web/live/actors.ex
+++ b/elixir/apps/web/lib/web/live/actors.ex
@@ -1388,7 +1388,7 @@ defmodule Web.Actors do
       </div>
       <span
         :if={@actor.identity_count > 0}
-        class="absolute top-0 left-0 inline-flex items-center justify-center w-3.5 h-3.5 text-[6px] font-semibold text-white bg-neutral-800 rounded-full"
+        class="absolute top-0 left-0 inline-flex items-center justify-center w-3.5 h-3.5 text-[8px] font-semibold text-white bg-neutral-800 rounded-full"
       >
         {@actor.identity_count}
       </span>


### PR DESCRIPTION
## Before

<img width="303" height="666" alt="Screenshot 2025-12-17 at 10 47 07 AM" src="https://github.com/user-attachments/assets/a34b7645-b60c-4363-93b9-4421999488b0" />


## After


<img width="337" height="655" alt="Screenshot 2025-12-17 at 10 46 55 AM" src="https://github.com/user-attachments/assets/bb7cd42b-9400-4d14-b2ba-535271c9ffc9" />


Fixes #11083