### PR TITLE
feat(portal): show client/session/token online status

### DIFF
--- a/elixir/apps/domain/lib/domain/client_token.ex
+++ b/elixir/apps/domain/lib/domain/client_token.ex
@@ -33,6 +33,9 @@ defmodule Domain.ClientToken do
     field :auth_provider_name, :string, virtual: true
     field :auth_provider_type, :string, virtual: true
 
+    # Virtual field for online status (populated via Presence)
+    field :online?, :boolean, virtual: true
+
     timestamps()
   end
 

--- a/elixir/apps/domain/lib/domain/portal_session.ex
+++ b/elixir/apps/domain/lib/domain/portal_session.ex
@@ -25,6 +25,9 @@ defmodule Domain.PortalSession do
     field :auth_provider_name, :string, virtual: true
     field :auth_provider_type, :string, virtual: true
 
+    # Virtual field for online status (populated via Presence)
+    field :online?, :boolean, virtual: true
+
     timestamps(updated_at: false)
   end
 end

--- a/elixir/apps/web/lib/web/live/clients/components.ex
+++ b/elixir/apps/web/lib/web/live/clients/components.ex
@@ -103,6 +103,7 @@ defmodule Web.Clients.Components do
     """
   end
 
+  def client_os_icon_name(nil), do: "hero-question-mark-circle"
   def client_os_icon_name("Windows/" <> _), do: "os-windows"
   def client_os_icon_name("Mac OS/" <> _), do: "os-macos"
   def client_os_icon_name("iOS/" <> _), do: "os-ios"

--- a/elixir/apps/web/lib/web/live_hooks/fetch_subject.ex
+++ b/elixir/apps/web/lib/web/live_hooks/fetch_subject.ex
@@ -2,6 +2,7 @@ defmodule Web.LiveHooks.FetchSubject do
   import Phoenix.LiveView
   alias Domain.Account
   alias Domain.Auth
+  alias Domain.Presence
 
   def on_mount(:default, _params, session, %{assigns: %{account: %Account{} = account}} = socket) do
     socket =
@@ -19,6 +20,14 @@ defmodule Web.LiveHooks.FetchSubject do
           _ -> nil
         end
       end)
+
+    # Track portal session presence when connected
+    if connected?(socket) and socket.assigns.subject do
+      Presence.PortalSessions.track(
+        socket.assigns.subject.actor.id,
+        socket.assigns.subject.credential.id
+      )
+    end
 
     {:cont, socket}
   end


### PR DESCRIPTION
When displaying sessions and tokens, it's helpful to be able to see whether the thing is currently online or not.

Turns out we can do this quite readily with Phoenix.Presence by tracking the token / session id in the metas and then looking this up when viewing the relevant entities.

This PR also shows GUI client tokens as before they weren't being loaded.

<img width="737" height="493" alt="Screenshot 2025-12-17 at 12 21 25 PM" src="https://github.com/user-attachments/assets/8ffc6feb-4fac-45e4-a540-e2f406ce2818" />



Fixes: #11199 