### PR TITLE
fix(portal): update API token creation handler

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
@@ -71,7 +71,7 @@ defmodule Web.Settings.ApiClients.NewToken do
     {:noreply, assign(socket, form: to_form(changeset))}
   end
 
-  def handle_event("submit", %{"token" => attrs}, socket) do
+  def handle_event("submit", %{"api_token" => attrs}, socket) do
     attrs = map_expires_at(attrs)
 
     with {:ok, encoded_token} <-


### PR DESCRIPTION
The form for the API token creation was updated, but the handler was still only matching on `token` rather than `api_token`