### PR TITLE
fix(gui-client): use `exit` instead of `return`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,17 @@ jobs:
             exit 1
           fi
 
+  shell:
+    name: shell-tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: bats-core/bats-action@42fcc8700f773c075a16a90eb11674c0318ad507 # v3.0.1
+        id: setup-bats
+      - run: bats scripts/tests/bats
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+
   kotlin:
     needs: planner
     if: contains(needs.planner.outputs.jobs_to_run, 'kotlin')

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,3 +7,6 @@ shellcheck 0.9.0
 
 # Formatting
 prettier 3.6.2
+
+# Bash unit testing
+bats 1.13.0

--- a/rust/gui-client/src-tauri/linux_package/prerm_rpm
+++ b/rust/gui-client/src-tauri/linux_package/prerm_rpm
@@ -9,7 +9,7 @@ SERVICE_NAME="firezone-client-tunnel"
 # If we are being upgraded, this will be 1.
 # In that case, we do _not_ want to stop the systemd service, otherwise the user will be greeted with "Firezone Tunnel service is not running".
 if [ "$1" == 1 ]; then
-    return
+    exit 0
 fi
 
 sudo systemctl disable "$SERVICE_NAME"

--- a/scripts/tests/bats/prerm_rpm.bats
+++ b/scripts/tests/bats/prerm_rpm.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)/rust/gui-client/src-tauri/linux_package"
+
+load test_helper
+
+setup() {
+    mock_sudo
+    mock_systemctl
+}
+
+teardown() {
+    cleanup_logs
+}
+
+@test "prerm_rpm: exits 0 during upgrade (param=1) without calling systemctl" {
+    run bash "$SCRIPT_DIR/prerm_rpm" 1
+    [ "$status" -eq 0 ]
+    assert_systemctl_not_called
+}
+
+@test "prerm_rpm: exits 0 during removal (param=0)" {
+    run bash "$SCRIPT_DIR/prerm_rpm" 0
+    [ "$status" -eq 0 ]
+}
+
+@test "prerm_rpm: exits 0 during complete removal (param=2)" {
+    run bash "$SCRIPT_DIR/prerm_rpm" 2
+    [ "$status" -eq 0 ]
+}

--- a/scripts/tests/bats/test_helper.bash
+++ b/scripts/tests/bats/test_helper.bash
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+setup_mock_dir() {
+    if [ -n "${MOCK_DIR:-}" ]; then
+        return 0
+    fi
+
+    export MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+mock_sudo() {
+    setup_mock_dir
+    cat >"$MOCK_DIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/sudo"
+}
+
+mock_systemctl() {
+    setup_mock_dir
+    export SYSTEMCTL_CALLS_LOG="$BATS_TEST_TMPDIR/systemctl_calls.log"
+    cat >"$MOCK_DIR/systemctl" <<'EOF'
+#!/usr/bin/env bash
+echo "systemctl $*" >> "$SYSTEMCTL_CALLS_LOG"
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/systemctl"
+}
+
+cleanup_logs() {
+    rm -f "$SYSTEMCTL_CALLS_LOG"
+}
+
+assert_systemctl_not_called() {
+    [ ! -f "$SYSTEMCTL_CALLS_LOG" ]
+}

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -34,6 +34,15 @@ export default function GUI({ os }: { os: OS }) {
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
+        {os == OS.Linux && (
+          <ChangeItem pull="11243">
+            Fixes an issue where upgrading from version 1.5.8 on Fedora fails
+            due to a bad scriptlet. To uninstall version 1.5.8, use{" "}
+            <code>
+              sudo dnf remove firezone-client-gui --setopt=tsflags=noscripts
+            </code>
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-10-16")}>
         <ChangeItem pull="10509">


### PR DESCRIPTION
Turns out returning from a shellscript is not allowed, you need to exit it. This currently fails the upgrade of the client on Fedora.