### PR TITLE
ci: fail rust tests if static-analysis fails

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: test-${{ matrix.runs-on }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -56,6 +56,13 @@ jobs:
       - run: cargo deny check --hide-inclusion-graph --deny unnecessary-skip
         shell: bash
 
+  monitor-static-analysis:
+    needs: [static-analysis]
+    if: needs.static-analysis.result == 'failure' && github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh run cancel ${{ github.run_id }}
+
   test:
     name: test-${{ matrix.runs-on }}
     strategy:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -58,7 +58,7 @@ jobs:
 
   monitor-static-analysis:
     needs: [static-analysis]
-    if: needs.static-analysis.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.static-analysis.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}


### PR DESCRIPTION
Our Rust tests can take a fair amount of time. If a job in a workflow is going to fail anyway because something within `static-analysis` failed, we can cancel the entire job as there is no point in continuing.