### PR TITLE
fix(portal): apply debouncing to all text inputs

### DIFF
--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -227,6 +227,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
                 ]}
                 value={@search_query}
                 phx-change="search"
+                phx-debounce="300"
                 phx-target={@myself}
               />
             </div>

--- a/elixir/apps/web/lib/web/live/clients/edit.ex
+++ b/elixir/apps/web/lib/web/live/clients/edit.ex
@@ -38,7 +38,13 @@ defmodule Web.Clients.Edit do
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <div>
-                <.input label="Name" field={@form[:name]} placeholder="Full Name" required />
+                <.input
+                  label="Name"
+                  field={@form[:name]}
+                  placeholder="Full Name"
+                  phx-debounce="300"
+                  required
+                />
               </div>
             </div>
             <.submit_button>

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -137,6 +137,7 @@ defmodule Web.Resources.Edit do
                 }
                 class={is_nil(@form[:type].value) && "cursor-not-allowed"}
                 disabled={is_nil(@form[:type].value)}
+                phx-debounce="300"
                 required
               />
 
@@ -178,6 +179,7 @@ defmodule Web.Resources.Edit do
                 type="text"
                 label="Address Description"
                 placeholder="Enter a description or URL"
+                phx-debounce="300"
               />
               <p class="mt-2 text-xs text-neutral-500">
                 Optional description or URL to show in Clients to help users access this Resource.
@@ -190,6 +192,7 @@ defmodule Web.Resources.Edit do
               type="text"
               label="Name"
               placeholder="Name this resource"
+              phx-debounce="300"
               required
             />
 

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -132,6 +132,7 @@ defmodule Web.Resources.New do
                 }
                 class={is_nil(@form[:type].value) && "cursor-not-allowed"}
                 disabled={is_nil(@form[:type].value)}
+                phx-debounce="300"
                 required
               />
 
@@ -173,6 +174,7 @@ defmodule Web.Resources.New do
                 type="text"
                 label="Address Description"
                 placeholder="Enter a description or URL"
+                phx-debounce="300"
               />
               <p class="mt-2 text-xs text-neutral-500">
                 Optional description or URL to show in Clients to help users access this Resource.
@@ -184,6 +186,7 @@ defmodule Web.Resources.New do
               type="text"
               label="Name"
               placeholder="Name this resource"
+              phx-debounce="300"
               required
             />
 

--- a/elixir/apps/web/lib/web/live/settings/account/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/account/edit.ex
@@ -33,7 +33,13 @@ defmodule Web.Settings.Account.Edit do
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <div>
-                <.input label="Name" field={@form[:name]} placeholder="Account Name" required />
+                <.input
+                  label="Name"
+                  field={@form[:name]}
+                  placeholder="Account Name"
+                  phx-debounce="300"
+                  required
+                />
               </div>
             </div>
             <.submit_button>

--- a/elixir/apps/web/lib/web/live/settings/api_clients/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/components.ex
@@ -12,6 +12,7 @@ defmodule Web.Settings.ApiClients.Components do
         label="Name"
         field={@form[:name]}
         placeholder="E.g. 'GitHub Actions' or 'Terraform'"
+        phx-debounce="300"
         required
       />
       <p class="mt-2 text-xs text-neutral-500">
@@ -26,7 +27,12 @@ defmodule Web.Settings.ApiClients.Components do
   def api_token_form(assigns) do
     ~H"""
     <div>
-      <.input label="Name" field={@form[:name]} placeholder="Name for this token (optional)" />
+      <.input
+        label="Name"
+        field={@form[:name]}
+        placeholder="Name for this token (optional)"
+        phx-debounce="300"
+      />
     </div>
 
     <div>

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -65,7 +65,11 @@ defmodule Web.Settings.DNS do
 
             <div class="mb-8">
               <.inputs_for :let={config_form} field={@form[:config]}>
-                <.input field={config_form[:search_domain]} placeholder="E.g. example.com" />
+                <.input
+                  field={config_form[:search_domain]}
+                  placeholder="E.g. example.com"
+                  phx-debounce="300"
+                />
                 <p class="mt-2 text-sm text-neutral-500">
                   Enter a valid FQDN to append to single-label DNS queries. The
                   resulting FQDN will be used to match against DNS Resources in
@@ -224,6 +228,7 @@ defmodule Web.Settings.DNS do
                             label="IP Address"
                             field={address_form[:address]}
                             placeholder="E.g. 1.1.1.1"
+                            phx-debounce="300"
                           />
                         </div>
                         <div class="justify-self-end">

--- a/elixir/apps/web/lib/web/live/sites/edit.ex
+++ b/elixir/apps/web/lib/web/live/sites/edit.ex
@@ -32,7 +32,13 @@ defmodule Web.Sites.Edit do
         <div class="py-8 px-4 mx-auto max-w-2xl lg:py-16">
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
-              <.input label="Name" field={@form[:name]} placeholder="Name of this Site" required />
+              <.input
+                label="Name"
+                field={@form[:name]}
+                placeholder="Name of this Site"
+                phx-debounce="300"
+                required
+              />
             </div>
             <.submit_button>
               Save

--- a/elixir/apps/web/lib/web/live/sites/new.ex
+++ b/elixir/apps/web/lib/web/live/sites/new.ex
@@ -28,6 +28,7 @@ defmodule Web.Sites.New do
                   label="Name"
                   field={@form[:name]}
                   placeholder="Enter a name for this Site"
+                  phx-debounce="300"
                   required
                 />
               </div>

--- a/elixir/apps/web/lib/web/live_table.ex
+++ b/elixir/apps/web/lib/web/live_table.ex
@@ -148,7 +148,6 @@ defmodule Web.LiveTable do
       id={"#{@live_table_id}-filters"}
       for={@form}
       phx-change="filter"
-      phx-debounce="100"
       onkeydown="return event.key != 'Enter';"
     >
       <.input type="hidden" name="table_id" value={@live_table_id} />
@@ -215,6 +214,7 @@ defmodule Web.LiveTable do
           id={@form[@filter.name].id}
           value={Phoenix.HTML.Form.normalize_value("text", @form[@filter.name].value)}
           placeholder={"Search by " <> @filter.title}
+          phx-debounce="300"
           class={[
             "bg-neutral-50 border border-neutral-300 text-neutral-900 text-sm rounded",
             "block w-full md:w-72 pl-10 p-2",
@@ -248,6 +248,7 @@ defmodule Web.LiveTable do
           id={@form[@filter.name].id}
           value={Phoenix.HTML.Form.normalize_value("text", @form[@filter.name].value)}
           placeholder={"Search by " <> @filter.title}
+          phx-debounce="300"
           class={[
             "bg-neutral-50 border border-neutral-300 text-neutral-900 text-sm rounded",
             "block w-full md:w-72 pl-10 p-2",


### PR DESCRIPTION
Adding `phx-debounce` to a `form` does not debounce its child `input` changes. This means we were issuing updates on each keypress / click in all of our live table filters.

We fix this by adding `phx-debounce="300"` to the inputs in the live_table implementation. We also add it to the group filter input in the policies forms.

Lastly, we add it to various other forms where we aren't neecessarily hitting the DB but are performing validations in order to prevent spurious roundtrips.

Fixes #11052