### PR TITLE
ci: add `!cancelled()` condition to monitor jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
   monitor-kotlin:
     needs: [kotlin]
-    if: needs.kotlin.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.kotlin.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -166,7 +166,7 @@ jobs:
 
   monitor-swift:
     needs: [swift]
-    if: needs.swift.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.swift.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -179,7 +179,7 @@ jobs:
 
   monitor-elixir:
     needs: [elixir]
-    if: needs.elixir.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.elixir.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -192,7 +192,7 @@ jobs:
 
   monitor-rust:
     needs: [rust]
-    if: needs.rust.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.rust.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -205,7 +205,7 @@ jobs:
 
   monitor-tauri:
     needs: [tauri]
-    if: needs.tauri.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.tauri.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -218,7 +218,7 @@ jobs:
 
   monitor-static-analysis:
     needs: [static-analysis]
-    if: needs.static-analysis.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.static-analysis.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -231,7 +231,7 @@ jobs:
 
   monitor-codeql:
     needs: [codeql]
-    if: needs.codeql.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.codeql.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -244,7 +244,7 @@ jobs:
 
   monitor-control-plane:
     needs: [control-plane]
-    if: needs.control-plane.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.control-plane.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -262,7 +262,7 @@ jobs:
 
   monitor-data-plane:
     needs: [data-plane]
-    if: needs.data-plane.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.data-plane.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}
@@ -275,7 +275,7 @@ jobs:
 
   monitor-loadtest:
     needs: [loadtest]
-    if: needs.loadtest.result == 'failure' && github.event_name == 'merge_group'
+    if: "!cancelled() && needs.loadtest.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
       - run: gh run cancel ${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
     if: "!cancelled() && needs.kotlin.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   swift:
@@ -169,6 +170,7 @@ jobs:
     if: "!cancelled() && needs.swift.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   elixir:
@@ -182,6 +184,7 @@ jobs:
     if: "!cancelled() && needs.elixir.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   rust:
@@ -195,6 +198,7 @@ jobs:
     if: "!cancelled() && needs.rust.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   tauri:
@@ -208,6 +212,7 @@ jobs:
     if: "!cancelled() && needs.tauri.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   static-analysis:
@@ -221,6 +226,7 @@ jobs:
     if: "!cancelled() && needs.static-analysis.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   codeql:
@@ -234,6 +240,7 @@ jobs:
     if: "!cancelled() && needs.codeql.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   control-plane:
@@ -247,6 +254,7 @@ jobs:
     if: "!cancelled() && needs.control-plane.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   data-plane:
@@ -265,6 +273,7 @@ jobs:
     if: "!cancelled() && needs.data-plane.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   loadtest:
@@ -278,6 +287,7 @@ jobs:
     if: "!cancelled() && needs.loadtest.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: gh run cancel ${{ github.run_id }}
 
   integration-tests:


### PR DESCRIPTION
It appears that without the additional `!cancelled()` condition, the "monitor" jobs get cancelled because the workflow they are depending on failed. Running them _on failure_ is the entire point though so we now add `!cancelled()` there.

I tested this in this PR by temporarily removing the `merge_group` condition and it now works as expected.