### PR TITLE
ci(rust): introduce dedicated, Linux-only "Tunnel proptest" job

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tool: ripgrep,cargo-llvm-cov
+          tool: cargo-llvm-cov
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
         if: ${{ runner.os == 'Linux' }}
         env:
@@ -79,11 +79,42 @@ jobs:
           tool: bpf-linker
       - name: "cargo test"
         shell: bash
+        run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture --skip tunnel_test
+        env:
+          # <https://github.com/rust-lang/cargo/issues/5999>
+          # Needed to create tunnel interfaces in unit tests
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
+
+      - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: rust/lcov.info
+          format: lcov
+          flag-name: rust-${{ matrix.runs-on }}
+          parallel: true
+
+  tunnel_test:
+    name: tunnel-test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup-rust
+        id: setup-rust
+      - uses: ./.github/actions/setup-tauri-v2
+      - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tool: ripgrep,cargo-llvm-cov
+      - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tool: bpf-linker
+      - name: Tunnel proptest
+        shell: bash
         run: |
-
-          set -x
-
-          cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture
+          cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test
 
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
           patterns=(
@@ -122,11 +153,8 @@ jobs:
           fi
 
         env:
-          # <https://github.com/rust-lang/cargo/issues/5999>
-          # Needed to create tunnel interfaces in unit tests
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
-          PROPTEST_CASES: ${{ runner.os == 'Windows' && '0' || '256' }} # Default is only 256. Windows is very slow in GitHub Actions, so only run the regression cases there.
+          PROPTEST_CASES: 256
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "libs/connlib/tunnel/testcases"
 

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -79,7 +79,7 @@ jobs:
           tool: bpf-linker
       - name: "cargo test"
         shell: bash
-        run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture --skip tunnel_test
+        run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture --skip tunnel_test --skip transitions_and_state_are_deterministic
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>
           # Needed to create tunnel interfaces in unit tests
@@ -114,7 +114,7 @@ jobs:
       - name: Tunnel proptest
         shell: bash
         run: |
-          cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test
+          cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test transitions_and_state_are_deterministic
 
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
           patterns=(

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -112,9 +112,14 @@ jobs:
           tool: bpf-linker
       - name: Tunnel proptest
         shell: bash
+        run: cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test transitions_and_state_are_deterministic
+        env:
+          PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
+          PROPTEST_CASES: 256
+          CARGO_PROFILE_TEST_OPT_LEVEL: 2 # Otherwise the tests take forever.
+      - name: Check coverage
+        shell: bash
         run: |
-          cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test transitions_and_state_are_deterministic
-
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
           patterns=(
             "SendIcmpPacket"
@@ -150,11 +155,7 @@ jobs:
             echo "$missing_patterns"
             exit 1
           fi
-
         env:
-          PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
-          PROPTEST_CASES: 256
-          CARGO_PROFILE_TEST_OPT_LEVEL: 2 # Otherwise the tests take forever.
           TESTCASES_DIR: "libs/connlib/tunnel/testcases"
 
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
           PROPTEST_CASES: 256
-          CARGO_PROFILE_TEST_OPT_LEVEL: 3 # Otherwise the tests take forever.
+          CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
       - name: Check coverage
         shell: bash
         run: |

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -155,7 +155,7 @@ jobs:
         env:
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
           PROPTEST_CASES: 256
-          CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
+          CARGO_PROFILE_TEST_OPT_LEVEL: 2 # Otherwise the tests take forever.
           TESTCASES_DIR: "libs/connlib/tunnel/testcases"
 
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -100,7 +100,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-rust
         id: setup-rust
-      - uses: ./.github/actions/setup-tauri-v2
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -90,7 +90,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/lcov.info
           format: lcov
-          flag-name: rust-${{ matrix.runs-on }}
+          flag-name: rust-test-${{ matrix.runs-on }}
           parallel: true
 
   tunnel_test:
@@ -163,7 +163,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/lcov.info
           format: lcov
-          flag-name: rust-${{ matrix.runs-on }}
+          flag-name: rust-tunnel-test
           parallel: true
 
   fuzz:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
           PROPTEST_CASES: 256
-          CARGO_PROFILE_TEST_OPT_LEVEL: 2 # Otherwise the tests take forever.
+          CARGO_PROFILE_TEST_OPT_LEVEL: 3 # Otherwise the tests take forever.
       - name: Check coverage
         shell: bash
         run: |


### PR DESCRIPTION
MacOS runners are scarse and Windows runners are slow. To speed up our CI and especially the merge queue, skip the `tunnel_test` during our regular Rust `test` job and instead add a dedicated `Tunnel proptest` job. This also has the additional advantage that we don't need to compile our all our unit-tests on an increased optimisation level just to make the proptests run fast.

The proptests are all purposely sans-IO and therefore it doesn't matter which platform they run on.