### PR TITLE
ci(rust): remove `DisableRealtimeMonitoring`

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -35,11 +35,6 @@ runs:
   steps:
     - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-    - name: Disable Windows Defender
-      if: ${{ runner.os == 'Windows' }}
-      run: Set-MpPreference -DisableRealtimeMonitoring $true
-      shell: powershell
-
     - name: Extract Rust version
       run: |
         RUST_TOOLCHAIN=$(grep 'channel' rust/rust-toolchain.toml | awk -F '"' '{print $2}')


### PR DESCRIPTION
This fails quite often and it is not clear that it has a real, positive performance impact.