### PR TITLE
ci: retry docker remote operations 5 times

### DIFF
--- a/.github/actions/ghcr-docker-login/action.yml
+++ b/.github/actions/ghcr-docker-login/action.yml
@@ -15,8 +15,30 @@ runs:
   using: "composite"
   steps:
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.github_token }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_ACTOR: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+
+        max_attempts=5
+        attempt=1
+
+        while [ $attempt -le $max_attempts ]; do
+          echo "Attempting to login to ghcr.io (attempt $attempt/$max_attempts)..."
+          if echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin; then
+            echo "Successfully logged in to ghcr.io"
+            exit 0
+          fi
+
+          if [ $attempt -lt $max_attempts ]; then
+            echo "Login failed, retrying in 5 seconds..."
+            sleep 5
+          fi
+
+          attempt=$((attempt + 1))
+        done
+
+        echo "Failed to login to ghcr.io after $max_attempts attempts"
+        exit 1

--- a/.github/actions/ghcr-docker-login/action.yml
+++ b/.github/actions/ghcr-docker-login/action.yml
@@ -14,31 +14,49 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Login to GitHub Container Registry
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-        GITHUB_ACTOR: ${{ github.actor }}
-      run: |
-        set -euo pipefail
+    - name: Login to GitHub Container Registry (attempt 1)
+      id: login1
+      continue-on-error: true
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
 
-        max_attempts=5
-        attempt=1
+    - name: Login to GitHub Container Registry (attempt 2)
+      id: login2
+      if: steps.login1.outcome == 'failure'
+      continue-on-error: true
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
 
-        while [ $attempt -le $max_attempts ]; do
-          echo "Attempting to login to ghcr.io (attempt $attempt/$max_attempts)..."
-          if echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin; then
-            echo "Successfully logged in to ghcr.io"
-            exit 0
-          fi
+    - name: Login to GitHub Container Registry (attempt 3)
+      id: login3
+      if: steps.login2.outcome == 'failure'
+      continue-on-error: true
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
 
-          if [ $attempt -lt $max_attempts ]; then
-            echo "Login failed, retrying in 5 seconds..."
-            sleep 5
-          fi
+    - name: Login to GitHub Container Registry (attempt 4)
+      id: login4
+      if: steps.login3.outcome == 'failure'
+      continue-on-error: true
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
 
-          attempt=$((attempt + 1))
-        done
-
-        echo "Failed to login to ghcr.io after $max_attempts attempts"
-        exit 1
+    - name: Login to GitHub Container Registry (attempt 5)
+      if: steps.login4.outcome == 'failure'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}

--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -83,7 +83,8 @@ runs:
         {
           "features": {
             "containerd-snapshotter": true
-          }
+          },
+          "max-download-attempts": 5
         }
         EOF
 


### PR DESCRIPTION
Most cases of CI flakiness happen due to Docker remote operation timeouts during either the login step or the remote image fetch.

By default, a single failure here means that particular job fails, taking the entire workflow run down with it.

To alleviate this, we allow retries up to a maximum of 5 attempts for the `ghcr-docker-login` action and remote operations in the `setup-docker` action.

There are other places where docker is used where these won't be applied, but hopefully this serves as a starting point and we can add more retries on an as-needed basis.