### PR TITLE
ci: carry-forward coverage from skipped builds

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -90,7 +90,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: rust/lcov.info
           format: lcov
-          flag-name: rust-test-${{ matrix.runs-on }}
+          flag-name: rust-test-${{ runner.os }}
           parallel: true
 
   tunnel_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,3 +350,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+          carryforward: elixir-api,elixir-web,elixir-domain,rust-tunnel-test,rust-test-Linux,rust-test-macOS,rust-test-Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,3 +351,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
           carryforward: elixir-api,elixir-web,elixir-domain,rust-tunnel-test,rust-test-Linux,rust-test-macOS,rust-test-Windows
+          fail-on-error: false # Make CI less flaky


### PR DESCRIPTION
This should allow us to enable Coverage reporting as a GitHub status and defined a threshold that prevents us from merging PRs that drop code coverage too much.