### PR TITLE
feat(connlib): don't concurrently create flows for new sites

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -463,6 +463,7 @@ impl ClientState {
                 resource,
                 ConnectionTrigger::IcmpDestinationUnreachableProhibited,
                 &self.resources_by_id,
+                &self.gateways_site,
                 now,
             );
         }
@@ -550,6 +551,7 @@ impl ClientState {
                     resource,
                     packet,
                     &self.resources_by_id,
+                    &self.gateways_site,
                     now,
                 );
                 return None;
@@ -1319,6 +1321,7 @@ impl ClientState {
                             message,
                         }),
                         &self.resources_by_id,
+                        &self.gateways_site,
                         now,
                     );
                     return None;

--- a/rust/libs/connlib/tunnel/src/client/pending_flows.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_flows.rs
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn sends_intent_for_same_site_in_paralle_if_already_connected() {
+    fn sends_intent_for_same_site_in_parallel_if_already_connected() {
         let _guard = logging::test("trace");
 
         let mut pending_flows = PendingFlows::default();

--- a/rust/libs/connlib/tunnel/src/client/pending_flows.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_flows.rs
@@ -1,0 +1,119 @@
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    time::{Duration, Instant},
+};
+
+use connlib_model::ResourceId;
+use ringbuffer::{AllocRingBuffer, RingBuffer as _};
+
+use crate::{
+    client::{ConnectionTrigger, DnsQueryForSite, Resource},
+    unique_packet_buffer::UniquePacketBuffer,
+};
+
+#[derive(Default)]
+pub struct PendingFlows {
+    inner: HashMap<ResourceId, PendingFlow>,
+
+    connection_intents: VecDeque<ResourceId>,
+}
+
+impl PendingFlows {
+    #[tracing::instrument(level = "debug", skip_all, fields(%rid))]
+    pub fn on_not_connected_resource(
+        &mut self,
+        rid: ResourceId,
+        trigger: impl Into<ConnectionTrigger>,
+        resources_by_id: &BTreeMap<ResourceId, Resource>,
+        now: Instant,
+    ) {
+        use std::collections::hash_map::Entry;
+
+        let trigger = trigger.into();
+        let trigger_name = trigger.name();
+
+        if !resources_by_id.contains_key(&rid) {
+            tracing::debug!(%rid, "Resource not found, skipping connection intent");
+            return;
+        }
+
+        match self.inner.entry(rid) {
+            Entry::Vacant(v) => {
+                v.insert(PendingFlow::new(now, trigger));
+            }
+            Entry::Occupied(mut o) => {
+                let pending_flow = o.get_mut();
+                pending_flow.push(trigger);
+
+                let time_since_last_intent = now.duration_since(pending_flow.last_intent_sent_at);
+
+                if time_since_last_intent < Duration::from_secs(2) {
+                    tracing::trace!(?time_since_last_intent, "Skipping connection intent");
+                    return;
+                }
+
+                pending_flow.last_intent_sent_at = now;
+            }
+        }
+
+        tracing::debug!(trigger = %trigger_name, "Sending connection intent");
+
+        self.connection_intents.push_back(rid);
+    }
+
+    pub fn remove(&mut self, rid: &ResourceId) -> Option<PendingFlow> {
+        self.inner.remove(rid)
+    }
+
+    pub fn poll_connection_intents(&mut self) -> Option<ResourceId> {
+        self.connection_intents.pop_front()
+    }
+}
+
+pub struct PendingFlow {
+    last_intent_sent_at: Instant,
+    resource_packets: UniquePacketBuffer,
+    dns_queries: AllocRingBuffer<DnsQueryForSite>,
+}
+
+impl PendingFlow {
+    /// How many packets we will at most buffer in a [`PendingFlow`].
+    ///
+    /// `PendingFlow`s are per _resource_ (which could be Internet Resource or wildcard DNS resources).
+    /// Thus, we may receive a fair few packets before we can send them.
+    const CAPACITY_POW_2: usize = 7; // 2^7 = 128
+
+    fn new(now: Instant, trigger: ConnectionTrigger) -> Self {
+        let mut this = Self {
+            last_intent_sent_at: now,
+            resource_packets: UniquePacketBuffer::with_capacity_power_of_2(
+                Self::CAPACITY_POW_2,
+                "pending-flow-resources",
+            ),
+            dns_queries: AllocRingBuffer::with_capacity_power_of_2(Self::CAPACITY_POW_2),
+        };
+        this.push(trigger);
+
+        this
+    }
+
+    fn push(&mut self, trigger: ConnectionTrigger) {
+        match trigger {
+            ConnectionTrigger::PacketForResource(packet) => self.resource_packets.push(packet),
+            ConnectionTrigger::DnsQueryForSite(query) => {
+                self.dns_queries.enqueue(query);
+            }
+            ConnectionTrigger::IcmpDestinationUnreachableProhibited => {}
+        }
+    }
+
+    pub fn into_buffered_packets(self) -> (UniquePacketBuffer, AllocRingBuffer<DnsQueryForSite>) {
+        let Self {
+            resource_packets,
+            dns_queries,
+            ..
+        } = self;
+
+        (resource_packets, dns_queries)
+    }
+}

--- a/rust/libs/connlib/tunnel/src/client/pending_flows.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_flows.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use connlib_model::ResourceId;
+use connlib_model::{GatewayId, ResourceId, SiteId};
 use ip_packet::IpPacket;
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 
@@ -24,6 +24,7 @@ impl PendingFlows {
         rid: ResourceId,
         trigger: impl Into<ConnectionTrigger>,
         resources_by_id: &BTreeMap<ResourceId, Resource>,
+        gateway_sites: &HashMap<GatewayId, SiteId>,
         now: Instant,
     ) {
         let trigger = trigger.into();
@@ -39,6 +40,8 @@ impl PendingFlows {
             return;
         };
 
+        #[expect(clippy::disallowed_methods, reason = "The order doesn't matter here.")]
+        let connected_to_site = gateway_sites.values().any(|s| s == &site.id);
         let has_pending_flows_for_site = resources_by_id
             .values()
             .filter_map(|r| r.sites().contains(site).then_some(r.id()))
@@ -52,7 +55,7 @@ impl PendingFlows {
 
         pending_flow.push(trigger);
 
-        if has_pending_flows_for_site {
+        if !connected_to_site && has_pending_flows_for_site {
             tracing::debug!(%rid, site = %site.name, "Already connecting to this site, skipping connection intent");
             return;
         }
@@ -178,13 +181,14 @@ mod tests {
         let mut now = Instant::now();
         let rid = ipv4_localhost_resource().id();
         let resources = BTreeMap::from([(rid, ipv4_localhost_resource())]);
+        let gateway_sites = HashMap::default();
 
-        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, now);
+        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
 
         now += Duration::from_secs(1);
 
-        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, now);
+        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), None);
     }
 
@@ -194,13 +198,14 @@ mod tests {
         let mut now = Instant::now();
         let rid = ipv4_localhost_resource().id();
         let resources = BTreeMap::from([(rid, ipv4_localhost_resource())]);
+        let gateway_sites = HashMap::default();
 
-        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, now);
+        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
 
         now += Duration::from_secs(3);
 
-        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, now);
+        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
     }
 
@@ -216,21 +221,42 @@ mod tests {
             (rid1, ipv4_localhost_resource()),
             (rid2, ipv6_localhost_resource()),
         ]);
+        let gateway_sites = HashMap::default();
 
-        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, now);
+        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid1));
-        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, now);
+        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), None);
 
         pending_flows.remove(&rid1);
 
-        pending_flows.on_not_connected_resource(rid2, trigger(3), &resources, now);
+        pending_flows.on_not_connected_resource(rid2, trigger(3), &resources, &gateway_sites, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid2));
 
         let (packets, dns_queries) = pending_flows.remove(&rid2).unwrap().into_buffered_packets();
 
         assert_eq!(packets.len(), 2, "should buffer both packets");
         assert!(dns_queries.is_empty());
+    }
+
+    #[test]
+    fn sends_intent_for_same_site_in_paralle_if_already_connected() {
+        let _guard = logging::test("trace");
+
+        let mut pending_flows = PendingFlows::default();
+        let now = Instant::now();
+        let rid1 = ipv4_localhost_resource().id();
+        let rid2 = ipv6_localhost_resource().id();
+        let resources = BTreeMap::from([
+            (rid1, ipv4_localhost_resource()),
+            (rid2, ipv6_localhost_resource()),
+        ]);
+        let gateway_sites = HashMap::from([(GatewayId::from_u128(1), SiteId::from_u128(1))]);
+
+        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, &gateway_sites, now);
+        assert_eq!(pending_flows.poll_connection_intents(), Some(rid1));
+        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, &gateway_sites, now);
+        assert_eq!(pending_flows.poll_connection_intents(), Some(rid2));
     }
 
     fn trigger(payload: u8) -> IpPacket {

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -29,6 +29,10 @@ export default function Android() {
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
+        <ChangeItem pull="11266">
+          Prevents connecting to more than one Gateway within a Site at a time,
+          which could lead to a crash under certain rare conditions.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.7" date={new Date("2025-12-05")}>
         <ChangeItem pull="10752">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -34,6 +34,10 @@ export default function Apple() {
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
+        <ChangeItem pull="11266">
+          Prevents connecting to more than one Gateway within a Site at a time,
+          which could lead to a crash under certain rare conditions.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.10" date={new Date("2025-12-04")}>
         <ChangeItem pull="10986">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -43,6 +43,10 @@ export default function GUI({ os }: { os: OS }) {
             </code>
           </ChangeItem>
         )}
+        <ChangeItem pull="11266">
+          Prevents connecting to more than one Gateway within a Site at a time,
+          which could lead to a crash under certain rare conditions.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-10-16")}>
         <ChangeItem pull="10509">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -28,6 +28,10 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
+        <ChangeItem pull="11266">
+          Prevents connecting to more than one Gateway within a Site at a time,
+          which could lead to a crash under certain rare conditions.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.4" date={new Date("2025-10-16")}>
         <ChangeItem pull="10533">


### PR DESCRIPTION
When connlib receives a packet for a resource that it isn't connected to yet, we send a `create_flow` message to the portal. Right now, those are only de-duplicated and debounced on a per-resources basis, i.e. if we have sent a `create_flow` message for a given resource in the last two seconds already, we suppress it in order to not overload the portal.

When we aren't connected to any resources yet and the user signs into Firezone, we very likely need to authorize connections for multiple resources in parallel. When we aren't connected to any sites yet, this creates a race condition.

When sending a `create_flow` message, we also include the Gateways we are already connected to. The portal then prefers those instead of connecting us to a new Gateway. But when sending `create_flow` messages for multiple resources in the same site in parallel, all of them will report no connected Gateways which may lead to us connecting to several Gateways.

To fix this, we hold back connection intents for resources in the same site if we aren't connected to the site yet and have a "pending flow" locally. Packets for these resources are still buffered and will be flushed once the flow for this resource is authorized.

To better test this logic, we extract the `PendingFlows` component which represents the state machine around these connection intents.