### PR TITLE
fix(connlib): don't allow more than 1 connection per site

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -23,7 +23,10 @@ use tunnel::messages::client::{
     EgressMessages, FailReason, FlowCreated, FlowCreationFailed, GatewayIceCandidates,
     GatewaysIceCandidates, IngressMessages, InitClient,
 };
-use tunnel::{ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig, TunnelError};
+use tunnel::{
+    AlreadyConnectedToSite, ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig,
+    TunnelError,
+};
 
 /// In-memory cache for DNS resource records.
 ///
@@ -435,6 +438,9 @@ impl Eventloop {
                             )))
                             .await
                             .context("Failed to connect phoenix-channel")?;
+                    }
+                    Err(e) if e.any_is::<AlreadyConnectedToSite>() => {
+                        tracing::debug!("Failed to request new connection: {e:#}");
                     }
                     Err(e) => {
                         tracing::warn!("Failed to request new connection: {e:#}");

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -426,10 +426,8 @@ impl Eventloop {
                     Instant::now(),
                 ) {
                     Ok(Ok(())) => {}
-                    Ok(Err(snownet::NoTurnServers {})) => {
-                        tracing::debug!(
-                            "Failed to request new connection: No TURN servers available"
-                        );
+                    Ok(Err(e @ snownet::NoTurnServers {})) => {
+                        tracing::debug!("Failed to handle flow created: {e}");
 
                         // Re-connecting to the portal means we will receive another `init` and thus new TURN servers.
                         self.portal_cmd_tx
@@ -440,10 +438,10 @@ impl Eventloop {
                             .context("Failed to connect phoenix-channel")?;
                     }
                     Err(e) if e.any_is::<AlreadyConnectedToSite>() => {
-                        tracing::debug!("Failed to request new connection: {e:#}");
+                        tracing::debug!("Failed to handle flow created: {e:#}");
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to request new connection: {e:#}");
+                        tracing::warn!("Failed to handle flow created: {e:#}");
                     }
                 };
             }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -624,7 +624,12 @@ impl ClientState {
             clippy::disallowed_methods,
             reason = "The iteration order doesn't matter here."
         )]
-        if self.gateways_site.values().any(|s| s == &site_id) {
+        if let Some(connected_gateway) = self
+            .gateways_site
+            .iter()
+            .find_map(|(gid, sid)| (sid == &site_id).then_some(gid))
+            && connected_gateway != &gid
+        {
             anyhow::bail!(AlreadyConnectedToSite)
         }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -627,7 +627,7 @@ impl ClientState {
         if let Some(connected_gateway) = self
             .gateways_site
             .iter()
-            .find_map(|(gid, sid)| (sid == &site_id).then_some(gid))
+            .find_map(|(existing_gateway, sid)| (sid == &site_id).then_some(existing_gateway))
             && connected_gateway != &gid
         {
             anyhow::bail!(AlreadyConnectedToSite)

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -26,7 +26,10 @@ use crate::dns::{DnsResourceRecord, StubResolver};
 use crate::messages::Interface as InterfaceConfig;
 use crate::messages::{IceCredentials, SecretKey};
 use crate::peer_store::PeerStore;
-use crate::{IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, TunConfig, dns, is_peer, p2p_control};
+use crate::{
+    AlreadyConnectedToSite, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, TunConfig, dns, is_peer,
+    p2p_control,
+};
 use anyhow::{Context, ErrorExt};
 use connlib_model::{
     GatewayId, IceCandidate, PublicKey, RelayId, ResourceId, ResourceStatus, ResourceView,
@@ -617,6 +620,14 @@ impl ClientState {
         gateway_ice: IceCredentials,
         now: Instant,
     ) -> anyhow::Result<Result<(), NoTurnServers>> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "The iteration order doesn't matter here."
+        )]
+        if self.gateways_site.values().any(|s| s == &site_id) {
+            anyhow::bail!(AlreadyConnectedToSite)
+        }
+
         tracing::debug!(%gid, "New flow authorized for resource");
 
         let resource = self.resources_by_id.get(&rid).context("Unknown resource")?;
@@ -626,15 +637,6 @@ impl ClientState {
 
             return Ok(Ok(()));
         };
-
-        if let Some(old_gateway_id) = self.resources_gateways.insert(rid, gid)
-            && self.peers.get(&old_gateway_id).is_some()
-        {
-            assert_eq!(
-                old_gateway_id, gid,
-                "Resources are not expected to change gateways without a previous message, resource_id = {rid}"
-            )
-        }
 
         match self.node.upsert_connection(
             gid,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -864,6 +864,7 @@ impl ClientState {
         self.resources_gateways
             .retain(|_, g| g != disconnected_gateway);
         self.dns_resource_nat.clear_by_gateway(disconnected_gateway);
+        self.gateways_site.remove(disconnected_gateway);
     }
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -697,6 +697,10 @@ pub(crate) struct NotAllowedResource(IpAddr);
 #[error("Failed to decapsulate '{0}' packet")]
 pub(crate) struct FailedToDecapsulate(packet_kind::Kind);
 
+#[derive(Debug, thiserror::Error)]
+#[error("Already connected to site")]
+pub struct AlreadyConnectedToSite;
+
 pub fn is_peer(dst: IpAddr) -> bool {
     match dst {
         IpAddr::V4(v4) => IPV4_TUNNEL.contains(v4),


### PR DESCRIPTION
Within connlib, we assume in several places that we are only connected to a single Gateway per site. For example, in order to maintain Gateway affinity, we send the list of currently connected Gateways to the portal with each `create_flow` message. If we somehow end up being connected to two Gateways in the same site, this may result in the portal giving us a Gateway for a resource that we previously routed to a different Gateway.

This is an issue because Firezone needs to be as transparent as possible to all network traffic. Ultimately, the Gateway's public IP will be observed as the source of the traffic by the resource. Multi-path protocols are technically possible and QUIC may support this in the future. In today's Internet though, most network connections cannot be roamed to a different endpoint. As such, it is important that we don't move connections between Gateways unless absolutely necessary (like if the admin moves a resource to a different site).