### PR TITLE
fix(portal): sync error email fixes

### DIFF
--- a/elixir/apps/domain/lib/domain/google/directory.ex
+++ b/elixir/apps/domain/lib/domain/google/directory.ex
@@ -3,12 +3,11 @@ defmodule Domain.Google.Directory do
   import Ecto.Changeset
   import Domain.Changeset
 
-  @primary_key false
+  @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime_usec]
+
   schema "google_directories" do
-    # Allows setting the id manually for easier associations
-    field :id, Ecto.UUID, primary_key: true
     belongs_to :account, Domain.Account
 
     belongs_to :directory, Domain.Directory,

--- a/elixir/apps/domain/lib/domain/mailer/sync_email.ex
+++ b/elixir/apps/domain/lib/domain/mailer/sync_email.ex
@@ -7,9 +7,15 @@ defmodule Domain.Mailer.SyncEmail do
   embed_templates "sync_email/*.text", suffix: "_text"
 
   def sync_error_email(directory, email) do
+    settings_url = url("/#{directory.account.slug}/settings/directory_sync")
+
     default_email()
     |> subject("Directory Sync Error - #{directory.name}")
     |> to(email)
-    |> render_body(__MODULE__, :sync_error, account: directory.account, directory: directory)
+    |> render_body(__MODULE__, :sync_error,
+      account: directory.account,
+      directory: directory,
+      settings_url: settings_url
+    )
   end
 end

--- a/elixir/apps/domain/lib/domain/mailer/sync_email/sync_error.html.eex
+++ b/elixir/apps/domain/lib/domain/mailer/sync_email/sync_error.html.eex
@@ -68,15 +68,17 @@
 											<%= @directory.name %> Sync Error!
 										</h1>
 										<p style="margin: 0; line-height: 24px">
-											<%= @directory.name %> has failed to sync <%= @directory.error_email_count + 1 %> time(s).
+											The <%= @directory.name %> directory has encountered an unrecoverable error and sync has been disabled.
+											Please visit your <a href="<%= @settings_url %>" style="color: #5e00d6; text-decoration: underline;">directory sync settings</a> to re-verify the directory and enable sync.
 										</p>
 										<div role="separator" style="line-height: 16px">&zwj;</div>
 										<p style="margin: 0; line-height: 24px;">
 											Below is the last sync error message:
-											<div>
-											<pre style="margin: 0; white-space: pre; border-radius: 4px; background-color: #f3f4f6; padding: 8px 12px; line-height: 24px; color: #1f2937"><code><%= @directory.error_message %></code></pre>
-											</div>
 										</p>
+										<div role="separator" style="line-height: 8px">&zwj;</div>
+										<div>
+											<pre style="margin: 0; white-space: pre; border-radius: 4px; background-color: #f3f4f6; padding: 8px 12px; line-height: 24px; color: #1f2937"><code><%= @directory.error_message %></code></pre>
+										</div>
 										<div role="separator" class="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0">&zwj;</div>
 										<p style="margin: 0; line-height: 24px;">
 											<span style="font-weight: 500; text-decoration-line: underline; text-underline-offset: 2px">Directory Details</span>
@@ -106,8 +108,7 @@
 										<p></p>
 										<div role="separator" class="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0;">&zwj;</div>
 										<p style="margin: 0; line-height: 24px;">
-											Please verify that all Directory information entered in to Firezone is correct. If the problem persists, please reach out to Firezone support
-											using Slack or email.
+											Please verify that all directory information entered into Firezone is correct. If the problem persists, please reach out to Firezone support via Slack or email.
 											<br>
 											<br>
 											Thanks, <br>The Firezone Team

--- a/elixir/apps/domain/lib/domain/mailer/sync_email/sync_error.text.eex
+++ b/elixir/apps/domain/lib/domain/mailer/sync_email/sync_error.text.eex
@@ -1,9 +1,11 @@
 Directory Sync Error!
 
-Directory "<%= @directory.name %>" in your Firezone Account has encountered a sync error.
-Failed to sync <%= @directory.error_email_count + 1 %> time(s).
+The "<%= @directory.name %>" directory has encountered an unrecoverable error and sync has been disabled.
+Please visit your directory sync settings to re-verify the directory and enable sync:
+<%= @settings_url %>
 
-The following is the error message:
+Below is the last sync error message:
+
 <%= @directory.error_message || "No error message available" %>
 
 Directory details:
@@ -12,3 +14,8 @@ Directory details:
   Directory Name: <%= @directory.name %>
   Directory ID: <%= @directory.id %>
   Error Occurred At: <%= @directory.errored_at || "Unknown" %>
+
+Please verify that all directory information entered into Firezone is correct. If the problem persists, please reach out to Firezone support via Slack or email.
+
+Thanks,
+The Firezone Team

--- a/elixir/apps/domain/lib/domain/telemetry/reporter/oban.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/reporter/oban.ex
@@ -283,6 +283,8 @@ defmodule Domain.Telemetry.Reporter.Oban do
   end
 
   # Handle 5xx errors - disable after 24 hours
+  # This allows for transient server issues to resolve before disabling
+  # a sync and alerting the admin about it.
   defp handle_5xx_error(provider, directory_id, error_message) do
     now = DateTime.utc_now()
 

--- a/elixir/apps/web/lib/web/live/settings/directory_sync.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_sync.ex
@@ -646,16 +646,38 @@ defmodule Web.Settings.DirectorySync do
       </div>
 
       <div class="mt-auto bg-white rounded-lg p-3 space-y-3 text-sm text-neutral-600">
-        <%= if @directory.is_disabled do %>
-          <div class="flex items-center gap-2">
-            <.icon name="hero-no-symbol" class="w-5 h-5 flex-shrink-0 text-red-600" title="Disabled" />
-            <span class="font-medium text-red-600">
-              Disabled
-              <%= if @directory.disabled_reason do %>
-                - {@directory.disabled_reason}
-              <% end %>
-            </span>
-          </div>
+        <%= if @directory.is_disabled and @directory.disabled_reason == "Sync error" do %>
+          <.flash kind={:error_inline}>
+            <p class="font-semibold">Sync has been disabled due to an error</p>
+            <%= if @directory.error_message do %>
+              <p class="mt-1 text-sm">{@directory.error_message}</p>
+            <% end %>
+            <p class="mt-2 text-sm">
+              <.link
+                patch={~p"/#{@account}/settings/directory_sync/#{@type}/#{@directory.id}/edit"}
+                class="underline font-medium"
+              >
+                Edit the directory
+              </.link>
+              and re-verify to enable syncing.
+            </p>
+          </.flash>
+        <% else %>
+          <%= if @directory.is_disabled do %>
+            <div class="flex items-center gap-2">
+              <.icon
+                name="hero-no-symbol"
+                class="w-5 h-5 flex-shrink-0 text-red-600"
+                title="Disabled"
+              />
+              <span class="font-medium text-red-600">
+                Disabled
+                <%= if @directory.disabled_reason do %>
+                  - {@directory.disabled_reason}
+                <% end %>
+              </span>
+            </div>
+          <% end %>
         <% end %>
 
         <div class="flex items-center gap-2">
@@ -737,19 +759,6 @@ defmodule Web.Settings.DirectorySync do
               </.button>
             </div>
           <% end %>
-        <% end %>
-
-        <%= if @directory.error_message do %>
-          <div class="flex items-start gap-2">
-            <.icon
-              name="hero-exclamation-triangle"
-              class="w-5 h-5 flex-shrink-0 text-orange-600"
-              title="Error"
-            />
-            <span class="font-medium text-orange-600 flex-1">
-              {@directory.error_message}
-            </span>
-          </div>
         <% end %>
 
         <div class="flex items-center gap-2">


### PR DESCRIPTION
- Updates the sync error email to remove mention of "times" since that is baked into the disable logic now. Instead, we track sent email count and back that off gradually.
- Fixes an issue where `okta` was not detected for sending sync error notifications
- Fixes an issue where the sync error email would have sent an email immediately for syncs with an errored_at. For 5xx errors, this is undesirable. Instead, we want to send the email only when the sync has been disabled due to `Sync error`.
- Updates the directory card with a short instruction on what to do for sync errors - edit the directory and re-verify.


<img width="672" height="1056" alt="Screenshot 2025-12-18 at 11 01 02 PM" src="https://github.com/user-attachments/assets/5acaa2a6-c7ea-482b-9bcb-3895cfe0375d" />


Fixes #11078 