### PR TITLE
ci: don't sign Windows headless client debug builds

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -139,7 +139,9 @@ jobs:
           cargo build $PROFILE -p ${{ matrix.package }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe "$ARTIFACT_PATH"
       - uses: ./.github/actions/setup-azure-sign-tool
+        if: inputs.profile == 'release'
       - name: Sign the binary
+        if: inputs.profile == 'release'
         shell: bash
         env:
           AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}


### PR DESCRIPTION
Installing the signing tool takes a fair while. Signing the debug builds is redundant so we can skip this step.