### PR TITLE
fix(connlib): replace `expect` with WARN log

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1502,15 +1502,15 @@ impl ClientState {
         }
     }
 
-    fn update_site_status_by_gateway(&mut self, gateway_id: &GatewayId, status: ResourceStatus) {
+    fn update_site_status_by_gateway(&mut self, gid: &GatewayId, status: ResourceStatus) {
         // Note: we can do this because in theory we shouldn't have multiple gateways for the same site
         // connected at the same time.
-        self.sites_status.insert(
-            *self.gateways_site.get(gateway_id).expect(
-                "if we're updating a site status there should be an associated site to a gateway",
-            ),
-            status,
-        );
+        let Some(sid) = self.gateways_site.get(gid) else {
+            tracing::warn!(%gid, "Cannot update status of unknown site");
+            return;
+        };
+
+        self.sites_status.insert(*sid, status);
         self.resource_list.update(self.resources());
     }
 


### PR DESCRIPTION
Panicking in connlib is a bad idea, even for "this should never happen" cases because it takes down the entire data plane and is really disruptive for the user. Meanwhile, having the UI not update, which sites we are connected to is at best annoying.

By logging a warning instead, we are on the safer side here and can fix any bug that comes up in a follow-up release.