### PR TITLE
fix(portal): use gin indexes for fulltext_search

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20251218000000_set_not_null_on_groups_name.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251218000000_set_not_null_on_groups_name.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.SetNotNullOnGroupsName do
+  use Ecto.Migration
+
+  def change do
+    alter table(:groups) do
+      modify(:name, :string, null: false, from: {:string, null: true})
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20251219000000_add_fulltext_search_indexes.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251219000000_add_fulltext_search_indexes.exs
@@ -1,0 +1,78 @@
+defmodule Domain.Repo.Migrations.AddFulltextSearchIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    # Enable pg_trgm extension for trigram indexes (needed for ILIKE optimization)
+    execute(
+      "CREATE EXTENSION IF NOT EXISTS pg_trgm",
+      "DROP EXTENSION IF EXISTS pg_trgm"
+    )
+
+    # Create an immutable wrapper for unaccent (required for index expressions)
+    execute(
+      """
+      CREATE OR REPLACE FUNCTION immutable_unaccent(text)
+      RETURNS text AS $$
+        SELECT public.unaccent($1)
+      $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+      """,
+      "DROP FUNCTION IF EXISTS immutable_unaccent(text)"
+    )
+
+    # Resources indexes
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS resources_name_trigram_idx
+      ON resources USING gin(immutable_unaccent(name) gin_trgm_ops)
+      """,
+      "DROP INDEX IF EXISTS resources_name_trigram_idx"
+    )
+
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS resources_address_trigram_idx
+      ON resources USING gin(immutable_unaccent(address) gin_trgm_ops)
+      """,
+      "DROP INDEX IF EXISTS resources_address_trigram_idx"
+    )
+
+    # Actors indexes
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS actors_name_trigram_idx
+      ON actors USING gin(immutable_unaccent(name) gin_trgm_ops)
+      """,
+      "DROP INDEX IF EXISTS actors_name_trigram_idx"
+    )
+
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS actors_email_trigram_idx
+      ON actors USING gin(immutable_unaccent(email) gin_trgm_ops)
+      WHERE email IS NOT NULL
+      """,
+      "DROP INDEX IF EXISTS actors_email_trigram_idx"
+    )
+
+    # Clients indexes
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS clients_name_trigram_idx
+      ON clients USING gin(immutable_unaccent(name) gin_trgm_ops)
+      """,
+      "DROP INDEX IF EXISTS clients_name_trigram_idx"
+    )
+
+    # Groups indexes
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS groups_name_trigram_idx
+      ON groups USING gin(immutable_unaccent(name) gin_trgm_ops)
+      """,
+      "DROP INDEX IF EXISTS groups_name_trigram_idx"
+    )
+  end
+end

--- a/elixir/apps/web/lib/web/live/actors.ex
+++ b/elixir/apps/web/lib/web/live/actors.ex
@@ -1604,6 +1604,7 @@ defmodule Web.Actors do
 
   defmodule DB do
     import Ecto.Query
+    import Domain.Repo.Query
     alias Domain.ExternalIdentity
     alias Domain.Actor
     alias Domain.Safe
@@ -1735,22 +1736,11 @@ defmodule Web.Actors do
     end
 
     def filter_by_name_or_email(queryable, search_term) do
-      search_pattern = "%#{search_term}%"
-
-      # Use a subquery to find actors by external identity email
-      identity_subquery =
-        from(i in ExternalIdentity,
-          where: ilike(i.email, ^search_pattern),
-          select: i.actor_id,
-          distinct: true
-        )
-
       {queryable,
        dynamic(
          [actors: actors],
-         ilike(actors.name, ^search_pattern) or
-           ilike(actors.email, ^search_pattern) or
-           actors.id in subquery(identity_subquery)
+         fulltext_search(actors.name, ^search_term) or
+           fulltext_search(actors.email, ^search_term)
        )}
     end
 

--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -813,6 +813,7 @@ defmodule Web.Policies.Components do
 
   defmodule DB do
     import Ecto.Query
+    import Domain.Repo.Query
     alias Domain.{Safe, Userpass, EmailOTP, OIDC, Google, Entra, Okta}
 
     def all_active_providers_for_account(account, subject) do
@@ -927,7 +928,7 @@ defmodule Web.Policies.Components do
 
       query =
         if search_query_or_nil != "" and search_query_or_nil != nil do
-          from(g in query, where: ilike(g.name, ^"%#{search_query_or_nil}%"))
+          from(g in query, where: fulltext_search(g.name, ^search_query_or_nil))
         else
           query
         end

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -256,6 +256,7 @@ defmodule Web.Policies.Edit do
 
   defmodule DB do
     import Ecto.Query
+    import Domain.Repo.Query
     alias Domain.{Policy, Safe, Userpass, EmailOTP, OIDC, Google, Entra, Okta, Group}
     alias Domain.Auth
 
@@ -358,7 +359,7 @@ defmodule Web.Policies.Edit do
 
       query =
         if search_query_or_nil != "" and search_query_or_nil != nil do
-          from(g in query, where: ilike(g.name, ^"%#{search_query_or_nil}%"))
+          from(g in query, where: fulltext_search(g.name, ^search_query_or_nil))
         else
           query
         end

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -178,10 +178,10 @@ defmodule Web.Policies.Index do
           fun: &filter_by_resource_name/2
         },
         %Domain.Repo.Filter{
-          name: :group_or_resource_name,
-          title: "Group Name or Resource Name",
+          name: :group_or_resource,
+          title: "Group or Resource",
           type: {:string, :websearch},
-          fun: &filter_by_group_or_resource_name/2
+          fun: &filter_by_group_or_resource/2
         },
         %Domain.Repo.Filter{
           name: :status,
@@ -214,13 +214,15 @@ defmodule Web.Policies.Index do
       {queryable, dynamic([resource: r], fulltext_search(r.name, ^name))}
     end
 
-    def filter_by_group_or_resource_name(queryable, name) do
+    def filter_by_group_or_resource(queryable, search_term) do
       queryable = queryable |> with_joined_group() |> with_joined_resource()
 
       {queryable,
        dynamic(
          [group: g, resource: r],
-         fulltext_search(g.name, ^name) or fulltext_search(r.name, ^name)
+         fulltext_search(g.name, ^search_term) or
+           fulltext_search(r.name, ^search_term) or
+           fulltext_search(r.address, ^search_term)
        )}
     end
 

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -285,6 +285,7 @@ defmodule Web.Policies.New do
 
   defmodule DB do
     import Ecto.Query
+    import Domain.Repo.Query
     alias Domain.{Safe, Userpass, EmailOTP, OIDC, Google, Entra, Okta, Group}
     alias Domain.Auth
 
@@ -379,7 +380,7 @@ defmodule Web.Policies.New do
 
       query =
         if search_query_or_nil != "" and search_query_or_nil != nil do
-          from(g in query, where: ilike(g.name, ^"%#{search_query_or_nil}%"))
+          from(g in query, where: fulltext_search(g.name, ^search_query_or_nil))
         else
           query
         end

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -392,7 +392,7 @@ defmodule Web.Resources.Components do
        dynamic(
          [resources: resources],
          fulltext_search(resources.name, ^name_or_address) or
-           ilike(resources.address, ^"%#{name_or_address}%")
+           fulltext_search(resources.address, ^name_or_address)
        )}
     end
   end

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -250,7 +250,7 @@ defmodule Web.Resources.Index do
        dynamic(
          [resources: resources],
          fulltext_search(resources.name, ^name_or_address) or
-           ilike(resources.address, ^"%#{name_or_address}%")
+           fulltext_search(resources.address, ^name_or_address)
        )}
     end
 

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -686,7 +686,7 @@ defmodule Web.Sites.Show do
        dynamic(
          [resources: resources],
          fulltext_search(resources.name, ^name_or_address) or
-           ilike(resources.address, ^"%#{name_or_address}%")
+           fulltext_search(resources.address, ^name_or_address)
        )}
     end
 


### PR DESCRIPTION
In nearly all of the places in the portal we expose a text input to filter by name or address in a live table, we were using naive `ilike` from Ecto.Query.

Without an index, this does a sequential scan on the tables involved. Depending on the size of the table (e.g. clients) this could be a substantial load on the DB.

To alleviate this, we:

- Simplify our fulltext_search function to only use trigram queries using the `unaccent` extension. This allows for partial matches on words like `café` when searching for `afe` for example.
- Add GIN indexes to all colums exposed for this

Fixes #11260