### PR TITLE
fix(portal): set NOT NULL for name on groups

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20251218000000_set_not_null_on_groups_name.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251218000000_set_not_null_on_groups_name.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.SetNotNullOnGroupsName do
+  use Ecto.Migration
+
+  def change do
+    alter table(:groups) do
+      modify(:name, :string, null: false, from: {:string, null: true})
+    end
+  end
+end


### PR DESCRIPTION
The groups table name field needs to not be null. Checked prod snapshot and we don't currently have any violations here.