### PR TITLE
fix(portal): invalidate tokens/sessions on auth_provider changes

### DIFF
--- a/elixir/apps/domain/lib/domain/changes/hooks/auth_providers.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/auth_providers.ex
@@ -6,11 +6,14 @@ defmodule Domain.Changes.Hooks.AuthProviders do
   def on_insert(_lsn, _data), do: :ok
 
   @impl true
-  def on_update(_lsn, old_data, %{"account_id" => account_id, "id" => provider_id} = data) do
-    if breaking_change?(old_data, data) do
-      DB.delete_client_tokens_for_provider(account_id, provider_id)
-      DB.delete_portal_sessions_for_provider(account_id, provider_id)
-    end
+
+  def on_update(
+        _lsn,
+        %{"is_disabled" => false},
+        %{"is_disabled" => true, "account_id" => account_id, "id" => provider_id}
+      ) do
+    DB.delete_client_tokens_for_provider(account_id, provider_id)
+    DB.delete_portal_sessions_for_provider(account_id, provider_id)
 
     :ok
   end
@@ -45,17 +48,5 @@ defmodule Domain.Changes.Hooks.AuthProviders do
       |> Safe.unscoped()
       |> Safe.delete_all()
     end
-  end
-
-  defp breaking_change?(old_data, data) do
-    old_data["is_disabled"] != data["is_disabled"] or
-      old_data["client_session_lifetime_secs"] != data["client_session_lifetime_secs"] or
-      old_data["portal_session_lifetime_secs"] != data["portal_session_lifetime_secs"] or
-      old_data["context"] != data["context"] or
-      old_data["issuer"] != data["issuer"] or
-      old_data["client_id"] != data["client_id"] or
-      old_data["client_secret"] != data["client_secret"] or
-      old_data["okta_domain"] != data["okta_domain"] or
-      old_data["discovery_document_uri"] != data["discovery_document_uri"]
   end
 end

--- a/elixir/apps/domain/lib/domain/changes/hooks/auth_providers.ex
+++ b/elixir/apps/domain/lib/domain/changes/hooks/auth_providers.ex
@@ -6,34 +6,11 @@ defmodule Domain.Changes.Hooks.AuthProviders do
   def on_insert(_lsn, _data), do: :ok
 
   @impl true
-  def on_update(
-        _lsn,
-        %{"is_disabled" => false, "id" => provider_id, "account_id" => account_id},
-        %{"is_disabled" => true}
-      ) do
-    DB.delete_client_tokens_for_provider(account_id, provider_id)
-    DB.delete_portal_sessions_for_provider(account_id, provider_id)
-
-    :ok
-  end
-
-  def on_update(
-        _lsn,
-        %{
-          "client_session_lifetime_secs" => old_client_lifetime,
-          "portal_session_lifetime_secs" => old_portal_lifetime,
-          "account_id" => account_id
-        },
-        %{
-          "client_session_lifetime_secs" => new_client_lifetime,
-          "portal_session_lifetime_secs" => new_portal_lifetime,
-          "id" => provider_id
-        }
-      )
-      when old_client_lifetime != new_client_lifetime or
-             old_portal_lifetime != new_portal_lifetime do
-    DB.delete_client_tokens_for_provider(account_id, provider_id)
-    DB.delete_portal_sessions_for_provider(account_id, provider_id)
+  def on_update(_lsn, old_data, %{"account_id" => account_id, "id" => provider_id} = data) do
+    if breaking_change?(old_data, data) do
+      DB.delete_client_tokens_for_provider(account_id, provider_id)
+      DB.delete_portal_sessions_for_provider(account_id, provider_id)
+    end
 
     :ok
   end
@@ -41,9 +18,7 @@ defmodule Domain.Changes.Hooks.AuthProviders do
   def on_update(_lsn, _old_data, _new_data), do: :ok
 
   @impl true
-  def on_delete(_lsn, _old_data) do
-    :ok
-  end
+  def on_delete(_lsn, _old_data), do: :ok
 
   defmodule DB do
     import Ecto.Query
@@ -51,7 +26,8 @@ defmodule Domain.Changes.Hooks.AuthProviders do
     alias Domain.PortalSession
     alias Domain.Safe
 
-    # Delete all client tokens for a provider and disconnect their sockets
+    # Delete all GUI client tokens for a provider and disconnect their sockets
+    # Service Account tokens do not have an auth provider set and will not be affected
     def delete_client_tokens_for_provider(account_id, provider_id) do
       # The ClientTokens hook will handle disconnecting sockets
       from(c in ClientToken,
@@ -62,12 +38,24 @@ defmodule Domain.Changes.Hooks.AuthProviders do
     end
 
     def delete_portal_sessions_for_provider(account_id, provider_id) do
-      # The ClientTokens hook will handle disconnecting sockets
+      # The PortalSessions hook will handle disconnecting sockets
       from(p in PortalSession,
         where: p.account_id == ^account_id and p.auth_provider_id == ^provider_id
       )
       |> Safe.unscoped()
       |> Safe.delete_all()
     end
+  end
+
+  defp breaking_change?(old_data, data) do
+    old_data["is_disabled"] != data["is_disabled"] or
+      old_data["client_session_lifetime_secs"] != data["client_session_lifetime_secs"] or
+      old_data["portal_session_lifetime_secs"] != data["portal_session_lifetime_secs"] or
+      old_data["context"] != data["context"] or
+      old_data["issuer"] != data["issuer"] or
+      old_data["client_id"] != data["client_id"] or
+      old_data["client_secret"] != data["client_secret"] or
+      old_data["okta_domain"] != data["okta_domain"] or
+      old_data["discovery_document_uri"] != data["discovery_document_uri"]
   end
 end


### PR DESCRIPTION
For better security, we update the side effect logic when changing an auth provider such that we sign out all clients and portal sessions whenever a "breaking change" is successfully committed.