### PR TITLE
fix(ci): upgrade workflow deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       default-days: 28
   - package-ecosystem: github-actions
     directories:
-      - "/"
+      - "/.github/workflows"
       # Dependabot doesn't look in these by default
       - "/.github/actions/create-sentry-release"
       - "/.github/actions/ghcr-docker-login"


### PR DESCRIPTION
For some reason the behavior has seemingly changed and Dependabot is no longer managing CI workflow dependencies. This adds our workflows dir to dependabot explicitly to avoid this going forward.

Related: #11294 