### PR TITLE
fix(portal): start CodeReloader only in Phoenix apps

### DIFF
--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -9,6 +9,7 @@ defmodule API.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
+      listeners: [Phoenix.CodeReloader],
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -9,6 +9,7 @@ defmodule Web.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
+      listeners: [Phoenix.CodeReloader],
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -8,7 +8,6 @@ defmodule Firezone.MixProject do
       version: version(),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
-      listeners: [Phoenix.CodeReloader],
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.detail": :test,


### PR DESCRIPTION
This is needed for Phoenix 1.8+. The domain app doesn't start any Phoenix endpoints and shouldn't need this listener.

Should hopefully fix this Dependabot error:

```
** (ArgumentError) The module Phoenix.CodeReloader was given as a child to a supervisor but it does not exist
    (elixir 1.18.4) lib/supervisor.ex:797: Supervisor.init_child/1
    (elixir 1.18.4) lib/supervisor.ex:905: Supervisor.child_spec/2
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (mix 1.18.4) lib/mix/pubsub.ex:77: Mix.PubSub.listener_supervisor/0
    (mix 1.18.4) lib/mix/pubsub.ex:59: Mix.PubSub.start_listeners/0
    (mix 1.18.4) lib/mix/tasks/deps.loadpaths.ex:76: Mix.Tasks.Deps.Loadpaths.run/1
    (mix 1.18.4) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.18.4) lib/mix/tasks/loadpaths.ex:37: Mix.Tasks.Loadpaths.run/1

{"error":""}
```