### PR TITLE
ci: shorten cooldowns to 2, 7, 14 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,31 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: pip
     directory: /.github
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directories:
       - "/.github/workflows"
@@ -43,16 +59,31 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: cargo
     directory: rust/
     open-pull-requests-limit: 100
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
       tauri:
         patterns:
           - tauri
@@ -94,13 +125,20 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
     ignore:
       # Depends on JDK version which is bundled with Android Studio (JDK 17)
       - dependency-name: org.jetbrains.kotlin:kotlin-gradle-plugin
       - dependency-name: org.jetbrains.kotlin.android
     groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
       com.android:
         patterns:
           - com.android.*
@@ -157,23 +195,46 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: npm
     directory: website/
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: npm
     directory: rust/gui-client/
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
     groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"
       tauri:
         patterns:
           - "@tauri-apps/*"
@@ -200,5 +261,13 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 28
+      semver-patch-days: 2
+      semver-minor-days: 7
+      semver-major-days: 14
+      default-days: 7
     open-pull-requests-limit: 100
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Unfortunately the `28` day cooldown means any package with a release cadence shorter than 28 days will _never_ be updated.

This PR fixes that by specifying a cascading cooldown period based on the patch, minor, and major:

- For patch updates, use a 2-day cooldown period
- For minor updates, use a 7-day cooldown period
- For major updates, use a 14-day cooldown period

Security updates are already configured to open ASAP as soon as Dependabot knows about them. I'm not sure cooldowns are the lever we want to pull here. We update the grouping for each ecosystem to ensure we only see _one_ PR to bump security updates to avoid PR spam.

Related: #11294 