### PR TITLE
ci: disable cooldowns for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,11 +58,10 @@ updates:
       - "/.github/actions/setup-tauri-v2"
     schedule:
       interval: weekly
-    cooldown:
-      semver-patch-days: 2
-      semver-minor-days: 7
-      semver-major-days: 14
-      default-days: 7
+    # Unfortunately the github-actions ecosystem doesn't support semver cooldowns, and because they update very frequently
+    # we need to disable cooldowns here. Otherwise some packages will just never get updated.
+    # cooldown:
+    #   default-days: 7
     open-pull-requests-limit: 100
     groups:
       security-all:


### PR DESCRIPTION
The github-actions ecosystem does not support semver-specific cooldowns. Coupled with the fact that releases here sometimes come out daily, we need to disable the cooldown period for github actions workflows.