### PR TITLE
fix(connlib): allow connecting to multiple Gateways in a site

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3415,7 +3415,6 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
- "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -4447,15 +4446,6 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "windows",
-]
-
-[[package]]
-name = "lru"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
-dependencies = [
- "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -8872,7 +8862,6 @@ dependencies = [
  "l4-udp-dns-client",
  "l4-udp-dns-server",
  "logging",
- "lru",
  "opentelemetry",
  "proptest",
  "proptest-state-machine",

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -274,13 +274,13 @@ impl Eventloop {
                     .context("Failed to send message to portal")?;
             }
             ClientEvent::ConnectionIntent {
-                connected_gateway_ids,
+                preferred_gateways,
                 resource,
             } => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(EgressMessages::CreateFlow {
                         resource_id: resource,
-                        connected_gateway_ids,
+                        preferred_gateways,
                     }))
                     .await
                     .context("Failed to send message to portal")?;

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -23,10 +23,7 @@ use tunnel::messages::client::{
     EgressMessages, FailReason, FlowCreated, FlowCreationFailed, GatewayIceCandidates,
     GatewaysIceCandidates, IngressMessages, InitClient,
 };
-use tunnel::{
-    AlreadyConnectedToSite, ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig,
-    TunnelError,
-};
+use tunnel::{ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig, TunnelError};
 
 /// In-memory cache for DNS resource records.
 ///
@@ -436,9 +433,6 @@ impl Eventloop {
                             )))
                             .await
                             .context("Failed to connect phoenix-channel")?;
-                    }
-                    Err(e) if e.any_is::<AlreadyConnectedToSite>() => {
-                        tracing::debug!("Failed to handle flow created: {e:#}");
                     }
                     Err(e) => {
                         tracing::warn!("Failed to handle flow created: {e:#}");

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -37,7 +37,6 @@ l4-tcp-dns-server = { workspace = true }
 l4-udp-dns-client = { workspace = true }
 l4-udp-dns-server = { workspace = true }
 logging = { workspace = true }
-lru = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1548,7 +1548,6 @@ impl ClientState {
 
         self.resources_gateways.clear(); // Clear Resource <> Gateway mapping (we will re-create this as new flows are authorized).
 
-        self.recently_connected_gateways.clear(); // Ensure we don't have sticky gateways when we roam.
         self.dns_resource_nat.clear(); // Clear all state related to DNS resource NATs.
         self.drain_node_events();
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -778,7 +778,7 @@ impl ClientState {
 
     // We tell the portal about all gateways we ever connected to, to encourage re-connecting us to the same ones during a session.
     // The LRU cache visits them in MRU order, meaning a gateway that we recently connected to should still be preferred.
-    fn connected_gateway_ids(&self) -> Vec<GatewayId> {
+    fn preferred_gateways(&self) -> Vec<GatewayId> {
         self.recently_connected_gateways
             .iter()
             .map(|(g, _)| *g)
@@ -1527,7 +1527,7 @@ impl ClientState {
         if let Some(resource) = self.pending_flows.poll_connection_intents() {
             return Some(ClientEvent::ConnectionIntent {
                 resource,
-                connected_gateway_ids: self.connected_gateway_ids(),
+                preferred_gateways: self.preferred_gateways(),
             });
         }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -100,6 +100,10 @@ pub struct ClientState {
     /// This state persists across `reset`s so we can re-connect to the same Gateway.
     authorized_resources: HashMap<ResourceId, GatewayId>,
     /// Tracks which gateways are in a site.
+    ///
+    /// This state gets populated as we connect to various Gateways.
+    /// Gateways are bound to a single site, hence this state is never cleaned up.
+    /// An entry in this data structure does _not_ mean that we are connected to the Gateway / site.
     gateways_by_site: HashMap<SiteId, HashSet<GatewayId>>,
     /// The online/offline status of a site.
     sites_status: HashMap<SiteId, ResourceStatus>,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -784,7 +784,7 @@ impl ClientState {
 
                 prefer_authorized
                     .then(prefer_connected)
-                    .then(default_ordering) // This makes it determinstic, even though we are using `HashSets
+                    .then(default_ordering) // This makes it deterministic, even though we are using `HashSets
             })
             .collect()
     }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -778,7 +778,7 @@ impl ClientState {
 
     // We tell the portal about all gateways we ever connected to, to encourage re-connecting us to the same ones during a session.
     // The LRU cache visits them in MRU order, meaning a gateway that we recently connected to should still be preferred.
-    fn connected_gateway_ids(&self) -> BTreeSet<GatewayId> {
+    fn connected_gateway_ids(&self) -> Vec<GatewayId> {
         self.recently_connected_gateways
             .iter()
             .map(|(g, _)| *g)

--- a/rust/libs/connlib/tunnel/src/client/pending_flows.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_flows.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     net::SocketAddr,
     time::{Duration, Instant},
 };
 
-use connlib_model::{GatewayId, ResourceId, SiteId};
+use connlib_model::{ResourceId, SiteId};
 use ip_packet::IpPacket;
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 
@@ -24,7 +24,7 @@ impl PendingFlows {
         rid: ResourceId,
         trigger: impl Into<ConnectionTrigger>,
         resources_by_id: &BTreeMap<ResourceId, Resource>,
-        gateways_by_site: &HashMap<SiteId, HashSet<GatewayId>>,
+        connected_to_site: impl Fn(SiteId) -> bool,
         now: Instant,
     ) {
         let trigger = trigger.into();
@@ -40,9 +40,6 @@ impl PendingFlows {
             return;
         };
 
-        let connected_to_site = gateways_by_site
-            .get(&site.id)
-            .is_some_and(|g| !g.is_empty());
         let has_pending_flows_for_site = resources_by_id
             .values()
             .filter_map(|r| r.sites().contains(site).then_some(r.id()))
@@ -56,7 +53,8 @@ impl PendingFlows {
 
         pending_flow.push(trigger);
 
-        if !connected_to_site && has_pending_flows_for_site {
+        // If we are not connected to the site yet, hold off on sending more connection intents.
+        if has_pending_flows_for_site && !connected_to_site(site.id) {
             tracing::debug!(%rid, site = %site.name, "Already connecting to this site, skipping connection intent");
             return;
         }
@@ -165,6 +163,12 @@ impl From<IpPacket> for ConnectionTrigger {
     }
 }
 
+impl From<DnsQueryForSite> for ConnectionTrigger {
+    fn from(v: DnsQueryForSite) -> Self {
+        Self::DnsQueryForSite(v)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -182,14 +186,13 @@ mod tests {
         let mut now = Instant::now();
         let rid = ipv4_localhost_resource().id();
         let resources = BTreeMap::from([(rid, ipv4_localhost_resource())]);
-        let gateway_sites = HashMap::default();
 
-        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
 
         now += Duration::from_secs(1);
 
-        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), None);
     }
 
@@ -199,14 +202,13 @@ mod tests {
         let mut now = Instant::now();
         let rid = ipv4_localhost_resource().id();
         let resources = BTreeMap::from([(rid, ipv4_localhost_resource())]);
-        let gateway_sites = HashMap::default();
 
-        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid, trigger(1), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
 
         now += Duration::from_secs(3);
 
-        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid, trigger(2), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
     }
 
@@ -222,16 +224,15 @@ mod tests {
             (rid1, ipv4_localhost_resource()),
             (rid2, ipv6_localhost_resource()),
         ]);
-        let gateway_sites = HashMap::default();
 
-        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid1));
-        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), None);
 
         pending_flows.remove(&rid1);
 
-        pending_flows.on_not_connected_resource(rid2, trigger(3), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid2, trigger(3), &resources, |_| false, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid2));
 
         let (packets, dns_queries) = pending_flows.remove(&rid2).unwrap().into_buffered_packets();
@@ -252,14 +253,10 @@ mod tests {
             (rid1, ipv4_localhost_resource()),
             (rid2, ipv6_localhost_resource()),
         ]);
-        let gateway_sites = HashMap::from([(
-            SiteId::from_u128(1),
-            HashSet::from([GatewayId::from_u128(1)]),
-        )]);
 
-        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, |_| true, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid1));
-        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, &gateway_sites, now);
+        pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, |_| true, now);
         assert_eq!(pending_flows.poll_connection_intents(), Some(rid2));
     }
 

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -583,7 +583,7 @@ pub enum ClientEvent {
     },
     ConnectionIntent {
         resource: ResourceId,
-        connected_gateway_ids: BTreeSet<GatewayId>,
+        connected_gateway_ids: Vec<GatewayId>,
     },
     /// The list of resources has changed and UI clients may have to be updated.
     ResourcesChanged {

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -697,10 +697,6 @@ pub(crate) struct NotAllowedResource(IpAddr);
 #[error("Failed to decapsulate '{0}' packet")]
 pub(crate) struct FailedToDecapsulate(packet_kind::Kind);
 
-#[derive(Debug, thiserror::Error)]
-#[error("Already connected to site")]
-pub struct AlreadyConnectedToSite;
-
 pub fn is_peer(dst: IpAddr) -> bool {
     match dst {
         IpAddr::V4(v4) => IPV4_TUNNEL.contains(v4),

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -583,7 +583,7 @@ pub enum ClientEvent {
     },
     ConnectionIntent {
         resource: ResourceId,
-        connected_gateway_ids: Vec<GatewayId>,
+        preferred_gateways: Vec<GatewayId>,
     },
     /// The list of resources has changed and UI clients may have to be updated.
     ResourcesChanged {

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -181,7 +181,8 @@ pub struct GatewayIceCandidates {
 pub enum EgressMessages {
     CreateFlow {
         resource_id: ResourceId,
-        connected_gateway_ids: Vec<GatewayId>,
+        #[serde(rename = "connected_gateway_ids")]
+        preferred_gateways: Vec<GatewayId>,
     },
     /// Candidates that can be used by the addressed gateways.
     BroadcastIceCandidates(GatewaysIceCandidates),
@@ -483,7 +484,7 @@ mod tests {
     fn serialize_create_flow_message() {
         let message = EgressMessages::CreateFlow {
             resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
-            connected_gateway_ids: Vec::new(),
+            preferred_gateways: Vec::new(),
         };
         let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[]}}"#;
         let actual_json = serde_json::to_string(&message).unwrap();

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -181,7 +181,7 @@ pub struct GatewayIceCandidates {
 pub enum EgressMessages {
     CreateFlow {
         resource_id: ResourceId,
-        connected_gateway_ids: BTreeSet<GatewayId>,
+        connected_gateway_ids: Vec<GatewayId>,
     },
     /// Candidates that can be used by the addressed gateways.
     BroadcastIceCandidates(GatewaysIceCandidates),
@@ -483,7 +483,7 @@ mod tests {
     fn serialize_create_flow_message() {
         let message = EgressMessages::CreateFlow {
             resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
-            connected_gateway_ids: BTreeSet::new(),
+            connected_gateway_ids: Vec::new(),
         };
         let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[]}}"#;
         let actual_json = serde_json::to_string(&message).unwrap();

--- a/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
@@ -153,7 +153,7 @@ impl StubPortal {
     pub(crate) fn handle_connection_intent(
         &self,
         resource: ResourceId,
-        _connected_gateway_ids: BTreeSet<GatewayId>,
+        _connected_gateway_ids: Vec<GatewayId>,
     ) -> (GatewayId, SiteId) {
         let site_id = self
             .sites_by_resource

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -850,10 +850,10 @@ impl TunnelTest {
             }
             ClientEvent::ConnectionIntent {
                 resource: resource_id,
-                connected_gateway_ids,
+                preferred_gateways,
             } => {
                 let (gateway_id, site_id) =
-                    portal.handle_connection_intent(resource_id, connected_gateway_ids);
+                    portal.handle_connection_intent(resource_id, preferred_gateways);
                 let gateway = self.gateways.get_mut(&gateway_id).expect("unknown gateway");
                 let resource = portal.map_client_resource_to_gateway_resource(resource_id);
 


### PR DESCRIPTION
Further testing and thinking has uncovered that the approach from #11267 is fundamentally flawed. The list of Gateways that we send to the portal is merely a preference. There are multiple reasons why the portal may not honor this request and just send us a different Gateway. The most obvious one is that the Gateway is in fact no longer online!

Therefore, the correct thing to do here is to just connect to the new Gateway that we are given, even if it means that we are now connected to two in the same site (after all, there may just be a network-partition between Gateway and portal but not Gateway and Client). This does not affect other resources because we track the Gateway to use on a per-Resource level.

With this insight, we can actually clean-up how we compute the list of preferred Gateways:

1. We used to sort this list lexically by the use of a `BTreeSet`. This makes absolutely no sense.
2. We used to always send the same list, irrespective of which resource we are trying to connect to.
	a. Given that we track Gateways on a per-Resource basis, it makes sense to vary the ordering of this list with the resource.
	b. We now prefer the Gateway that we have previously been authorized for.
	c. In case this resource has never been authorized before, we prefer Gateways that we are already connected to.
3. We use to keep a separate cache for the recently connected Gateways. This is now gone.

In order to enable the above state tracking, we now _no longer_ clear the `authorized_resources` list upon `reset`. This was unnecessary and with the new logic, would actually have prevented from "sticking" to the same Gateway upon roaming. The assumption here is that when users roam, they are very likely still in a location that is physically close to the previous one, i.e. going from WiFi to Data or vice versa. Thus, connected to the same Gateway should still give you a reasonably good connection.

One of the magical things of Firezone is that we can in fact roam TCP connections IF we re-connect to the same Gateway because the layer-3 connection through Firezone stays intact, even if underlying network connection changes. To allow for that, we need to make sure that we at least attempt to re-connect to the same Gateway.