### PR TITLE
fix(portal): do not redirect authed legacy provider callbacks

### DIFF
--- a/elixir/apps/domain/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/auth_provider_fixtures.ex
@@ -192,7 +192,8 @@ defmodule Domain.AuthProviderFixtures do
         :client_secret,
         :discovery_document_uri,
         :issuer,
-        :is_verified
+        :is_verified,
+        :is_default
       ])
       |> Ecto.Changeset.put_change(:id, auth_provider.id)
       |> Ecto.Changeset.put_assoc(:auth_provider, auth_provider)

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -69,6 +69,14 @@ defmodule Web.Router do
     get "/oidc/callback", OIDCController, :callback
   end
 
+  # Legacy OIDC callback - must be outside RedirectIfAuthenticated scope
+  # because IdP redirects don't include as=client param
+  scope "/:account_id_or_slug", Web do
+    pipe_through :public
+
+    get "/sign_in/providers/:auth_provider_id/handle_callback", OIDCController, :callback
+  end
+
   scope "/", Web do
     pipe_through :public
 
@@ -115,10 +123,6 @@ defmodule Web.Router do
       ] do
       live "/sign_in/email_otp/:auth_provider_id", SignIn.Email
     end
-
-    # Legacy OIDC auth entry point - we maintain indefinitely to avoid forcing admins to update
-    # their redirect URIs. Used if the oidc_auth_provider.is_legacy flag is set to true.
-    get "/sign_in/providers/:auth_provider_id/handle_callback", OIDCController, :callback
 
     # OIDC auth entry point (placed after LiveView routes to avoid conflicts)
     get "/sign_in/:auth_provider_type/:auth_provider_id", OIDCController, :sign_in

--- a/elixir/apps/web/test/web/controllers/oidc_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/oidc_controller_test.exs
@@ -1,0 +1,58 @@
+defmodule Web.OIDCControllerTest do
+  use Web.ConnCase, async: true
+
+  import Domain.AccountFixtures
+  import Domain.ActorFixtures
+  import Domain.AuthProviderFixtures
+
+  describe "callback routes do not redirect authenticated users" do
+    setup do
+      account = account_fixture()
+      actor = admin_actor_fixture(account: account)
+      provider = oidc_provider_fixture(account: account)
+
+      {:ok, account: account, actor: actor, provider: provider}
+    end
+
+    test "authenticated user can access /auth/oidc/callback without being redirected to portal",
+         %{
+           account: account,
+           conn: conn,
+           actor: actor
+         } do
+      # When an authenticated user hits the OIDC callback (after IdP redirects back),
+      # they should NOT be redirected to /sites. The callback should process normally.
+      # Since we don't have a valid state/code, we expect an error response, but NOT a redirect to /sites.
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/auth/oidc/callback", %{"state" => "test-state", "code" => "test-code"})
+
+      # Should not redirect to /sites (the portal)
+      location = get_resp_header(conn, "location") |> List.first()
+      refute location == ~p"/#{account.slug}/sites"
+    end
+
+    test "authenticated user can access legacy callback without being redirected to portal", %{
+      conn: conn,
+      actor: actor,
+      account: account,
+      provider: provider
+    } do
+      # When an authenticated user hits the legacy OIDC callback (after IdP redirects back),
+      # they should NOT be redirected to /sites. The callback should process normally.
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/#{account.slug}/sign_in/providers/#{provider.id}/handle_callback", %{
+          "state" => "test-state",
+          "code" => "test-code"
+        })
+
+      # Should not redirect to /sites (the portal)
+      # The callback will fail due to invalid state/code, but it should NOT redirect to /sites
+      location = get_resp_header(conn, "location") |> List.first()
+      refute location == ~p"/#{account.slug}/sites"
+    end
+  end
+end

--- a/elixir/apps/web/test/web/plugs/redirect_if_authenticated_test.exs
+++ b/elixir/apps/web/test/web/plugs/redirect_if_authenticated_test.exs
@@ -63,5 +63,63 @@ defmodule Web.Plugs.RedirectIfAuthenticatedTest do
 
       refute conn.halted
     end
+
+    test "integration: authenticated user with as=client goes through full pipeline", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      # This test simulates the real browser flow where an authenticated user
+      # opens a new tab with as=client parameter
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/#{account.slug}?as=client&nonce=test-nonce&state=test-state")
+
+      # Should render the sign-in page (200)
+      assert html_response(conn, 200) =~ "Sign In"
+    end
+
+    test "integration: authenticated user WITHOUT as=client redirects to portal", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      # This test verifies that authenticated users without as=client ARE redirected
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/#{account.slug}")
+
+      # Should redirect to /sites (portal)
+      assert redirected_to(conn) == ~p"/#{account.slug}/sites"
+    end
+
+    test "integration: authenticated user with default provider and as=client auto-redirects to provider",
+         %{
+           conn: conn,
+           actor: actor,
+           account: account
+         } do
+      # Create an OIDC provider marked as default for this account
+      provider =
+        Domain.AuthProviderFixtures.oidc_provider_fixture(account: account, is_default: true)
+
+      # Access the base sign-in page with as=client
+      # AutoRedirectDefaultProvider should redirect to the provider URL
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> get(~p"/#{account.slug}?as=client&nonce=test-nonce&state=test-state")
+
+      # With a default provider and as=client, should redirect to the provider-specific URL with params intact
+      location = redirected_to(conn)
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+      assert location =~ "as=client"
+      assert location =~ "nonce=test-nonce"
+      assert location =~ "state=test-state"
+    end
   end
 end


### PR DESCRIPTION
Legacy OIDC providers were mistakenly being caught in the `RedirectIfAuthenticated` plug which took an admin attempting to sign into a client straight to the admin portal.

To fix this, we move this route out to a `:public` pipeline with no plugs in the way and beef up the tests to prevent regressions like this going forward.

Fixes #11203