### PR TITLE
fix(portal): load listeners only in dev

### DIFF
--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -9,7 +9,6 @@ defmodule API.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      listeners: [Phoenix.CodeReloader],
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -9,7 +9,6 @@ defmodule Web.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      listeners: [Phoenix.CodeReloader],
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -8,6 +8,7 @@ defmodule Firezone.MixProject do
       version: version(),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
+      listeners: listeners(),
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.detail": :test,
@@ -26,6 +27,14 @@ defmodule Firezone.MixProject do
       aliases: aliases(),
       releases: releases()
     ]
+  end
+
+  defp listeners do
+    if Mix.env() == :dev do
+      [Phoenix.CodeReloader]
+    else
+      []
+    end
   end
 
   # Dependencies listed here are available only for this


### PR DESCRIPTION
Unfortunately the change introduced in #11301, while allowing Dependabot to run, results in warnings in local dev mode. Going to try adding a `:dev` filter here to see if this will help keep Dependabot from erroring out here.