### PR TITLE
fix(portal): don't send prompt for generic OIDC

### DIFF
--- a/elixir/apps/web/lib/web/controllers/oidc_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/oidc_controller.ex
@@ -120,7 +120,13 @@ defmodule Web.OIDCController do
   end
 
   defp provider_redirect(conn, account, provider, params) do
-    opts = [additional_params: %{prompt: "select_account"}]
+    opts =
+      case provider.__struct__ do
+        Domain.Google.AuthProvider -> [additional_params: %{prompt: "select_account"}]
+        Domain.Entra.AuthProvider -> [additional_params: %{prompt: "select_account"}]
+        Domain.Okta.AuthProvider -> [additional_params: %{prompt: "select_account"}]
+        _ -> []
+      end
 
     with {:ok, uri, state, verifier} <- Web.OIDC.authorization_uri(provider, opts) do
       cookie = %Web.Cookie.OIDC{

--- a/elixir/apps/web/lib/web/controllers/oidc_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/oidc_controller.ex
@@ -121,11 +121,14 @@ defmodule Web.OIDCController do
 
   defp provider_redirect(conn, account, provider, params) do
     opts =
-      case provider.__struct__ do
-        Domain.Google.AuthProvider -> [additional_params: %{prompt: "select_account"}]
-        Domain.Entra.AuthProvider -> [additional_params: %{prompt: "select_account"}]
-        Domain.Okta.AuthProvider -> [additional_params: %{prompt: "select_account"}]
-        _ -> []
+      if provider.__struct__ in [
+           Domain.Google.AuthProvider,
+           Domain.Entra.AuthProvider,
+           Domain.Okta.AuthProvider
+         ] do
+        [additional_params: %{prompt: "select_account"}]
+      else
+        []
       end
 
     with {:ok, uri, state, verifier} <- Web.OIDC.authorization_uri(provider, opts) do


### PR DESCRIPTION
Fixes an issue where some OIDC providers don't support the `select_account` prompt value.