### PR TITLE
fix(windows): allow auto-launching app after update

### DIFF
--- a/rust/gui-client/src-tauri/win_files/main.wxs
+++ b/rust/gui-client/src-tauri/win_files/main.wxs
@@ -357,7 +357,7 @@ component.
         </InstallExecuteSequence>
 
         <InstallExecuteSequence>
-          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP</Custom>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT REMOVE</Custom>
         </InstallExecuteSequence>
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>

--- a/rust/gui-client/src-tauri/win_files/main.wxs
+++ b/rust/gui-client/src-tauri/win_files/main.wxs
@@ -357,7 +357,7 @@ component.
         </InstallExecuteSequence>
 
         <InstallExecuteSequence>
-          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT Installed</Custom>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP</Custom>
         </InstallExecuteSequence>
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>


### PR DESCRIPTION
In order to be able automatically re-launch the app after an update when using the commandline installer, a user can set `AUTOLAUNCHAPP=1`. Except that this right now only works for the first install.

In our QA env, this creates a fair amount of friction where someone has to RDP into the VM every time we cut a new draft release and restart the client.

I am hoping that this change fixes that.