### PR TITLE
ci(data-plane): restore `mtime` of source code files

### DIFF
--- a/.github/actions/setup-rust-target-cache/action.yml
+++ b/.github/actions/setup-rust-target-cache/action.yml
@@ -10,6 +10,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Restore mtime for all files to avoid re-builds if they haven't changed.
+    # This requires `fetch-depth: 0` on the checkout action!
+    - uses: chetan/git-restore-mtime-action@bca85c11349c76b2dbac06d07edf6c2407dbab1e # v2.2
+
     - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         workspaces: rust

--- a/.github/actions/setup-rust-target-cache/action.yml
+++ b/.github/actions/setup-rust-target-cache/action.yml
@@ -16,5 +16,5 @@ runs:
         cache-targets: true
         cache-workspace-crates: true
         key: ${{ inputs.key }}
-        prefix-key: v1-rust
+        prefix-key: v2-rust
         save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -122,6 +122,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.sha }}
+          fetch-depth: 0 # To required to make `setup-rust-target-cache` effective.
       - uses: ./.github/actions/setup-rust-stable
         with:
           targets: ${{ matrix.target }}
@@ -227,6 +228,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.sha }}
+          fetch-depth: 0 # To required to make `setup-rust-target-cache` effective.
       - uses: ./.github/actions/ghcr-docker-login
         id: login
         with:

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: 0 # To required to make `setup-rust-target-cache` effective.
+          fetch-depth: 0 # Required to make `setup-rust-target-cache` effective.
       - uses: ./.github/actions/setup-rust-stable
         with:
           targets: ${{ matrix.target }}
@@ -228,7 +228,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: 0 # To required to make `setup-rust-target-cache` effective.
+          fetch-depth: 0 # Required to make `setup-rust-target-cache` effective.
       - uses: ./.github/actions/ghcr-docker-login
         id: login
         with:

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.sha }}
+          fetch-depth: 0 # To required to make `setup-rust-target-cache` effective.
 
       - uses: ./.github/actions/setup-rust-stable
         with:

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: 0 # To required to make `setup-rust-target-cache` effective.
+          fetch-depth: 0 # Required to make `setup-rust-target-cache` effective.
 
       - uses: ./.github/actions/setup-rust-stable
         with:


### PR DESCRIPTION
By default, Git does _not_ preserve the `mtime` attribute of source code files on checkout. This is by design as documented here [0].

Whilst good for a local development environment, this unfortunately breaks caching of build artifacts generated from our own source code because the cache will always be considered stale, even if the actual file itself was not modified. This results in unnecessarily long builds of our data-plane components, even if no Rust code has been changed at all.

To fix this, we leverage an already existing action that restores the `mtime` attribute of all files to when they were actually last modified in Git. With this in place (and setting `fetch-depth: 0` to actually have all the history available), the data-plane components rebuild essentially instantly and pretty much all of the remaining job duration is just setup and teardown of the environment.

[0]: https://archive.kernel.org/oldwiki/git.wiki.kernel.org/index.php/Git_FAQ.html#Why_isn.27t_Git_preserving_modification_time_on_files.3F