### PR TITLE
fix(portal): fix key error when creating gateway token

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -434,8 +434,7 @@ defmodule Web.Sites.NewToken do
 
     def create_token(site, subject) do
       with {:ok, token} <- Domain.Auth.create_gateway_token(site, subject) do
-        {:ok, %{token | secret_nonce: nil, secret_fragment: nil},
-         Domain.Auth.encode_fragment!(token)}
+        {:ok, %{token | secret_fragment: nil}, Domain.Auth.encode_fragment!(token)}
       end
     end
   end


### PR DESCRIPTION
When creating a gateway token we were attempting to set the key `secret_nonce`, however, gateway tokens don't have a nonce value.  This attempt to set the nonce key resulted in a crash, but only after the token had already been created in the DB.  When the process crashed, the liveview reloaded the page and started the process all over again.