### PR TITLE
fix(portal): only load CodeReloader listener if available

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -30,7 +30,8 @@ defmodule Firezone.MixProject do
   end
 
   defp listeners do
-    if Mix.env() == :dev do
+    # Dependabot complains about this dependency missing during its check - so only load it conditionally
+    if Code.ensure_loaded?(Phoenix.CodeReloader) do
       [Phoenix.CodeReloader]
     else
       []


### PR DESCRIPTION
In #11301 we tried to fix this, but it's a catch-22 between dev mode needing it and Dependabot puking about it.

So, we only load this listener if it seems to be available.