### PR TITLE
ci: call actionlint from pre-commit

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -55,3 +55,11 @@ repos:
     hooks:
       - id: cargo-sort
         args: ["--check", "--workspace", "rust/"]
+  - repo: local
+    hooks:
+      - id: actionlint
+        name: actionlint
+        entry: actionlint
+        language: system
+        types: [yaml]
+        files: ^\.github/workflows/

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,2 +1,3 @@
 pre-commit==4.5.0
 codespell==2.4.1
+pyflakes==3.4.0

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -57,12 +57,6 @@ jobs:
           fail: true
           args: --offline --verbose --no-progress **/*.md
 
-  actionlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: raven-actions/actionlint@963d4779ef039e217e5d0e6fd73ce9ab7764e493 # v2.1.0
-
   global-linter:
     runs-on: ubuntu-24.04
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -10,3 +10,6 @@ prettier 3.6.2
 
 # Bash unit testing
 bats 1.13.0
+
+# GitHub Actions linting
+actionlint 1.7.9


### PR DESCRIPTION
This way we can run actionlint locally.

Additionally, we can can reduce the number of jobs and pin the `actionlint` version more easily (the previous CI pin was pinning only the github workflow, not the actionlint itself, which was always 'latest').

Pyflakes dependency is for actionlint linting embedded Python code (optional dependency of actionlint).