### PR TITLE
fix(connlib): don't queue up exact dups of control messages

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -80,7 +80,7 @@ enum PortalCommand {
 impl Eventloop {
     pub(crate) fn new(
         tunnel: GatewayTunnel,
-        mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
+        mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         tun_device_manager: TunDeviceManager,
         resolver: TokioResolver,
     ) -> Result<Self> {
@@ -711,7 +711,7 @@ impl Eventloop {
 }
 
 async fn phoenix_channel_event_loop(
-    mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
+    mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     resolver: TokioResolver,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -99,7 +99,7 @@ impl Eventloop {
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         is_internet_resource_active: bool,
-        mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
+        mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
         resource_list_sender: watch::Sender<Vec<ResourceView>>,
         tun_config_sender: watch::Sender<Option<TunConfig>>,
@@ -486,7 +486,7 @@ impl Eventloop {
 }
 
 async fn phoenix_channel_event_loop(
-    mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
+    mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,

--- a/rust/libs/client-shared/src/lib.rs
+++ b/rust/libs/client-shared/src/lib.rs
@@ -4,6 +4,7 @@
 pub use connlib_model::StaticSecret;
 pub use eventloop::DisconnectError;
 pub use tunnel::TunConfig;
+use tunnel::messages::client::EgressMessages;
 pub use tunnel::messages::client::{IngressMessages, ResourceDescription};
 
 use anyhow::Result;
@@ -54,7 +55,7 @@ impl Session {
     pub fn connect(
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
-        portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
+        portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         is_internet_resource_active: bool,
         handle: tokio::runtime::Handle,
     ) -> (Self, EventStream) {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -318,7 +318,7 @@ where
     }
 
     /// Send a message to a topic.
-    pub fn send(&mut self, topic: impl Into<String>, message: impl Serialize) -> OutboundRequestId {
+    pub fn send(&mut self, topic: impl Into<String>, message: impl Serialize) {
         if self.pending_messages.len() > MAX_BUFFERED_MESSAGES {
             self.pending_messages.clear();
 
@@ -327,10 +327,8 @@ where
             );
         }
 
-        let (id, msg) = self.make_message(topic, message);
+        let (_, msg) = self.make_message(topic, message);
         self.pending_messages.push_back(msg);
-
-        id
     }
 
     /// Establishes a new connection, dropping the current one if any exists.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -37,11 +37,12 @@ pub use tokio_tungstenite::tungstenite::http::StatusCode;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
 
-pub struct PhoenixChannel<TInitReq, TInboundMsg, TFinish> {
+pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     state: State,
     waker: Option<Waker>,
     pending_joins: VecDeque<String>,
-    pending_messages: VecDeque<String>,
+    pending_messages: VecDeque<PhoenixMessage<TOutboundMsg>>,
+    pending_heartbeat: Option<String>,
     next_request_id: u64,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 
@@ -255,9 +256,11 @@ impl fmt::Display for OutboundRequestId {
 #[error("Cannot close websocket while we are connecting")]
 pub struct Connecting;
 
-impl<TInitReq, TInboundMsg, TFinish> PhoenixChannel<TInitReq, TInboundMsg, TFinish>
+impl<TInitReq, TOutboundMsg, TInboundMsg, TFinish>
+    PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish>
 where
     TInitReq: Serialize + Clone,
+    TOutboundMsg: Serialize,
     TInboundMsg: DeserializeOwned,
     TFinish: IntoIterator<Item = (&'static str, String)>,
 {
@@ -295,6 +298,7 @@ where
             waker: None,
             pending_joins: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
             pending_messages: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
+            pending_heartbeat: None,
             _phantom: PhantomData,
             heartbeat: tokio::time::interval(Duration::from_secs(30)),
             next_request_id: 0,
@@ -309,8 +313,9 @@ where
     /// Join the provided room.
     ///
     /// If successful, a [`Event::JoinedRoom`] event will be emitted.
-    pub fn join(&mut self, topic: impl Into<String>, payload: impl Serialize) {
-        let (request_id, msg) = self.make_message(topic, EgressControlMessage::PhxJoin(payload));
+    pub fn join(&mut self, topic: impl Into<String>, payload: TInitReq) {
+        let (request_id, msg) =
+            self.make_control_message(topic, EgressControlMessage::PhxJoin(payload));
 
         self.pending_joins.push_back(msg);
         self.pending_join_requests
@@ -318,7 +323,7 @@ where
     }
 
     /// Send a message to a topic.
-    pub fn send(&mut self, topic: impl Into<String>, message: impl Serialize) {
+    pub fn send(&mut self, topic: impl Into<String>, message: TOutboundMsg) {
         if self.pending_messages.len() > MAX_BUFFERED_MESSAGES {
             self.pending_messages.clear();
 
@@ -327,8 +332,13 @@ where
             );
         }
 
-        let (_, msg) = self.make_message(topic, message);
-        self.pending_messages.push_back(msg);
+        let request_id = self.fetch_add_request_id();
+
+        self.pending_messages.push_back(PhoenixMessage::new_message(
+            topic,
+            message,
+            Some(request_id),
+        ));
     }
 
     /// Establishes a new connection, dropping the current one if any exists.
@@ -513,6 +523,19 @@ where
             // Priority 2: Keep local buffers small and send pending messages.
             match stream.poll_ready_unpin(cx) {
                 Poll::Ready(Ok(())) => {
+                    if let Some(heartbeat) = self.pending_heartbeat.take() {
+                        match stream.start_send_unpin(Message::Text(heartbeat.clone().into())) {
+                            Ok(()) => {
+                                tracing::trace!(target: "wire::api::send", %heartbeat);
+                            }
+                            Err(e) => {
+                                self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                            }
+                        }
+
+                        continue;
+                    }
+
                     if let Some(join) = self.pending_joins.pop_front() {
                         match stream.start_send_unpin(Message::Text(join.clone().into())) {
                             Ok(()) => {
@@ -531,9 +554,15 @@ where
 
                     if self.pending_join_requests.is_empty() {
                         if let Some(msg) = self.pending_messages.pop_front() {
-                            match stream.start_send_unpin(Message::Text(msg.clone().into())) {
+                            let serialized_msg = serde_json::to_string(&msg)
+                                .map_err(io::Error::other)
+                                .map_err(Error::FatalIo)?;
+
+                            match stream
+                                .start_send_unpin(Message::Text(serialized_msg.clone().into()))
+                            {
                                 Ok(()) => {
-                                    tracing::trace!(target: "wire::api::send", %msg);
+                                    tracing::trace!(target: "wire::api::send", msg = %serialized_msg);
 
                                     self.heartbeat.reset()
                                 }
@@ -674,7 +703,10 @@ where
             // Priority 4: Handle heartbeats.
             match self.heartbeat.poll_tick(cx) {
                 Poll::Ready(_) => {
-                    self.send("phoenix", EgressControlMessage::<()>::Heartbeat(Empty {}));
+                    let (_, heartbeat) = self
+                        .make_control_message("phoenix", EgressControlMessage::Heartbeat(Empty {}));
+
+                    self.pending_heartbeat = Some(heartbeat);
 
                     return Poll::Ready(Ok(Event::HeartbeatSent));
                 }
@@ -692,10 +724,10 @@ where
         self.state = State::Connecting(future::ready(Err(e)).boxed())
     }
 
-    fn make_message(
+    fn make_control_message(
         &mut self,
         topic: impl Into<String>,
-        payload: impl Serialize,
+        payload: EgressControlMessage<TInitReq>,
     ) -> (OutboundRequestId, String) {
         let request_id = self.fetch_add_request_id();
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -117,13 +117,125 @@ async fn client_does_not_pipeline_messages() {
     join_res.unwrap();
 }
 
+#[tokio::test]
+async fn client_deduplicates_messages() {
+    use std::{str::FromStr, sync::Arc, time::Duration};
+
+    use backoff::exponential::ExponentialBackoff;
+    use futures::{SinkExt, StreamExt};
+    use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, PublicKeyParam};
+    use secrecy::SecretString;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+    use url::Url;
+
+    let _guard = logging::test("debug,wire::api=trace");
+
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        loop {
+            match ws.next().await {
+                Some(Ok(Message::Text(text))) => match text.as_str() {
+                    r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
+                        ws.send(Message::text(
+                            r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#,
+                        )).await.unwrap();
+                    }
+                    // We only handle the message with `ref: 1` and thus guarantee that not more than 1 is received
+                    r#"{"topic":"test","event":"bar","ref":1}"# => {
+                        ws.send(Message::text(
+                            r#"{"topic":"test","event":"foo","payload":null}"#,
+                        ))
+                        .await
+                        .unwrap();
+                    }
+                    other => panic!("Unexpected message: {other}"),
+                },
+                Some(Ok(Message::Close(_))) => continue,
+                Some(other) => {
+                    panic!("Unexpected message: {other:?}")
+                }
+                None => break,
+            }
+        }
+    });
+
+    let login_url = SecretBox::init_with(|| {
+        LoginUrl::client(
+            Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
+            &SecretString::from("secret"),
+            String::new(),
+            None,
+            DeviceInfo::default(),
+        )
+        .unwrap()
+    });
+
+    let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
+        login_url,
+        "test/1.0.0".to_owned(),
+        "test",
+        (),
+        ExponentialBackoff::default,
+        Arc::new(socket_factory::tcp),
+    )
+    .unwrap();
+
+    let mut num_responses = 0;
+
+    let client = async {
+        channel.connect(PublicKeyParam([0u8; 32]));
+
+        loop {
+            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+                phoenix_channel::Event::SuccessResponse { .. } => {}
+                phoenix_channel::Event::ErrorResponse { res, .. } => {
+                    panic!("Unexpected error: {res:?}")
+                }
+                phoenix_channel::Event::JoinedRoom { .. } => {
+                    channel.send("test", OutboundMsg::Bar);
+                    channel.send("test", OutboundMsg::Bar);
+                    channel.send("test", OutboundMsg::Bar);
+                    channel.send("test", OutboundMsg::Bar);
+                }
+                phoenix_channel::Event::HeartbeatSent => {}
+                phoenix_channel::Event::InboundMessage {
+                    msg: InboundMsg::Foo,
+                    ..
+                } => {
+                    num_responses += 1;
+                }
+                phoenix_channel::Event::Hiccup { error, .. } => {
+                    panic!("Unexpected hiccup: {error:?}")
+                }
+                phoenix_channel::Event::Closed => break,
+            }
+        }
+    };
+
+    let _ = tokio::time::timeout(
+        Duration::from_secs(2),
+        futures::future::join(server, client),
+    )
+    .await
+    .unwrap_err(); // We expect to timeout because we don't ever exit from the tasks.
+
+    assert_eq!(num_responses, 1);
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 enum InboundMsg {
     Foo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 enum OutboundMsg {
     Bar,

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -72,7 +72,7 @@ async fn client_does_not_pipeline_messages() {
         .unwrap()
     });
 
-    let mut channel = PhoenixChannel::<(), InboundMsg, _>::disconnected(
+    let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
         login_url,
         "test/1.0.0".to_owned(),
         "test",

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -156,7 +156,7 @@ pub enum IngressMessages {
     FlowCreationFailed(FlowCreationFailed),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct GatewaysIceCandidates {
     /// The list of gateway IDs these candidates will be broadcast to.
     pub gateway_ids: Vec<GatewayId>,
@@ -175,7 +175,7 @@ pub struct GatewayIceCandidates {
 }
 
 // These messages can be sent from a client to a control pane
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 // enum_variant_names: These are the names in the portal!
 pub enum EgressMessages {

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -263,7 +263,7 @@ pub struct AccessAuthorizationExpiryUpdated {
 }
 
 /// A client's ice candidate message.
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct ClientsIceCandidates {
     /// Client's id the ice candidates are meant for
     pub client_ids: Vec<ClientId>,
@@ -284,7 +284,7 @@ pub struct ClientIceCandidates {
 
 // These messages can be sent from a gateway
 // to a control pane.
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 pub enum EgressMessages {
     ConnectionReady(ConnectionReady), // Deprecated.
@@ -296,7 +296,7 @@ pub enum EgressMessages {
     },
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct ConnectionReady {
     #[serde(rename = "ref")]
     pub reference: String,

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -416,7 +416,7 @@ struct Eventloop<R> {
     sockets: Sockets,
 
     server: Server<R>,
-    channel: Option<PhoenixChannel<JoinMessage, IngressMessage, NoParams>>,
+    channel: Option<PhoenixChannel<JoinMessage, (), IngressMessage, NoParams>>,
     sleep: Sleep,
 
     ebpf: Option<ebpf::Program>,
@@ -438,7 +438,7 @@ where
     fn new(
         server: Server<R>,
         ebpf: Option<ebpf::Program>,
-        channel: PhoenixChannel<JoinMessage, IngressMessage, NoParams>,
+        channel: PhoenixChannel<JoinMessage, (), IngressMessage, NoParams>,
         public_address: IpStack,
         last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
     ) -> Result<Self> {


### PR DESCRIPTION
When we are network-partitioned from the portal, we are queuing up control messages and send them as soon as we are back online. In case the user tried to connect to something in the meantime, this meant that likely identical `create_flow` messages got queued and are flushed to the portal all at once. This is unnecessary, we only really need to send one of those.

This semantic actually applies to all messages that we send. If we have an exact duplicate of a message already queued, we do not need to queue another one.