### PR TITLE
fix(portal): fix/add links for auth/sync docs

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/authentication.ex
+++ b/elixir/apps/web/lib/web/live/settings/authentication.ex
@@ -382,7 +382,7 @@ defmodule Web.Settings.Authentication do
     </.breadcrumbs>
     <.section>
       <:title>Authentication Providers</:title>
-      <:action><.docs_action path="/guides/settings/authentication" /></:action>
+      <:action><.docs_action path="/authentication" /></:action>
       <:action>
         <.add_button patch={~p"/#{@account}/settings/authentication/select_type"}>
           Add Provider
@@ -484,7 +484,9 @@ defmodule Web.Settings.Authentication do
       on_close="close_modal"
       confirm_disabled={not @form.source.valid?}
     >
-      <:title icon={@type}>Add {titleize(@type)} Provider</:title>
+      <:title icon={@type}>
+        Add {titleize(@type)} Provider <.docs_action path={"/authenticate/#{@type}"} />
+      </:title>
       <:body>
         <.provider_form
           account_id={@account.id}
@@ -506,7 +508,9 @@ defmodule Web.Settings.Authentication do
         not @form.source.valid? or Enum.empty?(@form.source.changes) or not verified?(@form)
       }
     >
-      <:title icon={@type}>Edit {@provider_name}</:title>
+      <:title icon={@type}>
+        Edit {@provider_name} <.docs_action path={"/authenticate/#{@type}"} />
+      </:title>
       <:body>
         <.flash :if={assigns[:is_legacy]} kind={:warning_inline}>
           This provider uses legacy configuration. We recommend setting up a new authentication provider

--- a/elixir/apps/web/lib/web/live/settings/directory_sync.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_sync.ex
@@ -326,7 +326,7 @@ defmodule Web.Settings.DirectorySync do
     <%= if Domain.Account.idp_sync_enabled?(@account) do %>
       <.section>
         <:title>Directories</:title>
-        <:action><.docs_action path="/guides/settings/directory-sync" /></:action>
+        <:action><.docs_action path="/directory-sync" /></:action>
         <:action>
           <.add_button patch={~p"/#{@account}/settings/directory_sync/select_type"}>
             Add Directory
@@ -352,7 +352,7 @@ defmodule Web.Settings.DirectorySync do
     <% else %>
       <.section>
         <:title>Directories</:title>
-        <:action><.docs_action path="/guides/settings/directory-sync" /></:action>
+        <:action><.docs_action path="/directory-sync" /></:action>
         <:content>
           <div class="relative">
             <!-- Blurred preview content -->
@@ -497,7 +497,9 @@ defmodule Web.Settings.DirectorySync do
       on_close="close_modal"
       confirm_disabled={not @form.source.valid?}
     >
-      <:title icon={@type}>Add {titleize(@type)} Directory</:title>
+      <:title icon={@type}>
+        Add {titleize(@type)} Directory <.docs_action path={"/directory-sync/#{@type}"} />
+      </:title>
       <:body>
         <.directory_form
           verification_error={@verification_error}
@@ -520,7 +522,9 @@ defmodule Web.Settings.DirectorySync do
         not @form.source.valid? or Enum.empty?(@form.source.changes) or not verified?(@form)
       }
     >
-      <:title icon={@type}>Edit {@directory_name}</:title>
+      <:title icon={@type}>
+        Edit {@directory_name} <.docs_action path={"/directory-sync/#{@type}"} />
+      </:title>
       <:body>
         <.flash :if={assigns[:is_legacy]} kind={:warning_inline}>
           This directory uses legacy credentials and needs to be updated to use Firezone's shared service account.


### PR DESCRIPTION
Adds docs links icons for each auth/sync provider and fixes the existing ones.

<img width="762" height="641" alt="Screenshot 2025-12-21 at 9 26 59 PM" src="https://github.com/user-attachments/assets/771702c6-4a6a-4562-a967-661a3d889127" />
<img width="781" height="918" alt="Screenshot 2025-12-21 at 9 26 51 PM" src="https://github.com/user-attachments/assets/9c1ef7f3-33b8-4eba-9b51-cb9fce6e9a23" />
