### PR TITLE
fix(portal): sync empty state

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/directory_sync.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_sync.ex
@@ -336,17 +336,32 @@ defmodule Web.Settings.DirectorySync do
           Directories sync users and groups from an external source.
         </:help>
         <:content>
-          <div class="flex flex-wrap gap-4">
-            <%= for directory <- @directories do %>
-              <.directory_card
-                type={directory_type(directory)}
-                account={@account}
-                directory={directory}
-                subject={@subject}
-                is_legacy={directory.is_legacy}
-              />
-            <% end %>
-          </div>
+          <%= if Enum.empty?(@directories) do %>
+            <div class="flex justify-center text-center text-neutral-500 p-4">
+              <div class="w-auto pb-4">
+                No directories configured.
+                <.link
+                  class={[link_style()]}
+                  patch={~p"/#{@account}/settings/directory_sync/select_type"}
+                >
+                  Add a directory
+                </.link>
+                to sync users and groups from your identity provider.
+              </div>
+            </div>
+          <% else %>
+            <div class="flex flex-wrap gap-4">
+              <%= for directory <- @directories do %>
+                <.directory_card
+                  type={directory_type(directory)}
+                  account={@account}
+                  directory={directory}
+                  subject={@subject}
+                  is_legacy={directory.is_legacy}
+                />
+              <% end %>
+            </div>
+          <% end %>
         </:content>
       </.section>
     <% else %>


### PR DESCRIPTION
Adds an empty state the settings/directory_sync view.

<img width="1357" height="196" alt="Screenshot 2025-12-21 at 9 31 22 PM" src="https://github.com/user-attachments/assets/d1931d0b-a76d-4f70-ab87-a33bcf6a2bda" />
