### PR TITLE
ci: add retries to Rust setup actions

### DIFF
--- a/.github/actions/setup-rust-sccache/action.yml
+++ b/.github/actions/setup-rust-sccache/action.yml
@@ -21,6 +21,24 @@ runs:
 
     - name: Start sccache
       run: $SCCACHE_PATH --start-server
+      continue-on-error: true
+      id: sccache-1
+      shell: bash
+      env:
+        SCCACHE_CONF: ".github/actions/setup-rust-sccache/sccache.toml"
+
+    - name: Start sccache
+      continue-on-error: true
+      run: $SCCACHE_PATH --start-server
+      if: ${{ steps.sccache-1.outcome == 'failure' }}
+      id: sccache-2
+      shell: bash
+      env:
+        SCCACHE_CONF: ".github/actions/setup-rust-sccache/sccache.toml"
+
+    - name: Start sccache
+      run: $SCCACHE_PATH --start-server
+      if: ${{ steps.sccache-2.outcome == 'failure' }}
       shell: bash
       env:
         SCCACHE_CONF: ".github/actions/setup-rust-sccache/sccache.toml"

--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -37,7 +37,26 @@ runs:
       shell: bash
 
     - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
-      id: toolchain
+      id: toolchain-1
+      continue-on-error: true
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        components: rustfmt,clippy,llvm-tools-preview
+        target: ${{ inputs.targets }}
+        cache: false # We explicitly configure caching somewhere else.
+
+    - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+      if: ${{ steps.toolchain-1.outcome == 'failure' }}
+      continue-on-error: true
+      id: toolchain-2
+      with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
+        components: rustfmt,clippy,llvm-tools-preview
+        target: ${{ inputs.targets }}
+        cache: false # We explicitly configure caching somewhere else.
+
+    - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+      if: ${{ steps.toolchain-2.outcome == 'failure' }}
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy,llvm-tools-preview


### PR DESCRIPTION
The Windows runners appear to be plagued by bad IO. To mitigate this, we add retries to actions that recently failed.

Fixes: #11437