### PR TITLE
ci: include hash of all Rust source files in cache key

### DIFF
--- a/.github/actions/setup-rust-target-cache/action.yml
+++ b/.github/actions/setup-rust-target-cache/action.yml
@@ -19,6 +19,6 @@ runs:
         workspaces: rust
         cache-targets: true
         cache-workspace-crates: true
-        key: ${{ inputs.key }}
+        key: ${{ inputs.key }}-${{ hashFiles('rust/**/*.rs') }}
         prefix-key: v2-rust
         save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main


### PR DESCRIPTION
Typically, only the hash of lockfiles is incorporated into the cache key. In order to also cache the result of workspace crates to the point where we do not rebuild anything at all, we need to incorporate the Rust source files as well into the cache key. Otherwise, no new cache is saved for changes to Rust files that don't touch the lockfiles.