### PR TITLE
fix(portal): redact legacy service account key

### DIFF
--- a/elixir/apps/domain/lib/domain/google/directory.ex
+++ b/elixir/apps/domain/lib/domain/google/directory.ex
@@ -25,7 +25,7 @@ defmodule Domain.Google.Directory do
     field :error_message, :string
     field :error_email_count, :integer, default: 0, read_after_writes: true
     field :is_verified, :boolean, default: false, read_after_writes: true
-    field :legacy_service_account_key, :map
+    field :legacy_service_account_key, :map, redact: true
 
     timestamps()
   end


### PR DESCRIPTION
Will keep this out of logs.