### PR TITLE
fix(portal): delete client_tokens when account is disabled

### DIFF
--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -157,8 +157,7 @@ defmodule Domain.Auth do
   # Portal Sessions
 
   def create_portal_session(
-        account_id,
-        actor_id,
+        %Domain.Actor{type: :account_admin_user, account_id: account_id, id: actor_id},
         auth_provider_id,
         %Context{} = context,
         expires_at

--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -129,7 +129,7 @@
   </.flash>
 
   <.flash :if={not Domain.Account.active?(@account)} kind={:error} class="m-1">
-    This account has been disabled.
+    This account has been disabled and clients will not be able to connect.
     <span>
       Please
       <.link

--- a/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/email_otp_controller.ex
@@ -186,8 +186,7 @@ defmodule Web.EmailOTPController do
     case type do
       :portal ->
         Auth.create_portal_session(
-          actor.account_id,
-          actor.id,
+          actor,
           provider.id,
           context,
           expires_at

--- a/elixir/apps/web/lib/web/controllers/oidc_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/oidc_controller.ex
@@ -308,8 +308,7 @@ defmodule Web.OIDCController do
     case type do
       :portal ->
         Domain.Auth.create_portal_session(
-          identity.account_id,
-          identity.actor_id,
+          identity.actor,
           provider.id,
           context,
           expires_at

--- a/elixir/apps/web/lib/web/controllers/userpass_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/userpass_controller.ex
@@ -86,8 +86,7 @@ defmodule Web.UserpassController do
     case type do
       :portal ->
         Domain.Auth.create_portal_session(
-          actor.account_id,
-          actor.id,
+          actor,
           provider.id,
           context,
           expires_at

--- a/elixir/apps/web/test/support/conn_case.ex
+++ b/elixir/apps/web/test/support/conn_case.ex
@@ -73,8 +73,7 @@ defmodule Web.ConnCase do
 
     {:ok, session} =
       Domain.Auth.create_portal_session(
-        actor.account_id,
-        actor.id,
+        actor,
         auth_provider.id,
         context,
         expires_at


### PR DESCRIPTION
When an account is disabled, we need to:

- Disconnect all clients
- Show a banner
- Continue to allow admins to sign in and Gateways to remain connected

This PR fixes an issue where clients weren't disconnected, and adds tests to ensure all of the above.

We also apply a minor refactor in this PR to ensure portal_sessions can only be created by `account_admin_user` actor types.

Fixes #11108 