### PR TITLE
fix(portal): always use 'true' for checkbox value

### DIFF
--- a/elixir/apps/domain/test/domain/repo/filter_test.old
+++ b/elixir/apps/domain/test/domain/repo/filter_test.old
@@ -152,18 +152,6 @@ defmodule Domain.Repo.FilterTest do
                {:error, {:invalid_value, values: filter.values, value: "baz"}}
     end
 
-    test "validates that all values are whitelisted" do
-      filter = %Filter{
-        type: {:list, :string},
-        values: [{"Foo", "foo"}, {"Bar", "bar"}]
-      }
-
-      assert validate_value(filter, ["foo", "bar"]) == :ok
-
-      assert validate_value(filter, ["foo", "baz"]) ==
-               {:error, {:invalid_value, values: filter.values, value: ["foo", "baz"]}}
-    end
-
     test "returns error when type is invalid" do
       for {type, value} <- [
             {:string, 100},

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -153,8 +153,6 @@ defmodule Web.FormComponents do
         Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
       end)
 
-    dbg(assigns[:value])
-
     ~H"""
     <div>
       <input :if={@unchecked_value} type="hidden" name={@name} value={@unchecked_value} />

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -153,6 +153,8 @@ defmodule Web.FormComponents do
         Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
       end)
 
+    dbg(assigns[:value])
+
     ~H"""
     <div>
       <input :if={@unchecked_value} type="hidden" name={@name} value={@unchecked_value} />
@@ -161,7 +163,7 @@ defmodule Web.FormComponents do
           type="checkbox"
           id={@id}
           name={@name}
-          value={@value || "true"}
+          value="true"
           checked={@checked}
           class={[
             "bg-neutral-50",

--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -661,7 +661,6 @@ defmodule Web.Policies.Components do
             id="policy_conditions_client_verified_value"
             disabled={@disabled}
             checked={List.first(List.wrap(condition_form[:values].value)) == "true"}
-            value="true"
             unchecked_value={nil}
           />
         </div>

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -144,7 +144,6 @@ defmodule Web.Resources.Components do
               type="checkbox"
               name={"#{@form.name}[tcp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :tcp)}
-              value="true"
               disabled={!@traffic_filters_enabled?}
               label="TCP"
             />
@@ -175,7 +174,6 @@ defmodule Web.Resources.Components do
               type="checkbox"
               name={"#{@form.name}[udp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :udp)}
-              value="true"
               disabled={!@traffic_filters_enabled?}
               label="UDP"
             />
@@ -208,7 +206,6 @@ defmodule Web.Resources.Components do
               type="checkbox"
               name={"#{@form.name}[icmp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :icmp)}
-              value="true"
               disabled={!@traffic_filters_enabled?}
               label="ICMP echo"
             />

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -393,7 +393,7 @@ defmodule Web.Sites.Show do
                 >
                   Add a policy
                 </.link>
-                to configure access to the internet.
+                to configure secure access to the internet.
               </div>
             </div>
           </:empty>
@@ -647,11 +647,6 @@ defmodule Web.Sites.Show do
           type: {:string, :uuid},
           values: [],
           fun: &filter_by_site_id/2
-        },
-        %Domain.Repo.Filter{
-          name: :type,
-          type: {:list, :string},
-          fun: &filter_by_type/2
         }
       ]
     end
@@ -667,14 +662,6 @@ defmodule Web.Sites.Show do
 
     def filter_by_site_id(queryable, site_id) do
       {queryable, dynamic([resources: resources], resources.site_id == ^site_id)}
-    end
-
-    def filter_by_type(queryable, {:not_in, types}) do
-      {queryable, dynamic([resources: resources], resources.type not in ^types)}
-    end
-
-    def filter_by_type(queryable, types) do
-      {queryable, dynamic([resources: resources], resources.type in ^types)}
     end
   end
 

--- a/elixir/apps/web/lib/web/live_table.ex
+++ b/elixir/apps/web/lib/web/live_table.ex
@@ -382,66 +382,6 @@ defmodule Web.LiveTable do
     """
   end
 
-  defp filter(%{filter: %{type: {:list, :string}, values: values}} = assigns)
-       when values != [] and length(values) < 5 do
-    ~H"""
-    <div class="flex items-center order-first">
-      <div class="flex rounded w-full" role="group">
-        <.intersperse_blocks>
-          <:item>
-            <label
-              for={"#{@live_table_id}-#{@filter.name}-__all__"}
-              class={[
-                "px-4 py-2 text-sm border-neutral-300 text-neutral-900",
-                "hover:bg-neutral-200 hover:text-neutral-700",
-                "cursor-pointer",
-                "border-y border-l rounded-l",
-                is_nil(@form[@filter.name].value) && "bg-neutral-100"
-              ]}
-            >
-              <.input
-                id={"#{@live_table_id}-#{@filter.name}-__all__"}
-                type="checkbox"
-                field={@form[@filter.name]}
-                name={"_reset:" <> @form[@filter.name].name}
-                value={true}
-                checked={is_nil(@form[@filter.name].value)}
-                class="hidden"
-              /> All
-            </label>
-          </:item>
-
-          <:item :let={position} :for={{label, value} <- @filter.values}>
-            <label
-              for={"#{@live_table_id}-#{@filter.name}-#{value}"}
-              class={[
-                "px-4 py-2 text-sm border-neutral-300 text-neutral-900",
-                "hover:bg-neutral-200 hover:text-neutral-700",
-                "cursor-pointer",
-                @form[@filter.name].value && value in @form[@filter.name].value && "bg-neutral-100",
-                position == :first && "border-y border-l rounded-l",
-                position == :last && "border-y border-r rounded-r",
-                position != :first && position != :last && "border"
-              ]}
-            >
-              <.input
-                id={"#{@live_table_id}-#{@filter.name}-#{value}"}
-                type="checkbox"
-                field={@form[@filter.name]}
-                name={@form[@filter.name].name <> "[]"}
-                value={value}
-                checked={@form[@filter.name].value && value in @form[@filter.name].value}
-                class="hidden"
-              />
-              {label}
-            </label>
-          </:item>
-        </.intersperse_blocks>
-      </div>
-    </div>
-    """
-  end
-
   defp filter(%{filter: %{type: :string, values: values}} = assigns) when values != [] do
     ~H"""
     <div class="flex items-center order-4">

--- a/elixir/apps/web/test/web/live_table_test.old
+++ b/elixir/apps/web/test/web/live_table_test.old
@@ -216,56 +216,6 @@ defmodule Web.LiveTableTest do
              ]
     end
 
-    test "renders checkbox-like buttons for multi-select from up to 5 values", %{assigns: assigns} do
-      assigns = %{
-        assigns
-        | filters: [
-            %Domain.Repo.Filter{
-              name: :btn,
-              title: "Button",
-              type: {:list, :string},
-              values: [
-                {"One", "1"},
-                {"Two", "2"}
-              ]
-            }
-          ],
-          filter: filter_to_form(%{id: "1"}, "table-id")
-      }
-
-      form =
-        render_component(&live_table/1, assigns)
-        |> Floki.parse_fragment!()
-        |> Floki.find("form")
-
-      assert Floki.attribute(form, "id") == ["table-id-filters"]
-      assert Floki.attribute(form, "phx-change") == ["filter"]
-
-      input = form |> Floki.find("input[type=hidden]")
-      assert Floki.attribute(input, "name") == ["table_id"]
-      assert Floki.attribute(input, "value") == ["table-id"]
-
-      radio = form |> Floki.find("input[type=checkbox]")
-
-      assert Floki.attribute(radio, "id") == [
-               "table-id-btn-__all__",
-               "table-id-btn-1",
-               "table-id-btn-2"
-             ]
-
-      assert Floki.attribute(radio, "name") == [
-               "_reset:table-id[btn]",
-               "table-id[btn][]",
-               "table-id[btn][]"
-             ]
-
-      assert Floki.attribute(radio, "value") == [
-               "value",
-               "1",
-               "2"
-             ]
-    end
-
     test "renders value dropdown when there are more than 5 values", %{assigns: assigns} do
       assigns = %{
         assigns


### PR DESCRIPTION
When the live_table component was introduced, it exposed a `value` attribute to be passed into a checkbox in order to use for a multi-select style live table filter.

But those filters never got used.

What also happened is it introduced a bug wherein if you don't explicitly pass a `value="true"`, the checkbox state would be lost on LiveView DOM updates since _another_ change we made to all `input` components just above would set `value` to `""` if it was `nil` or not provided.

This meant that all checkboxes that don't explicitly pass `value="true"` would effectively have a bug where they lose their checked state on any form change.

Since we don't have a multi-select type of live table filter (and let's be honest, we need to rip it out anyway), we can unwind this ball of yarn by deleting the relevant live_table code and reverting checkboxes to always send `value="true"`.

Fixes #11418 