### PR TITLE
test(portal): fix & enable live_table tests

### DIFF
--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -153,8 +153,6 @@ defmodule PortalWeb.FormComponents do
         Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
       end)
 
-    dbg(assigns[:value])
-
     ~H"""
     <div>
       <input :if={@unchecked_value} type="hidden" name={@name} value={@unchecked_value} />

--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -153,6 +153,8 @@ defmodule PortalWeb.FormComponents do
         Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
       end)
 
+    dbg(assigns[:value])
+
     ~H"""
     <div>
       <input :if={@unchecked_value} type="hidden" name={@name} value={@unchecked_value} />

--- a/elixir/test/portal_web/live_table_test.exs
+++ b/elixir/test/portal_web/live_table_test.exs
@@ -1,13 +1,7 @@
-<<<<<<<< HEAD:elixir/test/portal_web/live_table_test.old
 defmodule PortalWeb.LiveTableTest do
   use PortalWeb.ConnCase, async: true
   import PortalWeb.LiveTable
-========
-defmodule Web.LiveTableTest do
-  use Web.ConnCase, async: true
-  import Web.LiveTable
-  import Domain.SubjectFixtures
->>>>>>>> 7c4afa0ce (test(portal): fix & enable live_table tests):elixir/test/portal_web/live_table_test.exs
+  import Portal.SubjectFixtures
 
   describe "<.live_table /> component" do
     setup do

--- a/elixir/test/support/conn_case.ex
+++ b/elixir/test/support/conn_case.ex
@@ -51,6 +51,26 @@ defmodule PortalWeb.ConnCase do
     MapSet.equal?(MapSet.new(list1), MapSet.new(list2))
   end
 
+  @doc """
+  Sets up socket assigns for URI-based navigation, simulating what
+  the SetCurrentUri hook does during handle_params.
+  """
+  def put_uri_assigns(socket, uri) do
+    parsed = URI.parse(uri)
+
+    query_params =
+      if parsed.query do
+        URI.decode_query(parsed.query)
+      else
+        %{}
+      end
+
+    Phoenix.Component.assign(socket,
+      current_path: parsed.path,
+      query_params: query_params
+    )
+  end
+
   def flash(conn, key) do
     Phoenix.Flash.get(conn.assigns.flash, key)
   end


### PR DESCRIPTION
Mostly just needed the new `current_path` and `query_params` assigns to be set, and subject fixture used.