### PR TITLE
ci: add retry command to setup-docker

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -66,6 +66,32 @@ runs:
         echo "Docker binaries installed successfully"
         docker --version
 
+    - name: Install retry script
+      shell: bash
+      run: |
+        cat <<'EOF' | sudo tee /usr/local/bin/retry
+        #!/bin/bash
+        set -euo pipefail
+
+        max_attempts="${RETRY_MAX_ATTEMPTS:-5}"
+        delay="${RETRY_DELAY:-5}"
+        attempt=1
+
+        while true; do
+          if "$@"; then
+            exit 0
+          fi
+          if [[ $attempt -ge $max_attempts ]]; then
+            echo "Command failed after $max_attempts attempts: $*" >&2
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts failed, retrying in ${delay}s..." >&2
+          sleep $delay
+          attempt=$((attempt + 1))
+        done
+        EOF
+        sudo chmod +x /usr/local/bin/retry
+
     - name: Configure and start Docker daemon
       shell: bash
       run: |

--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -66,32 +66,6 @@ runs:
         echo "Docker binaries installed successfully"
         docker --version
 
-    - name: Install retry script
-      shell: bash
-      run: |
-        cat <<'EOF' | sudo tee /usr/local/bin/retry
-        #!/bin/bash
-        set -euo pipefail
-
-        max_attempts="${RETRY_MAX_ATTEMPTS:-5}"
-        delay="${RETRY_DELAY:-5}"
-        attempt=1
-
-        while true; do
-          if "$@"; then
-            exit 0
-          fi
-          if [[ $attempt -ge $max_attempts ]]; then
-            echo "Command failed after $max_attempts attempts: $*" >&2
-            exit 1
-          fi
-          echo "Attempt $attempt/$max_attempts failed, retrying in ${delay}s..." >&2
-          sleep $delay
-          attempt=$((attempt + 1))
-        done
-        EOF
-        sudo chmod +x /usr/local/bin/retry
-
     - name: Configure and start Docker daemon
       shell: bash
       run: |

--- a/.github/actions/setup-rust-sccache/action.yml
+++ b/.github/actions/setup-rust-sccache/action.yml
@@ -19,26 +19,11 @@ runs:
         echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
         echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
 
-    - name: Start sccache
-      run: $SCCACHE_PATH --start-server
-      continue-on-error: true
-      id: sccache-1
-      shell: bash
-      env:
-        SCCACHE_CONF: ".github/actions/setup-rust-sccache/sccache.toml"
+    - uses: /.github/actions/setup-scripts
 
     - name: Start sccache
+      run: retry $SCCACHE_PATH --start-server
       continue-on-error: true
-      run: $SCCACHE_PATH --start-server
-      if: ${{ steps.sccache-1.outcome == 'failure' }}
-      id: sccache-2
-      shell: bash
-      env:
-        SCCACHE_CONF: ".github/actions/setup-rust-sccache/sccache.toml"
-
-    - name: Start sccache
-      run: $SCCACHE_PATH --start-server
-      if: ${{ steps.sccache-2.outcome == 'failure' }}
       shell: bash
       env:
         SCCACHE_CONF: ".github/actions/setup-rust-sccache/sccache.toml"

--- a/.github/actions/setup-rust-sccache/action.yml
+++ b/.github/actions/setup-rust-sccache/action.yml
@@ -19,10 +19,8 @@ runs:
         echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
         echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
 
-    - uses: /.github/actions/setup-scripts
-
     - name: Start sccache
-      run: retry $SCCACHE_PATH --start-server
+      run: ./scripts/retry.sh $SCCACHE_PATH --start-server
       continue-on-error: true
       shell: bash
       env:

--- a/.github/actions/setup-scripts/action.yml
+++ b/.github/actions/setup-scripts/action.yml
@@ -1,0 +1,9 @@
+name: "Setup Scripts"
+description: "Copies shared helper scripts to /usr/local/bin"
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        sudo cp scripts/retry.sh /usr/local/bin/retry
+        sudo chmod +x /usr/local/bin/retry

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,7 @@ updates:
       - "/.github/actions/setup-rust-stable"
       - "/.github/actions/setup-rust-target-cache"
       - "/.github/actions/setup-tauri-v2"
+      - "/.github/actions/setup-scripts"
     schedule:
       interval: weekly
     # Unfortunately the github-actions ecosystem doesn't support semver cooldowns, and because they update very frequently

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -190,16 +190,17 @@ jobs:
           docker compose build client-router gateway-router relay-1-router relay-2-router api-router
 
           # Start one-by-one to avoid variability in service startup order
-          docker compose up -d dns.httpbin.search.test --no-build
-          docker compose up -d httpbin --no-build
-          docker compose up -d download.httpbin --no-build
-          docker compose up -d api web domain --no-build
-          docker compose up -d otel --no-build
-          docker compose up -d relay-1 --no-build
-          docker compose up -d relay-2 --no-build
-          docker compose up -d gateway --no-build
-          docker compose up -d client --no-build
-          docker compose up -d network-config
+          # Retries are used because network I/O is flaky in GitHub Actions runners
+          retry docker compose up -d dns.httpbin.search.test --no-build
+          retry docker compose up -d httpbin --no-build
+          retry docker compose up -d download.httpbin --no-build
+          retry docker compose up -d api web domain --no-build
+          retry docker compose up -d otel --no-build
+          retry docker compose up -d relay-1 --no-build
+          retry docker compose up -d relay-2 --no-build
+          retry docker compose up -d gateway --no-build
+          retry docker compose up -d client --no-build
+          retry docker compose up -d network-config
 
           docker compose exec -d relay-1 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'
           docker compose exec -d relay-2 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -164,6 +164,7 @@ jobs:
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
       - uses: ./.github/actions/setup-docker
+      - uses: ./.github/actions/setup-scripts
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Start docker compose in the background

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -60,12 +60,13 @@ jobs:
           docker compose build client-router gateway-router relay-1-router relay-2-router api-router
 
           # Start services in the same order each time for the tests
-          docker compose up -d iperf3
-          docker compose up -d api web domain --no-build
-          docker compose up -d relay-1 relay-2 --no-build
-          docker compose up -d gateway --no-build
-          docker compose up -d client --no-build
-          docker compose up -d network-config
+          # Retries are used because network I/O is flaky in GitHub Actions runners
+          retry docker compose up -d iperf3
+          retry docker compose up -d api web domain --no-build
+          retry docker compose up -d relay-1 relay-2 --no-build
+          retry docker compose up -d gateway --no-build
+          retry docker compose up -d client --no-build
+          retry docker compose up -d network-config
       - name: "Performance test: ${{ matrix.flavour }}-${{ matrix.test }}"
         timeout-minutes: 5
         env:

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/setup-docker
+      - uses: ./.github/actions/setup-scripts
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Increase max UDP buffer sizes

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+max_attempts="${RETRY_MAX_ATTEMPTS:-5}"
+delay="${RETRY_DELAY:-5}"
+attempt=1
+
+while true; do
+    if "$@"; then
+        exit 0
+    fi
+    if [[ $attempt -ge $max_attempts ]]; then
+        echo "Command failed after $max_attempts attempts: $*" >&2
+        exit 1
+    fi
+    echo "Attempt $attempt/$max_attempts failed, retrying in ${delay}s..." >&2
+    sleep $delay
+    attempt=$((attempt + 1))
+done


### PR DESCRIPTION
Adds a `retry` script to the `setup-docker` action that can be used to retry certain docker commands. Didn't want to add this to _all_ docker commands because we sometimes run tests that way.