### PR TITLE
ci(tauri): cache dependencies via `target` directory

### DIFF
--- a/.github/actions/setup-rust-target-dependency-cache/action.yml
+++ b/.github/actions/setup-rust-target-dependency-cache/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: "Additional cache key"
     required: false
     default: ""
+  save-if:
+    description: "When to save the cache"
+    required: true
 
 runs:
   using: "composite"
@@ -17,4 +20,4 @@ runs:
         cache-workspace-crates: false
         key: ${{ inputs.key }}
         prefix-key: v2-rust-deps
-        # save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main
+        save-if: ${{ inputs.save-if }}

--- a/.github/actions/setup-rust-target-dependency-cache/action.yml
+++ b/.github/actions/setup-rust-target-dependency-cache/action.yml
@@ -1,0 +1,20 @@
+---
+name: "Setup Rust `target` dir caching"
+description: "Sets up caching for the Rust `target` directory, for dependencies only"
+inputs:
+  key:
+    description: "Additional cache key"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      with:
+        workspaces: rust
+        cache-targets: true
+        cache-workspace-crates: false
+        key: ${{ inputs.key }}
+        prefix-key: v2-rust-deps
+        # save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main

--- a/.github/actions/setup-rust-target-workspace-cache/action.yml
+++ b/.github/actions/setup-rust-target-workspace-cache/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: "Additional cache key"
     required: false
     default: ""
+  save-if:
+    description: "When to save the cache"
+    required: true
 
 runs:
   using: "composite"
@@ -21,4 +24,4 @@ runs:
         cache-workspace-crates: true
         key: ${{ inputs.key }}-${{ hashFiles('rust/**/*.rs') }}
         prefix-key: v2-rust
-        save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main
+        save-if: ${{ inputs.save-if }}

--- a/.github/actions/setup-rust-target-workspace-cache/action.yml
+++ b/.github/actions/setup-rust-target-workspace-cache/action.yml
@@ -1,6 +1,6 @@
 ---
 name: "Setup Rust `target` dir caching"
-description: "Sets up caching for the Rust `target` directory"
+description: "Sets up caching for the Rust `target` directory, including the workspace crates"
 inputs:
   key:
     description: "Additional cache key"

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -126,7 +126,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-stable
         with:
           targets: ${{ matrix.target }}
-      - uses: ./.github/actions/setup-rust-target-cache
+      - uses: ./.github/actions/setup-rust-target-workspace-cache
         with:
           key: ${{ matrix.package }}-${{ inputs.stage }}-${{ inputs.profile }}
       - name: Build binaries
@@ -241,7 +241,7 @@ jobs:
           targets: ${{ matrix.arch.target }}
       - uses: ./.github/actions/setup-rust-nightly
         if: matrix.name.package == 'firezone-relay'
-      - uses: ./.github/actions/setup-rust-target-cache
+      - uses: ./.github/actions/setup-rust-target-workspace-cache
         with:
           key: ${{ matrix.name.package }}-${{ inputs.stage }}-${{ inputs.profile }}
       - uses: taiki-e/install-action@bfc291e1e39400b67eda124e4a7b4380e93b3390 # v2.65.0

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -129,6 +129,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-target-workspace-cache
         with:
           key: ${{ matrix.package }}-${{ inputs.stage }}-${{ inputs.profile }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build binaries
         shell: bash
         run: |
@@ -244,6 +245,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-target-workspace-cache
         with:
           key: ${{ matrix.name.package }}-${{ inputs.stage }}-${{ inputs.profile }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@bfc291e1e39400b67eda124e4a7b4380e93b3390 # v2.65.0
         with:
           tool: bpf-linker,cargo-deb

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: ./.github/actions/setup-rust-target-cache
+      - uses: ./.github/actions/setup-rust-target-workspace-cache
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'linux'

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -52,6 +52,8 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: ./.github/actions/setup-rust-target-workspace-cache
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'linux'

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -140,6 +140,8 @@ jobs:
           lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust-stable
       - uses: ./.github/actions/setup-rust-target-dependency-cache
+        with:
+          save-if: ${{ github.event_name == 'merge_group' || github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -139,7 +139,9 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
           lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust-stable
-      - uses: ./.github/actions/setup-rust-sccache
+      - uses: ./.github/actions/setup-rust-target-dependency-cache
+        with:
+          key: ${{ matrix.arch }}
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -140,8 +140,6 @@ jobs:
           lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust-stable
       - uses: ./.github/actions/setup-rust-target-dependency-cache
-        with:
-          key: ${{ matrix.arch }}
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15


### PR DESCRIPTION
Saving the already pre-built dependencies in the Tauri workflow shaves about 4-5 minutes off the build. It appears that sccache is not quite as effective here, especially on Windows.