### PR TITLE
ci: use pinned release sha for bencher

### DIFF
--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -135,7 +135,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: bencherdev/bencher@main
+      - uses: bencherdev/bencher@2f1532643adc0e69e52acaec936d227ff14da24f # v0.5.9
       - name: Download performance test results
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:


### PR DESCRIPTION
Fixes https://github.com/firezone/firezone/actions/runs/20451525444/job/58765719849