### PR TITLE
fix(portal): use Req to fetch component versions

### DIFF
--- a/elixir/apps/domain/test/support/mocks/firezone_website.ex
+++ b/elixir/apps/domain/test/support/mocks/firezone_website.ex
@@ -1,4 +1,22 @@
 defmodule Domain.Mocks.FirezoneWebsite do
+  @doc """
+    elixir fix/component-versions % curl -iii https://www.firezone.dev/api/releases
+    HTTP/2 200
+    age: 178
+    cache-control: max-age=10
+    cdn-cache-control: max-age=60
+    content-type: application/json
+    date: Tue, 23 Dec 2025 06:03:29 GMT
+    permissions-policy: browsing-topics=()
+    server: Vercel
+    strict-transport-security: max-age=63072000
+    vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch
+    x-matched-path: /api/releases
+    x-vercel-cache: HIT
+    x-vercel-id: sfo1::iad1::j6p8c-1766469987502-dafdcbf7ae4c
+
+    {"portal":"90a15941f258e768a031e5db3d8aed1127793ef2","apple":"1.5.10","android":"1.5.7","gui":"1.5.8","headless":"1.5.4","gateway":"1.4.18"}
+  """
   def mock_versions_endpoint(bypass, versions \\ %{}) do
     versions_path = "/api/releases"
     test_pid = self()
@@ -6,7 +24,10 @@ defmodule Domain.Mocks.FirezoneWebsite do
     Bypass.stub(bypass, "GET", versions_path, fn conn ->
       conn = Plug.Conn.fetch_query_params(conn)
       send(test_pid, {:bypass_request, conn})
-      Plug.Conn.send_resp(conn, 200, JSON.encode!(versions))
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, JSON.encode!(versions))
     end)
   end
 end


### PR DESCRIPTION
Due to the nature of Finch pools and how we start them with `rest_for_one` instead of `one_for_one`, whenever we deploy, the `:shutdown` message needs to be explicitly handled, otherwise we get an exception.

To fix this, we can ditch `Finch` entirely for the ComponentVersions GenServer and use our shiny new `Req` dependency, which has its own internal request pool we don't need to manage.