### PR TITLE
fix(portal): handle empty params in /auth/oidc/callback

### DIFF
--- a/elixir/apps/web/lib/web/controllers/oidc_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/oidc_controller.ex
@@ -48,7 +48,9 @@ defmodule Web.OIDCController do
     end
   end
 
-  def callback(conn) do
+  def callback(conn, _params) do
+    Logger.debug("OIDC callback called with invalid params")
+
     conn
     |> Web.Cookie.OIDC.delete()
     |> handle_error(:invalid_callback_params)

--- a/elixir/apps/web/test/web/controllers/oidc_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/oidc_controller_test.exs
@@ -5,6 +5,26 @@ defmodule Web.OIDCControllerTest do
   import Domain.ActorFixtures
   import Domain.AuthProviderFixtures
 
+  describe "callback/2 with missing params" do
+    test "returns error when called with no params", %{conn: conn} do
+      conn = get(conn, ~p"/auth/oidc/callback")
+
+      assert redirected_to(conn) == "/"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "An unexpected error occurred while signing you in. Please try again."
+    end
+
+    test "returns error when called with empty params", %{conn: conn} do
+      conn = get(conn, ~p"/auth/oidc/callback", %{})
+
+      assert redirected_to(conn) == "/"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "An unexpected error occurred while signing you in. Please try again."
+    end
+  end
+
   describe "callback routes do not redirect authenticated users" do
     setup do
       account = account_fixture()


### PR DESCRIPTION
This function clause was missing the 2nd parameter causing a FunctionClauseError.

We fix that and add a test to prevent regressions.