### PR TITLE
fix(portal): add missing index for groups.name

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20251223175206_index_groups_on_name_and_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251223175206_index_groups_on_name_and_type.exs
@@ -1,0 +1,14 @@
+defmodule Domain.Repo.Migrations.IndexGroupsOnNameAndType do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    create_if_not_exists(
+      index(:groups, [:account_id, :name, :type],
+        name: :index_groups_on_account_id_name_type,
+        concurrently: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
Now that members are not maintained for the everyone group, determining which resources to load for its members needs to hit an index for the group.

To fix this, we index groups on `account_id, name, type` and then ensure that all of the joins involved use `account_id` since all pkey indexes have this as the first element in the composite index.

This query is critical as it's used in the hot path when setting up a new resource connection whenever the cache is not hit.

Related: #11493 