### PR TITLE
fix(portal): don't query DB to find online relays

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -159,7 +159,7 @@ defmodule API.Client.Channel do
   def handle_info(
         %Phoenix.Socket.Broadcast{
           event: "presence_diff",
-          topic: "presences:global_relays",
+          topic: "presences:global_relays" <> _,
           payload: %{joins: joins, leaves: leaves}
         },
         socket

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -112,7 +112,7 @@ defmodule API.Gateway.Channel do
   def handle_info(
         %Phoenix.Socket.Broadcast{
           event: "presence_diff",
-          topic: "presences:global_relays",
+          topic: "presences:global_relays" <> _,
           payload: %{joins: joins, leaves: leaves}
         },
         socket

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -552,7 +552,7 @@ defmodule API.Client.ChannelTest do
              } = relay_view
 
       # Untrack from global topic to trigger presence change notification
-      Domain.Presence.Relays.untrack(self(), "presences:global_relays", relay1.id)
+      Domain.Presence.Relays.untrack(self(), Domain.Presence.Relays.Global.topic(), relay1.id)
 
       assert_push "relays_presence",
                   %{
@@ -664,7 +664,7 @@ defmodule API.Client.ChannelTest do
              } = relay_view
 
       # Untrack from global topic to trigger presence change notification
-      Domain.Presence.Relays.untrack(self(), "presences:global_relays", relay1.id)
+      Domain.Presence.Relays.untrack(self(), Domain.Presence.Relays.Global.topic(), relay1.id)
 
       assert_push "relays_presence",
                   %{

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -1298,7 +1298,7 @@ defmodule API.Gateway.ChannelTest do
              } = relay_view
 
       # Untrack from global topic to trigger presence change notification
-      Domain.Presence.Relays.untrack(self(), "presences:global_relays", relay1.id)
+      Domain.Presence.Relays.untrack(self(), Domain.Presence.Relays.Global.topic(), relay1.id)
 
       assert_push "relays_presence",
                   %{

--- a/elixir/apps/api/test/support/channel_case.ex
+++ b/elixir/apps/api/test/support/channel_case.ex
@@ -21,6 +21,13 @@ defmodule API.ChannelCase do
   end
 
   setup tags do
+    # Isolate relay presence per test to prevent interference between async tests
+    Domain.Config.put_env_override(
+      :domain,
+      :relay_presence_topic,
+      "presences:global_relays:#{inspect(make_ref())}"
+    )
+
     for presence <- @presences, pid <- presence.fetchers_pids() do
       # TODO: If we start using Presence.fetch/2 callback we might want to
       # contribute to Phoenix.Presence a way to propagate sandbox access from

--- a/elixir/apps/domain/test/support/fixtures/relay_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/relay_fixtures.ex
@@ -120,7 +120,7 @@ defmodule Domain.RelayFixtures do
   Used to test relay presence debouncing in client/gateway channels.
   """
   def disconnect_relay(relay) do
-    :ok = Domain.Presence.untrack(self(), "presences:global_relays", relay.id)
+    :ok = Domain.Presence.untrack(self(), Domain.Presence.Relays.Global.topic(), relay.id)
     :ok = Domain.Presence.untrack(self(), "presences:relays:#{relay.id}", relay.id)
     :ok = Domain.PubSub.unsubscribe("relays:#{relay.id}")
     :ok

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -246,6 +246,8 @@ config :domain, docker_registry: "ghcr.io/firezone"
 
 config :domain, outbound_email_adapter_configured?: false
 
+config :domain, relay_presence_topic: "presences:global_relays"
+
 config :domain, web_external_url: "https://localhost:13443"
 
 ###############################


### PR DESCRIPTION
The nice thing about Phoenix Presence is that we get a cluster-wide CRDT that remains intact during deploys. We can save all of the metadata we need for each of the relays connected so that clients and gateways don't need to query the DB to find connected Relays.

These queries were number 2 on our highest-load queries list according to CloudSQL insights. Whenever relays reconnected, thousands of queries would hit this table to resolve online relays due to the way we react to relay joins and leaves in the channel modules.