### PR TITLE
fix(portal): link channel pid to transport pid

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -26,6 +26,9 @@ defmodule API.Client.Channel do
 
   @impl true
   def join("client", _payload, socket) do
+    # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
+    Process.link(socket.transport_pid)
+
     send(self(), :after_join)
 
     {:ok, socket}

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -23,6 +23,9 @@ defmodule API.Gateway.Channel do
 
   @impl true
   def join("gateway", _payload, socket) do
+    # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
+    Process.link(socket.transport_pid)
+
     send(self(), :after_join)
     {:ok, socket}
   end

--- a/elixir/apps/api/lib/api/relay/channel.ex
+++ b/elixir/apps/api/lib/api/relay/channel.ex
@@ -6,6 +6,9 @@ defmodule API.Relay.Channel do
 
   @impl true
   def join("relay", %{"stamp_secret" => stamp_secret}, socket) do
+    # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
+    Process.link(socket.transport_pid)
+
     OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)
     OpenTelemetry.Tracer.set_current_span(socket.assigns.opentelemetry_span_ctx)
 

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -85,6 +85,19 @@ defmodule API.Gateway.ChannelTest do
       assert is_number(online_at)
     end
 
+    test "channel crash takes down the transport", %{socket: socket} do
+      Process.flag(:trap_exit, true)
+
+      # In tests, we (the test process) are the transport_pid
+      assert socket.transport_pid == self()
+
+      # Kill the channel - we receive EXIT because we're linked
+      Process.exit(socket.channel_pid, :kill)
+
+      assert_receive {:EXIT, pid, :killed}
+      assert pid == socket.channel_pid
+    end
+
     test "sends init message after join", %{
       account: account,
       gateway: gateway

--- a/elixir/apps/api/test/api/relay/channel_test.exs
+++ b/elixir/apps/api/test/api/relay/channel_test.exs
@@ -31,6 +31,19 @@ defmodule API.Relay.ChannelTest do
       assert is_number(online_at)
     end
 
+    test "channel crash takes down the transport", %{socket: socket} do
+      Process.flag(:trap_exit, true)
+
+      # In tests, we (the test process) are the transport_pid
+      assert socket.transport_pid == self()
+
+      # Kill the channel - we receive EXIT because we're linked
+      Process.exit(socket.channel_pid, :kill)
+
+      assert_receive {:EXIT, pid, :killed}
+      assert pid == socket.channel_pid
+    end
+
     test "sends init message after join" do
       assert_push "init", %{}
     end


### PR DESCRIPTION
When a channel pid crashes, the transport pid (responsible for the WebSocket) does not automatically die with it. This is to prevent other multiplexed channels from being taken down.

Since we do not use other channels, this creates a problem because connlib happily stays connected to a WebSocket with no Phoenix channel alive in it.

Since heartbeats are managed in the transport pid (otherwise the number of heartbeats would grow with the number of multiplexed channels), this means the connection is effectively a zombie.

To fix this, we simply link the channel pid with the transport pid using [`Process.link/1`](https://hexdocs.pm/elixir/Process.html#link/1), which tears the transport down with the channel whenever it exits.

Fixes #11495 