### PR TITLE
fix(portal): maintain ipv4/6 client address

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -787,7 +787,14 @@ defmodule API.Client.Channel do
        )
        when id == client_id do
     # Update socket with the new client state, preserving loaded associations
-    updated_client = %{client | account: current_client.account, actor: current_client.actor}
+    updated_client = %{
+      client
+      | account: current_client.account,
+        actor: current_client.actor,
+        ipv4_address: current_client.ipv4_address,
+        ipv6_address: current_client.ipv6_address
+    }
+
     socket = assign(socket, :client, updated_client)
 
     # Changes in client verification can affect the list of allowed resources

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -1292,9 +1292,6 @@ defmodule API.Client.ChannelTest do
         struct: updated_client
       })
 
-      # Give time for the message to be processed
-      Process.sleep(10)
-
       # Verify the socket still has the original addresses preserved
       state = :sys.get_state(socket.channel_pid)
       assert state.assigns.client.name == "Updated Name"


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/11154, we changed the TUN interface addresses to be an association field.

Unfortunately this means they aren't populated when receiving change notifications from our CDC system. To handle that, we need to preserve the old fields when merging changes into a current client.

We did that in one place, but left a second place out. To prevent this from regressing in the future a unit test is added.