### PR TITLE
chore(portal): suppress Ecto.NoResultsError from sentry

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -3,13 +3,15 @@ defmodule Domain.Telemetry.Sentry do
     # This happens when libcluster loses connection to a node, which is normal during deploys.
     # We have threshold-based error logging in Domain.Cluster.GoogleComputeLabelsStrategy to report those.
     "Node ~p not responding **~n** Removing (timedout) connection",
-    "[libcluster:default] unable to connect to",
-
-    # These occur under normal operation whenever a particular account or resource can't be found in the DB.
-    "expected at least one result but got none in query"
+    "[libcluster:default] unable to connect to"
   ]
 
   def before_send(%{original_exception: %{skip_sentry: skip_sentry}}) when skip_sentry do
+    nil
+  end
+
+  # These occur under normal operation whenever a particular account or resource can't be found in the DB.
+  def before_send(%{original_exception: %Ecto.NoResultsError{}}) do
     nil
   end
 


### PR DESCRIPTION
These are expected under normal operation and are used to trigger a 404.