### PR TITLE
chore(portal): add account_id on join clauses

### DIFF
--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -435,7 +435,10 @@ defmodule Portal.Billing do
       from(c in Client, as: :clients)
       |> where([clients: c], c.account_id == ^account.id)
       |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> join(:inner, [clients: c], a in Actor, on: c.actor_id == a.id, as: :actor)
+      |> join(:inner, [clients: c], a in Actor,
+        on: c.actor_id == a.id and c.account_id == a.account_id,
+        as: :actor
+      )
       |> where([actor: a], is_nil(a.disabled_at))
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)

--- a/elixir/lib/portal/cache/gateway.ex
+++ b/elixir/lib/portal/cache/gateway.ex
@@ -331,7 +331,10 @@ defmodule Portal.Cache.Gateway do
       |> join(:inner, [policies: p], ag in assoc(p, :group), as: :group)
       |> join(:inner, [policies: p], r in assoc(p, :resource), as: :resource)
       |> where([resource: r], r.site_id == ^site_id)
-      |> join(:inner, [], actor in Portal.Actor, on: actor.id == ^actor_id, as: :actor)
+      |> join(:inner, [], actor in Portal.Actor,
+        on: actor.id == ^actor_id and actor.account_id == ^account_id,
+        as: :actor
+      )
       |> join(:left, [group: ag], m in assoc(ag, :memberships), as: :memberships)
       |> where(
         [memberships: m, group: ag, actor: a],

--- a/elixir/lib/portal/workers/check_account_limits.ex
+++ b/elixir/lib/portal/workers/check_account_limits.ex
@@ -187,7 +187,10 @@ defmodule Portal.Workers.CheckAccountLimits do
       from(c in Client, as: :clients)
       |> where([clients: c], c.account_id == ^account.id)
       |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> join(:inner, [clients: c], a in Actor, on: c.actor_id == a.id, as: :actor)
+      |> join(:inner, [clients: c], a in Actor,
+        on: c.actor_id == a.id and c.account_id == a.account_id,
+        as: :actor
+      )
       |> where([actor: a], is_nil(a.disabled_at))
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)

--- a/elixir/lib/portal/workers/outdated_gateways.ex
+++ b/elixir/lib/portal/workers/outdated_gateways.ex
@@ -150,7 +150,10 @@ defmodule Portal.Workers.OutdatedGateways do
           (fragment("split_part(?, '.', 1)::int", c.last_seen_version) == ^g_major and
              fragment("split_part(?, '.', 2)::int", c.last_seen_version) <= ^(g_minor - 2))
       )
-      |> join(:inner, [clients: c], a in Portal.Actor, on: c.actor_id == a.id, as: :actor)
+      |> join(:inner, [clients: c], a in Portal.Actor,
+        on: c.actor_id == a.id and c.account_id == a.account_id,
+        as: :actor
+      )
       |> where([actor: a], is_nil(a.disabled_at))
       |> Safe.unscoped()
       |> Safe.aggregate(:count)

--- a/elixir/lib/portal_api/controllers/account_json.ex
+++ b/elixir/lib/portal_api/controllers/account_json.ex
@@ -92,7 +92,10 @@ defmodule PortalAPI.AccountJSON do
       from(c in Client, as: :clients)
       |> where([clients: c], c.account_id == ^account.id)
       |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> join(:inner, [clients: c], a in Actor, on: c.actor_id == a.id, as: :actor)
+      |> join(:inner, [clients: c], a in Actor,
+        on: c.actor_id == a.id and c.account_id == a.account_id,
+        as: :actor
+      )
       |> where([actor: a], is_nil(a.disabled_at))
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -926,7 +926,7 @@ defmodule PortalWeb.Groups do
           as: :member_counts
         )
         |> join(:left, [groups: g], d in Directory,
-          on: d.id == g.directory_id,
+          on: d.id == g.directory_id and d.account_id == g.account_id,
           as: :directory
         )
         |> where(
@@ -1049,7 +1049,7 @@ defmodule PortalWeb.Groups do
     def get_group!(id, subject) do
       from(g in Portal.Group, as: :groups)
       |> join(:left, [groups: g], d in Directory,
-        on: d.id == g.directory_id,
+        on: d.id == g.directory_id and d.account_id == g.account_id,
         as: :directory
       )
       |> where([groups: groups], groups.id == ^id)

--- a/elixir/lib/portal_web/live/settings/billing.ex
+++ b/elixir/lib/portal_web/live/settings/billing.ex
@@ -329,7 +329,10 @@ defmodule PortalWeb.Settings.Billing do
       from(c in Client, as: :clients)
       |> where([clients: c], c.account_id == ^account.id)
       |> where([clients: c], c.last_seen_at > ago(1, "month"))
-      |> join(:inner, [clients: c], a in Actor, on: c.actor_id == a.id, as: :actor)
+      |> join(:inner, [clients: c], a in Actor,
+        on: c.actor_id == a.id and c.account_id == a.account_id,
+        as: :actor
+      )
       |> where([actor: a], is_nil(a.disabled_at))
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1681,7 +1681,7 @@ defmodule PortalWeb.Settings.DirectorySync do
       policies_count =
         from(p in Portal.Policy,
           join: g in Portal.Group,
-          on: p.group_id == g.id,
+          on: p.group_id == g.id and p.account_id == g.account_id,
           where: g.directory_id == ^directory_id
         )
         |> Safe.scoped(subject)

--- a/elixir/lib/portal_web/live/sites/index.ex
+++ b/elixir/lib/portal_web/live/sites/index.ex
@@ -235,7 +235,10 @@ defmodule PortalWeb.Sites.Index do
 
     def count_policies_by_site(site_ids, subject) do
       from(p in Portal.Policy, as: :policies)
-      |> join(:inner, [policies: p], r in Resource, on: r.id == p.resource_id, as: :resources)
+      |> join(:inner, [policies: p], r in Resource,
+        on: r.id == p.resource_id and r.account_id == p.account_id,
+        as: :resources
+      )
       |> where([resources: r], r.site_id in ^site_ids)
       |> group_by([resources: r], r.site_id)
       |> select([resources: r], {r.site_id, count()})


### PR DESCRIPTION
A minor downside to the composite primary key architecture is that we need to remember to add `account_id` to the join clause so that indexes are hit.