### PR TITLE
fix(portal): don't double-track relays presence

### DIFF
--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -5,6 +5,9 @@ defmodule Portal.Ops do
   @doc """
   Counts presences grouped by topic prefix.
 
+  Uses `Portal.Presence.list/1` to get the merged/deduplicated presence counts
+  across all nodes in the cluster.
+
   ## Examples
 
       iex> count_presences()
@@ -14,17 +17,28 @@ defmodule Portal.Ops do
         {"presences:actor_clients", 430},
         {"presences:global_relays", 34},
         {"presences:portal_sessions", 8},
-        {"presences:relays", 34},
         {"presences:sites", 421}
       ]
 
   """
   def count_presences(shard \\ Portal.Presence_shard0) do
-    :ets.tab2list(shard)
-    |> Enum.group_by(fn {{topic, _pid, _id}, _meta, _clock} ->
-      topic |> String.split(":") |> Enum.take(2) |> Enum.join(":")
+    # Get unique topics from the ETS shard
+    topics =
+      :ets.tab2list(shard)
+      |> Enum.map(fn {{topic, _pid, _id}, _meta, _clock} -> topic end)
+      |> Enum.uniq()
+
+    # For each topic, get the merged presence count using Presence.list/1
+    # which properly deduplicates entries across cluster nodes
+    topics
+    |> Enum.map(fn topic ->
+      count = topic |> Portal.Presence.list() |> map_size()
+      prefix = topic |> String.split(":") |> Enum.take(2) |> Enum.join(":")
+      {prefix, count}
     end)
-    |> Enum.map(fn {topic_prefix, entries} -> {topic_prefix, length(entries)} end)
+    |> Enum.group_by(fn {prefix, _count} -> prefix end, fn {_prefix, count} -> count end)
+    |> Enum.map(fn {prefix, counts} -> {prefix, Enum.sum(counts)} end)
+    |> Enum.sort()
   end
 
   def sync_pricing_plans do

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -21,10 +21,10 @@ defmodule Portal.Ops do
       ]
 
   """
-  def count_presences(shard \\ Portal.Presence_shard0) do
+  def count_presences do
     # Get unique topics from the ETS shard
     topics =
-      :ets.tab2list(shard)
+      :ets.tab2list(Portal.Presence_shard0)
       |> Enum.map(fn {{topic, _pid, _id}, _meta, _clock} -> topic end)
       |> Enum.uniq()
 

--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -335,9 +335,7 @@ defmodule Portal.Presence do
                port: relay.port,
                last_seen_remote_ip_location_lat: relay.last_seen_remote_ip_location_lat,
                last_seen_remote_ip_location_lon: relay.last_seen_remote_ip_location_lon
-             }),
-           {:ok, _} <-
-             Portal.Presence.track(self(), "presences:relays:#{relay.id}", relay.id, %{}) do
+             }) do
         :ok = PubSub.Relay.subscribe(relay.id)
         :ok
       end

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -33,17 +33,6 @@ defmodule Portal.OpsTest do
       assert {"presences:account_gateways", 1} in result
       assert {"presences:global_relays", 1} in result
     end
-
-    test "returns empty list when no presences exist" do
-      # Use a fresh shard that has no entries - the default shard may have
-      # entries from other tests, so we just verify the function doesn't crash
-      # when given an empty table
-      table = :ets.new(:test_presences_empty, [:set, :public])
-
-      assert count_presences(table) == []
-
-      :ets.delete(table)
-    end
   end
 
   describe "delete_disabled_account/1" do

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -12,26 +12,32 @@ defmodule Portal.OpsTest do
   import Portal.ResourceFixtures
   import Portal.TokenFixtures
 
-  describe "count_presences/1" do
+  describe "count_presences/0" do
     test "returns presence counts grouped by topic prefix" do
-      table = :ets.new(:test_presences, [:set, :public])
+      # Track actual presence entries using the Presence module
+      {:ok, _} =
+        Portal.Presence.track(self(), "presences:account_clients:acc1", "client1", %{})
 
-      # Insert mock presence entries matching the Phoenix.Presence format
-      :ets.insert(table, {{"presences:account_clients:acc1", self(), "client1"}, %{}, {1, 0}})
-      :ets.insert(table, {{"presences:account_clients:acc1", self(), "client2"}, %{}, {2, 0}})
-      :ets.insert(table, {{"presences:account_gateways:acc1", self(), "gw1"}, %{}, {3, 0}})
-      :ets.insert(table, {{"presences:global_relays", self(), "relay1"}, %{}, {4, 0}})
+      {:ok, _} =
+        Portal.Presence.track(self(), "presences:account_clients:acc1", "client2", %{})
 
-      result = count_presences(table)
+      {:ok, _} =
+        Portal.Presence.track(self(), "presences:account_gateways:acc1", "gw1", %{})
+
+      {:ok, _} =
+        Portal.Presence.track(self(), "presences:global_relays", "relay1", %{})
+
+      result = count_presences()
 
       assert {"presences:account_clients", 2} in result
       assert {"presences:account_gateways", 1} in result
       assert {"presences:global_relays", 1} in result
-
-      :ets.delete(table)
     end
 
     test "returns empty list when no presences exist" do
+      # Use a fresh shard that has no entries - the default shard may have
+      # entries from other tests, so we just verify the function doesn't crash
+      # when given an empty table
       table = :ets.new(:test_presences_empty, [:set, :public])
 
       assert count_presences(table) == []

--- a/elixir/test/support/fixtures/relay_fixtures.ex
+++ b/elixir/test/support/fixtures/relay_fixtures.ex
@@ -121,7 +121,6 @@ defmodule Portal.RelayFixtures do
   """
   def disconnect_relay(relay) do
     :ok = Portal.Presence.untrack(self(), Portal.Presence.Relays.Global.topic(), relay.id)
-    :ok = Portal.Presence.untrack(self(), "presences:relays:#{relay.id}", relay.id)
     :ok = Portal.PubSub.unsubscribe("relays:#{relay.id}")
     :ok
   end


### PR DESCRIPTION
These are being double-tracked leading to more joins/connects than we need to handle, and throwing off our count.