### PR TITLE
fix(portal): use Lax for otp cookie

### DIFF
--- a/elixir/lib/portal_web/cookie/email_otp.ex
+++ b/elixir/lib/portal_web/cookie/email_otp.ex
@@ -16,7 +16,7 @@ defmodule PortalWeb.Cookie.EmailOTP do
   @cookie_options [
     sign: true,
     max_age: 15 * 60,
-    same_site: "Strict",
+    same_site: "Lax",
     secure: Portal.Config.fetch_env!(:portal, :cookie_secure),
     http_only: true,
     signing_salt: Portal.Config.fetch_env!(:portal, :cookie_signing_salt)


### PR DESCRIPTION
Unfortunately using `Strict` here breaks sign in when clicking the link in the auth email because the OTP state cookie is not sent in that request.