### PR TITLE
fix(portal): don't disconnect pending relays on join

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -326,7 +326,7 @@ config :portal, PortalAPI.Endpoint,
   secret_key_base: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5SD",
   pubsub_server: Portal.PubSub
 
-config :portal, relays_presence_debounce_timeout_ms: 3_000
+config :portal, relays_presence_debounce_timeout_ms: 1_000
 
 config :portal, PortalAPI.RateLimit,
   refill_rate: 10,

--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -424,8 +424,11 @@ defmodule Portal.Presence do
         cached_stamp_secrets = Map.get(socket.assigns, :stamp_secrets, %{})
 
         # Check for stamp_secret changes in pending_leaves
+        # Only check relays that are in both pending_leaves AND joined_ids
         disconnected_from_pending =
-          Enum.reduce(pending_leaves, [], fn {relay_id, stamp_secret}, acc ->
+          pending_leaves
+          |> Enum.filter(fn {relay_id, _} -> relay_id in joined_ids end)
+          |> Enum.reduce([], fn {relay_id, stamp_secret}, acc ->
             if Map.get(joined_stamp_secrets, relay_id) != stamp_secret do
               [relay_id | acc]
             else


### PR DESCRIPTION
When a Relay temporarily disconnects (such as during deploy), we add it to a pending_leaves buffer so that if it rejoins with the same stamp_secret (indicating the Relay _has_not_ restarted) we can "cancel" the leave.

There was a bug where any relays in this list would be immediately disconnected if an unrelated relay joined within the window. The chance of this happening was not high, but also not negligible.

To prevent spurious `relays_presence` messages being pushed to the clients/gateways, we cross-check that the relay id is in `joined_ids`, that is, has been actually joined, before sending a disconnect for it. 