### PR TITLE
fix(relay): don't return early from event loop

### DIFF
--- a/rust/relay/server/src/sockets.rs
+++ b/rust/relay/server/src/sockets.rs
@@ -429,7 +429,7 @@ mod tests {
             }
         })
         .await
-        .ok();
+        .expect("timeout waiting for waker to be set");
 
         // The flush_waker should have been woken by the writeable event
         assert!(


### PR DESCRIPTION
### Problem

Inside the Relay event loop, the first thing we try to do is flush sockets - that is, send outbound datagrams. We do that with the ready! macro which expands to:

```rust
match self.sockets.flush(cx) {
    Poll::Ready(Ok(val)) => val,
    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
    Poll::Pending => return Poll::Pending,  // <-- HERE
}
```

If we're able to flush, great, we continue down the loop. However, if we're not able to flush, we return from the loop with `Poll::Pending`. The intent is to wait for `mio` to send an event to notify us when the socket is ready for writing again.

However, this event is only consumed in `poll_recv_from` further down the loop, which is never reached because we already returned.

The net effect is that the event loop is stuck until something else wakes us - typically the event_rx channel waker that was registered on a previous iteration. When we do wake, we call flush() again, which will succeed if the socket buffer has drained. But during this window, we never polled the phoenix channel, so no heartbeats were sent.

If this timing window overlaps with when a heartbeat was due, we miss it. After ~60 seconds of missed heartbeats, the portal closes the connection.

### Fix

Don't block the event loop on socket flushing:

```rust
if let Poll::Ready(result) = self.sockets.flush(cx) {
    result?;
}
```

Now the loop continues regardless of flush state, ensuring the phoenix channel is always polled and heartbeats are sent. The existing waker mechanism handles retrying the flush when the socket becomes writable.