### PR TITLE
chore(portal): warn before relay channel idle timeouts

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -35,7 +35,6 @@ defmodule PortalAPI.Client.Channel do
   end
 
   @impl true
-
   # Called immediately after the client joins the channel
   def handle_info(:after_join, socket) do
     # Schedule reassessing allowed resources

--- a/elixir/lib/portal_api/relay/channel.ex
+++ b/elixir/lib/portal_api/relay/channel.ex
@@ -4,10 +4,20 @@ defmodule PortalAPI.Relay.Channel do
   require OpenTelemetry.Tracer
   require Logger
 
+  # Cowboy divides the idle_timeout into 10 ticks. When timeout_num reaches 10,
+  # the connection is closed. We warn at 9 to catch it before termination.
+  @idle_timeout_warning_threshold 9
+
+  # Check transport idle ticks every second
+  @idle_check_interval_ms :timer.seconds(1)
+
   @impl true
   def join("relay", %{"stamp_secret" => stamp_secret}, socket) do
     # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
     Process.link(socket.transport_pid)
+
+    # Start periodic check for idle timeout
+    schedule_idle_check()
 
     OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)
     OpenTelemetry.Tracer.set_current_span(socket.assigns.opentelemetry_span_ctx)
@@ -28,6 +38,22 @@ defmodule PortalAPI.Relay.Channel do
   end
 
   @impl true
+  def handle_info(:check_idle_timeout, socket) do
+    case get_transport_timeout_num(socket.transport_pid) do
+      {:ok, timeout_num} when timeout_num >= @idle_timeout_warning_threshold ->
+        Logger.warning("Relay missed heartbeat, connection will timeout",
+          relay_id: socket.assigns.relay.id,
+          timeout_ticks: timeout_num
+        )
+
+      _ ->
+        :ok
+    end
+
+    schedule_idle_check()
+    {:noreply, socket}
+  end
+
   def handle_info(
         {:after_join, stamp_secret, {opentelemetry_ctx, opentelemetry_span_ctx}},
         socket
@@ -53,5 +79,26 @@ defmodule PortalAPI.Relay.Channel do
     Logger.error("Unknown relay message", message: message, payload: payload)
 
     {:reply, {:error, %{reason: :unknown_message}}, socket}
+  end
+
+  defp schedule_idle_check do
+    Process.send_after(self(), :check_idle_timeout, @idle_check_interval_ms)
+  end
+
+  # Extracts the timeout tick counter from cowboy's internal websocket state.
+  # Cowboy divides idle_timeout into 10 ticks; when timeout_num reaches 10, connection closes.
+  defp get_transport_timeout_num(transport_pid) do
+    case :sys.get_state(transport_pid, 100) do
+      {{:state, _parent, _ref, _socket, _transport, _opts, _active, _handler, _key, _timeout_ref,
+        timeout_num, _messages, _dyn_buf_size, _dyn_buf_avg, _hibernate, _frag_state,
+        _frag_buffer, _utf8_state, _deflate, _extensions, _req, _shutdown_reason}, _handler_state,
+       _parse_state} ->
+        {:ok, timeout_num}
+
+      _ ->
+        :error
+    end
+  catch
+    :exit, _ -> :error
   end
 end

--- a/elixir/test/portal_api/relay/channel_test.exs
+++ b/elixir/test/portal_api/relay/channel_test.exs
@@ -1,5 +1,6 @@
 defmodule PortalAPI.Relay.ChannelTest do
   use PortalAPI.ChannelCase, async: true
+  import ExUnit.CaptureLog
 
   import Portal.RelayFixtures
   import Portal.TokenFixtures
@@ -54,6 +55,88 @@ defmodule PortalAPI.Relay.ChannelTest do
       ref = push(socket, "unknown_message", %{})
 
       assert_reply ref, :error, %{reason: :unknown_message}, 1000
+    end
+  end
+
+  describe "handle_info/2 :check_idle_timeout" do
+    alias __MODULE__.MockTransport
+
+    test "logs warning when timeout_num reaches threshold", %{relay: relay} do
+      # Start a GenServer that mimics the cowboy transport state
+      {:ok, transport_pid} = MockTransport.start_link(timeout_num: 9)
+
+      socket = %Phoenix.Socket{
+        assigns: %{relay: relay},
+        transport_pid: transport_pid
+      }
+
+      log =
+        capture_log(fn ->
+          {:noreply, _socket} =
+            PortalAPI.Relay.Channel.handle_info(:check_idle_timeout, socket)
+        end)
+
+      assert log =~ "[warning]"
+      assert log =~ "Relay missed heartbeat"
+      assert log =~ relay.id
+      assert log =~ "timeout_ticks=9"
+    end
+
+    test "does not log when timeout_num is below threshold", %{relay: relay} do
+      {:ok, transport_pid} = MockTransport.start_link(timeout_num: 5)
+
+      socket = %Phoenix.Socket{
+        assigns: %{relay: relay},
+        transport_pid: transport_pid
+      }
+
+      log =
+        capture_log(fn ->
+          {:noreply, _socket} =
+            PortalAPI.Relay.Channel.handle_info(:check_idle_timeout, socket)
+        end)
+
+      refute log =~ "Relay missed heartbeat"
+    end
+
+    test "does not log when transport state cannot be read", %{relay: relay} do
+      # Use a dead process
+      pid = spawn(fn -> :ok end)
+      Process.sleep(10)
+
+      socket = %Phoenix.Socket{
+        assigns: %{relay: relay},
+        transport_pid: pid
+      }
+
+      log =
+        capture_log(fn ->
+          {:noreply, _socket} =
+            PortalAPI.Relay.Channel.handle_info(:check_idle_timeout, socket)
+        end)
+
+      refute log =~ "Relay missed heartbeat"
+    end
+  end
+
+  # GenServer that mimics cowboy websocket state for :sys.get_state/2
+  defmodule MockTransport do
+    use GenServer
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      timeout_num = Keyword.fetch!(opts, :timeout_num)
+
+      # Cowboy websocket state: {{:state, ...}, handler_state, parse_state}
+      state =
+        {{:state, nil, nil, nil, nil, %{}, nil, nil, nil, nil, timeout_num, nil, nil, nil, nil,
+          nil, nil, nil, nil, nil, nil, nil}, nil, nil}
+
+      {:ok, state}
     end
   end
 end


### PR DESCRIPTION
Unfortunately we don't get any meaningful info when our channel pid is cut due to transport timeout. However, we can poll `cowboy`'s state, which uses a tick-based system, to detect when are about to be closed due to missing a heartbeat.

This will allow us to better understand whether the WebSocket connection cuts seen by the Relay are due to missing heartbeats or some other cause.

Related: #11542 