### PR TITLE
fix(portal): delay reactions to relay presence events

### DIFF
--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -99,8 +99,8 @@ defmodule PortalAPI.Gateway.Channel do
   ####################################
 
   # Handle relay presence changes from global topic.
-  # Instead of reacting to joins/leaves (which can arrive out of order),
-  # we check the current CRDT state to see if our cached relays are still valid.
+  # Instead of reacting immediately, we debounce by scheduling a delayed check.
+  # This avoids spurious updates during transient relay disconnections.
   @impl true
   def handle_info(
         %Phoenix.Socket.Broadcast{
@@ -109,6 +109,13 @@ defmodule PortalAPI.Gateway.Channel do
         },
         socket
       ) do
+    debounce_ms = Portal.Config.get_env(:portal, :relay_presence_debounce_ms, 1_000)
+    Process.send_after(self(), :check_relay_presence, debounce_ms)
+    {:noreply, socket}
+  end
+
+  # Debounced relay presence check - queries the CRDT state after the debounce period.
+  def handle_info(:check_relay_presence, socket) do
     cached_secrets = socket.assigns[:stamp_secrets] || %{}
 
     # Check current presence state - this is the authoritative CRDT-merged state

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -1145,6 +1145,46 @@ defmodule PortalAPI.Client.ChannelTest do
       relay_ids = Enum.map(relays, & &1.id) |> Enum.uniq()
       assert length(relay_ids) <= 2
     end
+
+    test "debounces multiple rapid presence_diff events", %{
+      client: client,
+      subject: subject
+    } do
+      # Set debounce to 50ms so the test is fast but we can still observe coalescing
+      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 50)
+
+      _socket = join_channel(client, subject)
+
+      assert_push "init", %{relays: []}
+
+      stamp_secret = Ecto.UUID.generate()
+      relay = relay_fixture()
+
+      update_relay(relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second),
+        last_seen_remote_ip_location_lat: 37.0,
+        last_seen_remote_ip_location_lon: -120.0
+      )
+
+      relay_token = relay_token_fixture()
+
+      # Connect the relay - this triggers a presence_diff
+      :ok = Portal.Presence.Relays.connect(relay, stamp_secret, relay_token.id)
+
+      # Should receive exactly one relays_presence after debounce period
+      assert_push "relays_presence", %{connected: [_, _], disconnected_ids: []}, 200
+
+      # Rapidly disconnect and reconnect the relay multiple times
+      # Each triggers a presence_diff, but they should be coalesced
+      for _ <- 1..3 do
+        disconnect_relay(relay)
+        :ok = Portal.Presence.Relays.connect(relay, stamp_secret, relay_token.id)
+      end
+
+      # After debounce, should receive exactly one update reflecting final state
+      # Since the relay is online with the same stamp_secret, no disconnects should be reported
+      refute_push "relays_presence", %{disconnected_ids: [_]}, 200
+    end
   end
 
   describe "handle_info/2 for change events" do

--- a/elixir/test/support/channel_case.ex
+++ b/elixir/test/support/channel_case.ex
@@ -28,6 +28,9 @@ defmodule PortalAPI.ChannelCase do
       "presences:global_relays:#{inspect(make_ref())}"
     )
 
+    # Set debounce to 0 in tests for faster execution
+    Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 0)
+
     for presence <- @presences, pid <- presence.fetchers_pids() do
       # TODO: If we start using Presence.fetch/2 callback we might want to
       # contribute to Phoenix.Presence a way to propagate sandbox access from


### PR DESCRIPTION
Unfortunately WebSocket connections aren't always reliable. It seems GCP or another thing in the path between relay and load balancer is occasionally dropping connections, and this is not due to the 86400 `timeout_sec` maximum connection time in the GCP ALB, or (most likely) not a heartbeat timing issue in the Relay.

Before, we had a complex state tracking mechanism which was tricky to test and added much complexity to the already complex state tracking in the channel modules. This was removed in #11543 in favor of looking the "state of truth" from the Presence CRDT.

This new lookup is being extended in this PR to implement a much simpler debouncer system.

This works by delaying all reactions to Presence joins/leaves by 1s so that if a Relay disconnects and then reconnects, by the time we check its Presence it will appear to never have disconnected.

Supersedes: #11542 