### PR TITLE
fix(portal): always start api/web endpoint

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -259,9 +259,6 @@ config :portal, client_handler: "firezone-fd0020211111://"
 ##### PortalWeb Endpoint ######
 ###############################
 
-# Used to conditionally enable the PortalWeb endpoint in the supervision tree
-config :portal, PortalWeb, enabled: true
-
 config :portal, PortalWeb.Endpoint,
   url: [
     scheme: "http",
@@ -308,9 +305,6 @@ config :portal, api_url_override: "ws://localhost:13001/"
 ###############################
 ##### PortalAPI Endpoint ######
 ###############################
-
-# Used to conditionally enable the PortalAPI endpoint in the supervision tree
-config :portal, PortalAPI, enabled: true
 
 config :portal, PortalAPI.Endpoint,
   url: [

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -52,11 +52,6 @@ if config_env() == :prod do
           else: [{:hostname, env_var_to_config!(:database_host)}]
         )
 
-  # Web / API node coloring
-
-  config :portal, PortalWeb, enabled: env_var_to_config!(:portal_web_enabled)
-  config :portal, PortalAPI, enabled: env_var_to_config!(:portal_api_enabled)
-
   config :portal, Portal.Changes.ReplicationConnection,
     # TODO: Use a dedicated node for Change Data Capture replication
     enabled: env_var_to_config!(:background_jobs_enabled),

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -55,11 +55,6 @@ defmodule Portal.Config.Definitions do
   ##############################################
 
   @doc """
-  Enable or disable the Web Endpoint for this node.
-  """
-  defconfig(:portal_web_enabled, :boolean, default: false)
-
-  @doc """
   The external URL the UI will be accessible at.
 
   If this field is not set or set to `nil`, the server for `api` and `web` apps will not start.
@@ -72,11 +67,6 @@ defmodule Portal.Config.Definitions do
       |> Portal.Changeset.normalize_url(key)
     end
   )
-
-  @doc """
-  Enable or disable the API Endpoint for this node.
-  """
-  defconfig(:portal_api_enabled, :boolean, default: false)
 
   @doc """
   The external URL the API will be accessible at.

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -62,17 +62,9 @@ defmodule Portal.Health do
   end
 
   defp endpoints_ready? do
-    web_ready? = not web_enabled?() or Process.whereis(PortalWeb.Endpoint) != nil
-    api_ready? = not api_enabled?() or Process.whereis(PortalAPI.Endpoint) != nil
+    web_ready? = Process.whereis(PortalWeb.Endpoint) != nil
+    api_ready? = Process.whereis(PortalAPI.Endpoint) != nil
 
     web_ready? and api_ready?
-  end
-
-  defp web_enabled? do
-    Portal.Config.fetch_env!(:portal, PortalWeb)[:enabled]
-  end
-
-  defp api_enabled? do
-    Portal.Config.fetch_env!(:portal, PortalAPI)[:enabled]
   end
 end


### PR DESCRIPTION
For verified routes (`~p` sigil) to work at runtime in our email helpers, we unfortunately need to start the PortalWeb Endpoint.

Rather than conditionally starting these in the supervision tree, we can simply start them unconditionally even on background job nodes since there are no side effects to doing so. Firewall and load balancer configuration will prevent requests from hitting nodes that they aren't intended for.

Besides having working verified routes in email helpers, the other benefit to doing this is less supervision tree variability / complexity to reason about.