### PR TITLE
fix(portal): delete sessions for external_identities

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -22,3 +22,5 @@ DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:62,6EFEB9E
 Config.Secrets: Hardcoded Secret,config/config.exs:207,7165BCA
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:28,7369D64
+
+Config.Secrets: Hardcoded Secret,config/config.exs:209,8DFEA3

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -114,6 +114,7 @@ config :portal, Portal.Changes.ReplicationConnection,
     actors
     memberships
     clients
+    external_identities
     policy_authorizations
     gateways
     gateway_tokens

--- a/elixir/lib/portal/changes/hooks/external_identity.ex
+++ b/elixir/lib/portal/changes/hooks/external_identity.ex
@@ -1,0 +1,64 @@
+defmodule Portal.Changes.Hooks.ExternalIdentities do
+  @behaviour Portal.Changes.Hooks
+  alias __MODULE__.DB
+
+  @impl true
+  def on_insert(_lsn, _data), do: :ok
+
+  @impl true
+  def on_update(_lsn, _old_data, _new_data), do: :ok
+
+  @impl true
+  def on_delete(_lsn, %{
+        "account_id" => account_id,
+        "issuer" => issuer,
+        "actor_id" => actor_id
+      }) do
+    DB.delete_client_tokens(account_id, actor_id, issuer)
+    DB.delete_portal_sessions(account_id, actor_id, issuer)
+
+    :ok
+  end
+
+  defmodule DB do
+    alias Portal.ClientToken
+    alias Portal.PortalSession
+    alias Portal.Safe
+    import Ecto.Query
+
+    def delete_client_tokens(account_id, actor_id, issuer) do
+      auth_provider_ids = auth_provider_ids_for_issuer(issuer)
+
+      from(c in ClientToken,
+        where:
+          c.account_id == ^account_id and
+            c.actor_id == ^actor_id and
+            c.auth_provider_id in subquery(auth_provider_ids)
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+
+    def delete_portal_sessions(account_id, actor_id, issuer) do
+      auth_provider_ids = auth_provider_ids_for_issuer(issuer)
+
+      from(p in PortalSession,
+        where:
+          p.account_id == ^account_id and
+            p.actor_id == ^actor_id and
+            p.auth_provider_id in subquery(auth_provider_ids)
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+
+    defp auth_provider_ids_for_issuer(issuer) do
+      from(g in Portal.Google.AuthProvider, where: g.issuer == ^issuer, select: g.id)
+      |> union(^from(o in Portal.Okta.AuthProvider, where: o.issuer == ^issuer, select: o.id))
+      |> union(^from(e in Portal.Entra.AuthProvider, where: e.issuer == ^issuer, select: e.id))
+      |> union(
+        ^from(oidc in Portal.OIDC.AuthProvider, where: oidc.issuer == ^issuer, select: oidc.id)
+      )
+    end
+  end
+end

--- a/elixir/lib/portal/changes/replication_connection.ex
+++ b/elixir/lib/portal/changes/replication_connection.ex
@@ -7,6 +7,7 @@ defmodule Portal.Changes.ReplicationConnection do
     "actors" => Hooks.Actors,
     "memberships" => Hooks.Memberships,
     "clients" => Hooks.Clients,
+    "external_identities" => Hooks.ExternalIdentities,
     "policy_authorizations" => Hooks.PolicyAuthorizations,
     "gateways" => Hooks.Gateways,
     "gateway_tokens" => Hooks.GatewayTokens,

--- a/elixir/test/portal/changes/hooks/external_identities_test.exs
+++ b/elixir/test/portal/changes/hooks/external_identities_test.exs
@@ -1,0 +1,190 @@
+defmodule Portal.Changes.Hooks.ExternalIdentitiesTest do
+  use Portal.DataCase, async: true
+  import Portal.Changes.Hooks.ExternalIdentities
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+  import Portal.IdentityFixtures
+  import Portal.PortalSessionFixtures
+  import Portal.TokenFixtures
+
+  describe "on_insert/2" do
+    test "returns :ok" do
+      assert :ok == on_insert(0, %{})
+    end
+  end
+
+  describe "on_update/3" do
+    test "returns :ok" do
+      assert :ok == on_update(0, %{}, %{})
+    end
+  end
+
+  describe "on_delete/2" do
+    test "deletes client tokens for the matching issuer and actor" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      oidc_provider = oidc_provider_fixture(account: account, issuer: "https://auth.example.com")
+
+      client_token =
+        client_token_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: oidc_provider.auth_provider
+        )
+
+      identity =
+        identity_fixture(account: account, actor: actor, issuer: "https://auth.example.com")
+
+      old_data = %{
+        "account_id" => identity.account_id,
+        "actor_id" => identity.actor_id,
+        "issuer" => identity.issuer
+      }
+
+      assert :ok == on_delete(0, old_data)
+      assert Repo.get_by(Portal.ClientToken, id: client_token.id) == nil
+    end
+
+    test "deletes portal sessions for the matching issuer and actor" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      oidc_provider = oidc_provider_fixture(account: account, issuer: "https://auth.example.com")
+
+      portal_session =
+        portal_session_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: oidc_provider.auth_provider
+        )
+
+      identity =
+        identity_fixture(account: account, actor: actor, issuer: "https://auth.example.com")
+
+      old_data = %{
+        "account_id" => identity.account_id,
+        "actor_id" => identity.actor_id,
+        "issuer" => identity.issuer
+      }
+
+      assert :ok == on_delete(0, old_data)
+      assert Repo.get_by(Portal.PortalSession, id: portal_session.id) == nil
+    end
+
+    test "does not delete client tokens for a different actor" do
+      account = account_fixture()
+      actor1 = actor_fixture(account: account)
+      actor2 = actor_fixture(account: account)
+      oidc_provider = oidc_provider_fixture(account: account, issuer: "https://auth.example.com")
+
+      # Token belongs to actor2
+      client_token =
+        client_token_fixture(
+          account: account,
+          actor: actor2,
+          auth_provider: oidc_provider.auth_provider
+        )
+
+      # Identity belongs to actor1
+      identity =
+        identity_fixture(account: account, actor: actor1, issuer: "https://auth.example.com")
+
+      old_data = %{
+        "account_id" => identity.account_id,
+        "actor_id" => identity.actor_id,
+        "issuer" => identity.issuer
+      }
+
+      assert :ok == on_delete(0, old_data)
+      assert Repo.get_by(Portal.ClientToken, id: client_token.id) != nil
+    end
+
+    test "does not delete client tokens for a different issuer" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      oidc_provider =
+        oidc_provider_fixture(account: account, issuer: "https://different-issuer.example.com")
+
+      client_token =
+        client_token_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: oidc_provider.auth_provider
+        )
+
+      identity =
+        identity_fixture(account: account, actor: actor, issuer: "https://auth.example.com")
+
+      old_data = %{
+        "account_id" => identity.account_id,
+        "actor_id" => identity.actor_id,
+        "issuer" => identity.issuer
+      }
+
+      assert :ok == on_delete(0, old_data)
+      assert Repo.get_by(Portal.ClientToken, id: client_token.id) != nil
+    end
+
+    test "deletes client tokens for Google auth provider with matching issuer" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      google_provider =
+        google_provider_fixture(account: account, issuer: "https://accounts.google.com")
+
+      client_token =
+        client_token_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: google_provider.auth_provider
+        )
+
+      identity =
+        identity_fixture(account: account, actor: actor, issuer: "https://accounts.google.com")
+
+      old_data = %{
+        "account_id" => identity.account_id,
+        "actor_id" => identity.actor_id,
+        "issuer" => identity.issuer
+      }
+
+      assert :ok == on_delete(0, old_data)
+      assert Repo.get_by(Portal.ClientToken, id: client_token.id) == nil
+    end
+
+    test "deletes portal sessions for Entra auth provider with matching issuer" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      entra_provider =
+        entra_provider_fixture(
+          account: account,
+          issuer: "https://login.microsoftonline.com/tenant-id/v2.0"
+        )
+
+      portal_session =
+        portal_session_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: entra_provider.auth_provider
+        )
+
+      identity =
+        identity_fixture(
+          account: account,
+          actor: actor,
+          issuer: "https://login.microsoftonline.com/tenant-id/v2.0"
+        )
+
+      old_data = %{
+        "account_id" => identity.account_id,
+        "actor_id" => identity.actor_id,
+        "issuer" => identity.issuer
+      }
+
+      assert :ok == on_delete(0, old_data)
+      assert Repo.get_by(Portal.PortalSession, id: portal_session.id) == nil
+    end
+  end
+end


### PR DESCRIPTION
When an `external_identity` is deleted, it's a good idea to immediately clean up any associated `portal_session`s and `client_token`s as well.

In practice, most of the deletions here will happen during sync, in which the actor will be cleaned up as well triggering the cascade delete. But this is good insurance.

Fixes #11408 