### PR TITLE
test(portal): re-add api client view tests

### DIFF
--- a/elixir/lib/portal/accounts/limits.ex
+++ b/elixir/lib/portal/accounts/limits.ex
@@ -9,6 +9,8 @@ defmodule Portal.Accounts.Limits do
     field :service_accounts_count, :integer
     field :sites_count, :integer
     field :account_admin_users_count, :integer
+    field :api_clients_count, :integer, default: 100
+    field :api_tokens_per_client_count, :integer, default: 100
   end
 
   def changeset(limits \\ %__MODULE__{}, attrs) do
@@ -18,6 +20,8 @@ defmodule Portal.Accounts.Limits do
       service_accounts_count
       sites_count
       account_admin_users_count
+      api_clients_count
+      api_tokens_per_client_count
     ]a
 
     limits
@@ -27,5 +31,7 @@ defmodule Portal.Accounts.Limits do
     |> validate_number(:service_accounts_count, greater_than_or_equal_to: 0)
     |> validate_number(:sites_count, greater_than_or_equal_to: 0)
     |> validate_number(:account_admin_users_count, greater_than_or_equal_to: 0)
+    |> validate_number(:api_clients_count, greater_than_or_equal_to: 0)
+    |> validate_number(:api_tokens_per_client_count, greater_than_or_equal_to: 0)
   end
 end

--- a/elixir/test/portal/billing_test.exs
+++ b/elixir/test/portal/billing_test.exs
@@ -1,0 +1,169 @@
+defmodule Portal.BillingTest do
+  use Portal.DataCase, async: true
+
+  import Portal.Billing
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.TokenFixtures
+
+  setup do
+    account = account_fixture()
+
+    %{account: account}
+  end
+
+  describe "api_clients_limit_exceeded?/2" do
+    test "returns false when api_clients_count limit is not exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 10}})
+
+      assert api_clients_limit_exceeded?(account, 5) == false
+    end
+
+    test "returns false when api_clients_count equals limit", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 10}})
+
+      assert api_clients_limit_exceeded?(account, 10) == false
+    end
+
+    test "returns true when api_clients_count limit is exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 10}})
+
+      assert api_clients_limit_exceeded?(account, 11) == true
+    end
+
+    test "returns false when api_clients_count limit is not set", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: nil}})
+
+      assert api_clients_limit_exceeded?(account, 1000) == false
+    end
+  end
+
+  describe "can_create_api_clients?/1" do
+    test "returns true when api_clients limit is not exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 5}})
+
+      api_client_fixture(account: account)
+      api_client_fixture(account: account)
+
+      assert can_create_api_clients?(account) == true
+    end
+
+    test "returns false when api_clients limit is exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 1}})
+
+      api_client_fixture(account: account)
+
+      assert can_create_api_clients?(account) == false
+    end
+
+    test "returns false when account is disabled" do
+      account = disabled_account_fixture()
+
+      assert can_create_api_clients?(account) == false
+    end
+
+    test "returns true when api_clients limit is not set", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: nil}})
+
+      assert can_create_api_clients?(account) == true
+    end
+
+    test "disabled API clients are not counted against limit", %{account: account} do
+      account = update_account(account, %{limits: %{api_clients_count: 1}})
+
+      api_client = api_client_fixture(account: account)
+      disabled_actor_fixture(account: account, type: :api_client)
+
+      # Only the enabled one counts
+      refute can_create_api_clients?(account)
+
+      # Disable the enabled one
+      api_client
+      |> Ecto.Changeset.change(disabled_at: DateTime.utc_now())
+      |> Portal.Repo.update!()
+
+      # Now we can create more
+      assert can_create_api_clients?(account)
+    end
+  end
+
+  describe "api_tokens_limit_exceeded?/2" do
+    test "returns false when api_tokens_per_client_count limit is not exceeded", %{
+      account: account
+    } do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: 10}})
+
+      assert api_tokens_limit_exceeded?(account, 5) == false
+    end
+
+    test "returns false when api_tokens_per_client_count equals limit", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: 10}})
+
+      assert api_tokens_limit_exceeded?(account, 10) == false
+    end
+
+    test "returns true when api_tokens_per_client_count limit is exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: 10}})
+
+      assert api_tokens_limit_exceeded?(account, 11) == true
+    end
+
+    test "returns false when api_tokens_per_client_count limit is not set", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: nil}})
+
+      assert api_tokens_limit_exceeded?(account, 1000) == false
+    end
+  end
+
+  describe "can_create_api_tokens?/2" do
+    test "returns true when api_tokens limit is not exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: 5}})
+      api_client = api_client_fixture(account: account)
+
+      api_token_fixture(account: account, actor: api_client)
+      api_token_fixture(account: account, actor: api_client)
+
+      assert can_create_api_tokens?(account, api_client) == true
+    end
+
+    test "returns false when api_tokens limit is exceeded", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: 1}})
+      api_client = api_client_fixture(account: account)
+
+      api_token_fixture(account: account, actor: api_client)
+
+      assert can_create_api_tokens?(account, api_client) == false
+    end
+
+    test "returns false when account is disabled" do
+      account = disabled_account_fixture()
+      api_client = api_client_fixture(account: account)
+
+      assert can_create_api_tokens?(account, api_client) == false
+    end
+
+    test "returns true when api_tokens limit is not set", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: nil}})
+      api_client = api_client_fixture(account: account)
+
+      assert can_create_api_tokens?(account, api_client) == true
+    end
+
+    test "tokens are counted per API client, not globally", %{account: account} do
+      account = update_account(account, %{limits: %{api_tokens_per_client_count: 2}})
+
+      api_client1 = api_client_fixture(account: account)
+      api_client2 = api_client_fixture(account: account)
+
+      # Create 2 tokens for client1 (at limit)
+      api_token_fixture(account: account, actor: api_client1)
+      api_token_fixture(account: account, actor: api_client1)
+
+      # Client1 is at limit
+      assert can_create_api_tokens?(account, api_client1) == false
+
+      # Client2 can still create tokens
+      assert can_create_api_tokens?(account, api_client2) == true
+    end
+  end
+end

--- a/elixir/test/portal_web/live/settings/api_clients/new_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/new_test.exs
@@ -1,15 +1,16 @@
-defmodule PortalWeb.Live.Settings.ApiClient.NewTest do
+defmodule PortalWeb.Live.Settings.ApiClients.NewTest do
   use PortalWeb.ConnCase, async: true
 
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+
   setup do
-    account = Fixtures.Accounts.create_account()
-    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
-    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
 
     %{
       account: account,
-      actor: actor,
-      identity: identity
+      actor: actor
     }
   end
 
@@ -24,36 +25,50 @@ defmodule PortalWeb.Live.Settings.ApiClient.NewTest do
               {:redirect,
                %{
                  to: ~p"/#{account}?#{%{redirect_to: path}}",
-                 flash: %{"error" => "You must sign in to access this page."}
+                 flash: %{"error" => "You must sign in to access that page."}
                }}}
   end
 
   test "redirects to beta page when feature not enabled for account", %{
     account: account,
-    identity: identity,
+    actor: actor,
     conn: conn
   } do
-    features = Map.from_struct(account.features)
-    attrs = %{features: %{features | rest_api: false}}
-
-    account = Fixtures.Accounts.update_account(account, attrs)
+    account = update_account(account, %{features: %{rest_api: false}})
 
     assert {:error, {:live_redirect, %{to: path, flash: _}}} =
              conn
-             |> authorize_conn(identity)
+             |> authorize_conn(actor)
              |> live(~p"/#{account}/settings/api_clients/new")
 
     assert path == ~p"/#{account}/settings/api_clients/beta"
   end
 
+  test "redirects to index when API clients limit is reached", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    account = update_account(account, %{limits: %{api_clients_count: 1}})
+    _api_client = api_client_fixture(account: account)
+
+    assert {:error, {:live_redirect, %{to: path, flash: flash}}} =
+             conn
+             |> authorize_conn(actor)
+             |> live(~p"/#{account}/settings/api_clients/new")
+
+    assert path == ~p"/#{account}/settings/api_clients"
+    assert flash["error"] =~ "maximum number of API clients"
+  end
+
   test "renders breadcrumbs item", %{
     account: account,
-    identity: identity,
+    actor: actor,
     conn: conn
   } do
     {:ok, _lv, html} =
       conn
-      |> authorize_conn(identity)
+      |> authorize_conn(actor)
       |> live(~p"/#{account}/settings/api_clients/new")
 
     assert item = html |> Floki.parse_fragment!() |> Floki.find("[aria-label='Breadcrumb']")
@@ -64,52 +79,50 @@ defmodule PortalWeb.Live.Settings.ApiClient.NewTest do
 
   test "renders form", %{
     account: account,
-    identity: identity,
+    actor: actor,
     conn: conn
   } do
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
+      |> authorize_conn(actor)
       |> live(~p"/#{account}/settings/api_clients/new")
 
-    form = form(lv, "form")
+    form = form(lv, "form[phx-submit=submit]")
 
     assert find_inputs(form) == ["actor[name]"]
   end
 
   test "renders changeset errors on input change", %{
     account: account,
-    identity: identity,
+    actor: actor,
     conn: conn
   } do
-    attrs = Fixtures.Actors.actor_attrs() |> Map.take([:name])
-
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
+      |> authorize_conn(actor)
       |> live(~p"/#{account}/settings/api_clients/new")
 
     lv
-    |> form("form", actor: attrs)
+    |> form("form[phx-submit=submit]", actor: %{name: "Test"})
     |> validate_change(%{actor: %{name: String.duplicate("a", 555)}}, fn form, _html ->
       assert form_validation_errors(form) == %{
-               "actor[name]" => ["should be at most 512 character(s)"]
+               "actor[name]" => ["should be at most 255 character(s)"]
              }
     end)
   end
 
   test "renders changeset errors on submit", %{
     account: account,
-    identity: identity,
+    actor: actor,
     conn: conn
   } do
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
+      |> authorize_conn(actor)
       |> live(~p"/#{account}/settings/api_clients/new")
 
     assert lv
-           |> form("form", actor: %{})
+           |> form("form[phx-submit=submit]", actor: %{})
            |> render_submit()
            |> form_validation_errors() == %{
              "actor[name]" => ["can't be blank"]
@@ -118,24 +131,46 @@ defmodule PortalWeb.Live.Settings.ApiClient.NewTest do
 
   test "creates a new actor on valid attrs", %{
     account: account,
-    identity: identity,
+    actor: actor,
     conn: conn
   } do
     attrs = %{
-      name: Fixtures.Actors.actor_attrs().name
+      name: "Test API Client"
     }
 
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
+      |> authorize_conn(actor)
       |> live(~p"/#{account}/settings/api_clients/new")
 
     lv
-    |> form("form", actor: attrs)
+    |> form("form[phx-submit=submit]", actor: attrs)
     |> render_submit()
 
     assert api_client = Repo.get_by(Portal.Actor, name: attrs.name)
 
     assert_redirect(lv, ~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+  end
+
+  test "redirects when limit is reached during submit", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    account = update_account(account, %{limits: %{api_clients_count: 1}})
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/settings/api_clients/new")
+
+    # Create an API client after loading the page to simulate a race condition
+    _api_client = api_client_fixture(account: account)
+
+    lv
+    |> form("form[phx-submit=submit]", actor: %{name: "Test API Client"})
+    |> render_submit()
+
+    assert_redirect(lv, ~p"/#{account}/settings/api_clients")
   end
 end


### PR DESCRIPTION
Caught a bug with the API client new token form, so I've ported the old API client view tests over.

Related: #11056 