### PR TITLE
fix(tunnel): avoid GSO control message for single-packet DNS queries

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -307,7 +307,7 @@ impl UdpSocket {
             datagram.dst,
             datagram.src.map(|s| s.ip()),
             datagram.packet.chunk(),
-            datagram.segment_size,
+            Some(datagram.segment_size),
             datagram.ecn,
         )?;
 
@@ -415,7 +415,7 @@ impl UdpSocket {
         payload: &[u8],
     ) -> io::Result<Vec<u8>> {
         let transmit = self
-            .prepare_transmit(dst, None, payload, payload.len(), Ecn::NonEct)
+            .prepare_transmit(dst, None, payload, None, Ecn::NonEct)
             .map_err(|e| io::Error::other(format!("{e:#}")))?;
 
         self.inner
@@ -446,7 +446,7 @@ impl UdpSocket {
         dst: SocketAddr,
         src_ip: Option<IpAddr>,
         packet: &'a [u8],
-        segment_size: usize,
+        segment_size: Option<usize>,
         ecn: Ecn,
     ) -> Result<quinn_udp::Transmit<'a>> {
         let src_ip = match src_ip {
@@ -468,7 +468,7 @@ impl UdpSocket {
                 Ecn::Ce => Some(quinn_udp::EcnCodepoint::Ce),
             },
             contents: packet,
-            segment_size: Some(segment_size),
+            segment_size,
             src_ip,
         };
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -488,6 +488,14 @@ impl ClientState {
 
                 return; // Our UDP DNS query timeout is likely longer than the one from the OS, so don't bother sending a response.
             }
+            Err(e)
+                if e.any_downcast_ref::<io::Error>()
+                    .is_some_and(|e| e.kind() == io::ErrorKind::InvalidInput) =>
+            {
+                tracing::warn!("Recursive DNS query failed: {e:#}");
+
+                dns_types::Response::servfail(&response.query)
+            }
             Err(e) => {
                 tracing::debug!("Recursive DNS query failed: {e:#}");
 


### PR DESCRIPTION
When sending single-packet UDP DNS queries via the `handshake()` method, we were passing `segment_size: Some(payload.len())` which caused quinn-udp to add the `UDP_SEND_MSG_SIZE` control message to WSASendMsg on Windows.

On some Windows configurations, this control message causes WSAEINVAL (error 10022) even though the setsockopt-based GSO detection succeeded.

This change:
1. Makes `prepare_transmit` accept `Option<usize>` for segment_size
2. Passes `None` for single-packet sends in `handshake()`, avoiding the GSO control message entirely
3. Logs `InvalidInput` errors (which includes WSAEINVAL) at warn level to improve visibility of these issues

Fixes #11570 