### PR TITLE
refactor(portal): ephemeral relays

### DIFF
--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -61,22 +61,4 @@ defmodule Portal.PubSub do
       Atom.to_string(__MODULE__) <> ":" <> account_id
     end
   end
-
-  defmodule Relay do
-    def subscribe(relay_id) do
-      relay_id
-      |> topic()
-      |> Portal.PubSub.subscribe()
-    end
-
-    def broadcast(relay_id, payload) do
-      relay_id
-      |> topic()
-      |> Portal.PubSub.broadcast(payload)
-    end
-
-    defp topic(relay_id) do
-      "relays:" <> relay_id
-    end
-  end
 end

--- a/elixir/lib/portal/relay.ex
+++ b/elixir/lib/portal/relay.ex
@@ -1,60 +1,49 @@
 defmodule Portal.Relay do
-  use Ecto.Schema
-  import Ecto.Changeset
-  import Portal.Changeset
+  @moduledoc """
+  Represents a connected relay. This is a pure struct (not persisted to DB).
+  Relays are ephemeral and only exist while connected via presence.
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
-  @timestamps_opts [type: :utc_datetime_usec]
+  The `id` is a deterministic UUID derived from the stamp_secret at connection time.
+  The `stamp_secret` is kept for TURN credential generation but never exposed in APIs.
+  """
 
-  schema "relays" do
-    field :name, :string
+  defstruct [
+    :id,
+    :stamp_secret,
+    :ipv4,
+    :ipv6,
+    :port,
+    :lat,
+    :lon
+  ]
 
-    field :ipv4, Portal.Types.IP
-    field :ipv6, Portal.Types.IP
+  @type t :: %__MODULE__{
+          id: String.t() | nil,
+          stamp_secret: String.t() | nil,
+          ipv4: String.t() | nil,
+          ipv6: String.t() | nil,
+          port: integer(),
+          lat: float() | nil,
+          lon: float() | nil
+        }
 
-    field :port, :integer, default: 3478
+  @doc """
+  Generates a deterministic UUID from the stamp_secret.
+  This is used as the relay's public identifier without exposing the secret.
+  """
+  def generate_id(stamp_secret) when is_binary(stamp_secret) do
+    # Extract 122 bits from the SHA256 hash (32 + 16 + 12 + 62), discarding 6 bits
+    # that will be replaced with UUID version (4 bits) and variant (2 bits) metadata
+    <<a::32, b::16, _::4, c::12, _::2, d::62, _rest::binary>> =
+      :crypto.hash(:sha256, stamp_secret)
 
-    field :last_seen_user_agent, :string
-    field :last_seen_remote_ip, Portal.Types.IP
-    field :last_seen_remote_ip_location_region, :string
-    field :last_seen_remote_ip_location_city, :string
-    field :last_seen_remote_ip_location_lat, :float
-    field :last_seen_remote_ip_location_lon, :float
-    field :last_seen_version, :string
-    field :last_seen_at, :utc_datetime_usec
-
-    field :stamp_secret, :string, virtual: true
-
-    field :online?, :boolean, virtual: true
-
-    timestamps()
+    # Construct 128-bit UUID: 122 bits from hash + version 4 (4 bits) + variant 10 (2 bits)
+    <<a::32, b::16, 4::4, c::12, 2::2, d::62>>
+    |> Base.encode16(case: :lower)
+    |> format_uuid()
   end
 
-  def changeset(relay \\ %__MODULE__{}, attrs) do
-    relay
-    |> cast(attrs, [
-      :name,
-      :ipv4,
-      :ipv6,
-      :port,
-      :last_seen_user_agent,
-      :last_seen_remote_ip,
-      :last_seen_remote_ip_location_region,
-      :last_seen_remote_ip_location_city,
-      :last_seen_remote_ip_location_lat,
-      :last_seen_remote_ip_location_lon,
-      :last_seen_version,
-      :last_seen_at
-    ])
-    |> validate_required_one_of(~w[ipv4 ipv6]a)
-    |> validate_length(:name, min: 1, max: 255)
-    |> validate_number(:port, greater_than_or_equal_to: 1, less_than_or_equal_to: 65_535)
-    |> unique_constraint(:ipv4, name: :relays_unique_address_index)
-    |> unique_constraint(:ipv6, name: :relays_unique_address_index)
-    |> unique_constraint(:port, name: :relays_unique_address_index)
-    |> unique_constraint(:ipv4, name: :global_relays_unique_address_index)
-    |> unique_constraint(:ipv6, name: :global_relays_unique_address_index)
-    |> unique_constraint(:port, name: :global_relays_unique_address_index)
+  defp format_uuid(<<a::binary-8, b::binary-4, c::binary-4, d::binary-4, e::binary-12>>) do
+    "#{a}-#{b}-#{c}-#{d}-#{e}"
   end
 end

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -687,10 +687,6 @@ defmodule Portal.Safe do
   def permit(_action, Portal.Membership, :api_client), do: :ok
   def permit(:read, Portal.Membership, _), do: :ok
 
-  # Relay permissions
-  def permit(_action, Portal.Relay, :account_admin_user), do: :ok
-  def permit(:read, Portal.Relay, _), do: :ok
-
   def permit(_action, _struct, _type), do: {:error, :unauthorized}
 
   # Helper function to emit subject information to the replication stream

--- a/elixir/lib/portal_api/client/views/relay.ex
+++ b/elixir/lib/portal_api/client/views/relay.ex
@@ -31,11 +31,10 @@ defmodule PortalAPI.Client.Views.Relay do
     }
   end
 
-  defp format_address(%Postgrex.INET{address: address} = inet) when tuple_size(address) == 4,
-    do: inet
-
-  defp format_address(%Postgrex.INET{address: address} = inet) when tuple_size(address) == 8,
-    do: "[#{inet}]"
+  # IPv4 string
+  defp format_address(ip) when is_binary(ip) do
+    if String.contains?(ip, ":"), do: "[#{ip}]", else: ip
+  end
 
   defp generate_username_and_password(%Relay{stamp_secret: stamp_secret}, public_key, expires_at)
        when is_binary(stamp_secret) do

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -64,7 +64,7 @@ defmodule PortalAPI.Gateway.Channel do
     init(socket, account, relays)
 
     # Cache relay IDs and stamp secrets for tracking
-    socket = cache_stamp_secrets(socket, relays)
+    socket = cache_relays(socket, relays)
 
     {:noreply, socket}
   end
@@ -115,34 +115,30 @@ defmodule PortalAPI.Gateway.Channel do
   end
 
   # Debounced relay presence check - queries the CRDT state after the debounce period.
+  # cached_relay_ids is a MapSet of relay IDs we've sent to the gateway.
+  # Presence is keyed by relay ID.
   def handle_info(:check_relay_presence, socket) do
-    cached_secrets = socket.assigns[:stamp_secrets] || %{}
+    cached_relay_ids = socket.assigns[:cached_relay_ids] || MapSet.new()
 
     # Check current presence state - this is the authoritative CRDT-merged state
-    current_relays = Presence.Relays.Global.list()
+    # Presence is keyed by relay ID
+    current_relay_ids = Presence.Relays.Global.list() |> Map.keys() |> MapSet.new()
 
-    # Find which cached relays are now invalid (offline or stamp_secret changed)
+    # Find which cached relays are now disconnected (ID no longer in presence)
     disconnected_ids =
-      Enum.filter(cached_secrets, fn {relay_id, cached_secret} ->
-        case Map.get(current_relays, relay_id) do
-          # Relay is offline
-          nil -> true
-          # Relay is online but stamp_secret changed
-          %{metas: [%{secret: secret} | _]} -> secret != cached_secret
-          _ -> false
-        end
-      end)
-      |> Enum.map(&elem(&1, 0))
+      cached_relay_ids
+      |> Enum.reject(&MapSet.member?(current_relay_ids, &1))
+      |> Enum.to_list()
 
-    # Send relays_presence if any cached relays are invalid OR if we have fewer than 2 relays
+    # Send relays_presence if any cached relays are disconnected OR if we have fewer than 2 relays
     # and more are now available
     needs_update =
       disconnected_ids != [] or
-        (map_size(cached_secrets) < 2 and map_size(current_relays) > 0)
+        (MapSet.size(cached_relay_ids) < 2 and MapSet.size(current_relay_ids) > 0)
 
     if needs_update do
       {:ok, relays} = select_relays(socket)
-      socket = cache_stamp_secrets(socket, relays)
+      socket = cache_relays(socket, relays)
 
       relay_credentials_expire_at = DateTime.utc_now() |> DateTime.add(90, :day)
 
@@ -491,9 +487,9 @@ defmodule PortalAPI.Gateway.Channel do
     {:ok, relays}
   end
 
-  defp cache_stamp_secrets(socket, relays) do
-    stamp_secrets = Map.new(relays, fn relay -> {relay.id, relay.stamp_secret} end)
-    assign(socket, :stamp_secrets, stamp_secrets)
+  defp cache_relays(socket, relays) do
+    cached_relay_ids = MapSet.new(relays, fn relay -> relay.id end)
+    assign(socket, :cached_relay_ids, cached_relay_ids)
   end
 
   defp init(socket, account, relays) do
@@ -684,7 +680,7 @@ defmodule PortalAPI.Gateway.Channel do
   defp load_balance_relays({lat, lon}, relays) do
     relays
     |> Enum.map(fn relay ->
-      case {relay.last_seen_remote_ip_location_lat, relay.last_seen_remote_ip_location_lon} do
+      case {relay.lat, relay.lon} do
         {nil, _} -> {nil, relay}
         {_, nil} -> {nil, relay}
         {relay_lat, relay_lon} -> {Portal.Geo.distance({lat, lon}, {relay_lat, relay_lon}), relay}

--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -1,9 +1,7 @@
 defmodule PortalAPI.Relay.Socket do
   use Phoenix.Socket
-  import Ecto.Changeset
-  import Portal.Changeset
-  alias Portal.{Auth, Version, Relay}
-  alias __MODULE__.DB
+  alias Portal.Auth
+  alias Portal.Relay
   require Logger
   require OpenTelemetry.Tracer
 
@@ -19,14 +17,11 @@ defmodule PortalAPI.Relay.Socket do
 
     OpenTelemetry.Tracer.with_span "relay.connect" do
       context = PortalAPI.Sockets.auth_context(connect_info, :relay)
-      attrs = Map.take(attrs, ~w[ipv4 ipv6 name port])
 
       with {:ok, relay_token} <- Auth.verify_relay_token(encoded_token),
-           {:ok, relay} <- upsert_relay(attrs, context) do
+           {:ok, relay} <- build_relay(attrs, context) do
         OpenTelemetry.Tracer.set_attributes(%{
-          token_id: relay_token.id,
-          relay_id: relay.id,
-          version: relay.last_seen_version
+          token_id: relay_token.id
         })
 
         socket =
@@ -54,83 +49,22 @@ defmodule PortalAPI.Relay.Socket do
   @impl true
   def id(socket), do: Portal.Sockets.socket_id(socket.assigns.token_id)
 
-  defp upsert_relay(attrs, %Auth.Context{} = context) do
-    changeset = upsert_changeset(attrs, context)
-    DB.upsert_relay(changeset)
-  end
+  defp build_relay(attrs, %Auth.Context{} = context) do
+    ipv4 = attrs["ipv4"]
+    ipv6 = attrs["ipv6"]
 
-  defp upsert_changeset(attrs, %Auth.Context{} = context) do
-    upsert_fields = ~w[ipv4 ipv6 port name
-                       last_seen_user_agent
-                       last_seen_remote_ip
-                       last_seen_remote_ip_location_region
-                       last_seen_remote_ip_location_city
-                       last_seen_remote_ip_location_lat
-                       last_seen_remote_ip_location_lon]a
-
-    %Relay{}
-    |> cast(attrs, upsert_fields)
-    |> validate_required_one_of(~w[ipv4 ipv6]a)
-    |> validate_length(:name, min: 1, max: 255)
-    |> validate_number(:port, greater_than_or_equal_to: 1, less_than_or_equal_to: 65_535)
-    |> unique_constraint(:ipv4, name: :relays_unique_address_index)
-    |> unique_constraint(:ipv6, name: :relays_unique_address_index)
-    |> unique_constraint(:port, name: :relays_unique_address_index)
-    |> unique_constraint(:ipv4, name: :global_relays_unique_address_index)
-    |> unique_constraint(:ipv6, name: :global_relays_unique_address_index)
-    |> unique_constraint(:port, name: :global_relays_unique_address_index)
-    |> put_change(:last_seen_at, DateTime.utc_now())
-    |> put_change(:last_seen_user_agent, context.user_agent)
-    |> put_change(:last_seen_remote_ip, context.remote_ip)
-    |> put_change(:last_seen_remote_ip_location_region, context.remote_ip_location_region)
-    |> put_change(:last_seen_remote_ip_location_city, context.remote_ip_location_city)
-    |> put_change(:last_seen_remote_ip_location_lat, context.remote_ip_location_lat)
-    |> put_change(:last_seen_remote_ip_location_lon, context.remote_ip_location_lon)
-    |> put_relay_version()
-  end
-
-  defp put_relay_version(changeset) do
-    with {_data_or_changes, user_agent} when not is_nil(user_agent) <-
-           fetch_field(changeset, :last_seen_user_agent),
-         {:ok, version} <- Version.fetch_version(user_agent) do
-      put_change(changeset, :last_seen_version, version)
+    if is_nil(ipv4) and is_nil(ipv6) do
+      {:error, :missing_ip}
     else
-      {:error, :invalid_user_agent} -> add_error(changeset, :last_seen_user_agent, "is invalid")
-      _ -> changeset
-    end
-  end
+      relay = %Relay{
+        ipv4: ipv4,
+        ipv6: ipv6,
+        port: attrs["port"] || 3478,
+        lat: context.remote_ip_location_lat,
+        lon: context.remote_ip_location_lon
+      }
 
-  defmodule DB do
-    alias Portal.Safe
-
-    def upsert_relay(changeset) do
-      conflict_target = {:unsafe_fragment, ~s/(COALESCE(ipv4, ipv6), port)/}
-
-      conflict_replace_fields =
-        ~w[ipv4 ipv6 port name
-         last_seen_user_agent
-         last_seen_remote_ip
-         last_seen_remote_ip_location_region
-         last_seen_remote_ip_location_city
-         last_seen_remote_ip_location_lat
-         last_seen_remote_ip_location_lon
-         last_seen_version
-         last_seen_at
-         updated_at]a
-
-      on_conflict = {:replace, conflict_replace_fields}
-
-      Ecto.Multi.new()
-      |> Ecto.Multi.insert(:relay, changeset,
-        conflict_target: conflict_target,
-        on_conflict: on_conflict,
-        returning: true
-      )
-      |> Safe.transact()
-      |> case do
-        {:ok, %{relay: relay}} -> {:ok, relay}
-        {:error, :relay, changeset, _effects_so_far} -> {:error, changeset}
-      end
+      {:ok, relay}
     end
   end
 end

--- a/elixir/priv/repo/migrations/20251230104651_drop_relays_table.exs
+++ b/elixir/priv/repo/migrations/20251230104651_drop_relays_table.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.DropRelaysTable do
+  use Ecto.Migration
+
+  def change do
+    # Relays are now ephemeral and tracked only via Phoenix Presence.
+    # The relays table is no longer needed.
+    drop(table(:relays))
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -23,7 +23,6 @@ defmodule Portal.Repo.Seeds do
     NameGenerator,
     OIDC,
     Policy,
-    Relay,
     Resource,
     Site,
     ClientToken,
@@ -932,7 +931,7 @@ defmodule Portal.Repo.Seeds do
     IO.puts("")
 
     # Create relay token with static values
-    global_relay_token =
+    relay_token =
       %Portal.RelayToken{
         id: "e82fcdc1-057a-4015-b90b-3b18f0f28053",
         secret_fragment: "C14NGA87EJRR03G4QPR07A9C6G784TSSTHSF4TI5T0GD8D6L0VRG====",
@@ -941,58 +940,11 @@ defmodule Portal.Repo.Seeds do
       }
       |> Repo.insert!()
 
-    global_relay_encoded_token =
-      Auth.encode_fragment!(global_relay_token)
+    relay_encoded_token =
+      Auth.encode_fragment!(relay_token)
 
-    IO.puts("Created global relay token:")
-    IO.puts("  Token: #{global_relay_encoded_token}")
-    IO.puts("")
-
-    # Create relays directly using the inline upsert logic from PortalAPI.Relay.Socket
-    relay_context = %Auth.Context{
-      type: :relay,
-      user_agent: "Ubuntu/14.04 connlib/0.7.412",
-      remote_ip: {100, 64, 100, 58}
-    }
-
-    # Create first global relay
-    global_relay =
-      %Relay{}
-      |> Ecto.Changeset.cast(
-        %{
-          name: "global-relay-1",
-          ipv4: {189, 172, 72, 111},
-          ipv6: {0, 0, 0, 0, 0, 0, 0, 1}
-        },
-        [:name, :ipv4, :ipv6]
-      )
-      |> put_change(:last_seen_at, DateTime.utc_now())
-      |> put_change(:last_seen_user_agent, relay_context.user_agent)
-      |> put_change(:last_seen_remote_ip, relay_context.remote_ip)
-      |> put_change(:last_seen_version, "0.7.412")
-      |> Repo.insert!()
-
-    # Create additional global relays
-    for i <- 1..5 do
-      _global_relay =
-        %Relay{}
-        |> Ecto.Changeset.cast(
-          %{
-            name: "global-relay-#{i + 1}",
-            ipv4: {189, 172, 72, 111 + i},
-            ipv6: {0, 0, 0, 0, 0, 0, 0, i}
-          },
-          [:name, :ipv4, :ipv6]
-        )
-        |> put_change(:last_seen_at, DateTime.utc_now())
-        |> put_change(:last_seen_user_agent, relay_context.user_agent)
-        |> put_change(:last_seen_remote_ip, %Postgrex.INET{address: {189, 172, 72, 111 + i}})
-        |> put_change(:last_seen_version, "0.7.412")
-        |> Repo.insert!()
-    end
-
-    IO.puts("Created global relays:")
-    IO.puts("  Relay: IPv4: #{global_relay.ipv4} IPv6: #{global_relay.ipv6}")
+    IO.puts("Created relay token:")
+    IO.puts("  Token: #{relay_encoded_token}")
     IO.puts("")
 
     site =

--- a/elixir/test/support/fixtures/relay_fixtures.ex
+++ b/elixir/test/support/fixtures/relay_fixtures.ex
@@ -1,73 +1,37 @@
 defmodule Portal.RelayFixtures do
   @moduledoc """
   Test helpers for creating relays and related data.
+  Relays are ephemeral (not persisted to DB).
   """
 
-  @doc """
-  Generate valid relay attributes with sensible defaults.
-  """
-  def valid_relay_attrs(attrs \\ %{}) do
-    unique_num = System.unique_integer([:positive, :monotonic])
-
-    Enum.into(attrs, %{
-      name: "Relay #{unique_num}",
-      ipv4: {100, 64, rem(unique_num, 255), rem(unique_num, 255)},
-      ipv6: {0x2001, 0x0DB8, 0, 0, 0, 0, 0, rem(unique_num, 65535)},
-      port: 3478,
-      last_seen_user_agent: "Firezone-Relay/1.0.0",
-      last_seen_version: "1.3.0",
-      last_seen_remote_ip: {100, 64, 0, 1},
-      last_seen_at: DateTime.utc_now()
-    })
-  end
+  alias Portal.Relay
 
   @doc """
   Generate a relay with valid default attributes.
-
-  ## Examples
-
-      relay = relay_fixture()
-      relay = relay_fixture(name: "US West Relay")
-      relay = relay_fixture(port: 3479)
-
   """
   def relay_fixture(attrs \\ %{}) do
-    relay_attrs = valid_relay_attrs(attrs)
+    unique_num = System.unique_integer([:positive, :monotonic])
+    stamp_secret = attrs[:stamp_secret] || Portal.Crypto.random_token()
 
-    {:ok, relay} =
-      %Portal.Relay{}
-      |> Portal.Relay.changeset(relay_attrs)
-      |> Portal.Repo.insert()
-
-    relay
-  end
-
-  @doc """
-  Generate an online relay with last seen information.
-  """
-  def online_relay_fixture(attrs \\ %{}) do
-    attrs =
-      attrs
-      |> Map.put_new(:last_seen_at, DateTime.utc_now())
-      |> Map.put_new(:last_seen_user_agent, "Firezone-Relay/1.0.0")
-      |> Map.put_new(:last_seen_version, "1.0.0")
-      |> Map.put_new(:last_seen_remote_ip, {100, 64, 0, 1})
-
-    relay_fixture(attrs)
+    %Relay{
+      id: Relay.generate_id(stamp_secret),
+      stamp_secret: stamp_secret,
+      ipv4: attrs[:ipv4] || "100.64.#{rem(unique_num, 255)}.#{rem(unique_num, 255)}",
+      ipv6: attrs[:ipv6] || "2001:db8::#{Integer.to_string(rem(unique_num, 65535), 16)}",
+      port: attrs[:port] || 3478,
+      lat: attrs[:lat],
+      lon: attrs[:lon]
+    }
   end
 
   @doc """
   Generate a relay with location information.
   """
   def relay_with_location_fixture(attrs \\ %{}) do
-    attrs =
-      attrs
-      |> Map.put_new(:last_seen_remote_ip_location_region, "US-CA")
-      |> Map.put_new(:last_seen_remote_ip_location_city, "San Francisco")
-      |> Map.put_new(:last_seen_remote_ip_location_lat, 37.7749)
-      |> Map.put_new(:last_seen_remote_ip_location_lon, -122.4194)
-
-    relay_fixture(attrs)
+    attrs
+    |> Map.put_new(:lat, 37.7749)
+    |> Map.put_new(:lon, -122.4194)
+    |> relay_fixture()
   end
 
   @doc """
@@ -76,12 +40,10 @@ defmodule Portal.RelayFixtures do
   def ipv6_relay_fixture(attrs \\ %{}) do
     unique_num = System.unique_integer([:positive, :monotonic])
 
-    attrs =
-      attrs
-      |> Map.delete(:ipv4)
-      |> Map.put(:ipv6, {0x2001, 0x0DB8, 0, 0, 0, 0, 0, rem(unique_num, 65535)})
-
-    relay_fixture(attrs)
+    attrs
+    |> Map.put(:ipv4, nil)
+    |> Map.put_new(:ipv6, "2001:db8::#{Integer.to_string(rem(unique_num, 65535), 16)}")
+    |> relay_fixture()
   end
 
   @doc """
@@ -90,38 +52,18 @@ defmodule Portal.RelayFixtures do
   def dual_stack_relay_fixture(attrs \\ %{}) do
     unique_num = System.unique_integer([:positive, :monotonic])
 
-    attrs =
-      attrs
-      |> Map.put_new(:ipv4, {100, 64, rem(unique_num, 255), rem(unique_num, 255)})
-      |> Map.put_new(:ipv6, {0x2001, 0x0DB8, 0, 0, 0, 0, 0, rem(unique_num, 65535)})
-
-    relay_fixture(attrs)
+    attrs
+    |> Map.put_new(:ipv4, "100.64.#{rem(unique_num, 255)}.#{rem(unique_num, 255)}")
+    |> Map.put_new(:ipv6, "2001:db8::#{Integer.to_string(rem(unique_num, 65535), 16)}")
+    |> relay_fixture()
   end
 
   @doc """
-  Generate a relay with a custom port.
+  Create a relay and connect it to presence.
   """
-  def relay_with_custom_port_fixture(port, attrs \\ %{}) do
-    relay_fixture(Map.put(attrs, :port, port))
-  end
-
-  @doc """
-  Update a relay with the given changes.
-  """
-  def update_relay(relay, changes) do
+  def connect_relay(attrs \\ %{}) do
+    relay = relay_fixture(attrs)
+    :ok = Portal.Presence.Relays.connect(relay)
     relay
-    |> Ecto.Changeset.change(Enum.into(changes, %{}))
-    |> Portal.Repo.update!()
-  end
-
-  @doc """
-  Manually disconnects a relay for testing purposes.
-  This simulates the relay socket closing without token deletion.
-  Used to test relay presence debouncing in client/gateway channels.
-  """
-  def disconnect_relay(relay) do
-    :ok = Portal.Presence.untrack(self(), Portal.Presence.Relays.Global.topic(), relay.id)
-    :ok = Portal.PubSub.unsubscribe("relays:#{relay.id}")
-    :ok
   end
 end


### PR DESCRIPTION
There is no reason we need persistence for Relays, which come and go and are already tracked in the Presence state. Each client and gateway subscribes to a debounced stream of events for updates to this state so that they have up-to-date information on the list of relays available for them to use.

The one thing we lose here is the database ID, a UUIDv4. Since any ID will do here, this is now computed deterministically from the stamp_secret, so that clients and gateways can differentiate relays with different in-memory states (and therefore credentials) from each other.