### PR TITLE
chore(portal): remove 'Out of order...' log

### DIFF
--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -81,16 +81,17 @@ defmodule PortalAPI.Gateway.Channel do
   def handle_info(%Change{lsn: lsn} = change, socket) do
     last_lsn = Map.get(socket.assigns, :last_lsn, 0)
 
-    if lsn <= last_lsn do
-      Logger.warning("Out of order or duplicate change received; ignoring",
-        change: change,
-        last_lsn: last_lsn
-      )
+    if lsn > last_lsn do
+      case handle_change(change, socket) do
+        {:noreply, socket} ->
+          {:noreply, assign(socket, last_lsn: lsn)}
 
-      {:noreply, socket}
+        result ->
+          result
+      end
     else
-      socket = assign(socket, last_lsn: lsn)
-      handle_change(change, socket)
+      # Change already processed; ignore to prevent replaying it
+      {:noreply, socket}
     end
   end
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -3,7 +3,6 @@ defmodule PortalAPI.Gateway.ChannelTest do
   alias Portal.Changes
   alias Portal.PubSub
   import Portal.Cache.Cacheable, only: [to_cache: 1]
-  import ExUnit.CaptureLog
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -135,7 +134,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
   end
 
   describe "handle_info/2" do
-    test "logs warning and ignores out of order %Change{}", %{
+    test "ignores out of order %Change{}", %{
       gateway: gateway,
       site: site,
       token: token
@@ -146,16 +145,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert %{assigns: %{last_lsn: 100}} = :sys.get_state(socket.channel_pid)
 
-      message =
-        capture_log(fn ->
-          send(socket.channel_pid, %Changes.Change{lsn: 50})
-
-          # Force the channel to process the message before continuing
-          # :sys.get_state/1 is synchronous and will wait for all pending messages to be handled
-          :sys.get_state(socket.channel_pid)
-        end)
-
-      assert message =~ "[warning] Out of order or duplicate change received; ignoring"
+      send(socket.channel_pid, %Changes.Change{lsn: 50})
 
       assert %{assigns: %{last_lsn: 100}} = :sys.get_state(socket.channel_pid)
     end


### PR DESCRIPTION
After monitoring these logs for a few months, it's clear that duplicate changes are actually expected whenever we deploy or a replication consumer is restarted and picks up "from where it left off" so to speak.

The ordering of events is actually already guaranteed by both the nature of the replication stream, and the way mailboxes work in the BEAM.