### PR TITLE
refactor(connlib): pass token in x-authorization header

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -479,7 +479,6 @@ fn connect(
 
     let url = LoginUrl::client(
         api_url.as_str(),
-        &secret,
         device_id.clone(),
         device_name,
         device_info,
@@ -490,6 +489,7 @@ fn connect(
 
     let portal = PhoenixChannel::disconnected(
         url,
+        secret,
         get_user_agent(platform::COMPONENT, platform::VERSION),
         "client",
         (),

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -13,7 +13,7 @@ use backoff::ExponentialBackoffBuilder;
 use logging::sentry_layer;
 use phoenix_channel::{LoginUrl, PhoenixChannel, get_user_agent};
 use platform::RELEASE;
-use secrecy::{SecretBox, SecretString};
+use secrecy::SecretString;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use telemetry::{Telemetry, analytics};
 use tokio::sync::Mutex;
@@ -489,7 +489,7 @@ fn connect(
     let _guard = runtime.enter(); // Constructing `PhoenixChannel` requires a runtime context.
 
     let portal = PhoenixChannel::disconnected(
-        SecretBox::init_with(|| url),
+        url,
         get_user_agent(platform::COMPONENT, platform::VERSION),
         "client",
         (),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -21,7 +21,7 @@ use telemetry::{
 use tunnel::GatewayTunnel;
 
 use phoenix_channel::PhoenixChannel;
-use secrecy::{ExposeSecret, SecretBox, SecretString};
+use secrecy::{ExposeSecret, SecretString};
 use std::{collections::BTreeSet, fmt};
 use std::{path::PathBuf, process::ExitCode};
 use std::{sync::Arc, time::Duration};
@@ -198,7 +198,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         nameservers,
     );
     let portal = PhoenixChannel::disconnected(
-        SecretBox::init_with(|| login),
+        login,
         get_user_agent("gateway", env!("CARGO_PKG_VERSION")),
         PHOENIX_TOPIC,
         (),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -179,7 +179,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         opentelemetry::global::set_meter_provider(provider);
     }
 
-    let login = LoginUrl::gateway(cli.api_url, &token, firezone_id, cli.firezone_name)
+    let login = LoginUrl::gateway(cli.api_url, firezone_id, cli.firezone_name)
         .context("Failed to construct URL for logging into portal")?;
 
     let resolv_conf = resolv_conf::Config::parse(
@@ -199,6 +199,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     );
     let portal = PhoenixChannel::disconnected(
         login,
+        token,
         get_user_agent("gateway", env!("CARGO_PKG_VERSION")),
         PHOENIX_TOPIC,
         (),

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -21,7 +21,7 @@ use futures::{
 };
 use logging::{FilterReloadHandle, err_with_src};
 use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, get_user_agent};
-use secrecy::{ExposeSecret, SecretBox, SecretString};
+use secrecy::{ExposeSecret, SecretString};
 use std::{
     io::{self, Write},
     mem,
@@ -649,7 +649,7 @@ impl<'a> Handler<'a> {
 
         // Synchronous DNS resolution here
         let portal = PhoenixChannel::disconnected(
-            SecretBox::init_with(|| url),
+            url,
             get_user_agent("gui-client", env!("CARGO_PKG_VERSION")),
             "client",
             (),

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -636,7 +636,6 @@ impl<'a> Handler<'a> {
 
         let url = LoginUrl::client(
             Url::parse(api_url).context("Failed to parse URL")?,
-            &token,
             device_id.id.clone(),
             None,
             DeviceInfo {
@@ -650,6 +649,7 @@ impl<'a> Handler<'a> {
         // Synchronous DNS resolution here
         let portal = PhoenixChannel::disconnected(
             url,
+            token,
             get_user_agent("gui-client", env!("CARGO_PKG_VERSION")),
             "client",
             (),

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -16,7 +16,7 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::PhoenixChannel;
 use phoenix_channel::get_user_agent;
 use phoenix_channel::{DeviceInfo, LoginUrl};
-use secrecy::{SecretBox, SecretString};
+use secrecy::SecretString;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -336,8 +336,8 @@ fn try_main() -> Result<()> {
         // for an Internet connection if it launches us at startup.
         // When running interactively, it is useful for the user to see that we can't reach the portal.
         let portal = PhoenixChannel::disconnected(
-            SecretBox::init_with(|| url),
-            get_user_agent( "headless-client", env!("CARGO_PKG_VERSION")),
+            url,
+            get_user_agent("headless-client", env!("CARGO_PKG_VERSION")),
             "client",
             (),
             move || {

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -279,7 +279,6 @@ fn try_main() -> Result<()> {
 
     let url = LoginUrl::client(
         cli.api_url.clone(),
-        &token,
         firezone_id.clone(),
         cli.firezone_name,
         DeviceInfo {
@@ -337,6 +336,7 @@ fn try_main() -> Result<()> {
         // When running interactively, it is useful for the user to see that we can't reach the portal.
         let portal = PhoenixChannel::disconnected(
             url,
+            token,
             get_user_agent("headless-client", env!("CARGO_PKG_VERSION")),
             "client",
             (),

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -20,7 +20,7 @@ use futures::{FutureExt, SinkExt, StreamExt};
 use itertools::Itertools as _;
 use logging::err_with_src;
 use rand_core::{OsRng, RngCore};
-use secrecy::{ExposeSecret, SecretBox};
+use secrecy::{ExposeSecret as _, SecretString};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
 use std::task::{Context, Poll, Waker};
@@ -53,7 +53,7 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     pending_join_requests: BTreeMap<OutboundRequestId, Instant>,
 
     // Stored here to allow re-connecting.
-    url_prototype: SecretBox<LoginUrl<TFinish>>,
+    url_prototype: LoginUrl<TFinish>,
     last_url: Option<Url>,
     user_agent: String,
     make_reconnect_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
@@ -83,10 +83,12 @@ impl State {
         addresses: Vec<SocketAddr>,
         host: String,
         user_agent: String,
+        token: SecretString,
         socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     ) -> Self {
         Self::Connecting(
-            create_and_connect_websocket(url, addresses, host, user_agent, socket_factory).boxed(),
+            create_and_connect_websocket(url, addresses, host, user_agent, token, socket_factory)
+                .boxed(),
         )
     }
 }
@@ -96,6 +98,7 @@ async fn create_and_connect_websocket(
     addresses: Vec<SocketAddr>,
     host: String,
     user_agent: String,
+    token: SecretString,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError> {
     tracing::debug!(%host, ?addresses, %user_agent, "Connecting to portal");
@@ -105,7 +108,7 @@ async fn create_and_connect_websocket(
         .await
         .map_err(|_| InternalError::Timeout { duration })??;
 
-    let (stream, _) = client_async_tls(make_request(url, host, user_agent), socket)
+    let (stream, _) = client_async_tls(make_request(url, host, user_agent, &token), socket)
         .await
         .map_err(InternalError::WebSocket)?;
 
@@ -269,16 +272,15 @@ where
     /// You must explicitly call [`PhoenixChannel::connect`] to establish a connection.
     ///
     /// The provided URL must contain a host.
-    /// Additionally, you must already provide any query parameters required for authentication.
     pub fn disconnected(
-        url: SecretBox<LoginUrl<TFinish>>,
+        url: LoginUrl<TFinish>,
         user_agent: String,
         login: &'static str,
         init_req: TInitReq,
         make_reconnect_backoff: impl Fn() -> ExponentialBackoff + Send + 'static,
         socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     ) -> Result<Self> {
-        let host_and_port = url.expose_secret().host_and_port();
+        let host_and_port = url.host_and_port();
 
         // Statically resolve the host in the URL to a set of addresses.
         // We use these when connecting the socket to avoid a dependency on DNS resolution later on.
@@ -354,7 +356,7 @@ where
 
     /// Establishes a new connection, dropping the current one if any exists.
     pub fn connect(&mut self, params: TFinish) {
-        let url = self.url_prototype.expose_secret().to_url(params);
+        let url = self.url_prototype.to_url(params);
 
         if matches!(self.state, State::Connecting(_)) && Some(&url) == self.last_url.as_ref() {
             tracing::debug!("We are already connecting");
@@ -366,11 +368,13 @@ where
 
         // 2. Set state to `Connecting` without a timer.
         let user_agent = self.user_agent.clone();
+        let token = self.url_prototype.token().clone();
         self.state = State::connect(
             url.clone(),
             self.socket_addresses(),
             self.host(),
             user_agent,
+            token,
             self.socket_factory.clone(),
         );
         self.last_url = Some(url);
@@ -382,15 +386,11 @@ where
     }
 
     pub fn url(&self) -> String {
-        self.url_prototype.expose_secret().base_url()
+        self.url_prototype.base_url()
     }
 
     pub fn host(&self) -> String {
-        self.url_prototype
-            .expose_secret()
-            .host_and_port()
-            .0
-            .to_owned()
+        self.url_prototype.host_and_port().0.to_owned()
     }
 
     pub fn update_ips(&mut self, ips: Vec<IpAddr>) {
@@ -446,6 +446,7 @@ where
                         .expect("should have last URL if we receive connection error")
                         .clone();
                     let user_agent = self.user_agent.clone();
+                    let token = self.url_prototype.token().clone();
                     let socket_factory = self.socket_factory.clone();
 
                     self.state = State::Connecting(Box::pin(async move {
@@ -455,6 +456,7 @@ where
                             socket_addresses,
                             host,
                             user_agent,
+                            token,
                             socket_factory,
                         )
                         .await
@@ -473,7 +475,7 @@ where
                         self.pending_joins.clear();
                         self.pending_join_requests.clear();
 
-                        let (host, _) = self.url_prototype.expose_secret().host_and_port();
+                        let (host, _) = self.url_prototype.host_and_port();
 
                         tracing::info!(%host, "Connected to portal");
                         self.join(self.login, self.init_req.clone());
@@ -757,7 +759,7 @@ where
     }
 
     fn socket_addresses(&self) -> Vec<SocketAddr> {
-        let port = self.url_prototype.expose_secret().host_and_port().1;
+        let port = self.url_prototype.host_and_port().1;
 
         self.resolved_addresses
             .iter()
@@ -905,7 +907,7 @@ impl<T> PhoenixMessage<T> {
 }
 
 // This is basically the same as tungstenite does but we add some new headers (namely user-agent)
-fn make_request(url: Url, host: String, user_agent: String) -> Request {
+fn make_request(url: Url, host: String, user_agent: String, token: &SecretString) -> Request {
     let mut r = [0u8; 16];
     OsRng.fill_bytes(&mut r);
     let key = base64::engine::general_purpose::STANDARD.encode(r);
@@ -920,6 +922,10 @@ fn make_request(url: Url, host: String, user_agent: String) -> Request {
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", key)
         .header("User-Agent", user_agent)
+        .header(
+            "X-Authorization",
+            format!("Bearer {}", token.expose_secret()),
+        )
         .uri(url.to_string())
         .body(())
         .expect("should always be able to build a request if we only pass strings to it")

--- a/rust/libs/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/libs/connlib/phoenix-channel/src/login_url.rs
@@ -1,5 +1,4 @@
 use base64::{Engine, engine::general_purpose::STANDARD};
-use secrecy::SecretString;
 use serde::Deserialize;
 use sha2::Digest as _;
 use std::{
@@ -41,9 +40,6 @@ pub struct LoginUrl<TFinish> {
     host: String,
     port: u16,
 
-    /// The authentication token, sent via X-Authorization header.
-    token: SecretString,
-
     phantom: PhantomData<TFinish>,
 }
 
@@ -74,7 +70,6 @@ impl IntoIterator for NoParams {
 impl LoginUrl<PublicKeyParam> {
     pub fn client<E>(
         url: impl TryInto<Url, Error = E>,
-        firezone_token: &SecretString,
         device_id: String,
         device_name: Option<String>,
         device_info: DeviceInfo,
@@ -106,14 +101,12 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
-            token: firezone_token.clone(),
             phantom: PhantomData,
         })
     }
 
     pub fn gateway<E>(
         url: impl TryInto<Url, Error = E>,
-        firezone_token: &SecretString,
         device_id: String,
         device_name: Option<String>,
     ) -> Result<Self, LoginUrlError<E>> {
@@ -143,7 +136,6 @@ impl LoginUrl<PublicKeyParam> {
             host,
             port,
             url,
-            token: firezone_token.clone(),
             phantom: PhantomData,
         })
     }
@@ -152,7 +144,6 @@ impl LoginUrl<PublicKeyParam> {
 impl LoginUrl<NoParams> {
     pub fn relay<E>(
         url: impl TryInto<Url, Error = E>,
-        firezone_token: &SecretString,
         device_name: Option<String>,
         listen_port: u16,
         ipv4_address: Option<Ipv4Addr>,
@@ -175,7 +166,6 @@ impl LoginUrl<NoParams> {
             host,
             port,
             url,
-            token: firezone_token.clone(),
             phantom: PhantomData,
         })
     }
@@ -206,10 +196,6 @@ impl<TFinish> LoginUrl<TFinish> {
         url.set_query(None);
 
         url.to_string()
-    }
-
-    pub fn token(&self) -> &SecretString {
-        &self.token
     }
 }
 
@@ -329,7 +315,6 @@ mod tests {
     fn base_url_removes_params_and_path() {
         let login_url = LoginUrl::client(
             "wss://api.firez.one",
-            &SecretString::from("foobar"),
             "some-id".to_owned(),
             None,
             DeviceInfo::default(),

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -1,8 +1,6 @@
 #![cfg(not(windows))] // For some reason, Windows doesn't like this test.
 #![allow(clippy::unwrap_used)]
 
-use secrecy::SecretBox;
-
 #[tokio::test]
 async fn client_does_not_pipeline_messages() {
     use std::{str::FromStr, sync::Arc, time::Duration};
@@ -61,16 +59,14 @@ async fn client_does_not_pipeline_messages() {
         }
     });
 
-    let login_url = SecretBox::init_with(|| {
-        LoginUrl::client(
-            Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
-            &SecretString::from("secret"),
-            String::new(),
-            None,
-            DeviceInfo::default(),
-        )
-        .unwrap()
-    });
+    let login_url = LoginUrl::client(
+        Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
+        &SecretString::from("secret"),
+        String::new(),
+        None,
+        DeviceInfo::default(),
+    )
+    .unwrap();
 
     let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
         login_url,
@@ -166,16 +162,14 @@ async fn client_deduplicates_messages() {
         }
     });
 
-    let login_url = SecretBox::init_with(|| {
-        LoginUrl::client(
-            Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
-            &SecretString::from("secret"),
-            String::new(),
-            None,
-            DeviceInfo::default(),
-        )
-        .unwrap()
-    });
+    let login_url = LoginUrl::client(
+        Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
+        &SecretString::from("secret"),
+        String::new(),
+        None,
+        DeviceInfo::default(),
+    )
+    .unwrap();
 
     let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
         login_url,

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -61,7 +61,6 @@ async fn client_does_not_pipeline_messages() {
 
     let login_url = LoginUrl::client(
         Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
-        &SecretString::from("secret"),
         String::new(),
         None,
         DeviceInfo::default(),
@@ -70,6 +69,7 @@ async fn client_does_not_pipeline_messages() {
 
     let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
         login_url,
+        SecretString::from("secret"),
         "test/1.0.0".to_owned(),
         "test",
         (),
@@ -164,7 +164,6 @@ async fn client_deduplicates_messages() {
 
     let login_url = LoginUrl::client(
         Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
-        &SecretString::from("secret"),
         String::new(),
         None,
         DeviceInfo::default(),
@@ -173,6 +172,7 @@ async fn client_deduplicates_messages() {
 
     let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
         login_url,
+        SecretString::from("secret"),
         "test/1.0.0".to_owned(),
         "test",
         (),

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -14,7 +14,7 @@ use logging::{FilterReloadHandle, err_with_src, sentry_layer};
 use phoenix_channel::{Event, LoginUrl, NoParams, PhoenixChannel, get_user_agent};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use secrecy::{ExposeSecret, SecretBox, SecretString};
+use secrecy::{ExposeSecret, SecretString};
 use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
@@ -239,7 +239,7 @@ async fn try_main(args: Args) -> Result<()> {
     )?;
 
     let mut channel = PhoenixChannel::disconnected(
-        SecretBox::init_with(|| login),
+        login,
         get_user_agent("relay", env!("CARGO_PKG_VERSION")),
         "relay",
         JoinMessage {

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -231,7 +231,6 @@ async fn try_main(args: Args) -> Result<()> {
 
     let login = LoginUrl::relay(
         args.api_url.clone(),
-        &args.token,
         args.name.clone(),
         args.listen_port,
         args.public_ip4_addr,
@@ -240,6 +239,7 @@ async fn try_main(args: Args) -> Result<()> {
 
     let mut channel = PhoenixChannel::disconnected(
         login,
+        args.token.clone(),
         get_user_agent("relay", env!("CARGO_PKG_VERSION")),
         "relay",
         JoinMessage {

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11595">
+          Passes the authentication token in the x-authorization header instead
+          of in the URL, improving rate limiting for users behind shared IPs.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">
           Fixes an issue where the authentication link would not open in the

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11595">
+          Passes the authentication token in the x-authorization header instead
+          of in the URL, improving rate limiting for users behind shared IPs.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.11" date={new Date("2025-12-23")}>
         <ChangeItem pull="11141">
           Fixes an issue where spurious resource updates would result in

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11595">
+          Passes the authentication token in the x-authorization header instead
+          of in the URL, improving rate limiting for users behind shared IPs.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-12-23")}>
         {os == OS.Linux && (
           <ChangeItem pull="10742">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11595">
+          Passes the authentication token in the x-authorization header instead
+          of in the URL, improving rate limiting for users behind shared IPs.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.19" date={new Date("2025-12-23")}>
         <ChangeItem pull="10972">
           Fixes an issue where IPv6-only DNS resources could not be reached.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,12 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11595">
+          Passes the authentication token in the x-authorization header instead
+          of in the URL, improving rate limiting for users behind shared IPs.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.5" date={new Date("2025-12-23")}>
         {os == OS.Linux && (
           <ChangeItem pull="10742">


### PR DESCRIPTION
GCP ALB supports keying the rate limit counters off unique authz headers in addition to the client IP. This would prevent customers from hitting 503 or 429 for legitimate connection requests for multiple different users/clients behind the same IP.

Query params are not supported for this unfortunately.

Phoenix doesn't expose arbitrary headers in the WebSocket request, only `x-*` and `sec-websocket-*` headers, so the former is chosen because the latter is intended to be used for subprotocol negotiation.

Fixes: https://github.com/firezone/firezone/issues/9581