### PR TITLE
feat(portal): support token in x-authorization header

### DIFF
--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -12,42 +12,45 @@ defmodule PortalAPI.Relay.Socket do
   ## Authentication
 
   @impl true
-  def connect(%{"token" => encoded_token} = attrs, socket, connect_info) do
+  def connect(attrs, socket, connect_info) do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "relay.connect" do
-      context = PortalAPI.Sockets.auth_context(connect_info, :relay)
-
-      with {:ok, relay_token} <- Auth.verify_relay_token(encoded_token),
-           {:ok, relay} <- build_relay(attrs, context) do
-        OpenTelemetry.Tracer.set_attributes(%{
-          token_id: relay_token.id
-        })
-
-        socket =
-          socket
-          |> assign(:token_id, relay_token.id)
-          |> assign(:relay, relay)
-          |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
-          |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
-
-        {:ok, socket}
-      else
-        error ->
-          trace = Process.info(self(), :current_stacktrace)
-          Logger.info("Relay socket connection failed", error: error, stacktrace: trace)
-
-          error
+      case PortalAPI.Sockets.extract_token(attrs, connect_info) do
+        {:ok, encoded_token} -> do_connect(encoded_token, attrs, socket, connect_info)
+        :error -> {:error, :missing_token}
       end
     end
   end
 
-  def connect(_params, _socket, _connect_info) do
-    {:error, :missing_token}
-  end
-
   @impl true
   def id(socket), do: Portal.Sockets.socket_id(socket.assigns.token_id)
+
+  defp do_connect(encoded_token, attrs, socket, connect_info) do
+    context = PortalAPI.Sockets.auth_context(connect_info, :relay)
+
+    with {:ok, relay_token} <- Auth.verify_relay_token(encoded_token),
+         {:ok, relay} <- build_relay(attrs, context) do
+      OpenTelemetry.Tracer.set_attributes(%{
+        token_id: relay_token.id
+      })
+
+      socket =
+        socket
+        |> assign(:token_id, relay_token.id)
+        |> assign(:relay, relay)
+        |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
+        |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
+
+      {:ok, socket}
+    else
+      error ->
+        trace = Process.info(self(), :current_stacktrace)
+        Logger.info("Relay socket connection failed", error: error, stacktrace: trace)
+
+        error
+    end
+  end
 
   defp build_relay(attrs, %Auth.Context{} = context) do
     ipv4 = attrs["ipv4"]

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -1,0 +1,76 @@
+defmodule PortalAPI.SocketsTest do
+  use ExUnit.Case, async: true
+  alias PortalAPI.Sockets
+
+  describe "extract_token/2" do
+    test "returns token from x-authorization header with Bearer prefix" do
+      params = %{}
+      connect_info = %{x_headers: [{"x-authorization", "Bearer my-token-123"}]}
+
+      assert Sockets.extract_token(params, connect_info) == {:ok, "my-token-123"}
+    end
+
+    test "returns token from params when header is missing" do
+      params = %{"token" => "param-token-456"}
+      connect_info = %{x_headers: []}
+
+      assert Sockets.extract_token(params, connect_info) == {:ok, "param-token-456"}
+    end
+
+    test "returns token from params when x_headers key is missing" do
+      params = %{"token" => "param-token-789"}
+      connect_info = %{}
+
+      assert Sockets.extract_token(params, connect_info) == {:ok, "param-token-789"}
+    end
+
+    test "header takes precedence over params" do
+      params = %{"token" => "param-token"}
+      connect_info = %{x_headers: [{"x-authorization", "Bearer header-token"}]}
+
+      assert Sockets.extract_token(params, connect_info) == {:ok, "header-token"}
+    end
+
+    test "returns error when neither header nor param is present" do
+      params = %{}
+      connect_info = %{x_headers: []}
+
+      assert Sockets.extract_token(params, connect_info) == :error
+    end
+
+    test "returns error when header exists but without Bearer prefix" do
+      params = %{}
+      connect_info = %{x_headers: [{"x-authorization", "my-token"}]}
+
+      assert Sockets.extract_token(params, connect_info) == :error
+    end
+
+    test "returns error when header exists with wrong prefix" do
+      params = %{}
+      connect_info = %{x_headers: [{"x-authorization", "Basic my-token"}]}
+
+      assert Sockets.extract_token(params, connect_info) == :error
+    end
+
+    test "handles multiple x_headers correctly" do
+      params = %{}
+
+      connect_info = %{
+        x_headers: [
+          {"x-forwarded-for", "192.168.1.1"},
+          {"x-authorization", "Bearer correct-token"},
+          {"x-custom", "value"}
+        ]
+      }
+
+      assert Sockets.extract_token(params, connect_info) == {:ok, "correct-token"}
+    end
+
+    test "falls back to params when header value is empty" do
+      params = %{"token" => "fallback-token"}
+      connect_info = %{x_headers: [{"x-authorization", ""}]}
+
+      assert Sockets.extract_token(params, connect_info) == {:ok, "fallback-token"}
+    end
+  end
+end


### PR DESCRIPTION
Accepts the token in either the `x-authorization` header or the existing `token` param, prioritizing the former. The `X-` header is used because Phoenix doesn't expose arbitrary HTTP headers in the WebSocket connect callback.

Related: #9581
Related: #11595 