### PR TITLE
docs: update CONTRIBUTING.md with cert gen

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,20 +108,16 @@ After this you will have running:
 
 ### Generating a self-signed cert
 
-We recommend generating a valid self-signed ceriticate for local development to avoid debugging TLS issues.
+We recommend generating a trusted self-signed certificate for local development to avoid debugging TLS issues.
 
-On macOS or Linux you can use the `mkcert` utility:
+On macOS you can generate and trust a certificate with:
 
 ```sh
-brew install mkcert
-mkcert -install
-mkcert localhost 127.0.0.1 ::1
-mv localhost+2-key.pem elixir/priv/cert/selfsigned_key.pem
-mv localhost+2.pem elixir/priv/cert/selfsigned.pem
+cd elixir && mix phx.gen.cert
+sudo security add-trusted-cert -d -r trustAsRoot -k /Library/Keychains/System.keychain priv/cert/selfsigned.pem
 ```
 
-This will generate a self-signed certificate for `localhost` and place it in the
-correct location for the Elixir application to use, as well as adding the local CA to your
+This will generate a self-signed certificate for `localhost` and add it to your
 system trust store for easier testing in browsers.
 
 ### Ensure Everything Works

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -114,7 +114,7 @@ On macOS you can generate and trust a certificate with:
 
 ```sh
 cd elixir && mix phx.gen.cert
-sudo security add-trusted-cert -d -r trustAsRoot -k /Library/Keychains/System.keychain priv/cert/selfsigned.pem
+sudo security add-trusted-cert -d -p ssl -k /Library/Keychains/System.keychain priv/cert/selfsigned.pem
 ```
 
 This will generate a self-signed certificate for `localhost` and add it to your

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -119,7 +119,14 @@ cd elixir
 # Note: We use openssl instead of `mix phx.gen.cert` because of a Phoenix bug
 # that generates invalid certificates missing parameters: :NULL
 # See: https://github.com/phoenixframework/phoenix/issues/6319 which introduced this bug
-openssl req -x509 -newkey rsa:2048 -keyout priv/cert/selfsigned_key.pem -out priv/cert/selfsigned.pem -days 365 -nodes -subj "/O=Firezone Development/CN=localhost" -addext "subjectAltName=DNS:localhost"
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 365 \
+    -keyout priv/cert/selfsigned-key.pem \
+    -out priv/cert/selfsigned.pem \
+    -subj "/O=Firezone Development/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+    -addext "basicConstraints=critical,CA:FALSE" \
+    -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
+    -addext "extendedKeyUsage=critical,serverAuth"
 
 # Add the new cert to the system trust store
 sudo security add-trusted-cert -d -p ssl -k /Library/Keychains/System.keychain priv/cert/selfsigned.pem

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,12 +113,26 @@ We recommend generating a trusted self-signed certificate for local development 
 On macOS you can generate and trust a certificate with:
 
 ```sh
-cd elixir && mix phx.gen.cert
+cd elixir
+
+# Generate a self-signed certificate for localhost
+# Note: We use openssl instead of `mix phx.gen.cert` because of a Phoenix bug
+# that generates invalid certificates missing parameters: :NULL
+# See: https://github.com/phoenixframework/phoenix/issues/6319 which introduced this bug
+openssl req -x509 -newkey rsa:2048 -keyout priv/cert/selfsigned_key.pem -out priv/cert/selfsigned.pem -days 365 -nodes -subj "/O=Firezone Development/CN=localhost" -addext "subjectAltName=DNS:localhost"
+
+# Add the new cert to the system trust store
 sudo security add-trusted-cert -d -p ssl -k /Library/Keychains/System.keychain priv/cert/selfsigned.pem
 ```
 
 This will generate a self-signed certificate for `localhost` and add it to your
 system trust store for easier testing in browsers.
+
+**Note for Firefox users:** Firefox uses its own certificate store and ignores the
+macOS system keychain by default. To trust the certificate in Firefox, either:
+
+1. Go to `about:config` and set `security.enterprise_roots.enabled` to `true`, or
+2. Import the cert directly: Settings → Privacy & Security → Certificates → View Certificates → Authorities → Import `priv/cert/selfsigned.pem`
 
 ### Ensure Everything Works
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -106,6 +106,24 @@ After this you will have running:
 - A resource with IP `172.20.0.100` on a separate network shared with the
   gateway
 
+### Generating a self-signed cert
+
+We recommend generating a valid self-signed ceriticate for local development to avoid debugging TLS issues.
+
+On macOS or Linux you can use the `mkcert` utility:
+
+```sh
+brew install mkcert
+mkcert -install
+mkcert localhost 127.0.0.1 ::1
+mv localhost+2-key.pem elixir/priv/cert/selfsigned_key.pem
+mv localhost+2.pem elixir/priv/cert/selfsigned.pem
+```
+
+This will generate a self-signed certificate for `localhost` and place it in the
+correct location for the Elixir application to use, as well as adding the local CA to your
+system trust store for easier testing in browsers.
+
 ### Ensure Everything Works
 
 ```sh


### PR DESCRIPTION
When testing things like cookies / CSP / and client auth locally, it's helpful to have a trusted cert in place to avoid the iteration loop of sending things out to staging before they can be verified.