### PR TITLE
chore: Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-debug.log
 
 # Development environment configuration
 **/.env
+**/.envrc
 .oidc_env.json
 
 # Built packages


### PR DESCRIPTION
Why:

* .envrc is usually a place to put local secrets for your dev environment.  By having this file in the .gitignore it helps reduce the chance of committing any secret to the repo.