### PR TITLE
chore(portal): remove redundant cldr module

### DIFF
--- a/elixir/lib/portal_web/cldr.ex
+++ b/elixir/lib/portal_web/cldr.ex
@@ -1,5 +1,0 @@
-defmodule PortalWeb.CLDR do
-  use Cldr,
-    locales: ["en"],
-    providers: [Cldr.Number, Cldr.Calendar, Cldr.DateTime]
-end

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -945,7 +945,7 @@ defmodule PortalWeb.CoreComponents do
   def datetime(assigns) do
     ~H"""
     <span title={@datetime}>
-      {Cldr.DateTime.to_string!(@datetime, PortalWeb.CLDR, format: @format)}
+      {Cldr.DateTime.to_string!(@datetime, Portal.CLDR, format: @format)}
     </span>
     """
   end
@@ -970,7 +970,7 @@ defmodule PortalWeb.CoreComponents do
           "underline underline-offset-2 decoration-1 decoration-dotted",
           DateTime.compare(@datetime, @relative_to) == :lt && @negative_class
         ]}>
-          {Cldr.DateTime.Relative.to_string!(@datetime, PortalWeb.CLDR, relative_to: @relative_to)
+          {Cldr.DateTime.Relative.to_string!(@datetime, Portal.CLDR, relative_to: @relative_to)
           |> String.capitalize()}
         </span>
       </:target>
@@ -979,7 +979,7 @@ defmodule PortalWeb.CoreComponents do
       </:content>
     </.popover>
     <span :if={not @popover}>
-      {Cldr.DateTime.Relative.to_string!(@datetime, PortalWeb.CLDR, relative_to: @relative_to)
+      {Cldr.DateTime.Relative.to_string!(@datetime, Portal.CLDR, relative_to: @relative_to)
       |> String.capitalize()}
     </span>
     <span :if={is_nil(@datetime)}>
@@ -1047,7 +1047,7 @@ defmodule PortalWeb.CoreComponents do
         title={
           if @schema.last_seen_at,
             do:
-              "Last started #{Cldr.DateTime.Relative.to_string!(@schema.last_seen_at, PortalWeb.CLDR, relative_to: @relative_to)}",
+              "Last started #{Cldr.DateTime.Relative.to_string!(@schema.last_seen_at, Portal.CLDR, relative_to: @relative_to)}",
             else: "Never connected"
         }
       >
@@ -1297,7 +1297,7 @@ defmodule PortalWeb.CoreComponents do
 
     ~H"""
     <span data-value={@number} {@rest}>
-      {PortalWeb.CLDR.Number.Cardinal.pluralize(@number, :en, @opts)}
+      {Portal.CLDR.Number.Cardinal.pluralize(@number, :en, @opts)}
     </span>
     """
   end

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -104,7 +104,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
             </.badge>
           </:col>
           <:col :let={actor} label="created at">
-            {Cldr.DateTime.Formatter.date(actor.inserted_at, 1, "en", PortalWeb.CLDR, [])}
+            {Cldr.DateTime.Formatter.date(actor.inserted_at, 1, "en", Portal.CLDR, [])}
           </:col>
           <:empty>
             <div class="flex justify-center text-center text-neutral-500 p-4">

--- a/elixir/lib/portal_web/live/settings/api_clients/show.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/show.ex
@@ -113,7 +113,7 @@ defmodule PortalWeb.Settings.ApiClients.Show do
           <.vertical_table_row>
             <:label>Created</:label>
             <:value>
-              {Cldr.DateTime.Formatter.date(@actor.inserted_at, 1, "en", PortalWeb.CLDR, [])}
+              {Cldr.DateTime.Formatter.date(@actor.inserted_at, 1, "en", Portal.CLDR, [])}
             </:value>
           </.vertical_table_row>
         </.vertical_table>
@@ -164,7 +164,7 @@ defmodule PortalWeb.Settings.ApiClients.Show do
             {token.name}
           </:col>
           <:col :let={token} label="expires at">
-            {Cldr.DateTime.Formatter.date(token.expires_at, 1, "en", PortalWeb.CLDR, [])}
+            {Cldr.DateTime.Formatter.date(token.expires_at, 1, "en", Portal.CLDR, [])}
           </:col>
           <:col :let={token} label="last used">
             <.relative_datetime datetime={token.last_seen_at} />

--- a/elixir/test/portal_web/live/settings/api_clients/show_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/show_test.exs
@@ -77,7 +77,7 @@ defmodule PortalWeb.Live.Settings.ApiClients.ShowTest do
     assert html =~ "API Client"
 
     expected_date =
-      Cldr.DateTime.Formatter.date(api_client.inserted_at, 1, "en", PortalWeb.CLDR, [])
+      Cldr.DateTime.Formatter.date(api_client.inserted_at, 1, "en", Portal.CLDR, [])
 
     assert lv
            |> element("#api-client")


### PR DESCRIPTION
This was a leftover from #11475 and can be removed - it's an exact duplicate module. These take 10+ seconds to compile and so will add a healthy boost to our CI times.