### PR TITLE
chore(portal): use JSON over Jason

### DIFF
--- a/elixir/lib/portal/crypto/jwk.ex
+++ b/elixir/lib/portal/crypto/jwk.ex
@@ -43,7 +43,7 @@ defmodule Portal.Crypto.JWK do
 
     # Generate key ID using RFC 7638 thumbprint
     thumbprint_json =
-      Jason.encode!(%{
+      JSON.encode!(%{
         "e" => jwk["e"],
         "kty" => jwk["kty"],
         "n" => jwk["n"]

--- a/elixir/lib/portal/okta/api_client.ex
+++ b/elixir/lib/portal/okta/api_client.ex
@@ -62,7 +62,7 @@ defmodule Portal.Okta.APIClient do
     {_type, dpop_jwt} =
       key
       |> JOSE.JWK.from_map()
-      |> JOSE.JWS.sign(Jason.encode!(claims), header)
+      |> JOSE.JWS.sign(JSON.encode!(claims), header)
       |> JOSE.JWS.compact()
 
     dpop_jwt
@@ -369,7 +369,7 @@ defmodule Portal.Okta.APIClient do
     {_type, jwt} =
       client.private_key
       |> JOSE.JWK.from_map()
-      |> JOSE.JWS.sign(Jason.encode!(claims), header)
+      |> JOSE.JWS.sign(JSON.encode!(claims), header)
       |> JOSE.JWS.compact()
 
     jwt

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -25,7 +25,7 @@ defmodule Portal.HealthTest do
         |> Portal.Health.call([])
 
       assert conn.status == 200
-      assert Jason.decode!(conn.resp_body) == %{"status" => "ok"}
+      assert JSON.decode!(conn.resp_body) == %{"status" => "ok"}
     end
   end
 
@@ -37,7 +37,7 @@ defmodule Portal.HealthTest do
         |> Portal.Health.call([])
 
       assert conn.status == 200
-      assert Jason.decode!(conn.resp_body) == %{"status" => "ready"}
+      assert JSON.decode!(conn.resp_body) == %{"status" => "ready"}
     end
 
     test "returns 503 with status draining when draining file exists", %{
@@ -51,7 +51,7 @@ defmodule Portal.HealthTest do
         |> Portal.Health.call([])
 
       assert conn.status == 503
-      assert Jason.decode!(conn.resp_body) == %{"status" => "draining"}
+      assert JSON.decode!(conn.resp_body) == %{"status" => "draining"}
     end
   end
 


### PR DESCRIPTION
In #8011 we removed `Jason` in favor of stdlib's `JSON` module which has nearly the exact same API. This PR cleans up a few places where `Jason` crept back in.

The one place intentionally not updated is the return value when verifying OIDC setup - that comes from the openid_connect lib and so it needs to match. That will be fixed in https://github.com/firezone/openid_connect/issues/9