### PR TITLE
feat(portal): rate-limit websocket connects

### DIFF
--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -22,9 +22,6 @@ defmodule PortalAPI.Client.Socket do
       with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
            {:ok, token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
         do_connect(token, attrs, socket, connect_info)
-      else
-        {:error, :rate_limit} -> {:error, :rate_limit}
-        :error -> {:error, :missing_token}
       end
     end
   end

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -22,9 +22,6 @@ defmodule PortalAPI.Gateway.Socket do
       with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
            {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
         do_connect(encoded_token, attrs, socket, connect_info)
-      else
-        {:error, :rate_limit} -> {:error, :rate_limit}
-        :error -> {:error, :missing_token}
       end
     end
   end

--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -16,8 +16,11 @@ defmodule PortalAPI.Relay.Socket do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "relay.connect" do
-      case PortalAPI.Sockets.extract_token(attrs, connect_info) do
-        {:ok, encoded_token} -> do_connect(encoded_token, attrs, socket, connect_info)
+      with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
+           {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
+        do_connect(encoded_token, attrs, socket, connect_info)
+      else
+        {:error, :rate_limit} -> {:error, :rate_limit}
         :error -> {:error, :missing_token}
       end
     end

--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -19,9 +19,6 @@ defmodule PortalAPI.Relay.Socket do
       with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
            {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
         do_connect(encoded_token, attrs, socket, connect_info)
-      else
-        {:error, :rate_limit} -> {:error, :rate_limit}
-        :error -> {:error, :missing_token}
       end
     end
   end

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -11,10 +11,10 @@ defmodule PortalAPI.Sockets do
   Checks the `x-authorization` header first (expecting "Bearer {token}" format),
   then falls back to the `token` query parameter.
 
-  Returns `{:ok, token}` if found, or `:error` if no token is present.
+  Returns `{:ok, token}` if found, or `{:error, :missing_token}` if no token is present.
   """
   def extract_token(params, connect_info) do
-    with :error <- extract_token_from_header(connect_info) do
+    with {:error, :missing_token} <- extract_token_from_header(connect_info) do
       extract_token_from_params(params)
     end
   end
@@ -64,12 +64,12 @@ defmodule PortalAPI.Sockets do
   defp extract_token_from_header(%{x_headers: x_headers}) when is_list(x_headers) do
     case List.keyfind(x_headers, "x-authorization", 0) do
       {"x-authorization", "Bearer " <> token} -> {:ok, token}
-      _ -> :error
+      _ -> {:error, :missing_token}
     end
   end
 
-  defp extract_token_from_header(_connect_info), do: :error
+  defp extract_token_from_header(_connect_info), do: {:error, :missing_token}
 
   defp extract_token_from_params(%{"token" => token}) when is_binary(token), do: {:ok, token}
-  defp extract_token_from_params(_params), do: :error
+  defp extract_token_from_params(_params), do: {:error, :missing_token}
 end

--- a/elixir/lib/portal_api/sockets/rate_limit.ex
+++ b/elixir/lib/portal_api/sockets/rate_limit.ex
@@ -1,0 +1,61 @@
+defmodule PortalAPI.Sockets.RateLimit do
+  @moduledoc """
+  Rate limiting for WebSocket connections.
+
+  Limits connection attempts to 1 request per second per unique combination
+  of IP address and X-Authorization header value (hashed for security).
+  """
+
+  @refill_rate 1
+  @capacity 1
+  @cost 1
+  @retry_after_seconds 1
+
+  @doc """
+  Checks if a socket connection should be rate limited.
+
+  Uses the IP address and a hash of the X-Authorization header as a unique key.
+  Returns `:ok` if allowed, or `{:error, :rate_limit}` if rate limited.
+  """
+  def check(connect_info) do
+    key = build_key(connect_info)
+
+    case PortalAPI.RateLimit.hit(key, @refill_rate, @capacity, @cost) do
+      {:allow, _count} -> :ok
+      {:deny, _refill_time} -> {:error, :rate_limit}
+    end
+  end
+
+  @doc """
+  Returns the number of seconds to wait before retrying.
+  """
+  def retry_after_seconds, do: @retry_after_seconds
+
+  defp build_key(connect_info) do
+    ip = extract_ip(connect_info)
+    token_hash = hash_authorization(connect_info)
+    "socket:#{ip_to_string(ip)}:#{token_hash}"
+  end
+
+  defp extract_ip(%{x_headers: x_headers, peer_data: peer_data})
+       when is_list(x_headers) and x_headers != [] do
+    RemoteIp.from(x_headers, PortalAPI.Endpoint.real_ip_opts()) || peer_data.address
+  end
+
+  defp extract_ip(%{peer_data: peer_data}), do: peer_data.address
+
+  defp hash_authorization(%{x_headers: x_headers}) when is_list(x_headers) do
+    case List.keyfind(x_headers, "x-authorization", 0) do
+      {"x-authorization", value} ->
+        :crypto.hash(:sha256, value) |> Base.encode16(case: :lower) |> binary_part(0, 16)
+
+      _ ->
+        "none"
+    end
+  end
+
+  defp hash_authorization(_connect_info), do: "none"
+
+  defp ip_to_string(ip) when is_tuple(ip), do: :inet.ntoa(ip) |> to_string()
+  defp ip_to_string(ip), do: to_string(ip)
+end

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -10,21 +10,10 @@ defmodule PortalAPI.Gateway.SocketTest do
 
   @connlib_version "1.3.0"
 
-  @connect_info %{
-    user_agent: "iOS/12.7 (iPhone) connlib/#{@connlib_version}",
-    peer_data: %{address: {189, 172, 73, 001}},
-    x_headers: [
-      {"x-forwarded-for", "189.172.73.153"},
-      {"x-geo-location-region", "Ukraine"},
-      {"x-geo-location-city", "Kyiv"},
-      {"x-geo-location-coordinates", "50.4333,30.5167"}
-    ],
-    trace_context_headers: []
-  }
-
   describe "connect/3" do
     test "returns error when token is missing" do
-      assert connect(Socket, %{}, connect_info: @connect_info) == {:error, :missing_token}
+      connect_info = build_connect_info()
+      assert connect(Socket, %{}, connect_info: connect_info) == {:error, :missing_token}
     end
 
     test "accepts token from x-authorization header" do
@@ -37,11 +26,7 @@ defmodule PortalAPI.Gateway.SocketTest do
         |> Map.take([:external_id, :public_key])
         |> Enum.into(%{}, fn {k, v} -> {to_string(k), v} end)
 
-      # Add x-authorization header with Bearer token
-      connect_info = %{
-        @connect_info
-        | x_headers: [{"x-authorization", "Bearer #{encrypted_secret}"} | @connect_info.x_headers]
-      }
+      connect_info = build_connect_info(token: encrypted_secret)
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert gateway = Map.fetch!(socket.assigns, :gateway)
@@ -61,13 +46,7 @@ defmodule PortalAPI.Gateway.SocketTest do
 
       # Use token1 in header, token2 in params
       attrs = connect_attrs(token: encrypted_secret2)
-
-      connect_info = %{
-        @connect_info
-        | x_headers: [
-            {"x-authorization", "Bearer #{encrypted_secret1}"} | @connect_info.x_headers
-          ]
-      }
+      connect_info = build_connect_info(token: encrypted_secret1)
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       # Should use the header token (token1)
@@ -80,13 +59,15 @@ defmodule PortalAPI.Gateway.SocketTest do
 
       attrs = connect_attrs(token: encrypted_secret)
 
-      assert {:ok, socket} = connect(Socket, attrs, connect_info: @connect_info)
+      connect_info =
+        build_connect_info(user_agent: "iOS/12.7 (iPhone) connlib/#{@connlib_version}")
+
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert gateway = Map.fetch!(socket.assigns, :gateway)
 
       assert gateway.external_id == attrs["external_id"]
       assert gateway.public_key == attrs["public_key"]
-      assert gateway.last_seen_user_agent == @connect_info.user_agent
-      assert gateway.last_seen_remote_ip.address == {189, 172, 73, 153}
+      assert gateway.last_seen_user_agent == connect_info.user_agent
       assert gateway.last_seen_remote_ip_location_region == "Ukraine"
       assert gateway.last_seen_remote_ip_location_city == "Kyiv"
       assert gateway.last_seen_remote_ip_location_lat == 50.4333
@@ -99,8 +80,7 @@ defmodule PortalAPI.Gateway.SocketTest do
       encrypted_secret = encode_gateway_token(token)
 
       attrs = connect_attrs(token: encrypted_secret)
-
-      connect_info = %{@connect_info | x_headers: [{"x-geo-location-region", "UA"}]}
+      connect_info = build_connect_info(x_headers: [{"x-geo-location-region", "UA"}])
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert gateway = Map.fetch!(socket.assigns, :gateway)
@@ -122,7 +102,8 @@ defmodule PortalAPI.Gateway.SocketTest do
         {"traceparent", "00-a1bf53221e0be8000000000000000002-f316927eb144aa62-01"}
       ]
 
-      connect_info = %{@connect_info | trace_context_headers: trace_context_headers}
+      base_connect_info = build_connect_info()
+      connect_info = %{base_connect_info | trace_context_headers: trace_context_headers}
 
       assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
       assert span_ctx != OpenTelemetry.Tracer.current_span_ctx()
@@ -136,8 +117,9 @@ defmodule PortalAPI.Gateway.SocketTest do
       encrypted_secret = encode_gateway_token(token)
 
       attrs = connect_attrs(token: encrypted_secret, external_id: gateway.external_id)
+      connect_info = build_connect_info()
 
-      assert {:ok, socket} = connect(Socket, attrs, connect_info: @connect_info)
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert gateway = Repo.one(Portal.Gateway)
       assert gateway.id == socket.assigns.gateway.id
     end
@@ -156,9 +138,10 @@ defmodule PortalAPI.Gateway.SocketTest do
       encrypted_secret = encode_gateway_token(token)
 
       attrs = connect_attrs(token: encrypted_secret, external_id: existing_gateway.external_id)
+      connect_info = build_connect_info()
 
       # Reconnect
-      assert {:ok, socket} = connect(Socket, attrs, connect_info: @connect_info)
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert gateway = socket.assigns.gateway
 
       # Verify IPs are preserved
@@ -168,7 +151,72 @@ defmodule PortalAPI.Gateway.SocketTest do
 
     test "returns error when token is invalid" do
       attrs = connect_attrs(token: "foo")
-      assert connect(Socket, attrs, connect_info: @connect_info) == {:error, :invalid_token}
+      connect_info = build_connect_info()
+      assert connect(Socket, attrs, connect_info: connect_info) == {:error, :invalid_token}
+    end
+
+    test "rate limits repeated connection attempts from same IP and token" do
+      token = gateway_token_fixture()
+      encrypted_secret = encode_gateway_token(token)
+
+      attrs = connect_attrs(token: encrypted_secret)
+
+      # Use a unique IP for this test to avoid interference with other tests
+      ip = unique_ip()
+      connect_info = build_connect_info(ip: ip, token: encrypted_secret)
+
+      # First connection should succeed
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+
+      # Subsequent connections with same IP and token should be rate limited.
+      # The rate limiter uses a 1 token/second bucket, so we try multiple times
+      # to ensure we hit the rate limit even if we cross a second boundary.
+      rate_limited =
+        Enum.any?(1..3, fn _ ->
+          connect(Socket, attrs, connect_info: connect_info) == {:error, :rate_limit}
+        end)
+
+      assert rate_limited, "Expected at least one connection attempt to be rate limited"
+    end
+
+    test "allows connections from different IPs with same token" do
+      token = gateway_token_fixture()
+      encrypted_secret = encode_gateway_token(token)
+
+      attrs = connect_attrs(token: encrypted_secret)
+
+      ip1 = unique_ip()
+      ip2 = unique_ip()
+
+      connect_info_1 = build_connect_info(ip: ip1, token: encrypted_secret)
+      connect_info_2 = build_connect_info(ip: ip2, token: encrypted_secret)
+
+      # Both connections from different IPs should succeed
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info_1)
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info_2)
+    end
+
+    test "allows connections from same IP with different tokens" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+
+      token1 = gateway_token_fixture(account: account, site: site)
+      encrypted_secret1 = encode_gateway_token(token1)
+
+      token2 = gateway_token_fixture(account: account, site: site)
+      encrypted_secret2 = encode_gateway_token(token2)
+
+      ip = unique_ip()
+
+      attrs1 = connect_attrs(token: encrypted_secret1)
+      attrs2 = connect_attrs(token: encrypted_secret2)
+
+      connect_info_1 = build_connect_info(ip: ip, token: encrypted_secret1)
+      connect_info_2 = build_connect_info(ip: ip, token: encrypted_secret2)
+
+      # Both connections with different tokens should succeed
+      assert {:ok, _socket} = connect(Socket, attrs1, connect_info: connect_info_1)
+      assert {:ok, _socket} = connect(Socket, attrs2, connect_info: connect_info_2)
     end
   end
 

--- a/elixir/test/portal_api/sockets/rate_limit_test.exs
+++ b/elixir/test/portal_api/sockets/rate_limit_test.exs
@@ -1,0 +1,129 @@
+defmodule PortalAPI.Sockets.RateLimitTest do
+  use ExUnit.Case, async: true
+  alias PortalAPI.Sockets.RateLimit
+
+  describe "check/1" do
+    test "allows first request" do
+      connect_info = unique_connect_info()
+      assert RateLimit.check(connect_info) == :ok
+    end
+
+    test "rate limits second request with same IP and token" do
+      connect_info = unique_connect_info()
+
+      assert RateLimit.check(connect_info) == :ok
+      assert RateLimit.check(connect_info) == {:error, :rate_limit}
+    end
+
+    test "allows requests from different IPs with same token" do
+      token = unique_token()
+
+      connect_info_1 = build_connect_info(unique_ip(), token)
+      connect_info_2 = build_connect_info(unique_ip(), token)
+
+      assert RateLimit.check(connect_info_1) == :ok
+      assert RateLimit.check(connect_info_2) == :ok
+    end
+
+    test "allows requests from same IP with different tokens" do
+      ip = unique_ip()
+
+      connect_info_1 = build_connect_info(ip, "Bearer token_1")
+      connect_info_2 = build_connect_info(ip, "Bearer token_2")
+
+      assert RateLimit.check(connect_info_1) == :ok
+      assert RateLimit.check(connect_info_2) == :ok
+    end
+
+    test "uses x-forwarded-for header when present" do
+      token = unique_token()
+      real_ip = unique_ip()
+      proxy_ip = unique_ip()
+
+      connect_info_1 = %{
+        peer_data: %{address: proxy_ip},
+        x_headers: [
+          {"x-forwarded-for", :inet.ntoa(real_ip) |> to_string()},
+          {"x-authorization", token}
+        ]
+      }
+
+      # Same real IP should be rate limited
+      connect_info_2 = %{
+        peer_data: %{address: proxy_ip},
+        x_headers: [
+          {"x-forwarded-for", :inet.ntoa(real_ip) |> to_string()},
+          {"x-authorization", token}
+        ]
+      }
+
+      assert RateLimit.check(connect_info_1) == :ok
+      assert RateLimit.check(connect_info_2) == {:error, :rate_limit}
+    end
+
+    test "handles missing x-authorization header" do
+      connect_info = %{
+        peer_data: %{address: unique_ip()},
+        x_headers: []
+      }
+
+      assert RateLimit.check(connect_info) == :ok
+    end
+
+    test "handles missing x_headers" do
+      connect_info = %{
+        peer_data: %{address: unique_ip()}
+      }
+
+      assert RateLimit.check(connect_info) == :ok
+    end
+
+    test "treats requests without token as separate bucket" do
+      ip = unique_ip()
+
+      # Request without token
+      connect_info_no_token = %{
+        peer_data: %{address: ip},
+        x_headers: []
+      }
+
+      # Request with token
+      connect_info_with_token = %{
+        peer_data: %{address: ip},
+        x_headers: [{"x-authorization", "Bearer some_token"}]
+      }
+
+      assert RateLimit.check(connect_info_no_token) == :ok
+      assert RateLimit.check(connect_info_with_token) == :ok
+    end
+  end
+
+  describe "retry_after_seconds/0" do
+    test "returns retry-after value" do
+      assert RateLimit.retry_after_seconds() == 1
+    end
+  end
+
+  # Helper functions to generate unique test data
+  defp unique_connect_info do
+    ip = unique_ip()
+    token = unique_token()
+    build_connect_info(ip, token)
+  end
+
+  defp build_connect_info(ip, token) do
+    %{
+      peer_data: %{address: ip},
+      x_headers: [{"x-authorization", token}]
+    }
+  end
+
+  defp unique_ip do
+    # Generate a random IP to avoid test interference
+    {:rand.uniform(255), :rand.uniform(255), :rand.uniform(255), :rand.uniform(255)}
+  end
+
+  defp unique_token do
+    "Bearer " <> (:crypto.strong_rand_bytes(16) |> Base.encode64())
+  end
+end

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -73,4 +73,52 @@ defmodule PortalAPI.SocketsTest do
       assert Sockets.extract_token(params, connect_info) == {:ok, "fallback-token"}
     end
   end
+
+  describe "handle_error/2" do
+    test "returns 401 for invalid_token" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :invalid_token)
+
+      assert result.status == 401
+      assert result.resp_body == "Invalid token"
+    end
+
+    test "returns 401 for missing_token" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :missing_token)
+
+      assert result.status == 401
+      assert result.resp_body == "Missing token"
+    end
+
+    test "returns 403 for account_disabled" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :account_disabled)
+
+      assert result.status == 403
+      assert result.resp_body == "The account is disabled"
+    end
+
+    test "returns 403 for unauthenticated" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :unauthenticated)
+
+      assert result.status == 403
+      assert result.resp_body == "Forbidden"
+    end
+
+    test "returns 503 with retry-after header for rate_limit" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :rate_limit)
+
+      assert result.status == 503
+      assert result.resp_body == "Service Unavailable"
+      assert Plug.Conn.get_resp_header(result, "retry-after") == ["1"]
+    end
+  end
 end

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -35,21 +35,21 @@ defmodule PortalAPI.SocketsTest do
       params = %{}
       connect_info = %{x_headers: []}
 
-      assert Sockets.extract_token(params, connect_info) == :error
+      assert Sockets.extract_token(params, connect_info) == {:error, :missing_token}
     end
 
     test "returns error when header exists but without Bearer prefix" do
       params = %{}
       connect_info = %{x_headers: [{"x-authorization", "my-token"}]}
 
-      assert Sockets.extract_token(params, connect_info) == :error
+      assert Sockets.extract_token(params, connect_info) == {:error, :missing_token}
     end
 
     test "returns error when header exists with wrong prefix" do
       params = %{}
       connect_info = %{x_headers: [{"x-authorization", "Basic my-token"}]}
 
-      assert Sockets.extract_token(params, connect_info) == :error
+      assert Sockets.extract_token(params, connect_info) == {:error, :missing_token}
     end
 
     test "handles multiple x_headers correctly" do


### PR DESCRIPTION
The cloud load balancers offer broad rulesets for rate-limiting connections, only going down to the 10s window minimum. This means it's still possible for 5 connections in quick succession to occur, which may overload the cluster.

To fix this, we introduce a websocket connect rate limiter at the application level. This rate limiter is configured with a 1 req per second per ip-token rate today. If this limit is hit, a `503` is returned with the `retry-after` set properly. A `429` is not used because today this will trigger `fatal error` and tunnel shutdown.

Related: #11594 