### PR TITLE
fix(connlib): fail first portal connection sooner

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -13,6 +13,7 @@ use std::{fmt, future, marker::PhantomData};
 use std::{io, mem};
 
 use backoff::ExponentialBackoff;
+use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
 use base64::Engine;
 use futures::future::BoxFuture;
@@ -38,6 +39,25 @@ use tokio_tungstenite::tungstenite::http::header::RETRY_AFTER;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
 
+/// Maximum time to retry initial connection attempts before giving up.
+const INITIAL_CONNECT_MAX_ELAPSED_TIME: Duration = Duration::from_secs(15);
+
+/// Fixed interval between initial connection attempts.
+const INITIAL_CONNECT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Creates a backoff strategy for initial connection attempts (before ever connecting successfully).
+///
+/// Uses a fixed 1s interval with 15s max elapsed time to fail fast.
+fn make_initial_backoff() -> ExponentialBackoff {
+    ExponentialBackoffBuilder::default()
+        .with_initial_interval(INITIAL_CONNECT_INTERVAL)
+        .with_max_interval(INITIAL_CONNECT_INTERVAL)
+        .with_multiplier(1.0) // No exponential increase, fixed interval
+        .with_randomization_factor(0.0) // No jitter, predictable intervals
+        .with_max_elapsed_time(Some(INITIAL_CONNECT_MAX_ELAPSED_TIME))
+        .build()
+}
+
 pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     state: State,
     waker: Option<Waker>,
@@ -59,8 +79,19 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     user_agent: String,
     /// The authentication token, sent via X-Authorization header.
     token: SecretString,
+    make_initial_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     make_reconnect_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
-    reconnect_backoff: Option<ExponentialBackoff>,
+    /// The current backoff state, if any.
+    ///
+    /// When `was_connected` is false, uses `make_initial_backoff` (fixed 5s interval, 30s max).
+    /// When `was_connected` is true, uses `make_reconnect_backoff` (caller-provided, longer timeout).
+    backoff: Option<ExponentialBackoff>,
+    /// Whether we have ever successfully connected to the portal.
+    ///
+    /// Used to determine which backoff strategy to use:
+    /// - Initial connection: shorter timeout (e.g. 30s) to fail fast
+    /// - Reconnection: longer timeout to survive longer partitions
+    was_connected: bool,
 
     resolved_addresses: Vec<IpAddr>,
 
@@ -275,6 +306,12 @@ where
     /// You must explicitly call [`PhoenixChannel::connect`] to establish a connection.
     ///
     /// The provided URL must contain a host.
+    ///
+    /// # Arguments
+    ///
+    /// * `make_reconnect_backoff` - Backoff strategy for reconnection attempts (after a successful connection).
+    ///   Should have a longer max elapsed time to survive network partitions.
+    ///   For initial connection attempts (before ever connecting), a fixed 1s interval with 15s max is used.
     pub fn disconnected(
         url: LoginUrl<TFinish>,
         token: SecretString,
@@ -295,8 +332,10 @@ where
             .collect();
 
         Ok(Self {
+            make_initial_backoff: Box::new(make_initial_backoff),
             make_reconnect_backoff: Box::new(make_reconnect_backoff),
-            reconnect_backoff: None,
+            backoff: None,
+            was_connected: false,
             url_prototype: url,
             user_agent,
             token,
@@ -369,7 +408,7 @@ where
         }
 
         // 1. Reset the backoff.
-        self.reconnect_backoff = None;
+        self.backoff = None;
 
         // 2. Set state to `Connecting` without a timer.
         let user_agent = self.user_agent.clone();
@@ -471,7 +510,8 @@ where
                 }
                 State::Connecting(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(stream)) => {
-                        self.reconnect_backoff = None;
+                        self.backoff = None;
+                        self.was_connected = true;
                         self.heartbeat.reset();
                         self.state = State::Connected(stream);
 
@@ -534,25 +574,36 @@ where
                         return Poll::Ready(Err(Error::FatalIo(io)));
                     }
                     Poll::Ready(Err(e)) => {
-                        let backoff = match self.reconnect_backoff.as_mut() {
-                            Some(reconnect_backoff) => reconnect_backoff
-                                .next_backoff()
-                                .ok_or_else(|| Error::MaxRetriesReached {
-                                    final_error: err_with_src(&e).to_string(),
+                        let backoff_duration =
+                            match self.backoff.as_mut() {
+                                Some(backoff) => backoff.next_backoff().ok_or_else(|| {
+                                    Error::MaxRetriesReached {
+                                        final_error: err_with_src(&e).to_string(),
+                                    }
                                 })?,
-                            None => {
-                                self.reconnect_backoff = Some((self.make_reconnect_backoff)());
+                                None => {
+                                    // Create a new backoff based on whether we've ever connected.
+                                    // - Initial connection: fixed 1s interval, 15s max
+                                    // - Reconnection: caller-provided backoff (longer timeout)
+                                    let new_backoff = if self.was_connected {
+                                        (self.make_reconnect_backoff)()
+                                    } else {
+                                        (self.make_initial_backoff)()
+                                    };
+                                    self.backoff = Some(new_backoff);
 
-                                Duration::ZERO
-                            }
+                                    Duration::ZERO
+                                }
+                            };
+
+                        self.state = State::Reconnect {
+                            backoff: backoff_duration,
                         };
 
-                        self.state = State::Reconnect { backoff };
-
                         return Poll::Ready(Ok(Event::Hiccup {
-                            backoff,
+                            backoff: backoff_duration,
                             max_elapsed_time: self
-                                .reconnect_backoff
+                                .backoff
                                 .as_ref()
                                 .and_then(|b| b.max_elapsed_time),
                             error: anyhow::Error::new(e)

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -276,6 +276,11 @@ where
     TInboundMsg: DeserializeOwned,
     TFinish: IntoIterator<Item = (&'static str, String)>,
 {
+    /// Creates a new [PhoenixChannel] to the given endpoint in the `disconnected` state.
+    ///
+    /// You must explicitly call [`PhoenixChannel::connect`] to establish a connection.
+    ///
+    /// The provided URL must contain a host.
     pub fn disconnected(
         url: LoginUrl<TFinish>,
         token: SecretString,

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -240,7 +240,7 @@ async fn client_deduplicates_messages() {
     assert_eq!(num_responses, 1);
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 enum InboundMsg {
     Foo,
@@ -515,5 +515,213 @@ async fn http_503_with_retry_after_uses_header_value() {
                 "expected Event::Hiccup with 60s backoff for 503 with Retry-After, got {other:?}"
             )
         }
+    }
+}
+
+/// Tests that initial connection attempts use the fixed 1s interval backoff with 15s max.
+#[tokio::test]
+async fn initial_connection_uses_short_backoff() {
+    use std::{str::FromStr, sync::Arc, time::Duration};
+
+    use phoenix_channel::{DeviceInfo, Error, LoginUrl, PhoenixChannel, PublicKeyParam};
+    use secrecy::SecretString;
+    use url::Url;
+
+    let _guard = logging::test("debug");
+
+    // Use a port that nothing is listening on - connection will fail immediately
+    let login_url = LoginUrl::client(
+        Url::from_str("ws://127.0.0.1:1").unwrap(), // Port 1 is reserved, nothing should be listening
+        String::new(),
+        None,
+        DeviceInfo::default(),
+    )
+    .unwrap();
+
+    let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
+        login_url,
+        SecretString::from("secret"),
+        "test/1.0.0".to_owned(),
+        "test",
+        (),
+        || {
+            // This should NOT be used for initial connection attempts
+            backoff::ExponentialBackoffBuilder::default()
+                .with_max_elapsed_time(Some(Duration::from_secs(3600))) // 1 hour - way too long for initial
+                .build()
+        },
+        Arc::new(socket_factory::tcp),
+    )
+    .unwrap();
+
+    channel.connect(PublicKeyParam([0u8; 32]));
+
+    let mut hiccups = Vec::new();
+    let start = std::time::Instant::now();
+
+    loop {
+        match std::future::poll_fn(|cx| channel.poll(cx)).await {
+            Ok(phoenix_channel::Event::Hiccup {
+                backoff,
+                max_elapsed_time,
+                ..
+            }) => {
+                hiccups.push((backoff, max_elapsed_time));
+            }
+            Err(Error::MaxRetriesReached { .. }) => break,
+            other => panic!("Unexpected event: {other:?}"),
+        }
+    }
+
+    let elapsed = start.elapsed();
+
+    // Should have completed within ~15s (the initial backoff max), not 1 hour
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "Expected to complete within 20s, but took {elapsed:?}"
+    );
+
+    // All hiccups should report max_elapsed_time of 15s (initial backoff)
+    for (i, (backoff, max_elapsed_time)) in hiccups.iter().enumerate() {
+        assert_eq!(
+            *max_elapsed_time,
+            Some(Duration::from_secs(15)),
+            "Hiccup {i} should have max_elapsed_time of 15s for initial connection"
+        );
+        // First backoff is 0, subsequent ones should be ~1s
+        if i > 0 {
+            assert!(
+                *backoff >= Duration::from_millis(900) && *backoff <= Duration::from_millis(1100),
+                "Hiccup {i} backoff should be ~1s, got {backoff:?}"
+            );
+        }
+    }
+}
+
+/// Tests that after a successful connection, reconnection attempts use the caller-provided backoff.
+#[tokio::test]
+async fn reconnection_uses_callers_backoff() {
+    use std::{str::FromStr, sync::Arc, time::Duration};
+
+    use futures::{SinkExt, StreamExt};
+    use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, PublicKeyParam};
+    use secrecy::SecretString;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+    use url::Url;
+
+    let _guard = logging::test("debug");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    // Server that accepts one connection, sends join reply, then closes
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        // Wait for the join message and respond properly
+        while let Some(Ok(msg)) = ws.next().await {
+            if msg.is_text() {
+                let text = msg.into_text().unwrap();
+                if text.contains("phx_join") {
+                    // Send proper join reply first
+                    ws.send(Message::text(
+                        r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#,
+                    ))
+                    .await
+                    .unwrap();
+
+                    // Small delay to ensure the client processes the join
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+
+                    // Now close the connection
+                    ws.close(None).await.ok();
+                    break;
+                }
+            }
+        }
+
+        // Don't accept any more connections - let the client fail to reconnect
+    });
+
+    let login_url = LoginUrl::client(
+        Url::from_str(&format!("ws://127.0.0.1:{}", server_addr.port())).unwrap(),
+        String::new(),
+        None,
+        DeviceInfo::default(),
+    )
+    .unwrap();
+
+    const RECONNECT_MAX_ELAPSED: Duration = Duration::from_secs(5);
+
+    let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
+        login_url,
+        SecretString::from("secret"),
+        "test/1.0.0".to_owned(),
+        "test",
+        (),
+        || {
+            // This SHOULD be used for reconnection attempts (after successful connection)
+            backoff::ExponentialBackoffBuilder::default()
+                .with_max_elapsed_time(Some(RECONNECT_MAX_ELAPSED))
+                .build()
+        },
+        Arc::new(socket_factory::tcp),
+    )
+    .unwrap();
+
+    channel.connect(PublicKeyParam([0u8; 32]));
+
+    let mut connected = false;
+    let mut reconnect_hiccups = Vec::new();
+
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match std::future::poll_fn(|cx| channel.poll(cx)).await {
+                Ok(phoenix_channel::Event::JoinedRoom { .. }) => {
+                    connected = true;
+                    // Connection succeeded, now wait for it to be dropped by the server
+                }
+                Ok(phoenix_channel::Event::Hiccup {
+                    backoff,
+                    max_elapsed_time,
+                    ..
+                }) => {
+                    if connected {
+                        // This is a reconnection attempt
+                        reconnect_hiccups.push((backoff, max_elapsed_time));
+                    }
+                }
+                Ok(phoenix_channel::Event::HeartbeatSent) => {}
+                Ok(phoenix_channel::Event::SuccessResponse { .. }) => {}
+                Err(phoenix_channel::Error::MaxRetriesReached { .. }) => {
+                    break;
+                }
+                other => {
+                    // Continue on other events
+                    tracing::debug!(?other, "Got event");
+                }
+            }
+        }
+    })
+    .await;
+
+    server.abort();
+
+    assert!(result.is_ok(), "Test timed out");
+    assert!(connected, "Should have connected at least once");
+    assert!(
+        !reconnect_hiccups.is_empty(),
+        "Should have had reconnection hiccups"
+    );
+
+    // All reconnection hiccups should use the caller's max_elapsed_time
+    for (i, (_backoff, max_elapsed_time)) in reconnect_hiccups.iter().enumerate() {
+        assert_eq!(
+            *max_elapsed_time,
+            Some(RECONNECT_MAX_ELAPSED),
+            "Reconnection hiccup {i} should use caller's max_elapsed_time of {RECONNECT_MAX_ELAPSED:?}"
+        );
     }
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -518,9 +518,8 @@ async fn http_503_with_retry_after_uses_header_value() {
     }
 }
 
-/// Tests that initial connection attempts use the fixed 1s interval backoff with 15s max.
 #[tokio::test]
-async fn initial_connection_uses_short_backoff() {
+async fn initial_connection_uses_constant_1s_backoff() {
     use std::{str::FromStr, sync::Arc, time::Duration};
 
     use phoenix_channel::{DeviceInfo, Error, LoginUrl, PhoenixChannel, PublicKeyParam};
@@ -529,9 +528,8 @@ async fn initial_connection_uses_short_backoff() {
 
     let _guard = logging::test("debug");
 
-    // Use a port that nothing is listening on - connection will fail immediately
     let login_url = LoginUrl::client(
-        Url::from_str("ws://127.0.0.1:1").unwrap(), // Port 1 is reserved, nothing should be listening
+        Url::from_str("ws://127.0.0.1:1").unwrap(),
         String::new(),
         None,
         DeviceInfo::default(),
@@ -545,9 +543,8 @@ async fn initial_connection_uses_short_backoff() {
         "test",
         (),
         || {
-            // This should NOT be used for initial connection attempts
             backoff::ExponentialBackoffBuilder::default()
-                .with_max_elapsed_time(Some(Duration::from_secs(3600))) // 1 hour - way too long for initial
+                .with_max_elapsed_time(Some(Duration::from_secs(3600)))
                 .build()
         },
         Arc::new(socket_factory::tcp),
@@ -575,153 +572,15 @@ async fn initial_connection_uses_short_backoff() {
 
     let elapsed = start.elapsed();
 
-    // Should have completed within ~15s (the initial backoff max), not 1 hour
     assert!(
         elapsed < Duration::from_secs(20),
         "Expected to complete within 20s, but took {elapsed:?}"
     );
 
-    // All hiccups should report max_elapsed_time of 15s (initial backoff)
     for (i, (backoff, max_elapsed_time)) in hiccups.iter().enumerate() {
-        assert_eq!(
-            *max_elapsed_time,
-            Some(Duration::from_secs(15)),
-            "Hiccup {i} should have max_elapsed_time of 15s for initial connection"
-        );
-        // First backoff is 0, subsequent ones should be ~1s
+        assert_eq!(*max_elapsed_time, Some(Duration::from_secs(15)));
         if i > 0 {
-            assert!(
-                *backoff >= Duration::from_millis(900) && *backoff <= Duration::from_millis(1100),
-                "Hiccup {i} backoff should be ~1s, got {backoff:?}"
-            );
+            assert_eq!(*backoff, Duration::from_secs(1));
         }
-    }
-}
-
-/// Tests that after a successful connection, reconnection attempts use the caller-provided backoff.
-#[tokio::test]
-async fn reconnection_uses_callers_backoff() {
-    use std::{str::FromStr, sync::Arc, time::Duration};
-
-    use futures::{SinkExt, StreamExt};
-    use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, PublicKeyParam};
-    use secrecy::SecretString;
-    use tokio::net::TcpListener;
-    use tokio_tungstenite::tungstenite::Message;
-    use url::Url;
-
-    let _guard = logging::test("debug");
-
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let server_addr = listener.local_addr().unwrap();
-
-    // Server that accepts one connection, sends join reply, then closes
-    let server = tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.unwrap();
-        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
-
-        // Wait for the join message and respond properly
-        while let Some(Ok(msg)) = ws.next().await {
-            if msg.is_text() {
-                let text = msg.into_text().unwrap();
-                if text.contains("phx_join") {
-                    // Send proper join reply first
-                    ws.send(Message::text(
-                        r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#,
-                    ))
-                    .await
-                    .unwrap();
-
-                    // Small delay to ensure the client processes the join
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-
-                    // Now close the connection
-                    ws.close(None).await.ok();
-                    break;
-                }
-            }
-        }
-
-        // Don't accept any more connections - let the client fail to reconnect
-    });
-
-    let login_url = LoginUrl::client(
-        Url::from_str(&format!("ws://127.0.0.1:{}", server_addr.port())).unwrap(),
-        String::new(),
-        None,
-        DeviceInfo::default(),
-    )
-    .unwrap();
-
-    const RECONNECT_MAX_ELAPSED: Duration = Duration::from_secs(5);
-
-    let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
-        login_url,
-        SecretString::from("secret"),
-        "test/1.0.0".to_owned(),
-        "test",
-        (),
-        || {
-            // This SHOULD be used for reconnection attempts (after successful connection)
-            backoff::ExponentialBackoffBuilder::default()
-                .with_max_elapsed_time(Some(RECONNECT_MAX_ELAPSED))
-                .build()
-        },
-        Arc::new(socket_factory::tcp),
-    )
-    .unwrap();
-
-    channel.connect(PublicKeyParam([0u8; 32]));
-
-    let mut connected = false;
-    let mut reconnect_hiccups = Vec::new();
-
-    let result = tokio::time::timeout(Duration::from_secs(30), async {
-        loop {
-            match std::future::poll_fn(|cx| channel.poll(cx)).await {
-                Ok(phoenix_channel::Event::JoinedRoom { .. }) => {
-                    connected = true;
-                    // Connection succeeded, now wait for it to be dropped by the server
-                }
-                Ok(phoenix_channel::Event::Hiccup {
-                    backoff,
-                    max_elapsed_time,
-                    ..
-                }) => {
-                    if connected {
-                        // This is a reconnection attempt
-                        reconnect_hiccups.push((backoff, max_elapsed_time));
-                    }
-                }
-                Ok(phoenix_channel::Event::HeartbeatSent) => {}
-                Ok(phoenix_channel::Event::SuccessResponse { .. }) => {}
-                Err(phoenix_channel::Error::MaxRetriesReached { .. }) => {
-                    break;
-                }
-                other => {
-                    // Continue on other events
-                    tracing::debug!(?other, "Got event");
-                }
-            }
-        }
-    })
-    .await;
-
-    server.abort();
-
-    assert!(result.is_ok(), "Test timed out");
-    assert!(connected, "Should have connected at least once");
-    assert!(
-        !reconnect_hiccups.is_empty(),
-        "Should have had reconnection hiccups"
-    );
-
-    // All reconnection hiccups should use the caller's max_elapsed_time
-    for (i, (_backoff, max_elapsed_time)) in reconnect_hiccups.iter().enumerate() {
-        assert_eq!(
-            *max_elapsed_time,
-            Some(RECONNECT_MAX_ELAPSED),
-            "Reconnection hiccup {i} should use caller's max_elapsed_time of {RECONNECT_MAX_ELAPSED:?}"
-        );
     }
 }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11625">
+          Fails faster when the initial connection to the control plane cannot
+          be established, allowing the user to retry sooner.
+        </ChangeItem>
         <ChangeItem pull="11584">
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11625">
+          Fails faster when the initial connection to the control plane cannot
+          be established, allowing the user to retry sooner.
+        </ChangeItem>
         <ChangeItem pull="11634">
           Bumps minimum macOS version from 12.4 to 13.0 (Ventura) to enable
           SwiftUI MenuBarExtra API.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,10 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11625">
+          Fails faster when the initial connection to the control plane cannot
+          be established, allowing the user to retry sooner.
+        </ChangeItem>
         <ChangeItem pull="11584">
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -23,6 +23,10 @@ export default function Gateway() {
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
+        <ChangeItem pull="11625">
+          Fails faster when the initial connection to the control plane cannot
+          be established, allowing faster restarts by the process manager.
+        </ChangeItem>
         <ChangeItem pull="11584">
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,10 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11625">
+          Fails faster when the initial connection to the control plane cannot
+          be established, allowing the user to retry sooner.
+        </ChangeItem>
         <ChangeItem pull="11584">
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.


### PR DESCRIPTION
When connecting to the control plane for the first time (or after systemd restarts us), it's possible the connection attempt won't succeed. Currently, we (seem to?) initiate the exponential backoff mechanism here, which uses the max partition time per platform which means we might fail to connect indefinitely.

Since we weren't previously connected, we won't have any active network connections through the tunnel and so it makes sense to exit sooner here. `15s` is chosen as the timeout in this PR.

Additionally, since this is not a reconnect scenario, jitter doesn't matter as the timing here is determined by when the user or administrator initiated the attempt, which is inherently "random". As such, randomized jitter is removed and we try every `1s` until the max elapsed time of `15s` above.

For previously connected scenarios, we keep the existing backoff configuration passed in by the caller, which is currently platform-dependent.

Related: https://github.com/firezone/firezone/pull/11611