### PR TITLE
fix(connlib): resolve with system resolvers if no dns servers

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -495,6 +495,8 @@ async fn phoenix_channel_event_loop(
     use futures::future::select;
     use std::future::poll_fn;
 
+    // Initialize with empty DNS servers; the UdpDnsClient will fall back to
+    // the system resolver if no servers are configured.
     let mut udp_dns_client = UdpDnsClient::new(udp_socket_factory.clone(), vec![]);
 
     loop {

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -25,6 +25,10 @@ export default function Android() {
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
+        <ChangeItem pull="11626">
+          Fixes an issue where reconnecting to the portal would fail if the DNS
+          resolver list was empty due to a network reset or other edge case.
+        </ChangeItem>
         <ChangeItem pull="11595">
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -33,6 +33,10 @@ export default function Apple() {
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
+        <ChangeItem pull="11626">
+          Fixes an issue where reconnecting to the portal would fail if the DNS
+          resolver list was empty due to a network reset or other edge case.
+        </ChangeItem>
         <ChangeItem pull="11595">
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -15,6 +15,10 @@ export default function GUI({ os }: { os: OS }) {
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
+        <ChangeItem pull="11626">
+          Fixes an issue where reconnecting to the portal would fail if the DNS
+          resolver list was empty due to a network reset or other edge case.
+        </ChangeItem>
         <ChangeItem pull="11595">
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -27,6 +27,10 @@ export default function Gateway() {
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
+        <ChangeItem pull="11626">
+          Fixes an issue where reconnecting to the portal would fail if the DNS
+          resolver list was empty due to a network reset or other edge case.
+        </ChangeItem>
         <ChangeItem pull="11595">
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -14,6 +14,10 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
+        <ChangeItem pull="11626">
+          Fixes an issue where reconnecting to the portal would fail if the DNS
+          resolver list was empty due to a network reset or other edge case.
+        </ChangeItem>
         <ChangeItem pull="11595">
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.


### PR DESCRIPTION
When connecting to the portal, we were using whatever resolvers were last configured via the `setDns` command, initializing to the empty list `[]`. There were three related edge case issues here:

- If we ever failed to connect the portal on the first attempt, subsequent attempts would not resolve the portal and fail with socket errors
- If we get a network reset before the first `setDns` command, reconnecting to the portal will fail repeatedly (see https://github.com/firezone/firezone/actions/runs/20695702337/job/59410655664)
- If these somehow ever get set to `[]` (such as if there is a bug in the portal or misconfiguration in the portal that sends an empty list), reconnecting to the portal will never succeed

To make connecting to the portal more resilient, we update the udp resolver to fallback to system resolver resolution if there are no resolvers set.