### PR TITLE
fix(gui-client): use usermod for firezone-client membership

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -20,10 +20,34 @@ elif [ -n "${DISPLAY_USER:-}" ]; then
     echo "Detected invoking user from display session: $INVOKING_USER"
 fi
 
-sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
-
-# Creates the system group `firezone-client` and adds the group membership.
+# Creates the system group `firezone-client`.
 systemd-sysusers firezone-client-tunnel.conf
+
+# Fail if we couldn't detect an invoking user - this likely means there's no graphical
+# environment and the headless client should be used instead.
+if [ -z "${INVOKING_USER:-}" ]; then
+    echo ""
+    echo "****************************************************************************"
+    echo "ERROR: Could not detect a user to add to the firezone-client group."
+    echo "This likely means no graphical environment was detected."
+    echo "Consider using the headless client (firezone-headless-client) instead."
+    echo "****************************************************************************"
+    echo ""
+    exit 1
+fi
+
+# Add the invoking user to the firezone-client group.
+# We use usermod instead of sysusers.d because sysusers.d rejects usernames with dots.
+if ! id -nG "$INVOKING_USER" | grep -qw "firezone-client"; then
+    usermod -aG firezone-client "$INVOKING_USER"
+    echo ""
+    echo "****************************************************************************"
+    echo "IMPORTANT: User '$INVOKING_USER' was added to the firezone-client group."
+    echo "Please reboot your system for this change to take effect."
+    echo "Firezone will not work properly until you do."
+    echo "****************************************************************************"
+    echo ""
+fi
 
 systemctl daemon-reload
 systemctl enable "$SERVICE_NAME"

--- a/rust/gui-client/src-tauri/linux_package/sysusers.conf
+++ b/rust/gui-client/src-tauri/linux_package/sysusers.conf
@@ -2,4 +2,3 @@
 # This creates the `firezone-client` group automatically at startup
 
 g firezone-client -
-m <<USER>> firezone-client -


### PR DESCRIPTION
- Reverts a regression introduced in 024b1864b4 that prevented the GUI client linux package from installing if the username contained a dot. This is because `systemd` does not allow dots while Linux itself does.
- Detects when the `INVOKING_USER` could not be determined and fails with a more helpful error when this is the case as it likely means no graphical environment is running.
- Prints a warning when adding the user to the group for the first time instructing the user to reboot.

Fixes #11629 