### PR TITLE
test(portal): fix slow tests

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -88,6 +88,14 @@ config :portal, Portal.ComponentVersions,
     headless: "1.0.0"
   ]
 
+config :portal, Portal.Google.APIClient,
+  endpoint: "https://admin.googleapis.com",
+  token_endpoint: "https://oauth2.googleapis.com/token",
+  req_options: [
+    retry: false,
+    plug: {Req.Test, Portal.Google.APIClient}
+  ]
+
 config :portal, Portal.Telemetry.Reporter.GoogleCloudMetrics, project_id: "fz-test"
 
 config :portal, web_external_url: "http://localhost:13100"

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -38,9 +38,14 @@ defmodule Portal.Google.APIClient do
         "assertion" => jwt
       })
 
-    Req.post(token_endpoint,
-      headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
-      body: payload
+    req_options = config[:req_options] || []
+
+    Req.post(
+      token_endpoint,
+      [
+        headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
+        body: payload
+      ] ++ req_options
     )
   end
 
@@ -90,10 +95,11 @@ defmodule Portal.Google.APIClient do
 
   defp test_endpoint(path, access_token, params) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    req_options = config[:req_options] || []
     query = URI.encode_query(params)
     url = "#{config[:endpoint]}#{path}?#{query}"
 
-    case Req.get(url, headers: [Authorization: "Bearer #{access_token}"]) do
+    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_options) do
       {:ok, %Req.Response{status: 200}} -> :ok
       other -> other
     end
@@ -164,9 +170,10 @@ defmodule Portal.Google.APIClient do
 
   defp get(path, access_token) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    req_options = config[:req_options] || []
 
     (config[:endpoint] <> path)
-    |> Req.get(headers: [Authorization: "Bearer #{access_token}"])
+    |> Req.get([headers: [Authorization: "Bearer #{access_token}"]] ++ req_options)
   end
 
   defp stream_pages(path, query, access_token, result_key) do
@@ -188,9 +195,10 @@ defmodule Portal.Google.APIClient do
 
   defp fetch_page(current_path, current_query, access_token, result_key) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    req_options = config[:req_options] || []
     url = "#{config[:endpoint]}#{current_path}?#{current_query}"
 
-    case Req.get(url, headers: [Authorization: "Bearer #{access_token}"]) do
+    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_options) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         parse_page_response(body, current_path, current_query, result_key)
 

--- a/elixir/test/portal/replication/connection_test.exs
+++ b/elixir/test/portal/replication/connection_test.exs
@@ -96,11 +96,11 @@ defmodule Portal.Replication.ConnectionTest do
     end
 
     test "init/1 schedules flush when flush_interval > 0" do
-      initial_state = %TestReplicationConnection{flush_interval: 1000}
+      initial_state = %TestReplicationConnection{flush_interval: 10}
       {:ok, _state} = TestReplicationConnection.init(initial_state)
 
       # Should receive flush message after interval
-      assert_receive :flush, 1100
+      assert_receive :flush, 50
     end
 
     test "init/1 does not schedule flush when flush_interval is 0" do
@@ -108,7 +108,7 @@ defmodule Portal.Replication.ConnectionTest do
       {:ok, _state} = TestReplicationConnection.init(initial_state)
 
       # Should not receive flush message
-      refute_receive :flush, 100
+      refute_receive :flush, 10
     end
   end
 
@@ -152,7 +152,7 @@ defmodule Portal.Replication.ConnectionTest do
     test "handles :flush message when flush_interval > 0" do
       state =
         %TestReplicationConnection{
-          flush_interval: 1000,
+          flush_interval: 10,
           flush_buffer: %{1 => %{data: "test"}}
         }
         |> Map.put(:operations, [])
@@ -165,11 +165,11 @@ defmodule Portal.Replication.ConnectionTest do
       assert new_state.flush_buffer == %{}
 
       # Should schedule next flush
-      assert_receive :flush, 1100
+      assert_receive :flush, 50
     end
 
     test "handles :interval_logger message" do
-      state = %TestReplicationConnection{counter: 456, status_log_interval: 100}
+      state = %TestReplicationConnection{counter: 456, status_log_interval: 10}
 
       log =
         capture_log(fn ->
@@ -179,7 +179,7 @@ defmodule Portal.Replication.ConnectionTest do
       assert log =~ "Processed 456 write messages from the WAL stream"
 
       # Should schedule next log
-      assert_receive :interval_logger, 150
+      assert_receive :interval_logger, 50
     end
 
     test "handles warning threshold checks" do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -655,12 +655,12 @@ defmodule PortalAPI.Client.ChannelTest do
           site: site
         )
 
-      # Create a policy that becomes valid in one second
+      # Create a policy that becomes valid in 1 second
       now = DateTime.utc_now()
-      one_second_later = DateTime.add(now, 1, :second)
+      shortly_later = DateTime.add(now, 1, :second)
 
       day_letter =
-        case Date.day_of_week(one_second_later) do
+        case Date.day_of_week(shortly_later) do
           # Monday
           1 -> "M"
           # Tuesday
@@ -678,7 +678,7 @@ defmodule PortalAPI.Client.ChannelTest do
         end
 
       start_time =
-        one_second_later
+        shortly_later
         |> DateTime.to_time()
         |> Time.to_string()
 
@@ -713,7 +713,7 @@ defmodule PortalAPI.Client.ChannelTest do
       refute_push "resource_created_or_updated", _payload
       refute_push "resource_deleted", _payload
 
-      Process.sleep(2000)
+      Process.sleep(1100)
 
       send(socket.channel_pid, :recompute_authorized_resources)
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -713,7 +713,7 @@ defmodule PortalAPI.Client.ChannelTest do
       refute_push "resource_created_or_updated", _payload
       refute_push "resource_deleted", _payload
 
-      Process.sleep(1100)
+      Process.sleep(1500)
 
       send(socket.channel_pid, :recompute_authorized_resources)
 


### PR DESCRIPTION
- refactors the Google.APIClient tests to use Req.Test allowing us to disable retries
- Fixes replication test timers to be much shorter
- Fixes client channel policy condition test to shave ~1s off