### PR TITLE
fix(relay): split phoenix-channel from main event-loop

### DIFF
--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -23,6 +23,7 @@ use std::task::{Poll, ready};
 use std::time::{Duration, Instant};
 use stun_codec::rfc5766::attributes::ChannelNumber;
 use telemetry::{RELAY_DSN, Telemetry};
+use tokio::sync::mpsc;
 use tracing::Subscriber;
 use tracing_core::Dispatch;
 use tracing_stackdriver::CloudTraceConfiguration;
@@ -388,7 +389,7 @@ where
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
-enum IngressMessage {
+enum IngressMessages {
     Init(Init),
 }
 
@@ -416,7 +417,7 @@ struct Eventloop<R> {
     sockets: Sockets,
 
     server: Server<R>,
-    channel: Option<PhoenixChannel<JoinMessage, (), IngressMessage, NoParams>>,
+    event_rx: mpsc::Receiver<Result<IngressMessages, phoenix_channel::Error>>,
     sleep: Sleep,
 
     ebpf: Option<ebpf::Program>,
@@ -425,8 +426,6 @@ struct Eventloop<R> {
 
     stats_log_interval: tokio::time::Interval,
     last_num_bytes_relayed: u64,
-
-    last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
 
     buffer: [u8; MAX_UDP_SIZE],
 }
@@ -438,7 +437,7 @@ where
     fn new(
         server: Server<R>,
         ebpf: Option<ebpf::Program>,
-        channel: PhoenixChannel<JoinMessage, (), IngressMessage, NoParams>,
+        portal: PhoenixChannel<JoinMessage, (), IngressMessages, NoParams>,
         public_address: IpStack,
         last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
     ) -> Result<Self> {
@@ -465,16 +464,22 @@ where
                 })?;
         }
 
+        let (event_tx, event_rx) = mpsc::channel(128);
+        tokio::spawn(phoenix_channel_event_loop(
+            portal,
+            event_tx,
+            last_heartbeat_sent,
+        ));
+
         Ok(Self {
             server,
-            channel: Some(channel),
+            event_rx,
             sleep: Sleep::default(),
             stats_log_interval: tokio::time::interval(STATS_LOG_INTERVAL),
             last_num_bytes_relayed: 0,
             sockets,
             ebpf,
             buffer: [0u8; MAX_UDP_SIZE],
-            last_heartbeat_sent,
             sigterm: signals::Terminate::new()?,
         })
     }
@@ -651,14 +656,16 @@ where
             }
 
             // Priority 5: Handle portal messages
-            match self.channel.as_mut().map(|c| c.poll(cx)) {
-                Some(Poll::Ready(result)) => {
-                    let event = result.context("Portal connection failed")?;
-                    self.handle_portal_event(event);
-
+            match self.event_rx.poll_recv(cx) {
+                Poll::Ready(Some(Ok(IngressMessages::Init(Init {})))) => {
                     ready = true;
                 }
-                Some(Poll::Pending) | None => {}
+                Poll::Ready(Some(Err(e))) => {
+                    return Poll::Ready(Err(
+                        anyhow::Error::new(e).context("Portal connection failed")
+                    ));
+                }
+                Poll::Pending | Poll::Ready(None) => {}
             }
 
             match self.sigterm.poll_recv(cx) {
@@ -718,35 +725,47 @@ where
 
         Ok(())
     }
+}
 
-    fn handle_portal_event(&mut self, event: phoenix_channel::Event<IngressMessage>) {
-        match event {
-            Event::SuccessResponse { .. } => {}
-            Event::JoinedRoom { topic } => {
+async fn phoenix_channel_event_loop(
+    mut portal: PhoenixChannel<JoinMessage, (), IngressMessages, NoParams>,
+    event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
+    last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
+) {
+    loop {
+        match std::future::poll_fn(|cx| portal.poll(cx)).await {
+            Ok(Event::SuccessResponse { .. }) => {}
+            Ok(Event::JoinedRoom { topic }) => {
                 tracing::info!(target: "relay", "Successfully joined room '{topic}'");
             }
-            Event::ErrorResponse { topic, req_id, res } => {
+            Ok(Event::ErrorResponse { topic, req_id, res }) => {
                 tracing::warn!(target: "relay", "Request with ID {req_id} on topic {topic} failed: {res:?}");
             }
-            Event::HeartbeatSent => {
+            Ok(Event::HeartbeatSent) => {
                 tracing::debug!(target: "relay", "Heartbeat sent to portal");
-                *self
-                    .last_heartbeat_sent
+                *last_heartbeat_sent
                     .lock()
                     .unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
             }
-            Event::InboundMessage {
-                msg: IngressMessage::Init(Init {}),
-                ..
-            } => {}
-            Event::Closed => {
-                self.channel = None;
+            Ok(Event::InboundMessage { msg, .. }) => {
+                if event_tx.send(Ok(msg)).await.is_err() {
+                    tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
+                    break;
+                }
             }
-            Event::Hiccup {
+            Ok(Event::Closed) => {
+                break;
+            }
+            Ok(Event::Hiccup {
                 backoff,
                 max_elapsed_time,
                 error,
-            } => tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}"),
+            }) => tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}"),
+            Err(e) => {
+                let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.
+
+                break;
+            }
         }
     }
 }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -665,7 +665,12 @@ where
                         anyhow::Error::new(e).context("Portal connection failed")
                     ));
                 }
-                Poll::Pending | Poll::Ready(None) => {}
+                Poll::Ready(None) => {
+                    return Poll::Ready(Err(anyhow::Error::msg(
+                        "Portal connection task terminated",
+                    )));
+                }
+                Poll::Pending => {}
             }
 
             match self.sigterm.poll_recv(cx) {
@@ -753,9 +758,7 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
-            Ok(Event::Closed) => {
-                break;
-            }
+            Ok(Event::Closed) => break,
             Ok(Event::Hiccup {
                 backoff,
                 max_elapsed_time,


### PR DESCRIPTION
The relay's event-loop is currently quite complex in regards to how many async operation are multiplexed across it. This is still a relict from a time prior to having the eBPF kernel where we needed to be as memory and CPU-efficient as possible when it came to packet routing. Ever since introducing the eBPF kernel, the relay's event-loop doesn't do all that much however. Yet, the current complexity is still a potential source of bugs.

One of these is around the timing of heartbeats to the portal. To mitigate this, we extract a dedicated task for advancing the state of `PhoenixChannel` like we do for Clients and Gateways too. Using a dedicated task minimizes the risk of wake-up bugs in our async code and ensures this state is advanced independently of the relays sockets.

Resolves: #11586