### PR TITLE
fix(portal): only use Mix at compile-time

### DIFF
--- a/elixir/lib/portal/google_cloud_platform.ex
+++ b/elixir/lib/portal/google_cloud_platform.ex
@@ -3,13 +3,15 @@ defmodule Portal.GoogleCloudPlatform do
   alias Portal.GoogleCloudPlatform.Instance
   require Logger
 
+  @mix_env Mix.env()
+
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__.Supervisor)
   end
 
   @impl true
   def init(_opts) do
-    if enabled?() and Mix.env() != :test do
+    if enabled?() and @mix_env != :test do
       children = [
         Instance
       ]

--- a/elixir/lib/portal/google_cloud_platform/instance.ex
+++ b/elixir/lib/portal/google_cloud_platform/instance.ex
@@ -8,6 +8,8 @@ defmodule Portal.GoogleCloudPlatform.Instance do
   use GenServer
   alias Portal.GoogleCloudPlatform
 
+  @mix_env Mix.env()
+
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
@@ -23,7 +25,7 @@ defmodule Portal.GoogleCloudPlatform.Instance do
   In test mode, this bypasses caching and calls fetch_access_token directly.
   """
   def fetch_access_token do
-    if Mix.env() == :test do
+    if @mix_env == :test do
       # In tests, bypass caching entirely
       case GoogleCloudPlatform.fetch_access_token() do
         {:ok, access_token, _expires_at} -> {:ok, access_token}


### PR DESCRIPTION
Fixes errors like the below:

```
Application portal exited: Portal.Application.start(:normal, []) returned an error: shutdown: failed to start child: Portal.GoogleCloudPlatform
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Mix.env/0 is undefined (module Mix is not available). Make sure the module name is correct and has been specified in full (or that an alias has been defined)
            Mix.env()
            (portal 0.1.0+0e7d466c09b5c20587e6a26b564d7aa6036f95f8) lib/portal/google_cloud_platform.ex:12: Portal.GoogleCloudPlatform.init/1
            (stdlib 7.2) supervisor.erl:912: :supervisor.init/1
            (stdlib 7.2) gen_server.erl:2276: :gen_server.init_it/2
            (stdlib 7.2) gen_server.erl:2236: :gen_server.init_it/6
            (stdlib 7.2) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
```