### PR TITLE
fix(phoenix-channel): retry everything but 401

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -528,12 +528,6 @@ where
                             .context("Reconnecting to portal on transient error"),
                         }));
                     }
-                    // Unfortunately, the underlying error gets stringified by tungstenite so we cannot match on anything other than the string.
-                    Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Io(io))))
-                        if io.to_string().starts_with("invalid peer certificate") =>
-                    {
-                        return Poll::Ready(Err(Error::FatalIo(io)));
-                    }
                     Poll::Ready(Err(e)) => {
                         let backoff_duration =
                             match self.backoff.as_mut() {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -498,12 +498,7 @@ where
                     {
                         return Poll::Ready(Err(Error::InvalidToken));
                     }
-                    // Handle 408, 429 and 503 with Retry-After header, falling back to exponential backoff
-                    Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(r))))
-                        if r.status() == StatusCode::REQUEST_TIMEOUT
-                            || r.status() == StatusCode::TOO_MANY_REQUESTS
-                            || r.status() == StatusCode::SERVICE_UNAVAILABLE =>
-                    {
+                    Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(r)))) => {
                         let backoff = match parse_retry_after(&r) {
                             Some(duration) => duration,
                             None => {

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -7,6 +7,7 @@ use phoenix_channel::{DeviceInfo, Event, LoginUrl, PhoenixChannel, PublicKeyPara
 use secrecy::SecretString;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::http;
 
 #[tokio::test]
 async fn client_does_not_pipeline_messages() {
@@ -252,7 +253,7 @@ enum OutboundMsg {
 
 #[tokio::test]
 async fn http_429_triggers_retry() {
-    let port = http_status_server(429, "Too Many Requests").await;
+    let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;
 
     let mut channel = make_test_channel(port);
     channel.connect(PublicKeyParam([0u8; 32]));
@@ -272,7 +273,7 @@ async fn http_429_triggers_retry() {
 
 #[tokio::test]
 async fn http_408_triggers_retry() {
-    let port = http_status_server(408, "Request Timeout").await;
+    let port = http_status_server(http::StatusCode::REQUEST_TIMEOUT).await;
 
     let mut channel = make_test_channel(port);
     channel.connect(PublicKeyParam([0u8; 32]));
@@ -292,7 +293,7 @@ async fn http_408_triggers_retry() {
 
 #[tokio::test]
 async fn http_400_returns_client_error() {
-    let port = http_status_server(400, "Bad Request").await;
+    let port = http_status_server(http::StatusCode::BAD_REQUEST).await;
 
     let mut channel = make_test_channel(port);
     channel.connect(PublicKeyParam([0u8; 32]));
@@ -311,7 +312,7 @@ async fn http_400_returns_client_error() {
 
 #[tokio::test]
 async fn http_401_returns_invalid_token() {
-    let port = http_status_server(401, "Unauthorized").await;
+    let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
 
     let mut channel = make_test_channel(port);
     channel.connect(PublicKeyParam([0u8; 32]));
@@ -354,12 +355,14 @@ fn make_test_channel(port: u16) -> PhoenixChannel<(), (), (), PublicKeyParam> {
     .unwrap()
 }
 
-async fn http_status_server(status: u16, reason: &str) -> u16 {
+async fn http_status_server(code: http::StatusCode) -> u16 {
     http_response_server(format!(
         "HTTP/1.1 {status} {reason}\r\n\
          Connection: close\r\n\
          Content-Type: text/plain\r\n\
-         Content-Length: 0\r\n\r\n"
+         Content-Length: 0\r\n\r\n",
+        status = code.as_u16(),
+        reason = code.as_str()
     ))
     .await
 }
@@ -415,7 +418,7 @@ async fn http_response_server(response: String) -> u16 {
 
 #[tokio::test]
 async fn http_503_triggers_retry() {
-    let port = http_status_server(503, "Service Unavailable").await;
+    let port = http_status_server(http::StatusCode::SERVICE_UNAVAILABLE).await;
 
     let mut channel = make_test_channel(port);
     channel.connect(PublicKeyParam([0u8; 32]));

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -45,6 +45,11 @@ export default function Android() {
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
+        <ChangeItem pull="11654">
+          Implements retry with exponential backoff for anything but 401
+          responses. For example, this allows Firezone to automatically sign-in
+          even if Internet Access is gated by a captive portal.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -53,6 +53,11 @@ export default function Apple() {
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
+        <ChangeItem pull="11654">
+          Implements retry with exponential backoff for anything but 401
+          responses. For example, this allows Firezone to automatically sign-in
+          even if Internet Access is gated by a captive portal.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.11" date={new Date("2025-12-23")}>
         <ChangeItem pull="11141">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -35,6 +35,11 @@ export default function GUI({ os }: { os: OS }) {
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
+        <ChangeItem pull="11654">
+          Implements retry with exponential backoff for anything but 401
+          responses. For example, this allows Firezone to automatically sign-in
+          even if Internet Access is gated by a captive portal.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-12-23")}>
         {os == OS.Linux && (

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -18,6 +18,11 @@ export default function Headless({ os }: { os: OS }) {
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.
         </ChangeItem>
+        <ChangeItem pull="11654">
+          Implements retry with exponential backoff for anything but 401
+          responses. For example, this allows Firezone to automatically sign-in
+          even if Internet Access is gated by a captive portal.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.6" date={new Date("2026-01-06")}>
         <ChangeItem pull="11627">


### PR DESCRIPTION
Given the complexity of our infrastructure, we cannot really guarantee which error codes we are going to hit as part of our WebSocket connection. The only thing we can be sure about is that a 401 means that our token is invalid.

To ensure we don't negatively impact the UX of Firezone, we only exit our retry-loop on 401s and retry all other errors.