### PR TITLE
fix(portal): update default Req opts for Stripe API client

### DIFF
--- a/elixir/lib/portal/billing/stripe/api_client.ex
+++ b/elixir/lib/portal/billing/stripe/api_client.ex
@@ -86,7 +86,7 @@ defmodule Portal.Billing.Stripe.APIClient do
     ]
 
     req_options =
-      [method: method, url: url, headers: headers, body: body, retry: false]
+      [method: method, url: url, headers: headers, body: body]
       |> Keyword.merge(fetch_config(:req_options) || [])
 
     case Req.request(req_options) do


### PR DESCRIPTION
Looks like a default option of `retry: false` slipped in to the Stripe API client by accident.

This was likely added as part of making sure the tests ran quick as possible.  The `config/test.exs` does have this option set to `false` so the tests should still run without retries.