### PR TITLE
chore(apple): remove cruft after macOS 13.0 bump

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -11,6 +11,6 @@ linker = "rust-lld"
 
 # Set consistent macOS deployment target to prevent rebuilds
 # when environment variables change between Xcode and CLI builds
-# This must match the Xcode project setting (12.4)
+# This must match the Xcode project setting (13.0)
 [env]
-MACOSX_DEPLOYMENT_TARGET = "12.4"
+MACOSX_DEPLOYMENT_TARGET = "13.0"

--- a/rust/client-ffi/.cargo/config.toml
+++ b/rust/client-ffi/.cargo/config.toml
@@ -4,8 +4,8 @@
 [env]
 # Set a consistent macOS deployment target to prevent rebuilds
 # when switching between Xcode and command-line builds
-# This must match the Xcode project setting (12.4)
-MACOSX_DEPLOYMENT_TARGET = "12.4"
+# This must match the Xcode project setting (13.0)
+MACOSX_DEPLOYMENT_TARGET = "13.0"
 
 [build]
 # Use incremental compilation for faster rebuilds

--- a/swift/apple/FirezoneKit/Package.swift
+++ b/swift/apple/FirezoneKit/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "FirezoneKit",
-  platforms: [.iOS(.v15), .macOS(.v12)],
+  platforms: [.iOS(.v15), .macOS(.v13)],
   products: [
     // Products define the executables and libraries a package produces, and make them visible to
     // other packages.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -144,23 +144,20 @@ public class Configuration: ObservableObject {
   }
 
   #if os(macOS)
-    // Register / unregister our launch service based on configuration. This is a major pain to do on macOS 12 and below,
-    // so this feature only enabled for macOS 13 and higher given the tiny Firezone installbase for macOS 12.
+    // Register / unregister our launch service based on configuration.
     func updateAppService() async throws {
-      if #available(macOS 13.0, *) {
-        // Getting the status initially appears to be blocking sometimes
-        SentrySDK.pauseAppHangTracking()
-        defer { SentrySDK.resumeAppHangTracking() }
-        let status = SMAppService.mainApp.status
+      // Getting the status initially appears to be blocking sometimes
+      SentrySDK.pauseAppHangTracking()
+      defer { SentrySDK.resumeAppHangTracking() }
+      let status = SMAppService.mainApp.status
 
-        if !startOnLogin, status == .enabled {
-          try await SMAppService.mainApp.unregister()
-          return
-        }
+      if !startOnLogin, status == .enabled {
+        try await SMAppService.mainApp.unregister()
+        return
+      }
 
-        if startOnLogin, status != .enabled {
-          try SMAppService.mainApp.register()
-        }
+      if startOnLogin, status != .enabled {
+        try SMAppService.mainApp.register()
       }
     }
   #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -163,9 +163,7 @@ public final class Store: ObservableObject {
     #if os(macOS)
       // On macOS we must show notifications from the UI process. On iOS, we've already initiated the notification
       // from the tunnel process, because the UI process is not guaranteed to be alive.
-
-      // fetchLastDisconnectError is only available on macOS 13+
-      if #available(macOS 13, *), vpnStatus == .disconnected {
+      if vpnStatus == .disconnected {
         do {
           try manager().session()?.fetchLastDisconnectError { error in
             if let nsError = error as NSError?,


### PR DESCRIPTION
- remove unnecessary macOS 13.0 availability guards
- update MACOSX_DEPLOYMENT_TARGET from 12.4 to 13.0 in Cargo configs and Package.swift to match Xcode project settings.

Fixes #11643