### PR TITLE
feat(portal): add Postgres clustering strategy

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -28,3 +28,8 @@ Config.Secrets: Hardcoded Secret,config/config.exs:209,8DFEA3
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
 Config.Secrets: Hardcoded Secret,config/config.exs:201,3CFE1A
 Config.Secrets: Hardcoded Secret,config/config.exs:202,43A0604
+
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:375,2E0A7AD
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:217,3560D02
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:371,46EE6C5
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:212,5B50F1B

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -114,7 +114,9 @@ if config_env() == :prod do
 
   config :portal, Portal.Cluster,
     adapter: env_var_to_config!(:erlang_cluster_adapter),
-    adapter_config: env_var_to_config!(:erlang_cluster_adapter_config)
+    adapter_config: env_var_to_config!(:erlang_cluster_adapter_config),
+    secondary_adapter: env_var_to_config!(:erlang_cluster_adapter_secondary),
+    secondary_adapter_config: env_var_to_config!(:erlang_cluster_adapter_secondary_config)
 
   config :portal, :enabled_features,
     idp_sync: env_var_to_config!(:feature_idp_sync_enabled),

--- a/elixir/lib/portal/cluster.ex
+++ b/elixir/lib/portal/cluster.ex
@@ -1,4 +1,11 @@
 defmodule Portal.Cluster do
+  @moduledoc """
+  Supervisor for Erlang cluster discovery using libcluster.
+
+  Supports running multiple clustering strategies simultaneously, which is useful
+  during rolling deploys when migrating between strategies. Configure a secondary
+  adapter using `erlang_cluster_adapter_secondary` and its config.
+  """
   use Supervisor
 
   def start_link(opts) do
@@ -10,23 +17,36 @@ defmodule Portal.Cluster do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
     adapter = Keyword.fetch!(config, :adapter)
     adapter_config = Keyword.fetch!(config, :adapter_config)
+    secondary_adapter = Keyword.get(config, :secondary_adapter)
+    secondary_adapter_config = Keyword.get(config, :secondary_adapter_config, [])
 
-    topology_config = [
-      default: [
-        strategy: adapter,
-        config: adapter_config
-      ]
-    ]
+    topologies =
+      build_topologies(adapter, adapter_config, secondary_adapter, secondary_adapter_config)
 
     children =
-      if adapter do
-        [
-          {Cluster.Supervisor, [topology_config, [name: __MODULE__]]}
-        ]
+      if topologies != [] do
+        [{Cluster.Supervisor, [topologies, [name: __MODULE__]]}]
       else
         []
       end
 
     Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  defp build_topologies(nil, _, nil, _), do: []
+
+  defp build_topologies(adapter, adapter_config, nil, _) do
+    [default: [strategy: adapter, config: adapter_config]]
+  end
+
+  defp build_topologies(nil, _, secondary, secondary_config) do
+    [secondary: [strategy: secondary, config: secondary_config]]
+  end
+
+  defp build_topologies(adapter, adapter_config, secondary, secondary_config) do
+    [
+      default: [strategy: adapter, config: adapter_config],
+      secondary: [strategy: secondary, config: secondary_config]
+    ]
   end
 end

--- a/elixir/lib/portal/cluster/postgres_strategy.ex
+++ b/elixir/lib/portal/cluster/postgres_strategy.ex
@@ -1,0 +1,334 @@
+defmodule Portal.Cluster.PostgresStrategy do
+  @moduledoc """
+  A libcluster strategy that uses PostgreSQL LISTEN/NOTIFY for node discovery.
+
+  Inspired by [libcluster_postgres](https://github.com/supabase/libcluster_postgres),
+  this strategy adds proper node disconnect handling and graceful shutdown support.
+
+  ## Features
+
+  - Heartbeat-based discovery via PostgreSQL NOTIFY
+  - Automatic disconnect after missed heartbeats
+  - Graceful shutdown broadcasts goodbye for immediate disconnect
+  - Cloud-agnostic: works anywhere you have PostgreSQL
+
+  ## Configuration
+
+  Environment variables:
+
+      ERLANG_CLUSTER_ADAPTER=Elixir.Portal.Cluster.PostgresStrategy
+      ERLANG_CLUSTER_ADAPTER_CONFIG='{"repo":"Portal.Repo","channel_name":"cluster","heartbeat_interval":5000,"missed_heartbeats":3,"node_count":12}'
+
+  Or via Elixir config:
+
+      config :libcluster,
+        topologies: [
+          default: [
+            strategy: Portal.Cluster.PostgresStrategy,
+            config: [
+              repo: Portal.Repo,
+              channel_name: "cluster",
+              heartbeat_interval: 5_000,
+              missed_heartbeats: 3,
+              node_count: 3
+            ]
+          ]
+        ]
+
+  ## Options
+
+  - `:repo` - (required) Ecto Repo module for database config
+  - `:channel_name` - PostgreSQL channel name. Defaults to "cluster"
+  - `:heartbeat_interval` - Heartbeat interval in ms. Defaults to 5000
+  - `:missed_heartbeats` - Missed heartbeats before disconnect. Defaults to 3
+  - `:node_count` - Expected node count for threshold-based error logging
+
+  ## Rolling Deploys
+
+  When migrating from another clustering strategy (e.g., `GoogleComputeLabelsStrategy`),
+  nodes using different strategies cannot discover each other. To avoid split-brain
+  during rolling deploys, configure both strategies to run simultaneously using the
+  secondary adapter.
+
+  Example migrating from GoogleComputeLabelsStrategy to PostgresStrategy:
+
+      # Primary: new PostgresStrategy
+      ERLANG_CLUSTER_ADAPTER=Elixir.Portal.Cluster.PostgresStrategy
+      ERLANG_CLUSTER_ADAPTER_CONFIG='{"repo":"Portal.Repo","node_count":12}'
+
+      # Secondary: existing GoogleComputeLabelsStrategy (keep during transition)
+      ERLANG_CLUSTER_ADAPTER_SECONDARY=Elixir.Portal.Cluster.GoogleComputeLabelsStrategy
+      ERLANG_CLUSTER_ADAPTER_SECONDARY_CONFIG='{"project_id":"my-project","cluster_name":"firezone","cluster_name_label":"cluster_name","cluster_version_label":"cluster_version","cluster_version":"1_0","node_name_label":"application","polling_interval_ms":10000,"node_count":12,"release_name":"portal"}'
+
+  Both strategies will run in parallel, and nodes discovered by either mechanism
+  will be connected. After all nodes are running the new code, remove the secondary
+  adapter configuration in a subsequent deploy.
+  """
+
+  use GenServer
+  use Cluster.Strategy
+
+  require Logger
+
+  @default_channel_name "cluster"
+  @default_heartbeat_interval 5_000
+  @default_missed_heartbeats 3
+
+  def start_link(args), do: GenServer.start_link(__MODULE__, args)
+
+  @impl GenServer
+  def init([state]) do
+    Process.flag(:trap_exit, true)
+
+    repo = Keyword.fetch!(state.config, :repo)
+    channel_name = Keyword.get(state.config, :channel_name, @default_channel_name)
+
+    heartbeat_interval =
+      Keyword.get(state.config, :heartbeat_interval, @default_heartbeat_interval)
+
+    missed_heartbeats = Keyword.get(state.config, :missed_heartbeats, @default_missed_heartbeats)
+
+    state =
+      state
+      |> Map.put(:repo, repo)
+      |> Map.put(:channel_name, channel_name)
+      |> Map.put(:heartbeat_interval, heartbeat_interval)
+      |> Map.put(:missed_heartbeats, missed_heartbeats)
+      |> Map.put(:node_timestamps, %{})
+      |> Map.put(:connected_nodes, [])
+      |> Map.put(:below_threshold?, false)
+      |> Map.put(:listener_pid, nil)
+      |> Map.put(:notify_conn, nil)
+
+    {:ok, state, {:continue, :connect}}
+  end
+
+  @impl GenServer
+  def handle_continue(:connect, state) do
+    case start_connections(state) do
+      {:ok, listener_pid, notify_conn} ->
+        send(self(), :heartbeat)
+        {:noreply, %{state | listener_pid: listener_pid, notify_conn: notify_conn}}
+
+      {:error, reason} ->
+        Logger.error("Failed to start PostgreSQL connections", reason: inspect(reason))
+        Process.send_after(self(), :retry_connect, state.heartbeat_interval)
+        {:noreply, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:retry_connect, state) do
+    {:noreply, state, {:continue, :connect}}
+  end
+
+  def handle_info(:heartbeat, state) do
+    broadcast_heartbeat(state)
+    state = check_stale_nodes(state)
+
+    :telemetry.execute([:portal, :cluster], %{
+      discovered_nodes_count: map_size(state.node_timestamps)
+    })
+
+    Process.send_after(self(), :heartbeat, state.heartbeat_interval)
+    {:noreply, state}
+  end
+
+  def handle_info({:notification, _pid, _ref, channel, payload}, state)
+      when channel == state.channel_name do
+    {:noreply, handle_notification(payload, state)}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, reason}, %{listener_pid: pid} = state) do
+    Logger.warning("PostgreSQL listener died, reconnecting", reason: inspect(reason))
+    Process.send_after(self(), :retry_connect, state.heartbeat_interval)
+    {:noreply, %{state | listener_pid: nil}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, reason}, %{notify_conn: pid} = state) do
+    Logger.warning("PostgreSQL notify connection died, reconnecting", reason: inspect(reason))
+    Process.send_after(self(), :retry_connect, state.heartbeat_interval)
+    {:noreply, %{state | notify_conn: nil}}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    broadcast_goodbye(state)
+    :ok
+  end
+
+  defp start_connections(state) do
+    postgrex_config = build_postgrex_config(state.repo.config())
+
+    # Two connections needed: one for LISTEN (Notifications), one for NOTIFY (regular)
+    with {:ok, notify_conn} <- Postgrex.start_link(postgrex_config),
+         {:ok, listener} <- Postgrex.Notifications.start_link(postgrex_config),
+         {:ok, _ref} <- Postgrex.Notifications.listen(listener, state.channel_name) do
+      Process.monitor(notify_conn)
+      Process.monitor(listener)
+      {:ok, listener, notify_conn}
+    end
+  end
+
+  defp build_postgrex_config(repo_config) do
+    repo_config
+    |> Keyword.take([
+      :hostname,
+      :port,
+      :database,
+      :username,
+      :password,
+      :ssl,
+      :ssl_opts,
+      :socket_options,
+      :parameters
+    ])
+    |> Keyword.put_new(:hostname, "localhost")
+    |> Keyword.put_new(:port, 5432)
+  end
+
+  defp broadcast_heartbeat(state), do: notify(state, "heartbeat:#{node()}")
+  defp broadcast_goodbye(state), do: notify(state, "goodbye:#{node()}")
+
+  defp notify(%{notify_conn: nil}, _payload), do: :ok
+
+  defp notify(%{notify_conn: conn, channel_name: channel}, payload) do
+    case Postgrex.query(conn, "SELECT pg_notify($1, $2)", [channel, payload]) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to send cluster notification", reason: inspect(reason))
+    end
+  catch
+    :exit, reason -> Logger.error("Failed to send cluster notification", reason: inspect(reason))
+  end
+
+  defp handle_notification("heartbeat:" <> node_name, state) do
+    node = String.to_atom(node_name)
+    if node == node(), do: state, else: handle_heartbeat(node, state)
+  end
+
+  defp handle_notification("goodbye:" <> node_name, state) do
+    node = String.to_atom(node_name)
+    if node == node(), do: state, else: handle_goodbye(node, state)
+  end
+
+  defp handle_notification(_payload, state), do: state
+
+  defp handle_heartbeat(node, state) do
+    now = System.monotonic_time(:millisecond)
+    state = %{state | node_timestamps: Map.put(state.node_timestamps, node, now)}
+
+    case Cluster.Strategy.connect_nodes(state.topology, state.connect, state.list_nodes, [node]) do
+      :ok ->
+        state = %{state | connected_nodes: Enum.uniq([node | state.connected_nodes])}
+        maybe_log_threshold_recovery(state)
+
+      {:error, bad_nodes} ->
+        problem_nodes = Enum.map(bad_nodes, &elem(&1, 0))
+
+        Logger.info("Error connecting to nodes",
+          connected_nodes: inspect(state.connected_nodes),
+          problem_nodes: inspect(problem_nodes)
+        )
+
+        maybe_log_threshold_error(state, problem_nodes)
+    end
+  end
+
+  defp handle_goodbye(node, state) do
+    Logger.info("Received goodbye from node, disconnecting", node: node)
+
+    state = %{
+      state
+      | node_timestamps: Map.delete(state.node_timestamps, node),
+        connected_nodes: List.delete(state.connected_nodes, node)
+    }
+
+    Cluster.Strategy.disconnect_nodes(state.topology, state.disconnect, state.list_nodes, [node])
+    maybe_log_threshold_error(state, [node])
+  end
+
+  defp check_stale_nodes(state) do
+    now = System.monotonic_time(:millisecond)
+    stale_threshold = state.heartbeat_interval * state.missed_heartbeats
+
+    {stale_nodes, active_timestamps} =
+      Enum.reduce(state.node_timestamps, {[], %{}}, fn {node, last_seen}, {stale, active} ->
+        if now - last_seen > stale_threshold do
+          {[node | stale], active}
+        else
+          {stale, Map.put(active, node, last_seen)}
+        end
+      end)
+
+    if stale_nodes == [] do
+      %{state | node_timestamps: active_timestamps}
+    else
+      Logger.info("Disconnecting stale nodes", nodes: inspect(stale_nodes))
+
+      Cluster.Strategy.disconnect_nodes(
+        state.topology,
+        state.disconnect,
+        state.list_nodes,
+        stale_nodes
+      )
+
+      state = %{
+        state
+        | node_timestamps: active_timestamps,
+          connected_nodes: state.connected_nodes -- stale_nodes
+      }
+
+      maybe_log_threshold_error(state, stale_nodes)
+    end
+  end
+
+  # Only log when crossing the threshold boundary to avoid log flooding
+  defp maybe_log_threshold_error(state, problem_nodes) do
+    if enough_nodes_connected?(state) do
+      %{state | below_threshold?: false}
+    else
+      unless state.below_threshold? do
+        Logger.error("Connected nodes count is below threshold",
+          connected_nodes: inspect(state.connected_nodes),
+          problem_nodes: inspect(problem_nodes),
+          config: inspect(state.config)
+        )
+      end
+
+      %{state | below_threshold?: true}
+    end
+  end
+
+  defp maybe_log_threshold_recovery(state) do
+    if enough_nodes_connected?(state) do
+      if state.below_threshold? do
+        Logger.info("Connected nodes count is back above threshold",
+          connected_nodes: inspect(state.connected_nodes),
+          config: inspect(state.config)
+        )
+      end
+
+      %{state | below_threshold?: false}
+    else
+      state
+    end
+  end
+
+  defp enough_nodes_connected?(state) do
+    case Keyword.fetch(state.config, :node_count) do
+      {:ok, expected_node_count} ->
+        connected_node_count = [node() | state.connected_nodes] |> Enum.uniq() |> length()
+        connected_node_count >= expected_node_count
+
+      :error ->
+        true
+    end
+  end
+end

--- a/elixir/test/portal/cluster/postgres_strategy_test.exs
+++ b/elixir/test/portal/cluster/postgres_strategy_test.exs
@@ -1,0 +1,465 @@
+defmodule Portal.Cluster.PostgresStrategyTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Portal.Cluster.PostgresStrategy
+
+  describe "heartbeat and goodbye via LISTEN/NOTIFY" do
+    test "broadcasts heartbeat on startup and goodbye on termination" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      listener = start_supervised!({Postgrex.Notifications, Portal.Repo.config()})
+      {:ok, _ref} = Postgrex.Notifications.listen(listener, channel_name)
+
+      _pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      assert_receive {:notification, _, _, ^channel_name, "heartbeat:" <> _}, 1000
+      flush_notifications()
+
+      stop_supervised!(PostgresStrategy)
+      assert_receive {:notification, _, _, ^channel_name, "goodbye:" <> _}, 1000
+    end
+  end
+
+  describe "handle_info/2" do
+    test ":heartbeat emits telemetry and schedules next heartbeat" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        "test-handler-#{channel_name}",
+        [:portal, :cluster],
+        fn _event, measurements, _meta, _config ->
+          send(test_pid, {:telemetry, measurements})
+        end,
+        nil
+      )
+
+      _pid =
+        start_supervised!(
+          {PostgresStrategy, [build_state(channel_name: channel_name, heartbeat_interval: 50)]}
+        )
+
+      # Should receive telemetry events
+      assert_receive {:telemetry, %{discovered_nodes_count: 0}}, 1000
+
+      :telemetry.detach("test-handler-#{channel_name}")
+    end
+
+    test "handles notification from other nodes" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      listener = start_supervised!({Postgrex.Notifications, Portal.Repo.config()})
+      {:ok, _ref} = Postgrex.Notifications.listen(listener, channel_name)
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+      flush_notifications()
+
+      # Simulate a heartbeat from another node by sending directly to the process
+      send(pid, {:notification, self(), make_ref(), channel_name, "heartbeat:other@node"})
+      Process.sleep(50)
+
+      # The strategy should have tried to connect (will fail since node doesn't exist)
+      # We just verify it doesn't crash
+      assert Process.alive?(pid)
+    end
+
+    test "logs error when connecting to node fails" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {PostgresStrategy,
+           [build_state(channel_name: channel_name, connect_fn: :mock_connect_failing)]}
+        )
+
+      Process.sleep(100)
+
+      log =
+        capture_log(fn ->
+          send(pid, {:notification, self(), make_ref(), channel_name, "heartbeat:other@node"})
+          Process.sleep(50)
+        end)
+
+      assert log =~ "Error connecting to nodes"
+      assert Process.alive?(pid)
+    end
+
+    test "handles goodbye notification from other nodes" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      log =
+        capture_log(fn ->
+          send(pid, {:notification, self(), make_ref(), channel_name, "goodbye:other@node"})
+          Process.sleep(50)
+        end)
+
+      assert log =~ "Received goodbye from node"
+      assert Process.alive?(pid)
+    end
+
+    test "handles unknown notifications gracefully" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      # Send unknown notification
+      send(pid, {:notification, self(), make_ref(), channel_name, "unknown:payload"})
+      Process.sleep(50)
+
+      assert Process.alive?(pid)
+    end
+
+    test "handles unknown messages gracefully" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      send(pid, :some_random_message)
+      Process.sleep(50)
+
+      assert Process.alive?(pid)
+    end
+
+    test "reconnects when listener dies" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      # Get the listener pid from state and kill it
+      state = :sys.get_state(pid)
+      listener_pid = state.listener_pid
+
+      log =
+        capture_log(fn ->
+          Process.exit(listener_pid, :kill)
+          Process.sleep(200)
+        end)
+
+      assert log =~ "PostgreSQL listener died, reconnecting"
+      assert Process.alive?(pid)
+    end
+
+    test "reconnects when notify connection dies" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      state = :sys.get_state(pid)
+      notify_conn = state.notify_conn
+
+      log =
+        capture_log(fn ->
+          Process.exit(notify_conn, :kill)
+          Process.sleep(200)
+        end)
+
+      assert log =~ "PostgreSQL notify connection died, reconnecting"
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "stale node detection" do
+    test "disconnects stale nodes and logs" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {PostgresStrategy,
+           [build_state(channel_name: channel_name, heartbeat_interval: 50, missed_heartbeats: 1)]}
+        )
+
+      Process.sleep(100)
+
+      # Manually inject a stale node into state
+      state = :sys.get_state(pid)
+      stale_time = System.monotonic_time(:millisecond) - 200
+
+      new_state = %{
+        state
+        | node_timestamps: %{:stale@node => stale_time},
+          connected_nodes: [:stale@node]
+      }
+
+      :sys.replace_state(pid, fn _ -> new_state end)
+
+      log =
+        capture_log(fn ->
+          # Trigger heartbeat which checks stale nodes
+          send(pid, :heartbeat)
+          Process.sleep(100)
+        end)
+
+      assert log =~ "Disconnecting stale nodes"
+
+      # Verify node was removed
+      final_state = :sys.get_state(pid)
+      refute Map.has_key?(final_state.node_timestamps, :stale@node)
+    end
+  end
+
+  describe "threshold logging" do
+    test "logs error when falling below threshold" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {PostgresStrategy,
+           [build_state(channel_name: channel_name, node_count: 5, heartbeat_interval: 50)]}
+        )
+
+      Process.sleep(100)
+
+      # Inject a node and then simulate it going stale
+      state = :sys.get_state(pid)
+      stale_time = System.monotonic_time(:millisecond) - 200
+
+      new_state = %{
+        state
+        | node_timestamps: %{:node1@test => stale_time},
+          connected_nodes: [:node1@test],
+          missed_heartbeats: 1,
+          below_threshold?: false
+      }
+
+      :sys.replace_state(pid, fn _ -> new_state end)
+
+      log =
+        capture_log(fn ->
+          send(pid, :heartbeat)
+          Process.sleep(100)
+        end)
+
+      assert log =~ "Connected nodes count is below threshold"
+    end
+
+    test "logs recovery when coming back above threshold" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {PostgresStrategy, [build_state(channel_name: channel_name, node_count: 1)]}
+        )
+
+      Process.sleep(100)
+
+      # Set state to below threshold
+      state = :sys.get_state(pid)
+      new_state = %{state | below_threshold?: true, connected_nodes: []}
+      :sys.replace_state(pid, fn _ -> new_state end)
+
+      log =
+        capture_log(fn ->
+          # Simulate successful heartbeat from another node
+          send(pid, {:notification, self(), make_ref(), channel_name, "heartbeat:other@node"})
+          Process.sleep(100)
+        end)
+
+      assert log =~ "Connected nodes count is back above threshold"
+    end
+  end
+
+  describe "notify edge cases" do
+    test "does not crash when notify_conn is nil" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      # Set notify_conn to nil
+      state = :sys.get_state(pid)
+      :sys.replace_state(pid, fn _ -> %{state | notify_conn: nil} end)
+
+      # This should not crash
+      send(pid, :heartbeat)
+      Process.sleep(50)
+
+      assert Process.alive?(pid)
+    end
+
+    test "logs error when notify fails due to dead connection" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      # Replace notify_conn with a dead pid (simulate broken connection)
+      state = :sys.get_state(pid)
+      dead_pid = spawn(fn -> :ok end)
+      Process.sleep(10)
+      :sys.replace_state(pid, fn _ -> %{state | notify_conn: dead_pid} end)
+
+      log =
+        capture_log(fn ->
+          send(pid, :heartbeat)
+          Process.sleep(100)
+        end)
+
+      assert log =~ "Failed to send cluster notification"
+    end
+
+    test "logs error when pg_notify returns SQL error" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      # Inject an oversized channel name that exceeds PostgreSQL's limit
+      state = :sys.get_state(pid)
+      long_channel = String.duplicate("x", 9000)
+      :sys.replace_state(pid, fn _ -> %{state | channel_name: long_channel} end)
+
+      log =
+        capture_log(fn ->
+          send(pid, :heartbeat)
+          Process.sleep(100)
+        end)
+
+      assert log =~ "Failed to send cluster notification"
+    end
+  end
+
+  describe "connection failure" do
+    test "logs error and schedules retry on connection failure" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid = start_supervised!({PostgresStrategy, [build_state(channel_name: channel_name)]})
+      Process.sleep(100)
+
+      # Kill both connections to simulate failure
+      state = :sys.get_state(pid)
+      Process.exit(state.listener_pid, :kill)
+      Process.exit(state.notify_conn, :kill)
+      Process.sleep(50)
+
+      # Set connections to nil and trigger retry
+      :sys.replace_state(pid, fn s -> %{s | listener_pid: nil, notify_conn: nil} end)
+
+      send(pid, :retry_connect)
+      Process.sleep(200)
+
+      # Should have reconnected successfully
+      assert Process.alive?(pid)
+      new_state = :sys.get_state(pid)
+      assert new_state.listener_pid != nil
+      assert new_state.notify_conn != nil
+    end
+
+    test "logs error when initial connection fails" do
+      log =
+        capture_log(fn ->
+          # Use a repo with invalid config to trigger connection failure
+          state = build_state_with_invalid_repo()
+          {:ok, pid} = GenServer.start_link(PostgresStrategy, [state])
+          Process.sleep(200)
+          GenServer.stop(pid, :normal)
+        end)
+
+      assert log =~ "Failed to start PostgreSQL connections"
+    end
+  end
+
+  describe "threshold recovery edge case" do
+    test "does not log recovery when still below threshold" do
+      channel_name = "test_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {PostgresStrategy,
+           [build_state(channel_name: channel_name, node_count: 10, heartbeat_interval: 50)]}
+        )
+
+      Process.sleep(100)
+
+      # Set state with below_threshold? as false and only 1 connected node
+      # When we add another node via heartbeat, we'll still be below 10 nodes
+      state = :sys.get_state(pid)
+
+      new_state = %{
+        state
+        | below_threshold?: false,
+          connected_nodes: [:node1@test],
+          node_timestamps: %{:node1@test => System.monotonic_time(:millisecond)}
+      }
+
+      :sys.replace_state(pid, fn _ -> new_state end)
+
+      # Simulate heartbeat from another node - now we have 2 nodes + self = 3, still below 10
+      log =
+        capture_log(fn ->
+          send(pid, {:notification, self(), make_ref(), channel_name, "heartbeat:node2@test"})
+          Process.sleep(100)
+        end)
+
+      # Should not log recovery since we're still below threshold
+      refute log =~ "Connected nodes count is back above threshold"
+    end
+  end
+
+  # Helpers
+
+  defp build_state(opts) do
+    connect_fn = Keyword.get(opts, :connect_fn, :mock_connect)
+
+    %{
+      topology: :test_topology,
+      connect: {__MODULE__, connect_fn, []},
+      disconnect: {__MODULE__, :mock_disconnect, []},
+      list_nodes: {__MODULE__, :mock_list_nodes, []},
+      config:
+        [
+          repo: Portal.Repo,
+          channel_name: Keyword.get(opts, :channel_name, "test_cluster"),
+          heartbeat_interval: Keyword.get(opts, :heartbeat_interval, 60_000),
+          missed_heartbeats: Keyword.get(opts, :missed_heartbeats, 3),
+          node_count: Keyword.get(opts, :node_count, nil)
+        ]
+        |> Enum.reject(fn {_, v} -> is_nil(v) end)
+    }
+  end
+
+  defp build_state_with_invalid_repo do
+    %{
+      topology: :test_topology,
+      connect: {__MODULE__, :mock_connect, []},
+      disconnect: {__MODULE__, :mock_disconnect, []},
+      list_nodes: {__MODULE__, :mock_list_nodes, []},
+      config: [
+        repo: __MODULE__.InvalidRepo,
+        channel_name: "test_cluster",
+        heartbeat_interval: 100
+      ]
+    }
+  end
+
+  defp flush_notifications do
+    receive do
+      {:notification, _, _, _, _} -> flush_notifications()
+    after
+      0 -> :ok
+    end
+  end
+
+  # Mock functions for Cluster.Strategy callbacks
+  def mock_connect(_node), do: true
+  def mock_disconnect(_node), do: true
+  def mock_list_nodes, do: []
+  def mock_connect_failing(_node), do: false
+
+  # Mock repo module that returns invalid config
+  defmodule InvalidRepo do
+    def config do
+      [hostname: "invalid.host.that.does.not.exist", port: 9999, connect_timeout: 100]
+    end
+  end
+end


### PR DESCRIPTION
When migrating the control plane to Azure, we'll need to gradually move traffic over from the GCP infra to the new Azure infra. As part of that, we need the app servers in each to be joined in the same Erlang cluster.

This can be accomplished with a new, custom `libcluster` strategy using Postgres' LISTEN/NOTIFY system as a message bus. https://github.com/supabase/libcluster_postgres is used for inspiration / validation here that this technique works in production.

We build on that library with disconnect support that actively disconnects nodes from the cluster in two ways:

- missed heartbeats
- SIGTERM received

Tests are added to 100% coverage given the critical nature of this code.

Lastly, the config definitions for clustering are updated to support _two_ clustering strategies used simultaneously, by using two `topologies`. `libcluster` should handle dedup'ing connected nodes by their node name. This will prevent split brain scenarios during the rollout of this new Postgres strategy.

Related: #10419 
Related: firezone/infra#373