### PR TITLE
fix(relay): survive portal partitions up to 24 hours

### DIFF
--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -854,12 +854,12 @@ mod tests {
     }
 
     #[test]
-    fn given_last_heartbeat_older_than_15_min_is_not_healthy() {
-        let now = Instant::now() + Duration::from_hours(1); // Advance to the future to avoid underflow.
+    fn given_last_heartbeat_older_than_24_hours_is_not_healthy() {
+        let now = Instant::now() + Duration::from_hours(48); // Advance to the future to avoid underflow.
 
         let is_healthy = is_healthy(
             now,
-            Arc::new(Mutex::new(Some(now - Duration::from_secs(60 * 15)))),
+            Arc::new(Mutex::new(Some(now - Duration::from_hours(24)))),
         );
 
         assert!(!is_healthy)

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -32,7 +32,7 @@ use url::Url;
 
 const STATS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 
-const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 15);
+const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
 
 #[derive(Parser, Debug)]
 struct Args {


### PR DESCRIPTION
If the portal experiences an outage, a bug is shipped, or there's a cloud or load balancer outage, it's important to try and maintain existing data plane connections to limit customer impact.

Today, we shut the relay down after 15 minutes of no portal connectivity. Yes, the process manager will restart us, but:

1. We will have dropped allocations/bindings that may be still in use
2. Clients/gateways have their own unhealthy relay detection and removal mechanism

Related: #11518 