### PR TITLE
fix(gateway): survive portal partitions up to 24h

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2540,6 +2540,7 @@ dependencies = [
  "futures",
  "futures-bounded",
  "hickory-resolver",
+ "humantime",
  "ip-packet",
  "ip_network",
  "libc",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -36,6 +36,7 @@ either = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true }
 hickory-resolver = { workspace = true }
+humantime = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"] }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -33,6 +33,8 @@ mod eventloop;
 
 const RELEASE: &str = concat!("gateway@", env!("CARGO_PKG_VERSION"));
 
+const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -207,7 +209,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         (),
         || {
             ExponentialBackoffBuilder::default()
-                .with_max_elapsed_time(Some(Duration::from_secs(60 * 15)))
+                .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
                 .build()
         },
         Arc::new(tcp_socket_factory),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -33,7 +33,7 @@ mod eventloop;
 
 const RELEASE: &str = concat!("gateway@", env!("CARGO_PKG_VERSION"));
 
-const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
+const DEFAULT_MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -201,15 +201,20 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         nameservers,
         cli.flow_logs,
     );
+    let max_partition_time = cli
+        .max_partition_time
+        .map(|d| d.into())
+        .unwrap_or(DEFAULT_MAX_PARTITION_TIME);
+
     let portal = PhoenixChannel::disconnected(
         login,
         token,
         get_user_agent("gateway", env!("CARGO_PKG_VERSION")),
         PHOENIX_TOPIC,
         (),
-        || {
+        move || {
             ExponentialBackoffBuilder::default()
-                .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
+                .with_max_elapsed_time(Some(max_partition_time))
                 .build()
         },
         Arc::new(tcp_socket_factory),
@@ -358,6 +363,11 @@ struct Cli {
     /// Do not try to increase the `core.rmem_max` and `core.wmem_max` kernel parameters.
     #[arg(long, env = "FIREZONE_NO_INC_BUF", default_value_t = false)]
     no_inc_buf: bool,
+
+    /// Maximum length of time to retry connecting to the portal if we're having internet issues or
+    /// it's down. Accepts human times. e.g. "5m" or "1h" or "30d".
+    #[arg(short, long, env = "FIREZONE_MAX_PARTITION_TIME")]
+    max_partition_time: Option<humantime::Duration>,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -27,6 +27,12 @@ export default function Gateway() {
           Enables detailed flow logs for tunneled TCP and UDP connections. Set
           `FIREZONE_FLOW_LOGS=true` or `--flow-logs` to enable.
         </ChangeItem>
+        <ChangeItem pull="11664">
+          Adds a <code>FIREZONE_MAX_PARTITION_TIME</code> environment variable
+          to configure how long the Gateway will retry connecting to the portal
+          before exiting. Accepts human-readable durations like <code>5m</code>,{" "}
+          <code>1h</code>, or <code>30d</code>. Defaults to 24 hours.
+        </ChangeItem>
         <ChangeItem pull="11625">
           Fails faster when the initial connection to the control plane cannot
           be established, allowing faster restarts by the process manager.


### PR DESCRIPTION
Based on the same reasoning in #11663, we increase the amount of time the Gateway allows itself to be partitioned from the portal to 24 hours. This avoids abruptly tearing down any data plane connections for this window of time if we have any kind of infrastructure outage.

Fixes #11518 