### PR TITLE
feat(portal): add healthchecks to http endpoints

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -33,3 +33,13 @@ DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:375,2
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:217,3560D02
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:371,46EE6C5
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:212,5B50F1B
+
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:31,135D3E7
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,3660523
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:41,4C6E35C
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
+Config.Secrets: Hardcoded Secret,config/config.exs:206,611CC2E
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:51,68184B9
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,74777AB
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:75,780F62D
+Config.Secrets: Hardcoded Secret,config/config.exs:205,E9FD90

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -154,6 +154,10 @@ config :portal, Portal.Telemetry,
 
 config :portal, Portal.Health,
   health_port: 4000,
+  repo: Portal.Repo,
+  web_endpoint: PortalWeb.Endpoint,
+  api_endpoint: PortalAPI.Endpoint,
+  # TODO: Remove draining_file_path after Azure migration is complete
   draining_file_path: "/var/run/firezone/draining"
 
 config :portal, Portal.Entra.APIClient,

--- a/elixir/lib/portal/config.ex
+++ b/elixir/lib/portal/config.ex
@@ -98,7 +98,15 @@ defmodule Portal.Config do
     defdelegate get_env(app, key, default \\ nil), to: Application
   else
     def put_env_override(app \\ :portal, key, value) do
-      Process.put(pdict_key_function(app, key), value)
+      merged_value =
+        if Keyword.keyword?(value) do
+          base = Application.fetch_env!(app, key)
+          Keyword.merge(base, value)
+        else
+          value
+        end
+
+      Process.put(pdict_key_function(app, key), merged_value)
       :ok
     end
 

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -2,6 +2,9 @@ defmodule PortalAPI.Endpoint do
   use Sentry.PlugCapture
   use Phoenix.Endpoint, otp_app: :portal
 
+  # Health checks - early in pipeline for fast responses
+  plug Portal.Health
+
   if Application.compile_env(:portal, :sql_sandbox) do
     plug Phoenix.Ecto.SQL.Sandbox
   end

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -14,6 +14,9 @@ defmodule PortalWeb.Endpoint do
     signing_salt: {__MODULE__, :cookie_signing_salt, []}
   ]
 
+  # Health checks - early in pipeline for fast responses
+  plug Portal.Health
+
   if Application.compile_env(:portal, :sql_sandbox) do
     plug Phoenix.Ecto.SQL.Sandbox
     plug PortalWeb.Plugs.AllowEctoSandbox

--- a/elixir/test/portal/cluster/postgres_strategy_test.exs
+++ b/elixir/test/portal/cluster/postgres_strategy_test.exs
@@ -84,7 +84,7 @@ defmodule Portal.Cluster.PostgresStrategyTest do
           Process.sleep(50)
         end)
 
-      assert log =~ "Error connecting to nodes"
+      assert log =~ "unable to connect to"
       assert Process.alive?(pid)
     end
 


### PR DESCRIPTION
- Refactors `Portal.Health` to function both as a standalone server (for GCP) and as a plug that can be added to the HTTP endpoints (for Azure)
- Adds a `databse_ready?/0` check on `/readyz` that ensures we can successfully issue queries to the configured `repo`.

Due to the way Azure Front Door + regional LBs work, we need the health checks to be on the same service / port as the one the requests are coming in on.

We could clean this up to consolidate on a single port for GCP too, but this is intentionally kept as-is to avoid unnecessary terraform config changes there.

Related: #10419 