### PR TITLE
test(portal): add crypto tests

### DIFF
--- a/elixir/lib/portal/crypto.ex
+++ b/elixir/lib/portal/crypto.ex
@@ -45,15 +45,9 @@ defmodule Portal.Crypto do
   end
 
   defp generate_random_token(length, :numeric) do
-    n =
-      :math.pow(10, length)
-      |> round()
-      |> :rand.uniform()
-      |> floor()
-      |> Kernel.-(1)
-
-    :io_lib.format("~#{length}..0B", [n])
-    |> List.to_string()
+    max = Integer.pow(10, length)
+    n = :crypto.strong_rand_range(max)
+    :io_lib.format("~#{length}..0B", [n]) |> List.to_string()
   end
 
   defp encode_random_token(binary, _length, :raw) do

--- a/elixir/test/portal/crypto/jwk_test.exs
+++ b/elixir/test/portal/crypto/jwk_test.exs
@@ -208,18 +208,6 @@ defmodule Portal.Crypto.JWKTest do
   end
 
   describe "integration with JOSE libraries" do
-    # test "generated JWK can be used to sign JWT tokens" do
-    #  result = JWK.generate_jwk_and_jwks()
-
-    #  # Sign with JOSE
-    #  jwk = JOSE.JWK.from_map(result.jwk)
-    #  jws = %{"alg" => "RS256"}
-    #  {_jws, token} = JOSE.JWT.sign(jwk, jws, payload) |> JOSE.JWS.compact()
-
-    #  assert is_binary(token)
-    #  assert String.contains?(token, ".")
-    # end
-
     test "generated JWKS can be used to sign and verify JWT tokens" do
       result = JWK.generate_jwk_and_jwks()
       time = System.system_time(:second)
@@ -317,8 +305,7 @@ defmodule Portal.Crypto.JWKTest do
       qi = jwk["qi"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
 
       # Verify q * qi ≡ 1 (mod p)
-      result = rem(q * qi, p)
-      assert result == 1
+      assert rem(q * qi, p) == 1
     end
   end
 
@@ -379,6 +366,5 @@ defmodule Portal.Crypto.JWKTest do
       assert e_pos < kty_pos, "Key 'e' must appear before 'kty'"
       assert kty_pos < n_pos, "Key 'kty' must appear before 'n'"
     end
-
   end
 end

--- a/elixir/test/portal/crypto/jwk_test.exs
+++ b/elixir/test/portal/crypto/jwk_test.exs
@@ -1,0 +1,384 @@
+defmodule Portal.Crypto.JWKTest do
+  use ExUnit.Case, async: true
+  alias Portal.Crypto.JWK
+
+  describe "generate_jwk_and_jwks/0" do
+    test "generates JWK and JWKS with default 2048 bits" do
+      result = JWK.generate_jwk_and_jwks()
+
+      # Verify return structure
+      assert is_map(result)
+      assert is_map(result.jwk)
+      assert is_map(result.jwks)
+      assert is_binary(result.kid)
+
+      # Verify the modulus (n) is exactly 2048 bits
+      n_binary = Base.url_decode64!(result.jwk["n"], padding: false)
+      n_bits = bit_size(n_binary)
+
+      assert n_bits == 2048
+    end
+
+    test "JWK contains all required private key fields" do
+      result = JWK.generate_jwk_and_jwks()
+      jwk = result.jwk
+
+      assert jwk["kty"] == "RSA"
+      assert jwk["alg"] == "RS256"
+      assert jwk["use"] == "sig"
+      assert is_binary(jwk["kid"])
+      assert is_binary(jwk["n"])
+      assert is_binary(jwk["e"])
+      assert is_binary(jwk["d"])
+      assert is_binary(jwk["p"])
+      assert is_binary(jwk["q"])
+      assert is_binary(jwk["dp"])
+      assert is_binary(jwk["dq"])
+      assert is_binary(jwk["qi"])
+    end
+
+    test "JWK values are base64url encoded without padding" do
+      result = JWK.generate_jwk_and_jwks()
+      jwk = result.jwk
+
+      for field <- ["n", "e", "d", "p", "q", "dp", "dq", "qi"] do
+        value = jwk[field]
+        assert is_binary(value)
+        refute String.contains?(value, "=")
+        assert String.match?(value, ~r/^[A-Za-z0-9_-]+$/)
+      end
+    end
+
+    test "JWKS contains public keys array" do
+      result = JWK.generate_jwk_and_jwks()
+      jwks = result.jwks
+
+      assert is_map(jwks)
+      assert Map.has_key?(jwks, "keys")
+      assert is_list(jwks["keys"])
+      assert length(jwks["keys"]) == 1
+    end
+
+    test "JWKS public key contains only public fields" do
+      result = JWK.generate_jwk_and_jwks()
+      public_key = List.first(result.jwks["keys"])
+
+      assert public_key["kty"] == "RSA"
+      assert public_key["alg"] == "RS256"
+      assert public_key["use"] == "sig"
+      assert is_binary(public_key["kid"])
+      assert is_binary(public_key["n"])
+      assert is_binary(public_key["e"])
+
+      # Ensure no private fields
+      refute Map.has_key?(public_key, "d")
+      refute Map.has_key?(public_key, "p")
+      refute Map.has_key?(public_key, "q")
+      refute Map.has_key?(public_key, "dp")
+      refute Map.has_key?(public_key, "dq")
+      refute Map.has_key?(public_key, "qi")
+    end
+
+    test "kid in JWK matches kid in JWKS" do
+      result = JWK.generate_jwk_and_jwks()
+      jwk_kid = result.jwk["kid"]
+      jwks_kid = List.first(result.jwks["keys"])["kid"]
+
+      assert jwk_kid == jwks_kid
+      assert jwk_kid == result.kid
+    end
+
+    test "kid is RFC 7638 compliant thumbprint" do
+      result = JWK.generate_jwk_and_jwks()
+
+      # Manually calculate the thumbprint according to RFC 7638
+      thumbprint_json =
+        JSON.encode!(%{
+          "e" => result.jwk["e"],
+          "kty" => result.jwk["kty"],
+          "n" => result.jwk["n"]
+        })
+
+      expected_kid = :crypto.hash(:sha256, thumbprint_json) |> Base.url_encode64(padding: false)
+
+      assert result.kid == expected_kid
+      assert result.jwk["kid"] == expected_kid
+    end
+
+    test "kid is base64url encoded SHA256 hash without padding" do
+      result = JWK.generate_jwk_and_jwks()
+
+      assert is_binary(result.kid)
+      refute String.contains?(result.kid, "=")
+      assert String.match?(result.kid, ~r/^[A-Za-z0-9_-]+$/)
+      # SHA256 hash is 32 bytes, base64url encoded without padding should be 43 chars
+      assert String.length(result.kid) == 43
+    end
+
+    test "public key n and e values match in JWK and JWKS" do
+      result = JWK.generate_jwk_and_jwks()
+      public_key = List.first(result.jwks["keys"])
+
+      assert result.jwk["n"] == public_key["n"]
+      assert result.jwk["e"] == public_key["e"]
+    end
+
+    test "generates unique JWKs on each invocation" do
+      result1 = JWK.generate_jwk_and_jwks()
+      result2 = JWK.generate_jwk_and_jwks()
+
+      refute result1.jwk["n"] == result2.jwk["n"]
+      refute result1.jwk["d"] == result2.jwk["d"]
+      refute result1.kid == result2.kid
+    end
+
+    test "public exponent is 65537" do
+      result = JWK.generate_jwk_and_jwks()
+
+      # Decode the base64url encoded exponent
+      e_binary = Base.url_decode64!(result.jwk["e"], padding: false)
+      e_int = :binary.decode_unsigned(e_binary)
+
+      assert e_int == 65_537
+    end
+  end
+
+  describe "generate_jwk_and_jwks/1" do
+    test "generates JWK with custom bit size" do
+      for bits <- [1024, 2048, 4096] do
+        result = JWK.generate_jwk_and_jwks(bits)
+
+        assert is_map(result)
+        assert Map.has_key?(result, :jwk)
+        assert Map.has_key?(result, :jwks)
+        assert is_binary(result.jwk["n"])
+        assert is_binary(result.jwk["e"])
+        assert is_binary(result.kid)
+
+        # Verify the modulus (n) size is exactly the requested bit size
+        n_binary = Base.url_decode64!(result.jwk["n"], padding: false)
+        n_bits = bit_size(n_binary)
+
+        assert n_bits == bits
+      end
+    end
+  end
+
+  describe "extract_public_key_components/1" do
+    test "extracts only public key fields from private JWK" do
+      result = JWK.generate_jwk_and_jwks()
+      public_jwk = JWK.extract_public_key_components(result.jwk)
+
+      assert public_jwk["kty"] == "RSA"
+      assert public_jwk["alg"] == "RS256"
+      assert public_jwk["use"] == "sig"
+      assert public_jwk["kid"] == result.jwk["kid"]
+      assert public_jwk["n"] == result.jwk["n"]
+      assert public_jwk["e"] == result.jwk["e"]
+
+      # Verify no private fields are extracted
+      refute Map.has_key?(public_jwk, "d")
+      refute Map.has_key?(public_jwk, "p")
+      refute Map.has_key?(public_jwk, "q")
+      refute Map.has_key?(public_jwk, "dp")
+      refute Map.has_key?(public_jwk, "dq")
+      refute Map.has_key?(public_jwk, "qi")
+    end
+
+    test "extracted public key matches JWKS public key" do
+      result = JWK.generate_jwk_and_jwks()
+      extracted = JWK.extract_public_key_components(result.jwk)
+      jwks_public = List.first(result.jwks["keys"])
+
+      assert extracted == jwks_public
+    end
+
+    test "preserves all public fields exactly" do
+      result = JWK.generate_jwk_and_jwks()
+      public_jwk = JWK.extract_public_key_components(result.jwk)
+
+      # Verify no transformation of values
+      assert public_jwk["n"] == result.jwk["n"]
+      assert public_jwk["e"] == result.jwk["e"]
+      assert public_jwk["kid"] == result.jwk["kid"]
+      assert public_jwk["kty"] == result.jwk["kty"]
+      assert public_jwk["alg"] == result.jwk["alg"]
+      assert public_jwk["use"] == result.jwk["use"]
+    end
+  end
+
+  describe "integration with JOSE libraries" do
+    # test "generated JWK can be used to sign JWT tokens" do
+    #  result = JWK.generate_jwk_and_jwks()
+
+    #  # Sign with JOSE
+    #  jwk = JOSE.JWK.from_map(result.jwk)
+    #  jws = %{"alg" => "RS256"}
+    #  {_jws, token} = JOSE.JWT.sign(jwk, jws, payload) |> JOSE.JWS.compact()
+
+    #  assert is_binary(token)
+    #  assert String.contains?(token, ".")
+    # end
+
+    test "generated JWKS can be used to sign and verify JWT tokens" do
+      result = JWK.generate_jwk_and_jwks()
+      time = System.system_time(:second)
+
+      # Create a simple JWT payload
+      payload = %{
+        "sub" => "test-user",
+        "iat" => time,
+        "exp" => time + 3600
+      }
+
+      # Create and sign a token
+      jwk = JOSE.JWK.from_map(result.jwk)
+      jws = %{"alg" => "RS256"}
+      {_jws, token} = JOSE.JWT.sign(jwk, jws, payload) |> JOSE.JWS.compact()
+
+      assert is_binary(token)
+      assert String.split(token, ".", parts: 3) |> length() == 3
+
+      # Verify with public key from JWKS
+      public_jwk = List.first(result.jwks["keys"])
+      public_key = JOSE.JWK.from_map(public_jwk)
+
+      {verified, decoded_payload, _jws} = JOSE.JWT.verify(public_key, token)
+
+      assert verified
+      assert decoded_payload.fields["sub"] == "test-user"
+      assert decoded_payload.fields["iat"] == time
+      assert decoded_payload.fields["exp"] == time + 3600
+    end
+
+    test "verification fails with wrong public key" do
+      result1 = JWK.generate_jwk_and_jwks()
+      result2 = JWK.generate_jwk_and_jwks()
+
+      # Sign with result1's private key
+      payload = %{"sub" => "test-user"}
+      jwk1 = JOSE.JWK.from_map(result1.jwk)
+      jws = %{"alg" => "RS256"}
+      {_jws, token} = JOSE.JWT.sign(jwk1, jws, payload) |> JOSE.JWS.compact()
+
+      # Try to verify with result2's public key
+      public_jwk2 = List.first(result2.jwks["keys"])
+      public_key2 = JOSE.JWK.from_map(public_jwk2)
+
+      {verified, _decoded, _jws} = JOSE.JWT.verify(public_key2, token)
+
+      refute verified
+    end
+  end
+
+  describe "JWK mathematical properties" do
+    test "RSA private key components satisfy mathematical relationships" do
+      result = JWK.generate_jwk_and_jwks()
+      jwk = result.jwk
+
+      # Decode all components
+      n = jwk["n"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      e = jwk["e"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      p = jwk["p"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      q = jwk["q"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+
+      # Verify n = p * q
+      assert n == p * q
+
+      # Verify e is 65537
+      assert e == 65_537
+    end
+
+    test "dp and dq are correctly computed" do
+      result = JWK.generate_jwk_and_jwks()
+      jwk = result.jwk
+
+      # Decode components
+      d = jwk["d"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      p = jwk["p"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      q = jwk["q"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      dp = jwk["dp"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      dq = jwk["dq"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+
+      # dp should equal d mod (p-1)
+      assert dp == rem(d, p - 1)
+
+      # dq should equal d mod (q-1)
+      assert dq == rem(d, q - 1)
+    end
+
+    test "qi (CRT coefficient) satisfies q * qi ≡ 1 (mod p)" do
+      result = JWK.generate_jwk_and_jwks()
+      jwk = result.jwk
+
+      # Decode components
+      p = jwk["p"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      q = jwk["q"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+      qi = jwk["qi"] |> Base.url_decode64!(padding: false) |> :binary.decode_unsigned()
+
+      # Verify q * qi ≡ 1 (mod p)
+      result = rem(q * qi, p)
+      assert result == 1
+    end
+  end
+
+  describe "base64url encoding" do
+    test "all encoded values use URL-safe characters only" do
+      result = JWK.generate_jwk_and_jwks()
+
+      for field <- ["n", "e", "d", "p", "q", "dp", "dq", "qi"] do
+        value = result.jwk[field]
+        # Should only contain A-Z, a-z, 0-9, -, _
+        assert String.match?(value, ~r/^[A-Za-z0-9_-]+$/)
+        # Should not contain standard base64 characters +, /, or padding =
+        refute String.contains?(value, "+")
+        refute String.contains?(value, "/")
+        refute String.contains?(value, "=")
+      end
+    end
+
+    test "kid uses URL-safe base64 encoding" do
+      result = JWK.generate_jwk_and_jwks()
+
+      assert String.match?(result.kid, ~r/^[A-Za-z0-9_-]+$/)
+      refute String.contains?(result.kid, "+")
+      refute String.contains?(result.kid, "/")
+      refute String.contains?(result.kid, "=")
+    end
+
+    test "encoded values can be decoded back" do
+      result = JWK.generate_jwk_and_jwks()
+
+      for field <- ["n", "e", "d", "p", "q", "dp", "dq", "qi"] do
+        value = result.jwk[field]
+        # Should be decodable
+        assert {:ok, _decoded} = Base.url_decode64(value, padding: false)
+      end
+    end
+  end
+
+  describe "RFC 7638 thumbprint compliance" do
+    test "thumbprint uses lexicographically sorted keys" do
+      result = JWK.generate_jwk_and_jwks()
+
+      # RFC 7638 requires keys to be in lexicographic order: e, kty, n
+      thumbprint_json =
+        JSON.encode!(%{
+          "e" => result.jwk["e"],
+          "kty" => result.jwk["kty"],
+          "n" => result.jwk["n"]
+        })
+
+      # Verify the keys appear in lexicographic order in the serialized JSON
+      # Find the positions of each key
+      e_pos = :binary.match(thumbprint_json, ~s("e":)) |> elem(0)
+      kty_pos = :binary.match(thumbprint_json, ~s("kty":)) |> elem(0)
+      n_pos = :binary.match(thumbprint_json, ~s("n":)) |> elem(0)
+
+      # Keys must appear in order: e, kty, n
+      assert e_pos < kty_pos, "Key 'e' must appear before 'kty'"
+      assert kty_pos < n_pos, "Key 'kty' must appear before 'n'"
+    end
+
+  end
+end

--- a/elixir/test/portal/crypto/rsa_test.exs
+++ b/elixir/test/portal/crypto/rsa_test.exs
@@ -1,0 +1,210 @@
+defmodule Portal.Crypto.RSATest do
+  use ExUnit.Case, async: true
+  alias Portal.Crypto.RSA
+
+  describe "generate/0" do
+    test "generates RSA keypair with default 2048 bits" do
+      keypair = RSA.generate()
+
+      # Verify return structure and types
+      assert is_map(keypair)
+      assert is_tuple(keypair.private)
+      assert is_tuple(keypair.public)
+      assert is_binary(keypair.private_pem)
+      assert is_binary(keypair.public_pem)
+      assert is_binary(keypair.private_der)
+      assert is_binary(keypair.public_der)
+
+      # Verify the modulus is exactly 2048 bits
+      {:RSAPublicKey, n, _e} = keypair.public
+      modulus_bits = n |> :binary.encode_unsigned() |> bit_size()
+
+      assert modulus_bits == 2048
+    end
+
+    test "private key is an RSAPrivateKey tuple" do
+      keypair = RSA.generate()
+
+      assert {:RSAPrivateKey, _v, _n, _e, _d, _p, _q, _e1, _e2, _coeff, _other} = keypair.private
+    end
+
+    test "public key is an RSAPublicKey tuple" do
+      keypair = RSA.generate()
+
+      assert {:RSAPublicKey, _n, _e} = keypair.public
+    end
+
+    test "public key modulus matches private key modulus" do
+      keypair = RSA.generate()
+
+      {:RSAPrivateKey, _v, priv_n, _e, _d, _p, _q, _e1, _e2, _coeff, _other} = keypair.private
+      {:RSAPublicKey, pub_n, _e} = keypair.public
+
+      assert priv_n == pub_n
+    end
+
+    test "public key exponent matches private key exponent" do
+      keypair = RSA.generate()
+
+      {:RSAPrivateKey, _v, _n, priv_e, _d, _p, _q, _e1, _e2, _coeff, _other} = keypair.private
+      {:RSAPublicKey, _n, pub_e} = keypair.public
+
+      assert priv_e == pub_e
+    end
+
+    test "public exponent is 65537" do
+      keypair = RSA.generate()
+
+      {:RSAPublicKey, _n, e} = keypair.public
+
+      assert e == 65_537
+    end
+
+    test "private_pem is valid PEM format" do
+      keypair = RSA.generate()
+
+      assert is_binary(keypair.private_pem)
+      assert String.starts_with?(keypair.private_pem, "-----BEGIN RSA PRIVATE KEY-----")
+      assert String.contains?(keypair.private_pem, "-----END RSA PRIVATE KEY-----")
+    end
+
+    test "public_pem is valid PEM format" do
+      keypair = RSA.generate()
+
+      assert is_binary(keypair.public_pem)
+      assert String.starts_with?(keypair.public_pem, "-----BEGIN PUBLIC KEY-----")
+      assert String.contains?(keypair.public_pem, "-----END PUBLIC KEY-----")
+    end
+
+    test "private_der is binary" do
+      keypair = RSA.generate()
+
+      assert is_binary(keypair.private_der)
+      assert byte_size(keypair.private_der) > 0
+    end
+
+    test "public_der is binary" do
+      keypair = RSA.generate()
+
+      assert is_binary(keypair.public_der)
+      assert byte_size(keypair.public_der) > 0
+    end
+
+    test "private_pem can be decoded back to private key" do
+      keypair = RSA.generate()
+
+      [entry] = :public_key.pem_decode(keypair.private_pem)
+      decoded_key = :public_key.pem_entry_decode(entry)
+
+      assert {:RSAPrivateKey, _, _, _, _, _, _, _, _, _, _} = decoded_key
+    end
+
+    test "public_pem can be decoded back to public key" do
+      keypair = RSA.generate()
+
+      [entry] = :public_key.pem_decode(keypair.public_pem)
+      decoded_key = :public_key.pem_entry_decode(entry)
+
+      assert {:RSAPublicKey, _, _} = decoded_key
+    end
+
+    test "private_der can be decoded back to private key" do
+      keypair = RSA.generate()
+
+      decoded_key = :public_key.der_decode(:RSAPrivateKey, keypair.private_der)
+
+      assert {:RSAPrivateKey, _, _, _, _, _, _, _, _, _, _} = decoded_key
+      assert decoded_key == keypair.private
+    end
+
+    test "public_der can be decoded back to public key" do
+      keypair = RSA.generate()
+
+      decoded_key = :public_key.der_decode(:RSAPublicKey, keypair.public_der)
+
+      assert {:RSAPublicKey, _, _} = decoded_key
+      assert decoded_key == keypair.public
+    end
+
+    test "generates unique keypairs on each invocation" do
+      keypair1 = RSA.generate()
+      keypair2 = RSA.generate()
+
+      refute keypair1.private_pem == keypair2.private_pem
+      refute keypair1.public_pem == keypair2.public_pem
+    end
+  end
+
+  describe "generate/1" do
+    test "generates keypair with custom bit size" do
+      for bits <- [1024, 2048, 4096] do
+        keypair = RSA.generate(bits)
+
+        assert is_map(keypair)
+        assert Map.has_key?(keypair, :private)
+        assert Map.has_key?(keypair, :public)
+        assert String.starts_with?(keypair.private_pem, "-----BEGIN RSA PRIVATE KEY-----")
+
+        # Verify the modulus size matches requested bits exactly
+        {:RSAPublicKey, n, _e} = keypair.public
+        modulus_bits = n |> :binary.encode_unsigned() |> bit_size()
+
+        assert modulus_bits == bits
+      end
+    end
+  end
+
+  describe "key cryptographic properties" do
+    test "generated keys can be used for encryption and decryption" do
+      keypair = RSA.generate()
+      plaintext = "test message"
+
+      # Encrypt with public key
+      ciphertext = :public_key.encrypt_public(plaintext, keypair.public)
+
+      # Decrypt with private key
+      decrypted = :public_key.decrypt_private(ciphertext, keypair.private)
+
+      assert decrypted == plaintext
+    end
+
+    test "generated keys can be used for signing and verification" do
+      keypair = RSA.generate()
+      message = "test message"
+      digest = :crypto.hash(:sha256, message)
+
+      # Sign with private key
+      signature = :public_key.sign(digest, :sha256, keypair.private)
+
+      # Verify with public key
+      assert :public_key.verify(digest, :sha256, signature, keypair.public)
+    end
+
+    test "signature verification fails with wrong public key" do
+      keypair1 = RSA.generate()
+      keypair2 = RSA.generate()
+      message = "test message"
+      digest = :crypto.hash(:sha256, message)
+
+      # Sign with keypair1's private key
+      signature = :public_key.sign(digest, :sha256, keypair1.private)
+
+      # Verify with keypair2's public key should fail
+      refute :public_key.verify(digest, :sha256, signature, keypair2.public)
+    end
+
+    test "decryption fails with wrong private key" do
+      keypair1 = RSA.generate()
+      keypair2 = RSA.generate()
+      plaintext = "test message"
+
+      # Encrypt with keypair1's public key
+      ciphertext = :public_key.encrypt_public(plaintext, keypair1.public)
+
+      # Decrypt with keypair2's private key should fail
+      assert_raise ErlangError, fn ->
+        :public_key.decrypt_private(ciphertext, keypair2.private)
+      end
+    end
+  end
+end

--- a/elixir/test/portal/crypto/rsa_test.exs
+++ b/elixir/test/portal/crypto/rsa_test.exs
@@ -192,19 +192,5 @@ defmodule Portal.Crypto.RSATest do
       # Verify with keypair2's public key should fail
       refute :public_key.verify(digest, :sha256, signature, keypair2.public)
     end
-
-    test "decryption fails with wrong private key" do
-      keypair1 = RSA.generate()
-      keypair2 = RSA.generate()
-      plaintext = "test message"
-
-      # Encrypt with keypair1's public key
-      ciphertext = :public_key.encrypt_public(plaintext, keypair1.public)
-
-      # Decrypt with keypair2's private key should fail
-      assert_raise ErlangError, fn ->
-        :public_key.decrypt_private(ciphertext, keypair2.private)
-      end
-    end
   end
 end

--- a/elixir/test/portal/crypto_test.exs
+++ b/elixir/test/portal/crypto_test.exs
@@ -1,0 +1,296 @@
+defmodule Portal.CryptoTest do
+  use Portal.DataCase, async: true
+  import Portal.Crypto
+  import Portal.AccountFixtures
+  import Portal.ClientFixtures
+  import Portal.GatewayFixtures
+
+  describe "psk/2" do
+    setup do
+      account = account_fixture()
+      client = client_fixture(account: account)
+      gateway = gateway_fixture(account: account)
+
+      %{account: account, client: client, gateway: gateway}
+    end
+
+    test "returns a base64 encoded string of proper length", %{
+      client: client,
+      gateway: gateway
+    } do
+      psk = psk(client, gateway)
+      assert is_binary(psk)
+      # 32 bytes base64 encoded = 44 characters
+      assert 44 == String.length(psk)
+    end
+
+    test "returned value is valid base64", %{client: client, gateway: gateway} do
+      psk = psk(client, gateway)
+      assert {:ok, decoded} = Base.decode64(psk)
+      assert byte_size(decoded) == 32
+    end
+
+    test "changes when client or gateway inputs change", %{
+      account: account,
+      client: client,
+      gateway: gateway
+    } do
+      psk1 = psk(client, gateway)
+
+      other_client = client_fixture(account: account)
+      other_psk = psk(other_client, gateway)
+
+      assert other_psk != psk1
+
+      other_gateway = gateway_fixture(account: account)
+      other_psk = psk(client, other_gateway)
+
+      assert other_psk != psk1
+    end
+
+    test "remains consistent across calls", %{
+      client: client,
+      gateway: gateway
+    } do
+      psk1 = psk(client, gateway)
+      psk2 = psk(client, gateway)
+      assert psk1 == psk2
+    end
+
+    test "uses PBKDF2-HMAC-SHA256 with proper salt structure", %{
+      client: client,
+      gateway: gateway
+    } do
+      # Generate PSK
+      result = psk(client, gateway)
+
+      # Manually compute expected result to verify algorithm
+      secret_bytes = client.psk_base <> gateway.psk_base
+
+      salt =
+        "WG_PSK|C_ID:#{client.id}|G_ID:#{gateway.id}|C_PK:#{client.public_key}|G_PK:#{gateway.public_key}"
+
+      expected_psk_bytes = :crypto.pbkdf2_hmac(:sha256, secret_bytes, salt, 1, 32)
+      expected = Base.encode64(expected_psk_bytes)
+
+      assert result == expected
+    end
+
+    test "different client IDs produce different PSKs even with same keys", %{
+      account: account,
+      gateway: gateway
+    } do
+      # Create two clients with potentially similar data
+      client1 = client_fixture(account: account)
+      client2 = client_fixture(account: account)
+
+      psk1 = psk(client1, gateway)
+      psk2 = psk(client2, gateway)
+
+      # Different client IDs should produce different PSKs
+      refute psk1 == psk2
+    end
+
+    test "different gateway IDs produce different PSKs", %{
+      account: account,
+      client: client
+    } do
+      gateway1 = gateway_fixture(account: account)
+      gateway2 = gateway_fixture(account: account)
+
+      psk1 = psk(client, gateway1)
+      psk2 = psk(client, gateway2)
+
+      refute psk1 == psk2
+    end
+  end
+
+  describe "random_token/2" do
+    test "numeric tokens only contain digits" do
+      for length <- [1, 4, 16, 32], _i <- 0..10 do
+        token = random_token(length, generator: :numeric)
+        assert String.match?(token, ~r/^\d+$/)
+      end
+    end
+
+    test "generates a random number of given length" do
+      for length <- [1, 2, 4, 16, 32], _i <- 0..100 do
+        assert length == String.length(random_token(length, generator: :numeric))
+      end
+    end
+
+    test "generates a random binary of given byte size" do
+      for length <- [1, 2, 4, 16, 32], _i <- 0..100 do
+        assert length == byte_size(random_token(length, encoder: :raw))
+      end
+    end
+
+    test "returns base64 url encoded token by default" do
+      one_byte_token = random_token(1)
+      three_byte_token = random_token(3)
+
+      # 2 padding characters are stripped
+      assert String.length(one_byte_token) == 2
+      assert String.length(three_byte_token) == 4
+
+      refute String.ends_with?(one_byte_token, "=")
+      refute String.ends_with?(three_byte_token, "=")
+    end
+
+    test "returns base64 encoded token with padding characters" do
+      token = random_token(1, encoder: :base64)
+
+      assert String.length(token) == 4
+      assert String.ends_with?(token, "==")
+    end
+
+    test "hex32 encoder produces valid base32 hex" do
+      token = random_token(16, encoder: :hex32)
+      # Base32 hex uses 0-9 and A-V, and may include padding =
+      assert String.match?(token, ~r/^[0-9A-V=]+$/)
+    end
+
+    test "user friendly encoder produces safe, unambiguous tokens" do
+      for length <- [8, 16, 32, 64] do
+        token = random_token(length, encoder: :user_friendly)
+
+        # Respects length parameter
+        assert String.length(token) == length
+
+        # Only lowercase characters
+        assert String.downcase(token) == token
+        assert String.printable?(token)
+
+        # Never contains ambiguous characters:
+        refute String.contains?(token, "-")
+        refute String.contains?(token, "+")
+        refute String.contains?(token, "/")
+        refute String.contains?(token, "l")
+        refute String.contains?(token, "I")
+        refute String.contains?(token, "O")
+        refute String.contains?(token, "0")
+        refute String.contains?(token, "=")
+        refute String.contains?(token, "_")
+      end
+    end
+
+    test "default generator is binary" do
+      token1 = random_token(16)
+      token2 = random_token(16, generator: :binary)
+
+      # Both should be url_encode64 by default
+      assert String.match?(token1, ~r/^[A-Za-z0-9_-]+$/)
+      assert String.match?(token2, ~r/^[A-Za-z0-9_-]+$/)
+    end
+  end
+
+  describe "hash/2" do
+    test "raises an error when secret is an empty string" do
+      assert_raise FunctionClauseError, fn ->
+        hash(:argon2, "")
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        hash(:sha256, "")
+      end
+    end
+
+    test "raises an error when secret is not a binary" do
+      assert_raise FunctionClauseError, fn ->
+        hash(:argon2, 1)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        hash(:sha256, 1)
+      end
+    end
+
+    test "argon2 hash returns valid argon2 hash string" do
+      hash = hash(:argon2, "password123")
+      assert String.starts_with?(hash, "$argon2")
+      assert is_binary(hash)
+    end
+
+    test "argon2 hash produces different results each time (due to salt)" do
+      hash1 = hash(:argon2, "password123")
+      hash2 = hash(:argon2, "password123")
+
+      refute hash1 == hash2
+    end
+
+    test "non-argon2 algorithms return lowercase hex" do
+      for algo <- [:sha, :sha256, :sha3_256, :blake2b] do
+        hash = hash(algo, "test value")
+        assert is_binary(hash)
+        assert String.match?(hash, ~r/^[0-9a-f]+$/)
+        refute String.match?(hash, ~r/[A-F]/)
+      end
+    end
+  end
+
+  describe "equal?/3" do
+    test "returns false for nil and empty string edge cases" do
+      for algo <- [:argon2, :sha, :sha256, :sha3_256] do
+        # Empty strings
+        refute equal?(algo, "a", "")
+        refute equal?(algo, "", "a")
+        refute equal?(algo, "", "")
+
+        # Nils
+        refute equal?(algo, nil, "a")
+        refute equal?(algo, nil, "")
+        refute equal?(algo, "a", nil)
+        refute equal?(algo, "", nil)
+        refute equal?(algo, nil, nil)
+      end
+    end
+  end
+
+  describe "hash/2 and equal?/3 integration" do
+    test "hash and equal? work correctly together for all algorithms" do
+      for algo <- [:sha, :sha256, :sha3_256, :argon2, :blake2b],
+          value <- ["foo", random_token()] do
+        hash = hash(algo, value)
+
+        assert is_binary(hash)
+        assert hash != value
+
+        assert equal?(algo, value, hash)
+        refute equal?(algo, random_token(), hash)
+        refute equal?(algo, "", hash)
+        refute equal?(algo, nil, hash)
+      end
+    end
+
+    test "different hash algorithms produce different hashes for same input" do
+      value = "same input"
+
+      sha_hash = hash(:sha, value)
+      sha256_hash = hash(:sha256, value)
+      sha3_hash = hash(:sha3_256, value)
+      blake2b_hash = hash(:blake2b, value)
+
+      # All should be different
+      assert sha_hash != sha256_hash
+      assert sha_hash != sha3_hash
+      assert sha_hash != blake2b_hash
+      assert sha256_hash != sha3_hash
+      assert sha256_hash != blake2b_hash
+      assert sha3_hash != blake2b_hash
+    end
+
+    test "equal? fails when using wrong algorithm" do
+      value = "test"
+      sha256_hash = hash(:sha256, value)
+      sha_hash = hash(:sha, value)
+
+      # Using the correct algorithm should work
+      assert equal?(:sha256, value, sha256_hash)
+      assert equal?(:sha, value, sha_hash)
+
+      # Using the wrong algorithm should fail
+      refute equal?(:sha, value, sha256_hash)
+      refute equal?(:sha256, value, sha_hash)
+    end
+  end
+end


### PR DESCRIPTION
Add tests back for the crypto modules.  Also, update the crypto module `random_token` generator for numeric tokens to use the `:crypto` library rather than the `:rand` library.