### PR TITLE
feat(portal): validate azure front door id

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -1,61 +1,31 @@
 
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:33,122F186
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:38,17684C4
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:378,1DF17A0
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
-DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:172,1FD0413
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
 SQL.Query: SQL injection,lib/portal/safe.ex:285,224B461
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
+DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
-Config.Secrets: Hardcoded Secret,config/config.exs:208,4700588
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:48,49E8E80
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
 SQL.Query: SQL injection,lib/portal/safe.ex:291,4C5F170
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
-Config.Secrets: Hardcoded Secret,config/config.exs:106,56F4E1B
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
-Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:62,6EFEB9E
-Config.Secrets: Hardcoded Secret,config/config.exs:207,7165BCA
-Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:28,7369D64
-
-Config.Secrets: Hardcoded Secret,config/config.exs:209,8DFEA3
-
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
-Config.Secrets: Hardcoded Secret,config/config.exs:201,3CFE1A
-Config.Secrets: Hardcoded Secret,config/config.exs:202,43A0604
-
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:375,2E0A7AD
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:217,3560D02
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:371,46EE6C5
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:212,5B50F1B
-
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:31,135D3E7
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,3660523
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:41,4C6E35C
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
-Config.Secrets: Hardcoded Secret,config/config.exs:206,611CC2E
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:51,68184B9
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,74777AB
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:75,780F62D
-Config.Secrets: Hardcoded Secret,config/config.exs:205,E9FD90
-
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:366,2BF900
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:374,5E31712
+Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
 Config.Secrets: Hardcoded Secret,config/config.exs:104,61C15AF
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
-Config.Secrets: Hardcoded Secret,config/config.exs:203,6ED2CC5
-Config.Secrets: Hardcoded Secret,config/config.exs:204,7F38DEB
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:370,7F8C06D
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:40,1D07B78
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:30,75F2F69
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:50,7DE9449
-
-DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
-
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
+Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619
+Config.Secrets: Hardcoded Secret,config/config.exs:204,7F38DEB
+Config.Secrets: Hardcoded Secret,config/config.exs:205,E9FD90

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -205,7 +205,9 @@ config :portal, Portal.Billing,
   webhook_signing_secret: "whsec_test_1111",
   default_price_id: "price_1OkUIcADeNU9NGxvTNA4PPq6"
 
-config :portal, platform_adapter: nil
+config :portal,
+  platform_adapter: nil,
+  azure_front_door_id: nil
 
 config :portal, Portal.GoogleCloudPlatform,
   metadata_endpoint_url: "http://metadata.google.internal/computeMetadata/v1",

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -109,6 +109,9 @@ if config_env() == :prod do
     config :portal, platform_adapter, env_var_to_config!(:platform_adapter_config)
   end
 
+  # Azure Front Door ID validation - when set, rejects requests without matching X-Azure-FDID header
+  config :portal, azure_front_door_id: env_var_to_config!(:azure_front_door_id)
+
   config :portal, Portal.Cluster,
     adapter: env_var_to_config!(:erlang_cluster_adapter),
     adapter_config: env_var_to_config!(:erlang_cluster_adapter_config),

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -287,6 +287,14 @@ defmodule Portal.Config.Definitions do
   )
 
   @doc """
+  Azure Front Door ID (GUID format) for validating the X-Azure-FDID header.
+
+  When set, requests without a matching X-Azure-FDID header will be rejected with 502.
+  This prevents other Azure Front Door instances from sending traffic to this application.
+  """
+  defconfig(:azure_front_door_id, :string, default: nil)
+
+  @doc """
   Config for the platform adapter.
   """
   defconfig(:platform_adapter_config, :map,

--- a/elixir/lib/portal/plugs/validate_azure_front_door.ex
+++ b/elixir/lib/portal/plugs/validate_azure_front_door.ex
@@ -1,0 +1,76 @@
+defmodule Portal.Plugs.ValidateAzureFrontDoor do
+  @moduledoc """
+  Validates the X-Azure-FDID header matches the configured Azure Front Door ID.
+
+  This plug provides defense-in-depth security for Azure deployments. The NSG allows
+  traffic from all Azure Front Door instances globally (via AzureFrontDoor.Backend
+  service tag), so this header validation ensures only our specific Front Door
+  instance can send traffic to the application.
+
+  When `azure_front_door_id` is not configured, this plug is a no-op.
+  """
+  @behaviour Plug
+
+  import Plug.Conn
+
+  require Logger
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{} = conn, _opts) do
+    case Portal.Config.fetch_env!(:portal, :azure_front_door_id) do
+      nil ->
+        # Not configured, skip validation
+        conn
+
+      expected_id ->
+        validate_front_door_id(conn, expected_id)
+    end
+  end
+
+  defp validate_front_door_id(conn, expected_id) do
+    expected_id_lower = String.downcase(expected_id)
+
+    case get_req_header(conn, "x-azure-fdid") do
+      [received_id] ->
+        if String.downcase(received_id) == expected_id_lower do
+          conn
+        else
+          Logger.warning("Rejected request with invalid X-Azure-FDID header",
+            expected: expected_id,
+            received: received_id,
+            remote_ip: conn.remote_ip
+          )
+
+          reject(conn)
+        end
+
+      [] ->
+        Logger.warning("Rejected request missing X-Azure-FDID header",
+          expected: expected_id,
+          remote_ip: conn.remote_ip
+        )
+
+        reject(conn)
+
+      _multiple ->
+        Logger.warning("Rejected request with multiple X-Azure-FDID headers",
+          expected: expected_id,
+          remote_ip: conn.remote_ip
+        )
+
+        reject(conn)
+    end
+  end
+
+  # TODO: Change to 403 Forbidden once the majority of clients no longer
+  # disconnect immediately on 4xx errors.
+  defp reject(conn) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(502, "Bad Gateway")
+    |> halt()
+  end
+end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -4,6 +4,9 @@ defmodule PortalAPI.Endpoint do
   # Health checks - early in pipeline for fast responses
   plug Portal.Health
 
+  # Azure Front Door ID validation - rejects requests not from our Front Door instance
+  plug Portal.Plugs.ValidateAzureFrontDoor
+
   if Application.compile_env(:portal, :sql_sandbox) do
     plug Phoenix.Ecto.SQL.Sandbox
   end

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -16,6 +16,9 @@ defmodule PortalWeb.Endpoint do
   # Health checks - early in pipeline for fast responses
   plug Portal.Health
 
+  # Azure Front Door ID validation - rejects requests not from our Front Door instance
+  plug Portal.Plugs.ValidateAzureFrontDoor
+
   if Application.compile_env(:portal, :sql_sandbox) do
     plug Phoenix.Ecto.SQL.Sandbox
     plug PortalWeb.Plugs.AllowEctoSandbox

--- a/elixir/test/portal/plugs/validate_azure_front_door_test.exs
+++ b/elixir/test/portal/plugs/validate_azure_front_door_test.exs
@@ -1,0 +1,105 @@
+defmodule Portal.Plugs.ValidateAzureFrontDoorTest do
+  use Portal.DataCase, async: true
+  import Plug.Test
+  import Plug.Conn
+
+  alias Portal.Plugs.ValidateAzureFrontDoor
+
+  @expected_front_door_id "12345678-1234-1234-1234-123456789abc"
+
+  describe "call/2 when azure_front_door_id is not configured" do
+    setup do
+      Portal.Config.put_env_override(:portal, :azure_front_door_id, nil)
+      :ok
+    end
+
+    test "passes through requests without X-Azure-FDID header" do
+      conn =
+        :get
+        |> conn("/")
+        |> ValidateAzureFrontDoor.call([])
+
+      refute conn.halted
+    end
+
+    test "passes through requests with any X-Azure-FDID header" do
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("x-azure-fdid", "any-value")
+        |> ValidateAzureFrontDoor.call([])
+
+      refute conn.halted
+    end
+  end
+
+  describe "call/2 when azure_front_door_id is configured" do
+    setup do
+      Portal.Config.put_env_override(:portal, :azure_front_door_id, @expected_front_door_id)
+      :ok
+    end
+
+    test "passes through requests with matching X-Azure-FDID header" do
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("x-azure-fdid", @expected_front_door_id)
+        |> ValidateAzureFrontDoor.call([])
+
+      refute conn.halted
+    end
+
+    test "rejects requests without X-Azure-FDID header" do
+      conn =
+        :get
+        |> conn("/")
+        |> ValidateAzureFrontDoor.call([])
+
+      assert conn.halted
+      assert conn.status == 502
+      assert conn.resp_body == "Bad Gateway"
+    end
+
+    test "rejects requests with invalid X-Azure-FDID header" do
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("x-azure-fdid", "wrong-id")
+        |> ValidateAzureFrontDoor.call([])
+
+      assert conn.halted
+      assert conn.status == 502
+      assert conn.resp_body == "Bad Gateway"
+    end
+
+    test "rejects requests with multiple X-Azure-FDID headers" do
+      # Manually add duplicate headers since put_req_header replaces
+      base_conn = conn(:get, "/")
+
+      conn =
+        %{
+          base_conn
+          | req_headers: [
+              {"x-azure-fdid", @expected_front_door_id},
+              {"x-azure-fdid", "another-id"} | base_conn.req_headers
+            ]
+        }
+        |> ValidateAzureFrontDoor.call([])
+
+      assert conn.halted
+      assert conn.status == 502
+      assert conn.resp_body == "Bad Gateway"
+    end
+
+    test "GUID matching is case-insensitive" do
+      # GUIDs are case-insensitive, so uppercase should match lowercase config
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("x-azure-fdid", String.upcase(@expected_front_door_id))
+        |> ValidateAzureFrontDoor.call([])
+
+      refute conn.halted
+    end
+  end
+end


### PR DESCRIPTION
Azure front door sends an ID using the `X-Azure-FDID` header for all requests forwarded from it to our regional load balancers. This ID is scoped per tenant and should be the same for all requests.

To prevent our load balancers from fulfilling requests from other customers' Front Door instances, we can validate this ID matches the one configured for our tenant.

To do so we thread `AZURE_FRONT_DOOR_ID` through and check it with a new plug early in the pipeline for both the Web and API endpoints. If this value is `nil`, no validation occurs and this becomes a no-op.

Related: #10419 
Related: https://github.com/firezone/infra/pull/375