### PR TITLE
refactor(connlib): unify DNS resolution of portal hostname

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5650,6 +5650,7 @@ dependencies = [
  "logging",
  "os_info",
  "rand_core 0.6.4",
+ "regex",
  "secrecy",
  "serde",
  "serde_json",
@@ -6297,9 +6298,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6309,9 +6310,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "chrono",
  "connlib-model",
  "dns-types",
+ "etc-hosts-dns-client",
  "futures",
  "ip_network",
  "l4-udp-dns-client",
@@ -2412,6 +2413,16 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etc-hosts-dns-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "dns-types",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "etherparse"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2419,7 +2419,6 @@ name = "etc-hosts-dns-client"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
- "dns-types",
  "tokio",
  "tracing",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "roxmltree",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -725,7 +725,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ dependencies = [
  "aya-log-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1809,7 +1809,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1833,7 +1833,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1935,7 +1935,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1966,7 +1966,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1977,7 +1977,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.113",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -2113,7 +2113,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2138,7 +2138,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2161,7 +2161,7 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2242,7 +2242,7 @@ checksum = "8d1a6796ad411f6812d691955066ad27450196bfb181bb91b66a643cc3e8f5b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2358,7 +2358,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2379,7 +2379,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2927,7 +2927,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3222,7 +3222,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3344,7 +3344,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4538,7 +4538,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4961,7 +4961,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5603,7 +5603,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5649,7 +5649,6 @@ dependencies = [
  "logging",
  "os_info",
  "rand_core 0.6.4",
- "regex",
  "secrecy",
  "serde",
  "serde_json",
@@ -5680,7 +5679,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5749,7 +5748,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5919,7 +5918,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5945,7 +5944,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "version_check",
 ]
 
@@ -5995,7 +5994,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6292,14 +6291,14 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6309,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6677,7 +6676,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6703,7 +6702,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6990,7 +6989,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7001,7 +7000,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7035,7 +7034,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7105,7 +7104,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7127,7 +7126,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7421,7 +7420,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7523,7 +7522,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7534,7 +7533,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7556,7 +7555,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7639,9 +7638,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.113"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7665,7 +7664,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7735,7 +7734,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7837,7 +7836,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.113",
+ "syn 2.0.114",
  "tauri-utils",
  "thiserror 2.0.17",
  "time",
@@ -7855,7 +7854,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -8056,7 +8055,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8206,7 +8205,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8217,7 +8216,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "test-case-core",
 ]
 
@@ -8231,7 +8230,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8269,7 +8268,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8280,7 +8279,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8376,7 +8375,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8659,7 +8658,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9089,7 +9088,7 @@ dependencies = [
  "indexmap 2.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9104,7 +9103,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.113",
+ "syn 2.0.114",
  "toml 0.9.5",
  "uniffi_meta",
 ]
@@ -9364,7 +9363,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -9399,7 +9398,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9530,7 +9529,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9681,7 +9680,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9692,7 +9691,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10262,7 +10261,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -10342,7 +10341,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "zvariant_utils 2.1.0",
 ]
 
@@ -10355,7 +10354,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "zbus_names 4.2.0",
  "zvariant 5.5.3",
  "zvariant_utils 3.2.0",
@@ -10401,7 +10400,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10421,7 +10420,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -10442,7 +10441,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10475,7 +10474,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10548,7 +10547,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "zvariant_utils 2.1.0",
 ]
 
@@ -10561,7 +10560,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
  "zvariant_utils 3.2.0",
 ]
 
@@ -10573,7 +10572,7 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10586,6 +10585,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.113",
+ "syn 2.0.114",
  "winnow 0.7.10",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -148,6 +148,7 @@ quote = "1.0"
 rand = "0.8.5"
 rand_core = "0.6.4"
 rangemap = "1.7.1"
+regex = "1.12.2"
 reqwest = { version = "0.12.28", default-features = false }
 resolv-conf = "0.7.6"
 ringbuffer = "0.16.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,11 +12,11 @@ members = [
     "libs/connlib/bufferpool",
     "libs/connlib/dns-over-tcp",
     "libs/connlib/dns-types",
+    "libs/connlib/etc-hosts-dns-client",
     "libs/connlib/etherparse-ext",
     "libs/connlib/ip-packet",
     "libs/connlib/l3-tcp",
     "libs/connlib/l3-udp-dns-client",
-    "libs/connlib/etc-hosts-dns-client",
     "libs/connlib/l4-tcp-dns-server",
     "libs/connlib/l4-udp-dns-client",
     "libs/connlib/l4-udp-dns-server",
@@ -83,6 +83,7 @@ dns-over-tcp = { path = "libs/connlib/dns-over-tcp" }
 dns-types = { path = "libs/connlib/dns-types" }
 ebpf-shared = { path = "relay/ebpf-shared" }
 either = "1"
+etc-hosts-dns-client = { path = "libs/connlib/etc-hosts-dns-client" }
 etherparse = { version = "0.19", default-features = false }
 etherparse-ext = { path = "libs/connlib/etherparse-ext" }
 firezone-headless-client = { path = "headless-client" }
@@ -111,7 +112,6 @@ jni = "0.21.1"
 keyring = "3.6.3"
 known-folders = "1.4.0"
 l3-tcp = { path = "libs/connlib/l3-tcp" }
-etc-hosts-dns-client = { path = "libs/connlib/etc-hosts-dns-client" }
 l3-udp-dns-client = { path = "libs/connlib/l3-udp-dns-client" }
 l4-tcp-dns-server = { path = "libs/connlib/l4-tcp-dns-server" }
 l4-udp-dns-client = { path = "libs/connlib/l4-udp-dns-client" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "libs/connlib/ip-packet",
     "libs/connlib/l3-tcp",
     "libs/connlib/l3-udp-dns-client",
+    "libs/connlib/etc-hosts-dns-client",
     "libs/connlib/l4-tcp-dns-server",
     "libs/connlib/l4-udp-dns-client",
     "libs/connlib/l4-udp-dns-server",
@@ -110,6 +111,7 @@ jni = "0.21.1"
 keyring = "3.6.3"
 known-folders = "1.4.0"
 l3-tcp = { path = "libs/connlib/l3-tcp" }
+etc-hosts-dns-client = { path = "libs/connlib/etc-hosts-dns-client" }
 l3-udp-dns-client = { path = "libs/connlib/l3-udp-dns-client" }
 l4-tcp-dns-server = { path = "libs/connlib/l4-tcp-dns-server" }
 l4-udp-dns-client = { path = "libs/connlib/l4-udp-dns-client" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -148,7 +148,6 @@ quote = "1.0"
 rand = "0.8.5"
 rand_core = "0.6.4"
 rangemap = "1.7.1"
-regex = "1.12.2"
 reqwest = { version = "0.12.28", default-features = false }
 resolv-conf = "0.7.6"
 ringbuffer = "0.16.0"

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -499,8 +499,7 @@ fn connect(
                 .build()
         },
         tcp_socket_factory.clone(),
-    )
-    .context("Failed to create `PhoenixChannel`")?;
+    );
     let (session, events) = client_shared::Session::connect(
         tcp_socket_factory,
         udp_socket_factory,

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -505,6 +505,7 @@ fn connect(
         udp_socket_factory,
         portal,
         is_internet_resource_active,
+        Vec::default(),
         runtime.handle().clone(),
     );
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -803,7 +803,7 @@ async fn update_portal_host_ips(
         .await
         .context("Failed to lookup portal host")
     {
-        Ok(ips) => ips.into_iter().collect(),
+        Ok(ips) => ips,
         Err(e) => {
             tracing::debug!(host = %portal.host(), "{e:#}");
             return;

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -765,7 +765,8 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
-
+            }
+            Either::Left((Ok(phoenix_channel::Event::NoAddresses), _)) => {
                 let ips = match resolver
                     .lookup_ip(portal.host())
                     .await

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -209,8 +209,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
                 .build()
         },
         Arc::new(tcp_socket_factory),
-    )
-    .context("Failed to resolve portal URL")?;
+    );
 
     let mut tun_device_manager = TunDeviceManager::new(ip_packet::MAX_IP_SIZE)
         .context("Failed to create TUN device manager")?;

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -667,14 +667,11 @@ impl<'a> Handler<'a> {
             Arc::new(UdpSocketFactory::default()),
             portal,
             is_internet_resource_active,
+            dns,
             tokio::runtime::Handle::current(),
         );
 
         analytics::new_session(device_id.id, api_url.to_string());
-
-        // Call `set_dns` before `set_tun` so that the tunnel starts up with a valid list of resolvers.
-        tracing::debug!(?dns, "Calling `set_dns`...");
-        connlib.set_dns(dns);
 
         let tun = self
             .tun_device

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -646,7 +646,6 @@ impl<'a> Handler<'a> {
         )
         .context("Failed to create `LoginUrl`")?;
 
-        // Synchronous DNS resolution here
         let portal = PhoenixChannel::disconnected(
             url,
             token,
@@ -659,7 +658,7 @@ impl<'a> Handler<'a> {
                     .build()
             },
             Arc::new(tcp_socket_factory),
-        )?;
+        );
 
         // Read the resolvers before starting connlib, in case connlib's startup interferes.
         let dns = self.dns_controller.system_resolvers();

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -352,6 +352,7 @@ fn try_main() -> Result<()> {
             Arc::new(UdpSocketFactory::default()),
             portal,
             cli.activate_internet_resource,
+            dns_controller.system_resolvers(),
             rt.handle().clone(),
         );
 
@@ -372,7 +373,6 @@ fn try_main() -> Result<()> {
 
         let tun = tun_device.make_tun()?;
         session.set_tun(tun);
-        session.set_dns(dns_controller.system_resolvers());
 
         let result = loop {
             let event = tokio::select! {

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -346,7 +346,7 @@ fn try_main() -> Result<()> {
                     .build()
             },
             Arc::new(tcp_socket_factory),
-        )?;
+        );
         let (session, mut event_stream) = client_shared::Session::connect(
             Arc::new(tcp_socket_factory),
             Arc::new(UdpSocketFactory::default()),

--- a/rust/libs/client-shared/Cargo.toml
+++ b/rust/libs/client-shared/Cargo.toml
@@ -13,6 +13,7 @@ dns-types = { workspace = true }
 futures = { workspace = true }
 ip_network = { workspace = true }
 l4-udp-dns-client = { workspace = true }
+etc-hosts-dns-client = { workspace = true }
 libc = { workspace = true }
 logging = { workspace = true }
 parking_lot = { workspace = true }

--- a/rust/libs/client-shared/Cargo.toml
+++ b/rust/libs/client-shared/Cargo.toml
@@ -10,10 +10,10 @@ backoff = { workspace = true }
 bimap = { workspace = true }
 connlib-model = { workspace = true }
 dns-types = { workspace = true }
+etc-hosts-dns-client = { workspace = true }
 futures = { workspace = true }
 ip_network = { workspace = true }
 l4-udp-dns-client = { workspace = true }
-etc-hosts-dns-client = { workspace = true }
 libc = { workspace = true }
 logging = { workspace = true }
 parking_lot = { workspace = true }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -540,7 +540,8 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
-
+            }
+            Either::Left((Ok(phoenix_channel::Event::NoAddresses), _)) => {
                 let ips = match udp_dns_client
                     .resolve(portal.host())
                     .await

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -505,6 +505,8 @@ async fn phoenix_channel_event_loop(
     portal.connect(param);
 
     loop {
+        // We process commands from the channel first (i.e. it is polled first) to update the DNS servers as quickly as possible.
+        // This allows `NoAddresses` events to use the updated `UdpDnsClient` to resolve the domain.
         match select(pin!(cmd_rx.recv()), poll_fn(|cx| portal.poll(cx))).await {
             Either::Left((Some(PortalCommand::Send(msg)), _)) => {
                 portal.send(PHOENIX_TOPIC, msg);

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -547,7 +547,7 @@ async fn phoenix_channel_event_loop(
                     .await
                     .context("Failed to lookup portal host")
                 {
-                    Ok(ips) => ips.into_iter().collect(),
+                    Ok(ips) => ips,
                     Err(e) => {
                         tracing::debug!(host = %portal.host(), "{e:#}");
                         continue;

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -577,8 +577,8 @@ async fn phoenix_channel_event_loop(
 ///
 /// We combine the result of two sources here:
 ///
-/// - We read `/etc/hosts`.
 /// - We make UDP DNS queries to our configured system resolvers.
+/// - We read `/etc/hosts`.
 ///
 /// If any of these fail, we simply default to an empty list of IPs.
 /// This is fine as this routine will be triggered again if we ever run out of IPs to use.

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -571,6 +571,15 @@ async fn phoenix_channel_event_loop(
     }
 }
 
+/// Re-resolves the IPs of the portal hostname.
+///
+/// We combine the result of two sources here:
+///
+/// - We read `/etc/hosts`.
+/// - We make UDP DNS queries to our configured system resolvers.
+///
+/// If any of these fail, we simply default to an empty list of IPs.
+/// This is fine as this routine will be triggered again if we ever run out of IPs to use.
 async fn update_portal_host_ips(
     portal: &mut PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
     udp_dns_client: &UdpDnsClient,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -100,7 +100,7 @@ impl Eventloop {
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         is_internet_resource_active: bool,
         dns_servers: Vec<IpAddr>,
-        mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
+        portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
         resource_list_sender: watch::Sender<Vec<ResourceView>>,
         tun_config_sender: watch::Sender<Option<TunConfig>>,
@@ -115,10 +115,9 @@ impl Eventloop {
             is_internet_resource_active,
         );
 
-        portal.connect(PublicKeyParam(tunnel.public_key().to_bytes()));
-
         tokio::spawn(phoenix_channel_event_loop(
             portal,
+            PublicKeyParam(tunnel.public_key().to_bytes()),
             portal_event_tx,
             portal_cmd_rx,
             udp_socket_factory.clone(),
@@ -489,6 +488,7 @@ impl Eventloop {
 
 async fn phoenix_channel_event_loop(
     mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
+    param: PublicKeyParam,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
@@ -501,6 +501,7 @@ async fn phoenix_channel_event_loop(
     let mut udp_dns_client = UdpDnsClient::new(udp_socket_factory.clone(), dns_servers);
 
     update_portal_host_ips(&mut portal, &udp_dns_client).await;
+    portal.connect(param);
 
     loop {
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {

--- a/rust/libs/client-shared/src/lib.rs
+++ b/rust/libs/client-shared/src/lib.rs
@@ -57,6 +57,7 @@ impl Session {
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         is_internet_resource_active: bool,
+        dns_servers: Vec<IpAddr>,
         handle: tokio::runtime::Handle,
     ) -> (Self, EventStream) {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -70,6 +71,7 @@ impl Session {
                 tcp_socket_factory,
                 udp_socket_factory,
                 is_internet_resource_active,
+                dns_servers,
                 portal,
                 cmd_rx,
                 resource_list_sender,

--- a/rust/libs/connlib/etc-hosts-dns-client/Cargo.toml
+++ b/rust/libs/connlib/etc-hosts-dns-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "etc-hosts-dns-client"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+dns-types = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/rust/libs/connlib/etc-hosts-dns-client/Cargo.toml
+++ b/rust/libs/connlib/etc-hosts-dns-client/Cargo.toml
@@ -9,7 +9,6 @@ path = "lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-dns-types = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
 

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -20,8 +20,6 @@ where
 
         let ips = parse(&content, &host);
 
-        tracing::debug!(?ips, %host, "Resolved host");
-
         Ok(ips)
     }
 }

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -18,6 +18,8 @@ where
 
         let ips = parse(&content, &host);
 
+        tracing::debug!(?ips, %host, "Resolved host");
+
         Ok(ips)
     }
 }

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -33,6 +33,10 @@ fn parse(content: &str, host: &str) -> Vec<IpAddr> {
         .filter_map(|line| {
             tracing::trace!(%line, "Parsing entry");
 
+            if line.starts_with('#') {
+                return None;
+            }
+
             let mut tokens = line.split_ascii_whitespace();
             let ip = tokens.next()?;
             let ip = ip
@@ -139,5 +143,16 @@ mod tests {
         let ips = parse(content, "portal");
 
         assert_eq!(ips, vec![IpAddr::from([203, 0, 113, 10])]);
+    }
+
+    #[test]
+    fn ignores_lines_with_comments() {
+        let content = r#"
+            # 127.0.0.1       localhost
+        "#;
+
+        let ips = parse(content, "portal");
+
+        assert_eq!(ips, Vec::<IpAddr>::default());
     }
 }

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -1,0 +1,120 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::{borrow::Cow, net::IpAddr};
+
+use anyhow::{Context, Result};
+
+#[cfg(unix)]
+pub fn resolve<H>(host: H) -> impl Future<Output = Result<Vec<IpAddr>>> + use<H>
+where
+    H: Into<Cow<'static, str>>,
+{
+    let host = host.into();
+
+    async move {
+        let content = tokio::fs::read_to_string("/etc/hosts")
+            .await
+            .context("Failed to read `/etc/hosts`")?;
+
+        let ips = parse(&content, &host);
+
+        Ok(ips)
+    }
+}
+
+fn parse(content: &str, host: &str) -> Vec<IpAddr> {
+    content
+        .lines()
+        .filter_map(|line| {
+            tracing::trace!(%line, "Parsing entry");
+
+            let mut tokens = line.split_ascii_whitespace();
+            let ip = tokens.next()?;
+            let ip = ip
+                .parse::<IpAddr>()
+                .inspect_err(|e| tracing::debug!(%ip, "Failed to parse IP address: {e}"))
+                .ok()?;
+            let candidate = tokens.next()?;
+
+            (candidate == host).then_some(ip)
+        })
+        .collect()
+}
+
+#[cfg(not(unix))]
+pub fn resolve<H>(host: H) -> impl Future<Output = Result<Vec<IpAddr>>> + use<H>
+where
+    H: Into<Cow<'static, str>>,
+{
+    async { Ok(Vec::default()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn can_resolve_localhost() {
+        use std::net::Ipv4Addr;
+
+        let ips = resolve("localhost").await.unwrap();
+
+        assert!(ips.contains(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn returns_no_ips_for_unknown_host() {
+        let ips = resolve("example.com").await.unwrap();
+
+        assert_eq!(ips, Vec::<IpAddr>::default());
+    }
+
+    #[cfg(not(unix))]
+    #[tokio::test]
+    async fn does_not_fail_on_non_unix() {
+        let ips = resolve("localhost").await.unwrap();
+
+        assert_eq!(ips, Vec::<IpAddr>::default());
+    }
+
+    #[test]
+    fn can_parse_docker_etc_hosts() {
+        let content = r#"127.0.0.1       localhost
+        ::1     localhost ip6-localhost ip6-loopback
+        fe00::  ip6-localnet
+        ff00::  ip6-mcastprefix
+        ff02::1 ip6-allnodes
+        ff02::2 ip6-allrouters
+        203.0.113.10    portal
+        203:0:113::10   portal
+        172.30.0.100    20b5b769ce8f
+        172:30::100     20b5b769ce8f"#;
+
+        let ips = parse(content, "portal");
+
+        assert_eq!(
+            ips,
+            vec![
+                IpAddr::from([203, 0, 113, 10]),
+                IpAddr::from([
+                    0x0203, 0x0000, 0x0113, 0x0000, 0x0000, 0x0000, 0x0000, 0x0010
+                ]),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_lines_with_missing_host() {
+        let content = r#"
+            127.0.0.1       localhost
+            fe00::
+            203.0.113.10    portal
+        "#;
+
+        let ips = parse(content, "portal");
+
+        assert_eq!(ips, vec![IpAddr::from([203, 0, 113, 10])]);
+    }
+}

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -2,13 +2,15 @@
 
 use std::{borrow::Cow, net::IpAddr};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 #[cfg(unix)]
 pub fn resolve<H>(host: H) -> impl Future<Output = Result<Vec<IpAddr>>> + use<H>
 where
     H: Into<Cow<'static, str>>,
 {
+    use anyhow::Context as _;
+
     let host = host.into();
 
     async move {
@@ -24,6 +26,7 @@ where
     }
 }
 
+#[cfg(any(unix, test))]
 fn parse(content: &str, host: &str) -> Vec<IpAddr> {
     content
         .lines()
@@ -44,7 +47,7 @@ fn parse(content: &str, host: &str) -> Vec<IpAddr> {
 }
 
 #[cfg(not(unix))]
-pub fn resolve<H>(host: H) -> impl Future<Output = Result<Vec<IpAddr>>> + use<H>
+pub fn resolve<H>(_: H) -> impl Future<Output = Result<Vec<IpAddr>>> + use<H>
 where
     H: Into<Cow<'static, str>>,
 {

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -42,16 +42,6 @@ impl UdpDnsClient {
         let host = host.into();
 
         async move {
-            // If the host is already an IP address, return it directly without DNS resolution.
-            if let Ok(ip) = host.as_ref().parse::<IpAddr>() {
-                return Ok(vec![ip]);
-            }
-
-            // If no DNS servers are configured, fall back to the system resolver.
-            if servers.is_empty() {
-                return resolve_via_system(host.as_ref()).await;
-            }
-
             let domain =
                 DomainName::vec_from_str(host.as_ref()).context("Failed to parse domain name")?;
 
@@ -94,20 +84,6 @@ impl UdpDnsClient {
     }
 }
 
-/// Resolves a hostname using the system's default resolver.
-async fn resolve_via_system(host: &str) -> Result<Vec<IpAddr>> {
-    // Use port 0 as a placeholder; tokio::net::lookup_host requires host:port format
-    let host_with_port = format!("{host}:0");
-
-    let addrs = tokio::net::lookup_host(&host_with_port)
-        .await
-        .with_context(|| format!("System DNS lookup failed for {host}"))?;
-
-    let ips: Vec<IpAddr> = addrs.map(|addr| addr.ip()).collect();
-
-    Ok(ips)
-}
-
 async fn send_query(
     socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
     server: SocketAddr,
@@ -142,30 +118,6 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-
-    #[tokio::test]
-    async fn ip_address_returns_directly() {
-        let client = UdpDnsClient::new(
-            Arc::new(socket_factory::udp),
-            vec![], // No DNS servers needed for IP address resolution
-        );
-
-        let ips = client.resolve("192.168.1.1").await.unwrap();
-
-        assert_eq!(ips, vec![IpAddr::from([192, 168, 1, 1])]);
-    }
-
-    #[tokio::test]
-    async fn ipv6_address_returns_directly() {
-        let client = UdpDnsClient::new(
-            Arc::new(socket_factory::udp),
-            vec![], // No DNS servers needed for IP address resolution
-        );
-
-        let ips = client.resolve("::1").await.unwrap();
-
-        assert_eq!(ips, vec![IpAddr::from([0, 0, 0, 0, 0, 0, 0, 1])]);
-    }
 
     #[tokio::test]
     #[ignore = "Requires Internet"]
@@ -210,15 +162,5 @@ mod tests {
 
         assert!(!ips.is_empty());
         assert!(now.elapsed() >= UdpDnsClient::TIMEOUT) // Still need to wait for the unreachable server.
-    }
-
-    #[tokio::test]
-    #[ignore = "Requires Internet"]
-    async fn falls_back_to_system_resolver_when_no_servers_configured() {
-        let client = UdpDnsClient::new(Arc::new(socket_factory::udp), vec![]);
-
-        let ips = client.resolve("example.com").await.unwrap();
-
-        assert!(!ips.is_empty())
     }
 }

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -47,7 +47,9 @@ impl UdpDnsClient {
             let domain =
                 DomainName::vec_from_str(host.as_ref()).context("Failed to parse domain name")?;
 
-            let ips: Vec<IpAddr> = servers
+            tracing::debug!(?servers, %domain, "Resolving host");
+
+            let ips = servers
                 .iter()
                 .flat_map(|socket| {
                     let socket = SocketAddr::new(*socket, 53);
@@ -80,6 +82,8 @@ impl UdpDnsClient {
                 .collect::<BTreeSet<_>>() // Make them unique.
                 .into_iter()
                 .collect();
+
+            tracing::debug!(?ips, %host, "Resolved host");
 
             Ok(ips)
         }

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -81,8 +81,6 @@ impl UdpDnsClient {
                 .into_iter()
                 .collect();
 
-            tracing::debug!(?servers, ?ips, %host, "Resolved host");
-
             Ok(ips)
         }
     }

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -47,8 +47,6 @@ impl UdpDnsClient {
             let domain =
                 DomainName::vec_from_str(host.as_ref()).context("Failed to parse domain name")?;
 
-            tracing::debug!(?servers, %domain, "Resolving host");
-
             let ips = servers
                 .iter()
                 .flat_map(|socket| {
@@ -83,7 +81,7 @@ impl UdpDnsClient {
                 .into_iter()
                 .collect();
 
-            tracing::debug!(?ips, %host, "Resolved host");
+            tracing::debug!(?servers, ?ips, %host, "Resolved host");
 
             Ok(ips)
         }

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -38,6 +38,7 @@ tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 hostname = "0.4.2"
 
 [dev-dependencies]
+regex = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "tracing"] }
 
 [lints]

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -38,7 +38,6 @@ tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 hostname = "0.4.2"
 
 [dev-dependencies]
-regex = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "tracing"] }
 
 [lints]

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -441,9 +441,15 @@ where
     }
 
     pub fn update_ips(&mut self, ips: Vec<IpAddr>) {
-        tracing::debug!(host = %self.host(), current = ?self.resolved_addresses, new = ?ips, "Updating resolved IPs");
+        let new = BTreeSet::from_iter(ips);
 
-        self.resolved_addresses = BTreeSet::from_iter(ips);
+        if new == self.resolved_addresses {
+            return;
+        }
+
+        tracing::debug!(host = %self.host(), current = ?self.resolved_addresses, ?new, "Updating resolved IPs");
+
+        self.resolved_addresses = new;
     }
 
     /// Initiate a graceful close of the connection.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -544,9 +544,9 @@ where
                         continue;
                     }
                     Poll::Ready(Err(InternalError::NoAddresses)) => {
-                        // Reconnect immediately because we assume the caller updates us with new IPs before polling us again.
+                        // Fixed 1s interval to avoid busy-looping in case DNS resolution fails / is not possible.
                         self.state = State::Reconnect {
-                            backoff: Duration::ZERO,
+                            backoff: Duration::from_secs(1),
                         };
 
                         return Poll::Ready(Ok(Event::NoAddresses));

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -5,7 +5,7 @@ mod login_url;
 
 use anyhow::Result;
 use futures::stream::FuturesUnordered;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -68,7 +68,7 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     backoff: Option<ExponentialBackoff>,
     was_connected: bool,
 
-    resolved_addresses: Vec<IpAddr>,
+    resolved_addresses: BTreeSet<IpAddr>,
 
     login: &'static str,
     init_req: TInitReq,
@@ -347,7 +347,7 @@ where
             pending_join_requests: Default::default(),
             login,
             init_req,
-            resolved_addresses: Vec::default(),
+            resolved_addresses: Default::default(),
             last_url: None,
         }
     }
@@ -436,7 +436,7 @@ where
     pub fn update_ips(&mut self, ips: Vec<IpAddr>) {
         tracing::debug!(host = %self.host(), current = ?self.resolved_addresses, new = ?ips, "Updating resolved IPs");
 
-        self.resolved_addresses = ips;
+        self.resolved_addresses = BTreeSet::from_iter(ips);
     }
 
     /// Initiate a graceful close of the connection.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -447,7 +447,7 @@ where
         self.url_prototype.host_and_port().0.to_owned()
     }
 
-    pub fn update_ips(&mut self, ips: Vec<IpAddr>) {
+    pub fn update_ips(&mut self, ips: impl IntoIterator<Item = IpAddr>) {
         let new = BTreeSet::from_iter(ips);
 
         if new == self.resolved_addresses {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -3,10 +3,10 @@
 mod get_user_agent;
 mod login_url;
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use futures::stream::FuturesUnordered;
 use std::collections::{BTreeMap, VecDeque};
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs as _};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, future, marker::PhantomData};
@@ -326,18 +326,8 @@ where
         init_req: TInitReq,
         make_reconnect_backoff: impl Fn() -> ExponentialBackoff + Send + 'static,
         socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-    ) -> Result<Self> {
-        let host_and_port = url.host_and_port();
-
-        // Statically resolve the host in the URL to a set of addresses.
-        // We use these when connecting the socket to avoid a dependency on DNS resolution later on.
-        let resolved_addresses = host_and_port
-            .to_socket_addrs()
-            .with_context(|| format!("Failed to resolve '{}'", host_and_port.0))?
-            .map(|addr| addr.ip())
-            .collect();
-
-        Ok(Self {
+    ) -> Self {
+        Self {
             make_initial_backoff: Box::new(make_initial_backoff),
             make_reconnect_backoff: Box::new(make_reconnect_backoff),
             backoff: None,
@@ -357,9 +347,9 @@ where
             pending_join_requests: Default::default(),
             login,
             init_req,
-            resolved_addresses,
+            resolved_addresses: Vec::default(),
             last_url: None,
-        })
+        }
     }
 
     /// Join the provided room.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -128,6 +128,10 @@ async fn connect(
     addresses: Vec<SocketAddr>,
     socket_factory: &dyn SocketFactory<TcpSocket>,
 ) -> Result<TcpStream, InternalError> {
+    if addresses.is_empty() {
+        return Err(InternalError::NoAddresses);
+    }
+
     use futures::future::TryFutureExt;
 
     let mut sockets = addresses
@@ -184,6 +188,7 @@ enum InternalError {
     StreamClosed,
     RoomJoinTimedOut,
     SocketConnection(Vec<(SocketAddr, std::io::Error)>),
+    NoAddresses,
     Timeout { duration: Duration },
 }
 
@@ -258,6 +263,7 @@ impl fmt::Display for InternalError {
                 write!(f, "operation timed out after {duration:?}")
             }
             InternalError::RoomJoinTimedOut => write!(f, "room join timed out"),
+            InternalError::NoAddresses => write!(f, "no IP addresses available"),
         }
     }
 }
@@ -273,6 +279,7 @@ impl std::error::Error for InternalError {
             InternalError::StreamClosed => None,
             InternalError::Timeout { .. } => None,
             InternalError::RoomJoinTimedOut => None,
+            InternalError::NoAddresses => None,
         }
     }
 }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -334,6 +334,13 @@ where
         make_reconnect_backoff: impl Fn() -> ExponentialBackoff + Send + 'static,
         socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     ) -> Self {
+        let (host, _) = url.host_and_port();
+
+        let resolved_addresses = match host.parse::<IpAddr>() {
+            Ok(ip) => BTreeSet::from([ip]),
+            Err(_) => Default::default(),
+        };
+
         Self {
             make_initial_backoff: Box::new(make_initial_backoff),
             make_reconnect_backoff: Box::new(make_reconnect_backoff),
@@ -354,7 +361,7 @@ where
             pending_join_requests: Default::default(),
             login,
             init_req,
-            resolved_addresses: Default::default(),
+            resolved_addresses,
             last_url: None,
         }
     }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -355,7 +355,7 @@ async fn discards_failed_ips_on_hiccup() {
         panic!("Expected `Hiccup`")
     };
 
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
+    let result = tokio::time::timeout(Duration::from_secs(1), async {
         future::poll_fn(|cx| channel.poll(cx)).await
     })
     .await

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -5,7 +5,6 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::{future, sync::Arc, time::Duration};
 
 use phoenix_channel::{DeviceInfo, Event, LoginUrl, PhoenixChannel, PublicKeyParam};
-use regex::Regex;
 use secrecy::SecretString;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
@@ -352,14 +351,9 @@ async fn discards_failed_ips_on_hiccup() {
     .expect("should not timeout")
     .expect("should not error");
 
-    let phoenix_channel::Event::Hiccup { error, .. } = event else {
+    let phoenix_channel::Event::Hiccup { .. } = event else {
         panic!("Expected `Hiccup`")
     };
-
-    let regex = Regex::new(
-        r#"Reconnecting to portal on transient error: (.*): \[127\.0\.0\.1:443: (.*), 127\.0\.0\.10:443: (.*), 127\.0\.0\.111:443: (.*)\]"#,
-    ).unwrap();
-    assert!(regex.is_match(&format!("{error:#}")), "{error:#}");
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -261,7 +261,7 @@ enum OutboundMsg {
 async fn http_429_triggers_retry() {
     let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -281,7 +281,7 @@ async fn http_429_triggers_retry() {
 async fn http_408_triggers_retry() {
     let port = http_status_server(http::StatusCode::REQUEST_TIMEOUT).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -301,7 +301,7 @@ async fn http_408_triggers_retry() {
 async fn http_400_returns_client_error() {
     let port = http_status_server(http::StatusCode::BAD_REQUEST).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -320,7 +320,7 @@ async fn http_400_returns_client_error() {
 async fn http_401_returns_invalid_token() {
     let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -337,7 +337,7 @@ async fn http_401_returns_invalid_token() {
 
 #[tokio::test]
 async fn discards_failed_ips_on_hiccup() {
-    let mut channel = make_test_channel(443);
+    let mut channel = make_test_channel("localhost", 443); // Use a hostname so we run out of IPs
     channel.update_ips(vec![
         IpAddr::from(Ipv4Addr::from([127, 0, 0, 1])),
         IpAddr::from(Ipv4Addr::from([127, 0, 0, 10])),
@@ -375,8 +375,7 @@ async fn discards_failed_ips_on_hiccup() {
 
 #[tokio::test]
 async fn emits_no_addresses_when_no_ips() {
-    let mut channel = make_test_channel(443);
-    channel.update_ips(vec![]);
+    let mut channel = make_test_channel("localhost", 443); // Use a hostname so we run out of IPs
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -393,7 +392,7 @@ async fn emits_no_addresses_when_no_ips() {
 
 #[tokio::test]
 async fn does_not_clear_address_from_url_on_hiccup() {
-    let mut channel = make_test_channel(443); // `make_test_channel` uses an IP
+    let mut channel = make_test_channel("127.0.0.1", 443);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     loop {
@@ -405,9 +404,9 @@ async fn does_not_clear_address_from_url_on_hiccup() {
     }
 }
 
-fn make_test_channel(port: u16) -> PhoenixChannel<(), (), (), PublicKeyParam> {
+fn make_test_channel(host: &str, port: u16) -> PhoenixChannel<(), (), (), PublicKeyParam> {
     let url = LoginUrl::client(
-        format!("ws://127.0.0.1:{port}").as_str(),
+        format!("ws://{host}:{port}").as_str(),
         "test-device-id".to_string(),
         Some("test-device".to_string()),
         DeviceInfo::default(),
@@ -495,7 +494,7 @@ async fn http_response_server(response: String) -> u16 {
 async fn http_503_triggers_retry() {
     let port = http_status_server(http::StatusCode::SERVICE_UNAVAILABLE).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -515,7 +514,7 @@ async fn http_503_triggers_retry() {
 async fn http_429_with_retry_after_uses_header_value() {
     let port = http_status_server_with_retry_after(429, "Too Many Requests", 30).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
@@ -541,7 +540,7 @@ async fn http_429_with_retry_after_uses_header_value() {
 async fn http_503_with_retry_after_uses_header_value() {
     let port = http_status_server_with_retry_after(503, "Service Unavailable", 60).await;
 
-    let mut channel = make_test_channel(port);
+    let mut channel = make_test_channel("127.0.0.1", port);
     channel.connect(PublicKeyParam([0u8; 32]));
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -357,7 +357,7 @@ async fn discards_failed_ips_on_hiccup() {
     };
 
     let regex = Regex::new(
-        r#"Reconnecting to portal on transient error: ([\w\s]+): \[127\.0\.0\.1:443: (.*), 127\.0\.0\.10:443: (.*), 127\.0\.0\.111:443: (.*)\]"#,
+        r#"Reconnecting to portal on transient error: (.*): \[127\.0\.0\.1:443: (.*), 127\.0\.0\.10:443: (.*), 127\.0\.0\.111:443: (.*)\]"#,
     ).unwrap();
     assert!(regex.is_match(&format!("{error:#}")), "{error:#}");
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -595,6 +595,9 @@ async fn initial_connection_uses_constant_1s_backoff() {
             }) => {
                 hiccups.push((backoff, max_elapsed_time));
             }
+            Ok(phoenix_channel::Event::NoAddresses) => {
+                channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
+            }
             Err(Error::MaxRetriesReached { .. }) => break,
             other => panic!("Unexpected event: {other:?}"),
         }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -87,8 +87,7 @@ async fn client_does_not_pipeline_messages() {
                 .build()
         },
         Arc::new(socket_factory::tcp),
-    )
-    .unwrap();
+    );
 
     let client = async move {
         channel.connect(PublicKeyParam([0u8; 32]));
@@ -194,8 +193,7 @@ async fn client_deduplicates_messages() {
                 .build()
         },
         Arc::new(socket_factory::tcp),
-    )
-    .unwrap();
+    );
 
     let mut num_responses = 0;
 
@@ -352,7 +350,6 @@ fn make_test_channel(port: u16) -> PhoenixChannel<(), (), (), PublicKeyParam> {
         },
         Arc::new(socket_factory::tcp),
     )
-    .unwrap()
 }
 
 async fn http_status_server(code: http::StatusCode) -> u16 {
@@ -518,8 +515,7 @@ async fn initial_connection_uses_constant_1s_backoff() {
                 .build()
         },
         Arc::new(socket_factory::tcp),
-    )
-    .unwrap();
+    );
 
     channel.connect(PublicKeyParam([0u8; 32]));
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(not(windows))] // For some reason, Windows doesn't like this test.
 #![allow(clippy::unwrap_used)]
 
+use std::net::{IpAddr, Ipv4Addr};
 use std::{future, sync::Arc, time::Duration};
 
 use phoenix_channel::{DeviceInfo, Event, LoginUrl, PhoenixChannel, PublicKeyParam};
@@ -106,6 +107,9 @@ async fn client_does_not_pipeline_messages() {
                     ..
                 } => {
                     channel.close().unwrap();
+                }
+                phoenix_channel::Event::NoAddresses => {
+                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Hiccup { error, .. } => {
                     panic!("Unexpected hiccup: {error:?}")
@@ -221,6 +225,9 @@ async fn client_deduplicates_messages() {
                 }
                 phoenix_channel::Event::Hiccup { error, .. } => {
                     panic!("Unexpected hiccup: {error:?}")
+                }
+                phoenix_channel::Event::NoAddresses => {
+                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Closed => break,
             }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -357,7 +357,7 @@ async fn discards_failed_ips_on_hiccup() {
     };
 
     let regex = Regex::new(
-        r#"Reconnecting to portal on transient error: failed to connect socket: \[127\.0\.0\.1:443: (.*), 127\.0\.0\.10:443: (.*), 127\.0\.0\.111:443: (.*)\]"#,
+        r#"Reconnecting to portal on transient error: ([\w\s]+): \[127\.0\.0\.1:443: (.*), 127\.0\.0\.10:443: (.*), 127\.0\.0\.111:443: (.*)\]"#,
     ).unwrap();
     assert!(regex.is_match(&format!("{error:#}")));
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -359,7 +359,7 @@ async fn discards_failed_ips_on_hiccup() {
     let regex = Regex::new(
         r#"Reconnecting to portal on transient error: ([\w\s]+): \[127\.0\.0\.1:443: (.*), 127\.0\.0\.10:443: (.*), 127\.0\.0\.111:443: (.*)\]"#,
     ).unwrap();
-    assert!(regex.is_match(&format!("{error:#}")));
+    assert!(regex.is_match(&format!("{error:#}")), "{error:#}");
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -344,7 +344,7 @@ async fn discards_failed_ips_on_hiccup() {
     ]);
     channel.connect(PublicKeyParam([0u8; 32]));
 
-    let event = tokio::time::timeout(Duration::from_secs(5), async {
+    let event = tokio::time::timeout(Duration::from_secs(6), async {
         future::poll_fn(|cx| channel.poll(cx)).await
     })
     .await

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -373,6 +373,24 @@ async fn discards_failed_ips_on_hiccup() {
     );
 }
 
+#[tokio::test]
+async fn emits_no_addresses_when_no_ips() {
+    let mut channel = make_test_channel(443);
+    channel.update_ips(vec![]);
+    channel.connect(PublicKeyParam([0u8; 32]));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        future::poll_fn(|cx| channel.poll(cx)).await
+    })
+    .await
+    .expect("should not timeout");
+
+    assert!(
+        matches!(result, Ok(phoenix_channel::Event::NoAddresses)),
+        "expected Event::NoAddresses, got {result:?}"
+    );
+}
+
 fn make_test_channel(port: u16) -> PhoenixChannel<(), (), (), PublicKeyParam> {
     let url = LoginUrl::client(
         format!("ws://127.0.0.1:{port}").as_str(),

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -252,7 +252,7 @@ async fn try_main(args: Args) -> Result<()> {
                 .build()
         },
         Arc::new(socket_factory::tcp),
-    )?;
+    );
     channel.connect(NoParams);
 
     let mut eventloop = Eventloop::new(server, ebpf, channel, public_addr, last_heartbeat_sent)?;

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -785,7 +785,7 @@ async fn update_portal_host_ips(
         .await
         .context("Failed to lookup portal host")
     {
-        Ok(sockets) => sockets.map(|s| s.ip()).collect(),
+        Ok(sockets) => sockets.map(|s| s.ip()),
         Err(e) => {
             tracing::warn!(%host, "{e:#}");
             return;

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -238,7 +238,7 @@ async fn try_main(args: Args) -> Result<()> {
         args.public_ip6_addr,
     )?;
 
-    let mut channel = PhoenixChannel::disconnected(
+    let channel = PhoenixChannel::disconnected(
         login,
         args.token.clone(),
         get_user_agent("relay", env!("CARGO_PKG_VERSION")),
@@ -253,7 +253,6 @@ async fn try_main(args: Args) -> Result<()> {
         },
         Arc::new(socket_factory::tcp),
     );
-    channel.connect(NoParams);
 
     let mut eventloop = Eventloop::new(server, ebpf, channel, public_addr, last_heartbeat_sent)?;
 
@@ -738,6 +737,7 @@ async fn phoenix_channel_event_loop(
     last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
 ) {
     update_portal_host_ips(&mut portal).await;
+    portal.connect(NoParams);
 
     loop {
         match std::future::poll_fn(|cx| portal.poll(cx)).await {


### PR DESCRIPTION
The DNS resolution of the portal hostname is a rather tricky business. Most importantly, we need to ensure that we do not cause packet-loops as part of it. In other words, resolving DNS must not trigger IP packets that need to be routed by Firezone as we may have to establish new connections for routing those packets, effectively causing a deadlock if we are not connected to the portal at that point.

The only way we can guarantee that, is by explicitly sending DNS queries ourselves through a socket that has been created by one of our `SocketFactory`s. Those are configured to always bypass Firezone via platform-specific measures.

Currently, DNS resolution of the portal's hostname happens directly on startup, synchronously via libc when connlib is first initialized. At that point, connlib's network interface is not up yet and thus the above requirements are satisfied. It is however not a pretty solution and has several downsides:

1. It makes the `connect` call fail if the user wants to connect to Firezone without having Internet / network connectivity, forcing the host-app to have a retry mechanism for this situation.
2. `libc` only resolves a hostname for the IP stack supported by the current network interface. This means we don't receive IPv6 addresses if we are currently on an IPv4-only network, making roaming to an IPv6-only network impossible without additional DNS resolution.
3. `libc` is synchronous and thus blocks the startup of the connlib.
4. We have to implemented a dedicated mechanism for re-resolving the hostname whenever the connection experiences a hiccup, spreading this concerns over multiple places of the codebase.

To resolve all of the above, we take a more unified approach to DNS resolution of the portal hostname. The pillars of the new design are:

- `PhoenixChannel` itself never resolves DNS. It is now the responsibility of the caller.
- When given an IP as the hostname, it is used directly.
- On every connection hiccup, we remove all IPs that we failed to connect to.
- When `PhoenixChannel` cannot connect due to lack of IPs, it emits a dedicated event.
- All call-sites (Clients, Gateways & Relays) now use the same code-path for the initial DNS resolution and in the case of hiccups. They all have their own way of performing this DNS resolution.
	- Relays simply use `libc` to resolve this hostname.
	- Gateways use a userspace DNS client backed by `hickory_resolver`.
	- Clients use our custom, UDP-based Client with the list of system resolvers, plus they check the `/etc/hosts` file on UNIX platforms. The latter is required for our docker setup to work.

To keep the scope small, FFI Clients of connlib are not updated to pass in the initial list of resolvers. As a result, those Clients will initially loop on DNS resolution errors until the first `SetDns` command is received with a list of DNS servers to use.

Resolves: #11662