### PR TITLE
fix(portal): don't load Sentry.PlugCapture

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -51,3 +51,6 @@ DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.e
 Config.Secrets: Hardcoded Secret,config/config.exs:203,6ED2CC5
 Config.Secrets: Hardcoded Secret,config/config.exs:204,7F38DEB
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:370,7F8C06D
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:40,1D07B78
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:30,75F2F69
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:50,7DE9449

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -1,5 +1,4 @@
 defmodule PortalAPI.Endpoint do
-  use Sentry.PlugCapture
   use Phoenix.Endpoint, otp_app: :portal
 
   # Health checks - early in pipeline for fast responses

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -1,5 +1,4 @@
 defmodule PortalWeb.Endpoint do
-  use Sentry.PlugCapture
   use Phoenix.Endpoint, otp_app: :portal
 
   # NOTE: This is only used for the LiveView session. We store per-account cookies to allow

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -21,6 +21,46 @@ defmodule Portal.HealthTest do
     {:ok, draining_file_path: draining_file_path}
   end
 
+  describe "PortalWeb.Endpoint integration" do
+    test "GET /healthz returns 200" do
+      conn =
+        Plug.Test.conn(:get, "/healthz")
+        |> PortalWeb.Endpoint.call([])
+
+      assert conn.status == 200
+      assert JSON.decode!(conn.resp_body) == %{"status" => "ok"}
+    end
+
+    test "GET /readyz returns 200 when ready" do
+      conn =
+        Plug.Test.conn(:get, "/readyz")
+        |> PortalWeb.Endpoint.call([])
+
+      assert conn.status == 200
+      assert JSON.decode!(conn.resp_body) == %{"status" => "ready"}
+    end
+  end
+
+  describe "PortalAPI.Endpoint integration" do
+    test "GET /healthz returns 200" do
+      conn =
+        Plug.Test.conn(:get, "/healthz")
+        |> PortalAPI.Endpoint.call([])
+
+      assert conn.status == 200
+      assert JSON.decode!(conn.resp_body) == %{"status" => "ok"}
+    end
+
+    test "GET /readyz returns 200 when ready" do
+      conn =
+        Plug.Test.conn(:get, "/readyz")
+        |> PortalAPI.Endpoint.call([])
+
+      assert conn.status == 200
+      assert JSON.decode!(conn.resp_body) == %{"status" => "ready"}
+    end
+  end
+
   describe "GET /healthz" do
     test "returns 200 with status ok" do
       conn =


### PR DESCRIPTION
Sentry's docs state that `Sentry.PlugCapture` is meant for Cowboy only, and adding it for Bandit applications can result in double errors.

>[Sentry.PlugCapture](https://hexdocs.pm/sentry/Sentry.PlugCapture.html) is only recommended for Cowboy applications. For applications running on Bandit, which is the most recent default webserver in Phoenix, [Sentry.PlugContext](https://hexdocs.pm/sentry/Sentry.PlugContext.html) should be enough, and using [Sentry.PlugCapture](https://hexdocs.pm/sentry/Sentry.PlugCapture.html) might result in duplicate errors.

We are seeing a weird 404 not found for the Health plugs on prod-built images, so this is an attempt to fix those.

We also add integration tests to ensure the Health plugs function properly.