### PR TITLE
ci: inline `common` elixir container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,39 @@ services:
       RELEASE_HOSTNAME: "portal.cluster.local"
       RELEASE_NAME: "portal"
       LOG_LEVEL: "debug"
+      # Database
+      RUN_MANUAL_MIGRATIONS: "true"
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_NAME: firezone_dev
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres
+      # Feature flags
+      FEATURE_POLICY_CONDITIONS_ENABLED: "true"
+      FEATURE_MULTI_SITE_RESOURCES_ENABLED: "true"
+      FEATURE_SELF_HOSTED_RELAYS_ENABLED: "true"
+      FEATURE_IDP_SYNC_ENABLED: "true"
+      FEATURE_REST_API_ENABLED: "true"
+      FEATURE_INTERNET_RESOURCE_ENABLED: "true"
+      ## Warning: The token is for the blackhole Postmark server created in a separate isolated account,
+      ## that WILL NOT send any actual emails, but you can see and debug them in the Postmark dashboard.
+      OUTBOUND_EMAIL_ADAPTER_OPTS: '{"api_key":"7da7d1cd-111c-44a7-b5ac-4027b9d230e5"}'
+      # Secrets
+      TOKENS_KEY_BASE: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5S2"
+      TOKENS_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
+      SECRET_KEY_BASE: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5S2"
+      LIVE_VIEW_SIGNING_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
+      COOKIE_SIGNING_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
+      COOKIE_ENCRYPTION_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
+      # Erlang
+      ERLANG_DISTRIBUTION_PORT: 9000
+      RELEASE_COOKIE: "NksuBhJFBhjHD1uUa9mDOHV"
+      # Emails
+      OUTBOUND_EMAIL_FROM: "public-noreply@firez.one"
+      OUTBOUND_EMAIL_ADAPTER: "Elixir.Swoosh.Adapters.Postmark"
+      # Color nodes
+      PORTAL_API_ENABLED: true
+      PORTAL_WEB_ENABLED: true
     user: root # Needed to run `ip route` commands
     cap_add:
       - NET_ADMIN # Needed to run `tc` commands to add simulated delay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,6 @@ x-health-check: &health-check
 
 services:
   portal:
-    extends:
-      file: scripts/compose/portal.yml
-      service: common
     build:
       context: elixir
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,9 +123,6 @@ services:
   # This is a service container which allows to run mix tasks for local development
   # without having to install Elixir and Erlang on the host machine.
   elixir:
-    extends:
-      file: scripts/compose/portal.yml
-      service: common
     build:
       context: elixir
       target: compiler

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -49,45 +49,6 @@ services:
       retries: 10
       start_period: 5s
 
-  common:
-    image: alpine:latest # Dummy, will always be overridden.
-    environment:
-      # Database
-      RUN_MANUAL_MIGRATIONS: "true"
-      DATABASE_HOST: postgres
-      DATABASE_PORT: 5432
-      DATABASE_NAME: firezone_dev
-      DATABASE_USER: postgres
-      DATABASE_PASSWORD: postgres
-      # Feature flags
-      FEATURE_POLICY_CONDITIONS_ENABLED: "true"
-      FEATURE_MULTI_SITE_RESOURCES_ENABLED: "true"
-      FEATURE_SELF_HOSTED_RELAYS_ENABLED: "true"
-      FEATURE_IDP_SYNC_ENABLED: "true"
-      FEATURE_REST_API_ENABLED: "true"
-      FEATURE_INTERNET_RESOURCE_ENABLED: "true"
-      ## Warning: The token is for the blackhole Postmark server created in a separate isolated account,
-      ## that WILL NOT send any actual emails, but you can see and debug them in the Postmark dashboard.
-      OUTBOUND_EMAIL_ADAPTER_OPTS: '{"api_key":"7da7d1cd-111c-44a7-b5ac-4027b9d230e5"}'
-      # Secrets
-      TOKENS_KEY_BASE: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5S2"
-      TOKENS_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
-      SECRET_KEY_BASE: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5S2"
-      LIVE_VIEW_SIGNING_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
-      COOKIE_SIGNING_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
-      COOKIE_ENCRYPTION_SALT: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
-      # Erlang
-      ERLANG_DISTRIBUTION_PORT: 9000
-      RELEASE_COOKIE: "NksuBhJFBhjHD1uUa9mDOHV"
-      # Emails
-      OUTBOUND_EMAIL_FROM: "public-noreply@firez.one"
-      OUTBOUND_EMAIL_ADAPTER: "Elixir.Swoosh.Adapters.Postmark"
-      # Color nodes
-      PORTAL_API_ENABLED: true
-      PORTAL_WEB_ENABLED: true
-    networks:
-      - app-internal
-
 volumes:
   postgres-data:
   elixir-build-cache:


### PR DESCRIPTION
Without an other containers that inherit from `common`, it is unnecessary to have this indirection and we can just move all environment variables to the `portal` container.

This removes the number of containers we boot up locally by 1 as we currently boot up the `common` container as a dummy.