### PR TITLE
fix(portal): don't override RELEASE_NODE

### DIFF
--- a/elixir/rel/env.sh.eex
+++ b/elixir/rel/env.sh.eex
@@ -25,12 +25,12 @@ export RELEASE_DISTRIBUTION=name
 # this is to ensure that the hostname is correct in Google Cloud Compute.
 #
 # Having a valid DNS record is important to remotely connect to a running Erlang node.
-if [[ "${RELEASE_HOST_DISCOVERY_METHOD}" == "gce_metadata" ]]; then
+if [ "${RELEASE_HOST_DISCOVERY_METHOD}" = "gce_metadata" ]; then
   export GCP_PROJECT_ID=$(curl "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google" -s)
   export GCP_INSTANCE_NAME=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google" -s)
   export GCP_INSTANCE_ZONE=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google" -s | sed 's:.*/::')
   RELEASE_HOSTNAME="$GCP_INSTANCE_NAME.$GCP_INSTANCE_ZONE.c.${GCP_PROJECT_ID}.internal"
-elif [[ "${RELEASE_HOST_DISCOVERY_METHOD}" == "aws_ecs_metadata" ]]; then
+elif [ "${RELEASE_HOST_DISCOVERY_METHOD}" = "aws_ecs_metadata" ]; then
   RELEASE_HOSTNAME=$(curl "${ECS_CONTAINER_METADATA_URI_V4}" | jq -r '.Networks[0].IPv4Addresses[0]')
 else
   RELEASE_HOSTNAME=${RELEASE_HOSTNAME:-127.0.0.1}
@@ -39,7 +39,11 @@ fi
 # RELEASE_NAME is guaranteed to be set by the start script and defaults to 'firezone'
 # set RELEASE_NAME in the environment to a unique value when running multiple instances
 # in the same network namespace (i.e. with host networking in Podman)
-export RELEASE_NODE=${RELEASE_NAME}@${RELEASE_HOSTNAME}
+#
+# Only set RELEASE_NODE if not already provided (allows Azure/external node naming)
+if [ -z "${RELEASE_NODE}" ]; then
+  export RELEASE_NODE=${RELEASE_NAME}@${RELEASE_HOSTNAME}
+fi
 
 # Choices here are 'interactive' and 'embedded'. 'interactive' boots faster which
 # prevents some runit process management edge cases at the expense of the application


### PR DESCRIPTION
Don't override RELEASE_NODE if it's set externally, such as is the case when deployed on Azure.