### PR TITLE
fix(portal): use private IP for RELEASE_HOST

### DIFF
--- a/elixir/rel/env.sh.eex
+++ b/elixir/rel/env.sh.eex
@@ -26,10 +26,7 @@ export RELEASE_DISTRIBUTION=name
 #
 # Having a valid DNS record is important to remotely connect to a running Erlang node.
 if [ "${RELEASE_HOST_DISCOVERY_METHOD}" = "gce_metadata" ]; then
-  export GCP_PROJECT_ID=$(curl "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google" -s)
-  export GCP_INSTANCE_NAME=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google" -s)
-  export GCP_INSTANCE_ZONE=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google" -s | sed 's:.*/::')
-  RELEASE_HOSTNAME="$GCP_INSTANCE_NAME.$GCP_INSTANCE_ZONE.c.${GCP_PROJECT_ID}.internal"
+  RELEASE_HOSTNAME=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip" -H "Metadata-Flavor: Google" -s)
 elif [ "${RELEASE_HOST_DISCOVERY_METHOD}" = "aws_ecs_metadata" ]; then
   RELEASE_HOSTNAME=$(curl "${ECS_CONTAINER_METADATA_URI_V4}" | jq -r '.Networks[0].IPv4Addresses[0]')
 else


### PR DESCRIPTION
The current approach we use for `gce_metadata` spits out FQDNs that only GCP VMs can resolve. We need the actual private IPs here so that the gossip cluster formation from the azure side will work correctly.