### PR TITLE
fix(portal): expect <release>@<private-ip> node names

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -54,3 +54,5 @@ DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:370,7
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:40,1D07B78
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:30,75F2F69
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:50,7DE9449
+
+DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0

--- a/elixir/lib/portal/cluster/google_compute_labels_strategy.ex
+++ b/elixir/lib/portal/cluster/google_compute_labels_strategy.ex
@@ -167,11 +167,8 @@ defmodule Portal.Cluster.GoogleComputeLabelsStrategy do
            ) do
       nodes =
         instances
-        |> Enum.map(fn %{"zone" => zone, "name" => name} ->
-          zone = String.split(zone, "/") |> List.last()
-          node_name = :"#{release_name}@#{name}.#{zone}.c.#{project_id}.internal"
-
-          node_name
+        |> Enum.map(fn %{"networkInterfaces" => [%{"networkIP" => private_ip} | _]} ->
+          :"#{release_name}@#{private_ip}"
         end)
 
       count = length(nodes)

--- a/elixir/test/portal/cluster/google_compute_labels_strategy_test.exs
+++ b/elixir/test/portal/cluster/google_compute_labels_strategy_test.exs
@@ -45,7 +45,7 @@ defmodule Portal.Cluster.GoogleComputeLabelsStrategyTest do
       assert {:ok, nodes, _state} = fetch_nodes(state)
 
       assert nodes == [
-               :"portal@api-q3j6.us-east1-d.c.firezone-staging.internal"
+               :"portal@10.128.0.43"
              ]
     end
   end


### PR DESCRIPTION
The cluster joining strategy we use for Google still expected the FQDN. This needs to be changed to expect the same value we set the `RELEASE_NODE` to.

Follow up to #11702 