### PR TITLE
fix(portal): don't query DB in readiness check

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -56,3 +56,6 @@ Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:30,75F2F6
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:50,7DE9449
 
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
+
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -152,7 +152,6 @@ config :portal, Portal.Telemetry,
 
 config :portal, Portal.Health,
   health_port: 4000,
-  repo: Portal.Repo,
   web_endpoint: PortalWeb.Endpoint,
   api_endpoint: PortalAPI.Endpoint,
   # TODO: Remove draining_file_path after Azure migration is complete

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -65,9 +65,6 @@ defmodule Portal.Health do
       draining?() ->
         send_resp(conn, 503, JSON.encode!(%{status: :draining}))
 
-      not database_ready?() ->
-        send_resp(conn, 503, JSON.encode!(%{status: :database_unavailable}))
-
       not endpoints_ready?() ->
         send_resp(conn, 503, JSON.encode!(%{status: :starting}))
 
@@ -87,15 +84,6 @@ defmodule Portal.Health do
     api_endpoint = Keyword.fetch!(config, :api_endpoint)
 
     Process.whereis(web_endpoint) != nil and Process.whereis(api_endpoint) != nil
-  end
-
-  defp database_ready? do
-    repo = Portal.Config.fetch_env!(:portal, Portal.Health) |> Keyword.fetch!(:repo)
-
-    case repo.query("SELECT 1") do
-      {:ok, _result} -> true
-      {:error, _reason} -> false
-    end
   end
 end
 


### PR DESCRIPTION
It's important to keep the health / readiness checks as simple as possible to avoid cases where one service brings down an entire cluster because of the flappiness of rebooting VMs.

To fix this, we remove the DB query from the `/readyz` check. I had originally thought this query was trouble-free enough to be fine, but GCP will reboot these VMs if this starts to fail, which only exacerbates any issue we already may be experiencing.