### PR TITLE
chore(portal): allow disabling epmd

### DIFF
--- a/elixir/rel/env.sh.eex
+++ b/elixir/rel/env.sh.eex
@@ -1,15 +1,24 @@
 #!/bin/sh
 
+# Build ERL_OPTIONS based on environment
+ERL_DIST_OPTIONS="-kernel inet_dist_listen_min ${ERLANG_DISTRIBUTION_PORT} inet_dist_listen_max ${ERLANG_DISTRIBUTION_PORT}"
+
+# Optionally disable EPMD startup (for environments where EPMD runs on the host)
+# Defaults to true (start EPMD) for backwards compatibility
+if [ "${START_EPMD}" = "false" ]; then
+  ERL_DIST_OPTIONS="${ERL_DIST_OPTIONS} -start_epmd false"
+fi
+
 # Sets and enables heart (recommended only in daemon mode)
 case $RELEASE_COMMAND in
   daemon*)
     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
     export HEART_COMMAND
-    export ELIXIR_ERL_OPTIONS="-heart -kernel inet_dist_listen_min ${ERLANG_DISTRIBUTION_PORT} inet_dist_listen_max ${ERLANG_DISTRIBUTION_PORT}"
+    export ELIXIR_ERL_OPTIONS="-heart ${ERL_DIST_OPTIONS}"
     ;;
 
   start*)
-    export ELIXIR_ERL_OPTIONS="-kernel inet_dist_listen_min ${ERLANG_DISTRIBUTION_PORT} inet_dist_listen_max ${ERLANG_DISTRIBUTION_PORT}"
+    export ELIXIR_ERL_OPTIONS="${ERL_DIST_OPTIONS}"
     ;;
 
   *)


### PR DESCRIPTION
The Erlang Port Mapper Daemon (`epmd`) listens on tcp/4369 and maps local instances of the BEAM to listen ports, usually starting at port `tcp/9000`.

When upgrading our deployment strategy to blue/green deploys for Azure, we need to run a stable EPMD outside of the context of the portal containers we are upgrading. This is so the container can use their local node's EPMD without having to start their own (as we do now).

Related: #10419 