### PR TITLE
build(elixir): don't load CodeReloader for Dependabot

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -20,7 +20,7 @@ defmodule Portal.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
-      listeners: [Phoenix.CodeReloader],
+      listeners: listeners(Mix.env()),
       docs: [
         logo: "assets/static/images/logo.svg",
         extras: ["docs/README.md", "docs/SECURITY.md", "docs/CONTRIBUTING.md"]
@@ -50,6 +50,9 @@ defmodule Portal.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support", ".credo"]
   defp elixirc_paths(:dev), do: ["lib", ".credo"]
   defp elixirc_paths(_), do: ["lib"]
+
+  defp listeners(:dev), do: [Phoenix.CodeReloader]
+  defp listeners(_), do: []
 
   defp deps do
     [


### PR DESCRIPTION
Should hopefully fix this error Dependabot is seeing:

```
Dependabot failed to update your dependencies because there was an error evaluating your Elixir dependency files.

Dependabot encountered the following error:

** (ArgumentError) The module Phoenix.CodeReloader was given as a child to a supervisor but it does not exist
    (elixir 1.18.4) lib/supervisor.ex:797: Supervisor.init_child/1
    (elixir 1.18.4) lib/supervisor.ex:905: Supervisor.child_spec/2
    (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (mix 1.18.4) lib/mix/pubsub.ex:77: Mix.PubSub.listener_supervisor/0
    (mix 1.18.4) lib/mix/pubsub.ex:59: Mix.PubSub.start_listeners/0
    (mix 1.18.4) lib/mix/tasks/deps.loadpaths.ex:76: Mix.Tasks.Deps.Loadpaths.run/1
    (mix 1.18.4) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.18.4) lib/mix/tasks/loadpaths.ex:37: Mix.Tasks.Loadpaths.run/1

{"error":""}
```