### PR TITLE
ci(apple): add test coverage reporting

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -30,8 +30,17 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - run: sudo xcode-select --switch "$(find /Applications -maxdepth 1 -name "Xcode*${XCODE_VERSION}*.app" | sort -V | tail -n 1)"
-      - run: swift test
-        working-directory: swift/apple/FirezoneKit
+      - name: Run tests with coverage
+        run: ./mise-tasks/test-coverage.sh
+        working-directory: swift/apple
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: swift/apple/FirezoneKit/coverage.lcov
+          flag-name: swift-test
+          parallel: true
+          fail-on-error: false
 
   static-analysis:
     runs-on: macos-15

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -55,6 +55,8 @@ jobs:
 
   build:
     name: ${{ matrix.job_name }}
+    # Skip builds on CD (push to main) - only needed for PR validation and releases
+    if: github.event_name != 'push'
     needs: update-release-draft
     runs-on: macos-15
     env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,9 +84,13 @@ jobs:
     uses: ./.github/workflows/_elixir.yml
     secrets: inherit
 
+  swift:
+    uses: ./.github/workflows/_swift.yml
+    secrets: inherit
+
   coverage-finish:
     name: coverage-finish
-    needs: [elixir, rust]
+    needs: [elixir, rust, swift]
     runs-on: ubuntu-24.04
     steps:
       - name: Finalize coverage upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,8 +341,8 @@ jobs:
 
   coverage-finish:
     name: coverage-finish
-    needs: [elixir, rust]
-    if: needs.elixir.result != 'skipped' || needs.rust.result != 'skipped'
+    needs: [elixir, rust, swift]
+    if: needs.elixir.result != 'skipped' || needs.rust.result != 'skipped' || needs.swift.result != 'skipped'
     runs-on: ubuntu-24.04
     steps:
       - name: Finalize coverage upload
@@ -350,5 +350,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          carryforward: portal,rust-tunnel-test,rust-test-Linux,rust-test-macOS,rust-test-Windows
+          carryforward: portal,rust-tunnel-test,rust-test-Linux,rust-test-macOS,rust-test-Windows,swift-test
           fail-on-error: false # Make CI less flaky

--- a/swift/apple/mise-tasks/test-coverage.sh
+++ b/swift/apple/mise-tasks/test-coverage.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPLE_DIR="${SCRIPT_DIR}/.."
+FIREZONE_KIT_DIR="${APPLE_DIR}/FirezoneKit"
+
+echo "Running FirezoneKit tests with coverage..."
+cd "${FIREZONE_KIT_DIR}"
+swift test --enable-code-coverage
+
+echo "Converting coverage to lcov format..."
+BIN_PATH=$(swift build --show-bin-path)
+PROFDATA="${BIN_PATH}/codecov/default.profdata"
+TEST_BINARY="${BIN_PATH}/FirezoneKitPackageTests.xctest/Contents/MacOS/FirezoneKitPackageTests"
+COVERAGE_FILE="${FIREZONE_KIT_DIR}/coverage.lcov"
+
+xcrun llvm-cov export \
+    "${TEST_BINARY}" \
+    -instr-profile="${PROFDATA}" \
+    -format=lcov \
+    -ignore-filename-regex='\.build|Tests' \
+    > "${COVERAGE_FILE}"
+
+echo "Coverage report generated: ${COVERAGE_FILE}"
+
+# Calculate coverage percentage from lcov data
+# LF = lines found (total), LH = lines hit (covered)
+LINES_FOUND=$(grep "^LF:" "${COVERAGE_FILE}" | cut -d: -f2 | awk '{sum += $1} END {print sum}')
+LINES_HIT=$(grep "^LH:" "${COVERAGE_FILE}" | cut -d: -f2 | awk '{sum += $1} END {print sum}')
+
+if [ "${LINES_FOUND}" -gt 0 ]; then
+    PERCENTAGE=$(awk "BEGIN {printf \"%.1f\", (${LINES_HIT} / ${LINES_FOUND}) * 100}")
+    echo ""
+    echo "Coverage: ${PERCENTAGE}% (${LINES_HIT}/${LINES_FOUND} lines)"
+else
+    echo "No coverage data found"
+fi

--- a/swift/apple/mise.toml
+++ b/swift/apple/mise.toml
@@ -68,6 +68,10 @@ run = "./mise-tasks/check.sh"
 description = "Run FirezoneKit tests"
 run = "./mise-tasks/test.sh"
 
+[tasks.test-coverage]
+description = "Run FirezoneKit tests with coverage and generate lcov report"
+run = "./mise-tasks/test-coverage.sh"
+
 # =============================================================================
 # Log Tasks
 # =============================================================================


### PR DESCRIPTION
Add mise task and CI integration for Swift test coverage, uploading to
Coveralls.

mise-tasks/test-coverage.sh:
- Runs `swift test --enable-code-coverage`
- Converts profdata to lcov format via llvm-cov export
- Excludes test files and build artifacts from report

CI changes:
- _swift.yml: Call test-coverage.sh and upload to Coveralls
- ci.yml: Add swift to coverage-finish dependencies
- ci.yml: Add swift-test to carryforward list

Run locally with `mise`:
- from apple/swift dir: `mise run :test-coverage`
- from repo root: `mise run //swift/apple:test-coverage`