### PR TITLE
chore(ci): tag portal:staging

### DIFF
--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -87,3 +87,4 @@ jobs:
           tags: |
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ inputs.sha }}
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:staging


### PR DESCRIPTION
Previously, we would "push" deploys out via the infra repo using a trigger to notify a certain workflow in that repo. This triggers a cascading terraform run which, during day to day deploys, is unnecessary and time-consuming.

Instead, we can simply tag `main` with `staging`, and services on the portal VMs themselves will handle the blue/green deploy and cutover.

This is only for staging for now but the same technique is proposed to be used in production.

To roll back or revert, we can simply tag `staging` with whatever sha we desire and the rollback will take place.