### PR TITLE
refactor(apple): use DI in Store and test it

### DIFF
--- a/swift/apple/.gitignore
+++ b/swift/apple/.gitignore
@@ -6,3 +6,4 @@ xcuserdata/
 **/*.xcuserstate
 Firezone/xcconfig/dynamic_build_number.xcconfig
 FirezoneNetworkExtension/Connlib/Generated/
+coverage.lcov

--- a/swift/apple/.swiftlint.yml
+++ b/swift/apple/.swiftlint.yml
@@ -153,5 +153,10 @@ custom_rules:
     regex: '(handle|fileHandle)\.write\((?!contentsOf:)'
     message: "'write' can throw uncatchable NSExceptions  - prefer `.write(contentsOf:)`"
     severity: error
+  no_userdefaults_standard:
+    name: "Prefer injected UserDefaults"
+    regex: 'UserDefaults\.standard'
+    message: "Use injected userDefaults instead of .standard for testability. If this is a DI entry point or view code, add swiftlint:disable:next."
+    severity: error
 
 reporter: xcode

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -6,7 +6,6 @@
 
 import AppleArchive
 import Foundation
-@preconcurrency import NetworkExtension
 import SystemPackage
 
 /// Convenience module for smoothing over the differences between exporting logs on macOS and iOS.
@@ -29,7 +28,7 @@ import SystemPackage
     @MainActor
     static func export(
       to archiveURL: URL,
-      session: NETunnelProviderSession
+      store: Store
     ) async throws {
       guard let logFolderURL = SharedAccess.logFolderURL
       else {
@@ -59,7 +58,7 @@ import SystemPackage
       defer { try? fd.close() }
 
       // 3. Await tunnel log export from tunnel process
-      try await IPCClient.exportLogs(session: session, fd: fd)
+      try await store.exportLogs(fd: fd)
 
       // 4. Create app log archive
       let appLogURL = sharedLogFolderURL.appendingPathComponent("app.zip")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/RealTunnelController.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/RealTunnelController.swift
@@ -43,10 +43,7 @@ public final class RealTunnelController: TunnelControllerProtocol {
   }
 
   public func enable() async throws {
-    guard let manager = vpnManager else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await manager.enable()
+    try await requireManager().enable()
   }
 
   public func installConfiguration() async throws {
@@ -56,72 +53,44 @@ public final class RealTunnelController: TunnelControllerProtocol {
   // MARK: - IPC Operations
 
   public func fetchResources(currentHash: Data) async throws -> Data? {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    return try await IPCClient.fetchState(session: session, currentHash: currentHash)
+    try await IPCClient.fetchState(session: requireSession(), currentHash: currentHash)
   }
 
   public func setConfiguration(_ config: TunnelConfiguration) async throws {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.setConfiguration(session: session, config)
+    try await IPCClient.setConfiguration(session: requireSession(), config)
   }
 
   public func start(configuration: TunnelConfiguration) throws {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try IPCClient.start(session: session, configuration: configuration)
+    try IPCClient.start(session: requireSession(), configuration: configuration)
   }
 
   public func start(token: String, configuration: TunnelConfiguration) throws {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try IPCClient.start(session: session, token: token, configuration: configuration)
+    try IPCClient.start(session: requireSession(), token: token, configuration: configuration)
   }
 
   public func signOut() async throws {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.signOut(session: session)
+    try await IPCClient.signOut(session: requireSession())
   }
 
   public func clearLogs() async throws {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.clearLogs(session: session)
+    try await IPCClient.clearLogs(session: requireSession())
   }
 
   public func fetchFirezoneId() async throws -> String? {
-    guard let session = vpnManager?.session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    return try await IPCClient.fetchEncodedFirezoneId(session: session)
+    try await IPCClient.fetchEncodedFirezoneId(session: requireSession())
   }
 
   #if os(macOS)
     public func getLogFolderSize() async throws -> Int64 {
-      guard let session = vpnManager?.session() else {
-        throw VPNConfigurationManagerError.managerNotInitialized
-      }
-      return try await IPCClient.getLogFolderSize(session: session)
+      try await IPCClient.getLogFolderSize(session: requireSession())
     }
 
     public func exportLogs(fd: FileDescriptor) async throws {
-      guard let session = vpnManager?.session() else {
-        throw VPNConfigurationManagerError.managerNotInitialized
-      }
-      try await IPCClient.exportLogs(session: session, fd: fd)
+      try await IPCClient.exportLogs(session: requireSession(), fd: fd)
     }
 
     public func fetchLastDisconnectError(handler: @escaping @Sendable (Error?) -> Void) {
-      guard let session = vpnManager?.session() else { return }
-      session.fetchLastDisconnectError(completionHandler: handler)
+      vpnManager?.session()?.fetchLastDisconnectError(completionHandler: handler)
     }
   #endif
 
@@ -147,5 +116,21 @@ public final class RealTunnelController: TunnelControllerProtocol {
         }
       }
     }
+  }
+
+  // MARK: - Private
+
+  private func requireManager() throws -> VPNConfigurationManager {
+    guard let vpnManager else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    return vpnManager
+  }
+
+  private func requireSession() throws -> NETunnelProviderSession {
+    guard let session = try requireManager().session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    return session
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/RealTunnelController.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/RealTunnelController.swift
@@ -1,0 +1,151 @@
+//
+//  RealTunnelController.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import NetworkExtension
+import SystemPackage
+
+/// Production implementation of TunnelControllerProtocol.
+///
+/// Wraps VPNConfigurationManager for lifecycle operations and delegates
+/// IPC operations to IPCClient static methods.
+@MainActor
+public final class RealTunnelController: TunnelControllerProtocol {
+  private var vpnManager: VPNConfigurationManager?
+
+  // Task consuming VPN status updates; its presence means observers are active.
+  private var vpnStatusTask: CancellableTask?
+
+  public init() {}
+
+  // MARK: - State
+
+  public var session: TunnelSessionProtocol? {
+    vpnManager?.session()
+  }
+
+  public var isLoaded: Bool {
+    vpnManager != nil
+  }
+
+  // MARK: - Lifecycle
+
+  public func load() async throws -> Bool {
+    if let manager = try await VPNConfigurationManager.load() {
+      try await manager.maybeMigrateConfiguration()
+      self.vpnManager = manager
+      return true
+    }
+    return false
+  }
+
+  public func enable() async throws {
+    guard let manager = vpnManager else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try await manager.enable()
+  }
+
+  public func installConfiguration() async throws {
+    self.vpnManager = try await VPNConfigurationManager()
+  }
+
+  // MARK: - IPC Operations
+
+  public func fetchResources(currentHash: Data) async throws -> Data? {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    return try await IPCClient.fetchState(session: session, currentHash: currentHash)
+  }
+
+  public func setConfiguration(_ config: TunnelConfiguration) async throws {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try await IPCClient.setConfiguration(session: session, config)
+  }
+
+  public func start(configuration: TunnelConfiguration) throws {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try IPCClient.start(session: session, configuration: configuration)
+  }
+
+  public func start(token: String, configuration: TunnelConfiguration) throws {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try IPCClient.start(session: session, token: token, configuration: configuration)
+  }
+
+  public func signOut() async throws {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try await IPCClient.signOut(session: session)
+  }
+
+  public func clearLogs() async throws {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try await IPCClient.clearLogs(session: session)
+  }
+
+  public func fetchFirezoneId() async throws -> String? {
+    guard let session = vpnManager?.session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    return try await IPCClient.fetchEncodedFirezoneId(session: session)
+  }
+
+  #if os(macOS)
+    public func getLogFolderSize() async throws -> Int64 {
+      guard let session = vpnManager?.session() else {
+        throw VPNConfigurationManagerError.managerNotInitialized
+      }
+      return try await IPCClient.getLogFolderSize(session: session)
+    }
+
+    public func exportLogs(fd: FileDescriptor) async throws {
+      guard let session = vpnManager?.session() else {
+        throw VPNConfigurationManagerError.managerNotInitialized
+      }
+      try await IPCClient.exportLogs(session: session, fd: fd)
+    }
+
+    public func fetchLastDisconnectError(handler: @escaping @Sendable (Error?) -> Void) {
+      guard let session = vpnManager?.session() else { return }
+      session.fetchLastDisconnectError(completionHandler: handler)
+    }
+  #endif
+
+  // MARK: - Status
+
+  public func stop() {
+    session?.stopTunnel()
+  }
+
+  public func subscribeToStatusUpdates(
+    handler: @escaping @Sendable (NEVPNStatus) async throws -> Void
+  ) {
+    guard vpnStatusTask == nil else {
+      Log.debug("Status observers already active, skipping")
+      return
+    }
+    guard let session = vpnManager?.session() else { return }
+    let statusStream = IPCClient.vpnStatusUpdates(session: session)
+    vpnStatusTask = CancellableTask {
+      for await status in statusStream {
+        do { try await handler(status) } catch {
+          Log.error(error)
+        }
+      }
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -27,9 +27,13 @@ enum VPNConfigurationManagerError: Error {
 public final class VPNConfigurationManager {
   let manager: NETunnelProviderManager
 
-  // App cannot run without bundle identifier - force unwrap is safe
-  // swiftlint:disable:next force_unwrapping
-  public static let bundleIdentifier: String = "\(Bundle.main.bundleIdentifier!).network-extension"
+  nonisolated public static var bundleIdentifier: String {
+    guard let mainBundleId = Bundle.main.bundleIdentifier else {
+      // Return a placeholder for test environment where main bundle has no identifier
+      return "dev.firezone.firezone.network-extension"
+    }
+    return "\(mainBundleId).network-extension"
+  }
   static let bundleDescription = "Firezone"
 
   // Initialize and save a new VPN configuration in system Preferences

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -112,6 +112,7 @@ public final class VPNConfigurationManager {
     let configuration = Configuration.shared
 
     if let actorName = legacyConfiguration["actorName"] {
+      // swiftlint:disable:next no_userdefaults_standard - legacy migration, runs before DI is available
       UserDefaults.standard.set(actorName, forKey: "actorName")
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -119,6 +119,7 @@ public class Configuration: ObservableObject {
 
   private var defaults: UserDefaults
 
+  // swiftlint:disable:next no_userdefaults_standard - DI entry point
   init(userDefaults: UserDefaults = UserDefaults.standard) {
     defaults = userDefaults
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
@@ -34,6 +34,7 @@ public final class Favorites: ObservableObject {
     return ids.isEmpty
   }
 
+  // swiftlint:disable no_userdefaults_standard - standalone model, not DI-managed
   private func save() {
     // It's a run-time exception if we pass the `Set` directly here
     let ids = Array(ids)
@@ -42,6 +43,7 @@ public final class Favorites: ObservableObject {
 
   private static func load() -> Set<String> {
     if let ids = UserDefaults.standard.stringArray(forKey: key) {
+    // swiftlint:enable no_userdefaults_standard
       return Set(ids)
     }
     return []

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
@@ -3,9 +3,11 @@ import Foundation
 public final class Favorites: ObservableObject {
   private static let key = "favoriteResourceIDs"
   private var ids: Set<String>
+  private let userDefaults: UserDefaults
 
-  public init() {
-    ids = Favorites.load()
+  public init(userDefaults: UserDefaults = .standard) {
+    self.userDefaults = userDefaults
+    ids = Self.load(from: userDefaults)
   }
 
   func contains(_ id: String) -> Bool {
@@ -34,16 +36,14 @@ public final class Favorites: ObservableObject {
     return ids.isEmpty
   }
 
-  // swiftlint:disable no_userdefaults_standard - standalone model, not DI-managed
   private func save() {
     // It's a run-time exception if we pass the `Set` directly here
     let ids = Array(ids)
-    UserDefaults.standard.set(ids, forKey: Favorites.key)
+    userDefaults.set(ids, forKey: Favorites.key)
   }
 
-  private static func load() -> Set<String> {
-    if let ids = UserDefaults.standard.stringArray(forKey: key) {
-      // swiftlint:enable no_userdefaults_standard
+  private static func load(from userDefaults: UserDefaults) -> Set<String> {
+    if let ids = userDefaults.stringArray(forKey: key) {
       return Set(ids)
     }
     return []

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
@@ -43,7 +43,7 @@ public final class Favorites: ObservableObject {
 
   private static func load() -> Set<String> {
     if let ids = UserDefaults.standard.stringArray(forKey: key) {
-    // swiftlint:enable no_userdefaults_standard
+      // swiftlint:enable no_userdefaults_standard
       return Set(ids)
     }
     return []

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelControllerProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelControllerProtocol.swift
@@ -1,0 +1,79 @@
+//
+//  TunnelControllerProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import NetworkExtension
+import SystemPackage
+
+/// Unified tunnel control and IPC protocol.
+///
+/// This protocol abstracts all VPN tunnel management and IPC operations that Store needs,
+/// enabling dependency injection for testing without a real VPN configuration.
+/// Production uses `RealTunnelController`, tests use `MockTunnelController`.
+@MainActor
+public protocol TunnelControllerProtocol {
+  // MARK: - State
+
+  var session: TunnelSessionProtocol? { get }
+  var isLoaded: Bool { get }
+
+  // MARK: - Lifecycle
+
+  /// Loads an existing VPN configuration if available.
+  /// - Returns: `true` if a configuration was loaded, `false` if none exists.
+  func load() async throws -> Bool
+
+  /// Enables the VPN configuration.
+  func enable() async throws
+
+  /// Creates and installs a new VPN configuration.
+  func installConfiguration() async throws
+
+  // MARK: - IPC Operations
+
+  /// Fetches resources from the tunnel provider.
+  /// - Parameter currentHash: Hash of the current resource list for optimization.
+  /// - Returns: Resource data if changed, `nil` if unchanged.
+  /// - Throws: Error if tunnel communication fails.
+  func fetchResources(currentHash: Data) async throws -> Data?
+
+  /// Sends configuration to the tunnel provider.
+  func setConfiguration(_ config: TunnelConfiguration) async throws
+
+  /// Starts the tunnel without authentication.
+  func start(configuration: TunnelConfiguration) throws
+
+  /// Starts the tunnel with an authentication token.
+  func start(token: String, configuration: TunnelConfiguration) throws
+
+  /// Signs out and disconnects the tunnel.
+  func signOut() async throws
+
+  /// Clears tunnel logs.
+  func clearLogs() async throws
+
+  /// Fetches the encoded Firezone ID from the tunnel provider.
+  func fetchFirezoneId() async throws -> String?
+
+  #if os(macOS)
+    /// Gets the total size of the tunnel provider's log folder.
+    func getLogFolderSize() async throws -> Int64
+
+    /// Exports tunnel provider logs to the given file descriptor.
+    func exportLogs(fd: FileDescriptor) async throws
+
+    /// Fetches the last disconnect error from the tunnel session.
+    func fetchLastDisconnectError(handler: @escaping @Sendable (Error?) -> Void)
+  #endif
+
+  // MARK: - Status
+
+  /// Stops the tunnel.
+  func stop()
+
+  /// Subscribes to VPN status updates.
+  func subscribeToStatusUpdates(handler: @escaping @Sendable (NEVPNStatus) async throws -> Void)
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  TunnelSessionProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import NetworkExtension
+
+/// Abstracts NETunnelProviderSession for testing.
+///
+/// This protocol enables dependency injection in Store, allowing tests to
+/// simulate VPN status changes without requiring a real Network Extension.
+public protocol TunnelSessionProtocol: AnyObject {
+  var status: NEVPNStatus { get }
+  func stopTunnel()
+}
+
+// Default conformance for real session
+extension NETunnelProviderSession: TunnelSessionProtocol {}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/UpdateCheckerProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/UpdateCheckerProtocol.swift
@@ -7,11 +7,12 @@
 #if os(macOS)
   import Combine
 
-  /// Abstracts update checking for testing.
+  /// Abstracts update checking to support dependency injection.
   ///
-  /// This protocol enables dependency injection in Store, allowing tests to
-  /// run without accessing UNUserNotificationCenter which crashes in test context.
-  /// Production uses `UpdateChecker`, tests use `MockUpdateChecker`.
+  /// In production, `UpdateChecker` uses `UNUserNotificationCenter` indirectly
+  /// via `NotificationAdapter`, which can crash in test contexts.
+  /// By depending on this protocol, tests can inject `MockUpdateChecker` to
+  /// avoid that indirect `UNUserNotificationCenter` access.
   @MainActor
   public protocol UpdateCheckerProtocol: AnyObject, ObservableObject {
     var updateAvailable: Bool { get }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/UpdateCheckerProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/UpdateCheckerProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  UpdateCheckerProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import Combine
+
+  /// Abstracts update checking for testing.
+  ///
+  /// This protocol enables dependency injection in Store, allowing tests to
+  /// run without accessing UNUserNotificationCenter which crashes in test context.
+  /// Production uses `UpdateChecker`, tests use `MockUpdateChecker`.
+  @MainActor
+  public protocol UpdateCheckerProtocol: AnyObject, ObservableObject {
+    var updateAvailable: Bool { get }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -412,7 +412,7 @@ public final class Store: ObservableObject {
 
   private func fetchAndCacheFirezoneId() {
     // Skip IPC if we already have a cached Firezone ID for this session
-    if UserDefaults.standard.string(forKey: "encodedFirezoneId") != nil {
+    if userDefaults.string(forKey: "encodedFirezoneId") != nil {
       return
     }
 
@@ -421,7 +421,7 @@ public final class Store: ObservableObject {
         guard let firezoneId = try await tunnelController.fetchFirezoneId()
         else { return }
 
-        UserDefaults.standard.set(firezoneId, forKey: "encodedFirezoneId")
+        userDefaults.set(firezoneId, forKey: "encodedFirezoneId")
         Telemetry.setUser(firezoneId: firezoneId, accountSlug: configuration.accountSlug)
       } catch {
         Log.error(error)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -7,6 +7,7 @@
 import Combine
 import NetworkExtension
 import OSLog
+import SystemPackage
 import UserNotifications
 
 #if os(macOS)
@@ -39,6 +40,8 @@ public final class Store: ObservableObject {
     @Published public var menuBarOpenRequested = false
   #endif
 
+  /// Session notification handler. Production uses real implementation,
+  /// tests inject MockSessionNotification.
   private(set) var sessionNotification: SessionNotificationProtocol
   #if os(macOS)
     let updateChecker: UpdateChecker
@@ -49,41 +52,57 @@ public final class Store: ObservableObject {
   private var stateUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
   private var lastSavedConfiguration: TunnelConfiguration?
-  private var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
 
   // Track which session expired alerts have been shown to prevent duplicates
-  private var shownAlertIds: Set<String>
+  // Internal for @testable access
+  var shownAlertIds: Set<String>
 
   // Track which unreachable resource notifications we have already shown
   private var unreachableResources: Set<UnreachableResource> = []
 
-  // Task consuming VPN status updates; its presence means observers are active.
-  private var vpnStatusTask: CancellableTask?
+  /// UserDefaults instance for persisting GUI state.
+  /// Injected for testability; defaults to `.standard` in production.
+  private let userDefaults: UserDefaults
+
+  // MARK: - Dependency Injection
+
+  /// Tunnel controller for all VPN and IPC operations.
+  /// Production uses RealTunnelController, tests inject MockTunnelController.
+  private let tunnelController: TunnelControllerProtocol
 
   #if os(macOS)
     public init(
       configuration: Configuration? = nil,
+      tunnelController: TunnelControllerProtocol = RealTunnelController(),
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
-      systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil
+      systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
+      userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
       self.updateChecker = UpdateChecker(configuration: configuration)
+      self.tunnelController = tunnelController
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
-      self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
-      self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
+      self.userDefaults = userDefaults
+      self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
+      self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
     }
   #else
     public init(
       configuration: Configuration? = nil,
-      sessionNotification: SessionNotificationProtocol = SessionNotification()
+      tunnelController: TunnelControllerProtocol = RealTunnelController(),
+      sessionNotification: SessionNotificationProtocol = SessionNotification(),
+      userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
+      self.tunnelController = tunnelController
       self.sessionNotification = sessionNotification
-      self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
-      self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
+      self.userDefaults = userDefaults
+      self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
+      self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
+
       self.postInit()
     }
   #endif
@@ -92,37 +111,6 @@ public final class Store: ObservableObject {
     self.sessionNotification.signInHandler = {
       do { try await WebAuthSession.signIn(store: self) } catch { Log.error(error) }
     }
-
-    // We monitor for any configuration changes and tell the tunnel service about them
-    self.configuration.objectWillChange
-      .receive(on: DispatchQueue.main)
-      .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)  // These happen quite frequently
-      .sink(receiveValue: { [weak self] _ in
-        guard let self = self else { return }
-        let current = self.configuration.toTunnelConfiguration()
-
-        if self.vpnConfigurationManager == nil {
-          // No manager yet, nothing to update
-          return
-        }
-
-        if self.lastSavedConfiguration == current {
-          // No changes
-          return
-        }
-
-        self.lastSavedConfiguration = current
-
-        Task {
-          do {
-            guard let session = try self.manager().session() else { return }
-            try await IPCClient.setConfiguration(session: session, current)
-          } catch {
-            Log.error(error)
-          }
-        }
-      })
-      .store(in: &cancellables)
 
     // Forward favorites changes to Store's objectWillChange so SwiftUI redraws.
     // This is necessary because Favorites is a separate ObservableObject, and SwiftUI
@@ -147,12 +135,45 @@ public final class Store: ObservableObject {
       }
       .store(in: &cancellables)
 
+    // Monitor configuration changes and propagate to tunnel service
+    setupConfigurationObserver()
+
     // Load our state from the system. Based on what's loaded, we may need to ask the user for permission for things.
     // When everything loads correctly, we attempt to start the tunnel if connectOnStart is enabled.
     Task {
       await startupSequence()
       await initNotifications()
     }
+  }
+
+  // MARK: - Configuration Observer
+
+  /// Sets up the configuration change observer with debouncing.
+  private func setupConfigurationObserver() {
+    self.configuration.objectWillChange
+      .receive(on: DispatchQueue.main)
+      .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)  // These happen quite frequently
+      .sink(receiveValue: { [weak self] _ in
+        guard let self = self else { return }
+        let current = self.configuration.toTunnelConfiguration()
+
+        if self.lastSavedConfiguration == current {
+          // No changes
+          return
+        }
+
+        self.lastSavedConfiguration = current
+
+        Task {
+          do {
+            try await self.tunnelController.setConfiguration(current)
+          } catch {
+            // Tunnel controller not ready yet - this is expected during startup
+            Log.debug("Config change ignored: \(error)")
+          }
+        }
+      })
+      .store(in: &cancellables)
   }
 
   #if os(macOS)
@@ -193,30 +214,6 @@ public final class Store: ObservableObject {
     }
   #endif
 
-  private func setupTunnelObservers() async throws {
-    guard vpnStatusTask == nil else {
-      Log.debug("Tunnel observers already set up, skipping")
-      return
-    }
-
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-
-    let statusStream = IPCClient.vpnStatusUpdates(session: session)
-
-    vpnStatusTask = CancellableTask { [weak self] in
-      for await status in statusStream {
-        do { try await self?.handleVPNStatusChange(newVPNStatus: status) } catch {
-          Log.error(error)
-        }
-      }
-    }
-
-    // Handle initial status to ensure resources start loading if already connected
-    try await handleVPNStatusChange(newVPNStatus: session.status)
-  }
-
   private func handleVPNStatusChange(newVPNStatus: NEVPNStatus) async throws {
     self.vpnStatus = newVPNStatus
 
@@ -231,25 +228,22 @@ public final class Store: ObservableObject {
       // On macOS we must show notifications from the UI process. On iOS, we've already initiated the notification
       // from the tunnel process, because the UI process is not guaranteed to be alive.
       if vpnStatus == .disconnected {
-        do {
-          try manager().session()?.fetchLastDisconnectError { error in
-            if let nsError = error as NSError?,
-              nsError.domain == ConnlibError.errorDomain,
-              nsError.code == 0,  // sessionExpired error code
-              let reason = nsError.userInfo["reason"] as? String,
-              let id = nsError.userInfo["id"] as? String
-            {
-              // Only show the alert if we haven't shown this specific error before
-              Task { @MainActor in
-                if !self.shownAlertIds.contains(id) {
-                  await self.sessionNotification.showSignedOutAlertMacOS(reason)
-                  self.markAlertAsShown(id)
-                }
+        tunnelController.fetchLastDisconnectError { [weak self] error in
+          guard let self = self else { return }
+          if let nsError = error as NSError?,
+            nsError.domain == ConnlibError.errorDomain,
+            nsError.code == 0,  // sessionExpired error code
+            let reason = nsError.userInfo["reason"] as? String,
+            let id = nsError.userInfo["id"] as? String
+          {
+            // Only show the alert if we haven't shown this specific error before
+            Task { @MainActor in
+              if !self.shownAlertIds.contains(id) {
+                await self.sessionNotification.showSignedOutAlertMacOS(reason)
+                self.markAlertAsShown(id)
               }
             }
           }
-        } catch {
-          Log.error(error)
         }
       }
 
@@ -333,38 +327,35 @@ public final class Store: ObservableObject {
   }
 
   private func initVPNConfiguration() async throws {
-    // Try to load existing configuration
-    if let manager = try await VPNConfigurationManager.load() {
-      try await manager.maybeMigrateConfiguration()
-      self.vpnConfigurationManager = manager
-    } else {
+    // Try to load existing configuration via the tunnel controller
+    let loaded = try await tunnelController.load()
+    if !loaded {
       self.vpnStatus = .invalid
+    }
+  }
+
+  private func setupTunnelObservers() async throws {
+    // Subscribe to status updates - must be called after load() so the session exists
+    tunnelController.subscribeToStatusUpdates { [weak self] status in
+      try await self?.handleVPNStatusChange(newVPNStatus: status)
+    }
+
+    // Handle initial status to ensure resources start loading if already connected
+    if let initialStatus = tunnelController.session?.status {
+      try await handleVPNStatusChange(newVPNStatus: initialStatus)
     }
   }
 
   private func maybeAutoConnect() async throws {
     if configuration.connectOnStart {
-      try await manager().enable()
-      guard let session = try manager().session() else {
-        throw VPNConfigurationManagerError.managerNotInitialized
-      }
-      try IPCClient.start(session: session, configuration: configuration.toTunnelConfiguration())
+      try await tunnelController.enable()
+      try tunnelController.start(configuration: configuration.toTunnelConfiguration())
     }
   }
+
   func installVPNConfiguration() async throws {
     // Create a new VPN configuration in system settings.
-    self.vpnConfigurationManager = try await VPNConfigurationManager()
-
-    try await setupTunnelObservers()
-  }
-
-  func manager() throws -> VPNConfigurationManager {
-    guard let vpnConfigurationManager
-    else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-
-    return vpnConfigurationManager
+    try await tunnelController.installConfiguration()
   }
 
   func grantNotifications() async throws {
@@ -372,11 +363,7 @@ public final class Store: ObservableObject {
   }
 
   public func stop() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-
-    session.stopTunnel()
+    tunnelController.stop()
   }
 
   func signIn(authResponse: AuthResponse) async throws {
@@ -385,42 +372,39 @@ public final class Store: ObservableObject {
 
     // This is only shown in the GUI, cache it here
     self.actorName = actorName
-    UserDefaults.standard.set(actorName, forKey: "actorName")
+    userDefaults.set(actorName, forKey: "actorName")
 
     configuration.accountSlug = accountSlug
 
-    try await manager().enable()
-
     // Clear shown alerts when starting a new session so user can see new errors
     shownAlertIds.removeAll()
-    UserDefaults.standard.removeObject(forKey: "shownAlertIds")
+    userDefaults.removeObject(forKey: "shownAlertIds")
 
     // Clear notified unreachable resources for fresh session
     unreachableResources.removeAll()
 
-    // Bring the tunnel up and send it a token and configuration to start
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try IPCClient.start(
-      session: session, token: authResponse.token,
-      configuration: configuration.toTunnelConfiguration()
-    )
+    // Enable and start the tunnel with the auth token
+    try await tunnelController.enable()
+    try tunnelController.start(token: authResponse.token, configuration: configuration.toTunnelConfiguration())
   }
 
   func signOut() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.signOut(session: session)
+    try await tunnelController.signOut()
   }
 
   func clearLogs() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.clearLogs(session: session)
+    try await tunnelController.clearLogs()
   }
+
+  #if os(macOS)
+    func getLogFolderSize() async throws -> Int64 {
+      try await tunnelController.getLogFolderSize()
+    }
+
+    func exportLogs(fd: FileDescriptor) async throws {
+      try await tunnelController.exportLogs(fd: fd)
+    }
+  #endif
 
   // MARK: Private functions
 
@@ -432,8 +416,7 @@ public final class Store: ObservableObject {
 
     Task {
       do {
-        guard let session = try manager().session(),
-          let firezoneId = try await IPCClient.fetchEncodedFirezoneId(session: session)
+        guard let firezoneId = try await tunnelController.fetchFirezoneId()
         else { return }
 
         UserDefaults.standard.set(firezoneId, forKey: "encodedFirezoneId")
@@ -446,7 +429,7 @@ public final class Store: ObservableObject {
 
   private func markAlertAsShown(_ id: String) {
     shownAlertIds.insert(id)
-    UserDefaults.standard.set(Array(shownAlertIds), forKey: "shownAlertIds")
+    userDefaults.set(Array(shownAlertIds), forKey: "shownAlertIds")
   }
 
   // Network Extensions don't have a 2-way binding up to the GUI process,
@@ -459,6 +442,8 @@ public final class Store: ObservableObject {
     }
 
     // Define the Timer's closure
+    // Note: Strong capture of self is intentional - timer is invalidated in endUpdatingResources()
+    // when VPN disconnects, preventing retain cycles.
     let updateState: @Sendable (Timer) -> Void = { _ in
       Task {
         await MainActor.run {
@@ -466,8 +451,7 @@ public final class Store: ObservableObject {
           self.stateUpdateTask = Task {
             if !Task.isCancelled {
               do {
-                guard let session = try self.manager().session() else { return }
-                try await self.fetchState(session: session)
+                try await self.fetchResources()
               } catch let error as NSError {
                 // https://developer.apple.com/documentation/networkextension/nevpnerror-swift.struct/code
                 if error.domain == "NEVPNErrorDomain" && error.code == 1 {
@@ -509,16 +493,13 @@ public final class Store: ObservableObject {
   ///
   /// If the hash matches what the provider has, state is unchanged.
   /// Otherwise, fetches and caches the new state.
-  ///
-  /// - Parameter session: The tunnel provider session to communicate with
-  /// - Throws: IPCClient.Error if IPC communication fails
-  private func fetchState(session: NETunnelProviderSession) async throws {
+  /// Internal for `@testable` access.
+  func fetchResources() async throws {
     // Capture current hash before IPC call
     let currentHash = self.connlibStateHash
 
     // If no data returned, state hasn't changed - no update needed
-    guard let data = try await IPCClient.fetchState(session: session, currentHash: currentHash)
-    else {
+    guard let data = try await tunnelController.fetchResources(currentHash: currentHash) else {
       return
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -44,7 +44,7 @@ public final class Store: ObservableObject {
   /// tests inject MockSessionNotification.
   private(set) var sessionNotification: SessionNotificationProtocol
   #if os(macOS)
-    let updateChecker: UpdateChecker
+    let updateChecker: any UpdateCheckerProtocol
     private let systemExtensionManager: any SystemExtensionManagerProtocol
   #endif
 
@@ -76,11 +76,12 @@ public final class Store: ObservableObject {
       configuration: Configuration? = nil,
       tunnelController: TunnelControllerProtocol = RealTunnelController(),
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
+      updateChecker: (any UpdateCheckerProtocol)? = nil,
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
-      self.updateChecker = UpdateChecker(configuration: configuration)
+      self.updateChecker = updateChecker ?? UpdateChecker(configuration: configuration)
       self.tunnelController = tunnelController
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -386,7 +386,8 @@ public final class Store: ObservableObject {
 
     // Enable and start the tunnel with the auth token
     try await tunnelController.enable()
-    try tunnelController.start(token: authResponse.token, configuration: configuration.toTunnelConfiguration())
+    try tunnelController.start(
+      token: authResponse.token, configuration: configuration.toTunnelConfiguration())
   }
 
   func signOut() async throws {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -19,7 +19,7 @@ import UserNotifications
 // TODO: Move some state logic to view models
 public final class Store: ObservableObject {
   @Published private(set) var actorName: String
-  @Published private(set) var favorites = Favorites()
+  @Published private(set) var favorites: Favorites
   @Published private(set) var resourceList: ResourceList = .loading
 
   // Encapsulate Tunnel status here to make it easier for other components to observe
@@ -86,6 +86,7 @@ public final class Store: ObservableObject {
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
       self.userDefaults = userDefaults
+      self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
       self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
@@ -101,6 +102,7 @@ public final class Store: ObservableObject {
       self.tunnelController = tunnelController
       self.sessionNotification = sessionNotification
       self.userDefaults = userDefaults
+      self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
       self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
 
@@ -139,8 +141,8 @@ public final class Store: ObservableObject {
     // Monitor configuration changes and propagate to tunnel service
     setupConfigurationObserver()
 
-    // Load our state from the system. Based on what's loaded, we may need to ask the user for permission for things.
-    // When everything loads correctly, we attempt to start the tunnel if connectOnStart is enabled.
+    // Run the startup sequence: configure telemetry, check system extension (macOS),
+    // load VPN configuration, set up observers, and auto-connect if enabled.
     Task {
       await startupSequence()
       await initNotifications()
@@ -443,10 +445,9 @@ public final class Store: ObservableObject {
       return
     }
 
-    // Define the Timer's closure
-    // Note: Strong capture of self is intentional - timer is invalidated in endUpdatingResources()
+    // Note: Strong capture of self is intentional — timer is invalidated in endUpdatingState()
     // when VPN disconnects, preventing retain cycles.
-    let updateState: @Sendable (Timer) -> Void = { _ in
+    let updateState: @Sendable (Timer) -> Void = { [self] _ in
       Task {
         await MainActor.run {
           self.stateUpdateTask?.cancel()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -79,9 +79,11 @@ public struct AppView: View {
       }
     }
 
+    // swiftlint:disable no_userdefaults_standard - view-layer one-shot check
     private static func launchedBefore() -> Bool {
       let bool = UserDefaults.standard.bool(forKey: "launchedBefore")
       UserDefaults.standard.set(true, forKey: "launchedBefore")
+      // swiftlint:enable no_userdefaults_standard
 
       return bool
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -622,12 +622,9 @@ public struct SettingsView: View {
 
         Task {
           do {
-            guard let session = try store.manager().session() else {
-              throw VPNConfigurationManagerError.managerNotInitialized
-            }
             try await LogExporter.export(
               to: destinationURL,
-              session: session
+              store: store
             )
 
             window.contentViewController?.presentingViewController?.dismiss(self)
@@ -710,10 +707,7 @@ public struct SettingsView: View {
 
     do {
       #if os(macOS)
-        guard let session = try store.manager().session() else {
-          throw VPNConfigurationManagerError.managerNotInitialized
-        }
-        let providerLogFolderSize = try await IPCClient.getLogFolderSize(session: session)
+        let providerLogFolderSize = try await store.getLogFolderSize()
         let totalSize = logFolderSize + providerLogFolderSize
       #else
         let totalSize = logFolderSize

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -253,6 +253,7 @@
     loadVersion(key: lastNotifiedVersionKey)
   }
 
+  // swiftlint:disable no_userdefaults_standard - view-layer update notification state
   func setVersion(key: String, version: SemanticVersion) {
     let encoder = PropertyListEncoder()
 
@@ -268,6 +269,7 @@
     let decoder = PropertyListDecoder()
 
     guard let data = UserDefaults.standard.object(forKey: lastDismissedVersionKey) as? Data
+    // swiftlint:enable no_userdefaults_standard
     else { return nil }
 
     do {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -11,7 +11,7 @@
   import Cocoa
 
   @MainActor
-  class UpdateChecker {
+  class UpdateChecker: UpdateCheckerProtocol {
     enum UpdateError: Error {
       case invalidVersion(String)
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockSessionNotification.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockSessionNotification.swift
@@ -1,0 +1,53 @@
+//
+//  MockSessionNotification.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import UserNotifications
+
+@testable import FirezoneKit
+
+/// Mock implementation of SessionNotificationProtocol for testing.
+///
+/// This mock allows tests to run without accessing UNUserNotificationCenter,
+/// which is unavailable in test context.
+@MainActor
+final class MockSessionNotification: SessionNotificationProtocol {
+  var signInHandler: () async -> Void = {}
+
+  // Tracking
+  var askUserForNotificationPermissionsCallCount = 0
+  var loadAuthorizationStatusCallCount = 0
+  var showSignedOutAlertCallCount = 0
+  var lastAlertMessage: String?
+  var showResourceNotificationCallCount = 0
+  var lastResourceNotificationTitle: String?
+  var lastResourceNotificationBody: String?
+
+  // Configurable responses
+  var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+  func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus {
+    askUserForNotificationPermissionsCallCount += 1
+    return authorizationStatus
+  }
+
+  func loadAuthorizationStatus() async -> UNAuthorizationStatus {
+    loadAuthorizationStatusCallCount += 1
+    return authorizationStatus
+  }
+
+  func showResourceNotification(title: String, body: String) async {
+    showResourceNotificationCallCount += 1
+    lastResourceNotificationTitle = title
+    lastResourceNotificationBody = body
+  }
+
+  #if os(macOS)
+    func showSignedOutAlertMacOS(_ message: String?) async {
+      showSignedOutAlertCallCount += 1
+      lastAlertMessage = message
+    }
+  #endif
+}

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockTunnelController.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockTunnelController.swift
@@ -67,12 +67,10 @@ final class MockTunnelController: TunnelControllerProtocol {
   var fetchResourcesSequence: [Data?] = []
   private var sequenceIndex = 0
 
-  /// Enable realistic hash-based behavior for fetchResources.
-  /// When true, the mock simulates the tunnel provider's hash comparison:
-  /// - Returns nil if the incoming hash matches the current response's hash
-  /// - Returns data if hashes differ
-  /// When false (default), returns fetchResourcesResponse directly (legacy behavior).
-  var simulateHashBehavior: Bool = false
+  /// When true, returns nil from `fetchResources` if the incoming hash matches the
+  /// response's hash (simulating the tunnel provider's "no changes" optimisation).
+  /// When false (default), always returns `fetchResourcesResponse` directly.
+  var enableHashBasedFiltering: Bool = false
   /// The last hash received from the client (for test inspection).
   private(set) var lastReceivedHash: Data?
 
@@ -139,7 +137,7 @@ final class MockTunnelController: TunnelControllerProtocol {
     }
 
     // When hash behavior is enabled, simulate realistic tunnel provider behavior
-    if simulateHashBehavior, let data = fetchResourcesResponse {
+    if enableHashBasedFiltering, let data = fetchResourcesResponse {
       let responseHash = Data(SHA256.hash(data: data))
       // Return nil if hashes match (no changes), data if different
       return currentHash == responseHash ? nil : data

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockTunnelController.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockTunnelController.swift
@@ -1,0 +1,266 @@
+//
+//  MockTunnelController.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import CryptoKit
+import Foundation
+import NetworkExtension
+import SystemPackage
+
+@testable import FirezoneKit
+
+// MARK: - Shared Test Helpers
+
+enum TestError: Error {
+  case simulatedFailure
+  case initializationTimeout
+}
+
+/// Mock tunnel controller for testing Store.
+///
+/// Combines tunnel control and IPC functionality in one mock,
+/// matching the unified TunnelControllerProtocol design.
+@MainActor
+final class MockTunnelController: TunnelControllerProtocol {
+  let mockSession = MockTunnelSession()
+
+  // MARK: - State
+
+  /// Returns the session only if load succeeded (matches real behavior)
+  var session: TunnelSessionProtocol? {
+    loadResult ? mockSession : nil
+  }
+  var isLoaded: Bool = true
+
+  // MARK: - Call Order Tracking
+
+  /// Records the order of method calls for verifying sequences.
+  enum CallType: Equatable {
+    case load
+    case enable
+    case start
+    case startWithToken(String)
+    case signOut
+    case setConfiguration
+    case fetchResources
+    case subscribeToStatusUpdates
+  }
+  private(set) var callLog: [CallType] = []
+
+  // MARK: - Lifecycle Tracking
+
+  var loadCallCount = 0
+  var loadResult: Bool = true
+  var enableCallCount = 0
+  var enableError: Error?
+  var installConfigurationCallCount = 0
+
+  // MARK: - IPC Tracking (merged from MockIPCClient)
+
+  var fetchResourcesResponse: Data?
+  var fetchResourcesError: Error?
+  var fetchResourcesCallCount = 0
+
+  /// When set, responses are returned in sequence. Once exhausted, falls back to fetchResourcesResponse.
+  var fetchResourcesSequence: [Data?] = []
+  private var sequenceIndex = 0
+
+  /// Enable realistic hash-based behavior for fetchResources.
+  /// When true, the mock simulates the tunnel provider's hash comparison:
+  /// - Returns nil if the incoming hash matches the current response's hash
+  /// - Returns data if hashes differ
+  /// When false (default), returns fetchResourcesResponse directly (legacy behavior).
+  var simulateHashBehavior: Bool = false
+  /// The last hash received from the client (for test inspection).
+  private(set) var lastReceivedHash: Data?
+
+  var setConfigurationCallCount = 0
+  var setConfigurationError: Error?
+  var lastConfiguration: TunnelConfiguration?
+  var startCallCount = 0
+  var startError: Error?
+  var lastStartToken: String?
+  var lastStartConfiguration: TunnelConfiguration?
+  var signOutCallCount = 0
+  var signOutError: Error?
+  var clearLogsCallCount = 0
+
+  var fetchFirezoneIdCallCount = 0
+  var fetchFirezoneIdResult: String?
+
+  #if os(macOS)
+    var getLogFolderSizeCallCount = 0
+    var getLogFolderSizeResult: Int64 = 0
+
+    var exportLogsCallCount = 0
+    var exportLogsError: Error?
+
+    var fetchLastDisconnectErrorCallCount = 0
+    var fetchLastDisconnectErrorResult: Error?
+  #endif
+
+  // MARK: - Status
+
+  var statusHandler: (@Sendable (NEVPNStatus) async throws -> Void)?
+
+  // MARK: - Lifecycle Implementations
+
+  func load() async throws -> Bool {
+    loadCallCount += 1
+    callLog.append(.load)
+    return loadResult
+  }
+
+  func enable() async throws {
+    enableCallCount += 1
+    callLog.append(.enable)
+    if let error = enableError { throw error }
+  }
+
+  func installConfiguration() async throws {
+    installConfigurationCallCount += 1
+  }
+
+  // MARK: - IPC Implementations
+
+  func fetchResources(currentHash: Data) async throws -> Data? {
+    fetchResourcesCallCount += 1
+    callLog.append(.fetchResources)
+    lastReceivedHash = currentHash
+    if let error = fetchResourcesError { throw error }
+
+    // If sequence is configured, use it
+    if sequenceIndex < fetchResourcesSequence.count {
+      let response = fetchResourcesSequence[sequenceIndex]
+      sequenceIndex += 1
+      return response
+    }
+
+    // When hash behavior is enabled, simulate realistic tunnel provider behavior
+    if simulateHashBehavior, let data = fetchResourcesResponse {
+      let responseHash = Data(SHA256.hash(data: data))
+      // Return nil if hashes match (no changes), data if different
+      return currentHash == responseHash ? nil : data
+    }
+
+    return fetchResourcesResponse
+  }
+
+  func setConfiguration(_ config: TunnelConfiguration) async throws {
+    setConfigurationCallCount += 1
+    callLog.append(.setConfiguration)
+    lastConfiguration = config
+    if let error = setConfigurationError { throw error }
+  }
+
+  func start(configuration: TunnelConfiguration) throws {
+    startCallCount += 1
+    callLog.append(.start)
+    lastStartConfiguration = configuration
+    if let error = startError { throw error }
+  }
+
+  func start(token: String, configuration: TunnelConfiguration) throws {
+    startCallCount += 1
+    callLog.append(.startWithToken(token))
+    lastStartToken = token
+    lastStartConfiguration = configuration
+    if let error = startError { throw error }
+  }
+
+  func signOut() async throws {
+    signOutCallCount += 1
+    callLog.append(.signOut)
+    if let error = signOutError { throw error }
+  }
+
+  func clearLogs() async throws {
+    clearLogsCallCount += 1
+  }
+
+  func fetchFirezoneId() async throws -> String? {
+    fetchFirezoneIdCallCount += 1
+    return fetchFirezoneIdResult
+  }
+
+  #if os(macOS)
+    func getLogFolderSize() async throws -> Int64 {
+      getLogFolderSizeCallCount += 1
+      return getLogFolderSizeResult
+    }
+
+    func exportLogs(fd: FileDescriptor) async throws {
+      exportLogsCallCount += 1
+      if let error = exportLogsError { throw error }
+    }
+
+    func fetchLastDisconnectError(handler: @escaping @Sendable (Error?) -> Void) {
+      fetchLastDisconnectErrorCallCount += 1
+      handler(fetchLastDisconnectErrorResult)
+    }
+  #endif
+
+  // MARK: - Status Implementations
+
+  func stop() {
+    mockSession.stopTunnel()
+  }
+
+  func subscribeToStatusUpdates(handler: @escaping @Sendable (NEVPNStatus) async throws -> Void) {
+    callLog.append(.subscribeToStatusUpdates)
+    statusHandler = handler
+  }
+
+  // MARK: - Test Helpers
+
+  /// Simulate a VPN status change.
+  func simulateStatusChange(_ status: NEVPNStatus) async throws {
+    mockSession.mockStatus = status
+    try await statusHandler?(status)
+  }
+
+  /// Reset the fetch resources sequence index (useful between test phases).
+  func resetFetchSequence() {
+    sequenceIndex = 0
+  }
+
+  /// Waits for Store initialization to complete (status handler registered).
+  ///
+  /// Call this after creating a Store via `makeMockStore()` before testing
+  /// status-dependent behavior like `simulateStatusChange()`.
+  func waitForStatusSubscription(timeout: TimeInterval = 1.0) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while statusHandler == nil && Date() < deadline {
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    guard statusHandler != nil else {
+      throw TestError.initializationTimeout
+    }
+  }
+}
+
+/// Mock tunnel session for testing.
+///
+/// Not isolated to MainActor to match NETunnelProviderSession's non-isolated methods.
+final class MockTunnelSession: TunnelSessionProtocol {
+  private let lock = NSLock()
+  private var _mockStatus: NEVPNStatus = .disconnected
+  private var _stopCallCount = 0
+
+  var mockStatus: NEVPNStatus {
+    get { lock.withLock { _mockStatus } }
+    set { lock.withLock { _mockStatus = newValue } }
+  }
+
+  var status: NEVPNStatus { mockStatus }
+
+  var stopCallCount: Int {
+    lock.withLock { _stopCallCount }
+  }
+
+  func stopTunnel() {
+    lock.withLock { _stopCallCount += 1 }
+  }
+}

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockUpdateChecker.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockUpdateChecker.swift
@@ -1,0 +1,17 @@
+//
+//  MockUpdateChecker.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import Combine
+
+  @testable import FirezoneKit
+
+  /// Mock implementation of UpdateCheckerProtocol for testing.
+  @MainActor
+  final class MockUpdateChecker: UpdateCheckerProtocol {
+    @Published var updateAvailable = false
+  }
+#endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSignInTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSignInTests.swift
@@ -1,0 +1,204 @@
+//
+//  StoreSignInTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import Testing
+
+@testable import FirezoneKit
+
+@Suite("Store Sign-In Tests")
+struct StoreSignInTests {
+
+  @Test("Token is passed to tunnel controller when signing in")
+  @MainActor
+  func tokenPassedToTunnelController() async throws {
+    let fixture = try await makeMockStore()
+
+    let authResponse = AuthResponse(
+      actorName: "Test Actor",
+      accountSlug: "test-account",
+      token: "secret-auth-token-12345"
+    )
+
+    try await fixture.store.signIn(authResponse: authResponse)
+
+    // Verify token was passed correctly (implies start was called)
+    #expect(fixture.controller.lastStartToken == "secret-auth-token-12345")
+  }
+
+  @Test("Actor name is saved after sign-in")
+  @MainActor
+  func actorNameSaved() async throws {
+    let fixture = try await makeMockStore()
+
+    // Initial state
+    #expect(fixture.store.actorName == "Unknown user")
+
+    let authResponse = AuthResponse(
+      actorName: "Alice Smith",
+      accountSlug: "acme-corp",
+      token: "token-xyz"
+    )
+
+    try await fixture.store.signIn(authResponse: authResponse)
+
+    #expect(fixture.store.actorName == "Alice Smith")
+  }
+
+  @Test("Shown alert IDs are cleared on sign-in")
+  @MainActor
+  func alertIdsClearedOnSignIn() async throws {
+    // Pre-populate shown alert IDs in UserDefaults before creating fixture
+    let defaults = makeTestDefaults()
+    defaults.set(["alert-1", "alert-2", "alert-3"], forKey: "shownAlertIds")
+
+    let config = Configuration(userDefaults: defaults)
+    let controller = MockTunnelController()
+    let notification = MockSessionNotification()
+
+    #if os(macOS)
+      let systemExtension = MockSystemExtensionManager()
+      let store = Store(
+        configuration: config,
+        tunnelController: controller,
+        sessionNotification: notification,
+        systemExtensionManager: systemExtension,
+        userDefaults: defaults
+      )
+    #else
+      let store = Store(
+        configuration: config,
+        tunnelController: controller,
+        sessionNotification: notification,
+        userDefaults: defaults
+      )
+    #endif
+
+    // Verify initial state has pre-populated alerts
+    #expect(store.shownAlertIds.isEmpty == false)
+
+    let authResponse = AuthResponse(
+      actorName: "Bob Jones",
+      accountSlug: "example-org",
+      token: "token-abc"
+    )
+
+    try await store.signIn(authResponse: authResponse)
+
+    // Alert IDs should be cleared for fresh session
+    #expect(store.shownAlertIds.isEmpty == true)
+  }
+
+  @Test("Account slug is saved to configuration on sign-in")
+  @MainActor
+  func accountSlugSaved() async throws {
+    let fixture = try await makeMockStore()
+
+    // Initial state
+    #expect(fixture.config.accountSlug.isEmpty)
+
+    let authResponse = AuthResponse(
+      actorName: "Charlie Brown",
+      accountSlug: "peanuts-inc",
+      token: "token-123"
+    )
+
+    try await fixture.store.signIn(authResponse: authResponse)
+
+    #expect(fixture.config.accountSlug == "peanuts-inc")
+  }
+
+  @Test("Enable is called before start on sign-in")
+  @MainActor
+  func enableCalledBeforeStart() async throws {
+    let fixture = try await makeMockStore()
+
+    let authResponse = AuthResponse(
+      actorName: "Test User",
+      accountSlug: "test-account",
+      token: "token-123"
+    )
+
+    try await fixture.store.signIn(authResponse: authResponse)
+
+    // Both enable and start were called in correct order
+    #expect(fixture.controller.enableCallCount == 1)
+    #expect(fixture.controller.startCallCount == 1)
+
+    // Verify enable comes before start in the call log
+    let enableIndex = fixture.controller.callLog.firstIndex(of: .enable)
+    let startIndex = fixture.controller.callLog.firstIndex(where: {
+      if case .startWithToken = $0 { return true }
+      return false
+    })
+    guard let enableIdx = enableIndex, let startIdx = startIndex else {
+      Issue.record("enable and start should both have been called")
+      return
+    }
+    #expect(enableIdx < startIdx, "enable must be called before start")
+  }
+
+  // MARK: - Error Path Tests
+
+  @Test("Sign-in throws when enable fails")
+  @MainActor
+  func signInThrowsWhenEnableFails() async throws {
+    let fixture = try await makeMockStore { controller, _ in
+      controller.enableError = TestError.simulatedFailure
+    }
+
+    let authResponse = AuthResponse(
+      actorName: "Test User",
+      accountSlug: "test-account",
+      token: "token-123"
+    )
+
+    await #expect(throws: TestError.self) {
+      try await fixture.store.signIn(authResponse: authResponse)
+    }
+
+    // enable was called but start was not (failed before start)
+    #expect(fixture.controller.enableCallCount == 1)
+    #expect(fixture.controller.startCallCount == 0)
+  }
+
+  @Test("Sign-in throws when start fails")
+  @MainActor
+  func signInThrowsWhenStartFails() async throws {
+    let fixture = try await makeMockStore { controller, _ in
+      controller.startError = TestError.simulatedFailure
+    }
+
+    let authResponse = AuthResponse(
+      actorName: "Test User",
+      accountSlug: "test-account",
+      token: "token-123"
+    )
+
+    await #expect(throws: TestError.self) {
+      try await fixture.store.signIn(authResponse: authResponse)
+    }
+
+    // both enable and start were called (failed during start)
+    #expect(fixture.controller.enableCallCount == 1)
+    #expect(fixture.controller.startCallCount == 1)
+  }
+
+  // MARK: - Sign-Out Tests
+
+  @Test("Sign-out throws when tunnel controller fails")
+  @MainActor
+  func signOutThrowsOnFailure() async throws {
+    let fixture = try await makeMockStore { controller, _ in
+      controller.signOutError = TestError.simulatedFailure
+    }
+
+    // Error should propagate from tunnel controller
+    await #expect(throws: TestError.self) {
+      try await fixture.store.signOut()
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSignInTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/StoreSignInTests.swift
@@ -65,6 +65,7 @@ struct StoreSignInTests {
         configuration: config,
         tunnelController: controller,
         sessionNotification: notification,
+        updateChecker: MockUpdateChecker(),
         systemExtensionManager: systemExtension,
         userDefaults: defaults
       )

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestHelpers.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestHelpers.swift
@@ -58,6 +58,7 @@ struct MockStoreFixture {
 
   #if os(macOS)
     let systemExtension: MockSystemExtensionManager
+    let updateChecker: MockUpdateChecker
   #endif
 }
 
@@ -78,10 +79,12 @@ func makeMockStore(
 
   #if os(macOS)
     let systemExtension = MockSystemExtensionManager()
+    let updateChecker = MockUpdateChecker()
     let store = Store(
       configuration: config,
       tunnelController: controller,
       sessionNotification: notification,
+      updateChecker: updateChecker,
       systemExtensionManager: systemExtension,
       userDefaults: defaults
     )
@@ -91,7 +94,8 @@ func makeMockStore(
       config: config,
       defaults: defaults,
       notification: notification,
-      systemExtension: systemExtension
+      systemExtension: systemExtension,
+      updateChecker: updateChecker
     )
   #else
     let store = Store(

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestHelpers.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestHelpers.swift
@@ -1,0 +1,124 @@
+//
+//  TestHelpers.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+
+@testable import FirezoneKit
+
+/// Creates an isolated UserDefaults suite for test isolation.
+///
+/// Each call returns a unique suite that won't interfere with other tests.
+func makeTestDefaults() -> UserDefaults {
+  let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
+  guard let defaults = UserDefaults(suiteName: suiteName) else {
+    fatalError("Failed to create UserDefaults suite: \(suiteName)")
+  }
+  defaults.removePersistentDomain(forName: suiteName)
+  return defaults
+}
+
+/// Creates a test Resource with default values for non-essential fields.
+func makeResource(
+  id: String = UUID().uuidString,
+  name: String = "Test Resource",
+  address: String? = "test.example.com",
+  type: ResourceType = .dns
+) -> Resource {
+  Resource(
+    id: id,
+    name: name,
+    address: address,
+    addressDescription: nil,
+    status: .online,
+    sites: [],
+    type: type
+  )
+}
+
+/// Encodes resources to PropertyList data.
+func encodeResources(_ resources: [Resource]) throws -> Data {
+  try PropertyListEncoder().encode(resources)
+}
+
+// MARK: - Mock Store Fixture
+
+/// Contains all components needed for Store tests.
+///
+/// Use `makeMockStore()` to create this fixture with sensible defaults.
+/// Access individual components to configure mocks or verify interactions.
+struct MockStoreFixture {
+  let store: Store
+  let controller: MockTunnelController
+  let config: Configuration
+  let defaults: UserDefaults
+  let notification: MockSessionNotification
+
+  #if os(macOS)
+    let systemExtension: MockSystemExtensionManager
+  #endif
+}
+
+/// Creates a fully mocked Store with all dependencies.
+///
+/// Waits for Store initialization to complete before returning,
+/// ensuring status handlers and Combine pipelines are ready.
+@MainActor
+func makeMockStore(
+  configure: ((MockTunnelController, Configuration) -> Void)? = nil
+) async throws -> MockStoreFixture {
+  let defaults = makeTestDefaults()
+  let config = Configuration(userDefaults: defaults)
+  let controller = MockTunnelController()
+  let notification = MockSessionNotification()
+
+  configure?(controller, config)
+
+  #if os(macOS)
+    let systemExtension = MockSystemExtensionManager()
+    let store = Store(
+      configuration: config,
+      tunnelController: controller,
+      sessionNotification: notification,
+      systemExtensionManager: systemExtension,
+      userDefaults: defaults
+    )
+    let fixture = MockStoreFixture(
+      store: store,
+      controller: controller,
+      config: config,
+      defaults: defaults,
+      notification: notification,
+      systemExtension: systemExtension
+    )
+  #else
+    let store = Store(
+      configuration: config,
+      tunnelController: controller,
+      sessionNotification: notification,
+      userDefaults: defaults
+    )
+    let fixture = MockStoreFixture(
+      store: store,
+      controller: controller,
+      config: config,
+      defaults: defaults,
+      notification: notification
+    )
+  #endif
+
+  // Wait for Store's async initialization to complete
+  try await controller.waitForStatusSubscription()
+
+  // Wait longer than the debounce window (0.3s) to ensure any
+  // initialization-triggered config changes have settled
+  try await Task.sleep(nanoseconds: 400_000_000)
+
+  // Reset the call count so tests start from a clean state
+  controller.setConfigurationCallCount = 0
+  controller.lastConfiguration = nil
+
+  return fixture
+}

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/VPNConfigurationManagerTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/VPNConfigurationManagerTests.swift
@@ -1,0 +1,54 @@
+//
+//  VPNConfigurationManagerTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import NetworkExtension
+import Testing
+
+@testable import FirezoneKit
+
+@Suite("VPNConfigurationManager Tests")
+struct VPNConfigurationManagerTests {
+
+  @Test("legacyConfiguration returns config when providerConfiguration has valid [String: String]")
+  func legacyConfigurationReturnsValidConfig() {
+    let proto = NETunnelProviderProtocol()
+    proto.providerConfiguration = [
+      "accountSlug": "test-account",
+      "authURL": "https://app.firezone.dev",
+    ]
+
+    let result = VPNConfigurationManager.legacyConfiguration(protocolConfiguration: proto)
+
+    #expect(result == ["accountSlug": "test-account", "authURL": "https://app.firezone.dev"])
+  }
+
+  @Test("legacyConfiguration returns nil when protocolConfiguration is nil")
+  func legacyConfigurationNilProtocol() {
+    let result = VPNConfigurationManager.legacyConfiguration(protocolConfiguration: nil)
+
+    #expect(result == nil)
+  }
+
+  @Test("legacyConfiguration returns nil when providerConfiguration is nil")
+  func legacyConfigurationNilProvider() {
+    let proto = NETunnelProviderProtocol()
+    proto.providerConfiguration = nil
+
+    let result = VPNConfigurationManager.legacyConfiguration(protocolConfiguration: proto)
+
+    #expect(result == nil)
+  }
+
+  @Test("legacyConfiguration returns nil when providerConfiguration has wrong value type")
+  func legacyConfigurationWrongType() {
+    let proto = NETunnelProviderProtocol()
+    proto.providerConfiguration = ["key": 42]
+
+    let result = VPNConfigurationManager.legacyConfiguration(protocolConfiguration: proto)
+
+    #expect(result == nil)
+  }
+}

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -30,6 +30,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
   private var logExportState: LogExportState = .idle
   private var tunnelConfiguration: TunnelConfiguration?
+  // swiftlint:disable:next no_userdefaults_standard
   private let defaults = UserDefaults.standard
 
   override init() {
@@ -104,6 +105,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     handleTokenSave(token)
 
     // The firezone id should be initialized by now
+    // swiftlint:disable:next no_userdefaults_standard
     guard let rawId = UserDefaults.standard.string(forKey: "firezoneId")
     else {
       completionHandler(PacketTunnelProviderError.firezoneIdIsInvalid)
@@ -243,6 +245,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           completionHandler?(connlibState)
         }
       case .getEncodedFirezoneId:
+        // swiftlint:disable:next no_userdefaults_standard
         guard let rawId = UserDefaults.standard.string(forKey: "firezoneId") else {
           Log.error(PacketTunnelProviderError.firezoneIdIsInvalid)
           completionHandler?(nil)
@@ -524,12 +527,14 @@ extension TunnelConfiguration {
       "internetResourceEnabled": internetResourceEnabled,
     ]
 
+    // swiftlint:disable:next no_userdefaults_standard
     UserDefaults.standard.set(dict, forKey: key)
   }
 
   static func tryLoad() -> TunnelConfiguration? {
     let key = "configurationCache"
 
+    // swiftlint:disable:next no_userdefaults_standard
     guard let dict = UserDefaults.standard.dictionary(forKey: key)
     else {
       return nil


### PR DESCRIPTION
Add protocol-based dependency injection to enable unit testing of Store.
This is a prerequisite for testing the SwiftUI as we cannot test the NetworkExtension or Apple APIs.

Protocols:
- TunnelControllerProtocol: lifecycle + IPC operations
- SystemExtensionManagerProtocol: system extension status checks
- SessionNotificationProtocol: notification center abstraction
- TunnelSessionProtocol: tunnel session interface

Production implementations:
- RealTunnelController wraps existing TunnelController logic

Mocks for testing:
- MockTunnelController, MockSystemExtensionManager, MockSessionNotification
- Thread-safe call tracking for verification

Store unit tests:
- StoreConfigurationTests: config propagation and debouncing
- StoreResourceFetchTests: hash-based resource fetching
- StoreResourceTimerTests: timer lifecycle on VPN status changes
- StoreSignInTests: sign-in flow and state management
- StoreObservabilityTests: full mock integration