### PR TITLE
chore: Separate apple linting task

### DIFF
--- a/swift/apple/mise-tasks/format.sh
+++ b/swift/apple/mise-tasks/format.sh
@@ -4,8 +4,5 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${SCRIPT_DIR}/.."
 
-echo "Auto-fixing SwiftLint violations..."
-swiftlint --fix
-
 echo "Formatting Swift code..."
 git ls-files '*.swift' | xargs swift format format --in-place --parallel

--- a/swift/apple/mise-tasks/lint.sh
+++ b/swift/apple/mise-tasks/lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+echo "Auto-fixing SwiftLint violations..."
+swiftlint --fix --config .swiftlint.yml
+
+echo "Running SwiftLint..."
+swiftlint lint --config .swiftlint.yml

--- a/swift/apple/mise.toml
+++ b/swift/apple/mise.toml
@@ -66,6 +66,11 @@ description = "Format Swift code"
 run = "./mise-tasks/format.sh"
 raw = true
 
+[tasks.lint]
+description = "Run SwiftLint on Swift code"
+run = "./mise-tasks/lint.sh"
+raw = true
+
 [tasks.check]
 description = "Check Swift code formatting and linting"
 run = "./mise-tasks/check.sh"


### PR DESCRIPTION
Turns out that `swiftlint` is inaccessible when called via xcode UI as it sanitises the environment in order to prevent malicious code execution during build.

Create a `mise run :lint` task instead for easy fixing linting issues.