### PR TITLE
fix(ci): always run mix dialyzer

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -89,7 +89,7 @@ jobs:
           restore-keys: dialyzer-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
 
       - name: Create PLTs
-        if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
+        # Always run to incrementally update PLT if restored from cache with different mix.lock
         run: mix dialyzer --plt
 
       - name: Save PLT cache


### PR DESCRIPTION
Fixes an issue where we're skip PLT generation since the `restore-keys` could pull in an old version of the PLT cache.

Related: https://github.com/firezone/firezone/actions/runs/20999274030/job/60364490006