### PR TITLE
fix(portal): use x-azure-geo-country header

### DIFF
--- a/elixir/lib/portal/geo.ex
+++ b/elixir/lib/portal/geo.ex
@@ -279,6 +279,15 @@ defmodule Portal.Geo do
   end
 
   def location_from_headers(headers) do
+    # Azure Front Door only provides country via {geo_country}.
+    # GCP provides country, city, and coordinates.
+    case get_header(headers, "x-azure-geo-country") do
+      nil -> location_from_gcp_headers(headers)
+      country -> {country, nil, maybe_put_default_coordinates(country, {nil, nil})}
+    end
+  end
+
+  defp location_from_gcp_headers(headers) do
     region = get_header(headers, "x-geo-location-region")
     city = get_header(headers, "x-geo-location-city")
 

--- a/elixir/test/portal/geo_test.exs
+++ b/elixir/test/portal/geo_test.exs
@@ -17,4 +17,50 @@ defmodule Portal.GeoTest do
       assert 5569 < distance and distance < 5571
     end
   end
+
+  describe "location_from_headers/1" do
+    test "returns country and default coordinates from Azure Front Door header" do
+      headers = [{"x-azure-geo-country", "US"}]
+
+      assert {country, city, coords} = location_from_headers(headers)
+      assert country == "US"
+      assert city == nil
+      # Falls back to US default coordinates
+      assert coords == {38.0, -97.0}
+    end
+
+    test "returns country, city, and coordinates from GCP headers" do
+      headers = [
+        {"x-geo-location-region", "US"},
+        {"x-geo-location-city", "Los Angeles"},
+        {"x-geo-location-coordinates", "34.0522,-118.2437"}
+      ]
+
+      assert {country, city, {lat, lon}} = location_from_headers(headers)
+      assert country == "US"
+      assert city == "Los Angeles"
+      assert lat == 34.0522
+      assert lon == -118.2437
+    end
+
+    test "prefers Azure header over GCP headers when both present" do
+      headers = [
+        {"x-azure-geo-country", "GB"},
+        {"x-geo-location-region", "US"},
+        {"x-geo-location-city", "Los Angeles"},
+        {"x-geo-location-coordinates", "34.0522,-118.2437"}
+      ]
+
+      assert {country, city, coords} = location_from_headers(headers)
+      assert country == "GB"
+      assert city == nil
+      # Falls back to GB default coordinates, not the GCP coords
+      assert coords == {54.0, -2.0}
+    end
+
+    test "returns nils when no geo headers present" do
+      headers = [{"x-other-header", "value"}]
+      assert {nil, nil, {nil, nil}} = location_from_headers(headers)
+    end
+  end
 end


### PR DESCRIPTION
Unfortunately Azure Front Door only gives us the two-letter country code. We need to use this and populate the lat/lon for that country which will be a very coarse location not ideal for routing decisions, but will get things working for now.

A follow up PR is being added to further refine these locations as a background job or async task decoupled from the request hot paths that we need these for.