### PR TITLE
fix(portal): don't crash on missing csp nonce

### DIFF
--- a/elixir/lib/portal_web/components/layouts/root.html.heex
+++ b/elixir/lib/portal_web/components/layouts/root.html.heex
@@ -16,20 +16,20 @@
     <link
       phx-track-static
       rel="stylesheet"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       href={~p"/assets/app.css"}
     />
     <link
       phx-track-static
       rel="stylesheet"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       href={~p"/assets/main.css"}
     />
     <script
       defer
       phx-track-static
       type="text/javascript"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       src={~p"/assets/app.js"}
     >
     </script>

--- a/elixir/lib/portal_web/controllers/error_html/404.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/404.html.heex
@@ -14,20 +14,20 @@
     <link
       phx-track-static
       rel="stylesheet"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       href={~p"/assets/app.css"}
     />
     <link
       phx-track-static
       rel="stylesheet"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       href={~p"/assets/main.css"}
     />
     <script
       defer
       phx-track-static
       type="text/javascript"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       src={~p"/assets/app.js"}
     >
     </script>

--- a/elixir/lib/portal_web/controllers/error_html/500.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/500.html.heex
@@ -14,20 +14,20 @@
     <link
       phx-track-static
       rel="stylesheet"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       href={~p"/assets/app.css"}
     />
     <link
       phx-track-static
       rel="stylesheet"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       href={~p"/assets/main.css"}
     />
     <script
       defer
       phx-track-static
       type="text/javascript"
-      nonce={@conn.private.csp_nonce}
+      nonce={@conn.private[:csp_nonce]}
       src={~p"/assets/app.js"}
     >
     </script>

--- a/elixir/lib/portal_web/controllers/sign_in_html.ex
+++ b/elixir/lib/portal_web/controllers/sign_in_html.ex
@@ -22,13 +22,13 @@ defmodule PortalWeb.SignInHTML do
         <link
           phx-track-static
           rel="stylesheet"
-          nonce={@conn.private.csp_nonce}
+          nonce={@conn.private[:csp_nonce]}
           href={~p"/assets/app.css"}
         />
         <link
           phx-track-static
           rel="stylesheet"
-          nonce={@conn.private.csp_nonce}
+          nonce={@conn.private[:csp_nonce]}
           href={~p"/assets/main.css"}
         />
       </head>

--- a/elixir/test/portal_web/controllers/error_html_test.exs
+++ b/elixir/test/portal_web/controllers/error_html_test.exs
@@ -19,4 +19,14 @@ defmodule PortalWeb.ErrorHTMLTest do
     assert body =~ "Something went wrong"
     assert body =~ "We've already been notified and will get it fixed as soon as possible"
   end
+
+  test "renders 404.html without csp_nonce", %{conn: conn} do
+    html = Phoenix.Template.render_to_string(PortalWeb.ErrorHTML, "404", "html", conn: conn)
+    assert html =~ "Sorry, we couldn't find this page"
+  end
+
+  test "renders 500.html without csp_nonce", %{conn: conn} do
+    html = Phoenix.Template.render_to_string(PortalWeb.ErrorHTML, "500", "html", conn: conn)
+    assert html =~ "Something went wrong"
+  end
 end


### PR DESCRIPTION
If some other error occurs in the Plug pipeline prior to putting the CSP nonce, we'll get a 500 error page that itself will 500 because the CSP nonce is missing.

To fix this and uncover the original error, we need a safe `[]` accessor for the nonce in case the private assigns don't have it.