### PR TITLE
fix(portal): SecureHeaders -> PutCSPHeader

### DIFF
--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -151,7 +151,7 @@ config :portal,
 
 config :phoenix_live_reload, :dirs, [File.cwd!()]
 
-config :portal, PortalWeb.Plugs.SecureHeaders,
+config :portal, PortalWeb.Plugs.PutCSPHeader,
   csp_policy: [
     "default-src 'self' 'nonce-${nonce}' https://firezone.statuspage.io",
     "img-src 'self' data: https://www.gravatar.com https://www.firezone.dev https://firezone.statuspage.io",

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -136,7 +136,7 @@ config :portal, PortalWeb.Endpoint,
   url: [port: 13_100],
   server: true
 
-config :portal, PortalWeb.Plugs.SecureHeaders,
+config :portal, PortalWeb.Plugs.PutCSPHeader,
   csp_policy: [
     "default-src 'self' 'nonce-${nonce}' https://firezone.statuspage.io",
     "img-src 'self' data: https://www.gravatar.com https://firezone.statuspage.io",


### PR DESCRIPTION
Fixes leftover typo from the Great Refactor that was affecting test and dev only.

The CSP header configuration had been moved into a dedicated plug.