### PR TITLE
fix(portal): fail open for region-based policy conditions

### DIFF
--- a/elixir/lib/portal/policies/evaluator.ex
+++ b/elixir/lib/portal/policies/evaluator.ex
@@ -34,6 +34,15 @@ defmodule Portal.Policies.Evaluator do
   defp min_expires_at(expires_at, min_expires_at),
     do: Enum.min([expires_at, min_expires_at], DateTime)
 
+  # When region is unknown (nil), geo-based policies should fail conservatively
+  def fetch_conformation_expiration(
+        %{property: :remote_ip_location_region},
+        %Client{last_seen_remote_ip_location_region: nil},
+        _auth_provider_id
+      ) do
+    :error
+  end
+
   def fetch_conformation_expiration(
         %{property: :remote_ip_location_region, operator: :is_in, values: values},
         %Client{} = client,

--- a/elixir/test/portal/policies/condition/evaluator_test.exs
+++ b/elixir/test/portal/policies/condition/evaluator_test.exs
@@ -228,6 +228,76 @@ defmodule Portal.Policies.EvaluatorTest do
   #  end
   # end
 
+  describe "fetch_conformation_expiration/3 with remote_ip_location_region" do
+    test "returns error when region is nil regardless of operator" do
+      client = %Portal.Client{last_seen_remote_ip_location_region: nil}
+
+      is_in_condition = %{
+        property: :remote_ip_location_region,
+        operator: :is_in,
+        values: ["US", "CA"]
+      }
+
+      is_not_in_condition = %{
+        property: :remote_ip_location_region,
+        operator: :is_not_in,
+        values: ["US", "CA"]
+      }
+
+      # Both should fail when region is unknown - conservative approach
+      assert fetch_conformation_expiration(is_in_condition, client, nil) == :error
+      assert fetch_conformation_expiration(is_not_in_condition, client, nil) == :error
+    end
+
+    test "returns ok when region matches is_in values" do
+      client = %Portal.Client{last_seen_remote_ip_location_region: "US"}
+
+      condition = %{
+        property: :remote_ip_location_region,
+        operator: :is_in,
+        values: ["US", "CA"]
+      }
+
+      assert fetch_conformation_expiration(condition, client, nil) == {:ok, nil}
+    end
+
+    test "returns error when region does not match is_in values" do
+      client = %Portal.Client{last_seen_remote_ip_location_region: "GB"}
+
+      condition = %{
+        property: :remote_ip_location_region,
+        operator: :is_in,
+        values: ["US", "CA"]
+      }
+
+      assert fetch_conformation_expiration(condition, client, nil) == :error
+    end
+
+    test "returns ok when region does not match is_not_in values" do
+      client = %Portal.Client{last_seen_remote_ip_location_region: "GB"}
+
+      condition = %{
+        property: :remote_ip_location_region,
+        operator: :is_not_in,
+        values: ["US", "CA"]
+      }
+
+      assert fetch_conformation_expiration(condition, client, nil) == {:ok, nil}
+    end
+
+    test "returns error when region matches is_not_in values" do
+      client = %Portal.Client{last_seen_remote_ip_location_region: "US"}
+
+      condition = %{
+        property: :remote_ip_location_region,
+        operator: :is_not_in,
+        values: ["US", "CA"]
+      }
+
+      assert fetch_conformation_expiration(condition, client, nil) == :error
+    end
+  end
+
   describe "find_day_of_the_week_time_range/2" do
     test "returns true when datetime is in the day of the week time ranges" do
       # Friday


### PR DESCRIPTION
When a client connects without any country-level IP information (which should be exceedingly rare, as both cloud providers populate this header), we would fail open in the country-level `is not in` condition. We fix that so that if the client region is `nil` and there is a region-based policy condition in effect, we conservatively fail open.