### PR TITLE
refactor(portal): rename req_options -> req_opts

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -69,7 +69,7 @@ config :portal, Portal.Billing,
 
 config :portal, Portal.Billing.Stripe.APIClient,
   endpoint: "https://api.stripe.com",
-  req_options: [
+  req_opts: [
     plug: {Req.Test, Portal.Billing.Stripe.APIClient},
     retry: false
   ]
@@ -84,7 +84,7 @@ config :portal, Portal.Entra.APIClient,
   client_secret: "test_client_secret",
   endpoint: "https://graph.microsoft.com",
   token_base_url: "https://login.microsoftonline.com",
-  req_options: [
+  req_opts: [
     plug: {Req.Test, Portal.Entra.APIClient},
     retry: false
   ]
@@ -97,7 +97,7 @@ config :portal, platform_adapter: Portal.GoogleCloudPlatform
 
 config :portal, Portal.GoogleCloudPlatform,
   service_account_email: "foo@iam.example.com",
-  req_options: [
+  req_opts: [
     plug: {Req.Test, Portal.GoogleCloudPlatform},
     retry: false
   ]
@@ -115,7 +115,7 @@ config :portal, Portal.ComponentVersions,
 config :portal, Portal.Google.APIClient,
   endpoint: "https://admin.googleapis.com",
   token_endpoint: "https://oauth2.googleapis.com/token",
-  req_options: [
+  req_opts: [
     retry: false,
     plug: {Req.Test, Portal.Google.APIClient}
   ]

--- a/elixir/lib/portal/billing/stripe/api_client.ex
+++ b/elixir/lib/portal/billing/stripe/api_client.ex
@@ -85,11 +85,11 @@ defmodule Portal.Billing.Stripe.APIClient do
       {"stripe-version", "2023-10-16"}
     ]
 
-    req_options =
+    req_opts =
       [method: method, url: url, headers: headers, body: body]
-      |> Keyword.merge(fetch_config(:req_options) || [])
+      |> Keyword.merge(fetch_config(:req_opts) || [])
 
-    case Req.request(req_options) do
+    case Req.request(req_opts) do
       {:ok, %Req.Response{status: status, body: response}} when status in 200..299 ->
         {:ok, response}
 

--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -24,14 +24,14 @@ defmodule Portal.Entra.APIClient do
         "grant_type" => "client_credentials"
       })
 
-    req_options = fetch_config(:req_options) || []
+    req_opts = fetch_config(:req_opts) || []
 
     Req.post(
       token_endpoint,
       [
         headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
         body: payload
-      ] ++ req_options
+      ] ++ req_opts
     )
   end
 
@@ -130,7 +130,7 @@ defmodule Portal.Entra.APIClient do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
     endpoint = config[:endpoint] || "https://graph.microsoft.com"
     url = "#{endpoint}/v1.0/$batch"
-    req_options = fetch_config(:req_options) || []
+    req_opts = fetch_config(:req_opts) || []
 
     require Logger
 
@@ -142,7 +142,7 @@ defmodule Portal.Entra.APIClient do
                {"Content-Type", "application/json"}
              ],
              json: batch_body
-           ] ++ req_options
+           ] ++ req_opts
          ) do
       {:ok, %Req.Response{status: 200, body: %{"responses" => responses}}} ->
         Logger.debug("Batch API response",
@@ -253,10 +253,10 @@ defmodule Portal.Entra.APIClient do
   defp get(path, query, access_token) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
     endpoint = config[:endpoint] || "https://graph.microsoft.com"
-    req_options = fetch_config(:req_options) || []
+    req_opts = fetch_config(:req_opts) || []
 
     url = "#{endpoint}#{path}?#{query}"
-    Req.get(url, [headers: [{"Authorization", "Bearer #{access_token}"}]] ++ req_options)
+    Req.get(url, [headers: [{"Authorization", "Bearer #{access_token}"}]] ++ req_opts)
   end
 
   defp stream_pages(path, query, access_token) do

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -38,14 +38,14 @@ defmodule Portal.Google.APIClient do
         "assertion" => jwt
       })
 
-    req_options = config[:req_options] || []
+    req_opts = config[:req_opts] || []
 
     Req.post(
       token_endpoint,
       [
         headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
         body: payload
-      ] ++ req_options
+      ] ++ req_opts
     )
   end
 
@@ -95,11 +95,11 @@ defmodule Portal.Google.APIClient do
 
   defp test_endpoint(path, access_token, params) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_options = config[:req_options] || []
+    req_opts = config[:req_opts] || []
     query = URI.encode_query(params)
     url = "#{config[:endpoint]}#{path}?#{query}"
 
-    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_options) do
+    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_opts) do
       {:ok, %Req.Response{status: 200}} -> :ok
       other -> other
     end
@@ -196,10 +196,10 @@ defmodule Portal.Google.APIClient do
 
   defp get(path, access_token) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_options = config[:req_options] || []
+    req_opts = config[:req_opts] || []
 
     (config[:endpoint] <> path)
-    |> Req.get([headers: [Authorization: "Bearer #{access_token}"]] ++ req_options)
+    |> Req.get([headers: [Authorization: "Bearer #{access_token}"]] ++ req_opts)
   end
 
   defp stream_pages(path, query, access_token, result_key) do
@@ -221,10 +221,10 @@ defmodule Portal.Google.APIClient do
 
   defp fetch_page(current_path, current_query, access_token, result_key) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_options = config[:req_options] || []
+    req_opts = config[:req_opts] || []
     url = "#{config[:endpoint]}#{current_path}?#{current_query}"
 
-    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_options) do
+    case Req.get(url, [headers: [Authorization: "Bearer #{access_token}"]] ++ req_opts) do
       {:ok, %Req.Response{status: 200, body: body}} ->
         parse_page_response(body, current_path, current_query, result_key)
 

--- a/elixir/lib/portal/google_cloud_platform.ex
+++ b/elixir/lib/portal/google_cloud_platform.ex
@@ -41,16 +41,16 @@ defmodule Portal.GoogleCloudPlatform do
     config = fetch_config!()
     metadata_endpoint_url = Keyword.fetch!(config, :metadata_endpoint_url)
 
-    req_options =
+    req_opts =
       Keyword.merge(
         [
           url: metadata_endpoint_url <> "/instance/service-accounts/default/token",
           headers: [{"metadata-flavor", "Google"}]
         ],
-        Keyword.get(config, :req_options, [])
+        Keyword.get(config, :req_opts, [])
       )
 
-    case Req.get(req_options) do
+    case Req.get(req_opts) do
       {:ok, %Req.Response{status: 200, body: response}} ->
         %{"access_token" => access_token, "expires_in" => expires_in} = response
         access_token_expires_at = DateTime.utc_now() |> DateTime.add(expires_in - 1, :second)
@@ -70,17 +70,17 @@ defmodule Portal.GoogleCloudPlatform do
     config = fetch_config!()
     metadata_endpoint_url = Keyword.fetch!(config, :metadata_endpoint_url)
 
-    req_options =
+    req_opts =
       Keyword.merge(
         [
           url: metadata_endpoint_url <> "/instance/id",
           headers: [{"metadata-flavor", "Google"}],
           decode_body: false
         ],
-        Keyword.get(config, :req_options, [])
+        Keyword.get(config, :req_opts, [])
       )
 
-    case Req.get(req_options) do
+    case Req.get(req_opts) do
       {:ok, %Req.Response{status: 200, body: instance_id}} ->
         {:ok, instance_id}
 
@@ -98,17 +98,17 @@ defmodule Portal.GoogleCloudPlatform do
     config = fetch_config!()
     metadata_endpoint_url = Keyword.fetch!(config, :metadata_endpoint_url)
 
-    req_options =
+    req_opts =
       Keyword.merge(
         [
           url: metadata_endpoint_url <> "/instance/zone",
           headers: [{"metadata-flavor", "Google"}],
           decode_body: false
         ],
-        Keyword.get(config, :req_options, [])
+        Keyword.get(config, :req_opts, [])
       )
 
-    case Req.get(req_options) do
+    case Req.get(req_opts) do
       {:ok, %Req.Response{status: 200, body: zone}} ->
         {:ok, zone |> String.split("/") |> List.last()}
 
@@ -136,17 +136,17 @@ defmodule Portal.GoogleCloudPlatform do
     filter = "#{filter} AND status=RUNNING"
 
     with {:ok, access_token} <- fetch_and_cache_access_token() do
-      req_options =
+      req_opts =
         Keyword.merge(
           [
             url: aggregated_list_endpoint_url,
             params: [filter: filter],
             headers: [{"authorization", "Bearer #{access_token}"}]
           ],
-          Keyword.get(config, :req_options, [])
+          Keyword.get(config, :req_opts, [])
         )
 
-      case Req.get(req_options) do
+      case Req.get(req_opts) do
         {:ok, %Req.Response{status: 200, body: %{"items" => items}}} ->
           instances =
             Enum.flat_map(items, fn
@@ -180,17 +180,17 @@ defmodule Portal.GoogleCloudPlatform do
       |> String.replace("${project_id}", project_id)
 
     with {:ok, access_token} <- fetch_and_cache_access_token() do
-      req_options =
+      req_opts =
         Keyword.merge(
           [
             url: cloud_metrics_endpoint_url,
             headers: [{"authorization", "Bearer #{access_token}"}],
             json: %{"timeSeries" => time_series}
           ],
-          Keyword.get(config, :req_options, [])
+          Keyword.get(config, :req_opts, [])
         )
 
-      case Req.post(req_options) do
+      case Req.post(req_opts) do
         {:ok, %Req.Response{status: 200}} ->
           :ok
 

--- a/elixir/lib/portal/okta/api_client.ex
+++ b/elixir/lib/portal/okta/api_client.ex
@@ -137,11 +137,11 @@ defmodule Portal.Okta.APIClient do
       "client_assertion" => client_assertion
     }
 
-    req_options =
+    req_opts =
       [base_url: client.base_url]
       |> Keyword.merge(req_opts())
 
-    Req.new(req_options)
+    Req.new(req_opts)
     |> Req.merge(url: "/oauth2/v1/introspect")
     |> Req.Request.put_header("content-type", "application/x-www-form-urlencoded")
     |> Req.post(form: form_data)
@@ -267,11 +267,11 @@ defmodule Portal.Okta.APIClient do
   end
 
   defp new_request(%APIClient{} = client, access_token, nonce \\ nil) do
-    req_options =
+    req_opts =
       [base_url: client.base_url]
       |> Keyword.merge(req_opts())
 
-    Req.new(req_options)
+    Req.new(req_opts)
     |> ReqDPoP.attach(
       sign_fun: &dpop_sign(&1, client.private_key, client.kid),
       access_token: access_token,

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -59,7 +59,7 @@ defmodule Portal.Google.SyncTest do
             "auth_provider_x509_cert_url" => "https://www.googleapis.com/oauth2/v1/certs"
           }
           |> JSON.encode!(),
-        req_options: [plug: {Req.Test, APIClient}, retry: false]
+        req_opts: [plug: {Req.Test, APIClient}, retry: false]
       ]
 
       Application.put_env(:portal, APIClient, test_config)

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -510,7 +510,7 @@ defmodule PortalWeb.SignUpTest do
       # Enable retry for these tests
       Portal.Config.put_env_override(Portal.Billing.Stripe.APIClient,
         endpoint: "https://api.stripe.com",
-        req_options: [
+        req_opts: [
           plug: {Req.Test, Portal.Billing.Stripe.APIClient},
           retry: :transient,
           max_retries: 1


### PR DESCRIPTION
This is done to be consistent with `opts` naming we use elsewhere.