### PR TITLE
chore(gateway): remove <= 1.3 connection scheme

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         include:
           # mark:next-gateway-version
-          - release_name: gateway-1.4.20
+          - release_name: gateway-1.5.0
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
           - release_name: headless-client-1.5.7
@@ -210,9 +210,9 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            release_name: gateway-1.4.20
+            release_name: gateway-1.5.0
             # mark:next-gateway-version
-            version: 1.4.20
+            version: 1.5.0
           - package: http-test-server
             artifact: http-test-server
             image_name: http-test-server
@@ -421,7 +421,7 @@ jobs:
           - name: relay
           - name: gateway
             # mark:next-gateway-version
-            version: 1.4.20
+            version: 1.5.0
           - name: client
             # mark:next-client-version
             version: 1.0.6

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway"
-version = "1.4.20"
+version = "1.5.0"
 dependencies = [
  "anyhow-ext",
  "backoff",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gateway"
 # mark:next-gateway-version
-version = "1.4.20"
+version = "1.5.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Gateway for the Firezone zero-trust access product."

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -12,8 +12,6 @@ mod stats;
 mod utils;
 
 pub use allocation::RelaySocket;
-#[allow(deprecated)] // Rust bug: `expect` doesn't seem to work on imports?
-pub use node::{Answer, Offer};
 pub use node::{
     Client, ClientNode, Credentials, Event, HANDSHAKE_TIMEOUT, NoTurnServers, Node, Server,
     ServerNode, Transmit, UnknownConnection,

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -12,7 +12,7 @@ pub(crate) use crate::gateway::unroutable_packet::RoutingError;
 use crate::gateway::client_on_gateway::TranslateOutboundResult;
 use crate::gateway::flow_tracker::FlowTracker;
 use crate::messages::gateway::{Client, ResourceDescription, Subject};
-use crate::messages::{Answer, IceCredentials, ResolveRequest};
+use crate::messages::{IceCredentials, ResolveRequest};
 use crate::peer_store::PeerStore;
 use crate::{FailedToDecapsulate, GatewayEvent, IpConfig, p2p_control, packet_kind};
 use anyhow::{Context, ErrorExt, Result};
@@ -284,23 +284,6 @@ impl GatewayState {
         for peer in self.peers.iter_mut() {
             peer.update_resource(&resource);
         }
-    }
-
-    /// Accept a connection request from a client.
-    #[expect(deprecated, reason = "Will be deleted together with deprecated API")]
-    pub fn accept(
-        &mut self,
-        client_id: ClientId,
-        offer: snownet::Offer,
-        client: PublicKey,
-        now: Instant,
-    ) -> Result<Answer, NoTurnServers> {
-        let answer = self.node.accept_connection(client_id, offer, client, now)?;
-
-        Ok(Answer {
-            username: answer.credentials.username,
-            password: answer.credentials.password,
-        })
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(cid = %client.id))]

--- a/rust/libs/connlib/tunnel/src/messages.rs
+++ b/rust/libs/connlib/tunnel/src/messages.rs
@@ -1,12 +1,10 @@
 //! Message types that are used by both the gateway and client.
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use boringtun::x25519;
 use chrono::{DateTime, Utc, serde::ts_seconds};
 use connlib_model::RelayId;
 use dns_types::{DoHUrl, DomainName};
 use ip_network::IpNetwork;
-use secrecy::ExposeSecret as _;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -52,58 +50,10 @@ pub struct ResolveRequest {
     pub proxy_ips: Vec<IpAddr>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Answer {
-    pub username: String,
-    pub password: String,
-}
-
-#[expect(deprecated)]
-impl From<Answer> for snownet::Answer {
-    fn from(val: Answer) -> Self {
-        snownet::Answer {
-            credentials: snownet::Credentials {
-                username: val.username,
-                password: val.password,
-            },
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Offer {
-    pub username: String,
-    pub password: String,
-}
-
-#[expect(deprecated)]
-impl Offer {
-    // Not a very clean API but it is deprecated anyway.
-    pub fn into_snownet_offer(self, key: SecretKey) -> snownet::Offer {
-        snownet::Offer {
-            session_key: x25519::StaticSecret::from(key.expose_secret().0),
-            credentials: snownet::Credentials {
-                username: self.username,
-                password: self.password,
-            },
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize, Clone, Hash, PartialEq, Eq)]
 pub struct DomainResponse {
     pub domain: DomainName,
     pub address: Vec<IpAddr>,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-pub struct ConnectionAccepted {
-    pub ice_parameters: Answer,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-pub enum GatewayResponse {
-    ConnectionAccepted(ConnectionAccepted),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -202,7 +202,7 @@ function headless() {
 # 4. Commit the changes and open a PR.
 function gateway() {
     current_gateway_version="1.4.19"
-    next_gateway_version="1.4.20"
+    next_gateway_version="1.5.0"
 
     update_changelog "website/src/components/Changelog/Gateway.tsx" "$current_gateway_version"
     update_version_marker "mark:current-gateway-version" "$current_gateway_version"

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -23,6 +23,9 @@ export default function Gateway() {
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
+        <ChangeItem pull="11771">
+          BREAKING: Remove support for Firezone 1.3.x Clients and lower.
+        </ChangeItem>
         <ChangeItem pull="11770">
           Enables detailed flow logs for tunneled TCP and UDP connections. Set
           `FIREZONE_FLOW_LOGS=true` or `--flow-logs` to enable.


### PR DESCRIPTION
This removes the legacy connection scheme from Firezone 1.3.x. The last 1.3.x Clients have been released in November 2024 so are well over a year old. According to our versioning scheme, this is a breaking change and therefore needs to bump the Gateway's version to 1.5.0.