### PR TITLE
fix(portal): increase global Req timeouts

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -1,61 +1,31 @@
 
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:38,17684C4
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
+Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:40,1D07B78
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
-DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:172,1FD0413
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
 SQL.Query: SQL injection,lib/portal/safe.ex:285,224B461
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:366,2BF900
+DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
 Config.Secrets: Hardcoded Secret,config/config.exs:208,4700588
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:48,49E8E80
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
 SQL.Query: SQL injection,lib/portal/safe.ex:291,4C5F170
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
-Config.Secrets: Hardcoded Secret,config/config.exs:106,56F4E1B
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
-Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:62,6EFEB9E
-Config.Secrets: Hardcoded Secret,config/config.exs:207,7165BCA
-Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:28,7369D64
-
-Config.Secrets: Hardcoded Secret,config/config.exs:209,8DFEA3
-
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
-Config.Secrets: Hardcoded Secret,config/config.exs:201,3CFE1A
-Config.Secrets: Hardcoded Secret,config/config.exs:202,43A0604
-
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:375,2E0A7AD
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:217,3560D02
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:371,46EE6C5
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:212,5B50F1B
-
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:31,135D3E7
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,3660523
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:41,4C6E35C
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
-Config.Secrets: Hardcoded Secret,config/config.exs:206,611CC2E
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:51,68184B9
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,74777AB
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:75,780F62D
-Config.Secrets: Hardcoded Secret,config/config.exs:205,E9FD90
-
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:366,2BF900
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
+Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
 Config.Secrets: Hardcoded Secret,config/config.exs:104,61C15AF
+XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
-Config.Secrets: Hardcoded Secret,config/config.exs:203,6ED2CC5
-Config.Secrets: Hardcoded Secret,config/config.exs:204,7F38DEB
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:370,7F8C06D
-Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:40,1D07B78
+Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:30,75F2F69
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:50,7DE9449
-
-DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
-
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
-XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:370,7F8C06D
+Config.Secrets: Hardcoded Secret,config/config.exs:209,8DFEA3

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -161,12 +161,15 @@ config :portal, Portal.Entra.APIClient,
   client_id: System.get_env("ENTRA_SYNC_CLIENT_ID"),
   client_secret: System.get_env("ENTRA_SYNC_CLIENT_SECRET"),
   endpoint: "https://graph.microsoft.com",
-  token_base_url: "https://login.microsoftonline.com"
+  token_base_url: "https://login.microsoftonline.com",
+  # 15 minutes in milliseconds
+  req_opts: [receive_timeout: 900_000]
 
 config :portal, Portal.Google.APIClient,
   endpoint: "https://admin.googleapis.com",
   service_account_key: System.get_env("GOOGLE_SERVICE_ACCOUNT_KEY"),
-  token_endpoint: "https://oauth2.googleapis.com/token"
+  token_endpoint: "https://oauth2.googleapis.com/token",
+  req_opts: [receive_timeout: 60_000]
 
 config :portal, Portal.Google.AuthProvider,
   # Should match an external OAuth2 client in Google Cloud Console
@@ -181,7 +184,8 @@ config :portal, Portal.Okta.AuthProvider,
   response_type: "code",
   scope: "openid email profile"
 
-config :portal, Portal.Okta.APIClient, req_opts: [receive_timeout: 60_000, pool_timeout: 5_000]
+# 15 minutes in milliseconds
+config :portal, Portal.Okta.APIClient, req_opts: [receive_timeout: 900_000]
 
 config :portal, Portal.Entra.AuthProvider,
   # Should match an external OAuth2 client in Azure


### PR DESCRIPTION
Increasing global timeouts to avoid hitting issues during sync.

Since entra and okta use a unique connection pool per request essentially, these can be safely increased to something very long.

Since Google does not, we keep it a bit shorter and increase its pool size.

Related: #11734 