### PR TITLE
fix(portal): use plain logger for azure

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -53,7 +53,11 @@ defmodule Portal.Application do
     # Configure Logger severity at runtime
     :ok = LoggerJSON.configure_log_level_from_env!("LOG_LEVEL")
 
-    if config = Application.get_env(:logger_json, :config) do
+    config = Application.get_env(:logger_json, :config)
+    platform_adapter = Application.get_env(:portal, :platform_adapter)
+
+    # TODO: Remove this after azure migration
+    if not is_nil(config) and platform_adapter == Portal.GoogleCloudPlatform do
       formatter = LoggerJSON.Formatters.GoogleCloud.new(config)
       :logger.update_handler_config(:default, :formatter, formatter)
     end


### PR DESCRIPTION
Azure includes low-friction log ingestion for standard syslog-style logs which we already use for system and other application logs (gateway/relay). It also includes a performant and powerful query language `KQL` which can be used to project / transform logs as needed.

To align with this theme and remove one dependency from our Azure infra we switch to using the plain Elixir logger there.