### PR TITLE
docs: revise Gateway 1.4.19 changelog

### DIFF
--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -67,8 +67,8 @@ export default function Gateway() {
           is present but not routable.
         </ChangeItem>
         <ChangeItem pull="11208">
-          Fixes an issue where the Gateway would not boot up if IPv6 was
-          disabled on the system.
+          Fixes an issue where the Gateway could reboot when the WebSocket
+          connection to the portal got cut.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.18" date={new Date("2025-11-10")}>


### PR DESCRIPTION
Whilst being primarily IPv6 related, the issue that got fixed in this particular PR does affect all installations, even if you are not using IPv6.