### PR TITLE
fix(windows): use `any_downcast_ref`

### DIFF
--- a/rust/libs/bin-shared/src/dns_control/windows.rs
+++ b/rust/libs/bin-shared/src/dns_control/windows.rs
@@ -15,7 +15,7 @@
 
 use crate::DnsController;
 use crate::windows::{CREATE_NO_WINDOW, TUNNEL_UUID, error::EPT_S_NOT_REGISTERED};
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, ErrorExt as _, Result};
 use dns_types::DomainName;
 use std::{io, net::IpAddr, os::windows::process::CommandExt, path::Path, process::Command};
 use windows::Win32::System::GroupPolicy::{RP_FORCE, RefreshPolicyEx};
@@ -59,8 +59,7 @@ impl DnsController {
         match refresh_group_policy() {
             Ok(()) => {}
             Err(e)
-                if e.root_cause()
-                    .downcast_ref::<windows::core::Error>()
+                if e.any_downcast_ref::<windows::core::Error>()
                     .is_some_and(|e| e.code() == EPT_S_NOT_REGISTERED) =>
             {
                 // This may happen if we make this syscall multiple times in a row (which we do as we shut down).


### PR DESCRIPTION
For some reason that I am still investigating, this lint only showed up when opening the project on a Windows machine and not in CI.