### PR TITLE
ci(rust): deny all warnings

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: "write"
 
 env:
-  RUSTFLAGS: "--cfg tokio_unstable"
+  RUSTFLAGS: "--cfg tokio_unstable --deny warnings"
 
 jobs:
   static-analysis:

--- a/rust/libs/bin-shared/src/dns_control/windows.rs
+++ b/rust/libs/bin-shared/src/dns_control/windows.rs
@@ -30,9 +30,9 @@ pub enum DnsControlMethod {
     ///
     /// We don't use an `Option<Method>` because leaving out the CLI arg should
     /// use NRPT, not disable DNS control.
-    #[default]
     Disabled,
     /// NRPT, the only DNS control method we use on Windows.
+    #[default]
     Nrpt,
 }
 

--- a/rust/libs/bin-shared/src/dns_control/windows.rs
+++ b/rust/libs/bin-shared/src/dns_control/windows.rs
@@ -24,21 +24,16 @@ use windows::Win32::System::GroupPolicy::{RP_FORCE, RefreshPolicyEx};
 // Copied from the deep link schema
 const FZ_MAGIC: &str = "firezone-fd0020211111";
 
-#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default)]
 pub enum DnsControlMethod {
     /// Explicitly disable DNS control.
     ///
     /// We don't use an `Option<Method>` because leaving out the CLI arg should
     /// use NRPT, not disable DNS control.
+    #[default]
     Disabled,
     /// NRPT, the only DNS control method we use on Windows.
     Nrpt,
-}
-
-impl Default for DnsControlMethod {
-    fn default() -> Self {
-        Self::Nrpt
-    }
 }
 
 impl DnsController {

--- a/rust/libs/bin-shared/src/network_changes/windows.rs
+++ b/rust/libs/bin-shared/src/network_changes/windows.rs
@@ -667,7 +667,7 @@ mod async_dns {
                 .inner
                 .as_ref()
                 .context("Can't register callback after dropped")?;
-            let key_handle = Registry::HKEY(self.key.raw_handle() as *mut c_void);
+            let key_handle = Registry::HKEY(self.key.raw_handle());
             let notify_flags = Registry::REG_NOTIFY_CHANGE_NAME
                 | Registry::REG_NOTIFY_CHANGE_LAST_SET
                 | Registry::REG_NOTIFY_THREAD_AGNOSTIC;

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -58,7 +58,7 @@ pub async fn resolve<H>(_: H) -> Result<Vec<IpAddr>>
 where
     H: Into<Cow<'static, str>>,
 {
-    async { Ok(Vec::default()) }
+    Ok(Vec::default())
 }
 
 #[cfg(test)]

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -54,6 +54,7 @@ fn parse(content: &str, host: &str) -> Vec<IpAddr> {
 }
 
 #[cfg(not(unix))]
+#[expect(clippy::unused_async, reason = "Must match unix API.")]
 pub async fn resolve<H>(_: H) -> Result<Vec<IpAddr>>
 where
     H: Into<Cow<'static, str>>,

--- a/rust/libs/connlib/etc-hosts-dns-client/lib.rs
+++ b/rust/libs/connlib/etc-hosts-dns-client/lib.rs
@@ -54,7 +54,7 @@ fn parse(content: &str, host: &str) -> Vec<IpAddr> {
 }
 
 #[cfg(not(unix))]
-pub fn resolve<H>(_: H) -> impl Future<Output = Result<Vec<IpAddr>>> + use<H>
+pub async fn resolve<H>(_: H) -> Result<Vec<IpAddr>>
 where
     H: Into<Cow<'static, str>>,
 {


### PR DESCRIPTION
It appears that we have lost the "treat warnings as errors" config somewhere in our CI refactoring and thus, a few warnings slipped through on Windows.