### PR TITLE
refactor(gui-client): unify notification API

### DIFF
--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -33,7 +33,7 @@ pub struct Controller<I: GuiIntegration> {
     // Sign-in state with the portal / deep links
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
-    ctlr_tx: CtlrTx,
+    ctrl_tx: CtlrTx,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -190,7 +190,7 @@ impl<I: GuiIntegration> Controller<I> {
             advanced_settings,
             auth: auth::Auth::new()?,
             clear_logs_callback: None,
-            ctlr_tx,
+            ctrl_tx: ctlr_tx,
             ipc_client,
             ipc_rx,
             integration,
@@ -743,7 +743,7 @@ impl<I: GuiIntegration> Controller<I> {
                 format!("Firezone {} available for download", release.version),
                 body,
             )?;
-            let ctrl_tx = self.ctlr_tx.clone();
+            let ctrl_tx = self.ctrl_tx.clone();
 
             tokio::spawn(async move {
                 on_click.await;

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -71,7 +71,7 @@ pub trait GuiIntegration {
         &self,
         title: impl Into<String>,
         body: impl Into<String>,
-    ) -> Result<impl Future<Item = ()>>;
+    ) -> Result<impl Future<Output = ()>>;
 
     fn set_window_visible(&self, visible: bool) -> Result<()>;
     fn show_overview_page(&self, session: &SessionViewModel) -> Result<()>;

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -71,7 +71,7 @@ pub trait GuiIntegration {
         &self,
         title: impl Into<String>,
         body: impl Into<String>,
-    ) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static>;
+    ) -> Result<NotificationHandle>;
 
     fn set_window_visible(&self, visible: bool) -> Result<()>;
     fn show_overview_page(&self, session: &SessionViewModel) -> Result<()>;
@@ -82,6 +82,10 @@ pub trait GuiIntegration {
         settings: AdvancedSettings,
     ) -> Result<()>;
     fn show_about_page(&self) -> Result<()>;
+}
+
+pub struct NotificationHandle {
+    pub on_click: futures::channel::oneshot::Receiver<()>,
 }
 
 #[derive(strum::Display)]
@@ -737,7 +741,7 @@ impl<I: GuiIntegration> Controller<I> {
             #[cfg(target_os = "windows")]
             let body = "Click here to download the new version";
 
-            let on_click = self.integration.show_notification(
+            let NotificationHandle { on_click } = self.integration.show_notification(
                 format!("Firezone {} available for download", release.version),
                 body,
             )?;

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -748,9 +748,11 @@ impl<I: GuiIntegration> Controller<I> {
             tokio::spawn(async move {
                 on_click.await;
 
-                ctrl_tx.send(ControllerRequest::UpdateNotificationClicked(
-                    release.download_url,
-                ))
+                let _ = ctrl_tx
+                    .send(ControllerRequest::UpdateNotificationClicked(
+                        release.download_url,
+                    ))
+                    .await;
             });
         }
         Ok(())

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -24,8 +24,6 @@ use url::Url;
 
 mod ran_before;
 
-pub type CtlrTx = mpsc::Sender<ControllerRequest>;
-
 pub struct Controller<I: GuiIntegration> {
     general_settings: GeneralSettings,
     mdm_settings: MdmSettings,
@@ -33,7 +31,7 @@ pub struct Controller<I: GuiIntegration> {
     // Sign-in state with the portal / deep links
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
-    ctrl_tx: CtlrTx,
+    ctrl_tx: mpsc::Sender<ControllerRequest>,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -165,7 +163,7 @@ pub struct FailedToReceiveHello(anyhow::Error);
 
 impl<I: GuiIntegration> Controller<I> {
     pub(crate) async fn start(
-        ctlr_tx: CtlrTx,
+        ctrl_tx: mpsc::Sender<ControllerRequest>,
         integration: I,
         rx: mpsc::Receiver<ControllerRequest>,
         general_settings: GeneralSettings,
@@ -190,7 +188,7 @@ impl<I: GuiIntegration> Controller<I> {
             advanced_settings,
             auth: auth::Auth::new()?,
             clear_logs_callback: None,
-            ctrl_tx: ctlr_tx,
+            ctrl_tx,
             ipc_client,
             ipc_rx,
             integration,

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -69,7 +69,11 @@ pub trait GuiIntegration {
 
     fn set_tray_icon(&mut self, icon: system_tray::Icon);
     fn set_tray_menu(&mut self, app_state: system_tray::AppState);
-    fn show_notification(&self, title: &str, body: &str) -> Result<impl Future<Item = ()>>;
+    fn show_notification(
+        &self,
+        title: impl Into<String>,
+        body: impl Into<String>,
+    ) -> Result<impl Future<Item = ()>>;
 
     fn set_window_visible(&self, visible: bool) -> Result<()>;
     fn show_overview_page(&self, session: &SessionViewModel) -> Result<()>;
@@ -408,7 +412,7 @@ impl<I: GuiIntegration> Controller<I> {
                 // Refresh the menu in case the favorites were reset.
                 self.refresh_ui_state();
 
-                self.integration.show_notification("Settings saved", "")?
+                self.integration.show_notification("Settings saved", "")?;
             }
             ApplyGeneralSettings(settings) => {
                 let account_slug = settings.account_slug.trim();
@@ -736,7 +740,7 @@ impl<I: GuiIntegration> Controller<I> {
             let body = "Click here to download the new version";
 
             let on_click = self.integration.show_notification(
-                &format!("Firezone {} available for download", release.version),
+                format!("Firezone {} available for download", release.version),
                 body,
             )?;
             let ctrl_tx = self.ctlr_tx.clone();

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -412,7 +412,7 @@ impl<I: GuiIntegration> Controller<I> {
                 // Refresh the menu in case the favorites were reset.
                 self.refresh_ui_state();
 
-                self.integration.show_notification("Settings saved", "")?;
+                let _ = self.integration.show_notification("Settings saved", "")?;
             }
             ApplyGeneralSettings(settings) => {
                 let account_slug = settings.account_slug.trim();
@@ -575,7 +575,7 @@ impl<I: GuiIntegration> Controller<I> {
         gui::set_autostart(self.general_settings.start_on_login.is_some_and(|v| v)).await?;
 
         self.notify_settings_changed()?;
-        self.integration.show_notification("Settings saved", "")?;
+        let _ = self.integration.show_notification("Settings saved", "")?;
 
         Ok(())
     }
@@ -609,7 +609,7 @@ impl<I: GuiIntegration> Controller<I> {
                 self.sign_out().await?;
                 if is_authentication_error {
                     tracing::info!(?error_msg, "Auth error");
-                    self.integration.show_notification(
+                    let _ = self.integration.show_notification(
                         "Firezone disconnected",
                         "To access resources, sign in again.",
                     )?;
@@ -630,7 +630,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 // If this is the first time we receive resources, show the notification that we are connected.
                 if let &Status::WaitingForTunnel = &self.status {
-                    self.integration.show_notification(
+                    let _ = self.integration.show_notification(
                         "Firezone connected",
                         "You are now signed in and able to access resources.",
                     )?;
@@ -647,7 +647,7 @@ impl<I: GuiIntegration> Controller<I> {
                 tracing::info!("Tunnel service exited gracefully");
                 self.integration
                     .set_tray_icon(system_tray::icon_terminating());
-                self.integration.show_notification(
+                let _ = self.integration.show_notification(
                     "Firezone disconnected",
                     "The Firezone Tunnel service was shut down, quitting GUI process.",
                 )?;

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -161,7 +161,7 @@ impl GuiIntegration for TauriIntegration {
         &self,
         title: impl Into<String>,
         body: impl Into<String>,
-    ) -> Result<impl Future<Item = ()>> {
+    ) -> Result<impl Future<Output = ()>> {
         os::show_notification(&self.app, title.into(), body.into())
     }
 

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -157,8 +157,12 @@ impl GuiIntegration for TauriIntegration {
         self.tray.update(app_state)
     }
 
-    fn show_notification(&self, title: &str, body: &str) -> Result<impl Future<Item = ()>> {
-        os::show_notification(&self.app, title, body)
+    fn show_notification(
+        &self,
+        title: impl Into<String>,
+        body: impl Into<String>,
+    ) -> Result<impl Future<Item = ()>> {
+        os::show_notification(&self.app, title.into(), body.into())
     }
 
     fn set_window_visible(&self, visible: bool) -> Result<()> {

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -4,7 +4,7 @@
 //! The real macOS Client is in `swift/apple`
 
 use crate::{
-    controller::{Controller, ControllerRequest, CtlrTx, Failure, GuiIntegration},
+    controller::{Controller, ControllerRequest, Failure, GuiIntegration},
     deep_link,
     ipc::{self, ClientRead, ClientWrite, SocketId},
     logging::FileCount,
@@ -466,7 +466,7 @@ pub fn run(
 }
 
 #[cfg(not(debug_assertions))]
-async fn smoke_test(_: CtlrTx) -> Result<()> {
+async fn smoke_test(_: mpsc::Sender<ControllerRequest>) -> Result<()> {
     bail!("Smoke test is not built for release binaries.");
 }
 
@@ -475,7 +475,7 @@ async fn smoke_test(_: CtlrTx) -> Result<()> {
 /// You can purposely fail this test by deleting the exported zip file during
 /// the 10-second sleep.
 #[cfg(debug_assertions)]
-async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
+async fn smoke_test(ctrl_tx: mpsc::Sender<ControllerRequest>) -> Result<()> {
     let delay = 10;
     tracing::info!("Will quit on purpose in {delay} seconds as part of the smoke test.");
     let quit_time = tokio::time::Instant::now() + Duration::from_secs(delay);
@@ -492,7 +492,7 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
             }
         }
     }
-    ctlr_tx
+    ctrl_tx
         .send(ControllerRequest::ExportLogs {
             path: path.clone(),
             stem,
@@ -500,7 +500,7 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
         .await
         .context("Failed to send `ExportLogs` request")?;
     let (tx, rx) = tokio::sync::oneshot::channel();
-    ctlr_tx
+    ctrl_tx
         .send(ControllerRequest::ClearLogs(tx))
         .await
         .context("Failed to send `ClearLogs` request")?;
@@ -532,7 +532,7 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
     anyhow::ensure!(tokio::fs::try_exists(settings::advanced_settings_path()?).await?);
 
     tracing::info!("Quitting on purpose because of `smoke-test` subcommand");
-    ctlr_tx
+    ctrl_tx
         .send(ControllerRequest::SystemTrayMenu(system_tray::Event::Quit))
         .await
         .context("Failed to send Quit request")?;

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -161,7 +161,7 @@ impl GuiIntegration for TauriIntegration {
         &self,
         title: impl Into<String>,
         body: impl Into<String>,
-    ) -> Result<impl Future<Output = ()>> {
+    ) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
         os::show_notification(&self.app, title.into(), body.into())
     }
 

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -157,12 +157,8 @@ impl GuiIntegration for TauriIntegration {
         self.tray.update(app_state)
     }
 
-    fn show_notification(&self, title: &str, body: &str) -> Result<()> {
+    fn show_notification(&self, title: &str, body: &str) -> Result<impl Future<Item = ()>> {
         os::show_notification(&self.app, title, body)
-    }
-
-    fn show_update_notification(&self, ctlr_tx: CtlrTx, title: &str, url: url::Url) -> Result<()> {
-        os::show_update_notification(&self.app, ctlr_tx, title, url)
     }
 
     fn set_window_visible(&self, visible: bool) -> Result<()> {

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -4,7 +4,7 @@
 //! The real macOS Client is in `swift/apple`
 
 use crate::{
-    controller::{Controller, ControllerRequest, Failure, GuiIntegration},
+    controller::{Controller, ControllerRequest, Failure, GuiIntegration, NotificationHandle},
     deep_link,
     ipc::{self, ClientRead, ClientWrite, SocketId},
     logging::FileCount,
@@ -161,7 +161,7 @@ impl GuiIntegration for TauriIntegration {
         &self,
         title: impl Into<String>,
         body: impl Into<String>,
-    ) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
+    ) -> Result<NotificationHandle> {
         os::show_notification(&self.app, title.into(), body.into())
     }
 

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -32,24 +32,16 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     Ok(())
 }
 
-/// Since clickable notifications don't work on Linux yet, the update text
-/// must be different on different platforms
-pub(crate) fn show_update_notification(
+pub(crate) fn show_notification(
     app: &AppHandle,
-    _ctlr_tx: super::CtlrTx,
     title: &str,
-    download_url: url::Url,
-) -> Result<()> {
-    show_notification(app, title, download_url.to_string().as_ref())?;
-    Ok(())
-}
-
-/// Show a notification in the bottom right of the screen
-pub(crate) fn show_notification(app: &AppHandle, title: &str, body: &str) -> Result<()> {
+    body: &str,
+) -> Result<impl Future<Output = ()>> {
     app.notification()
         .builder()
         .title(title)
         .body(body)
         .show()?;
-    Ok(())
+
+    Ok(futures::future::pending()) // TODO: Make clickable notifications work on Linux.
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -34,13 +34,13 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 
 pub(crate) fn show_notification(
     app: &AppHandle,
-    title: &str,
-    body: &str,
+    title: String,
+    body: String,
 ) -> Result<impl Future<Output = ()>> {
     app.notification()
         .builder()
-        .title(title)
-        .body(body)
+        .title(&title)
+        .body(&body)
         .show()?;
 
     Ok(futures::future::pending()) // TODO: Make clickable notifications work on Linux.

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -2,6 +2,8 @@ use anyhow::{Context as _, Result};
 use tauri::AppHandle;
 use tauri_plugin_notification::NotificationExt as _;
 
+use crate::controller::NotificationHandle;
+
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     let dir = dirs::config_local_dir()
         .context("Can't compute `config_local_dir`")?
@@ -36,12 +38,14 @@ pub(crate) fn show_notification(
     app: &AppHandle,
     title: String,
     body: String,
-) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
+) -> Result<NotificationHandle> {
+    let (_, rx) = futures::channel::oneshot::channel();
+
     app.notification()
         .builder()
         .title(&title)
         .body(&body)
         .show()?;
 
-    Ok(futures::future::pending()) // TODO: Make clickable notifications work on Linux.
+    Ok(NotificationHandle { on_click: rx })
 }

--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -36,7 +36,7 @@ pub(crate) fn show_notification(
     app: &AppHandle,
     title: String,
     body: String,
-) -> Result<impl Future<Output = ()>> {
+) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
     app.notification()
         .builder()
         .title(&title)

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -8,8 +8,8 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
 
 pub(crate) fn show_notification(
     _app: &AppHandle,
-    _title: &str,
-    _body: &str,
+    _title: String,
+    _body: String,
 ) -> Result<impl Future<Output = ()>> {
     bail!("Not implemented")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -6,15 +6,10 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     bail!("Not implemented")
 }
 
-pub(crate) fn show_notification(_app: &tauri::AppHandle, _title: &str, _body: &str) -> Result<()> {
-    bail!("Not implemented")
-}
-
-pub(crate) fn show_update_notification(
-    _app: &tauri::AppHandle,
-    _ctlr_tx: CtlrTx,
+pub(crate) fn show_notification(
+    _app: &AppHandle,
+    _title: &str,
     _body: &str,
-    _url: url::Url,
-) -> Result<()> {
+) -> Result<impl Future<Output = ()>> {
     bail!("Not implemented")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -10,6 +10,6 @@ pub(crate) fn show_notification(
     _app: &AppHandle,
     _title: String,
     _body: String,
-) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
+) -> Result<futures::future::Pending<Result<(), ()>>> {
     bail!("Not implemented")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -10,6 +10,6 @@ pub(crate) fn show_notification(
     _app: &AppHandle,
     _title: String,
     _body: String,
-) -> Result<impl Future<Output = ()>> {
+) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
     bail!("Not implemented")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -1,5 +1,4 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
-use super::CtlrTx;
 use anyhow::{Result, bail};
 
 pub async fn set_autostart(_enabled: bool) -> Result<()> {

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -1,5 +1,6 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
 use anyhow::{Result, bail};
+use tauri::AppHandle;
 
 pub async fn set_autostart(_enabled: bool) -> Result<()> {
     bail!("Not implemented")

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -2,6 +2,8 @@
 use anyhow::{Result, bail};
 use tauri::AppHandle;
 
+use crate::controller::NotificationHandle;
+
 pub async fn set_autostart(_enabled: bool) -> Result<()> {
     bail!("Not implemented")
 }
@@ -10,6 +12,6 @@ pub(crate) fn show_notification(
     _app: &AppHandle,
     _title: String,
     _body: String,
-) -> Result<futures::future::Pending<Result<(), ()>>> {
+) -> Result<NotificationHandle> {
     bail!("Not implemented")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -42,23 +42,6 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
     Ok(())
 }
 
-/// Since clickable notifications don't work on Linux yet, the update text
-/// must be different on different platforms
-pub(crate) fn show_update_notification(
-    _app: &AppHandle,
-    ctlr_tx: CtlrTx,
-    title: &str,
-    download_url: url::Url,
-) -> Result<()> {
-    show_clickable_notification(
-        title,
-        "Click here to download the new version.",
-        ctlr_tx,
-        ControllerRequest::UpdateNotificationClicked(download_url),
-    )?;
-    Ok(())
-}
-
 /// Show a notification in the bottom right of the screen
 ///
 /// May say "Windows Powershell" and have the wrong icon in dev mode
@@ -66,22 +49,6 @@ pub(crate) fn show_update_notification(
 ///
 /// TODO: Warn about silent failure if the AppID is not installed:
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
-pub(crate) fn show_notification(_app: &AppHandle, title: &str, body: &str) -> Result<()> {
-    tracing::debug!(?title, ?body, "show_notification");
-
-    tauri_winrt_notification::Toast::new(BUNDLE_ID)
-        .title(title)
-        .text1(body)
-        .show()
-        .context("Couldn't show notification")?;
-
-    Ok(())
-}
-
-/// Show a notification that signals `Controller` when clicked
-///
-/// May say "Windows Powershell" and have the wrong icon in dev mode
-/// See <https://github.com/tauri-apps/tauri/issues/3700>
 ///
 /// Known issue: If the notification times out and goes into the notification center
 /// (the little thing that pops up when you click the bell icon), then we may not get the
@@ -94,31 +61,29 @@ pub(crate) fn show_notification(_app: &AppHandle, title: &str, body: &str) -> Re
 /// - <https://answers.microsoft.com/en-us/windows/forum/all/notifications-not-activating-the-associated-app/7a3b31b0-3a20-4426-9c88-c6e3f2ac62c6>
 ///
 /// Firefox doesn't have this problem. Maybe they're using a different API.
-pub(crate) fn show_clickable_notification(
+pub(crate) fn show_notification(
+    _app: &AppHandle,
     title: &str,
     body: &str,
-    tx: CtlrTx,
-    req: ControllerRequest,
-) -> Result<()> {
+) -> Result<impl Future<Output = ()>> {
+    let (tx, rx) = futures::future::oneshot::channel();
+
     // For some reason `on_activated` is FnMut
-    let mut req = Some(req);
+    let mut req = Some(tx);
 
     tauri_winrt_notification::Toast::new(BUNDLE_ID)
         .title(title)
         .text1(body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)
         .on_activated(move |_| {
-            if let Some(req) = req.take()
-                && let Err(error) = tx.blocking_send(req)
-            {
-                tracing::error!(
-                    "User clicked on notification, but we couldn't tell `Controller`: {}",
-                    err_with_src(&error)
-                );
-            }
+            let Some(tx) = tx.take() else { return Ok(()) };
+
+            let _ = tx.send(());
+
             Ok(())
         })
         .show()
         .context("Couldn't show clickable URL notification")?;
-    Ok(())
+
+    Ok(rx)
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -63,8 +63,8 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 /// Firefox doesn't have this problem. Maybe they're using a different API.
 pub(crate) fn show_notification(
     _app: &AppHandle,
-    title: &str,
-    body: &str,
+    title: String,
+    body: String,
 ) -> Result<impl Future<Output = ()>> {
     let (tx, rx) = futures::future::oneshot::channel();
 
@@ -72,8 +72,8 @@ pub(crate) fn show_notification(
     let mut req = Some(tx);
 
     tauri_winrt_notification::Toast::new(BUNDLE_ID)
-        .title(title)
-        .text1(body)
+        .title(&title)
+        .text1(&body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)
         .on_activated(move |_| {
             let Some(tx) = tx.take() else { return Ok(()) };

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use bin_shared::BUNDLE_ID;
-use futures::TryFutureExt;
 use std::env;
 use tauri::AppHandle;
 use winreg::RegKey;

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -6,6 +6,8 @@ use tauri::AppHandle;
 use winreg::RegKey;
 use winreg::enums::*;
 
+use crate::controller::NotificationHandle;
+
 pub async fn set_autostart(enabled: bool) -> Result<()> {
     // Get path to the current executable
     let exec_path = env::current_exe().context("Failed to get current executable path")?;
@@ -64,7 +66,7 @@ pub(crate) fn show_notification(
     _app: &AppHandle,
     title: String,
     body: String,
-) -> Result<impl Future<Output = Result<(), ()>> + Send + 'static> {
+) -> Result<NotificationHandle> {
     let (tx, rx) = futures::channel::oneshot::channel();
 
     // For some reason `on_activated` is FnMut
@@ -84,5 +86,5 @@ pub(crate) fn show_notification(
         .show()
         .context("Couldn't show clickable URL notification")?;
 
-    Ok(rx.map_err(|_| ()))
+    Ok(NotificationHandle { on_click: rx })
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,4 +1,4 @@
-use super::{ControllerRequest, CtlrTx};
+use super::ControllerRequest;
 use anyhow::{Context, Result};
 use bin_shared::BUNDLE_ID;
 use logging::err_with_src;


### PR DESCRIPTION
Currently, the notification API for the GUI client is split into two:

- Regular notifications
- Clickable notifications

We can unify that into a single API that returns a `Future` as the `on_click` handler. That way, notifications which don't care about the click can ignore it.