### PR TITLE
refactor(gui-client): add infrastructure for controller tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2620,6 +2620,7 @@ dependencies = [
  "native-dialog",
  "nix",
  "output_vt100",
+ "parking_lot",
  "phoenix-channel",
  "png",
  "rand 0.8.5",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ keyring-core = { workspace = true }
 logging = { workspace = true }
 native-dialog = { workspace = true }
 output_vt100 = { workspace = true }
+parking_lot = { workspace = true }
 phoenix-channel = { workspace = true }
 png = { workspace = true } # `png` is mostly free since we already need it for Tauri
 rand = { workspace = true }

--- a/rust/gui-client/src-tauri/src/auth.rs
+++ b/rust/gui-client/src-tauri/src/auth.rs
@@ -102,12 +102,12 @@ struct SessionAndToken {
 impl Auth {
     /// Creates a new Auth struct using the "dev.firezone.client/token" keyring key. If the token is stored on disk, the struct is automatically signed in.
     ///
-    /// Performs I/O.
+    /// Performs I/O except on `cfg(test)`.
     pub fn new() -> Result<Self> {
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", not(test)))]
         let store = dbus_secret_service_keyring_store::Store::new()?;
 
-        #[cfg(target_os = "windows")]
+        #[cfg(all(target_os = "windows", not(test)))]
         let store = windows_native_keyring_store::Store::new_with_configuration(
             &std::collections::HashMap::from([(
                 // We want to avoid an appended `.` at the end.
@@ -115,7 +115,7 @@ impl Auth {
             )]),
         )?;
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", test))]
         let store = keyring_core::mock::Store::new()?;
 
         Self::new_with_key(

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -1024,7 +1024,7 @@ mod tests {
         ) {
             ipc::connect(
                 SocketId::Test(self.gui_id),
-                ipc::ConnectOptions { num_attempts: 1 },
+                ipc::ConnectOptions { num_attempts: 2 },
             )
             .await
             .unwrap()

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -939,7 +939,6 @@ mod tests {
     use std::sync::Arc;
 
     use parking_lot::{Mutex, MutexGuard};
-    use uuid::Uuid;
 
     use super::*;
 
@@ -1002,7 +1001,7 @@ mod tests {
         ctrl_tx: mpsc::Sender<ControllerRequest>,
         updates_tx: mpsc::Sender<Option<updates::Notification>>,
         integration: Arc<Mutex<TestIntegration>>,
-        gui_id: &'static str,
+        gui_id: u32,
     }
 
     impl TestController {
@@ -1144,11 +1143,8 @@ mod tests {
 
     impl Controller<Arc<Mutex<TestIntegration>>> {
         fn start_for_test() -> TestController {
-            let id = Uuid::new_v4().to_string().leak();
-
-            // Leaking memory here is fine because we are in a test and the process is terminated at the end.
-            let tunnel_id = format!("{id}_tunnel").leak();
-            let gui_id = format!("{id}_gui").leak();
+            let tunnel_id = rand::random::<u32>();
+            let gui_id = rand::random::<u32>();
 
             let tunnel_ipc_server = ipc::Server::new(SocketId::Test(tunnel_id)).unwrap();
             let gui_ipc_server = ipc::Server::new(SocketId::Test(gui_id)).unwrap();

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -971,7 +971,7 @@ mod tests {
         let (_tunnel_rx, mut tunnel_tx) = test_controller.tunnel_service_ipc_accept().await;
         tunnel_tx.send(&service::ServerMsg::Hello).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         assert_eq!(test_controller.integration().shown_overview_page.len(), 1);
     }

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -971,7 +971,7 @@ mod tests {
         let (_tunnel_rx, mut tunnel_tx) = test_controller.tunnel_service_ipc_accept().await;
         tunnel_tx.send(&service::ServerMsg::Hello).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
 
         assert_eq!(test_controller.integration().shown_overview_page.len(), 1);
     }
@@ -987,8 +987,6 @@ mod tests {
         let (mut gui_rx, mut gui_tx) = test_controller.gui_ipc_connect().await;
         gui_tx.send(&gui::ClientMsg::NewInstance).await.unwrap();
         let response = gui_rx.next().await.unwrap().unwrap();
-
-        tokio::time::sleep(Duration::from_millis(500)).await;
 
         assert_eq!(test_controller.integration().shown_overview_page.len(), 2);
         assert_eq!(response, gui::ServerMsg::Ack)

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -956,9 +956,10 @@ mod tests {
             .unwrap()
             .unwrap_err();
 
-        assert_eq!(
-            start_error.to_string(),
-            "Failed to receive hello: Timeout while waiting for message from tunnel service for 5s: deadline has elapsed"
+        assert!(
+            start_error
+                .any_downcast_ref::<FailedToReceiveHello>()
+                .is_some()
         );
     }
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -167,6 +167,7 @@ pub struct FailedToReceiveHello(anyhow::Error);
 
 impl<I: GuiIntegration> Controller<I> {
     pub(crate) async fn start(
+        socket: SocketId,
         ctrl_tx: mpsc::Sender<ControllerRequest>,
         integration: I,
         rx: mpsc::Receiver<ControllerRequest>,
@@ -179,8 +180,7 @@ impl<I: GuiIntegration> Controller<I> {
     ) -> Result<()> {
         tracing::debug!("Starting new instance of `Controller`");
 
-        let (mut ipc_rx, ipc_client) =
-            ipc::connect(SocketId::Tunnel, ipc::ConnectOptions::default()).await?;
+        let (mut ipc_rx, ipc_client) = ipc::connect(socket, ipc::ConnectOptions::default()).await?;
 
         receive_hello(&mut ipc_rx)
             .await

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -936,8 +936,9 @@ async fn receive_hello(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Resu
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex, MutexGuard};
+    use std::sync::Arc;
 
+    use parking_lot::{Mutex, MutexGuard};
     use uuid::Uuid;
 
     use super::*;
@@ -1032,7 +1033,7 @@ mod tests {
         }
 
         fn integration(&self) -> MutexGuard<'_, TestIntegration> {
-            self.integration.lock().unwrap()
+            self.integration.lock()
         }
     }
 
@@ -1055,7 +1056,7 @@ mod tests {
 
     impl GuiIntegration for Arc<Mutex<TestIntegration>> {
         fn notify_session_changed(&self, session: &SessionViewModel) -> Result<()> {
-            self.lock().unwrap().sessions.push(session.clone());
+            self.lock().sessions.push(session.clone());
 
             Ok(())
         }
@@ -1066,7 +1067,7 @@ mod tests {
             general_settings: GeneralSettings,
             advanced_settings: AdvancedSettings,
         ) -> Result<()> {
-            let mut guard = self.lock().unwrap();
+            let mut guard = self.lock();
 
             guard.mdm_settings.push(mdm_settings);
             guard.general_settings.push(general_settings);
@@ -1076,26 +1077,23 @@ mod tests {
         }
 
         fn notify_logs_recounted(&self, file_count: &FileCount) -> Result<()> {
-            self.lock().unwrap().file_counts.push(file_count.clone());
+            self.lock().file_counts.push(file_count.clone());
 
             Ok(())
         }
 
         fn open_url<P: AsRef<str>>(&self, url: P) -> Result<()> {
-            self.lock()
-                .unwrap()
-                .opened_urls
-                .push(url.as_ref().to_owned());
+            self.lock().opened_urls.push(url.as_ref().to_owned());
 
             Ok(())
         }
 
         fn set_tray_icon(&mut self, icon: system_tray::Icon) {
-            self.lock().unwrap().tray_icons.push(icon);
+            self.lock().tray_icons.push(icon);
         }
 
         fn set_tray_menu(&mut self, app_state: system_tray::AppState) {
-            self.lock().unwrap().tray_states.push(app_state);
+            self.lock().tray_states.push(app_state);
         }
 
         fn show_notification(
@@ -1106,7 +1104,6 @@ mod tests {
             let (tx, rx) = futures::channel::oneshot::channel();
 
             self.lock()
-                .unwrap()
                 .notifications
                 .push((title.into(), body.into(), tx));
 
@@ -1114,16 +1111,13 @@ mod tests {
         }
 
         fn set_window_visible(&self, visible: bool) -> Result<()> {
-            self.lock().unwrap().window_visibilities.push(visible);
+            self.lock().window_visibilities.push(visible);
 
             Ok(())
         }
 
         fn show_overview_page(&self, session: &SessionViewModel) -> Result<()> {
-            self.lock()
-                .unwrap()
-                .shown_overview_page
-                .push(session.clone());
+            self.lock().shown_overview_page.push(session.clone());
 
             Ok(())
         }
@@ -1134,17 +1128,15 @@ mod tests {
             general_settings: GeneralSettings,
             settings: AdvancedSettings,
         ) -> Result<()> {
-            self.lock().unwrap().shown_settings_page.push((
-                mdm_settings,
-                general_settings,
-                settings,
-            ));
+            self.lock()
+                .shown_settings_page
+                .push((mdm_settings, general_settings, settings));
 
             Ok(())
         }
 
         fn show_about_page(&self) -> Result<()> {
-            self.lock().unwrap().shown_about_page.push(());
+            self.lock().shown_about_page.push(());
 
             Ok(())
         }

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -344,6 +344,7 @@ pub fn run(
 
         // Spawn the controller
         let ctrl_task = tokio::spawn(Controller::start(
+            SocketId::Tunnel,
             ctlr_tx,
             integration,
             ctlr_rx,

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -345,8 +345,8 @@ pub fn run(
         // Spawn the controller
         let ctrl_task = tokio::spawn(Controller::start(
             SocketId::Tunnel,
-            ctlr_tx,
             integration,
+            ctlr_tx,
             ctlr_rx,
             general_settings,
             mdm_settings,

--- a/rust/gui-client/src-tauri/src/ipc.rs
+++ b/rust/gui-client/src-tauri/src/ipc.rs
@@ -70,10 +70,8 @@ pub enum SocketId {
     ///
     /// Includes an ID so that multiple tests can
     /// run in parallel.
-    ///
-    /// The ID should have A-Z, 0-9 only, no dots or slashes, because of Windows named pipes name restrictions.
     #[cfg(test)]
-    Test(&'static str),
+    Test(u32),
 }
 
 pub struct Decoder<D> {
@@ -204,7 +202,7 @@ mod tests {
     #[tokio::test]
     async fn no_such_service() -> Result<()> {
         let _guard = logging::test("trace");
-        const ID: SocketId = SocketId::Test("H56FRXVH");
+        const ID: SocketId = SocketId::Test(0xC41CD2FA);
 
         if super::connect::<(), ()>(ID, super::ConnectOptions::default())
             .await
@@ -230,7 +228,7 @@ mod tests {
     async fn smoke() -> Result<()> {
         let _guard = logging::test("trace");
         let loops = 10;
-        const ID: SocketId = SocketId::Test("OB5SZCGN");
+        const ID: SocketId = SocketId::Test(0x2071B40E);
 
         let mut server = Server::new(ID).expect("Error while starting IPC server");
 
@@ -311,7 +309,7 @@ mod tests {
     async fn loop_to_next_client() -> Result<()> {
         let _guard = logging::test("trace");
 
-        let mut server = Server::new(SocketId::Test("H6L73DG5"))?;
+        let mut server = Server::new(SocketId::Test(0x92967990))?;
         for i in 0..5 {
             if let Ok(Err(err)) = timeout(Duration::from_secs(1), server.next_client()).await {
                 Err(err).with_context(|| {

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -193,7 +193,7 @@ mod tests {
     #[tokio::test]
     async fn single_instance() -> anyhow::Result<()> {
         let _guard = logging::test("trace");
-        const ID: SocketId = SocketId::Test("2GOCMPBG");
+        const ID: SocketId = SocketId::Test(0x1A6FE1F6);
         let mut server_1 = Server::new(ID)?;
         let pipe_path = server_1.pipe_path.clone();
 

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::unwrap_in_result))]
 
 mod updates;
 mod uptime;

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -59,7 +59,7 @@ pub struct AdvancedSettings {
     pub log_filter: String,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, Default)]
 pub struct GeneralSettings {
     #[serde(default)]
     pub favorite_resources: HashSet<ResourceId>,

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -20,7 +20,7 @@ pub struct GeneralSettingsForm {
     pub account_slug: String,
 }
 
-#[derive(Clone, serde::Serialize, specta::Type)]
+#[derive(Clone, Debug, serde::Serialize, specta::Type, PartialEq, Eq)]
 pub enum SessionViewModel {
     SignedIn {
         account_slug: String,


### PR DESCRIPTION
Adds some boilerplate infrastructure for writing unit tests for the `Controller` of the GUI client. This component is mostly connected with all other parts of the Client (like tray menu, tunnel service, etc) via various channels or IPC mechanisms. Pretty much all of that can be replaced with stubs in a test, allowing us to test the event-loop within the `Controller` itself.

To demonstrate this, we add a few tests around the startup behaviour. In #11779, will build on top of this to test the new notifications around offline / unavailable Gateways.