### PR TITLE
chore(apple): Deploy macOS during post-build

### DIFF
--- a/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/Firezone.xcscheme
+++ b/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/Firezone.xcscheme
@@ -9,6 +9,22 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
+               title = "Update LSP compile flags"
+               scriptText = "command -v xcode-build-server &gt;/dev/null 2&gt;&amp;1 &amp;&amp; xcode-build-server postaction | bash &amp;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "8DCC021828D512AC007E12D2"
+                     BuildableName = "Firezone.app"
+                     BlueprintName = "Firezone"
+                     ReferencedContainer = "container:Firezone.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
                title = "Deploy to Applications"
                scriptText = "rm -rf /Applications/Firezone.app; if ! cp -R &quot;${BUILT_PRODUCTS_DIR}/${FULL_PRODUCT_NAME}&quot; /Applications/; then osascript -e &apos;display alert &quot;Deploy Failed&quot; message &quot;Could not copy Firezone.app to /Applications. Check permissions.&quot; as critical&apos;; exit 1; fi">
                <EnvironmentBuildable>

--- a/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/Firezone.xcscheme
+++ b/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/Firezone.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Deploy to Applications"
+               scriptText = "rm -rf /Applications/Firezone.app; if ! cp -R &quot;${BUILT_PRODUCTS_DIR}/${FULL_PRODUCT_NAME}&quot; /Applications/; then osascript -e &apos;display alert &quot;Deploy Failed&quot; message &quot;Could not copy Firezone.app to /Applications. Check permissions.&quot; as critical&apos;; exit 1; fi">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "8DCC021828D512AC007E12D2"
+                     BuildableName = "Firezone.app"
+                     BlueprintName = "Firezone"
+                     ReferencedContainer = "container:Firezone.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -61,8 +79,11 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Applications/Firezone.app">
+      </PathRunnable>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8DCC021828D512AC007E12D2"
@@ -70,7 +91,7 @@
             BlueprintName = "Firezone"
             ReferencedContainer = "container:Firezone.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
- Add post-build shell script to deploy Firezone.app to /Applications,
  improving developer workflow by automating installation after build
- Show alert if deploy fails, providing immediate feedback on permission
  issues
- Change launch action to run the app from /Applications instead of build
  directory, ensuring everything uses the deployed version consistently
- Add shell script post-action in Xcode scheme to update LSP compile
  flags after build