### PR TITLE
build(deps): use released version of `moka`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4620,8 +4620,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.11"
-source = "git+https://github.com/moka-rs/moka?branch=main#8dbc8e5c6ee804470b1144960f4065959658232a"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -4632,7 +4633,6 @@ dependencies = [
  "futures-util",
  "parking_lot",
  "portable-atomic",
- "rustc_version",
  "smallvec",
  "tagptr",
  "uuid",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -255,7 +255,6 @@ ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.30" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
-moka = { git = "https://github.com/moka-rs/moka", branch = "main" } # Waiting for release.
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.


### PR DESCRIPTION
The patch we have been waiting for has been merged and released. Hence, we can get rid of the git dependency.