### PR TITLE
chore(rust): add tools to `.tool-versions`

### DIFF
--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,2 +1,3 @@
 # GUI client
 pnpm 10.18.3
+nodejs 20.14.0

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,3 +1,3 @@
 pnpm             10.18.3
-nodejs           20.14.0
+nodejs           24.13.0
 cargo:cargo-sort 2.0.2

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,3 +1,3 @@
-# GUI client
-pnpm 10.18.3
-nodejs 20.14.0
+pnpm             10.18.3
+nodejs           20.14.0
+cargo:cargo-sort 2.0.2


### PR DESCRIPTION
At least for my Windows machine, I had to install nodejs in order to make the GUI client build work. It is better to explicitly track that in `.tool-versions`. Additionally, `cargo-sort` is something we need locally too.