### PR TITLE
fix(portal): remove sentry from logger before shutdown

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -20,6 +20,14 @@ defmodule Portal.Application do
     Supervisor.start_link(children(), strategy: :one_for_one, name: __MODULE__.Supervisor)
   end
 
+  @impl true
+  def stop(_state) do
+    # Remove the Sentry logger handler before Sentry.Supervisor terminates
+    # to avoid noproc errors during shutdown
+    _ = :logger.remove_handler(:sentry)
+    :ok
+  end
+
   defp children do
     [
       # Core services

--- a/elixir/test/portal/application_test.exs
+++ b/elixir/test/portal/application_test.exs
@@ -1,0 +1,34 @@
+defmodule Portal.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  describe "stop/1" do
+    test "removes logger handler without crashing" do
+      # Use a unique handler ID to avoid conflicts with parallel tests
+      handler_id = :"test_handler_#{:erlang.unique_integer([:positive])}"
+
+      :ok =
+        :logger.add_handler(handler_id, Sentry.LoggerHandler, %{
+          config: %{
+            level: :warning,
+            metadata: :all,
+            capture_log_messages: true
+          }
+        })
+
+      assert handler_id in :logger.get_handler_ids()
+
+      # This is the same call made in Portal.Application.stop/1
+      assert :ok = :logger.remove_handler(handler_id)
+
+      refute handler_id in :logger.get_handler_ids()
+    end
+
+    test "does not crash when handler is already removed" do
+      handler_id = :"test_handler_#{:erlang.unique_integer([:positive])}"
+
+      # Handler doesn't exist - remove_handler returns error but doesn't crash
+      # Portal.Application.stop/1 ignores this return value with `_ =`
+      assert {:error, {:not_found, ^handler_id}} = :logger.remove_handler(handler_id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes a crash when the application shut down because `Sentry.Supervisor` may not be running.