### PR TITLE
fix(connlib): add server-reflexive candidates to local agent

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -1246,8 +1246,9 @@ fn update_candidate(
 ) -> bool {
     match (maybe_new, &maybe_current) {
         (Some(new), Some(current)) if &new != current => {
+            // This case is basically about detecting roaming without being told we are roaming.
+            // To ensure we don't create false-positive disconnects, we only emit the new candidate but not invalidate the old one.
             events.push_back(Event::New(new.clone()));
-            events.push_back(Event::Invalid(current.clone()));
             *maybe_current = Some(new);
 
             true

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1134,7 +1134,11 @@ fn remove_local_candidate<TId>(
     TId: fmt::Display,
 {
     if candidate.kind() != CandidateKind::Relayed {
-        debug_assert!(false, "we should only ever invalidate relay candidates");
+        debug_assert_eq!(
+            candidate.kind(),
+            CandidateKind::Relayed,
+            "we should only ever invalidate relay candidates"
+        );
         return;
     }
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -13,10 +13,7 @@ use str0m::ice::IceAgent;
 
 use crate::{
     ConnectionStats, Event,
-    node::{
-        Connection, ConnectionState, add_local_candidate, allocations::Allocations,
-        new_ice_candidate_event,
-    },
+    node::{Connection, ConnectionState, allocations::Allocations, new_ice_candidate_event},
 };
 
 pub struct Connections<TId, RId> {
@@ -113,7 +110,7 @@ where
 
             for candidate in allocation
                 .current_relay_candidates()
-                .filter_map(|candidate| add_local_candidate(&mut c.agent, candidate))
+                .filter_map(|candidate| c.agent.add_local_candidate(candidate).cloned())
             {
                 pending_events.push_back(new_ice_candidate_event(cid, candidate));
             }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -50,6 +50,10 @@ export default function Android() {
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
+        <ChangeItem pull="11804">
+          Fixes an issue where connections would flap between relayed and
+          direct, causing WireGuard connection timeouts.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -29,6 +29,10 @@ export default function Apple() {
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>
+        <ChangeItem pull="11804">
+          Fixes an issue where connections would flap between relayed and
+          direct, causing WireGuard connection timeouts.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.12" date={new Date("2026-01-20")}>
         <ChangeItem pull="11735">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -40,6 +40,10 @@ export default function GUI({ os }: { os: OS }) {
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
+        <ChangeItem pull="11804">
+          Fixes an issue where connections would flap between relayed and
+          direct, causing WireGuard connection timeouts.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-12-23")}>
         {os == OS.Linux && (

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -60,6 +60,10 @@ export default function Gateway() {
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
+        <ChangeItem pull="11804">
+          Fixes an issue where connections would flap between relayed and
+          direct, causing WireGuard connection timeouts.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.19" date={new Date("2025-12-23")}>
         <ChangeItem pull="10972">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -41,6 +41,10 @@ export default function Headless({ os }: { os: OS }) {
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
+        <ChangeItem pull="11804">
+          Fixes an issue where connections would flap between relayed and
+          direct, causing WireGuard connection timeouts.
+        </ChangeItem>
       </Entry>
       <Entry version="1.5.5" date={new Date("2025-12-23")}>
         {os == OS.Linux && (


### PR DESCRIPTION
In #5283, we revised how candidates got invalidated within `snownet`. As we identified, invalidating server-reflexive candidates is a bad idea as their address may be mistaken for a host candidate and therefore lead to false-positive disconnects.

Thus, as a first measure of defense, we revise the code for `remove_local_candidate` to bail out for anything other than relay candidates.

Second, when tracing through, where we event emit `allocation::Event::Invalid` it turns out that it is used for two things:
- Invalidating relay candidates when the allocation goes away / is malfunctioning
- Invalidating host and server-reflexive candidates when we detect a "change" in those

As indicated by a newly added comment, the latter is actually a kind of roaming detection that would only kick in if we weren't told by the host-app that we are roaming networks. Many other things in connlib rely on the fact that we are being told that we are roaming networks, so this code-path can be removed as well.

Thirdly, in #10920 we changed our `upsert_connection` function to send all candidates over. Unfortunately, what we overlooked there is that this also sends over locally created peer-reflexive candidates. That by itself isn't an issue. What does create an issue is that we would also already have sent our server-reflexive candidate to the remote but without adding it to the local agent (see #5283 for why). This creates a split-brain kind of situation where the two agents don't have the same view of all candidates. Upon repeated access authorizations, this can create a race condition where the connection flaps between relayed and direct, which I believe causes us to sometimes lose the WireGuard handshake message which then results in a timeout and us force-closing the connection.

To avoid this, we now add back the server-reflexive candidate to the agent which prevents the agent from creating a peer-reflexive candidate with the same address and port. Additionally, this should ensure that both peers always have the same view of all candidates.