### PR TITLE
fix(portal): add missing assoc_constraints

### DIFF
--- a/elixir/.gitignore
+++ b/elixir/.gitignore
@@ -58,3 +58,6 @@ npm-debug.log
 
 # ElixirLS
 .elixir_ls/
+
+# Generated DB structure file
+priv/repo/structure.sql

--- a/elixir/lib/portal/actor.ex
+++ b/elixir/lib/portal/actor.ex
@@ -44,6 +44,7 @@ defmodule Portal.Actor do
     |> normalize_email(:email)
     |> validate_email(:email)
     |> assoc_constraint(:account)
+    |> assoc_constraint(:directory, name: :actors_created_by_directory_id_fkey)
     |> unique_constraint(:email, name: :actors_account_id_email_index)
     |> check_constraint(:type, name: :type_is_valid)
   end

--- a/elixir/lib/portal/membership.ex
+++ b/elixir/lib/portal/membership.ex
@@ -24,8 +24,6 @@ defmodule Portal.Membership do
   end
 
   def changeset(changeset) do
-    import Ecto.Changeset
-
     changeset
     |> assoc_constraint(:actor)
     |> assoc_constraint(:group)

--- a/elixir/lib/portal/one_time_passcode.ex
+++ b/elixir/lib/portal/one_time_passcode.ex
@@ -1,5 +1,6 @@
 defmodule Portal.OneTimePasscode do
   use Ecto.Schema
+  import Ecto.Changeset
 
   @primary_key false
   @foreign_key_type :binary_id
@@ -17,5 +18,11 @@ defmodule Portal.OneTimePasscode do
     field :expires_at, :utc_datetime_usec
 
     timestamps()
+  end
+
+  def changeset(changeset) do
+    changeset
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:actor)
   end
 end

--- a/elixir/lib/portal/policy.ex
+++ b/elixir/lib/portal/policy.ex
@@ -42,6 +42,7 @@ defmodule Portal.Policy do
       name: :policies_account_id_resource_id_group_id_index,
       message: "Policy for the selected Group and Resource already exists"
     )
+    |> assoc_constraint(:account)
     |> assoc_constraint(:resource)
     |> assoc_constraint(:group)
     |> unique_constraint(

--- a/elixir/lib/portal/policy_authorization.ex
+++ b/elixir/lib/portal/policy_authorization.ex
@@ -45,23 +45,13 @@ defmodule Portal.PolicyAuthorization do
   end
 
   def changeset(changeset) do
-    import Ecto.Changeset
-
-    changeset =
-      changeset
-      |> assoc_constraint(:token)
-      |> assoc_constraint(:policy)
-      |> assoc_constraint(:client)
-      |> assoc_constraint(:gateway)
-      |> assoc_constraint(:resource)
-      |> assoc_constraint(:account)
-
-    # Only validate membership constraint if membership_id is present
-    # (nil for "Everyone" group policies which have no explicit membership)
-    if get_field(changeset, :membership_id) do
-      assoc_constraint(changeset, :membership)
-    else
-      changeset
-    end
+    changeset
+    |> assoc_constraint(:token)
+    |> assoc_constraint(:policy)
+    |> assoc_constraint(:client)
+    |> assoc_constraint(:gateway)
+    |> assoc_constraint(:resource)
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:membership)
   end
 end

--- a/elixir/lib/portal/portal_session.ex
+++ b/elixir/lib/portal/portal_session.ex
@@ -1,5 +1,6 @@
 defmodule Portal.PortalSession do
   use Ecto.Schema
+  import Ecto.Changeset
 
   @primary_key false
   @foreign_key_type :binary_id
@@ -29,5 +30,12 @@ defmodule Portal.PortalSession do
     field :online?, :boolean, virtual: true
 
     timestamps(updated_at: false)
+  end
+
+  def changeset(changeset) do
+    changeset
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:actor)
+    |> assoc_constraint(:auth_provider)
   end
 end

--- a/elixir/lib/portal/resource.ex
+++ b/elixir/lib/portal/resource.ex
@@ -66,6 +66,7 @@ defmodule Portal.Resource do
     )
     |> cast_embed(:filters, with: &filter_changeset/2)
     |> assoc_constraint(:site)
+    |> assoc_constraint(:account)
     |> unique_constraint(:name,
       name: :resources_account_id_name_index,
       message: "resource with this name already exists"

--- a/elixir/lib/portal/site.ex
+++ b/elixir/lib/portal/site.ex
@@ -35,5 +35,6 @@ defmodule Portal.Site do
     |> validate_required(:name)
     |> validate_length(:name, min: 1, max: 64)
     |> unique_constraint(:name, name: :sites_account_id_name_managed_by_index)
+    |> assoc_constraint(:account)
   end
 end

--- a/elixir/priv/repo/migrations/20260122071547_rename_fk_constraints_for_assoc_constraint.exs
+++ b/elixir/priv/repo/migrations/20260122071547_rename_fk_constraints_for_assoc_constraint.exs
@@ -1,0 +1,42 @@
+defmodule Portal.Repo.Migrations.RenameFkConstraintsForAssocConstraint do
+  use Ecto.Migration
+
+  @doc """
+  Renames FK constraints to match Ecto's default assoc_constraint naming convention.
+
+  This allows us to use `assoc_constraint(:assoc_name)` without explicit `:name` options,
+  since Ecto derives the constraint name as `{table}_{assoc_name}_id_fkey`.
+
+  These are metadata-only operations that don't require table locks.
+  """
+
+  def up do
+    # client_tokens was renamed from tokens, but FK constraints kept old names
+    execute(
+      "ALTER TABLE client_tokens RENAME CONSTRAINT tokens_actor_id_fkey TO client_tokens_actor_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE client_tokens RENAME CONSTRAINT tokens_auth_provider_id_fkey TO client_tokens_auth_provider_id_fkey"
+    )
+
+    # resources has a non-standard composite FK name
+    execute(
+      "ALTER TABLE resources RENAME CONSTRAINT resources_account_id_site_id_fkey TO resources_site_id_fkey"
+    )
+  end
+
+  def down do
+    execute(
+      "ALTER TABLE client_tokens RENAME CONSTRAINT client_tokens_actor_id_fkey TO tokens_actor_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE client_tokens RENAME CONSTRAINT client_tokens_auth_provider_id_fkey TO tokens_auth_provider_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE resources RENAME CONSTRAINT resources_site_id_fkey TO resources_account_id_site_id_fkey"
+    )
+  end
+end

--- a/elixir/test/portal/actor_test.exs
+++ b/elixir/test/portal/actor_test.exs
@@ -1,0 +1,92 @@
+defmodule Portal.ActorTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  import Portal.AccountFixtures
+  import Portal.DirectoryFixtures
+
+  alias Portal.Actor
+
+  describe "changeset/1 association constraints" do
+    test "enforces account association constraint" do
+      {:error, changeset} =
+        %Actor{}
+        |> cast(
+          %{
+            account_id: Ecto.UUID.generate(),
+            name: "Test Actor",
+            type: :account_user,
+            email: "test@example.com"
+          },
+          [:account_id, :name, :type, :email]
+        )
+        |> Actor.changeset()
+        |> Repo.insert()
+
+      assert %{account: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces directory association constraint" do
+      account = account_fixture()
+
+      {:error, changeset} =
+        %Actor{}
+        |> cast(
+          %{
+            account_id: account.id,
+            name: "Test Actor",
+            type: :account_user,
+            email: "test@example.com",
+            created_by_directory_id: Ecto.UUID.generate()
+          },
+          [:account_id, :name, :type, :email, :created_by_directory_id]
+        )
+        |> Actor.changeset()
+        |> Repo.insert()
+
+      assert %{directory: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows nil directory" do
+      account = account_fixture()
+
+      {:ok, actor} =
+        %Actor{}
+        |> cast(
+          %{
+            name: "Test Actor",
+            type: :account_user,
+            email: "test@example.com"
+          },
+          [:name, :type, :email]
+        )
+        |> put_assoc(:account, account)
+        |> Actor.changeset()
+        |> Repo.insert()
+
+      assert actor.created_by_directory_id == nil
+    end
+
+    test "allows valid directory association" do
+      account = account_fixture()
+      directory = directory_fixture(account: account)
+
+      {:ok, actor} =
+        %Actor{}
+        |> cast(
+          %{
+            name: "Test Actor",
+            type: :account_user,
+            email: "test@example.com",
+            created_by_directory_id: directory.id
+          },
+          [:name, :type, :email, :created_by_directory_id]
+        )
+        |> put_assoc(:account, account)
+        |> Actor.changeset()
+        |> Repo.insert()
+
+      assert actor.created_by_directory_id == directory.id
+    end
+  end
+end

--- a/elixir/test/portal/membership_test.exs
+++ b/elixir/test/portal/membership_test.exs
@@ -1,0 +1,96 @@
+defmodule Portal.MembershipTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.GroupFixtures
+
+  alias Portal.Membership
+
+  describe "changeset/1 association constraints" do
+    test "enforces account association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      group = group_fixture(account: account)
+
+      {:error, changeset} =
+        %Membership{}
+        |> cast(
+          %{
+            account_id: Ecto.UUID.generate(),
+            actor_id: actor.id,
+            group_id: group.id
+          },
+          [:account_id, :actor_id, :group_id]
+        )
+        |> Membership.changeset()
+        |> Repo.insert()
+
+      assert %{account: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces actor association constraint" do
+      account = account_fixture()
+      group = group_fixture(account: account)
+
+      {:error, changeset} =
+        %Membership{}
+        |> cast(
+          %{
+            actor_id: Ecto.UUID.generate(),
+            group_id: group.id
+          },
+          [:actor_id, :group_id]
+        )
+        |> put_assoc(:account, account)
+        |> Membership.changeset()
+        |> Repo.insert()
+
+      assert %{actor: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces group association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      {:error, changeset} =
+        %Membership{}
+        |> cast(
+          %{
+            actor_id: actor.id,
+            group_id: Ecto.UUID.generate()
+          },
+          [:actor_id, :group_id]
+        )
+        |> put_assoc(:account, account)
+        |> Membership.changeset()
+        |> Repo.insert()
+
+      assert %{group: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows valid associations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      group = group_fixture(account: account)
+
+      {:ok, membership} =
+        %Membership{}
+        |> cast(
+          %{
+            actor_id: actor.id,
+            group_id: group.id
+          },
+          [:actor_id, :group_id]
+        )
+        |> put_assoc(:account, account)
+        |> Membership.changeset()
+        |> Repo.insert()
+
+      assert membership.account_id == account.id
+      assert membership.actor_id == actor.id
+      assert membership.group_id == group.id
+    end
+  end
+end

--- a/elixir/test/portal/one_time_passcode_test.exs
+++ b/elixir/test/portal/one_time_passcode_test.exs
@@ -1,0 +1,53 @@
+defmodule Portal.OneTimePasscodeTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+
+  alias Portal.OneTimePasscode
+
+  describe "changeset/1 association constraints" do
+    test "enforces actor association constraint" do
+      account = account_fixture()
+
+      {:error, changeset} =
+        %OneTimePasscode{}
+        |> cast(
+          %{
+            actor_id: Ecto.UUID.generate(),
+            code_hash: "some_hash",
+            expires_at: DateTime.add(DateTime.utc_now(), 300, :second)
+          },
+          [:actor_id, :code_hash, :expires_at]
+        )
+        |> put_assoc(:account, account)
+        |> OneTimePasscode.changeset()
+        |> Repo.insert()
+
+      assert %{actor: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows valid associations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      {:ok, otp} =
+        %OneTimePasscode{}
+        |> cast(
+          %{
+            code_hash: "some_hash",
+            expires_at: DateTime.add(DateTime.utc_now(), 300, :second)
+          },
+          [:code_hash, :expires_at]
+        )
+        |> put_assoc(:account, account)
+        |> put_assoc(:actor, actor)
+        |> OneTimePasscode.changeset()
+        |> Repo.insert()
+
+      assert otp.account_id == account.id
+      assert otp.actor_id == actor.id
+    end
+  end
+end

--- a/elixir/test/portal/policy_authorization_test.exs
+++ b/elixir/test/portal/policy_authorization_test.exs
@@ -1,0 +1,447 @@
+defmodule Portal.PolicyAuthorizationTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.ClientFixtures
+  import Portal.GatewayFixtures
+  import Portal.GroupFixtures
+  import Portal.MembershipFixtures
+  import Portal.PolicyFixtures
+  import Portal.ResourceFixtures
+  import Portal.SiteFixtures
+  import Portal.TokenFixtures
+
+  alias Portal.PolicyAuthorization
+
+  @valid_ip {100, 64, 0, 1}
+  @valid_user_agent "Mozilla/5.0"
+  @valid_gateway_ip {100, 64, 0, 2}
+
+  describe "changeset/1 association constraints" do
+    test "enforces account association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            account_id: Ecto.UUID.generate(),
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :account_id,
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{account: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces token association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: Ecto.UUID.generate(),
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{token: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces policy association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: Ecto.UUID.generate(),
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{policy: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces client association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: Ecto.UUID.generate(),
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{client: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces gateway association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: Ecto.UUID.generate(),
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{gateway: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces resource association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: Ecto.UUID.generate(),
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{resource: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces membership association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: Ecto.UUID.generate(),
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{membership: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows nil membership for Everyone group policies" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:ok, pa} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: nil,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert pa.membership_id == nil
+    end
+
+    test "allows valid associations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:ok, pa} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert pa.account_id == account.id
+      assert pa.policy_id == policy.id
+      assert pa.client_id == client.id
+      assert pa.gateway_id == gateway.id
+      assert pa.resource_id == resource.id
+      assert pa.token_id == token.id
+      assert pa.membership_id == membership.id
+    end
+  end
+end

--- a/elixir/test/portal/policy_test.exs
+++ b/elixir/test/portal/policy_test.exs
@@ -114,6 +114,26 @@ defmodule Portal.PolicyTest do
   end
 
   describe "changeset/1 association constraints" do
+    test "enforces account association constraint" do
+      group = group_fixture()
+      resource = resource_fixture(account: group.account)
+
+      {:error, changeset} =
+        %Policy{}
+        |> cast(
+          %{
+            account_id: Ecto.UUID.generate(),
+            group_id: group.id,
+            resource_id: resource.id
+          },
+          [:account_id, :group_id, :resource_id]
+        )
+        |> Policy.changeset()
+        |> Repo.insert()
+
+      assert %{account: ["does not exist"]} = errors_on(changeset)
+    end
+
     test "enforces resource association constraint" do
       account = account_fixture()
       group = group_fixture(account: account)

--- a/elixir/test/portal/portal_session_test.exs
+++ b/elixir/test/portal/portal_session_test.exs
@@ -1,0 +1,78 @@
+defmodule Portal.PortalSessionTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+
+  alias Portal.PortalSession
+
+  describe "changeset/1 association constraints" do
+    test "enforces actor association constraint" do
+      account = account_fixture()
+      auth_provider = email_otp_provider_fixture(account: account).auth_provider
+
+      {:error, changeset} =
+        %PortalSession{}
+        |> cast(
+          %{
+            actor_id: Ecto.UUID.generate(),
+            auth_provider_id: auth_provider.id,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [:actor_id, :auth_provider_id, :expires_at]
+        )
+        |> put_assoc(:account, account)
+        |> PortalSession.changeset()
+        |> Repo.insert()
+
+      assert %{actor: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces auth_provider association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+
+      {:error, changeset} =
+        %PortalSession{}
+        |> cast(
+          %{
+            auth_provider_id: Ecto.UUID.generate(),
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [:auth_provider_id, :expires_at]
+        )
+        |> put_assoc(:account, account)
+        |> put_assoc(:actor, actor)
+        |> PortalSession.changeset()
+        |> Repo.insert()
+
+      assert %{auth_provider: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows valid associations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      auth_provider = email_otp_provider_fixture(account: account).auth_provider
+
+      {:ok, session} =
+        %PortalSession{}
+        |> cast(
+          %{
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [:expires_at]
+        )
+        |> put_assoc(:account, account)
+        |> put_assoc(:actor, actor)
+        |> put_assoc(:auth_provider, auth_provider)
+        |> PortalSession.changeset()
+        |> Repo.insert()
+
+      assert session.account_id == account.id
+      assert session.actor_id == actor.id
+      assert session.auth_provider_id == auth_provider.id
+    end
+  end
+end

--- a/elixir/test/portal/resource_test.exs
+++ b/elixir/test/portal/resource_test.exs
@@ -1,6 +1,8 @@
 defmodule Portal.ResourceTest do
-  use ExUnit.Case, async: true
-  import Ecto.Changeset
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.SiteFixtures
 
   alias Portal.Resource
 
@@ -426,11 +428,70 @@ defmodule Portal.ResourceTest do
     end
   end
 
-  defp errors_on(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
-        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
-      end)
-    end)
+  describe "changeset/1 association constraints" do
+    test "enforces account association constraint" do
+      site = site_fixture()
+
+      {:error, changeset} =
+        %Resource{}
+        |> cast(
+          %{
+            account_id: Ecto.UUID.generate(),
+            name: "Test Resource",
+            type: :cidr,
+            address: "10.0.0.0/24",
+            site_id: site.id
+          },
+          [:account_id, :name, :type, :address, :site_id]
+        )
+        |> Resource.changeset()
+        |> Repo.insert()
+
+      assert %{account: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "enforces site association constraint" do
+      account = account_fixture()
+
+      {:error, changeset} =
+        %Resource{}
+        |> cast(
+          %{
+            name: "Test Resource",
+            type: :cidr,
+            address: "10.0.0.0/24",
+            site_id: Ecto.UUID.generate()
+          },
+          [:name, :type, :address, :site_id]
+        )
+        |> put_assoc(:account, account)
+        |> Resource.changeset()
+        |> Repo.insert()
+
+      assert %{site: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows valid associations" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+
+      {:ok, resource} =
+        %Resource{}
+        |> cast(
+          %{
+            name: "Test Resource",
+            type: :cidr,
+            address: "10.0.0.0/24"
+          },
+          [:name, :type, :address]
+        )
+        |> put_assoc(:account, account)
+        |> put_assoc(:site, site)
+        |> Resource.changeset()
+        |> Repo.insert()
+
+      assert resource.account_id == account.id
+      assert resource.site_id == site.id
+    end
   end
 end

--- a/elixir/test/portal/site_test.exs
+++ b/elixir/test/portal/site_test.exs
@@ -1,0 +1,94 @@
+defmodule Portal.SiteTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  import Portal.AccountFixtures
+
+  alias Portal.Site
+
+  defp build_changeset(attrs) do
+    %Site{}
+    |> cast(attrs, [:name, :managed_by, :account_id])
+    |> Site.changeset()
+  end
+
+  describe "changeset/1 basic validations" do
+    test "validates name is required" do
+      changeset = build_changeset(%{})
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "validates name length minimum" do
+      changeset = build_changeset(%{name: ""})
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "validates name length maximum" do
+      changeset = build_changeset(%{name: String.duplicate("a", 65)})
+      assert %{name: ["should be at most 64 character(s)"]} = errors_on(changeset)
+    end
+
+    test "accepts valid name length" do
+      changeset = build_changeset(%{name: "Valid Site Name"})
+      refute Map.has_key?(errors_on(changeset), :name)
+    end
+
+    test "accepts name at maximum length" do
+      changeset = build_changeset(%{name: String.duplicate("a", 64)})
+      refute Map.has_key?(errors_on(changeset), :name)
+    end
+  end
+
+  describe "changeset/1 association constraints" do
+    test "enforces account association constraint" do
+      {:error, changeset} =
+        %Site{}
+        |> cast(
+          %{
+            account_id: Ecto.UUID.generate(),
+            name: "Test Site"
+          },
+          [:account_id, :name]
+        )
+        |> Site.changeset()
+        |> Repo.insert()
+
+      assert %{account: ["does not exist"]} = errors_on(changeset)
+    end
+
+    test "allows valid account association" do
+      account = account_fixture()
+
+      {:ok, site} =
+        %Site{}
+        |> cast(%{name: "Test Site"}, [:name])
+        |> put_assoc(:account, account)
+        |> Site.changeset()
+        |> Repo.insert()
+
+      assert site.account_id == account.id
+    end
+  end
+
+  describe "changeset/1 unique constraints" do
+    test "enforces unique constraint on account_id and name with managed_by" do
+      account = account_fixture()
+
+      {:ok, _site} =
+        %Site{}
+        |> cast(%{name: "Test Site", managed_by: :account}, [:name, :managed_by])
+        |> put_assoc(:account, account)
+        |> Site.changeset()
+        |> Repo.insert()
+
+      {:error, changeset} =
+        %Site{}
+        |> cast(%{name: "Test Site", managed_by: :account}, [:name, :managed_by])
+        |> put_assoc(:account, account)
+        |> Site.changeset()
+        |> Repo.insert()
+
+      assert %{name: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+end


### PR DESCRIPTION
Adds missing `assoc_constraint/2` helpers to map the fk constraints we have to usable error messages and avoid a crash.