### PR TITLE
test(portal): allow configurable DPoP retries

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -79,7 +79,8 @@ config :portal, Portal.Billing.Stripe.APIClient,
 
 config :portal, Portal.Okta.APIClient,
   req_opts: [
-    plug: {Req.Test, Portal.Okta.APIClient}
+    plug: {Req.Test, Portal.Okta.APIClient},
+    retry: false
   ]
 
 config :portal, Portal.Entra.APIClient,

--- a/elixir/lib/portal/okta/api_client.ex
+++ b/elixir/lib/portal/okta/api_client.ex
@@ -456,11 +456,18 @@ defmodule Portal.Okta.ReqDPoP do
 
   @spec attach(Req.Request.t(), keyword()) :: Req.Request.t()
   def attach(%Req.Request{} = req, opts) do
-    req
-    |> Req.Request.register_options([:sign_fun, :nonce, :access_token])
-    |> Req.Request.merge_options(opts)
-    |> wrap_adapter()
-    |> Req.Request.merge_options(retry: &retry/2)
+    req =
+      req
+      |> Req.Request.register_options([:sign_fun, :nonce, :access_token])
+      |> Req.Request.merge_options(opts)
+      |> wrap_adapter()
+
+    # Only set custom retry if not already explicitly set (allows tests to disable retries)
+    if is_nil(req.options[:retry]) do
+      Req.Request.merge_options(req, retry: &retry/2)
+    else
+      req
+    end
   end
 
   defp retry(%Req.Request{} = req, %Req.Response{} = resp) do


### PR DESCRIPTION
- Fixes slow (~7s) Okta DPoP retry tests that were not respecting the `req_opts` being passed for the module.
- Adds tests to exercise the custom retry logic for the Okta API Client

```
  - pagination handles server errors in stream: 7007.8ms → 34.5ms
  - Okta 500 error: 7073.6ms → 286.1ms
```