### PR TITLE
test(portal): fix flaky auth/sync/oidc tests

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -36,10 +36,7 @@ jobs:
         env:
           E2E_DEFAULT_WAIT_SECONDS: 20
           CI_ASSERT_RECEIVE_TIMEOUT_MS: 250
-        run: |
-          # TODO: IDP-REFACTOR make sure to re-enable the --warnings-as-errors flag
-          mix coveralls.lcov --exclude flaky:true --exclude acceptance:true || \
-          mix coveralls.lcov --exclude flaky:true --exclude acceptance:true --failed
+        run: mix coveralls.lcov --exclude acceptance:true
 
       - name: Test Report
         if: github.event.pull_request.head.repo.full_name == github.repository && (success() || failure())

--- a/elixir/test/portal_web/settings/authentication_test.exs
+++ b/elixir/test/portal_web/settings/authentication_test.exs
@@ -2257,8 +2257,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Discovery document contains invalid JSON"
+      wait_for_verification_error(lv, "Discovery document contains invalid JSON")
     end
 
     test "validates okta_domain must be a valid FQDN", %{
@@ -2979,8 +2978,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Failed to fetch discovery document (HTTP 403)"
+      wait_for_verification_error(lv, "Failed to fetch discovery document (HTTP 403)")
     end
   end
 
@@ -3178,8 +3176,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Failed to fetch discovery document (HTTP 400)"
+      wait_for_verification_error(lv, "Failed to fetch discovery document (HTTP 400)")
     end
 
     test "handles malformed JSON in discovery document", %{
@@ -3207,8 +3204,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Discovery document contains invalid JSON"
+      wait_for_verification_error(lv, "Discovery document contains invalid JSON")
     end
 
     test "handles connection refused error", %{
@@ -3292,8 +3288,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Failed to fetch discovery document (HTTP 418)"
+      wait_for_verification_error(lv, "Failed to fetch discovery document (HTTP 418)")
     end
   end
 
@@ -3506,8 +3501,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Discovery document contains invalid JSON"
+      wait_for_verification_error(lv, "Discovery document contains invalid JSON")
     end
 
     test "handles JSON with invalid byte sequences", %{
@@ -3536,8 +3530,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Discovery document contains invalid JSON"
+      wait_for_verification_error(lv, "Discovery document contains invalid JSON")
     end
 
     test "handles HTTP 401 error", %{
@@ -3568,8 +3561,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv |> element("#verify-button") |> render_click()
 
-      html = render(lv)
-      assert html =~ "Failed to fetch discovery document (HTTP 401)"
+      wait_for_verification_error(lv, "Failed to fetch discovery document (HTTP 401)")
     end
 
     test "handles Okta DNS lookup failure", %{

--- a/elixir/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/test/support/fixtures/auth_provider_fixtures.ex
@@ -151,6 +151,7 @@ defmodule Portal.AuthProviderFixtures do
 
   """
   def oidc_provider_fixture(:mock, attrs) do
+    # Use dynamic endpoint for cache key isolation when tests run in parallel
     mock_endpoint = PortalWeb.Mocks.OIDC.mock_endpoint()
 
     attrs


### PR DESCRIPTION
- Wait for verification errors to show on page before expecting them
- Use a unique OIDC endpoint per test since there is actually global state maintained by the openid_connect lib