### PR TITLE
test(portal): speed up tests

### DIFF
--- a/elixir/test/portal/crypto/jwk_test.exs
+++ b/elixir/test/portal/crypto/jwk_test.exs
@@ -124,8 +124,9 @@ defmodule Portal.Crypto.JWKTest do
     end
 
     test "generates unique JWKs on each invocation" do
-      result1 = JWK.generate_jwk_and_jwks()
-      result2 = JWK.generate_jwk_and_jwks()
+      # Use 1024 bits for faster test - uniqueness behavior is the same
+      result1 = JWK.generate_jwk_and_jwks(1024)
+      result2 = JWK.generate_jwk_and_jwks(1024)
 
       refute result1.jwk["n"] == result2.jwk["n"]
       refute result1.jwk["d"] == result2.jwk["d"]
@@ -240,8 +241,9 @@ defmodule Portal.Crypto.JWKTest do
     end
 
     test "verification fails with wrong public key" do
-      result1 = JWK.generate_jwk_and_jwks()
-      result2 = JWK.generate_jwk_and_jwks()
+      # Use 1024 bits for faster test
+      result1 = JWK.generate_jwk_and_jwks(1024)
+      result2 = JWK.generate_jwk_and_jwks(1024)
 
       # Sign with result1's private key
       payload = %{"sub" => "test-user"}

--- a/elixir/test/portal/crypto/rsa_test.exs
+++ b/elixir/test/portal/crypto/rsa_test.exs
@@ -127,8 +127,9 @@ defmodule Portal.Crypto.RSATest do
     end
 
     test "generates unique keypairs on each invocation" do
-      keypair1 = RSA.generate()
-      keypair2 = RSA.generate()
+      # Use 1024 bits for faster test - uniqueness behavior is the same
+      keypair1 = RSA.generate(1024)
+      keypair2 = RSA.generate(1024)
 
       refute keypair1.private_pem == keypair2.private_pem
       refute keypair1.public_pem == keypair2.public_pem
@@ -181,8 +182,9 @@ defmodule Portal.Crypto.RSATest do
     end
 
     test "signature verification fails with wrong public key" do
-      keypair1 = RSA.generate()
-      keypair2 = RSA.generate()
+      # Use 1024 bits for faster test
+      keypair1 = RSA.generate(1024)
+      keypair2 = RSA.generate(1024)
       message = "test message"
       digest = :crypto.hash(:sha256, message)
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -713,7 +713,7 @@ defmodule PortalAPI.Client.ChannelTest do
       refute_push "resource_created_or_updated", _payload
       refute_push "resource_deleted", _payload
 
-      Process.sleep(1500)
+      Process.sleep(1050)
 
       send(socket.channel_pid, :recompute_authorized_resources)
 

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -507,13 +507,14 @@ defmodule PortalWeb.SignUpTest do
 
   describe "Stripe API resilience" do
     setup do
-      # Enable retry for these tests
+      # Enable retry for these tests with fast retry delay for testing
       Portal.Config.put_env_override(Portal.Billing.Stripe.APIClient,
         endpoint: "https://api.stripe.com",
         req_opts: [
           plug: {Req.Test, Portal.Billing.Stripe.APIClient},
           retry: :transient,
-          max_retries: 1
+          max_retries: 1,
+          retry_delay: fn _attempt -> 10 end
         ]
       )
 


### PR DESCRIPTION
A single slow tests can sometimes block the test executor more than we think.

In this PR we avoid sleeping and waiting for more time than we need to, resulting in an overall test speedup of ~15-20%.

Given the changes here are basically zero-cost it would be good to conventionalize on these patterns.