### PR TITLE
build(deps): bump to Rust 1.93

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -63,7 +63,7 @@ COPY ${PACKAGE} .
 FROM runtime AS dev
 
 ARG PACKAGE
-ARG RUST_VERSION="1.92.0" # Keep in sync with `rust-toolchain.toml`
+ARG RUST_VERSION="1.93.0" # Keep in sync with `rust-toolchain.toml`
 
 WORKDIR /app
 

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0" # Keep in sync with `Dockerfile`
+channel = "1.93.0" # Keep in sync with `Dockerfile`
 components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Rust 1.93 brings a few stdlib improvements and also a bump to musl 1.2.5. See https://github.com/rust-lang/rust/releases/tag/1.93.0 for details.