### PR TITLE
fix(apple/ios): avoid using semaphore in main runloop

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Token: CustomStringConvertible {
+public struct Token: CustomStringConvertible, Sendable {
   #if DEBUG
     private static let label = "Firezone token (debug)"
     private static let account = "1 (debug)"

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -183,33 +183,25 @@ class Adapter: @unchecked Sendable {
     // which cancels the Task, triggering onTermination -> monitor.cancel()
   }
 
-  func start() throws {
+  func start() async throws {
     Log.log("Adapter.start: Starting session for account: \(accountSlug)")
 
-    // Get device metadata - synchronously get values from MainActor
+    // Get device metadata - asynchronously get values from MainActor
+    let deviceName: String
     #if os(iOS)
-      let deviceMetadata = LockedState<(String, String?)>(initialState: ("", nil))
+      let identifierForVendor: String?
+      (deviceName, identifierForVendor) = await MainActor.run {
+        (DeviceMetadata.getDeviceName(), DeviceMetadata.getIdentifierForVendor())
+      }
     #else
-      let deviceMetadata = LockedState<String>(initialState: "")
+      deviceName = await MainActor.run {
+        DeviceMetadata.getDeviceName()
+      }
     #endif
-    let semaphore = DispatchSemaphore(value: 0)
-
-    Task { @MainActor in
-      let name = DeviceMetadata.getDeviceName()
-      #if os(iOS)
-        let identifier = DeviceMetadata.getIdentifierForVendor()
-        deviceMetadata.withLock { $0 = (name, identifier) }
-      #else
-        deviceMetadata.withLock { $0 = name }
-      #endif
-      semaphore.signal()
-    }
-    semaphore.wait()
 
     let logDir = SharedAccess.connlibLogFolderURL?.path ?? "/tmp/firezone"
 
     #if os(iOS)
-      let (deviceName, identifierForVendor) = deviceMetadata.withLock { $0 }
       let deviceInfo = DeviceInfo(
         firebaseInstallationId: nil,
         deviceUuid: nil,
@@ -217,7 +209,6 @@ class Adapter: @unchecked Sendable {
         identifierForVendor: identifierForVendor
       )
     #else
-      let deviceName = deviceMetadata.withLock { $0 }
       let deviceInfo = DeviceInfo(
         firebaseInstallationId: nil,
         deviceUuid: getDeviceUuid(),
@@ -431,6 +422,7 @@ class Adapter: @unchecked Sendable {
         self.applyNetworkSettings(tunnelNetworkSettings) {
           if firstStart {
             self.startCompletionHandler(nil)
+            self.packetTunnelProvider?.startLogCleanupTask()
           }
         }
       }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -56,7 +56,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // Dummy start to attach a utun for cleanup later
     if options?["cycleStart"] as? Bool == true {
       Log.info("Cycle start requested - extension awakened and temporarily starting tunnel")
-      return completionHandler(nil)
+      completionHandler(nil)
+      return
     }
 
     // Log version on actual tunnel start
@@ -72,39 +73,46 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       protocolConfiguration: protocolConfiguration as? NETunnelProviderProtocol
     )
 
+    // Extract token from options before any async work
+    let passedToken = options?["token"] as? String
+
+    // Load token synchronously - Keychain access is thread-safe
+    guard let token = loadToken(passedToken: passedToken)
+    else {
+      completionHandler(PacketTunnelProviderError.tokenNotFoundInKeychain)
+      return
+    }
+
+    // Try to save the token back to the Keychain but continue if we can't
+    handleTokenSave(token)
+
+    // The firezone id should be initialized by now
+    guard let id = UserDefaults.standard.string(forKey: "firezoneId")
+    else {
+      completionHandler(PacketTunnelProviderError.firezoneIdIsInvalid)
+      return
+    }
+
+    guard let apiURL = legacyConfiguration?["apiURL"] ?? tunnelConfiguration?.apiURL,
+      let logFilter = legacyConfiguration?["logFilter"] ?? tunnelConfiguration?.logFilter,
+      let accountSlug = legacyConfiguration?["accountSlug"] ?? tunnelConfiguration?.accountSlug
+    else {
+      completionHandler(PacketTunnelProviderError.tunnelConfigurationIsInvalid)
+      return
+    }
+
+    // Configure telemetry (sync part)
+    Telemetry.setEnvironmentOrClose(apiURL)
+
+    let enabled = legacyConfiguration?["internetResourceEnabled"]
+    let internetResourceEnabled =
+      enabled != nil ? enabled == "true" : (tunnelConfiguration?.internetResourceEnabled ?? false)
+
+    // Create the adapter synchronously - it stores completionHandler internally
+    // and will call it (along with startLogCleanupTask) when startup succeeds
+    let adapter: Adapter
     do {
-      // If we don't have a token, we can't continue.
-      guard let token = loadAndSaveToken(from: options)
-      else {
-        return completionHandler(PacketTunnelProviderError.tokenNotFoundInKeychain)
-      }
-
-      // Try to save the token back to the Keychain but continue if we can't
-      handleTokenSave(token)
-
-      // The firezone id should be initialized by now
-      guard let id = UserDefaults.standard.string(forKey: "firezoneId")
-      else {
-        throw PacketTunnelProviderError.firezoneIdIsInvalid
-      }
-
-      guard let apiURL = legacyConfiguration?["apiURL"] ?? tunnelConfiguration?.apiURL,
-        let logFilter = legacyConfiguration?["logFilter"] ?? tunnelConfiguration?.logFilter,
-        let accountSlug = legacyConfiguration?["accountSlug"] ?? tunnelConfiguration?.accountSlug
-      else {
-        throw PacketTunnelProviderError.tunnelConfigurationIsInvalid
-      }
-
-      // Configure telemetry
-      Telemetry.setEnvironmentOrClose(apiURL)
-      Task { await Telemetry.setAccountSlug(accountSlug) }
-
-      let enabled = legacyConfiguration?["internetResourceEnabled"]
-      let internetResourceEnabled =
-        enabled != nil ? enabled == "true" : (tunnelConfiguration?.internetResourceEnabled ?? false)
-
-      // Create the adapter with all configuration
-      let adapter = try Adapter(
+      adapter = try Adapter(
         apiURL: apiURL,
         token: token,
         deviceId: id,
@@ -114,19 +122,42 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         packetTunnelProvider: self,
         startCompletionHandler: completionHandler
       )
-
-      // Start the adapter
-      try adapter.start()
-
-      self.adapter = adapter
-
-      // Enforce log size cap at startup and schedule hourly cleanup
-      startLogCleanupTask()
-
     } catch {
       Log.error(error)
       completionHandler(error)
+      return
     }
+
+    // Store adapter reference so it's accessible to wake() and stopTunnel()
+    self.adapter = adapter
+
+    // Start the adapter asynchronously. The Task only captures Sendable values:
+    // - adapter: @unchecked Sendable
+    // - completionHandler: @Sendable
+    // - accountSlug: String (Sendable)
+    Task {
+      // Set account slug for telemetry (async)
+      await Telemetry.setAccountSlug(accountSlug)
+
+      do {
+        try await adapter.start()
+        // On success, Adapter internally calls completionHandler(nil) and startLogCleanupTask()
+      } catch {
+        Log.error(error)
+        completionHandler(error)
+      }
+    }
+  }
+
+  /// Loads the token from passed value or Keychain.
+  private func loadToken(passedToken: String?) -> Token? {
+    // Try to load saved token from Keychain, continuing if Keychain is unavailable.
+    let keychainToken: Token? = {
+      do { return try Token.load() } catch { Log.error(error) }
+      return nil
+    }()
+
+    return Token(passedToken) ?? keychainToken
   }
 
   override func wake() {
@@ -197,21 +228,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       Log.error(error)
       completionHandler?(nil)
     }
-  }
-
-  // swiftlint:disable:next discouraged_optional_collection - matches Apple API parameter type
-  func loadAndSaveToken(from options: [String: NSObject]?) -> Token? {
-    let passedToken = options?["token"] as? String
-
-    // Try to load saved token from Keychain, continuing if Keychain is
-    // unavailable.
-    let keychainToken = {
-      do { return try Token.load() } catch { Log.error(error) }
-
-      return nil
-    }()
-
-    return Token(passedToken) ?? keychainToken
   }
 
   func clearLogs(_ completionHandler: (@Sendable (Data?) -> Void)? = nil) {
@@ -301,7 +317,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
   }
 
-  private func startLogCleanupTask() {
+  func startLogCleanupTask() {
     // Hardcoded 100MB limit for log cleanup
     let maxSizeMb: UInt32 = 100
 

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11834">
+          Fixes an issue where the tunnel might hang or crash on iOS immediately
+          after signing in.
+        </ChangeItem>
         <ChangeItem pull="11659">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.


### PR DESCRIPTION
In bf95dc45 we introduced some refactors to conform to Swift 6.2's enhanced safety requirements.

Unfortunately one of the workarounds we added was a semaphore to read the device metadata synchronously when starting the tunnel. The device metadata is required when starting the tunnel in order to inform the portal of the device's serial, IDs, etc to determine which Resources are accessible to the device.

Calling `semaphore.wait()` unfortunately is not async-friendly, completely halting the main runloop and causing the system watchdog to kill our thread due to hang.

This would manifest to the user as the following:

1. User signs in
2. App hangs at `Connecting...` for 2-5 seconds
3. semaphore is signaled and `startTunnel` completes

In certain cases, the semaphore would not signal in time and the watchdog would kill us, leading to the app failing to sign in.

This issue appears to be exacerbated on iOS 26 (where our Sentry errors are coming from) possibly due to slower reads of the UIDevice APIs we use here.