### PR TITLE
feat(portal): enable DB keepalives

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -2,7 +2,6 @@
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:33,122F186
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:378,1DF17A0
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
 SQL.Query: SQL injection,lib/portal/safe.ex:285,224B461
@@ -20,11 +19,12 @@ DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.e
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:374,5E31712
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
 Config.Secrets: Hardcoded Secret,config/config.exs:104,61C15AF
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:395,66000F3
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:391,6BBB04E
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -19,6 +19,10 @@ if config_env() == :prod do
            {:ssl, env_var_to_config!(:database_ssl)},
            {:parameters, env_var_to_config!(:database_parameters)}
          ] ++
+           if(env_var_to_config!(:database_socket_options) != [],
+             do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
+             else: []
+           ) ++
            if(env_var_to_config(:database_password),
              do: [{:password, env_var_to_config!(:database_password)}],
              else: []
@@ -41,6 +45,10 @@ if config_env() == :prod do
         username: env_var_to_config!(:database_user),
         database: env_var_to_config!(:database_name)
       ] ++
+        if(env_var_to_config!(:database_socket_options) != [],
+          do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
+          else: []
+        ) ++
         if(env_var_to_config(:database_password),
           do: [{:password, env_var_to_config!(:database_password)}],
           else: []
@@ -63,6 +71,10 @@ if config_env() == :prod do
         username: env_var_to_config!(:database_user),
         database: env_var_to_config!(:database_name)
       ] ++
+        if(env_var_to_config!(:database_socket_options) != [],
+          do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
+          else: []
+        ) ++
         if(env_var_to_config(:database_password),
           do: [{:password, env_var_to_config!(:database_password)}],
           else: []

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -223,6 +223,23 @@ defmodule Portal.Config.Definitions do
   defconfig(:database_queue_interval, :integer, default: 1000)
 
   @doc """
+  Socket options for database connections.
+
+  These options are passed to the underlying TCP socket. The most important option is
+  `keepalive: true` which enables TCP keepalive probes to detect dead connections.
+
+  Without keepalive, connections can become "zombies" when the database server becomes
+  unavailable (e.g., during Azure platform maintenance), causing queries to hang until
+  the checkout timeout is reached.
+
+  Accepts a JSON object with socket options (e.g. `{"keepalive": true}`).
+  """
+  defconfig(:database_socket_options, :map,
+    default: %{},
+    dump: &Dumper.keyword/1
+  )
+
+  @doc """
   Name of the replication slot used by Firezone.
   """
   defconfig(:database_changes_replication_slot_name, :string, default: "changes_slot")


### PR DESCRIPTION
If a TCP connection drops or goes stale, we won't learn about it until that connection becomes selected by the pool to use for a query.

To more quickly detect hung / broken TCP connections, we set the `keepalive: true` socket option which enables the Linux kernel's TCP probes to be sent on our DB connection pool connections.

This will disconnect the TCP connection much sooner after a certain number of keepalive probes have failed.