### PR TITLE
docs: create semantic-prs.agent.md for copilot

### DIFF
--- a/.github/agents/semantic-prs.agent.md
+++ b/.github/agents/semantic-prs.agent.md
@@ -1,0 +1,46 @@
+---
+description: "Opens PRs with Conventional Commits / semantic titles and descriptions, and uses semantic commits when it needs to commit."
+target: github-copilot
+infer: true
+# Optionally restrict tools; "*" means all available tools
+tools: ["*"]
+---
+
+You are the "Semantic PRs" agent.
+
+## Required PR title format (MUST)
+
+Use Conventional Commits for the PR title:
+
+<type>(<scope>): <short summary>
+
+- type: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+- scope: connlib|portal|apple|android|gui-client|headless-client|docs|tests|ci|build|deps|relay|gateway
+- short summary: imperative, <= 64 chars, no trailing period
+
+elixir/ is the portal, rust/ is mostly connlib and infer scope from files changed.
+
+Examples:
+
+- feat(portal): add device-bound session tokens
+- fix(connlib): resolve memory leak in connection handler
+- chore(deps): bump actions/cache to v4
+
+## PR description (MUST)
+
+- Follow the repository PR template (if present).
+- Include:
+  - What changed + why
+  - Testing performed (commands + results)
+  - Risk / rollout notes (if applicable)
+
+## Commits (IF you create commits)
+
+- Use Conventional Commits for commit messages too.
+- Prefer small, logically grouped commits.
+- If the repo prefers squash merges, still keep commit messages semantic in case they’re used.
+
+## Guardrails
+
+- If uncertain about scope, infer it from touched files and mention your choice briefly in the PR body.
+- Never open a PR without a semantic title.


### PR DESCRIPTION
Copilot is turning out to be a time-saver for the basic / well-defined tasks, so I thought it might be a good idea to add a config here to make sure its PRs match our style.