### PR TITLE
feat(portal): add database read replica support

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -9,23 +9,23 @@ DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
-Config.Secrets: Hardcoded Secret,config/config.exs:208,4700588
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
+Config.Secrets: Hardcoded Secret,config/config.exs:219,48EA898
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
 SQL.Query: SQL injection,lib/portal/safe.ex:291,4C5F170
+Config.Secrets: Hardcoded Secret,config/config.exs:218,4EA833B
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:403,5BB84FC
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:399,5F2DE06
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
-Config.Secrets: Hardcoded Secret,config/config.exs:104,61C15AF
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:395,66000F3
+Config.Secrets: Hardcoded Secret,config/config.exs:114,67D22E3
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:391,6BBB04E
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619
-Config.Secrets: Hardcoded Secret,config/config.exs:209,8DFEA3

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -12,7 +12,7 @@ import Config
 ##### Portal ##################
 ###############################
 
-config :portal, ecto_repos: [Portal.Repo]
+config :portal, ecto_repos: [Portal.Repo, Portal.Repo.Replica]
 config :portal, generators: [binary_id: true]
 
 config :portal, sql_sandbox: false
@@ -32,6 +32,16 @@ config :portal, Portal.Repo,
   migration_timestamps: [type: :timestamptz],
   migration_lock: :pg_advisory_lock,
   start_apps_before_migration: [:ssl, :logger_json]
+
+config :portal, Portal.Repo.Replica,
+  hostname: "localhost",
+  username: "postgres",
+  password: "postgres",
+  database: "firezone_dev",
+  show_sensitive_data_on_connection_error: true,
+  pool_size: :erlang.system_info(:logical_processors_available) * 2,
+  queue_target: 500,
+  queue_interval: 1000
 
 config :portal, Portal.ChangeLogs.ReplicationConnection,
   replication_slot_name: "change_logs_slot",

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -26,6 +26,7 @@ db_opts = [
 ###############################
 
 config :portal, Portal.Repo, db_opts
+config :portal, Portal.Repo.Replica, db_opts
 
 config :portal, Portal.ChangeLogs.ReplicationConnection,
   replication_slot_name: db_opts[:database] <> "_clog_slot",

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -32,6 +32,28 @@ if config_env() == :prod do
              else: [{:hostname, env_var_to_config!(:database_host)}]
            )
 
+  config :portal,
+         Portal.Repo.Replica,
+         [
+           {:database, env_var_to_config!(:database_name)},
+           {:username, env_var_to_config!(:database_user)},
+           {:port, env_var_to_config!(:database_port)},
+           {:pool_size, env_var_to_config!(:database_pool_size)},
+           {:queue_target, env_var_to_config!(:database_queue_target)},
+           {:queue_interval, env_var_to_config!(:database_queue_interval)},
+           {:ssl, env_var_to_config!(:database_ssl)},
+           {:parameters, env_var_to_config!(:database_parameters)},
+           {:hostname, env_var_to_config!(:database_host_replica)}
+         ] ++
+           if(env_var_to_config!(:database_socket_options) != [],
+             do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
+             else: []
+           ) ++
+           if(env_var_to_config(:database_password),
+             do: [{:password, env_var_to_config!(:database_password)}],
+             else: []
+           )
+
   config :portal, Portal.ChangeLogs.ReplicationConnection,
     # TODO: Use a dedicated node for Change Log replication
     enabled: env_var_to_config!(:background_jobs_enabled),

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -23,6 +23,11 @@ config :portal, Portal.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   queue_target: 1000
 
+config :portal, Portal.Repo.Replica,
+  database: "firezone_test#{partition_suffix}",
+  pool: Ecto.Adapters.SQL.Sandbox,
+  queue_target: 1000
+
 # Oban has its own config validation that prevents overriding config in runtime.exs,
 # so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
 config :portal, Oban,

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -14,6 +14,7 @@ defmodule Portal.Application do
     # OpenTelemetry setup
     :ok = OpentelemetryLoggerMetadata.setup()
     :ok = OpentelemetryEcto.setup([:portal, :repo])
+    :ok = OpentelemetryEcto.setup([:portal, :repo, :replica])
     :ok = OpentelemetryBandit.setup()
     :ok = OpentelemetryPhoenix.setup(adapter: :bandit)
     :ok = OpentelemetryOban.setup()
@@ -33,6 +34,7 @@ defmodule Portal.Application do
     [
       # Core services
       Portal.Repo,
+      Portal.Repo.Replica,
       Portal.PubSub,
 
       # Infrastructure services

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -181,6 +181,14 @@ defmodule Portal.Config.Definitions do
   defconfig(:database_host, :string, default: "postgres")
 
   @doc """
+  PostgreSQL replica host for read-only queries.
+  Falls back to DATABASE_HOST if not set.
+  """
+  defconfig(:database_host_replica, :string,
+    default: fn -> System.get_env("DATABASE_HOST", "postgres") end
+  )
+
+  @doc """
   PostgreSQL socket directory (takes precedence over hostname).
   """
   defconfig(:database_socket_dir, :string, default: nil)

--- a/elixir/lib/portal/repo/replica.ex
+++ b/elixir/lib/portal/repo/replica.ex
@@ -1,0 +1,6 @@
+defmodule Portal.Repo.Replica do
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres,
+    read_only: true
+end

--- a/elixir/test/portal/repo/replica_test.exs
+++ b/elixir/test/portal/repo/replica_test.exs
@@ -1,0 +1,118 @@
+defmodule Portal.Repo.ReplicaTest do
+  use Portal.DataCase, async: true
+
+  alias Portal.Repo.Replica
+
+  describe "read operations" do
+    # Note: Due to sandbox isolation, data inserted via Portal.Repo is not visible
+    # to Portal.Repo.Replica in tests. These tests verify the read functions exist
+    # and can be called without error.
+
+    test "all/1 returns a list" do
+      result = Replica.all(Portal.Account)
+      assert is_list(result)
+    end
+
+    test "get/2 returns nil for non-existent record" do
+      result = Replica.get(Portal.Account, Ecto.UUID.generate())
+      assert is_nil(result)
+    end
+
+    test "get!/2 raises for non-existent record" do
+      assert_raise Ecto.NoResultsError, fn ->
+        Replica.get!(Portal.Account, Ecto.UUID.generate())
+      end
+    end
+
+    test "one/1 returns nil for empty query" do
+      import Ecto.Query
+      query = from(a in Portal.Account, where: a.id == ^Ecto.UUID.generate())
+
+      result = Replica.one(query)
+      assert is_nil(result)
+    end
+
+    test "aggregate/2 returns a count" do
+      count = Replica.aggregate(Portal.Account, :count)
+      assert is_integer(count)
+      assert count >= 0
+    end
+
+    test "exists?/1 returns false for non-matching query" do
+      import Ecto.Query
+      query = from(a in Portal.Account, where: a.id == ^Ecto.UUID.generate())
+
+      refute Replica.exists?(query)
+    end
+
+    test "preload/2 works on structs" do
+      # Create a struct manually to test preload function exists
+      account = %Portal.Account{id: Ecto.UUID.generate(), actors: %Ecto.Association.NotLoaded{}}
+
+      # preload should work even if the underlying query returns nothing
+      # (the struct will keep the NotLoaded marker if no DB records found)
+      result = Replica.preload(account, :actors)
+      assert result.id == account.id
+    end
+  end
+
+  describe "write operations are not available" do
+    # read_only: true in Ecto.Repo means write functions are not defined
+    # This is the key behavior we want to verify
+
+    test "insert/2 is not defined" do
+      refute function_exported?(Replica, :insert, 2)
+    end
+
+    test "insert!/2 is not defined" do
+      refute function_exported?(Replica, :insert!, 2)
+    end
+
+    test "update/2 is not defined" do
+      refute function_exported?(Replica, :update, 2)
+    end
+
+    test "update!/2 is not defined" do
+      refute function_exported?(Replica, :update!, 2)
+    end
+
+    test "delete/2 is not defined" do
+      refute function_exported?(Replica, :delete, 2)
+    end
+
+    test "delete!/2 is not defined" do
+      refute function_exported?(Replica, :delete!, 2)
+    end
+
+    test "insert_all/3 is not defined" do
+      refute function_exported?(Replica, :insert_all, 3)
+    end
+
+    test "update_all/3 is not defined" do
+      refute function_exported?(Replica, :update_all, 3)
+    end
+
+    test "delete_all/2 is not defined" do
+      refute function_exported?(Replica, :delete_all, 2)
+    end
+  end
+
+  describe "configuration" do
+    test "is configured as a valid repo" do
+      assert Replica.get_dynamic_repo() == Replica
+    end
+
+    test "returns correct config" do
+      config = Replica.config()
+
+      assert Keyword.has_key?(config, :database)
+      assert Keyword.has_key?(config, :hostname) or Keyword.has_key?(config, :socket_dir)
+      assert config[:database] == "firezone_test"
+    end
+
+    test "uses sandbox pool in test environment" do
+      config = Replica.config()
+      assert config[:pool] == Ecto.Adapters.SQL.Sandbox
+    end
+  end
+end

--- a/elixir/test/support/case_template.ex
+++ b/elixir/test/support/case_template.ex
@@ -9,9 +9,11 @@ defmodule Portal.CaseTemplate do
     quote do
       setup tags do
         :ok = Sandbox.checkout(Portal.Repo)
+        :ok = Sandbox.checkout(Portal.Repo.Replica)
 
         unless tags[:async] do
           Sandbox.mode(Portal.Repo, {:shared, self()})
+          Sandbox.mode(Portal.Repo.Replica, {:shared, self()})
         end
 
         :ok


### PR DESCRIPTION
For regional redundancy and lower latency to customers, we've deployed geographically distributed postgres read replicas.

To make use of these in the application code, we add a new Repo module, `Portal.Repo.Replica` which is configured with an env var, `DATABASE_HOST_REPLICA` to point to that region's local replica.

In dev, test, and the primary region, this env var simply matches the Primary, so that application code does not need to be region-aware.

Related: #10419 