### PR TITLE
feat(portal): use replica for client/gateway cache hydration

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -4,17 +4,18 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
-SQL.Query: SQL injection,lib/portal/safe.ex:285,224B461
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
+Config.Secrets: Hardcoded Secret,config/config.exs:220,29A4EF2
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
+SQL.Query: SQL injection,lib/portal/safe.ex:344,2C3D7F0
+SQL.Query: SQL injection,lib/portal/safe.ex:350,3C9C61F
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
 Config.Secrets: Hardcoded Secret,config/config.exs:219,48EA898
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
+Config.Secrets: Hardcoded Secret,config/config.exs:115,496262
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
-SQL.Query: SQL injection,lib/portal/safe.ex:291,4C5F170
-Config.Secrets: Hardcoded Secret,config/config.exs:218,4EA833B
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
@@ -23,7 +24,6 @@ XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:403,5BB84FC
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:399,5F2DE06
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
-Config.Secrets: Hardcoded Secret,config/config.exs:114,67D22E3
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -16,6 +16,7 @@ config :portal, ecto_repos: [Portal.Repo, Portal.Repo.Replica]
 config :portal, generators: [binary_id: true]
 
 config :portal, sql_sandbox: false
+config :portal, replica_repo: Portal.Repo.Replica
 
 # Don't run manual migrations by default
 config :portal, run_manual_migrations: false

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -12,6 +12,7 @@ partition_suffix =
   end
 
 config :portal, sql_sandbox: true
+config :portal, replica_repo: Portal.Repo
 
 # Use ephemeral port for health server to avoid conflicts between test runs
 config :portal, Portal.Health, health_port: 0

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -12,6 +12,7 @@ partition_suffix =
   end
 
 config :portal, sql_sandbox: true
+# Replica is not used in tests; use the primary DB instead
 config :portal, replica_repo: Portal.Repo
 
 # Use ephemeral port for health server to avoid conflicts between test runs

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -558,6 +558,8 @@ defmodule Portal.Cache.Client do
     import Ecto.Query
     alias Portal.Safe
 
+    defp repo, do: Portal.Config.fetch_env!(:portal, :replica_repo)
+
     def all_policies_for_actor_id!(actor_id, subject) do
       # Service accounts don't get access to the "Everyone" group - they must have explicit memberships
       include_everyone_group = subject.actor.type in [:account_user, :account_admin_user]
@@ -584,7 +586,7 @@ defmodule Portal.Cache.Client do
              ag.name == "Everyone")
       )
       |> preload(resource: :site)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, repo())
       |> Safe.all()
     end
 
@@ -592,7 +594,7 @@ defmodule Portal.Cache.Client do
       # Get real memberships
       memberships =
         from(m in Portal.Membership, where: m.actor_id == ^actor_id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, repo())
         |> Safe.all()
         |> case do
           {:error, :unauthorized} -> []
@@ -609,7 +611,7 @@ defmodule Portal.Cache.Client do
                 g.name == "Everyone" and
                 g.account_id == ^subject.account.id
           )
-          |> Safe.scoped(subject)
+          |> Safe.scoped(subject, repo())
           |> Safe.one()
 
         # Append a synthetic membership for the Everyone group
@@ -631,7 +633,7 @@ defmodule Portal.Cache.Client do
     def fetch_resource_by_id(id, subject) do
       result =
         from(r in Portal.Resource, where: r.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, repo())
         |> Safe.one()
 
       case result do
@@ -642,7 +644,7 @@ defmodule Portal.Cache.Client do
     end
 
     def preload_site(resource) do
-      Safe.preload(resource, :site)
+      Safe.preload(resource, :site, repo())
     end
 
     def get_site(nil, _subject), do: nil
@@ -651,7 +653,7 @@ defmodule Portal.Cache.Client do
       id = Ecto.UUID.load!(site.id)
 
       from(s in Portal.Site, where: s.id == ^id)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, repo())
       |> Safe.one()
     end
 
@@ -659,7 +661,7 @@ defmodule Portal.Cache.Client do
       id = Ecto.UUID.load!(site_id)
 
       from(s in Portal.Site, where: s.id == ^id)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, repo())
       |> Safe.one()
     end
   end

--- a/elixir/lib/portal/cache/gateway.ex
+++ b/elixir/lib/portal/cache/gateway.ex
@@ -226,6 +226,8 @@ defmodule Portal.Cache.Gateway do
 
     @infinity ~U[9999-12-31 23:59:59.999999Z]
 
+    defp repo, do: Portal.Config.fetch_env!(:portal, :replica_repo)
+
     def all_gateway_policy_authorizations_for_cache!(%Portal.Gateway{} = gateway) do
       now = DateTime.utc_now()
 
@@ -237,7 +239,7 @@ defmodule Portal.Cache.Gateway do
         [policy_authorizations: f],
         {{f.client_id, f.resource_id}, {f.id, f.expires_at}}
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(repo())
       |> Safe.all()
     end
 

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -15,10 +15,11 @@ defmodule Portal.Safe do
     """
     @type t :: %__MODULE__{
             subject: Subject.t(),
-            queryable: Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t() | nil
+            queryable: Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t() | nil,
+            repo: module()
           }
 
-    defstruct [:subject, :queryable]
+    defstruct [:subject, :queryable, repo: Portal.Repo]
   end
 
   defmodule Unscoped do
@@ -26,15 +27,16 @@ defmodule Portal.Safe do
     Unscoped context for operations without authorization.
     """
     @type t :: %__MODULE__{
-            queryable: Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t() | nil
+            queryable: Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t() | nil,
+            repo: module()
           }
 
-    defstruct [:queryable]
+    defstruct [:queryable, repo: Portal.Repo]
   end
 
   @doc """
   Returns a scoped context for operations with authorization and account filtering.
-  Can optionally accept a queryable to enable chaining.
+  Can optionally accept a queryable to enable chaining and a repo module.
 
   ## Examples
 
@@ -43,38 +45,70 @@ defmodule Portal.Safe do
 
       # Chainable style
       query |> Safe.scoped(subject) |> Safe.one()
+
+      # With replica
+      Safe.scoped(subject, Portal.Repo.Replica) |> Safe.one(query)
+      query |> Safe.scoped(subject, Portal.Repo.Replica) |> Safe.one()
   """
   @spec scoped(Subject.t()) :: Scoped.t()
   def scoped(%Subject{} = subject) do
-    %Scoped{subject: subject, queryable: nil}
+    %Scoped{subject: subject, queryable: nil, repo: Repo}
+  end
+
+  @spec scoped(Subject.t(), module()) :: Scoped.t()
+  def scoped(%Subject{} = subject, repo) when is_atom(repo) do
+    %Scoped{subject: subject, queryable: nil, repo: repo}
   end
 
   @spec scoped(Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t(), Subject.t()) ::
           Scoped.t()
   def scoped(queryable, %Subject{} = subject) do
-    %Scoped{subject: subject, queryable: queryable}
+    %Scoped{subject: subject, queryable: queryable, repo: Repo}
+  end
+
+  @spec scoped(Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t(), Subject.t(), module()) ::
+          Scoped.t()
+  def scoped(queryable, %Subject{} = subject, repo) do
+    %Scoped{subject: subject, queryable: queryable, repo: repo}
   end
 
   @doc """
   Returns an unscoped context for operations without authorization or filtering.
-  Can optionally accept a queryable to enable chaining.
+  Can optionally accept a queryable to enable chaining and a repo module.
 
   ## Examples
 
       # Traditional style
       Safe.unscoped() |> Safe.one(query)
 
+      # With replica
+      Safe.unscoped(Portal.Repo.Replica) |> Safe.one(query)
+
       # Chainable style
       query |> Safe.unscoped() |> Safe.one()
+
+      # Chainable with replica
+      query |> Safe.unscoped(Portal.Repo.Replica) |> Safe.one()
   """
   @spec unscoped() :: Unscoped.t()
   def unscoped do
-    %Unscoped{queryable: nil}
+    %Unscoped{queryable: nil, repo: Repo}
+  end
+
+  @spec unscoped(module()) :: Unscoped.t()
+  def unscoped(repo) when is_atom(repo) do
+    %Unscoped{queryable: nil, repo: repo}
   end
 
   @spec unscoped(Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t()) :: Unscoped.t()
   def unscoped(queryable) do
-    %Unscoped{queryable: queryable}
+    %Unscoped{queryable: queryable, repo: Repo}
+  end
+
+  @spec unscoped(Ecto.Queryable.t() | Ecto.Changeset.t() | Ecto.Schema.t(), module()) ::
+          Unscoped.t()
+  def unscoped(queryable, repo) do
+    %Unscoped{queryable: queryable, repo: repo}
   end
 
   defp safe_repo(fun) when is_function(fun, 0) do
@@ -111,65 +145,10 @@ defmodule Portal.Safe do
 
   # Query operations
   @spec one(Scoped.t()) :: Ecto.Schema.t() | nil | {:error, :unauthorized}
-  def one(%Scoped{subject: %Subject{account: %{id: account_id}} = subject, queryable: queryable}) do
-    schema = get_schema_module(queryable)
-
-    with :ok <- permit(:read, schema, subject) do
-      safe_repo(fn ->
-        queryable
-        |> apply_account_filter(schema, account_id)
-        |> Repo.one()
-      end)
-    end
-  end
-
-  @spec one(Unscoped.t()) :: Ecto.Schema.t() | nil
-  def one(%Unscoped{queryable: queryable}), do: safe_repo(fn -> Repo.one(queryable) end)
-
-  @spec one(Portal.Repo, Ecto.Queryable.t()) :: Ecto.Schema.t() | nil
-  def one(repo, queryable) when repo == Repo, do: safe_repo(fn -> Repo.one(queryable) end)
-
-  @spec one!(Scoped.t()) :: Ecto.Schema.t() | no_return()
-  def one!(%Scoped{subject: %Subject{account: %{id: account_id}} = subject, queryable: queryable}) do
-    schema = get_schema_module(queryable)
-
-    with :ok <- permit(:read, schema, subject) do
-      filtered_query = apply_account_filter(queryable, schema, account_id)
-      safe_repo!(fn -> Repo.one!(filtered_query) end, filtered_query)
-    end
-  end
-
-  @spec one!(Unscoped.t()) :: Ecto.Schema.t() | no_return()
-  def one!(%Unscoped{queryable: queryable}),
-    do: safe_repo!(fn -> Repo.one!(queryable) end, queryable)
-
-  @spec one!(Portal.Repo, Ecto.Queryable.t()) :: Ecto.Schema.t() | no_return()
-  def one!(repo, queryable) when repo == Repo,
-    do: safe_repo!(fn -> Repo.one!(queryable) end, queryable)
-
-  @spec all(Scoped.t()) :: [Ecto.Schema.t()] | {:error, :unauthorized}
-  def all(%Scoped{subject: %Subject{account: %{id: account_id}} = subject, queryable: queryable}) do
-    schema = get_schema_module(queryable)
-
-    with :ok <- permit(:read, schema, subject) do
-      safe_repo(fn ->
-        queryable
-        |> apply_account_filter(schema, account_id)
-        |> Repo.all()
-      end) || []
-    end
-  end
-
-  @spec all(Unscoped.t()) :: [Ecto.Schema.t()]
-  def all(%Unscoped{queryable: queryable}), do: safe_repo(fn -> Repo.all(queryable) end) || []
-
-  @spec all(Portal.Repo, Ecto.Queryable.t()) :: [Ecto.Schema.t()]
-  def all(repo, queryable) when repo == Repo, do: safe_repo(fn -> Repo.all(queryable) end) || []
-
-  @spec exists?(Scoped.t()) :: boolean() | {:error, :unauthorized}
-  def exists?(%Scoped{
+  def one(%Scoped{
         subject: %Subject{account: %{id: account_id}} = subject,
-        queryable: queryable
+        queryable: queryable,
+        repo: repo
       }) do
     schema = get_schema_module(queryable)
 
@@ -177,14 +156,84 @@ defmodule Portal.Safe do
       safe_repo(fn ->
         queryable
         |> apply_account_filter(schema, account_id)
-        |> Repo.exists?()
+        |> repo.one()
+      end)
+    end
+  end
+
+  @spec one(Unscoped.t()) :: Ecto.Schema.t() | nil
+  def one(%Unscoped{queryable: queryable, repo: repo}),
+    do: safe_repo(fn -> repo.one(queryable) end)
+
+  @spec one(Portal.Repo, Ecto.Queryable.t()) :: Ecto.Schema.t() | nil
+  def one(repo, queryable) when repo == Repo, do: safe_repo(fn -> Repo.one(queryable) end)
+
+  @spec one!(Scoped.t()) :: Ecto.Schema.t() | no_return()
+  def one!(%Scoped{
+        subject: %Subject{account: %{id: account_id}} = subject,
+        queryable: queryable,
+        repo: repo
+      }) do
+    schema = get_schema_module(queryable)
+
+    with :ok <- permit(:read, schema, subject) do
+      filtered_query = apply_account_filter(queryable, schema, account_id)
+      safe_repo!(fn -> repo.one!(filtered_query) end, filtered_query)
+    end
+  end
+
+  @spec one!(Unscoped.t()) :: Ecto.Schema.t() | no_return()
+  def one!(%Unscoped{queryable: queryable, repo: repo}),
+    do: safe_repo!(fn -> repo.one!(queryable) end, queryable)
+
+  @spec one!(Portal.Repo, Ecto.Queryable.t()) :: Ecto.Schema.t() | no_return()
+  def one!(repo, queryable) when repo == Repo,
+    do: safe_repo!(fn -> Repo.one!(queryable) end, queryable)
+
+  @spec all(Scoped.t()) :: [Ecto.Schema.t()] | {:error, :unauthorized}
+  def all(%Scoped{
+        subject: %Subject{account: %{id: account_id}} = subject,
+        queryable: queryable,
+        repo: repo
+      }) do
+    schema = get_schema_module(queryable)
+
+    with :ok <- permit(:read, schema, subject) do
+      safe_repo(fn ->
+        queryable
+        |> apply_account_filter(schema, account_id)
+        |> repo.all()
+      end) || []
+    end
+  end
+
+  @spec all(Unscoped.t()) :: [Ecto.Schema.t()]
+  def all(%Unscoped{queryable: queryable, repo: repo}),
+    do: safe_repo(fn -> repo.all(queryable) end) || []
+
+  @spec all(Portal.Repo, Ecto.Queryable.t()) :: [Ecto.Schema.t()]
+  def all(repo, queryable) when repo == Repo, do: safe_repo(fn -> Repo.all(queryable) end) || []
+
+  @spec exists?(Scoped.t()) :: boolean() | {:error, :unauthorized}
+  def exists?(%Scoped{
+        subject: %Subject{account: %{id: account_id}} = subject,
+        queryable: queryable,
+        repo: repo
+      }) do
+    schema = get_schema_module(queryable)
+
+    with :ok <- permit(:read, schema, subject) do
+      safe_repo(fn ->
+        queryable
+        |> apply_account_filter(schema, account_id)
+        |> repo.exists?()
       end) || false
     end
   end
 
   @spec exists?(Unscoped.t()) :: boolean()
-  def exists?(%Unscoped{queryable: queryable}),
-    do: safe_repo(fn -> Repo.exists?(queryable) end) || false
+  def exists?(%Unscoped{queryable: queryable, repo: repo}),
+    do: safe_repo(fn -> repo.exists?(queryable) end) || false
 
   @spec exists?(Portal.Repo, Ecto.Queryable.t()) :: boolean()
   def exists?(repo, queryable) when repo == Repo,
@@ -202,7 +251,11 @@ defmodule Portal.Safe do
   @spec list(Scoped.t(), module(), Keyword.t()) ::
           {:ok, [Ecto.Schema.t()], map()} | {:error, :unauthorized}
   def list(
-        %Scoped{subject: %Subject{account: %{id: account_id}} = subject, queryable: queryable},
+        %Scoped{
+          subject: %Subject{account: %{id: account_id}} = subject,
+          queryable: queryable,
+          repo: repo
+        },
         query_module,
         opts \\ []
       ) do
@@ -212,20 +265,25 @@ defmodule Portal.Safe do
       safe_repo(fn ->
         queryable
         |> apply_account_filter(schema, account_id)
-        |> Repo.list(query_module, opts)
+        |> repo.list(query_module, opts)
       end) || {:ok, [], %{}}
     end
   end
 
   @spec stream(Unscoped.t(), Keyword.t()) :: Enum.t()
-  def stream(%Unscoped{queryable: queryable}, opts \\ []), do: Repo.stream(queryable, opts)
+  def stream(%Unscoped{queryable: queryable, repo: repo}, opts \\ []),
+    do: repo.stream(queryable, opts)
 
   @spec stream(Portal.Repo, Ecto.Queryable.t(), Keyword.t()) :: Enum.t()
   def stream(repo, queryable, opts) when repo == Repo, do: Repo.stream(queryable, opts)
 
   @spec aggregate(Scoped.t(), atom()) :: term() | {:error, :unauthorized}
   def aggregate(
-        %Scoped{subject: %Subject{account: %{id: account_id}} = subject, queryable: queryable},
+        %Scoped{
+          subject: %Subject{account: %{id: account_id}} = subject,
+          queryable: queryable,
+          repo: repo
+        },
         aggregate
       ) do
     schema = get_schema_module(queryable)
@@ -234,25 +292,26 @@ defmodule Portal.Safe do
       safe_repo(fn ->
         queryable
         |> apply_account_filter(schema, account_id)
-        |> Repo.aggregate(aggregate)
+        |> repo.aggregate(aggregate)
       end) || 0
     end
   end
 
   @spec aggregate(Unscoped.t(), atom()) :: term()
-  def aggregate(%Unscoped{queryable: queryable}, aggregate),
-    do: safe_repo(fn -> Repo.aggregate(queryable, aggregate) end) || 0
+  def aggregate(%Unscoped{queryable: queryable, repo: repo}, aggregate),
+    do: safe_repo(fn -> repo.aggregate(queryable, aggregate) end) || 0
 
   @spec aggregate(Unscoped.t(), atom(), atom()) :: term()
-  def aggregate(%Unscoped{queryable: queryable}, aggregate, field),
-    do: safe_repo(fn -> Repo.aggregate(queryable, aggregate, field) end) || 0
+  def aggregate(%Unscoped{queryable: queryable, repo: repo}, aggregate, field),
+    do: safe_repo(fn -> repo.aggregate(queryable, aggregate, field) end) || 0
 
   @spec load(module(), {list(), list()}) :: Ecto.Schema.t()
   def load(schema, data) when is_atom(schema), do: Repo.load(schema, data)
 
-  @spec preload(Ecto.Schema.t() | [Ecto.Schema.t()], term()) ::
+  @spec preload(Ecto.Schema.t() | [Ecto.Schema.t()], term(), module()) ::
           Ecto.Schema.t() | [Ecto.Schema.t()]
-  def preload(struct_or_structs, preloads), do: Repo.preload(struct_or_structs, preloads)
+  def preload(struct_or_structs, preloads, repo \\ Repo),
+    do: repo.preload(struct_or_structs, preloads)
 
   @doc """
   Executes a transaction using either a function or an Ecto.Multi struct.

--- a/elixir/test/test_helper.exs
+++ b/elixir/test/test_helper.exs
@@ -1,3 +1,2 @@
 Ecto.Adapters.SQL.Sandbox.mode(Portal.Repo, :manual)
-Ecto.Adapters.SQL.Sandbox.mode(Portal.Repo.Replica, :manual)
 ExUnit.start(formatters: [ExUnit.CLIFormatter, JUnitFormatter])

--- a/elixir/test/test_helper.exs
+++ b/elixir/test/test_helper.exs
@@ -1,2 +1,3 @@
 Ecto.Adapters.SQL.Sandbox.mode(Portal.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(Portal.Repo.Replica, :manual)
 ExUnit.start(formatters: [ExUnit.CLIFormatter, JUnitFormatter])


### PR DESCRIPTION
These are by far the most expensive DB queries and can be moved to the regional replicas so that the regional API nodes can hit them for this data on WebSocket connect.