### PR TITLE
refactor(portal): update maxmind db every 24h

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -46,6 +46,7 @@ defmodule Portal.Application do
       Portal.Presence,
       Portal.Mailer.RateLimiter,
       Portal.ComponentVersions,
+      Portal.Geo,
 
       # Health check server (always enabled)
       Portal.Health,


### PR DESCRIPTION
Because we won't have a timer to call us due to a simplified new system, we instead refresh the db every 24h.