### PR TITLE
fix(portal): use pg for global process registry

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -35,6 +35,8 @@ defmodule Portal.Application do
       # Core services
       Portal.Repo,
       Portal.Repo.Replica,
+      # Default pg scope for distributed process discovery (used by replication)
+      %{id: :pg, start: {:pg, :start_link, []}},
       Portal.PubSub,
 
       # Infrastructure services

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -2252,9 +2252,23 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
 
       # Prime cache
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2306,9 +2320,23 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = Presence.Gateways.connect(gateway, gateway_token.id)
       PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
 
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2347,9 +2375,23 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = Portal.Presence.Relays.connect(global_relay)
       :ok = PubSub.Account.subscribe(gateway.account_id)
 
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       :ok = Presence.Gateways.connect(gateway, gateway_token.id)
       PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
@@ -2461,9 +2503,23 @@ defmodule PortalAPI.Client.ChannelTest do
 
       :ok = PubSub.Account.subscribe(account.id)
 
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2582,9 +2638,23 @@ defmodule PortalAPI.Client.ChannelTest do
 
       :ok = PubSub.Account.subscribe(account.id)
 
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -3061,9 +3131,23 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = Presence.Gateways.connect(gateway, gateway_token.id)
       :ok = PubSub.Account.subscribe(account.id)
 
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       ref = push(socket, "reuse_connection", attrs)
 
@@ -3215,9 +3299,23 @@ defmodule PortalAPI.Client.ChannelTest do
 
       :ok = PubSub.Account.subscribe(account.id)
 
-      send(socket.channel_pid, {:created, resource})
-      send(socket.channel_pid, {:created, policy})
-      send(socket.channel_pid, {:created, membership})
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: resource
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: policy
+      })
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :insert,
+        struct: membership
+      })
 
       push(socket, "reuse_connection", %{
         "resource_id" => resource.id,


### PR DESCRIPTION
In the replication connection, we started the process with a `{:global, __MODULE__}` name registration. For other domain nodes attempting to start the connection they were supposed to find this node and link its replication pid.

However, that turned out not to always be the case. If both nodes start at roughly the same time, they'll never discovery each other's PID because they are both trying to register the same `{:global, _MODULE__}` name before they attempt to find the other PID.

To fix this, we use process groups, or the `:pg` system in Erlang, to discover where the replication connection is running and link it that way instead, with no global process name registration.