### PR TITLE
fix(portal): only run migrations on Repo

### DIFF
--- a/elixir/lib/portal/release.ex
+++ b/elixir/lib/portal/release.ex
@@ -2,7 +2,6 @@ defmodule Portal.Release do
   require Logger
 
   @otp_app :portal
-  @repos Application.compile_env!(@otp_app, :ecto_repos)
 
   def migrate(opts \\ []) do
     IO.puts("Starting sentry app..")
@@ -19,13 +18,7 @@ defmodule Portal.Release do
         )
       )
 
-    # Filter out read-only repos (like Replica) - they share the same database
-    # and should not have migrations run against them
-    repos = Enum.reject(@repos, &read_only_repo?/1)
-
-    for repo <- repos do
-      {:ok, _, _} = do_migration(repo, manual)
-    end
+    {:ok, _, _} = do_migration(Portal.Repo, manual)
   end
 
   def seed(directory \\ seed_script_path(@otp_app)) do
@@ -95,10 +88,6 @@ defmodule Portal.Release do
           |> maybe_log_error()
       end
     end
-  end
-
-  defp read_only_repo?(repo) do
-    function_exported?(repo, :read_only?, 0) and repo.read_only?()
   end
 
   defp maybe_log_error(0), do: nil

--- a/elixir/lib/portal/repo.ex
+++ b/elixir/lib/portal/repo.ex
@@ -6,8 +6,6 @@ defmodule Portal.Repo do
   alias Portal.Repo.{Paginator, Preloader, Filter}
   require Ecto.Query
 
-  def read_only?, do: false
-
   def valid_uuid?(binary) when is_binary(binary),
     do: match?(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>>, binary)
 

--- a/elixir/lib/portal/repo/replica.ex
+++ b/elixir/lib/portal/repo/replica.ex
@@ -3,6 +3,4 @@ defmodule Portal.Repo.Replica do
     otp_app: :portal,
     adapter: Ecto.Adapters.Postgres,
     read_only: true
-
-  def read_only?, do: true
 end

--- a/elixir/test/portal/repo/replica_test.exs
+++ b/elixir/test/portal/repo/replica_test.exs
@@ -115,33 +115,4 @@ defmodule Portal.Repo.ReplicaTest do
       assert config[:pool] == Ecto.Adapters.SQL.Sandbox
     end
   end
-
-  describe "read_only?/0" do
-    test "Portal.Repo returns false" do
-      refute Portal.Repo.read_only?()
-    end
-
-    test "Portal.Repo.Replica returns true" do
-      assert Replica.read_only?()
-    end
-
-    test "Release.migrate filters out read-only repos" do
-      # This tests that the Release module correctly identifies read-only repos
-      # by verifying the repos that would be used for migration
-      repos = Application.fetch_env!(:portal, :ecto_repos)
-
-      # Both repos should be configured
-      assert Portal.Repo in repos
-      assert Replica in repos
-
-      # But only non-read-only repos should be migrated
-      migration_repos =
-        Enum.reject(repos, fn repo ->
-          function_exported?(repo, :read_only?, 0) and repo.read_only?()
-        end)
-
-      assert Portal.Repo in migration_repos
-      refute Replica in migration_repos
-    end
-  end
 end


### PR DESCRIPTION
Unfortunately #11842 didn't quite solve the issue. To make this more foolproof we can simplify the Release module to only run migrations on `Portal.Repo`.