### PR TITLE
revert(portal): don't run Geo as GenServer

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -48,7 +48,6 @@ defmodule Portal.Application do
       Portal.Presence,
       Portal.Mailer.RateLimiter,
       Portal.ComponentVersions,
-      Portal.Geo,
 
       # Health check server (always enabled)
       Portal.Health,

--- a/elixir/lib/portal/geo.ex
+++ b/elixir/lib/portal/geo.ex
@@ -1,33 +1,12 @@
 defmodule Portal.Geo do
-  use GenServer
-  require Logger
+  @moduledoc """
+  Geolocation utilities for IP address lookups using the MaxMind GeoLite2-City database.
+
+  Database reloading is handled externally by the maxmind-sync service, which calls
+  `Geolix.reload_databases()` via RPC when a new database is downloaded.
+  """
 
   @radius_of_earth_km 6371.0
-  @refresh_interval :timer.hours(24)
-
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
-
-  @impl true
-  def init(_opts) do
-    schedule_refresh()
-    {:ok, %{}}
-  end
-
-  @impl true
-  def handle_info(:refresh, state) do
-    Logger.info("Reloading Geolix databases")
-    :ok = Geolix.reload_databases()
-    Logger.info("Geolix databases reloaded successfully")
-
-    schedule_refresh()
-    {:noreply, state}
-  end
-
-  defp schedule_refresh do
-    Process.send_after(self(), :refresh, @refresh_interval)
-  end
 
   # ISO 3166-1 alpha-2
   # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2


### PR DESCRIPTION
The approach here has changed slightly and we will be updating the DB more intelligently with an RPC.