### PR TITLE
ci: add git sha label to built images

### DIFF
--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -69,6 +69,8 @@ jobs:
           tags: |
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ inputs.sha }}
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.sha }}
 
       # main: read/write cache
       - name: Build and push control plane images (read/write cache)
@@ -88,3 +90,5 @@ jobs:
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ inputs.sha }}
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:staging
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.sha }}

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -366,6 +366,8 @@ jobs:
           # no cache-to -> read-only
           target: ${{ matrix.stage }}
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.sha }}
       # main: read/write cache
       - name: Build Docker images (read/write cache)
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -384,6 +386,8 @@ jobs:
             type=gha,scope=${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max,ignore-error=true
           target: ${{ matrix.stage }}
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.sha }}
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -462,7 +466,9 @@ jobs:
           echo "Sources: $sources"
 
           # shellcheck disable=SC2086 # $tags and $sources must be split by whitespace
-          docker buildx imagetools create $tags $sources
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.revision=${{ inputs.sha }}" \
+            $tags $sources
           docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}"
 
   regenerate-apt-index:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,6 +72,7 @@ jobs:
           SOURCE_TAG=ghcr.io/firezone/${{ steps.set-variables.outputs.artifact }}:${{ steps.set-variables.outputs.sha }}
 
           docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.revision=${{ steps.set-variables.outputs.sha }}" \
             -t ghcr.io/firezone/${{ steps.set-variables.outputs.artifact }}:${{ steps.set-variables.outputs.version }} \
             -t ghcr.io/firezone/${{ steps.set-variables.outputs.artifact }}:${{ steps.set-variables.outputs.version }}-${{ steps.set-variables.outputs.sha }} \
             -t ghcr.io/firezone/${{ steps.set-variables.outputs.artifact }}:${{ steps.set-variables.outputs.major_version }} \


### PR DESCRIPTION
In the portal (and soon relays) we push to a consistent `ghcr.io/firezone/portal:staging` tag. When the VM pulls a new version of this image, it's help to know what repo / base SHA these correspond to, as we get in that manifest is the digest SHA.

To have this info, we can annotate the image with the `org.opencontainers.image.revision` label which is common practice.