### PR TITLE
fix(portal): ignore unknown billing products

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -217,7 +217,18 @@ config :portal, Portal.Billing,
   enabled: true,
   secret_key: "sk_test_1111",
   webhook_signing_secret: "whsec_test_1111",
-  default_price_id: "price_1OkUIcADeNU9NGxvTNA4PPq6"
+  default_price_id: "price_1OkUIcADeNU9NGxvTNA4PPq6",
+  # Stripe sandbox/test mode product IDs
+  plan_product_ids: [
+    # Starter
+    "prod_PZdZiSBX1HdXO2",
+    # Team
+    "prod_PZdbLazRNU3Bdi",
+    # Enterprise
+    "prod_PZdb7NJhcdyjRV"
+  ],
+  # Adhoc Device
+  adhoc_device_product_id: "prod_TrPXF2LVHSJpMk"
 
 config :portal,
   platform_adapter: nil,

--- a/elixir/config/prod.exs
+++ b/elixir/config/prod.exs
@@ -19,6 +19,19 @@ config :portal, PortalWeb.Endpoint,
 
 config :portal, PortalAPI.Endpoint, server: true
 
+config :portal, Portal.Billing,
+  # Stripe live mode product IDs
+  plan_product_ids: [
+    # Starter
+    "prod_PY9HpTq72kNPk7",
+    # Team
+    "prod_PnvjiKBrSTBVqp",
+    # Enterprise
+    "prod_PY9QUBMAlUEYes"
+  ],
+  # Adhoc Device
+  adhoc_device_product_id: "prod_TrOXz3nZyOI15i"
+
 ###############################
 ##### Third-party configs #####
 ###############################

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -73,7 +73,17 @@ config :portal, Portal.Billing,
   enabled: true,
   secret_key: "sk_test_123",
   webhook_signing_secret: "whsec_test_123",
-  default_price_id: "price_test_123"
+  default_price_id: "price_test_123",
+  plan_product_ids: [
+    # Starter
+    "prod_test_starter",
+    # Team
+    "prod_test_team",
+    # Enterprise
+    "prod_test_enterprise"
+  ],
+  # Adhoc Device
+  adhoc_device_product_id: "prod_test_adhoc_device"
 
 config :portal, Portal.Billing.Stripe.APIClient,
   endpoint: "https://api.stripe.com",

--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -15,6 +15,14 @@ defmodule Portal.Billing do
     fetch_config!(:webhook_signing_secret)
   end
 
+  def plan_product_ids do
+    fetch_config!(:plan_product_ids)
+  end
+
+  def adhoc_device_product_id do
+    fetch_config!(:adhoc_device_product_id)
+  end
+
   # Limits and Features
 
   def users_limit_exceeded?(%Portal.Account{} = account, users_count) do

--- a/elixir/test/support/mocks/stripe.ex
+++ b/elixir/test/support/mocks/stripe.ex
@@ -264,7 +264,7 @@ defmodule Portal.Mocks.Stripe do
               "livemode" => false,
               "metadata" => plan_metadata,
               "nickname" => nil,
-              "product" => "prod_Na6dGcTsmU0I4R",
+              "product" => "prod_test_team",
               "tiers_mode" => nil,
               "transform_usage" => nil,
               "trial_period_days" => nil,
@@ -282,7 +282,7 @@ defmodule Portal.Mocks.Stripe do
               "lookup_key" => nil,
               "metadata" => %{},
               "nickname" => nil,
-              "product" => "prod_Na6dGcTsmU0I4R",
+              "product" => "prod_test_team",
               "recurring" => %{
                 "aggregate_usage" => nil,
                 "interval" => "month",
@@ -395,7 +395,9 @@ defmodule Portal.Mocks.Stripe do
   def build_all(type, customer_id, seats, metadata \\ %{})
 
   def build_all(:starter, customer_id, seats, metadata) do
-    product = build_product(name: "Starter", metadata: starter_metadata())
+    product =
+      build_product(id: "prod_test_starter", name: "Starter", metadata: starter_metadata())
+
     price = build_price(product: product["id"], amount: 0)
 
     subscription =
@@ -409,7 +411,7 @@ defmodule Portal.Mocks.Stripe do
   end
 
   def build_all(:team, customer_id, seats, metadata) do
-    product = build_product(name: "Team", metadata: team_metadata())
+    product = build_product(id: "prod_test_team", name: "Team", metadata: team_metadata())
     price = build_price(product: product["id"], amount: 500)
 
     subscription =
@@ -423,7 +425,13 @@ defmodule Portal.Mocks.Stripe do
   end
 
   def build_all(:enterprise, customer_id, seats, metadata) do
-    product = build_product(name: "Enterprise", metadata: enterprise_metadata())
+    product =
+      build_product(
+        id: "prod_test_enterprise",
+        name: "Enterprise",
+        metadata: enterprise_metadata()
+      )
+
     price = build_price(product: product["id"], amount: 1000)
 
     subscription =


### PR DESCRIPTION
When parsing events from Stripe, we were pattern matching on the structure of the received event in such a way that asserted the subscription only had one product in it.

Since products correspond to line items in a customer invoice, and we sometimes need to add custom line items / products to a customer's invoice in order to get paid for things, this meant that anytime we updated a customer's subscription with more than one product, the update would not go through on the portal side (Stripe updated just fine).

Now, we check against a known list of plan products to determine if there is a product we need to go back out and get the metadata for (for example, for seat count / limits etc), and if not, we ignore the product and log either a warning or error.

Related: #8668 

Related: https://console.cloud.google.com/errors/detail/CMHzjMeOkLXo0gE;locations=global;time=P30D?project=firezone-prod&utm_source=error-reporting-notification&utm_medium=slack&utm_content=new-error