### PR TITLE
feat: add browser sign-in for headless clients

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -27,7 +27,7 @@ internal class AuthViewModel
                 repo.saveNonceSync(nonce)
                 repo.saveStateSync(state)
                 val config = repo.getConfigSync()
-                val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=client"
+                val authUrl = "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=gui-client"
 
                 actionMutableStateFlow.value =
                     ViewAction.LaunchAuthFlow(authUrl)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2562,6 +2562,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "phoenix-channel",
+ "rpassword",
  "rustls",
  "sd-notify",
  "secrecy",

--- a/rust/gui-client/src-tauri/src/auth.rs
+++ b/rust/gui-client/src-tauri/src/auth.rs
@@ -74,7 +74,7 @@ impl Request {
         let base = url.to_string();
 
         SecretString::from(format!(
-            "{base}?as=client&nonce={}&state={}",
+            "{base}?as=gui-client&nonce={}&state={}",
             self.nonce.expose_secret(),
             self.state.expose_secret()
         ))
@@ -444,7 +444,7 @@ mod tests {
         };
         assert_eq!(
             req.to_url(&auth_base_url, None).expose_secret(),
-            "https://app.firez.one/?as=client&nonce=some_nonce&state=some_state"
+            "https://app.firez.one/?as=gui-client&nonce=some_nonce&state=some_state"
         );
     }
 

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -25,6 +25,7 @@ opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
 opentelemetry-stdout = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 phoenix-channel = { workspace = true }
+rpassword = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
 socket-factory = { workspace = true }

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -46,6 +46,26 @@ pub(crate) fn check_token_permissions(path: &Path) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn set_token_permissions(path: &Path) -> Result<()> {
+    use nix::sys::stat::Mode;
+    use nix::unistd::{Gid, Uid, chown};
+
+    chown(
+        path,
+        Some(Uid::from_raw(ROOT_USER)),
+        Some(Gid::from_raw(ROOT_GROUP)),
+    )?;
+
+    nix::sys::stat::fchmodat(
+        AT_FDCWD,
+        path,
+        Mode::S_IRUSR | Mode::S_IWUSR,
+        nix::sys::stat::FchmodatFlags::FollowSymlink,
+    )?;
+
+    Ok(())
+}
+
 pub(crate) fn notify_service_controller() -> Result<()> {
     Ok(sd_notify::notify(true, &[sd_notify::NotifyState::Ready])?)
 }

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -66,6 +66,34 @@ pub(crate) fn set_token_permissions(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Writes a token to the specified path with secure permissions.
+/// Creates the parent directory if needed, writes the file with mode 0o600,
+/// and sets ownership to root:root.
+pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
+    use anyhow::Context as _;
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("Failed to create token directory")?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .context("Failed to create token file")?;
+
+    file.write_all(token.as_bytes())
+        .context("Failed to write token to file")?;
+
+    set_token_permissions(path)?;
+
+    Ok(())
+}
+
 pub(crate) fn notify_service_controller() -> Result<()> {
     Ok(sd_notify::notify(true, &[sd_notify::NotifyState::Ready])?)
 }

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -1,19 +1,54 @@
+use anyhow::Result;
+use bin_shared::BUNDLE_ID;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
-
+// The return value is useful on Linux
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
-    bail!("Not implemented")
+    // TODO: Implement token permission checks on macOS
+    Ok(())
 }
 
+// The return value is useful on Linux
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn set_token_permissions(_path: &Path) -> Result<()> {
-    bail!("Not implemented")
+    // TODO: Implement token permission setting on macOS
+    Ok(())
+}
+
+/// Writes a token to the specified path with secure permissions.
+/// Creates the parent directory if needed and writes the file with mode 0o600.
+pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
+    use anyhow::Context as _;
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("Failed to create token directory")?;
+    }
+
+    // Create file with restrictive permissions from the start
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .context("Failed to create token file")?;
+
+    file.write_all(token.as_bytes())
+        .context("Failed to write token to file")?;
+
+    Ok(())
 }
 
 pub(crate) fn default_token_path() -> PathBuf {
-    PathBuf::from("/etc/dummy")
+    PathBuf::from("/etc").join(BUNDLE_ID).join("token")
 }
 
+// The return value is useful on Linux
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn notify_service_controller() -> Result<()> {
-    bail!("Not implemented")
+    // No equivalent to sd_notify on macOS
+    Ok(())
 }

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -39,6 +39,8 @@ pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
     file.write_all(token.as_bytes())
         .context("Failed to write token to file")?;
 
+    set_token_permissions(path)?;
+
     Ok(())
 }
 

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -6,6 +6,10 @@ pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
     bail!("Not implemented")
 }
 
+pub(crate) fn set_token_permissions(_path: &Path) -> Result<()> {
+    bail!("Not implemented")
+}
+
 pub(crate) fn default_token_path() -> PathBuf {
     PathBuf::from("/etc/dummy")
 }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -495,6 +495,30 @@ fn try_main() -> Result<()> {
     Ok(())
 }
 
+/// Constructs the authentication URL for browser-based sign-in.
+fn build_auth_url(auth_base_url: &url::Url, account_slug: Option<&str>) -> url::Url {
+    let mut auth_url = auth_base_url.clone();
+    if let Some(slug) = account_slug {
+        auth_url.set_path(slug);
+    }
+    auth_url
+        .query_pairs_mut()
+        .append_pair("as", "headless-client");
+    auth_url
+}
+
+/// Removes the token file at the given path.
+/// Returns Ok(true) if the file was removed, Ok(false) if it didn't exist.
+fn remove_token_file(token_path: &Path) -> Result<bool> {
+    match std::fs::remove_file(token_path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => {
+            Err(e).with_context(|| format!("Failed to remove token file: {}", token_path.display()))
+        }
+    }
+}
+
 #[expect(
     clippy::print_stdout,
     reason = "This command is designed to print to stdout for user interaction"
@@ -506,14 +530,7 @@ fn handle_sign_in(
 ) -> Result<()> {
     use std::io::{self, Write};
 
-    let mut auth_url = auth_base_url.clone();
-    if let Some(slug) = account_slug {
-        auth_url.set_path(slug);
-    }
-
-    auth_url
-        .query_pairs_mut()
-        .append_pair("as", "headless-client");
+    let auth_url = build_auth_url(auth_base_url, account_slug);
 
     println!("\n==========================================================================");
     println!("Firezone Headless Client - Browser Authentication");
@@ -583,8 +600,7 @@ fn handle_sign_out(token_path: &Path, force: bool) -> Result<()> {
         }
     }
 
-    std::fs::remove_file(token_path)
-        .with_context(|| format!("Failed to remove token file: {}", token_path_display))?;
+    remove_token_file(token_path)?;
 
     println!(
         "\n✓ Token removed successfully from: {}",
@@ -784,6 +800,141 @@ mod tests {
         // Verify that check_token_permissions is satisfied
         super::platform::check_token_permissions(&token_path)
             .expect("check_token_permissions should succeed after set_token_permissions");
+
+        // Cleanup
+        let _ = std::fs::remove_file(&token_path);
+    }
+
+    // =========================================================================
+    // Tests for sign-in/sign-out core logic
+    // =========================================================================
+
+    #[test]
+    fn build_auth_url_without_slug() {
+        let base_url = Url::parse("https://app.firezone.dev").unwrap();
+        let auth_url = super::build_auth_url(&base_url, None);
+
+        assert_eq!(auth_url.host_str(), Some("app.firezone.dev"));
+        assert_eq!(auth_url.path(), "/");
+        assert_eq!(auth_url.query(), Some("as=headless-client"));
+    }
+
+    #[test]
+    fn build_auth_url_with_slug() {
+        let base_url = Url::parse("https://app.firezone.dev").unwrap();
+        let auth_url = super::build_auth_url(&base_url, Some("my-team"));
+
+        assert_eq!(auth_url.host_str(), Some("app.firezone.dev"));
+        assert_eq!(auth_url.path(), "/my-team");
+        assert_eq!(auth_url.query(), Some("as=headless-client"));
+    }
+
+    #[test]
+    fn build_auth_url_with_custom_base() {
+        let base_url = Url::parse("https://auth.example.com").unwrap();
+        let auth_url = super::build_auth_url(&base_url, Some("acme-corp"));
+
+        assert_eq!(auth_url.host_str(), Some("auth.example.com"));
+        assert_eq!(auth_url.path(), "/acme-corp");
+        assert_eq!(auth_url.query(), Some("as=headless-client"));
+    }
+
+    #[test]
+    fn write_token_creates_file_with_content() {
+        let token_path = std::env::temp_dir().join("firezone_test_write_token");
+        let _ = std::fs::remove_file(&token_path); // Clean up any previous test run
+
+        let test_token = "test_token_content_12345";
+        super::platform::write_token(&token_path, test_token).expect("write_token should succeed");
+
+        // Verify the file exists and has correct content
+        let content = std::fs::read_to_string(&token_path).expect("Should be able to read token");
+        assert_eq!(content, test_token);
+
+        // Cleanup
+        let _ = std::fs::remove_file(&token_path);
+    }
+
+    #[test]
+    fn write_token_creates_parent_directories() {
+        let token_path = std::env::temp_dir()
+            .join("firezone_test_nested")
+            .join("subdir")
+            .join("token");
+        let parent = token_path.parent().unwrap();
+
+        // Ensure the directory doesn't exist
+        let _ = std::fs::remove_dir_all(parent);
+
+        let test_token = "nested_token";
+        super::platform::write_token(&token_path, test_token)
+            .expect("write_token should create parent directories");
+
+        assert!(token_path.exists());
+        let content = std::fs::read_to_string(&token_path).unwrap();
+        assert_eq!(content, test_token);
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(std::env::temp_dir().join("firezone_test_nested"));
+    }
+
+    #[test]
+    fn write_token_overwrites_existing() {
+        let token_path = std::env::temp_dir().join("firezone_test_overwrite");
+
+        // Write initial token
+        super::platform::write_token(&token_path, "first_token").unwrap();
+
+        // Overwrite with new token
+        super::platform::write_token(&token_path, "second_token").unwrap();
+
+        let content = std::fs::read_to_string(&token_path).unwrap();
+        assert_eq!(content, "second_token");
+
+        // Cleanup
+        let _ = std::fs::remove_file(&token_path);
+    }
+
+    #[test]
+    fn remove_token_file_removes_existing() {
+        let token_path = std::env::temp_dir().join("firezone_test_remove");
+
+        // Create a token file
+        std::fs::write(&token_path, "token_to_remove").unwrap();
+        assert!(token_path.exists());
+
+        // Remove it
+        let removed = super::remove_token_file(&token_path).unwrap();
+        assert!(removed);
+        assert!(!token_path.exists());
+    }
+
+    #[test]
+    fn remove_token_file_returns_false_for_nonexistent() {
+        let token_path = std::env::temp_dir().join("firezone_test_nonexistent_token");
+        let _ = std::fs::remove_file(&token_path); // Ensure it doesn't exist
+
+        let removed = super::remove_token_file(&token_path).unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn token_roundtrip_write_and_read() {
+        let token_path = std::env::temp_dir().join("firezone_test_roundtrip");
+        let _ = std::fs::remove_file(&token_path);
+
+        let test_token = "roundtrip_test_token_abc123";
+
+        // Write token
+        super::platform::write_token(&token_path, test_token).unwrap();
+
+        // Read it back using the same function used by the client
+        let read_token = super::read_token_file(&token_path)
+            .expect("read_token_file should succeed")
+            .expect("Token should exist");
+
+        use secrecy::ExposeSecret;
+        assert_eq!(read_token.expose_secret(), test_token);
 
         // Cleanup
         let _ = std::fs::remove_file(&token_path);

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -16,6 +16,14 @@ pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+// The return value is useful on Linux
+#[expect(clippy::unnecessary_wraps)]
+pub(crate) fn set_token_permissions(_path: &Path) -> Result<()> {
+    // TODO: Restrict token file access to SYSTEM and Administrators on Windows
+    tracing::warn!("Token file permissions are not restricted on Windows");
+    Ok(())
+}
+
 pub(crate) fn default_token_path() -> PathBuf {
     get_known_folder_path(KnownFolder::ProgramData)
         .expect("ProgramData folder not found. Is %PROGRAMDATA% set?")

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -20,7 +20,8 @@ pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn set_token_permissions(_path: &Path) -> Result<()> {
     // TODO: Restrict token file access to SYSTEM and Administrators on Windows
-    tracing::warn!("Token file permissions are not restricted on Windows");
+    // Using eprintln! because logging isn't initialized when sign-in runs
+    eprintln!("Note: Token file permissions are not restricted on Windows.");
     Ok(())
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -20,8 +20,33 @@ pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn set_token_permissions(_path: &Path) -> Result<()> {
     // TODO: Restrict token file access to SYSTEM and Administrators on Windows
-    // Using eprintln! because logging isn't initialized when sign-in runs
+    Ok(())
+}
+
+/// Writes a token to the specified path.
+/// Creates the parent directory if needed.
+/// TODO: Implement proper Windows ACLs to restrict access.
+pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
+    use anyhow::Context as _;
+    use std::io::Write;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("Failed to create token directory")?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .context("Failed to create token file")?;
+
+    file.write_all(token.as_bytes())
+        .context("Failed to write token to file")?;
+
+    // TODO: Set proper Windows ACLs here
     eprintln!("Note: Token file permissions are not restricted on Windows.");
+
     Ok(())
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -4,7 +4,7 @@
 //! service to be stopped even if its only process ends, for some reason.
 //! We must tell Windows explicitly when our service is stopping.
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use bin_shared::BUNDLE_ID;
 use known_folders::{KnownFolder, get_known_folder_path};
 use std::path::{Path, PathBuf};
@@ -12,7 +12,8 @@ use std::path::{Path, PathBuf};
 // The return value is useful on Linux
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
-    // TODO: For Headless Client, make sure the token is only readable by admin / our service user on Windows
+    // TODO: Verify that the token file has the correct ACLs
+    // https://github.com/firezone/firezone/issues/XXXXX
     Ok(())
 }
 
@@ -20,14 +21,13 @@ pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn set_token_permissions(_path: &Path) -> Result<()> {
     // TODO: Restrict token file access to SYSTEM and Administrators on Windows
+    // https://github.com/firezone/firezone/issues/XXXXX
     Ok(())
 }
 
 /// Writes a token to the specified path.
 /// Creates the parent directory if needed.
-/// TODO: Implement proper Windows ACLs to restrict access.
 pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
-    use anyhow::Context as _;
     use std::io::Write;
 
     if let Some(parent) = path.parent() {
@@ -44,8 +44,7 @@ pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
     file.write_all(token.as_bytes())
         .context("Failed to write token to file")?;
 
-    // TODO: Set proper Windows ACLs here
-    eprintln!("Note: Token file permissions are not restricted on Windows.");
+    set_token_permissions(path)?;
 
     Ok(())
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthClient.swift
@@ -51,7 +51,7 @@ struct AuthClient {
       authURL
       .appendingQueryItem(URLQueryItem(name: "state", value: state))
       .appendingQueryItem(URLQueryItem(name: "nonce", value: nonce))
-      .appendingQueryItem(URLQueryItem(name: "as", value: "client"))
+      .appendingQueryItem(URLQueryItem(name: "as", value: "gui-client"))
   }
 
   func response(url: URL?) throws -> AuthResponse {

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,10 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11882">
+          Adds the <code>sign-in</code> command to allow authenticating the
+          Client as a normal user via browser-based authentication.
+        </ChangeItem>
         <ChangeItem pull="11625">
           Fails faster when the initial connection to the control plane cannot
           be established, allowing the user to retry sooner.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,8 +11,9 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="11882">
-          Adds the <code>sign-in</code> command to allow authenticating the
-          Client as a normal user via browser-based authentication.
+          Adds the <code>sign-in</code> and <code>sign-out</code> commands to
+          allow authenticating the Client as a normal user via browser-based
+          authentication.
         </ChangeItem>
         <ChangeItem pull="11625">
           Fails faster when the initial connection to the control plane cannot


### PR DESCRIPTION
- Adds new `sign-in` and `sign-out` commands to facilitate browser-based authentication flow for the headless clients.
- Updates the sent param identifying what type of client this is to `gui-client` and `headless-client`

**NOTE**: Requires #11799 to ship before this can be released.

Related: #11799 
Fixes: #8132 