### PR TITLE
fix(connlib): honor changes to "IP stack" after initial query

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -54,6 +54,11 @@ export default function Android() {
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
+        <ChangeItem pull="11891">
+          Fixes an issue where cached IPv6 addresses for a resource got returned
+          for IPv4-only DNS resources if the setting was only changed after a
+          DNS query had already been processed.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -40,6 +40,11 @@ export default function Apple() {
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
+        <ChangeItem pull="11891">
+          Fixes an issue where cached IPv6 addresses for a resource got returned
+          for IPv4-only DNS resources if the setting was only changed after a
+          DNS query had already been processed.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.12" date={new Date("2026-01-20")}>
         <ChangeItem pull="11735">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -49,6 +49,11 @@ export default function GUI({ os }: { os: OS }) {
             Fixes an issue where notifications would not always be displayed.
           </ChangeItem>
         )}
+        <ChangeItem pull="11891">
+          Fixes an issue where cached IPv6 addresses for a resource got returned
+          for IPv4-only DNS resources if the setting was only changed after a
+          DNS query had already been processed.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-12-23")}>
         {os == OS.Linux && (

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -23,6 +23,11 @@ export default function Headless({ os }: { os: OS }) {
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
+        <ChangeItem pull="11891">
+          Fixes an issue where cached IPv6 addresses for a resource got returned
+          for IPv4-only DNS resources if the setting was only changed after a
+          DNS query had already been processed.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.6" date={new Date("2026-01-06")}>
         <ChangeItem pull="11627">


### PR DESCRIPTION
When Firezone first resolves a DNS query for a resource, it assigns the IPs based on the "IP stack" setting at the time. If this is set to "Dual", then both IPv4 and IPv6 addresses are assigned. These IPs are then cached in a process-wide cache to ensure we have sticky DNS resource IPs even across sessions.

Changing the IP stack setting after an initial DNS query was therefore not supported. The IPs were already assigned and thus got returned, essentially bypassing the setting. Signing out of Firezone and signing back in does not fix this due to the process-wide cache.

The solution here is not to invalidate the cache but to instead always assign IPv4 and IPv6 addresses but check the _current_ IP stack setting every time we answer a query. This ensures that even when changing the setting later, it is immediately honored.

Resolves: #11814