### PR TITLE
fix(macos): Export all logs in plain text

### DIFF
--- a/swift/apple/mise-tasks/log/client-pretty.sh
+++ b/swift/apple/mise-tasks/log/client-pretty.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Opening latest Firezone client log (formatted)..."
-latest_log=$(find ~/Library/Group\ Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/app -name "*.jsonl" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+echo "Opening latest Firezone client log..."
+latest_log=$(find ~/Library/Group\ Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/app -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
 if [ -n "$latest_log" ]; then
-    jq -r '[.timestamp, .level, .message] | @tsv' "$latest_log" | less
+    less "$latest_log"
 else
     echo "No log files found"
 fi

--- a/swift/apple/mise-tasks/log/client-show.sh
+++ b/swift/apple/mise-tasks/log/client-show.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "Opening latest Firezone client log..."
-latest_log=$(find ~/Library/Group\ Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/app -name "*.jsonl" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+latest_log=$(find ~/Library/Group\ Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/app -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
 if [ -n "$latest_log" ]; then
     less "$latest_log"
 else

--- a/swift/apple/mise-tasks/log/client-tail.sh
+++ b/swift/apple/mise-tasks/log/client-tail.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "Tailing latest Firezone client log..."
-latest_log=$(find ~/Library/Group\ Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/app -name "*.jsonl" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+latest_log=$(find ~/Library/Group\ Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/app -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
 if [ -n "$latest_log" ]; then
     exec tail -f "$latest_log"
 else

--- a/swift/apple/mise-tasks/log/tunnel-show.sh
+++ b/swift/apple/mise-tasks/log/tunnel-show.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "Viewing latest tunnel log (requires sudo)..."
-latest_log=$(sudo find "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/tunnel" -name "*.jsonl" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+latest_log=$(sudo find "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/tunnel" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
 if [ -n "$latest_log" ]; then
     sudo less "$latest_log"
 else

--- a/swift/apple/mise-tasks/log/tunnel-tail.sh
+++ b/swift/apple/mise-tasks/log/tunnel-tail.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "Following latest tunnel log (requires sudo)..."
-latest_log=$(sudo find "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/tunnel" -name "*.jsonl" -print0 2>/dev/null | xargs -0 ls -t | head -1)
+latest_log=$(sudo find "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/tunnel" -name "*.log" -print0 2>/dev/null | xargs -0 ls -t | head -1)
 if [ -n "$latest_log" ]; then
     exec sudo tail -f "$latest_log"
 else

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem>
+          Exported logs now use plain text format instead of JSONL for easier
+          reading.
+        </ChangeItem>
         <ChangeItem pull="11834">
           Fixes an issue where the tunnel might hang or crash on iOS immediately
           after signing in.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,9 +25,8 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem>
-          Exports logs in plain text format instead of JSONL for easier
-          reading.
+        <ChangeItem pull="11892">
+          Exports logs in plain text format instead of JSONL for easier reading.
         </ChangeItem>
         <ChangeItem pull="11834">
           Fixes an issue where the tunnel might hang or crash on iOS immediately

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -26,7 +26,7 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem>
-          Exported logs now use plain text format instead of JSONL for easier
+          Exports logs in plain text format instead of JSONL for easier
           reading.
         </ChangeItem>
         <ChangeItem pull="11834">


### PR DESCRIPTION
Makes it easier to parse exported app and tunnel logs. Connlib logs were already in plain text.