### PR TITLE
chore: bump UniFFI to 0.31.0

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -568,18 +568,42 @@ class TunnelService : VpnService() {
 
     private fun convertResource(resource: uniffi.connlib.Resource): Resource =
         when (resource) {
-            is uniffi.connlib.Resource.Dns -> resource.resource.let { r ->
-                Resource(ResourceType.DNS, r.id, r.address, r.addressDescription,
-                    r.sites.map { it.toModel() }, r.name, r.status.toModel())
-            }
-            is uniffi.connlib.Resource.Cidr -> resource.resource.let { r ->
-                Resource(ResourceType.CIDR, r.id, r.address, r.addressDescription,
-                    r.sites.map { it.toModel() }, r.name, r.status.toModel())
-            }
-            is uniffi.connlib.Resource.Internet -> resource.resource.let { r ->
-                Resource(ResourceType.Internet, r.id, null, null,
-                    r.sites.map { it.toModel() }, r.name, r.status.toModel())
-            }
+            is uniffi.connlib.Resource.Dns ->
+                resource.resource.let { r ->
+                    Resource(
+                        ResourceType.DNS,
+                        r.id,
+                        r.address,
+                        r.addressDescription,
+                        r.sites.map { it.toModel() },
+                        r.name,
+                        r.status.toModel(),
+                    )
+                }
+            is uniffi.connlib.Resource.Cidr ->
+                resource.resource.let { r ->
+                    Resource(
+                        ResourceType.CIDR,
+                        r.id,
+                        r.address,
+                        r.addressDescription,
+                        r.sites.map { it.toModel() },
+                        r.name,
+                        r.status.toModel(),
+                    )
+                }
+            is uniffi.connlib.Resource.Internet ->
+                resource.resource.let { r ->
+                    Resource(
+                        ResourceType.Internet,
+                        r.id,
+                        null,
+                        null,
+                        r.sites.map { it.toModel() },
+                        r.name,
+                        r.status.toModel(),
+                    )
+                }
         }
 
     companion object {
@@ -620,8 +644,9 @@ class TunnelService : VpnService() {
 
 private fun uniffi.connlib.Site.toModel() = Site(id = id, name = name)
 
-private fun uniffi.connlib.ResourceStatus.toModel() = when (this) {
-    uniffi.connlib.ResourceStatus.UNKNOWN -> StatusEnum.UNKNOWN
-    uniffi.connlib.ResourceStatus.ONLINE -> StatusEnum.ONLINE
-    uniffi.connlib.ResourceStatus.OFFLINE -> StatusEnum.OFFLINE
-}
+private fun uniffi.connlib.ResourceStatus.toModel() =
+    when (this) {
+        uniffi.connlib.ResourceStatus.UNKNOWN -> StatusEnum.UNKNOWN
+        uniffi.connlib.ResourceStatus.ONLINE -> StatusEnum.ONLINE
+        uniffi.connlib.ResourceStatus.OFFLINE -> StatusEnum.OFFLINE
+    }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "askama"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
  "itoa",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",
@@ -8969,9 +8969,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
+checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
 dependencies = [
  "anyhow",
  "camino",
@@ -8992,9 +8992,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
+checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
 dependencies = [
  "anyhow",
  "askama",
@@ -9018,9 +9018,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
+checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9030,9 +9030,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
+checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -9043,9 +9043,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
+checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
 dependencies = [
  "camino",
  "fs-err",
@@ -9060,21 +9060,21 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
+checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
 dependencies = [
  "anyhow",
- "siphasher 0.3.11",
+ "siphasher 1.0.1",
  "uniffi_internal_macros",
  "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
+checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -9085,9 +9085,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
+checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -220,7 +220,7 @@ tracing-subscriber = { version = "0.3.22", features = ["parking_lot"] }
 trackable = "1.3.0"
 tun = { path = "libs/connlib/tun" }
 tunnel = { path = "libs/connlib/tunnel" }
-uniffi = "0.30.0"
+uniffi = "0.31.0"
 url = "2.5.2"
 uuid = "1.19.0"
 webpki-roots = "1.0.5"

--- a/rust/client-ffi/uniffi.toml
+++ b/rust/client-ffi/uniffi.toml
@@ -1,11 +1,9 @@
 # UniFFI Configuration for client-ffi
 
 [bindings.swift]
-# Enable experimental features for better async support
-experimental_sendable_value_types = true
-
-# Generate proper Swift concurrency annotations
 generate_immutable_records = true
+generate_codable_conformance = true
+generate_case_iterable_conformance = true
 
 [bindings.kotlin]
 android = true

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -529,59 +529,42 @@ class Adapter: @unchecked Sendable {
 
   // MARK: - Resource conversion (uniffi → FirezoneKit)
 
-  private func convertResource(_ resource: Resource) -> FirezoneKit.Resource {
-    switch resource {
-    case .dns(let dnsResource):
-      return FirezoneKit.Resource(
-        id: dnsResource.id,
-        name: dnsResource.name,
-        address: dnsResource.address,
-        addressDescription: dnsResource.addressDescription,
-        status: convertResourceStatus(dnsResource.status),
-        sites: dnsResource.sites.map { convertSite($0) },
-        type: .dns
-      )
-    case .cidr(let cidrResource):
-      return FirezoneKit.Resource(
-        id: cidrResource.id,
-        name: cidrResource.name,
-        address: cidrResource.address,
-        addressDescription: cidrResource.addressDescription,
-        status: convertResourceStatus(cidrResource.status),
-        sites: cidrResource.sites.map { convertSite($0) },
-        type: .cidr
-      )
-    case .internet(let internetResource):
-      return FirezoneKit.Resource(
-        id: internetResource.id,
-        name: internetResource.name,
-        address: nil,
-        addressDescription: nil,
-        status: convertResourceStatus(internetResource.status),
-        sites: internetResource.sites.map { convertSite($0) },
-        type: .internet
-      )
+  private func convertResource(_ uniffiResource: Resource) -> FirezoneKit.Resource {
+    switch uniffiResource {
+    case .dns(let resource):
+      FirezoneKit.Resource(
+        id: resource.id, name: resource.name, address: resource.address,
+        addressDescription: resource.addressDescription,
+        status: .init(resource.status), sites: resource.sites.map { .init($0) }, type: .dns)
+    case .cidr(let resource):
+      FirezoneKit.Resource(
+        id: resource.id, name: resource.name, address: resource.address,
+        addressDescription: resource.addressDescription,
+        status: .init(resource.status), sites: resource.sites.map { .init($0) }, type: .cidr)
+    case .internet(let resource):
+      FirezoneKit.Resource(
+        id: resource.id, name: resource.name, address: nil, addressDescription: nil,
+        status: .init(resource.status), sites: resource.sites.map { .init($0) }, type: .internet)
     }
   }
+}
 
-  private func convertSite(_ site: Site) -> FirezoneKit.Site {
-    return FirezoneKit.Site(
-      id: site.id,
-      name: site.name
-    )
+// MARK: - UniFFI → FirezoneKit type conversions
+
+extension FirezoneKit.Site {
+  init(_ site: Site) {
+    self.init(id: site.id, name: site.name)
   }
+}
 
-  private func convertResourceStatus(_ status: ResourceStatus) -> FirezoneKit.ResourceStatus {
+extension FirezoneKit.ResourceStatus {
+  init(_ status: ResourceStatus) {
     switch status {
-    case .unknown:
-      return .unknown
-    case .online:
-      return .online
-    case .offline:
-      return .offline
+    case .unknown: self = .unknown
+    case .online: self = .online
+    case .offline: self = .offline
     }
   }
-
 }
 
 extension Network.NWPath {


### PR DESCRIPTION
- Enable `generate_codable_conformance` and `generate_case_iterable_conformance` for Swift bindings (removes need for `experimental_sendable_value_types`)
- Simplify type conversion code in Swift Adapter and Kotlin TunnelService using extension initializers/functions instead of standalone converter functions
- Fix target directory detection in uniffi-bindings.sh and build.gradle.kts to use `cargo metadata` instead of hardcoded path (supports custom cargo config)
- Add mise.toml for Android with setup-ndk, build, and test tasks