### PR TITLE
test(gui-client): simulate connlib boot

### DIFF
--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -966,8 +966,7 @@ mod tests {
         let mut test_controller = Controller::start_for_test();
 
         // Accept the IPC connection
-        let mut mock_tunnel = test_controller.tunnel_service_ipc_accept().await;
-        mock_tunnel.send_hello().await;
+        let _mock_tunnel = test_controller.tunnel_service_ipc_accept().await;
 
         let start_error = tokio::time::timeout(Duration::from_secs(6), test_controller.join_handle)
             .await

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -1117,7 +1117,7 @@ mod tests {
                 return val;
             }
 
-            panic!("Timeout while waiting for `TestIntegration` to change")
+            panic!("Timeout while waiting for `MockIntegration` to change")
         }
     }
 
@@ -1140,9 +1140,9 @@ mod tests {
 
     impl MockIntegration {
         fn nth_notification(&self, idx: usize) -> Option<(String, String)> {
-            let (body, title, _) = self.notifications.get(idx)?;
+            let (title, body, _) = self.notifications.get(idx)?;
 
-            Some((body.clone(), title.clone()))
+            Some((title.clone(), body.clone()))
         }
     }
 

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -209,6 +209,18 @@ impl GuiIntegration for TauriIntegration {
 
         Ok(())
     }
+
+    async fn save_general_settings(&self, settings: &GeneralSettings) -> Result<()> {
+        settings::save_general(settings).await?;
+
+        Ok(())
+    }
+
+    async fn save_advanced_settings(&self, settings: &AdvancedSettings) -> Result<()> {
+        settings::save_advanced(settings).await?;
+
+        Ok(())
+    }
 }
 
 pub struct RunConfig {


### PR DESCRIPTION
As part of improving the unit-test coverage of the GUI client, we are adding a test to simulate the "handshake" that happens as part of booting up connlib. The entire tunnel process is mocked out here but what we do cover is the process of producing a sign-in URL, extracting the token and then sending the appropriate message to the tunnel process.

Right now, not all side-effects of the `Controller` are stubbed out yet which is why we move the saving of settings into the `GuiIntegration` trait with this change.

Finally, on the first resource list update, we then show a notification that Firezone is connected.