### PR TITLE
test(phoenix-channel): increase timeout to 2s

### DIFF
--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -355,7 +355,7 @@ async fn discards_failed_ips_on_hiccup() {
         panic!("Expected `Hiccup`")
     };
 
-    let result = tokio::time::timeout(Duration::from_secs(1), async {
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
         future::poll_fn(|cx| channel.poll(cx)).await
     })
     .await


### PR DESCRIPTION
This fixes a flaky test because we are also waiting for 1 second within `PhoenixChannel` before we issue the `NoAddresses` event.