### PR TITLE
chore(android): add basic mise config

### DIFF
--- a/kotlin/android/mise-tasks/format.sh
+++ b/kotlin/android/mise-tasks/format.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+echo "Formatting Kotlin code..."
+mise exec -- ./gradlew spotlessApply

--- a/kotlin/android/mise-tasks/lint.sh
+++ b/kotlin/android/mise-tasks/lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+echo "Checking Kotlin code style..."
+mise exec -- ./gradlew spotlessCheck
+
+echo "Running Android Lint..."
+mise exec -- ./gradlew lint

--- a/kotlin/android/mise.toml
+++ b/kotlin/android/mise.toml
@@ -1,0 +1,19 @@
+# Android development tasks
+#
+# Tasks are auto-discovered from mise-tasks/ directory.
+# Task names match filenames (e.g., mise-tasks/format.sh -> //kotlin/android:format)
+
+[task_config]
+includes = ["mise-tasks"]
+
+[tasks.setup-ndk]
+description = "Install required NDK version (must match build.gradle.kts)"
+run = "sdkmanager 'ndk;28.1.13356709'"
+
+[tasks.build]
+description = "Build debug APK"
+run = "./gradlew assembleDebug"
+
+[tasks.test]
+description = "Run unit tests"
+run = "./gradlew test"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,11 @@
 experimental_monorepo_root = true
 
+[monorepo]
+config_roots = [
+    "kotlin/android",
+    "swift/apple",
+]
+
 [tasks.lint-setup]
 description = "Install linting tools from version-pinned files (managed by Dependabot)"
 run = """


### PR DESCRIPTION
Make basic tasks for working with Android more discoverable.

While at there, fix deprecation warning - we now should explicitly declare mise "child projects", ie. locations where to find other `mise.toml` files.