### PR TITLE
chore: retrieve rust dir from cargo

### DIFF
--- a/swift/apple/mise-tasks/uniffi-bindings.sh
+++ b/swift/apple/mise-tasks/uniffi-bindings.sh
@@ -10,7 +10,11 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUST_DIR="$(cd "${SCRIPT_DIR}/../../../rust" && pwd)"
-RUST_TARGET_DIR="$(cd "${RUST_DIR}" && cargo metadata --format-version 1 | jq -r .target_directory)"
+if ! RUST_TARGET_DIR="$(cd "${RUST_DIR}" && cargo metadata --format-version 1 | jq -r .target_directory)"; then
+    echo "Error: failed to determine Rust target directory using 'cargo metadata' in '${RUST_DIR}'." >&2
+    echo "Please ensure Rust and Cargo are installed, and that the Rust project in '${RUST_DIR}' is valid." >&2
+    exit 1
+fi
 GENERATED_DIR="${SCRIPT_DIR}/../FirezoneNetworkExtension/Connlib/Generated"
 
 echo "Generating UniFFI bindings..."

--- a/swift/apple/mise-tasks/uniffi-bindings.sh
+++ b/swift/apple/mise-tasks/uniffi-bindings.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Validate required tools
 if ! command -v jq >/dev/null 2>&1; then
     echo "Error: jq is required but not installed." >&2
-    echo "Install it with: brew install jq" >&2
+    echo "On macOS, install it with: brew install jq" >&2
     exit 1
 fi
 

--- a/swift/apple/mise-tasks/uniffi-bindings.sh
+++ b/swift/apple/mise-tasks/uniffi-bindings.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Validate required tools
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required but not installed." >&2
+    echo "Install it with: brew install jq" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUST_DIR="$(cd "${SCRIPT_DIR}/../../../rust" && pwd)"
-RUST_TARGET_DIR="${RUST_DIR}/target"
+RUST_TARGET_DIR="$(cd "${RUST_DIR}" && cargo metadata --format-version 1 | jq -r .target_directory)"
 GENERATED_DIR="${SCRIPT_DIR}/../FirezoneNetworkExtension/Connlib/Generated"
 
 echo "Generating UniFFI bindings..."


### PR DESCRIPTION
Switch to using `cargo metadata` to determine the Rust target directory in both Kotlin and Swift UniFFI bindings scripts.

This ensures correct handling of custom or globally configured target directories.