### PR TITLE
chore(portal): set RLS context

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -4,7 +4,6 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
-SQL.Query: SQL injection,lib/portal/safe.ex:285,224B461
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
@@ -13,9 +12,9 @@ XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
 Config.Secrets: Hardcoded Secret,config/config.exs:219,48EA898
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
-SQL.Query: SQL injection,lib/portal/safe.ex:291,4C5F170
 Config.Secrets: Hardcoded Secret,config/config.exs:218,4EA833B
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
+SQL.Query: SQL injection,lib/portal/safe.ex:336,50D0377
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
@@ -23,6 +22,7 @@ XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:403,5BB84FC
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:399,5F2DE06
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
+SQL.Query: SQL injection,lib/portal/safe.ex:342,64B4C98
 Config.Secrets: Hardcoded Secret,config/config.exs:114,67D22E3
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0


### PR DESCRIPTION
To prepare for enforcing row-level security, we update the `Safe` module to set the `account_id` context. We will need still a migration to enforce the policy which will be coming after.

Related: #11036 