### PR TITLE
fix(apple): pass configuration to startTunnel

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -33,15 +33,25 @@ enum IPCClient {
 
   // Auto-connect
   @MainActor
-  static func start(session: NETunnelProviderSession) throws {
-    try session.startTunnel()
+  static func start(
+    session: NETunnelProviderSession, configuration: TunnelConfiguration
+  ) throws {
+    let configData = try encoder.encode(configuration)
+    let options: [String: NSObject] = [
+      "configuration": configData as NSObject
+    ]
+    try session.startTunnel(options: options)
   }
 
   // Sign in
   @MainActor
-  static func start(session: NETunnelProviderSession, token: String) throws {
+  static func start(
+    session: NETunnelProviderSession, token: String, configuration: TunnelConfiguration
+  ) throws {
+    let configData = try encoder.encode(configuration)
     let options: [String: NSObject] = [
-      "token": token as NSObject
+      "token": token as NSObject,
+      "configuration": configData as NSObject,
     ]
 
     try session.startTunnel(options: options)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -227,7 +227,7 @@ public final class Store: ObservableObject {
       guard let session = try manager().session() else {
         throw VPNConfigurationManagerError.managerNotInitialized
       }
-      try IPCClient.start(session: session)
+      try IPCClient.start(session: session, configuration: configuration.toTunnelConfiguration())
     }
   }
   func installVPNConfiguration() async throws {
@@ -279,7 +279,10 @@ public final class Store: ObservableObject {
     guard let session = try manager().session() else {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
-    try IPCClient.start(session: session, token: authResponse.token)
+    try IPCClient.start(
+      session: session, token: authResponse.token,
+      configuration: configuration.toTunnelConfiguration()
+    )
   }
 
   func signOut() async throws {

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="11901">
+          Fixes an issue where the tunnel may not come up after a fresh install
+          of the Firezone client.
+        </ChangeItem>
         <ChangeItem pull="11892">
           Exports logs in plain text format instead of JSONL for easier reading.
         </ChangeItem>


### PR DESCRIPTION
In #10855, we removed the passing of the configuration through startTunnel based on the assumption that a prior `setConfiguration` call would have occurred in order to hydrate the configuration cache.

Unfortunately, on iOS, this is not the case, resulting in a bug on fresh installs of iOS that prevents the tunnel from starting because it has no configuration.

Related: https://app.hubspot.com/live-messages/23723443/inbox/10333087281