### PR TITLE
chore(connlib): fix flaky IO test

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -729,7 +729,7 @@ mod tests {
         let mut io = Io::for_test();
 
         let result = io.rebind_dns(vec![
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40000), // This one will almost definitely work.
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0), // This one will almost definitely work.
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 40000), // This one will fail.
         ]);
 


### PR DESCRIPTION
It appears that sometimes, something is listening on port 40000 on GitHub Actions runners. By switching to port 0, we pretty much guarantee that binding to the first address will work.

Resolves: #11904