### PR TITLE
fix(gui-client): don't await notifications

### DIFF
--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -157,12 +157,12 @@ impl GuiIntegration for TauriIntegration {
         self.tray.update(app_state)
     }
 
-    async fn show_notification(
+    fn show_notification(
         &self,
-        title: impl Into<String> + Send,
-        body: impl Into<String> + Send,
+        title: impl Into<String>,
+        body: impl Into<String>,
     ) -> Result<NotificationHandle> {
-        os::show_notification(title.into(), body.into()).await
+        os::show_notification(title.into(), body.into())
     }
 
     fn set_window_visible(&self, visible: bool) -> Result<()> {

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -7,10 +7,6 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     bail!("Not implemented")
 }
 
-#[expect(
-    clippy::unused_async,
-    reason = "Signature must match other operating systems"
-)]
-pub(crate) async fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
+pub(crate) fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
     bail!("Not implemented")
 }

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -60,11 +60,7 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 /// - <https://answers.microsoft.com/en-us/windows/forum/all/notifications-not-activating-the-associated-app/7a3b31b0-3a20-4426-9c88-c6e3f2ac62c6>
 ///
 /// Firefox doesn't have this problem. Maybe they're using a different API.
-#[expect(
-    clippy::unused_async,
-    reason = "Signature must match other operating systems"
-)]
-pub(crate) async fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
+pub(crate) fn show_notification(title: String, body: String) -> Result<NotificationHandle> {
     let (tx, rx) = futures::channel::oneshot::channel();
 
     // For some reason `on_activated` is FnMut
@@ -82,7 +78,9 @@ pub(crate) async fn show_notification(title: String, body: String) -> Result<Not
             Ok(())
         })
         .show()
-        .context("Couldn't show clickable URL notification")?;
+        .context("Failed to show notification")?;
+
+    tracing::debug!(%title, %body, "Showing notification");
 
     Ok(NotificationHandle { on_click: rx })
 }


### PR DESCRIPTION
The notification refactor in #11813 introduced a regression where on Linux, the controller would get stuck until the notification was dismissed. To avoid that, we spawn away the notification in a dedicated task.