### PR TITLE
chore(windows): improve busy-loop when buffer is exhausted

### DIFF
--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -444,7 +444,9 @@ fn start_send_thread(
                         if e.raw_os_error()
                             .is_some_and(|code| code == ERROR_BUFFER_OVERFLOW) =>
                     {
-                        tracing::trace!("WinTUN ring buffer is full");
+                        if attempts == 0 {
+                            tracing::trace!("WinTUN ring buffer is full");
+                        }
 
                         if attempts < 10 {
                             std::hint::spin_loop(); // Spin around and try again, as quickly as possible for minimum latency.

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -440,6 +440,7 @@ fn start_send_thread(
                         if e.raw_os_error()
                             .is_some_and(|code| code == ERROR_BUFFER_OVERFLOW) =>
                     {
+                        tracing::trace!("WinTUN ring buffer is full");
                         std::hint::spin_loop(); // Spin around and try again, as quickly as possible for minimum latency.
                     }
                     Err(e) => {

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -440,8 +440,7 @@ fn start_send_thread(
                         if e.raw_os_error()
                             .is_some_and(|code| code == ERROR_BUFFER_OVERFLOW) =>
                     {
-                        tracing::debug!("WinTUN ring buffer is full");
-                        std::thread::sleep(Duration::from_millis(10)); // Suspend for a bit to avoid busy-looping.
+                        std::hint::spin_loop(); // Spin around and try again, as quickly as possible for minimum latency.
                     }
                     Err(e) => {
                         tracing::error!("Failed to allocate WinTUN packet: {e}");

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -417,14 +417,14 @@ fn start_send_thread(
                 tracing::debug!(
                     "Stopping TUN send worker thread because the packet channel closed"
                 );
-                break;
+                break 'next_packet;
             };
 
             let bytes = packet.packet();
 
             let Ok(len) = bytes.len().try_into() else {
                 tracing::warn!("Packet too large; length does not fit into u16");
-                continue;
+                continue 'next_packet;
             };
 
             'next_attempt: for attempt in 0..MAX_ATTEMPTS {

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -438,6 +438,10 @@ fn start_send_thread(
                         // space in the ring buffer.
                         session.send_packet(pkt);
 
+                        if attempts > 0 {
+                            tracing::trace!(%attempts, "Sent packet with delay");
+                        }
+
                         break;
                     }
                     Err(wintun::Error::Io(e))


### PR DESCRIPTION
WinTUN maintains a ringbuffer that holds all IP packets that are to be emitted by the network device. When this ringbuffer is full, we need to wait until space is available.

Right now, we do this by suspending the thread for 10ms. This is very likely way too long on a high-throughput connection and causes unnecessary delays of packets which in turn can affect the congestion control algorithm within the kernel.

To improve this, we instead emit a platform-dependent `spin_loop` hint. This hint translates to a dedicated CPU instruction that tells the processor that it can make a tiny pause but should not context-switch because we are very likely going to be able to continue very soon.

I could not reliably measure a noticable performance gain which is why I am not including a changelog entry. I do still think that this is worthwhile shipping because it just seems more correct to not wait unnecessarily. I was also able to confirm that we are definitely hitting this condition in high-throughput scenarios.