### PR TITLE
fix(website): fix css layering for tailwind4

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -82,29 +82,31 @@ h6 {
   font-family: var(--font-manrope);
 }
 
-/* Fix inline headings */
-*:is(h1, h2, h3, h4, h5, h6) {
-  @apply flex items-center gap-1;
-}
+@layer base {
+  /* Fix inline headings */
+  *:is(h1, h2, h3, h4, h5, h6) {
+    @apply flex items-center gap-1;
+  }
 
-/* Fix anchor slug links and scroll position due to fixed navbar */
-*:is(h1, h2, h3, h4, h5, h6, li[id^="user-content-"]) {
-  @apply scroll-mt-20;
-}
+  /* Fix anchor slug links and scroll position due to fixed navbar */
+  *:is(h1, h2, h3, h4, h5, h6, li[id^="user-content-"]) {
+    @apply scroll-mt-20;
+  }
 
-/* Remove styling for anchors inside headings */
-*:is(h1, h2, h3, h4, h5, h6) a {
-  text-decoration: none !important;
-  font-weight: 700 !important;
-  color: var(--color-neutral-800) !important;
-}
+  /* Remove styling for anchors inside headings */
+  *:is(h1, h2, h3, h4, h5, h6) a {
+    text-decoration: none !important;
+    font-weight: 700 !important;
+    color: var(--color-neutral-800) !important;
+  }
 
-*:is(h1, h2, h3, h4, h5, h6) a:hover {
-  text-decoration: underline !important;
-}
+  *:is(h1, h2, h3, h4, h5, h6) a:hover {
+    text-decoration: underline !important;
+  }
 
-*:is(code) {
-  @apply overflow-x-auto rounded-sm text-sm;
+  *:is(code) {
+    @apply overflow-x-auto rounded-sm text-sm;
+  }
 }
 
 /* Default hr color for Tailwind v4 compatibility */


### PR DESCRIPTION
Due to changes in how Tailwind 4 applies CSS rules for its layers, we need to move all of the custom styles into the base layer for them to apply.

#### Before
<img width="1927" height="876" alt="Screenshot 2026-01-27 at 8 40 07 PM" src="https://github.com/user-attachments/assets/4d016985-518b-434b-8778-86a4ddf9ef87" />

<img width="555" height="539" alt="Screenshot 2026-01-27 at 8 40 12 PM" src="https://github.com/user-attachments/assets/7eed2b3b-1520-4e34-8379-75493bb00e34" />



#### After

<img width="1063" height="995" alt="Screenshot 2026-01-27 at 8 38 35 PM" src="https://github.com/user-attachments/assets/186e8ed9-d41e-407e-8095-1b7ff557a80a" />
<img width="552" height="536" alt="Screenshot 2026-01-27 at 8 38 38 PM" src="https://github.com/user-attachments/assets/2eea7796-7e6a-4e90-8255-26cf6435676f" />


Fixes #11900 
