### PR TITLE
fix(portal): don't log cluster node warnings while starting

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -8,7 +8,6 @@ DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
 Config.Secrets: Hardcoded Secret,config/config.exs:220,29A4EF2
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 SQL.Query: SQL injection,lib/portal/safe.ex:344,2C3D7F0
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:217,3560D02
 SQL.Query: SQL injection,lib/portal/safe.ex:350,3C9C61F
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
@@ -18,14 +17,15 @@ Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB2
 Config.Secrets: Hardcoded Secret,config/config.exs:115,496262
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:66,58F0C9B
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:212,5B50F1B
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:403,5BB84FC
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:399,5F2DE06
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619

--- a/elixir/lib/portal/cluster/postgres_strategy.ex
+++ b/elixir/lib/portal/cluster/postgres_strategy.ex
@@ -99,7 +99,6 @@ defmodule Portal.Cluster.PostgresStrategy do
       |> Map.put(:below_threshold?, false)
       |> Map.put(:listener_pid, nil)
       |> Map.put(:notify_conn, nil)
-      |> Map.put(:started_at, System.monotonic_time(:millisecond))
 
     {:ok, state, {:continue, :connect}}
   end
@@ -112,7 +111,7 @@ defmodule Portal.Cluster.PostgresStrategy do
         {:noreply, %{state | listener_pid: listener_pid, notify_conn: notify_conn}}
 
       {:error, reason} ->
-        Logger.error("Failed to start PostgreSQL connections", reason: inspect(reason))
+        Logger.error("Failed to start PostgreSQL connections", reason: reason)
         Process.send_after(self(), :retry_connect, state.heartbeat_interval)
         {:noreply, state}
     end
@@ -141,13 +140,13 @@ defmodule Portal.Cluster.PostgresStrategy do
   end
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{listener_pid: pid} = state) do
-    Logger.warning("PostgreSQL listener died, reconnecting", reason: inspect(reason))
+    Logger.warning("PostgreSQL listener died, reconnecting", reason: reason)
     Process.send_after(self(), :retry_connect, state.heartbeat_interval)
     {:noreply, %{state | listener_pid: nil}}
   end
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{notify_conn: pid} = state) do
-    Logger.warning("PostgreSQL notify connection died, reconnecting", reason: inspect(reason))
+    Logger.warning("PostgreSQL notify connection died, reconnecting", reason: reason)
     Process.send_after(self(), :retry_connect, state.heartbeat_interval)
     {:noreply, %{state | notify_conn: nil}}
   end
@@ -202,10 +201,10 @@ defmodule Portal.Cluster.PostgresStrategy do
         :ok
 
       {:error, reason} ->
-        Logger.error("Failed to send cluster notification", reason: inspect(reason))
+        Logger.error("Failed to send cluster notification", reason: reason)
     end
   catch
-    :exit, reason -> Logger.error("Failed to send cluster notification", reason: inspect(reason))
+    :exit, reason -> Logger.error("Failed to send cluster notification", reason: reason)
   end
 
   defp handle_notification("heartbeat:" <> node_name, state) do
@@ -233,8 +232,8 @@ defmodule Portal.Cluster.PostgresStrategy do
         problem_nodes = Enum.map(bad_nodes, &elem(&1, 0))
 
         Logger.info("Error connecting to nodes",
-          connected_nodes: inspect(state.connected_nodes),
-          problem_nodes: inspect(problem_nodes)
+          connected_nodes: state.connected_nodes,
+          problem_nodes: problem_nodes
         )
 
         maybe_log_threshold_error(state, problem_nodes)
@@ -281,7 +280,7 @@ defmodule Portal.Cluster.PostgresStrategy do
       nodes_to_disconnect = Enum.filter(stale_nodes, &(&1 in state.connected_nodes))
 
       if nodes_to_disconnect != [] do
-        Logger.info("Disconnecting stale nodes", nodes: inspect(nodes_to_disconnect))
+        Logger.info("Disconnecting stale nodes", nodes: nodes_to_disconnect)
 
         Cluster.Strategy.disconnect_nodes(
           state.topology,
@@ -301,31 +300,49 @@ defmodule Portal.Cluster.PostgresStrategy do
     end
   end
 
-  # Only log when crossing the threshold boundary to avoid log flooding.
-  # Skip threshold checks during the startup grace period — newly started nodes
-  # need time to receive heartbeats from all peers before the count is meaningful.
+  # Only log after sustained threshold violation to avoid transient alerts during
+  # deploys. When a node departs (goodbye or stale), the count may briefly dip below
+  # the threshold before the replacement node's heartbeats are processed.
+  #
+  # below_threshold? states:
+  #   false               — at or above threshold
+  #   {:pending, mono_ms} — first dropped below threshold at this time, waiting
+  #   true                — sustained violation confirmed, error already logged
   defp maybe_log_threshold_error(state, problem_nodes) do
-    if in_startup_grace_period?(state) or enough_nodes_connected?(state) do
+    if enough_nodes_connected?(state) do
       %{state | below_threshold?: false}
     else
-      unless state.below_threshold? do
-        Logger.error("Connected nodes count is below threshold",
-          connected_nodes: inspect(state.connected_nodes),
-          problem_nodes: inspect(problem_nodes),
-          config: inspect(state.config)
-        )
-      end
+      now = System.monotonic_time(:millisecond)
+      sustained_period = state.heartbeat_interval * state.missed_heartbeats
 
-      %{state | below_threshold?: true}
+      case state.below_threshold? do
+        false ->
+          %{state | below_threshold?: {:pending, now}}
+
+        {:pending, since} when now - since >= sustained_period ->
+          Logger.error("Connected nodes count is below threshold",
+            connected_nodes: state.connected_nodes,
+            problem_nodes: problem_nodes,
+            config: state.config
+          )
+
+          %{state | below_threshold?: true}
+
+        {:pending, _} ->
+          state
+
+        true ->
+          state
+      end
     end
   end
 
   defp maybe_log_threshold_recovery(state) do
     if enough_nodes_connected?(state) do
-      if state.below_threshold? do
+      if state.below_threshold? == true do
         Logger.info("Connected nodes count is back above threshold",
-          connected_nodes: inspect(state.connected_nodes),
-          config: inspect(state.config)
+          connected_nodes: state.connected_nodes,
+          config: state.config
         )
       end
 
@@ -344,10 +361,5 @@ defmodule Portal.Cluster.PostgresStrategy do
       :error ->
         true
     end
-  end
-
-  defp in_startup_grace_period?(state) do
-    elapsed = System.monotonic_time(:millisecond) - state.started_at
-    elapsed < state.heartbeat_interval * state.missed_heartbeats
   end
 end


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/11909 we introduced a fix that prevented warnings from logging during node startup due to the node's connected count being lower than threshold.

However, there is a still a race where the old container's goodbye might be processed before the new containers heartbeat, leading to the log emitting again.

All we really care about here is that the cluster is fully-joined. There may be temporary blips that drop this below the expected node count, but those need to be tolerated.

Based on the above, the fix here is the allow a grace period where we can dip below the threshold for a short period of time before logging a warning.