### PR TITLE
fix(website): use plain apostrophe in testimonials

### DIFF
--- a/website/src/components/CustomerTestimonials/index.tsx
+++ b/website/src/components/CustomerTestimonials/index.tsx
@@ -23,7 +23,7 @@ const customerData = [
   },
   {
     href: new URL("https://beakon.com.au"),
-    desc: `Firezone&apos;s easy-to-setup, sleek, and simple interface makes management
+    desc: `Firezone's easy-to-setup, sleek, and simple interface makes management
       effortless. It perfectly met our zero-trust security needs without the
       complexity found in other products we tested.`,
     authorName: "Mark Sim",
@@ -34,7 +34,7 @@ const customerData = [
   {
     href: new URL("https://www.corrdyn.com/"),
     desc: `After comparing Tailscale, we ultimately chose Firezone to secure access
-      to our data warehouses. Firezone&apos;s ease of configuration and robust
+      to our data warehouses. Firezone's ease of configuration and robust
       policy-based access system made it the clear choice for our needs.`,
     authorName: "James Winegar",
     companyName: "Corrdyn",


### PR DESCRIPTION
HTML entities do not render there as they're not HTML or JSX.

The regression was likely introduced with sed to comply with overly zealous defaults of the eslint rule `react/no-unescaped-entities`.