### PR TITLE
fix(website): restore correct navbar spacing

### DIFF
--- a/website/src/components/RootNavbar/index.tsx
+++ b/website/src/components/RootNavbar/index.tsx
@@ -42,7 +42,7 @@ const navbarThemeLight: CustomFlowbiteTheme["navbar"] = {
   },
   collapse: {
     base: "translate-y-0.5 w-full md:block md:w-auto shadow-sm md:shadow-none",
-    list: "mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-md md:font-medium",
+    list: "mt-4 flex flex-col md:mt-0 md:flex-row md:gap-8 md:space-x-0 md:text-md md:font-medium",
     hidden: {
       on: "hidden",
       off: "",
@@ -89,7 +89,7 @@ const navbarThemeDark: CustomFlowbiteTheme["navbar"] = {
   },
   collapse: {
     base: "translate-y-0.5 w-full md:block md:w-auto shadow-sm md:shadow-none",
-    list: "mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-md md:font-medium",
+    list: "mt-4 flex flex-col md:mt-0 md:flex-row md:gap-8 md:space-x-0 md:text-md md:font-medium",
     hidden: {
       on: "hidden",
       off: "",


### PR DESCRIPTION
Restore the old navbar position following tailwind v4 migration.

Tailwind v4 changed how space-x-* utilities work:
- v3: applies margin-left to all children except the first
- v4: applies margin-right to all children

This caused an extra 32px margin on the first nav item, shifting the navbar content 16px to the left (due to justify-between distribution).

Fix: Replace md:space-x-8 with md:gap-8 md:space-x-0:
- gap-8 provides spacing between items without edge margins
- space-x-0 explicitly overrides Flowbite's default space-x-8