### PR TITLE
fix(portal): wait for geolix to load on start

### DIFF
--- a/elixir/test/portal/application_test.exs
+++ b/elixir/test/portal/application_test.exs
@@ -1,6 +1,15 @@
 defmodule Portal.ApplicationTest do
   use ExUnit.Case, async: true
 
+  describe "start/2" do
+    test "geolix databases are loaded before supervision tree starts" do
+      for %{id: id} <- Portal.Config.get_env(:geolix, :databases, []) do
+        assert Geolix.metadata(where: id) != nil,
+               "expected Geolix database #{inspect(id)} to be loaded"
+      end
+    end
+  end
+
   describe "stop/1" do
     test "removes logger handler without crashing" do
       # Use a unique handler ID to avoid conflicts with parallel tests


### PR DESCRIPTION
When starting the application, Geolix processes the DB asynchronously. In production environments we actually want to block here because we don't want to start serving requests without a valid GeoIP database.

This also fixes a logger warning we are getting about the DB not being available on start.