### PR TITLE
fix(website): restore main title styling

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
             </Banner>
             <h1
               className={
-                "mb-8 text-5xl sm:text-6xl md:text-7xl text-center drop-shadow-[inset_0_2px_0_0_rgba(255,255,255,100)] font-medium tracking-tight leading-tight bg-gradient-to-b from-white from-70% to-slate-200 text-transparent bg-clip-text"
+                "mb-8 text-5xl sm:text-6xl md:text-7xl text-center drop-shadow-[inset_0_2px_0_0_rgba(255,255,255,100)] font-medium tracking-tight leading-none bg-gradient-to-b from-white from-70% to-slate-200 text-transparent bg-clip-text"
               }
             >
               Upgrade your VPN to zero-trust access


### PR DESCRIPTION
One can see the title font regression easiest by flicking between 3 tabs:

some old pre-v4 deployment - https://firezone-1m6ngw8xl-firezone.vercel.app/
current production - https://firezone.dev/
the current deployment (which restores the tighter font)