### PR TITLE
ci: bump xcode to 26.2

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -29,7 +29,7 @@ jobs:
   test:
     runs-on: macos-15
     env:
-      XCODE_VERSION: "26.0"
+      XCODE_VERSION: "26.2"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: sudo xcode-select --switch "$(find /Applications -maxdepth 1 -name "Xcode*${XCODE_VERSION}*.app" | sort -V | tail -n 1)"
@@ -49,7 +49,7 @@ jobs:
   static-analysis:
     runs-on: macos-15
     env:
-      XCODE_VERSION: "26.0"
+      XCODE_VERSION: "26.2"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: sudo xcode-select --switch "$(find /Applications -maxdepth 1 -name "Xcode*${XCODE_VERSION}*.app" | sort -V | tail -n 1)"
@@ -66,7 +66,7 @@ jobs:
     needs: update-release-draft
     runs-on: macos-15
     env:
-      XCODE_VERSION: "26.0"
+      XCODE_VERSION: "26.2"
       MISE_EXPERIMENTAL: "1"
     permissions:
       contents: write # for attaching the build artifacts to the release


### PR DESCRIPTION
Bumps Xcode to the latest version to fix intermittent issues with runner images missing things.

Related: https://github.com/firezone/firezone/actions/runs/21446524264/job/61763750788?pr=11822