### PR TITLE
fix(portal): minor race condition in relays_presence

### DIFF
--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -121,24 +121,33 @@ defmodule PortalAPI.Gateway.Channel do
   def handle_info(:check_relay_presence, socket) do
     cached_relay_ids = socket.assigns[:cached_relay_ids] || MapSet.new()
 
-    # Check current presence state - this is the authoritative CRDT-merged state
-    # Presence is keyed by relay ID
-    current_relay_ids = Presence.Relays.Global.list() |> Map.keys() |> MapSet.new()
+    # Query presence ONCE - use this single snapshot for both determining
+    # disconnected relays and selecting connected relays. This avoids a race
+    # condition where CRDT state changes between queries during rapid
+    # disconnect/reconnect cycles.
+    {:ok, all_online_relays} = Presence.Relays.all_connected_relays()
+    online_relay_ids = MapSet.new(all_online_relays, & &1.id)
 
-    # Find which cached relays are now disconnected (ID no longer in presence)
+    # Find which cached relays are now truly offline (ID no longer in presence)
     disconnected_ids =
       cached_relay_ids
-      |> Enum.reject(&MapSet.member?(current_relay_ids, &1))
+      |> Enum.reject(&MapSet.member?(online_relay_ids, &1))
       |> Enum.to_list()
 
     # Send relays_presence if any cached relays are disconnected OR if we have fewer than 2 relays
     # and more are now available
     needs_update =
       disconnected_ids != [] or
-        (MapSet.size(cached_relay_ids) < 2 and MapSet.size(current_relay_ids) > 0)
+        (MapSet.size(cached_relay_ids) < 2 and MapSet.size(online_relay_ids) > 0)
 
     if needs_update do
-      {:ok, relays} = select_relays(socket)
+      # Select best relays from the SAME snapshot we used for disconnected_ids
+      location = {
+        socket.assigns.gateway.last_seen_remote_ip_location_lat,
+        socket.assigns.gateway.last_seen_remote_ip_location_lon
+      }
+
+      relays = load_balance_relays(location, all_online_relays)
       socket = cache_relays(socket, relays)
 
       relay_credentials_expire_at = DateTime.utc_now() |> DateTime.add(90, :day)

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -2276,6 +2276,64 @@ defmodule PortalAPI.Gateway.ChannelTest do
       assert relay_id == relay1.id
     end
 
+    test "disconnected_ids only contains relays that are truly offline", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      # This test validates that disconnected_ids only contains relays that are
+      # no longer in presence (truly offline), not relays that happen to not be
+      # selected by load balancing.
+      #
+      # The fix uses a single presence snapshot for both:
+      # 1. Determining which cached relays are now offline (disconnected_ids)
+      # 2. Selecting the best relays to send to the gateway (connected)
+      #
+      # This ensures a relay can never appear in both lists due to CRDT
+      # eventual consistency during rapid disconnect/reconnect cycles.
+
+      relay = relay_fixture(%{lat: 37.0, lon: -120.0})
+
+      :ok = Portal.Presence.Relays.connect(relay)
+
+      PortalAPI.Gateway.Socket
+      |> socket("gateway:#{gateway.id}", %{
+        token_id: token.id,
+        gateway: gateway,
+        site: site,
+        opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+        opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test")
+      })
+      |> subscribe_and_join(PortalAPI.Gateway.Channel, "gateway")
+
+      assert_push "init", %{relays: [_, _]}
+
+      # Disconnect and immediately reconnect - without the fix, this could cause
+      # the relay to appear in both connected and disconnected_ids
+      Portal.Presence.Relays.disconnect(relay)
+      :ok = Portal.Presence.Relays.connect(relay)
+
+      # If we receive any relays_presence message, verify the invariant:
+      # a relay should NEVER appear in both connected and disconnected_ids
+      receive do
+        %Phoenix.Socket.Message{event: "relays_presence", payload: payload} ->
+          connected_ids = MapSet.new(payload.connected, & &1.id)
+          disconnected_ids = MapSet.new(payload.disconnected_ids)
+
+          intersection = MapSet.intersection(connected_ids, disconnected_ids)
+
+          assert MapSet.size(intersection) == 0,
+                 "Relay IDs #{inspect(MapSet.to_list(intersection))} appear in both " <>
+                   "connected and disconnected_ids - disconnected_ids should only " <>
+                   "contain relays that are truly offline"
+      after
+        100 ->
+          # No message received is also acceptable - relay reconnected before
+          # the presence check ran, so no update was needed
+          :ok
+      end
+    end
+
     test "selects closest relays by distance when gateway has location", %{
       account: account,
       site: site,


### PR DESCRIPTION
When computing the list of relays for `relays_presence`, we were using two independent `Presence.list` calls to figure out which relays are connected, and which ones are now disconnected.

This led to a race condition that a flaky unit test caught where the same Relay ID could end up in both the `connected` list and the `disconnected_ids` list we send to clients and gateways.

To fix this fetch the list of online relays with `Presence.list` once, and then determine connected and disconnected from this single source of truth.