### PR TITLE
chore(gui-client): improve logging around connlib-startup

### DIFF
--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -409,10 +409,15 @@ impl<'a> Handler<'a> {
                         let msg = match result {
                             Ok(session) => {
                                 self.session = session;
+                                tracing::debug!("Created new session");
 
                                 ServerMsg::connect_result(Ok(()))
                             }
-                            Err(e) => ServerMsg::connect_result(Err(e)),
+                            Err(e) => {
+                                tracing::debug!("Failed to create new session: {e}");
+
+                                ServerMsg::connect_result(Err(e))
+                            }
                         };
 
                         let _ = self

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -414,7 +414,7 @@ impl<'a> Handler<'a> {
                                 ServerMsg::connect_result(Ok(()))
                             }
                             Err(e) => {
-                                tracing::debug!("Failed to create new session: {e}");
+                                tracing::debug!("Failed to create new session: {e:#}");
 
                                 ServerMsg::connect_result(Err(e))
                             }


### PR DESCRIPTION
When we are failing to start up connlib, we currently do not report anything in the tunnel process but instead directly send the result over IPC to the GUI process. When just viewing the logs of the tunnel, this can be confusing and hard to diagnose.

To aid debugging the tunnel process, we now log both the happy and unhappy path of creating a new session.