### PR TITLE
fix(portal): ensure postgrex is started before app

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -42,7 +42,9 @@ defmodule Portal.MixProject do
         :logger,
         :runtime_tools,
         :crypto,
-        :dialyzer
+        :dialyzer,
+        # Ensure Postgrex.SCRAM.LockedCache is started before any database connections
+        :postgrex
       ]
     ]
   end


### PR DESCRIPTION
We're seeing intermittent crashes on Azure that look like:


```
{"message":":gen_statem #PID<0.1778.0> terminating\n** (stop) exited in: GenServer.call(Postgrex.SCRAM.LockedCache, {:lock, {<<53, 233, 194, 222, 253, 73, 184, 206, 104, 219, 92, 160, 250, 192, 122, 81, 242, 3, 67, 157, 79, 74, 211, 169, 223, 148, 81, 45, 194, 93, 33, 167>>, <<131, 48, 200, 139, 176, 153, 200, 128, 196, 186, 182, 216, 2, 150, 164, 139>>, 4096}}, :infinity)\n    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly
```

Some cursory research suggests this might be a small race that gets hit if the app supervision tree starts before postgrex is done starting.

---

Related: https://portal.azure.com/#view/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId~/%2Fsubscriptions%2F3ea78439-33cc-4350-812e-5e3703087cc6%2Fresourcegroups%2Fstaging-rg%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fstaging-rg-logs%2Fproviders%2FMicrosoft.AlertsManagement%2Falerts%2F1f16f84e-ca62-cac0-ce3c-38a203d00002/invokedFrom/CopyLinkFeature
