### PR TITLE
chore(portal): enable credo db checks

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -41,9 +41,9 @@
       #
       requires: [
         ".credo/check/warning/unsafe_repo_usage.ex",
-        ".credo/check/warning/safe_calls_outside_db_module.ex",
-        ".credo/check/warning/missing_db_alias.ex",
-        ".credo/check/warning/cross_module_db_call.ex",
+        ".credo/check/warning/safe_calls_outside_database_module.ex",
+        ".credo/check/warning/missing_database_alias.ex",
+        ".credo/check/warning/cross_module_database_call.ex",
         ".credo/check/warning/action_fallback_usage.ex",
         ".credo/check/warning/missing_changeset_function.ex"
       ],
@@ -161,14 +161,13 @@
 
           # Custom Checks
           {Credo.Check.Warning.ActionFallbackUsage, []},
-          {Credo.Check.Warning.MissingChangesetFunction, []}
+          {Credo.Check.Warning.MissingChangesetFunction, []},
+          {Credo.Check.Warning.SafeCallsOutsideDatabaseModule, []},
+          {Credo.Check.Warning.UnsafeRepoUsage, []},
+          {Credo.Check.Warning.MissingDatabaseAlias, []},
+          {Credo.Check.Warning.CrossModuleDatabaseCall, []}
         ],
         disabled: [
-          # Custom Checks for Portal conventions
-          {Credo.Check.Warning.UnsafeRepoUsage, []},
-          {Credo.Check.Warning.SafeCallsOutsideDBModule, []},
-          {Credo.Check.Warning.MissingDBAlias, []},
-          {Credo.Check.Warning.CrossModuleDBCall, []},
           {Credo.Check.Readability.AliasOrder, []},
 
           #

--- a/elixir/.credo/check/warning/cross_module_database_call.ex
+++ b/elixir/.credo/check/warning/cross_module_database_call.ex
@@ -1,4 +1,4 @@
-defmodule Credo.Check.Warning.CrossModuleDBCall do
+defmodule Credo.Check.Warning.CrossModuleDatabaseCall do
   use Credo.Check,
     base_priority: :high,
     category: :warning,

--- a/elixir/.credo/check/warning/missing_database_alias.ex
+++ b/elixir/.credo/check/warning/missing_database_alias.ex
@@ -1,4 +1,4 @@
-defmodule Credo.Check.Warning.MissingDBAlias do
+defmodule Credo.Check.Warning.MissingDatabaseAlias do
   use Credo.Check,
     base_priority: :high,
     category: :warning,

--- a/elixir/.credo/check/warning/safe_calls_outside_database_module.ex
+++ b/elixir/.credo/check/warning/safe_calls_outside_database_module.ex
@@ -1,4 +1,4 @@
-defmodule Credo.Check.Warning.SafeCallsOutsideDBModule do
+defmodule Credo.Check.Warning.SafeCallsOutsideDatabaseModule do
   use Credo.Check,
     base_priority: :high,
     category: :warning,
@@ -17,7 +17,7 @@ defmodule Credo.Check.Warning.SafeCallsOutsideDBModule do
     issue_meta = IssueMeta.for(source_file, params)
 
     # Skip checking the Portal.Safe module itself
-    if String.ends_with?(source_file.filename, "domain/lib/domain/safe.ex") do
+    if String.ends_with?(source_file.filename, "lib/portal/safe.ex") do
       []
     else
       source_file

--- a/elixir/.credo/check/warning/unsafe_repo_usage.ex
+++ b/elixir/.credo/check/warning/unsafe_repo_usage.ex
@@ -24,11 +24,11 @@ defmodule Credo.Check.Warning.UnsafeRepoUsage do
 
     cond do
       # Allow in Portal.Safe module
-      String.ends_with?(file_path, "domain/lib/domain/safe.ex") ->
+      String.ends_with?(file_path, "lib/portal/safe.ex") ->
         []
 
       # Allow in Portal.Repo itself and its submodules (Preloader, Paginator, Filter, Query)
-      String.contains?(file_path, "domain/lib/domain/repo") ->
+      String.contains?(file_path, "lib/portal/repo") ->
         []
 
       # Allow in seeds.exs files
@@ -69,6 +69,24 @@ defmodule Credo.Check.Warning.UnsafeRepoUsage do
          issue_meta
        ) do
     {ast, [issue_for(ast, meta[:line], issue_meta) | issues]}
+  end
+
+  # Allow Portal.Repo.valid_uuid? - it's a utility function, not a database operation
+  defp traverse(
+         {{:., _meta, [{:__aliases__, _, [:Portal, :Repo]}, :valid_uuid?]}, _, _} = ast,
+         issues,
+         _issue_meta
+       ) do
+    {ast, issues}
+  end
+
+  # Allow Repo.valid_uuid? (when aliased)
+  defp traverse(
+         {{:., _meta, [{:__aliases__, _, [:Repo]}, :valid_uuid?]}, _, _} = ast,
+         issues,
+         _issue_meta
+       ) do
+    {ast, issues}
   end
 
   # Check for direct Portal.Repo calls

--- a/elixir/lib/portal/ipv4_address.ex
+++ b/elixir/lib/portal/ipv4_address.ex
@@ -1,7 +1,7 @@
 defmodule Portal.IPv4Address do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Portal.Safe
+  alias __MODULE__.Database
   require Logger
 
   @primary_key false
@@ -71,11 +71,7 @@ defmodule Portal.IPv4Address do
     client_id_binary = if client_id, do: Ecto.UUID.dump!(client_id)
     gateway_id_binary = if gateway_id, do: Ecto.UUID.dump!(gateway_id)
 
-    case Safe.query(
-           Safe.unscoped(),
-           "SELECT * FROM allocate_address($1, $2, $3, $4, $5)",
-           [account_id_binary, "ipv4", cidr, client_id_binary, gateway_id_binary]
-         ) do
+    case Database.allocate_address(account_id_binary, cidr, client_id_binary, gateway_id_binary) do
       {:ok, %Postgrex.Result{rows: [[account_id, address, client_id, gateway_id, inserted_at]]}} ->
         {:ok,
          %__MODULE__{
@@ -89,6 +85,18 @@ defmodule Portal.IPv4Address do
       {:error, error} ->
         Logger.error("Failed to allocate IPv4 address", account_id: account_id, error: error)
         {:error, error}
+    end
+  end
+
+  defmodule Database do
+    alias Portal.Safe
+
+    def allocate_address(account_id_binary, cidr, client_id_binary, gateway_id_binary) do
+      Safe.query(
+        Safe.unscoped(),
+        "SELECT * FROM allocate_address($1, $2, $3, $4, $5)",
+        [account_id_binary, "ipv4", cidr, client_id_binary, gateway_id_binary]
+      )
     end
   end
 end


### PR DESCRIPTION
We had some credo modules around our `Database` and `Safe` patterns that were disabled. Those are now enabled.
