### PR TITLE
chore(rust): bump str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -801,12 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,12 +1485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,30 +1877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "der_derive",
- "flagset",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,23 +1964,16 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc08e641e661b5b2e6c232ca5a86543c107b38a4aabaa799d28b58ab533be6c6"
+version = "0.2.6"
+source = "git+https://github.com/algesten/dimpl?branch=main#97c9e9d83a7a7548f90cfb5cc99a8f23832e48be"
 dependencies = [
  "arrayvec",
- "der",
  "log",
  "nom",
  "once_cell",
- "pkcs8",
  "rand 0.9.1",
- "sec1",
- "signature",
- "spki",
  "subtle",
  "time",
- "x509-cert",
 ]
 
 [[package]]
@@ -2713,12 +2670,6 @@ dependencies = [
  "url",
  "uuid",
 ]
-
-[[package]]
-name = "flagset"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -5428,15 +5379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,16 +5588,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -6665,18 +6597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "zeroize",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7124,12 +7044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7377,16 +7291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -10197,17 +10101,6 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "x509-cert"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
-dependencies = [
- "const-oid",
- "der",
- "spki",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1969,7 +1969,7 @@ source = "git+https://github.com/algesten/dimpl?branch=main#97c9e9d83a7a7548f90c
 dependencies = [
  "arrayvec",
  "log",
- "nom",
+ "nom 7.1.3",
  "once_cell",
  "rand 0.9.1",
  "subtle",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -801,6 +801,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +817,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "basic-toml"
@@ -1203,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1479,6 +1491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
 dependencies = [
  "crc-catalog",
 ]
@@ -1871,6 +1889,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +1996,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dimpl"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc08e641e661b5b2e6c232ca5a86543c107b38a4aabaa799d28b58ab533be6c6"
+dependencies = [
+ "arrayvec",
+ "der",
+ "log",
+ "nom",
+ "once_cell",
+ "pkcs8",
+ "rand 0.9.1",
+ "sec1",
+ "signature",
+ "spki",
+ "subtle",
+ "time",
+ "x509-cert",
 ]
 
 [[package]]
@@ -2388,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "findshlibs"
@@ -2650,6 +2713,12 @@ dependencies = [
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -5359,6 +5428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,6 +5646,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6554,17 +6642,17 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dea4fe3384a24652f065296ac333c810dfd0c5b39b98a2214762c16aaadc3c"
+checksum = "57239be45f014795255107f85dfe3503791711e77c4995f936caf89a2afe0c16"
 dependencies = [
  "bytes",
  "crc",
- "fxhash",
  "log",
- "rand 0.8.5",
+ "rand 0.9.1",
+ "rustc-hash",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6574,6 +6662,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -6976,16 +7076,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "sha1-asm",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -7032,6 +7122,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
 name = "simd-adler32"
@@ -7127,12 +7223,14 @@ dependencies = [
  "derive_more 2.1.1",
  "hex",
  "hex-display",
+ "hmac",
  "ip-packet",
  "itertools",
  "logging",
  "once_cell",
  "rand 0.8.5",
  "ringbuffer",
+ "sha1",
  "sha2",
  "str0m",
  "stun_codec",
@@ -7282,6 +7380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7295,19 +7403,31 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.9.0"
-source = "git+https://github.com/algesten/str0m?branch=main#44ab8e39ec6d4b4d8efd9f3c45994b55404f6b70"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125b7a32aab44af55205b5055794fc34ce4841b309ccb65b8883d5eb16e65a00"
 dependencies = [
+ "arrayvec",
  "combine",
  "crc",
+ "dimpl",
  "fastrand",
- "hmac",
- "once_cell",
  "sctp-proto",
  "serde",
- "sha1",
- "thiserror 1.0.69",
+ "str0m-proto",
+ "subtle",
  "tracing",
+]
+
+[[package]]
+name = "str0m-proto"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132cc3c4a8197f7d514887dc6cf5341447d3cbe290773641081b9fa04126c994"
+dependencies = [
+ "base64ct",
+ "dimpl",
+ "subtle",
 ]
 
 [[package]]
@@ -10077,6 +10197,17 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -169,6 +169,7 @@ serde = "1.0.228"
 serde_json = "1.0.149"
 serde_variant = "0.1.3"
 serde_with = "3.16.0"
+sha1 = "0.10.6"
 sha2 = "0.10.9"
 smallvec = "1.15.1"
 smbios-lib = "0.9.2"
@@ -179,7 +180,7 @@ socket2 = { version = "0.6.2" }
 specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 static_assertions = "1.1.0"
-str0m = { version = "0.9.0", default-features = false, features = ["sha1"] }
+str0m = { version = "0.16.1", default-features = false }
 strum = { version = "0.27.2", features = ["derive"] }
 stun_codec = "0.4.0"
 subprocess = "0.2.13"
@@ -257,7 +258,6 @@ ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "mas
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.30" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
-str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -254,6 +254,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
+dimpl = { git = "https://github.com/algesten/dimpl", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.30" } # Waiting for release.

--- a/rust/libs/connlib/snownet/Cargo.toml
+++ b/rust/libs/connlib/snownet/Cargo.toml
@@ -14,12 +14,14 @@ bytes = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 hex = { workspace = true }
 hex-display = { workspace = true }
+hmac = { workspace = true }
 ip-packet = { workspace = true }
 itertools = { workspace = true }
 logging = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 ringbuffer = { workspace = true }
+sha1 = { workspace = true }
 sha2 = { workspace = true }
 str0m = { workspace = true }
 stun_codec = { workspace = true }

--- a/rust/libs/connlib/snownet/src/crypto.rs
+++ b/rust/libs/connlib/snownet/src/crypto.rs
@@ -8,7 +8,7 @@ type HmacSha1 = Hmac<Sha1>;
 pub(crate) static CRYPTO_PROVIDER: RustCryptoSha1HmacProvider = RustCryptoSha1HmacProvider;
 
 #[derive(Debug)]
-pub(super) struct RustCryptoSha1HmacProvider;
+struct RustCryptoSha1HmacProvider;
 
 impl Sha1HmacProvider for RustCryptoSha1HmacProvider {
     fn sha1_hmac(&self, key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {

--- a/rust/libs/connlib/snownet/src/crypto.rs
+++ b/rust/libs/connlib/snownet/src/crypto.rs
@@ -8,7 +8,7 @@ type HmacSha1 = Hmac<Sha1>;
 pub(crate) static CRYPTO_PROVIDER: RustCryptoSha1HmacProvider = RustCryptoSha1HmacProvider;
 
 #[derive(Debug)]
-struct RustCryptoSha1HmacProvider;
+pub(crate) struct RustCryptoSha1HmacProvider;
 
 impl Sha1HmacProvider for RustCryptoSha1HmacProvider {
     fn sha1_hmac(&self, key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {

--- a/rust/libs/connlib/snownet/src/crypto.rs
+++ b/rust/libs/connlib/snownet/src/crypto.rs
@@ -1,0 +1,27 @@
+use hmac::{Hmac, Mac};
+use sha1::Sha1;
+
+use str0m::crypto::Sha1HmacProvider;
+
+type HmacSha1 = Hmac<Sha1>;
+
+pub(crate) static CRYPTO_PROVIDER: RustCryptoSha1HmacProvider = RustCryptoSha1HmacProvider;
+
+#[derive(Debug)]
+pub(super) struct RustCryptoSha1HmacProvider;
+
+impl Sha1HmacProvider for RustCryptoSha1HmacProvider {
+    fn sha1_hmac(&self, key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+        let mut mac = HmacSha1::new_from_slice(key).expect("HMAC can take key of any size");
+
+        for payload in payloads {
+            mac.update(payload);
+        }
+
+        let result = mac.finalize();
+        let bytes = result.into_bytes();
+        let mut output = [0u8; 20];
+        output.copy_from_slice(&bytes);
+        output
+    }
+}

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -6,6 +6,7 @@
 mod allocation;
 mod backoff;
 mod channel_data;
+mod crypto;
 mod index;
 mod node;
 mod stats;
@@ -17,6 +18,8 @@ pub use node::{
     ServerNode, Transmit, UnknownConnection,
 };
 pub use stats::{ConnectionStats, NodeStats};
+
+pub(crate) use crypto::CRYPTO_PROVIDER;
 
 pub fn is_wireguard(payload: &[u8]) -> bool {
     boringtun::noise::Tunn::parse_incoming_packet(payload).is_ok()

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -2119,7 +2119,7 @@ where
 }
 
 fn new_client_agent() -> IceAgent {
-    let mut agent = IceAgent::new();
+    let mut agent = IceAgent::new(str0m::IceCreds::new(), &crate::CRYPTO_PROVIDER);
     agent.set_controlling(true);
     agent.set_timing_advance(Duration::ZERO);
 
@@ -2129,7 +2129,7 @@ fn new_client_agent() -> IceAgent {
 }
 
 fn new_server_agent() -> IceAgent {
-    let mut agent = IceAgent::new();
+    let mut agent = IceAgent::new(str0m::IceCreds::new(), &crate::CRYPTO_PROVIDER);
     agent.set_controlling(false);
     agent.set_timing_advance(Duration::ZERO);
 
@@ -2228,7 +2228,7 @@ mod tests {
         let srvflx =
             Candidate::server_reflexive(SocketAddr::new(addr, 40000), base, "udp").unwrap();
 
-        let mut agent = IceAgent::new();
+        let mut agent = IceAgent::new(str0m::IceCreds::new(), &crate::CRYPTO_PROVIDER);
         agent.add_remote_candidate(host);
         agent.add_remote_candidate(srvflx);
 
@@ -2254,7 +2254,7 @@ mod tests {
         let srvflx =
             Candidate::server_reflexive(SocketAddr::new(addr, 40000), base, "udp").unwrap();
 
-        let mut agent = IceAgent::new();
+        let mut agent = IceAgent::new(str0m::IceCreds::new(), &crate::CRYPTO_PROVIDER);
         agent.add_remote_candidate(host);
         agent.add_remote_candidate(srvflx);
 
@@ -2281,7 +2281,7 @@ mod tests {
         let srflx3 =
             Candidate::server_reflexive(SocketAddr::new(addr3, 40000), base, "udp").unwrap();
 
-        let mut agent = IceAgent::new();
+        let mut agent = IceAgent::new(str0m::IceCreds::new(), &crate::CRYPTO_PROVIDER);
         agent.add_remote_candidate(host);
         agent.add_remote_candidate(srflx1);
         agent.add_remote_candidate(srflx2);

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -463,7 +463,7 @@ mod tests {
         let new_local = Index::new_local(idx);
 
         Connection {
-            agent: IceAgent::new(),
+            agent: IceAgent::new(str0m::IceCreds::new(), &crate::CRYPTO_PROVIDER),
             index: new_local,
             tunnel: Tunn::new_at(
                 private,


### PR DESCRIPTION
We have been lagging behind in the releases of str0m for a while now and recently, at least 1 PR landed that would actually be beneficial to Firezone too.

Bumping the version requires us to implement our own crypto-provider as str0m now offers several different crypto backends. We only use the ICE agent and therefore, the only crypto we need to provide is HMAC-SHA1.

Despite being a large version jump, this update is quite safe as almost no code within the `ice` module of `str0m` has changed in those versions.