### PR TITLE
fix: only set routes of supported IP stack

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "futures",
  "ip-packet",
  "ip_network",
+ "itertools 0.14.0",
  "libc",
  "log",
  "logging",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "hex",
  "humantime",
  "ip-packet",
+ "ip_network",
  "keyring-core",
  "logging",
  "native-dialog",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1354,7 +1354,7 @@ dependencies = [
  "futures",
  "ip-packet",
  "ip_network",
- "itertools 0.14.0",
+ "itertools",
  "libc",
  "log",
  "logging",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "futures",
  "humantime",
  "ip-packet",
+ "ip_network",
  "known-folders",
  "libc",
  "logging",

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -19,10 +19,10 @@ flume = { workspace = true }
 futures = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
+itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 logging = { workspace = true }
-itertools = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -22,6 +22,7 @@ ip_network = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 logging = { workspace = true }
+itertools = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -391,7 +391,7 @@ impl Session {
                                 address: v4.network_address().to_string(),
                                 prefix: v4.netmask(),
                             }),
-                            IpNetwork::V6(v6) => itertools::Either::Left(Cidr {
+                            IpNetwork::V6(v6) => itertools::Either::Right(Cidr {
                                 address: v6.network_address().to_string(),
                                 prefix: v6.netmask(),
                             }),

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -10,6 +10,8 @@ use std::{
 
 use anyhow::{Context as _, Result, anyhow};
 use backoff::ExponentialBackoffBuilder;
+use ip_network::IpNetwork;
+use itertools::Itertools as _;
 use logging::sentry_layer;
 use phoenix_channel::{LoginUrl, PhoenixChannel, get_user_agent};
 use platform::RELEASE;
@@ -380,23 +382,20 @@ impl Session {
                     .map(|ip| ip.to_string())
                     .collect();
 
-                let ipv4_routes: Vec<Cidr> = config
-                    .ipv4_routes
-                    .into_iter()
-                    .map(|network| Cidr {
-                        address: network.network_address().to_string(),
-                        prefix: network.netmask(),
-                    })
-                    .collect();
-
-                let ipv6_routes: Vec<Cidr> = config
-                    .ipv6_routes
-                    .into_iter()
-                    .map(|network| Cidr {
-                        address: network.network_address().to_string(),
-                        prefix: network.netmask(),
-                    })
-                    .collect();
+                let (ipv4_routes, ipv6_routes) =
+                    config
+                        .routes
+                        .into_iter()
+                        .partition_map(|route| match route {
+                            IpNetwork::V4(v4) => itertools::Either::Left(Cidr {
+                                address: v4.network_address().to_string(),
+                                prefix: v4.netmask(),
+                            }),
+                            IpNetwork::V6(v6) => itertools::Either::Left(Cidr {
+                                address: v6.network_address().to_string(),
+                                prefix: v6.netmask(),
+                            }),
+                        });
 
                 Some(Event::TunInterfaceUpdated {
                     ipv4: config.ip.v4.to_string(),

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -430,7 +430,7 @@ impl Eventloop {
                 tracing::debug!(stack = %tun_ip_stack, "Initialized TUN device");
 
                 self.tun_device_manager
-                    .set_routes(vec![IPV4_TUNNEL], vec![IPV6_TUNNEL])
+                    .set_routes(vec![IPV4_TUNNEL.into(), IPV6_TUNNEL.into()])
                     .await
                     .context("Failed to set TUN routes")?;
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -429,8 +429,14 @@ impl Eventloop {
 
                 tracing::debug!(stack = %tun_ip_stack, "Initialized TUN device");
 
+                let routes = match tun_ip_stack {
+                    bin_shared::TunIpStack::V4Only => vec![IPV4_TUNNEL.into()],
+                    bin_shared::TunIpStack::V6Only => vec![IPV6_TUNNEL.into()],
+                    bin_shared::TunIpStack::Dual => vec![IPV4_TUNNEL.into(), IPV6_TUNNEL.into()],
+                };
+
                 self.tun_device_manager
-                    .set_routes(vec![IPV4_TUNNEL.into(), IPV6_TUNNEL.into()])
+                    .set_routes(routes)
                     .await
                     .context("Failed to set TUN routes")?;
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ derive_more = { workspace = true, features = ["debug"] }
 futures = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }
-ip-network = { workspace = true }
+ip_network = { workspace = true }
 ip-packet = { workspace = true }
 keyring-core = { workspace = true }
 logging = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ derive_more = { workspace = true, features = ["debug"] }
 futures = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }
+ip-network = { workspace = true }
 ip-packet = { workspace = true }
 keyring-core = { workspace = true }
 logging = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -32,8 +32,8 @@ derive_more = { workspace = true, features = ["debug"] }
 futures = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }
-ip_network = { workspace = true }
 ip-packet = { workspace = true }
+ip_network = { workspace = true }
 keyring-core = { workspace = true }
 logging = { workspace = true }
 native-dialog = { workspace = true }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -485,9 +485,7 @@ impl<'a> Handler<'a> {
                 self.dns_controller
                     .set_dns(config.dns_by_sentinel.sentinel_ips(), config.search_domain)
                     .await?;
-                self.tun_device
-                    .set_routes(config.ipv4_routes, config.ipv6_routes)
-                    .await?;
+                self.tun_device.set_routes(config.routes).await?;
                 self.dns_controller.flush()?;
             }
             client_shared::Event::ResourcesUpdated(resources) => {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -19,6 +19,7 @@ use futures::{
     stream::{self, BoxStream},
     task::{Context, Poll},
 };
+use ip_network::IpNetwork;
 use logging::{FilterReloadHandle, err_with_src};
 use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, get_user_agent};
 use secrecy::{ExposeSecret, SecretString};

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -486,13 +486,12 @@ impl<'a> Handler<'a> {
                 self.dns_controller
                     .set_dns(config.dns_by_sentinel.sentinel_ips(), config.search_domain)
                     .await?;
-
-                let routes = config.routes.into_iter().filter(|r| match r {
-                    IpNetwork::V4(_) => tun_ip_stack.supports_ipv4(),
-                    IpNetwork::V6(_) => tun_ip_stack.supports_ipv6(),
-                });
-
-                self.tun_device.set_routes(routes).await?;
+                self.tun_device
+                    .set_routes(config.routes.into_iter().filter(|r| match r {
+                        IpNetwork::V4(_) => tun_ip_stack.supports_ipv4(),
+                        IpNetwork::V6(_) => tun_ip_stack.supports_ipv6(),
+                    }))
+                    .await?;
                 self.dns_controller.flush()?;
             }
             client_shared::Event::ResourcesUpdated(resources) => {

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -18,6 +18,7 @@ dns-types = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }
+ip_network = { workspace = true }
 logging = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -415,7 +415,7 @@ fn try_main() -> Result<()> {
                 client_shared::Event::TunInterfaceUpdated(config) => {
                     tun_device.set_ips(config.ip.v4, config.ip.v6).await?;
                     dns_controller.set_dns(config.dns_by_sentinel.sentinel_ips(), config.search_domain).await?;
-                    tun_device.set_routes(config.ipv4_routes, config.ipv6_routes).await?;
+                    tun_device.set_routes(config.routes).await?;
 
                     // `on_set_interface_config` is guaranteed to be called when the tunnel is completely ready
                     // <https://github.com/firezone/firezone/pull/6026#discussion_r1692297438>

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -11,6 +11,7 @@ use bin_shared::{
     signals,
 };
 use clap::Parser;
+use ip_network::IpNetwork;
 use opentelemetry_otlp::WithExportConfig as _;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::PhoenixChannel;
@@ -415,7 +416,7 @@ fn try_main() -> Result<()> {
                 client_shared::Event::TunInterfaceUpdated(config) => {
                     let tun_ip_stack = tun_device.set_ips(config.ip.v4, config.ip.v6).await?;
                     dns_controller.set_dns(config.dns_by_sentinel.sentinel_ips(), config.search_domain).await?;
-                    self.tun_device.set_routes(config.routes.into_iter().filter(|r| match r {
+                    tun_device.set_routes(config.routes.into_iter().filter(|r| match r {
                         IpNetwork::V4(_) => tun_ip_stack.supports_ipv4(),
                         IpNetwork::V6(_) => tun_ip_stack.supports_ipv6(),
                     })).await?;

--- a/rust/libs/bin-shared/src/tun_device_manager.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager.rs
@@ -27,6 +27,22 @@ pub enum TunIpStack {
     Dual,
 }
 
+impl TunIpStack {
+    pub fn supports_ipv4(&self) -> bool {
+        match self {
+            TunIpStack::V4Only | TunIpStack::Dual => true,
+            TunIpStack::V6Only => false,
+        }
+    }
+
+    pub fn supports_ipv6(&self) -> bool {
+        match self {
+            TunIpStack::V6Only | TunIpStack::Dual => true,
+            TunIpStack::V4Only => false,
+        }
+    }
+}
+
 impl fmt::Display for TunIpStack {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -224,16 +224,8 @@ impl TunDeviceManager {
         Ok(tun_ip_stack)
     }
 
-    pub async fn set_routes(
-        &mut self,
-        ipv4: impl IntoIterator<Item = Ipv4Network>,
-        ipv6: impl IntoIterator<Item = Ipv6Network>,
-    ) -> Result<()> {
-        let new_routes = ipv4
-            .into_iter()
-            .map(IpNetwork::from)
-            .chain(ipv6.into_iter().map(IpNetwork::from))
-            .collect::<BTreeSet<_>>();
+    pub async fn set_routes(&mut self, routes: impl IntoIterator<Item = IpNetwork>) -> Result<()> {
+        let new_routes = BTreeSet::from_iter(routes);
 
         tracing::info!(new_routes = %DisplayBTreeSet(&new_routes), "Setting new routes");
 

--- a/rust/libs/bin-shared/src/tun_device_manager/macos.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/macos.rs
@@ -1,7 +1,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use anyhow::{Result, bail};
-use ip_network::{Ipv4Network, Ipv6Network};
+use ip_network::IpNetwork;
 use tun::Tun;
 
 use crate::tun_device_manager::TunIpStack;
@@ -29,11 +29,7 @@ impl TunDeviceManager {
         clippy::unused_async,
         reason = "Signture must match other operating systems"
     )]
-    pub async fn set_routes(
-        &mut self,
-        _ipv4: impl IntoIterator<Item = Ipv4Network>,
-        _ipv6: impl IntoIterator<Item = Ipv6Network>,
-    ) -> Result<()> {
+    pub async fn set_routes(&mut self, _routes: impl IntoIterator<Item = IpNetwork>) -> Result<()> {
         bail!("Not implemented")
     }
 }

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -3,7 +3,7 @@ use crate::tun_device_manager::TunIpStack;
 use crate::windows::TUNNEL_UUID;
 use crate::windows::error::{NOT_FOUND, NOT_SUPPORTED, OBJECT_EXISTS};
 use anyhow::{Context as _, Result};
-use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
+use ip_network::IpNetwork;
 use ip_packet::{IpPacket, IpPacketBuf};
 use logging::err_with_src;
 use ring::digest;

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -111,20 +111,12 @@ impl TunDeviceManager {
     }
 
     #[expect(clippy::unused_async, reason = "Must match Linux API")]
-    pub async fn set_routes(
-        &mut self,
-        v4: impl IntoIterator<Item = Ipv4Network>,
-        v6: impl IntoIterator<Item = Ipv6Network>,
-    ) -> Result<()> {
+    pub async fn set_routes(&mut self, routes: impl IntoIterator<Item = IpNetwork>) -> Result<()> {
         let iface_idx = self
             .iface_idx
             .context("Cannot set routes without having created TUN device")?;
 
-        let new_routes = HashSet::from_iter(
-            v4.into_iter()
-                .map(IpNetwork::from)
-                .chain(v6.into_iter().map(IpNetwork::from)),
-        );
+        let new_routes = HashSet::from_iter(routes);
 
         for old_route in self.routes.difference(&new_routes) {
             remove_route(*old_route, iface_idx);

--- a/rust/libs/bin-shared/tests/no_packet_loops_tcp.rs
+++ b/rust/libs/bin-shared/tests/no_packet_loops_tcp.rs
@@ -21,10 +21,9 @@ async fn no_packet_loops_tcp() {
 
     // Configure `0.0.0.0/0` route.
     device_manager
-        .set_routes(
-            vec![Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap()],
-            vec![],
-        )
+        .set_routes(vec![
+            Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap().into(),
+        ])
         .await
         .unwrap();
 

--- a/rust/libs/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/libs/bin-shared/tests/no_packet_loops_udp.rs
@@ -30,10 +30,9 @@ async fn no_packet_loops_udp() {
 
     // Configure `0.0.0.0/0` route.
     device_manager
-        .set_routes(
-            vec![Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap()],
-            vec![],
-        )
+        .set_routes(vec![
+            Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap().into(),
+        ])
         .await
         .unwrap();
 

--- a/rust/libs/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/libs/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -30,10 +30,11 @@ async fn smoke() {
     let tun = device_manager.make_tun().unwrap();
     device_manager.set_ips(ipv4, ipv6).await.unwrap();
     device_manager
-        .set_routes(
-            vec![Ipv4Network::new(Ipv4Addr::new(100, 100, 111, 0), 24).unwrap()],
-            vec![],
-        )
+        .set_routes(vec![
+            Ipv4Network::new(Ipv4Addr::new(100, 100, 111, 0), 24)
+                .unwrap()
+                .into(),
+        ])
         .await
         .unwrap();
 

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -14,7 +14,7 @@ use dns_types::DomainName;
 use futures::{FutureExt, future::BoxFuture};
 use gat_lending_iterator::LendingIterator;
 use io::{Buffers, Io};
-use ip_network::{Ipv4Network, Ipv6Network};
+use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use logging::DisplayBTreeSet;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
@@ -610,10 +610,8 @@ pub struct TunConfig {
     pub dns_by_sentinel: DnsMapping,
     pub search_domain: Option<DomainName>,
 
-    #[debug("{}", DisplayBTreeSet(ipv4_routes))]
-    pub ipv4_routes: BTreeSet<Ipv4Network>,
-    #[debug("{}", DisplayBTreeSet(ipv6_routes))]
-    pub ipv6_routes: BTreeSet<Ipv6Network>,
+    #[debug("{}", DisplayBTreeSet(routes))]
+    pub routes: BTreeSet<IpNetwork>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/libs/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/libs/connlib/tunnel/src/tests/assertions.rs
@@ -314,24 +314,14 @@ pub(crate) fn assert_search_domain_is_valid(ref_client: &RefClient, sim_client: 
 }
 
 pub(crate) fn assert_routes_are_valid(ref_client: &RefClient, sim_client: &SimClient) {
-    let (expected_ipv4, expected_ipv6) = ref_client.expected_routes();
-    let (actual_ipv4, actual_ipv6) = (
-        sim_client.ipv4_routes.clone(),
-        sim_client.ipv6_routes.clone(),
-    );
+    let expected = ref_client.expected_routes();
+    let actual = sim_client.routes.clone();
 
-    if actual_ipv4 != expected_ipv4 {
-        let expected_ipv4 = expected_ipv4.iter().join(", ");
-        let actual_ipv4 = actual_ipv4.iter().join(", ");
+    if actual != expected {
+        let expected = expected.iter().join(", ");
+        let actual = actual.iter().join(", ");
 
-        tracing::error!(target: "assertions", actual = ?actual_ipv4, expected = ?expected_ipv4, "❌ IPv4 routes don't match");
-    }
-
-    if actual_ipv6 != expected_ipv6 {
-        let expected_ipv6 = expected_ipv6.iter().join(", ");
-        let actual_ipv6 = actual_ipv6.iter().join(", ");
-
-        tracing::error!(target: "assertions", actual = ?actual_ipv6, expected = ?expected_ipv6, "❌ IPv6 routes don't match");
+        tracing::error!(target: "assertions", ?actual, ?expected, "❌ Routes don't match");
     }
 }
 

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -928,8 +928,7 @@ impl TunnelTest {
             }
             ClientEvent::TunInterfaceUpdated(config) => {
                 if self.client.inner().dns_mapping() == &config.dns_by_sentinel
-                    && self.client.inner().ipv4_routes == config.ipv4_routes
-                    && self.client.inner().ipv6_routes == config.ipv6_routes
+                    && self.client.inner().routes == config.routes
                     && self.client.inner().search_domain == config.search_domain
                 {
                     tracing::error!(
@@ -956,8 +955,7 @@ impl TunnelTest {
 
                 self.client.exec_mut(|c| {
                     c.set_new_dns_servers(config.dns_by_sentinel);
-                    c.ipv4_routes = config.ipv4_routes;
-                    c.ipv6_routes = config.ipv6_routes;
+                    c.routes = config.routes;
                     c.search_domain = config.search_domain;
                     c.tcp_dns_client
                         .set_source_interface(config.ip.v4, config.ip.v6);


### PR DESCRIPTION
Righ now, we always attempt to set all routes on the system, regardless of what IP stack is supported on the TUN device. This works because internally, we don't fail when adding a route but only log it as a warning and keep going. Additionally, we do check for certain error codes like `EEXIST` to not unnecessarily spam Sentry with warnings.

As another defense-in-depth measure, we unify the `set_routes` API and only pass those routes that are supported by the TUN device's IP stack.