### PR TITLE
chore(website): address middleware deprecation

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "pnpm install && bash ./timestamps.sh",
+    "predev": "bash ./timestamps.sh",
     "dev": "next dev --webpack",
     "prebuild": "pnpm lint && bash ./timestamps.sh",
     "build": "next build --webpack",

--- a/website/src/proxy.ts
+++ b/website/src/proxy.ts
@@ -1,6 +1,6 @@
 import { NextResponse, NextRequest } from "next/server";
 
-// This middleware is needed because NextJS doesn't populate params in the destination
+// This proxy is needed because NextJS doesn't populate params in the destination
 // more than once. See https://github.com/vercel/next.js/issues/66891
 const versionedRedirects = [
   {
@@ -88,7 +88,7 @@ export const config = {
   ],
 };
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   for (const redirect of versionedRedirects) {


### PR DESCRIPTION
- gets rid of a deprecation warning when starting `pnpm` - nextjs changed "middleware" to "proxy".
- also  ensures that timestamps are generated before running `pnpm dev` to make it easier to do local dev.