### PR TITLE
chore(website): refactor apostrophe usage

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -1,6 +1,12 @@
 repos:
   - repo: local
     hooks:
+      - id: no-html-entity-apostrophe
+        name: "jsx: no HTML entity apostrophes"
+        entry: website/scripts/check-no-html-entity-apostrophe.sh
+        language: system
+        types_or: [tsx, jsx]
+        files: ^website/
       - id: no-tracing-macro-imports
         name: "rust: no direct tracing macro imports"
         entry: "bash -c 'if grep -E \"use tracing::(trace|debug|info|warn|error)[^_]|use tracing::\\{[^}]*(trace|debug|info|warn|error)[^_]\" \"$@\"; then echo \"Error: Do not import tracing macros\"; exit 1; fi' --"

--- a/website/scripts/check-no-html-entity-apostrophe.sh
+++ b/website/scripts/check-no-html-entity-apostrophe.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Pre-commit hook to discourage HTML entity apostrophes in JSX files.
+# Use {"'"} or wrap text in JSX expressions instead of &apos; or &#39;
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <file1> [file2] ..."
+    exit 0
+fi
+
+found=0
+for file in "$@"; do
+    if grep -n "&apos;\|&#39;" "$file" 2>/dev/null; then
+        found=1
+    fi
+done
+
+if [ "$found" -eq 1 ]; then
+    echo ""
+    echo "Error: Found HTML entity apostrophe (&apos; or &#39;)"
+    echo "Use {\"'\"} or wrap the text in a JSX expression instead."
+    exit 1
+fi

--- a/website/src/app/about/mission.tsx
+++ b/website/src/app/about/mission.tsx
@@ -6,9 +6,11 @@ export default function Mission() {
           Our mission
         </h2>
         <p className="mb-8 text-4xl tracking-tight text-neutral-100 sm:px-16 xl:px-32">
-          To <span className="text-primary-500">secure</span> the world&apos;s
-          information and <span className="text-primary-500">restore</span>{" "}
-          global trust in internet-connected systems.
+          {"To "}
+          <span className="text-primary-500">secure</span>
+          {" the world's information and "}
+          <span className="text-primary-500">restore</span>
+          {" global trust in internet-connected systems."}
         </p>
       </div>
     </section>

--- a/website/src/app/about/principles.tsx
+++ b/website/src/app/about/principles.tsx
@@ -29,8 +29,9 @@ export default function Principles() {
               Collaboration
             </h3>
             <p className="leading-6 tracking-tight text-lg py-8">
-              We work together to achieve our goals, and celebrate our successes
-              as a team. Everyone&apos;s voice is heard and respected.
+              {
+                "We work together to achieve our goals, and celebrate our successes as a team. Everyone's voice is heard and respected."
+              }
             </p>
           </div>
           <div>
@@ -38,8 +39,9 @@ export default function Principles() {
               Sensibility
             </h3>
             <p className="leading-6 tracking-tight text-lg py-8">
-              We don&apos;t believe in hype or buzzwords. We believe in building
-              products that solve real problems for real people.
+              {
+                "We don't believe in hype or buzzwords. We believe in building products that solve real problems for real people."
+              }
             </p>
           </div>
           <div>

--- a/website/src/app/about/story.tsx
+++ b/website/src/app/about/story.tsx
@@ -15,7 +15,7 @@ export default function Story() {
             WireGuard.{" "}
             <span className="text-primary-500 font-medium">130 releases</span>{" "}
             and <span className="text-primary-500 font-medium">15,000+</span>{" "}
-            users later, it&apos;s grown into something much more.
+            {"users later, it's grown into something much more."}
           </p>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-12">
@@ -83,7 +83,7 @@ export default function Story() {
                   YC acceptance
                 </h3>
                 <p className="text-base font-normal text-neutral-800">
-                  Firezone is accepted into YC&apos;s Winter 2022 batch.
+                  {"Firezone is accepted into YC's Winter 2022 batch."}
                 </p>
               </li>
               <li className="mb-12 ms-4">

--- a/website/src/app/blog/posts.tsx
+++ b/website/src/app/blog/posts.tsx
@@ -35,10 +35,9 @@ export default function Posts() {
       type: "Announcement",
       description: (
         <p className="mb-2">
-          On November 28, 2025, a PII leak incident occurred affecting a small
-          number of user names and email addresses. This post-mortem details the
-          incident, its impact, and the steps we&apos;re taking to prevent
-          future occurrences.
+          {
+            "On November 28, 2025, a PII leak incident occurred affecting a small number of user names and email addresses. This post-mortem details the incident, its impact, and the steps we're taking to prevent future occurrences."
+          }
         </p>
       ),
     },
@@ -67,11 +66,9 @@ export default function Posts() {
       type: "Engineering",
       description: (
         <p className="mb-2">
-          October delivered substantial improvements to Gateway observability,
-          Linux networking stack refinements, and new deployment mechanisms.
-          This month&apos;s work focused on implementing comprehensive flow
-          logging, addressing routing conflicts through tiered routing tables,
-          and introducing native Debian packages for easier deployments.
+          {
+            "October delivered substantial improvements to Gateway observability, Linux networking stack refinements, and new deployment mechanisms. This month's work focused on implementing comprehensive flow logging, addressing routing conflicts through tiered routing tables, and introducing native Debian packages for easier deployments."
+          }
         </p>
       ),
     },
@@ -84,12 +81,9 @@ export default function Posts() {
       type: "Engineering",
       description: (
         <p className="mb-2">
-          September brought significant improvements to Firezone&apos;s
-          networking stack, administrative tooling, and cross-platform
-          reliability. This month&apos;s work focused on optimizing relay
-          performance through eBPF, improving DNS resolution behavior, and
-          enhancing the admin portal&apos;s visibility into client and Gateway
-          states. )
+          {
+            "September brought significant improvements to Firezone's networking stack, administrative tooling, and cross-platform reliability. This month's work focused on optimizing relay performance through eBPF, improving DNS resolution behavior, and enhancing the admin portal's visibility into client and Gateway states."
+          }
         </p>
       ),
     },
@@ -104,9 +98,11 @@ export default function Posts() {
       src: "/images/blog/migrate-your-internet-resource/migrate-internet-resource.svg",
       description: (
         <p className="mb-2">
-          We&apos;re making some changes to the way Internet Resources work to
-          improve security and performance. Migrate your Internet Resources by
-          <strong>March 15, 2025</strong> to avoid any interruptions.
+          {
+            "We're making some changes to the way Internet Resources work to improve security and performance. Migrate your Internet Resources by "
+          }
+          <strong>March 15, 2025</strong>
+          {" to avoid any interruptions."}
         </p>
       ),
     },
@@ -160,9 +156,9 @@ export default function Posts() {
       type: "Learn",
       description: (
         <p className="mb-2">
-          Firezone&apos;s data plane extensively uses the sans-IO design
-          pattern. This post explains why we chose it and how you too can make
-          use of it.
+          {
+            "Firezone's data plane extensively uses the sans-IO design pattern. This post explains why we chose it and how you too can make use of it."
+          }
         </p>
       ),
     },
@@ -232,10 +228,9 @@ export default function Posts() {
       type: "Announcement",
       description: (
         <p className="mb-2">
-          We&apos;re making some changes to the way DNS Resources are routed in
-          Firezone. These changes will be coming in Client and Gateway versions
-          1.1 and later. Continue reading to understand how these changes will
-          affect your network and what you need to do to take advantage of them.
+          {
+            "We're making some changes to the way DNS Resources are routed in Firezone. These changes will be coming in Client and Gateway versions 1.1 and later. Continue reading to understand how these changes will affect your network and what you need to do to take advantage of them."
+          }
         </p>
       ),
     },
@@ -263,10 +258,9 @@ export default function Posts() {
       src: "/images/blog/how-dns-works-in-firezone/how-dns-works-in-firezone.png",
       description: (
         <p className="mb-2">
-          Firezone&apos;s approach to DNS works a bit differently than one might
-          expect. One question we often get from new users is, &quot;why do my
-          DNS Resources resolve to a different IP address with Firezone
-          enabled?&quot;. Great question -- read on to find out.
+          {
+            'Firezone\'s approach to DNS works a bit differently than one might expect. One question we often get from new users is, "why do my DNS Resources resolve to a different IP address with Firezone enabled?". Great question -- read on to find out.'
+          }
         </p>
       ),
     },
@@ -378,11 +372,9 @@ export default function Posts() {
         <>
           <p className="mb-2">Happy new year from the Firezone team!</p>
           <p>
-            After a long year of building, we&apos;re incredibly excited to
-            announce 1.0 beta testing for Apple and Android platforms. Firezone
-            1.0 is an entirely new product with a brand new architecture that
-            includes many of the features you&apos;ve been asking for. To
-            summarize just a few:
+            {
+              "After a long year of building, we're incredibly excited to announce 1.0 beta testing for Apple and Android platforms. Firezone 1.0 is an entirely new product with a brand new architecture that includes many of the features you've been asking for. To summarize just a few:"
+            }
           </p>
         </>
       ),
@@ -451,11 +443,9 @@ export default function Posts() {
       type: "Announcement",
       description: (
         <p>
-          Today, I&apos;m excited to announce we&apos;ve closed the first public
-          issue on our GitHub repository, more than a year after it was
-          originally opened: Containerization support! We&apos;re also releasing
-          preliminary support for SAML 2.0 identity providers like Okta and
-          OneLogin.
+          {
+            "Today, I'm excited to announce we've closed the first public issue on our GitHub repository, more than a year after it was originally opened: Containerization support! We're also releasing preliminary support for SAML 2.0 identity providers like Okta and OneLogin."
+          }
         </p>
       ),
     },
@@ -468,11 +458,9 @@ export default function Posts() {
       type: "Announcement",
       description: (
         <p>
-          As the first post on our new blog, we thought it&apos;d be fitting to
-          kick things off with a release announcement. So without further ado,
-          we&apos;re excited to announce: Firezone 0.5.0 is here! It&apos;s
-          packed with new features, bug fixes, and other improvements — more on
-          that below.
+          {
+            "As the first post on our new blog, we thought it'd be fitting to kick things off with a release announcement. So without further ado, we're excited to announce: Firezone 0.5.0 is here! It's packed with new features, bug fixes, and other improvements — more on that below."
+          }
         </p>
       ),
     },

--- a/website/src/app/not-found.tsx
+++ b/website/src/app/not-found.tsx
@@ -40,7 +40,7 @@ export default function NotFound() {
             >
               contact us
             </Link>{" "}
-            if you&apos;re still having trouble.
+            {"if you're still having trouble."}
           </p>
         </div>
       </div>

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -287,9 +287,9 @@ export default function Page() {
             </div>
             <div className="mt-auto text-center md:text-left">
               <p className="text-lg text-neutral-800">
-                Gateways are lightweight Linux binaries you deploy anywhere you
-                need access. Just configure a token with your preferred tool and
-                you&apos;re done.
+                {
+                  "Gateways are lightweight Linux binaries you deploy anywhere you need access. Just configure a token with your preferred tool and you're done."
+                }
               </p>
               <p className="mt-4">
                 <ActionLink
@@ -320,9 +320,9 @@ export default function Page() {
 
         <div className="mx-auto px-4 max-w-screen-md">
           <p className="text-lg text-center -mt-3 text-neutral-800 text-pretty">
-            How can you trust a zero-trust solution if you can&apos;t see its
-            source? We build Firezone in the open so anyone can make sure it
-            does exactly what we claim it does, and nothing more.
+            {
+              "How can you trust a zero-trust solution if you can't see its source? We build Firezone in the open so anyone can make sure it does exactly what we claim it does, and nothing more."
+            }
           </p>
         </div>
 

--- a/website/src/app/pricing/_page.tsx
+++ b/website/src/app/pricing/_page.tsx
@@ -371,9 +371,9 @@ export default function Page() {
                 >
                   GitHub repository
                 </Link>
-                , and you&apos;re free to self-host Firezone for your
-                organization without restriction. However, we don&apos;t offer
-                documentation or support for self-hosting Firezone at this time.
+                {
+                  ", and you're free to self-host Firezone for your organization without restriction. However, we don't offer documentation or support for self-hosting Firezone at this time."
+                }
               </AccordionContent>
             </AccordionPanel>
             <AccordionPanel>
@@ -381,10 +381,9 @@ export default function Page() {
                 Do I need to rip and replace my current VPN to use Firezone?
               </AccordionTitle>
               <AccordionContent>
-                No. As long they&apos;re set up to access different resources,
-                you can run Firezone alongside your existing remote access
-                solutions, and switch over whenever you’re ready. There’s no
-                need for any downtime or unnecessary disruptions.
+                {
+                  "No. As long they're set up to access different resources, you can run Firezone alongside your existing remote access solutions, and switch over whenever you're ready. There's no need for any downtime or unnecessary disruptions."
+                }
               </AccordionContent>
             </AccordionPanel>
             <AccordionPanel>
@@ -412,17 +411,18 @@ export default function Page() {
               <AccordionContent>
                 <p>Yes.</p>
                 <p className="mt-2">
-                  For the <strong>Team</strong> plan, you can add or remove
-                  seats at any time. When adding seats, you&apos;ll be charged a
-                  prorated amount for the remainder of the billing cycle. When
-                  removing seats, the change will take effect at the end of the
-                  billing cycle.
+                  {"For the "}
+                  <strong>Team</strong>
+                  {
+                    " plan, you can add or remove seats at any time. When adding seats, you'll be charged a prorated amount for the remainder of the billing cycle. When removing seats, the change will take effect at the end of the billing cycle."
+                  }
                 </p>
                 <p className="mt-2">
-                  For the <strong>Enterprise</strong> plan, contact your account
-                  manager to request a seat increase. You&apos;ll then be billed
-                  for the prorated amount for the remainder of the billing
-                  cycle.
+                  {"For the "}
+                  <strong>Enterprise</strong>
+                  {
+                    " plan, contact your account manager to request a seat increase. You'll then be billed for the prorated amount for the remainder of the billing cycle."
+                  }
                 </p>
               </AccordionContent>
             </AccordionPanel>
@@ -447,7 +447,7 @@ export default function Page() {
                 For Starter and Team plans, you can downgrade by going to your
                 Account settings in your Firezone admin portal. For Enterprise
                 plans, contact your account manager for subscription updates. If
-                you&apos;d like to completely delete your account,{" "}
+                {"you'd like to completely delete your account, "}
                 <Link
                   href="mailto:support@firezone.dev"
                   className="hover:underline text-accent-500"

--- a/website/src/app/support/_page.tsx
+++ b/website/src/app/support/_page.tsx
@@ -110,9 +110,9 @@ export default function _Page() {
         </h2>
         <hr />
         <p className="text-md md:text-lg mt-8">
-          Didn&apos;t find what you were looking for? We build Firezone in the
-          open -- there&apos;s a good chance someone&apos;s already opened an
-          issue.
+          {
+            "Didn't find what you were looking for? We build Firezone in the open -- there's a good chance someone's already opened an issue."
+          }
         </p>
         <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
           <Link
@@ -136,8 +136,9 @@ export default function _Page() {
               Product roadmap
             </h3>
             <p className="mt-8">
-              View our public roadmap for a glimpse into what we&apos;ve
-              recently shipped and what&apos;s coming soon.
+              {
+                "View our public roadmap for a glimpse into what we've recently shipped and what's coming soon."
+              }
             </p>
           </Link>
           <Link

--- a/website/src/app/support/layout.tsx
+++ b/website/src/app/support/layout.tsx
@@ -20,8 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             Support
           </h1>
           <p className="text-center text-md md:text-lg lg:text-xl mt-2 md:mt-4 tracking-tight">
-            Need help? We&apos;ve got you covered. See our support options
-            below.
+            {"Need help? We've got you covered. See our support options below."}
           </p>
         </div>
       </div>

--- a/website/src/components/Blog/AboutFirezone/index.tsx
+++ b/website/src/components/Blog/AboutFirezone/index.tsx
@@ -5,11 +5,9 @@ export default function AboutFirezone() {
     <div className="bg-neutral-100 border-l-4 border-primary-500 p-6 my-8">
       <h2 className="text-2xl font-bold mb-4">About Firezone</h2>
       <p className="mb-4">
-        Firezone is an open source platform for securely managing remote access
-        to your organization&apos;s networks and applications. Unlike
-        traditional VPNs, Firezone takes a granular, least-privileged approach
-        with group-based policies that control access to individual
-        applications, entire subnets, and everything in between.{" "}
+        {
+          "Firezone is an open source platform for securely managing remote access to your organization's networks and applications. Unlike traditional VPNs, Firezone takes a granular, least-privileged approach with group-based policies that control access to individual applications, entire subnets, and everything in between. "
+        }
         <Link
           href="https://app.firezone.dev/sign_up"
           className="text-accent-500 underline hover:no-underline"

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -104,10 +104,9 @@ export default function Android() {
           if Firefox is set as the default browser.
         </ChangeItem>
         <ChangeItem pull="10104">
-          Fixes an issue where DNS resources would resolve to a different IP
-          after signing out and back into Firezone. This would break
-          connectivity for long-running services that don&apos;t re-resolve DNS,
-          like SSH sessions or mongoose.
+          {
+            "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.3" date={new Date("2025-08-05")}>
@@ -134,8 +133,9 @@ export default function Android() {
       </Entry>
       <Entry version="1.5.2" date={new Date("2025-06-30")}>
         <ChangeItem pull="9621">
-          Fixes an issue where the VPN permission screen wouldn&apos;t dismiss
-          after granting the VPN permission.
+          {
+            "Fixes an issue where the VPN permission screen wouldn't dismiss after granting the VPN permission."
+          }
         </ChangeItem>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both
@@ -155,8 +155,9 @@ export default function Android() {
           the administrator.
         </ChangeItem>
         <ChangeItem pull="9227">
-          Adds full support for managed configurations to configure the client
-          using your organization&apos;s MDM solution. See the{" "}
+          {
+            "Adds full support for managed configurations to configure the client using your organization's MDM solution. See the "
+          }
           <Link
             href={"/kb/deploy/clients#provision-with-mdm" as Route}
             className="text-accent-500 underline hover:no-underline"
@@ -215,8 +216,9 @@ export default function Android() {
       </Entry>
       <Entry version="1.4.5" date={new Date("2025-03-15")}>
         <ChangeItem pull="8445">
-          Fixes a bug where search domains changes weren&apos;t applied if
-          already signed in.
+          {
+            "Fixes a bug where search domains changes weren't applied if already signed in."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.4.4" date={new Date("2025-03-14")}>
@@ -302,8 +304,9 @@ export default function Android() {
       </Entry>
       <Entry version="1.3.5" date={new Date("2024-10-03")}>
         <ChangeItem pull="6831">
-          Ensures Firefox doesn&apos;t attempt to use DNS over HTTPS when
-          Firezone is active.
+          {
+            "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
+          }
         </ChangeItem>
         <ChangeItem pull="6845">
           Fixes connectivity issues on idle connections by entering an
@@ -364,8 +367,9 @@ export default function Android() {
           Advanced screen.
         </ChangeItem>
         <ChangeItem pull="6495">
-          Fixes a bug where the Firezone tunnel wasn&apos;t shut down properly
-          if you disconnect the VPN in system settings.
+          {
+            "Fixes a bug where the Firezone tunnel wasn't shut down properly if you disconnect the VPN in system settings."
+          }
         </ChangeItem>
         <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
       </Entry>
@@ -374,9 +378,9 @@ export default function Android() {
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
         <ChangeItem pull="6361">
-          Connections to Gateways are now sticky for the duration of the
-          Client&apos;s session. This fixes potential issues maintaining
-          long-lived TCP connections to Gateways in a high-availability setup.
+          {
+            "Connections to Gateways are now sticky for the duration of the Client's session. This fixes potential issues maintaining long-lived TCP connections to Gateways in a high-availability setup."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.1.6" date={new Date("2024-08-13")}>
@@ -423,9 +427,9 @@ export default function Android() {
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-07-03")}>
         <li className="pl-2">
-          Prevents Firezone&apos;s stub resolver from intercepting DNS record
-          types besides A, AAAA, and PTR. These are now forwarded to your
-          upstream DNS resolver.
+          {
+            "Prevents Firezone's stub resolver from intercepting DNS record types besides A, AAAA, and PTR. These are now forwarded to your upstream DNS resolver."
+          }
         </li>
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-29")}>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -155,10 +155,9 @@ export default function Apple() {
           resolve for a few seconds after showing up in the Resource List.
         </ChangeItem>
         <ChangeItem pull="10104">
-          Fixes an issue where DNS resources would resolve to a different IP
-          after signing out and back into Firezone. This would break
-          connectivity for long-running services that don&apos;t re-resolve DNS,
-          like SSH sessions or mongoose.
+          {
+            "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.7" date={new Date("2025-08-07")}>
@@ -523,15 +522,16 @@ export default function Apple() {
       </Entry>
       <Entry version="1.3.6" date={new Date("2024-10-02")}>
         <ChangeItem pull="6831">
-          Ensures Firefox doesn&apos;t attempt to use DNS over HTTPS when
-          Firezone is active.
+          {
+            "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
+          }
         </ChangeItem>
         <ChangeItem pull="6845">
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
         </ChangeItem>
         <ChangeItem pull="6857">
-          MacOS: sends hardware&apos;s UUID for device verification.
+          {"MacOS: sends hardware's UUID for device verification."}
         </ChangeItem>
         <ChangeItem pull="6857">
           iOS: sends Id for vendor for device verification.
@@ -565,8 +565,9 @@ export default function Apple() {
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-18")}>
         <ChangeItem pull="6632">
-          (macOS) Fixes a bug where the addressDescription wasn&apos;t fully
-          displayed in the macOS menu bar if it exceeded a certain length.
+          {
+            "(macOS) Fixes a bug where the addressDescription wasn't fully displayed in the macOS menu bar if it exceeded a certain length."
+          }
         </ChangeItem>
         <ChangeItem pull="6679">
           (macOS) Displays a notification when a new version is available.
@@ -574,9 +575,9 @@ export default function Apple() {
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
         <ChangeItem pull="6521">
-          Gracefully handles cases where the device&apos;s local interface
-          IPv4/IPv6 address or local network gateway changes while the client is
-          connected.
+          {
+            "Gracefully handles cases where the device's local interface IPv4/IPv6 address or local network gateway changes while the client is connected."
+          }
         </ChangeItem>
         <ChangeItem pull="6518">
           Minor improvements to the look of the internet resource and makes the
@@ -605,9 +606,9 @@ export default function Apple() {
           Adds the ability to mark Resources as favorites.
         </ChangeItem>
         <ChangeItem pull="6361">
-          Connections to Gateways are now sticky for the duration of the
-          Client&apos;s session. This fixes potential issues maintaining
-          long-lived TCP connections to Gateways in a high-availability setup.
+          {
+            "Connections to Gateways are now sticky for the duration of the Client's session. This fixes potential issues maintaining long-lived TCP connections to Gateways in a high-availability setup."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-13")}>
@@ -638,9 +639,9 @@ export default function Apple() {
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-07-03")}>
         <li className="pl-2">
-          Prevents Firezone&apos;s stub resolver from intercepting DNS record
-          types besides A, AAAA, and PTR. These are now forwarded to your
-          upstream DNS resolver.
+          {
+            "Prevents Firezone's stub resolver from intercepting DNS record types besides A, AAAA, and PTR. These are now forwarded to your upstream DNS resolver."
+          }
         </li>
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-29")}>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -112,10 +112,9 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.5.7" date={new Date("2025-09-10")}>
         <ChangeItem pull="10104">
-          Fixes an issue where DNS resources would resolve to a different IP
-          after signing out and back into Firezone. This would break
-          connectivity for long-running services that don&apos;t re-resolve DNS,
-          like SSH sessions or mongoose.
+          {
+            "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.6" date={new Date("2025-07-28")}>
@@ -504,16 +503,19 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="6931">
-            Mitigates an issue where <code>ipconfig</code> and WSL weren&apos;t
-            aware of Firezone DNS resolvers. Users may need to restart WSL after
-            signing in to Firezone.
+            {"Mitigates an issue where "}
+            <code>ipconfig</code>
+            {
+              " and WSL weren't aware of Firezone DNS resolvers. Users may need to restart WSL after signing in to Firezone."
+            }
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.3.7" date={new Date("2024-10-02")}>
         <ChangeItem pull="6831">
-          Ensures Firefox doesn&apos;t attempt to use DNS over HTTPS when
-          Firezone is active.
+          {
+            "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
+          }
         </ChangeItem>
         <ChangeItem pull="6845">
           Fixes connectivity issues on idle connections by entering an
@@ -528,7 +530,7 @@ export default function GUI({ os }: { os: OS }) {
           </ChangeItem>
         )}
         <ChangeItem pull="6857">
-          Tries to send motherboard&apos;s hardware ID for device verification.
+          {"Tries to send motherboard's hardware ID for device verification."}
         </ChangeItem>
       </Entry>
       <Entry version="1.3.6" date={new Date("2024-09-25")}>
@@ -545,13 +547,15 @@ export default function GUI({ os }: { os: OS }) {
         </ChangeItem>
         {os === OS.Linux && (
           <ChangeItem pull="6780">
-            Fixes a bug where the Linux Clients didn&apos;t work on ZFS
-            filesystems.
+            {
+              "Fixes a bug where the Linux Clients didn't work on ZFS filesystems."
+            }
           </ChangeItem>
         )}
         <ChangeItem pull="6795">
-          Fixes a bug where auto-sign-in with an expired token would cause a
-          &quot;Couldn&apos;t send Disconnect&quot; error message.
+          {
+            'Fixes a bug where auto-sign-in with an expired token would cause a "Couldn\'t send Disconnect" error message.'
+          }
         </ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="6810">
@@ -607,15 +611,17 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="6449">Checks for updates once a day</ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="6472">
-            Fixes an issue where Split DNS didn&apos;t work for domain-joined
-            Windows machines
+            {
+              "Fixes an issue where Split DNS didn't work for domain-joined Windows machines"
+            }
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.2.1" date={new Date("2024-08-27")}>
         <ChangeItem pull="6414">
-          Waits for Internet to connect to Firezone if there&apos;s no Internet
-          at startup and you&apos;re already signed in.
+          {
+            "Waits for Internet to connect to Firezone if there's no Internet at startup and you're already signed in."
+          }
         </ChangeItem>
         <ChangeItem pull="6455">
           Fixes a false positive warning log at startup about DNS interception
@@ -646,8 +652,9 @@ export default function GUI({ os }: { os: OS }) {
           change the setting in the GUI.
         </ChangeItem>
         <ChangeItem pull="6361">
-          Connections to Gateways are now sticky for the duration of the
-          Client&apos;s session to fix issues with long-lived TCP connections.
+          {
+            "Connections to Gateways are now sticky for the duration of the Client's session to fix issues with long-lived TCP connections."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.1.12" date={new Date("2024-08-13")}>
@@ -753,9 +760,9 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.1.3" date={new Date("2024-07-03")}>
         <li className="pl-2">
-          Prevents Firezone&apos;s stub resolver from intercepting DNS record
-          types besides A, AAAA, and PTR. These are now forwarded to your
-          upstream DNS resolver.
+          {
+            "Prevents Firezone's stub resolver from intercepting DNS record types besides A, AAAA, and PTR. These are now forwarded to your upstream DNS resolver."
+          }
         </li>
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-06-29")}>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -203,8 +203,9 @@ export default function Gateway() {
           not be sent.
         </ChangeItem>
         <ChangeItem pull="9060">
-          Fixes an issue where service discovery for DNS resources would fail in
-          case the Gateway&apos;s started up with no network connectivity.
+          {
+            "Fixes an issue where service discovery for DNS resources would fail in case the Gateway's started up with no network connectivity."
+          }
         </ChangeItem>
         <ChangeItem pull="9088">
           Fixes an issue where large batches of packets to the same Client got
@@ -276,8 +277,9 @@ export default function Gateway() {
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-01-28")}>
         <ChangeItem pull="7567">
-          Fixes an issue where ICMPv6&apos;s &apos;PacketTooBig&apos; errors
-          were not correctly translated by the NAT64 module.
+          {
+            "Fixes an issue where ICMPv6's 'PacketTooBig' errors were not correctly translated by the NAT64 module."
+          }
         </ChangeItem>
         <ChangeItem pull="7565">
           Fails early in case the binary is not started as <code>root</code> or
@@ -343,9 +345,9 @@ export default function Gateway() {
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-10-02")}>
         <ChangeItem pull="6733">
-          Reduces log level of the &quot;Couldn&apos;t find connection by
-          IP&quot; message so that it doesn&apos;t log each time a client
-          disconnects.
+          {
+            "Reduces log level of the \"Couldn't find connection by IP\" message so that it doesn't log each time a client disconnects."
+          }
         </ChangeItem>
         <ChangeItem pull="6845">
           Fixes connectivity issues on idle connections by entering an

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -92,10 +92,9 @@ export default function Headless({ os }: { os: OS }) {
           the headless client Docker image.
         </ChangeItem>
         <ChangeItem pull="10104">
-          Fixes an issue where DNS resources would resolve to a different IP
-          after signing out and back into Firezone. This would break
-          connectivity for long-running services that don&apos;t re-resolve DNS,
-          like SSH sessions or mongoose.
+          {
+            "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
+          }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.2" date={new Date("2025-07-28")}>
@@ -329,8 +328,9 @@ export default function Headless({ os }: { os: OS }) {
           </Entry>
           <Entry version="1.3.4" date={new Date("2024-10-02")}>
             <ChangeItem pull="6831">
-              Ensures Firefox doesn&apos;t attempt to use DNS over HTTPS when
-              Firezone is active.
+              {
+                "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
+              }
             </ChangeItem>
             <ChangeItem pull="6845">
               Fixes connectivity issues on idle connections by entering an
@@ -340,7 +340,7 @@ export default function Headless({ os }: { os: OS }) {
               Adds always-on error reporting using sentry.io.
             </ChangeItem>
             <ChangeItem pull="6857">
-              Sends the motherboard&apos;s hardware ID for device verification.
+              {"Sends the motherboard's hardware ID for device verification."}
             </ChangeItem>
           </Entry>
           <Entry version="1.3.3" date={new Date("2024-09-25")}>
@@ -360,8 +360,9 @@ export default function Headless({ os }: { os: OS }) {
               gets disabled / removed.
             </ChangeItem>
             <ChangeItem pull="6780">
-              Fixes a bug where the Linux Clients didn&apos;t work on ZFS
-              filesystems.
+              {
+                "Fixes a bug where the Linux Clients didn't work on ZFS filesystems."
+              }
             </ChangeItem>
             <ChangeItem pull="6788">
               Fixes an issue where some browsers may fail to route DNS Resources
@@ -384,9 +385,9 @@ export default function Headless({ os }: { os: OS }) {
               Implements glob-like matching of domains for DNS resources.
             </ChangeItem>
             <ChangeItem pull="6361">
-              Connections to Gateways are now sticky for the duration of the
-              Client&apos;s session to fix issues with long-lived TCP
-              connections.
+              {
+                "Connections to Gateways are now sticky for the duration of the Client's session to fix issues with long-lived TCP connections."
+              }
             </ChangeItem>
           </Entry>
           <Entry version="1.1.7" date={new Date("2024-08-13")}>
@@ -436,9 +437,9 @@ export default function Headless({ os }: { os: OS }) {
           </Entry>
           <Entry version="1.1.2" date={new Date("2024-07-03")}>
             <li className="pl-2">
-              Prevents Firezone&apos;s stub resolver from intercepting DNS
-              record types besides A, AAAA, and PTR. These are now forwarded to
-              your upstream DNS resolver.
+              {
+                "Prevents Firezone's stub resolver from intercepting DNS record types besides A, AAAA, and PTR. These are now forwarded to your upstream DNS resolver."
+              }
             </li>
           </Entry>
           <Entry version="1.1.1" date={new Date("2024-06-29")}>

--- a/website/src/components/SalesLeadForm/index.tsx
+++ b/website/src/components/SalesLeadForm/index.tsx
@@ -22,7 +22,7 @@ export default function SalesLeadForm() {
           <ul className="md:text-xl mb-8 list-inside list-disc">
             <li>Dedicated Email and Slack support</li>
             <li>
-              Leverage Firezone&apos;s Relay network to guarantee connectivity
+              {"Leverage Firezone's Relay network to guarantee connectivity"}
             </li>
             <li>White-glove onboarding and deployment assistance</li>
           </ul>

--- a/website/src/components/UseCaseCards/index.tsx
+++ b/website/src/components/UseCaseCards/index.tsx
@@ -146,8 +146,9 @@ export default function UseCaseCards() {
             <div className="w-full mt-2 md:mt-4 lg:mt-6 text-center md:text-left">
               <CardHeading>Block malicious DNS</CardHeading>
               <p>
-                Use Firezone to improve your team&apos;s Internet security by
-                blocking DNS queries to known malicious domains.
+                {
+                  "Use Firezone to improve your team's Internet security by blocking DNS queries to known malicious domains."
+                }
               </p>
               <Button text="Secure your DNS" href="/kb/use-cases/secure-dns" />
             </div>


### PR DESCRIPTION
Replace escaped apostrophes (&apos;) with direct apostrophes in JSX strings following a incident where our main website displayed incorrectly escaped apostrophes undetected for months. 

Makes it more readable when editing or grepping through the codebase and prevents

Note: alternative way would be to disable the offending lint for apostrophes, as they're not risky - and perhaps less annoying than wrapping things in `{}` blocks. 