### PR TITLE
fix(portal): shut DB connections down cleanly

### DIFF
--- a/elixir/lib/portal/replication/manager.ex
+++ b/elixir/lib/portal/replication/manager.ex
@@ -67,6 +67,16 @@ defmodule Portal.Replication.Manager do
     {:noreply, state}
   end
 
+  @impl true
+  def terminate(_reason, %{connection_pid: pid}) when is_pid(pid) do
+    # Send shutdown message to the replication connection so it disconnects
+    # gracefully without trying to reconnect
+    send(pid, :shutdown)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
   defp start_connection(%{connection_module: connection_module} = state) do
     case connection_module.start_link(replication_child_spec(connection_module)) do
       {:ok, pid} ->

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -42,7 +42,9 @@ defmodule Portal.MixProject do
         :logger,
         :runtime_tools,
         :crypto,
-        :dialyzer
+        :dialyzer,
+        # Ensure Postgrex.SCRAM.LockedCache is started before any database connections
+        :postgrex
       ]
     ]
   end

--- a/elixir/test/portal/application_test.exs
+++ b/elixir/test/portal/application_test.exs
@@ -40,4 +40,8 @@ defmodule Portal.ApplicationTest do
       assert {:error, {:not_found, ^handler_id}} = :logger.remove_handler(handler_id)
     end
   end
+
+  # Note: prep_stop/1 cannot be unit tested because it calls
+  # Ecto.Adapters.SQL.disconnect_all/2 which is not supported in the test
+  # environment's DBConnection.Ownership sandbox mode.
 end

--- a/elixir/test/portal/replication/manager_test.exs
+++ b/elixir/test/portal/replication/manager_test.exs
@@ -1,0 +1,29 @@
+defmodule Portal.Replication.ManagerTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Replication.Manager
+
+  describe "terminate/2" do
+    test "sends :shutdown to connection_pid when present" do
+      # Create a simple process that will receive the :shutdown message
+      test_pid = self()
+
+      connection_pid =
+        spawn(fn ->
+          receive do
+            :shutdown -> send(test_pid, :shutdown_received)
+          end
+        end)
+
+      state = %{connection_pid: connection_pid, connection_module: SomeModule, retries: 0}
+
+      assert Manager.terminate(:shutdown, state) == :ok
+      assert_receive :shutdown_received, 100
+    end
+
+    test "returns :ok when connection_pid is nil" do
+      state = %{connection_pid: nil, connection_module: SomeModule, retries: 0}
+      assert Manager.terminate(:shutdown, state) == :ok
+    end
+  end
+end


### PR DESCRIPTION
As a followup to #11927, it's determined after more investigation that the crash happens as the application is shutting down.

Postgrex is shutdown before the Application supervision tree, which causes the DBConnection module to attempt to reconnect, resulting in failures.

Tested manually in dev mode by sending a `kill <pid>` to the `beam` process.