### PR TITLE
fix(portal): allow configuring stripe ids at runtime

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -131,11 +131,22 @@ if config_env() == :prod do
 
   config :portal, Portal.Billing.Stripe.APIClient, endpoint: "https://api.stripe.com"
 
-  config :portal, Portal.Billing,
-    enabled: env_var_to_config!(:billing_enabled),
-    secret_key: env_var_to_config!(:stripe_secret_key),
-    webhook_signing_secret: env_var_to_config!(:stripe_webhook_signing_secret),
-    default_price_id: env_var_to_config!(:stripe_default_price_id)
+  config :portal,
+         Portal.Billing,
+         [
+           enabled: env_var_to_config!(:billing_enabled),
+           secret_key: env_var_to_config!(:stripe_secret_key),
+           webhook_signing_secret: env_var_to_config!(:stripe_webhook_signing_secret),
+           default_price_id: env_var_to_config!(:stripe_default_price_id)
+         ] ++
+           if(env_var_to_config(:stripe_plan_product_ids) != [],
+             do: [plan_product_ids: env_var_to_config!(:stripe_plan_product_ids)],
+             else: []
+           ) ++
+           if(env_var_to_config(:stripe_adhoc_device_product_id),
+             do: [adhoc_device_product_id: env_var_to_config!(:stripe_adhoc_device_product_id)],
+             else: []
+           )
 
   config :portal, platform_adapter: env_var_to_config!(:platform_adapter)
 

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -680,6 +680,8 @@ defmodule Portal.Config.Definitions do
   defconfig(:stripe_secret_key, :string, sensitive: true, default: nil)
   defconfig(:stripe_webhook_signing_secret, :string, sensitive: true, default: nil)
   defconfig(:stripe_default_price_id, :string, default: nil)
+  defconfig(:stripe_plan_product_ids, {:json_array, :string}, default: [])
+  defconfig(:stripe_adhoc_device_product_id, :string, default: nil)
 
   ##############################################
   ## Local development and Staging Helpers


### PR DESCRIPTION
As a followup to #11877, we need to configure staging which uses the `prod.exs` config to use the Stripe sandbox mode product IDs.

To do so, we expose these as runtime-configurable from env vars.