### PR TITLE
fix(portal): enforce billing limits

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -4,7 +4,6 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
-DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:83,2831B26
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 SQL.Query: SQL injection,lib/portal/safe.ex:344,2C3D7F0
 SQL.Query: SQL injection,lib/portal/safe.ex:350,3C9C61F
@@ -25,6 +24,7 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
 Config.Secrets: Hardcoded Secret,config/config.exs:221,6D192B
+DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:127,6E6B215
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619

--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -3,6 +3,8 @@ defmodule Portal.Account do
   import Ecto.Changeset
   alias Portal.Config
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime_usec]
@@ -58,8 +60,14 @@ defmodule Portal.Account do
     has_one :email_otp_auth_provider, Portal.EmailOTP.AuthProvider
     has_one :userpass_auth_provider, Portal.Userpass.AuthProvider
 
-    field :warning, :string
-    field :warning_delivery_attempts, :integer, default: 0
+    # Billing limit exceeded flags - set by CheckAccountLimits worker and Stripe event processing
+    field :users_limit_exceeded, :boolean, default: false
+    field :seats_limit_exceeded, :boolean, default: false
+    field :service_accounts_limit_exceeded, :boolean, default: false
+    field :sites_limit_exceeded, :boolean, default: false
+    field :admins_limit_exceeded, :boolean, default: false
+
+    # Tracks when the last limit exceeded email was sent (for throttling)
     field :warning_last_sent_at, :utc_datetime_usec
 
     field :disabled_reason, :string
@@ -76,8 +84,44 @@ defmodule Portal.Account do
     |> unique_constraint(:slug, name: :accounts_slug_index)
   end
 
+  @spec active?(t()) :: boolean()
   def active?(%__MODULE__{disabled_at: nil}), do: true
   def active?(%__MODULE__{}), do: false
+
+  @doc """
+  Returns true if any billing limit is exceeded.
+  """
+  @spec any_limit_exceeded?(t()) :: boolean()
+  def any_limit_exceeded?(%__MODULE__{} = account) do
+    account.users_limit_exceeded or
+      account.seats_limit_exceeded or
+      account.service_accounts_limit_exceeded or
+      account.sites_limit_exceeded or
+      account.admins_limit_exceeded
+  end
+
+  @doc """
+  Builds a human-readable warning message from the exceeded limit flags.
+  Returns nil if no limits are exceeded.
+  """
+  @spec build_limits_exceeded_message(t()) :: String.t() | nil
+  def build_limits_exceeded_message(%__MODULE__{} = account) do
+    limits =
+      []
+      |> maybe_add("users", account.users_limit_exceeded)
+      |> maybe_add("monthly active users", account.seats_limit_exceeded)
+      |> maybe_add("service accounts", account.service_accounts_limit_exceeded)
+      |> maybe_add("sites", account.sites_limit_exceeded)
+      |> maybe_add("account admins", account.admins_limit_exceeded)
+
+    case limits do
+      [] -> nil
+      limits -> "You have exceeded the following limits: #{Enum.join(limits, ", ")}"
+    end
+  end
+
+  defp maybe_add(list, label, true), do: list ++ [label]
+  defp maybe_add(list, _label, false), do: list
 
   for feature <- Portal.Accounts.Features.__schema__(:fields) do
     def unquote(:"#{feature}_enabled?")(account) do

--- a/elixir/lib/portal/mailer/notifications.ex
+++ b/elixir/lib/portal/mailer/notifications.ex
@@ -26,4 +26,11 @@ defmodule Portal.Mailer.Notifications do
       latest_version: Portal.ComponentVersions.gateway_version()
     )
   end
+
+  def limits_exceeded_email(warning, email) do
+    default_email()
+    |> subject("Firezone Account Limits Exceeded")
+    |> to(email)
+    |> render_body(__MODULE__, :limits_exceeded, warning: warning)
+  end
 end

--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+  <meta charset="utf-8">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="format-detection" content="telephone=no, date=no, address=no, email=no, url=no">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings xmlns:o="urn:schemas-microsoft-com:office:office">
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <style>
+    td,th,div,p,a,h1,h2,h3,h4,h5,h6 {font-family: "Segoe UI", sans-serif; mso-line-height-rule: exactly;}
+  </style>
+  <![endif]-->
+  <title>Account Limits Exceeded</title>
+  <style>
+    .hover-important-text-decoration-underline:hover {
+      text-decoration: underline !important
+    }
+    @media (max-width: 600px) {
+      .sm-my-8 {
+        margin-top: 32px !important;
+        margin-bottom: 32px !important
+      }
+      .sm-px-4 {
+        padding-left: 16px !important;
+        padding-right: 16px !important
+      }
+      .sm-px-6 {
+        padding-left: 24px !important;
+        padding-right: 24px !important
+      }
+      .sm-leading-8 {
+        line-height: 32px !important
+      }
+    }
+    .rtl-text-right:where([dir="rtl"], [dir="rtl"] *) {
+      text-align: right !important
+    }
+    <%= File.read!(Application.app_dir(:portal, "priv/static/emails/dark_mode.css")) %>
+  </style>
+</head>
+<body style="margin: 0; width: 100%; background-color: #f6f6f6; padding: 0; -webkit-font-smoothing: antialiased; word-break: break-word">
+  <div style="display: none">
+    Account Limits Exceeded
+  </div>
+  <div role="article" aria-roledescription="email" aria-label="Account Limits Exceeded" lang="en">
+    <div class="sm-px-4 email-container" style="background-color: #f6f6f6; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif">
+      <table align="center" cellpadding="0" cellspacing="0" role="none">
+        <tr>
+          <td style="width: 552px; max-width: 100%">
+            <div class="sm-my-8" style="margin-top: 48px; margin-bottom: 48px; text-align: center">
+              <a href="https://firezone.dev">
+                <div>
+                  <img class="logo-light" src="https://www.firezone.dev/images/logo-lockup.png" width="250" alt="Firezone logo" style="max-width: 100%; vertical-align: middle; line-height: 1">
+                  <img class="logo-dark" src="https://www.firezone.dev/images/logo-text-dark.svg" width="250" alt="Firezone logo" style="display: none; max-width: 100%; vertical-align: middle; line-height: 1">
+                </div>
+              </a>
+            </div>
+            <table style="width: 100%;" cellpadding="0" cellspacing="0" role="none">
+              <tr>
+                <td class="sm-px-6 content-box" style="border-radius: 4px; background-color: #ffffff; padding: 48px; font-size: 16px; color: #4f4f4f; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05)">
+                  <h1 class="sm-leading-8" style="margin: 0 0 24px; font-size: 24px; font-weight: 600; color: #000000">
+                    Account Limits Exceeded
+                  </h1>
+                  <p style="margin: 0; line-height: 24px">
+                    Your Firezone account has exceeded the following limits:
+                  </p>
+                  <div role="separator" style="line-height: 16px">&zwj;</div>
+                  <p style="margin: 0; padding: 16px; background-color: #fef2f2; border-radius: 4px; color: #991b1b; font-weight: 500; line-height: 24px">
+                    <%= @warning %>
+                  </p>
+                  <div role="separator" style="line-height: 16px">&zwj;</div>
+                  <p style="margin: 0; line-height: 24px">
+                    Please upgrade your plan or remove resources to resolve this issue.
+                  </p>
+                  <div role="separator" class="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0">&zwj;</div>
+                  <p style="margin: 0 0 16px 0; line-height: 24px;">
+                    <span style="font-weight: 600">What happens next?</span>
+                  </p>
+                  <ul style="margin: 0; padding-left: 24px; line-height: 24px">
+                    <li>Your existing connections will continue to work</li>
+                    <li>New client sign-ins will be blocked until limits are resolved</li>
+                    <li>Account administrators can still access the admin portal</li>
+                  </ul>
+                  <div role="separator" class="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0">&zwj;</div>
+                  <p style="margin: 0 0 16px 0; line-height: 24px;">
+                    <span style="font-weight: 600">To resolve this:</span>
+                  </p>
+                  <ol style="margin: 0; padding-left: 24px; line-height: 24px">
+                    <li>Log into your Firezone admin portal</li>
+                    <li>Navigate to Settings -> Billing to upgrade your plan</li>
+                    <li>Or remove excess resources to get back within your limits</li>
+                  </ol>
+                  <div role="separator" style="line-height: 24px">&zwj;</div>
+                  <p style="margin: 0; line-height: 24px">
+                    If you have any questions, please contact our support team.
+                  </p>
+                  <p style="margin: 0; margin-top: 16px; line-height: 24px">
+                    Thanks, <br>The Firezone Team
+                  </p>
+                  <div role="separator" style="line-height: 16px">&zwj;</div>
+                </td>
+              </tr>
+              <tr role="separator">
+                <td style="line-height: 48px">&zwj;</td>
+              </tr>
+              <tr>
+                <td class="footer-text" style="padding-left: 24px; padding-right: 24px; text-align: center; font-size: 12px; color: #575757">
+                  <p style="margin: 0; font-style: italic">
+                    Blazing-fast alternative to legacy VPNs
+                  </p>
+                  <p style="cursor: default">
+                    <a href="https://www.firezone.dev/kb" class="hover-important-text-decoration-underline" style="color: #5e00d6; text-decoration: none">Docs</a>
+                    &bull;
+                    <a href="https://github.com/firezone" class="hover-important-text-decoration-underline" style="color: #5e00d6; text-decoration: none;">GitHub</a>
+                    &bull;
+                    <a href="https://x.com/firezonehq" class="hover-important-text-decoration-underline" style="color: #5e00d6; text-decoration: none;">X</a>
+                  </p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.text.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.text.eex
@@ -1,0 +1,22 @@
+Account Limits Exceeded
+
+Your Firezone account has exceeded the following limits:
+
+<%= @warning %>
+
+Please upgrade your plan or remove resources to resolve this issue.
+
+What happens next?
+- Your existing connections will continue to work
+- New client sign-ins will be blocked until limits are resolved
+- Account administrators can still access the admin portal
+
+To resolve this:
+1. Log into your Firezone admin portal
+2. Navigate to Settings -> Billing to upgrade your plan
+3. Or remove excess resources to get back within your limits
+
+If you have any questions, please contact our support team.
+
+Thanks,
+The Firezone Team

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -93,6 +93,8 @@ defmodule PortalAPI.Client.Socket do
 
     with {:ok, %{credential: %{type: :client_token, id: token_id}} = subject} <-
            Authentication.authenticate(token, context),
+         false <- Portal.Billing.client_connect_restricted?(subject.account),
+         :ok = Portal.Billing.log_seats_limit_exceeded(subject.account, subject.actor.id),
          changeset = upsert_changeset(subject.actor, subject, attrs),
          {:ok, client} <- Database.upsert_client(changeset, subject) do
       OpenTelemetry.Tracer.set_attributes(%{
@@ -116,6 +118,10 @@ defmodule PortalAPI.Client.Socket do
       {:error, :unauthorized} ->
         OpenTelemetry.Tracer.set_status(:error, "unauthorized")
         {:error, :invalid_token}
+
+      true ->
+        OpenTelemetry.Tracer.set_status(:error, "limits_exceeded")
+        {:error, :limits_exceeded}
 
       {:error, reason} ->
         OpenTelemetry.Tracer.set_status(:error, inspect(reason))

--- a/elixir/lib/portal_api/sockets.ex
+++ b/elixir/lib/portal_api/sockets.ex
@@ -25,6 +25,15 @@ defmodule PortalAPI.Sockets do
   def handle_error(conn, :missing_token),
     do: Plug.Conn.send_resp(conn, 401, "Missing token")
 
+  def handle_error(conn, :limits_exceeded),
+    do:
+      Plug.Conn.send_resp(
+        conn,
+        402,
+        "This account is temporarily suspended from client authentication " <>
+          "due to exceeding billing limits. Please contact your administrator to add more seats."
+      )
+
   def handle_error(conn, :account_disabled),
     do: Plug.Conn.send_resp(conn, 403, "The account is disabled")
 

--- a/elixir/lib/portal_web/components/layouts/app.html.heex
+++ b/elixir/lib/portal_web/components/layouts/app.html.heex
@@ -117,8 +117,8 @@
   >
     {Phoenix.HTML.raw(banner.message)}
   </div>
-  <.flash :if={@account.warning} kind={:warning} class="m-1">
-    {@account.warning}.
+  <.flash :if={Portal.Account.any_limit_exceeded?(@account)} kind={:warning} class="m-1">
+    {Portal.Account.build_limits_exceeded_message(@account)}.
     <span :if={Portal.Billing.account_provisioned?(@account)}>
       Please
       <.link navigate={~p"/#{@account}/settings/billing"} class={link_style()}>

--- a/elixir/priv/replica/migrations/20260129172644_add_limit_exceeded_flags_to_accounts.exs
+++ b/elixir/priv/replica/migrations/20260129172644_add_limit_exceeded_flags_to_accounts.exs
@@ -1,0 +1,18 @@
+defmodule Portal.Repo.Replica.Migrations.AddLimitExceededFlagsToAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      # Add boolean flags for each limit type
+      add(:users_limit_exceeded, :boolean, default: false, null: false)
+      add(:seats_limit_exceeded, :boolean, default: false, null: false)
+      add(:service_accounts_limit_exceeded, :boolean, default: false, null: false)
+      add(:sites_limit_exceeded, :boolean, default: false, null: false)
+      add(:admins_limit_exceeded, :boolean, default: false, null: false)
+
+      # Remove the old warning text field and delivery attempts counter
+      remove(:warning, :string)
+      remove(:warning_delivery_attempts, :integer)
+    end
+  end
+end

--- a/elixir/priv/repo/migrations/20260129172644_add_limit_exceeded_flags_to_accounts.exs
+++ b/elixir/priv/repo/migrations/20260129172644_add_limit_exceeded_flags_to_accounts.exs
@@ -1,0 +1,18 @@
+defmodule Portal.Repo.Migrations.AddLimitExceededFlagsToAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      # Add boolean flags for each limit type
+      add(:users_limit_exceeded, :boolean, default: false, null: false)
+      add(:seats_limit_exceeded, :boolean, default: false, null: false)
+      add(:service_accounts_limit_exceeded, :boolean, default: false, null: false)
+      add(:sites_limit_exceeded, :boolean, default: false, null: false)
+      add(:admins_limit_exceeded, :boolean, default: false, null: false)
+
+      # Remove the old warning text field and delivery attempts counter
+      remove(:warning, :string)
+      remove(:warning_delivery_attempts, :integer)
+    end
+  end
+end

--- a/elixir/test/portal/billing_test.exs
+++ b/elixir/test/portal/billing_test.exs
@@ -1,6 +1,7 @@
 defmodule Portal.BillingTest do
   use Portal.DataCase, async: true
 
+  import ExUnit.CaptureLog
   import Portal.Billing
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -417,6 +418,395 @@ defmodule Portal.BillingTest do
 
       # Client2 can still create tokens
       assert can_create_api_tokens?(account, api_client2) == true
+    end
+  end
+
+  describe "client_sign_in_restricted?/1" do
+    test "returns false when no limits are exceeded", %{account: account} do
+      refute client_sign_in_restricted?(account)
+    end
+
+    test "returns true when users_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{users_limit_exceeded: true})
+      assert client_sign_in_restricted?(account)
+    end
+
+    test "returns false when only seats_limit_exceeded is true", %{account: account} do
+      # seats_limit_exceeded no longer blocks sign-in, it only logs
+      account = update_account(account, %{seats_limit_exceeded: true})
+      refute client_sign_in_restricted?(account)
+    end
+
+    test "returns true when users_limit_exceeded is true even with seats_limit_exceeded", %{
+      account: account
+    } do
+      account = update_account(account, %{users_limit_exceeded: true, seats_limit_exceeded: true})
+      assert client_sign_in_restricted?(account)
+    end
+
+    test "returns false when only sites_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{sites_limit_exceeded: true})
+      refute client_sign_in_restricted?(account)
+    end
+
+    test "returns false when only service_accounts_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{service_accounts_limit_exceeded: true})
+      refute client_sign_in_restricted?(account)
+    end
+
+    test "returns false when only admins_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{admins_limit_exceeded: true})
+      refute client_sign_in_restricted?(account)
+    end
+  end
+
+  describe "log_seats_limit_exceeded/2" do
+    test "logs error when seats_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{seats_limit_exceeded: true})
+      actor = actor_fixture(account: account)
+
+      log =
+        capture_log(fn ->
+          assert log_seats_limit_exceeded(account, actor.id) == :ok
+        end)
+
+      assert log =~ "Account seats limit exceeded"
+      assert log =~ "account_id=#{account.id}"
+      assert log =~ "account_slug=#{account.slug}"
+      assert log =~ "actor_id=#{actor.id}"
+    end
+
+    test "does not log when seats_limit_exceeded is false", %{account: account} do
+      actor = actor_fixture(account: account)
+
+      log =
+        capture_log(fn ->
+          assert log_seats_limit_exceeded(account, actor.id) == :ok
+        end)
+
+      refute log =~ "Account seats limit exceeded"
+    end
+  end
+
+  describe "client_connect_restricted?/1" do
+    test "returns false when no limits are exceeded", %{account: account} do
+      refute client_connect_restricted?(account)
+    end
+
+    test "returns true when users_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{users_limit_exceeded: true})
+      assert client_connect_restricted?(account)
+    end
+
+    test "returns false when only seats_limit_exceeded is true", %{account: account} do
+      # seats_limit_exceeded no longer blocks connections, it only logs
+      account = update_account(account, %{seats_limit_exceeded: true})
+      refute client_connect_restricted?(account)
+    end
+
+    test "returns true when service_accounts_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{service_accounts_limit_exceeded: true})
+      assert client_connect_restricted?(account)
+    end
+
+    test "returns false when only sites_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{sites_limit_exceeded: true})
+      refute client_connect_restricted?(account)
+    end
+
+    test "returns false when only admins_limit_exceeded is true", %{account: account} do
+      account = update_account(account, %{admins_limit_exceeded: true})
+      refute client_connect_restricted?(account)
+    end
+  end
+
+  describe "evaluate_account_limits/1" do
+    test "returns account unchanged when not provisioned", %{account: account} do
+      # Account without customer_id is not provisioned
+      account = update_account(account, %{metadata: %{stripe: %{}}})
+      assert {:ok, ^account} = Portal.Billing.evaluate_account_limits(account)
+    end
+  end
+
+  describe "create_customer/1" do
+    test "returns error when Stripe API returns 400 status", %{account: account} do
+      Stripe.stub([{"POST", "/v1/customers", 400, %{"error" => "Bad request"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.create_customer(account)
+    end
+
+    test "returns error when Stripe API returns 500 status", %{account: account} do
+      Stripe.stub([{"POST", "/v1/customers", 500, %{"error" => "Server error"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.create_customer(account)
+    end
+
+    test "uses billing_email from metadata when present", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{billing_email: "billing@example.com"}}
+        })
+
+      Stripe.stub(Stripe.mock_create_customer_endpoint(account))
+
+      assert {:ok, _updated} = Portal.Billing.create_customer(account)
+    end
+
+    test "sends nil email when no billing_email in metadata", %{account: account} do
+      # Account without billing_email in metadata
+      account = update_account(account, %{metadata: %{stripe: %{}}})
+
+      Stripe.stub(Stripe.mock_create_customer_endpoint(account))
+
+      assert {:ok, _updated} = Portal.Billing.create_customer(account)
+    end
+
+    test "handles account with nil stripe metadata", %{account: account} do
+      # Create a raw account struct with nil stripe metadata to test the edge case
+      # This tests the `_ -> %{}` branch in update_account_metadata_changeset
+      raw_account = %Portal.Account{
+        id: account.id,
+        name: account.name,
+        legal_name: account.legal_name,
+        slug: account.slug,
+        metadata: %Portal.Account.Metadata{stripe: nil}
+      }
+
+      Stripe.stub(Stripe.mock_create_customer_endpoint(account))
+
+      # This should still work even with nil stripe metadata
+      assert {:ok, _updated} = Portal.Billing.create_customer(raw_account)
+    end
+  end
+
+  describe "update_stripe_customer/1" do
+    test "returns error when Stripe API returns 400 status", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      Stripe.stub([{"POST", "/v1/customers/cus_test123", 400, %{"error" => "Bad request"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.update_stripe_customer(account)
+    end
+
+    test "returns error when Stripe API returns 500 status", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      Stripe.stub([{"POST", "/v1/customers/cus_test123", 500, %{"error" => "Server error"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.update_stripe_customer(account)
+    end
+  end
+
+  describe "fetch_customer_account_id/1" do
+    test "returns error when Stripe API returns 400 status" do
+      Stripe.stub([{"GET", "/v1/customers/cus_test123", 400, %{"error" => "Bad request"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.fetch_customer_account_id("cus_test123")
+    end
+
+    test "returns error when Stripe API returns 500 status" do
+      Stripe.stub([{"GET", "/v1/customers/cus_test123", 500, %{"error" => "Server error"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.fetch_customer_account_id("cus_test123")
+    end
+
+    test "returns error when customer has no account_id in metadata" do
+      customer =
+        Stripe.build_customer(
+          id: "cus_test123",
+          metadata: %{"other_key" => "other_value"}
+        )
+
+      Stripe.stub([{"GET", "/v1/customers/cus_test123", 200, customer}])
+
+      assert {:error, :customer_not_provisioned} =
+               Portal.Billing.fetch_customer_account_id("cus_test123")
+    end
+  end
+
+  describe "list_all_subscriptions/0" do
+    test "calls Stripe API to list subscriptions" do
+      subscriptions = %{
+        "object" => "list",
+        "has_more" => false,
+        "data" => [Stripe.subscription_object("cus_test123", %{}, %{}, 1)]
+      }
+
+      Stripe.stub([{"GET", ~r/\/v1\/subscriptions/, 200, subscriptions}])
+
+      assert {:ok, result} = Portal.Billing.list_all_subscriptions()
+      assert is_list(result)
+    end
+  end
+
+  describe "create_subscription/1" do
+    test "returns error when Stripe API returns 400 status", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      Stripe.stub([{"POST", "/v1/subscriptions", 400, %{"error" => "Bad request"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.create_subscription(account)
+    end
+
+    test "returns error when Stripe API returns 500 status", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      Stripe.stub([{"POST", "/v1/subscriptions", 500, %{"error" => "Server error"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.create_subscription(account)
+    end
+  end
+
+  describe "fetch_product/1" do
+    test "returns error when Stripe API returns 400 status" do
+      Stripe.stub([{"GET", "/v1/products/prod_test123", 400, %{"error" => "Bad request"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.fetch_product("prod_test123")
+    end
+
+    test "returns error when Stripe API returns 500 status" do
+      Stripe.stub([{"GET", "/v1/products/prod_test123", 500, %{"error" => "Server error"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.fetch_product("prod_test123")
+    end
+  end
+
+  describe "provision_account/1" do
+    test "only creates internet site when billing is disabled", %{account: account} do
+      Portal.Config.put_env_override(Portal.Billing, enabled: false)
+
+      # Account should not have internet site yet
+      assert {:error, :not_found} =
+               Portal.Billing.Database.fetch_internet_site(account)
+
+      assert {:ok, ^account} = Portal.Billing.provision_account(account)
+
+      # Internet site and resource should be created
+      assert {:ok, _site} = Portal.Billing.Database.fetch_internet_site(account)
+      assert {:ok, _resource} = Portal.Billing.Database.fetch_internet_resource(account)
+    end
+
+    test "only creates internet site when account is already provisioned", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_already_provisioned"}}
+        })
+
+      assert {:ok, ^account} = Portal.Billing.provision_account(account)
+
+      # Internet site and resource should be created
+      assert {:ok, _site} = Portal.Billing.Database.fetch_internet_site(account)
+      assert {:ok, _resource} = Portal.Billing.Database.fetch_internet_resource(account)
+    end
+
+    test "creates internet site and resource when they don't exist", %{account: account} do
+      # Stub successful Stripe calls for the full provisioning flow
+      customer = Stripe.build_customer(id: "cus_new123", metadata: %{"account_id" => account.id})
+      subscription = Stripe.subscription_object("cus_new123", %{}, %{}, 1)
+
+      Stripe.stub([
+        {"POST", "/v1/customers", 200, customer},
+        {"POST", "/v1/subscriptions", 200, subscription}
+      ])
+
+      assert {:ok, _provisioned} = Portal.Billing.provision_account(account)
+
+      # Internet site and resource should be created
+      assert {:ok, _site} = Portal.Billing.Database.fetch_internet_site(account)
+      assert {:ok, _resource} = Portal.Billing.Database.fetch_internet_resource(account)
+    end
+
+    test "returns error when provisioning fails", %{account: account} do
+      Stripe.stub([{"POST", "/v1/customers", 500, %{"error" => "Server error"}}])
+
+      assert {:error, :retry_later} = Portal.Billing.provision_account(account)
+    end
+  end
+
+  describe "on_account_name_or_slug_changed/1" do
+    test "returns :ok when account is not provisioned", %{account: account} do
+      account = update_account(account, %{metadata: %{stripe: %{}}})
+      assert :ok = Portal.Billing.on_account_name_or_slug_changed(account)
+    end
+
+    test "returns :ok when billing is disabled", %{account: account} do
+      Portal.Config.put_env_override(Portal.Billing, enabled: false)
+
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      assert :ok = Portal.Billing.on_account_name_or_slug_changed(account)
+    end
+
+    test "updates Stripe customer when provisioned and enabled", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      Stripe.stub(Stripe.mock_update_customer_endpoint(account))
+
+      assert :ok = Portal.Billing.on_account_name_or_slug_changed(account)
+    end
+  end
+
+  describe "billing_portal_url/3" do
+    test "returns error when subject is not admin", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      actor = actor_fixture(type: :account_user, account: account)
+      subject = Portal.SubjectFixtures.subject_fixture(account: account, actor: actor)
+
+      assert {:error, :unauthorized} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+    end
+
+    test "returns error when subject is admin of different account", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      other_account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: other_account)
+      subject = Portal.SubjectFixtures.subject_fixture(account: other_account, actor: actor)
+
+      assert {:error, :unauthorized} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+    end
+
+    test "returns URL when subject is admin of same account", %{account: account} do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test123"}}
+        })
+
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = Portal.SubjectFixtures.subject_fixture(account: account, actor: actor)
+
+      Stripe.stub(Stripe.mock_create_billing_session_endpoint(account))
+
+      assert {:ok, url} =
+               Portal.Billing.billing_portal_url(account, "https://example.com", subject)
+
+      assert url =~ "billing.stripe.com"
     end
   end
 end

--- a/elixir/test/portal/workers/check_account_limits_test.exs
+++ b/elixir/test/portal/workers/check_account_limits_test.exs
@@ -1,0 +1,280 @@
+defmodule Portal.Workers.CheckAccountLimitsTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+
+  alias Portal.Workers.CheckAccountLimits
+
+  describe "perform/1" do
+    test "does nothing when limits are not violated" do
+      account = provisioned_account_fixture()
+      admin_actor_fixture(account: account)
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      account = Repo.get!(Portal.Account, account.id)
+      refute account.users_limit_exceeded
+      refute account.seats_limit_exceeded
+      refute account.service_accounts_limit_exceeded
+      refute account.sites_limit_exceeded
+      refute account.admins_limit_exceeded
+      refute account.warning_last_sent_at
+    end
+
+    test "sets warning when limits are violated" do
+      account = provisioned_account_fixture()
+      admin_actor_fixture(account: account)
+
+      # Create multiple admins to exceed limit
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+
+      update_account(account, %{
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      account = Repo.get!(Portal.Account, account.id)
+
+      assert account.admins_limit_exceeded
+      refute account.users_limit_exceeded
+      refute account.seats_limit_exceeded
+      refute account.service_accounts_limit_exceeded
+      refute account.sites_limit_exceeded
+      assert account.warning_last_sent_at
+    end
+
+    test "sends email to admins when limits are first exceeded" do
+      account = provisioned_account_fixture()
+      admin1 = admin_actor_fixture(account: account)
+      admin2 = admin_actor_fixture(account: account)
+      admin3 = admin_actor_fixture(account: account)
+
+      update_account(account, %{
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      # Collect all sent emails
+      emails_sent = collect_sent_emails()
+
+      # All 3 admins should receive emails
+      assert length(emails_sent) == 3
+
+      email_recipients =
+        emails_sent
+        |> Enum.flat_map(fn email -> email.to end)
+        |> Enum.map(fn
+          {_name, email} -> email
+          email when is_binary(email) -> email
+        end)
+
+      assert admin1.email in email_recipients
+      assert admin2.email in email_recipients
+      assert admin3.email in email_recipients
+
+      # Verify email content
+      [first_email | _] = emails_sent
+      assert first_email.subject == "Firezone Account Limits Exceeded"
+      assert first_email.text_body =~ "exceeded the following limits"
+      assert first_email.text_body =~ "account admins"
+    end
+
+    test "does not send email if warning_last_sent_at is less than 3 days ago" do
+      account = provisioned_account_fixture()
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+
+      # Set warning_last_sent_at to 2 days ago
+      two_days_ago = DateTime.utc_now() |> DateTime.add(-2, :day)
+
+      update_account(account, %{
+        admins_limit_exceeded: true,
+        warning_last_sent_at: two_days_ago,
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      # No new emails should be sent
+      refute_email_sent()
+
+      # warning_last_sent_at should not be updated
+      account = Repo.get!(Portal.Account, account.id)
+      assert DateTime.compare(account.warning_last_sent_at, two_days_ago) == :eq
+    end
+
+    test "sends email again if warning_last_sent_at is more than 3 days ago" do
+      account = provisioned_account_fixture()
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+
+      # Set warning_last_sent_at to 4 days ago
+      four_days_ago = DateTime.utc_now() |> DateTime.add(-4, :day)
+
+      update_account(account, %{
+        admins_limit_exceeded: true,
+        warning_last_sent_at: four_days_ago,
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      # Email should be sent again
+      assert_email_sent(fn email ->
+        assert email.subject == "Firezone Account Limits Exceeded"
+      end)
+
+      # warning_last_sent_at should be updated
+      account = Repo.get!(Portal.Account, account.id)
+      assert DateTime.compare(account.warning_last_sent_at, four_days_ago) == :gt
+    end
+
+    test "clears limit flags and warning_last_sent_at when limits are no longer exceeded" do
+      account = provisioned_account_fixture()
+      admin_actor_fixture(account: account)
+
+      # Set existing limit flags
+      update_account(account, %{
+        admins_limit_exceeded: true,
+        warning_last_sent_at: DateTime.utc_now()
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      account = Repo.get!(Portal.Account, account.id)
+      refute account.users_limit_exceeded
+      refute account.seats_limit_exceeded
+      refute account.service_accounts_limit_exceeded
+      refute account.sites_limit_exceeded
+      refute account.admins_limit_exceeded
+      refute account.warning_last_sent_at
+    end
+
+    test "does not process non-provisioned accounts" do
+      # Account without stripe metadata is not provisioned
+      account = account_fixture()
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+
+      update_account(account, %{
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      account = Repo.get!(Portal.Account, account.id)
+      refute Portal.Account.any_limit_exceeded?(account)
+      refute_email_sent()
+    end
+
+    test "does not process disabled accounts" do
+      account = provisioned_account_fixture()
+      admin_actor_fixture(account: account)
+      admin_actor_fixture(account: account)
+
+      update_account(account, %{
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      # Disable the account
+      account
+      |> Ecto.Changeset.change(disabled_at: DateTime.utc_now(), disabled_reason: "Test")
+      |> Repo.update!()
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      account = Repo.get!(Portal.Account, account.id)
+      refute Portal.Account.any_limit_exceeded?(account)
+      refute_email_sent()
+    end
+
+    test "only sends emails to enabled admin actors" do
+      account = provisioned_account_fixture()
+      admin1 = admin_actor_fixture(account: account)
+
+      # Create disabled admin
+      disabled_admin = admin_actor_fixture(account: account)
+
+      disabled_admin
+      |> Ecto.Changeset.change(disabled_at: DateTime.utc_now())
+      |> Repo.update!()
+
+      # Create another enabled admin
+      admin2 = admin_actor_fixture(account: account)
+
+      update_account(account, %{
+        limits: %{
+          account_admin_users_count: 1
+        }
+      })
+
+      assert :ok = perform_job(CheckAccountLimits, %{})
+
+      # Collect all sent emails
+      emails_sent = collect_sent_emails()
+
+      # Only 2 enabled admins should receive emails
+      assert length(emails_sent) == 2
+
+      email_recipients =
+        emails_sent
+        |> Enum.flat_map(fn email -> email.to end)
+        |> Enum.map(fn {_name, email} -> email end)
+
+      assert admin1.email in email_recipients
+      assert admin2.email in email_recipients
+      refute disabled_admin.email in email_recipients
+    end
+  end
+
+  defp provisioned_account_fixture(attrs \\ %{}) do
+    account = account_fixture(attrs)
+
+    account
+    |> Ecto.Changeset.cast(
+      %{
+        metadata: %{
+          stripe: %{
+            customer_id: "cus_#{System.unique_integer([:positive])}",
+            subscription_id: "sub_#{System.unique_integer([:positive])}",
+            product_name: "Team"
+          }
+        }
+      },
+      []
+    )
+    |> Ecto.Changeset.cast_embed(:metadata)
+    |> Repo.update!()
+  end
+
+  defp collect_sent_emails do
+    collect_sent_emails([])
+  end
+
+  defp collect_sent_emails(acc) do
+    receive do
+      {:email, email} -> collect_sent_emails([email | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/elixir/test/portal_api/sockets_test.exs
+++ b/elixir/test/portal_api/sockets_test.exs
@@ -93,6 +93,18 @@ defmodule PortalAPI.SocketsTest do
       assert result.resp_body == "Missing token"
     end
 
+    test "returns 402 for seats_limit_exceeded" do
+      conn = Plug.Test.conn(:get, "/")
+
+      result = Sockets.handle_error(conn, :limits_exceeded)
+
+      assert result.status == 402
+
+      assert result.resp_body ==
+               "This account is temporarily suspended from client authentication " <>
+                 "due to exceeding billing limits. Please contact your administrator to add more seats."
+    end
+
     test "returns 403 for account_disabled" do
       conn = Plug.Test.conn(:get, "/")
 

--- a/elixir/test/portal_web/controllers/userpass_controller_test.exs
+++ b/elixir/test/portal_web/controllers/userpass_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule PortalWeb.UserpassControllerTest do
   use PortalWeb.ConnCase, async: true
 
+  import ExUnit.CaptureLog
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
@@ -237,6 +238,148 @@ defmodule PortalWeb.UserpassControllerTest do
       # account_user should be allowed in gui-client context
       assert conn.status == 200
       assert conn.resp_body =~ "client_redirect"
+    end
+
+    test "rejects client sign-in when account has exceeded user limits", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      # Set limit exceeded flag on the account
+      update_account(account, %{users_limit_exceeded: true})
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_user, account: account},
+          password_hash
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "as" => "client",
+          "state" => "test-state",
+          "nonce" => "test-nonce"
+        })
+
+      assert redirected_to(conn) =~ "/#{account.id}"
+      assert flash(conn, :error) =~ "exceeding billing limits"
+    end
+
+    test "logs error and allows gui-client sign-in when account has exceeded monthly active users limits",
+         %{
+           conn: conn,
+           account: account,
+           provider: provider,
+           password_hash: password_hash
+         } do
+      # Set limit exceeded flag on the account (seats_limit_exceeded is used for monthly active users)
+      update_account(account, %{seats_limit_exceeded: true})
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_user, account: account},
+          password_hash
+        )
+
+      log =
+        capture_log(fn ->
+          conn =
+            post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+              "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+              "as" => "gui-client",
+              "state" => "test-state",
+              "nonce" => "test-nonce"
+            })
+
+          # Sign-in should still succeed
+          assert conn.status == 200
+          assert conn.resp_body =~ "client_redirect"
+        end)
+
+      assert log =~ "Account seats limit exceeded"
+      assert log =~ "account_id=#{account.id}"
+      assert log =~ "account_slug=#{account.slug}"
+      assert log =~ "actor_id=#{actor.id}"
+    end
+
+    test "rejects headless-client sign-in when account has exceeded limits", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      # Set multiple limit exceeded flags including users
+      update_account(account, %{users_limit_exceeded: true, sites_limit_exceeded: true})
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_user, account: account},
+          password_hash
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "as" => "headless-client",
+          "state" => "test-state"
+        })
+
+      assert redirected_to(conn) =~ "/#{account.id}"
+      assert flash(conn, :error) =~ "exceeding billing limits"
+    end
+
+    test "allows client sign-in when account warning does not include user limits", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      # Set a limit flag that doesn't include users or seats
+      update_account(account, %{sites_limit_exceeded: true})
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_user, account: account},
+          password_hash
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "as" => "client",
+          "state" => "test-state",
+          "nonce" => "test-nonce"
+        })
+
+      # Should be allowed - sites warning doesn't block client auth
+      assert conn.status == 200
+      assert conn.resp_body =~ "client_redirect"
+    end
+
+    test "allows portal sign-in when account has exceeded user limits", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      # Set limit exceeded flag on the account
+      update_account(account, %{users_limit_exceeded: true})
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_admin_user, account: account},
+          password_hash
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password}
+        })
+
+      # Portal sign-in should still be allowed so admins can manage billing
+      assert redirected_to(conn) =~ "/sites"
     end
   end
 end

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -120,7 +120,19 @@ defmodule Portal.AccountFixtures do
     attrs = Enum.into(attrs, %{})
 
     account
-    |> cast(attrs, [:name, :legal_name, :slug, :disabled_at, :disabled_reason])
+    |> cast(attrs, [
+      :name,
+      :legal_name,
+      :slug,
+      :disabled_at,
+      :disabled_reason,
+      :users_limit_exceeded,
+      :seats_limit_exceeded,
+      :service_accounts_limit_exceeded,
+      :sites_limit_exceeded,
+      :admins_limit_exceeded,
+      :warning_last_sent_at
+    ])
     |> cast_embed(:config)
     |> cast_embed(:features)
     |> cast_embed(:limits)


### PR DESCRIPTION
Depending on the customer's plan tier and configured limits, we need to restrict certain actions such as signing in from a client or connecting to the API with a headless client.

This PR fixes a few holes we had here to make sure that:

1. If users or monthly active users limits are exceeded, client sign-ins don't work
2. If users, monthly active users, or service accounts limits are exceeded, client API connections don't work (fail with a `402` - payment required).
3. Adds an outbound email to be sent whenever the account goes past its limits (this was previously only shown in the UI).

This is required to support adding adhoc features to plans on an as-needed basis.

<img width="663" height="1118" alt="Screenshot 2026-01-29 at 9 06 19 AM" src="https://github.com/user-attachments/assets/d4de9334-3864-4707-a1c7-70fe2c453f4f" />



---

Related: #8668 