### PR TITLE
chore(gui-client): spawn a dedicated `connlib` thread

### DIFF
--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -708,7 +708,9 @@ pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
     if !elevation_check()? {
         bail!("Tunnel service failed its elevation check, try running as admin / root");
     }
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("connlib")
         .enable_all()
         .build()?;
     let _guard = rt.enter();

--- a/rust/gui-client/src-tauri/src/service/windows.rs
+++ b/rust/gui-client/src-tauri/src/service/windows.rs
@@ -212,7 +212,9 @@ fn run_service(arguments: Vec<OsString>) {
         return;
     }
 
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("connlib")
         .enable_all()
         .build()
         .expect("Failed to create tokio runtime");


### PR DESCRIPTION
For consistency between all our platforms, we now spawn a multi-threaded tokio runtime with a single worker thread within the Windows and Linux tunnel service binaries instead of using the main thread for it. We do the same thing in the FFI layer for Android and MacOS.

This makes performance profiling easier because the threads end up being clearly labelled.

Related: #11944