### PR TITLE
chore(headless-client): spawn a dedicated connlib thread

### DIFF
--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -231,9 +231,12 @@ fn try_main() -> Result<()> {
     // and we need to recover. <https://github.com/firezone/firezone/issues/4899>
     dns_controller.deactivate()?;
 
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("connlib")
         .enable_all()
-        .build()?;
+        .build()
+        .context("Failed to create tokio runtime")?;
 
     if cfg!(target_os = "linux") && cli.is_inc_buf_allowed() {
         let recv_buf_size = socket_factory::RECV_BUFFER_SIZE;


### PR DESCRIPTION
For consistency between all our platforms, we now spawn a multi-threaded tokio runtime with a single worker thread within the Windows and Linux headless client instead of using the main thread for it. We do the same thing in the FFI layer for Android and MacOS.

This makes performance profiling easier because the threads end up being clearly labelled.

Related: #11943