### PR TITLE
fix(portal): gracefully shutdown postgrex supervisors

### DIFF
--- a/elixir/test/portal/application_test.exs
+++ b/elixir/test/portal/application_test.exs
@@ -41,7 +41,7 @@ defmodule Portal.ApplicationTest do
     end
   end
 
-  # Note: prep_stop/1 cannot be unit tested because it calls
-  # Ecto.Adapters.SQL.disconnect_all/2 which is not supported in the test
+  # Note: prep_stop/1 cannot be easily unit tested because it calls
+  # Supervisor.stop/3 on the Repo processes, which would break the test
   # environment's DBConnection.Ownership sandbox mode.
 end


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/11937 we identified a race condition upon shutdown that caused DBConnection to briefly reconnect while shutting down resulting in a Postgrex crash.

Unfortunately that did not fix the issue because the Supervisor pids were still alive.

In this PR we stop the Repo supervisors cleanly upon Application shutdown so that reconnections are not erroneously attempted.

---

Related: https://github.com/firezone/firezone/pull/11937
