### PR TITLE
chore(portal): stream changes from pg replicas

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -77,7 +77,7 @@ if config_env() == :prod do
         ) ++
         if(env_var_to_config(:database_socket_dir),
           do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
-          else: [{:hostname, env_var_to_config!(:database_host)}]
+          else: [{:hostname, env_var_to_config!(:database_host_replica)}]
         )
 
   config :portal, Portal.Changes.ReplicationConnection,
@@ -103,7 +103,7 @@ if config_env() == :prod do
         ) ++
         if(env_var_to_config(:database_socket_dir),
           do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
-          else: [{:hostname, env_var_to_config!(:database_host)}]
+          else: [{:hostname, env_var_to_config!(:database_host_replica)}]
         )
 
   config :portal, Portal.Tokens,


### PR DESCRIPTION
Postgres 17 supports streaming changes from replicas directly instead of the primary. This avoids a potential race where an API node may receive a Change from the primary before the replica has received it, which would cause an issue if we needed to go back to the replica for hydration.
