### PR TITLE
fix(gui-client): set initial system resolvers on tunnel

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -108,12 +108,13 @@ impl Eventloop {
         let (portal_event_tx, portal_event_rx) = mpsc::channel(128);
         let (portal_cmd_tx, portal_cmd_rx) = mpsc::channel(128);
 
-        let tunnel = ClientTunnel::new(
+        let mut tunnel = ClientTunnel::new(
             tcp_socket_factory,
             udp_socket_factory.clone(),
             DNS_RESOURCE_RECORDS_CACHE.lock().clone(),
             is_internet_resource_active,
         );
+        tunnel.update_system_resolvers(dns_servers.clone());
 
         tokio::spawn(phoenix_channel_event_loop(
             portal,


### PR DESCRIPTION
In #11694, we refactored the DNS resolution of the portal's hostname to be fully independent of the `libc` APIs by always explicitly sending UDP DNS queries instead via a routing-loop protected socket. To ensure the initial connection attempt to the portal is successful, we are now also passing the system resolvers via the constructor of `Tunnel` instead of calling `set_dns` directly after.

Due to the differences in how the various platforms monitor the system resolvers, this created a bug in the GUI client where we missed to set the initial system resolvers also on the tunnel. As a result, DNS resources would not work until we processed at least 1 change event from the system DNS notifier task.

Luckily, this only affects the Linux GUI client, which has not been released yet since #11694:

- The macOS and Android clients still rely on the initial `set_dns` call to initialize the resolvers.
- The headless client does not proactively watch for system resolver changes and instead reads and sets them on an interval.
- The Windows client appears to trigger a call to `set_dns` during startup, also masking the problem.