### PR TITLE
fix(apple): use throwing Swift API for writing files

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -128,7 +128,7 @@ public final class Log {
 
 /// Thread-safe: All mutable state access is serialised through workQueue.
 /// Log writes are queued asynchronously to avoid blocking the caller.
-private final class LogWriter: @unchecked Sendable {
+internal final class LogWriter: @unchecked Sendable {
   enum Severity: String {
     case trace = "TRACE"
     case debug = "DEBUG"
@@ -192,7 +192,7 @@ private final class LogWriter: @unchecked Sendable {
   }
 
   // Returns a valid file handle, recreating file if necessary
-  private func ensureFileExists() -> FileHandle? {
+  internal func ensureFileExists() -> FileHandle? {
     let fileManager = FileManager.default
 
     // Check if current file still exists

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -230,7 +230,7 @@ internal final class LogWriter: @unchecked Sendable {
       guard let self = self else { return }
       guard let handle = self.ensureFileExists() else { return }
 
-      handle.write(Data(line.utf8))
+      try? handle.write(contentsOf: Data(line.utf8))
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -128,7 +128,7 @@ public final class Log {
 
 /// Thread-safe: All mutable state access is serialised through workQueue.
 /// Log writes are queued asynchronously to avoid blocking the caller.
-internal final class LogWriter: @unchecked Sendable {
+final class LogWriter: @unchecked Sendable {
   enum Severity: String {
     case trace = "TRACE"
     case debug = "DEBUG"
@@ -192,7 +192,7 @@ internal final class LogWriter: @unchecked Sendable {
   }
 
   // Returns a valid file handle, recreating file if necessary
-  internal func ensureFileExists() -> FileHandle? {
+  func ensureFileExists() -> FileHandle? {
     let fileManager = FileManager.default
 
     // Check if current file still exists

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/LogWriterTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/LogWriterTests.swift
@@ -1,0 +1,47 @@
+//
+//  LogWriterTests.swift
+//  (c) 2024 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import OSLog
+import Testing
+
+@testable import FirezoneKit
+
+@Suite("LogWriter Tests")
+struct LogWriterTests {
+
+  @Test("LogWriter doesn't crash when handle is closed during writes")
+  func doesntCrashWhenHandleClosedDuringWrites() async throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let logger = Logger(subsystem: "dev.firezone.firezone", category: "test")
+    guard let writer = LogWriter(folderURL: tempDir, logger: logger) else {
+      Issue.record("Failed to create LogWriter")
+      return
+    }
+
+    // Trigger race condition: close handle while writes are in flight
+    await withTaskGroup(of: Void.self) { group in
+      // Writer task: queue many writes
+      group.addTask {
+        for i in 0..<10000 {
+          writer.write(severity: .info, message: "Message \(i)")
+        }
+      }
+
+      // Closer task: grab handle via ensureFileExists and close it
+      group.addTask {
+        try? await Task.sleep(for: .milliseconds(5))
+        if let handle = writer.ensureFileExists() {
+          try? handle.close()
+        }
+      }
+    }
+  }
+}

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,11 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="11988">
+          Fixes a crash if the currently active log file gets deleted.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.13" date={new Date("2026-01-30")}>
         <ChangeItem pull="11901">
           Fixes an issue where the tunnel may not come up after a fresh install


### PR DESCRIPTION
The `FileHandle::write` API is deprecated and throws `NSException`s which are not catch-able in Swift. To avoid race-conditions when the file gets deleted after we have obtained the handle, we switch to the non-deprecated API and silence the error with `try?`.

Resolves: #11983