### PR TITLE
chore(swift): don't use `FileHandle::write`

### DIFF
--- a/swift/apple/.swiftlint.yml
+++ b/swift/apple/.swiftlint.yml
@@ -148,5 +148,10 @@ custom_rules:
     regex: 'DispatchQueue\.main\.sync'
     message: "DispatchQueue.main.sync can deadlock - use async or MainActor"
     severity: error
+  avoid_file_handle_write:
+    name: "FileHandle.write is dangerous"
+    regex: '(handle|fileHandle)\.write\((?!contentsOf:)'
+    message: "'write' can throw uncatchable NSExceptions"
+    severity: error
 
 reporter: xcode

--- a/swift/apple/.swiftlint.yml
+++ b/swift/apple/.swiftlint.yml
@@ -151,7 +151,7 @@ custom_rules:
   avoid_file_handle_write:
     name: "FileHandle.write is dangerous"
     regex: '(handle|fileHandle)\.write\((?!contentsOf:)'
-    message: "'write' can throw uncatchable NSExceptions"
+    message: "'write' can throw uncatchable NSExceptions  - prefer `.write(contentsOf:)`"
     severity: error
 
 reporter: xcode

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -136,7 +136,7 @@ enum IPCClient {
       let chunk = try await nextChunk()
 
       try fileHandle.seekToEnd()
-      fileHandle.write(chunk.data)
+      try fileHandle.write(contentsOf: chunk.data)
 
       if chunk.done { break }
     }


### PR DESCRIPTION
Motivated by #11983, we also remove the use of `FileHandle::write` inside the `IPCClient` class. To ensure this doesn't regress, we add a custom swiftlint rule that reminds us to not use this API.