### PR TITLE
fix(portal): faster dead node detection

### DIFF
--- a/elixir/rel/vm.args.eex
+++ b/elixir/rel/vm.args.eex
@@ -1,6 +1,21 @@
 # Customize flags given to the VM: http://erlang.org/doc/man/erl.html
 # -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
 
+# Erlang distribution tick time - controls dead node detection speed.
+#
+# Erlang sends "ticks" between connected nodes. If 4 consecutive ticks are
+# missed, the node is considered dead and disconnected. With the default
+# net_ticktime of 60s, dead nodes take ~4 minutes to detect.
+#
+# We reduce this to 15s so dead nodes are detected in ~60 seconds. This is
+# important during rolling deployments when VMs are terminated - faster
+# detection means the cluster stabilizes more quickly and avoids prolonged
+# partition detection by the `global` module.
+#
+# Trade-off: More sensitive to transient network issues. 15s is still
+# conservative enough for cloud environments with occasional packet loss.
+-kernel net_ticktime 15
+
 # Number of dirty schedulers doing IO work (file, sockets, and others)
 #
 # Interacting with the file system usually goes through the async pool.


### PR DESCRIPTION
When old nodes are destroyed without gracefully shutting down, it currently takes the Erlang cluster up to ~4 minutes to disconnect them from the cluster. To decrease this we can decrease the tick time to 15s from 60s which will detect dead nodes sooner.

The downside here is a slightly chattier message bus, but this is not a major concern given the connection reliability between nodes.
