### PR TITLE
fix(portal): log limits exceeded once

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -8,6 +8,7 @@ Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 SQL.Query: SQL injection,lib/portal/safe.ex:344,2C3D7F0
 SQL.Query: SQL injection,lib/portal/safe.ex:350,3C9C61F
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
+DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:92,43C74D4
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:72,476160D
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
@@ -24,7 +25,6 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:69,696A7C1
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
 Config.Secrets: Hardcoded Secret,config/config.exs:221,6D192B
-DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:127,6E6B215
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619

--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -88,41 +88,6 @@ defmodule Portal.Account do
   def active?(%__MODULE__{disabled_at: nil}), do: true
   def active?(%__MODULE__{}), do: false
 
-  @doc """
-  Returns true if any billing limit is exceeded.
-  """
-  @spec any_limit_exceeded?(t()) :: boolean()
-  def any_limit_exceeded?(%__MODULE__{} = account) do
-    account.users_limit_exceeded or
-      account.seats_limit_exceeded or
-      account.service_accounts_limit_exceeded or
-      account.sites_limit_exceeded or
-      account.admins_limit_exceeded
-  end
-
-  @doc """
-  Builds a human-readable warning message from the exceeded limit flags.
-  Returns nil if no limits are exceeded.
-  """
-  @spec build_limits_exceeded_message(t()) :: String.t() | nil
-  def build_limits_exceeded_message(%__MODULE__{} = account) do
-    limits =
-      []
-      |> maybe_add("users", account.users_limit_exceeded)
-      |> maybe_add("monthly active users", account.seats_limit_exceeded)
-      |> maybe_add("service accounts", account.service_accounts_limit_exceeded)
-      |> maybe_add("sites", account.sites_limit_exceeded)
-      |> maybe_add("account admins", account.admins_limit_exceeded)
-
-    case limits do
-      [] -> nil
-      limits -> "You have exceeded the following limits: #{Enum.join(limits, ", ")}"
-    end
-  end
-
-  defp maybe_add(list, label, true), do: list ++ [label]
-  defp maybe_add(list, _label, false), do: list
-
   for feature <- Portal.Accounts.Features.__schema__(:fields) do
     def unquote(:"#{feature}_enabled?")(account) do
       Config.global_feature_enabled?(unquote(feature)) and

--- a/elixir/lib/portal/mailer/notifications.ex
+++ b/elixir/lib/portal/mailer/notifications.ex
@@ -27,10 +27,18 @@ defmodule Portal.Mailer.Notifications do
     )
   end
 
-  def limits_exceeded_email(warning, email) do
+  def limits_exceeded_email(account, warning, email) do
+    billing_url = url(~p"/#{account.id}/settings/billing")
+    plan_type = Portal.Billing.plan_type(account)
+
     default_email()
     |> subject("Firezone Account Limits Exceeded")
     |> to(email)
-    |> render_body(__MODULE__, :limits_exceeded, warning: warning)
+    |> render_body(__MODULE__, :limits_exceeded,
+      account: account,
+      warning: warning,
+      billing_url: billing_url,
+      plan_type: plan_type
+    )
   end
 end

--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
@@ -71,16 +71,14 @@
                     Account Limits Exceeded
                   </h1>
                   <p style="margin: 0; line-height: 24px">
-                    Your Firezone account has exceeded the following limits:
+                    Your Firezone account <strong><%= @account.slug %></strong> (<code style="font-size: 12px; background-color: #f3f4f6; padding: 2px 4px; border-radius: 3px;"><%= @account.id %></code>) has exceeded the following limits:
                   </p>
                   <div role="separator" style="line-height: 16px">&zwj;</div>
-                  <p style="margin: 0; padding: 16px; background-color: #fef2f2; border-radius: 4px; color: #991b1b; font-weight: 500; line-height: 24px">
-                    <%= @warning %>
-                  </p>
-                  <div role="separator" style="line-height: 16px">&zwj;</div>
-                  <p style="margin: 0; line-height: 24px">
-                    Please upgrade your plan or remove resources to resolve this issue.
-                  </p>
+                  <div style="margin: 0; padding: 16px; background-color: #fef2f2; border-radius: 4px; color: #991b1b; font-weight: 500; line-height: 24px">
+                    <%= for line <- String.split(@warning, "\n") do %>
+                      <div><%= line %></div>
+                    <% end %>
+                  </div>
                   <div role="separator" class="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0">&zwj;</div>
                   <p style="margin: 0 0 16px 0; line-height: 24px;">
                     <span style="font-weight: 600">What happens next?</span>
@@ -94,11 +92,26 @@
                   <p style="margin: 0 0 16px 0; line-height: 24px;">
                     <span style="font-weight: 600">To resolve this:</span>
                   </p>
+                  <%= case @plan_type do %>
+                  <% :enterprise -> %>
+                  <p style="margin: 0; line-height: 24px">
+                    Please contact your account manager to increase these limits, or remove excess resources to get back within your current limits.
+                  </p>
+                  <% :team -> %>
+                  <p style="margin: 0; line-height: 24px">
+                    You can change your paid users by going to <a href="<%= @billing_url %>" style="color: #5e00d6; text-decoration: none;">Settings &rarr; Billing</a> in the admin portal and clicking the "Manage" button in the upper-right. Or remove excess resources to get back within your current limits.
+                  </p>
+                  <% :starter -> %>
+                  <p style="margin: 0; line-height: 24px">
+                    You can upgrade to Team by going to <a href="<%= @billing_url %>" style="color: #5e00d6; text-decoration: none;">Settings &rarr; Billing</a> in the admin portal. Or remove excess resources to get back within your current limits.
+                  </p>
+                  <% _ -> %>
                   <ol style="margin: 0; padding-left: 24px; line-height: 24px">
                     <li>Log into your Firezone admin portal</li>
-                    <li>Navigate to Settings -> Billing to upgrade your plan</li>
+                    <li>Navigate to <a href="<%= @billing_url %>" style="color: #5e00d6; text-decoration: none;">Settings &rarr; Billing</a> to upgrade your plan</li>
                     <li>Or remove excess resources to get back within your limits</li>
                   </ol>
+                  <% end %>
                   <div role="separator" style="line-height: 24px">&zwj;</div>
                   <p style="margin: 0; line-height: 24px">
                     If you have any questions, please contact our support team.

--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.text.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.text.eex
@@ -1,20 +1,30 @@
 Account Limits Exceeded
 
-Your Firezone account has exceeded the following limits:
+Your Firezone account "<%= @account.slug %>" (<%= @account.id %>) has exceeded the following limits:
 
 <%= @warning %>
-
-Please upgrade your plan or remove resources to resolve this issue.
 
 What happens next?
 - Your existing connections will continue to work
 - New client sign-ins will be blocked until limits are resolved
 - Account administrators can still access the admin portal
 
+<%= case @plan_type do %>
+<% :enterprise -> %>
+To resolve this:
+Please contact your account manager to increase these limits, or remove excess resources to get back within your current limits.
+<% :team -> %>
+To resolve this:
+You can change your paid users by going to Settings -> Billing (<%= @billing_url %>) in the admin portal and clicking the "Manage" button in the upper-right. Or remove excess resources to get back within your current limits.
+<% :starter -> %>
+To resolve this:
+You can upgrade to Team by going to Settings -> Billing (<%= @billing_url %>) in the admin portal. Or remove excess resources to get back within your current limits.
+<% _ -> %>
 To resolve this:
 1. Log into your Firezone admin portal
-2. Navigate to Settings -> Billing to upgrade your plan
+2. Navigate to Settings -> Billing (<%= @billing_url %>) to upgrade your plan
 3. Or remove excess resources to get back within your limits
+<% end %>
 
 If you have any questions, please contact our support team.
 

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -94,7 +94,6 @@ defmodule PortalAPI.Client.Socket do
     with {:ok, %{credential: %{type: :client_token, id: token_id}} = subject} <-
            Authentication.authenticate(token, context),
          false <- Portal.Billing.client_connect_restricted?(subject.account),
-         :ok = Portal.Billing.log_seats_limit_exceeded(subject.account, subject.actor.id),
          changeset = upsert_changeset(subject.actor, subject, attrs),
          {:ok, client} <- Database.upsert_client(changeset, subject) do
       OpenTelemetry.Tracer.set_attributes(%{

--- a/elixir/lib/portal_web/components/layouts/app.html.heex
+++ b/elixir/lib/portal_web/components/layouts/app.html.heex
@@ -117,8 +117,8 @@
   >
     {Phoenix.HTML.raw(banner.message)}
   </div>
-  <.flash :if={Portal.Account.any_limit_exceeded?(@account)} kind={:warning} class="m-1">
-    {Portal.Account.build_limits_exceeded_message(@account)}.
+  <.flash :if={Portal.Billing.any_limit_exceeded?(@account)} kind={:warning} class="m-1">
+    {Portal.Billing.build_limits_exceeded_message(@account)}.
     <span :if={Portal.Billing.account_provisioned?(@account)}>
       Please
       <.link navigate={~p"/#{@account}/settings/billing"} class={link_style()}>

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -76,7 +76,6 @@ defmodule PortalWeb.EmailOTPController do
              entered_code
            ),
          :ok <- check_admin(passcode.actor, context_type),
-         :ok = log_seats_limit_exceeded(account, passcode.actor, context_type),
          {:ok, session_or_token} <-
            create_session_or_token(conn, passcode.actor, provider, params) do
       {:ok,
@@ -182,13 +181,6 @@ defmodule PortalWeb.EmailOTPController do
   end
 
   defp client_sign_in_restricted?(_account, _context_type), do: false
-
-  defp log_seats_limit_exceeded(account, actor, context_type)
-       when context_type in [:gui_client, :headless_client] do
-    Portal.Billing.log_seats_limit_exceeded(account, actor.id)
-  end
-
-  defp log_seats_limit_exceeded(_account, _actor, _context_type), do: :ok
 
   defp create_session_or_token(conn, actor, provider, params) do
     user_agent = conn.assigns[:user_agent]

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -67,7 +67,6 @@ defmodule PortalWeb.OIDCController do
          userinfo = fetch_userinfo(provider, tokens["access_token"]),
          {:ok, identity} <- upsert_identity(account, claims, userinfo),
          :ok <- check_admin(identity, context_type),
-         :ok = log_seats_limit_exceeded(account, identity, context_type),
          {:ok, session_or_token} <-
            create_session_or_token(conn, identity, provider, cookie.params) do
       signed_in(
@@ -411,13 +410,6 @@ defmodule PortalWeb.OIDCController do
   end
 
   defp client_sign_in_restricted?(_account, _context_type), do: false
-
-  defp log_seats_limit_exceeded(account, identity, context_type)
-       when context_type in [:gui_client, :headless_client] do
-    Portal.Billing.log_seats_limit_exceeded(account, identity.actor_id)
-  end
-
-  defp log_seats_limit_exceeded(_account, _identity, _context_type), do: :ok
 
   defp create_session_or_token(conn, identity, provider, params) do
     user_agent = conn.assigns[:user_agent]

--- a/elixir/lib/portal_web/controllers/userpass_controller.ex
+++ b/elixir/lib/portal_web/controllers/userpass_controller.ex
@@ -30,7 +30,6 @@ defmodule PortalWeb.UserpassController do
          %Portal.Actor{} = actor <- fetch_actor(account, email),
          :ok <- check_admin(actor, context_type),
          {:ok, actor, _expires_at} <- verify_password(actor, password, conn),
-         :ok = log_seats_limit_exceeded(account, actor, context_type),
          {:ok, session_or_token} <- create_session_or_token(conn, actor, provider, params) do
       signed_in(conn, context_type, account, actor, session_or_token, params)
     else
@@ -72,13 +71,6 @@ defmodule PortalWeb.UserpassController do
   end
 
   defp client_sign_in_restricted?(_account, _context_type), do: false
-
-  defp log_seats_limit_exceeded(account, actor, context_type)
-       when context_type in [:gui_client, :headless_client] do
-    Portal.Billing.log_seats_limit_exceeded(account, actor.id)
-  end
-
-  defp log_seats_limit_exceeded(_account, _actor, _context_type), do: :ok
 
   defp create_session_or_token(conn, actor, provider, params) do
     user_agent = conn.assigns[:user_agent]

--- a/elixir/test/portal/billing/event_handler_test.exs
+++ b/elixir/test/portal/billing/event_handler_test.exs
@@ -371,7 +371,7 @@ defmodule Portal.Billing.EventHandlerTest do
 
       # Limit flags should be cleared after subscription update
       updated = Portal.Repo.get!(Portal.Account, account.id)
-      refute Portal.Account.any_limit_exceeded?(updated)
+      refute Portal.Billing.any_limit_exceeded?(updated)
     end
 
     test "sets account limit flags when subscription update results in exceeded limits", %{
@@ -384,7 +384,7 @@ defmodule Portal.Billing.EventHandlerTest do
       Portal.ActorFixtures.actor_fixture(account: account, type: :account_user)
 
       # Account starts with no limit flags set
-      refute Portal.Account.any_limit_exceeded?(account)
+      refute Portal.Billing.any_limit_exceeded?(account)
 
       # Process subscription update with low limits (1 user)
       {product, _price, subscription} =

--- a/elixir/test/portal/billing_test.exs
+++ b/elixir/test/portal/billing_test.exs
@@ -460,34 +460,6 @@ defmodule Portal.BillingTest do
     end
   end
 
-  describe "log_seats_limit_exceeded/2" do
-    test "logs error when seats_limit_exceeded is true", %{account: account} do
-      account = update_account(account, %{seats_limit_exceeded: true})
-      actor = actor_fixture(account: account)
-
-      log =
-        capture_log(fn ->
-          assert log_seats_limit_exceeded(account, actor.id) == :ok
-        end)
-
-      assert log =~ "Account seats limit exceeded"
-      assert log =~ "account_id=#{account.id}"
-      assert log =~ "account_slug=#{account.slug}"
-      assert log =~ "actor_id=#{actor.id}"
-    end
-
-    test "does not log when seats_limit_exceeded is false", %{account: account} do
-      actor = actor_fixture(account: account)
-
-      log =
-        capture_log(fn ->
-          assert log_seats_limit_exceeded(account, actor.id) == :ok
-        end)
-
-      refute log =~ "Account seats limit exceeded"
-    end
-  end
-
   describe "client_connect_restricted?/1" do
     test "returns false when no limits are exceeded", %{account: account} do
       refute client_connect_restricted?(account)
@@ -807,6 +779,239 @@ defmodule Portal.BillingTest do
                Portal.Billing.billing_portal_url(account, "https://example.com", subject)
 
       assert url =~ "billing.stripe.com"
+    end
+  end
+
+  describe "Database.count_users_for_account/1" do
+    test "counts enabled users and admin users", %{account: account} do
+      actor_fixture(type: :account_user, account: account)
+      actor_fixture(type: :account_user, account: account)
+      actor_fixture(type: :account_admin_user, account: account)
+
+      assert Portal.Billing.Database.count_users_for_account(account) == 3
+    end
+
+    test "excludes disabled users", %{account: account} do
+      actor_fixture(type: :account_user, account: account)
+      disabled_actor_fixture(type: :account_user, account: account)
+
+      assert Portal.Billing.Database.count_users_for_account(account) == 1
+    end
+
+    test "excludes service accounts", %{account: account} do
+      actor_fixture(type: :account_user, account: account)
+      actor_fixture(type: :service_account, account: account)
+
+      assert Portal.Billing.Database.count_users_for_account(account) == 1
+    end
+
+    test "excludes api clients", %{account: account} do
+      actor_fixture(type: :account_user, account: account)
+      api_client_fixture(account: account)
+
+      assert Portal.Billing.Database.count_users_for_account(account) == 1
+    end
+
+    test "returns 0 for account with no users", %{account: account} do
+      assert Portal.Billing.Database.count_users_for_account(account) == 0
+    end
+  end
+
+  describe "Database.count_service_accounts_for_account/1" do
+    test "counts enabled service accounts", %{account: account} do
+      actor_fixture(type: :service_account, account: account)
+      actor_fixture(type: :service_account, account: account)
+
+      assert Portal.Billing.Database.count_service_accounts_for_account(account) == 2
+    end
+
+    test "excludes disabled service accounts", %{account: account} do
+      actor_fixture(type: :service_account, account: account)
+      disabled_actor_fixture(type: :service_account, account: account)
+
+      assert Portal.Billing.Database.count_service_accounts_for_account(account) == 1
+    end
+
+    test "excludes users and admin users", %{account: account} do
+      actor_fixture(type: :service_account, account: account)
+      actor_fixture(type: :account_user, account: account)
+      actor_fixture(type: :account_admin_user, account: account)
+
+      assert Portal.Billing.Database.count_service_accounts_for_account(account) == 1
+    end
+
+    test "returns 0 for account with no service accounts", %{account: account} do
+      assert Portal.Billing.Database.count_service_accounts_for_account(account) == 0
+    end
+  end
+
+  describe "Database.count_account_admin_users_for_account/1" do
+    test "counts enabled admin users", %{account: account} do
+      actor_fixture(type: :account_admin_user, account: account)
+      actor_fixture(type: :account_admin_user, account: account)
+
+      assert Portal.Billing.Database.count_account_admin_users_for_account(account) == 2
+    end
+
+    test "excludes disabled admin users", %{account: account} do
+      actor_fixture(type: :account_admin_user, account: account)
+      disabled_actor_fixture(type: :account_admin_user, account: account)
+
+      assert Portal.Billing.Database.count_account_admin_users_for_account(account) == 1
+    end
+
+    test "excludes regular users", %{account: account} do
+      actor_fixture(type: :account_admin_user, account: account)
+      actor_fixture(type: :account_user, account: account)
+
+      assert Portal.Billing.Database.count_account_admin_users_for_account(account) == 1
+    end
+
+    test "returns 0 for account with no admin users", %{account: account} do
+      assert Portal.Billing.Database.count_account_admin_users_for_account(account) == 0
+    end
+  end
+
+  describe "Database.count_1m_active_users_for_account/1" do
+    test "counts distinct active users within last month", %{account: account} do
+      actor1 = actor_fixture(type: :account_user, account: account)
+      actor2 = actor_fixture(type: :account_admin_user, account: account)
+
+      # Create clients seen within last month
+      client_fixture(account: account, actor: actor1)
+      client_fixture(account: account, actor: actor2)
+
+      assert Portal.Billing.Database.count_1m_active_users_for_account(account) == 2
+    end
+
+    test "counts user only once even with multiple clients", %{account: account} do
+      actor = actor_fixture(type: :account_user, account: account)
+
+      # Same actor with multiple clients
+      client_fixture(account: account, actor: actor)
+      client_fixture(account: account, actor: actor)
+
+      assert Portal.Billing.Database.count_1m_active_users_for_account(account) == 1
+    end
+
+    test "excludes users not seen in last month", %{account: account} do
+      actor1 = actor_fixture(type: :account_user, account: account)
+      actor2 = actor_fixture(type: :account_user, account: account)
+
+      # Actor1 seen recently
+      client_fixture(account: account, actor: actor1)
+
+      # Actor2 seen more than a month ago
+      client =
+        client_fixture(account: account, actor: actor2)
+
+      client
+      |> Ecto.Changeset.change(last_seen_at: DateTime.add(DateTime.utc_now(), -35, :day))
+      |> Portal.Repo.update!()
+
+      assert Portal.Billing.Database.count_1m_active_users_for_account(account) == 1
+    end
+
+    test "excludes disabled users", %{account: account} do
+      actor = actor_fixture(type: :account_user, account: account)
+      disabled_actor = disabled_actor_fixture(type: :account_user, account: account)
+
+      client_fixture(account: account, actor: actor)
+      client_fixture(account: account, actor: disabled_actor)
+
+      assert Portal.Billing.Database.count_1m_active_users_for_account(account) == 1
+    end
+
+    test "excludes service accounts", %{account: account} do
+      user = actor_fixture(type: :account_user, account: account)
+      service_account = actor_fixture(type: :service_account, account: account)
+
+      client_fixture(account: account, actor: user)
+      client_fixture(account: account, actor: service_account)
+
+      # Only the user should be counted, not the service account
+      assert Portal.Billing.Database.count_1m_active_users_for_account(account) == 1
+    end
+
+    test "returns 0 for account with no active users", %{account: account} do
+      assert Portal.Billing.Database.count_1m_active_users_for_account(account) == 0
+    end
+  end
+
+  describe "Database.count_sites_for_account/1" do
+    test "counts account-managed sites", %{account: account} do
+      site_fixture(account: account, managed_by: :account)
+      site_fixture(account: account, managed_by: :account)
+
+      assert Portal.Billing.Database.count_sites_for_account(account) == 2
+    end
+
+    test "excludes system-managed sites", %{account: account} do
+      site_fixture(account: account, managed_by: :account)
+      site_fixture(account: account, managed_by: :system)
+
+      assert Portal.Billing.Database.count_sites_for_account(account) == 1
+    end
+
+    test "returns 0 for account with no sites", %{account: account} do
+      assert Portal.Billing.Database.count_sites_for_account(account) == 0
+    end
+  end
+
+  describe "Database.count_api_clients_for_account/1" do
+    test "counts enabled API clients", %{account: account} do
+      api_client_fixture(account: account)
+      api_client_fixture(account: account)
+
+      assert Portal.Billing.Database.count_api_clients_for_account(account) == 2
+    end
+
+    test "excludes disabled API clients", %{account: account} do
+      api_client_fixture(account: account)
+      disabled_actor_fixture(type: :api_client, account: account)
+
+      assert Portal.Billing.Database.count_api_clients_for_account(account) == 1
+    end
+
+    test "excludes users and service accounts", %{account: account} do
+      api_client_fixture(account: account)
+      actor_fixture(type: :account_user, account: account)
+      actor_fixture(type: :service_account, account: account)
+
+      assert Portal.Billing.Database.count_api_clients_for_account(account) == 1
+    end
+
+    test "returns 0 for account with no API clients", %{account: account} do
+      assert Portal.Billing.Database.count_api_clients_for_account(account) == 0
+    end
+  end
+
+  describe "Database.count_api_tokens_for_actor/1" do
+    test "counts tokens for the given actor", %{account: account} do
+      api_client = api_client_fixture(account: account)
+
+      api_token_fixture(account: account, actor: api_client)
+      api_token_fixture(account: account, actor: api_client)
+
+      assert Portal.Billing.Database.count_api_tokens_for_actor(api_client) == 2
+    end
+
+    test "does not count tokens from other actors", %{account: account} do
+      api_client1 = api_client_fixture(account: account)
+      api_client2 = api_client_fixture(account: account)
+
+      api_token_fixture(account: account, actor: api_client1)
+      api_token_fixture(account: account, actor: api_client2)
+      api_token_fixture(account: account, actor: api_client2)
+
+      assert Portal.Billing.Database.count_api_tokens_for_actor(api_client1) == 1
+      assert Portal.Billing.Database.count_api_tokens_for_actor(api_client2) == 2
+    end
+
+    test "returns 0 for actor with no tokens", %{account: account} do
+      api_client = api_client_fixture(account: account)
+
+      assert Portal.Billing.Database.count_api_tokens_for_actor(api_client) == 0
     end
   end
 end

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -304,7 +304,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert connect(Socket, attrs, connect_info: connect_info) == {:error, :limits_exceeded}
     end
 
-    test "logs error and allows connection when seats_limit_exceeded is true" do
+    test "allows connection when seats_limit_exceeded is true (soft limit)" do
       account = account_fixture()
       update_account(account, %{seats_limit_exceeded: true})
 
@@ -315,15 +315,7 @@ defmodule PortalAPI.Client.SocketTest do
       attrs = connect_attrs(token: encoded_token)
       connect_info = build_connect_info(token: encoded_token)
 
-      log =
-        capture_log(fn ->
-          assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
-        end)
-
-      assert log =~ "Account seats limit exceeded"
-      assert log =~ "account_id=#{account.id}"
-      assert log =~ "account_slug=#{account.slug}"
-      assert log =~ "actor_id=#{actor.id}"
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
     end
 
     test "returns error when service_accounts_limit_exceeded is true" do

--- a/elixir/test/portal_web/controllers/userpass_controller_test.exs
+++ b/elixir/test/portal_web/controllers/userpass_controller_test.exs
@@ -267,7 +267,7 @@ defmodule PortalWeb.UserpassControllerTest do
       assert flash(conn, :error) =~ "exceeding billing limits"
     end
 
-    test "logs error and allows gui-client sign-in when account has exceeded monthly active users limits",
+    test "allows gui-client sign-in when account has exceeded monthly active users limits (soft limit)",
          %{
            conn: conn,
            account: account,
@@ -283,25 +283,17 @@ defmodule PortalWeb.UserpassControllerTest do
           password_hash
         )
 
-      log =
-        capture_log(fn ->
-          conn =
-            post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
-              "userpass" => %{"idp_id" => actor.email, "secret" => @password},
-              "as" => "gui-client",
-              "state" => "test-state",
-              "nonce" => "test-nonce"
-            })
+      # Sign-in should still succeed since seats is a soft limit
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "as" => "gui-client",
+          "state" => "test-state",
+          "nonce" => "test-nonce"
+        })
 
-          # Sign-in should still succeed
-          assert conn.status == 200
-          assert conn.resp_body =~ "client_redirect"
-        end)
-
-      assert log =~ "Account seats limit exceeded"
-      assert log =~ "account_id=#{account.id}"
-      assert log =~ "account_slug=#{account.slug}"
-      assert log =~ "actor_id=#{actor.id}"
+      assert conn.status == 200
+      assert conn.resp_body =~ "client_redirect"
     end
 
     test "rejects headless-client sign-in when account has exceeded limits", %{


### PR DESCRIPTION
In #11941 we introduced logging around when sign-ins for Enterprise accounts when they were over their limit. Unfortunately this results in lots of log spam.

In this PR we switch that to log only when the threshold is crossed.

We also introduce a few QoL improvements in the notification email:

- show `used / paid` counts
- show the account id and slug
- show an action item for fixing the issue
