### PR TITLE
fix(portal): fail stripe webhook if processing fails

### DIFF
--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -501,7 +501,12 @@ defmodule Portal.Billing do
   end
 
   def handle_events(events) when is_list(events) do
-    Enum.each(events, &EventHandler.handle_event/1)
+    Enum.reduce_while(events, :ok, fn event, :ok ->
+      case EventHandler.handle_event(event) do
+        {:ok, _event} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
   end
 
   defp fetch_config!(key) do


### PR DESCRIPTION
When processing a Stripe webhook, we need to hit Stripe's API to get the product details / metadata in order to potentially update an account with any updated subscription-related info (e.g. limits).

If any of these Stripe API calls failed (which they do from time to time), we would return 200 but then also failed to insert these into `stripe_processed_events`, meaning the update could get silently swallowed.

In one customer's case, it looks like the plan change updated their account properly but some of the limits did not get successfully applied, resulting in a support ticket.

---

Related: https://app.hubspot.com/live-messages/23723443/inbox/10376784295
