### PR TITLE
build(deps): bump bytes 1.11.0 -> 1.11.1 in rust/

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1057,9 +1057,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -3654,7 +3654,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -66,7 +66,7 @@ bnum = "0.13.0"
 boringtun = { version = "0.6.0", default-features = false }
 bufferpool = { path = "libs/connlib/bufferpool" }
 bytecodec = "0.5.0"
-bytes = { version = "1.11.0", default-features = false }
+bytes = { version = "1.11.1", default-features = false }
 caps = "0.5.6"
 chrono = { version = "0.4.43", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
 clap = "4.5.56"


### PR DESCRIPTION

---

Related: https://rustsec.org/advisories/RUSTSEC-2026-0007.html
