### PR TITLE
chore(ci): don't tag ghcr.io images with staging

### DIFF
--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -89,6 +89,5 @@ jobs:
           tags: |
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ inputs.sha }}
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
-            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:staging
           labels: |
             org.opencontainers.image.revision=${{ inputs.sha }}


### PR DESCRIPTION
These tags will instead be added to the new Azure container registry we are setting up which staging and production will pull from.