### PR TITLE
chore: gate test function to avoid warning

### DIFF
--- a/rust/libs/connlib/tunnel/src/client/dns_config.rs
+++ b/rust/libs/connlib/tunnel/src/client/dns_config.rs
@@ -54,7 +54,7 @@ impl DnsMapping {
     // For such small numbers, linear search is usually more efficient.
     // Most importantly, it is much easier for us to retain the ordering of the DNS servers if we don't use a map.
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "proptest"))]
     pub(crate) fn sentinel_by_upstream(&self, upstream: &dns::Upstream) -> Option<IpAddr> {
         self.inner
             .iter()


### PR DESCRIPTION
This function was only used by proptest, and triggered warnings in rust-analyzer and during normal build (proptest is not enabled by default).

Warning successfully disappears.