### PR TITLE
test(apple): use sorted resolvers in assertion

### DIFF
--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SystemConfigurationResolversTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SystemConfigurationResolversTests.swift
@@ -158,7 +158,7 @@ struct SystemConfigurationResolversTests {
         let isValidIPv6 = IPv6Address(server) != nil
         #expect(isValidIPv4 || isValidIPv6, "'\(server)' should be a valid IPv4 or IPv6 address")
       }
-      #expect(scopedResult == sysConfigResult, "should return same result")
+      #expect(scopedResult.sorted() == sysConfigResult.sorted(), "should return same result")
     }
   #endif
 }


### PR DESCRIPTION
Fixes a flaky test that was occurring locally:


```
􀢄  Test "Both implementations return results for active interface" recorded an issue at SystemConfigurationResolversTests.swift:161:7: Expectation failed: (scopedResult → ["2600:1700:3ecb:2410::1", "192.168.1.254"]) == (sysConfigResult → ["192.168.1.254", "2600:1700:3ecb:2410::1"])
􀅺  inserted ["192.168.1.254"], removed ["192.168.1.254"]
􀄵  should return same result
```
