### PR TITLE
fix(apple): restore CURRENT_PROJECT_VERSION for first build

### DIFF
--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -7,6 +7,10 @@ APP_GROUP_ID[sdk=iphoneos*] = group.dev.firezone.firezone
 APP_GROUP_ID_PRE_1_4_0[sdk=iphoneos*] = group.dev.firezone.firezone
 CODE_SIGN_STYLE = Automatic
 
+// Default build number - will be overridden by dynamic_build_number.xcconfig if it exists
+// This ensures Xcode builds work even on first run before mise creates the dynamic file
+CURRENT_PROJECT_VERSION = 0
+
 // Include the dynamic build number created during the build phase
 #include? "dynamic_build_number.xcconfig"
 


### PR DESCRIPTION
Fixes a regression introduced in 4e61ba958 (#9072) where CURRENT_PROJECT_VERSION became undefined on the first build.

That commit removed the hardcoded `CURRENT_PROJECT_VERSION = 0` in favor of dynamically including it from `dynamic_build_number.xcconfig`. However, that file is created by mise during the build phase, so on the first build it doesn't exist yet. Since `#include?` is optional, Xcode would continue without it, leaving CURRENT_PROJECT_VERSION undefined.

This restores the default value of 0 before the optional include, so:
- First build: uses default value 0 (dynamic file doesn't exist yet)
- Subsequent builds: dynamic file overrides with generated value

Resolves: #12003