### PR TITLE
feat(android): ask for notification permissions

### DIFF
--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -72,6 +72,10 @@
             android:exported="false" />
 
         <activity
+            android:name="dev.firezone.android.features.permission.notification.ui.NotificationPermissionActivity"
+            android:exported="false" />
+
+        <activity
             android:name="dev.firezone.android.features.session.ui.SessionActivity"
             android:exported="false" />
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -345,6 +345,12 @@ class Repository
 
         fun isConnectOnStartManaged(): Boolean = sharedPreferences.contains(MANAGED_CONNECT_ON_START_KEY)
 
+        fun hasRequestedNotificationPermission(): Boolean = sharedPreferences.getBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, false)
+
+        fun setNotificationPermissionRequested() {
+            sharedPreferences.edit().putBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, true).apply()
+        }
+
         companion object {
             private const val AUTH_URL_KEY = "authUrl"
             private const val ACTOR_NAME_KEY = "actorName"
@@ -365,5 +371,6 @@ class Repository
             private const val STATE_KEY = "state"
             private const val DEVICE_ID_KEY = "deviceId"
             private const val ENABLED_INTERNET_RESOURCE_KEY = "enabledInternetResource"
+            private const val NOTIFICATION_PERMISSION_REQUESTED_KEY = "notificationPermissionRequested"
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/permission/notification/ui/NotificationPermissionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/permission/notification/ui/NotificationPermissionActivity.kt
@@ -1,0 +1,69 @@
+// Licensed under Apache 2.0 (C) 2024 Firezone, Inc.
+package dev.firezone.android.features.permission.notification.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.AndroidEntryPoint
+import dev.firezone.android.core.data.Repository
+import dev.firezone.android.databinding.ActivityNotificationPermissionBinding
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class NotificationPermissionActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityNotificationPermissionBinding
+
+    @Inject
+    lateinit var repository: Repository
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            // Mark that we've requested permission regardless of the result
+            repository.setNotificationPermissionRequested()
+            // Always finish - we don't fail if user denies
+            finish()
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityNotificationPermissionBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.btnRequest.setOnClickListener {
+            requestNotificationPermission()
+        }
+
+        binding.btnSkip.setOnClickListener {
+            // Mark as requested even if user skips
+            repository.setNotificationPermissionRequested()
+            finish()
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS,
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    // Permission already granted
+                    repository.setNotificationPermissionRequested()
+                    finish()
+                }
+                else -> {
+                    // Request permission
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+        } else {
+            // Notification permission not needed for Android < 13
+            repository.setNotificationPermissionRequested()
+            finish()
+        }
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -61,6 +61,10 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
                                 findNavController().navigate(
                                     R.id.vpnPermissionActivity,
                                 )
+                            SplashViewModel.ViewAction.NavigateToNotificationPermission ->
+                                findNavController().navigate(
+                                    R.id.notificationPermissionActivity,
+                                )
                             SplashViewModel.ViewAction.NavigateToSignIn ->
                                 findNavController().navigate(
                                     R.id.signInFragment,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -50,7 +50,7 @@ internal class SplashViewModel
 
                 // Check if we need to request notification permission (only once)
                 if (shouldRequestNotificationPermission(context)) {
-                    actionMutableLiveData.postValue(ViewAction.NavigateToNotificationPermission)
+                    actionMutableStateFlow.value = ViewAction.NavigateToNotificationPermission
                     return@launch
                 }
 

--- a/kotlin/android/app/src/main/res/layout/activity_notification_permission.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_notification_permission.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/spacing_medium"
+    tools:context=".features.permission.notification.ui.NotificationPermissionActivity"
+    android:fitsSystemWindows="true">
+
+  <androidx.appcompat.widget.AppCompatImageView
+      android:id="@+id/ivLogo"
+      android:layout_width="@dimen/iv_logo_size"
+      android:layout_height="@dimen/iv_logo_size"
+      android:layout_marginTop="8dp"
+      android:src="@drawable/ic_firezone_logo"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.498"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <com.google.android.material.textview.MaterialTextView
+      style="@style/AppTheme.Base.HeaderText"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:gravity="center"
+      android:text="@string/app_short_name"
+      android:textSize="48sp"
+      app:fontFamily="@font/manrope_bold"
+      app:layout_constraintBottom_toTopOf="@+id/constraintLayout"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/ivLogo" />
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/constraintLayout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:padding="@dimen/spacing_medium"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      tools:ignore="MissingConstraints"
+      tools:layout_editor_absoluteX="16dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tvHeaderTitle"
+        style="@style/AppTheme.Base.H5"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="36dp"
+        android:text="@string/enable_notification_permission"
+        android:textAlignment="center"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tvBody"
+        style="@style/AppTheme.Base.Body1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/notification_permission_description"
+        android:textAlignment="center"
+        app:layout_constraintTop_toBottomOf="@+id/tvHeaderTitle"
+        tools:layout_editor_absoluteX="16dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnRequest"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/request_permission"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvBody" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnSkip"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/skip"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnRequest" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/kotlin/android/app/src/main/res/navigation/app_nav_graph.xml
+++ b/kotlin/android/app/src/main/res/navigation/app_nav_graph.xml
@@ -34,4 +34,8 @@
         android:id="@+id/vpnPermissionActivity"
         android:name="dev.firezone.android.features.permission.vpn.ui.VpnPermissionActivity" />
 
+    <activity
+        android:id="@+id/notificationPermissionActivity"
+        android:name="dev.firezone.android.features.permission.notification.ui.NotificationPermissionActivity" />
+
 </navigation>

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -51,6 +51,13 @@
 		the button below.
 	</string>
 	<string name="request_permission">Request Permission</string>
+	<string name="enable_notification_permission">Enable Notifications</string>
+	<string name="notification_permission_description">
+		Firezone can send notifications to keep you informed about your connection status.
+		This helps you know when you\'re connected to resources and if any issues occur.
+		You can change this later in your device settings.
+	</string>
+	<string name="skip">Skip</string>
 
 	<!-- Managed Configuration -->
 	<string name="config_token_title">Token</string>

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -59,6 +59,9 @@ export default function Android() {
           for IPv4-only DNS resources if the setting was only changed after a
           DNS query had already been processed.
         </ChangeItem>
+        <ChangeItem pull="12013">
+          Asks for notification permissions on launch.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">


### PR DESCRIPTION
Right now, we do not ask for notification permissions on Android. As a result, users are unlikely to actually see the notifications we are sending because they will not just randomly grant the notification permission to our app.

To fix this, we introduce a new splash screen that asks for (optional) notification permissions. The user can skip that if they want to and we won't ask them again then. Notifications are not mandatory for Firezone to function.