### PR TITLE
refactor(android): split tunnel status notification

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
@@ -18,7 +18,7 @@ class NetworkMonitor(
     ) {
         if (tunnelService.tunnelState != TunnelService.Companion.State.UP) {
             tunnelService.tunnelState = TunnelService.Companion.State.UP
-            tunnelService.updateStatusNotification(TunnelStatusNotification.Connected)
+            tunnelService.startConnectedNotification()
         }
 
         if (lastDns != linkProperties.dnsServers) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -287,7 +287,7 @@ class TunnelService : VpnService() {
 
             commandChannel = Channel<TunnelCommand>(Channel.UNLIMITED)
 
-            val context = this;
+            val context = this
 
             serviceScope.launch {
                 try {


### PR DESCRIPTION
Right now, the tunnel status notification on Android has three states:

1. Connecting
2. Connected
3. Disconnected

We align this implementation with how iOS works but also take into account the Android-specific requirements. As a foreground service, we must show a persistent notification to inform the user that our app is still actively doing something. Starting from Android 14+, this notification is dismissable. Dismissing it doesn't stop our service though.

To satisfy this requirement, we only show a "Connected" status notification and send a separate one when we do end up getting disconnected unexpectedly. This is also the behaviour that we have on iOS.