### PR TITLE
chore: add Rust mise tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ experimental_monorepo_root = true
 [monorepo]
 config_roots = [
     "kotlin/android",
+    "rust",
     "swift/apple",
 ]
 

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,3 +1,6 @@
-pnpm             10.18.3
-nodejs           24.13.0
-cargo:cargo-sort 2.0.2
+pnpm               10.18.3
+nodejs             24.13.0
+cargo:cargo-binstall 1.17.4
+cargo:cargo-sort   2.0.2
+cargo:cargo-deny   0.19.0
+cargo:cargo-udeps  0.1.60

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -1,0 +1,53 @@
+# Rust development tasks
+#
+# Usage: mise run <task> (from this directory) or mise //rust:<task> (from repo root)
+
+[env]
+# Match CI environment - enables tokio unstable features and denies warnings
+RUSTFLAGS = "--cfg tokio_unstable --deny warnings"
+# Nightly version used for cargo-udeps (keep in sync with .github/actions/setup-rust-nightly)
+NIGHTLY_VERSION = "nightly-2025-09-30"
+
+# =============================================================================
+# Individual checks (matching CI)
+# =============================================================================
+
+[tasks.fmt]
+description = "Format Rust code"
+run = "cargo fmt"
+
+[tasks.fmt-check]
+description = "Check Rust formatting (CI check)"
+run = "cargo fmt -- --check"
+
+[tasks.clippy]
+description = "Run clippy lints (CI check)"
+run = "cargo clippy --all-targets --all-features"
+
+[tasks.doc]
+description = "Build documentation (CI check)"
+run = "cargo doc --all-features --no-deps --document-private-items"
+
+[tasks.udeps]
+description = "Check for unused dependencies (CI check, requires nightly)"
+run = "cargo +$NIGHTLY_VERSION udeps --all-targets --all-features"
+
+[tasks.deny]
+description = "Check licenses and security advisories (CI check)"
+run = "cargo deny check --hide-inclusion-graph --deny unnecessary-skip"
+
+[tasks.test]
+description = "Run tests (CI check)"
+run = "cargo test --all-features -- --include-ignored --nocapture"
+
+# =============================================================================
+# Composite tasks
+# =============================================================================
+
+[tasks.check]
+description = "Run all CI static analysis checks"
+depends = ["fmt-check", "clippy", "doc", "deny"]
+
+[tasks.check-all]
+description = "Run all CI static analysis checks including udeps (requires nightly)"
+depends = ["fmt-check", "clippy", "doc", "udeps", "deny"]


### PR DESCRIPTION
It makes it much easier to run all the Rust checks that we do on CI locally, and include all the utils.

- Create rust/mise.toml defining tasks mirroring CI checks, including formatting, linting, docs, license/security, and unused dependency checks for local and CI parity
- Set up environment variables in rust/mise.toml to match CI, ensuring consistent builds and linting
- Update rust/.tool-versions to include cargo-binstall, cargo-deny, and cargo-udeps for required tooling in local and CI workflows
- Add composite tasks in rust/mise.toml to run all static analysis checks together for developer convenience

Note: `cargo-binstall` speeds up downloading the other tools, as they don't need to be built from scratch (https://mise.jdx.dev/dev-tools/backends/cargo.html)

