### PR TITLE
fix(gui-client): explicitly catch panics inside `Handler::run`

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -104,6 +104,7 @@ tauri-build = { workspace = true, features = [] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+bin-shared = { workspace = true, features = ["test"] }
 
 [lints]
 workspace = true

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -32,6 +32,7 @@ use std::{
 };
 use telemetry::{Telemetry, analytics};
 use tokio::time::Instant;
+use tracing::Instrument as _;
 use url::Url;
 
 #[cfg(target_os = "linux")]
@@ -67,6 +68,8 @@ pub enum ClientMsg {
         release: String,
         account_slug: Option<String>,
     },
+    #[cfg(debug_assertions)]
+    Panic,
 }
 
 fn serialize_token<S>(token: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
@@ -110,12 +113,17 @@ impl ServerMsg {
 async fn ipc_listen(
     dns_control_method: DnsControlMethod,
     log_filter_reloader: &FilterReloadHandle,
+    socket_id: SocketId,
     signals: &mut signals::Terminate,
 ) -> Result<()> {
     // Create the device ID and Tunnel service config dir if needed
     // This also gives the GUI a safe place to put the log filter config
+    #[cfg(not(test))]
     let device_id =
         device_id::get_or_create_client().context("Failed to read / create device ID")?;
+
+    #[cfg(test)]
+    let device_id = device_id::DeviceId::test();
 
     // Fix up the group of the device ID file and directory so the GUI client can access it.
     #[cfg(target_os = "linux")]
@@ -134,7 +142,7 @@ async fn ipc_listen(
             .with_context(|| format!("Failed to change ownership of '{}'", dir.display()))?;
     }
 
-    let mut server = ipc::Server::new(SocketId::Tunnel)?;
+    let mut server = ipc::Server::new(socket_id)?;
     let mut dns_controller = DnsController { dns_control_method };
     loop {
         let mut handler_fut = pin!(Handler::new(
@@ -348,10 +356,9 @@ impl<'a> Handler<'a> {
                 Event::Ipc(msg) => {
                     let msg_variant = serde_variant::to_variant_name(&msg)
                         .expect("IPC messages should be enums, not structs or anything else.");
-                    let _entered =
-                        tracing::error_span!("handle_ipc_msg", msg = %msg_variant).entered();
-                    if let Err(error) = self.handle_ipc_msg(msg).await {
-                        tracing::error!("Error while handling IPC message from client: {error:#}");
+                    let span = tracing::error_span!("handle_ipc_msg", msg = %msg_variant);
+                    if let Err(error) = self.handle_ipc_msg(msg).instrument(span).await {
+                        tracing::error!(%msg_variant, "Error while handling IPC message from client: {error:#}");
                         continue;
                     }
                 }
@@ -601,6 +608,8 @@ impl<'a> Handler<'a> {
                     }
                 }
             }
+            #[cfg(debug_assertions)]
+            ClientMsg::Panic => panic!("Explicit panic"),
         }
         Ok(())
     }
@@ -716,7 +725,12 @@ pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
     let _guard = rt.enter();
     let mut signals = signals::Terminate::new()?;
 
-    rt.block_on(ipc_listen(dns_control, &log_filter_reloader, &mut signals))
+    rt.block_on(ipc_listen(
+        dns_control,
+        &log_filter_reloader,
+        SocketId::Tunnel,
+        &mut signals,
+    ))
 }
 
 /// Listen for exactly one connection from a GUI, then exit
@@ -793,4 +807,39 @@ async fn new_network_notifier() -> Result<impl Stream<Item = Result<()>>> {
 
         Ok(Some(((), worker)))
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn panic_inside_handler_doesnt_interrupt_service() {
+        let _guard = logging::test("debug");
+
+        let id = SocketId::Test(rand::random());
+
+        let handle = tokio::spawn(async move {
+            let (_, log_filter_reloader) = logging::try_filter::<()>("info").unwrap();
+            let mut signals = signals::Terminate::new().unwrap();
+
+            ipc_listen(
+                DnsControlMethod::default(),
+                &log_filter_reloader,
+                id,
+                &mut signals,
+            )
+            .await
+        });
+
+        let (_, mut tx) = ipc::connect::<ServerMsg, ClientMsg>(id, ipc::ConnectOptions::default())
+            .await
+            .unwrap();
+
+        tx.send(&ClientMsg::Panic).await.unwrap();
+
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .unwrap_err(); // We want to timeout because that means the task is still running.
+    }
 }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -855,5 +855,10 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(1), handle)
             .await
             .unwrap_err(); // We want to timeout because that means the task is still running.
+
+        // We can reconnect another instance.
+        let (_, _) = ipc::connect::<ServerMsg, ClientMsg>(id, ipc::ConnectOptions::default())
+            .await
+            .unwrap();
     }
 }

--- a/rust/gui-client/src-tauri/src/service/linux.rs
+++ b/rust/gui-client/src-tauri/src/service/linux.rs
@@ -3,6 +3,8 @@ use std::{path::PathBuf, time::Duration};
 use anyhow::{Context as _, Result, bail};
 use bin_shared::{DnsControlMethod, signals};
 
+use crate::ipc::SocketId;
+
 /// Cross-platform entry point for systemd / Windows services
 ///
 /// Linux uses the CLI args from here, Windows does not
@@ -23,6 +25,7 @@ pub fn run(log_dir: Option<PathBuf>, dns_control: DnsControlMethod) -> Result<()
     rt.block_on(super::ipc_listen(
         dns_control,
         &log_filter_reloader,
+        SocketId::Tunnel,
         &mut signals,
     ))
     .inspect_err(|e| tracing::error!("IPC service failed: {e:#}"))?;

--- a/rust/gui-client/src-tauri/src/service/windows.rs
+++ b/rust/gui-client/src-tauri/src/service/windows.rs
@@ -27,6 +27,8 @@ use windows_service::{
     service_manager::{ServiceManager, ServiceManagerAccess},
 };
 
+use crate::ipc::SocketId;
+
 const SERVICE_NAME: &str = "firezone_client_ipc";
 const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
@@ -285,6 +287,7 @@ fn run_service(arguments: Vec<OsString>) {
         .block_on(super::ipc_listen(
             DnsControlMethod::Nrpt,
             &log_filter_reloader,
+            SocketId::Tunnel,
             &mut signals,
         ))
         .inspect_err(|e| tracing::error!("Tunnel service failed: {e:#}"));

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -6,6 +6,9 @@ description = "Firezone-specific modules shared between binaries."
 license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+test = [] # APIs only exposed for testing.
+
 [dependencies]
 anyhow = { workspace = true }
 atomicwrites = { workspace = true }

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -25,6 +25,15 @@ pub struct DeviceId {
     pub source: Source,
 }
 
+impl DeviceId {
+    pub fn test() -> Self {
+        Self {
+            id: String::new(),
+            source: Source::HardwareId,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Source {
     Disk,

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -26,10 +26,11 @@ pub struct DeviceId {
 }
 
 impl DeviceId {
+    #[cfg(feature = "test")]
     pub fn test() -> Self {
         Self {
-            id: String::new(),
-            source: Source::HardwareId,
+            id: "FF85E1A39B9489356C5F5A23134CC80442530B76ED44925FAF787AF4B33ABA94".to_owned(),
+            source: Source::Test,
         }
     }
 }
@@ -38,6 +39,8 @@ impl DeviceId {
 pub enum Source {
     Disk,
     HardwareId,
+    #[cfg(feature = "test")]
+    Test,
 }
 
 /// Returns the path of the randomly-generated Firezone device ID


### PR DESCRIPTION
Right now, when `Handler::run` within the tunnel process panics, we take down the whole process. Unless the OS or the user restarts the process, they won't be able to launch Firezone anymore. Note that we also already have a panic-catching boundary for connlib itself (which also lives inside the tunnel process).

Even though these panics should be rare, they do happen and in that case, it is a bad user experience. To fix that, we now explicitly catch these panics, log an error and restart the IPC listening loop, allowing a new instance of the GUI client to connect.