### PR TITLE
fix(apple): disable app hang tracking in NE

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -52,13 +52,14 @@ public enum Telemetry {
     await state.setAccountSlug(slug)
   }
 
-  public static func start() {
+  public static func start(enableAppHangTracking: Bool = true) {
     SentrySDK.start { options in
       options.dsn =
         "https://66c71f83675f01abfffa8eb977bcbbf7@o4507971108339712.ingest.us.sentry.io/4508175177023488"
       options.environment = "entrypoint"  // will be reconfigured in VPNConfigurationManager
       options.releaseName = releaseName()
       options.dist = distributionType()
+      options.enableAppHangTracking = enableAppHangTracking
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -33,8 +33,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   private let defaults = UserDefaults.standard
 
   override init() {
-    // Initialize Telemetry as early as possible
-    Telemetry.start()
+    // Initialize Telemetry as early as possible.
+    // Disable app hang tracking because Network Extensions legitimately block
+    // on mach_msg when idle, causing false positive reports.
+    Telemetry.start(enableAppHangTracking: false)
 
     super.init()
 


### PR DESCRIPTION
Sentry's app hang tracking works by scheduling a task on the main queue and then monitoring that it does not get blocked.

For Network Extensions on recent versions of iOS, it appears that Apple has implemented more power saving controls that pause execution of Network Extensions (and possibly all XPC services) while they're idle (i.e. waiting for a message). Because of this, Sentry reports this as "App Hang fully blocked".

To alleviate this issue, we disable App Hang tracking for the Network Extension.
