### PR TITLE
chore(rust): remove `--deny warnings` from mise env

### DIFF
--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -4,7 +4,7 @@
 
 [env]
 # Match CI environment - enables tokio unstable features and denies warnings
-RUSTFLAGS = "--cfg tokio_unstable --deny warnings"
+RUSTFLAGS = "--cfg tokio_unstable"
 # Nightly version used for cargo-udeps (keep in sync with .github/actions/setup-rust-nightly)
 NIGHTLY_VERSION = "nightly-2025-09-30"
 


### PR DESCRIPTION
IDEs with support for mise will pick up this configuration and correctly set the environment. This is counter-productive during local development where you often want to run tests whilst there are still warnings.