### PR TITLE
feat(portal): scope changes replication to region

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -6,26 +6,26 @@ Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 SQL.Query: SQL injection,lib/portal/safe.ex:344,2C3D7F0
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:421,2C8D29D
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:74,2D2B0E3
 SQL.Query: SQL injection,lib/portal/safe.ex:350,3C9C61F
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
+Config.Secrets: Hardcoded Secret,config/config.exs:223,43157EC
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/account.ex:92,43C74D4
+Config.Secrets: Hardcoded Secret,config/config.exs:119,43E3939
 Config.Headers: Missing Secure Browser Headers,lib/portal_api/router.ex:15,464028
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:4,490DB25
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:71,49978F4
-Config.Secrets: Hardcoded Secret,config/config.exs:222,4A8C9E3
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:20,4C29336
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/email_otp.ex:65,5078E69
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:211,52B9024
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:403,5BB84FC
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:399,5F2DE06
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
+Config.Secrets: Hardcoded Secret,config/config.exs:224,6691ED9
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
-Config.Secrets: Hardcoded Secret,config/config.exs:221,6D192B
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:68,7331603
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619
-Config.Secrets: Hardcoded Secret,config/config.exs:117,C7408A
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:417,A073CD

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -49,6 +49,7 @@ config :portal, Portal.Repo.Replica,
 config :portal, Portal.ChangeLogs.ReplicationConnection,
   replication_slot_name: "change_logs_slot",
   publication_name: "change_logs_publication",
+  region: "default",
   enabled: true,
   connection_opts: [
     hostname: "localhost",
@@ -106,6 +107,7 @@ config :portal, Portal.ChangeLogs.ReplicationConnection,
 config :portal, Portal.Changes.ReplicationConnection,
   replication_slot_name: "changes_slot",
   publication_name: "changes_publication",
+  region: "default",
   enabled: true,
   connection_opts: [
     hostname: "localhost",
@@ -277,6 +279,8 @@ config :portal, docker_registry: "ghcr.io/firezone"
 config :portal, outbound_email_adapter_configured?: false
 
 config :portal, relay_presence_topic: "presences:global_relays"
+
+config :portal, changes_pubsub_region: "default"
 
 config :portal, web_external_url: "https://localhost:13443"
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -55,8 +55,7 @@ if config_env() == :prod do
            )
 
   config :portal, Portal.ChangeLogs.ReplicationConnection,
-    # TODO: Use a dedicated node for Change Log replication
-    enabled: env_var_to_config!(:background_jobs_enabled),
+    enabled: env_var_to_config!(:change_logs_replication_enabled),
     replication_slot_name: env_var_to_config!(:database_change_logs_replication_slot_name),
     publication_name: env_var_to_config!(:database_change_logs_publication_name),
     connection_opts:
@@ -81,8 +80,8 @@ if config_env() == :prod do
         )
 
   config :portal, Portal.Changes.ReplicationConnection,
-    # TODO: Use a dedicated node for Change Data Capture replication
-    enabled: env_var_to_config!(:background_jobs_enabled),
+    enabled: env_var_to_config!(:changes_replication_enabled),
+    region: env_var_to_config!(:changes_pubsub_region),
     replication_slot_name: env_var_to_config!(:database_changes_replication_slot_name),
     publication_name: env_var_to_config!(:database_changes_publication_name),
     connection_opts:
@@ -153,6 +152,8 @@ if config_env() == :prod do
   if platform_adapter = env_var_to_config!(:platform_adapter) do
     config :portal, platform_adapter, env_var_to_config!(:platform_adapter_config)
   end
+
+  config :portal, changes_pubsub_region: env_var_to_config!(:changes_pubsub_region)
 
   # Azure Front Door ID validation - when set, rejects requests without matching X-Azure-FDID header
   config :portal, azure_front_door_id: env_var_to_config!(:azure_front_door_id)

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -50,6 +50,24 @@ defmodule Portal.Config.Definitions do
   """
   defconfig(:background_jobs_enabled, :boolean, default: false)
 
+  @doc """
+  Region identifier used to scope Changes PubSub topics.
+
+  In a multi-region deployment, this ensures subscribers only receive change
+  events from their own region.
+  """
+  defconfig(:changes_pubsub_region, :string, default: "default")
+
+  @doc """
+  Enable or disable the Changes (CDC) replication consumer for this app instance.
+  """
+  defconfig(:changes_replication_enabled, :boolean, default: false)
+
+  @doc """
+  Enable or disable the ChangeLogs replication consumer for this app instance.
+  """
+  defconfig(:change_logs_replication_enabled, :boolean, default: false)
+
   ##############################################
   ## Web Server
   ##############################################

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -58,7 +58,8 @@ defmodule Portal.PubSub do
     end
 
     defp topic(account_id) do
-      Atom.to_string(__MODULE__) <> ":" <> account_id
+      region = Portal.Config.get_env(:portal, :changes_pubsub_region, "default")
+      Atom.to_string(__MODULE__) <> ":" <> region <> ":" <> account_id
     end
   end
 end


### PR DESCRIPTION
The Changes replication consumer is responsible for logically decoding the replication stream and then broadcasting to relevant listeners.

To avoid broadcasting across regions, we scope the replication consumer to each region so that one is started per region, and then only broadcasts to its region's topic. API and web nodes in that region then subscribe to a region-scoped PubSub topic so that they don't receive events from other region's replication consumers.
