### PR TITLE
feat(portal): allow additional websocket origins

### DIFF
--- a/elixir/.sobelow-skips
+++ b/elixir/.sobelow-skips
@@ -2,11 +2,11 @@
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:33,122F186
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/oidc.ex:72,1687D24
 Config.CSRFRoute: CSRF via Action Reuse,lib/portal_web/router.ex:109,17FA088
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:437,1C01840
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal/types/filter.ex:22,1E1F28F
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/mailer.ex:49,2064866
 Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
 SQL.Query: SQL injection,lib/portal/safe.ex:344,2C3D7F0
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:421,2C8D29D
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:74,2D2B0E3
 SQL.Query: SQL injection,lib/portal/safe.ex:350,3C9C61F
 DOS.BinToAtom: Unsafe atom interpolation,lib/portal/cluster/google_compute_labels_strategy.ex:171,3D848A0
@@ -22,10 +22,10 @@ DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.e
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:24,5775968
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/dumper.ex:33,58DA1AC
 Misc.BinToTerm: Unsafe `binary_to_term`,lib/portal_web/cookie/client_auth.ex:42,5F2F213
+DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:433,62C4B8B
 Config.Secrets: Hardcoded Secret,config/config.exs:224,6691ED9
 DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/cluster/postgres_strategy.ex:216,69DCAC0
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:53,7047850
 Config.Headers: Missing Secure Browser Headers,lib/portal_web/router.ex:13,7269EC9
 XSS.SendResp: XSS in `send_resp`,lib/portal/health.ex:68,7331603
 Config.CSWH: Cross-Site Websocket Hijacking,lib/portal_api/endpoint.ex:43,7695619
-DOS.StringToAtom: Unsafe `String.to_atom`,lib/portal/config/definitions.ex:417,A073CD

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -304,12 +304,13 @@ if config_env() == :prod do
         path: web_external_url_path
       ],
       secret_key_base: env_var_to_config!(:secret_key_base),
-      check_origin: [
-        "#{web_external_url_scheme}://#{web_external_url_host}:#{web_external_url_port}",
-        "#{web_external_url_scheme}://*.#{web_external_url_host}:#{web_external_url_port}",
-        "#{web_external_url_scheme}://#{web_external_url_host}",
-        "#{web_external_url_scheme}://*.#{web_external_url_host}"
-      ],
+      check_origin:
+        [
+          "#{web_external_url_scheme}://#{web_external_url_host}:#{web_external_url_port}",
+          "#{web_external_url_scheme}://*.#{web_external_url_host}:#{web_external_url_port}",
+          "#{web_external_url_scheme}://#{web_external_url_host}",
+          "#{web_external_url_scheme}://*.#{web_external_url_host}"
+        ] ++ env_var_to_config!(:websocket_additional_origins),
       live_view: [
         signing_salt: env_var_to_config!(:live_view_signing_salt)
       ]

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -73,6 +73,22 @@ defmodule Portal.Config.Definitions do
   ##############################################
 
   @doc """
+  Additional origins allowed for WebSocket connections.
+
+  By default, origins are derived from `WEB_EXTERNAL_URL`. Use this setting to allow
+  WebSocket connections from additional origins, for example when the application is
+  accessed via multiple domains or a CDN.
+
+  Accepts a comma-separated list of origins (e.g. `https://app.example.com,https://cdn.example.com`).
+  """
+  defconfig(:websocket_additional_origins, {:array, ",", :string},
+    default: [],
+    changeset: fn changeset, key ->
+      Portal.Changeset.validate_uri(changeset, key)
+    end
+  )
+
+  @doc """
   The external URL the UI will be accessible at.
 
   If this field is not set or set to `nil`, the server for `api` and `web` apps will not start.


### PR DESCRIPTION
When testing, it's helpful to be able to connect directly to the Azure Front Door domain for the running portal instead of going through the GCP LB.

To achieve this, we need a configuration option to accept additional origins so that they're allowed by Phoenix's websocket origin validators.
