### PR TITLE
fix(portal): use empty region for backwards-compat

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -49,7 +49,7 @@ config :portal, Portal.Repo.Replica,
 config :portal, Portal.ChangeLogs.ReplicationConnection,
   replication_slot_name: "change_logs_slot",
   publication_name: "change_logs_publication",
-  region: "default",
+  region: "",
   enabled: true,
   connection_opts: [
     hostname: "localhost",
@@ -107,7 +107,7 @@ config :portal, Portal.ChangeLogs.ReplicationConnection,
 config :portal, Portal.Changes.ReplicationConnection,
   replication_slot_name: "changes_slot",
   publication_name: "changes_publication",
-  region: "default",
+  region: "",
   enabled: true,
   connection_opts: [
     hostname: "localhost",
@@ -280,7 +280,7 @@ config :portal, outbound_email_adapter_configured?: false
 
 config :portal, relay_presence_topic: "presences:global_relays"
 
-config :portal, changes_pubsub_region: "default"
+config :portal, changes_pubsub_region: ""
 
 config :portal, web_external_url: "https://localhost:13443"
 

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -56,7 +56,7 @@ defmodule Portal.Config.Definitions do
   In a multi-region deployment, this ensures subscribers only receive change
   events from their own region.
   """
-  defconfig(:changes_pubsub_region, :string, default: "default")
+  defconfig(:changes_pubsub_region, :string, default: "")
 
   @doc """
   Enable or disable the Changes (CDC) replication consumer for this app instance.

--- a/elixir/lib/portal/config/validator.ex
+++ b/elixir/lib/portal/config/validator.ex
@@ -72,7 +72,7 @@ defmodule Portal.Config.Validator do
 
     changeset =
       {%{}, %{key => type}}
-      |> cast(%{key => value}, [key])
+      |> cast(%{key => value}, [key], empty_values: [])
       |> apply_validations(callback, type, key)
 
     if changeset.valid? do

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -58,8 +58,8 @@ defmodule Portal.PubSub do
     end
 
     defp topic(account_id) do
-      region = Portal.Config.get_env(:portal, :changes_pubsub_region, "default")
-      Atom.to_string(__MODULE__) <> ":" <> region <> ":" <> account_id
+      region = Portal.Config.get_env(:portal, :changes_pubsub_region, "")
+      region <> Atom.to_string(__MODULE__) <> ":" <> account_id
     end
   end
 end

--- a/elixir/lib/portal/replication/connection.ex
+++ b/elixir/lib/portal/replication/connection.ex
@@ -137,7 +137,7 @@ defmodule Portal.Replication.Connection do
         # last keep alive message received at
         last_keep_alive: nil,
         # region for scoping :pg leader election
-        region: "default"
+        region: ""
       )
     end
   end

--- a/elixir/lib/portal/replication/manager.ex
+++ b/elixir/lib/portal/replication/manager.ex
@@ -20,7 +20,7 @@ defmodule Portal.Replication.Manager do
   def init(connection_module) do
     Process.flag(:trap_exit, true)
     config = Application.fetch_env!(:portal, connection_module)
-    pg_key = {connection_module, config[:region] || "default"}
+    pg_key = {connection_module, config[:region] || ""}
     send(self(), :connect)
 
     {:ok,


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/12041 we introduced region-scoped replication consumers. However, this changes the PubSub topic even when regions are not in use, which may cause clients/gateways to temporary not receive messages for each other during the span of a deploy.

To mitigate this, we default the region to the empty string and ensure the topic stays consistent between old and new nodes.