### PR TITLE
fix(portal): separate CDC from operational topics

### DIFF
--- a/elixir/lib/portal/changes/hooks/accounts.ex
+++ b/elixir/lib/portal/changes/hooks/accounts.ex
@@ -38,7 +38,7 @@ defmodule Portal.Changes.Hooks.Accounts do
       end)
     end
 
-    PubSub.Account.broadcast(account.id, change)
+    PubSub.Changes.broadcast(account.id, change)
   end
 
   @impl true
@@ -47,7 +47,7 @@ defmodule Portal.Changes.Hooks.Accounts do
     account = struct_from_params(Portal.Account, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: account}
 
-    PubSub.Account.broadcast(account.id, change)
+    PubSub.Changes.broadcast(account.id, change)
   end
 
   defmodule Database do

--- a/elixir/lib/portal/changes/hooks/clients.ex
+++ b/elixir/lib/portal/changes/hooks/clients.ex
@@ -20,7 +20,7 @@ defmodule Portal.Changes.Hooks.Clients do
       Database.delete_policy_authorizations_for_client(client)
     end
 
-    PubSub.Account.broadcast(client.account_id, change)
+    PubSub.Changes.broadcast(client.account_id, change)
   end
 
   @impl true
@@ -28,7 +28,7 @@ defmodule Portal.Changes.Hooks.Clients do
     client = struct_from_params(Portal.Client, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: client}
 
-    PubSub.Account.broadcast(client.account_id, change)
+    PubSub.Changes.broadcast(client.account_id, change)
   end
 
   defmodule Database do

--- a/elixir/lib/portal/changes/hooks/directories.ex
+++ b/elixir/lib/portal/changes/hooks/directories.ex
@@ -14,6 +14,6 @@ defmodule Portal.Changes.Hooks.Directories do
 
   # Used to notify the Settings -> Directory Sync LiveView
   defp broadcast(account_id) do
-    PubSub.Account.broadcast(account_id, :directories_changed)
+    PubSub.Changes.broadcast(account_id, :directories_changed)
   end
 end

--- a/elixir/lib/portal/changes/hooks/gateways.ex
+++ b/elixir/lib/portal/changes/hooks/gateways.ex
@@ -14,6 +14,6 @@ defmodule Portal.Changes.Hooks.Gateways do
     gateway = struct_from_params(Gateway, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: gateway}
 
-    PubSub.Account.broadcast(gateway.account_id, change)
+    PubSub.Changes.broadcast(gateway.account_id, change)
   end
 end

--- a/elixir/lib/portal/changes/hooks/memberships.ex
+++ b/elixir/lib/portal/changes/hooks/memberships.ex
@@ -8,7 +8,7 @@ defmodule Portal.Changes.Hooks.Memberships do
     membership = struct_from_params(Portal.Membership, data)
     change = %Change{lsn: lsn, op: :insert, struct: membership}
 
-    PubSub.Account.broadcast(membership.account_id, change)
+    PubSub.Changes.broadcast(membership.account_id, change)
   end
 
   @impl true
@@ -19,6 +19,6 @@ defmodule Portal.Changes.Hooks.Memberships do
     membership = struct_from_params(Portal.Membership, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: membership}
 
-    PubSub.Account.broadcast(membership.account_id, change)
+    PubSub.Changes.broadcast(membership.account_id, change)
   end
 end

--- a/elixir/lib/portal/changes/hooks/policies.ex
+++ b/elixir/lib/portal/changes/hooks/policies.ex
@@ -9,7 +9,7 @@ defmodule Portal.Changes.Hooks.Policies do
     policy = struct_from_params(Policy, data)
     change = %Change{lsn: lsn, op: :insert, struct: policy}
 
-    PubSub.Account.broadcast(policy.account_id, change)
+    PubSub.Changes.broadcast(policy.account_id, change)
   end
 
   @impl true
@@ -47,7 +47,7 @@ defmodule Portal.Changes.Hooks.Policies do
       Database.delete_policy_authorizations_for_policy(old_policy)
     end
 
-    PubSub.Account.broadcast(policy.account_id, change)
+    PubSub.Changes.broadcast(policy.account_id, change)
   end
 
   @impl true
@@ -55,7 +55,7 @@ defmodule Portal.Changes.Hooks.Policies do
     policy = struct_from_params(Policy, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: policy}
 
-    PubSub.Account.broadcast(policy.account_id, change)
+    PubSub.Changes.broadcast(policy.account_id, change)
   end
 
   defmodule Database do

--- a/elixir/lib/portal/changes/hooks/policy_authorizations.ex
+++ b/elixir/lib/portal/changes/hooks/policy_authorizations.ex
@@ -21,6 +21,6 @@ defmodule Portal.Changes.Hooks.PolicyAuthorizations do
   def on_delete(lsn, old_data) do
     policy_authorization = struct_from_params(PolicyAuthorization, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: policy_authorization}
-    PubSub.Account.broadcast(policy_authorization.account_id, change)
+    PubSub.Changes.broadcast(policy_authorization.account_id, change)
   end
 end

--- a/elixir/lib/portal/changes/hooks/resources.ex
+++ b/elixir/lib/portal/changes/hooks/resources.ex
@@ -9,7 +9,7 @@ defmodule Portal.Changes.Hooks.Resources do
     resource = struct_from_params(Portal.Resource, data)
     change = %Change{lsn: lsn, op: :insert, struct: resource}
 
-    PubSub.Account.broadcast(resource.account_id, change)
+    PubSub.Changes.broadcast(resource.account_id, change)
   end
 
   @impl true
@@ -34,7 +34,7 @@ defmodule Portal.Changes.Hooks.Resources do
       Database.delete_policy_authorizations_for(resource)
     end
 
-    PubSub.Account.broadcast(resource.account_id, change)
+    PubSub.Changes.broadcast(resource.account_id, change)
   end
 
   @impl true
@@ -42,7 +42,7 @@ defmodule Portal.Changes.Hooks.Resources do
     resource = struct_from_params(Portal.Resource, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: resource}
 
-    PubSub.Account.broadcast(resource.account_id, change)
+    PubSub.Changes.broadcast(resource.account_id, change)
   end
 
   defmodule Database do

--- a/elixir/lib/portal/changes/hooks/sites.ex
+++ b/elixir/lib/portal/changes/hooks/sites.ex
@@ -12,7 +12,7 @@ defmodule Portal.Changes.Hooks.Sites do
     site = struct_from_params(Portal.Site, data)
     change = %Change{lsn: lsn, op: :update, old_struct: old_site, struct: site}
 
-    PubSub.Account.broadcast(site.account_id, change)
+    PubSub.Changes.broadcast(site.account_id, change)
   end
 
   @impl true

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -58,6 +58,24 @@ defmodule Portal.PubSub do
     end
 
     defp topic(account_id) do
+      Atom.to_string(__MODULE__) <> ":" <> account_id
+    end
+  end
+
+  defmodule Changes do
+    def subscribe(account_id) do
+      account_id
+      |> topic()
+      |> Portal.PubSub.subscribe()
+    end
+
+    def broadcast(account_id, payload) do
+      account_id
+      |> topic()
+      |> Portal.PubSub.broadcast(payload)
+    end
+
+    defp topic(account_id) do
       region = Portal.Config.get_env(:portal, :changes_pubsub_region, "")
       region <> Atom.to_string(__MODULE__) <> ":" <> account_id
     end

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -64,6 +64,7 @@ defmodule PortalAPI.Client.Channel do
 
     # Subscribe to all account updates
     :ok = PubSub.Account.subscribe(socket.assigns.client.account_id)
+    :ok = PubSub.Changes.subscribe(socket.assigns.client.account_id)
 
     push(socket, "init", %{
       resources: Views.Resource.render_many(resources),

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -54,6 +54,7 @@ defmodule PortalAPI.Gateway.Channel do
 
     # Subscribe to all account updates
     :ok = PubSub.Account.subscribe(socket.assigns.gateway.account_id)
+    :ok = PubSub.Changes.subscribe(socket.assigns.gateway.account_id)
 
     # Return all connected relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)

--- a/elixir/lib/portal_web/live/policies/index.ex
+++ b/elixir/lib/portal_web/live/policies/index.ex
@@ -5,7 +5,7 @@ defmodule PortalWeb.Policies.Index do
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      :ok = PubSub.Account.subscribe(socket.assigns.account.id)
+      :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
     end
 
     socket =

--- a/elixir/lib/portal_web/live/resources/index.ex
+++ b/elixir/lib/portal_web/live/resources/index.ex
@@ -5,7 +5,7 @@ defmodule PortalWeb.Resources.Index do
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      :ok = PubSub.Account.subscribe(socket.assigns.account.id)
+      :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
     end
 
     socket =

--- a/elixir/lib/portal_web/live/resources/show.ex
+++ b/elixir/lib/portal_web/live/resources/show.ex
@@ -9,7 +9,7 @@ defmodule PortalWeb.Resources.Show do
     resource = get_resource!(id, socket.assigns.subject)
 
     if connected?(socket) do
-      :ok = PubSub.Account.subscribe(resource.account_id)
+      :ok = PubSub.Changes.subscribe(resource.account_id)
     end
 
     socket =

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -35,7 +35,7 @@ defmodule PortalWeb.Settings.DirectorySync do
     socket = assign(socket, page_title: "Directory Sync")
 
     if connected?(socket) do
-      :ok = PubSub.Account.subscribe(socket.assigns.subject.account.id)
+      :ok = PubSub.Changes.subscribe(socket.assigns.subject.account.id)
     end
 
     {:ok, init(socket, new: true)}

--- a/elixir/test/portal/changes/hooks/accounts_test.exs
+++ b/elixir/test/portal/changes/hooks/accounts_test.exs
@@ -17,7 +17,7 @@ defmodule Portal.Changes.Hooks.AccountsTest do
     test "sends delete when account is disabled" do
       account_id = "00000000-0000-0000-0000-000000000001"
 
-      :ok = PubSub.Account.subscribe(account_id)
+      :ok = PubSub.Changes.subscribe(account_id)
 
       old_data = %{
         "id" => account_id,
@@ -75,7 +75,7 @@ defmodule Portal.Changes.Hooks.AccountsTest do
   describe "delete/1" do
     test "delete broadcasts deleted account" do
       account_id = "00000000-0000-0000-0000-000000000003"
-      :ok = PubSub.Account.subscribe(account_id)
+      :ok = PubSub.Changes.subscribe(account_id)
 
       old_data = %{"id" => account_id}
 

--- a/elixir/test/portal/changes/hooks/policy_authorizations_test.exs
+++ b/elixir/test/portal/changes/hooks/policy_authorizations_test.exs
@@ -17,7 +17,7 @@ defmodule Portal.Changes.Hooks.PolicyAuthorizationsTest do
 
   describe "delete/1" do
     test "delete broadcasts deleted policy_authorization" do
-      :ok = PubSub.Account.subscribe("00000000-0000-0000-0000-000000000000")
+      :ok = PubSub.Changes.subscribe("00000000-0000-0000-0000-000000000000")
 
       old_data = %{
         "id" => "00000000-0000-0000-0000-000000000001",

--- a/elixir/test/portal/changes/hooks/sites_test.exs
+++ b/elixir/test/portal/changes/hooks/sites_test.exs
@@ -13,7 +13,7 @@ defmodule Portal.Changes.Hooks.SitesTest do
     test "broadcasts updated site" do
       account_id = "00000000-0000-0000-0000-000000000000"
 
-      :ok = PubSub.Account.subscribe(account_id)
+      :ok = PubSub.Changes.subscribe(account_id)
 
       old_data = %{
         "id" => "00000000-0000-0000-0000-000000000001",

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -336,7 +336,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
     } do
       _socket = join_channel(gateway, site, token)
 
-      :ok = PubSub.Account.subscribe(account.id)
+      :ok = PubSub.Changes.subscribe(account.id)
 
       old_data = %{
         "id" => account.id,
@@ -405,7 +405,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       Process.flag(:trap_exit, true)
 
-      :ok = PubSub.Account.subscribe(account.id)
+      :ok = PubSub.Changes.subscribe(account.id)
 
       data = %{
         "id" => gateway.id,
@@ -569,7 +569,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       in_one_hour = DateTime.utc_now() |> DateTime.add(1, :hour)
       in_one_day = DateTime.utc_now() |> DateTime.add(1, :day)
 
-      :ok = PubSub.Account.subscribe(account.id)
+      :ok = PubSub.Changes.subscribe(account.id)
 
       policy_authorization1 =
         policy_authorization_fixture(
@@ -988,7 +988,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
           group: group
         )
 
-      :ok = PubSub.Account.subscribe(account.id)
+      :ok = PubSub.Changes.subscribe(account.id)
 
       send(
         socket.channel_pid,


### PR DESCRIPTION
In #12041 we scoped change messages per region. This had the side effect of causing a netsplit between regions for operational (signaling) messages as well.

This PR splits the two so that we can have different topics for regional vs global messages.
