### PR TITLE
fix(phoenix-channel): clear pending messages on `connect`

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -420,8 +420,9 @@ where
             return;
         }
 
-        // 1. Reset the backoff.
+        // 1. Reset the backoff and local state.
         self.backoff = None;
+        self.pending_messages.clear();
 
         // 2. Set state to `Connecting` without a timer.
         let user_agent = self.user_agent.clone();


### PR DESCRIPTION
Whenever we explicitly reconnect the WebSocket, i.e. when roaming, we want to clear all pending messages. Previously scheduled connection intents of candidates are unlikely to be valid at that point so there is no point in sending them.

Resolves: #10375