### PR TITLE
ci(rust): deny warnings in rustdoc builds

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   RUSTFLAGS: "--cfg tokio_unstable --deny warnings"
+  RUSTDOCFLAGS: "--deny warnings"
 
 jobs:
   static-analysis:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2474,7 +2474,6 @@ dependencies = [
  "serde_json",
  "snownet",
  "socket-factory",
- "static_assertions",
  "telemetry",
  "tempfile",
  "thiserror 2.0.18",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -179,7 +179,6 @@ socket-factory = { path = "libs/connlib/socket-factory" }
 socket2 = { version = "0.6.2" }
 specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
-static_assertions = "1.1.0"
 str0m = { version = "0.16.1", default-features = false }
 strum = { version = "0.27.2", features = ["derive"] }
 stun_codec = "0.4.0"

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -52,7 +52,6 @@ secrecy = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
-static_assertions = { workspace = true }
 telemetry = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "fs", "signal", "rt"] }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -32,12 +32,6 @@ pub const PHOENIX_TOPIC: &str = "gateway";
 /// How long we allow a DNS resolution via hickory.
 const DNS_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
-// DNS resolution happens as part of every connection setup.
-// For a connection to succeed, DNS resolution must be less than `snownet`'s handshake timeout.
-static_assertions::const_assert!(
-    DNS_RESOLUTION_TIMEOUT.as_secs() < snownet::HANDSHAKE_TIMEOUT.as_secs()
-);
-
 pub struct Eventloop {
     // Tunnel is `Option` because we need to take ownership on shutdown.
     tunnel: Option<GatewayTunnel>,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -168,7 +168,7 @@ enum Cmd {
 
     /// Sign in via browser-based authentication
     SignIn {
-        /// Auth base URL (e.g., https://app.firezone.dev)
+        /// Auth base URL
         #[arg(
             long,
             env = "FIREZONE_AUTH_BASE_URL",

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -14,8 +14,8 @@ mod utils;
 
 pub use allocation::RelaySocket;
 pub use node::{
-    Client, ClientNode, Credentials, Event, HANDSHAKE_TIMEOUT, NoTurnServers, Node, Server,
-    ServerNode, Transmit, UnknownConnection,
+    Client, ClientNode, Credentials, Event, NoTurnServers, Node, Server, ServerNode, Transmit,
+    UnknownConnection,
 };
 pub use stats::{ConnectionStats, NodeStats};
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -46,9 +46,6 @@ const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Grace-period for when we will act on an ICE disconnect.
 const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// How long we will at most wait for an [`Answer`] from the remote.
-pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
-
 /// Manages a set of wireguard connections for a server.
 pub type ServerNode<TId, RId> = Node<Server, TId, RId>;
 /// Manages a set of wireguard connections for a client.

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -771,7 +771,7 @@ where
     /// Tries to handle the packet using one of our [`Allocation`]s.
     ///
     /// This function is in the hot-path of packet processing and thus must be as efficient as possible.
-    /// Even look-ups in [`BTreeMap`]s and linear searches across small lists are expensive at this point.
+    /// Even look-ups in [`BTreeMap`](std::collections::BTreeMap)s and linear searches across small lists are expensive at this point.
     /// Thus, we use the first byte of the message as a heuristic for whether we should attempt to handle it here.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc8656#name-channels-2> for details on de-multiplexing.

--- a/rust/libs/logging/src/format.rs
+++ b/rust/libs/logging/src/format.rs
@@ -16,7 +16,7 @@ use tracing_subscriber::{
     registry::LookupSpan,
 };
 
-/// A custom [`FormatEvent`] implementation for [`tracing-subscriber`] that renders compact, yet informative logs.
+/// A custom [`FormatEvent`] implementation for [`tracing_subscriber`] that renders compact, yet informative logs.
 ///
 /// Most importantly, we log:
 ///


### PR DESCRIPTION
In order to fail on warnings in our Rust docs, we need to set `RUSTDOCFLAGS` in addition to `RUSTFLAGS`in CI.