### PR TITLE
ci: use `target/` directory caching for Swift jobs

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -109,7 +109,9 @@ jobs:
       - uses: ./.github/actions/setup-rust-stable
         with:
           targets: ${{ matrix.rust-targets }}
-      - uses: ./.github/actions/setup-rust-sccache
+      - uses: ./.github/actions/setup-rust-target-dependency-cache
+        with:
+          save-if: ${{ github.event_name == 'merge_group' || github.ref == 'refs/heads/main' }}
       - run: ${{ matrix.build-script }}
         env:
           IOS_APP_PROVISIONING_PROFILE: "${{ secrets.APPLE_IOS_APP_PROVISIONING_PROFILE }}"


### PR DESCRIPTION
Caching the `target/` directory directly is more effective than using sccache at the expense of a bit more cache storage but it is still bounded by the number of jobs we have and not by how many workflows we run.