### PR TITLE
feat(gateway): set max interval for WebSocket backoff to 1m

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -214,6 +214,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         (),
         move || {
             ExponentialBackoffBuilder::default()
+                .with_max_interval(Duration::from_secs(60))
                 .with_max_elapsed_time(Some(max_partition_time))
                 .build()
         },


### PR DESCRIPTION
Resolves: #12040