### PR TITLE
fix(portal): explicit null in migration for pg18

### DIFF
--- a/elixir/priv/repo/migrations/20221223190406_migrate_pks_to_uuid.exs
+++ b/elixir/priv/repo/migrations/20221223190406_migrate_pks_to_uuid.exs
@@ -5,7 +5,7 @@ defmodule Portal.Repo.Migrations.MigratePksToUuid do
     ## connectivity_checks
     alter table("connectivity_checks") do
       remove(:id)
-      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:id, :binary_id, primary_key: true, null: false, default: fragment("gen_random_uuid()"))
     end
 
     ## devices
@@ -31,7 +31,7 @@ defmodule Portal.Repo.Migrations.MigratePksToUuid do
     ## oidc_connections
     alter table("oidc_connections") do
       remove(:id)
-      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:id, :binary_id, primary_key: true, null: false, default: fragment("gen_random_uuid()"))
     end
 
     ## users

--- a/elixir/test/portal/replication/connection_test.exs
+++ b/elixir/test/portal/replication/connection_test.exs
@@ -179,7 +179,7 @@ defmodule Portal.Replication.ConnectionTest do
       assert log =~ "Processed 456 write messages from the WAL stream"
 
       # Should schedule next log
-      assert_receive :interval_logger, 50
+      assert_receive :interval_logger, 500
     end
 
     test "handles warning threshold checks" do


### PR DESCRIPTION
Postgres 18 no longer implies NOT NULL for binary_id primary keys so this must be added explicitly.
