### PR TITLE
refactor(connlib): de-duplicate ID definitions

### DIFF
--- a/rust/libs/connlib/model/src/lib.rs
+++ b/rust/libs/connlib/model/src/lib.rs
@@ -5,6 +5,8 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
+#[macro_use]
+mod make_id;
 mod view;
 
 pub use boringtun::x25519::PublicKey;
@@ -15,128 +17,12 @@ pub use view::{
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::str::FromStr;
-use uuid::Uuid;
 
-#[derive(Hash, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct GatewayId(Uuid);
-
-#[derive(Hash, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ResourceId(Uuid);
-
-#[derive(Hash, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RelayId(Uuid);
-
-impl RelayId {
-    pub const fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
-    }
-}
-
-impl FromStr for RelayId {
-    type Err = uuid::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(RelayId(Uuid::parse_str(s)?))
-    }
-}
-
-impl ResourceId {
-    pub fn random() -> ResourceId {
-        ResourceId(Uuid::new_v4())
-    }
-
-    pub const fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
-    }
-}
-
-impl GatewayId {
-    pub const fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
-    }
-}
-
-#[derive(Hash, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ClientId(Uuid);
-
-impl FromStr for ClientId {
-    type Err = uuid::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ClientId(Uuid::parse_str(s)?))
-    }
-}
-
-impl ClientId {
-    pub const fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
-    }
-}
-
-impl FromStr for ResourceId {
-    type Err = uuid::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ResourceId(Uuid::parse_str(s)?))
-    }
-}
-
-impl FromStr for GatewayId {
-    type Err = uuid::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(GatewayId(Uuid::parse_str(s)?))
-    }
-}
-
-impl fmt::Display for ResourceId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for ClientId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for GatewayId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for RelayId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Debug for ResourceId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
-
-impl fmt::Debug for ClientId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
-
-impl fmt::Debug for GatewayId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
-
-impl fmt::Debug for RelayId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
+make_id!(GatewayId);
+make_id!(ResourceId);
+make_id!(RelayId);
+make_id!(ClientId);
+make_id!(SiteId);
 
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialOrd, Ord)]
 pub struct Site {
@@ -153,35 +39,6 @@ impl std::hash::Hash for Site {
 impl PartialEq for Site {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
-    }
-}
-
-#[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct SiteId(Uuid);
-
-impl FromStr for SiteId {
-    type Err = uuid::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(SiteId(Uuid::parse_str(s)?))
-    }
-}
-
-impl SiteId {
-    pub const fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
-    }
-}
-
-impl fmt::Display for SiteId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Debug for SiteId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
     }
 }
 

--- a/rust/libs/connlib/model/src/make_id.rs
+++ b/rust/libs/connlib/model/src/make_id.rs
@@ -1,0 +1,37 @@
+#[macro_export]
+macro_rules! make_id {
+    ($name:ident) => {
+        #[derive(Hash, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct $name(::uuid::Uuid);
+
+        impl $name {
+            pub const fn from_u128(v: u128) -> Self {
+                Self(::uuid::Uuid::from_u128(v))
+            }
+
+            pub fn random() -> Self {
+                Self(::uuid::Uuid::new_v4())
+            }
+        }
+
+        impl ::std::str::FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(::uuid::Uuid::parse_str(s)?))
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::fmt::Result {
+                ::std::fmt::Display::fmt(&self, f)
+            }
+        }
+    };
+}


### PR DESCRIPTION
Giving the `connlib-model` crate a bit of TLC to reduce some code duplication.

Related: #11143 