### PR TITLE
test(portal): make replica use primary connection

### DIFF
--- a/elixir/test/portal/repo/replica_test.exs
+++ b/elixir/test/portal/repo/replica_test.exs
@@ -99,7 +99,8 @@ defmodule Portal.Repo.ReplicaTest do
 
   describe "configuration" do
     test "is configured as a valid repo" do
-      assert Replica.get_dynamic_repo() == Replica
+      # In tests, Replica is routed through Portal.Repo's sandbox connection
+      assert Replica.get_dynamic_repo() == Portal.Repo
     end
 
     test "returns correct config" do

--- a/elixir/test/support/case_template.ex
+++ b/elixir/test/support/case_template.ex
@@ -9,11 +9,13 @@ defmodule Portal.CaseTemplate do
     quote do
       setup tags do
         :ok = Sandbox.checkout(Portal.Repo)
-        :ok = Sandbox.checkout(Portal.Repo.Replica)
+
+        # Route Replica queries through the primary Repo's sandbox connection
+        # so that Replica can see data created via Repo in the same test
+        Portal.Repo.Replica.put_dynamic_repo(Portal.Repo)
 
         unless tags[:async] do
           Sandbox.mode(Portal.Repo, {:shared, self()})
-          Sandbox.mode(Portal.Repo.Replica, {:shared, self()})
         end
 
         :ok


### PR DESCRIPTION
In tests, the transactions never commit, so the replica cannot see any data written to the primary. Since we aren't interested in Elixir unit-testing the functionality of Postgres replication we can safely make the Replica use the Primary's connection so that all Elixir code is exercised as if they are independent DBs.
