### PR TITLE
fix(portal): use replica for sign-in flow reads

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -194,6 +194,7 @@ config :portal, PortalWeb.Plugs.PutCSPHeader,
   ]
 
 config :portal, :constant_execution_time, 1
+config :portal, replica_repo: Portal.Repo
 
 ###############################
 ##### PortalAPI Endpoint ######

--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -376,19 +376,20 @@ defmodule Portal.Authentication do
     alias Portal.Safe
     alias Portal.Account
     alias Portal.Actor
+
     alias Portal.ClientToken
     alias Portal.OneTimePasscode
 
     def get_account_by_id!(id) do
       from(a in Account, where: a.id == ^id)
-      |> Safe.unscoped()
-      |> Safe.one!()
+      |> Safe.unscoped(:replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def fetch_active_actor_by_id(id) do
       from(a in Actor, where: a.id == ^id, where: is_nil(a.disabled_at))
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
       |> case do
         nil -> {:error, :not_found}
         actor -> {:ok, actor}
@@ -417,8 +418,8 @@ defmodule Portal.Authentication do
 
     def fetch_relay_token(id) do
       from(rt in Portal.RelayToken, where: rt.id == ^id)
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
       |> case do
         nil -> {:error, :not_found}
         relay_token -> {:ok, relay_token}
@@ -442,8 +443,8 @@ defmodule Portal.Authentication do
         where: gt.account_id == ^account_id,
         where: gt.id == ^id
       )
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
       |> case do
         nil -> {:error, :not_found}
         gateway_token -> {:ok, gateway_token}

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -967,7 +967,7 @@ defmodule PortalAPI.Client.Channel do
       result =
         from(g in Gateway, as: :gateways)
         |> where([gateways: g], g.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do
@@ -991,7 +991,7 @@ defmodule PortalAPI.Client.Channel do
       online_gateways =
         from(g in Gateway, as: :gateways)
         |> where([gateways: g], g.id in ^connected_gateway_ids and g.site_id == ^resource_site_id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> case do
           {:error, :unauthorized} -> []

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -743,12 +743,12 @@ defmodule PortalAPI.Gateway.Channel do
 
     def get_account_by_id!(id) do
       from(a in Account, where: a.id == ^id)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.one!()
     end
 
     def preload_client_addresses(%Client{} = client) do
-      Safe.preload(client, [:ipv4_address, :ipv6_address])
+      Safe.preload(client, [:ipv4_address, :ipv6_address], :replica)
     end
   end
 end

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -111,13 +111,14 @@ defmodule PortalAPI.Gateway.Socket do
     alias Portal.Gateway
     alias Portal.IPv4Address
     alias Portal.IPv6Address
+
     alias Portal.Safe
     alias Portal.Site
 
     def fetch_site(id) do
       result =
         from(s in Site, where: s.id == ^id)
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -392,7 +392,7 @@ defmodule PortalWeb.EmailOTPController do
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
       query
-      |> Safe.unscoped(Portal.Repo.Replica)
+      |> Safe.unscoped(:replica)
       |> Safe.one()
       |> handle_nil()
     end
@@ -401,7 +401,7 @@ defmodule PortalWeb.EmailOTPController do
       from(p in EmailOTP.AuthProvider,
         where: p.account_id == ^account.id and p.id == ^id and not p.is_disabled
       )
-      |> Safe.unscoped(Portal.Repo.Replica)
+      |> Safe.unscoped(:replica)
       |> Safe.one()
       |> handle_nil()
     end
@@ -415,7 +415,7 @@ defmodule PortalWeb.EmailOTPController do
             a.allow_email_otp_sign_in == true
       )
       |> preload(:account)
-      |> Safe.unscoped(Portal.Repo.Replica)
+      |> Safe.unscoped(:replica)
       |> Safe.one()
       |> handle_nil()
     end

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -10,7 +10,7 @@ defmodule PortalWeb.EmailOTPController do
 
   require Logger
 
-  @constant_execution_time Application.compile_env(:portal, :constant_execution_time, 2000)
+  @constant_execution_time Application.compile_env(:portal, :constant_execution_time, 3000)
 
   @spec sign_in(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def sign_in(
@@ -392,7 +392,7 @@ defmodule PortalWeb.EmailOTPController do
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
       query
-      |> Safe.unscoped()
+      |> Safe.unscoped(Portal.Repo.Replica)
       |> Safe.one()
       |> handle_nil()
     end
@@ -401,7 +401,7 @@ defmodule PortalWeb.EmailOTPController do
       from(p in EmailOTP.AuthProvider,
         where: p.account_id == ^account.id and p.id == ^id and not p.is_disabled
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(Portal.Repo.Replica)
       |> Safe.one()
       |> handle_nil()
     end
@@ -415,7 +415,7 @@ defmodule PortalWeb.EmailOTPController do
             a.allow_email_otp_sign_in == true
       )
       |> preload(:account)
-      |> Safe.unscoped()
+      |> Safe.unscoped(Portal.Repo.Replica)
       |> Safe.one()
       |> handle_nil()
     end

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -707,7 +707,7 @@ defmodule PortalWeb.OIDCController do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one!()
+      query |> Safe.unscoped(Portal.Repo.Replica) |> Safe.one!()
     end
 
     def get_provider!(account_id, type, id) do
@@ -716,7 +716,7 @@ defmodule PortalWeb.OIDCController do
       from(p in schema,
         where: p.account_id == ^account_id and p.id == ^id and p.is_disabled == false
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(Portal.Repo.Replica)
       |> Safe.one!()
     end
 
@@ -808,7 +808,8 @@ defmodule PortalWeb.OIDCController do
           {:error, :actor_not_found}
 
         {_, [%ExternalIdentity{} = identity]} ->
-          {:ok, Safe.preload(identity, [:actor, :account])}
+          # actor and account are long-lived records, safe to read from replica
+          {:ok, Safe.preload(identity, [:actor, :account], Portal.Repo.Replica)}
       end
     end
   end

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -707,7 +707,7 @@ defmodule PortalWeb.OIDCController do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped(Portal.Repo.Replica) |> Safe.one!()
+      query |> Safe.unscoped(:replica) |> Safe.one!()
     end
 
     def get_provider!(account_id, type, id) do
@@ -716,7 +716,7 @@ defmodule PortalWeb.OIDCController do
       from(p in schema,
         where: p.account_id == ^account_id and p.id == ^id and p.is_disabled == false
       )
-      |> Safe.unscoped(Portal.Repo.Replica)
+      |> Safe.unscoped(:replica)
       |> Safe.one!()
     end
 
@@ -809,7 +809,7 @@ defmodule PortalWeb.OIDCController do
 
         {_, [%ExternalIdentity{} = identity]} ->
           # actor and account are long-lived records, safe to read from replica
-          {:ok, Safe.preload(identity, [:actor, :account], Portal.Repo.Replica)}
+          {:ok, Safe.preload(identity, [:actor, :account], :replica)}
       end
     end
   end

--- a/elixir/lib/portal_web/controllers/userpass_controller.ex
+++ b/elixir/lib/portal_web/controllers/userpass_controller.ex
@@ -233,14 +233,14 @@ defmodule PortalWeb.UserpassController do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one()
+      query |> Safe.unscoped(Portal.Repo.Replica) |> Safe.one()
     end
 
     def get_provider(account, id) do
       from(p in Userpass.AuthProvider,
         where: p.account_id == ^account.id and p.id == ^id and not p.is_disabled
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(Portal.Repo.Replica)
       |> Safe.one()
     end
 
@@ -248,7 +248,7 @@ defmodule PortalWeb.UserpassController do
       from(a in Portal.Actor,
         where: a.email == ^email and a.account_id == ^account.id and is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(Portal.Repo.Replica)
       |> Safe.one()
     end
   end

--- a/elixir/lib/portal_web/controllers/userpass_controller.ex
+++ b/elixir/lib/portal_web/controllers/userpass_controller.ex
@@ -233,14 +233,14 @@ defmodule PortalWeb.UserpassController do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped(Portal.Repo.Replica) |> Safe.one()
+      query |> Safe.unscoped(:replica) |> Safe.one()
     end
 
     def get_provider(account, id) do
       from(p in Userpass.AuthProvider,
         where: p.account_id == ^account.id and p.id == ^id and not p.is_disabled
       )
-      |> Safe.unscoped(Portal.Repo.Replica)
+      |> Safe.unscoped(:replica)
       |> Safe.one()
     end
 
@@ -248,7 +248,7 @@ defmodule PortalWeb.UserpassController do
       from(a in Portal.Actor,
         where: a.email == ^email and a.account_id == ^account.id and is_nil(a.disabled_at)
       )
-      |> Safe.unscoped(Portal.Repo.Replica)
+      |> Safe.unscoped(:replica)
       |> Safe.one()
     end
   end

--- a/elixir/test/portal/repo/replica_test.exs
+++ b/elixir/test/portal/repo/replica_test.exs
@@ -99,8 +99,7 @@ defmodule Portal.Repo.ReplicaTest do
 
   describe "configuration" do
     test "is configured as a valid repo" do
-      # In tests, Replica is routed through Portal.Repo's sandbox connection
-      assert Replica.get_dynamic_repo() == Portal.Repo
+      assert Replica.get_dynamic_repo() == Replica
     end
 
     test "returns correct config" do

--- a/elixir/test/support/case_template.ex
+++ b/elixir/test/support/case_template.ex
@@ -10,10 +10,6 @@ defmodule Portal.CaseTemplate do
       setup tags do
         :ok = Sandbox.checkout(Portal.Repo)
 
-        # Route Replica queries through the primary Repo's sandbox connection
-        # so that Replica can see data created via Repo in the same test
-        Portal.Repo.Replica.put_dynamic_repo(Portal.Repo)
-
         unless tags[:async] do
           Sandbox.mode(Portal.Repo, {:shared, self()})
         end


### PR DESCRIPTION
During sign-in flows, multiple reads of the account/actor are performed in order to authenticate the user. These can be performed on the replicas which will make for a snappier sign-in experience.
