### PR TITLE
ci: remove GCP login

### DIFF
--- a/.github/README_CI.md
+++ b/.github/README_CI.md
@@ -28,7 +28,3 @@ do
   done
 done
 ```
-
-## Adding a new repository to Google Cloud workload identity
-
-Use Terraform configuration for this. See the `iam.tf` configuration in the https://github.com/firezone/infra repo for an example.

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -269,15 +269,6 @@ jobs:
 
           # Used for release artifact
           cp ${{ matrix.name.package }} "$BINARY_DEST_PATH"
-      # For pushing built images to Google Cloud Storage
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && (matrix.name.artifact == 'firezone-relay' || matrix.name.artifact == 'firezone-gateway') }}
-        with:
-          token_format: access_token
-          workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "github-account@firezone-staging.iam.gserviceaccount.com"
-          export_environment_variables: true
-          create_credentials_file: true
       - name: Copy binary to Azure Blob Storage
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && (matrix.name.artifact == 'firezone-relay' || matrix.name.artifact == 'firezone-gateway') }}
         run: |


### PR DESCRIPTION
Removes the unused google auth steps and any GCP documentation related to CI.

---

Fixes https://github.com/firezone/firezone/actions/runs/21837771452/job/63017988532