### PR TITLE
fix(portal): await Geolix load for 15s

### DIFF
--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -141,7 +141,7 @@ defmodule Portal.Application do
     # not be ready by the time Portal.Application.start/2 runs. Wait for the
     # async load to finish before proceeding with supervision tree startup.
     for %{id: id, source: source} <- Portal.Config.get_env(:geolix, :databases, []) do
-      await_geolix_database(id, source, _retries = 50)
+      await_geolix_database(id, source, _retries = 15)
     end
   end
 
@@ -152,7 +152,7 @@ defmodule Portal.Application do
   defp await_geolix_database(id, source, retries) do
     case Geolix.metadata(where: id) do
       nil ->
-        Process.sleep(100)
+        Process.sleep(1000)
         await_geolix_database(id, source, retries - 1)
 
       _metadata ->


### PR DESCRIPTION
The Geolix database is loaded when the app boots. Since the file is compressed, Geolix will extract it and then load it into memory.

On our app VMs, this sometimes takes longer than 5s - the configured threshold before we report an error. To avoid false positives, we increase this to 15s.
