### PR TITLE
refactor(apple): remove UI code from model

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -7,10 +7,6 @@
 import Foundation
 import UserNotifications
 
-#if os(macOS)
-  import AppKit
-#endif
-
 // SessionNotification helps with showing iOS local notifications
 // when the session ends.
 // In macOS, it helps with showing an alert when the session ends.
@@ -99,19 +95,8 @@ public class SessionNotification: NSObject {
     // This gets called from the app side.
     @MainActor
     func showSignedOutAlertmacOS(_ message: String?) async {
-      let alert = NSAlert()
-      alert.messageText = "Your Firezone session has ended"
-      alert.informativeText = """
-        Please sign in again to reconnect.
-
-        \(message ?? "")
-        """
-      alert.addButton(withTitle: "Sign In")
-      alert.addButton(withTitle: "Cancel")
-      NSApp.activate(ignoringOtherApps: true)
-
-      let response = await MacOSAlert.show(alert)
-      if response == .alertFirstButtonReturn {
+      let signInClicked = await MacOSAlert.showSignedOutAlert(message)
+      if signInClicked {
         Log.log("\(#function): 'Sign In' clicked in notification")
         signInHandler()
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
@@ -6,7 +6,6 @@
 
 import Combine
 import Foundation
-import SwiftUI
 
 @MainActor
 class SettingsViewModel: ObservableObject {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
@@ -305,6 +305,25 @@
 
       show(alert)
     }
+
+    /// Shows a signed-out session alert and returns whether the user clicked "Sign In".
+    ///
+    /// - Returns: `true` if the user clicked "Sign In", `false` otherwise.
+    public static func showSignedOutAlert(_ message: String?) async -> Bool {
+      let alert = NSAlert()
+      alert.messageText = "Your Firezone session has ended"
+      alert.informativeText = """
+        Please sign in again to reconnect.
+
+        \(message ?? "")
+        """
+      alert.addButton(withTitle: "Sign In")
+      alert.addButton(withTitle: "Cancel")
+      NSApp.activate(ignoringOtherApps: true)
+
+      let response = await show(alert)
+      return response == .alertFirstButtonReturn
+    }
   }
 
 #endif


### PR DESCRIPTION
- Move NSAlert creation from SessionNotification model to MacOSAlert view
- Remove unnecessary SwiftUI import from SettingsViewModel (only needs Combine)

Models should not depend on AppKit/UIKit.

It was tested by triggering the signOut alert by removing the client session from the portal.
