### PR TITLE
chore(elixir): add test-dependency overrides

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -147,6 +147,11 @@ defmodule Portal.MixProject do
       {:excoveralls, "~> 0.18", only: :test},
       {:junit_formatter, "~> 3.3", only: :test},
 
+      # `ecto_sql` and `postgrex` have conflicting requirements
+      {:db_connection, "~> 2.9", only: :test, override: true},
+      # `opentelemetry_phoenix` and `opentelemetry_exporter` have conflicting requirements
+      {:opentelemetry_api, "~> 1.5.0", only: :test, override: true},
+
       # Dev/test deps
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Without these lines, running elixir-ls fails for me with the following error:

```
Unchecked dependencies for environment test:
* db_connection (Hex package)
  the dependency db_connection 2.8.1

  > In deps/ecto_sql/mix.exs:
    {:db_connection, "~> 2.4.1 or ~> 2.5", [env: :prod, hex: "db_connection", repo: "hexpm", optional: false]}

  does not match the requirement specified

  > In deps/postgrex/mix.exs:
    {:db_connection, "~> 2.9", [env: :prod, hex: "db_connection", repo: "hexpm", optional: false]}

  Ensure they match or specify one of the above in your deps and set "override: true"
* opentelemetry_api (Hex package)
  the dependency opentelemetry_api 1.4.1

  > In deps/opentelemetry_phoenix/mix.exs:
    {:opentelemetry_api, "~> 1.4", [env: :prod, hex: "opentelemetry_api", repo: "hexpm", optional: false]}

  does not match the requirement specified

  > In deps/opentelemetry_exporter/rebar.config:
    {:opentelemetry_api, "~> 1.5.0", [env: :prod, hex: "opentelemetry_api", repo: "hexpm", optional: false]}

  Ensure they match or specify one of the above in your deps and set "override: true"
Process #PID<0.240.0> raised an exception
** (Mix.Error) Can't continue due to errors on dependencies
    (mix 1.19.4) lib/mix.ex:647: Mix.raise/2
    (mix 1.19.4) lib/mix/tasks/deps.loadpaths.ex:107: Mix.Tasks.Deps.Loadpaths.deps_check/3
    (mix 1.19.4) lib/mix/tasks/deps.loadpaths.ex:73: Mix.Tasks.Deps.Loadpaths.run/1
    (mix 1.19.4) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.19.4) lib/mix/tasks/loadpaths.ex:43: Mix.Tasks.Loadpaths.run/1
    (mix 1.19.4) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.19.4) lib/mix/tasks/compile.ex:139: Mix.Tasks.Compile.run/1
    (mix 1.19.4) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (language_server 0.30.0) lib/language_server/build.ex:566: ElixirLS.LanguageServer.Build.run_mix_compile/1
    (language_server 0.30.0) lib/language_server/build.ex:198: ElixirLS.LanguageServer.Build.handle_compile_phase/6
    (stdlib 7.2) timer.erl:599: :timer.tc/2
    (language_server 0.30.0) lib/language_server/build.ex:22: anonymous fn/3 in ElixirLS.LanguageServer.Build.build/3
    (kernel 10.5) global.erl:703: :global.trans/4
```