### PR TITLE
chore: remove `_resource` postfix from test functions

### DIFF
--- a/scripts/tests/create-flow-from-icmp-error.sh
+++ b/scripts/tests/create-flow-from-icmp-error.sh
@@ -3,11 +3,11 @@
 source "./scripts/tests/lib.sh"
 
 # Authorize resource 1
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"
 
 # Authorize resource 2 (important, otherwise the Gateway will close the connection on the last resource being removed)
-client_ping_resource download.httpbin
+client_ping download.httpbin
 
 # Revoke access to resource 1
 portal_send_reject_access "mycro-aws-gws" "MyCorp Network"        # This is the 172.20.0.1/16 network
@@ -18,5 +18,5 @@ portal_send_reject_access "mycro-aws-gws" "MyCorp Network (IPv6)" # This is the 
 expect_error client_curl_resource "172.20.0.100/get"
 expect_error client_curl_resource "[172:20:0::100]/get"
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"

--- a/scripts/tests/create-flow-from-icmp-error.sh
+++ b/scripts/tests/create-flow-from-icmp-error.sh
@@ -15,8 +15,8 @@ portal_send_reject_access "mycro-aws-gws" "MyCorp Network (IPv6)" # This is the 
 
 # Try to access resource 1 again
 # First one for each IP will fail because we get an ICMP error.
-expect_error client_curl_resource "172.20.0.100/get"
-expect_error client_curl_resource "[172:20:0::100]/get"
+expect_error client_curl "172.20.0.100/get"
+expect_error client_curl "[172:20:0::100]/get"
 
 client_curl "172.20.0.100/get"
 client_curl "[172:20:0::100]/get"

--- a/scripts/tests/curl-ecn.sh
+++ b/scripts/tests/curl-ecn.sh
@@ -4,5 +4,5 @@ source "./scripts/tests/lib.sh"
 
 client sysctl -w net.ipv4.tcp_ecn=1
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"

--- a/scripts/tests/curl-portal-down.sh
+++ b/scripts/tests/curl-portal-down.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"
 
 docker compose stop portal
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"

--- a/scripts/tests/curl-portal-restart.sh
+++ b/scripts/tests/curl-portal-restart.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"
 
 docker compose restart portal
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"

--- a/scripts/tests/direct-curl-gateway-restart.sh
+++ b/scripts/tests/direct-curl-gateway-restart.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"
 
 docker compose restart gateway
 
-client_curl_resource "172.20.0.100/get"
-client_curl_resource "[172:20:0::100]/get"
+client_curl "172.20.0.100/get"
+client_curl "[172:20:0::100]/get"

--- a/scripts/tests/dns-portal-down.sh
+++ b/scripts/tests/dns-portal-down.sh
@@ -6,7 +6,7 @@ HTTPBIN=dns
 
 function run_test() {
     echo "# Access httpbin by DNS"
-    client_curl_resource "$HTTPBIN/get"
+    client_curl "$HTTPBIN/get"
 
     echo "# Make sure it's going through the tunnel"
     client_nslookup "$HTTPBIN" | grep "100\\.96\\.0\\."

--- a/scripts/tests/dns-two-resources.sh
+++ b/scripts/tests/dns-two-resources.sh
@@ -9,7 +9,7 @@ RESOURCE1=dns
 RESOURCE2=download.httpbin
 
 echo "# Try to ping httpbin as DNS resource 1"
-client_ping_resource "$RESOURCE1"
+client_ping "$RESOURCE1"
 
 echo "# Try to ping httpbin as DNS resource 2"
-client_ping_resource "$RESOURCE2"
+client_ping "$RESOURCE2"

--- a/scripts/tests/dns.sh
+++ b/scripts/tests/dns.sh
@@ -18,10 +18,10 @@ echo "# Make sure gateway can reach httpbin by DNS"
 gateway sh -c "curl --fail $HTTPBIN_FQDN/get"
 
 echo "# Try to ping httpbin as a DNS resource"
-client_ping_resource "$HTTPBIN"
+client_ping "$HTTPBIN"
 
 echo "# Access httpbin by DNS"
-client_curl_resource "$HTTPBIN/get"
+client_curl "$HTTPBIN/get"
 
 echo "# Make sure it's going through the tunnel"
 client_nslookup "$HTTPBIN" | grep "100\\.96\\.0\\."
@@ -31,6 +31,6 @@ echo "# Make sure a non-resource doesn't go through the tunnel"
 
 echo "# Stop the gateway and make sure the resource is inaccessible"
 docker compose stop gateway
-client_curl_resource "$HTTPBIN/get" && exit 1
+client_curl "$HTTPBIN/get" && exit 1
 
 exit 0

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -18,11 +18,11 @@ function relay2() {
     docker compose exec -T relay-2 "$@"
 }
 
-function client_curl_resource() {
+function client_curl() {
     client curl --connect-timeout 10 --fail "$1" >/dev/null
 }
 
-function client_ping_resource() {
+function client_ping() {
     client timeout 30 \
         sh -c "until ping -W 1 -c 1 $1 &>/dev/null; do true; done"
 }


### PR DESCRIPTION
Within our test scripts, we use several functions for testing connectivity. Two of those are called `client_curl_resource` and `client_ping_resource`. The `_resource` postfix is actually unnecessary: We can pass whatever URL or IP in there and the client will simply try to curl / ping it.

In preparation for testing client <> client connectivity, we remove those postfix.

Related: #11143 