### PR TITLE
fix(portal): use default ghcr.io registry

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -174,8 +174,6 @@ if config_env() == :prod do
 
   config :portal, sign_up_whitelisted_domains: env_var_to_config!(:sign_up_whitelisted_domains)
 
-  config :portal, docker_registry: env_var_to_config!(:docker_registry)
-
   config :portal,
     outbound_email_adapter_configured?: !!env_var_to_config!(:outbound_email_adapter)
 


### PR DESCRIPTION
This was being set by the infra env to azurecr which is private. To fix, we remove the override and let the compile time config value from `config/config.exs` be used, which is `ghcr.io/firezone`.
