### PR TITLE
fix(apple): Ensure AppKit init in CI Swift tests

### DIFF
--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/MacOSAlertTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/MacOSAlertTests.swift
@@ -10,13 +10,8 @@
 
   @testable import FirezoneKit
 
-  @Suite("MacOSAlert Tests")
+  @Suite("MacOSAlert Tests", .requiresAppKit)
   struct MacOSAlertTests {
-    init() {
-      // Bootstrap AppKit's connection to the window server.
-      NSApp.setActivationPolicy(.accessory)
-    }
-
     /// Waits for an alert's sheet to become visible before interacting with it.
     /// This is more reliable than arbitrary sleep delays as it polls for actual window state.
     @MainActor

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/MacOSAlertTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/MacOSAlertTests.swift
@@ -12,6 +12,11 @@
 
   @Suite("MacOSAlert Tests")
   struct MacOSAlertTests {
+    init() {
+      // Bootstrap AppKit's connection to the window server.
+      NSApp.setActivationPolicy(.accessory)
+    }
+
     /// Waits for an alert's sheet to become visible before interacting with it.
     /// This is more reliable than arbitrary sleep delays as it polls for actual window state.
     @MainActor

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/RequiresAppKit.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/RequiresAppKit.swift
@@ -5,15 +5,22 @@
 //
 
 #if os(macOS)
-  import AppKit
+  @preconcurrency import AppKit
   import Testing
 
-  /// Bootstraps AppKit's connection to the window server for GUI testing.
+  /// Bootstraps AppKit's connection to the window server for GUI testing
+  /// and makes all windows transparent so nothing appears on screen.
   ///
   /// `swift test` processes run without `NSApplication`, so GUI objects like
   /// `NSAlert` crash when loading nibs (CoreUI's system appearance renderer
   /// is uninitialised). This trait sets `.accessory` activation policy on
   /// `@MainActor` to bootstrap the connection before the suite runs.
+  ///
+  /// An observer on `NSWindow.didUpdateNotification` sets `alphaValue = 0`
+  /// on every window as it appears, keeping tests invisible. This does not
+  /// affect `NSWindow.isVisible` or programmatic `performClick(nil)` calls,
+  /// so assertions and interactions still work normally. If a test crashes,
+  /// only invisible windows remain — nothing to manually dismiss.
   ///
   /// Usage:
   ///
@@ -28,6 +35,21 @@
       await MainActor.run {
         _ = NSApplication.shared.setActivationPolicy(.accessory)
       }
+
+      nonisolated(unsafe) let observer = await MainActor.run {
+        NotificationCenter.default.addObserver(
+          forName: NSWindow.didUpdateNotification,
+          object: nil,
+          queue: .main
+        ) { notification in
+          let window = notification.object as? NSWindow
+          MainActor.assumeIsolated {
+            window?.alphaValue = 0
+          }
+        }
+      }
+
+      defer { NotificationCenter.default.removeObserver(observer) }
       try await function()
     }
   }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/RequiresAppKit.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/RequiresAppKit.swift
@@ -1,0 +1,38 @@
+//
+//  RequiresAppKit.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import AppKit
+  import Testing
+
+  /// Bootstraps AppKit's connection to the window server for GUI testing.
+  ///
+  /// `swift test` processes run without `NSApplication`, so GUI objects like
+  /// `NSAlert` crash when loading nibs (CoreUI's system appearance renderer
+  /// is uninitialised). This trait sets `.accessory` activation policy on
+  /// `@MainActor` to bootstrap the connection before the suite runs.
+  ///
+  /// Usage:
+  ///
+  ///     @Suite("My Tests", .requiresAppKit)
+  ///     struct MyTests { ... }
+  struct RequiresAppKitTrait: SuiteTrait, TestScoping {
+    func provideScope(
+      for test: Test,
+      testCase: Test.Case?,
+      performing function: @Sendable () async throws -> Void
+    ) async throws {
+      await MainActor.run {
+        _ = NSApplication.shared.setActivationPolicy(.accessory)
+      }
+      try await function()
+    }
+  }
+
+  extension Trait where Self == RequiresAppKitTrait {
+    static var requiresAppKit: Self { Self() }
+  }
+#endif


### PR DESCRIPTION
 - Fix `swift test` crashes caused by CoreUI's system appearance renderer
    being uninitialised when `NSAlert` loads nibs
  - Introduce a `RequiresAppKitTrait` (`SuiteTrait + TestScoping`) that
    bootstraps `NSApplication` on `@MainActor` before the suite runs
  - Suites opt in declaratively: `@Suite("Name", .requiresAppKit)`
  - change the alpha channel of the UI components 0 to ensure they're not distracting or problematic during a crash

  ## Background

  `swift test` runs as a plain CLI process — `NSApplication` is never
  created and the window server connection is never established. Any test
  that instantiates AppKit GUI objects (e.g. `NSAlert`) triggers a fatal
  crash in `+[NSImage imageNamed:]` via CoreUI.

  Setting `.accessory` activation policy on `NSApplication.shared` is the
  minimal bootstrap that makes AppKit functional in a headless test runner.
  
  Fixes #12072 