### PR TITLE
refactor(snownet): decouple ICE role from FZ role

### DIFF
--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -19,6 +19,12 @@ pub use node::{
 };
 pub use stats::{ConnectionStats, NodeStats};
 
+#[derive(Debug, Clone, Copy)]
+pub enum IceRole {
+    Controlling,
+    Controlled,
+}
+
 pub(crate) use crypto::CRYPTO_PROVIDER;
 
 pub fn is_wireguard(payload: &[u8]) -> bool {

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -265,6 +265,7 @@ where
                 .is_some_and(|c| c == &remote_creds)
             && c.tunnel.remote_static_public() == remote
             && c.tunnel.preshared_key().as_bytes() == preshared_key.as_bytes()
+            && c.agent.controlling() == matches!(ice_role, IceRole::Controlling)
         {
             tracing::info!(local = ?local_creds, "Reusing existing connection");
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -13,9 +13,7 @@ use str0m::ice::IceAgent;
 
 use crate::{
     ConnectionStats, Event,
-    node::{
-        Connection, ConnectionState, FzRoleKind, allocations::Allocations, new_ice_candidate_event,
-    },
+    node::{Connection, ConnectionState, Mode, allocations::Allocations, new_ice_candidate_event},
 };
 
 pub struct Connections<TId, RId> {
@@ -90,7 +88,7 @@ where
         allocations: &Allocations<RId>,
         pending_events: &mut VecDeque<Event<TId>>,
         rng: &mut impl Rng,
-        role: FzRoleKind,
+        role: Mode,
         now: Instant,
     ) {
         for (cid, c) in self.iter_established_mut() {

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -13,7 +13,9 @@ use str0m::ice::IceAgent;
 
 use crate::{
     ConnectionStats, Event,
-    node::{Connection, ConnectionState, allocations::Allocations, new_ice_candidate_event},
+    node::{
+        Connection, ConnectionState, FzRoleKind, allocations::Allocations, new_ice_candidate_event,
+    },
 };
 
 pub struct Connections<TId, RId> {
@@ -88,6 +90,7 @@ where
         allocations: &Allocations<RId>,
         pending_events: &mut VecDeque<Event<TId>>,
         rng: &mut impl Rng,
+        role: FzRoleKind,
         now: Instant,
     ) {
         for (cid, c) in self.iter_established_mut() {
@@ -115,7 +118,7 @@ where
                 pending_events.push_back(new_ice_candidate_event(cid, candidate));
             }
 
-            c.state.on_candidate(cid, &mut c.agent, now);
+            c.state.on_candidate(cid, &mut c.agent, role, now);
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -624,6 +624,7 @@ impl ClientState {
                 username: gateway_ice.username,
                 password: gateway_ice.password,
             },
+            snownet::IceRole::Controlling,
             now,
         ) {
             Ok(()) => {}

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -22,7 +22,7 @@ use connlib_model::{ClientId, IceCandidate, RelayId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::ExposeSecret as _;
-use snownet::{Credentials, NoTurnServers, RelaySocket, ServerNode, Transmit};
+use snownet::{Credentials, IceRole, NoTurnServers, RelaySocket, ServerNode, Transmit};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
 use std::net::{IpAddr, SocketAddr};
@@ -309,6 +309,7 @@ impl GatewayState {
                 username: client_ice.username,
                 password: client_ice.password,
             },
+            IceRole::Controlled,
             now,
         )?;
 


### PR DESCRIPTION
Within `snownet`, we currently infer the role of the ICE agent from the Firezone-specific role of the binary, i.e. client or server. With the upcoming client <> client connectivity feature, we need to configure the ICE role dynamically for a client to either be controlling or controlled.

With this PR, we introduce a new `IceRole` enum that one needs to pass in on `upsert_connection`. To disambiguate it with the current `Role` trait and `RoleKind` enum, those are renamed to `DynMode` and `Mode`.

Related: #11143 