### PR TITLE
feat(portal): read from replicas in all views

### DIFF
--- a/elixir/lib/portal/repo/list.ex
+++ b/elixir/lib/portal/repo/list.ex
@@ -1,0 +1,28 @@
+defmodule Portal.Repo.List do
+  @moduledoc false
+
+  alias Portal.Repo.{Paginator, Preloader, Filter}
+
+  def call(repo, queryable, query_module, opts) do
+    {preload, opts} = Keyword.pop(opts, :preload, [])
+    {filter, opts} = Keyword.pop(opts, :filter, [])
+    {order_by, opts} = Keyword.pop(opts, :order_by, [])
+    {paginator_opts, opts} = Keyword.pop(opts, :page, [])
+
+    with {:ok, paginator_opts} <- Paginator.init(query_module, order_by, paginator_opts),
+         {:ok, queryable} <- Filter.filter(queryable, query_module, filter) do
+      count = repo.aggregate(queryable, :count, :id)
+
+      {results, metadata} =
+        queryable
+        |> Paginator.query(paginator_opts)
+        |> repo.all(opts)
+        |> Paginator.metadata(paginator_opts)
+
+      {results, ecto_preloads} = Preloader.preload(results, preload, query_module)
+      results = repo.preload(results, ecto_preloads)
+
+      {:ok, results, %{metadata | count: count}}
+    end
+  end
+end

--- a/elixir/lib/portal/repo/replica.ex
+++ b/elixir/lib/portal/repo/replica.ex
@@ -3,4 +3,21 @@ defmodule Portal.Repo.Replica do
     otp_app: :portal,
     adapter: Ecto.Adapters.Postgres,
     read_only: true
+
+  alias Portal.Repo.{List, Paginator}
+
+  @spec list(
+          queryable :: Ecto.Queryable.t(),
+          query_module :: module(),
+          opts :: Keyword.t()
+        ) ::
+          {:ok, [Ecto.Schema.t()], Paginator.Metadata.t()}
+          | {:error, :invalid_cursor}
+          | {:error, {:unknown_filter, metadata :: Keyword.t()}}
+          | {:error, {:invalid_type, metadata :: Keyword.t()}}
+          | {:error, {:invalid_value, metadata :: Keyword.t()}}
+          | {:error, term()}
+  def list(queryable, query_module, opts \\ []) do
+    List.call(__MODULE__, queryable, query_module, opts)
+  end
 end

--- a/elixir/lib/portal_web/controllers/home_controller.ex
+++ b/elixir/lib/portal_web/controllers/home_controller.ex
@@ -54,7 +54,7 @@ defmodule PortalWeb.HomeController do
 
     def get_accounts_by_ids(account_ids) do
       from(a in Portal.Account, where: a.id in ^account_ids)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
   end

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1831,7 +1831,7 @@ defmodule PortalWeb.Actors do
           },
           order_by: [asc: fragment("COALESCE(?, ?, ?)", google.name, entra.name, okta.name)]
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> case do
           {:error, _} ->
@@ -1892,7 +1892,7 @@ defmodule PortalWeb.Actors do
 
     def list_actors(subject, opts \\ []) do
       all()
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -1900,8 +1900,8 @@ defmodule PortalWeb.Actors do
       from(a in Actor, as: :actors)
       |> where([actors: a], a.id == ^id)
       |> where([actors: a], a.type != :api_client)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def get_identities_for_actor(actor_id, subject) do
@@ -1933,7 +1933,7 @@ defmodule PortalWeb.Actors do
         }
       )
       |> order_by([identities: i], desc: i.inserted_at)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
@@ -1944,15 +1944,15 @@ defmodule PortalWeb.Actors do
         where: a.id != ^actor_id,
         where: is_nil(a.disabled_at)
       )
-      |> Safe.scoped(subject)
-      |> Safe.exists?()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.exists?(fallback_to_primary: true)
     end
 
     def get_client_tokens_for_actor(actor_id, subject) do
       from(c in ClientToken, as: :client_tokens)
       |> where([client_tokens: c], c.actor_id == ^actor_id)
       |> order_by([client_tokens: c], desc: c.inserted_at)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> Presence.Clients.preload_client_tokens_presence()
     end
@@ -1960,15 +1960,15 @@ defmodule PortalWeb.Actors do
     def get_identity_by_id(identity_id, subject) do
       from(i in ExternalIdentity, as: :identities)
       |> where([identities: i], i.id == ^identity_id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def get_client_token_by_id(token_id, subject) do
       from(c in ClientToken, as: :client_tokens)
       |> where([client_tokens: c], c.id == ^token_id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def get_portal_sessions_for_actor(actor_id, subject) do
@@ -1998,7 +1998,7 @@ defmodule PortalWeb.Actors do
           )
       })
       |> order_by([portal_sessions: ps], desc: ps.inserted_at)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> Presence.PortalSessions.preload_portal_sessions_presence()
     end
@@ -2006,8 +2006,8 @@ defmodule PortalWeb.Actors do
     def get_portal_session_by_id(session_id, subject) do
       from(ps in PortalSession, as: :portal_sessions)
       |> where([portal_sessions: ps], ps.id == ^session_id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def get_groups_for_actor(actor_id, subject) do
@@ -2038,7 +2038,7 @@ defmodule PortalWeb.Actors do
         }
       )
       |> order_by([groups: g], asc: g.name)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 

--- a/elixir/lib/portal_web/live/clients/edit.ex
+++ b/elixir/lib/portal_web/live/clients/edit.ex
@@ -97,8 +97,8 @@ defmodule PortalWeb.Clients.Edit do
       from(c in Client, as: :clients)
       |> where([clients: c], c.id == ^id)
       |> preload(:actor)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_client(changeset, subject) do

--- a/elixir/lib/portal_web/live/clients/index.ex
+++ b/elixir/lib/portal_web/live/clients/index.ex
@@ -167,7 +167,7 @@ defmodule PortalWeb.Clients.Index do
         end
 
       base_query
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 

--- a/elixir/lib/portal_web/live/clients/show.ex
+++ b/elixir/lib/portal_web/live/clients/show.ex
@@ -478,8 +478,8 @@ defmodule PortalWeb.Clients.Show do
       from(c in Client, as: :clients)
       |> where([clients: c], c.id == ^id)
       |> preload([:actor, :ipv4_address, :ipv6_address])
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def verify_client(changeset, subject) do
@@ -577,7 +577,7 @@ defmodule PortalWeb.Clients.Show do
 
     defp list_policy_authorizations(queryable, subject, opts) do
       queryable
-      |> Portal.Safe.scoped(subject)
+      |> Portal.Safe.scoped(subject, :replica)
       |> Portal.Safe.list(Database.PolicyAuthorizationQuery, opts)
     end
   end

--- a/elixir/lib/portal_web/live/gateways/show.ex
+++ b/elixir/lib/portal_web/live/gateways/show.ex
@@ -184,8 +184,8 @@ defmodule PortalWeb.Gateways.Show do
       from(g in Gateway, as: :gateways)
       |> where([gateways: g], g.id == ^id)
       |> preload([:site, :ipv4_address, :ipv6_address])
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def delete_gateway(gateway, subject) do

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -986,7 +986,7 @@ defmodule PortalWeb.Groups do
         end
 
       query
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, Keyword.put(opts, :order_by, final_order_by))
     end
 
@@ -1037,7 +1037,7 @@ defmodule PortalWeb.Groups do
           },
           order_by: [asc: fragment("COALESCE(?, ?, ?)", google.name, entra.name, okta.name)]
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> case do
           {:error, _} ->
@@ -1078,15 +1078,15 @@ defmodule PortalWeb.Groups do
       |> select_merge([groups: g, directory: d], %{
         directory_type: d.type
       })
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def get_actor!(id, subject) do
       from(a in Portal.Actor, as: :actors)
       |> where([actors: a], a.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def search_actors(search_term, subject, exclude_actors) do
@@ -1099,7 +1099,7 @@ defmodule PortalWeb.Groups do
                a.id not in ^exclude_ids
            )
            |> limit(10)
-           |> Safe.scoped(subject)
+           |> Safe.scoped(subject, :replica)
            |> Safe.all() do
         actors when is_list(actors) -> actors
         {:error, _} -> []
@@ -1142,7 +1142,7 @@ defmodule PortalWeb.Groups do
         )
         |> preload([memberships: m, actors: a], memberships: m, actors: a)
 
-      query |> Safe.scoped(subject) |> Safe.one!()
+      query |> Safe.scoped(subject, :replica) |> Safe.one!(fallback_to_primary: true)
     end
 
     def preloads do

--- a/elixir/lib/portal_web/live/policies/edit.ex
+++ b/elixir/lib/portal_web/live/policies/edit.ex
@@ -264,8 +264,8 @@ defmodule PortalWeb.Policies.Edit do
       from(p in Policy, as: :policies)
       |> where([policies: p], p.id == ^id)
       |> preload([:group, :resource])
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_policy(changeset, %Authentication.Subject{} = subject) do
@@ -284,7 +284,7 @@ defmodule PortalWeb.Policies.Edit do
       ]
       |> Enum.flat_map(fn schema ->
         from(p in schema, where: not p.is_disabled)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
       end)
     end
@@ -319,8 +319,8 @@ defmodule PortalWeb.Policies.Edit do
             directory_type: d.type
           }
         )
-        |> Safe.scoped(subject)
-        |> Safe.one!()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       {:ok, group_option(group)}
     end
@@ -364,7 +364,7 @@ defmodule PortalWeb.Policies.Edit do
           query
         end
 
-      groups = query |> Safe.scoped(subject) |> Safe.all()
+      groups = query |> Safe.scoped(subject, :replica) |> Safe.all()
       metadata = %{limit: 25, count: length(groups)}
 
       {:ok, grouped_select_options(groups), metadata}

--- a/elixir/lib/portal_web/live/policies/index.ex
+++ b/elixir/lib/portal_web/live/policies/index.ex
@@ -175,20 +175,20 @@ defmodule PortalWeb.Policies.Index do
     def get_site(id, subject) do
       from(s in Site, as: :sites)
       |> where([sites: s], s.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def get_resource(id, subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def list_policies(subject, opts \\ []) do
       from(p in Policy, as: :policies)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 

--- a/elixir/lib/portal_web/live/policies/new.ex
+++ b/elixir/lib/portal_web/live/policies/new.ex
@@ -305,7 +305,7 @@ defmodule PortalWeb.Policies.New do
       ]
       |> Enum.flat_map(fn schema ->
         from(p in schema, where: not p.is_disabled)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
       end)
     end
@@ -340,8 +340,8 @@ defmodule PortalWeb.Policies.New do
             directory_type: d.type
           }
         )
-        |> Safe.scoped(subject)
-        |> Safe.one!()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       {:ok, group_option(group)}
     end
@@ -385,7 +385,7 @@ defmodule PortalWeb.Policies.New do
           query
         end
 
-      groups = query |> Safe.scoped(subject) |> Safe.all()
+      groups = query |> Safe.scoped(subject, :replica) |> Safe.all()
       metadata = %{limit: 25, count: length(groups)}
 
       {:ok, grouped_select_options(groups), metadata}

--- a/elixir/lib/portal_web/live/policies/show.ex
+++ b/elixir/lib/portal_web/live/policies/show.ex
@@ -328,8 +328,8 @@ defmodule PortalWeb.Policies.Show do
       from(p in Policy, as: :policies)
       |> where([policies: p], p.id == ^id)
       |> preload(group: [], resource: [])
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_policy(changeset, %Authentication.Subject{} = subject) do
@@ -353,7 +353,7 @@ defmodule PortalWeb.Policies.Show do
       ]
       |> Enum.flat_map(fn schema ->
         from(p in schema, where: not p.is_disabled)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
       end)
     end
@@ -365,7 +365,7 @@ defmodule PortalWeb.Policies.Show do
         ) do
       Database.PolicyAuthorizationQuery.all()
       |> Database.PolicyAuthorizationQuery.by_policy_id(policy.id)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(Database.PolicyAuthorizationQuery, opts)
     end
   end

--- a/elixir/lib/portal_web/live/resources/edit.ex
+++ b/elixir/lib/portal_web/live/resources/edit.ex
@@ -295,7 +295,7 @@ defmodule PortalWeb.Resources.Edit do
     def all_sites(subject) do
       from(s in Portal.Site, as: :sites)
       |> where([sites: s], s.managed_by != :system)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
@@ -303,8 +303,8 @@ defmodule PortalWeb.Resources.Edit do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
       |> preload(:site)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_resource(changeset, subject) do

--- a/elixir/lib/portal_web/live/resources/index.ex
+++ b/elixir/lib/portal_web/live/resources/index.ex
@@ -192,14 +192,14 @@ defmodule PortalWeb.Resources.Index do
     def get_site(id, subject) do
       from(s in Site, as: :sites)
       |> where([sites: s], s.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def list_resources(subject, opts \\ []) do
       from(resources in Resource, as: :resources)
       |> where([resources: r], r.type != :internet)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -211,7 +211,7 @@ defmodule PortalWeb.Resources.Index do
       |> where([policies: p], is_nil(p.disabled_at))
       |> group_by([policies: p], p.resource_id)
       |> select([policies: p], {p.resource_id, count(p.id)})
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> case do
         {:error, _} -> %{}

--- a/elixir/lib/portal_web/live/resources/new.ex
+++ b/elixir/lib/portal_web/live/resources/new.ex
@@ -297,7 +297,7 @@ defmodule PortalWeb.Resources.New do
     def all_sites(subject) do
       from(g in Portal.Site, as: :sites)
       |> where([sites: s], s.managed_by != :system)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 

--- a/elixir/lib/portal_web/live/resources/show.ex
+++ b/elixir/lib/portal_web/live/resources/show.ex
@@ -424,16 +424,16 @@ defmodule PortalWeb.Resources.Show do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
       |> preload([:site, :policies])
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def get_internet_resource!(subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.type == :internet)
       |> preload([:site, :policies])
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def delete_resource(resource, subject) do
@@ -443,7 +443,7 @@ defmodule PortalWeb.Resources.Show do
 
     def list_policies(subject, opts \\ []) do
       from(p in Policy, as: :policies)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(Database, opts)
     end
 
@@ -608,7 +608,7 @@ defmodule PortalWeb.Resources.Show do
 
     defp list_policy_authorizations(queryable, subject, opts) do
       queryable
-      |> Portal.Safe.scoped(subject)
+      |> Portal.Safe.scoped(subject, :replica)
       |> Portal.Safe.list(Database.PolicyAuthorizationQuery, opts)
     end
   end

--- a/elixir/lib/portal_web/live/settings/api_clients/edit.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/edit.ex
@@ -93,8 +93,8 @@ defmodule PortalWeb.Settings.ApiClients.Edit do
         where: a.id == ^id,
         where: a.type == :api_client
       )
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_api_client(changeset, subject) do

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -8,7 +8,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
     def list_actors(subject, opts \\ []) do
       from(a in Portal.Actor, as: :actors)
       |> where([actors: a], a.type == :api_client)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 

--- a/elixir/lib/portal_web/live/settings/api_clients/new_token.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/new_token.ex
@@ -139,8 +139,8 @@ defmodule PortalWeb.Settings.ApiClients.NewToken do
         where: a.id == ^id,
         where: a.type == :api_client
       )
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
   end
 end

--- a/elixir/lib/portal_web/live/settings/api_clients/show.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/show.ex
@@ -307,8 +307,8 @@ defmodule PortalWeb.Settings.ApiClients.Show do
         where: a.id == ^id,
         where: a.type == :api_client
       )
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_actor(changeset, subject) do
@@ -323,7 +323,7 @@ defmodule PortalWeb.Settings.ApiClients.Show do
         where: t.actor_id == ^actor.id,
         order_by: [desc: t.inserted_at, desc: t.id]
       )
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -1386,20 +1386,20 @@ defmodule PortalWeb.Settings.Authentication do
 
     def list_all_providers(subject) do
       [
-        EmailOTP.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
-        Userpass.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
-        Google.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
-        Entra.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
-        Okta.AuthProvider |> Safe.scoped(subject) |> Safe.all(),
-        OIDC.AuthProvider |> Safe.scoped(subject) |> Safe.all()
+        EmailOTP.AuthProvider |> Safe.scoped(subject, :replica) |> Safe.all(),
+        Userpass.AuthProvider |> Safe.scoped(subject, :replica) |> Safe.all(),
+        Google.AuthProvider |> Safe.scoped(subject, :replica) |> Safe.all(),
+        Entra.AuthProvider |> Safe.scoped(subject, :replica) |> Safe.all(),
+        Okta.AuthProvider |> Safe.scoped(subject, :replica) |> Safe.all(),
+        OIDC.AuthProvider |> Safe.scoped(subject, :replica) |> Safe.all()
       ]
       |> List.flatten()
     end
 
     def get_provider!(schema, id, subject) do
       from(p in schema, where: p.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def insert_provider(changeset, subject) do
@@ -1467,7 +1467,7 @@ defmodule PortalWeb.Settings.Authentication do
           group_by: ct.auth_provider_id,
           select: {ct.auth_provider_id, count(ct.id)}
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> Map.new()
 
@@ -1477,7 +1477,7 @@ defmodule PortalWeb.Settings.Authentication do
           group_by: ps.auth_provider_id,
           select: {ps.auth_provider_id, count(ps.id)}
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> Map.new()
 

--- a/elixir/lib/portal_web/live/settings/billing.ex
+++ b/elixir/lib/portal_web/live/settings/billing.ex
@@ -301,7 +301,7 @@ defmodule PortalWeb.Settings.Billing do
         where: is_nil(a.disabled_at),
         where: a.type == :account_admin_user
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -311,7 +311,7 @@ defmodule PortalWeb.Settings.Billing do
         where: is_nil(a.disabled_at),
         where: a.type == :service_account
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -321,7 +321,7 @@ defmodule PortalWeb.Settings.Billing do
         where: is_nil(a.disabled_at),
         where: a.type in [:account_admin_user, :account_user]
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -337,7 +337,7 @@ defmodule PortalWeb.Settings.Billing do
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)
       |> distinct(true)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -346,7 +346,7 @@ defmodule PortalWeb.Settings.Billing do
         where: g.account_id == ^account.id,
         where: g.managed_by == :account
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
   end

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1610,9 +1610,9 @@ defmodule PortalWeb.Settings.DirectorySync do
 
     def list_all_directories(subject) do
       [
-        Entra.Directory |> Safe.scoped(subject) |> Safe.all(),
-        Google.Directory |> Safe.scoped(subject) |> Safe.all(),
-        Okta.Directory |> Safe.scoped(subject) |> Safe.all()
+        Entra.Directory |> Safe.scoped(subject, :replica) |> Safe.all(),
+        Google.Directory |> Safe.scoped(subject, :replica) |> Safe.all(),
+        Okta.Directory |> Safe.scoped(subject, :replica) |> Safe.all()
       ]
       |> List.flatten()
       |> enrich_with_job_status()
@@ -1621,8 +1621,8 @@ defmodule PortalWeb.Settings.DirectorySync do
 
     def get_directory!(schema, id, subject) do
       from(d in schema, where: d.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def insert_directory(changeset, subject) do
@@ -1654,21 +1654,21 @@ defmodule PortalWeb.Settings.DirectorySync do
         from(a in Portal.Actor,
           where: a.created_by_directory_id == ^directory_id
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       identities_count =
         from(ei in Portal.ExternalIdentity,
           where: ei.directory_id == ^directory_id
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       groups_count =
         from(g in Portal.Group,
           where: g.directory_id == ^directory_id
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       policies_count =
@@ -1677,7 +1677,7 @@ defmodule PortalWeb.Settings.DirectorySync do
           on: p.group_id == g.id and p.account_id == g.account_id,
           where: g.directory_id == ^directory_id
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       %{
@@ -1695,8 +1695,8 @@ defmodule PortalWeb.Settings.DirectorySync do
       schema = directory.__struct__
 
       from(d in schema, where: d.id == ^directory.id)
-      |> Safe.scoped(subject)
-      |> Safe.one()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     defp enrich_with_job_status(directories) do
@@ -1713,7 +1713,7 @@ defmodule PortalWeb.Settings.DirectorySync do
           where: fragment("?->>'directory_id'", j.args) in ^directory_ids,
           order_by: [desc: j.inserted_at]
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.all()
         |> Enum.map(fn job -> {job.args["directory_id"], job} end)
         |> Map.new()
@@ -1726,7 +1726,7 @@ defmodule PortalWeb.Settings.DirectorySync do
           where: fragment("?->>'directory_id'", j.args) in ^directory_ids,
           order_by: [desc: j.completed_at]
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.all()
         |> Enum.uniq_by(& &1.args["directory_id"])
         |> Enum.map(fn job -> {job.args["directory_id"], job} end)
@@ -1772,7 +1772,7 @@ defmodule PortalWeb.Settings.DirectorySync do
           group_by: ei.directory_id,
           select: {ei.directory_id, count(ei.actor_id, :distinct)}
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> Map.new()
 
@@ -1783,7 +1783,7 @@ defmodule PortalWeb.Settings.DirectorySync do
           group_by: g.directory_id,
           select: {g.directory_id, count(g.id)}
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.all()
         |> Map.new()
 

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -325,8 +325,8 @@ defmodule PortalWeb.Settings.DNS do
 
     def get_account_by_id!(id, subject) do
       from(a in Account, where: a.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update(changeset, subject) do

--- a/elixir/lib/portal_web/live/sites/edit.ex
+++ b/elixir/lib/portal_web/live/sites/edit.ex
@@ -100,8 +100,8 @@ defmodule PortalWeb.Sites.Edit do
       from(s in Portal.Site, as: :site)
       |> where([site: s], s.id == ^id)
       |> preload(:account)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def update_site(changeset, subject) do

--- a/elixir/lib/portal_web/live/sites/gateways/index.ex
+++ b/elixir/lib/portal_web/live/sites/gateways/index.ex
@@ -144,13 +144,13 @@ defmodule PortalWeb.Sites.Gateways.Index do
     def get_site!(id, subject) do
       from(s in Portal.Site, as: :sites)
       |> where([sites: s], s.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def list_gateways(subject, opts \\ []) do
       from(g in Gateway, as: :gateways)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 

--- a/elixir/lib/portal_web/live/sites/index.ex
+++ b/elixir/lib/portal_web/live/sites/index.ex
@@ -219,7 +219,7 @@ defmodule PortalWeb.Sites.Index do
     def list_sites(subject, opts \\ []) do
       from(g in Site, as: :sites)
       |> where([sites: s], s.managed_by != :system)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -228,7 +228,7 @@ defmodule PortalWeb.Sites.Index do
       |> where([resources: r], r.site_id in ^site_ids)
       |> group_by([resources: r], r.site_id)
       |> select([resources: r], {r.site_id, count(r.id)})
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -242,7 +242,7 @@ defmodule PortalWeb.Sites.Index do
       |> where([resources: r], r.site_id in ^site_ids)
       |> group_by([resources: r], r.site_id)
       |> select([resources: r], {r.site_id, count()})
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -252,8 +252,8 @@ defmodule PortalWeb.Sites.Index do
         from(r in Resource, as: :resources)
         |> where([resources: r], r.type == :internet)
         |> preload(site: :gateways)
-        |> Safe.scoped(subject)
-        |> Safe.one()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one(fallback_to_primary: true)
 
       case resource do
         nil ->

--- a/elixir/lib/portal_web/live/sites/new_token.ex
+++ b/elixir/lib/portal_web/live/sites/new_token.ex
@@ -428,8 +428,8 @@ defmodule PortalWeb.Sites.NewToken do
     def get_site!(id, subject) do
       from(s in Portal.Site, as: :sites)
       |> where([sites: s], s.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def create_token(site, subject) do

--- a/elixir/lib/portal_web/live/sites/show.ex
+++ b/elixir/lib/portal_web/live/sites/show.ex
@@ -513,8 +513,8 @@ defmodule PortalWeb.Sites.Show do
     def get_site!(id, subject) do
       from(s in Portal.Site, as: :sites)
       |> where([sites: s], s.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def delete_tokens_for_site(site, subject) do
@@ -525,7 +525,7 @@ defmodule PortalWeb.Sites.Show do
 
     def list_gateways(subject, opts \\ []) do
       from(g in Gateway, as: :gateways)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -575,17 +575,17 @@ defmodule PortalWeb.Sites.Show do
     def count_site_deletion_stats(site, subject) do
       gateways =
         from(g in Gateway, where: g.site_id == ^site.id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       tokens =
         from(t in Portal.GatewayToken, where: t.site_id == ^site.id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       resources =
         from(r in Portal.Resource, where: r.site_id == ^site.id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.aggregate(:count)
 
       %{gateways: gateways, tokens: tokens, resources: resources}
@@ -595,13 +595,13 @@ defmodule PortalWeb.Sites.Show do
       from(r in Portal.Resource, as: :resources)
       |> where([resources: r], r.type == :internet)
       |> limit(1)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def list_resources(subject, opts \\ []) do
       from(r in Portal.Resource, as: :resources)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(Database.ResourceQuery, opts)
     end
 
@@ -610,14 +610,14 @@ defmodule PortalWeb.Sites.Show do
       |> where([policies: p], p.resource_id in ^resource_ids)
       |> group_by([policies: p], p.resource_id)
       |> select([policies: p], {p.resource_id, count(p.id)})
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> Map.new()
     end
 
     def list_policies(subject, opts \\ []) do
       from(p in Portal.Policy, as: :policies)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(Database.PolicyQuery, opts)
     end
   end

--- a/elixir/test/portal/repo/replica_test.exs
+++ b/elixir/test/portal/repo/replica_test.exs
@@ -3,6 +3,10 @@ defmodule Portal.Repo.ReplicaTest do
 
   alias Portal.Repo.Replica
 
+  defmodule AccountQuery do
+    def cursor_fields, do: [{:accounts, :asc, :inserted_at}, {:accounts, :asc, :id}]
+  end
+
   describe "read operations" do
     # Note: Due to sandbox isolation, data inserted via Portal.Repo is not visible
     # to Portal.Repo.Replica in tests. These tests verify the read functions exist
@@ -43,6 +47,17 @@ defmodule Portal.Repo.ReplicaTest do
       query = from(a in Portal.Account, where: a.id == ^Ecto.UUID.generate())
 
       refute Replica.exists?(query)
+    end
+
+    test "list/3 returns {:ok, results, metadata}" do
+      import Ecto.Query
+      queryable = from(a in Portal.Account, as: :accounts)
+
+      assert {:ok, results, metadata} = Replica.list(queryable, AccountQuery)
+      assert is_list(results)
+      assert is_map(metadata)
+      assert Map.has_key?(metadata, :count)
+      assert is_integer(metadata.count)
     end
 
     test "preload/2 works on structs" do


### PR DESCRIPTION
Now that we have regional read replicas and web nodes, it makes sense to read from these replicas in each view in `PortalWeb`.

Of course, this introduces the possibility for data races, where the replica may not have the data that was just created on the primary. This is solved in the following way:

1. For individual record reads, we try these on the replica and fallback to the primary if not found
2. For `all()` and search queries (like filtering), we just read from the replica with no fallback

Given that we've never seen replication lag above 1s thus far, this should be a solid approach for a v1 and we can take edge cases on as they arise.
