### PR TITLE
feat(portal): use replica for REST API reads

### DIFF
--- a/elixir/lib/portal_api/api_spec.ex
+++ b/elixir/lib/portal_api/api_spec.ex
@@ -12,7 +12,13 @@ defmodule PortalAPI.ApiSpec do
       ],
       info: %Info{
         title: "Firezone API",
-        version: "1.0"
+        version: "1.0",
+        description: """
+        The Firezone REST API is eventually consistent. After creating or updating \
+        a resource, it may take a second or two for the change to be reflected in \
+        subsequent read requests. If you receive a 404 for a recently created or \
+        updated entity, wait briefly and retry the request.\
+        """
       },
       # Populate the paths from a phoenix router
       paths: Paths.from_router(Router),

--- a/elixir/lib/portal_api/controllers/account_controller.ex
+++ b/elixir/lib/portal_api/controllers/account_controller.ex
@@ -31,7 +31,7 @@ defmodule PortalAPI.AccountController do
     def fetch_account(id, subject) do
       result =
         from(a in Account, where: a.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/actor_controller.ex
+++ b/elixir/lib/portal_api/controllers/actor_controller.ex
@@ -196,7 +196,7 @@ defmodule PortalAPI.ActorController do
 
     def list_actors(subject, opts \\ []) do
       from(a in Portal.Actor, as: :actors)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -209,7 +209,7 @@ defmodule PortalAPI.ActorController do
 
     def fetch_actor(id, subject) do
       from(a in Portal.Actor, where: a.id == ^id)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.one()
       |> case do
         nil -> {:error, :not_found}

--- a/elixir/lib/portal_api/controllers/client_controller.ex
+++ b/elixir/lib/portal_api/controllers/client_controller.ex
@@ -200,7 +200,7 @@ defmodule PortalAPI.ClientController do
 
     def list_clients(subject, opts \\ []) do
       from(c in Client, as: :clients)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -222,7 +222,7 @@ defmodule PortalAPI.ClientController do
         from(c in Client, as: :clients)
         |> where([clients: c], c.id == ^id)
         |> preload([:ipv4_address, :ipv6_address])
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/email_otp_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/email_otp_auth_provider_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.EmailOTPAuthProviderController do
 
     def list_providers(subject) do
       from(p in EmailOTP.AuthProvider, as: :providers, order_by: [desc: p.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_provider(id, subject) do
       result =
         from(p in EmailOTP.AuthProvider, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/entra_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/entra_auth_provider_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.EntraAuthProviderController do
 
     def list_providers(subject) do
       from(p in Entra.AuthProvider, as: :providers, order_by: [desc: p.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_provider(id, subject) do
       result =
         from(p in Entra.AuthProvider, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/entra_directory_controller.ex
+++ b/elixir/lib/portal_api/controllers/entra_directory_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.EntraDirectoryController do
 
     def list_directories(subject) do
       from(d in Entra.Directory, as: :directories, order_by: [desc: d.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_directory(id, subject) do
       result =
         from(d in Entra.Directory, where: d.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/external_identity_controller.ex
+++ b/elixir/lib/portal_api/controllers/external_identity_controller.ex
@@ -107,7 +107,7 @@ defmodule PortalAPI.ExternalIdentityController do
         where: ei.actor_id == ^actor_id,
         order_by: [desc: ei.inserted_at]
       )
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -121,7 +121,7 @@ defmodule PortalAPI.ExternalIdentityController do
     def fetch_external_identity(id, subject) do
       result =
         from(ei in ExternalIdentity, where: ei.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/gateway_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_controller.ex
@@ -115,7 +115,7 @@ defmodule PortalAPI.GatewayController do
 
     def list_gateways(subject, opts \\ []) do
       from(g in Gateway, as: :gateways)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -153,7 +153,7 @@ defmodule PortalAPI.GatewayController do
         from(g in Gateway, as: :gateways)
         |> where([gateways: g], g.id == ^id)
         |> preload([:ipv4_address, :ipv6_address])
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/gateway_token_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_token_controller.ex
@@ -107,7 +107,7 @@ defmodule PortalAPI.GatewayTokenController do
       result =
         from(s in Site, as: :sites)
         |> where([sites: s], s.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do
@@ -120,7 +120,7 @@ defmodule PortalAPI.GatewayTokenController do
     def fetch_token(id, subject) do
       result =
         from(t in GatewayToken, where: t.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/google_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/google_auth_provider_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.GoogleAuthProviderController do
 
     def list_providers(subject) do
       from(p in Google.AuthProvider, as: :providers, order_by: [desc: p.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_provider(id, subject) do
       result =
         from(p in Google.AuthProvider, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/google_directory_controller.ex
+++ b/elixir/lib/portal_api/controllers/google_directory_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.GoogleDirectoryController do
 
     def list_directories(subject) do
       from(d in Google.Directory, as: :directories, order_by: [desc: d.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_directory(id, subject) do
       result =
         from(d in Google.Directory, where: d.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/group_controller.ex
+++ b/elixir/lib/portal_api/controllers/group_controller.ex
@@ -180,7 +180,7 @@ defmodule PortalAPI.GroupController do
         [groups: g],
         not (g.type == :managed and is_nil(g.idp_id) and g.name == "Everyone")
       )
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -190,7 +190,7 @@ defmodule PortalAPI.GroupController do
           where: g.id == ^id,
           where: g.type != :managed
         )
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/membership_controller.ex
+++ b/elixir/lib/portal_api/controllers/membership_controller.ex
@@ -170,14 +170,14 @@ defmodule PortalAPI.MembershipController do
 
     def list_actors(subject, opts) do
       from(a in Portal.Actor, as: :actors)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
     def fetch_group(id, subject) do
       from(g in Portal.Group, where: g.id == ^id)
       |> preload(:memberships)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.one()
       |> case do
         nil -> {:error, :not_found}

--- a/elixir/lib/portal_api/controllers/oidc_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/oidc_auth_provider_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.OIDCAuthProviderController do
 
     def list_providers(subject) do
       from(p in OIDC.AuthProvider, as: :providers, order_by: [desc: p.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_provider(id, subject) do
       result =
         from(p in OIDC.AuthProvider, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/okta_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/okta_auth_provider_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.OktaAuthProviderController do
 
     def list_providers(subject) do
       from(p in Okta.AuthProvider, as: :providers, order_by: [desc: p.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_provider(id, subject) do
       result =
         from(p in Okta.AuthProvider, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/okta_directory_controller.ex
+++ b/elixir/lib/portal_api/controllers/okta_directory_controller.ex
@@ -50,14 +50,14 @@ defmodule PortalAPI.OktaDirectoryController do
 
     def list_directories(subject) do
       from(d in Okta.Directory, as: :directories, order_by: [desc: d.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_directory(id, subject) do
       result =
         from(d in Okta.Directory, where: d.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -145,14 +145,14 @@ defmodule PortalAPI.PolicyController do
 
     def list_policies(subject, opts \\ []) do
       from(p in Policy, as: :policies)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
     def fetch_policy(id, subject) do
       result =
         from(p in Policy, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do
@@ -175,7 +175,7 @@ defmodule PortalAPI.PolicyController do
       if resource_id do
         resource =
           from(r in Portal.Resource, where: r.id == ^resource_id)
-          |> Safe.scoped(subject)
+          |> Safe.scoped(subject, :replica)
           |> Safe.one()
 
         case resource do

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -166,14 +166,14 @@ defmodule PortalAPI.ResourceController do
 
     def list_resources(subject, opts \\ []) do
       from(r in Portal.Resource, as: :resources)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
     def fetch_resource(id, subject) do
       result =
         from(r in Portal.Resource, where: r.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/site_controller.ex
+++ b/elixir/lib/portal_api/controllers/site_controller.ex
@@ -165,7 +165,7 @@ defmodule PortalAPI.SiteController do
 
     def list_sites(subject, opts \\ []) do
       from(g in Site, as: :sites)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
     end
 
@@ -173,7 +173,7 @@ defmodule PortalAPI.SiteController do
       result =
         from(s in Site, as: :sites)
         |> where([sites: s], s.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal_api/controllers/userpass_auth_provider_controller.ex
+++ b/elixir/lib/portal_api/controllers/userpass_auth_provider_controller.ex
@@ -51,14 +51,14 @@ defmodule PortalAPI.UserpassAuthProviderController do
 
     def list_providers(subject) do
       from(p in Userpass.AuthProvider, as: :providers, order_by: [desc: p.inserted_at])
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.all()
     end
 
     def fetch_provider(id, subject) do
       result =
         from(p in Userpass.AuthProvider, where: p.id == ^id)
-        |> Safe.scoped(subject)
+        |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
       case result do


### PR DESCRIPTION
- Updates the REST API controllers to hit replicas for all reads
- Updates the Swagger `Info` section to mention API is eventually consistent
