### PR TITLE
feat(portal): use pid - pid for channel - channel coms

### DIFF
--- a/elixir/lib/portal/channels.ex
+++ b/elixir/lib/portal/channels.ex
@@ -1,0 +1,67 @@
+defmodule Portal.Channels do
+  @moduledoc """
+  Targeted message delivery to client and gateway channel processes using `:pg` process groups.
+
+  Replaces the previous `PubSub.Account.broadcast` pattern which sent messages to every
+  channel in an account. Instead, processes register under their specific ID and messages
+  are sent directly to the registered processes.
+
+  `:pg` works natively across distributed Erlang clusters, auto-deregisters dead processes,
+  and handles netsplits by removing unreachable members from the local view.
+  """
+
+  @doc """
+  Registers the calling process as a client channel for the given client ID.
+  """
+  def register_client(client_id) do
+    :ok = :pg.join(group(:client, client_id), self())
+  end
+
+  @doc """
+  Registers the calling process as a gateway channel for the given gateway ID.
+  """
+  def register_gateway(gateway_id) do
+    :ok = :pg.join(group(:gateway, gateway_id), self())
+  end
+
+  @doc """
+  Sends a message to all processes registered for the given client ID.
+
+  Returns `:ok` if at least one process is registered, `{:error, :not_found}` otherwise.
+  """
+  def send_to_client(client_id, message) do
+    send_to_group(group(:client, client_id), message)
+  end
+
+  @doc """
+  Sends a message to all processes registered for the given gateway ID.
+
+  Returns `:ok` if at least one process is registered, `{:error, :not_found}` otherwise.
+  """
+  def send_to_gateway(gateway_id, message) do
+    send_to_group(group(:gateway, gateway_id), message)
+  end
+
+  @doc """
+  Tells a gateway to reject access for a client to a resource.
+
+  This is the public API for triggering reject_access from outside the channel system
+  (e.g. integration tests, admin actions).
+  """
+  def reject_access(gateway_id, client_id, resource_id) do
+    send_to_gateway(gateway_id, {:reject_access, client_id, resource_id})
+  end
+
+  defp send_to_group(group, message) do
+    case :pg.get_members(group) do
+      [] ->
+        {:error, :not_found}
+
+      pids ->
+        Enum.each(pids, &send(&1, message))
+        :ok
+    end
+  end
+
+  defp group(type, id), do: {__MODULE__, type, id}
+end

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -44,24 +44,6 @@ defmodule Portal.PubSub do
     Phoenix.PubSub.unsubscribe(__MODULE__, topic)
   end
 
-  defmodule Account do
-    def subscribe(account_id) do
-      account_id
-      |> topic()
-      |> Portal.PubSub.subscribe()
-    end
-
-    def broadcast(account_id, payload) do
-      account_id
-      |> topic()
-      |> Portal.PubSub.broadcast(payload)
-    end
-
-    defp topic(account_id) do
-      Atom.to_string(__MODULE__) <> ":" <> account_id
-    end
-  end
-
   defmodule Changes do
     def subscribe(account_id) do
       account_id

--- a/elixir/test/portal/channels_test.exs
+++ b/elixir/test/portal/channels_test.exs
@@ -1,0 +1,107 @@
+defmodule Portal.ChannelsTest do
+  use ExUnit.Case, async: true
+  alias Portal.Channels
+
+  describe "register_client/1 and send_to_client/2" do
+    test "delivers message to a registered client process" do
+      client_id = Ecto.UUID.generate()
+      Channels.register_client(client_id)
+
+      assert :ok = Channels.send_to_client(client_id, :hello)
+      assert_receive :hello
+    end
+
+    test "delivers message to multiple registered processes" do
+      client_id = Ecto.UUID.generate()
+      parent = self()
+
+      pids =
+        for _ <- 1..3 do
+          spawn(fn ->
+            Channels.register_client(client_id)
+            send(parent, {:registered, self()})
+
+            receive do
+              msg -> send(parent, {:received, self(), msg})
+            end
+          end)
+        end
+
+      for pid <- pids, do: assert_receive({:registered, ^pid})
+
+      assert :ok = Channels.send_to_client(client_id, :broadcast)
+
+      for pid <- pids, do: assert_receive({:received, ^pid, :broadcast})
+    end
+
+    test "returns {:error, :not_found} when no process is registered" do
+      client_id = Ecto.UUID.generate()
+      assert {:error, :not_found} = Channels.send_to_client(client_id, :hello)
+    end
+  end
+
+  describe "register_gateway/1 and send_to_gateway/2" do
+    test "delivers message to a registered gateway process" do
+      gateway_id = Ecto.UUID.generate()
+      Channels.register_gateway(gateway_id)
+
+      assert :ok = Channels.send_to_gateway(gateway_id, :hello)
+      assert_receive :hello
+    end
+
+    test "returns {:error, :not_found} when no process is registered" do
+      gateway_id = Ecto.UUID.generate()
+      assert {:error, :not_found} = Channels.send_to_gateway(gateway_id, :hello)
+    end
+  end
+
+  describe "process exit cleanup" do
+    test "removes process from group when it exits" do
+      client_id = Ecto.UUID.generate()
+      parent = self()
+
+      pid =
+        spawn(fn ->
+          Channels.register_client(client_id)
+          send(parent, :registered)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive :registered
+
+      # Confirm delivery works while process is alive
+      assert :ok = Channels.send_to_client(client_id, :ping)
+
+      # Stop the process and wait for :pg to clean up
+      Process.monitor(pid)
+      send(pid, :stop)
+      assert_receive {:DOWN, _, :process, ^pid, :normal}
+
+      # :pg cleanup is async; give it a moment
+      Process.sleep(50)
+
+      assert {:error, :not_found} = Channels.send_to_client(client_id, :ping)
+    end
+  end
+
+  describe "reject_access/3" do
+    test "sends reject_access message to the gateway" do
+      gateway_id = Ecto.UUID.generate()
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+
+      Channels.register_gateway(gateway_id)
+
+      assert :ok = Channels.reject_access(gateway_id, client_id, resource_id)
+      assert_receive {:reject_access, ^client_id, ^resource_id}
+    end
+
+    test "returns {:error, :not_found} when gateway is not registered" do
+      gateway_id = Ecto.UUID.generate()
+      assert {:error, :not_found} = Channels.reject_access(gateway_id, "c", "r")
+    end
+  end
+end

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -46,7 +46,7 @@ site = Portal.Repo.get_by!(Portal.Site, account_id: account_id, name: \"$site_na
 [client_id | _] = Portal.Presence.Clients.Account.list(account_id) |> Map.keys()
 resource = Portal.Repo.get_by!(Portal.Resource, account_id: account_id, name: \"$resource_name\")
 
-Portal.PubSub.Account.broadcast(account_id, {{:reject_access, gateway_id}, client_id, resource.id})
+Portal.Channels.reject_access(gateway_id, client_id, resource.id)
 "
 }
 


### PR DESCRIPTION
Phoenix.PubSub's `broadcast` sends the messages **across the whole cluster, to every node**. We are currently using these messages to communicate between client and gateway channel modules.

This is the "N + 1" problem equivalent for our message bus. As we scale to add more nodes, the message bus "signal to noise" ratio, if you will, will decrease, because each message only applies to a single client pid and single gateway pid.

Furthermore, the messages themselves include entire structs with fields we don't use, wasting bandwidth. It's important to keep message sizes small, as this message bus is also used for operational messages, such a Node heartbeats.

In short, this refactor is done as a precautionary measure, following the best practices laid out [this guide](https://learnyousomeerlang.com/distribunomicon).