### PR TITLE
chore(android): always resolve target directory

### DIFF
--- a/kotlin/android/mise.toml
+++ b/kotlin/android/mise.toml
@@ -17,3 +17,7 @@ run = "./gradlew assembleDebug"
 [tasks.test]
 description = "Run unit tests"
 run = "./gradlew test"
+
+[tasks.install-phone]
+description = "Build debug APK and install on connected Android device"
+run = "./gradlew installDebug"


### PR DESCRIPTION
Dynamically resolve cargo target directory in all places.
Before this it used to build, but failed to deploy APK to the phone as it still
relied on hard-coded path.

While at there, add a mise task to facilitate phone deployment.