### PR TITLE
refactor(snownet): replace role with ICE config

### DIFF
--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -14,8 +14,7 @@ mod utils;
 
 pub use allocation::RelaySocket;
 pub use node::{
-    Client, ClientNode, Credentials, Event, NoTurnServers, Node, Server, ServerNode, Transmit,
-    UnknownConnection,
+    Credentials, Event, IceConfig, IceRole, NoTurnServers, Node, Transmit, UnknownConnection,
 };
 pub use stats::{ConnectionStats, NodeStats};
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -13,7 +13,9 @@ use str0m::ice::IceAgent;
 
 use crate::{
     ConnectionStats, Event,
-    node::{Connection, ConnectionState, allocations::Allocations, new_ice_candidate_event},
+    node::{
+        Connection, ConnectionState, IceConfig, allocations::Allocations, new_ice_candidate_event,
+    },
 };
 
 pub struct Connections<TId, RId> {
@@ -87,6 +89,7 @@ where
         &mut self,
         allocations: &Allocations<RId>,
         pending_events: &mut VecDeque<Event<TId>>,
+        default_ice_config: IceConfig,
         rng: &mut impl Rng,
         now: Instant,
     ) {
@@ -115,7 +118,8 @@ where
                 pending_events.push_back(new_ice_candidate_event(cid, candidate));
             }
 
-            c.state.on_candidate(cid, &mut c.agent, now);
+            c.state
+                .on_candidate(cid, &mut c.agent, default_ice_config, now);
         }
     }
 
@@ -495,6 +499,8 @@ mod tests {
             first_handshake_completed_at: None,
             buffer: Default::default(),
             buffer_pool: BufferPool::new(0, "test"),
+            default_ice_config: IceConfig::client_default(),
+            idle_ice_config: IceConfig::client_idle(),
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -84,7 +84,7 @@ const NUM_CONCURRENT_TCP_DNS_CLIENTS: usize = 10;
 
 /// A sans-IO implementation of a Client's functionality.
 ///
-/// Internally, this composes a [`snownet::ClientNode`] with firezone's policy engine around resources.
+/// Internally, this composes a [`snownet::Node`] with firezone's policy engine around resources.
 /// Clients differ from gateways in that they also implement a DNS resolver for DNS resources.
 /// They also initiate connections to Gateways based on packets sent to Resources. Gateways only accept incoming connections.
 pub struct ClientState {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -39,7 +39,7 @@ use itertools::Itertools;
 use logging::{unwrap_or_debug, unwrap_or_warn};
 
 use crate::ClientEvent;
-use snownet::{ClientNode, NoTurnServers, RelaySocket, Transmit};
+use snownet::{NoTurnServers, Node, RelaySocket, Transmit};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -89,7 +89,7 @@ const NUM_CONCURRENT_TCP_DNS_CLIENTS: usize = 10;
 /// They also initiate connections to Gateways based on packets sent to Resources. Gateways only accept incoming connections.
 pub struct ClientState {
     /// Manages wireguard tunnels to gateways.
-    node: ClientNode<GatewayId, RelayId>,
+    node: Node<GatewayId, RelayId>,
     /// All gateways we are connected to and the associated, connection-specific state.
     gateways: PeerStore<GatewayId, GatewayOnClient>,
     /// Tracks the flows to resources that we are currently trying to establish.
@@ -157,7 +157,13 @@ impl ClientState {
             buffered_events: Default::default(),
             tun_config: Default::default(),
             buffered_packets: Default::default(),
-            node: ClientNode::new(seed, now, unix_ts),
+            node: Node::new(
+                seed,
+                now,
+                unix_ts,
+                snownet::IceConfig::client_default(),
+                snownet::IceConfig::client_idle(),
+            ),
             sites_status: Default::default(),
             gateways_by_site: Default::default(),
             stub_resolver: StubResolver::new(records),
@@ -624,6 +630,7 @@ impl ClientState {
                 username: gateway_ice.username,
                 password: gateway_ice.password,
             },
+            snownet::IceRole::Controlling,
             now,
         ) {
             Ok(()) => {}
@@ -1783,7 +1790,7 @@ fn encapsulate_and_buffer(
     packet: IpPacket,
     gid: GatewayId,
     now: Instant,
-    node: &mut ClientNode<GatewayId, RelayId>,
+    node: &mut Node<GatewayId, RelayId>,
     buffered_transmits: &mut VecDeque<Transmit>,
 ) {
     let Some(transmit) = node

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -22,7 +22,7 @@ use connlib_model::{ClientId, IceCandidate, RelayId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::ExposeSecret as _;
-use snownet::{Credentials, NoTurnServers, RelaySocket, ServerNode, Transmit};
+use snownet::{Credentials, IceConfig, IceRole, NoTurnServers, Node, RelaySocket, Transmit};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
 use std::net::{IpAddr, SocketAddr};
@@ -40,7 +40,7 @@ pub struct GatewayState {
     /// The [`snownet::ClientNode`].
     ///
     /// Manages wireguard tunnels to clients.
-    node: ServerNode<ClientId, RelayId>,
+    node: Node<ClientId, RelayId>,
     /// All clients we are connected to and the associated, connection-specific state.
     peers: PeerStore<ClientId, ClientOnGateway>,
 
@@ -76,7 +76,13 @@ impl GatewayState {
     pub(crate) fn new(flow_logs: bool, seed: [u8; 32], now: Instant, unix_ts: Duration) -> Self {
         Self {
             peers: Default::default(),
-            node: ServerNode::new(seed, now, unix_ts),
+            node: Node::new(
+                seed,
+                now,
+                unix_ts,
+                IceConfig::server_default(),
+                IceConfig::server_idle(),
+            ),
             next_expiry_resources_check: Default::default(),
             buffered_events: VecDeque::default(),
             buffered_transmits: VecDeque::default(),
@@ -309,6 +315,7 @@ impl GatewayState {
                 username: client_ice.username,
                 password: client_ice.password,
             },
+            IceRole::Controlled,
             now,
         )?;
 
@@ -699,7 +706,7 @@ fn handle_assigned_ips_event(
 fn encrypt_packet(
     packet: IpPacket,
     cid: ClientId,
-    node: &mut ServerNode<ClientId, RelayId>,
+    node: &mut Node<ClientId, RelayId>,
     now: Instant,
 ) -> Result<Option<Transmit>> {
     let transmit = node

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -35,10 +35,8 @@ const EXPIRE_RESOURCES_INTERVAL: Duration = Duration::from_secs(1);
 
 /// A SANS-IO implementation of a gateway's functionality.
 ///
-/// Internally, this composes a [`snownet::ServerNode`] with firezone's policy engine around resources.
+/// Internally, this composes a [`snownet::Node`] with firezone's policy engine around resources.
 pub struct GatewayState {
-    /// The [`snownet::ClientNode`].
-    ///
     /// Manages wireguard tunnels to clients.
     node: Node<ClientId, RelayId>,
     /// All clients we are connected to and the associated, connection-specific state.


### PR DESCRIPTION
Currently, a `snownet::Node` can be instantiated in one of two ways: As a `Client` or as a `Server`. The only thing this does is change the ICE timings we apply to agent for idle connections.

To prepare for client <> client connectivity, we get rid of this distinction and simply parameterize the `Node` with two `IceConfig`s. Those allow for a dynamic configuration of these ICE timings and remove the need for the internal role.

In order to determine, whether a `snownet::Node` should assume the controlling or controlled ICE role for a particular connection, we add a new parameter to `upsert_connection`.

Related: #11143 
Supersedes: #12096