### PR TITLE
chore: run all Rust tests on macOS

### DIFF
--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -109,31 +109,16 @@ impl Server {
 ///
 /// Test sockets live in e.g. `/run/user/1000/dev.firezone.client/data/`
 fn ipc_path(id: SocketId) -> Result<PathBuf> {
-    #[cfg(target_os = "linux")]
-    {
-        use bin_shared::BUNDLE_ID;
-        Ok(match id {
-            SocketId::Tunnel => PathBuf::from("/run").join(BUNDLE_ID).join("tunnel.sock"),
-            SocketId::Gui => bin_shared::known_dirs::runtime()
-                .context("$XDG_RUNTIME_DIR not set")?
-                .join("gui.sock"),
-            #[cfg(test)]
-            SocketId::Test(id) => bin_shared::known_dirs::runtime()
-                .context("$XDG_RUNTIME_DIR not set")?
-                .join(format!("ipc_test_{id}.sock")),
-        })
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        let runtime_dir =
-            bin_shared::known_dirs::runtime().context("Failed to get runtime directory")?;
-
-        Ok(match id {
-            SocketId::Tunnel => runtime_dir.join("tunnel.sock"),
-            SocketId::Gui => runtime_dir.join("gui.sock"),
-            #[cfg(test)]
-            SocketId::Test(id) => runtime_dir.join(format!("ipc_test_{id}.sock")),
-        })
-    }
+    Ok(match id {
+        SocketId::Tunnel => bin_shared::known_dirs::root_runtime()
+            .context("Failed to get root runtime directory")?
+            .join("tunnel.sock"),
+        SocketId::Gui => bin_shared::known_dirs::user_runtime()
+            .context("Failed to get user runtime directory")?
+            .join("gui.sock"),
+        #[cfg(test)]
+        SocketId::Test(id) => bin_shared::known_dirs::user_runtime()
+            .context("Failed to get user runtime directory")?
+            .join(format!("ipc_test_{id}.sock")),
+    })
 }

--- a/rust/libs/bin-shared/src/known_dirs.rs
+++ b/rust/libs/bin-shared/src/known_dirs.rs
@@ -11,8 +11,7 @@ use anyhow::{Context as _, Result};
 use std::path::PathBuf;
 
 pub use platform::{
-    logs, root_runtime, session, settings, tunnel_service_config, tunnel_service_logs,
-    user_runtime,
+    logs, root_runtime, session, settings, tunnel_service_config, tunnel_service_logs, user_runtime,
 };
 
 #[cfg(target_os = "linux")]

--- a/rust/libs/bin-shared/src/known_dirs.rs
+++ b/rust/libs/bin-shared/src/known_dirs.rs
@@ -10,7 +10,10 @@
 use anyhow::{Context as _, Result};
 use std::path::PathBuf;
 
-pub use platform::{logs, runtime, session, settings, tunnel_service_config, tunnel_service_logs};
+pub use platform::{
+    logs, root_runtime, session, settings, tunnel_service_config, tunnel_service_logs,
+    user_runtime,
+};
 
 #[cfg(target_os = "linux")]
 #[path = "known_dirs/linux.rs"]
@@ -40,7 +43,8 @@ mod tests {
             tunnel_service_config(),
             tunnel_service_logs(),
             logs(),
-            runtime(),
+            root_runtime(),
+            user_runtime(),
             session(),
             settings(),
         ] {

--- a/rust/libs/bin-shared/src/known_dirs/linux.rs
+++ b/rust/libs/bin-shared/src/known_dirs/linux.rs
@@ -33,10 +33,19 @@ pub fn logs() -> Option<PathBuf> {
     Some(dirs::cache_dir()?.join(BUNDLE_ID).join("data").join("logs"))
 }
 
+/// e.g. `/run/dev.firezone.client`
+///
+/// System-wide runtime directory, typically root-owned.
+/// Used for the tunnel service IPC socket.
+#[expect(clippy::unnecessary_wraps)] // Signature must match other platforms
+pub fn root_runtime() -> Option<PathBuf> {
+    Some(PathBuf::from("/run").join(BUNDLE_ID))
+}
+
 /// e.g. `/run/user/1000/dev.firezone.client/data`
 ///
-/// Crash handler socket and other temp files go here
-pub fn runtime() -> Option<PathBuf> {
+/// Per-user runtime directory. Crash handler socket and other temp files go here.
+pub fn user_runtime() -> Option<PathBuf> {
     Some(dirs::runtime_dir()?.join(BUNDLE_ID).join("data"))
 }
 

--- a/rust/libs/bin-shared/src/known_dirs/macos.rs
+++ b/rust/libs/bin-shared/src/known_dirs/macos.rs
@@ -40,10 +40,14 @@ pub fn root_runtime() -> Option<PathBuf> {
     user_runtime()
 }
 
-/// Per-user runtime directory for temporary files
+/// Per-user runtime directory for temporary files.
+///
+/// Uses the OS-assigned per-user temp directory (`TMPDIR` on macOS) rather than
+/// hardcoding `/tmp` with the `USER` env var, which is unreliable and can be
+/// influenced by the process environment.
+#[expect(clippy::unnecessary_wraps)] // Signature must match other platforms
 pub fn user_runtime() -> Option<PathBuf> {
-    let user = std::env::var("USER").ok()?;
-    Some(PathBuf::from("/tmp").join(BUNDLE_ID).join(user))
+    Some(std::env::temp_dir().join(BUNDLE_ID))
 }
 
 /// User session data directory

--- a/rust/libs/bin-shared/src/known_dirs/macos.rs
+++ b/rust/libs/bin-shared/src/known_dirs/macos.rs
@@ -32,10 +32,18 @@ pub fn logs() -> Option<PathBuf> {
     )
 }
 
-/// Runtime directory for temporary files
-pub fn runtime() -> Option<PathBuf> {
+/// System-wide runtime directory for temporary files.
+///
+/// On macOS, this is the same as [`user_runtime`] because the production
+/// macOS client uses the native Swift IPC implementation.
+pub fn root_runtime() -> Option<PathBuf> {
+    user_runtime()
+}
+
+/// Per-user runtime directory for temporary files
+pub fn user_runtime() -> Option<PathBuf> {
     let user = std::env::var("USER").ok()?;
-    Some(PathBuf::from("/tmp").join(format!("{BUNDLE_ID}-{user}")))
+    Some(PathBuf::from("/tmp").join(BUNDLE_ID).join(user))
 }
 
 /// User session data directory

--- a/rust/libs/bin-shared/src/known_dirs/windows.rs
+++ b/rust/libs/bin-shared/src/known_dirs/windows.rs
@@ -44,10 +44,18 @@ pub fn logs() -> Option<PathBuf> {
     Some(app_local_data_dir().ok()?.join("data").join("logs"))
 }
 
+/// System-wide runtime directory.
+///
+/// On Windows, this is the same as [`user_runtime`] because Windows
+/// uses named pipes for IPC rather than filesystem paths.
+pub fn root_runtime() -> Option<PathBuf> {
+    user_runtime()
+}
+
 /// e.g. `C:\Users\Alice\AppData\Local\dev.firezone.client\data`
 ///
 /// Crash handler socket and other temp files go here
-pub fn runtime() -> Option<PathBuf> {
+pub fn user_runtime() -> Option<PathBuf> {
     Some(app_local_data_dir().ok()?.join("data"))
 }
 

--- a/rust/libs/bin-shared/src/uptime/mod.rs
+++ b/rust/libs/bin-shared/src/uptime/mod.rs
@@ -54,6 +54,7 @@ pub fn get() -> Option<Duration> {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg_attr(target_os = "macos", ignore = "uptime::get is stubbed on macOS")]
     fn test_uptime_get() {
         assert!(super::get().is_some());
     }

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -10,6 +10,7 @@ use tokio::time::timeout;
 /// Turn them on, wait a second, turn them off.
 /// This tests that the threads quit gracefully when we call `close`, and they don't crash on startup.
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore = "Network notifiers not implemented on macOS")]
 async fn notifiers() {
     logging::test_global("debug");
     let tokio_handle = tokio::runtime::Handle::current();

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -10,7 +10,10 @@ use tokio::time::timeout;
 /// Turn them on, wait a second, turn them off.
 /// This tests that the threads quit gracefully when we call `close`, and they don't crash on startup.
 #[tokio::test]
-#[cfg_attr(target_os = "macos", ignore = "Network notifiers not implemented on macOS")]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Network notifiers not implemented on macOS"
+)]
 async fn notifiers() {
     logging::test_global("debug");
     let tokio_handle = tokio::runtime::Handle::current();


### PR DESCRIPTION
Follow-up of recent PR suggestion on how to cleanly remove cfg -dependent code from unix domain socket implementation.

By ignoring 2 more tests in bin-shared, entire Rust test suite runs now.