### PR TITLE
fix: cap log size on all platforms

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -618,6 +618,18 @@ pub fn enforce_log_size_cap(log_dirs: Vec<String>, max_size_mb: u32) -> u64 {
     logging::cleanup::enforce_size_cap(&path_refs, max_size_mb)
 }
 
+/// Default maximum total log size in MB across all log directories.
+#[uniffi::export]
+pub fn log_cleanup_default_max_size_mb() -> u32 {
+    logging::DEFAULT_MAX_SIZE_MB
+}
+
+/// Default interval between log cleanup runs in seconds (1 hour).
+#[uniffi::export]
+pub fn log_cleanup_default_interval_secs() -> u64 {
+    logging::DEFAULT_CLEANUP_INTERVAL.as_secs()
+}
+
 impl From<connlib_model::ResourceView> for Resource {
     fn from(resource: connlib_model::ResourceView) -> Self {
         match resource {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -109,6 +109,7 @@ fn try_main(
     let logging::Handles {
         logger: _logger,
         reloader,
+        cleanup: _cleanup,
     } = firezone_gui_client::logging::setup_gui(&log_filter)?;
 
     match cli.command {

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -19,7 +19,7 @@ use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt};
 pub struct Handles {
     pub logger: logging::file::Handle,
     pub reloader: FilterReloadHandle,
-    pub cleanup: Option<logging::CleanupHandle>,
+    pub cleanup: logging::CleanupHandle,
 }
 
 struct LogPath {
@@ -103,7 +103,7 @@ pub fn setup_gui(directives: &str) -> Result<Handles> {
         log_dirs,
         logging::DEFAULT_MAX_SIZE_MB,
         logging::DEFAULT_CLEANUP_INTERVAL,
-    );
+    )?;
 
     Ok(Handles {
         logger,

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -13,8 +13,8 @@ use std::{
 use tokio::task::spawn_blocking;
 use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt};
 
-/// If you don't store `Handles` in a variable, the file logger handle will drop immediately,
-/// resulting in empty log files.
+/// If you don't store `Handles` in a variable, the file logger and cleanup thread will
+/// stop immediately, resulting in empty log files and no log rotation.
 #[must_use]
 pub struct Handles {
     pub logger: logging::file::Handle,

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -99,7 +99,7 @@ pub fn setup_gui(directives: &str) -> Result<Handles> {
         .into_iter()
         .map(|lp| lp.src)
         .collect();
-    let cleanup = logging::start_cleanup_thread(
+    let cleanup = logging::start_log_cleanup_thread(
         log_dirs,
         logging::DEFAULT_MAX_SIZE_MB,
         logging::DEFAULT_CLEANUP_INTERVAL,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -273,8 +273,8 @@ fn try_main() -> Result<()> {
     .context("Failed to set up logging")?;
 
     // Start background log cleanup if file logging is enabled
-    let _cleanup_handle = cli.log_dir.as_ref().map(|log_dir| {
-        logging::start_cleanup_thread(
+    let _cleanup_handle = cli.log_dir.as_ref().and_then(|log_dir| {
+        logging::start_log_cleanup_thread(
             vec![log_dir.clone()],
             cli.log_max_size_mb,
             Duration::from_secs(cli.log_cleanup_interval_secs),

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -265,13 +265,18 @@ fn try_main() -> Result<()> {
     .context("Failed to set up logging")?;
 
     // Start background log cleanup if file logging is enabled
-    let _cleanup_handle = cli.log_dir.as_ref().and_then(|log_dir| {
-        logging::start_log_cleanup_thread(
-            vec![log_dir.clone()],
-            logging::DEFAULT_MAX_SIZE_MB,
-            logging::DEFAULT_CLEANUP_INTERVAL,
-        )
-    });
+    let _cleanup_handle = cli
+        .log_dir
+        .as_ref()
+        .map(|log_dir| {
+            logging::start_log_cleanup_thread(
+                vec![log_dir.clone()],
+                logging::DEFAULT_MAX_SIZE_MB,
+                logging::DEFAULT_CLEANUP_INTERVAL,
+            )
+        })
+        .transpose()
+        .context("Failed to start log cleanup thread")?;
 
     // Deactivate DNS control before starting telemetry or connecting to the portal,
     // in case a previous run of Firezone left DNS control on and messed anything up.

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -65,14 +65,6 @@ struct Cli {
     #[arg(short, long, env = "LOG_DIR")]
     log_dir: Option<PathBuf>,
 
-    /// Maximum total log size in MB before old files are cleaned up.
-    #[arg(long, env = "LOG_MAX_SIZE_MB", default_value_t = logging::DEFAULT_MAX_SIZE_MB)]
-    log_max_size_mb: u32,
-
-    /// Interval in seconds between log cleanup runs.
-    #[arg(long, env = "LOG_CLEANUP_INTERVAL_SECS", default_value_t = logging::DEFAULT_CLEANUP_INTERVAL.as_secs())]
-    log_cleanup_interval_secs: u64,
-
     /// Maximum length of time to retry connecting to the portal if we're having internet issues or
     /// it's down. Accepts human times. e.g. "5m" or "1h" or "30d".
     #[arg(short, long, env = "MAX_PARTITION_TIME")]
@@ -276,8 +268,8 @@ fn try_main() -> Result<()> {
     let _cleanup_handle = cli.log_dir.as_ref().and_then(|log_dir| {
         logging::start_log_cleanup_thread(
             vec![log_dir.clone()],
-            cli.log_max_size_mb,
-            Duration::from_secs(cli.log_cleanup_interval_secs),
+            logging::DEFAULT_MAX_SIZE_MB,
+            logging::DEFAULT_CLEANUP_INTERVAL,
         )
     });
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -264,6 +264,15 @@ fn try_main() -> Result<()> {
     )
     .context("Failed to set up logging")?;
 
+    // Start background log cleanup if file logging is enabled
+    let _cleanup_handle = cli.log_dir.as_ref().map(|log_dir| {
+        logging::start_cleanup_thread(
+            vec![log_dir.clone()],
+            logging::DEFAULT_MAX_SIZE_MB,
+            logging::DEFAULT_CLEANUP_INTERVAL,
+        )
+    });
+
     // Deactivate DNS control before starting telemetry or connecting to the portal,
     // in case a previous run of Firezone left DNS control on and messed anything up.
     let dns_control_method = cli.dns_control;

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -65,6 +65,14 @@ struct Cli {
     #[arg(short, long, env = "LOG_DIR")]
     log_dir: Option<PathBuf>,
 
+    /// Maximum total log size in MB before old files are cleaned up.
+    #[arg(long, env = "LOG_MAX_SIZE_MB", default_value_t = logging::DEFAULT_MAX_SIZE_MB)]
+    log_max_size_mb: u32,
+
+    /// Interval in seconds between log cleanup runs.
+    #[arg(long, env = "LOG_CLEANUP_INTERVAL_SECS", default_value_t = logging::DEFAULT_CLEANUP_INTERVAL.as_secs())]
+    log_cleanup_interval_secs: u64,
+
     /// Maximum length of time to retry connecting to the portal if we're having internet issues or
     /// it's down. Accepts human times. e.g. "5m" or "1h" or "30d".
     #[arg(short, long, env = "MAX_PARTITION_TIME")]
@@ -268,8 +276,8 @@ fn try_main() -> Result<()> {
     let _cleanup_handle = cli.log_dir.as_ref().map(|log_dir| {
         logging::start_cleanup_thread(
             vec![log_dir.clone()],
-            logging::DEFAULT_MAX_SIZE_MB,
-            logging::DEFAULT_CLEANUP_INTERVAL,
+            cli.log_max_size_mb,
+            Duration::from_secs(cli.log_cleanup_interval_secs),
         )
     });
 

--- a/rust/libs/logging/src/cleanup.rs
+++ b/rust/libs/logging/src/cleanup.rs
@@ -43,7 +43,7 @@ pub fn start_log_cleanup_thread(
 ) -> Option<CleanupHandle> {
     // Prevent excessively frequent cleanup that could cause performance issues
     let interval = if interval < MIN_CLEANUP_INTERVAL {
-        tracing::warn!(
+        tracing::info!(
             ?interval,
             "Requested log cleanup interval is very short, increasing to 30 seconds to prevent performance issues"
         );

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -2,6 +2,10 @@
 
 pub mod cleanup;
 pub mod file;
+
+pub use cleanup::{
+    CleanupHandle, DEFAULT_CLEANUP_INTERVAL, DEFAULT_MAX_SIZE_MB, start_cleanup_thread,
+};
 mod format;
 #[macro_use]
 mod unwrap_or;

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -4,7 +4,7 @@ pub mod cleanup;
 pub mod file;
 
 pub use cleanup::{
-    CleanupHandle, DEFAULT_CLEANUP_INTERVAL, DEFAULT_MAX_SIZE_MB, start_cleanup_thread,
+    CleanupHandle, DEFAULT_CLEANUP_INTERVAL, DEFAULT_MAX_SIZE_MB, start_log_cleanup_thread,
 };
 mod format;
 #[macro_use]

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -357,15 +357,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   }
 
   func startLogCleanupTask() {
-    // Hardcoded 100MB limit for log cleanup
-    let maxSizeMb: UInt32 = 100
+    let maxSizeMb = logCleanupDefaultMaxSizeMb()
+    let intervalNs = UInt64(logCleanupDefaultIntervalSecs()) * 1_000_000_000
 
-    // Run cleanup in background task - both immediately and hourly
+    // Run cleanup in background task - both immediately and at the default interval
     logCleanupTask = CancellableTask {
       Self.performLogCleanup(maxSizeMb: maxSizeMb)
 
       while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: 3600 * 1_000_000_000)
+        try? await Task.sleep(nanoseconds: intervalNs)
         guard !Task.isCancelled else { break }
         Self.performLogCleanup(maxSizeMb: maxSizeMb)
       }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,7 +21,7 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem>
+        <ChangeItem pull="#12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem>
+          Prevents unbounded log growth by enforcing a 100 MB log size cap with
+          automatic cleanup of oldest files.
+        </ChangeItem>
         <ChangeItem pull="11625">
           Fails faster when the initial connection to the control plane cannot
           be established, allowing the user to retry sooner.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,7 +11,7 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem>
+        <ChangeItem pull="#12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,10 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem>
+          Prevents unbounded log growth by enforcing a 100 MB log size cap with
+          automatic cleanup of oldest files.
+        </ChangeItem>
         <ChangeItem pull="11779">
           Notifies the user when a connection to a resource cannot be
           established.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,7 +10,7 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem>
+        <ChangeItem pull="#12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,10 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem>
+          Prevents unbounded log growth by enforcing a 100 MB log size cap with
+          automatic cleanup of oldest files.
+        </ChangeItem>
         <ChangeItem pull="11882">
           Adds the <code>sign-in</code> and <code>sign-out</code> commands to
           allow authenticating the Client as a normal user via browser-based


### PR DESCRIPTION
Enforce log size cap with background cleanup on all desktop platforms (including Linux headless client) and Android client.
All platforms reuse the same constants, ie. cleanup interval and max log size.

On desktop clients, we spawn a background thread, and on Android we use a coroutine.

Fixes #2343 