### PR TITLE
fix(portal): broadcast directly to nodes

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -270,7 +270,7 @@ config :portal, outbound_email_adapter_configured?: false
 
 config :portal, relay_presence_topic: "presences:global_relays"
 
-config :portal, changes_pubsub_region: ""
+config :portal, region: ""
 
 config :portal, web_external_url: "https://localhost:13443"
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -81,7 +81,7 @@ if config_env() == :prod do
 
   config :portal, Portal.Changes.ReplicationConnection,
     enabled: env_var_to_config!(:changes_replication_enabled),
-    region: env_var_to_config!(:changes_pubsub_region),
+    region: env_var_to_config!(:region),
     replication_slot_name: env_var_to_config!(:database_changes_replication_slot_name),
     publication_name: env_var_to_config!(:database_changes_publication_name),
     connection_opts:
@@ -147,7 +147,7 @@ if config_env() == :prod do
              else: []
            )
 
-  config :portal, changes_pubsub_region: env_var_to_config!(:changes_pubsub_region)
+  config :portal, region: env_var_to_config!(:region)
 
   # Azure Front Door ID validation - when set, rejects requests without matching X-Azure-FDID header
   config :portal, azure_front_door_id: env_var_to_config!(:azure_front_door_id)

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -51,12 +51,12 @@ defmodule Portal.Config.Definitions do
   defconfig(:background_jobs_enabled, :boolean, default: false)
 
   @doc """
-  Region identifier used to scope Changes PubSub topics.
+  Region identifier used to target direct_broadcast! to web/api nodes.
 
-  In a multi-region deployment, this ensures subscribers only receive change
-  events from their own region.
+  In a multi-region deployment, this ensures change events are only sent to
+  web and api nodes in the same region. Maps to the `REGION` env var.
   """
-  defconfig(:changes_pubsub_region, :string, default: "")
+  defconfig(:region, :string, default: "")
 
   @doc """
   Enable or disable the Changes (CDC) replication consumer for this app instance.

--- a/elixir/lib/portal/pubsub.ex
+++ b/elixir/lib/portal/pubsub.ex
@@ -52,14 +52,33 @@ defmodule Portal.PubSub do
     end
 
     def broadcast(account_id, payload) do
-      account_id
-      |> topic()
-      |> Portal.PubSub.broadcast(payload)
+      topic = topic(account_id)
+      region = Portal.Config.get_env(:portal, :region, "")
+
+      for node <- target_nodes(region) do
+        Phoenix.PubSub.direct_broadcast!(node, Portal.PubSub, topic, payload)
+      end
+
+      :ok
     end
 
     defp topic(account_id) do
-      region = Portal.Config.get_env(:portal, :changes_pubsub_region, "")
-      region <> Atom.to_string(__MODULE__) <> ":" <> account_id
+      Atom.to_string(__MODULE__) <> ":" <> account_id
+    end
+
+    # In dev / test region we don't have a cluster / region; send to self
+    defp target_nodes(""), do: [Node.self()]
+
+    # Node names: portal-{region}-{type}-{index}-{hash}@{ip}
+    defp target_nodes(region) do
+      web_prefix = "portal-" <> region <> "-web"
+      api_prefix = "portal-" <> region <> "-api"
+
+      Node.list()
+      |> Enum.filter(fn node ->
+        name = Atom.to_string(node)
+        String.starts_with?(name, web_prefix) or String.starts_with?(name, api_prefix)
+      end)
     end
   end
 end


### PR DESCRIPTION
Phoenix.PubSub.broadcast sends messages to ALL nodes in the cluster. For logical decoding, this is wasteful because each region has its own replication connection.

Instead, we can filter the list of nodes to send this to and use `direct_broadcast` instead, which reduces cross-region chatter.
