### PR TITLE
fix(portal): don't start rate_limiter on domain/web

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -148,6 +148,7 @@ if config_env() == :prod do
            )
 
   config :portal, region: env_var_to_config!(:region)
+  config :portal, node_type: env_var_to_config!(:node_type)
 
   # Azure Front Door ID validation - when set, rejects requests without matching X-Azure-FDID header
   config :portal, azure_front_door_id: env_var_to_config!(:azure_front_door_id)

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -83,9 +83,8 @@ defmodule Portal.Application do
 
       # Web and API apps are always started to allow VerifiedRoutes to work
       PortalWeb.Endpoint,
-      PortalAPI.Endpoint,
-      PortalAPI.RateLimit
-    ] ++ telemetry() ++ oban() ++ replication()
+      PortalAPI.Endpoint
+    ] ++ rate_limit() ++ telemetry() ++ oban() ++ replication()
   end
 
   defp configure_logger do
@@ -156,6 +155,13 @@ defmodule Portal.Application do
         enabled
       end
     end)
+  end
+
+  defp rate_limit do
+    case Portal.Config.get_env(:portal, :node_type, "portal") do
+      type when type in ["api", "portal"] -> [PortalAPI.RateLimit]
+      _ -> []
+    end
   end
 
   defp verify_geolix_databases do

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -59,6 +59,13 @@ defmodule Portal.Config.Definitions do
   defconfig(:region, :string, default: "")
 
   @doc """
+  Role of this node in the deployment.
+
+  Used to conditionally enable node-specific services.
+  """
+  defconfig(:node_type, :string, default: "portal")
+
+  @doc """
   Enable or disable the Changes (CDC) replication consumer for this app instance.
   """
   defconfig(:changes_replication_enabled, :boolean, default: false)


### PR DESCRIPTION
Fixes an edge case where if the RateLimit pid is started but receives a broadcast update before receiving a hit, its data structure is not initialized, leading to errors like the below:

```
{"message":"GenServer #PID<0.1019.0> terminating\n** (MatchError) no match of right hand side value:\n\n    []\n\n    (hammer 7.1.0) lib/hammer/ets/token_bucket.ex:122: Hammer.ETS.TokenBucket.hit/5\n    (portal 0.1.0+3aa8c6f97b0027912ace8253c0a44138b8427938) lib/portal_api/rate_limit.ex:45: PortalAPI.RateLimit.Listener.handle_info/2\n    (stdlib 7.2) gen_server.erl:2434: :gen_server.try_handle_info/3\n    (stdlib 7.2) gen_server.erl:2420: :gen_server.handle_msg/3\n    (stdlib 7.2) proc_lib.erl:3
```
