### PR TITLE
fix(portal): dont dump database_ssl in dev

### DIFF
--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -9,7 +9,6 @@ db_ssl =
   case System.get_env("DATABASE_SSL", "false") do
     "true" -> true
     "false" -> false
-    json -> json |> JSON.decode!() |> Portal.Config.Dumper.dump_ssl_opts()
   end
 
 db_opts = [


### PR DESCRIPTION
Fixes a compilation issue when trying to pass `DATABASE_SSL` in dev.
