### PR TITLE
refactor(portal): add gateway_sessions

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -116,6 +116,7 @@ config :opentelemetry_experimental, sdk_disabled: true
 
 config :portal, Portal.ConnectivityChecks, enabled: false
 config :portal, Portal.ClientSession.Buffer, enabled: false
+config :portal, Portal.GatewaySession.Buffer, enabled: false
 
 config :portal, Portal.ComponentVersions,
   fetch_from_url: false,

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -83,7 +83,9 @@ defmodule Portal.Application do
       # Web and API apps are always started to allow VerifiedRoutes to work
       PortalWeb.Endpoint,
       PortalAPI.Endpoint
-    ] ++ client_session_buffer() ++ rate_limit() ++ telemetry() ++ oban() ++ replication()
+    ] ++
+      client_session_buffer() ++
+      gateway_session_buffer() ++ rate_limit() ++ telemetry() ++ oban() ++ replication()
   end
 
   defp configure_logger do
@@ -124,6 +126,16 @@ defmodule Portal.Application do
 
     if Keyword.get(config, :enabled, true) do
       [Portal.ClientSession.Buffer]
+    else
+      []
+    end
+  end
+
+  defp gateway_session_buffer do
+    config = Portal.Config.get_env(:portal, Portal.GatewaySession.Buffer, [])
+
+    if Keyword.get(config, :enabled, true) do
+      [Portal.GatewaySession.Buffer]
     else
       []
     end

--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -522,7 +522,7 @@ defmodule Portal.Authentication do
         where: a.allow_email_otp_sign_in == true,
         preload: [actor: a]
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.one()
       |> case do
         nil -> {:error, :not_found}
@@ -572,7 +572,7 @@ defmodule Portal.Authentication do
         where: ps.auth_provider_id in subquery(enabled_provider_ids),
         preload: [actor: a]
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.one()
       |> case do
         nil -> {:error, :not_found}

--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -567,7 +567,7 @@ defmodule Portal.Billing do
         where: is_nil(a.disabled_at),
         where: a.type in [:account_admin_user, :account_user]
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -577,7 +577,7 @@ defmodule Portal.Billing do
         where: is_nil(a.disabled_at),
         where: a.type == :service_account
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -587,7 +587,7 @@ defmodule Portal.Billing do
         where: is_nil(a.disabled_at),
         where: a.type == :account_admin_user
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -607,7 +607,7 @@ defmodule Portal.Billing do
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)
       |> distinct(true)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -616,7 +616,7 @@ defmodule Portal.Billing do
         where: g.account_id == ^account.id,
         where: g.managed_by == :account
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -626,7 +626,7 @@ defmodule Portal.Billing do
         where: is_nil(a.disabled_at),
         where: a.type == :api_client
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -635,7 +635,7 @@ defmodule Portal.Billing do
         where: t.actor_id == ^actor.id,
         where: t.account_id == ^actor.account_id
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -646,7 +646,7 @@ defmodule Portal.Billing do
           where: s.name == "Internet",
           where: s.managed_by == :system
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.one()
 
       case result do
@@ -671,7 +671,7 @@ defmodule Portal.Billing do
           where: r.account_id == ^account.id,
           where: r.type == :internet
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.one()
 
       case result do

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -673,7 +673,7 @@ defmodule Portal.Cache.Client do
                 g.account_id == ^subject.account.id
           )
           |> Safe.scoped(subject, :replica)
-          |> Safe.one(fallback_to_primary: true)
+          |> Safe.one()
 
         # Append a synthetic membership for the Everyone group
         case everyone_group do
@@ -695,7 +695,7 @@ defmodule Portal.Cache.Client do
       result =
         from(r in Portal.Resource, where: r.id == ^id)
         |> Safe.scoped(subject, :replica)
-        |> Safe.one(fallback_to_primary: true)
+        |> Safe.one()
 
       case result do
         nil -> {:error, :not_found}
@@ -715,7 +715,7 @@ defmodule Portal.Cache.Client do
 
       from(s in Portal.Site, where: s.id == ^id)
       |> Safe.scoped(subject, :replica)
-      |> Safe.one(fallback_to_primary: true)
+      |> Safe.one()
     end
 
     def get_site_by_id(site_id, subject) when is_binary(site_id) do
@@ -723,7 +723,7 @@ defmodule Portal.Cache.Client do
 
       from(s in Portal.Site, where: s.id == ^id)
       |> Safe.scoped(subject, :replica)
-      |> Safe.one(fallback_to_primary: true)
+      |> Safe.one()
     end
   end
 end

--- a/elixir/lib/portal/cache/gateway.ex
+++ b/elixir/lib/portal/cache/gateway.ex
@@ -246,7 +246,7 @@ defmodule Portal.Cache.Gateway do
         from(c in Portal.Client, as: :clients)
         |> where([clients: c], c.account_id == ^account_id and c.id == ^id)
         |> Safe.unscoped(:replica)
-        |> Safe.one(fallback_to_primary: true)
+        |> Safe.one()
 
       if client do
         {:ok, client}
@@ -260,7 +260,7 @@ defmodule Portal.Cache.Gateway do
         from(g in Portal.Gateway, as: :gateways)
         |> where([gateways: g], g.account_id == ^account_id and g.id == ^id)
         |> Safe.unscoped(:replica)
-        |> Safe.one(fallback_to_primary: true)
+        |> Safe.one()
 
       if result do
         {:ok, result}
@@ -277,7 +277,7 @@ defmodule Portal.Cache.Gateway do
           where: t.expires_at > ^DateTime.utc_now()
         )
         |> Safe.unscoped(:replica)
-        |> Safe.one(fallback_to_primary: true)
+        |> Safe.one()
 
       if result do
         {:ok, result}
@@ -313,7 +313,7 @@ defmodule Portal.Cache.Gateway do
              ag.account_id == a.account_id)
       )
       |> preload(resource: :site)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
 
@@ -403,7 +403,7 @@ defmodule Portal.Cache.Gateway do
           limit: 1
         )
         |> Safe.unscoped(:replica)
-        |> Safe.one(fallback_to_primary: true)
+        |> Safe.one()
 
       if result, do: {:ok, result}, else: {:error, :not_found}
     end
@@ -432,7 +432,7 @@ defmodule Portal.Cache.Gateway do
             g.name == "Everyone"
       )
       |> Safe.unscoped(:replica)
-      |> Safe.exists?(fallback_to_primary: true)
+      |> Safe.exists?()
     end
 
     defp fetch_membership_id_or_nil_for_everyone(account_id, actor_id, group_id) do

--- a/elixir/lib/portal/entra/error_handler.ex
+++ b/elixir/lib/portal/entra/error_handler.ex
@@ -175,8 +175,8 @@ defmodule Portal.Entra.ErrorHandler do
 
     def get_directory(directory_id) do
       from(d in Entra.Directory, where: d.id == ^directory_id)
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def update_directory(directory, attrs) do

--- a/elixir/lib/portal/entra/scheduler.ex
+++ b/elixir/lib/portal/entra/scheduler.ex
@@ -27,7 +27,7 @@ defmodule Portal.Entra.Scheduler do
           where: is_nil(a.disabled_at),
           where: fragment("(?)->>'idp_sync' = 'true'", a.features)
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.stream()
         |> Stream.each(fn directory ->
           args = %{directory_id: directory.id}

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -737,8 +737,8 @@ defmodule Portal.Entra.Sync do
         where: d.is_disabled == false,
         where: is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def update_directory(changeset) do

--- a/elixir/lib/portal/gateway_session.ex
+++ b/elixir/lib/portal/gateway_session.ex
@@ -1,0 +1,49 @@
+defmodule Portal.GatewaySession do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t() | nil,
+          account_id: Ecto.UUID.t(),
+          gateway_id: Ecto.UUID.t(),
+          gateway_token_id: Ecto.UUID.t(),
+          user_agent: String.t() | nil,
+          remote_ip: :inet.ip_address() | nil,
+          remote_ip_location_region: String.t() | nil,
+          remote_ip_location_city: String.t() | nil,
+          remote_ip_location_lat: float() | nil,
+          remote_ip_location_lon: float() | nil,
+          version: String.t() | nil,
+          inserted_at: DateTime.t() | nil
+        }
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "gateway_sessions" do
+    belongs_to :account, Portal.Account, primary_key: true
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    belongs_to :gateway, Portal.Gateway, references: :id
+    belongs_to :gateway_token, Portal.GatewayToken, references: :id
+
+    field :user_agent, :string
+    field :remote_ip, Portal.Types.IP
+    field :remote_ip_location_region, :string
+    field :remote_ip_location_city, :string
+    field :remote_ip_location_lat, :float
+    field :remote_ip_location_lon, :float
+    field :version, :string
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required([:account_id, :gateway_id, :gateway_token_id])
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:gateway)
+    |> assoc_constraint(:gateway_token)
+  end
+end

--- a/elixir/lib/portal/gateway_session/buffer.ex
+++ b/elixir/lib/portal/gateway_session/buffer.ex
@@ -1,0 +1,94 @@
+defmodule Portal.GatewaySession.Buffer do
+  use GenServer
+  alias Portal.GatewaySession
+  alias __MODULE__.Database
+  require Logger
+
+  @flush_interval :timer.seconds(60)
+  @flush_threshold 1_000
+
+  @drop_keys [:__struct__, :__meta__, :account, :gateway, :gateway_token]
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec insert(GatewaySession.t(), GenServer.server()) :: :ok
+  def insert(%GatewaySession{} = session, server \\ __MODULE__) do
+    GenServer.cast(server, {:insert, session})
+  end
+
+  @doc """
+  Synchronously flushes the buffer.
+  """
+  @spec flush(GenServer.server()) :: :ok
+  def flush(server \\ __MODULE__) do
+    GenServer.call(server, :flush)
+  end
+
+  @impl true
+  def init(opts) do
+    callers = Keyword.get(opts, :callers, [])
+    Process.put(:"$callers", callers)
+    schedule_flush()
+    {:ok, %{buffer: [], count: 0}}
+  end
+
+  @impl true
+  def handle_cast({:insert, session}, state) do
+    state = %{state | buffer: [session | state.buffer], count: state.count + 1}
+
+    if state.count >= @flush_threshold do
+      {:noreply, flush_buffer(state)}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:flush, _from, state) do
+    {:reply, :ok, flush_buffer(state)}
+  end
+
+  @impl true
+  def handle_info(:flush, state) do
+    schedule_flush()
+    {:noreply, flush_buffer(state)}
+  end
+
+  defp flush_buffer(%{buffer: [], count: 0} = state), do: state
+
+  defp flush_buffer(%{buffer: buffer, count: count}) do
+    now = DateTime.utc_now()
+
+    entries =
+      Enum.map(buffer, fn session ->
+        session
+        |> Map.from_struct()
+        |> Map.drop(@drop_keys)
+        |> Map.put(:id, Ecto.UUID.generate())
+        |> Map.put(:inserted_at, now)
+      end)
+
+    Database.insert_all(entries)
+
+    Logger.info("Flushed #{count} gateway sessions")
+
+    %{buffer: [], count: 0}
+  end
+
+  defp schedule_flush do
+    Process.send_after(self(), :flush, @flush_interval)
+  end
+
+  defmodule Database do
+    alias Portal.GatewaySession
+    alias Portal.Safe
+
+    def insert_all(entries) do
+      Safe.unscoped()
+      |> Safe.insert_all(GatewaySession, entries)
+    end
+  end
+end

--- a/elixir/lib/portal/gateway_token.ex
+++ b/elixir/lib/portal/gateway_token.ex
@@ -12,6 +12,8 @@ defmodule Portal.GatewayToken do
 
     belongs_to :site, Portal.Site
 
+    has_many :gateway_sessions, Portal.GatewaySession, references: :id
+
     field :secret_hash, :string, redact: true
     field :secret_salt, :string, redact: true
 

--- a/elixir/lib/portal/google/error_handler.ex
+++ b/elixir/lib/portal/google/error_handler.ex
@@ -136,8 +136,8 @@ defmodule Portal.Google.ErrorHandler do
 
     def get_directory(directory_id) do
       from(d in Google.Directory, where: d.id == ^directory_id)
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def update_directory(directory, attrs) do

--- a/elixir/lib/portal/google/scheduler.ex
+++ b/elixir/lib/portal/google/scheduler.ex
@@ -27,7 +27,7 @@ defmodule Portal.Google.Scheduler do
           where: is_nil(a.disabled_at),
           where: fragment("(?)->>'idp_sync' = 'true'", a.features)
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.stream()
         |> Stream.each(fn directory ->
           args = %{directory_id: directory.id}

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -557,8 +557,8 @@ defmodule Portal.Google.Sync do
         where: d.is_disabled == false,
         where: is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def update_directory(changeset) do

--- a/elixir/lib/portal/mailer/notifications/outdated_gateway.html.eex
+++ b/elixir/lib/portal/mailer/notifications/outdated_gateway.html.eex
@@ -92,7 +92,7 @@
                   <%= for gateway <- @gateways do %>
                     <tr style="border-bottom-width: 1px; background-color: #ffffff">
                       <th scope="row" style="white-space: nowrap; padding-left: 24px; padding-right: 24px; font-weight: 500; color: #3d3d3d"><%= gateway.name %></th>
-                      <td style="padding: 4px 24px"><%= gateway.last_seen_version %></td>
+                      <td style="padding: 4px 24px"><%= gateway.latest_session && gateway.latest_session.version %></td>
                     </tr>
                   <% end %>
                   </table>

--- a/elixir/lib/portal/mailer/notifications/outdated_gateway.text.eex
+++ b/elixir/lib/portal/mailer/notifications/outdated_gateway.text.eex
@@ -6,7 +6,7 @@ See what's changed: https://www.firezone.dev/changelog?tab=gateway
 
 The following list of Gateways in your Firezone Account can be upgraded:
 <%= for gateway <- @gateways do %>
-<%= "- #{gateway.name} -> #{gateway.last_seen_version}" %>
+<%= "- #{gateway.name} -> #{gateway.latest_session && gateway.latest_session.version}" %>
 <% end %>
 
 <%= if @incompatible_client_count > 0 do %>

--- a/elixir/lib/portal/okta/error_handler.ex
+++ b/elixir/lib/portal/okta/error_handler.ex
@@ -120,8 +120,8 @@ defmodule Portal.Okta.ErrorHandler do
 
     def get_directory(directory_id) do
       from(d in Okta.Directory, where: d.id == ^directory_id)
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def update_directory(directory, attrs) do

--- a/elixir/lib/portal/okta/scheduler.ex
+++ b/elixir/lib/portal/okta/scheduler.ex
@@ -26,7 +26,7 @@ defmodule Portal.Okta.Scheduler do
           where: is_nil(a.disabled_at),
           where: fragment("(?)->>'idp_sync' = 'true'", a.features)
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.stream()
         |> Stream.each(fn directory ->
           args = %{directory_id: directory.id}

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -557,8 +557,8 @@ defmodule Portal.Okta.Sync do
         where: d.is_disabled == false,
         where: is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
-      |> Safe.one()
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def update_directory(changeset) do
@@ -577,8 +577,8 @@ defmodule Portal.Okta.Sync do
           where: i.directory_id == ^directory_id,
           select: count(i.id)
         )
-        |> Safe.unscoped()
-        |> Safe.one!()
+        |> Safe.unscoped(:replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       to_delete =
         from(i in Portal.ExternalIdentity,
@@ -587,8 +587,8 @@ defmodule Portal.Okta.Sync do
           where: i.last_synced_at < ^synced_at or is_nil(i.last_synced_at),
           select: count(i.id)
         )
-        |> Safe.unscoped()
-        |> Safe.one!()
+        |> Safe.unscoped(:replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       %{total: total, to_delete: to_delete}
     end
@@ -604,8 +604,8 @@ defmodule Portal.Okta.Sync do
           where: g.directory_id == ^directory_id,
           select: count(g.id)
         )
-        |> Safe.unscoped()
-        |> Safe.one!()
+        |> Safe.unscoped(:replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       to_delete =
         from(g in Portal.Group,
@@ -614,8 +614,8 @@ defmodule Portal.Okta.Sync do
           where: g.last_synced_at < ^synced_at or is_nil(g.last_synced_at),
           select: count(g.id)
         )
-        |> Safe.unscoped()
-        |> Safe.one!()
+        |> Safe.unscoped(:replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       %{total: total, to_delete: to_delete}
     end
@@ -628,7 +628,7 @@ defmodule Portal.Okta.Sync do
         where: not is_nil(g.idp_id),
         select: g.idp_id
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
 

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -86,7 +86,7 @@ defmodule Portal.Ops do
         where: a.id == ^id,
         where: not is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.one!()
     end
 

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -840,6 +840,12 @@ defmodule Portal.Safe do
   def permit(:read, Portal.ClientSession, :account_user), do: :ok
   def permit(:read, Portal.ClientSession, :service_account), do: :ok
 
+  # GatewaySession permissions
+  def permit(_action, Portal.GatewaySession, :account_admin_user), do: :ok
+  def permit(_action, Portal.GatewaySession, :api_client), do: :ok
+  def permit(:read, Portal.GatewaySession, :account_user), do: :ok
+  def permit(:read, Portal.GatewaySession, :service_account), do: :ok
+
   # PolicyAuthorization permissions - all actor types can read and create policy_authorizations
   def permit(:read, Portal.PolicyAuthorization, _), do: :ok
   def permit(:insert, Portal.PolicyAuthorization, _), do: :ok

--- a/elixir/lib/portal/workers/check_account_limits.ex
+++ b/elixir/lib/portal/workers/check_account_limits.ex
@@ -244,7 +244,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         limit: ^limit
       )
       |> maybe_after_cursor(cursor)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
 
@@ -268,7 +268,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         group_by: a.account_id,
         select: {a.account_id, count(a.id)}
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -282,7 +282,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         group_by: a.account_id,
         select: {a.account_id, count(a.id)}
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -296,7 +296,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         group_by: a.account_id,
         select: {a.account_id, count(a.id)}
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -327,7 +327,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         group_by: s.account_id,
         select: {s.account_id, count(s.actor_id)}
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -340,7 +340,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         group_by: g.account_id,
         select: {g.account_id, count(g.id)}
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
       |> Map.new()
     end
@@ -351,7 +351,7 @@ defmodule Portal.Workers.CheckAccountLimits do
         where: a.type == :account_admin_user,
         where: is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
   end

--- a/elixir/lib/portal/workers/delete_old_gateway_sessions.ex
+++ b/elixir/lib/portal/workers/delete_old_gateway_sessions.ex
@@ -1,0 +1,36 @@
+defmodule Portal.Workers.DeleteOldGatewaySessions do
+  @moduledoc """
+  Oban worker that deletes gateway sessions older than 90 days.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
+
+  alias __MODULE__.Database
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    {count, _} = Database.delete_old_gateway_sessions()
+
+    Logger.info("Deleted #{count} old gateway_sessions")
+
+    :ok
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.GatewaySession
+    alias Portal.Safe
+
+    def delete_old_gateway_sessions do
+      from(s in GatewaySession, as: :gateway_sessions)
+      |> where([gateway_sessions: s], s.inserted_at < ago(90, "day"))
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+  end
+end

--- a/elixir/lib/portal/workers/sync_error_notification.ex
+++ b/elixir/lib/portal/workers/sync_error_notification.ex
@@ -132,7 +132,7 @@ defmodule Portal.Workers.SyncErrorNotification do
     def errored_disabled_directories(schema, frequency) do
       schema
       |> errored_disabled_directories_query(frequency)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
 
@@ -180,7 +180,7 @@ defmodule Portal.Workers.SyncErrorNotification do
         where: a.type == :account_admin_user,
         where: is_nil(a.disabled_at)
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
   end

--- a/elixir/lib/portal_api/controllers/account_json.ex
+++ b/elixir/lib/portal_api/controllers/account_json.ex
@@ -64,7 +64,7 @@ defmodule PortalAPI.AccountJSON do
         where: is_nil(a.disabled_at),
         where: a.type in [:account_admin_user, :account_user]
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -74,7 +74,7 @@ defmodule PortalAPI.AccountJSON do
         where: is_nil(a.disabled_at),
         where: a.type == :service_account
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -84,7 +84,7 @@ defmodule PortalAPI.AccountJSON do
         where: is_nil(a.disabled_at),
         where: a.type == :account_admin_user
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -104,7 +104,7 @@ defmodule PortalAPI.AccountJSON do
       |> where([actor: a], a.type in [:account_user, :account_admin_user])
       |> select([clients: c], c.actor_id)
       |> distinct(true)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
 
@@ -113,7 +113,7 @@ defmodule PortalAPI.AccountJSON do
         where: g.account_id == ^account.id,
         where: g.managed_by == :account
       )
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.aggregate(:count)
     end
   end

--- a/elixir/lib/portal_api/controllers/gateway_session_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_session_controller.ex
@@ -1,0 +1,112 @@
+defmodule PortalAPI.GatewaySessionController do
+  use PortalAPI, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias PortalAPI.Error
+  alias PortalAPI.Pagination
+  alias __MODULE__.Database
+
+  tags(["Gateway Sessions"])
+
+  operation(:index,
+    summary: "List Gateway Sessions",
+    parameters: [
+      gateway_id: [
+        in: :query,
+        description: "Filter by Gateway ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
+    responses: [
+      ok:
+        {"Gateway Sessions Response", "application/json",
+         PortalAPI.Schemas.GatewaySession.ListResponse}
+    ]
+  )
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, params) do
+    list_opts = Pagination.params_to_list_opts(params)
+
+    with {:ok, gateway_sessions, metadata} <-
+           Database.list_gateway_sessions(conn.assigns.subject, params, list_opts) do
+      render(conn, :index, gateway_sessions: gateway_sessions, metadata: metadata)
+    else
+      error -> Error.handle(conn, error)
+    end
+  end
+
+  operation(:show,
+    summary: "Show Gateway Session",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Gateway Session ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
+    responses: [
+      ok:
+        {"Gateway Session Response", "application/json",
+         PortalAPI.Schemas.GatewaySession.Response}
+    ]
+  )
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, %{"id" => id}) do
+    with {:ok, gateway_session} <- Database.fetch_gateway_session(id, conn.assigns.subject) do
+      render(conn, :show, gateway_session: gateway_session)
+    else
+      error -> Error.handle(conn, error)
+    end
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.GatewaySession
+    alias Portal.Safe
+
+    def list_gateway_sessions(subject, params, opts \\ []) do
+      query = from(gs in GatewaySession, as: :gateway_sessions)
+
+      query =
+        case params do
+          %{"gateway_id" => gateway_id} ->
+            where(query, [gateway_sessions: gs], gs.gateway_id == ^gateway_id)
+
+          _ ->
+            query
+        end
+
+      query
+      |> Safe.scoped(subject, :replica)
+      |> Safe.list(__MODULE__, opts)
+    end
+
+    def cursor_fields do
+      [
+        {:gateway_sessions, :desc, :inserted_at},
+        {:gateway_sessions, :asc, :id}
+      ]
+    end
+
+    def preloads do
+      []
+    end
+
+    def fetch_gateway_session(id, subject) do
+      result =
+        from(gs in GatewaySession, as: :gateway_sessions)
+        |> where([gateway_sessions: gs], gs.id == ^id)
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one()
+
+      case result do
+        nil -> {:error, :not_found}
+        {:error, :unauthorized} -> {:error, :unauthorized}
+        gateway_session -> {:ok, gateway_session}
+      end
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/gateway_session_json.ex
+++ b/elixir/lib/portal_api/controllers/gateway_session_json.ex
@@ -1,0 +1,32 @@
+defmodule PortalAPI.GatewaySessionJSON do
+  alias PortalAPI.Pagination
+  alias Portal.GatewaySession
+
+  def index(%{gateway_sessions: gateway_sessions, metadata: metadata}) do
+    %{
+      data: Enum.map(gateway_sessions, &data/1),
+      metadata: Pagination.metadata(metadata)
+    }
+  end
+
+  def show(%{gateway_session: gateway_session}) do
+    %{data: data(gateway_session)}
+  end
+
+  defp data(%GatewaySession{} = session) do
+    %{
+      id: session.id,
+      gateway_id: session.gateway_id,
+      gateway_token_id: session.gateway_token_id,
+      last_seen_user_agent: session.user_agent,
+      last_seen_remote_ip: session.remote_ip && "#{session.remote_ip}",
+      last_seen_remote_ip_location_region: session.remote_ip_location_region,
+      last_seen_remote_ip_location_city: session.remote_ip_location_city,
+      last_seen_remote_ip_location_lat: session.remote_ip_location_lat,
+      last_seen_remote_ip_location_lon: session.remote_ip_location_lon,
+      last_seen_version: session.version,
+      last_seen_at: session.inserted_at,
+      created_at: session.inserted_at
+    }
+  end
+end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -42,6 +42,7 @@ defmodule PortalAPI.Router do
     put "/clients/:id/unverify", ClientController, :unverify
 
     resources "/client_sessions", ClientSessionController, only: [:index, :show]
+    resources "/gateway_sessions", GatewaySessionController, only: [:index, :show]
 
     resources "/resources", ResourceController, except: [:new, :edit]
     resources "/policies", PolicyController, except: [:new, :edit]

--- a/elixir/lib/portal_api/schemas/gateway_session_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_session_schema.ex
@@ -1,0 +1,150 @@
+defmodule PortalAPI.Schemas.GatewaySession do
+  alias OpenApiSpex.Schema
+
+  defmodule GetSchema do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "GatewaySession",
+      description: "Gateway Session",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Gateway Session ID"},
+        gateway_id: %Schema{type: :string, description: "Gateway ID"},
+        gateway_token_id: %Schema{type: :string, description: "Gateway Token ID"},
+        last_seen_user_agent: %Schema{
+          type: :string,
+          description: "User agent at time of session"
+        },
+        last_seen_remote_ip: %Schema{
+          type: :string,
+          description: "Remote IP at time of session"
+        },
+        last_seen_remote_ip_location_region: %Schema{
+          type: :string,
+          description: "Remote IP location region"
+        },
+        last_seen_remote_ip_location_city: %Schema{
+          type: :string,
+          description: "Remote IP location city"
+        },
+        last_seen_remote_ip_location_lat: %Schema{
+          type: :number,
+          description: "Remote IP location latitude"
+        },
+        last_seen_remote_ip_location_lon: %Schema{
+          type: :number,
+          description: "Remote IP location longitude"
+        },
+        last_seen_version: %Schema{
+          type: :string,
+          description: "Gateway version at time of session"
+        },
+        last_seen_at: %Schema{
+          type: :string,
+          description: "Timestamp of the session"
+        },
+        created_at: %Schema{
+          type: :string,
+          description: "Session creation timestamp"
+        }
+      },
+      required: [
+        :id,
+        :gateway_id,
+        :gateway_token_id,
+        :last_seen_at,
+        :created_at
+      ],
+      example: %{
+        "id" => "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "gateway_id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+        "gateway_token_id" => "6ecc106b-75c1-48a5-846c-14782180c1ff",
+        "last_seen_user_agent" => "Linux/6.1.0 connlib/1.4.5 (x86_64)",
+        "last_seen_remote_ip" => "1.2.3.4",
+        "last_seen_remote_ip_location_region" => "California",
+        "last_seen_remote_ip_location_city" => "San Francisco",
+        "last_seen_remote_ip_location_lat" => 37.7749,
+        "last_seen_remote_ip_location_lon" => -122.4194,
+        "last_seen_version" => "1.4.5",
+        "last_seen_at" => "2025-01-01T00:00:00Z",
+        "created_at" => "2025-01-01T00:00:00Z"
+      }
+    })
+  end
+
+  defmodule Response do
+    require OpenApiSpex
+    alias PortalAPI.Schemas.GatewaySession
+
+    OpenApiSpex.schema(%{
+      title: "GatewaySessionResponse",
+      description: "Response schema for single Gateway Session",
+      type: :object,
+      properties: %{
+        data: GatewaySession.GetSchema
+      },
+      example: %{
+        "data" => %{
+          "id" => "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "gateway_id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "gateway_token_id" => "6ecc106b-75c1-48a5-846c-14782180c1ff",
+          "last_seen_user_agent" => "Linux/6.1.0 connlib/1.4.5 (x86_64)",
+          "last_seen_remote_ip" => "1.2.3.4",
+          "last_seen_remote_ip_location_region" => "California",
+          "last_seen_remote_ip_location_city" => "San Francisco",
+          "last_seen_remote_ip_location_lat" => 37.7749,
+          "last_seen_remote_ip_location_lon" => -122.4194,
+          "last_seen_version" => "1.4.5",
+          "last_seen_at" => "2025-01-01T00:00:00Z",
+          "created_at" => "2025-01-01T00:00:00Z"
+        }
+      }
+    })
+  end
+
+  defmodule ListResponse do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+    alias PortalAPI.Schemas.GatewaySession
+
+    OpenApiSpex.schema(%{
+      title: "GatewaySessionsResponse",
+      description: "Response schema for multiple Gateway Sessions",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          description: "Gateway Sessions details",
+          type: :array,
+          items: GatewaySession.GetSchema
+        },
+        metadata: %Schema{description: "Pagination metadata", type: :object}
+      },
+      example: %{
+        "data" => [
+          %{
+            "id" => "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "gateway_id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "gateway_token_id" => "6ecc106b-75c1-48a5-846c-14782180c1ff",
+            "last_seen_user_agent" => "Linux/6.1.0 connlib/1.4.5 (x86_64)",
+            "last_seen_remote_ip" => "1.2.3.4",
+            "last_seen_remote_ip_location_region" => "California",
+            "last_seen_remote_ip_location_city" => "San Francisco",
+            "last_seen_remote_ip_location_lat" => 37.7749,
+            "last_seen_remote_ip_location_lon" => -122.4194,
+            "last_seen_version" => "1.4.5",
+            "last_seen_at" => "2025-01-01T00:00:00Z",
+            "created_at" => "2025-01-01T00:00:00Z"
+          }
+        ],
+        "metadata" => %{
+          "limit" => 50,
+          "total" => 100,
+          "prev_page" => nil,
+          "next_page" => "abc123"
+        }
+      }
+    })
+  end
+end

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1297,6 +1297,15 @@ defmodule PortalWeb.CoreComponents do
     |> assign(:display_remote_ip_location_lon, s.remote_ip_location_lon)
   end
 
+  defp assign_last_seen_fields(%{schema: %Portal.GatewaySession{} = s} = assigns) do
+    assigns
+    |> assign(:display_remote_ip, s.remote_ip)
+    |> assign(:display_remote_ip_location_city, s.remote_ip_location_city)
+    |> assign(:display_remote_ip_location_region, s.remote_ip_location_region)
+    |> assign(:display_remote_ip_location_lat, s.remote_ip_location_lat)
+    |> assign(:display_remote_ip_location_lon, s.remote_ip_location_lon)
+  end
+
   defp assign_last_seen_fields(%{schema: s} = assigns) do
     assigns
     |> assign(:display_remote_ip, s.last_seen_remote_ip)

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -887,8 +887,8 @@ defmodule PortalWeb.Policies.Components do
             directory_type: d.type
           }
         )
-        |> Safe.scoped(subject)
-        |> Safe.one!()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       {:ok, group_option(group)}
     end
@@ -1037,7 +1037,7 @@ defmodule PortalWeb.Policies.Components do
 
     defp list_policy_authorizations(queryable, subject, opts) do
       queryable
-      |> Portal.Safe.scoped(subject)
+      |> Portal.Safe.scoped(subject, :replica)
       |> Portal.Safe.list(Database.PolicyAuthorizationQuery, opts)
     end
   end

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -348,13 +348,13 @@ defmodule PortalWeb.Resources.Components do
     def get_resource!(id, subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
-      |> Safe.scoped(subject)
-      |> Safe.one!()
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def list_resources(subject, opts \\ []) do
       from(r in Resource, as: :resources)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.list(Database.ListQuery, opts)
     end
   end

--- a/elixir/lib/portal_web/live/settings/api_clients/show.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/show.ex
@@ -339,8 +339,8 @@ defmodule PortalWeb.Settings.ApiClients.Show do
           where: t.id == ^token_id,
           where: t.expires_at > ^DateTime.utc_now() or is_nil(t.expires_at)
         )
-        |> Safe.scoped(subject)
-        |> Safe.one()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one(fallback_to_primary: true)
 
       case result do
         nil -> {:error, :not_found}

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -1418,8 +1418,8 @@ defmodule PortalWeb.Settings.Authentication do
       # Delete the parent auth_provider, which will CASCADE delete the child and tokens
       parent =
         from(p in AuthProvider, where: p.id == ^provider.id)
-        |> Safe.scoped(subject)
-        |> Safe.one!()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       parent |> Safe.scoped(subject) |> Safe.delete()
     end

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1673,8 +1673,8 @@ defmodule PortalWeb.Settings.DirectorySync do
       # Delete the parent Portal.Directory, which will CASCADE delete the child
       parent =
         from(d in Portal.Directory, where: d.id == ^directory.id)
-        |> Safe.scoped(subject)
-        |> Safe.one!()
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one!(fallback_to_primary: true)
 
       parent |> Safe.scoped(subject) |> Safe.delete()
     end
@@ -1728,7 +1728,7 @@ defmodule PortalWeb.Settings.DirectorySync do
 
       from(d in schema, where: d.id == ^directory.id)
       |> Safe.scoped(subject, :replica)
-      |> Safe.one(fallback_to_primary: true)
+      |> Safe.one()
     end
 
     defp enrich_with_job_status(directories) do

--- a/elixir/lib/portal_web/live/sign_in.ex
+++ b/elixir/lib/portal_web/live/sign_in.ex
@@ -310,18 +310,18 @@ defmodule PortalWeb.SignIn do
           do: from(a in Account, where: a.id == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one!()
+      query |> Safe.unscoped(:replica) |> Safe.one!()
     end
 
     def get_auth_provider(account, module) do
       from(ap in module, where: ap.account_id == ^account.id and not ap.is_disabled)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.one()
     end
 
     def list_auth_providers(account, module) do
       from(ap in module, where: ap.account_id == ^account.id and not ap.is_disabled)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.all()
     end
   end

--- a/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
+++ b/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
@@ -86,7 +86,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProvider do
       else
         where(Account, [a], a.slug == ^id_or_slug)
       end
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.one()
     end
 
@@ -106,7 +106,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProvider do
           where: p.account_id == ^account_id and p.is_default == true and p.is_disabled == false,
           limit: 1
         )
-        |> Safe.unscoped()
+        |> Safe.unscoped(:replica)
         |> Safe.one()
       end)
     end

--- a/elixir/priv/repo/migrations/20260212000000_create_gateway_sessions.exs
+++ b/elixir/priv/repo/migrations/20260212000000_create_gateway_sessions.exs
@@ -1,0 +1,106 @@
+defmodule Portal.Repo.Migrations.CreateGatewaySessions do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    # Make gateways' last_seen_* fields nullable to make the deploy smoother
+    alter table(:gateways) do
+      modify(:last_seen_user_agent, :string, null: true, from: {:string, null: true})
+      modify(:last_seen_remote_ip, :inet, null: true, from: {:inet, null: true})
+      modify(:last_seen_version, :string, null: true, from: {:string, null: true})
+
+      modify(:last_seen_at, :utc_datetime_usec,
+        null: true,
+        from: {:utc_datetime_usec, null: true}
+      )
+    end
+
+    create table(:gateway_sessions, primary_key: false) do
+      add(:account_id, :binary_id, primary_key: true, null: false)
+      add(:id, :binary_id, primary_key: true, null: false)
+      add(:gateway_id, :binary_id, null: false)
+      add(:gateway_token_id, :binary_id, null: false)
+
+      add(:user_agent, :string)
+      add(:remote_ip, :inet)
+      add(:remote_ip_location_region, :string)
+      add(:remote_ip_location_city, :string)
+      add(:remote_ip_location_lat, :float)
+      add(:remote_ip_location_lon, :float)
+      add(:version, :string)
+
+      timestamps(updated_at: false)
+    end
+
+    execute(
+      "ALTER TABLE gateway_sessions ADD CONSTRAINT gateway_sessions_account_id_fkey FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE",
+      "ALTER TABLE gateway_sessions DROP CONSTRAINT gateway_sessions_account_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE gateway_sessions ADD CONSTRAINT gateway_sessions_gateway_id_fkey FOREIGN KEY (account_id, gateway_id) REFERENCES gateways(account_id, id) ON DELETE CASCADE",
+      "ALTER TABLE gateway_sessions DROP CONSTRAINT gateway_sessions_gateway_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE gateway_sessions ADD CONSTRAINT gateway_sessions_gateway_token_id_fkey FOREIGN KEY (account_id, gateway_token_id) REFERENCES gateway_tokens(account_id, id) ON DELETE CASCADE",
+      "ALTER TABLE gateway_sessions DROP CONSTRAINT gateway_sessions_gateway_token_id_fkey"
+    )
+
+    create(
+      index(:gateway_sessions, [:gateway_id],
+        name: :gateway_sessions_gateway_id_index,
+        concurrently: true
+      )
+    )
+
+    create(
+      index(:gateway_sessions, [:inserted_at],
+        name: :gateway_sessions_inserted_at_index,
+        concurrently: true
+      )
+    )
+
+    create(
+      index(:gateway_sessions, [:gateway_token_id],
+        name: :gateway_sessions_gateway_token_id_index,
+        concurrently: true
+      )
+    )
+
+    # Populate the gateway_sessions table with the data from gateways and gateway_tokens
+    execute(
+      """
+      INSERT INTO gateway_sessions (
+        account_id, id, gateway_id, gateway_token_id,
+        user_agent, remote_ip, remote_ip_location_region, remote_ip_location_city,
+        remote_ip_location_lat, remote_ip_location_lon, version, inserted_at
+      )
+      SELECT
+        g.account_id,
+        gen_random_uuid(),
+        g.id,
+        t.id,
+        g.last_seen_user_agent,
+        g.last_seen_remote_ip,
+        g.last_seen_remote_ip_location_region,
+        g.last_seen_remote_ip_location_city,
+        g.last_seen_remote_ip_location_lat,
+        g.last_seen_remote_ip_location_lon,
+        g.last_seen_version,
+        COALESCE(g.last_seen_at, g.inserted_at)
+      FROM gateways g
+      INNER JOIN LATERAL (
+        SELECT t.id
+        FROM gateway_tokens t
+        WHERE t.site_id = g.site_id AND t.account_id = g.account_id
+        ORDER BY t.inserted_at DESC
+        LIMIT 1
+      ) t ON true
+      WHERE g.last_seen_at IS NOT NULL
+      """,
+      "DELETE FROM gateway_sessions"
+    )
+  end
+end

--- a/elixir/priv/repo/migrations/20260213000000_rename_client_sessions_inserted_at_index.exs
+++ b/elixir/priv/repo/migrations/20260213000000_rename_client_sessions_inserted_at_index.exs
@@ -1,0 +1,10 @@
+defmodule Portal.Repo.Migrations.RenameClientSessionsInsertedAtIndex do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "ALTER INDEX client_sessions_account_id_inserted_at_index RENAME TO client_sessions_inserted_at_index",
+      "ALTER INDEX client_sessions_inserted_at_index RENAME TO client_sessions_account_id_inserted_at_index"
+    )
+  end
+end

--- a/elixir/test/portal/gateway_session/buffer_test.exs
+++ b/elixir/test/portal/gateway_session/buffer_test.exs
@@ -1,0 +1,206 @@
+defmodule Portal.GatewaySession.BufferTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.SiteFixtures
+  import Portal.GatewayFixtures
+  import Portal.TokenFixtures
+
+  alias Portal.GatewaySession
+  alias Portal.GatewaySession.Buffer
+
+  setup do
+    account = account_fixture()
+    site = site_fixture(account: account)
+    gateway = gateway_fixture(account: account, site: site)
+    token = gateway_token_fixture(account: account, site: site)
+
+    buffer =
+      start_supervised!({Buffer, name: :"buffer_#{inspect(make_ref())}", callers: [self()]})
+
+    %{buffer: buffer, account: account, gateway: gateway, token: token}
+  end
+
+  defp count_sessions(ctx) do
+    import Ecto.Query
+    Repo.aggregate(from(s in GatewaySession, where: s.gateway_token_id == ^ctx.token.id), :count)
+  end
+
+  defp build_session(ctx, overrides \\ %{}) do
+    defaults = %{
+      account_id: ctx.account.id,
+      gateway_id: ctx.gateway.id,
+      gateway_token_id: ctx.token.id,
+      user_agent: "Linux/6.1.0 connlib/1.3.0 (x86_64)",
+      remote_ip: {100, 64, 0, 1},
+      remote_ip_location_region: "US",
+      remote_ip_location_city: "New York",
+      remote_ip_location_lat: 40.7128,
+      remote_ip_location_lon: -74.006,
+      version: "1.3.0"
+    }
+
+    struct!(GatewaySession, Map.merge(defaults, overrides))
+  end
+
+  describe "insert/2 and flush/1" do
+    test "inserts a single session into the database on flush", ctx do
+      session = build_session(ctx)
+
+      Buffer.insert(session, ctx.buffer)
+      Buffer.flush(ctx.buffer)
+
+      import Ecto.Query
+
+      [persisted] =
+        Repo.all(from(s in GatewaySession, where: s.gateway_token_id == ^ctx.token.id))
+
+      assert persisted.account_id == ctx.account.id
+      assert persisted.gateway_id == ctx.gateway.id
+      assert persisted.gateway_token_id == ctx.token.id
+      assert persisted.user_agent == "Linux/6.1.0 connlib/1.3.0 (x86_64)"
+      assert persisted.remote_ip.address == {100, 64, 0, 1}
+      assert persisted.remote_ip_location_region == "US"
+      assert persisted.remote_ip_location_city == "New York"
+      assert persisted.remote_ip_location_lat == 40.7128
+      assert persisted.remote_ip_location_lon == -74.006
+      assert persisted.version == "1.3.0"
+    end
+
+    test "generates id and inserted_at for each entry", ctx do
+      Buffer.insert(build_session(ctx), ctx.buffer)
+      Buffer.flush(ctx.buffer)
+
+      import Ecto.Query
+
+      [persisted] =
+        Repo.all(from(s in GatewaySession, where: s.gateway_token_id == ^ctx.token.id))
+
+      assert persisted.id
+      assert persisted.inserted_at
+    end
+
+    test "buffers multiple sessions and flushes them all at once", ctx do
+      for _ <- 1..5 do
+        Buffer.insert(build_session(ctx), ctx.buffer)
+      end
+
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 5
+    end
+
+    test "flush is a no-op when buffer is empty", ctx do
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 0
+    end
+
+    test "flush clears the buffer so subsequent flush is a no-op", ctx do
+      Buffer.insert(build_session(ctx), ctx.buffer)
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 1
+
+      # Second flush should not insert duplicates
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 1
+    end
+
+    test "handles sessions with nil optional fields", ctx do
+      session =
+        build_session(ctx, %{
+          remote_ip: nil,
+          remote_ip_location_region: nil,
+          remote_ip_location_city: nil,
+          remote_ip_location_lat: nil,
+          remote_ip_location_lon: nil,
+          user_agent: nil,
+          version: nil
+        })
+
+      Buffer.insert(session, ctx.buffer)
+      Buffer.flush(ctx.buffer)
+
+      import Ecto.Query
+
+      [persisted] =
+        Repo.all(from(s in GatewaySession, where: s.gateway_token_id == ^ctx.token.id))
+
+      assert persisted.account_id == ctx.account.id
+      assert is_nil(persisted.remote_ip)
+      assert is_nil(persisted.user_agent)
+      assert is_nil(persisted.version)
+    end
+
+    test "each flushed session gets a unique id", ctx do
+      for _ <- 1..3 do
+        Buffer.insert(build_session(ctx), ctx.buffer)
+      end
+
+      Buffer.flush(ctx.buffer)
+
+      import Ecto.Query
+
+      ids =
+        Repo.all(from(s in GatewaySession, where: s.gateway_token_id == ^ctx.token.id))
+        |> Enum.map(& &1.id)
+
+      assert length(Enum.uniq(ids)) == 3
+    end
+  end
+
+  describe "threshold-based flush" do
+    test "auto-flushes when buffer reaches threshold", ctx do
+      for _ <- 1..1_000 do
+        Buffer.insert(build_session(ctx), ctx.buffer)
+      end
+
+      # Give the GenServer time to process all casts and auto-flush
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 1_000
+    end
+  end
+
+  describe "timer-based flush" do
+    test "schedules a flush timer on init", ctx do
+      # The timer message is :flush — sending it manually simulates the timer firing
+      send(ctx.buffer, :flush)
+
+      # Insert after the timer fires to verify the timer reschedules itself
+      Buffer.insert(build_session(ctx), ctx.buffer)
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 1
+    end
+
+    test "flushes buffered sessions when timer fires", ctx do
+      Buffer.insert(build_session(ctx), ctx.buffer)
+      Buffer.insert(build_session(ctx), ctx.buffer)
+
+      # Simulate the timer firing
+      send(ctx.buffer, :flush)
+      # Synchronize to ensure the :flush message has been processed
+      Buffer.flush(ctx.buffer)
+
+      assert count_sessions(ctx) == 2
+    end
+  end
+
+  describe "start_link/1" do
+    test "registers with the given name" do
+      name = :"buffer_custom_#{inspect(make_ref())}"
+
+      pid =
+        start_supervised!(
+          {Buffer, name: name, callers: [self()]},
+          id: :custom_name_buffer
+        )
+
+      assert Process.alive?(pid)
+      assert GenServer.whereis(name) == pid
+    end
+  end
+end

--- a/elixir/test/portal/gateway_session_test.exs
+++ b/elixir/test/portal/gateway_session_test.exs
@@ -1,0 +1,158 @@
+defmodule Portal.GatewaySessionTest do
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.SiteFixtures
+  import Portal.GatewayFixtures
+  import Portal.TokenFixtures
+  import Portal.GatewaySessionFixtures
+
+  alias Portal.GatewaySession
+
+  describe "changeset/1" do
+    test "validates required fields" do
+      changeset =
+        %GatewaySession{}
+        |> Ecto.Changeset.cast(%{}, [])
+        |> GatewaySession.changeset()
+
+      assert errors_on(changeset).account_id
+      assert errors_on(changeset).gateway_id
+      assert errors_on(changeset).gateway_token_id
+    end
+
+    test "valid changeset with all required fields" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      token = gateway_token_fixture(account: account, site: site)
+
+      changeset =
+        %GatewaySession{}
+        |> Ecto.Changeset.cast(
+          %{
+            account_id: account.id,
+            gateway_id: gateway.id,
+            gateway_token_id: token.id,
+            user_agent: "Linux/6.1.0 connlib/1.0.0 (x86_64)",
+            version: "1.0.0"
+          },
+          [:account_id, :gateway_id, :gateway_token_id, :user_agent, :version]
+        )
+        |> GatewaySession.changeset()
+
+      assert changeset.valid?
+    end
+
+    test "enforces account association constraint" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      token = gateway_token_fixture(account: account, site: site)
+
+      assert {:error, changeset} =
+               %GatewaySession{}
+               |> Ecto.Changeset.cast(
+                 %{
+                   account_id: Ecto.UUID.generate(),
+                   gateway_id: gateway.id,
+                   gateway_token_id: token.id
+                 },
+                 [:account_id, :gateway_id, :gateway_token_id]
+               )
+               |> GatewaySession.changeset()
+               |> Repo.insert()
+
+      assert errors_on(changeset).account
+    end
+
+    test "enforces gateway association constraint" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      token = gateway_token_fixture(account: account, site: site)
+
+      assert {:error, changeset} =
+               %GatewaySession{}
+               |> Ecto.Changeset.cast(
+                 %{
+                   account_id: account.id,
+                   gateway_id: Ecto.UUID.generate(),
+                   gateway_token_id: token.id
+                 },
+                 [:account_id, :gateway_id, :gateway_token_id]
+               )
+               |> GatewaySession.changeset()
+               |> Repo.insert()
+
+      assert errors_on(changeset).gateway
+    end
+
+    test "enforces gateway_token association constraint" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+
+      assert {:error, changeset} =
+               %GatewaySession{}
+               |> Ecto.Changeset.cast(
+                 %{
+                   account_id: account.id,
+                   gateway_id: gateway.id,
+                   gateway_token_id: Ecto.UUID.generate()
+                 },
+                 [:account_id, :gateway_id, :gateway_token_id]
+               )
+               |> GatewaySession.changeset()
+               |> Repo.insert()
+
+      assert errors_on(changeset).gateway_token
+    end
+  end
+
+  describe "schema" do
+    test "creates a session with all fields" do
+      session =
+        gateway_session_fixture(
+          remote_ip_location_city: "Kyiv",
+          remote_ip_location_lat: 50.45,
+          remote_ip_location_lon: 30.52
+        )
+
+      assert session.id
+      assert session.account_id
+      assert session.gateway_id
+      assert session.gateway_token_id
+      assert session.user_agent
+      assert session.remote_ip
+      assert session.remote_ip_location_region
+      assert session.remote_ip_location_city == "Kyiv"
+      assert session.remote_ip_location_lat == 50.45
+      assert session.remote_ip_location_lon == 30.52
+      assert session.version
+      assert session.inserted_at
+    end
+
+    test "inserted_at is set automatically" do
+      session = gateway_session_fixture()
+      assert session.inserted_at
+    end
+
+    test "session belongs to a gateway" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      session = gateway_session_fixture(account: account, site: site, gateway: gateway)
+
+      assert session.gateway_id == gateway.id
+    end
+
+    test "session belongs to a gateway_token" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      token = gateway_token_fixture(account: account, site: site)
+      session = gateway_session_fixture(account: account, site: site, token: token)
+
+      assert session.gateway_token_id == token.id
+    end
+  end
+end

--- a/elixir/test/portal/workers/delete_old_gateway_sessions_test.exs
+++ b/elixir/test/portal/workers/delete_old_gateway_sessions_test.exs
@@ -1,0 +1,51 @@
+defmodule Portal.Workers.DeleteOldGatewaySessionsTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Portal.GatewaySessionFixtures
+
+  alias Portal.GatewaySession
+  alias Portal.Workers.DeleteOldGatewaySessions
+
+  describe "perform/1" do
+    test "deletes gateway sessions older than 90 days" do
+      session = gateway_session_fixture()
+
+      session
+      |> Ecto.Changeset.change(inserted_at: DateTime.utc_now() |> DateTime.add(-91, :day))
+      |> Repo.update!()
+
+      assert Repo.get_by(GatewaySession, id: session.id)
+
+      assert :ok = perform_job(DeleteOldGatewaySessions, %{})
+
+      refute Repo.get_by(GatewaySession, id: session.id)
+    end
+
+    test "does not delete gateway sessions newer than 90 days" do
+      session = gateway_session_fixture()
+
+      assert Repo.get_by(GatewaySession, id: session.id)
+
+      assert :ok = perform_job(DeleteOldGatewaySessions, %{})
+
+      assert Repo.get_by(GatewaySession, id: session.id)
+    end
+
+    test "deletes multiple old sessions across accounts" do
+      session1 = gateway_session_fixture()
+      session2 = gateway_session_fixture()
+
+      for session <- [session1, session2] do
+        session
+        |> Ecto.Changeset.change(inserted_at: DateTime.utc_now() |> DateTime.add(-91, :day))
+        |> Repo.update!()
+      end
+
+      assert :ok = perform_job(DeleteOldGatewaySessions, %{})
+
+      refute Repo.get_by(GatewaySession, id: session1.id)
+      refute Repo.get_by(GatewaySession, id: session2.id)
+    end
+  end
+end

--- a/elixir/test/portal_api/controllers/gateway_session_controller_test.exs
+++ b/elixir/test/portal_api/controllers/gateway_session_controller_test.exs
@@ -1,0 +1,189 @@
+defmodule PortalAPI.GatewaySessionControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.SiteFixtures
+  import Portal.GatewayFixtures
+  import Portal.GatewaySessionFixtures
+
+  setup do
+    account = account_fixture()
+    actor = api_client_fixture(account: account)
+    site = site_fixture(account: account)
+    gateway = gateway_fixture(account: account, site: site)
+
+    %{
+      account: account,
+      actor: actor,
+      site: site,
+      gateway: gateway
+    }
+  end
+
+  describe "index/2" do
+    test "returns error when not authorized", %{conn: conn} do
+      conn = get(conn, ~p"/gateway_sessions")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "lists all gateway sessions", %{
+      conn: conn,
+      actor: actor,
+      account: account,
+      site: site,
+      gateway: gateway
+    } do
+      sessions =
+        for _ <- 1..3,
+            do: gateway_session_fixture(account: account, site: site, gateway: gateway)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/gateway_sessions")
+
+      assert %{
+               "data" => data,
+               "metadata" => %{
+                 "count" => count,
+                 "limit" => limit,
+                 "next_page" => next_page,
+                 "prev_page" => prev_page
+               }
+             } = json_response(conn, 200)
+
+      # 3 from fixture + 1 from gateway_fixture's default session
+      assert count == 4
+      assert limit == 50
+      assert is_nil(next_page)
+      assert is_nil(prev_page)
+
+      data_ids = Enum.map(data, & &1["id"])
+      session_ids = Enum.map(sessions, & &1.id)
+
+      for id <- session_ids do
+        assert id in data_ids
+      end
+    end
+
+    test "filters by gateway_id", %{
+      conn: conn,
+      actor: actor,
+      account: account,
+      site: site,
+      gateway: gateway
+    } do
+      # Create sessions for target gateway
+      target_sessions =
+        for _ <- 1..2,
+            do: gateway_session_fixture(account: account, site: site, gateway: gateway)
+
+      # Create session for a different gateway
+      other_gateway = gateway_fixture(account: account, site: site)
+
+      _other_session =
+        gateway_session_fixture(account: account, site: site, gateway: other_gateway)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/gateway_sessions", gateway_id: gateway.id)
+
+      assert %{
+               "data" => data,
+               "metadata" => %{"count" => count}
+             } = json_response(conn, 200)
+
+      # 2 from fixture + 1 from gateway_fixture's default session
+      assert count == 3
+
+      data_ids = Enum.map(data, & &1["id"])
+      target_ids = Enum.map(target_sessions, & &1.id)
+
+      for id <- target_ids do
+        assert id in data_ids
+      end
+    end
+
+    test "lists with limit", %{
+      conn: conn,
+      actor: actor,
+      account: account,
+      site: site,
+      gateway: gateway
+    } do
+      for _ <- 1..3,
+          do: gateway_session_fixture(account: account, site: site, gateway: gateway)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/gateway_sessions", limit: "2")
+
+      assert %{
+               "data" => data,
+               "metadata" => %{
+                 "count" => count,
+                 "limit" => limit,
+                 "next_page" => next_page,
+                 "prev_page" => prev_page
+               }
+             } = json_response(conn, 200)
+
+      assert length(data) == 2
+      assert limit == 2
+      # 3 from fixture + 1 from gateway_fixture's default session
+      assert count == 4
+      refute is_nil(next_page)
+      assert is_nil(prev_page)
+    end
+  end
+
+  describe "show/2" do
+    test "returns error when not authorized", %{
+      conn: conn,
+      account: account,
+      site: site,
+      gateway: gateway
+    } do
+      session = gateway_session_fixture(account: account, site: site, gateway: gateway)
+      conn = get(conn, ~p"/gateway_sessions/#{session.id}")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "returns a single gateway session", %{
+      conn: conn,
+      actor: actor,
+      account: account,
+      site: site,
+      gateway: gateway
+    } do
+      session = gateway_session_fixture(account: account, site: site, gateway: gateway)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/gateway_sessions/#{session.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert data["id"] == session.id
+      assert data["gateway_id"] == session.gateway_id
+      assert data["gateway_token_id"] == session.gateway_token_id
+    end
+
+    test "returns not found for non-existent session", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/gateway_sessions/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404) == %{"error" => %{"reason" => "Not Found"}}
+    end
+  end
+end

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -67,12 +67,14 @@ defmodule PortalAPI.Gateway.SocketTest do
 
       assert gateway.external_id == attrs["external_id"]
       assert gateway.public_key == attrs["public_key"]
-      assert gateway.last_seen_user_agent == connect_info.user_agent
-      assert gateway.last_seen_remote_ip_location_region == "Ukraine"
-      assert gateway.last_seen_remote_ip_location_city == "Kyiv"
-      assert gateway.last_seen_remote_ip_location_lat == 50.4333
-      assert gateway.last_seen_remote_ip_location_lon == 30.5167
-      assert gateway.last_seen_version == @connlib_version
+
+      assert session = Map.fetch!(socket.assigns, :session)
+      assert session.user_agent == connect_info.user_agent
+      assert session.remote_ip_location_region == "Ukraine"
+      assert session.remote_ip_location_city == "Kyiv"
+      assert session.remote_ip_location_lat == 50.4333
+      assert session.remote_ip_location_lon == 30.5167
+      assert session.version == @connlib_version
     end
 
     test "uses region code to put default coordinates" do
@@ -83,11 +85,12 @@ defmodule PortalAPI.Gateway.SocketTest do
       connect_info = build_connect_info(x_headers: [{"x-geo-location-region", "UA"}])
 
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
-      assert gateway = Map.fetch!(socket.assigns, :gateway)
-      assert gateway.last_seen_remote_ip_location_region == "UA"
-      assert gateway.last_seen_remote_ip_location_city == nil
-      assert gateway.last_seen_remote_ip_location_lat == 49.0
-      assert gateway.last_seen_remote_ip_location_lon == 32.0
+      assert Map.fetch!(socket.assigns, :gateway)
+      assert session = Map.fetch!(socket.assigns, :session)
+      assert session.remote_ip_location_region == "UA"
+      assert session.remote_ip_location_city == nil
+      assert session.remote_ip_location_lat == 49.0
+      assert session.remote_ip_location_lon == 32.0
     end
 
     test "propagates trace context" do

--- a/elixir/test/portal_web/live/gateways/show_test.exs
+++ b/elixir/test/portal_web/live/gateways/show_test.exs
@@ -88,10 +88,10 @@ defmodule PortalWeb.Live.Gateways.ShowTest do
     assert table["site"] =~ gateway.site.name
     assert table["name"] =~ gateway.name
     assert table["last started"]
-    assert table["last seen remote ip"] =~ to_string(gateway.last_seen_remote_ip)
+    assert table["last seen remote ip"] =~ "100.64.0.1"
     assert table["status"] =~ "Offline"
-    assert table["version"] =~ gateway.last_seen_version
-    assert table["user agent"] =~ gateway.last_seen_user_agent
+    assert table["version"] =~ gateway.latest_session.version
+    assert table["user agent"] =~ gateway.latest_session.user_agent
     assert table["tunnel interface ipv4 address"] =~ to_string(gateway.ipv4_address.address)
     assert table["tunnel interface ipv6 address"] =~ to_string(gateway.ipv6_address.address)
   end

--- a/elixir/test/support/fixtures/gateway_session_fixtures.ex
+++ b/elixir/test/support/fixtures/gateway_session_fixtures.ex
@@ -1,0 +1,46 @@
+defmodule Portal.GatewaySessionFixtures do
+  @moduledoc """
+  Test helpers for creating gateway sessions.
+  """
+
+  import Portal.AccountFixtures
+  import Portal.SiteFixtures
+  import Portal.GatewayFixtures
+  import Portal.TokenFixtures
+
+  def gateway_session_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+
+    account = Map.get(attrs, :account) || account_fixture()
+    site = Map.get(attrs, :site) || site_fixture(account: account)
+    gateway = Map.get(attrs, :gateway) || gateway_fixture(account: account, site: site)
+    token = Map.get(attrs, :token) || gateway_token_fixture(account: account, site: site)
+
+    session_attrs =
+      attrs
+      |> Map.drop([:account, :site, :gateway, :token])
+      |> Map.put_new(:user_agent, "Linux/6.1.0 connlib/1.3.0 (x86_64)")
+      |> Map.put_new(:remote_ip, {100, 64, 0, 1})
+      |> Map.put_new(:remote_ip_location_region, "US")
+      |> Map.put_new(:version, "1.3.0")
+
+    {:ok, session} =
+      %Portal.GatewaySession{}
+      |> Ecto.Changeset.cast(session_attrs, [
+        :user_agent,
+        :remote_ip,
+        :remote_ip_location_region,
+        :remote_ip_location_city,
+        :remote_ip_location_lat,
+        :remote_ip_location_lon,
+        :version
+      ])
+      |> Ecto.Changeset.put_change(:account_id, account.id)
+      |> Ecto.Changeset.put_change(:gateway_id, gateway.id)
+      |> Ecto.Changeset.put_change(:gateway_token_id, token.id)
+      |> Portal.GatewaySession.changeset()
+      |> Portal.Repo.insert()
+
+    session
+  end
+end


### PR DESCRIPTION
As a followup to #12125, we introduce all of the same changes for gateways. Since authentication and state tracking works nearly exactly the same, this PR closely follows that one.

---

Related: #12125 
