### PR TITLE
fix(snownet): never send invalidated candidates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7308,9 +7308,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125b7a32aab44af55205b5055794fc34ce4841b309ccb65b8883d5eb16e65a00"
+version = "0.16.2"
+source = "git+https://github.com/algesten/str0m?branch=main#29000b1c6452ab8009f24171ba737f7428348d08"
 dependencies = [
  "arrayvec",
  "combine",
@@ -7327,8 +7326,7 @@ dependencies = [
 [[package]]
 name = "str0m-proto"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132cc3c4a8197f7d514887dc6cf5341447d3cbe290773641081b9fa04126c994"
+source = "git+https://github.com/algesten/str0m?branch=main#29000b1c6452ab8009f24171ba737f7428348d08"
 dependencies = [
  "base64ct",
  "dimpl",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -179,7 +179,7 @@ socket-factory = { path = "libs/connlib/socket-factory" }
 socket2 = { version = "0.6.2" }
 specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
-str0m = { version = "0.16.1", default-features = false }
+str0m = { version = "0.16.2", default-features = false }
 strum = { version = "0.27.2", features = ["derive"] }
 stun_codec = "0.4.0"
 subprocess = "0.2.15"
@@ -253,6 +253,7 @@ large_enum_variant = "allow" # Don't care.
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.
 
 [patch.crates-io]
+str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 dimpl = { git = "https://github.com/algesten/dimpl", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -115,7 +115,7 @@ where
                 .current_relay_candidates()
                 .filter_map(|candidate| c.agent.add_local_candidate(candidate).cloned())
             {
-                pending_events.push_back(new_ice_candidate_event(cid, candidate));
+                pending_events.extend(new_ice_candidate_event(cid, candidate));
             }
 
             c.state

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -115,7 +115,7 @@ where
                 .current_relay_candidates()
                 .filter_map(|candidate| c.agent.add_local_candidate(candidate).cloned())
             {
-                pending_events.extend(new_ice_candidate_event(cid, candidate));
+                pending_events.push_back(new_ice_candidate_event(cid, candidate));
             }
 
             c.state

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="12134">
+          Fixes an issue where outdated and thus irrelevant candidates were sent
+          to Clients, causing connectivity issues in rare situations.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.0" date={new Date("2026-02-02")}>
         <ChangeItem pull="11771">
           BREAKING: Remove support for Firezone 1.3.x Clients and lower.


### PR DESCRIPTION
When we have to drop and recreate an allocation with a relay, the previous candidates become invalid and therefore need to be discarded. str0m however internally retains those candidates and still returns them from functions such as `local_candidates`.

We don't ever want to send such candidates to the remote and therefore need to filter by that. `discarded` is currently not exposed by str0m which is why we need to resort to a hack of filtering by the debug representation.

A proper fix with upstream is in the works.