### PR TITLE
fix(connlib): re-query portal DNS on Hiccup event

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -581,6 +581,7 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
+                update_portal_host_ips(&mut portal, &resolver).await;
             }
             Either::Left((Ok(phoenix_channel::Event::NoAddresses), _)) => {
                 update_portal_host_ips(&mut portal, &resolver).await

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -587,6 +587,8 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
+                let ips = resolve_portal_host_ips(portal.host(), &udp_dns_client).await;
+                portal.update_ips(ips);
             }
             Either::Right((Ok(phoenix_channel::Event::NoAddresses), _)) => {
                 let ips = resolve_portal_host_ips(portal.host(), &udp_dns_client).await;

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -42,7 +42,7 @@ const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are
 const INITIAL_CONNECT_MAX_ELAPSED_TIME: Duration = Duration::from_secs(15);
 const INITIAL_CONNECT_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Overall timeout for a single connection attempt (TCP + TLS + WebSocket handshake).
+// Overall timeout for a single connection attempt (TCP + TLS + WebSocket handshake).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -800,6 +800,7 @@ async fn phoenix_channel_event_loop(
             }) => {
                 is_connected.store(false, Ordering::Relaxed);
                 tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}");
+                update_portal_host_ips(&mut portal).await;
             }
             Err(e) => {
                 is_connected.store(false, Ordering::Relaxed);


### PR DESCRIPTION
When a Phoenix channel connection fails, the `PhoenixChannel` emits an `Event::Hiccup` and enters a backoff-retry loop. However, prior to this change, none of the three consumers (gateway, client, relay) re-resolved DNS on `Hiccup` — they only logged the error. DNS was only re-queried on `Event::NoAddresses`, which is emitted when the `resolved_addresses` set is completely empty.

The only way that set gets depleted is through TCP-level failures (`SocketConnection` errors), which remove each failing IP one by one. Crucially, TLS/WebSocket handshake failures and the new `ConnectTimeout` error do **not** remove IPs from the set (since there's no single failing IP to attribute — the timeout covers the whole attempt). This means if the portal moves to a new IP and the old IP is reachable at the TCP level but broken at the TLS/application level, the channel will retry that stale IP indefinitely without ever re-resolving DNS.

The fix adds a DNS re-resolution call in the `Hiccup` handler of all three consumers (gateway, client, relay). Because `State::Reconnect` captures `socket_addresses()` on the **next** poll — after the consumer has processed the `Hiccup` event — the freshly resolved IPs are picked up automatically by the subsequent connection attempt. This ensures every reconnect uses current DNS records regardless of the error type.

The main downside is increased DNS query volume. Previously, DNS was only queried at startup and when all IPs were exhausted; now it's queried on every connection failure. For a channel that's experiencing rapid repeated failures (e.g., portal is down and returning 503s), this means a DNS query on every backoff cycle. In practice the backoff intervals limit this (starting at 1s and growing exponentially), so the additional load should be modest. There's also a minor latency cost: the DNS resolution is `await`ed synchronously in the event loop before returning to poll the channel, so the actual reconnect backoff is extended by the time it takes to resolve DNS. If the DNS server itself is slow or unreachable, this could delay reconnection attempts. However, the existing `NoAddresses` handler already had this same behavior, and the DNS resolution functions in all three consumers are designed to return empty results gracefully on failure rather than blocking indefinitely.

