### PR TITLE
chore(portal): drop unused last_seen_* fields

### DIFF
--- a/elixir/lib/portal/client.ex
+++ b/elixir/lib/portal/client.ex
@@ -31,8 +31,6 @@ defmodule Portal.Client do
     belongs_to :account, Portal.Account, primary_key: true
     field :id, :binary_id, primary_key: true, autogenerate: true
 
-    # TODO: remove last_seen_* fields in migration
-
     field :external_id, :string
     field :name, :string
     field :psk_base, :binary, read_after_writes: true

--- a/elixir/lib/portal/crypto.ex
+++ b/elixir/lib/portal/crypto.ex
@@ -12,9 +12,9 @@ defmodule Portal.Crypto do
         client_pubkey,
         %Gateway{
           id: gateway_id,
-          public_key: gateway_pubkey,
           psk_base: gateway_psk_base
-        }
+        },
+        gateway_pubkey
       )
       when not (is_nil(client_id) or is_nil(client_pubkey) or is_nil(client_psk_base) or
                   is_nil(gateway_id) or is_nil(gateway_pubkey) or is_nil(gateway_psk_base)) do

--- a/elixir/lib/portal/gateway.ex
+++ b/elixir/lib/portal/gateway.ex
@@ -11,18 +11,9 @@ defmodule Portal.Gateway do
           id: Ecto.UUID.t(),
           external_id: String.t(),
           name: String.t(),
-          public_key: String.t(),
           psk_base: binary(),
           ipv4_address: Portal.IPv4Address.t(),
           ipv6_address: Portal.IPv6Address.t(),
-          last_seen_user_agent: String.t(),
-          last_seen_remote_ip: Portal.Types.IP.t(),
-          last_seen_remote_ip_location_region: String.t(),
-          last_seen_remote_ip_location_city: String.t(),
-          last_seen_remote_ip_location_lat: float(),
-          last_seen_remote_ip_location_lon: float(),
-          last_seen_version: String.t(),
-          last_seen_at: DateTime.t(),
           online?: boolean(),
           account_id: Ecto.UUID.t(),
           site_id: Ecto.UUID.t(),
@@ -38,17 +29,7 @@ defmodule Portal.Gateway do
 
     field :name, :string
 
-    field :public_key, :string
     field :psk_base, :binary, read_after_writes: true
-
-    field :last_seen_user_agent, :string
-    field :last_seen_remote_ip, Portal.Types.IP
-    field :last_seen_remote_ip_location_region, :string
-    field :last_seen_remote_ip_location_city, :string
-    field :last_seen_remote_ip_location_lat, :float
-    field :last_seen_remote_ip_location_lon, :float
-    field :last_seen_version, :string
-    field :last_seen_at, :utc_datetime_usec
 
     field :online?, :boolean, virtual: true
     field :latest_session, :any, virtual: true
@@ -67,9 +48,7 @@ defmodule Portal.Gateway do
     |> trim_change(:name)
     |> validate_length(:name, min: 1, max: 255)
     |> unique_constraint(:name, name: :gateways_site_id_name_index)
-    |> unique_constraint([:public_key])
     |> unique_constraint(:external_id)
-    |> unique_constraint(:public_key, name: :gateways_account_id_public_key_index)
     |> assoc_constraint(:account)
     |> assoc_constraint(:site)
   end

--- a/elixir/lib/portal/gateway_session.ex
+++ b/elixir/lib/portal/gateway_session.ex
@@ -7,6 +7,7 @@ defmodule Portal.GatewaySession do
           account_id: Ecto.UUID.t(),
           gateway_id: Ecto.UUID.t(),
           gateway_token_id: Ecto.UUID.t(),
+          public_key: String.t(),
           user_agent: String.t() | nil,
           remote_ip: :inet.ip_address() | nil,
           remote_ip_location_region: String.t() | nil,
@@ -28,6 +29,7 @@ defmodule Portal.GatewaySession do
     belongs_to :gateway, Portal.Gateway, references: :id
     belongs_to :gateway_token, Portal.GatewayToken, references: :id
 
+    field :public_key, :string
     field :user_agent, :string
     field :remote_ip, Portal.Types.IP
     field :remote_ip_location_region, :string

--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -213,10 +213,10 @@ defmodule Portal.Presence do
         id: gateway_id,
         account_id: account_id,
         site_id: meta.site_id,
-        public_key: meta.public_key,
         psk_base: meta.psk_base,
         online?: true,
         latest_session: %{
+          public_key: meta.public_key,
           version: meta.version,
           remote_ip: normalize_ip(meta.remote_ip),
           remote_ip_location_lat: meta.remote_ip_location_lat,

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -55,7 +55,7 @@ defmodule PortalAPI.Gateway.Channel do
 
     session_meta = %{
       site_id: gateway.site_id,
-      public_key: gateway.public_key,
+      public_key: session.public_key,
       psk_base: gateway.psk_base,
       version: session.version,
       remote_ip: session.remote_ip,
@@ -197,7 +197,7 @@ defmodule PortalAPI.Gateway.Channel do
           connected:
             Views.Relay.render_many(
               relays,
-              socket.assigns.gateway.public_key,
+              socket.assigns.session.public_key,
               @relay_credentials_expire_at
             )
         })
@@ -388,7 +388,7 @@ defmodule PortalAPI.Gateway.Channel do
             resource_id,
             socket.assigns.gateway.site_id,
             socket.assigns.gateway.id,
-            socket.assigns.gateway.public_key,
+            socket.assigns.session.public_key,
             socket.assigns.gateway.ipv4_address.address,
             socket.assigns.gateway.ipv6_address.address,
             preshared_key,
@@ -418,7 +418,7 @@ defmodule PortalAPI.Gateway.Channel do
       {:ok, {channel_pid, socket_ref, rid_bytes}} ->
         send(
           channel_pid,
-          {:connect, socket_ref, rid_bytes, socket.assigns.gateway.public_key, payload}
+          {:connect, socket_ref, rid_bytes, socket.assigns.session.public_key, payload}
         )
 
         {:reply, :ok, socket}
@@ -523,7 +523,7 @@ defmodule PortalAPI.Gateway.Channel do
       relays:
         Views.Relay.render_many(
           relays,
-          socket.assigns.gateway.public_key,
+          socket.assigns.session.public_key,
           @relay_credentials_expire_at
         ),
       # These aren't used but needed for API compatibility

--- a/elixir/priv/repo/migrations/20260213000001_drop_last_seen_and_move_gateway_public_key.exs
+++ b/elixir/priv/repo/migrations/20260213000001_drop_last_seen_and_move_gateway_public_key.exs
@@ -1,0 +1,62 @@
+defmodule Portal.Repo.Migrations.DropLastSeenAndMoveGatewayPublicKey do
+  use Ecto.Migration
+
+  @last_seen_columns [
+    :last_seen_user_agent,
+    :last_seen_remote_ip,
+    :last_seen_remote_ip_location_region,
+    :last_seen_remote_ip_location_city,
+    :last_seen_remote_ip_location_lat,
+    :last_seen_remote_ip_location_lon,
+    :last_seen_version,
+    :last_seen_at
+  ]
+
+  def change do
+    # Drop last_seen_* columns from clients, gateways, and client_tokens
+    alter table(:clients) do
+      for col <- @last_seen_columns do
+        remove(col)
+      end
+
+      remove(:public_key)
+    end
+
+    alter table(:gateways) do
+      for col <- @last_seen_columns do
+        remove(col)
+      end
+    end
+
+    alter table(:client_tokens) do
+      for col <- @last_seen_columns do
+        remove(col)
+      end
+    end
+
+    # Add public_key to gateway_sessions and backfill from gateways
+    alter table(:gateway_sessions) do
+      add(:public_key, :string)
+    end
+
+    flush()
+
+    execute("""
+    UPDATE gateway_sessions gs
+    SET public_key = g.public_key
+    FROM gateways g
+    WHERE gs.gateway_id = g.id
+      AND gs.account_id = g.account_id
+      AND g.public_key IS NOT NULL
+    """)
+
+    alter table(:gateway_sessions) do
+      modify(:public_key, :string, null: false)
+    end
+
+    # Now drop public_key from gateways (also auto-drops gateways_account_id_public_key_index)
+    alter table(:gateways) do
+      remove(:public_key)
+    end
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -146,14 +146,15 @@ defmodule Portal.Repo.Seeds do
     site = Repo.get_by!(Site, id: site_id)
     external_id = attrs["external_id"] || attrs[:external_id]
 
+    public_key = attrs["public_key"] || attrs[:public_key]
+
     # First create the gateway
     gateway =
       %Gateway{
         site_id: site_id,
         account_id: site.account_id,
         name: attrs["name"] || attrs[:name],
-        external_id: external_id,
-        public_key: attrs["public_key"] || attrs[:public_key]
+        external_id: external_id
       }
       |> Repo.insert!()
 
@@ -175,6 +176,7 @@ defmodule Portal.Repo.Seeds do
       account_id: site.account_id,
       gateway_id: gateway.id,
       gateway_token_id: gateway_token.id,
+      public_key: public_key,
       user_agent: context.user_agent,
       remote_ip: context.remote_ip,
       remote_ip_location_region: "US-CA",
@@ -211,7 +213,7 @@ defmodule Portal.Repo.Seeds do
       }
       |> Repo.insert!()
 
-    # Create a client session to record last_seen data
+    # Create a client session
     Repo.insert!(%ClientSession{
       account_id: subject.account.id,
       client_id: client.id,
@@ -587,7 +589,7 @@ defmodule Portal.Repo.Seeds do
           }
           |> Repo.insert!()
 
-        # Create a client session to record last_seen data
+        # Create a client session
         Repo.insert!(%ClientSession{
           account_id: subject.account.id,
           client_id: client.id,
@@ -1094,14 +1096,12 @@ defmodule Portal.Repo.Seeds do
     gateway_name = "#{site.name}-#{gateway1.name}"
     IO.puts("  #{gateway_name}:")
     IO.puts("    External UUID: #{gateway1.external_id}")
-    IO.puts("    Public Key: #{gateway1.public_key}")
     IO.puts("    IPv4: #{gateway1.ipv4_address.address} IPv6: #{gateway1.ipv6_address.address}")
     IO.puts("")
 
     gateway_name = "#{site.name}-#{gateway2.name}"
     IO.puts("  #{gateway_name}:")
-    IO.puts("    External UUID: #{gateway1.external_id}")
-    IO.puts("    Public Key: #{gateway2.public_key}")
+    IO.puts("    External UUID: #{gateway2.external_id}")
     IO.puts("    IPv4: #{gateway2.ipv4_address.address} IPv6: #{gateway2.ipv6_address.address}")
     IO.puts("")
 

--- a/elixir/test/portal/gateway_session/buffer_test.exs
+++ b/elixir/test/portal/gateway_session/buffer_test.exs
@@ -31,6 +31,7 @@ defmodule Portal.GatewaySession.BufferTest do
       account_id: ctx.account.id,
       gateway_id: ctx.gateway.id,
       gateway_token_id: ctx.token.id,
+      public_key: ctx.gateway.latest_session.public_key,
       user_agent: "Linux/6.1.0 connlib/1.3.0 (x86_64)",
       remote_ip: {100, 64, 0, 1},
       remote_ip_location_region: "US",

--- a/elixir/test/portal/gateway_session_test.exs
+++ b/elixir/test/portal/gateway_session_test.exs
@@ -56,9 +56,10 @@ defmodule Portal.GatewaySessionTest do
                  %{
                    account_id: Ecto.UUID.generate(),
                    gateway_id: gateway.id,
-                   gateway_token_id: token.id
+                   gateway_token_id: token.id,
+                   public_key: gateway.latest_session.public_key
                  },
-                 [:account_id, :gateway_id, :gateway_token_id]
+                 [:account_id, :gateway_id, :gateway_token_id, :public_key]
                )
                |> GatewaySession.changeset()
                |> Repo.insert()
@@ -77,9 +78,10 @@ defmodule Portal.GatewaySessionTest do
                  %{
                    account_id: account.id,
                    gateway_id: Ecto.UUID.generate(),
-                   gateway_token_id: token.id
+                   gateway_token_id: token.id,
+                   public_key: "dGVzdHB1YmxpY2tleXRlc3RwdWJsaWNrZXl0ZXN0cHU="
                  },
-                 [:account_id, :gateway_id, :gateway_token_id]
+                 [:account_id, :gateway_id, :gateway_token_id, :public_key]
                )
                |> GatewaySession.changeset()
                |> Repo.insert()
@@ -98,9 +100,10 @@ defmodule Portal.GatewaySessionTest do
                  %{
                    account_id: account.id,
                    gateway_id: gateway.id,
-                   gateway_token_id: Ecto.UUID.generate()
+                   gateway_token_id: Ecto.UUID.generate(),
+                   public_key: gateway.latest_session.public_key
                  },
-                 [:account_id, :gateway_id, :gateway_token_id]
+                 [:account_id, :gateway_id, :gateway_token_id, :public_key]
                )
                |> GatewaySession.changeset()
                |> Repo.insert()

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -59,7 +59,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
     session_meta = %{
       site_id: gateway.site_id,
-      public_key: gateway.public_key,
+      public_key: gateway.latest_session.public_key,
       psk_base: gateway.psk_base,
       version: session && session.version,
       remote_ip: session && session.remote_ip,
@@ -2662,14 +2662,14 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(
         channel_pid,
-        {:connect, socket_ref, rid_bytes, gateway.site_id, gateway.id, gateway.public_key,
-         gateway.ipv4_address.address, gateway.ipv6_address.address, preshared_key,
-         ice_credentials}
+        {:connect, socket_ref, rid_bytes, gateway.site_id, gateway.id,
+         gateway.latest_session.public_key, gateway.ipv4_address.address,
+         gateway.ipv6_address.address, preshared_key, ice_credentials}
       )
 
       gateway_group_id = gateway.site_id
       gateway_id = gateway.id
-      gateway_public_key = gateway.public_key
+      gateway_public_key = gateway.latest_session.public_key
       gateway_ipv4 = gateway.ipv4_address.address
       gateway_ipv6 = gateway.ipv6_address.address
 
@@ -3035,9 +3035,9 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(
         channel_pid,
-        {:connect, socket_ref, rid_bytes, gateway.site_id, gateway.id, gateway.public_key,
-         gateway.ipv4_address.address, gateway.ipv6_address.address, payload.preshared_key,
-         payload.ice_credentials}
+        {:connect, socket_ref, rid_bytes, gateway.site_id, gateway.id,
+         gateway.latest_session.public_key, gateway.ipv4_address.address,
+         gateway.ipv6_address.address, payload.preshared_key, payload.ice_credentials}
       )
 
       # The late connect should be ignored — no "flow_created" push
@@ -3089,9 +3089,9 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(
         channel_pid,
-        {:connect, socket_ref, rid_bytes, gateway.site_id, gateway.id, gateway.public_key,
-         gateway.ipv4_address.address, gateway.ipv6_address.address, payload.preshared_key,
-         payload.ice_credentials}
+        {:connect, socket_ref, rid_bytes, gateway.site_id, gateway.id,
+         gateway.latest_session.public_key, gateway.ipv4_address.address,
+         gateway.ipv6_address.address, payload.preshared_key, payload.ice_credentials}
       )
 
       assert_push "flow_created", %{resource_id: resource_id}
@@ -3675,7 +3675,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       assert_push "init", %{resources: _, relays: _, interface: _}
-      public_key = gateway.public_key
+      public_key = gateway.latest_session.public_key
       resource_id = resource.id
       client_id = client.id
 
@@ -3730,7 +3730,8 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(
         channel_pid,
-        {:connect, socket_ref, Ecto.UUID.dump!(resource.id), gateway.public_key, "DNS_RPL"}
+        {:connect, socket_ref, Ecto.UUID.dump!(resource.id), gateway.latest_session.public_key,
+         "DNS_RPL"}
       )
 
       assert_reply ref, :ok, %{
@@ -4005,7 +4006,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       assert_push "init", %{resources: _, relays: _, interface: _}
-      public_key = gateway.public_key
+      public_key = gateway.latest_session.public_key
       resource_id = resource.id
 
       gateway = Repo.preload(gateway, :site)
@@ -4040,7 +4041,8 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(
         channel_pid,
-        {:connect, socket_ref, Ecto.UUID.dump!(resource.id), gateway.public_key, "FULL_RTC_SD"}
+        {:connect, socket_ref, Ecto.UUID.dump!(resource.id), gateway.latest_session.public_key,
+         "FULL_RTC_SD"}
       )
 
       assert_reply ref, :ok, %{

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -43,6 +43,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       gateway_id: gateway.id,
       account_id: gateway.account_id,
       gateway_token_id: token.id,
+      public_key: gateway.latest_session && gateway.latest_session.public_key,
       user_agent: "Firezone-Gateway/1.3.0",
       remote_ip: gateway.latest_session && gateway.latest_session.remote_ip,
       remote_ip_location_region:
@@ -1949,7 +1950,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       public_key = Portal.ClientFixtures.generate_public_key()
       site_id = gateway.site_id
       gateway_id = gateway.id
-      gateway_public_key = gateway.public_key
+      gateway_public_key = gateway.latest_session.public_key
       gateway_ipv4 = gateway.ipv4_address.address
       gateway_ipv6 = gateway.ipv6_address.address
       rid_bytes = Ecto.UUID.dump!(resource.id)
@@ -2043,7 +2044,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
       preshared_key = "PSK"
       public_key = Portal.ClientFixtures.generate_public_key()
-      gateway_public_key = gateway.public_key
+      gateway_public_key = gateway.latest_session.public_key
       payload = "RTC_SD"
 
       :ok = Portal.Presence.Relays.connect(relay)

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -66,9 +66,9 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert gateway = Map.fetch!(socket.assigns, :gateway)
 
       assert gateway.external_id == attrs["external_id"]
-      assert gateway.public_key == attrs["public_key"]
 
       assert session = Map.fetch!(socket.assigns, :session)
+      assert session.public_key == attrs["public_key"]
       assert session.user_agent == connect_info.user_agent
       assert session.remote_ip_location_region == "Ukraine"
       assert session.remote_ip_location_city == "Kyiv"

--- a/elixir/test/support/fixtures/gateway_fixtures.ex
+++ b/elixir/test/support/fixtures/gateway_fixtures.ex
@@ -79,8 +79,7 @@ defmodule Portal.GatewayFixtures do
       %Portal.Gateway{}
       |> Ecto.Changeset.cast(gateway_attrs, [
         :name,
-        :external_id,
-        :public_key
+        :external_id
       ])
       |> Ecto.Changeset.put_assoc(:account, account)
       |> Ecto.Changeset.put_assoc(:site, site)
@@ -94,11 +93,14 @@ defmodule Portal.GatewayFixtures do
     # Always create a gateway session (gateways always have sessions in practice)
     token = gateway_token_fixture(account: account, site: site)
 
+    public_key = Map.get(gateway_attrs, :public_key, generate_public_key())
+
     session =
       %Portal.GatewaySession{
         account_id: account.id,
         gateway_id: gateway.id,
         gateway_token_id: token.id,
+        public_key: public_key,
         user_agent: Map.get(session_attrs, :last_seen_user_agent, "Firezone-Gateway/1.3.0"),
         remote_ip: Map.get(session_attrs, :last_seen_remote_ip, {100, 64, 0, 1}),
         remote_ip_location_region: Map.get(session_attrs, :last_seen_remote_ip_location_region),

--- a/elixir/test/support/fixtures/gateway_session_fixtures.ex
+++ b/elixir/test/support/fixtures/gateway_session_fixtures.ex
@@ -19,6 +19,10 @@ defmodule Portal.GatewaySessionFixtures do
     session_attrs =
       attrs
       |> Map.drop([:account, :site, :gateway, :token])
+      |> Map.put_new(
+        :public_key,
+        (gateway.latest_session && gateway.latest_session.public_key) || generate_public_key()
+      )
       |> Map.put_new(:user_agent, "Linux/6.1.0 connlib/1.3.0 (x86_64)")
       |> Map.put_new(:remote_ip, {100, 64, 0, 1})
       |> Map.put_new(:remote_ip_location_region, "US")
@@ -27,6 +31,7 @@ defmodule Portal.GatewaySessionFixtures do
     {:ok, session} =
       %Portal.GatewaySession{}
       |> Ecto.Changeset.cast(session_attrs, [
+        :public_key,
         :user_agent,
         :remote_ip,
         :remote_ip_location_region,
@@ -42,5 +47,9 @@ defmodule Portal.GatewaySessionFixtures do
       |> Portal.Repo.insert()
 
     session
+  end
+
+  defp generate_public_key do
+    :crypto.strong_rand_bytes(32) |> Base.encode64()
   end
 end


### PR DESCRIPTION
As a final cleanup for making client and gateway sessions their own table, we drop the last_seen_* fields. This may incur a brief period of hiccups as the application rolls over to the new schemas without these fields populated, but this is expected to be around ~30s max.

---

Related: https://github.com/firezone/firezone/pull/12130
Related: https://github.com/firezone/firezone/pull/12125
