### PR TITLE
fix(portal): hide clients with no sessions

### DIFF
--- a/elixir/lib/portal/client.ex
+++ b/elixir/lib/portal/client.ex
@@ -35,6 +35,9 @@ defmodule Portal.Client do
     field :name, :string
     field :psk_base, :binary, read_after_writes: true
     field :latest_session, :any, virtual: true
+    field :latest_session_inserted_at, :utc_datetime_usec, virtual: true
+    field :latest_session_version, :string, virtual: true
+    field :latest_session_user_agent, :string, virtual: true
     field :online?, :boolean, virtual: true
 
     belongs_to :actor, Portal.Actor

--- a/elixir/lib/portal_web/live/clients/index.ex
+++ b/elixir/lib/portal_web/live/clients/index.ex
@@ -152,7 +152,7 @@ defmodule PortalWeb.Clients.Index do
       base_query =
         from(c in Client, as: :clients)
         |> join(
-          :left_lateral,
+          :inner_lateral,
           [clients: c],
           s in subquery(
             from(s in ClientSession,
@@ -165,6 +165,11 @@ defmodule PortalWeb.Clients.Index do
           on: true,
           as: :latest_session
         )
+        |> select_merge([latest_session: s], %{
+          latest_session_inserted_at: s.inserted_at,
+          latest_session_version: s.version,
+          latest_session_user_agent: s.user_agent
+        })
 
       # Check if we need to prefilter by presence
       base_query =

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -853,10 +853,9 @@ defmodule PortalWeb.LiveTable do
 
   defp put_filter_to_params(params, id, filter) do
     filter_params = flatten_filter(filter, "#{id}_filter", %{})
-    filter_keys = Map.keys(filter) |> Enum.map(&"#{id}_filter[#{&1}]")
 
     params
-    |> Map.drop(filter_keys)
+    |> Map.reject(fn {key, _} -> String.starts_with?(key, "#{id}_filter[") end)
     |> Map.merge(filter_params)
   end
 

--- a/elixir/test/portal_web/live_table_test.exs
+++ b/elixir/test/portal_web/live_table_test.exs
@@ -681,12 +681,23 @@ defmodule PortalWeb.LiveTableTest do
     test "updates query parameters with new filter and resets the cursor", %{socket: socket} do
       assert handle_live_table_event(
                "filter",
-               %{"table_id" => "table-id", "table-id" => %{"name" => "foo"}},
+               %{"table_id" => "table-id", "table-id" => %{"name" => "foo", "email" => "bar"}},
                socket
              )
              |> fetch_patched_query_params!() == %{
                "table-id_filter[email]" => "bar",
                "table-id_filter[name]" => "foo",
+               "table-id_order_by" => "actors:asc:name"
+             }
+    end
+
+    test "clears all filter parameters when filter is empty", %{socket: socket} do
+      assert handle_live_table_event(
+               "filter",
+               %{"table_id" => "table-id"},
+               socket
+             )
+             |> fetch_patched_query_params!() == %{
                "table-id_order_by" => "actors:asc:name"
              }
     end


### PR DESCRIPTION
Now that client sessions are decoupled from the clients themselves, and we are cleaning up old client sessions older than 90 days, the clients table needs to be updated not to display clients with no sessions.

---

Related: #12125 
