### PR TITLE
chore(rust): create mise tasks for running `tunnel-test`

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -158,19 +158,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust-stable
-        id: setup-rust
       - uses: ./.github/actions/setup-rust-nightly
       - uses: ./.github/actions/setup-rust-sccache
-      - uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
         with:
-          tool: ripgrep,cargo-llvm-cov
-      - uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tool: bpf-linker
+          install_args: --cd rust
+      # This is purposely not a mise task because we want to run coverage here and also include `transitions_and_state_are_deterministic`
       - name: Tunnel proptest
         shell: bash
         run: cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test transitions_and_state_are_deterministic
@@ -180,44 +173,7 @@ jobs:
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
       - name: Check coverage
         shell: bash
-        run: |
-          # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
-          patterns=(
-            "SendIcmpPacket"
-            "SendUdpPacket"
-            "ConnectTcp"
-            "SendDnsQueries"
-            "Packet for DNS resource"
-            "Packet for CIDR resource"
-            "Packet for Internet resource"
-            "Truncating DNS response"
-            "ICMP Error error=V4Unreachable"
-            "ICMP Error error=V6Unreachable"
-            "ICMP Error error=V4TimeExceeded"
-            "ICMP Error error=V6TimeExceeded"
-            "Forwarding query for DNS resource to corresponding site"
-            "Revoking resource authorization"
-            "Re-seeding records for DNS resources"
-            "Resource is known but its addressability changed"
-            "No A / AAAA records for domain"
-            "State change \(got new possible\): Disconnected -> Checking"
-          )
-
-          missing_patterns=$(
-            for pattern in "${patterns[@]}"; do
-              if ! rg --quiet --no-ignore "$pattern" "$TESTCASES_DIR"; then
-                echo "$pattern"
-              fi
-            done
-          )
-
-          if [ -n "$missing_patterns" ]; then
-            echo "Error: Some required patterns were not found in test logs:"
-            echo "$missing_patterns"
-            exit 1
-          fi
-        env:
-          TESTCASES_DIR: "libs/connlib/tunnel/testcases"
+        run: mise run //rust:tunnel-log-coverage
 
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -160,9 +160,6 @@ jobs:
       - uses: ./.github/actions/setup-rust-stable
       - uses: ./.github/actions/setup-rust-nightly
       - uses: ./.github/actions/setup-rust-sccache
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
-        with:
-          install_args: --cd rust
       - uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -167,7 +167,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tool: bpf-linker
+          tool: bpf-linker,cargo-llvm-cov
       # This is purposely not a mise task because we want to run coverage here and also include `transitions_and_state_are_deterministic`
       - name: Tunnel proptest
         shell: bash

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -163,6 +163,11 @@ jobs:
       - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
         with:
           install_args: --cd rust
+      - uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tool: bpf-linker
       # This is purposely not a mise task because we want to run coverage here and also include `transitions_and_state_are_deterministic`
       - name: Tunnel proptest
         shell: bash

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,6 +1,8 @@
-pnpm               10.18.3
-nodejs             24.13.0
+pnpm                 10.18.3
+nodejs               24.13.0
+ripgrep              15.1.0
 cargo:cargo-binstall 1.17.4
-cargo:cargo-sort   2.0.2
-cargo:cargo-deny   0.19.0
-cargo:cargo-udeps  0.1.60
+cargo:cargo-sort     2.0.2
+cargo:cargo-deny     0.19.0
+cargo:cargo-udeps    0.1.60
+cargo:cargo-llvm-cov 0.8.4

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,7 +1,7 @@
 pnpm                 10.18.3
 nodejs               24.13.0
 ripgrep              15.1.0
-cargo:cargo-binstall 1.17.4
+cargo-binstall       1.17.4
 cargo:cargo-sort     2.0.2
 cargo:cargo-deny     0.19.0
 cargo:cargo-udeps    0.1.60

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -8,10 +8,6 @@ RUSTFLAGS = "--cfg tokio_unstable"
 # Nightly version used for cargo-udeps (keep in sync with .github/actions/setup-rust-nightly)
 NIGHTLY_VERSION = "nightly-2025-09-30"
 
-# =============================================================================
-# Individual checks (matching CI)
-# =============================================================================
-
 [tasks.fmt]
 description = "Format Rust code"
 run = "cargo fmt"
@@ -40,9 +36,54 @@ run = "cargo deny check --hide-inclusion-graph --deny unnecessary-skip"
 description = "Run tests (CI check)"
 run = "cargo test --all-features -- --include-ignored --nocapture"
 
-# =============================================================================
-# Composite tasks
-# =============================================================================
+[tasks.tunnel-test]
+description = "Run tunnel-test"
+run = "cargo test --features proptest --package tunnel -- --nocapture tunnel_test"
+env = { CARGO_PROFILE_TEST_OPT_LEVEL = '1', PROPTEST_VERBOSE = '0' }
+
+[tasks.tunnel-log-coverage]
+description = "Check tunnel test coverage by validating log patterns"
+dir = "{{config_root}}"
+run = '''
+#!/usr/bin/env bash
+#
+# Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
+patterns=(
+  "SendIcmpPacket"
+  "SendUdpPacket"
+  "ConnectTcp"
+  "SendDnsQueries"
+  "Packet for DNS resource"
+  "Packet for CIDR resource"
+  "Packet for Internet resource"
+  "Truncating DNS response"
+  "ICMP Error error=V4Unreachable"
+  "ICMP Error error=V6Unreachable"
+  "ICMP Error error=V4TimeExceeded"
+  "ICMP Error error=V6TimeExceeded"
+  "Forwarding query for DNS resource to corresponding site"
+  "Revoking resource authorization"
+  "Re-seeding records for DNS resources"
+  "Resource is known but its addressability changed"
+  "No A / AAAA records for domain"
+  "State change \(got new possible\): Disconnected -> Checking"
+)
+
+missing_patterns=$(
+  for pattern in "${patterns[@]}"; do
+    if ! rg --quiet --no-ignore "$pattern" "$TESTCASES_DIR"; then
+      echo "$pattern"
+    fi
+  done
+)
+
+if [ -n "$missing_patterns" ]; then
+  echo "Error: Some required patterns were not found in test logs:"
+  echo "$missing_patterns"
+  exit 1
+fi
+'''
+env = { TESTCASES_DIR = "libs/connlib/tunnel/testcases" }
 
 [tasks.check]
 description = "Run all CI static analysis checks"
@@ -51,3 +92,6 @@ depends = ["fmt-check", "clippy", "doc", "deny"]
 [tasks.check-all]
 description = "Run all CI static analysis checks including udeps (requires nightly)"
 depends = ["fmt-check", "clippy", "doc", "udeps", "deny"]
+
+[tools]
+"cargo:bpf-linker" = { version = "0.10.1", os = ["linux"] }

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -38,6 +38,7 @@ run = "cargo test --all-features -- --include-ignored --nocapture"
 
 [tasks.tunnel-test]
 description = "Run tunnel-test"
+dir = "{{config_root}}"
 run = "cargo test --features proptest --package tunnel -- --nocapture tunnel_test"
 env = { CARGO_PROFILE_TEST_OPT_LEVEL = '1', PROPTEST_VERBOSE = '0' }
 

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -93,6 +93,3 @@ depends = ["fmt-check", "clippy", "doc", "deny"]
 [tasks.check-all]
 description = "Run all CI static analysis checks including udeps (requires nightly)"
 depends = ["fmt-check", "clippy", "doc", "udeps", "deny"]
-
-[tools]
-"cargo:bpf-linker" = { version = "0.10.1", os = ["linux"] }


### PR DESCRIPTION
Running `tunnel-test` locally currently requires a somewhat obscure combination of env variables and parameters. To make this easier, we create a `mise` task for it. We cannot use the same one in CI unfortunately because there we want to run a coverage report as well and include additional tests which is unnecessary when we want to iterate fast on the `tunnel-test` locally. Additionally, there are some build errors around coverage and the eBPF module which couldn't be resolved quickly and were thus seemed not important. The usecases of CI and local execution differ and the priority here is to make running `tunnel-test` and its accompanied coverage checking easier and not to perfectly align CI and local usage.