### PR TITLE
docs: add language-specific agent instructions

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -27,6 +27,11 @@ These three components are split into multiple threads and connected via bounded
 - 1 thread for handling IPv6 UDP traffic with 1 task each for sending / receiving
 - 1 task on the "main" thread that holds the state and reads / writes from and to the channels connecting to the IO threads
 
+## Coding guidelines
+
+For guidelines on generating or reviewing specific parts of the codebase, check for an `AGENT.md` file in the corresponding sub-directory.
+For example, for Rust code, checking `rust/AGENT.md`, for Elixir code, check `elixir/AGENT.md`, etc.
+
 ## Code review guidelines
 
 - Assume that code compiles and is syntactically correct.

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -30,7 +30,7 @@ These three components are split into multiple threads and connected via bounded
 ## Coding guidelines
 
 For guidelines on generating or reviewing specific parts of the codebase, check for an `AGENT.md` file in the corresponding sub-directory.
-For example, for Rust code, checking `rust/AGENT.md`, for Elixir code, check `elixir/AGENT.md`, etc.
+For example, for Rust code, check `rust/AGENT.md`; for Elixir code, check `elixir/AGENT.md`, etc.
 
 ## Code review guidelines
 

--- a/rust/AGENT.md
+++ b/rust/AGENT.md
@@ -1,0 +1,7 @@
+# AI agent rules for Firezone Rust code
+
+## Code style
+
+- Do not generate excessive comments
+- Prefer a functional style (i.e. Iterators) over imperative code
+- Prefer turbo-fish over explicit type-hints

--- a/rust/AGENT.md
+++ b/rust/AGENT.md
@@ -4,4 +4,4 @@
 
 - Do not generate excessive comments
 - Prefer a functional style (i.e. Iterators) over imperative code
-- Prefer turbo-fish over explicit type-hints
+- Prefer turbofish over explicit type-hints


### PR DESCRIPTION
In order to not clutter the main `AGENT.md` rules file with language-specific instructions, we add an indirection to `$language/AGENT.md`.

Same as before, developers are encouraged to symlink `docs/AGENT.md` to whatever file it needs to be locally for the specific agents / IDE they are using. For example, for Zed, one needs to symlink this to `.rules` in the repository root.