### PR TITLE
chore(gateway): ignore fragmented IP packets from old clients

### DIFF
--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -695,7 +695,7 @@ pub(crate) struct NotAllowedResource(IpAddr);
 
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to decapsulate '{0}' packet")]
-pub(crate) struct FailedToDecapsulate(packet_kind::Kind);
+pub struct FailedToDecapsulate(packet_kind::Kind);
 
 pub fn is_peer(dst: IpAddr) -> bool {
     match dst {


### PR DESCRIPTION
All Clients released after https://github.com/firezone/firezone/pull/10488 don't encapsulated fragmented IP packets anymore. But Clients released before that may still send them, yet we cannot process them on the Gateway. Therefore, log these cases on DEBUG instead of WARN.