### PR TITLE
chore(connlib): ignore multicast traffic

### DIFF
--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -174,6 +174,10 @@ impl GatewayState {
             return Ok(None);
         };
 
+        if packet.destination().is_multicast() {
+            return Ok(None);
+        }
+
         flow_tracker::inbound_wg::record_decrypted_packet(&packet);
 
         let peer = self


### PR DESCRIPTION
Routing multicast traffic through Firezone does not really make sense as the permission model is designed for traffic targeting a specific resource. Many systems generate multicast traffic for e.g. IPv6 neighbour discovery which ends up cluttering our Sentry issues.

To fix this, we explicitly test for multicast destination IPs and drop such traffic early.