### PR TITLE
chore(rust): remove unused `ImpossibleTranslation` error

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -273,12 +273,6 @@ impl Eventloop {
                 continue;
             }
 
-            if e.any_is::<ip_packet::ImpossibleTranslation>() {
-                // Some IP packets cannot be translated and should be dropped "silently".
-                // Do so by ignoring the error here.
-                continue;
-            }
-
             if let Some(e) = e.any_downcast_ref::<tunnel::UnroutablePacket>() {
                 tracing::debug!(src = %e.source(), dst = %e.destination(), proto = %e.proto(), "{e:#}");
                 continue;

--- a/rust/libs/connlib/ip-packet/src/lib.rs
+++ b/rust/libs/connlib/ip-packet/src/lib.rs
@@ -1013,10 +1013,6 @@ pub enum UnsupportedProtocol {
     UnsupportedIcmpv6Type(Icmpv6Type),
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error("Packet cannot be translated as part of NAT64/46")]
-pub struct ImpossibleTranslation;
-
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};


### PR DESCRIPTION
The `ImpossibleTranslation` error is no longer used. We have since removed the NAT64 component of the Gateway.