### PR TITLE
fix(portal): preload last_seen for gateways

### DIFF
--- a/elixir/lib/portal_web/live/sites/gateways/index.ex
+++ b/elixir/lib/portal_web/live/sites/gateways/index.ex
@@ -35,7 +35,7 @@ defmodule PortalWeb.Sites.Gateways.Index do
   end
 
   def handle_gateways_update!(socket, list_opts) do
-    list_opts = Keyword.put(list_opts, :preload, [:online?])
+    list_opts = Keyword.put(list_opts, :preload, [:online?, :last_seen])
 
     with {:ok, gateways, metadata} <- Database.list_gateways(socket.assigns.subject, list_opts) do
       {:ok,

--- a/elixir/lib/portal_web/live/sites/show.ex
+++ b/elixir/lib/portal_web/live/sites/show.ex
@@ -81,7 +81,7 @@ defmodule PortalWeb.Sites.Show do
 
     list_opts =
       list_opts
-      |> Keyword.put(:preload, [:online?])
+      |> Keyword.put(:preload, [:online?, :last_seen])
       |> Keyword.update(:filter, [], fn filter ->
         filter ++ [{:ids, online_ids}]
       end)

--- a/elixir/test/portal_web/live/sites/gateways/index_test.exs
+++ b/elixir/test/portal_web/live/sites/gateways/index_test.exs
@@ -1,0 +1,85 @@
+defmodule PortalWeb.Live.Sites.Gateways.IndexTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.GatewayFixtures
+  import Portal.SiteFixtures
+  import Portal.TokenFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    site = site_fixture(account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      site: site
+    }
+  end
+
+  test "renders gateways table with version", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    gateway =
+      gateway_fixture(
+        account: account,
+        site: site,
+        last_seen_version: "1.3.2"
+      )
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/sites/#{site}/gateways")
+
+    [row] =
+      lv
+      |> element("#gateways")
+      |> render()
+      |> table_to_map()
+
+    assert row["instance"] == gateway.name
+    assert row["version"] =~ "1.3.2"
+    assert row["remote ip"] =~ "100.64.0.1"
+  end
+
+  test "renders gateways table with version after presence update", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    gateway =
+      gateway_fixture(
+        account: account,
+        site: site,
+        last_seen_version: "1.3.2"
+      )
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/sites/#{site}/gateways")
+
+    :ok = Portal.Presence.Gateways.Site.subscribe(site.id)
+    gateway_token = gateway_token_fixture(site: site, account: account)
+    :ok = Portal.Presence.Gateways.connect(gateway, gateway_token.id)
+    assert_receive %Phoenix.Socket.Broadcast{topic: "presences:sites:" <> _}
+
+    wait_for(fn ->
+      [row] =
+        lv
+        |> element("#gateways")
+        |> render()
+        |> table_to_map()
+
+      assert row["version"] =~ "1.3.2"
+      assert row["status"] =~ "Online"
+    end)
+  end
+end

--- a/elixir/test/portal_web/live/sites/show_test.exs
+++ b/elixir/test/portal_web/live/sites/show_test.exs
@@ -1,0 +1,91 @@
+defmodule PortalWeb.Live.Sites.ShowTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.GatewayFixtures
+  import Portal.SiteFixtures
+  import Portal.TokenFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    site = site_fixture(account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      site: site
+    }
+  end
+
+  test "renders online gateways table with version", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    gateway =
+      gateway_fixture(
+        account: account,
+        site: site,
+        last_seen_version: "1.3.2"
+      )
+
+    gateway_token = gateway_token_fixture(site: site, account: account)
+    :ok = Portal.Presence.Gateways.connect(gateway, gateway_token.id)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/sites/#{site}")
+
+    rows =
+      lv
+      |> element("#gateways")
+      |> render()
+      |> table_to_map()
+
+    rows
+    |> with_table_row("instance", gateway.name, fn row ->
+      assert row["version"] =~ "1.3.2"
+      assert row["remote ip"] =~ "100.64.0.1"
+      assert row["status"] =~ "Online"
+    end)
+  end
+
+  test "renders gateway version after presence update", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    gateway =
+      gateway_fixture(
+        account: account,
+        site: site,
+        last_seen_version: "1.3.2"
+      )
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/sites/#{site}")
+
+    :ok = Portal.Presence.Gateways.Site.subscribe(site.id)
+    gateway_token = gateway_token_fixture(site: site, account: account)
+    :ok = Portal.Presence.Gateways.connect(gateway, gateway_token.id)
+    assert_receive %Phoenix.Socket.Broadcast{topic: "presences:sites:" <> _}
+
+    wait_for(fn ->
+      lv
+      |> element("#gateways")
+      |> render()
+      |> table_to_map()
+      |> with_table_row("instance", gateway.name, fn row ->
+        assert row["version"] =~ "1.3.2"
+        assert row["status"] =~ "Online"
+      end)
+    end)
+  end
+end


### PR DESCRIPTION
As fallout from #12130, we need to preload the new virtual fields so they are visible in the admin portal UI.

---

Related: https://firezonehq.slack.com/archives/C08FPHECLUF/p1771255920611509?thread_ts=1771252682.325129&cid=C08FPHECLUF
Related: https://firezonehq.slack.com/archives/C06L41XN05T/p1771235868693439