### PR TITLE
fix(portal): retry session inserts on failure

### DIFF
--- a/elixir/lib/portal/gateway_session/buffer.ex
+++ b/elixir/lib/portal/gateway_session/buffer.ex
@@ -71,9 +71,16 @@ defmodule Portal.GatewaySession.Buffer do
         |> Map.put(:inserted_at, now)
       end)
 
-    Database.insert_all(entries)
+    {inserted, _} = Database.insert_all(entries)
+    skipped = count - inserted
 
-    Logger.info("Flushed #{count} gateway sessions")
+    if skipped > 0 do
+      Logger.warning(
+        "Skipped #{skipped} gateway sessions due to deleted associations (tokens/accounts/gateways)"
+      )
+    end
+
+    Logger.info("Flushed #{inserted} gateway sessions")
 
     %{buffer: [], count: 0}
   end
@@ -85,10 +92,71 @@ defmodule Portal.GatewaySession.Buffer do
   defmodule Database do
     alias Portal.GatewaySession
     alias Portal.Safe
+    import Ecto.Query
+
+    def insert_all([]), do: {0, nil}
 
     def insert_all(entries) do
       Safe.unscoped()
       |> Safe.insert_all(GatewaySession, entries)
+    rescue
+      error in [Postgrex.Error] ->
+        case error.postgres do
+          %{code: :foreign_key_violation, constraint: constraint} ->
+            entries
+            |> filter_existing(constraint)
+            |> insert_all()
+
+          _ ->
+            reraise error, __STACKTRACE__
+        end
+    end
+
+    defp filter_existing(entries, "gateway_sessions_account_id_fkey") do
+      filter_by_existing(entries, :account_id, Portal.Account)
+    end
+
+    defp filter_existing(entries, "gateway_sessions_gateway_id_fkey") do
+      filter_by_composite(entries, :gateway_id, Portal.Gateway)
+    end
+
+    defp filter_existing(entries, "gateway_sessions_gateway_token_id_fkey") do
+      filter_by_composite(entries, :gateway_token_id, Portal.GatewayToken)
+    end
+
+    defp filter_existing(_entries, _constraint), do: []
+
+    defp filter_by_existing(entries, key, schema) do
+      ids = entries |> Enum.map(& &1[key]) |> Enum.uniq()
+
+      existing_ids =
+        from(t in schema, where: t.id in ^ids, select: t.id)
+        |> Safe.unscoped()
+        |> Safe.all()
+        |> MapSet.new()
+
+      Enum.filter(entries, fn entry ->
+        MapSet.member?(existing_ids, entry[key])
+      end)
+    end
+
+    defp filter_by_composite(entries, key, schema) do
+      pairs = entries |> Enum.map(fn e -> {e[:account_id], e[key]} end) |> Enum.uniq()
+
+      conditions =
+        Enum.reduce(pairs, dynamic(false), fn {account_id, id}, acc ->
+          dynamic([t], ^acc or (t.account_id == ^account_id and t.id == ^id))
+        end)
+
+      existing_pairs =
+        from(t in schema, where: ^conditions, select: {t.account_id, t.id})
+        |> Safe.unscoped()
+        |> Safe.all()
+        |> MapSet.new()
+
+      Enum.filter(entries, fn entry ->
+        MapSet.member?(existing_pairs, {entry[:account_id], entry[key]})
+      end)
     end
   end
 end


### PR DESCRIPTION
Both `ClientSession.Buffer` and `GatewaySession.Buffer` are GenServers that batch session records in memory and flush them to the database periodically (every 60s or at 1,000 entries). When a token (or
client/gateway/account) is deleted between the time a session is buffered and the time it's flushed, the `Repo.insert_all/3` call raises a `Postgrex.Error` with `:foreign_key_violation`. This crashes the
GenServer, losing **all** buffered sessions — not just the ones referencing the deleted record.

We considered a few alternatives:

- **Pre-filtering every flush** by querying for existing token IDs before inserting. This adds an extra query on every single flush even when nothing is wrong, which defeats the purpose of batching for efficiency.
- **Switching from `insert_all` to individual `insert`s** so we can skip failures per-row. This is far slower for large batches (up to 1,000 entries) and fundamentally changes the performance characteristics of
the buffer.
- **Dropping the entire batch on error.** This silently loses valid session data that could have been persisted.

Instead, we keep the optimistic `insert_all` on the happy path (zero extra queries) and only pay the cost of recovery when a FK violation actually occurs. On a `:foreign_key_violation`, the `Database.insert_all/1`
function rescues the error, parses the constraint name to determine which association is missing (`account_id`, `client_id`/`gateway_id`, or `client_token_id`/`gateway_token_id`), filters the entries against the
referenced table, and recursively calls `insert_all/1` with the remaining valid entries. This naturally handles cascading issues — if the retry hits a different FK violation, it filters again and converges to
either a successful insert or an empty list. Any non-FK `Postgrex.Error` is re-raised unchanged.