### PR TITLE
fix(website): remove remaining discourse refs

### DIFF
--- a/website/src/app/kb/architecture/security-controls/readme.mdx
+++ b/website/src/app/kb/architecture/security-controls/readme.mdx
@@ -25,7 +25,7 @@ soon as they're reported.
 
 We'll announce major security issues on our security mailing list located at:
 
-https://discourse.firez.one/?utm_source=docs.firezone.dev
+https://www.github.com/firezone/firezone/discussions/categories/security-announcements
 
 ### Supported versions
 

--- a/website/src/app/kb/client-apps/macos-client/readme.mdx
+++ b/website/src/app/kb/client-apps/macos-client/readme.mdx
@@ -245,9 +245,7 @@ Normal system DNS:
 - **Cloudflare WARP client conflicts with other VPN apps**: The Cloudflare WARP
   client may interfere with Firezone's ability to initialize its tunnel
   interface or resolve DNS resources. Ensure the Cloudflare WARP client is
-  disabled completely or uninstalled to prevent these issues. See
-  [this thread on our forum](https://discourse.firez.one/t/firezone-app-on-macos/682)
-  for more information.
+  disabled completely or uninstalled to prevent these issues.
 - **SentinelOne agent can block DNS queries**: The SentinelOne agent for macOS
   may interfere with Firezone's ability to successfully forward and reply to DNS
   queries made by applications on macOS. The symptom when this occurs is that

--- a/website/src/app/support/_page.tsx
+++ b/website/src/app/support/_page.tsx
@@ -284,7 +284,7 @@ export default function _Page() {
                 </th>
                 <td className="px-6 py-4" colSpan={3}>
                   <Link
-                    href="https://www.github.com/firezone/firezone/discussions"
+                    href="https://github.com/firezone/firezone/discussions"
                     className="text-accent-500 hover:underline"
                   >
                     https://github.com/firezone/firezone/discussions

--- a/website/src/app/support/_page.tsx
+++ b/website/src/app/support/_page.tsx
@@ -14,7 +14,7 @@ import {
   HiOutlineEnvelope,
 } from "react-icons/hi2";
 import { AiOutlineDiscord } from "react-icons/ai";
-import { FaDiscourse } from "react-icons/fa";
+import { FaGithub } from "react-icons/fa";
 import { FaSlack } from "react-icons/fa";
 
 export default function _Page() {
@@ -278,16 +278,16 @@ export default function _Page() {
                   className="px-6 py-4 font-medium text-neutral-800"
                 >
                   <span className="flex items-center">
-                    <FaDiscourse className="w-5 h-5 mr-2" />
+                    <FaGithub className="w-5 h-5 mr-2" />
                     Community forums
                   </span>
                 </th>
                 <td className="px-6 py-4" colSpan={3}>
                   <Link
-                    href="https://discourse.firez.one"
+                    href="https://www.github.com/firezone/firezone/discussions"
                     className="text-accent-500 hover:underline"
                   >
-                    https://discourse.firez.one
+                    https://github.com/firezone/firezone/discussions
                   </Link>
                 </td>
               </tr>

--- a/website/src/components/Footer/index.tsx
+++ b/website/src/components/Footer/index.tsx
@@ -193,7 +193,7 @@ export default function Footer() {
                 </li>
                 <li className="mb-4">
                   <Link
-                    href="https://discourse.firez.one"
+                    href="https://github.com/firezone/firezone/discussions"
                     className="text-neutral-200 hover:underline hover:text-neutral-50"
                   >
                     Forums

--- a/website/src/components/SupportOptions/index.tsx
+++ b/website/src/components/SupportOptions/index.tsx
@@ -18,7 +18,7 @@ export default function SupportOptions() {
         </p>
         <ul>
           <li>
-            <Link href="https://discourse.firez.one/?utm_source=docs.firezone.dev">
+            <Link href="https://www.github.com/firezone/firezone/discussions">
               Discussion forums
             </Link>
             : Ask questions, report bugs, and suggest features.


### PR DESCRIPTION
Updates last remaining discourse links to point to our new GitHub Discussions forums.

---

Fixes #12136
