### PR TITLE
ci: use multi-ecosystem-group for Tauri dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@
 
 version: 2
 
+multi-ecosystem-groups:
+  tauri:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: mix
     directory: elixir/
@@ -87,10 +92,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-      tauri:
-        patterns:
-          - tauri
-          - tauri-*
       netlink:
         patterns:
           - rtnetlink
@@ -244,9 +245,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-      tauri:
-        patterns:
-          - "@tauri-apps/*"
       tailwind:
         patterns:
           - tailwindcss
@@ -280,3 +278,20 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+
+  # Tauri group
+  - package-ecosystem: npm
+    directory: rust/gui-client/
+    schedule:
+      interval: weekly
+    multi-ecosystem-group: tauri
+    patterns:
+      - "@tauri-apps/*"
+  - package-ecosystem: cargo
+    directory: rust/
+    schedule:
+      interval: weekly
+    multi-ecosystem-group: tauri
+    patterns:
+      - tauri
+      - tauri-*


### PR DESCRIPTION
Recent releases of Tauri validate that the same minor version is used across the JS and Rust ecosystem, see the failing build in #12150.

We can use a multi-ecosystem-group to teach dependabot that these two things need to be updated in the same PR.