### PR TITLE
fix(portal): fallback to primary for billing acct create

### DIFF
--- a/elixir/lib/portal/billing.ex
+++ b/elixir/lib/portal/billing.ex
@@ -647,7 +647,7 @@ defmodule Portal.Billing do
           where: s.managed_by == :system
         )
         |> Safe.unscoped(:replica)
-        |> Safe.one()
+        |> Safe.one(fallback_to_primary: true)
 
       case result do
         nil -> {:error, :not_found}
@@ -672,7 +672,7 @@ defmodule Portal.Billing do
           where: r.type == :internet
         )
         |> Safe.unscoped(:replica)
-        |> Safe.one()
+        |> Safe.one(fallback_to_primary: true)
 
       case result do
         nil -> {:error, :not_found}


### PR DESCRIPTION
Accounts can be created via two ways: the normal sign up flow, and via the Hubspot integration, which creates a Stripe account and Firezone account. For both flows, the billing handler contains logic to ensure the site and resource both exist.

In that logic, we read from the replica, which unfortunately lags far enough behind the primary such that the existence check for internet site/resource returns false, causing the billing handler to try and insert these.

These have been created during the sign up flow however, and so the creation fails.

To fix this, we simply fallback to reading from the primary.

---

Fixes #12196 