### PR TITLE
chore(apple): use encoded FirezoneId for Sentry 

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -630,6 +630,15 @@ pub fn log_cleanup_default_interval_secs() -> u64 {
     logging::DEFAULT_CLEANUP_INTERVAL.as_secs()
 }
 
+/// Hashes a device ID using SHA256 and returns the hex-encoded result.
+///
+/// This is exposed via FFI so that clients an produce
+/// the exact same hash as connlib, without reimplementing the algorithm.
+#[uniffi::export]
+pub fn hash_device_id(id: String) -> String {
+    telemetry::hash_device_id(id)
+}
+
 impl From<connlib_model::ResourceView> for Resource {
     fn from(resource: connlib_model::ResourceView) -> Self {
         match resource {

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -11,7 +11,6 @@ use std::{
 use anyhow::{Context as _, Result, bail};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use sha2::Digest as _;
 use tracing::{Metadata, level_filters::LevelFilter};
 use tracing_subscriber::filter::Targets;
 
@@ -112,11 +111,7 @@ async fn decide(
     maybe_legacy_id: String,
     api_key: String,
 ) -> Result<(FeatureFlagsResponse, FeatureFlagPayloadsResponse)> {
-    let distinct_id = if uuid::Uuid::from_str(&maybe_legacy_id).is_ok() {
-        hex::encode(sha2::Sha256::digest(&maybe_legacy_id))
-    } else {
-        maybe_legacy_id
-    };
+    let distinct_id = crate::maybe_hash_device_id(maybe_legacy_id);
 
     let response = posthog::CLIENT
         .as_ref()?

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -7,8 +7,7 @@ use opentelemetry_sdk::{
 pub mod attr {
     use ip_packet::{IpPacket, IpVersion};
     use opentelemetry::Value;
-    use sha2::Digest as _;
-    use std::{io, net::SocketAddr, str::FromStr as _};
+    use std::{io, net::SocketAddr};
 
     use super::*;
 
@@ -30,13 +29,10 @@ pub mod attr {
     pub use service_version;
 
     pub fn service_instance_id(maybe_legacy_id: String) -> KeyValue {
-        let id = if uuid::Uuid::from_str(&maybe_legacy_id).is_ok() {
-            hex::encode(sha2::Sha256::digest(&maybe_legacy_id))
-        } else {
-            maybe_legacy_id
-        };
-
-        KeyValue::new("service.instance.id", id)
+        KeyValue::new(
+            "service.instance.id",
+            crate::maybe_hash_device_id(maybe_legacy_id),
+        )
     }
 
     pub fn network_transport_udp() -> KeyValue {

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		C1892134991C462C8E137DE3 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09DC14A4A04715A37BC04C /* Channel.swift */; };
 		C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */; };
 		CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2847ACC9D73EA6F356F2DEE1 /* connlib.swift */; };
+		6F0EDF222E79B00000D6D632 /* FirezoneId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EDF232E79B00000D6D632 /* FirezoneId.swift */; };
+		6F0EDF242E79B00000D6D632 /* FirezoneId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0EDF232E79B00000D6D632 /* FirezoneId.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +89,7 @@
 
 /* Begin PBXFileReference section */
 		05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
+		6F0EDF232E79B00000D6D632 /* FirezoneId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirezoneId.swift; sourceTree = "<group>"; };
 		05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "dev.firezone.firezone.network-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		05CF1CF6290B1CEE00CF4755 /* FirezoneNetworkExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FirezoneNetworkExtension.entitlements; sourceTree = "<group>"; };
 		05D3BB1628FDBD8A00BC3727 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
@@ -165,6 +168,7 @@
 				05CF1CF6290B1CEE00CF4755 /* FirezoneNetworkExtension.entitlements */,
 				8D5047E82CE6A8F4009802E9 /* main.swift */,
 				177FB893F19457A113042247 /* Adapter.swift */,
+				6F0EDF232E79B00000D6D632 /* FirezoneId.swift */,
 				05833DFA28F73B070008FAB0 /* PacketTunnelProvider.swift */,
 				8D41B9A42D15DD6800D16065 /* TunnelLogArchive.swift */,
 				6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */,
@@ -485,6 +489,7 @@
 				6F0EDF1F2E79A13800D6D632 /* Adapter.swift in Sources */,
 				8DC08BD72B297DB400675F46 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */,
 				8D41B9A52D15DD6800D16065 /* TunnelLogArchive.swift in Sources */,
+				6F0EDF222E79B00000D6D632 /* FirezoneId.swift in Sources */,
 				05CF1D17290B1FE700CF4755 /* PacketTunnelProvider.swift in Sources */,
 				146C8E809FF744D18C053A79 /* Channel.swift in Sources */,
 				8D0000012D4100000003 /* NetworkPathUpdates.swift in Sources */,
@@ -500,6 +505,7 @@
 				8D41B9A62D15DD6800D16065 /* TunnelLogArchive.swift in Sources */,
 				8DE452A82CE6C194004CEDF9 /* main.swift in Sources */,
 				8D5047FB2CE6AA37009802E9 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */,
+				6F0EDF242E79B00000D6D632 /* FirezoneId.swift in Sources */,
 				8D5047FE2CE6AA54009802E9 /* PacketTunnelProvider.swift in Sources */,
 				C1892134991C462C8E137DE3 /* Channel.swift in Sources */,
 				8D0000012D4100000004 /* NetworkPathUpdates.swift in Sources */,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/FirezoneId.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/FirezoneId.swift
@@ -1,0 +1,28 @@
+//
+//  FirezoneId.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+
+/// A device identifier that stores a raw UUID and can produce
+/// a SHA256-encoded form for Sentry/analytics via the Rust FFI.
+public struct FirezoneId {
+  /// The raw UUID string, as stored on disk.
+  public let uuid: String
+
+  public init(uuid: String) {
+    self.uuid = uuid
+  }
+
+  /// The SHA256 hex-encoded form, for use in Sentry and analytics.
+  public var encoded: String {
+    hashDeviceId(id: uuid)
+  }
+
+  /// Generates a new firezone ID backed by a random UUID.
+  public static func generate() -> FirezoneId {
+    FirezoneId(uuid: UUID().uuidString)
+  }
+}

--- a/swift/apple/FirezoneNetworkExtension/FirezoneId.swift
+++ b/swift/apple/FirezoneNetworkExtension/FirezoneId.swift
@@ -8,21 +8,17 @@ import Foundation
 
 /// A device identifier that stores a raw UUID and can produce
 /// a SHA256-encoded form for Sentry/analytics via the Rust FFI.
-public struct FirezoneId {
+struct FirezoneId: Sendable {
   /// The raw UUID string, as stored on disk.
-  public let uuid: String
-
-  public init(uuid: String) {
-    self.uuid = uuid
-  }
+  let uuid: String
 
   /// The SHA256 hex-encoded form, for use in Sentry and analytics.
-  public var encoded: String {
+  var encoded: String {
     hashDeviceId(id: uuid)
   }
 
   /// Generates a new firezone ID backed by a random UUID.
-  public static func generate() -> FirezoneId {
+  static func generate() -> FirezoneId {
     FirezoneId(uuid: UUID().uuidString)
   }
 }


### PR DESCRIPTION
This matches connlib's behaviour and soon will allow us to correlate the device id in Sentry.

To be absolutely safe, instead of migrating the UUID to hex-encoded string, we keep it as-is and call out to connlib to use the same encoding function before setting the user in sentry.

Related to #12126 - a necessary dependency.
