### PR TITLE
fix(portal): handle cases where policy group_id null

### DIFF
--- a/elixir/lib/portal/cache/cacheable.ex
+++ b/elixir/lib/portal/cache/cacheable.ex
@@ -41,8 +41,12 @@ defimpl Portal.Cache.Cacheable, for: Portal.Policy do
     %Portal.Cache.Cacheable.Policy{
       id: Ecto.UUID.dump!(policy.id),
       resource_id: Ecto.UUID.dump!(policy.resource_id),
-      group_id: Ecto.UUID.dump!(policy.group_id),
+      # group_id is nullable for orphaned policies (before IdP group reconciliation).
+      group_id: dump_uuid_or_nil(policy.group_id),
       conditions: Enum.map(policy.conditions, &Map.from_struct/1)
     }
   end
+
+  defp dump_uuid_or_nil(nil), do: nil
+  defp dump_uuid_or_nil(uuid), do: Ecto.UUID.dump!(uuid)
 end

--- a/elixir/lib/portal/cache/cacheable/policy.ex
+++ b/elixir/lib/portal/cache/cacheable/policy.ex
@@ -28,7 +28,7 @@ defmodule Portal.Cache.Cacheable.Policy do
   @type t :: %__MODULE__{
           id: Portal.Cache.Cacheable.uuid_binary(),
           resource_id: Portal.Cache.Cacheable.uuid_binary(),
-          group_id: Portal.Cache.Cacheable.uuid_binary(),
+          group_id: Portal.Cache.Cacheable.uuid_binary() | nil,
           conditions: [condition()]
         }
 end

--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -165,6 +165,7 @@ defmodule PortalAPI.PolicyController do
     def update_policy(policy, attrs, subject) do
       policy
       |> changeset(attrs)
+      |> populate_group_idp_id(subject)
       |> Safe.scoped(subject)
       |> Safe.update()
     end
@@ -207,13 +208,13 @@ defmodule PortalAPI.PolicyController do
     end
 
     defp populate_group_idp_id(changeset, subject) do
-      case get_field(changeset, :group_id) do
+      case get_change(changeset, :group_id) do
         nil ->
           changeset
 
         group_id ->
           case get_group_idp_id(group_id, subject) do
-            nil -> changeset
+            nil -> put_change(changeset, :group_idp_id, nil)
             idp_id -> put_change(changeset, :group_idp_id, idp_id)
           end
       end

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -11,11 +11,11 @@ defmodule PortalAPI.Schemas.Policy do
       type: :object,
       properties: %{
         id: %Schema{type: :string, description: "Policy ID"},
-        group_id: %Schema{type: :string, description: "Group ID"},
+        group_id: %Schema{type: :string, description: "Group ID", nullable: true},
         resource_id: %Schema{type: :string, description: "Resource ID"},
-        description: %Schema{type: :string, description: "Policy Description"}
+        description: %Schema{type: :string, description: "Policy Description", nullable: true}
       },
-      required: [:name, :type],
+      required: [:id, :group_id, :resource_id, :description],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "group_id" => "88eae9ce-9179-48c6-8430-770e38dd4775",

--- a/elixir/test/portal/cache/client_test.exs
+++ b/elixir/test/portal/cache/client_test.exs
@@ -14,6 +14,23 @@ defmodule Portal.Cache.ClientTest do
   import Portal.SiteFixtures
   import Portal.SubjectFixtures
 
+  describe "Portal.Cache.Cacheable.to_cache/1 for policy" do
+    test "allows nil group_id for orphaned policies" do
+      policy = %Portal.Policy{
+        id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        group_id: nil,
+        conditions: []
+      }
+
+      cached_policy = Cacheable.to_cache(policy)
+
+      assert cached_policy.group_id == nil
+      assert cached_policy.id == Ecto.UUID.dump!(policy.id)
+      assert cached_policy.resource_id == Ecto.UUID.dump!(policy.resource_id)
+    end
+  end
+
   describe "update_resource/5" do
     setup do
       account = account_fixture()

--- a/elixir/test/portal_web/live/policies/new_test.exs
+++ b/elixir/test/portal_web/live/policies/new_test.exs
@@ -320,6 +320,32 @@ defmodule PortalWeb.Live.Policies.NewTest do
     assert flash["success"] == "Policy created successfully"
   end
 
+  test "sets group_idp_id when creating a new policy for a synced group", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    synced_group = synced_group_fixture(account: account, idp_id: "synced_group_liveview_123")
+    resource = resource_fixture(account: account)
+
+    attrs = %{
+      group_id: synced_group.id,
+      resource_id: resource.id
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/policies/new")
+
+    assert lv
+           |> form("form[phx-submit=submit]", policy: attrs)
+           |> render_submit()
+
+    assert policy = Repo.get_by(Portal.Policy, attrs)
+    assert policy.group_idp_id == "synced_group_liveview_123"
+  end
+
   test "creates a new policy on valid attrs and pre-set resource_id", %{
     account: account,
     actor: actor,


### PR DESCRIPTION
Fixes policy group sync metadata handling and a nil-UUID crash in cache conversion.

- Fixed crash when caching policies with group_id = nil by making policy cache UUID dumping nil-safe.
- Ensured group_idp_id is synchronized whenever group_id changes in both REST API (POST/PUT /policies) and LiveView policy forms (new and edit).
- Sync behavior is now:
    1. If selected group_id is a synced group, set group_idp_id to that group’s idp_id.
    2. If selected group_id is not synced, set group_idp_id to nil.
- Updated policy API schema to allow nullable group_id in responses.
- Added/updated tests for nil group_id cache conversion, REST create/update sync behavior, LiveView new/edit sync behavior, and orphaned policy response with group_id = nil.

---

Fixes #12204 
