### PR TITLE
refactor(apple): extract SystemExtensionManagerProtocol

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
@@ -51,13 +51,21 @@
     }
   }
 
+  @MainActor
+  protocol SystemExtensionManagerProtocol: Sendable {
+    func check() async throws -> SystemExtensionStatus
+    func tryInstall() async throws -> SystemExtensionStatus
+  }
+
   enum SystemExtensionRequestType {
     case install
     case check
   }
 
   @MainActor
-  class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate, ObservableObject {
+  class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate, ObservableObject,
+    SystemExtensionManagerProtocol
+  {
     // Delegate methods complete with either a true or false outcome or an Error
     private var continuation: CheckedContinuation<SystemExtensionStatus, Error>?
 
@@ -170,6 +178,28 @@
       withExtension ext: OSSystemExtensionProperties
     ) -> OSSystemExtensionRequest.ReplacementAction {
       return .replace
+    }
+
+    // MARK: - SystemExtensionManagerProtocol
+
+    func check() async throws -> SystemExtensionStatus {
+      try await withCheckedThrowingContinuation { continuation in
+        sendRequest(
+          requestType: .check,
+          identifier: VPNConfigurationManager.bundleIdentifier,
+          continuation: continuation
+        )
+      }
+    }
+
+    func tryInstall() async throws -> SystemExtensionStatus {
+      try await withCheckedThrowingContinuation { continuation in
+        sendRequest(
+          requestType: .install,
+          identifier: VPNConfigurationManager.bundleIdentifier,
+          continuation: continuation
+        )
+      }
     }
 
     private func resume(throwing error: Error) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
@@ -18,7 +18,7 @@
     }
   }
 
-  enum SystemExtensionStatus {
+  enum SystemExtensionStatus: Equatable {
     // Not installed or enabled at all
     case needsInstall
 
@@ -28,6 +28,27 @@
 
     // Installed and version is current with our app bundle
     case installed
+
+    /// Determines extension status by comparing installed extensions against the app version.
+    static func fromInstalledExtensions(
+      _ extensions: [(bundleVersion: String, bundleShortVersion: String)],
+      appBundleVersion: String,
+      appBundleShortVersion: String
+    ) -> SystemExtensionStatus {
+      let isCurrentVersionInstalled = extensions.contains { ext in
+        ext.bundleVersion == appBundleVersion
+          && ext.bundleShortVersion == appBundleShortVersion
+      }
+      if isCurrentVersionInstalled {
+        return .installed
+      }
+
+      if extensions.first != nil {
+        return .needsReplacement
+      }
+
+      return .needsInstall
+    }
   }
 
   enum SystemExtensionRequestType {
@@ -35,6 +56,7 @@
     case check
   }
 
+  @MainActor
   class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate, ObservableObject {
     // Delegate methods complete with either a true or false outcome or an Error
     private var continuation: CheckedContinuation<SystemExtensionStatus, Error>?
@@ -65,23 +87,23 @@
 
     // MARK: - OSSystemExtensionRequestDelegate
 
-    // Result of system extension installation
-    func request(
+    // Delegate callbacks are non-async and nonisolated.
+    // Use Task { @MainActor in } to safely hop to our actor.
+
+    nonisolated func request(
       _ request: OSSystemExtensionRequest,
       didFinishWithResult result: OSSystemExtensionRequest.Result
     ) {
-      guard result == .completed else {
-        resume(throwing: SystemExtensionError.unknownResult(result))
-
-        return
+      Task { @MainActor in
+        guard result == .completed else {
+          self.resume(throwing: SystemExtensionError.unknownResult(result))
+          return
+        }
+        self.resume(returning: .installed)
       }
-
-      // Installation succeeded
-      resume(returning: .installed)
     }
 
-    // Result of properties request
-    func request(
+    nonisolated func request(
       _ request: OSSystemExtensionRequest,
       foundProperties properties: [OSSystemExtensionProperties]
     ) {
@@ -95,54 +117,54 @@
         fatalError("Version should exist in bundle")
       }
 
-      Log.info(
-        "Checking system extension - Client version: \(ourBundleShortVersion) (\(ourBundleVersion))"
-      )
+      let enabledExtensions =
+        properties
+        .filter { $0.isEnabled }
+        .map { (bundleVersion: $0.bundleVersion, bundleShortVersion: $0.bundleShortVersion) }
 
-      // Log all found extensions for debugging
-      for sysex in properties where sysex.isEnabled {
+      Task { @MainActor in
         Log.info(
-          "Found enabled extension - Version: \(sysex.bundleShortVersion) (\(sysex.bundleVersion))"
+          "Checking system extension - Client version: \(ourBundleShortVersion) (\(ourBundleVersion))"
         )
-      }
 
-      // Up to date if version and build number match
-      let isCurrentVersionInstalled = properties.contains { sysex in
-        sysex.isEnabled
-          && sysex.bundleVersion == ourBundleVersion
-          && sysex.bundleShortVersion == ourBundleShortVersion
-      }
-      if isCurrentVersionInstalled {
-        resume(returning: .installed)
+        for sysex in enabledExtensions {
+          Log.info(
+            "Found enabled extension - Version: \(sysex.bundleShortVersion) (\(sysex.bundleVersion))"
+          )
+        }
 
-        return
-      }
-
-      // Needs replacement if we found our extension, but its version doesn't match
-      // Note this can happen for upgrades _or_ downgrades
-      let enabledExtension = properties.first { $0.isEnabled }
-      if let enabledExtension = enabledExtension {
-        Log.warning(
-          "Extension version mismatch - Installed: \(enabledExtension.bundleShortVersion) (\(enabledExtension.bundleVersion)), Expected: \(ourBundleShortVersion) (\(ourBundleVersion))"
+        let status = SystemExtensionStatus.fromInstalledExtensions(
+          enabledExtensions,
+          appBundleVersion: ourBundleVersion,
+          appBundleShortVersion: ourBundleShortVersion
         )
-        resume(returning: .needsReplacement)
 
-        return
+        if case .needsReplacement = status, let ext = enabledExtensions.first {
+          Log.warning(
+            "Extension version mismatch - Installed: \(ext.bundleShortVersion) (\(ext.bundleVersion)), Expected: \(ourBundleShortVersion) (\(ourBundleVersion))"
+          )
+        } else if case .needsInstall = status {
+          Log.info("No system extension found - needs install")
+        }
+
+        self.resume(returning: status)
       }
-
-      Log.info("No system extension found - needs install")
-      resume(returning: .needsInstall)
     }
 
-    func request(_ request: OSSystemExtensionRequest, didFailWithError error: Error) {
-      resume(throwing: error)
+    nonisolated func request(
+      _ request: OSSystemExtensionRequest,
+      didFailWithError error: Error
+    ) {
+      Task { @MainActor in
+        self.resume(throwing: error)
+      }
     }
 
-    func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
+    nonisolated func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
       // We assume this state until we receive a success response.
     }
 
-    func request(
+    nonisolated func request(
       _ request: OSSystemExtensionRequest,
       actionForReplacingExtension existing: OSSystemExtensionProperties,
       withExtension ext: OSSystemExtensionProperties

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/SystemExtensionManager.swift
@@ -18,7 +18,7 @@
     }
   }
 
-  enum SystemExtensionStatus: Equatable {
+  public enum SystemExtensionStatus: Equatable, Sendable {
     // Not installed or enabled at all
     case needsInstall
 
@@ -52,7 +52,7 @@
   }
 
   @MainActor
-  protocol SystemExtensionManagerProtocol: Sendable {
+  public protocol SystemExtensionManagerProtocol: Sendable {
     func check() async throws -> SystemExtensionStatus
     func tryInstall() async throws -> SystemExtensionStatus
   }
@@ -69,30 +69,6 @@
     // Delegate methods complete with either a true or false outcome or an Error
     private var continuation: CheckedContinuation<SystemExtensionStatus, Error>?
 
-    func sendRequest(
-      requestType: SystemExtensionRequestType,
-      identifier: String,
-      continuation: CheckedContinuation<SystemExtensionStatus, Error>
-    ) {
-      self.continuation = continuation
-
-      let request =
-        switch requestType {
-        case .install:
-          OSSystemExtensionRequest.activationRequest(
-            forExtensionWithIdentifier: identifier, queue: .main)
-        case .check:
-          OSSystemExtensionRequest.propertiesRequest(
-            forExtensionWithIdentifier: identifier,
-            queue: .main
-          )
-        }
-
-      request.delegate = self
-
-      OSSystemExtensionManager.shared.submitRequest(request)
-    }
-
     // MARK: - OSSystemExtensionRequestDelegate
 
     // Delegate callbacks are non-async and nonisolated.
@@ -104,10 +80,10 @@
     ) {
       Task { @MainActor in
         guard result == .completed else {
-          self.resume(throwing: SystemExtensionError.unknownResult(result))
+          self.resumeErr(throwing: SystemExtensionError.unknownResult(result))
           return
         }
-        self.resume(returning: .installed)
+        self.resumeOk(returning: .installed)
       }
     }
 
@@ -155,7 +131,7 @@
           Log.info("No system extension found - needs install")
         }
 
-        self.resume(returning: status)
+        self.resumeOk(returning: status)
       }
     }
 
@@ -164,7 +140,7 @@
       didFailWithError error: Error
     ) {
       Task { @MainActor in
-        self.resume(throwing: error)
+        self.resumeErr(throwing: error)
       }
     }
 
@@ -202,12 +178,36 @@
       }
     }
 
-    private func resume(throwing error: Error) {
+    private func sendRequest(
+      requestType: SystemExtensionRequestType,
+      identifier: String,
+      continuation: CheckedContinuation<SystemExtensionStatus, Error>
+    ) {
+      self.continuation = continuation
+
+      let request =
+        switch requestType {
+        case .install:
+          OSSystemExtensionRequest.activationRequest(
+            forExtensionWithIdentifier: identifier, queue: .main)
+        case .check:
+          OSSystemExtensionRequest.propertiesRequest(
+            forExtensionWithIdentifier: identifier,
+            queue: .main
+          )
+        }
+
+      request.delegate = self
+
+      OSSystemExtensionManager.shared.submitRequest(request)
+    }
+
+    private func resumeErr(throwing error: Error) {
       self.continuation?.resume(throwing: error)
       self.continuation = nil
     }
 
-    private func resume(returning val: SystemExtensionStatus) {
+    private func resumeOk(returning val: SystemExtensionStatus) {
       self.continuation?.resume(returning: val)
       self.continuation = nil
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -60,27 +60,28 @@ public final class Store: ObservableObject {
   // Track which unreachable resource notifications we have already shown
   private var unreachableResources: Set<UnreachableResource> = []
 
-  public convenience init(configuration: Configuration? = nil) {
-    self.init(
-      configuration: configuration,
-      systemExtensionManager: nil
-    )
-  }
-
-  init(
-    configuration: Configuration?,
-    systemExtensionManager: (any SystemExtensionManagerProtocol)?
-  ) {
-    self.configuration = configuration ?? Configuration.shared
-    #if os(macOS)
+  #if os(macOS)
+    public init(
+      configuration: Configuration? = nil,
+      systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil
+    ) {
+      self.configuration = configuration ?? Configuration.shared
       self.updateChecker = UpdateChecker(configuration: configuration)
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
-    #endif
+      self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
+      self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
+      self.postInit()
+    }
+  #else
+    public init(configuration: Configuration? = nil) {
+      self.configuration = configuration ?? Configuration.shared
+      self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
+      self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
+      self.postInit()
+    }
+  #endif
 
-    // Load GUI-only cached state
-    self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
-    self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
-
+  private func postInit() {
     self.sessionNotification.signInHandler = {
       Task {
         do { try await WebAuthSession.signIn(store: self) } catch { Log.error(error) }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -44,6 +44,7 @@ public final class Store: ObservableObject {
   let sessionNotification = SessionNotification()
   #if os(macOS)
     let updateChecker: UpdateChecker
+    private let systemExtensionManager: any SystemExtensionManagerProtocol
   #endif
 
   private var resourcesTimer: Timer?
@@ -59,10 +60,21 @@ public final class Store: ObservableObject {
   // Track which unreachable resource notifications we have already shown
   private var unreachableResources: Set<UnreachableResource> = []
 
-  public init(configuration: Configuration? = nil) {
+  public convenience init(configuration: Configuration? = nil) {
+    self.init(
+      configuration: configuration,
+      systemExtensionManager: nil
+    )
+  }
+
+  init(
+    configuration: Configuration?,
+    systemExtensionManager: (any SystemExtensionManagerProtocol)?
+  ) {
     self.configuration = configuration ?? Configuration.shared
     #if os(macOS)
       self.updateChecker = UpdateChecker(configuration: configuration)
+      self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
     #endif
 
     // Load GUI-only cached state
@@ -177,18 +189,8 @@ public final class Store: ObservableObject {
       }
     }
 
-    func systemExtensionRequest(_ requestType: SystemExtensionRequestType) async throws {
-      let manager = SystemExtensionManager()
-
-      self.systemExtensionStatus =
-        try await withCheckedThrowingContinuation {
-          (continuation: CheckedContinuation<SystemExtensionStatus, Error>) in
-          manager.sendRequest(
-            requestType: requestType,
-            identifier: VPNConfigurationManager.bundleIdentifier,
-            continuation: continuation
-          )
-        }
+    func installSystemExtension() async throws {
+      self.systemExtensionStatus = try await systemExtensionManager.tryInstall()
     }
   #endif
 
@@ -248,7 +250,7 @@ public final class Store: ObservableObject {
       // When this happens, it's because either our VPN configuration or System Extension (or both) were removed.
       // So load the system extension status again to determine which view to load.
       if vpnStatus == .invalid {
-        try await systemExtensionRequest(.check)
+        self.systemExtensionStatus = try await systemExtensionManager.check()
       }
     #endif
   }
@@ -259,12 +261,12 @@ public final class Store: ObservableObject {
 
   private func initSystemExtension() async throws {
     #if os(macOS)
-      try await systemExtensionRequest(.check)
+      self.systemExtensionStatus = try await systemExtensionManager.check()
 
       // If already installed but the wrong version, go ahead and install. This shouldn't prompt the user.
       if systemExtensionStatus == .needsReplacement {
         Log.info("Replacing system extension with current version")
-        try await systemExtensionRequest(.install)
+        self.systemExtensionStatus = try await systemExtensionManager.tryInstall()
         Log.info("System extension replacement completed successfully")
       }
     #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -144,7 +144,7 @@ struct GrantVPNView: View {
     func installSystemExtension() {
       Task {
         do {
-          try await store.systemExtensionRequest(.install)
+          try await store.installSystemExtension()
 
           // The window has a tendency to go to the background after installing
           // the system extension

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
@@ -108,7 +108,7 @@
     func grantPermission() {
       Task {
         do {
-          try await store.systemExtensionRequest(.install)
+          try await store.installSystemExtension()
           try await store.installVPNConfiguration()
         } catch let error as NSError {
           if error.domain == "NEVPNErrorDomain" && error.code == 5 {

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockSystemExtensionManager.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/Mocks/MockSystemExtensionManager.swift
@@ -1,0 +1,28 @@
+//
+//  MockSystemExtensionManager.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  @testable import FirezoneKit
+
+  @MainActor
+  final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
+    var checkResult: Result<SystemExtensionStatus, Error> = .success(.installed)
+    var tryInstallResult: Result<SystemExtensionStatus, Error> = .success(.installed)
+
+    private(set) var checkCallCount = 0
+    private(set) var tryInstallCallCount = 0
+
+    func check() async throws -> SystemExtensionStatus {
+      checkCallCount += 1
+      return try checkResult.get()
+    }
+
+    func tryInstall() async throws -> SystemExtensionStatus {
+      tryInstallCallCount += 1
+      return try tryInstallResult.get()
+    }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SystemExtensionStatusTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SystemExtensionStatusTests.swift
@@ -1,0 +1,90 @@
+//
+//  SystemExtensionStatusTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import Testing
+
+  @testable import FirezoneKit
+
+  @Suite("SystemExtensionStatus.fromInstalledExtensions")
+  struct SystemExtensionStatusTests {
+    @Test("returns .needsInstall when no extensions are present")
+    func noExtensions() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .needsInstall)
+    }
+
+    @Test("returns .installed when version matches exactly")
+    func exactMatch() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [(bundleVersion: "42", bundleShortVersion: "1.0.0")],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .installed)
+    }
+
+    @Test("returns .needsReplacement when short version differs (upgrade)")
+    func upgradeNeeded() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [(bundleVersion: "41", bundleShortVersion: "0.9.0")],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .needsReplacement)
+    }
+
+    @Test("returns .needsReplacement when build number differs but short version matches")
+    func buildNumberMismatch() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [(bundleVersion: "41", bundleShortVersion: "1.0.0")],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .needsReplacement)
+    }
+
+    @Test("returns .needsReplacement on downgrade")
+    func downgrade() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [(bundleVersion: "99", bundleShortVersion: "2.0.0")],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .needsReplacement)
+    }
+
+    @Test("returns .installed if any extension matches among multiple")
+    func multipleExtensionsOneMatches() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [
+          (bundleVersion: "40", bundleShortVersion: "0.8.0"),
+          (bundleVersion: "42", bundleShortVersion: "1.0.0"),
+        ],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .installed)
+    }
+
+    @Test("returns .needsReplacement when multiple extensions exist but none match")
+    func multipleExtensionsNoneMatch() {
+      let status = SystemExtensionStatus.fromInstalledExtensions(
+        [
+          (bundleVersion: "40", bundleShortVersion: "0.8.0"),
+          (bundleVersion: "41", bundleShortVersion: "0.9.0"),
+        ],
+        appBundleVersion: "42",
+        appBundleShortVersion: "1.0.0"
+      )
+      #expect(status == .needsReplacement)
+    }
+  }
+#endif


### PR DESCRIPTION
Make the SystemExtensionManager sendable by setting it as main actor, and extract parts of it as a testable function (with unit tests).

Add simple protocol on top of it for DI.

Part of the #12089  