### PR TITLE
fix(apple): fetch firezoneId from NE via IPC

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -106,6 +106,13 @@ enum IPCClient {
   }
 
   @MainActor
+  static func fetchEncodedFirezoneId(session: NETunnelProviderSession) async throws -> String? {
+    guard let data = try await sendProviderMessage(session: session, message: .getEncodedFirezoneId)
+    else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  @MainActor
   static func exportLogs(session: NETunnelProviderSession, fd: FileDescriptor) async throws {
     let isCycleStart = try await maybeCycleStart(session)
     defer {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -6,50 +6,14 @@
 
 import Sentry
 
-/// Actor that manages telemetry state with thread-safe access.
-actor TelemetryState {
-  private var firezoneId: String?
-  private var accountSlug: String?
-
-  func setFirezoneId(_ id: String?) {
-    firezoneId = id
-    updateUser()
-  }
-
-  func setAccountSlug(_ slug: String?) {
-    accountSlug = slug
-    updateUser()
-  }
-
-  private func updateUser() {
-    guard let firezoneId, let accountSlug else {
-      return
-    }
-
-    SentrySDK.configureScope { configuration in
-      // Matches the format we use in rust/telemetry/lib.rs
+public enum Telemetry {
+  /// Sets the Sentry user from the firezone device ID and account slug.
+  public static func setUser(firezoneId: String, accountSlug: String) {
+    SentrySDK.configureScope { scope in
       let user = User(userId: firezoneId)
       user.data = ["account_slug": accountSlug]
-
-      configuration.setUser(user)
+      scope.setUser(user)
     }
-  }
-}
-
-public enum Telemetry {
-  // We can only create a new User object after Sentry is started; not retrieve
-  // the existing one. So we need to collect these fields from various codepaths
-  // during initialization / sign in so we can build a new User object any time
-  // one of these is updated.
-
-  private static let state = TelemetryState()
-
-  public static func setFirezoneId(_ id: String?) async {
-    await state.setFirezoneId(id)
-  }
-
-  public static func setAccountSlug(_ slug: String?) async {
-    await state.setAccountSlug(slug)
   }
 
   public static func start(enableAppHangTracking: Bool = true) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
@@ -14,6 +14,7 @@ public enum ProviderMessage: Codable {
   case clearLogs
   case getLogFolderSize
   case exportLogs
+  case getEncodedFirezoneId
 
   enum CodingKeys: String, CodingKey {
     case type
@@ -27,6 +28,7 @@ public enum ProviderMessage: Codable {
     case clearLogs
     case getLogFolderSize
     case exportLogs
+    case getEncodedFirezoneId
   }
 
   public init(from decoder: Decoder) throws {
@@ -47,6 +49,8 @@ public enum ProviderMessage: Codable {
       self = .getLogFolderSize
     case .exportLogs:
       self = .exportLogs
+    case .getEncodedFirezoneId:
+      self = .getEncodedFirezoneId
     }
   }
 
@@ -67,6 +71,8 @@ public enum ProviderMessage: Codable {
       try container.encode(MessageType.getLogFolderSize, forKey: .type)
     case .exportLogs:
       try container.encode(MessageType.exportLogs, forKey: .type)
+    case .getEncodedFirezoneId:
+      try container.encode(MessageType.getEncodedFirezoneId, forKey: .type)
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -362,6 +362,11 @@ public final class Store: ObservableObject {
   // MARK: Private functions
 
   private func fetchAndCacheFirezoneId() {
+    // Skip IPC if we already have a cached Firezone ID for this session
+    if UserDefaults.standard.string(forKey: "encodedFirezoneId") != nil {
+      return
+    }
+
     Task {
       do {
         guard let session = try manager().session(),

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -39,8 +39,6 @@ public final class Store: ObservableObject {
     @Published public var menuBarOpenRequested = false
   #endif
 
-  var firezoneId: String?
-
   let sessionNotification = SessionNotification()
   #if os(macOS)
     let updateChecker: UpdateChecker
@@ -215,6 +213,7 @@ public final class Store: ObservableObject {
 
     if newVPNStatus == .connected {
       beginUpdatingResources()
+      fetchAndCacheFirezoneId()
     } else {
       endUpdatingResources()
     }
@@ -326,7 +325,6 @@ public final class Store: ObservableObject {
     UserDefaults.standard.set(actorName, forKey: "actorName")
 
     configuration.accountSlug = accountSlug
-    await Telemetry.setAccountSlug(accountSlug)
 
     try await manager().enable()
 
@@ -362,6 +360,21 @@ public final class Store: ObservableObject {
   }
 
   // MARK: Private functions
+
+  private func fetchAndCacheFirezoneId() {
+    Task {
+      do {
+        guard let session = try manager().session(),
+          let firezoneId = try await IPCClient.fetchEncodedFirezoneId(session: session)
+        else { return }
+
+        UserDefaults.standard.set(firezoneId, forKey: "encodedFirezoneId")
+        Telemetry.setUser(firezoneId: firezoneId, accountSlug: configuration.accountSlug)
+      } catch {
+        Log.error(error)
+      }
+    }
+  }
 
   private func markAlertAsShown(_ id: String) {
     shownAlertIds.insert(id)

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -119,8 +119,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       return
     }
 
-    // Configure telemetry (sync part)
     Telemetry.setEnvironmentOrClose(apiURL)
+    Telemetry.setUser(firezoneId: firezoneId.encoded, accountSlug: accountSlug)
 
     let enabled = legacyConfiguration?["internetResourceEnabled"]
     let internetResourceEnabled =
@@ -162,12 +162,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // Start the adapter asynchronously. The Task only captures Sendable values:
     // - adapter: actor (Sendable)
     // - completionHandler: @Sendable
-    // - accountSlug: String (Sendable)
     Task { @Sendable in
-      // Set telemetry identifiers (async)
-      await Telemetry.setFirezoneId(firezoneId.encoded)
-      await Telemetry.setAccountSlug(accountSlug)
-
       do {
         try await adapter.start()
         completionHandler(nil)
@@ -254,6 +249,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           let connlibState = await adapter.getStateIfVersionDifferentFrom(hash: hash)
           completionHandler?(connlibState)
         }
+      case .getEncodedFirezoneId:
+        let rawId = UserDefaults.standard.string(forKey: "firezoneId") ?? ""
+        let encodedId = FirezoneId(uuid: rawId).encoded
+        completionHandler?(encodedId.data(using: .utf8))
       case .clearLogs:
         clearLogs(completionHandler)
       case .getLogFolderSize:

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -250,7 +250,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           completionHandler?(connlibState)
         }
       case .getEncodedFirezoneId:
-        let rawId = UserDefaults.standard.string(forKey: "firezoneId") ?? ""
+        guard let rawId = UserDefaults.standard.string(forKey: "firezoneId") else {
+          Log.error(PacketTunnelProviderError.firezoneIdIsInvalid)
+          completionHandler?(nil)
+          return
+        }
         let encodedId = FirezoneId(uuid: rawId).encoded
         completionHandler?(encodedId.data(using: .utf8))
       case .clearLogs:


### PR DESCRIPTION
The Sentry userId was never actually set in the main app process because the TelemetryState actor required both firezoneId and accountSlug to be set before emitting a user and firezoneId never was passed into the main app.

Building on #12199 which switched to the encoded FirezoneId for Sentry, add a `getEncodedFirezoneId` IPC message so the GUI app can fetch the canonical value directly from the Network Extension on connect. This also simplifies the Telemetry API from an async actor with partial state accumulation down to a single synchronous `setUser` call, since both values are now available together.

Tested correct ID by provoking a fatal crash that was correctly shown in sentry with relevant encoded ID.

Fixes #12126 