### PR TITLE
refactor(rust): introduce `known_dirs` crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2522,7 +2522,7 @@ dependencies = [
  "humantime",
  "ip-packet",
  "ip_network",
- "known-folders",
+ "known-dirs",
  "libc",
  "logging",
  "nix",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -844,7 +844,6 @@ dependencies = [
  "bytes",
  "clap",
  "dashmap",
- "dirs",
  "dns-types",
  "futures",
  "gat-lending-iterator",
@@ -856,7 +855,7 @@ dependencies = [
  "ip_network",
  "ipconfig",
  "itertools",
- "known-folders",
+ "known-dirs",
  "libc",
  "logging",
  "netlink-packet-core",
@@ -2457,6 +2456,7 @@ dependencies = [
  "ip-packet",
  "ip_network",
  "keyring-core",
+ "known-dirs",
  "logging",
  "native-dialog",
  "nix",
@@ -4017,6 +4017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f668c4c52e5e79879d9ce68b2da363b78a378c4becae267f8cfc26c55db4ed3"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "known-dirs"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "dirs",
+ "known-folders",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "libs/connlib/tun",
     "libs/connlib/tunnel",
     "libs/http-client",
+    "libs/known-dirs",
     "libs/logging",
     "libs/telemetry",
     "relay/ebpf-shared",
@@ -112,6 +113,7 @@ ip_network_table = { version = "0.2.0", default-features = false }
 itertools = "0.14.0"
 jni = "0.21.1"
 keyring-core = "0.7.0"
+known-dirs = { path = "libs/known-dirs" }
 known-folders = "1.4.0"
 l3-tcp = { path = "libs/connlib/l3-tcp" }
 l3-udp-dns-client = { path = "libs/connlib/l3-udp-dns-client" }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ humantime = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 keyring-core = { workspace = true }
+known-dirs = { workspace = true }
 logging = { workspace = true }
 native-dialog = { workspace = true }
 output_vt100 = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -104,8 +104,8 @@ anyhow = { workspace = true }
 tauri-build = { workspace = true, features = [] }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 bin-shared = { workspace = true, features = ["test"] }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -35,8 +35,8 @@ humantime = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 keyring-core = { workspace = true }
-logging = { workspace = true }
 known-dirs = { workspace = true }
+logging = { workspace = true }
 native-dialog = { workspace = true }
 output_vt100 = { workspace = true }
 parking_lot = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -35,8 +35,8 @@ humantime = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 keyring-core = { workspace = true }
-known-dirs = { workspace = true }
 logging = { workspace = true }
+known-dirs = { workspace = true }
 native-dialog = { workspace = true }
 output_vt100 = { workspace = true }
 parking_lot = { workspace = true }

--- a/rust/gui-client/src-tauri/src/auth.rs
+++ b/rust/gui-client/src-tauri/src/auth.rs
@@ -1,7 +1,6 @@
 //! Fulfills <https://github.com/firezone/firezone/issues/2823>
 
 use anyhow::{Context, Result};
-use bin_shared::known_dirs;
 use keyring_core::CredentialStore;
 use logging::err_with_src;
 use rand::{RngCore, thread_rng};

--- a/rust/gui-client/src-tauri/src/controller/ran_before.rs
+++ b/rust/gui-client/src-tauri/src/controller/ran_before.rs
@@ -25,6 +25,6 @@ pub(crate) async fn set() -> Result<()> {
 }
 
 fn path() -> Result<PathBuf> {
-    let session_dir = bin_shared::known_dirs::session().context("Couldn't find session dir")?;
+    let session_dir = known_dirs::session().context("Couldn't find session dir")?;
     Ok(session_dir.join("ran_before.txt"))
 }

--- a/rust/gui-client/src-tauri/src/deep_link/windows.rs
+++ b/rust/gui-client/src-tauri/src/deep_link/windows.rs
@@ -3,7 +3,6 @@
 
 use super::FZ_SCHEME;
 use anyhow::{Context, Result};
-use bin_shared::BUNDLE_ID;
 use std::{
     io,
     path::{Path, PathBuf},
@@ -16,7 +15,7 @@ use std::{
 pub fn register(exe: PathBuf) -> Result<()> {
     let exe = exe.display().to_string().replace("\\\\?\\", "");
 
-    set_registry_values(BUNDLE_ID, &exe).context("Can't set Windows Registry values")?;
+    set_registry_values(crate::BUNDLE_ID, &exe).context("Can't set Windows Registry values")?;
 
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -338,7 +338,7 @@ pub fn run(
         }
 
         assert_eq!(
-            bin_shared::BUNDLE_ID,
+            crate::BUNDLE_ID,
             app_handle.config().identifier,
             "BUNDLE_ID should match bundle ID in tauri.conf.json"
         );

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use bin_shared::BUNDLE_ID;
 use std::env;
 use winreg::RegKey;
 use winreg::enums::*;
@@ -66,7 +65,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
     // For some reason `on_activated` is FnMut
     let mut tx = Some(tx);
 
-    tauri_winrt_notification::Toast::new(BUNDLE_ID)
+    tauri_winrt_notification::Toast::new(crate::BUNDLE_ID)
         .title(&title)
         .text1(&body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)

--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -110,14 +110,14 @@ impl Server {
 /// Test sockets live in e.g. `/run/user/1000/dev.firezone.client/data/`
 fn ipc_path(id: SocketId) -> Result<PathBuf> {
     Ok(match id {
-        SocketId::Tunnel => bin_shared::known_dirs::root_runtime()
+        SocketId::Tunnel => known_dirs::root_runtime()
             .context("Failed to get root runtime directory")?
             .join("tunnel.sock"),
-        SocketId::Gui => bin_shared::known_dirs::user_runtime()
+        SocketId::Gui => known_dirs::user_runtime()
             .context("Failed to get user runtime directory")?
             .join("gui.sock"),
         #[cfg(test)]
-        SocketId::Test(id) => bin_shared::known_dirs::user_runtime()
+        SocketId::Test(id) => known_dirs::user_runtime()
             .context("Failed to get user runtime directory")?
             .join(format!("ipc_test_{id}.sock")),
     })

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -1,6 +1,5 @@
 use super::{NotFound, SocketId};
 use anyhow::{Context as _, Result, bail};
-use bin_shared::BUNDLE_ID;
 use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Duration};
 use tokio::net::windows::named_pipe;
 use windows::Win32::{
@@ -151,10 +150,10 @@ fn create_pipe_server(pipe_path: &str) -> Result<named_pipe::NamedPipeServer, Pi
 /// Named pipe for an IPC connection
 fn ipc_path(id: SocketId) -> String {
     let name = match id {
-        SocketId::Tunnel => format!("{BUNDLE_ID}_tunnel.ipc"),
-        SocketId::Gui => format!("{BUNDLE_ID}_gui.ipc"),
+        SocketId::Tunnel => format!("{}_tunnel.ipc", crate::BUNDLE_ID),
+        SocketId::Gui => format!("{}_gui.ipc", crate::BUNDLE_ID),
         #[cfg(test)]
-        SocketId::Test(id) => format!("{BUNDLE_ID}_test_{id}.ipc"),
+        SocketId::Test(id) => format!("{}_test_{id}.ipc", crate::BUNDLE_ID),
     };
     named_pipe_path(&name)
 }

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -17,6 +17,17 @@ pub mod logging;
 pub mod service;
 pub mod settings;
 
+/// Bundle ID / App ID that the client uses to distinguish itself from other programs on the system
+///
+/// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
+/// but sometimes I need to use this before Tauri has booted up, or in a place where
+/// getting the Tauri app handle would be awkward.
+///
+/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
+/// so if your dev system has Firezone installed by MSI, the notifications will look right.
+/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
+pub const BUNDLE_ID: &str = "dev.firezone.client";
+
 /// The Sentry "release" we are part of.
 ///
 /// Tunnel service and GUI client are always bundled into a single release.

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -3,7 +3,6 @@
 pub use ::logging::*;
 
 use anyhow::{Context as _, Result, bail};
-use bin_shared::known_dirs;
 use serde::Serialize;
 use std::{
     fs,
@@ -193,8 +192,8 @@ pub(crate) fn get_log_filter() -> Result<String> {
         return Ok(filter);
     }
 
-    if let Ok(filter) = std::fs::read_to_string(bin_shared::known_dirs::tunnel_log_filter()?)
-        .map(|s| s.trim().to_string())
+    if let Ok(filter) =
+        std::fs::read_to_string(known_dirs::tunnel_log_filter()?).map(|s| s.trim().to_string())
     {
         return Ok(filter);
     }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -8,7 +8,7 @@ use backoff::ExponentialBackoffBuilder;
 use bin_shared::{
     DnsControlMethod, DnsController, TunDeviceManager,
     device_id::{self, DeviceId},
-    device_info, known_dirs,
+    device_info,
     platform::{UdpSocketFactory, tcp_socket_factory},
     signals,
 };

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -2,7 +2,6 @@
 //! advanced settings and code for manipulating diagnostic logs.
 
 use anyhow::{Context as _, Result};
-use bin_shared::known_dirs;
 use connlib_model::ResourceId;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -205,7 +205,7 @@ impl Checker {
 }
 
 fn version_file_path() -> Result<PathBuf> {
-    Ok(bin_shared::known_dirs::session()
+    Ok(known_dirs::session()
         .context("Couldn't find session dir")?
         .join("latest_version_seen.txt"))
 }

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -19,6 +19,7 @@ futures = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
+known-dirs = { workspace = true }
 logging = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
@@ -42,9 +43,6 @@ url = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["fs", "user", "socket"] }
 sd-notify = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-known-folders = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -2,18 +2,13 @@
 
 use super::TOKEN_ENV_KEY;
 use anyhow::{Result, bail};
-use bin_shared::BUNDLE_ID;
 use nix::fcntl::AT_FDCWD;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // The Client currently must run as root to control DNS
 // Root group and user are used to check file ownership on the token
 const ROOT_GROUP: u32 = 0;
 const ROOT_USER: u32 = 0;
-
-pub(crate) fn default_token_path() -> PathBuf {
-    PathBuf::from("/etc").join(BUNDLE_ID).join("token")
-}
 
 pub(crate) fn check_token_permissions(path: &Path) -> Result<()> {
     let Ok(stat) = nix::sys::stat::fstatat(AT_FDCWD, path, nix::fcntl::AtFlags::empty()) else {

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
-use bin_shared::BUNDLE_ID;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // The return value is useful on Linux
 #[expect(clippy::unnecessary_wraps)]
@@ -42,10 +41,6 @@ pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
     set_token_permissions(path)?;
 
     Ok(())
-}
-
-pub(crate) fn default_token_path() -> PathBuf {
-    PathBuf::from("/etc").join(BUNDLE_ID).join("token")
 }
 
 // The return value is useful on Linux

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -137,7 +137,7 @@ struct Cli {
     // until anyone asks for it, env vars are okay and files on disk are slightly better.
     // (Since we run as root and the env var on a headless system is probably stored
     // on disk somewhere anyway.)
-    #[arg(default_value = platform::default_token_path().display().to_string(), env = "FIREZONE_TOKEN_PATH", long)]
+    #[arg(default_value = known_dirs::default_token_path().display().to_string(), env = "FIREZONE_TOKEN_PATH", long)]
     token_path: PathBuf,
 
     /// Increase the `core.rmem_max` and `core.wmem_max` kernel parameters.
@@ -757,7 +757,7 @@ mod tests {
     fn sign_in_uses_default_token_path() {
         let actual = Cli::try_parse_from(["firezone-headless-client", "sign-in"]).unwrap();
 
-        assert_eq!(actual.token_path, super::platform::default_token_path());
+        assert_eq!(actual.token_path, known_dirs::default_token_path());
     }
 
     #[test]

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -5,9 +5,7 @@
 //! We must tell Windows explicitly when our service is stopping.
 
 use anyhow::{Context as _, Result};
-use bin_shared::BUNDLE_ID;
-use known_folders::{KnownFolder, get_known_folder_path};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // The return value is useful on Linux
 #[expect(clippy::unnecessary_wraps)]
@@ -47,13 +45,6 @@ pub(crate) fn write_token(path: &Path, token: &str) -> Result<()> {
     set_token_permissions(path)?;
 
     Ok(())
-}
-
-pub(crate) fn default_token_path() -> PathBuf {
-    get_known_folder_path(KnownFolder::ProgramData)
-        .expect("ProgramData folder not found. Is %PROGRAMDATA% set?")
-        .join(BUNDLE_ID)
-        .join("token.txt")
 }
 
 // Does nothing on Windows. On Linux this notifies systemd that we're ready.

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -21,6 +21,7 @@ hex = { workspace = true }
 hex-literal = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true, features = ["serde"] }
+known-dirs = { workspace = true }
 logging = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -36,7 +37,6 @@ uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 atomicwrites = { workspace = true }
-dirs = { workspace = true }
 hmac = { workspace = true }
 libc = { workspace = true }
 netlink-packet-core = { workspace = true }
@@ -51,7 +51,6 @@ zbus = { workspace = true } # Can't use `zbus`'s `tokio` feature here, or it wil
 dashmap = { workspace = true }
 ipconfig = "0.3.2"
 itertools = { workspace = true }
-known-folders = { workspace = true }
 ring = "0.17"
 tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -48,7 +48,7 @@ pub enum Source {
 /// e.g. `C:\ProgramData\dev.firezone.client/firezone-id.json` or
 /// `/var/lib/dev.firezone.client/config/firezone-id.json`.
 pub fn client_path() -> Result<PathBuf> {
-    let path = crate::known_dirs::tunnel_service_config()
+    let path = known_dirs::tunnel_service_config()
         .context("Failed to compute path for firezone-id file")?
         .join("firezone-id.json");
     Ok(path)

--- a/rust/libs/bin-shared/src/lib.rs
+++ b/rust/libs/bin-shared/src/lib.rs
@@ -26,7 +26,6 @@ pub use macos as platform;
 
 pub mod device_id;
 pub mod device_info;
-pub mod known_dirs;
 pub mod signals;
 pub mod uptime;
 

--- a/rust/libs/bin-shared/src/lib.rs
+++ b/rust/libs/bin-shared/src/lib.rs
@@ -29,8 +29,6 @@ pub mod device_info;
 pub mod signals;
 pub mod uptime;
 
-pub use known_dirs::BUNDLE_ID;
-
 pub const TOKEN_ENV_KEY: &str = "FIREZONE_TOKEN";
 
 // wintun automatically append " Tunnel" to this

--- a/rust/libs/bin-shared/src/lib.rs
+++ b/rust/libs/bin-shared/src/lib.rs
@@ -29,25 +29,12 @@ pub mod device_info;
 pub mod signals;
 pub mod uptime;
 
+pub use known_dirs::BUNDLE_ID;
+
 pub const TOKEN_ENV_KEY: &str = "FIREZONE_TOKEN";
 
 // wintun automatically append " Tunnel" to this
 pub const TUNNEL_NAME: &str = "Firezone";
-
-/// Bundle ID / App ID that the client uses to distinguish itself from other programs on the system
-///
-/// e.g. In ProgramData and AppData we use this to name our subdirectories for configs and data,
-/// and Windows may use it to track things like the MSI installer, notification titles,
-/// deep link registration, etc.
-///
-/// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
-/// but sometimes I need to use this before Tauri has booted up, or in a place where
-/// getting the Tauri app handle would be awkward.
-///
-/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
-/// so if your dev system has Firezone installed by MSI, the notifications will look right.
-/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
-pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 /// Mark for Firezone sockets to prevent routing loops on Linux.
 pub const FIREZONE_MARK: u32 = 0xfd002021;

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -695,7 +695,7 @@ fn file_length(f: &std::fs::File) -> Result<usize> {
 ///
 /// e.g. `C:\Users\User\AppData\Local\dev.firezone.client\data\wintun.dll`
 fn wintun_dll_path() -> Result<PathBuf> {
-    let path = crate::known_dirs::platform::app_local_data_dir()?
+    let path = known_dirs::platform::app_local_data_dir()?
         .join("data")
         .join("wintun.dll");
     Ok(path)

--- a/rust/libs/known-dirs/Cargo.toml
+++ b/rust/libs/known-dirs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "known-dirs"
+version = "0.1.0"
+edition = { workspace = true }
+description = "Platform-specific known directory paths for Firezone"
+license = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dirs = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+known-folders = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/known-dirs/src/lib.rs
+++ b/rust/libs/known-dirs/src/lib.rs
@@ -15,16 +15,31 @@ pub use platform::{
 };
 
 #[cfg(target_os = "linux")]
-#[path = "known_dirs/linux.rs"]
+#[path = "platform/linux.rs"]
 pub mod platform;
 
 #[cfg(target_os = "macos")]
-#[path = "known_dirs/macos.rs"]
+#[path = "platform/macos.rs"]
 pub mod platform;
 
 #[cfg(target_os = "windows")]
-#[path = "known_dirs/windows.rs"]
+#[path = "platform/windows.rs"]
 pub mod platform;
+
+/// Bundle ID / App ID that the client uses to distinguish itself from other programs on the system
+///
+/// e.g. In ProgramData and AppData we use this to name our subdirectories for configs and data,
+/// and Windows may use it to track things like the MSI installer, notification titles,
+/// deep link registration, etc.
+///
+/// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
+/// but sometimes I need to use this before Tauri has booted up, or in a place where
+/// getting the Tauri app handle would be awkward.
+///
+/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
+/// so if your dev system has Firezone installed by MSI, the notifications will look right.
+/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
+pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 pub fn tunnel_log_filter() -> Result<PathBuf> {
     Ok(tunnel_service_config()
@@ -48,10 +63,9 @@ mod tests {
             settings(),
         ] {
             let dir = dir.expect("should have gotten Some(path)");
-            assert!(
-                dir.components()
-                    .any(|x| x == std::path::Component::Normal("dev.firezone.client".as_ref()))
-            );
+            assert!(dir
+                .components()
+                .any(|x| x == std::path::Component::Normal("dev.firezone.client".as_ref())));
         }
     }
 }

--- a/rust/libs/known-dirs/src/lib.rs
+++ b/rust/libs/known-dirs/src/lib.rs
@@ -31,15 +31,7 @@ pub mod platform;
 /// e.g. In ProgramData and AppData we use this to name our subdirectories for configs and data,
 /// and Windows may use it to track things like the MSI installer, notification titles,
 /// deep link registration, etc.
-///
-/// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
-/// but sometimes I need to use this before Tauri has booted up, or in a place where
-/// getting the Tauri app handle would be awkward.
-///
-/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
-/// so if your dev system has Firezone installed by MSI, the notifications will look right.
-/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
-pub const BUNDLE_ID: &str = "dev.firezone.client";
+const BUNDLE_ID: &str = "dev.firezone.client";
 
 pub fn tunnel_log_filter() -> Result<PathBuf> {
     Ok(tunnel_service_config()

--- a/rust/libs/known-dirs/src/lib.rs
+++ b/rust/libs/known-dirs/src/lib.rs
@@ -47,6 +47,16 @@ pub fn tunnel_log_filter() -> Result<PathBuf> {
         .join("log-filter"))
 }
 
+/// Returns the default path for storing the authentication token
+///
+/// This is used by the headless client to store tokens persistently on disk.
+/// The path varies by platform:
+/// - Linux/macOS: `/etc/dev.firezone.client/token`
+/// - Windows: `C:\ProgramData\dev.firezone.client\token.txt`
+pub fn default_token_path() -> PathBuf {
+    platform::default_token_path()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -63,9 +73,10 @@ mod tests {
             settings(),
         ] {
             let dir = dir.expect("should have gotten Some(path)");
-            assert!(dir
-                .components()
-                .any(|x| x == std::path::Component::Normal("dev.firezone.client".as_ref())));
+            assert!(
+                dir.components()
+                    .any(|x| x == std::path::Component::Normal("dev.firezone.client".as_ref()))
+            );
         }
     }
 }

--- a/rust/libs/known-dirs/src/platform/linux.rs
+++ b/rust/libs/known-dirs/src/platform/linux.rs
@@ -14,14 +14,13 @@ use std::path::PathBuf;
 /// `BUNDLE_ID` because we need our own subdir
 ///
 /// `config` to match how Windows has `config` and `data` both under `AppData/Local/$BUNDLE_ID`
-#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
+#[expect(clippy::unnecessary_wraps)]
 pub fn tunnel_service_config() -> Option<PathBuf> {
     Some(PathBuf::from("/var/lib").join(BUNDLE_ID).join("config"))
 }
 
-#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
+#[expect(clippy::unnecessary_wraps)]
 pub fn tunnel_service_logs() -> Option<PathBuf> {
-    // TODO: This is magic, it must match the systemd file
     Some(PathBuf::from("/var/log").join(BUNDLE_ID))
 }
 
@@ -37,7 +36,7 @@ pub fn logs() -> Option<PathBuf> {
 ///
 /// System-wide runtime directory, typically root-owned.
 /// Used for the tunnel service IPC socket.
-#[expect(clippy::unnecessary_wraps)] // Signature must match other platforms
+#[expect(clippy::unnecessary_wraps)]
 pub fn root_runtime() -> Option<PathBuf> {
     Some(PathBuf::from("/run").join(BUNDLE_ID))
 }

--- a/rust/libs/known-dirs/src/platform/linux.rs
+++ b/rust/libs/known-dirs/src/platform/linux.rs
@@ -14,13 +14,14 @@ use std::path::PathBuf;
 /// `BUNDLE_ID` because we need our own subdir
 ///
 /// `config` to match how Windows has `config` and `data` both under `AppData/Local/$BUNDLE_ID`
-#[expect(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
 pub fn tunnel_service_config() -> Option<PathBuf> {
     Some(PathBuf::from("/var/lib").join(BUNDLE_ID).join("config"))
 }
 
-#[expect(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
 pub fn tunnel_service_logs() -> Option<PathBuf> {
+    // TODO: This is magic, it must match the systemd file
     Some(PathBuf::from("/var/log").join(BUNDLE_ID))
 }
 
@@ -36,7 +37,7 @@ pub fn logs() -> Option<PathBuf> {
 ///
 /// System-wide runtime directory, typically root-owned.
 /// Used for the tunnel service IPC socket.
-#[expect(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)] // Signature must match other platforms
 pub fn root_runtime() -> Option<PathBuf> {
     Some(PathBuf::from("/run").join(BUNDLE_ID))
 }
@@ -62,4 +63,11 @@ pub fn session() -> Option<PathBuf> {
 /// See connlib docs for details
 pub fn settings() -> Option<PathBuf> {
     Some(dirs::config_local_dir()?.join(BUNDLE_ID).join("config"))
+}
+
+/// Returns the default path for storing the authentication token
+///
+/// e.g. `/etc/dev.firezone.client/token`
+pub fn default_token_path() -> PathBuf {
+    PathBuf::from("/etc").join(BUNDLE_ID).join("token")
 }

--- a/rust/libs/known-dirs/src/platform/macos.rs
+++ b/rust/libs/known-dirs/src/platform/macos.rs
@@ -7,7 +7,7 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 /// Path for Tunnel service config that the Tunnel service can write
-#[expect(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
 pub fn tunnel_service_config() -> Option<PathBuf> {
     Some(
         PathBuf::from("/Library/Application Support")
@@ -17,7 +17,7 @@ pub fn tunnel_service_config() -> Option<PathBuf> {
 }
 
 /// Path for Tunnel service logs
-#[expect(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
 pub fn tunnel_service_logs() -> Option<PathBuf> {
     Some(PathBuf::from("/Library/Logs").join(BUNDLE_ID))
 }
@@ -45,7 +45,7 @@ pub fn root_runtime() -> Option<PathBuf> {
 /// Uses the OS-assigned per-user temp directory (`TMPDIR` on macOS) rather than
 /// hardcoding `/tmp` with the `USER` env var, which is unreliable and can be
 /// influenced by the process environment.
-#[expect(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)] // Signature must match other platforms
 pub fn user_runtime() -> Option<PathBuf> {
     Some(std::env::temp_dir().join(BUNDLE_ID))
 }
@@ -68,4 +68,11 @@ pub fn settings() -> Option<PathBuf> {
             .join(BUNDLE_ID)
             .join("config"),
     )
+}
+
+/// Returns the default path for storing the authentication token
+///
+/// e.g. `/etc/dev.firezone.client/token`
+pub fn default_token_path() -> PathBuf {
+    PathBuf::from("/etc").join(BUNDLE_ID).join("token")
 }

--- a/rust/libs/known-dirs/src/platform/macos.rs
+++ b/rust/libs/known-dirs/src/platform/macos.rs
@@ -7,7 +7,7 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 /// Path for Tunnel service config that the Tunnel service can write
-#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
+#[expect(clippy::unnecessary_wraps)]
 pub fn tunnel_service_config() -> Option<PathBuf> {
     Some(
         PathBuf::from("/Library/Application Support")
@@ -17,7 +17,7 @@ pub fn tunnel_service_config() -> Option<PathBuf> {
 }
 
 /// Path for Tunnel service logs
-#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
+#[expect(clippy::unnecessary_wraps)]
 pub fn tunnel_service_logs() -> Option<PathBuf> {
     Some(PathBuf::from("/Library/Logs").join(BUNDLE_ID))
 }
@@ -45,7 +45,7 @@ pub fn root_runtime() -> Option<PathBuf> {
 /// Uses the OS-assigned per-user temp directory (`TMPDIR` on macOS) rather than
 /// hardcoding `/tmp` with the `USER` env var, which is unreliable and can be
 /// influenced by the process environment.
-#[expect(clippy::unnecessary_wraps)] // Signature must match other platforms
+#[expect(clippy::unnecessary_wraps)]
 pub fn user_runtime() -> Option<PathBuf> {
     Some(std::env::temp_dir().join(BUNDLE_ID))
 }

--- a/rust/libs/known-dirs/src/platform/windows.rs
+++ b/rust/libs/known-dirs/src/platform/windows.rs
@@ -1,6 +1,6 @@
 use crate::BUNDLE_ID;
 use anyhow::{Context as _, Result};
-use known_folders::{get_known_folder_path, KnownFolder};
+use known_folders::{KnownFolder, get_known_folder_path};
 use std::path::PathBuf;
 
 /// Returns e.g. `C:/Users/User/AppData/Local/dev.firezone.client
@@ -71,4 +71,14 @@ pub fn session() -> Option<PathBuf> {
 /// See connlib docs for details
 pub fn settings() -> Option<PathBuf> {
     Some(app_local_data_dir().ok()?.join("config"))
+}
+
+/// Returns the default path for storing the authentication token
+///
+/// e.g. `C:\ProgramData\dev.firezone.client\token.txt`
+pub fn default_token_path() -> PathBuf {
+    get_known_folder_path(KnownFolder::ProgramData)
+        .expect("ProgramData folder not found. Is %PROGRAMDATA% set?")
+        .join(BUNDLE_ID)
+        .join("token.txt")
 }

--- a/rust/libs/known-dirs/src/platform/windows.rs
+++ b/rust/libs/known-dirs/src/platform/windows.rs
@@ -1,6 +1,6 @@
 use crate::BUNDLE_ID;
 use anyhow::{Context as _, Result};
-use known_folders::{KnownFolder, get_known_folder_path};
+use known_folders::{get_known_folder_path, KnownFolder};
 use std::path::PathBuf;
 
 /// Returns e.g. `C:/Users/User/AppData/Local/dev.firezone.client


### PR DESCRIPTION
References to known directories are useful outside of the `bin-shared` crate. More specifically, the `device_id` module in `bin-shared` needs access to some of these paths. In order to extract the `device_id` module into a separate crate we first need to split out `known_dirs`.