### PR TITLE
fix(portal): update auth_button on portal sign in page

### DIFF
--- a/elixir/lib/portal_web/live/sign_in.ex
+++ b/elixir/lib/portal_web/live/sign_in.ex
@@ -209,7 +209,7 @@ defmodule PortalWeb.SignIn do
       class={[button_style("info"), button_size("md"), "w-full space-x-1"]}
       href={~p"/#{@account}/sign_in/#{@type}/#{@provider.id}?#{@params}"}
     >
-      {render_slot(@icon)} Sign in with <strong>{@provider.name}</strong>
+      {render_slot(@icon)} <span>Sign in with <strong>{@provider.name}</strong></span>
     </.link>
     """
   end


### PR DESCRIPTION
Why:

* The upgrade from Tailwind v3 to v4 brought some changes to how `<strong>` tags are rendered inside a flexbox element.  It appears whitespace is more aggressively stripped as "insignificant" whitespace of flexbox elements during the build phase. This caused the sign in buttons on the portal to have no space between "Sign in with" and the auth provider name.  Adding a `<span>` tag around all of the text preserves the space.

Fixes: #12220 