### PR TITLE
feat(portal): static device pools

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -84,6 +84,7 @@ config :portal, Portal.ChangeLogs.ReplicationConnection,
     gateway_tokens
     policies
     resources
+    static_device_pool_members
     client_tokens
     one_time_passcodes
     portal_sessions
@@ -134,6 +135,7 @@ config :portal, Portal.Changes.ReplicationConnection,
     sites
     policies
     resources
+    static_device_pool_members
     client_tokens
     google_auth_providers
     entra_auth_providers

--- a/elixir/lib/portal/accounts/features.ex
+++ b/elixir/lib/portal/accounts/features.ex
@@ -9,6 +9,7 @@ defmodule Portal.Accounts.Features do
     field :idp_sync, :boolean
     field :rest_api, :boolean
     field :internet_resource, :boolean
+    field :client_to_client, :boolean
   end
 
   def changeset(features \\ %__MODULE__{}, attrs) do
@@ -18,6 +19,7 @@ defmodule Portal.Accounts.Features do
       idp_sync
       rest_api
       internet_resource
+      client_to_client
     ]a
 
     features

--- a/elixir/lib/portal/cache/cacheable/resource.ex
+++ b/elixir/lib/portal/cache/cacheable/resource.ex
@@ -18,7 +18,7 @@ defmodule Portal.Cache.Cacheable.Resource do
   @type t :: %__MODULE__{
           id: Portal.Cache.Cacheable.uuid_binary(),
           name: String.t(),
-          type: :cidr | :ip | :dns | :internet,
+          type: :cidr | :ip | :dns | :internet | :static_device_pool,
           address: String.t(),
           address_description: String.t(),
           ip_stack: atom(),

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -71,14 +71,22 @@ defmodule Portal.Cache.Client do
     # 1. The resource is authorized based on policies and conditions
     # 2. The resource is compatible with the client (i.e. the client can connect to it)
     # 3. The resource has at least one site associated with it
-    :connectable_resources
+    :connectable_resources,
+
+    # Map of client_id => IPv4 tuple for all clients in currently connectable static device pools.
+    :connectable_devices,
+
+    # IPv4 addresses of clients previously authorized to connect to this client.
+    :authorized_device_ipv4s
   ]
 
   @type t :: %__MODULE__{
           policies: %{Cache.Cacheable.uuid_binary() => Portal.Cache.Cacheable.Policy.t()},
           resources: %{Cache.Cacheable.uuid_binary() => Portal.Cache.Cacheable.Resource.t()},
           memberships: %{Cache.Cacheable.uuid_binary() => Cache.Cacheable.uuid_binary()},
-          connectable_resources: [Cache.Cacheable.Resource.t()]
+          connectable_resources: [Cache.Cacheable.Resource.t()],
+          connectable_devices: %{Ecto.UUID.t() => {byte(), byte(), byte(), byte()}},
+          authorized_device_ipv4s: MapSet.t({byte(), byte(), byte(), byte()})
         }
 
   @doc """
@@ -143,6 +151,27 @@ defmodule Portal.Cache.Client do
     end
   end
 
+  @spec authorize_device_access(t(), {byte(), byte(), byte(), byte()}) ::
+          :ok | {:error, :forbidden}
+  def authorize_device_access(cache, {_, _, _, _} = target_ipv4) do
+    if Enum.any?(cache.connectable_devices, fn {_, ipv4} -> ipv4 == target_ipv4 end),
+      do: :ok,
+      else: {:error, :forbidden}
+  end
+
+  @spec track_authorized_device_ipv4(t(), Postgrex.INET.t() | nil) :: t()
+  def track_authorized_device_ipv4(cache, nil), do: cache
+
+  def track_authorized_device_ipv4(cache, %Postgrex.INET{address: ipv4_tuple}) do
+    %{cache | authorized_device_ipv4s: MapSet.put(cache.authorized_device_ipv4s, ipv4_tuple)}
+  end
+
+  @spec device_ipv4_relevant?(t(), {byte(), byte(), byte(), byte()}) :: boolean()
+  def device_ipv4_relevant?(cache, {_, _, _, _} = ipv4) do
+    MapSet.member?(cache.authorized_device_ipv4s, ipv4) or
+      Enum.any?(cache.connectable_devices, fn {_, v} -> v == ipv4 end)
+  end
+
   @doc """
     Recomputes the list of connectable resources, returning the newly connectable resources
     and the IDs of resources that are no longer connectable so that the client may update its
@@ -185,7 +214,17 @@ defmodule Portal.Cache.Client do
         load!(r.id)
       end
 
-    cache = %{cache | connectable_resources: connectable_resources}
+    connectable_devices =
+      connectable_resources
+      |> Enum.filter(&(&1.type == :static_device_pool))
+      |> Enum.map(&load!(&1.id))
+      |> Database.all_member_ipv4s(subject)
+
+    cache = %{
+      cache
+      | connectable_resources: connectable_resources,
+        connectable_devices: connectable_devices
+    }
 
     {:ok, added, removed_ids, cache}
   end
@@ -462,6 +501,35 @@ defmodule Portal.Cache.Client do
     end
   end
 
+  @spec add_static_device_pool_member(
+          t(),
+          Portal.StaticDevicePoolMember.t(),
+          Authentication.Subject.t()
+        ) :: {:ok, t()}
+  def add_static_device_pool_member(cache, %Portal.StaticDevicePoolMember{} = member, subject) do
+    if connectable_resource?(cache, member.resource_id) do
+      ipv4 = Database.get_client_ipv4(member.client_id, subject)
+
+      updated =
+        if ipv4 do
+          Map.put(cache.connectable_devices, member.client_id, ipv4)
+        else
+          cache.connectable_devices
+        end
+
+      {:ok, %{cache | connectable_devices: updated}}
+    else
+      {:ok, cache}
+    end
+  end
+
+  @spec delete_static_device_pool_member(t(), Portal.StaticDevicePoolMember.t()) ::
+          {:ok, {byte(), byte(), byte(), byte()} | nil, t()}
+  def delete_static_device_pool_member(cache, %Portal.StaticDevicePoolMember{} = member) do
+    {ipv4, updated} = Map.pop(cache.connectable_devices, member.client_id)
+    {:ok, ipv4, %{cache | connectable_devices: updated}}
+  end
+
   defp hydrate(client, subject) do
     attributes = %{
       actor_id: client.actor_id
@@ -489,6 +557,8 @@ defmodule Portal.Cache.Client do
       cache
       |> Map.put(:memberships, memberships)
       |> Map.put(:connectable_resources, [])
+      |> Map.put(:connectable_devices, %{})
+      |> Map.put(:authorized_device_ipv4s, Database.authorized_ipv4s(client.id, subject))
     end
   end
 
@@ -496,9 +566,22 @@ defmodule Portal.Cache.Client do
     for id <- conforming_resource_ids,
         adapted_resource = Map.get(resources, id) |> adapt(session),
         not is_nil(adapted_resource),
-        not is_nil(adapted_resource.site) do
+        resource_connectable_without_gateway?(adapted_resource) or
+          not is_nil(adapted_resource.site) do
       adapted_resource
     end
+  end
+
+  defp resource_connectable_without_gateway?(%Cache.Cacheable.Resource{
+         type: :static_device_pool
+       }),
+       do: true
+
+  defp resource_connectable_without_gateway?(%Cache.Cacheable.Resource{}), do: false
+
+  defp connectable_resource?(cache, resource_id) do
+    resource_id_bytes = dump!(resource_id)
+    Enum.any?(cache.connectable_resources, &(&1.id == resource_id_bytes))
   end
 
   defp adapt(resource, session) do
@@ -694,6 +777,7 @@ defmodule Portal.Cache.Client do
     def fetch_resource_by_id(id, subject) do
       result =
         from(r in Portal.Resource, where: r.id == ^id)
+        |> preload([:site])
         |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
@@ -724,6 +808,70 @@ defmodule Portal.Cache.Client do
       from(s in Portal.Site, where: s.id == ^id)
       |> Safe.scoped(subject, :replica)
       |> Safe.one()
+    end
+
+    def all_member_ipv4s([], _subject), do: %{}
+
+    def all_member_ipv4s(resource_ids, subject) do
+      from(r in Portal.Resource, as: :resources)
+      |> where([resources: r], r.id in ^resource_ids)
+      |> join(:inner, [resources: r], m in assoc(r, :static_pool_members), as: :members)
+      |> join(:inner, [members: m], c in assoc(m, :client), as: :clients)
+      |> join(:inner, [clients: c], ipv4 in assoc(c, :ipv4_address), as: :ipv4)
+      |> select([members: m, ipv4: ipv4], {m.client_id, ipv4.address})
+      |> Safe.scoped(subject, :replica)
+      |> Safe.all()
+      |> case do
+        {:error, :unauthorized} ->
+          %{}
+
+        rows ->
+          Map.new(rows, fn {client_id, ipv4} -> {Ecto.UUID.cast!(client_id), ipv4.address} end)
+      end
+    end
+
+    def get_client_ipv4(client_id, subject) do
+      from(c in Portal.Client, where: c.id == ^client_id)
+      |> join(:inner, [c], ipv4 in assoc(c, :ipv4_address), as: :ipv4)
+      |> select([ipv4: ipv4], ipv4.address)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        %Postgrex.INET{address: tuple} ->
+          tuple
+
+        nil ->
+          Logger.error("IPv4 address not found for client", client_id: client_id)
+          nil
+
+        {:error, reason} ->
+          Logger.error("Failed to fetch IPv4 for client",
+            client_id: client_id,
+            reason: inspect(reason)
+          )
+
+          nil
+      end
+    end
+
+    def authorized_ipv4s(client_id, subject) do
+      now = DateTime.utc_now()
+
+      from(pa in Portal.PolicyAuthorization, as: :policy_authorizations)
+      |> where([policy_authorizations: pa], pa.receiving_client_id == ^client_id)
+      |> where([policy_authorizations: pa], pa.expires_at > ^now)
+      |> join(:inner, [policy_authorizations: pa], c in Portal.Client,
+        on: c.id == pa.client_id,
+        as: :clients
+      )
+      |> join(:inner, [clients: c], ipv4 in assoc(c, :ipv4_address), as: :ipv4)
+      |> select([ipv4: ipv4], ipv4.address)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.all()
+      |> case do
+        {:error, :unauthorized} -> MapSet.new()
+        rows -> MapSet.new(rows, & &1.address)
+      end
     end
   end
 end

--- a/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
+++ b/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
@@ -1,0 +1,30 @@
+defmodule Portal.Changes.Hooks.StaticDevicePoolMembers do
+  @behaviour Portal.Changes.Hooks
+  alias Portal.{Changes.Change, PubSub}
+  import Portal.SchemaHelpers
+
+  @impl true
+  def on_insert(lsn, data) do
+    member = struct_from_params(Portal.StaticDevicePoolMember, data)
+    change = %Change{lsn: lsn, op: :insert, struct: member}
+
+    PubSub.Changes.broadcast(member.account_id, change)
+  end
+
+  @impl true
+  def on_update(lsn, old_data, data) do
+    old_member = struct_from_params(Portal.StaticDevicePoolMember, old_data)
+    member = struct_from_params(Portal.StaticDevicePoolMember, data)
+    change = %Change{lsn: lsn, op: :update, old_struct: old_member, struct: member}
+
+    PubSub.Changes.broadcast(member.account_id, change)
+  end
+
+  @impl true
+  def on_delete(lsn, old_data) do
+    member = struct_from_params(Portal.StaticDevicePoolMember, old_data)
+    change = %Change{lsn: lsn, op: :delete, old_struct: member}
+
+    PubSub.Changes.broadcast(member.account_id, change)
+  end
+end

--- a/elixir/lib/portal/changes/replication_connection.ex
+++ b/elixir/lib/portal/changes/replication_connection.ex
@@ -14,6 +14,7 @@ defmodule Portal.Changes.ReplicationConnection do
     "sites" => Hooks.Sites,
     "policies" => Hooks.Policies,
     "resources" => Hooks.Resources,
+    "static_device_pool_members" => Hooks.StaticDevicePoolMembers,
     "client_tokens" => Hooks.ClientTokens,
     "portal_sessions" => Hooks.PortalSessions,
     "google_auth_providers" => Hooks.AuthProviders,

--- a/elixir/lib/portal/policy_authorization.ex
+++ b/elixir/lib/portal/policy_authorization.ex
@@ -10,7 +10,8 @@ defmodule Portal.PolicyAuthorization do
           id: Ecto.UUID.t(),
           policy_id: Ecto.UUID.t(),
           client_id: Ecto.UUID.t(),
-          gateway_id: Ecto.UUID.t(),
+          receiving_client_id: Ecto.UUID.t() | nil,
+          gateway_id: Ecto.UUID.t() | nil,
           resource_id: Ecto.UUID.t(),
           token_id: Ecto.UUID.t(),
           # nil for "Everyone" group policies which have no explicit membership
@@ -18,7 +19,7 @@ defmodule Portal.PolicyAuthorization do
           account_id: Ecto.UUID.t(),
           client_remote_ip: Portal.Types.IP.t(),
           client_user_agent: String.t(),
-          gateway_remote_ip: Portal.Types.IP.t(),
+          gateway_remote_ip: Portal.Types.IP.t() | nil,
           expires_at: DateTime.t(),
           inserted_at: DateTime.t()
         }
@@ -29,6 +30,7 @@ defmodule Portal.PolicyAuthorization do
 
     belongs_to :policy, Portal.Policy
     belongs_to :client, Portal.Client
+    belongs_to :receiving_client, Portal.Client
     belongs_to :gateway, Portal.Gateway
     belongs_to :resource, Portal.Resource
     belongs_to :token, Portal.ClientToken
@@ -49,6 +51,7 @@ defmodule Portal.PolicyAuthorization do
     |> assoc_constraint(:token)
     |> assoc_constraint(:policy)
     |> assoc_constraint(:client)
+    |> assoc_constraint(:receiving_client)
     |> assoc_constraint(:gateway)
     |> assoc_constraint(:resource)
     |> assoc_constraint(:account)

--- a/elixir/lib/portal/resource.ex
+++ b/elixir/lib/portal/resource.ex
@@ -17,7 +17,7 @@ defmodule Portal.Resource do
           address: String.t(),
           address_description: String.t() | nil,
           name: String.t(),
-          type: :cidr | :ip | :dns | :internet,
+          type: :cidr | :ip | :dns | :internet | :static_device_pool,
           ip_stack: :ipv4_only | :ipv6_only | :dual,
           filters: [filter()],
           account_id: Ecto.UUID.t(),
@@ -34,7 +34,8 @@ defmodule Portal.Resource do
     field :address_description, :string
     field :name, :string
 
-    field :type, Ecto.Enum, values: [:cidr, :ip, :dns, :internet]
+    field :type, Ecto.Enum, values: [:cidr, :ip, :dns, :internet, :static_device_pool]
+
     field :ip_stack, Ecto.Enum, values: [:ipv4_only, :ipv6_only, :dual]
 
     embeds_many :filters, Filter, on_replace: :delete, primary_key: false do
@@ -47,6 +48,8 @@ defmodule Portal.Resource do
     has_many :policies, Portal.Policy, references: :id
     has_many :groups, through: [:policies, :group]
 
+    has_many :static_pool_members, Portal.StaticDevicePoolMember, references: :id
+
     timestamps()
   end
 
@@ -58,6 +61,7 @@ defmodule Portal.Resource do
     |> validate_length(:name, min: 1, max: 255)
     |> validate_length(:address_description, min: 1, max: 255)
     |> maybe_put_default_ip_stack()
+    |> validate_device_pool_site_id()
     |> validate_address_format()
     |> check_constraint(:ip_stack,
       name: :resources_ip_stack_not_null,
@@ -110,6 +114,7 @@ defmodule Portal.Resource do
       {_, :cidr} -> validate_cidr_address(changeset)
       {_, :ip} -> validate_ip_address(changeset)
       {_, :internet} -> put_change(changeset, :address, nil)
+      {_, :static_device_pool} -> put_change(changeset, :address, nil)
       _ -> changeset
     end
   end
@@ -302,6 +307,16 @@ defmodule Portal.Resource do
         []
       end
     end)
+  end
+
+  defp validate_device_pool_site_id(changeset) do
+    case fetch_field(changeset, :type) do
+      {_, :static_device_pool} ->
+        put_change(changeset, :site_id, nil)
+
+      _ ->
+        changeset
+    end
   end
 
   defp maybe_put_default_ip_stack(changeset) do

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -950,6 +950,11 @@ defmodule Portal.Safe do
   def permit(_action, Portal.Resource, :api_client), do: :ok
   def permit(:read, Portal.Resource, _), do: :ok
 
+  # StaticDevicePoolMember permissions
+  def permit(_action, Portal.StaticDevicePoolMember, :account_admin_user), do: :ok
+  def permit(_action, Portal.StaticDevicePoolMember, :api_client), do: :ok
+  def permit(:read, Portal.StaticDevicePoolMember, _), do: :ok
+
   # Policy permissions
   def permit(_action, Portal.Policy, :account_admin_user), do: :ok
   def permit(_action, Portal.Policy, :api_client), do: :ok

--- a/elixir/lib/portal/static_device_pool_member.ex
+++ b/elixir/lib/portal/static_device_pool_member.ex
@@ -1,0 +1,29 @@
+defmodule Portal.StaticDevicePoolMember do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          resource_id: Ecto.UUID.t(),
+          client_id: Ecto.UUID.t(),
+          account_id: Ecto.UUID.t()
+        }
+
+  schema "static_device_pool_members" do
+    belongs_to :account, Portal.Account, primary_key: true
+    field :id, :binary_id, primary_key: true, autogenerate: true
+
+    belongs_to :resource, Portal.Resource
+    belongs_to :client, Portal.Client
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:resource)
+    |> assoc_constraint(:client)
+  end
+end

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -86,7 +86,13 @@ defmodule PortalAPI.Client.Channel do
     :ok = PubSub.Changes.subscribe(socket.assigns.client.account_id)
 
     push(socket, "init", %{
-      resources: Views.Resource.render_many(resources),
+      # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
+      resources:
+        resources
+        |> Enum.reject(&(&1.type == :static_device_pool))
+        |> Views.Resource.render_many(),
+      # TODO: Re-enable after verifying compatibility with older clients
+      # authorized_ipv4s: render_ipv4s(cache.authorized_device_ipv4s),
       relays:
         Views.Relay.render_many(
           relays,
@@ -145,11 +151,12 @@ defmodule PortalAPI.Client.Channel do
         socket.assigns.subject
       )
 
+    # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
     for resource_id <- removed_ids do
       push(socket, "resource_deleted", resource_id)
     end
 
-    for resource <- added_resources do
+    for resource <- added_resources, resource.type != :static_device_pool do
       push(socket, "resource_created_or_updated", Views.Resource.render(resource))
     end
 
@@ -348,7 +355,8 @@ defmodule PortalAPI.Client.Channel do
 
   def handle_info({:client_device_access_authorized, payload}, socket) do
     push(socket, "client_device_access_authorized", payload)
-    {:noreply, socket}
+    cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
+    {:noreply, assign(socket, cache: cache)}
   end
 
   def handle_info({:client_ice_candidates, client_id, candidates}, socket) do
@@ -718,10 +726,11 @@ defmodule PortalAPI.Client.Channel do
   def handle_in("request_device_access", %{"ipv4" => ipv4_string}, socket) do
     account_id = socket.assigns.client.account_id
 
-    with true <- client_to_client_enabled?(),
+    with true <- client_to_client_enabled?(socket.assigns.subject.account),
          {:ok, ipv4_tuple} <- parse_ipv4(ipv4_string),
-         {target_client_id, target_meta} <-
-           Presence.Clients.Account.find_by_ipv4(account_id, ipv4_tuple) || :not_found do
+         :ok <- Cache.Client.authorize_device_access(socket.assigns.cache, ipv4_tuple),
+         {:ok, target_client_id, target_meta} <-
+           find_online_client_by_ipv4(account_id, ipv4_tuple) do
       client = socket.assigns.client
       client_public_key = socket.assigns.session.public_key
       target_client = %Portal.Client{id: target_client_id, psk_base: target_meta.psk_base}
@@ -783,8 +792,12 @@ defmodule PortalAPI.Client.Channel do
 
         {:noreply, socket}
 
-      :not_found ->
-        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :not_found})
+      :offline ->
+        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :offline})
+        {:noreply, socket}
+
+      {:error, :forbidden} ->
+        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :forbidden})
         {:noreply, socket}
     end
   end
@@ -816,7 +829,7 @@ defmodule PortalAPI.Client.Channel do
         %{"candidates" => candidates, "client_id" => target_client_id},
         socket
       ) do
-    with true <- client_to_client_enabled?(),
+    with true <- client_to_client_enabled?(socket.assigns.subject.account),
          :ok <-
            Channels.send_to_client(
              target_client_id,
@@ -844,7 +857,7 @@ defmodule PortalAPI.Client.Channel do
         %{"candidates" => candidates, "client_id" => target_client_id},
         socket
       ) do
-    with true <- client_to_client_enabled?(),
+    with true <- client_to_client_enabled?(socket.assigns.subject.account),
          :ok <-
            Channels.send_to_client(
              target_client_id,
@@ -908,7 +921,7 @@ defmodule PortalAPI.Client.Channel do
     {:reply, {:error, %{reason: :unknown_message}}, socket}
   end
 
-  defp client_to_client_enabled?, do: Database.client_to_client_enabled?()
+  defp client_to_client_enabled?(account), do: Database.client_to_client_enabled?(account)
 
   defp parse_ipv4(ipv4_string) when is_binary(ipv4_string) do
     case :inet.parse_address(String.to_charlist(ipv4_string)) do
@@ -916,6 +929,21 @@ defmodule PortalAPI.Client.Channel do
       _ -> {:error, :invalid_ipv4}
     end
   end
+
+  defp find_online_client_by_ipv4(account_id, ipv4_tuple) do
+    case Presence.Clients.Account.find_by_ipv4(account_id, ipv4_tuple) do
+      {target_client_id, target_meta} -> {:ok, target_client_id, target_meta}
+      nil -> :offline
+    end
+  end
+
+  # TODO: Re-enable after verifying compatibility with older clients
+  # defp render_ipv4s(ipv4s) do
+  #   ipv4s
+  #   |> Enum.map(&:inet.ntoa/1)
+  #   |> Enum.map(&to_string/1)
+  #   |> Enum.sort()
+  # end
 
   defp select_relays(socket, except_ids \\ []) do
     {:ok, relays} = Presence.Relays.all_connected_relays(except_ids)
@@ -1205,6 +1233,39 @@ defmodule PortalAPI.Client.Channel do
     |> push_resource_updates(socket)
   end
 
+  # STATIC DEVICE POOL MEMBERS
+
+  defp handle_change(
+         %Change{op: :insert, struct: %Portal.StaticDevicePoolMember{} = member},
+         socket
+       ) do
+    {:ok, cache} =
+      Cache.Client.add_static_device_pool_member(
+        socket.assigns.cache,
+        member,
+        socket.assigns.subject
+      )
+
+    {:noreply, assign(socket, cache: cache)}
+  end
+
+  defp handle_change(
+         %Change{op: :delete, old_struct: %Portal.StaticDevicePoolMember{} = member},
+         socket
+       ) do
+    {:ok, ipv4, cache} =
+      Cache.Client.delete_static_device_pool_member(socket.assigns.cache, member)
+
+    if ipv4 do
+      push(socket, "client_device_access_denied", %{
+        ipv4: to_string(:inet.ntoa(ipv4)),
+        reason: :forbidden
+      })
+    end
+
+    {:noreply, assign(socket, cache: cache)}
+  end
+
   defp handle_change(%Change{}, socket), do: {:noreply, socket}
 
   defp push_resource_updates({:ok, added_resources, removed_ids, cache}, socket) do
@@ -1216,7 +1277,8 @@ defmodule PortalAPI.Client.Channel do
       push(socket, "resource_deleted", resource_id)
     end
 
-    for resource <- added_resources do
+    # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
+    for resource <- added_resources, resource.type != :static_device_pool do
       push(socket, "resource_created_or_updated", Views.Resource.render(resource))
     end
 
@@ -1228,11 +1290,14 @@ defmodule PortalAPI.Client.Channel do
 
     alias Portal.Features
 
-    def client_to_client_enabled? do
+    def client_to_client_enabled?(account) do
       query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
 
-      Portal.Safe.unscoped(query, :replica)
-      |> Portal.Safe.exists?()
+      account_feature_enabled? =
+        account.features &&
+          Map.get(account.features, :client_to_client, false)
+
+      Portal.Safe.unscoped(query, :replica) |> Portal.Safe.exists?() and account_feature_enabled?
     end
 
     def all_compatible_gateways_for_client_and_resource(
@@ -1418,7 +1483,8 @@ defmodule PortalAPI.Client.Channel do
   defp create_policy_authorization_changeset(attrs) do
     import Ecto.Changeset
 
-    fields = ~w[id token_id policy_id client_id gateway_id resource_id membership_id
+    fields =
+      ~w[id token_id policy_id client_id receiving_client_id gateway_id resource_id membership_id
                 account_id
                 expires_at
                 client_remote_ip client_user_agent
@@ -1426,7 +1492,9 @@ defmodule PortalAPI.Client.Channel do
 
     %Portal.PolicyAuthorization{}
     |> cast(attrs, fields)
-    |> validate_required(fields -- [:membership_id])
+    |> validate_required(
+      fields -- [:membership_id, :receiving_client_id, :gateway_id, :gateway_remote_ip]
+    )
     |> Portal.PolicyAuthorization.changeset()
   end
 

--- a/elixir/lib/portal_api/client/views/resource.ex
+++ b/elixir/lib/portal_api/client/views/resource.ex
@@ -50,6 +50,17 @@ defmodule PortalAPI.Client.Views.Resource do
     }
   end
 
+  defp render_resource(%{type: :static_device_pool} = resource) do
+    %{
+      id: resource.id,
+      type: :static_device_pool,
+      name: resource.name,
+      # Device pools do not require gateway groups.
+      gateway_groups: [],
+      filters: Enum.flat_map(resource.filters, &render_filter/1)
+    }
+  end
+
   defp render_resource(%{} = resource) do
     %{
       id: resource.id,

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -153,11 +153,19 @@ defmodule PortalAPI.ResourceController do
   end
 
   defp create_changeset(attrs, subject) do
-    %Portal.Resource{}
-    |> Ecto.Changeset.cast(attrs, ~w[address address_description name type ip_stack site_id]a)
-    |> Portal.Resource.changeset()
-    |> Ecto.Changeset.validate_required(~w[name type site_id]a)
-    |> Ecto.Changeset.put_change(:account_id, subject.account.id)
+    changeset =
+      %Portal.Resource{account_id: subject.account.id}
+      |> Ecto.Changeset.cast(attrs, ~w[address address_description name type ip_stack site_id]a)
+      |> Portal.Resource.changeset()
+
+    required =
+      if Ecto.Changeset.get_field(changeset, :type) == :static_device_pool do
+        ~w[name type]a
+      else
+        ~w[name type site_id]a
+      end
+
+    Ecto.Changeset.validate_required(changeset, required)
   end
 
   defmodule Database do
@@ -203,12 +211,20 @@ defmodule PortalAPI.ResourceController do
 
     defp changeset(resource, attrs, _subject) do
       update_fields = ~w[address address_description name type ip_stack site_id]a
-      required_fields = ~w[name type site_id]a
 
-      resource
-      |> Ecto.Changeset.cast(attrs, update_fields)
-      |> Ecto.Changeset.validate_required(required_fields)
-      |> Portal.Resource.changeset()
+      changeset =
+        resource
+        |> Ecto.Changeset.cast(attrs, update_fields)
+        |> Portal.Resource.changeset()
+
+      required_fields =
+        if Ecto.Changeset.get_field(changeset, :type) == :static_device_pool do
+          ~w[name type]a
+        else
+          ~w[name type site_id]a
+        end
+
+      Ecto.Changeset.validate_required(changeset, required_fields)
     end
 
     def cursor_fields do

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -16,8 +16,8 @@ defmodule PortalAPI.Schemas.Resource do
         address_description: %Schema{type: :string, description: "Resource address description"},
         type: %Schema{
           type: :string,
-          description: "Resource type",
-          enum: ["cidr", "ip", "dns"]
+          description: "Resource type. For `static_device_pool`, `address` is not applicable.",
+          enum: ["cidr", "ip", "dns", "static_device_pool"]
         },
         ip_stack: %Schema{
           type: :string,
@@ -30,7 +30,7 @@ defmodule PortalAPI.Schemas.Resource do
           type: :string
         }
       },
-      required: [:name, :type, :site_id],
+      required: [:name, :type],
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Prod DB",

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -27,7 +27,8 @@ defmodule PortalWeb.Policies.Components do
     internet: @all_conditions -- [:current_utc_datetime],
     dns: @all_conditions,
     ip: @all_conditions,
-    cidr: @all_conditions
+    cidr: @all_conditions,
+    static_device_pool: @all_conditions
   }
 
   attr(:policy, :map, required: true)

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -6,7 +6,8 @@ defmodule PortalWeb.Resources.Components do
     internet: %{index: 1, label: nil},
     dns: %{index: 2, label: "DNS"},
     ip: %{index: 3, label: "IP"},
-    cidr: %{index: 4, label: "CIDR"}
+    cidr: %{index: 4, label: "CIDR"},
+    static_device_pool: %{index: 5, label: "Device Pools"}
   }
 
   def fetch_resource_option(id, subject) do
@@ -328,6 +329,93 @@ defmodule PortalWeb.Resources.Components do
     """
   end
 
+  attr :selected_clients, :list, required: true
+  attr :client_search_results, :any, default: nil
+  attr :client_search, :string, default: ""
+
+  def client_picker(assigns) do
+    ~H"""
+    <div class="border border-neutral-200 rounded-sm">
+      <div
+        class="p-3 bg-neutral-50 border-b border-neutral-200 relative"
+        phx-click-away="blur_client_search"
+      >
+        <input
+          type="text"
+          name="client_search"
+          value={@client_search}
+          placeholder="Search clients to add..."
+          phx-change="search_client"
+          phx-debounce="300"
+          phx-focus="focus_client_search"
+          autocomplete="off"
+          data-1p-ignore
+          class="block w-full rounded-md border-neutral-300 focus:border-accent-400 focus:ring-3 focus:ring-accent-200/50 text-neutral-900 text-sm"
+        />
+
+        <div
+          :if={@client_search_results != nil}
+          class="absolute z-10 left-3 right-3 mt-1 bg-white border border-neutral-300 rounded-md shadow-md max-h-48 overflow-y-auto"
+        >
+          <button
+            :for={client <- @client_search_results}
+            type="button"
+            phx-click="add_client"
+            phx-value-client_id={client.id}
+            class="w-full text-left px-3 py-2 hover:bg-accent-50 border-b border-neutral-100 last:border-b-0"
+          >
+            <div class="space-y-0.5">
+              <div class="text-sm font-medium text-neutral-900">{client.name}</div>
+              <div class="text-xs text-neutral-500">
+                {client_details(client)}
+              </div>
+            </div>
+          </button>
+          <div
+            :if={@client_search_results == []}
+            class="px-3 py-4 text-center text-sm text-neutral-500"
+          >
+            No clients found
+          </div>
+        </div>
+      </div>
+
+      <ul :if={@selected_clients != []} class="divide-y divide-neutral-200 max-h-64 overflow-y-auto">
+        <li :for={client <- @selected_clients} class="p-3 flex items-center justify-between">
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-neutral-900 truncate">{client.name}</p>
+            <p class="text-xs text-neutral-500 truncate">{client_details(client)}</p>
+          </div>
+          <button
+            type="button"
+            phx-click="remove_client"
+            phx-value-client_id={client.id}
+            class="text-xs text-red-600 hover:text-red-700"
+          >
+            Remove
+          </button>
+        </li>
+      </ul>
+
+      <div :if={@selected_clients == []} class="p-4 text-sm text-neutral-500">
+        No devices selected.
+      </div>
+    </div>
+    """
+  end
+
+  defp client_details(client) do
+    [
+      client.ipv4_address && Portal.Types.INET.to_string(client.ipv4_address.address),
+      client.ipv6_address && Portal.Types.INET.to_string(client.ipv6_address.address),
+      client.device_serial,
+      client.device_uuid,
+      client.id
+    ]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" | ")
+  end
+
   @known_recommendations %{
     "mongodb.net" => "ipv4_only"
   }
@@ -343,7 +431,7 @@ defmodule PortalWeb.Resources.Components do
 
   defmodule Database do
     import Ecto.Query
-    alias Portal.{Safe, Resource}
+    alias Portal.{Features, Safe, Resource, StaticDevicePoolMember}
 
     def get_resource!(id, subject) do
       from(r in Resource, as: :resources)
@@ -356,6 +444,170 @@ defmodule PortalWeb.Resources.Components do
       from(r in Resource, as: :resources)
       |> Safe.scoped(subject, :replica)
       |> Safe.list(Database.ListQuery, opts)
+    end
+
+    def client_to_client_enabled?(account) do
+      query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
+
+      account_feature_enabled? =
+        account.features &&
+          Map.get(account.features, :client_to_client, false)
+
+      Safe.unscoped(query, :replica) |> Safe.exists?() and account_feature_enabled?
+    end
+
+    def all_sites(subject) do
+      from(s in Portal.Site, as: :sites)
+      |> where([sites: s], s.managed_by != :system)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.all()
+    end
+
+    def get_client(client_id, subject) do
+      from(c in Portal.Client, as: :clients)
+      |> where([clients: c], c.id == ^client_id)
+      |> preload([:ipv4_address, :ipv6_address])
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one(fallback_to_primary: true)
+    end
+
+    def search_clients(search_term, _subject, _selected_clients) when search_term in [nil, ""],
+      do: nil
+
+    def search_clients(search_term, subject, selected_clients) do
+      selected_ids = Enum.map(selected_clients, & &1.id)
+      pattern = "%#{search_term}%"
+
+      query =
+        from(c in Portal.Client, as: :clients)
+        |> join(:left, [clients: c], ipv4 in assoc(c, :ipv4_address), as: :ipv4)
+        |> join(:left, [clients: c], ipv6 in assoc(c, :ipv6_address), as: :ipv6)
+        |> where([clients: c], c.id not in ^selected_ids)
+        |> where(
+          [clients: c, ipv4: ipv4, ipv6: ipv6],
+          ilike(c.name, ^pattern) or
+            ilike(type(c.id, :string), ^pattern) or
+            ilike(coalesce(c.external_id, ""), ^pattern) or
+            ilike(coalesce(c.device_serial, ""), ^pattern) or
+            ilike(coalesce(c.device_uuid, ""), ^pattern) or
+            ilike(coalesce(c.identifier_for_vendor, ""), ^pattern) or
+            ilike(coalesce(c.firebase_installation_id, ""), ^pattern) or
+            ilike(type(ipv4.address, :string), ^pattern) or
+            ilike(type(ipv6.address, :string), ^pattern)
+        )
+        |> preload([:ipv4_address, :ipv6_address])
+        |> limit(10)
+
+      case query |> Safe.scoped(subject, :replica) |> Safe.all() do
+        {:error, _} -> []
+        clients -> clients
+      end
+    end
+
+    def validate_selected_clients([], _subject), do: {:ok, []}
+
+    def validate_selected_clients(selected_clients, subject) do
+      ids =
+        selected_clients
+        |> Enum.map(& &1.id)
+        |> Enum.uniq()
+
+      from(c in Portal.Client, as: :clients)
+      |> where([clients: c], c.id in ^ids)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.all()
+      |> case do
+        {:error, _} ->
+          {:error, :invalid_clients}
+
+        clients when length(clients) == length(ids) ->
+          {:ok, clients}
+
+        _ ->
+          {:error, :invalid_clients}
+      end
+    end
+
+    def validate_static_device_pool_feature_enabled(changeset, account) do
+      if Ecto.Changeset.get_field(changeset, :type) == :static_device_pool and
+           not client_to_client_enabled?(account) do
+        Ecto.Changeset.add_error(
+          changeset,
+          :type,
+          "device pools are not enabled for this account"
+        )
+      else
+        changeset
+      end
+    end
+
+    def sync_static_pool_members(
+          %Portal.Resource{type: :static_device_pool} = resource,
+          clients,
+          subject
+        ) do
+      selected_client_ids = clients |> Enum.map(& &1.id) |> Enum.uniq()
+
+      existing_client_ids =
+        from(m in StaticDevicePoolMember,
+          where: m.resource_id == ^resource.id,
+          select: m.client_id
+        )
+        |> Safe.scoped(subject, :replica)
+        |> Safe.all()
+        |> case do
+          {:error, _} -> []
+          ids -> ids
+        end
+
+      to_remove = existing_client_ids -- selected_client_ids
+      to_add = selected_client_ids -- existing_client_ids
+
+      with :ok <- maybe_delete_pool_members(resource, to_remove, subject),
+           :ok <- maybe_insert_pool_members(resource, to_add, subject) do
+        :ok
+      end
+    end
+
+    def sync_static_pool_members(%Portal.Resource{} = resource, _clients, subject) do
+      case from(m in StaticDevicePoolMember, where: m.resource_id == ^resource.id)
+           |> Safe.scoped(subject)
+           |> Safe.delete_all() do
+        {:error, reason} -> {:error, reason}
+        {_, _} -> :ok
+      end
+    end
+
+    defp maybe_delete_pool_members(_resource, [], _subject), do: :ok
+
+    defp maybe_delete_pool_members(resource, to_remove, subject) do
+      case from(m in StaticDevicePoolMember,
+             where: m.resource_id == ^resource.id and m.client_id in ^to_remove
+           )
+           |> Safe.scoped(subject)
+           |> Safe.delete_all() do
+        {:error, reason} -> {:error, reason}
+        {_, _} -> :ok
+      end
+    end
+
+    defp maybe_insert_pool_members(_resource, [], _subject), do: :ok
+
+    defp maybe_insert_pool_members(resource, to_add, subject) do
+      entries =
+        Enum.map(to_add, fn client_id ->
+          %{
+            account_id: resource.account_id,
+            resource_id: resource.id,
+            client_id: client_id,
+            id: Ecto.UUID.generate()
+          }
+        end)
+
+      case Safe.scoped(subject) |> Safe.insert_all(StaticDevicePoolMember, entries) do
+        {:error, reason} -> {:error, reason}
+        {_, _} -> :ok
+      end
     end
   end
 

--- a/elixir/lib/portal_web/live/resources/edit.ex
+++ b/elixir/lib/portal_web/live/resources/edit.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Warning.CrossModuleDatabaseCall
 defmodule PortalWeb.Resources.Edit do
   use PortalWeb, :live_view
   import PortalWeb.Resources.Components
@@ -6,19 +7,29 @@ defmodule PortalWeb.Resources.Edit do
   def mount(%{"id" => id} = params, _session, socket) do
     resource = Database.get_resource!(id, socket.assigns.subject)
     sites = Database.all_sites(socket.assigns.subject)
+
+    client_to_client_enabled? =
+      Database.client_to_client_enabled?(socket.assigns.account) or
+        resource.type == :static_device_pool
+
     form = change_resource(resource, socket.assigns.subject) |> to_form()
+    selected_clients = resource.static_pool_members |> Enum.map(& &1.client)
 
     socket =
       assign(
         socket,
         resource: resource,
         sites: sites,
+        client_to_client_enabled?: client_to_client_enabled?,
+        selected_clients: selected_clients,
+        client_search_results: nil,
+        client_search: "",
         form: form,
         params: Map.take(params, ["site_id"]),
         page_title: "Edit #{resource.name}"
       )
 
-    {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
+    {:ok, socket}
   end
 
   def render(assigns) do
@@ -43,8 +54,8 @@ defmodule PortalWeb.Resources.Edit do
               <p class="mb-2 text-sm text-neutral-900">
                 Type
               </p>
-              <ul class="grid w-full gap-6 md:grid-cols-3">
-                <li>
+              <ul class="grid w-full gap-6 md:grid-cols-4">
+                <li class="flex flex-col">
                   <.input
                     id="resource-type--dns"
                     type="radio_button_group"
@@ -54,22 +65,20 @@ defmodule PortalWeb.Resources.Edit do
                     required
                   />
                   <label for="resource-type--dns" class={~w[
-                    inline-flex items-center justify-between w-full
-                    p-5 text-neutral-500 bg-white border border-neutral-200
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
                     rounded-sm cursor-pointer peer-checked:border-accent-500
                     peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
                   ]}>
-                    <div class="block">
-                      <div class="w-full font-semibold mb-3">
-                        <.icon name="hero-globe-alt" class="w-5 h-5 mr-1" /> DNS
-                      </div>
-                      <div class="w-full text-sm">
-                        Manage access to an application or service by DNS address.
-                      </div>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-globe-alt" class="w-5 h-5 mr-1" /> DNS
+                    </div>
+                    <div class="text-sm">
+                      Manage access to an application or service by DNS address.
                     </div>
                   </label>
                 </li>
-                <li>
+                <li class="flex flex-col">
                   <.input
                     id="resource-type--ip"
                     type="radio_button_group"
@@ -79,22 +88,20 @@ defmodule PortalWeb.Resources.Edit do
                     required
                   />
                   <label for="resource-type--ip" class={~w[
-                    inline-flex items-center justify-between w-full
-                    p-5 text-neutral-500 bg-white border border-neutral-200
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
                     rounded-sm cursor-pointer peer-checked:border-accent-600
                     peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
                   ]}>
-                    <div class="block">
-                      <div class="w-full font-semibold mb-3">
-                        <.icon name="hero-server" class="w-5 h-5 mr-1" /> IP
-                      </div>
-                      <div class="w-full text-sm">
-                        Manage access to a specific host by IP address.
-                      </div>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-server" class="w-5 h-5 mr-1" /> IP
+                    </div>
+                    <div class="text-sm">
+                      Manage access to a specific host by IP address.
                     </div>
                   </label>
                 </li>
-                <li>
+                <li class="flex flex-col">
                   <.input
                     id="resource-type--cidr"
                     type="radio_button_group"
@@ -104,25 +111,48 @@ defmodule PortalWeb.Resources.Edit do
                     required
                   />
                   <label for="resource-type--cidr" class={~w[
-                    inline-flex items-center justify-between w-full
-                    p-5 text-neutral-500 bg-white border border-neutral-200
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
                     rounded-sm cursor-pointer peer-checked:border-accent-500
                     peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
                   ]}>
-                    <div class="block">
-                      <div class="w-full font-semibold mb-3">
-                        <.icon name="hero-server-stack" class="w-5 h-5 mr-1" /> CIDR
-                      </div>
-                      <div class="w-full text-sm">
-                        Manage access to a network, VPC or subnet by CIDR address.
-                      </div>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-server-stack" class="w-5 h-5 mr-1" /> CIDR
+                    </div>
+                    <div class="text-sm">
+                      Manage access to a network, VPC or subnet by CIDR address.
+                    </div>
+                  </label>
+                </li>
+                <li :if={@client_to_client_enabled?} class="flex flex-col">
+                  <.input
+                    id="resource-type--static-device-pool"
+                    type="radio_button_group"
+                    field={@form[:type]}
+                    value="static_device_pool"
+                    checked={to_string(@form[:type].value) == "static_device_pool"}
+                    required
+                  />
+                  <label for="resource-type--static-device-pool" class={~w[
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
+                    rounded-sm cursor-pointer peer-checked:border-accent-500
+                    peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
+                  ]}>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-computer-desktop" class="w-5 h-5 mr-1" /> Device Pool
+                    </div>
+                    <div class="text-sm">
+                      Direct access to other Firezone devices without a Gateway.
                     </div>
                   </label>
                 </li>
               </ul>
             </div>
 
-            <div :if={@resource.type != :internet}>
+            <div :if={
+              @resource.type != :internet and to_string(@form[:type].value) != "static_device_pool"
+            }>
               <.input
                 field={@form[:address]}
                 autocomplete="off"
@@ -173,7 +203,9 @@ defmodule PortalWeb.Resources.Edit do
               </div>
             </div>
 
-            <div :if={@resource.type != :internet}>
+            <div :if={
+              @resource.type != :internet and to_string(@form[:type].value) != "static_device_pool"
+            }>
               <.input
                 field={@form[:address_description]}
                 type="text"
@@ -184,6 +216,18 @@ defmodule PortalWeb.Resources.Edit do
               <p class="mt-2 text-xs text-neutral-500">
                 Optional description or URL to show in Clients to help users access this Resource.
               </p>
+            </div>
+
+            <div :if={to_string(@form[:type].value) == "static_device_pool"}>
+              <legend class="text-xl mb-2">Devices</legend>
+              <p class="text-sm text-neutral-500 mb-4">
+                Select clients to include in this pool. Search by name, IPv4, IPv6, id, serial, UUID, and other identifiers.
+              </p>
+              <.client_picker
+                selected_clients={@selected_clients}
+                client_search={@client_search}
+                client_search_results={@client_search_results}
+              />
             </div>
 
             <.input
@@ -205,7 +249,9 @@ defmodule PortalWeb.Resources.Edit do
             />
 
             <.site_form
-              :if={is_nil(@params["site_id"])}
+              :if={
+                is_nil(@params["site_id"]) and to_string(@form[:type].value) != "static_device_pool"
+              }
               form={@form}
               sites={@sites}
             />
@@ -233,15 +279,79 @@ defmodule PortalWeb.Resources.Edit do
     {:noreply, assign(socket, form: to_form(changeset))}
   end
 
+  def handle_event("focus_client_search", _params, socket) do
+    results =
+      Database.search_clients(
+        socket.assigns.client_search,
+        socket.assigns.subject,
+        socket.assigns.selected_clients
+      )
+
+    {:noreply, assign(socket, client_search_results: results)}
+  end
+
+  def handle_event("blur_client_search", _params, socket) do
+    {:noreply, assign(socket, client_search_results: nil)}
+  end
+
+  def handle_event("search_client", %{"client_search" => search}, socket) do
+    results =
+      Database.search_clients(search, socket.assigns.subject, socket.assigns.selected_clients)
+
+    {:noreply,
+     assign(socket,
+       client_search: search,
+       client_search_results: results
+     )}
+  end
+
+  def handle_event("add_client", %{"client_id" => client_id}, socket) do
+    case Database.get_client(client_id, socket.assigns.subject) do
+      nil ->
+        {:noreply, socket}
+
+      client ->
+        selected_clients = Enum.uniq_by([client | socket.assigns.selected_clients], & &1.id)
+
+        {:noreply,
+         assign(socket,
+           selected_clients: selected_clients,
+           client_search: "",
+           client_search_results: nil
+         )}
+    end
+  end
+
+  def handle_event("remove_client", %{"client_id" => client_id}, socket) do
+    selected_clients = Enum.reject(socket.assigns.selected_clients, &(&1.id == client_id))
+
+    results =
+      Database.search_clients(
+        socket.assigns.client_search,
+        socket.assigns.subject,
+        selected_clients
+      )
+
+    {:noreply,
+     assign(socket,
+       selected_clients: selected_clients,
+       client_search_results: results
+     )}
+  end
+
   def handle_event("submit", %{"resource" => attrs}, socket) do
     attrs =
       attrs
       |> map_filters_form_attrs(socket.assigns.account)
       |> maybe_update_site_id(socket.assigns.params)
 
-    changeset = update_changeset(socket.assigns.resource, attrs, socket.assigns.subject)
+    changeset = change_resource(socket.assigns.resource, attrs, socket.assigns.subject)
 
-    case Database.update_resource(changeset, socket.assigns.subject) do
+    case Database.update_resource(
+           changeset,
+           socket.assigns.selected_clients,
+           socket.assigns.subject
+         ) do
       {:ok, resource} ->
         socket = put_flash(socket, :success, "Resource #{resource.name} updated successfully")
 
@@ -261,6 +371,14 @@ defmodule PortalWeb.Resources.Edit do
   end
 
   defp maybe_update_site_id(attrs, params) do
+    if attrs["type"] == "static_device_pool" do
+      Map.delete(attrs, "site_id")
+    else
+      maybe_update_site_id_for_non_static_pool(attrs, params)
+    end
+  end
+
+  defp maybe_update_site_id_for_non_static_pool(attrs, params) do
     if site_id = params["site_id"] do
       Map.put(attrs, "site_id", site_id)
     else
@@ -270,17 +388,13 @@ defmodule PortalWeb.Resources.Edit do
 
   defp change_resource(resource, attrs \\ %{}, _subject) do
     update_fields = ~w[address address_description name type ip_stack site_id]a
-    required_fields = ~w[name type site_id]a
 
-    resource
-    |> Ecto.Changeset.cast(attrs, update_fields)
-    |> Ecto.Changeset.validate_required(required_fields)
-    |> Portal.Resource.changeset()
-  end
-
-  defp update_changeset(resource, attrs, _subject) do
-    update_fields = ~w[address address_description name type ip_stack site_id]a
-    required_fields = ~w[name type site_id]a
+    required_fields =
+      if attrs["type"] == "static_device_pool" do
+        ~w[name type]a
+      else
+        ~w[name type site_id]a
+      end
 
     resource
     |> Ecto.Changeset.cast(attrs, update_fields)
@@ -291,25 +405,50 @@ defmodule PortalWeb.Resources.Edit do
   defmodule Database do
     import Ecto.Query
     alias Portal.{Safe, Resource}
+    alias PortalWeb.Resources.Components
 
-    def all_sites(subject) do
-      from(s in Portal.Site, as: :sites)
-      |> where([sites: s], s.managed_by != :system)
-      |> Safe.scoped(subject, :replica)
-      |> Safe.all()
-    end
+    defdelegate client_to_client_enabled?(account), to: Components.Database
+    defdelegate all_sites(subject), to: Components.Database
+    defdelegate get_client(client_id, subject), to: Components.Database
+    defdelegate search_clients(search_term, subject, selected_clients), to: Components.Database
 
     def get_resource!(id, subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
-      |> preload(:site)
+      |> preload([:site, static_pool_members: [client: [:ipv4_address, :ipv6_address]]])
       |> Safe.scoped(subject, :replica)
-      |> Safe.one!(fallback_to_primary: true)
+      |> Safe.one!()
     end
 
-    def update_resource(changeset, subject) do
-      Safe.scoped(changeset, subject)
-      |> Safe.update()
+    def update_resource(changeset, selected_clients, subject) do
+      changeset =
+        Components.Database.validate_static_device_pool_feature_enabled(
+          changeset,
+          subject.account
+        )
+
+      with {:ok, selected_clients} <-
+             Components.Database.validate_selected_clients(selected_clients, subject),
+           {:ok, resource} <- Safe.scoped(changeset, subject) |> Safe.update(),
+           :ok <-
+             Components.Database.sync_static_pool_members(resource, selected_clients, subject) do
+        {:ok, resource}
+      else
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:error, changeset}
+
+        {:error, :invalid_clients} ->
+          {:error,
+           Ecto.Changeset.add_error(changeset, :name, "one or more selected clients are invalid")}
+
+        {:error, :unauthorized} ->
+          {:error,
+           Ecto.Changeset.add_error(
+             changeset,
+             :name,
+             "you are not authorized to perform this action"
+           )}
+      end
     end
   end
 end

--- a/elixir/lib/portal_web/live/resources/index.ex
+++ b/elixir/lib/portal_web/live/resources/index.ex
@@ -99,11 +99,14 @@ defmodule PortalWeb.Resources.Index do
             </.link>
           </:col>
           <:col :let={resource} field={{:resources, :address}} label="Address">
-            <code :if={resource.type != :internet} class="block text-xs">
+            <code :if={resource.type not in [:internet, :static_device_pool]} class="block text-xs">
               {resource.address}
             </code>
             <span :if={resource.type == :internet} class="block text-xs">
               <code>0.0.0.0/0</code>, <code>::/0 </code>
+            </span>
+            <span :if={resource.type == :static_device_pool} class="block text-xs">
+              Device Pool
             </span>
           </:col>
           <:col :let={resource} label="site">

--- a/elixir/lib/portal_web/live/resources/new.ex
+++ b/elixir/lib/portal_web/live/resources/new.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Warning.CrossModuleDatabaseCall
 defmodule PortalWeb.Resources.New do
   use PortalWeb, :live_view
   import PortalWeb.Resources.Components
@@ -6,11 +7,16 @@ defmodule PortalWeb.Resources.New do
   def mount(params, _session, socket) do
     sites = Database.all_sites(socket.assigns.subject)
     changeset = Database.new_resource(socket.assigns.account)
+    client_to_client_enabled? = Database.client_to_client_enabled?(socket.assigns.account)
 
     socket =
       assign(
         socket,
         sites: sites,
+        selected_clients: [],
+        client_search_results: nil,
+        client_search: "",
+        client_to_client_enabled?: client_to_client_enabled?,
         address_description_changed?: false,
         name_changed?: false,
         form: to_form(changeset),
@@ -18,7 +24,7 @@ defmodule PortalWeb.Resources.New do
         page_title: "New Resource"
       )
 
-    {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
+    {:ok, socket}
   end
 
   def render(assigns) do
@@ -38,8 +44,8 @@ defmodule PortalWeb.Resources.New do
               <p class="mb-2 text-sm text-neutral-900">
                 Type
               </p>
-              <ul class="grid w-full gap-6 md:grid-cols-3">
-                <li>
+              <ul class="grid w-full gap-6 md:grid-cols-4">
+                <li class="flex flex-col">
                   <.input
                     id="resource-type--dns"
                     type="radio_button_group"
@@ -49,22 +55,20 @@ defmodule PortalWeb.Resources.New do
                     required
                   />
                   <label for="resource-type--dns" class={~w[
-                    inline-flex items-center justify-between w-full
-                    p-5 text-neutral-500 bg-white border border-neutral-200
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
                     rounded-sm cursor-pointer peer-checked:border-accent-500
                     peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
                   ]}>
-                    <div class="block">
-                      <div class="w-full font-semibold mb-3">
-                        <.icon name="hero-globe-alt" class="w-5 h-5 mr-1" /> DNS
-                      </div>
-                      <div class="w-full text-sm">
-                        Manage access to an application or service by DNS address.
-                      </div>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-globe-alt" class="w-5 h-5 mr-1" /> DNS
+                    </div>
+                    <div class="text-sm">
+                      Manage access to an application or service by DNS address.
                     </div>
                   </label>
                 </li>
-                <li>
+                <li class="flex flex-col">
                   <.input
                     id="resource-type--ip"
                     type="radio_button_group"
@@ -74,22 +78,20 @@ defmodule PortalWeb.Resources.New do
                     required
                   />
                   <label for="resource-type--ip" class={~w[
-                    inline-flex items-center justify-between w-full
-                    p-5 text-neutral-500 bg-white border border-neutral-200
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
                     rounded-sm cursor-pointer peer-checked:border-accent-600
                     peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
                   ]}>
-                    <div class="block">
-                      <div class="w-full font-semibold mb-3">
-                        <.icon name="hero-server" class="w-5 h-5 mr-1" /> IP
-                      </div>
-                      <div class="w-full text-sm">
-                        Manage access to a specific host by IP address.
-                      </div>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-server" class="w-5 h-5 mr-1" /> IP
+                    </div>
+                    <div class="text-sm">
+                      Manage access to a specific host by IP address.
                     </div>
                   </label>
                 </li>
-                <li>
+                <li class="flex flex-col">
                   <.input
                     id="resource-type--cidr"
                     type="radio_button_group"
@@ -99,25 +101,46 @@ defmodule PortalWeb.Resources.New do
                     required
                   />
                   <label for="resource-type--cidr" class={~w[
-                    inline-flex items-center justify-between w-full
-                    p-5 text-neutral-500 bg-white border border-neutral-200
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
                     rounded-sm cursor-pointer peer-checked:border-accent-500
                     peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
                   ]}>
-                    <div class="block">
-                      <div class="w-full font-semibold mb-3">
-                        <.icon name="hero-server-stack" class="w-5 h-5 mr-1" /> CIDR
-                      </div>
-                      <div class="w-full text-sm">
-                        Manage access to a network, VPC or subnet by CIDR address.
-                      </div>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-server-stack" class="w-5 h-5 mr-1" /> CIDR
+                    </div>
+                    <div class="text-sm">
+                      Manage access to a network, VPC or subnet by CIDR address.
+                    </div>
+                  </label>
+                </li>
+                <li :if={@client_to_client_enabled?} class="flex flex-col">
+                  <.input
+                    id="resource-type--static-device-pool"
+                    type="radio_button_group"
+                    field={@form[:type]}
+                    value="static_device_pool"
+                    checked={@form[:type].value == :static_device_pool}
+                    required
+                  />
+                  <label for="resource-type--static-device-pool" class={~w[
+                    flex flex-1 flex-col justify-between w-full
+                    p-4 text-neutral-500 bg-white border border-neutral-200
+                    rounded-sm cursor-pointer peer-checked:border-accent-500
+                    peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
+                  ]}>
+                    <div class="font-semibold mb-2 whitespace-nowrap">
+                      <.icon name="hero-computer-desktop" class="w-5 h-5 mr-1" /> Device Pool
+                    </div>
+                    <div class="text-sm">
+                      Direct access to other Firezone devices without a Gateway.
                     </div>
                   </label>
                 </li>
               </ul>
             </div>
 
-            <div>
+            <div :if={@form[:type].value != :static_device_pool}>
               <.input
                 field={@form[:address]}
                 autocomplete="off"
@@ -168,7 +191,7 @@ defmodule PortalWeb.Resources.New do
               </div>
             </div>
 
-            <div>
+            <div :if={@form[:type].value != :static_device_pool}>
               <.input
                 field={@form[:address_description]}
                 type="text"
@@ -179,6 +202,18 @@ defmodule PortalWeb.Resources.New do
               <p class="mt-2 text-xs text-neutral-500">
                 Optional description or URL to show in Clients to help users access this Resource.
               </p>
+            </div>
+
+            <div :if={@form[:type].value == :static_device_pool}>
+              <legend class="text-xl mb-2">Devices</legend>
+              <p class="text-sm text-neutral-500 mb-4">
+                Select clients to include in this pool. Search by name, IPv4, IPv6, id, serial, UUID, and other identifiers.
+              </p>
+              <.client_picker
+                selected_clients={@selected_clients}
+                client_search={@client_search}
+                client_search_results={@client_search_results}
+              />
             </div>
 
             <.input
@@ -195,7 +230,7 @@ defmodule PortalWeb.Resources.New do
             <.filters_form account={@account} form={@form[:filters]} />
 
             <.site_form
-              :if={is_nil(@params["site_id"])}
+              :if={is_nil(@params["site_id"]) and @form[:type].value != :static_device_pool}
               form={@form}
               sites={@sites}
             />
@@ -246,7 +281,7 @@ defmodule PortalWeb.Resources.New do
       |> map_filters_form_attrs(socket.assigns.account)
       |> maybe_put_site_id(socket.assigns.params)
 
-    case Database.create_resource(attrs, socket.assigns.subject) do
+    case Database.create_resource(attrs, socket.assigns.selected_clients, socket.assigns.subject) do
       {:ok, resource} ->
         socket = put_flash(socket, :success, "Resource #{resource.name} created successfully")
 
@@ -271,6 +306,66 @@ defmodule PortalWeb.Resources.New do
     end
   end
 
+  def handle_event("focus_client_search", _params, socket) do
+    results =
+      Database.search_clients(
+        socket.assigns.client_search,
+        socket.assigns.subject,
+        socket.assigns.selected_clients
+      )
+
+    {:noreply, assign(socket, client_search_results: results)}
+  end
+
+  def handle_event("blur_client_search", _params, socket) do
+    {:noreply, assign(socket, client_search_results: nil)}
+  end
+
+  def handle_event("search_client", %{"client_search" => search}, socket) do
+    results =
+      Database.search_clients(search, socket.assigns.subject, socket.assigns.selected_clients)
+
+    {:noreply,
+     assign(socket,
+       client_search: search,
+       client_search_results: results
+     )}
+  end
+
+  def handle_event("add_client", %{"client_id" => client_id}, socket) do
+    case Database.get_client(client_id, socket.assigns.subject) do
+      nil ->
+        {:noreply, socket}
+
+      client ->
+        selected_clients = Enum.uniq_by([client | socket.assigns.selected_clients], & &1.id)
+
+        {:noreply,
+         assign(socket,
+           selected_clients: selected_clients,
+           client_search: "",
+           client_search_results: nil
+         )}
+    end
+  end
+
+  def handle_event("remove_client", %{"client_id" => client_id}, socket) do
+    selected_clients = Enum.reject(socket.assigns.selected_clients, &(&1.id == client_id))
+
+    results =
+      Database.search_clients(
+        socket.assigns.client_search,
+        socket.assigns.subject,
+        selected_clients
+      )
+
+    {:noreply,
+     assign(socket,
+       selected_clients: selected_clients,
+       client_search_results: results
+     )}
+  end
+
   defp maybe_put_default_name(attrs, name_changed? \\ true)
 
   defp maybe_put_default_name(attrs, true) do
@@ -282,6 +377,14 @@ defmodule PortalWeb.Resources.New do
   end
 
   defp maybe_put_site_id(attrs, params) do
+    if attrs["type"] == "static_device_pool" do
+      Map.delete(attrs, "site_id")
+    else
+      maybe_put_site_id_for_non_static_pool(attrs, params)
+    end
+  end
+
+  defp maybe_put_site_id_for_non_static_pool(attrs, params) do
     if site_id = params["site_id"] do
       Map.put(attrs, "site_id", site_id)
     else
@@ -290,33 +393,59 @@ defmodule PortalWeb.Resources.New do
   end
 
   defmodule Database do
-    import Ecto.Query
     import Ecto.Changeset
     alias Portal.{Safe, Resource}
+    alias PortalWeb.Resources.Components
 
-    def all_sites(subject) do
-      from(g in Portal.Site, as: :sites)
-      |> where([sites: s], s.managed_by != :system)
-      |> Safe.scoped(subject, :replica)
-      |> Safe.all()
-    end
+    defdelegate client_to_client_enabled?(account), to: Components.Database
+    defdelegate all_sites(subject), to: Components.Database
+    defdelegate get_client(client_id, subject), to: Components.Database
+    defdelegate search_clients(search_term, subject, selected_clients), to: Components.Database
 
     # TODO: Keep all changeset logic out of the DB module
     def new_resource(account, attrs \\ %{}) do
-      %Resource{}
-      |> cast(attrs, [:name, :address, :address_description, :type, :ip_stack, :site_id])
-      |> validate_required([:name, :address])
-      |> put_change(:account_id, account.id)
-      |> Resource.changeset()
+      changeset =
+        %Resource{account_id: account.id}
+        |> cast(attrs, [:name, :address, :address_description, :type, :ip_stack, :site_id])
+        |> Resource.changeset()
+
+      if get_field(changeset, :type) == :static_device_pool do
+        validate_required(changeset, [:name])
+      else
+        validate_required(changeset, [:name, :address])
+      end
     end
 
-    def create_resource(attrs, subject) do
+    def create_resource(attrs, selected_clients, subject) do
       changeset =
         new_resource(subject.account, attrs)
-        |> validate_required([:site_id])
+        |> maybe_validate_required_fields()
+        |> Components.Database.validate_static_device_pool_feature_enabled(subject.account)
 
-      Safe.scoped(changeset, subject)
-      |> Safe.insert()
+      with {:ok, selected_clients} <-
+             Components.Database.validate_selected_clients(selected_clients, subject),
+           {:ok, resource} <- Safe.scoped(changeset, subject) |> Safe.insert(),
+           :ok <-
+             Components.Database.sync_static_pool_members(resource, selected_clients, subject) do
+        {:ok, resource}
+      else
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:error, changeset}
+
+        {:error, :invalid_clients} ->
+          {:error, add_error(changeset, :name, "one or more selected clients are invalid")}
+
+        {:error, :unauthorized} ->
+          {:error, add_error(changeset, :name, "you are not authorized to perform this action")}
+      end
+    end
+
+    defp maybe_validate_required_fields(changeset) do
+      if get_field(changeset, :type) == :static_device_pool do
+        validate_required(changeset, [:name])
+      else
+        validate_required(changeset, [:site_id])
+      end
     end
   end
 end

--- a/elixir/lib/portal_web/live/resources/show.ex
+++ b/elixir/lib/portal_web/live/resources/show.ex
@@ -123,6 +123,14 @@ defmodule PortalWeb.Resources.Show do
           </.vertical_table_row>
           <.vertical_table_row>
             <:label>
+              Type
+            </:label>
+            <:value>
+              {format_resource_type(@resource.type)}
+            </:value>
+          </.vertical_table_row>
+          <.vertical_table_row :if={@resource.type != :static_device_pool}>
+            <:label>
               Address
             </:label>
             <:value>
@@ -134,7 +142,7 @@ defmodule PortalWeb.Resources.Show do
               </span>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row>
+          <.vertical_table_row :if={@resource.type != :static_device_pool}>
             <:label>
               Address Description
             </:label>
@@ -165,7 +173,7 @@ defmodule PortalWeb.Resources.Show do
               </span>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row>
+          <.vertical_table_row :if={@resource.type != :static_device_pool}>
             <:label>
               Site
             </:label>
@@ -181,6 +189,41 @@ defmodule PortalWeb.Resources.Show do
               </.link>
               <span :if={is_nil(@resource.site)}>
                 Not linked to a site
+              </span>
+            </:value>
+          </.vertical_table_row>
+          <.vertical_table_row :if={@resource.type == :static_device_pool}>
+            <:label>
+              Devices
+            </:label>
+            <:value>
+              <span :if={@resource.static_pool_members == []} class="text-neutral-500 text-sm">
+                No devices in pool
+              </span>
+              <ul :if={@resource.static_pool_members != []} class="space-y-1">
+                <li
+                  :for={member <- Enum.take(@resource.static_pool_members, 5)}
+                  class="flex items-center gap-2"
+                >
+                  <.link navigate={~p"/#{@account}/clients/#{member.client_id}"} class={link_style()}>
+                    {(member.client && member.client.name) || member.client_id}
+                  </.link>
+                  <span
+                    :if={member.client && member.client.ipv4_address}
+                    class="text-xs text-neutral-400"
+                  >
+                    {Portal.Types.INET.to_string(member.client.ipv4_address.address)}
+                  </span>
+                </li>
+              </ul>
+              <span
+                :if={length(@resource.static_pool_members) > 5}
+                class="text-xs text-neutral-500 mt-1 block"
+              >
+                and {length(@resource.static_pool_members) - 5} more —
+                <.link navigate={~p"/#{@account}/resources/#{@resource.id}/edit"} class={link_style()}>
+                  view all
+                </.link>
               </span>
             </:value>
           </.vertical_table_row>
@@ -415,6 +458,12 @@ defmodule PortalWeb.Resources.Show do
   defp format_ip_stack(:ipv4_only), do: "IPv4 only"
   defp format_ip_stack(:ipv6_only), do: "IPv6 only"
 
+  defp format_resource_type(:internet), do: "Internet"
+  defp format_resource_type(:dns), do: "DNS"
+  defp format_resource_type(:ip), do: "IP"
+  defp format_resource_type(:cidr), do: "CIDR"
+  defp format_resource_type(:static_device_pool), do: "Device Pool"
+
   defmodule Database do
     import Ecto.Query
     import Portal.Repo.Query
@@ -423,7 +472,7 @@ defmodule PortalWeb.Resources.Show do
     def get_resource!(id, subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
-      |> preload([:site, :policies])
+      |> preload([:site, :policies, static_pool_members: [client: [:ipv4_address]]])
       |> Safe.scoped(subject, :replica)
       |> Safe.one!(fallback_to_primary: true)
     end

--- a/elixir/priv/repo/migrations/20260218000001_add_device_pool_resources.exs
+++ b/elixir/priv/repo/migrations/20260218000001_add_device_pool_resources.exs
@@ -1,0 +1,61 @@
+defmodule Portal.Repo.Migrations.AddDevicePoolResources do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER TABLE resources DROP CONSTRAINT require_resources_address")
+
+    execute("""
+    ALTER TABLE resources
+    ADD CONSTRAINT require_resources_address CHECK (
+      (type IN ('cidr', 'ip', 'dns') AND address IS NOT NULL)
+      OR (type IN ('internet', 'static_device_pool') AND address IS NULL)
+    );
+    """)
+
+    create table(:static_device_pool_members, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
+
+      add(
+        :resource_id,
+        references(:resources,
+          type: :binary_id,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        ),
+        null: false
+      )
+
+      add(
+        :client_id,
+        references(:clients,
+          type: :binary_id,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        ),
+        null: false
+      )
+    end
+
+    create(index(:static_device_pool_members, [:resource_id]))
+    create(index(:static_device_pool_members, [:client_id]))
+  end
+
+  def down do
+    drop(table(:static_device_pool_members))
+
+    execute("ALTER TABLE resources DROP CONSTRAINT require_resources_address")
+
+    execute("""
+    ALTER TABLE resources
+    ADD CONSTRAINT require_resources_address CHECK (
+      (type IN ('cidr', 'ip', 'dns') AND address IS NOT NULL)
+      OR (type = 'internet' AND address IS NULL)
+    );
+    """)
+  end
+end

--- a/elixir/priv/repo/migrations/20260304110000_add_receiving_client_id_to_policy_authorizations.exs
+++ b/elixir/priv/repo/migrations/20260304110000_add_receiving_client_id_to_policy_authorizations.exs
@@ -1,0 +1,60 @@
+defmodule Portal.Repo.Migrations.AddReceivingClientIdToPolicyAuthorizations do
+  use Ecto.Migration
+
+  def up do
+    alter table(:policy_authorizations) do
+      modify(:gateway_id, :binary_id, null: true)
+      modify(:gateway_remote_ip, :inet, null: true)
+
+      add(
+        :receiving_client_id,
+        references(:clients,
+          with: [account_id: :account_id],
+          type: :binary_id,
+          on_delete: :delete_all
+        )
+      )
+    end
+
+    drop_if_exists(
+      index(:policy_authorizations, [:gateway_id], name: :policy_authorizations_gateway_id_index)
+    )
+
+    create(
+      index(:policy_authorizations, [:gateway_id],
+        name: :policy_authorizations_gateway_id_index,
+        where: "gateway_id IS NOT NULL"
+      )
+    )
+
+    create(
+      index(:policy_authorizations, [:receiving_client_id],
+        name: :policy_authorizations_receiving_client_id_index,
+        where: "receiving_client_id IS NOT NULL"
+      )
+    )
+  end
+
+  def down do
+    drop_if_exists(
+      index(:policy_authorizations, [:gateway_id], name: :policy_authorizations_gateway_id_index)
+    )
+
+    create(
+      index(:policy_authorizations, [:gateway_id], name: :policy_authorizations_gateway_id_index)
+    )
+
+    drop_if_exists(
+      index(:policy_authorizations, [:receiving_client_id],
+        name: :policy_authorizations_receiving_client_id_index
+      )
+    )
+
+    alter table(:policy_authorizations) do
+      modify(:gateway_id, :binary_id, null: false)
+      modify(:gateway_remote_ip, :inet, null: false)
+
+      remove(:receiving_client_id)
+    end
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -262,7 +262,8 @@ defmodule Portal.Repo.Seeds do
         traffic_filters: true,
         idp_sync: true,
         rest_api: true,
-        internet_resource: true
+        internet_resource: true,
+        client_to_client: true
       })
       |> put_change(:metadata, %{
         stripe: %{

--- a/elixir/test/portal/cache/client_test.exs
+++ b/elixir/test/portal/cache/client_test.exs
@@ -250,4 +250,55 @@ defmodule Portal.Cache.ClientTest do
       assert cached.name == "Updated Name"
     end
   end
+
+  describe "authorize_device_access/2" do
+    test "allows access when target client belongs to an authorized static device pool" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+
+      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: resource)
+
+      session = %Portal.ClientSession{
+        client_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip
+      }
+
+      cache = Cache.recompute_connectable_resources(nil, client, session, subject) |> elem(3)
+
+      target_ipv4 = target_client.ipv4_address.address.address
+
+      assert :ok = Cache.authorize_device_access(cache, target_ipv4)
+    end
+
+    test "rejects access when target client is not in an authorized static device pool" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+
+      session = %Portal.ClientSession{
+        client_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip
+      }
+
+      cache = Cache.recompute_connectable_resources(nil, client, session, subject) |> elem(3)
+
+      target_ipv4 = target_client.ipv4_address.address.address
+
+      assert {:error, :forbidden} = Cache.authorize_device_access(cache, target_ipv4)
+    end
+  end
 end

--- a/elixir/test/portal/policy_authorization_test.exs
+++ b/elixir/test/portal/policy_authorization_test.exs
@@ -252,6 +252,55 @@ defmodule Portal.PolicyAuthorizationTest do
       assert %{gateway: ["does not exist"]} = errors_on(changeset)
     end
 
+    test "enforces receiving_client association constraint" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      resource = resource_fixture(account: account, site: site)
+      group = group_fixture(account: account)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+      membership = membership_fixture(account: account, actor: actor, group: group)
+      token = client_token_fixture(account: account, actor: actor)
+
+      {:error, changeset} =
+        %PolicyAuthorization{}
+        |> cast(
+          %{
+            policy_id: policy.id,
+            client_id: client.id,
+            receiving_client_id: Ecto.UUID.generate(),
+            gateway_id: gateway.id,
+            resource_id: resource.id,
+            token_id: token.id,
+            membership_id: membership.id,
+            client_remote_ip: @valid_ip,
+            client_user_agent: @valid_user_agent,
+            gateway_remote_ip: @valid_gateway_ip,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          },
+          [
+            :policy_id,
+            :client_id,
+            :receiving_client_id,
+            :gateway_id,
+            :resource_id,
+            :token_id,
+            :membership_id,
+            :client_remote_ip,
+            :client_user_agent,
+            :gateway_remote_ip,
+            :expires_at
+          ]
+        )
+        |> put_assoc(:account, account)
+        |> PolicyAuthorization.changeset()
+        |> Repo.insert()
+
+      assert %{receiving_client: ["does not exist"]} = errors_on(changeset)
+    end
+
     test "enforces resource association constraint" do
       account = account_fixture()
       actor = actor_fixture(account: account)

--- a/elixir/test/portal/resource_test.exs
+++ b/elixir/test/portal/resource_test.exs
@@ -196,6 +196,28 @@ defmodule Portal.ResourceTest do
     end
   end
 
+  describe "changeset/1 static device pool type" do
+    test "sets address and site_id to nil for static device pool type" do
+      changeset =
+        build_changeset(%{
+          type: :static_device_pool,
+          address: "ignored.example.com",
+          site_id: Ecto.UUID.generate()
+        })
+
+      assert get_change(changeset, :address) == nil
+      assert get_change(changeset, :site_id) == nil
+    end
+
+    test "clears existing address and site when changing to static device pool" do
+      existing = %Resource{type: :dns, address: "example.com", site_id: Ecto.UUID.generate()}
+      changeset = build_changeset_on_existing(existing, %{type: :static_device_pool})
+
+      assert get_change(changeset, :address) == nil
+      assert get_change(changeset, :site_id) == nil
+    end
+  end
+
   describe "changeset/1 type change revalidation" do
     test "revalidates address when type changes from cidr to ip" do
       # A valid CIDR but invalid IP

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -88,7 +88,8 @@ defmodule PortalAPI.Client.ChannelTest do
           search_domain: "example.com"
         },
         features: %{
-          internet_resource: true
+          internet_resource: true,
+          client_to_client: true
         }
       )
 
@@ -474,6 +475,38 @@ defmodule PortalAPI.Client.ChannelTest do
                search_domain: "example.com"
              }
     end
+
+    # TODO: re-enable after verifying this won't break older clients
+    # test "includes authorized_ipv4s from non-expired policy authorizations", %{
+    #   account: account,
+    #   actor: actor,
+    #   client: client,
+    #   subject: subject
+    # } do
+    #   other_actor = actor_fixture(account: account)
+    #   other_client = client_fixture(account: account, actor: other_actor)
+    #
+    #   policy_authorization_fixture(
+    #     account: account,
+    #     actor: actor,
+    #     client: other_client,
+    #     receiving_client_id: client.id,
+    #     expires_at: DateTime.add(DateTime.utc_now(), 60, :second)
+    #   )
+    #
+    #   expired_policy_authorization_fixture(
+    #     account: account,
+    #     actor: actor,
+    #     client: other_client,
+    #     receiving_client_id: client.id
+    #   )
+    #
+    #   _socket = join_channel(client, subject)
+    #
+    #   assert_push "init", %{authorized_ipv4s: authorized_ipv4s}
+    #
+    #   assert authorized_ipv4s == [Portal.Types.INET.to_string(other_client.ipv4_address.address)]
+    # end
 
     test "only sends the same resource once", %{
       account: account,
@@ -4270,8 +4303,25 @@ defmodule PortalAPI.Client.ChannelTest do
       assert_push "client_device_access_denied", %{ipv4: "100.64.0.2", reason: :disabled}
     end
 
-    test "sends denied with :not_found when target IP is not in presence", %{
-      account: account,
+    test "sends denied with :disabled when account feature is off even if global feature is on",
+         %{
+           account: account,
+           client: client,
+           subject: subject
+         } do
+      enable_feature(:client_to_client)
+      account = update_account(account, %{features: %{client_to_client: false}})
+      subject = %{subject | account: account}
+
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      push(socket, "request_device_access", %{"ipv4" => "100.64.0.2"})
+
+      assert_push "client_device_access_denied", %{ipv4: "100.64.0.2", reason: :disabled}
+    end
+
+    test "sends denied with :forbidden when target IP is not authorized", %{
       client: client,
       subject: subject
     } do
@@ -4284,14 +4334,14 @@ defmodule PortalAPI.Client.ChannelTest do
       unknown_ip = "100.96.200.1"
       push(socket, "request_device_access", %{"ipv4" => unknown_ip})
 
-      assert_push "client_device_access_denied", %{ipv4: ^unknown_ip, reason: :not_found}
-      refute Presence.Clients.Account.find_by_ipv4(account.id, {100, 96, 200, 1})
+      assert_push "client_device_access_denied", %{ipv4: ^unknown_ip, reason: :forbidden}
     end
 
     test "sends authorized to both clients when target IP is found in presence", %{
       account: account,
       client: client,
-      subject: subject
+      subject: subject,
+      group: group
     } do
       enable_feature(:client_to_client)
 
@@ -4305,6 +4355,9 @@ defmodule PortalAPI.Client.ChannelTest do
           type: :client,
           user_agent: "Linux/24.04 connlib/1.3.0"
         )
+
+      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: resource)
 
       initiating_socket = join_channel(client, subject)
       assert_push "init", _
@@ -4329,6 +4382,58 @@ defmodule PortalAPI.Client.ChannelTest do
         client_id: ^initiating_client_id,
         ice_role: :controlled
       }
+    end
+
+    test "sends denied with :forbidden when target is not in an authorized device pool", %{
+      account: account,
+      client: client,
+      subject: subject
+    } do
+      enable_feature(:client_to_client)
+
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+
+      target_subject =
+        subject_fixture(
+          account: account,
+          actor: target_actor,
+          type: :client,
+          user_agent: "Linux/24.04 connlib/1.3.0"
+        )
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      _target_socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4_address.address)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :forbidden}
+    end
+
+    test "sends denied with :offline when authorized target is offline", %{
+      account: account,
+      client: client,
+      subject: subject,
+      group: group
+    } do
+      enable_feature(:client_to_client)
+
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: resource)
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4_address.address)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :offline}
     end
 
     test "does not find clients from other accounts", %{
@@ -4359,7 +4464,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       push(initiating_socket, "request_device_access", %{"ipv4" => other_ip})
 
-      assert_push "client_device_access_denied", %{ipv4: ^other_ip, reason: :not_found}
+      assert_push "client_device_access_denied", %{ipv4: ^other_ip, reason: :forbidden}
     end
   end
 

--- a/elixir/test/portal_api/controllers/resource_controller_test.exs
+++ b/elixir/test/portal_api/controllers/resource_controller_test.exs
@@ -182,6 +182,27 @@ defmodule PortalAPI.ResourceControllerTest do
       assert resp["data"]["type"] == attrs["type"]
       assert resp["data"]["ip_stack"] == attrs["ip_stack"]
     end
+
+    test "creates a static device pool without site_id or address", %{
+      conn: conn,
+      actor: actor
+    } do
+      attrs = %{
+        "name" => "Shared Devices",
+        "type" => "static_device_pool"
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", resource: attrs)
+
+      assert resp = json_response(conn, 201)
+      assert resp["data"]["name"] == attrs["name"]
+      assert resp["data"]["type"] == attrs["type"]
+      assert resp["data"]["address"] == nil
+    end
   end
 
   describe "update/2" do

--- a/elixir/test/portal_web/live/policies/new_test.exs
+++ b/elixir/test/portal_web/live/policies/new_test.exs
@@ -3,6 +3,7 @@ defmodule PortalWeb.Live.Policies.NewTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.ClientFixtures
   import Portal.GroupFixtures
   import Portal.ResourceFixtures
   import Portal.PolicyFixtures
@@ -439,6 +440,61 @@ defmodule PortalWeb.Live.Policies.NewTest do
     assert policy.resource_id == resource.id
 
     assert assert_redirect(lv, ~p"/#{account}/groups/#{group}")
+  end
+
+  test "creates a policy for a static device pool resource", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    account = update_account(account, features: %{client_to_client: true})
+    group = group_fixture(account: account)
+    client = client_fixture(account: account)
+    resource = static_device_pool_resource_fixture(account: account, clients: [client])
+
+    attrs = %{
+      group_id: group.id,
+      resource_id: resource.id
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/policies/new")
+
+    assert lv
+           |> form("form[phx-submit=submit]", policy: attrs)
+           |> render_submit()
+
+    policy = Repo.get_by(Portal.Policy, attrs)
+    assert policy
+    assert policy.resource_id == resource.id
+
+    flash = assert_redirect(lv, ~p"/#{account}/policies")
+    assert flash["success"] == "Policy created successfully"
+  end
+
+  test "shows all conditions for static device pool resource", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    account = update_account(account, features: %{client_to_client: true})
+    resource = static_device_pool_resource_fixture(account: account)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/policies/new?resource_id=#{resource.id}")
+
+    form = form(lv, "form[phx-submit=submit]")
+    html = render(form)
+
+    # All standard conditions are available for device pools
+    assert html =~ "client_verified"
+    assert html =~ "current_utc_datetime"
+    assert html =~ "auth_provider_id"
+    assert html =~ "remote_ip"
   end
 
   test "redirects back to site when a new policy is created with pre-set site_id", %{

--- a/elixir/test/portal_web/live/resources/edit_test.exs
+++ b/elixir/test/portal_web/live/resources/edit_test.exs
@@ -1,0 +1,277 @@
+defmodule PortalWeb.Live.Resources.EditTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.ClientFixtures
+  import Portal.FeaturesFixtures
+  import Portal.ResourceFixtures
+  import Portal.SiteFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    site = site_fixture(account: account)
+
+    resource = resource_fixture(account: account, site: site)
+
+    %{
+      account: account,
+      actor: actor,
+      site: site,
+      resource: resource
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    resource: resource,
+    conn: conn
+  } do
+    path = ~p"/#{account}/resources/#{resource}/edit"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access that page."}
+               }}}
+  end
+
+  test "renders not found error when resource is deleted", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    Repo.delete!(resource)
+
+    assert_raise Ecto.NoResultsError, fn ->
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+    end
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    assert item = html |> Floki.parse_fragment!() |> Floki.find("[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "Resources"
+    assert breadcrumbs =~ resource.name
+    assert breadcrumbs =~ "Edit"
+  end
+
+  test "renders form", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    form = form(lv, "form[phx-submit='submit']")
+    inputs = find_inputs(form)
+
+    assert "resource[name]" in inputs
+    assert "resource[address]" in inputs
+    assert "resource[type]" in inputs
+    assert "resource[site_id]" in inputs
+  end
+
+  test "renders changeset errors on submit", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    errors =
+      lv
+      |> form("form[phx-submit='submit']", resource: %{name: String.duplicate("a", 256)})
+      |> render_submit()
+      |> form_validation_errors()
+
+    assert "should be at most 255 character(s)" in errors["resource[name]"]
+  end
+
+  test "updates a resource on valid attrs", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    authorized_conn = authorize_conn(conn, actor)
+
+    attrs = %{
+      name: "updated-resource.com",
+      address: resource.address
+    }
+
+    {:ok, lv, _html} =
+      authorized_conn
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    {:ok, _lv, html} =
+      lv
+      |> form("form[phx-submit='submit']", resource: attrs)
+      |> render_submit()
+      |> follow_redirect(authorized_conn, ~p"/#{account}/resources")
+
+    assert updated_resource = Repo.get_by(Portal.Resource, id: resource.id)
+    assert updated_resource.name == attrs.name
+    assert html =~ "Resource #{updated_resource.name} updated successfully"
+  end
+
+  test "redirects to a site when site_id query param is set", %{
+    account: account,
+    actor: actor,
+    site: site,
+    resource: resource,
+    conn: conn
+  } do
+    authorized_conn = authorize_conn(conn, actor)
+
+    attrs = %{name: "updated-resource.com"}
+
+    {:ok, lv, _html} =
+      authorized_conn
+      |> live(~p"/#{account}/resources/#{resource}/edit?site_id=#{site}")
+
+    {:ok, _lv, html} =
+      lv
+      |> form("form[phx-submit='submit']", resource: attrs)
+      |> render_submit()
+      |> follow_redirect(authorized_conn, ~p"/#{account}/sites/#{site}")
+
+    assert html =~ "Resource #{attrs.name} updated successfully"
+  end
+
+  # Device pool tests
+
+  test "renders device pool edit form with client picker", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    client = client_fixture(account: account, name: "ExistingDevice")
+    resource = static_device_pool_resource_fixture(account: account, clients: [client])
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    assert html =~ "Search clients to add"
+    assert html =~ "ExistingDevice"
+  end
+
+  test "can add a client to an existing device pool", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    existing_client = client_fixture(account: account, name: "ExistingDevice")
+    new_client = client_fixture(account: account, name: "NewDevice")
+    resource = static_device_pool_resource_fixture(account: account, clients: [existing_client])
+
+    authorized_conn = authorize_conn(conn, actor)
+
+    {:ok, lv, _html} =
+      authorized_conn
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    lv
+    |> element("input[name='client_search']")
+    |> render_change(%{"client_search" => "NewDevice"})
+
+    lv
+    |> element("button[phx-click='add_client'][phx-value-client_id='#{new_client.id}']")
+    |> render_click()
+
+    {:ok, _lv, html} =
+      lv
+      |> form("form[phx-submit='submit']",
+        resource: %{name: resource.name, type: "static_device_pool"}
+      )
+      |> render_submit()
+      |> follow_redirect(authorized_conn, ~p"/#{account}/resources")
+
+    assert html =~ "Resource #{resource.name} updated successfully"
+
+    assert Repo.get_by(Portal.StaticDevicePoolMember, %{
+             resource_id: resource.id,
+             client_id: new_client.id
+           })
+
+    assert Repo.get_by(Portal.StaticDevicePoolMember, %{
+             resource_id: resource.id,
+             client_id: existing_client.id
+           })
+  end
+
+  test "can remove a client from an existing device pool", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    client_to_keep = client_fixture(account: account, name: "KeepMe")
+    client_to_remove = client_fixture(account: account, name: "RemoveMe")
+
+    resource =
+      static_device_pool_resource_fixture(
+        account: account,
+        clients: [client_to_keep, client_to_remove]
+      )
+
+    authorized_conn = authorize_conn(conn, actor)
+
+    {:ok, lv, _html} =
+      authorized_conn
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    lv
+    |> element("button[phx-click='remove_client'][phx-value-client_id='#{client_to_remove.id}']")
+    |> render_click()
+
+    lv
+    |> form("form[phx-submit='submit']",
+      resource: %{name: resource.name, type: "static_device_pool"}
+    )
+    |> render_submit()
+    |> follow_redirect(authorized_conn, ~p"/#{account}/resources")
+
+    assert Repo.get_by(Portal.StaticDevicePoolMember, %{
+             resource_id: resource.id,
+             client_id: client_to_keep.id
+           })
+
+    refute Repo.get_by(Portal.StaticDevicePoolMember, %{
+             resource_id: resource.id,
+             client_id: client_to_remove.id
+           })
+  end
+end

--- a/elixir/test/portal_web/live/resources/new_test.exs
+++ b/elixir/test/portal_web/live/resources/new_test.exs
@@ -1,0 +1,368 @@
+defmodule PortalWeb.Live.Resources.NewTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.ClientFixtures
+  import Portal.FeaturesFixtures
+  import Portal.SiteFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    site = site_fixture(account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      site: site
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    conn: conn
+  } do
+    path = ~p"/#{account}/resources/new"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access that page."}
+               }}}
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    assert item = html |> Floki.parse_fragment!() |> Floki.find("[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "Resources"
+    assert breadcrumbs =~ "Add Resource"
+  end
+
+  test "renders form", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new?site_id=#{site}")
+
+    form = form(lv, "form[phx-submit='submit']")
+
+    expected_inputs =
+      [
+        "resource[address]",
+        "resource[address_description]",
+        "resource[filters][icmp][enabled]",
+        "resource[filters][icmp][protocol]",
+        "resource[filters][tcp][enabled]",
+        "resource[filters][tcp][ports]",
+        "resource[filters][tcp][protocol]",
+        "resource[filters][udp][enabled]",
+        "resource[filters][udp][ports]",
+        "resource[filters][udp][protocol]",
+        "resource[name]",
+        "resource[type]"
+      ]
+      |> Enum.sort()
+
+    assert find_inputs(form) == expected_inputs
+  end
+
+  test "renders changeset errors on submit", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new?site_id=#{site}")
+
+    lv |> form("form[phx-submit='submit']") |> render_change(resource: %{type: :dns})
+
+    errors =
+      lv
+      |> form("form[phx-submit='submit']",
+        resource: %{name: String.duplicate("a", 256), address: "example.com"}
+      )
+      |> render_submit()
+      |> form_validation_errors()
+
+    assert "should be at most 255 character(s)" in errors["resource[name]"]
+  end
+
+  test "creates a resource on valid attrs", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    attrs = %{
+      name: "foobar.com",
+      address: "foobar.com",
+      address_description: "http://foobar.com:3000/"
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new?site_id=#{site}")
+
+    lv |> form("form[phx-submit='submit']") |> render_change(resource: %{type: :dns})
+    lv |> form("form[phx-submit='submit']", resource: attrs) |> render_submit()
+
+    resource = Repo.get_by(Portal.Resource, %{name: attrs.name, address: attrs.address})
+    assert resource.site_id == site.id
+
+    flash =
+      assert_redirect(lv, ~p"/#{account}/policies/new?resource_id=#{resource}&site_id=#{site}")
+
+    assert flash["success"] =~ "Resource #{resource.name} created successfully"
+  end
+
+  test "creates a resource with site selected from the form", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    attrs = %{
+      name: "example.com",
+      address: "example.com",
+      type: "dns",
+      site_id: site.id
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    lv |> form("form[phx-submit='submit']") |> render_change(resource: %{type: :dns})
+    lv |> form("form[phx-submit='submit']", resource: attrs) |> render_submit()
+
+    resource = Repo.get_by(Portal.Resource, %{name: attrs.name, address: attrs.address})
+
+    flash = assert_redirect(lv, ~p"/#{account}/policies/new?resource_id=#{resource}")
+    assert flash["success"] =~ "Resource #{resource.name} created successfully"
+  end
+
+  test "renders changeset errors on change", %{
+    account: account,
+    actor: actor,
+    site: site,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new?site_id=#{site}")
+
+    lv |> form("form[phx-submit='submit']") |> render_change(resource: %{type: :dns})
+
+    html =
+      lv
+      |> form("form[phx-submit='submit']",
+        resource: %{name: String.duplicate("a", 256), address: "example.com", type: "dns"}
+      )
+      |> render_submit()
+
+    assert html =~ "should be at most 255 character(s)"
+  end
+
+  # Device pool tests
+
+  test "does not show Device Pool type when client_to_client feature is disabled", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    refute html =~ "Device Pool"
+  end
+
+  test "shows Device Pool type when client_to_client feature is enabled", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    update_account(account, features: %{client_to_client: true})
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    assert html =~ "Device Pool"
+  end
+
+  test "selecting device pool type shows client picker and hides address/site fields", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    update_account(account, features: %{client_to_client: true})
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    html =
+      lv
+      |> form("form[phx-submit='submit']")
+      |> render_change(resource: %{type: :static_device_pool})
+
+    assert html =~ "Search clients to add"
+    refute html =~ ~r/label.*Address/
+    refute html =~ "site_id"
+  end
+
+  test "can search for clients in device pool picker", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    update_account(account, features: %{client_to_client: true})
+    _client = client_fixture(account: account, name: "MyLaptop")
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    lv
+    |> form("form[phx-submit='submit']")
+    |> render_change(resource: %{type: :static_device_pool})
+
+    html =
+      lv
+      |> element("input[name='client_search']")
+      |> render_change(%{"client_search" => "MyLaptop"})
+
+    assert html =~ "MyLaptop"
+  end
+
+  test "can add a client to the device pool", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    update_account(account, features: %{client_to_client: true})
+    client = client_fixture(account: account, name: "MyLaptop")
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    lv
+    |> form("form[phx-submit='submit']")
+    |> render_change(resource: %{type: :static_device_pool})
+
+    lv
+    |> element("input[name='client_search']")
+    |> render_change(%{"client_search" => "MyLaptop"})
+
+    html =
+      lv
+      |> element("button[phx-click='add_client'][phx-value-client_id='#{client.id}']")
+      |> render_click()
+
+    # Client appears in selected list
+    assert html =~ "MyLaptop"
+    # Search dropdown is dismissed
+    refute html =~ "phx-click=\"add_client\""
+  end
+
+  test "creates a device pool resource with selected clients", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    client = client_fixture(account: account, name: "TestDevice")
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    lv
+    |> form("form[phx-submit='submit']")
+    |> render_change(resource: %{type: :static_device_pool})
+
+    lv
+    |> element("input[name='client_search']")
+    |> render_change(%{"client_search" => "TestDevice"})
+
+    lv
+    |> element("button[phx-click='add_client'][phx-value-client_id='#{client.id}']")
+    |> render_click()
+
+    lv
+    |> form("form[phx-submit='submit']",
+      resource: %{name: "My Device Pool", type: "static_device_pool"}
+    )
+    |> render_submit()
+
+    resource = Repo.get_by(Portal.Resource, %{name: "My Device Pool", type: :static_device_pool})
+    assert resource
+
+    flash = assert_redirect(lv, ~p"/#{account}/policies/new?resource_id=#{resource}")
+    assert flash["success"] =~ "Resource My Device Pool created successfully"
+
+    member =
+      Repo.get_by(Portal.StaticDevicePoolMember, %{resource_id: resource.id, client_id: client.id})
+
+    assert member
+  end
+
+  test "device pool resource does not require site or address", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    html =
+      lv
+      |> form("form[phx-submit='submit']")
+      |> render_change(resource: %{type: :static_device_pool})
+
+    # Site and address inputs are not shown for device pool type
+    refute html =~ ~r/name="resource\[site_id\]"/
+    refute html =~ ~r/name="resource\[address\]"/
+  end
+end

--- a/elixir/test/portal_web/live/resources/show_test.exs
+++ b/elixir/test/portal_web/live/resources/show_test.exs
@@ -1,0 +1,309 @@
+defmodule PortalWeb.Live.Resources.ShowTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.ClientFixtures
+  import Portal.FeaturesFixtures
+  import Portal.PolicyFixtures
+  import Portal.ResourceFixtures
+  import Portal.SiteFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    site = site_fixture(account: account)
+
+    resource =
+      resource_fixture(
+        account: account,
+        site: site,
+        type: :dns,
+        address: "example.com",
+        ip_stack: :ipv4_only
+      )
+
+    %{
+      account: account,
+      actor: actor,
+      site: site,
+      resource: resource
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    resource: resource,
+    conn: conn
+  } do
+    path = ~p"/#{account}/resources/#{resource}"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access that page."}
+               }}}
+  end
+
+  test "raises NotFoundError for deleted resource", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    Repo.delete!(resource)
+
+    assert_raise Ecto.NoResultsError, fn ->
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+    end
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    assert item = html |> Floki.parse_fragment!() |> Floki.find("[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "Resources"
+    assert breadcrumbs =~ resource.name
+  end
+
+  test "allows editing resource", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    assert lv
+           |> element("a", "Edit Resource")
+           |> render_click() ==
+             {:error,
+              {:live_redirect, %{to: ~p"/#{account}/resources/#{resource}/edit", kind: :push}}}
+  end
+
+  test "renders resource details", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    table =
+      lv
+      |> element("#resource")
+      |> render()
+      |> vertical_table_to_map()
+
+    assert table["name"] =~ resource.name
+    assert table["address"] =~ resource.address
+    assert table["ip stack"] =~ "IPv4 only"
+  end
+
+  test "renders sites row", %{
+    account: account,
+    actor: actor,
+    site: site,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    table =
+      lv
+      |> element("#resource")
+      |> render()
+      |> vertical_table_to_map()
+
+    assert table["site"] =~ site.name
+  end
+
+  test "renders policies table", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    policy_fixture(account: account, resource: resource)
+    policy_fixture(account: account, resource: resource)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    rows =
+      lv
+      |> element("#policies")
+      |> render()
+      |> table_to_map()
+
+    assert Enum.all?(rows, fn row ->
+             assert row["group"]
+             assert row["id"]
+             assert row["status"] == "Active"
+           end)
+  end
+
+  test "allows deleting resource", %{
+    account: account,
+    actor: actor,
+    resource: resource,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    assert {:error, {:live_redirect, %{to: redirect_path, kind: :push}}} =
+             lv
+             |> element("button[type=submit]", "Delete Resource")
+             |> render_click()
+
+    assert redirect_path == ~p"/#{account}/resources"
+
+    refute Repo.get_by(Portal.Resource, id: resource.id)
+  end
+
+  # Device pool tests
+
+  test "renders device pool details with member list", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    client1 = client_fixture(account: account, name: "AlphaDevice")
+    client2 = client_fixture(account: account, name: "BetaDevice")
+
+    resource =
+      static_device_pool_resource_fixture(
+        account: account,
+        name: "My Device Pool",
+        clients: [client1, client2]
+      )
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    html =
+      lv
+      |> element("#resource")
+      |> render()
+
+    assert html =~ "AlphaDevice"
+    assert html =~ "BetaDevice"
+  end
+
+  test "renders device pool details page without site or address rows", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+
+    resource = static_device_pool_resource_fixture(account: account, name: "Pool")
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    table =
+      lv
+      |> element("#resource")
+      |> render()
+      |> vertical_table_to_map()
+
+    assert table["name"] =~ "Pool"
+    refute Map.has_key?(table, "address")
+    refute Map.has_key?(table, "connected sites")
+  end
+
+  test "truncates device pool member list to 5 with 'and N more' link", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+
+    clients =
+      for i <- 1..7 do
+        client_fixture(account: account, name: "Device#{i}")
+      end
+
+    resource =
+      static_device_pool_resource_fixture(
+        account: account,
+        name: "Big Pool",
+        clients: clients
+      )
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    html =
+      lv
+      |> element("#resource")
+      |> render()
+
+    # Shows 5 items max, then truncation message
+    assert html =~ "and 2 more"
+  end
+
+  test "shows device pool member IPv4 address", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    client = client_fixture(account: account, name: "IPDevice")
+
+    resource = static_device_pool_resource_fixture(account: account, clients: [client])
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    html =
+      lv
+      |> element("#resource")
+      |> render()
+
+    assert html =~ "IPDevice"
+    # IPv4 address should be shown (client_fixture creates one by default)
+    assert html =~ ~r/\d+\.\d+\.\d+\.\d+/
+  end
+end

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -30,7 +30,8 @@ defmodule Portal.AccountFixtures do
         policy_conditions: true,
         traffic_filters: true,
         idp_sync: true,
-        rest_api: true
+        rest_api: true,
+        client_to_client: false
       },
       limits: %{
         monthly_active_users_count: 100

--- a/elixir/test/support/fixtures/policy_authorization_fixtures.ex
+++ b/elixir/test/support/fixtures/policy_authorization_fixtures.ex
@@ -153,6 +153,7 @@ defmodule Portal.PolicyAuthorizationFixtures do
         :account_id,
         :policy_id,
         :client_id,
+        :receiving_client_id,
         :gateway_id,
         :resource_id,
         :token_id,

--- a/elixir/test/support/fixtures/resource_fixtures.ex
+++ b/elixir/test/support/fixtures/resource_fixtures.ex
@@ -192,6 +192,43 @@ defmodule Portal.ResourceFixtures do
   end
 
   @doc """
+  Generate a static device pool resource and optionally attach clients to it.
+  """
+  def static_device_pool_resource_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+    account = Map.get(attrs, :account) || account_fixture()
+    clients = Map.get(attrs, :clients, [])
+    unique_num = System.unique_integer([:positive, :monotonic])
+
+    resource =
+      resource_fixture(
+        attrs
+        |> Map.delete(:clients)
+        |> Map.put(:account, account)
+        |> Map.put(:type, :static_device_pool)
+        |> Map.put_new(:name, "Device Pool #{unique_num}")
+        |> Map.delete(:site)
+        |> Map.delete(:address)
+      )
+
+    Enum.each(clients, fn client ->
+      %Portal.StaticDevicePoolMember{}
+      |> Ecto.Changeset.cast(
+        %{
+          account_id: account.id,
+          resource_id: resource.id,
+          client_id: client.id
+        },
+        [:account_id, :resource_id, :client_id]
+      )
+      |> Portal.StaticDevicePoolMember.changeset()
+      |> Portal.Repo.insert!()
+    end)
+
+    resource
+  end
+
+  @doc """
   Update a resource with the given attributes.
   """
   def update_resource(resource, attrs) do


### PR DESCRIPTION
Adds basic functionality to create / manage pools of devices under a new `static_device_pool` resource type. This is locked behind a feature flag for now as this feature still has a lot more work to get done before hitting prod.

---

Related: #11143 
