### PR TITLE
refactor(apple): extract SessionNotificationProtocol for DI

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -19,7 +19,7 @@ public enum NotificationIndentifier: String {
 
 @MainActor
 public class SessionNotification: NSObject, SessionNotificationProtocol {
-  public var signInHandler: () -> Void = {}
+  public var signInHandler: () async -> Void = {}
   private let notificationCenter = UNUserNotificationCenter.current()
 
   override public init() {
@@ -131,7 +131,7 @@ public class SessionNotification: NSObject, SessionNotificationProtocol {
       let signInClicked = await MacOSAlert.showSignedOutAlert(message)
       if signInClicked {
         Log.log("\(#function): 'Sign In' clicked in notification")
-        signInHandler()
+        await signInHandler()
       }
     }
   #endif
@@ -152,7 +152,7 @@ public class SessionNotification: NSObject, SessionNotificationProtocol {
       {
         // User clicked on 'Sign In' in the notification
         Task { @MainActor in
-          signInHandler()
+          await signInHandler()
         }
       }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -18,8 +18,8 @@ public enum NotificationIndentifier: String {
 }
 
 @MainActor
-public class SessionNotification: NSObject {
-  public var signInHandler = {}
+public class SessionNotification: NSObject, SessionNotificationProtocol {
+  public var signInHandler: () -> Void = {}
   private let notificationCenter = UNUserNotificationCenter.current()
 
   override public init() {
@@ -49,7 +49,7 @@ public class SessionNotification: NSObject {
     #endif
   }
 
-  func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus {
+  public func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus {
     // Ask the user for permission.
     try await notificationCenter.requestAuthorization(options: [.sound, .alert])
 
@@ -57,7 +57,7 @@ public class SessionNotification: NSObject {
     return await loadAuthorizationStatus()
   }
 
-  func loadAuthorizationStatus() async -> UNAuthorizationStatus {
+  public func loadAuthorizationStatus() async -> UNAuthorizationStatus {
     let settings = await notificationCenter.notificationSettings()
 
     return settings.authorizationStatus
@@ -68,7 +68,7 @@ public class SessionNotification: NSObject {
   /// - Parameters:
   ///   - title: The notification title
   ///   - body: The notification body text
-  func showResourceNotification(title: String, body: String) async {
+  public func showResourceNotification(title: String, body: String) async {
     // Check if we have permission to show notifications
     let settings = await notificationCenter.notificationSettings()
     guard settings.authorizationStatus == .authorized else {
@@ -127,7 +127,7 @@ public class SessionNotification: NSObject {
     // In macOS, use a Cocoa alert.
     // This gets called from the app side.
     @MainActor
-    func showSignedOutAlertmacOS(_ message: String?) async {
+    public func showSignedOutAlertMacOS(_ message: String?) async {
       let signInClicked = await MacOSAlert.showSignedOutAlert(message)
       if signInClicked {
         Log.log("\(#function): 'Sign In' clicked in notification")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/SessionNotificationProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/SessionNotificationProtocol.swift
@@ -14,7 +14,7 @@ import UserNotifications
 @MainActor
 public protocol SessionNotificationProtocol: AnyObject {
   /// Handler called when user clicks "Sign In" in a session expired notification.
-  var signInHandler: () -> Void { get set }
+  var signInHandler: () async -> Void { get set }
 
   /// Requests notification permissions from the user.
   func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/SessionNotificationProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/SessionNotificationProtocol.swift
@@ -1,0 +1,32 @@
+//
+//  SessionNotificationProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import UserNotifications
+
+/// Abstracts session notification operations for testing.
+///
+/// This protocol enables dependency injection in Store, allowing tests to
+/// run without accessing UNUserNotificationCenter which is unavailable in test context.
+/// Production uses `SessionNotification`, tests use `MockSessionNotification`.
+@MainActor
+public protocol SessionNotificationProtocol: AnyObject {
+  /// Handler called when user clicks "Sign In" in a session expired notification.
+  var signInHandler: () -> Void { get set }
+
+  /// Requests notification permissions from the user.
+  func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus
+
+  /// Loads the current notification authorization status.
+  func loadAuthorizationStatus() async -> UNAuthorizationStatus
+
+  /// Shows a notification for an unreachable resource.
+  func showResourceNotification(title: String, body: String) async
+
+  #if os(macOS)
+    /// Shows a signed-out alert on macOS.
+    func showSignedOutAlertMacOS(_ message: String?) async
+  #endif
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -87,9 +87,7 @@ public final class Store: ObservableObject {
 
   private func postInit() {
     self.sessionNotification.signInHandler = {
-      Task {
-        do { try await WebAuthSession.signIn(store: self) } catch { Log.error(error) }
-      }
+      do { try await WebAuthSession.signIn(store: self) } catch { Log.error(error) }
     }
 
     // We monitor for any configuration changes and tell the tunnel service about them

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -39,7 +39,7 @@ public final class Store: ObservableObject {
     @Published public var menuBarOpenRequested = false
   #endif
 
-  let sessionNotification = SessionNotification()
+  private(set) var sessionNotification: SessionNotificationProtocol
   #if os(macOS)
     let updateChecker: UpdateChecker
     private let systemExtensionManager: any SystemExtensionManagerProtocol
@@ -61,18 +61,24 @@ public final class Store: ObservableObject {
   #if os(macOS)
     public init(
       configuration: Configuration? = nil,
+      sessionNotification: SessionNotificationProtocol = SessionNotification(),
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil
     ) {
       self.configuration = configuration ?? Configuration.shared
       self.updateChecker = UpdateChecker(configuration: configuration)
+      self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
       self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
       self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
     }
   #else
-    public init(configuration: Configuration? = nil) {
+    public init(
+      configuration: Configuration? = nil,
+      sessionNotification: SessionNotificationProtocol = SessionNotification()
+    ) {
       self.configuration = configuration ?? Configuration.shared
+      self.sessionNotification = sessionNotification
       self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
       self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
@@ -236,7 +242,7 @@ public final class Store: ObservableObject {
               // Only show the alert if we haven't shown this specific error before
               Task { @MainActor in
                 if !self.shownAlertIds.contains(id) {
-                  await self.sessionNotification.showSignedOutAlertmacOS(reason)
+                  await self.sessionNotification.showSignedOutAlertMacOS(reason)
                   self.markAlertAsShown(id)
                 }
               }


### PR DESCRIPTION
Add SessionNotificationProtocol to abstract notification operations, enabling dependency injection in Store for testability.

- Create SessionNotificationProtocol with all notification methods
- Add protocol conformance to SessionNotification
- Make protocol methods public for cross-module access
- Accept SessionNotificationProtocol in Store init (defaults to real impl)
- Fix naming: showSignedOutAlertmacOS -> showSignedOutAlertMacOS

Part of #12089
