### PR TITLE
chore(rust): remove `flume` dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1351,7 +1351,6 @@ dependencies = [
  "client-shared",
  "connlib-model",
  "dns-types",
- "flume",
  "futures",
  "ip-packet",
  "ip_network",
@@ -2628,18 +2627,6 @@ dependencies = [
  "crc32fast",
  "libz-rs-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
 ]
 
 [[package]]
@@ -4444,15 +4431,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -7116,15 +7094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7786,7 +7755,6 @@ name = "telemetry"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
- "flume",
  "futures",
  "hex",
  "ip-packet",
@@ -8493,7 +8461,6 @@ dependencies = [
  "dns-over-tcp",
  "dns-types",
  "firezone-relay",
- "flume",
  "futures",
  "futures-bounded",
  "gat-lending-iterator",

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -15,7 +15,6 @@ backoff = { workspace = true }
 client-shared = { workspace = true }
 connlib-model = { workspace = true }
 dns-types = { workspace = true }
-flume = { workspace = true }
 futures = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -21,7 +21,6 @@ derive_more = { workspace = true, features = ["debug", "from", "display"] }
 divan = { workspace = true, optional = true }
 dns-over-tcp = { workspace = true }
 dns-types = { workspace = true }
-flume = { workspace = true, features = ["async"] }
 futures = { workspace = true }
 futures-bounded = { workspace = true, features = ["tokio"] }
 gat-lending-iterator = { workspace = true }

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -186,7 +186,7 @@ impl ThreadedUdpSocket {
     fn new(sf: Arc<dyn SocketFactory<UdpSocket>>, preferred_addr: SocketAddr) -> io::Result<Self> {
         let (outbound_tx, mut outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (error_tx, error_rx) = flume::bounded(0);
+        let (error_tx, error_rx) = std::sync::mpsc::sync_channel(0);
 
         tokio::spawn(otel::metrics::periodic_system_queue_length(
             outbound_tx.downgrade(),

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -6,7 +6,6 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-flume = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 ip-packet = { workspace = true }

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -180,18 +180,6 @@ where
     }
 }
 
-impl<T> QueueLength for flume::WeakSender<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn queue_length(&self) -> Option<u64> {
-        let sender = self.upgrade()?;
-        let len = sender.len();
-
-        Some(len as u64)
-    }
-}
-
 pub fn default_resource_with<const N: usize>(attributes: [KeyValue; N]) -> Resource {
     Resource::builder_empty()
         .with_detector(Box::new(TelemetryResourceDetector))


### PR DESCRIPTION
Turns out we are not really using `flume` for anything critical and it can easily be removed from our dependency tree.