### PR TITLE
test(connlib): call `shutdown` before restarting client

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -201,6 +201,8 @@ jobs:
             "Resource is known but its addressability changed"
             "No A / AAAA records for domain"
             "State change \(got new possible\): Disconnected -> Checking"
+            "Initiating graceful shutdown"
+            "Connection closed proactively \(sent goodbye\)"
           )
 
           missing_patterns=$(

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -741,23 +741,7 @@ impl TunnelTest {
                 });
             }
 
-            for (_, gateway) in self.gateways.iter_mut() {
-                let Some(transmit) = gateway.exec_mut(|g| g.sut.poll_transmit()) else {
-                    continue;
-                };
-
-                buffered_transmits.push_from(transmit, gateway, now);
-                continue 'outer;
-            }
-
-            for (_, client) in self.clients.iter_mut() {
-                let Some(transmit) = client.exec_mut(|g| g.sut.poll_transmit()) else {
-                    continue;
-                };
-
-                buffered_transmits.push_from(transmit, client, now);
-                continue 'outer;
-            }
+            self.drain_transmits(buffered_transmits, now);
 
             if let Some(transmit) = buffered_transmits.pop(now) {
                 self.dispatch_transmit(transmit, now);
@@ -782,6 +766,20 @@ impl TunnelTest {
 
         for (transmit, at) in buffered_transmits.drain() {
             self.dispatch_transmit(transmit, at);
+        }
+    }
+
+    fn drain_transmits(&mut self, buffered_transmits: &mut BufferedTransmits, now: Instant) {
+        for (_, gateway) in self.gateways.iter_mut() {
+            while let Some(transmit) = gateway.exec_mut(|g| g.sut.poll_transmit()) {
+                buffered_transmits.push_from(transmit, gateway, now);
+            }
+        }
+
+        for (_, client) in self.clients.iter_mut() {
+            while let Some(transmit) = client.exec_mut(|g| g.sut.poll_transmit()) {
+                buffered_transmits.push_from(transmit, client, now);
+            }
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -733,6 +733,14 @@ impl TunnelTest {
                 continue 'outer;
             }
 
+            for client in self.clients.values_mut() {
+                client.exec_mut(|sim| {
+                    while let Some(packet) = sim.sut.poll_packets() {
+                        sim.on_received_packet(packet)
+                    }
+                });
+            }
+
             for (_, gateway) in self.gateways.iter_mut() {
                 let Some(transmit) = gateway.exec_mut(|g| g.sut.poll_transmit()) else {
                     continue;
@@ -749,14 +757,6 @@ impl TunnelTest {
 
                 buffered_transmits.push_from(transmit, client, now);
                 continue 'outer;
-            }
-
-            for client in self.clients.values_mut() {
-                client.exec_mut(|sim| {
-                    while let Some(packet) = sim.sut.poll_packets() {
-                        sim.on_received_packet(packet)
-                    }
-                });
             }
 
             if let Some(transmit) = buffered_transmits.pop(now) {

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -742,16 +742,13 @@ impl TunnelTest {
                 continue 'outer;
             }
 
-            let mut found_transmit = false;
-            for client in self.clients.values_mut() {
-                if let Some(transmit) = client.exec_mut(|sim| sim.sut.poll_transmit()) {
-                    buffered_transmits.push_from(transmit, client, now);
-                    found_transmit = true;
-                    break;
-                }
-            }
-            if found_transmit {
-                continue;
+            for (_, client) in self.clients.iter_mut() {
+                let Some(transmit) = client.exec_mut(|g| g.sut.poll_transmit()) else {
+                    continue;
+                };
+
+                buffered_transmits.push_from(transmit, client, now);
+                continue 'outer;
             }
 
             for client in self.clients.values_mut() {

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -492,6 +492,12 @@ impl TunnelTest {
                 }
             }
             Transition::RestartClient { client_id, key } => {
+                // Cleanly shut down the client.
+                let client = state.clients.get_mut(&client_id).unwrap();
+                client.exec_mut(|c| c.sut.shut_down(now));
+                // Drain transmits so they don't get lost as part of the restart.
+                state.drain_transmits(&mut buffered_transmits, now);
+
                 let client = state.clients.get_mut(&client_id).unwrap();
                 let ref_client = ref_state.clients.get(&client_id).unwrap();
 


### PR DESCRIPTION
As part of `tunnel_test`, we also simulate what happens when a clients gets restarted. Right now though, we don't call `shutdown` as part of the test and therefore, we don't send any `goodbye` messages on all existing connections. In production, Clients do make a best-effort attempt at gracefully closing all connections before they sign out or shutdown.

Doing this in the test suite as well brings us closer to simulating actual production behaviour.