### PR TITLE
test(connlib): ensure consistent timeout handling

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sim_gateway.rs
@@ -174,6 +174,12 @@ impl SimGateway {
         }
     }
 
+    pub fn handle_timeout(&mut self, now: Instant, utc_now: DateTime<Utc>) {
+        if self.sut.poll_timeout().is_some_and(|(t, _)| t <= now) {
+            self.sut.handle_timeout(now, utc_now)
+        }
+    }
+
     /// Process an IP packet received on the gateway.
     fn on_received_packet(
         &mut self,

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -825,12 +825,13 @@ impl TunnelTest {
             }) {
                 buffered_transmits.push_from(transmit, client, now)
             }
-            client.exec_mut(|c| c.handle_timeout(now));
 
             // Handle the client's `Transmit`s.
             while let Some(transmit) = client.poll_inbox(now) {
                 client.exec_mut(|c| c.receive(transmit, now))
             }
+
+            client.exec_mut(|c| c.handle_timeout(now));
         }
 
         // Handle all gateway `Transmit`s and timeouts.
@@ -849,11 +850,7 @@ impl TunnelTest {
                 buffered_transmits.push_from(reply, gateway, now);
             }
 
-            gateway.exec_mut(|g| {
-                if g.sut.poll_timeout().is_some_and(|(t, _)| t <= now) {
-                    g.sut.handle_timeout(now, self.flux_capacitor.now())
-                }
-            });
+            gateway.exec_mut(|g| g.handle_timeout(now, self.flux_capacitor.now()));
         }
 
         // Handle all relay `Transmit`s and timeouts.


### PR DESCRIPTION
For `tunnel_test`, we emulate the entire IO layer including time. Time-handling in sans-IO systems can be a bit finicky. In order to keep internal buffers small, state machine functions like `handle_timeout` need to be call after any state modification (like an incoming packet).

Right now, this doesn't consistently happen for the clients in `tunnel_test` but it is being masked by the fact that we do not yet send packets between clients, only between clients and gateways.

This patch fixes this by calling `handle_timeout` _after_ we have dispatched the transmits to the client.

Related: #11143 