### PR TITLE
fix(apple): stop `updateState` timer when NE disconnects

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -46,7 +46,7 @@ public final class Store: ObservableObject {
   #endif
 
   private var stateTimer: Timer?
-  private var resourceUpdateTask: Task<Void, Never>?
+  private var stateUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
   private var lastSavedConfiguration: TunnelConfiguration?
   private var vpnConfigurationManager: VPNConfigurationManager?
@@ -402,8 +402,8 @@ public final class Store: ObservableObject {
     let updateState: @Sendable (Timer) -> Void = { _ in
       Task {
         await MainActor.run {
-          self.resourceUpdateTask?.cancel()
-          self.resourceUpdateTask = Task {
+          self.stateUpdateTask?.cancel()
+          self.stateUpdateTask = Task {
             if !Task.isCancelled {
               do {
                 guard let session = try self.manager().session() else { return }
@@ -437,7 +437,7 @@ public final class Store: ObservableObject {
   }
 
   private func endUpdatingState() {
-    resourceUpdateTask?.cancel()
+    stateUpdateTask?.cancel()
     stateTimer?.invalidate()
     stateTimer = nil
     resourceList = ResourceList.loading

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -408,6 +408,9 @@ public final class Store: ObservableObject {
               do {
                 guard let session = try self.manager().session() else { return }
                 try await self.fetchState(session: session)
+              } catch IPCClient.Error.invalidStatus(.disconnecting) {
+                Log.debug("Network extension is shutting down, stopping `updateState` timer")
+                self.endUpdatingState()
               } catch let error as NSError {
                 // https://developer.apple.com/documentation/networkextension/nevpnerror-swift.struct/code
                 if error.domain == "NEVPNErrorDomain" && error.code == 1 {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -45,7 +45,7 @@ public final class Store: ObservableObject {
     private let systemExtensionManager: any SystemExtensionManagerProtocol
   #endif
 
-  private var resourcesTimer: Timer?
+  private var stateTimer: Timer?
   private var resourceUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
   private var lastSavedConfiguration: TunnelConfiguration?
@@ -392,7 +392,7 @@ public final class Store: ObservableObject {
   // Network Extensions don't have a 2-way binding up to the GUI process,
   // so we need to periodically ask the tunnel process for them.
   private func beginUpdatingState() {
-    if self.resourcesTimer != nil {
+    if self.stateTimer != nil {
       // Prevent duplicate timer scheduling. This will happen if the system sends us two .connected status updates
       // in a row, which can happen occasionally.
       return
@@ -430,7 +430,7 @@ public final class Store: ObservableObject {
 
     // Schedule the timer on the main runloop
     RunLoop.main.add(timer, forMode: .common)
-    resourcesTimer = timer
+    stateTimer = timer
 
     // We're impatient, make one call now
     updateState(timer)
@@ -438,8 +438,8 @@ public final class Store: ObservableObject {
 
   private func endUpdatingState() {
     resourceUpdateTask?.cancel()
-    resourcesTimer?.invalidate()
-    resourcesTimer = nil
+    stateTimer?.invalidate()
+    stateTimer = nil
     resourceList = ResourceList.loading
     connlibStateHash = Data()
     unreachableResources.removeAll()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -215,10 +215,10 @@ public final class Store: ObservableObject {
     self.vpnStatus = newVPNStatus
 
     if newVPNStatus == .connected {
-      beginUpdatingResources()
+      beginUpdatingState()
       fetchAndCacheFirezoneId()
     } else {
-      endUpdatingResources()
+      endUpdatingState()
     }
 
     #if os(macOS)
@@ -391,7 +391,7 @@ public final class Store: ObservableObject {
 
   // Network Extensions don't have a 2-way binding up to the GUI process,
   // so we need to periodically ask the tunnel process for them.
-  private func beginUpdatingResources() {
+  private func beginUpdatingState() {
     if self.resourcesTimer != nil {
       // Prevent duplicate timer scheduling. This will happen if the system sends us two .connected status updates
       // in a row, which can happen occasionally.
@@ -436,7 +436,7 @@ public final class Store: ObservableObject {
     updateState(timer)
   }
 
-  private func endUpdatingResources() {
+  private func endUpdatingState() {
     resourceUpdateTask?.cancel()
     resourcesTimer?.invalidate()
     resourcesTimer = nil


### PR DESCRIPTION
In order for our Swift application to receive updates from the Network Extension, we poll it on a 1s interval over the system-provided IPC channel. When the Network Extension shuts down whilst an IPC operation is in progress, it may fail with `NEVPNStatus.disconnecting`. In such cases, we should gracefully stop the timer just like we do once we receive the actual status update.

This silences a false-positive issue in Sentry.