### PR TITLE
chore(portal): remove multi-site resources

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -255,7 +255,6 @@ config :portal, :enabled_features,
   traffic_filters: true,
   sign_up: true,
   policy_conditions: true,
-  multi_site_resources: true,
   rest_api: true,
   internet_resource: true
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -160,7 +160,6 @@ if config_env() == :prod do
     idp_sync: env_var_to_config!(:feature_idp_sync_enabled),
     sign_up: env_var_to_config!(:feature_sign_up_enabled),
     policy_conditions: env_var_to_config!(:feature_policy_conditions_enabled),
-    multi_site_resources: env_var_to_config!(:feature_multi_site_resources_enabled),
     rest_api: env_var_to_config!(:feature_rest_api_enabled),
     internet_resource: env_var_to_config!(:feature_internet_resource_enabled)
 

--- a/elixir/lib/portal/accounts/features.ex
+++ b/elixir/lib/portal/accounts/features.ex
@@ -5,7 +5,6 @@ defmodule Portal.Accounts.Features do
   @primary_key false
   embedded_schema do
     field :policy_conditions, :boolean
-    field :multi_site_resources, :boolean
     field :traffic_filters, :boolean
     field :idp_sync, :boolean
     field :rest_api, :boolean
@@ -15,7 +14,6 @@ defmodule Portal.Accounts.Features do
   def changeset(features \\ %__MODULE__{}, attrs) do
     fields = ~w[
       policy_conditions
-      multi_site_resources
       traffic_filters
       idp_sync
       rest_api

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -731,11 +731,6 @@ defmodule Portal.Config.Definitions do
   defconfig(:feature_policy_conditions_enabled, :boolean, default: false)
 
   @doc """
-  Boolean flag to turn Multi-Site resources functionality on/off for all accounts.
-  """
-  defconfig(:feature_multi_site_resources_enabled, :boolean, default: false)
-
-  @doc """
   Boolean flag to turn API Client UI functionality on/off for all accounts.
   """
   defconfig(:feature_rest_api_enabled, :boolean, default: false)

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1578,12 +1578,6 @@ defmodule PortalWeb.CoreComponents do
     """
   end
 
-  def feature_name(%{feature: :multi_site_resources} = assigns) do
-    ~H"""
-    Define globally-distributed Resources
-    """
-  end
-
   def feature_name(%{feature: :traffic_filters} = assigns) do
     ~H"""
     Restrict access based on port and protocol rules

--- a/elixir/priv/repo/migrations/20260220024750_remove_multi_site_resources_feature.exs
+++ b/elixir/priv/repo/migrations/20260220024750_remove_multi_site_resources_feature.exs
@@ -1,0 +1,14 @@
+defmodule Portal.Repo.Migrations.RemoveMultiSiteResourcesFeature do
+  use Ecto.Migration
+
+  def up do
+    execute(
+      "UPDATE accounts SET features = features - 'multi_site_resources' WHERE features ? 'multi_site_resources'"
+    )
+  end
+
+  def down do
+    raise Ecto.MigrationError,
+          "multi_site_resources feature data cannot be restored after removal"
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -255,7 +255,6 @@ defmodule Portal.Repo.Seeds do
       |> put_change(:id, "c89bcc8c-9392-4dae-a40d-888aef6d28e0")
       |> put_change(:features, %{
         policy_conditions: true,
-        multi_site_resources: true,
         traffic_filters: true,
         idp_sync: true,
         rest_api: true,

--- a/elixir/test/portal_web/live/settings/api_clients/beta_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/beta_test.exs
@@ -68,7 +68,6 @@ defmodule PortalWeb.Live.Settings.ApiClients.BetaTest do
           rest_api: false,
           traffic_filters: true,
           policy_conditions: true,
-          multi_site_resources: true,
           idp_sync: true
         }
       })

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -28,7 +28,6 @@ defmodule Portal.AccountFixtures do
       },
       features: %{
         policy_conditions: true,
-        multi_site_resources: true,
         traffic_filters: true,
         idp_sync: true,
         rest_api: true


### PR DESCRIPTION
These were experimented with and determined to be needlessly complex to roll out since we can just implement more granular gateway routing rules.

---

Resolves: #3133 
Related: #10993 
