### PR TITLE
fix(portal): decrease client heartbeat timeout

### DIFF
--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -43,7 +43,7 @@ defmodule PortalAPI.Endpoint do
       check_origin: :conn,
       connect_info: [:trace_context_headers, :user_agent, :peer_data, :x_headers],
       error_handler: {PortalAPI.Sockets, :handle_error, []},
-      timeout: :timer.seconds(307)
+      timeout: :timer.seconds(37)
     ],
     longpoll: false
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -3115,7 +3115,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", %{resources: _, relays: _, interface: _}
       ref = push(socket, "prepare_connection", %{"resource_id" => Ecto.UUID.generate()})
-      assert_reply ref, :error, %{reason: :not_found}, 1000
+      assert_reply ref, :error, %{reason: :not_found}
     end
 
     test "returns error when there are no online relays", %{

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -3115,7 +3115,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", %{resources: _, relays: _, interface: _}
       ref = push(socket, "prepare_connection", %{"resource_id" => Ecto.UUID.generate()})
-      assert_reply ref, :error, %{reason: :not_found}
+      assert_reply ref, :error, %{reason: :not_found}, 1000
     end
 
     test "returns error when there are no online relays", %{


### PR DESCRIPTION
Clients that are connected to the Firezone control plane currently only timeout after 307 seconds (~5 minutes), meaning that if the client does not explicitly close its WebSocket connection (for example, their device goes to sleep), we will not detect the client as offline for 5 minutes.

This will cause issues for client - client connections because it lengthens the window of time where the portal thinks a client is "online" and able to receive messages.

To alleviate this, we use a similar timeout as the gateway / relay channels here and set this closer to 37s, similar to the gateway/relay timeouts.