### PR TITLE
fix(connlib): reconnect after 3 missed heartbeats

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -5,7 +5,7 @@ mod login_url;
 
 use anyhow::Result;
 use futures::stream::FuturesUnordered;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -25,6 +25,7 @@ use secrecy::{ExposeSecret as _, SecretString};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
 use std::task::{Context, Poll, Waker};
+use tokio_tungstenite::tungstenite::http::header::RETRY_AFTER;
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
     tungstenite::{Message, handshake::client::Request},
@@ -35,7 +36,6 @@ use url::Url;
 pub use get_user_agent::get_user_agent;
 pub use login_url::{DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam};
 pub use tokio_tungstenite::tungstenite::http::StatusCode;
-use tokio_tungstenite::tungstenite::http::header::RETRY_AFTER;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
 
@@ -55,6 +55,7 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 
     heartbeat: tokio::time::Interval,
+    inflight_heartbeats: HashSet<OutboundRequestId>,
 
     _phantom: PhantomData<TInboundMsg>,
 
@@ -215,6 +216,7 @@ enum InternalError {
     SocketConnection(Vec<(SocketAddr, io::Error)>),
     NoAddresses,
     ConnectTimeout,
+    TooManyUnansweredHearbeats,
 }
 
 impl InternalError {
@@ -295,6 +297,9 @@ impl fmt::Display for InternalError {
             InternalError::RoomJoinTimedOut => write!(f, "room join timed out"),
             InternalError::NoAddresses => write!(f, "no IP addresses available"),
             InternalError::ConnectTimeout => write!(f, "connection to portal timed out"),
+            InternalError::TooManyUnansweredHearbeats => {
+                write!(f, "too many heartbeats were unanswered")
+            }
         }
     }
 }
@@ -311,6 +316,7 @@ impl std::error::Error for InternalError {
             InternalError::RoomJoinTimedOut => None,
             InternalError::NoAddresses => None,
             InternalError::ConnectTimeout => None,
+            InternalError::TooManyUnansweredHearbeats => None,
         }
     }
 }
@@ -380,7 +386,8 @@ where
             pending_messages: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
             pending_heartbeat: None,
             _phantom: PhantomData,
-            heartbeat: tokio::time::interval(Duration::from_secs(30)),
+            heartbeat: tokio::time::interval(Duration::from_secs(10)),
+            inflight_heartbeats: Default::default(),
             next_request_id: 0,
             pending_join_requests: Default::default(),
             login,
@@ -767,6 +774,11 @@ where
                                 }));
                             }
 
+                            if self.inflight_heartbeats.remove(&req_id) {
+                                tracing::trace!(%req_id, "Received heartbeat reply");
+                                continue;
+                            }
+
                             tracing::trace!("Received empty reply for request {req_id:?}");
 
                             continue;
@@ -816,14 +828,20 @@ where
             // Priority 4: Handle heartbeats.
             match self.heartbeat.poll_tick(cx) {
                 Poll::Ready(_) => {
-                    let (_, heartbeat) = self
+                    let (id, heartbeat) = self
                         .make_control_message("phoenix", EgressControlMessage::Heartbeat(Empty {}));
 
                     self.pending_heartbeat = Some(heartbeat);
+                    self.inflight_heartbeats.insert(id);
 
                     return Poll::Ready(Ok(Event::HeartbeatSent));
                 }
                 Poll::Pending => {}
+            }
+
+            if self.inflight_heartbeats.len() > 3 {
+                self.reconnect_on_transient_error(InternalError::TooManyUnansweredHearbeats);
+                continue;
             }
 
             return Poll::Pending;

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -562,6 +562,7 @@ where
                         self.backoff = None;
                         self.was_connected = true;
                         self.heartbeat.reset();
+                        self.inflight_heartbeats.clear();
                         self.state = State::Connected(stream);
 
                         // Clear local state.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -216,7 +216,7 @@ enum InternalError {
     SocketConnection(Vec<(SocketAddr, io::Error)>),
     NoAddresses,
     ConnectTimeout,
-    TooManyUnansweredHearbeats,
+    TooManyUnansweredHeartbeats,
 }
 
 impl InternalError {
@@ -297,7 +297,7 @@ impl fmt::Display for InternalError {
             InternalError::RoomJoinTimedOut => write!(f, "room join timed out"),
             InternalError::NoAddresses => write!(f, "no IP addresses available"),
             InternalError::ConnectTimeout => write!(f, "connection to portal timed out"),
-            InternalError::TooManyUnansweredHearbeats => {
+            InternalError::TooManyUnansweredHeartbeats => {
                 write!(f, "too many heartbeats were unanswered")
             }
         }
@@ -316,7 +316,7 @@ impl std::error::Error for InternalError {
             InternalError::RoomJoinTimedOut => None,
             InternalError::NoAddresses => None,
             InternalError::ConnectTimeout => None,
-            InternalError::TooManyUnansweredHearbeats => None,
+            InternalError::TooManyUnansweredHeartbeats => None,
         }
     }
 }
@@ -840,7 +840,7 @@ where
             }
 
             if self.inflight_heartbeats.len() > 3 {
-                self.reconnect_on_transient_error(InternalError::TooManyUnansweredHearbeats);
+                self.reconnect_on_transient_error(InternalError::TooManyUnansweredHeartbeats);
                 continue;
             }
 

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -70,6 +70,10 @@ export default function Android() {
           Notifies the user when a connection to a resource cannot be
           established.
         </ChangeItem>
+        <ChangeItem pull="12248">
+          Re-establishes the WebSocket connection to the control plane if it
+          becomes unresponsive.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -32,6 +32,10 @@ export default function Apple() {
           Notifies the user when a connection to a resource cannot be
           established.
         </ChangeItem>
+        <ChangeItem pull="12248">
+          Re-establishes the WebSocket connection to the control plane if it
+          becomes unresponsive.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.13" date={new Date("2026-01-30")}>
         <ChangeItem pull="11901">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -19,6 +19,10 @@ export default function GUI({ os }: { os: OS }) {
           Notifies the user when a connection to a resource cannot be
           established.
         </ChangeItem>
+        <ChangeItem pull="12248">
+          Re-establishes the WebSocket connection to the control plane if it
+          becomes unresponsive.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.10" date={new Date("2026-02-02")}>
         <ChangeItem pull="11625">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -27,6 +27,10 @@ export default function Gateway() {
           Fixes an issue where outdated and thus irrelevant candidates were sent
           to Clients, causing connectivity issues in rare situations.
         </ChangeItem>
+        <ChangeItem pull="12248">
+          Re-establishes the WebSocket connection to the control plane if it
+          becomes unresponsive.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.0" date={new Date("2026-02-02")}>
         <ChangeItem pull="11771">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -37,6 +37,10 @@ export default function Headless({ os }: { os: OS }) {
           for IPv4-only DNS resources if the setting was only changed after a
           DNS query had already been processed.
         </ChangeItem>
+        <ChangeItem pull="12248">
+          Re-establishes the WebSocket connection to the control plane if it
+          becomes unresponsive.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.6" date={new Date("2026-01-06")}>
         <ChangeItem pull="11627">


### PR DESCRIPTION
The only real reliable way of knowing whether the portal connection works is by performing a handshake. The phoenix channel heartbeat is such a handshake. Right now, we only send those but do not validate the replies.

With this PR, we keep track of the heartbeats that we sent and fail the connection once there are more than 3 missing ones.