### PR TITLE
fix(portal): drain websocket connections

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -81,9 +81,9 @@ jobs:
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: elixir/priv/plts
-          key: dialyzer-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('elixir/mix.lock') }}
+          key: plt-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('elixir/mix.lock') }}
           # This will make sure that we can incrementally build the PLT from older cache and save it under a new key
-          restore-keys: dialyzer-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
+          restore-keys: plt-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
 
       - name: Create PLTs
         # Always run to incrementally update PLT if restored from cache with different mix.lock

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -35,7 +35,8 @@ defmodule PortalAPI.Endpoint do
       error_handler: {PortalAPI.Sockets, :handle_error, []},
       timeout: :timer.seconds(37)
     ],
-    longpoll: false
+    longpoll: false,
+    drainer: []
 
   socket "/client", PortalAPI.Client.Socket,
     websocket: [
@@ -45,7 +46,8 @@ defmodule PortalAPI.Endpoint do
       error_handler: {PortalAPI.Sockets, :handle_error, []},
       timeout: :timer.seconds(37)
     ],
-    longpoll: false
+    longpoll: false,
+    drainer: []
 
   socket "/relay", PortalAPI.Relay.Socket,
     websocket: [
@@ -55,7 +57,8 @@ defmodule PortalAPI.Endpoint do
       error_handler: {PortalAPI.Sockets, :handle_error, []},
       timeout: :timer.seconds(41)
     ],
-    longpoll: false
+    longpoll: false,
+    drainer: []
 
   plug :fetch_user_agent
   plug PortalAPI.Router

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -77,7 +77,8 @@ defmodule PortalWeb.Endpoint do
         session: {__MODULE__, :live_view_session_options, []}
       ]
     ],
-    longpoll: false
+    longpoll: false,
+    drainer: []
 
   def real_ip_opts do
     [


### PR DESCRIPTION
Phoenix.Socket supports gradual socket draining mechanisms. The defaults, closing 15k connections at a time, every 2s, on SIGTERM will take us pretty far.

See https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-options