### PR TITLE
fix(phoenix-channel): handle websocket close frame

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -219,6 +219,7 @@ enum InternalError {
     WebSocket(tungstenite::Error),
     Serde(serde_json::Error),
     CloseMessage,
+    WsClose(Option<tungstenite::protocol::CloseFrame>),
     StreamClosed,
     RoomJoinTimedOut,
     SocketConnection(Vec<(SocketAddr, io::Error)>),
@@ -291,6 +292,13 @@ impl fmt::Display for InternalError {
             InternalError::WebSocket(_) => write!(f, "websocket connection failed"),
             InternalError::Serde(_) => write!(f, "failed to deserialize message"),
             InternalError::CloseMessage => write!(f, "portal closed the websocket connection"),
+            InternalError::WsClose(frame) => {
+                write!(f, "portal sent websocket close frame")?;
+                if let Some(frame) = frame {
+                    write!(f, ": {} {}", frame.code, frame.reason)?;
+                }
+                Ok(())
+            }
             InternalError::StreamClosed => write!(f, "websocket stream was closed"),
             InternalError::SocketConnection(errors) => {
                 write!(
@@ -320,6 +328,7 @@ impl std::error::Error for InternalError {
             InternalError::Serde(e) => Some(e),
             InternalError::SocketConnection(_) => None,
             InternalError::CloseMessage => None,
+            InternalError::WsClose(_) => None,
             InternalError::StreamClosed => None,
             InternalError::RoomJoinTimedOut => None,
             InternalError::NoAddresses => None,
@@ -751,16 +760,10 @@ where
             // Priority 3: Handle incoming messages.
             match stream.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(Message::Close(frame)))) => {
-                    tracing::debug!(?frame, "Portal sent WebSocket close frame");
-                    self.reconnect_on_transient_error(InternalError::StreamClosed);
+                    self.reconnect_on_transient_error(InternalError::WsClose(frame));
                     continue;
                 }
-                Poll::Ready(Some(Ok(message))) => {
-                    let Ok(message) = message.into_text() else {
-                        tracing::warn!("Received non-text message from portal");
-                        continue;
-                    };
-
+                Poll::Ready(Some(Ok(Message::Text(message)))) => {
                     tracing::trace!(target: "wire::api::recv", %message);
 
                     let message =
@@ -849,6 +852,13 @@ where
                             return Poll::Ready(Err(Error::InvalidToken));
                         }
                     }
+                }
+                Poll::Ready(Some(Ok(Message::Binary(_)))) => {
+                    tracing::warn!("Received unexpected binary message from portal");
+                    continue;
+                }
+                Poll::Ready(Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)))) => {
+                    continue;
                 }
                 Poll::Ready(Some(Err(e))) => {
                     self.reconnect_on_transient_error(InternalError::WebSocket(e));

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -759,7 +759,36 @@ where
             // Priority 3: Handle incoming messages.
             match stream.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(Message::Close(frame)))) => {
-                    self.reconnect_on_transient_error(InternalError::WsClose(frame));
+                    // Grab ownership of the `stream`.
+                    let mut stream = match std::mem::replace(&mut self.state, State::Closed) {
+                        State::Connected(stream) => stream,
+                        State::Reconnect { .. }
+                        | State::Connecting(_)
+                        | State::Closing(_)
+                        | State::Closed => {
+                            // Defense-in-depth: This should not happen but never know what kind of bugs we might introduce in the future.
+                            debug_assert!(
+                                false,
+                                "Should be in Connected after receiving Close frame"
+                            );
+                            self.reconnect_on_transient_error(InternalError::WsClose(frame));
+                            continue;
+                        }
+                    };
+
+                    // If an endpoint receives a Close frame and did not previously send a Close frame,
+                    // the endpoint MUST send a Close frame in response.
+                    // See <https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1>.
+                    self.state = State::Connecting(
+                        async move {
+                            let _ = stream.send(Message::Close(frame.clone())).await;
+                            let _ = stream.flush().await;
+                            let _ = SinkExt::close(&mut stream).await;
+
+                            Err(InternalError::WsClose(frame))
+                        }
+                        .boxed(),
+                    );
                     continue;
                 }
                 Poll::Ready(Some(Ok(Message::Text(message)))) => {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -292,12 +292,11 @@ impl fmt::Display for InternalError {
             InternalError::WebSocket(_) => write!(f, "websocket connection failed"),
             InternalError::Serde(_) => write!(f, "failed to deserialize message"),
             InternalError::CloseMessage => write!(f, "portal closed the websocket connection"),
-            InternalError::WsClose(frame) => {
-                write!(f, "portal sent websocket close frame")?;
-                if let Some(frame) = frame {
-                    write!(f, ": {} {}", frame.code, frame.reason)?;
-                }
-                Ok(())
+            InternalError::WsClose(Some(frame)) => {
+                write!(f, "portal sent websocket close frame: {frame}")
+            }
+            InternalError::WsClose(None) => {
+                write!(f, "portal sent empty websocket close frame")
             }
             InternalError::StreamClosed => write!(f, "websocket stream was closed"),
             InternalError::SocketConnection(errors) => {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -750,6 +750,11 @@ where
 
             // Priority 3: Handle incoming messages.
             match stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(Message::Close(frame)))) => {
+                    tracing::debug!(?frame, "Portal sent WebSocket close frame");
+                    self.reconnect_on_transient_error(InternalError::StreamClosed);
+                    continue;
+                }
                 Poll::Ready(Some(Ok(message))) => {
                     let Ok(message) = message.into_text() else {
                         tracing::warn!("Received non-text message from portal");

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -3,7 +3,7 @@
 mod get_user_agent;
 mod login_url;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use futures::stream::FuturesUnordered;
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::net::{IpAddr, SocketAddr};
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, future, marker::PhantomData};
 use std::{io, mem};
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
 use backoff::ExponentialBackoff;
 use backoff::ExponentialBackoffBuilder;
@@ -79,7 +80,7 @@ enum State<TOutboundMsg> {
     Connecting(
         BoxFuture<'static, Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError>>,
     ),
-    Closing(WebSocketStream<MaybeTlsStream<TcpStream>>),
+    Closing(BoxFuture<'static, Result<()>>),
     Closed,
 }
 
@@ -219,7 +220,7 @@ enum InternalError {
     WebSocket(tungstenite::Error),
     Serde(serde_json::Error),
     CloseMessage,
-    WsClose(Option<tungstenite::protocol::CloseFrame>),
+    WsClose(Option<CloseFrame>),
     StreamClosed,
     RoomJoinTimedOut,
     SocketConnection(Vec<(SocketAddr, io::Error)>),
@@ -533,7 +534,27 @@ where
 
         match mem::replace(&mut self.state, State::Closed) {
             State::Connecting(_) => return Err(Connecting),
-            State::Closing(stream) | State::Connected(Connected { stream, .. }) => {
+            State::Connected(Connected { mut stream, .. }) => {
+                self.state = State::Closing(
+                    async move {
+                        stream
+                            .send(Message::Close(Some(CloseFrame {
+                                code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                                reason: Default::default(),
+                            })))
+                            .await
+                            .context("Failed to send Close frame")?;
+                        stream.flush().await.context("Failed to flush")?;
+                        SinkExt::close(&mut stream)
+                            .await
+                            .context("failed to close connection")?;
+
+                        anyhow::Ok(())
+                    }
+                    .boxed(),
+                );
+            }
+            State::Closing(stream) => {
                 self.state = State::Closing(stream);
             }
             State::Closed | State::Reconnect { .. } => {}
@@ -556,7 +577,7 @@ where
                 next_request_id,
             } = match &mut self.state {
                 State::Closed => return Poll::Ready(Ok(Event::Closed)),
-                State::Closing(stream) => match stream.poll_close_unpin(cx) {
+                State::Closing(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(())) => {
                         tracing::info!("Closed websocket connection to portal");
 
@@ -565,7 +586,9 @@ where
                         return Poll::Ready(Ok(Event::Closed));
                     }
                     Poll::Ready(Err(e)) => {
-                        tracing::warn!("Error while closing websocket: {}", err_with_src(&e));
+                        tracing::info!("Error while closing websocket connection to portal: {e:#}");
+
+                        self.state = State::Closed;
 
                         return Poll::Ready(Ok(Event::Closed));
                     }
@@ -761,7 +784,7 @@ where
                 Poll::Ready(Some(Ok(Message::Close(frame)))) => {
                     // Grab ownership of the `stream`.
                     let mut stream = match std::mem::replace(&mut self.state, State::Closed) {
-                        State::Connected(stream) => stream,
+                        State::Connected(Connected { stream, .. }) => stream,
                         State::Reconnect { .. }
                         | State::Connecting(_)
                         | State::Closing(_)

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -4,10 +4,12 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::{future, sync::Arc, time::Duration};
 
+use futures::SinkExt as _;
 use phoenix_channel::{DeviceInfo, Event, LoginUrl, PhoenixChannel, PublicKeyParam};
 use secrecy::SecretString;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
+use tokio::task::JoinError;
 use tokio_tungstenite::tungstenite::http;
 
 #[tokio::test]
@@ -169,7 +171,7 @@ async fn client_deduplicates_messages() {
 
     let _ = tokio::time::timeout(
         Duration::from_secs(2),
-        futures::future::join(server, client),
+        futures::future::join(server.wait(), client),
     )
     .await
     .unwrap_err(); // We expect to timeout because we don't ever exit from the tasks.
@@ -232,7 +234,63 @@ async fn client_clears_local_message_on_connect() {
     };
 
     client.await;
-    server.await.unwrap();
+    server.wait().await;
+}
+
+#[tokio::test]
+async fn replies_with_close_frame_upon_close() {
+    use phoenix_channel::PublicKeyParam;
+
+    let _guard = logging::test("debug,wire::api=trace");
+
+    let (server, port) = spawn_websocket_server(|text| {
+        match text {
+            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
+                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+            }
+            other => panic!("Unexpected message: {other}"),
+        }
+    })
+    .await;
+
+    let mut channel = make_websocket_test_channel(port);
+
+    let (mut join_tx, mut join_rx) = futures::channel::mpsc::channel(1);
+
+    let client = tokio::spawn(async move {
+        channel.connect(PublicKeyParam([0u8; 32]));
+
+        loop {
+            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+                phoenix_channel::Event::SuccessResponse { .. } => {}
+                phoenix_channel::Event::ErrorResponse { res, .. } => {
+                    panic!("Unexpected error: {res:?}")
+                }
+                phoenix_channel::Event::JoinedRoom { .. } => {
+                    join_tx.send(()).await.unwrap();
+                }
+                phoenix_channel::Event::HeartbeatSent => {}
+                phoenix_channel::Event::InboundMessage { .. } => {}
+                phoenix_channel::Event::Hiccup { error, .. } => break error,
+                phoenix_channel::Event::NoAddresses => {
+                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
+                }
+                phoenix_channel::Event::Closed => panic!("Should not close"),
+            }
+        }
+    });
+
+    join_rx.recv().await.unwrap(); // Wait for successful join.
+
+    let server_result = server.stop().await;
+    let client_result = client.await.unwrap();
+
+    server_result.unwrap(); // Server should shutdown cleanly.
+
+    assert_eq!(
+        format!("{client_result:#}"),
+        "Reconnecting to portal on transient error: portal sent empty websocket close frame"
+    );
 }
 
 #[tokio::test]
@@ -455,7 +513,7 @@ async fn does_not_clear_address_from_url_on_hiccup() {
 
 /// Spawns a WebSocket server that responds to requests using a handler function.
 /// Returns the server task handle and the port number.
-async fn spawn_websocket_server<F>(handler: F) -> (tokio::task::JoinHandle<()>, u16)
+async fn spawn_websocket_server<F>(handler: F) -> (ServerHandle, u16)
 where
     F: Fn(&str) -> &str + Send + 'static,
 {
@@ -465,27 +523,57 @@ where
 
     let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
+    let (close_tx, mut close_rx) = futures::channel::mpsc::channel(1);
 
     let server = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
         let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
 
         loop {
-            match ws.next().await {
-                Some(Ok(Message::Text(text))) => {
+            match futures::future::select(ws.next(), close_rx.recv()).await {
+                futures::future::Either::Left((Some(Ok(Message::Text(text))), _)) => {
                     let response = handler(text.as_str());
                     ws.send(Message::text(response)).await.unwrap();
                 }
-                Some(Ok(Message::Close(_))) => continue,
-                Some(other) => {
+                futures::future::Either::Left((Some(Ok(Message::Close(_))), _)) => continue,
+                futures::future::Either::Left((Some(other), _)) => {
                     panic!("Unexpected message: {other:?}")
                 }
-                None => break,
+                futures::future::Either::Left((None, _)) => break,
+                futures::future::Either::Right((Err(_), _)) => continue,
+                futures::future::Either::Right((Ok(()), _)) => {
+                    ws.close(None).await.unwrap();
+                    ws.flush().await.unwrap();
+                    SinkExt::close(&mut ws).await.unwrap();
+                }
             }
         }
     });
 
-    (server, port)
+    (
+        ServerHandle {
+            task: server,
+            close_tx,
+        },
+        port,
+    )
+}
+
+struct ServerHandle {
+    task: tokio::task::JoinHandle<()>,
+    close_tx: futures::channel::mpsc::Sender<()>,
+}
+
+impl ServerHandle {
+    async fn stop(mut self) -> Result<(), JoinError> {
+        let _ = self.close_tx.send(()).await;
+
+        self.task.await
+    }
+
+    async fn wait(self) {
+        self.task.await.unwrap()
+    }
 }
 
 fn make_websocket_test_channel(

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -276,6 +276,7 @@ async fn replies_with_close_frame_upon_close() {
                     channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Closed => panic!("Should not close"),
+                phoenix_channel::Event::Connected => {}
             }
         }
     });
@@ -573,6 +574,10 @@ impl ServerHandle {
 
     async fn wait(self) {
         self.task.await.unwrap()
+    }
+
+    fn abort(self) {
+        self.task.abort();
     }
 }
 

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12251">
+          Gracefully handles WebSocket closes from the portal instead of logging
+          a deserialization error.
+        </ChangeItem>
         <ChangeItem pull="#12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -29,6 +29,10 @@ export default function Apple() {
           Bumps minimum iOS version from 15.6 to 16.0 to enable SwiftUI
           NavigationStack and NavigationSplitView API.
         </ChangeItem>
+        <ChangeItem pull="12251">
+          Gracefully handles WebSocket closes from the portal instead of logging
+          a deserialization error.
+        </ChangeItem>
         <ChangeItem pull="11988">
           Fixes a crash if the currently active log file gets deleted.
         </ChangeItem>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,10 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12251">
+          Gracefully handles WebSocket closes from the portal instead of logging
+          a deserialization error.
+        </ChangeItem>
         <ChangeItem pull="#12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -23,6 +23,10 @@ export default function Gateway() {
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
+        <ChangeItem pull="12251">
+          Gracefully handles WebSocket closes from the portal instead of logging
+          a deserialization error.
+        </ChangeItem>
         <ChangeItem pull="12134">
           Fixes an issue where outdated and thus irrelevant candidates were sent
           to Clients, causing connectivity issues in rare situations.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,10 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12251">
+          Gracefully handles WebSocket closes from the portal instead of logging
+          a deserialization error.
+        </ChangeItem>
         <ChangeItem pull="#12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.


### PR DESCRIPTION
The final message in a WebSocket connection is a Close frame. Close frames may have an optional code and reason. The previous use of `Message::into_text` used the Close frame's reason text to try and deserialize a message.

This misinterpretation resulted in a deserialisation error every time the portal gracefully closed the WebSocket connection, such as during a deploy. To fix this, we now explicitly match on each variant of `Message` and only try to deserialize them when they are an actual message.

According to https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1, an endpoint MUST reply with a Close frame if it hasn't sent one already. In addition to that, we now also first send a Close frame before closing the connection.