### PR TITLE
fix(phoenix-channel): introduce ephemeral `Connected` state

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -593,7 +593,12 @@ async fn phoenix_channel_event_loop(
                 break;
             }
             Either::Right((Some(PortalCommand::Send(msg)), _)) => {
-                portal.send(PHOENIX_TOPIC, msg);
+                match portal.send(PHOENIX_TOPIC, msg) {
+                    Ok(()) => {}
+                    Err(phoenix_channel::NotConnected(msg)) => {
+                        tracing::debug!(?msg, "Failed to send message to portal: Not connected")
+                    }
+                }
             }
             Either::Right((Some(PortalCommand::Connect(param)), _)) => {
                 portal.connect(param);

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -586,6 +586,7 @@ async fn phoenix_channel_event_loop(
             Either::Left((Ok(phoenix_channel::Event::NoAddresses), _)) => {
                 update_portal_host_ips(&mut portal, &resolver).await
             }
+            Either::Left((Ok(phoenix_channel::Event::Connected), _)) => {}
             Either::Left((Err(e), _)) => {
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -594,6 +594,7 @@ async fn phoenix_channel_event_loop(
                 let ips = resolve_portal_host_ips(portal.host(), &udp_dns_client).await;
                 portal.update_ips(ips);
             }
+            Either::Right((Ok(phoenix_channel::Event::Connected), _)) => {}
             Either::Right((Err(e), _)) => {
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -536,7 +536,12 @@ async fn phoenix_channel_event_loop(
         // This allows `NoAddresses` events to use the updated `UdpDnsClient` to resolve the domain.
         match select(pin!(cmd_rx.recv()), poll_fn(|cx| portal.poll(cx))).await {
             Either::Left((Some(PortalCommand::Send(msg)), _)) => {
-                portal.send(PHOENIX_TOPIC, msg);
+                match portal.send(PHOENIX_TOPIC, msg) {
+                    Ok(()) => {}
+                    Err(phoenix_channel::NotConnected(msg)) => {
+                        tracing::debug!(?msg, "Failed to send message to portal: Not connected")
+                    }
+                }
             }
             Either::Left((Some(PortalCommand::Connect(param)), _)) => {
                 portal.connect(param);

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -605,7 +605,7 @@ where
                         tracing::info!(%host, "Connected to portal");
                         self.join(self.login, self.init_req.clone());
 
-                        continue;
+                        return Poll::Ready(Ok(Event::Connected));
                     }
                     Poll::Ready(Err(InternalError::NoAddresses)) => {
                         // Fixed 1s interval to avoid busy-looping in case DNS resolution fails / is not possible.
@@ -966,6 +966,8 @@ pub enum Event<TInboundMsg> {
     NoAddresses,
     /// The connection was closed successfully.
     Closed,
+    /// The WebSocket connection was established.
+    Connected,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -468,7 +468,7 @@ where
             return;
         }
 
-        // 1. Reset the backoff and local state.
+        // 1. Reset the backoff.
         self.backoff = None;
 
         // 2. Set state to `Connecting` without a timer.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -411,7 +411,7 @@ where
             ..
         }) = &mut self.state
         else {
-            tracing::debug!(%topic, "Cannot join topic while being disconnected");
+            tracing::debug!(%topic, "Cannot join topic when disconnected");
             return;
         };
 
@@ -435,7 +435,7 @@ where
             ..
         }) = &mut self.state
         else {
-            tracing::debug!(%topic, "Cannot send message while disconnected");
+            tracing::debug!(%topic, "Cannot send message when disconnected");
             return;
         };
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -42,24 +42,17 @@ const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are
 const INITIAL_CONNECT_MAX_ELAPSED_TIME: Duration = Duration::from_secs(15);
 const INITIAL_CONNECT_INTERVAL: Duration = Duration::from_secs(1);
 
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
 /// Overall timeout for a single connection attempt (TCP + TLS + WebSocket handshake).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
-    state: State,
+    state: State<TOutboundMsg>,
     waker: Option<Waker>,
-    pending_joins: VecDeque<String>,
-    pending_messages: VecDeque<PhoenixMessage<TOutboundMsg>>,
-    pending_heartbeat: Option<String>,
-    next_request_id: u64,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 
-    heartbeat: tokio::time::Interval,
-    inflight_heartbeats: HashSet<OutboundRequestId>,
-
     _phantom: PhantomData<TInboundMsg>,
-
-    pending_join_requests: BTreeMap<OutboundRequestId, Instant>,
 
     // Stored here to allow re-connecting.
     url_prototype: LoginUrl<TFinish>,
@@ -78,11 +71,11 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     init_req: TInitReq,
 }
 
-enum State {
+enum State<TOutboundMsg> {
     Reconnect {
         backoff: Duration,
     },
-    Connected(WebSocketStream<MaybeTlsStream<TcpStream>>),
+    Connected(Connected<TOutboundMsg>),
     Connecting(
         BoxFuture<'static, Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError>>,
     ),
@@ -90,7 +83,22 @@ enum State {
     Closed,
 }
 
-impl State {
+struct Connected<TOutboundMsg> {
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+
+    heartbeat: tokio::time::Interval,
+    inflight_heartbeats: HashSet<OutboundRequestId>,
+    pending_heartbeat: Option<String>,
+
+    pending_joins: VecDeque<String>,
+    pending_join_requests: BTreeMap<OutboundRequestId, Instant>,
+
+    pending_messages: VecDeque<PhoenixMessage<TOutboundMsg>>,
+
+    next_request_id: u64,
+}
+
+impl<TOutboundMsg> State<TOutboundMsg> {
     fn connect(
         url: Url,
         addresses: Vec<SocketAddr>,
@@ -382,14 +390,7 @@ where
             state: State::Closed,
             socket_factory,
             waker: None,
-            pending_joins: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
-            pending_messages: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
-            pending_heartbeat: None,
             _phantom: PhantomData,
-            heartbeat: tokio::time::interval(Duration::from_secs(10)),
-            inflight_heartbeats: Default::default(),
-            next_request_id: 0,
-            pending_join_requests: Default::default(),
             login,
             init_req,
             resolved_addresses: Default::default(),
@@ -401,25 +402,44 @@ where
     ///
     /// If successful, a [`Event::JoinedRoom`] event will be emitted.
     pub fn join(&mut self, topic: impl Into<String>, payload: TInitReq) {
-        let (request_id, msg) =
-            self.make_control_message(topic, EgressControlMessage::PhxJoin(payload));
+        let topic = topic.into();
 
-        self.pending_joins.push_back(msg);
-        self.pending_join_requests
-            .insert(request_id, Instant::now());
+        let State::Connected(Connected {
+            pending_joins,
+            pending_join_requests,
+            next_request_id,
+            ..
+        }) = &mut self.state
+        else {
+            tracing::debug!(%topic, "Cannot join topic while being disconnected");
+            return;
+        };
+
+        let (request_id, msg) = make_control_message(
+            next_request_id,
+            topic,
+            EgressControlMessage::PhxJoin(payload),
+        );
+
+        pending_joins.push_back(msg);
+        pending_join_requests.insert(request_id, Instant::now());
     }
 
     /// Send a message to a topic.
     pub fn send(&mut self, topic: impl Into<String>, message: TOutboundMsg) {
-        if self.pending_messages.len() > MAX_BUFFERED_MESSAGES {
-            self.pending_messages.clear();
+        let topic = topic.into();
 
-            tracing::debug!(
-                "Dropping pending messages to portal because we exceeded the maximum of {MAX_BUFFERED_MESSAGES}"
-            );
-        }
+        let State::Connected(Connected {
+            pending_messages,
+            next_request_id,
+            ..
+        }) = &mut self.state
+        else {
+            tracing::debug!(%topic, "Cannot send message while disconnected");
+            return;
+        };
 
-        if self.pending_messages.iter().any(|m| match &m.payload {
+        if pending_messages.iter().any(|m| match &m.payload {
             Payload::Message(m) => m == &message,
             Payload::Reply(_) => false,
             Payload::Error(_) => false,
@@ -430,9 +450,9 @@ where
             return;
         }
 
-        let request_id = self.fetch_add_request_id();
+        let request_id = fetch_add_request_id(next_request_id);
 
-        self.pending_messages.push_back(PhoenixMessage::new_message(
+        pending_messages.push_back(PhoenixMessage::new_message(
             topic,
             message,
             Some(request_id),
@@ -450,7 +470,6 @@ where
 
         // 1. Reset the backoff and local state.
         self.backoff = None;
-        self.pending_messages.clear();
 
         // 2. Set state to `Connecting` without a timer.
         let user_agent = self.user_agent.clone();
@@ -497,7 +516,7 @@ where
 
         match mem::replace(&mut self.state, State::Closed) {
             State::Connecting(_) => return Err(Connecting),
-            State::Closing(stream) | State::Connected(stream) => {
+            State::Closing(stream) | State::Connected(Connected { stream, .. }) => {
                 self.state = State::Closing(stream);
             }
             State::Closed | State::Reconnect { .. } => {}
@@ -509,7 +528,16 @@ where
     pub fn poll(&mut self, cx: &mut Context) -> Poll<Result<Event<TInboundMsg>, Error>> {
         loop {
             // First, check if we are connected.
-            let stream = match &mut self.state {
+            let Connected {
+                stream,
+                heartbeat,
+                inflight_heartbeats,
+                pending_heartbeat,
+                pending_joins,
+                pending_join_requests,
+                pending_messages,
+                next_request_id,
+            } = match &mut self.state {
                 State::Closed => return Poll::Ready(Ok(Event::Closed)),
                 State::Closing(stream) => match stream.poll_close_unpin(cx) {
                     Poll::Ready(Ok(())) => {
@@ -561,14 +589,16 @@ where
                     Poll::Ready(Ok(stream)) => {
                         self.backoff = None;
                         self.was_connected = true;
-                        self.heartbeat.reset();
-                        self.inflight_heartbeats.clear();
-                        self.state = State::Connected(stream);
-
-                        // Clear local state.
-                        // Joins are only valid whilst we are connected, so we need to discard any previous ones on reconnect.
-                        self.pending_joins.clear();
-                        self.pending_join_requests.clear();
+                        self.state = State::Connected(Connected {
+                            stream,
+                            heartbeat: tokio::time::interval(HEARTBEAT_INTERVAL),
+                            inflight_heartbeats: Default::default(),
+                            pending_heartbeat: Default::default(),
+                            pending_joins: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
+                            pending_join_requests: Default::default(),
+                            pending_messages: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
+                            next_request_id: 0,
+                        });
 
                         let (host, _) = self.url_prototype.host_and_port();
 
@@ -644,7 +674,7 @@ where
             // Priority 2: Keep local buffers small and send pending messages.
             match stream.poll_ready_unpin(cx) {
                 Poll::Ready(Ok(())) => {
-                    if let Some(heartbeat) = self.pending_heartbeat.take() {
+                    if let Some(heartbeat) = pending_heartbeat.take() {
                         match stream.start_send_unpin(Message::Text(heartbeat.clone().into())) {
                             Ok(()) => {
                                 tracing::trace!(target: "wire::api::send", %heartbeat);
@@ -657,15 +687,15 @@ where
                         continue;
                     }
 
-                    if let Some(join) = self.pending_joins.pop_front() {
+                    if let Some(join) = pending_joins.pop_front() {
                         match stream.start_send_unpin(Message::Text(join.clone().into())) {
                             Ok(()) => {
                                 tracing::trace!(target: "wire::api::send", %join);
 
-                                self.heartbeat.reset()
+                                heartbeat.reset()
                             }
                             Err(e) => {
-                                self.pending_joins.push_front(join);
+                                pending_joins.push_front(join);
                                 self.reconnect_on_transient_error(InternalError::WebSocket(e));
                             }
                         }
@@ -673,8 +703,8 @@ where
                         continue;
                     }
 
-                    if self.pending_join_requests.is_empty() {
-                        if let Some(msg) = self.pending_messages.pop_front() {
+                    if pending_join_requests.is_empty() {
+                        if let Some(msg) = pending_messages.pop_front() {
                             let serialized_msg = serde_json::to_string(&msg)
                                 .map_err(io::Error::other)
                                 .map_err(Error::FatalIo)?;
@@ -685,19 +715,19 @@ where
                                 Ok(()) => {
                                     tracing::trace!(target: "wire::api::send", msg = %serialized_msg);
 
-                                    self.heartbeat.reset()
+                                    heartbeat.reset()
                                 }
                                 Err(e) => {
-                                    self.pending_messages.push_front(msg);
+                                    pending_messages.push_front(msg);
                                     self.reconnect_on_transient_error(InternalError::WebSocket(e));
                                 }
                             }
 
                             continue;
                         }
-                    } else if !self.pending_messages.is_empty() {
+                    } else if !pending_messages.is_empty() {
                         tracing::trace!(
-                            requests = ?self.pending_join_requests,
+                            requests = ?pending_join_requests,
                             "Unable to send message because we are waiting for JOIN requests to complete"
                         );
                     }
@@ -748,7 +778,7 @@ where
                         }
                         (Payload::Reply(Reply::Error { reason }), Some(req_id)) => {
                             if message.topic == self.login
-                                && self.pending_join_requests.contains_key(&req_id)
+                                && pending_join_requests.contains_key(&req_id)
                             {
                                 return Poll::Ready(Err(Error::LoginFailed(reason)));
                             }
@@ -766,7 +796,7 @@ where
                             }));
                         }
                         (Payload::Reply(Reply::Ok(OkReply::NoMessage(Empty {}))), Some(req_id)) => {
-                            if self.pending_join_requests.remove(&req_id).is_some() {
+                            if pending_join_requests.remove(&req_id).is_some() {
                                 tracing::debug!("Joined {} room on portal", message.topic);
 
                                 // For `phx_join` requests, `reply` is empty so we can safely ignore it.
@@ -775,7 +805,7 @@ where
                                 }));
                             }
 
-                            if self.inflight_heartbeats.remove(&req_id) {
+                            if inflight_heartbeats.remove(&req_id) {
                                 tracing::trace!(%req_id, "Received heartbeat reply");
                                 continue;
                             }
@@ -817,8 +847,7 @@ where
                 Poll::Pending => {}
             }
 
-            if self
-                .pending_join_requests
+            if pending_join_requests
                 .values()
                 .any(|sent_at| sent_at.elapsed() > Duration::from_secs(5))
             {
@@ -827,20 +856,23 @@ where
             }
 
             // Priority 4: Handle heartbeats.
-            match self.heartbeat.poll_tick(cx) {
+            match heartbeat.poll_tick(cx) {
                 Poll::Ready(_) => {
-                    let (id, heartbeat) = self
-                        .make_control_message("phoenix", EgressControlMessage::Heartbeat(Empty {}));
+                    let (id, heartbeat) = make_control_message(
+                        next_request_id,
+                        "phoenix",
+                        EgressControlMessage::<()>::Heartbeat(Empty {}),
+                    );
 
-                    self.pending_heartbeat = Some(heartbeat);
-                    self.inflight_heartbeats.insert(id);
+                    pending_heartbeat.replace(heartbeat);
+                    inflight_heartbeats.insert(id);
 
                     return Poll::Ready(Ok(Event::HeartbeatSent));
                 }
                 Poll::Pending => {}
             }
 
-            if self.inflight_heartbeats.len() > 3 {
+            if inflight_heartbeats.len() > 3 {
                 self.reconnect_on_transient_error(InternalError::TooManyUnansweredHeartbeats);
                 continue;
             }
@@ -856,27 +888,6 @@ where
         self.state = State::Connecting(future::ready(Err(e)).boxed())
     }
 
-    fn make_control_message(
-        &mut self,
-        topic: impl Into<String>,
-        payload: EgressControlMessage<TInitReq>,
-    ) -> (OutboundRequestId, String) {
-        let request_id = self.fetch_add_request_id();
-
-        // We don't care about the reply type when serializing
-        let msg = serialize_msg(topic, payload, request_id.copy());
-
-        (request_id, msg)
-    }
-
-    fn fetch_add_request_id(&mut self) -> OutboundRequestId {
-        let id = self.next_request_id;
-
-        self.next_request_id += 1;
-
-        OutboundRequestId(id)
-    }
-
     fn socket_addresses(&self) -> Vec<SocketAddr> {
         let (host, port) = self.url_prototype.host_and_port();
 
@@ -887,6 +898,30 @@ where
             .map(|ip| SocketAddr::new(ip, port))
             .collect()
     }
+}
+
+fn make_control_message<TInitReq>(
+    next_request_id: &mut u64,
+    topic: impl Into<String>,
+    payload: EgressControlMessage<TInitReq>,
+) -> (OutboundRequestId, String)
+where
+    TInitReq: serde::Serialize,
+{
+    let request_id = fetch_add_request_id(next_request_id);
+
+    // We don't care about the reply type when serializing
+    let msg = serialize_msg(topic, payload, request_id.copy());
+
+    (request_id, msg)
+}
+
+fn fetch_add_request_id(next_request_id: &mut u64) -> OutboundRequestId {
+    let id = *next_request_id;
+
+    *next_request_id += 1;
+
+    OutboundRequestId(id)
 }
 
 fn make_initial_backoff() -> ExponentialBackoff {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -357,6 +357,10 @@ impl fmt::Display for OutboundRequestId {
 #[error("Cannot close websocket while we are connecting")]
 pub struct Connecting;
 
+#[derive(Debug, thiserror::Error)]
+#[error("Not connected")]
+pub struct NotConnected<T>(pub T);
+
 impl<TInitReq, TOutboundMsg, TInboundMsg, TFinish>
     PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish>
 where
@@ -426,7 +430,11 @@ where
     }
 
     /// Send a message to a topic.
-    pub fn send(&mut self, topic: impl Into<String>, message: TOutboundMsg) {
+    pub fn send(
+        &mut self,
+        topic: impl Into<String>,
+        message: TOutboundMsg,
+    ) -> Result<(), NotConnected<TOutboundMsg>> {
         let topic = topic.into();
 
         let State::Connected(Connected {
@@ -435,8 +443,7 @@ where
             ..
         }) = &mut self.state
         else {
-            tracing::debug!(%topic, "Cannot send message when disconnected");
-            return;
+            return Err(NotConnected(message));
         };
 
         if pending_messages.iter().any(|m| match &m.payload {
@@ -447,7 +454,7 @@ where
             Payload::Disconnect { .. } => false,
         }) {
             tracing::debug!(?message, "Refusing to queue exact duplicate");
-            return;
+            return Ok(());
         }
 
         let request_id = fetch_add_request_id(next_request_id);
@@ -457,6 +464,8 @@ where
             message,
             Some(request_id),
         ));
+
+        Ok(())
     }
 
     /// Establishes a new connection, dropping the current one if any exists.

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -32,7 +32,7 @@ async fn client_does_not_pipeline_messages() {
         loop {
             match ws.next().await {
                 Some(Ok(Message::Text(text))) => match text.as_str() {
-                    r#"{"topic":"test","event":"phx_join","payload":null,"ref":1}"# => {
+                    r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
                         // The real Elixir backend processes messages in parallel and therefore may drop messages if we pipeline them instead of waiting for the channel join.
                         // This is difficult to assert in a test because we need to mimic this behaviour of not processing messages sequentially.
                         // The way we assert this is by checking, whether any messages are pipelined.
@@ -44,10 +44,10 @@ async fn client_does_not_pipeline_messages() {
                         }
 
                         ws.send(Message::text(
-                            r#"{"event":"phx_reply","ref":1,"topic":"client","payload":{"status":"ok","response":{}}}"#,
+                            r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#,
                         )).await.unwrap();
                     }
-                    r#"{"topic":"test","event":"bar","ref":0}"# => {
+                    r#"{"topic":"test","event":"bar","ref":1}"# => {
                         ws.send(Message::text(
                             r#"{"topic":"test","event":"foo","payload":null}"#,
                         ))
@@ -69,7 +69,6 @@ async fn client_does_not_pipeline_messages() {
 
     let client = async move {
         channel.connect(PublicKeyParam([0u8; 32]));
-        channel.send("test", OutboundMsg::Bar);
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
@@ -92,6 +91,9 @@ async fn client_does_not_pipeline_messages() {
                     panic!("Unexpected hiccup: {error:?}")
                 }
                 phoenix_channel::Event::Closed => break,
+                phoenix_channel::Event::Connected => {
+                    channel.send("test", OutboundMsg::Bar);
+                }
             }
         }
     };
@@ -160,6 +162,7 @@ async fn client_deduplicates_messages() {
                     channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Closed => break,
+                phoenix_channel::Event::Connected => {}
             }
         }
     };
@@ -182,8 +185,8 @@ async fn client_clears_local_message_on_connect() {
 
     let (server, port) = spawn_websocket_server(|text| {
         match text {
-            r#"{"topic":"test","event":"phx_join","payload":null,"ref":2}"# => {
-                r#"{"event":"phx_reply","ref":2,"topic":"client","payload":{"status":"ok","response":{}}}"#
+            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
+                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
             }
             // We only handle the message with `ref: 1` and thus guarantee that the first one is not received.
             r#"{"topic":"test","event":"bar","ref":1}"# => {
@@ -199,7 +202,6 @@ async fn client_clears_local_message_on_connect() {
     let client = async {
         channel.send("test", OutboundMsg::Bar);
         channel.connect(PublicKeyParam([0u8; 32]));
-        channel.send("test", OutboundMsg::Bar);
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
@@ -207,7 +209,9 @@ async fn client_clears_local_message_on_connect() {
                 phoenix_channel::Event::ErrorResponse { res, .. } => {
                     panic!("Unexpected error: {res:?}")
                 }
-                phoenix_channel::Event::JoinedRoom { .. } => {}
+                phoenix_channel::Event::JoinedRoom { .. } => {
+                    channel.send("test", OutboundMsg::Bar);
+                }
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
@@ -222,6 +226,7 @@ async fn client_clears_local_message_on_connect() {
                     channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Closed => break,
+                phoenix_channel::Event::Connected => {}
             }
         }
     };
@@ -280,6 +285,7 @@ async fn times_out_after_missed_heartbeats() {
                 phoenix_channel::Event::Closed => {
                     panic!("Channel closed")
                 }
+                phoenix_channel::Event::Connected => {}
             }
         }
     };

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -92,7 +92,7 @@ async fn client_does_not_pipeline_messages() {
                 }
                 phoenix_channel::Event::Closed => break,
                 phoenix_channel::Event::Connected => {
-                    channel.send("test", OutboundMsg::Bar);
+                    channel.send("test", OutboundMsg::Bar).unwrap();
                 }
             }
         }
@@ -143,10 +143,10 @@ async fn client_deduplicates_messages() {
                     panic!("Unexpected error: {res:?}")
                 }
                 phoenix_channel::Event::JoinedRoom { .. } => {
-                    channel.send("test", OutboundMsg::Bar);
-                    channel.send("test", OutboundMsg::Bar);
-                    channel.send("test", OutboundMsg::Bar);
-                    channel.send("test", OutboundMsg::Bar);
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                    channel.send("test", OutboundMsg::Bar).unwrap();
                 }
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
@@ -200,7 +200,7 @@ async fn client_clears_local_message_on_connect() {
     let mut channel = make_websocket_test_channel(port);
 
     let client = async {
-        channel.send("test", OutboundMsg::Bar);
+        channel.send("test", OutboundMsg::Bar).unwrap_err();
         channel.connect(PublicKeyParam([0u8; 32]));
 
         loop {
@@ -210,7 +210,7 @@ async fn client_clears_local_message_on_connect() {
                     panic!("Unexpected error: {res:?}")
                 }
                 phoenix_channel::Event::JoinedRoom { .. } => {
-                    channel.send("test", OutboundMsg::Bar);
+                    channel.send("test", OutboundMsg::Bar).unwrap();
                 }
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -801,6 +801,7 @@ async fn phoenix_channel_event_loop(
                 is_connected.store(false, Ordering::Relaxed);
                 tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}");
             }
+            Ok(Event::Connected) => {}
             Err(e) => {
                 is_connected.store(false, Ordering::Relaxed);
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.


### PR DESCRIPTION
The `PhoenixChannel` component is designed to be stateful in order to allow for reconnects when the connection fails. Several aspects of its state however are tied to a particular instance of the connection. For example, queued "join" messages for a topic only make sense within the scope of a particular connection. When the WebSocket connection gets teared down, these need to be cleared.

It is easy to forget to clear this kind of state. To prevent further bugs in this code, we introduce a dedicated `Connected` state which holds all pieces of state that are specific to a certain connection. As soon as we disconnect, the entire `Connected` state is discarded and only recreated once the connection is reestablished.