### PR TITLE
fix(portal): better discovery document uri validation

### DIFF
--- a/elixir/lib/portal/entra/auth_provider.ex
+++ b/elixir/lib/portal/entra/auth_provider.ex
@@ -1,6 +1,7 @@
 defmodule Portal.Entra.AuthProvider do
   use Ecto.Schema
   import Ecto.Changeset
+  import Portal.Changeset
 
   @primary_key false
   @foreign_key_type :binary_id
@@ -48,6 +49,7 @@ defmodule Portal.Entra.AuthProvider do
     |> validate_required([:name, :context, :issuer, :is_verified])
     |> validate_acceptance(:is_verified)
     |> validate_length(:issuer, min: 1, max: 2_000)
+    |> validate_uri(:issuer, block_private_ips: true)
     |> validate_number(:portal_session_lifetime_secs,
       greater_than_or_equal_to: @portal_session_lifetime_min,
       less_than_or_equal_to: @portal_session_lifetime_max

--- a/elixir/lib/portal/oidc/auth_provider.ex
+++ b/elixir/lib/portal/oidc/auth_provider.ex
@@ -65,7 +65,7 @@ defmodule Portal.OIDC.AuthProvider do
     |> validate_acceptance(:is_verified)
     |> validate_length(:client_id, min: 1, max: 255)
     |> validate_length(:client_secret, min: 1, max: 255)
-    |> validate_uri(:discovery_document_uri)
+    |> validate_uri(:discovery_document_uri, block_private_ips: true)
     |> validate_length(:discovery_document_uri, min: 1, max: 2000)
     |> validate_length(:issuer, min: 1, max: 2000)
     |> validate_number(:portal_session_lifetime_secs,

--- a/elixir/lib/portal/okta/auth_provider.ex
+++ b/elixir/lib/portal/okta/auth_provider.ex
@@ -63,7 +63,7 @@ defmodule Portal.Okta.AuthProvider do
     |> validate_acceptance(:is_verified)
     |> put_discovery_document_uri()
     |> validate_required(:discovery_document_uri)
-    |> validate_uri(:discovery_document_uri)
+    |> validate_uri(:discovery_document_uri, block_private_ips: true)
     |> validate_length(:okta_domain, min: 1, max: 255)
     |> validate_fqdn(:okta_domain)
     |> validate_length(:issuer, min: 1, max: 2_000)

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -1219,7 +1219,7 @@ defmodule PortalWeb.Settings.Authentication do
           "Unable to fetch discovery document: Connection timed out. Please try again."
 
         _ ->
-          "Unable to fetch discovery document: #{inspect(reason)}. Please check your network connection."
+          "Unable to fetch discovery document. Please check your network connection."
       end
 
     add_verification_error(msg, field, socket)
@@ -1227,11 +1227,11 @@ defmodule PortalWeb.Settings.Authentication do
 
   # HTTP protocol errors
   defp handle_verification_setup_error(
-         {:error, %Req.HTTPError{protocol: protocol, reason: reason}},
+         {:error, %Req.HTTPError{protocol: _protocol, reason: _reason}},
          field,
          socket
        ) do
-    msg = "Identity provider returned a #{protocol} protocol error: #{inspect(reason)}."
+    msg = "Identity provider returned an unexpected protocol error. Please try again."
     add_verification_error(msg, field, socket)
   end
 
@@ -1245,9 +1245,6 @@ defmodule PortalWeb.Settings.Authentication do
 
         {status, _} when status in 500..599 ->
           "Identity provider returned a server error (HTTP #{status}). Please try again later."
-
-        {status, %{"error" => error_code}} ->
-          "Identity provider returned an error: #{error_code} (HTTP #{status})."
 
         {status, _} ->
           "Failed to fetch discovery document (HTTP #{status}). Please verify your configuration."
@@ -1279,6 +1276,12 @@ defmodule PortalWeb.Settings.Authentication do
     add_verification_error(msg, field, socket)
   end
 
+  # Private IP blocked
+  defp handle_verification_setup_error({:error, :private_ip_blocked}, field, socket) do
+    msg = "The Discovery Document URI must not point to a private or reserved IP address."
+    add_verification_error(msg, field, socket)
+  end
+
   # Catch-all for unexpected errors
   defp handle_verification_setup_error({:error, reason}, field, socket) do
     Logger.info(
@@ -1287,7 +1290,7 @@ defmodule PortalWeb.Settings.Authentication do
       reason: reason
     )
 
-    msg = "An unexpected error occurred: #{inspect(reason)}. Please try again or contact support."
+    msg = "An unexpected error occurred. Please try again or contact support."
     add_verification_error(msg, field, socket)
   end
 

--- a/elixir/test/portal/changeset_test.exs
+++ b/elixir/test/portal/changeset_test.exs
@@ -1,0 +1,36 @@
+defmodule Portal.ChangesetTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Changeset
+
+  describe "private_ip?/1" do
+    test "blocks IPv4-mapped IPv6 addresses when embedded IPv4 is blocked" do
+      for ip <- ["::ffff:127.0.0.1", "::ffff:169.254.169.254", "::ffff:10.0.0.1"] do
+        assert Changeset.private_ip?(parse_ip!(ip)), "Expected #{ip} to be blocked"
+      end
+    end
+
+    test "allows IPv4-mapped IPv6 addresses when embedded IPv4 is public" do
+      refute Changeset.private_ip?(parse_ip!("::ffff:8.8.8.8"))
+    end
+  end
+
+  describe "public_host?/1" do
+    test "returns false for private and reserved hosts" do
+      refute Changeset.public_host?("127.0.0.1")
+      refute Changeset.public_host?("::1")
+      refute Changeset.public_host?("::ffff:127.0.0.1")
+      refute Changeset.public_host?("localhost")
+    end
+
+    test "returns true for public hosts" do
+      assert Changeset.public_host?("8.8.8.8")
+      assert Changeset.public_host?("accounts.google.com")
+    end
+  end
+
+  defp parse_ip!(ip) do
+    {:ok, parsed_ip} = :inet.parse_address(String.to_charlist(ip))
+    parsed_ip
+  end
+end

--- a/elixir/test/portal/okta/auth_provider_test.exs
+++ b/elixir/test/portal/okta/auth_provider_test.exs
@@ -15,6 +15,38 @@ defmodule Portal.Okta.AuthProviderTest do
     |> AuthProvider.changeset()
   end
 
+  describe "changeset/1 discovery_document_uri IP blocking" do
+    test "rejects private IP in okta_domain (169.254.169.254)" do
+      changeset =
+        build_changeset(%{
+          okta_domain: "169.254.169.254",
+          issuer: "https://169.254.169.254"
+        })
+
+      assert "must not be a private or reserved IP address" in errors_on(changeset).discovery_document_uri
+    end
+
+    test "rejects private IP in okta_domain (10.0.0.1)" do
+      changeset =
+        build_changeset(%{
+          okta_domain: "10.0.0.1",
+          issuer: "https://10.0.0.1"
+        })
+
+      assert "must not be a private or reserved IP address" in errors_on(changeset).discovery_document_uri
+    end
+
+    test "accepts valid okta domain" do
+      changeset =
+        build_changeset(%{
+          okta_domain: "myorg.okta.com",
+          issuer: "https://myorg.okta.com"
+        })
+
+      refute :discovery_document_uri in Keyword.keys(changeset.errors)
+    end
+  end
+
   describe "changeset/1 basic validations" do
     test "inserts okta_domain at maximum length" do
       domain = String.duplicate("a", 251) <> ".com"

--- a/elixir/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/test/support/fixtures/auth_provider_fixtures.ex
@@ -197,9 +197,9 @@ defmodule Portal.AuthProviderFixtures do
       |> Map.put_new(:client_secret, "client-secret-#{unique_num}")
       |> Map.put_new(
         :discovery_document_uri,
-        "https://auth.example.com/.well-known/openid-configuration"
+        "https://accounts.google.com/.well-known/openid-configuration"
       )
-      |> Map.put_new(:issuer, "https://auth.example.com")
+      |> Map.put_new(:issuer, "https://accounts.google.com")
       |> Map.put_new(:is_verified, true)
       |> Map.put_new(:is_disabled, false)
 


### PR DESCRIPTION
When an OIDC discovery URI is entered into the Auth Provider form, we fetch it and validate that it returns a valid JSON discovery document.

This PR hardens the list of URIs we accept here to filter out private IPs and other restricted hosts.

---

Credit to @boltyx0 for the finding and suggested fix.

Fixes: https://github.com/firezone/firezone/security/advisories/GHSA-pvx9-hvqh-472x
