### PR TITLE
test(connlib): reset `FluxCapacitor` before test

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests.rs
+++ b/rust/libs/connlib/tunnel/src/tests.rs
@@ -72,6 +72,7 @@ fn tunnel_test() {
         |(mut ref_state, transitions, mut seen_counter)| {
             let test_index = test_index.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
+            flux_capacitor.reset();
             let _guard = init_logging(flux_capacitor.clone(), test_index);
 
             std::fs::write(

--- a/rust/libs/connlib/tunnel/src/tests/flux_capacitor.rs
+++ b/rust/libs/connlib/tunnel/src/tests/flux_capacitor.rs
@@ -62,6 +62,17 @@ impl FluxCapacitor {
         }
     }
 
+    pub(crate) fn reset(&self) {
+        let elapsed = self.elapsed();
+
+        {
+            let mut guard = self.now.lock().unwrap();
+
+            guard.0 -= elapsed;
+            guard.1 -= elapsed;
+        }
+    }
+
     fn elapsed(&self) -> Duration {
         self.now::<Instant>().duration_since(self.start)
     }


### PR DESCRIPTION
The `FluxCapacitor` component helps us to simulate time in inside the `tunnel_test`. To ensure each test run starts at t = 0, we introduce a `reset` functionality that resets it back to the start.

Previously, the `FluxCapacitor` was scoped to a single test but that got refactored in #10796 to get access to the starting time in the initial state. That introduced the regression that the time-keeping was no longer per test and thus, later test runs would include the previous test runs.