### PR TITLE
fix(portal): strip port from x-forwarded-for

### DIFF
--- a/elixir/lib/portal/remote_ip/x_forwarded_for_parser.ex
+++ b/elixir/lib/portal/remote_ip/x_forwarded_for_parser.ex
@@ -1,0 +1,56 @@
+defmodule Portal.RemoteIp.XForwardedForParser do
+  @behaviour RemoteIp.Parser
+
+  @moduledoc """
+  A custom `RemoteIp.Parser` for the `X-Forwarded-For` header that handles
+  Azure Application Gateway's non-standard port appending.
+
+  Azure App Gateway appends the source port directly to the IP address without
+  RFC 7239 bracket notation, producing values like:
+
+  - IPv4: `"107.197.104.68:53859"` instead of `"107.197.104.68"`
+  - IPv6: `"2601:5c1:8200:4e5:49f9:23d9:a1c0:bb0b:64828"` instead of
+    `"[2601:5c1:8200:4e5:49f9:23d9:a1c0:bb0b]:64828"`
+
+  These fail `:inet.parse_strict_address/1`, causing `RemoteIp` to see no
+  valid client IP and fall back to `peer_data.address` (the App Gateway's own
+  private IP). This parser strips the trailing `:port` before delegating to
+  the standard parser.
+  """
+
+  @impl RemoteIp.Parser
+  def parse(header) do
+    header
+    |> String.trim()
+    |> String.split(~r/\s*,\s*/)
+    |> Enum.flat_map(&parse_ip/1)
+  end
+
+  defp parse_ip(str) do
+    trimmed = String.trim(str)
+
+    case :inet.parse_strict_address(to_charlist(trimmed)) do
+      {:ok, ip} ->
+        [ip]
+
+      {:error, _} ->
+        trimmed
+        |> strip_port()
+        |> then(fn candidate ->
+          case :inet.parse_strict_address(to_charlist(candidate)) do
+            {:ok, ip} -> [ip]
+            {:error, _} -> []
+          end
+        end)
+    end
+  end
+
+  # Strips the last colon-delimited segment, which is how App Gateway appends
+  # the source port to both IPv4 and IPv6 addresses.
+  defp strip_port(str) do
+    case String.split(str, ":") do
+      parts when length(parts) > 1 -> parts |> Enum.drop(-1) |> Enum.join(":")
+      _ -> str
+    end
+  end
+end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -19,6 +19,7 @@ defmodule PortalAPI.Endpoint do
 
   plug RemoteIp,
     headers: ["x-forwarded-for"],
+    parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
     proxies: {__MODULE__, :external_trusted_proxies, []},
     clients: {__MODULE__, :clients, []}
 
@@ -91,6 +92,7 @@ defmodule PortalAPI.Endpoint do
   def real_ip_opts do
     [
       headers: ["x-forwarded-for"],
+      parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
       proxies: {__MODULE__, :external_trusted_proxies, []},
       clients: {__MODULE__, :clients, []}
     ]

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -30,6 +30,7 @@ defmodule PortalWeb.Endpoint do
 
   plug RemoteIp,
     headers: ["x-forwarded-for"],
+    parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
     proxies: {__MODULE__, :external_trusted_proxies, []},
     clients: {__MODULE__, :clients, []}
 

--- a/elixir/test/portal/remote_ip/x_forwarded_for_parser_test.exs
+++ b/elixir/test/portal/remote_ip/x_forwarded_for_parser_test.exs
@@ -1,0 +1,50 @@
+defmodule Portal.RemoteIp.XForwardedForParserTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.RemoteIp.XForwardedForParser
+
+  describe "parse/1" do
+    # Azure App Gateway appends source port to IPv4 addresses
+    test "strips port from IPv4:port" do
+      assert XForwardedForParser.parse("107.197.104.68:53859") == [{107, 197, 104, 68}]
+    end
+
+    # Azure App Gateway appends source port to IPv6 addresses without brackets
+    test "strips port from IPv6:port" do
+      assert XForwardedForParser.parse("2601:5c1:8200:4e5:49f9:23d9:a1c0:bb0b:64828") ==
+               [{0x2601, 0x5C1, 0x8200, 0x04E5, 0x49F9, 0x23D9, 0xA1C0, 0xBB0B}]
+    end
+
+    test "passes through valid IPv4 unchanged" do
+      assert XForwardedForParser.parse("107.197.104.68") == [{107, 197, 104, 68}]
+    end
+
+    test "passes through valid IPv6 unchanged" do
+      assert XForwardedForParser.parse("2601:5c1:8200:4e5:49f9:23d9:a1c0:bb0b") ==
+               [{0x2601, 0x5C1, 0x8200, 0x04E5, 0x49F9, 0x23D9, 0xA1C0, 0xBB0B}]
+    end
+
+    test "passes through compressed IPv6 unchanged" do
+      assert XForwardedForParser.parse("::1") == [{0, 0, 0, 0, 0, 0, 0, 1}]
+    end
+
+    test "handles comma-separated chain with mixed formats" do
+      # Typical App Gateway chain: client IP:port, internal proxy
+      assert XForwardedForParser.parse("107.197.104.68:53859, 10.115.8.5") ==
+               [{107, 197, 104, 68}, {10, 115, 8, 5}]
+    end
+
+    test "handles comma-separated chain of valid IPs" do
+      assert XForwardedForParser.parse("1.2.3.4, 5.6.7.8") ==
+               [{1, 2, 3, 4}, {5, 6, 7, 8}]
+    end
+
+    test "filters out truly invalid values" do
+      assert XForwardedForParser.parse("not-an-ip") == []
+    end
+
+    test "handles whitespace around values" do
+      assert XForwardedForParser.parse("  107.197.104.68:53859  ") == [{107, 197, 104, 68}]
+    end
+  end
+end


### PR DESCRIPTION
Azure's Application Gateway appends the port to the IP address in the `X-Forwarded-For` header. This was causing the IP to fail to parse, falling back to the peer's layer 3 address, which is the Application Gateway itself.

To fix this, we first try to parse the address as usual, and if we fail, we strip the port and try parsing again.
