### PR TITLE
feat(portal): support bracketed x-forwarded-for headers

### DIFF
--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -84,6 +84,7 @@ defmodule PortalWeb.Endpoint do
   def real_ip_opts do
     [
       headers: ["x-forwarded-for"],
+      parsers: %{"x-forwarded-for" => Portal.RemoteIp.XForwardedForParser},
       proxies: {__MODULE__, :external_trusted_proxies, []},
       clients: {__MODULE__, :clients, []}
     ]

--- a/elixir/test/portal/remote_ip/x_forwarded_for_parser_test.exs
+++ b/elixir/test/portal/remote_ip/x_forwarded_for_parser_test.exs
@@ -46,5 +46,16 @@ defmodule Portal.RemoteIp.XForwardedForParserTest do
     test "handles whitespace around values" do
       assert XForwardedForParser.parse("  107.197.104.68:53859  ") == [{107, 197, 104, 68}]
     end
+
+    # RFC 7239 bracketed IPv6 – brackets confuse :inet.parse_strict_address/1
+    test "strips brackets and port from bracketed IPv6" do
+      assert XForwardedForParser.parse("[2601:5c1:8200:4e5:49f9:23d9:a1c0:bb0b]:64828") ==
+               [{0x2601, 0x5C1, 0x8200, 0x04E5, 0x49F9, 0x23D9, 0xA1C0, 0xBB0B}]
+    end
+
+    test "strips brackets from bracketed IPv6 without port" do
+      assert XForwardedForParser.parse("[2601:5c1:8200:4e5:49f9:23d9:a1c0:bb0b]") ==
+               [{0x2601, 0x5C1, 0x8200, 0x04E5, 0x49F9, 0x23D9, 0xA1C0, 0xBB0B}]
+    end
   end
 end


### PR DESCRIPTION
Updates our header parser to support bracketed-style IPv6 notation in case an upstream proxy uses these.
