### PR TITLE
chore(rust): specify list of targets for `cargo-deny`

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -25,7 +25,26 @@
 targets = [
     # The triple can be any string, but only the target triples built in to
     # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
+
+    # Windows
+    "x86_64-pc-windows-msvc",
+
+    # Linux
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "armv7-unknown-linux-musleabihf",
+
+    # Apple
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+
+    # Android
+    "armv7-linux-androideabi",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "i686-linux-android"
+
     # You can also specify which target_features you promise are enabled for a
     # particular target. target_features are currently not validated against
     # the actual valid features supported by the target architecture.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -108,8 +108,6 @@ ignore = [
     "RUSTSEC-2025-0012", # backoff, See #8386
     "RUSTSEC-2024-0436", # paste, See #8387
 
-    "RUSTSEC-2024-0429", # `glib`, need to wait for tauri to upgrade
-
     "RUSTSEC-2025-0057", # `fxhash` is unmaintained, used by transitive dependencies. See #10297.
 
     # `rust-unic` crates are unmaintained but still pulled in via tauri.
@@ -292,20 +290,11 @@ skip = [
     "toml",
     "toml_datetime",
     "toml_edit",
-    "wasi",
-    "wasm-streams",
     "webpki-roots",
     "which",
     "windows-link",
     "windows-sys",
     "windows-targets",
-    "windows_aarch64_gnullvm",
-    "windows_aarch64_msvc",
-    "windows_i686_gnu",
-    "windows_i686_gnullvm",
-    "windows_i686_msvc",
-    "windows_x86_64_gnu",
-    "windows_x86_64_gnullvm",
     "windows_x86_64_msvc",
     "winnow",
     "winreg",

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -43,7 +43,7 @@ targets = [
     "armv7-linux-androideabi",
     "aarch64-linux-android",
     "x86_64-linux-android",
-    "i686-linux-android"
+    "i686-linux-android",
 
     # You can also specify which target_features you promise are enabled for a
     # particular target. target_features are currently not validated against

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -108,6 +108,8 @@ ignore = [
     "RUSTSEC-2025-0012", # backoff, See #8386
     "RUSTSEC-2024-0436", # paste, See #8387
 
+    "RUSTSEC-2024-0429", # `glib`, need to wait for tauri to upgrade
+
     "RUSTSEC-2025-0057", # `fxhash` is unmaintained, used by transitive dependencies. See #10297.
 
     # `rust-unic` crates are unmaintained but still pulled in via tauri.


### PR DESCRIPTION
Our Rust workspace only gets compiled against specific targets, the lockfile however needs to track the dependencies of potentially all targets. To order to make `cargo-deny` more useful, we can configure it with the specific targets we are compiling for. This allows us to remove some exclusions rules for e.g. duplicate dependencies or advisories that don't affect us in practice.

Related: https://github.com/rust-random/getrandom/issues/817