### PR TITLE
refactor(phoenix-channel): explicitly reconnect on hiccup

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -563,8 +563,7 @@ async fn phoenix_channel_event_loop(
             }
             Either::Left((
                 Ok(
-                    phoenix_channel::Event::SuccessResponse { .. }
-                    | phoenix_channel::Event::HeartbeatSent
+                    phoenix_channel::Event::HeartbeatSent
                     | phoenix_channel::Event::JoinedRoom { .. },
                 ),
                 _,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -544,19 +544,6 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
-            Either::Left((
-                Ok(phoenix_channel::Event::ErrorResponse {
-                    topic,
-                    res: phoenix_channel::ErrorReply::UnmatchedTopic,
-                    ..
-                }),
-                _,
-            )) => {
-                portal.join(topic, ());
-            }
-            Either::Left((Ok(phoenix_channel::Event::ErrorResponse { topic, req_id, res }), _)) => {
-                tracing::warn!(%topic, %req_id, "Request failed: {res:?}");
-            }
             Either::Left((Ok(phoenix_channel::Event::Closed), _)) => {
                 tracing::debug!("Portal connection clsed: exiting phoenix-channel event-loop");
                 break;

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -538,7 +538,7 @@ async fn phoenix_channel_event_loop(
 
     loop {
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {
-            Either::Left((Ok(phoenix_channel::Event::InboundMessage { msg, .. }), _)) => {
+            Either::Left((Ok(phoenix_channel::Event::Message { msg, .. }), _)) => {
                 if event_tx.send(Ok(msg)).await.is_err() {
                     tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
                     break;

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -548,7 +548,6 @@ async fn phoenix_channel_event_loop(
                 tracing::debug!("Portal connection clsed: exiting phoenix-channel event-loop");
                 break;
             }
-            Either::Left((Ok(phoenix_channel::Event::HeartbeatSent), _)) => {}
             Either::Left((
                 Ok(phoenix_channel::Event::Hiccup {
                     backoff,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -525,7 +525,7 @@ impl Eventloop {
 
 async fn phoenix_channel_event_loop(
     mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
-    param: PublicKeyParam,
+    mut public_key: PublicKeyParam,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     resolver: TokioResolver,
@@ -534,7 +534,7 @@ async fn phoenix_channel_event_loop(
     use futures::future::select;
 
     let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
-    portal.connect(ips, Duration::ZERO, param.clone());
+    portal.connect(ips, Duration::ZERO, public_key.clone());
 
     loop {
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {
@@ -563,7 +563,7 @@ async fn phoenix_channel_event_loop(
                 );
 
                 let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
-                portal.connect(ips, backoff, param.clone());
+                portal.connect(ips, backoff, public_key.clone());
             }
             Either::Left((Ok(phoenix_channel::Event::Connected), _)) => {}
             Either::Left((Err(e), _)) => {
@@ -579,9 +579,11 @@ async fn phoenix_channel_event_loop(
                     }
                 }
             }
-            Either::Right((Some(PortalCommand::Connect(param)), _)) => {
+            Either::Right((Some(PortalCommand::Connect(new_public_key)), _)) => {
+                public_key = new_public_key; // Important! Update the current public key so we can re-use on connection hiccups!
+
                 let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
-                portal.connect(ips, Duration::ZERO, param);
+                portal.connect(ips, Duration::ZERO, public_key.clone());
             }
             Either::Right((Some(PortalCommand::Close), _)) => {
                 let _ = portal.close();

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -545,7 +545,7 @@ async fn phoenix_channel_event_loop(
                 }
             }
             Either::Left((Ok(phoenix_channel::Event::Closed), _)) => {
-                tracing::debug!("Portal connection clsed: exiting phoenix-channel event-loop");
+                tracing::debug!("Portal connection closed: exiting phoenix-channel event-loop");
                 break;
             }
             Either::Left((

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -548,13 +548,7 @@ async fn phoenix_channel_event_loop(
                 tracing::debug!("Portal connection clsed: exiting phoenix-channel event-loop");
                 break;
             }
-            Either::Left((
-                Ok(
-                    phoenix_channel::Event::HeartbeatSent
-                    | phoenix_channel::Event::JoinedRoom { .. },
-                ),
-                _,
-            )) => {}
+            Either::Left((Ok(phoenix_channel::Event::HeartbeatSent), _)) => {}
             Either::Left((
                 Ok(phoenix_channel::Event::Hiccup {
                     backoff,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -533,8 +533,8 @@ async fn phoenix_channel_event_loop(
     use futures::future::Either;
     use futures::future::select;
 
-    update_portal_host_ips(&mut portal, &resolver).await;
-    portal.connect(param);
+    let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
+    portal.connect(ips, Duration::ZERO, param.clone());
 
     loop {
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {
@@ -582,9 +582,9 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
-            }
-            Either::Left((Ok(phoenix_channel::Event::NoAddresses), _)) => {
-                update_portal_host_ips(&mut portal, &resolver).await
+
+                let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
+                portal.connect(ips, backoff, param.clone());
             }
             Either::Left((Ok(phoenix_channel::Event::Connected), _)) => {}
             Either::Left((Err(e), _)) => {
@@ -601,7 +601,8 @@ async fn phoenix_channel_event_loop(
                 }
             }
             Either::Right((Some(PortalCommand::Connect(param)), _)) => {
-                portal.connect(param);
+                let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
+                portal.connect(ips, Duration::ZERO, param);
             }
             Either::Right((Some(PortalCommand::Close), _)) => {
                 let _ = portal.close();
@@ -614,23 +615,14 @@ async fn phoenix_channel_event_loop(
     }
 }
 
-async fn update_portal_host_ips(
-    portal: &mut PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
-    resolver: &TokioResolver,
-) {
-    let ips = match resolver
-        .lookup_ip(portal.host())
+async fn resolve_portal_host_ips(resolver: &TokioResolver, host: String) -> Vec<IpAddr> {
+    resolver
+        .lookup_ip(host.clone())
         .await
         .context("Failed to lookup portal host")
-    {
-        Ok(ips) => ips,
-        Err(e) => {
-            tracing::debug!(host = %portal.host(), "{e:#}");
-            return;
-        }
-    };
-
-    portal.update_ips(ips);
+        .inspect_err(|e| tracing::debug!(%host, "{e:#}"))
+        .map(|ips| ips.into_iter().collect())
+        .unwrap_or_default()
 }
 
 fn is_unreachable(e: &io::Error) -> bool {

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -515,7 +515,7 @@ impl Eventloop {
 
 async fn phoenix_channel_event_loop(
     mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
-    param: PublicKeyParam,
+    mut public_key: PublicKeyParam,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
@@ -528,7 +528,7 @@ async fn phoenix_channel_event_loop(
     let mut udp_dns_client = UdpDnsClient::new(udp_socket_factory.clone(), dns_servers);
 
     let ips = resolve_portal_host_ips(&udp_dns_client, portal.host()).await;
-    portal.connect(ips, Duration::ZERO, param.clone());
+    portal.connect(ips, Duration::ZERO, public_key.clone());
 
     loop {
         // We process commands from the channel first (i.e. it is polled first) to update the DNS servers as quickly as possible.
@@ -542,9 +542,11 @@ async fn phoenix_channel_event_loop(
                     }
                 }
             }
-            Either::Left((Some(PortalCommand::Connect(param)), _)) => {
+            Either::Left((Some(PortalCommand::Connect(new_public_key)), _)) => {
+                public_key = new_public_key; // Important! Update the current public key so we can re-use on connection hiccups!
+
                 let ips = resolve_portal_host_ips(&udp_dns_client, portal.host()).await;
-                portal.connect(ips, Duration::ZERO, param);
+                portal.connect(ips, Duration::ZERO, public_key.clone());
             }
             Either::Left((Some(PortalCommand::UpdateDnsServers(servers)), _)) => {
                 udp_dns_client = UdpDnsClient::new(udp_socket_factory.clone(), servers);
@@ -579,7 +581,7 @@ async fn phoenix_channel_event_loop(
                 );
 
                 let ips = resolve_portal_host_ips(&udp_dns_client, portal.host()).await;
-                portal.connect(ips, backoff, param.clone());
+                portal.connect(ips, backoff, public_key.clone());
             }
             Either::Right((Ok(phoenix_channel::Event::Connected), _)) => {}
             Either::Right((Err(e), _)) => {

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -554,7 +554,7 @@ async fn phoenix_channel_event_loop(
 
                 break;
             }
-            Either::Right((Ok(phoenix_channel::Event::InboundMessage { msg, .. }), _)) => {
+            Either::Right((Ok(phoenix_channel::Event::Message { msg, .. }), _)) => {
                 if event_tx.send(Ok(msg)).await.is_err() {
                     tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -562,7 +562,6 @@ async fn phoenix_channel_event_loop(
                 }
             }
             Either::Right((Ok(phoenix_channel::Event::HeartbeatSent), _)) => {}
-            Either::Right((Ok(phoenix_channel::Event::JoinedRoom { .. }), _)) => {}
             Either::Right((Ok(phoenix_channel::Event::Closed), _)) => {
                 unimplemented!("Client never actively closes the portal connection")
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -3,7 +3,7 @@ use anyhow::{Context as _, ErrorExt as _, Result};
 use connlib_model::{PublicKey, ResourceId, ResourceView};
 use l4_udp_dns_client::UdpDnsClient;
 use parking_lot::Mutex;
-use phoenix_channel::{ErrorReply, PhoenixChannel, PublicKeyParam};
+use phoenix_channel::{PhoenixChannel, PublicKeyParam};
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::ops::ControlFlow;
 use std::pin::pin;
@@ -561,20 +561,6 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
-            Either::Right((
-                Ok(phoenix_channel::Event::ErrorResponse { res, req_id, topic }),
-                _,
-            )) => match res {
-                ErrorReply::Disabled => {
-                    tracing::debug!(%req_id, "Functionality is disabled");
-                }
-                ErrorReply::UnmatchedTopic => {
-                    portal.join(topic, ());
-                }
-                reason @ (ErrorReply::InvalidVersion | ErrorReply::Other) => {
-                    tracing::debug!(%req_id, %reason, "Request failed");
-                }
-            },
             Either::Right((Ok(phoenix_channel::Event::HeartbeatSent), _)) => {}
             Either::Right((Ok(phoenix_channel::Event::JoinedRoom { .. }), _)) => {}
             Either::Right((Ok(phoenix_channel::Event::Closed), _)) => {

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -561,7 +561,6 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
-            Either::Right((Ok(phoenix_channel::Event::HeartbeatSent), _)) => {}
             Either::Right((Ok(phoenix_channel::Event::Closed), _)) => {
                 unimplemented!("Client never actively closes the portal connection")
             }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -561,7 +561,6 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
-            Either::Right((Ok(phoenix_channel::Event::SuccessResponse { .. }), _)) => {}
             Either::Right((
                 Ok(phoenix_channel::Event::ErrorResponse { res, req_id, topic }),
                 _,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -532,7 +532,7 @@ async fn phoenix_channel_event_loop(
 
     loop {
         // We process commands from the channel first (i.e. it is polled first) to update the DNS servers as quickly as possible.
-        // This allows `NoAddresses` events to use the updated `UdpDnsClient` to resolve the domain.
+        // This allows `Hiccup` events to use the updated `UdpDnsClient` to resolve the domain.
         match select(pin!(cmd_rx.recv()), poll_fn(|cx| portal.poll(cx))).await {
             Either::Left((Some(PortalCommand::Send(msg)), _)) => {
                 match portal.send(PHOENIX_TOPIC, msg) {

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -8,14 +8,14 @@ use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::ops::ControlFlow;
 use std::pin::pin;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use std::{
     collections::BTreeSet,
     io,
     net::IpAddr,
     task::{Context, Poll},
 };
-use std::{future, mem};
+use std::{future, iter, mem};
 use tokio::sync::{mpsc, watch};
 use tun::Tun;
 use tunnel::messages::RelaysPresence;
@@ -527,9 +527,8 @@ async fn phoenix_channel_event_loop(
 
     let mut udp_dns_client = UdpDnsClient::new(udp_socket_factory.clone(), dns_servers);
 
-    let ips = resolve_portal_host_ips(portal.host(), &udp_dns_client).await;
-    portal.update_ips(ips);
-    portal.connect(param);
+    let ips = resolve_portal_host_ips(&udp_dns_client, portal.host()).await;
+    portal.connect(ips, Duration::ZERO, param.clone());
 
     loop {
         // We process commands from the channel first (i.e. it is polled first) to update the DNS servers as quickly as possible.
@@ -544,7 +543,8 @@ async fn phoenix_channel_event_loop(
                 }
             }
             Either::Left((Some(PortalCommand::Connect(param)), _)) => {
-                portal.connect(param);
+                let ips = resolve_portal_host_ips(&udp_dns_client, portal.host()).await;
+                portal.connect(ips, Duration::ZERO, param);
             }
             Either::Left((Some(PortalCommand::UpdateDnsServers(servers)), _)) => {
                 udp_dns_client = UdpDnsClient::new(udp_socket_factory.clone(), servers);
@@ -594,10 +594,9 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
-            }
-            Either::Right((Ok(phoenix_channel::Event::NoAddresses), _)) => {
-                let ips = resolve_portal_host_ips(portal.host(), &udp_dns_client).await;
-                portal.update_ips(ips);
+
+                let ips = resolve_portal_host_ips(&udp_dns_client, portal.host()).await;
+                portal.connect(ips, backoff, param.clone());
             }
             Either::Right((Ok(phoenix_channel::Event::Connected), _)) => {}
             Either::Right((Err(e), _)) => {
@@ -618,10 +617,7 @@ async fn phoenix_channel_event_loop(
 ///
 /// If any of these fail, we simply default to an empty list of IPs.
 /// This is fine as this routine will be triggered again if we ever run out of IPs to use.
-async fn resolve_portal_host_ips(
-    host: String,
-    udp_dns_client: &UdpDnsClient,
-) -> impl IntoIterator<Item = IpAddr> {
+async fn resolve_portal_host_ips(udp_dns_client: &UdpDnsClient, host: String) -> Vec<IpAddr> {
     let udp_ips = udp_dns_client
         .resolve(host.clone())
         .await
@@ -635,7 +631,7 @@ async fn resolve_portal_host_ips(
         .inspect_err(|e| tracing::debug!(%host, "{e:#}"))
         .unwrap_or_default();
 
-    udp_ips.into_iter().chain(etc_hosts_ips)
+    iter::empty().chain(udp_ips).chain(etc_hosts_ips).collect()
 }
 
 fn is_unreachable(e: &io::Error) -> bool {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -633,7 +633,7 @@ where
 
             // Priority 1: Ensure we are fully flushed.
             if let Err(e) = std::task::ready!(stream.poll_flush_unpin(cx)) {
-                self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                self.handle_internal_error(InternalError::WebSocket(e));
                 continue;
             }
 
@@ -646,7 +646,7 @@ where
                                 tracing::trace!(target: "wire::api::send", %heartbeat);
                             }
                             Err(e) => {
-                                self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                                self.handle_internal_error(InternalError::WebSocket(e));
                             }
                         }
 
@@ -662,7 +662,7 @@ where
                             }
                             Err(e) => {
                                 pending_joins.push_front(join);
-                                self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                                self.handle_internal_error(InternalError::WebSocket(e));
                             }
                         }
 
@@ -685,7 +685,7 @@ where
                                 }
                                 Err(e) => {
                                     pending_messages.push_front(msg);
-                                    self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                                    self.handle_internal_error(InternalError::WebSocket(e));
                                 }
                             }
 
@@ -699,7 +699,7 @@ where
                     }
                 }
                 Poll::Ready(Err(e)) => {
-                    self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                    self.handle_internal_error(InternalError::WebSocket(e));
                     continue;
                 }
                 Poll::Pending => {}
@@ -747,7 +747,7 @@ where
                         match serde_json::from_str::<PhoenixMessage<TInboundMsg>>(&message) {
                             Ok(m) => m,
                             Err(e) if e.is_io() || e.is_eof() => {
-                                self.reconnect_on_transient_error(InternalError::Serde(e));
+                                self.handle_internal_error(InternalError::Serde(e));
                                 continue;
                             }
                             Err(e) => {
@@ -831,7 +831,7 @@ where
                             continue;
                         }
                         (Payload::Close(Empty {}), _) => {
-                            self.reconnect_on_transient_error(InternalError::CloseMessage);
+                            self.handle_internal_error(InternalError::CloseMessage);
                             continue;
                         }
                         (
@@ -852,11 +852,11 @@ where
                     continue;
                 }
                 Poll::Ready(Some(Err(e))) => {
-                    self.reconnect_on_transient_error(InternalError::WebSocket(e));
+                    self.handle_internal_error(InternalError::WebSocket(e));
                     continue;
                 }
                 Poll::Ready(None) => {
-                    self.reconnect_on_transient_error(InternalError::StreamClosed);
+                    self.handle_internal_error(InternalError::StreamClosed);
                     continue;
                 }
                 Poll::Pending => {}
@@ -866,7 +866,7 @@ where
                 .values()
                 .any(|sent_at| sent_at.elapsed() > Duration::from_secs(5))
             {
-                self.reconnect_on_transient_error(InternalError::RoomJoinTimedOut);
+                self.handle_internal_error(InternalError::RoomJoinTimedOut);
                 continue;
             }
 
@@ -888,7 +888,7 @@ where
             }
 
             if inflight_heartbeats.len() > 3 {
-                self.reconnect_on_transient_error(InternalError::TooManyUnansweredHeartbeats);
+                self.handle_internal_error(InternalError::TooManyUnansweredHeartbeats);
                 continue;
             }
 
@@ -898,8 +898,8 @@ where
 
     /// Sets the channels state to [`State::Connecting`] with the given error.
     ///
-    /// The [`PhoenixChannel::poll`] function will handle the reconnect if appropriate for the given error.
-    fn reconnect_on_transient_error(&mut self, e: InternalError) {
+    /// The [`PhoenixChannel::poll`] function will handle the error appropriately.
+    fn handle_internal_error(&mut self, e: InternalError) {
         self.state = State::Connecting(future::ready(Err(e)).boxed())
     }
 }
@@ -942,6 +942,9 @@ fn make_initial_backoff() -> ExponentialBackoff {
 pub enum Event<TInboundMsg> {
     /// The server sent us a message.
     Message { topic: String, msg: TInboundMsg },
+    /// The connection failed with a transient error.
+    ///
+    /// You must call [`PhoenixChannel::connect`] after this (or discard the instance).
     Hiccup {
         backoff: Duration,
         max_elapsed_time: Option<Duration>,

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -788,11 +788,9 @@ where
                                 res: reason,
                             }));
                         }
-                        (Payload::Reply(Reply::Ok(OkReply::Message(()))), Some(req_id)) => {
-                            return Poll::Ready(Ok(Event::SuccessResponse {
-                                topic: message.topic,
-                                req_id,
-                            }));
+                        (Payload::Reply(Reply::Ok(OkReply::Message(()))), Some(_)) => {
+                            // We don't use the reply feature of phoenix-channel.
+                            continue;
                         }
                         (Payload::Reply(Reply::Ok(OkReply::NoMessage(Empty {}))), Some(req_id)) => {
                             if pending_join_requests.remove(&req_id).is_some() {
@@ -931,10 +929,6 @@ fn make_initial_backoff() -> ExponentialBackoff {
 
 #[derive(Debug)]
 pub enum Event<TInboundMsg> {
-    SuccessResponse {
-        topic: String,
-        req_id: OutboundRequestId,
-    },
     ErrorResponse {
         topic: String,
         req_id: OutboundRequestId,

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -881,7 +881,7 @@ where
                     pending_heartbeat.replace(heartbeat);
                     inflight_heartbeats.insert(id);
 
-                    return Poll::Ready(Ok(Event::HeartbeatSent));
+                    continue;
                 }
                 Poll::Pending => {}
             }
@@ -939,12 +939,8 @@ fn make_initial_backoff() -> ExponentialBackoff {
 
 #[derive(Debug)]
 pub enum Event<TInboundMsg> {
-    HeartbeatSent,
     /// The server sent us a message, most likely this is a broadcast to all connected clients.
-    InboundMessage {
-        topic: String,
-        msg: TInboundMsg,
-    },
+    InboundMessage { topic: String, msg: TInboundMsg },
     Hiccup {
         backoff: Duration,
         max_elapsed_time: Option<Duration>,

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -5,7 +5,7 @@ mod login_url;
 
 use anyhow::{Context as _, Result};
 use futures::stream::FuturesUnordered;
-use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -66,16 +66,11 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     backoff: Option<ExponentialBackoff>,
     was_connected: bool,
 
-    resolved_addresses: BTreeSet<IpAddr>,
-
     login: &'static str,
     init_req: TInitReq,
 }
 
 enum State<TOutboundMsg> {
-    Reconnect {
-        backoff: Duration,
-    },
     Connected(Connected<TOutboundMsg>),
     Connecting(
         BoxFuture<'static, Result<WebSocketStream<MaybeTlsStream<TcpStream>>, InternalError>>,
@@ -107,8 +102,10 @@ impl<TOutboundMsg> State<TOutboundMsg> {
         user_agent: String,
         token: SecretString,
         socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+        backoff: Duration,
     ) -> Self {
-        Self::Connecting(
+        Self::Connecting(Box::pin(async move {
+            tokio::time::sleep(backoff).await;
             create_and_connect_websocket(
                 url,
                 addresses,
@@ -118,8 +115,8 @@ impl<TOutboundMsg> State<TOutboundMsg> {
                 socket_factory,
                 CONNECT_TIMEOUT,
             )
-            .boxed(),
-        )
+            .await
+        }))
     }
 }
 
@@ -245,14 +242,6 @@ impl InternalError {
         let duration = parse_retry_after_value(value)?;
 
         Some(duration)
-    }
-
-    pub(crate) fn failed_ips(&self) -> Vec<(IpAddr, &io::Error)> {
-        let Self::SocketConnection(errors) = self else {
-            return Vec::default();
-        };
-
-        errors.iter().map(|(s, e)| (s.ip(), e)).collect()
     }
 }
 
@@ -406,7 +395,6 @@ where
             _phantom: PhantomData,
             login,
             init_req,
-            resolved_addresses: Default::default(),
             last_url: None,
         }
     }
@@ -478,27 +466,24 @@ where
     }
 
     /// Establishes a new connection, dropping the current one if any exists.
-    pub fn connect(&mut self, params: TFinish) {
+    pub fn connect(&mut self, addresses: Vec<IpAddr>, backoff: Duration, params: TFinish) {
         let url = self.url_prototype.to_url(params);
 
-        if matches!(self.state, State::Connecting(_)) && Some(&url) == self.last_url.as_ref() {
-            tracing::debug!("We are already connecting");
-            return;
-        }
-
-        // 1. Reset the backoff.
-        self.backoff = None;
-
-        // 2. Set state to `Connecting` without a timer.
         let user_agent = self.user_agent.clone();
         let token = self.token.clone();
+
         self.state = State::connect(
             url.clone(),
-            self.socket_addresses(),
+            addresses
+                .into_iter()
+                .chain(self.host().parse::<IpAddr>().ok())
+                .map(|ip| SocketAddr::new(ip, self.port()))
+                .collect(),
             self.host(),
             user_agent,
             token,
             self.socket_factory.clone(),
+            backoff,
         );
         self.last_url = Some(url);
 
@@ -516,16 +501,8 @@ where
         self.url_prototype.host_and_port().0.to_owned()
     }
 
-    pub fn update_ips(&mut self, ips: impl IntoIterator<Item = IpAddr>) {
-        let new = BTreeSet::from_iter(ips);
-
-        if new == self.resolved_addresses {
-            return;
-        }
-
-        tracing::debug!(host = %self.host(), current = ?self.resolved_addresses, ?new, "Updating resolved IPs");
-
-        self.resolved_addresses = new;
+    fn port(&self) -> u16 {
+        self.url_prototype.host_and_port().1
     }
 
     /// Initiate a graceful close of the connection.
@@ -557,7 +534,7 @@ where
             State::Closing(stream) => {
                 self.state = State::Closing(stream);
             }
-            State::Closed | State::Reconnect { .. } => {}
+            State::Closed => {}
         }
 
         Ok(())
@@ -595,39 +572,9 @@ where
                     Poll::Pending => return Poll::Pending,
                 },
                 State::Connected(stream) => stream,
-                State::Reconnect { backoff } => {
-                    let backoff = *backoff;
-                    let socket_addresses = self.socket_addresses();
-                    let host = self.host();
-
-                    let secret_url = self
-                        .last_url
-                        .as_ref()
-                        .expect("should have last URL if we receive connection error")
-                        .clone();
-                    let user_agent = self.user_agent.clone();
-                    let token = self.token.clone();
-                    let socket_factory = self.socket_factory.clone();
-
-                    self.state = State::Connecting(Box::pin(async move {
-                        tokio::time::sleep(backoff).await;
-                        create_and_connect_websocket(
-                            secret_url,
-                            socket_addresses,
-                            host,
-                            user_agent,
-                            token,
-                            socket_factory,
-                            CONNECT_TIMEOUT,
-                        )
-                        .await
-                    }));
-
-                    continue;
-                }
                 State::Connecting(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(stream)) => {
-                        self.backoff = None;
+                        self.backoff = None; // TODO: Should we only reset this once we have joined the room?
                         self.was_connected = true;
                         self.state = State::Connected(Connected {
                             stream,
@@ -646,14 +593,6 @@ where
                         self.join(self.login, self.init_req.clone());
 
                         return Poll::Ready(Ok(Event::Connected));
-                    }
-                    Poll::Ready(Err(InternalError::NoAddresses)) => {
-                        // Fixed 1s interval to avoid busy-looping in case DNS resolution fails / is not possible.
-                        self.state = State::Reconnect {
-                            backoff: Duration::from_secs(1),
-                        };
-
-                        return Poll::Ready(Ok(Event::NoAddresses));
                     }
                     Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(r))))
                         if r.status() == StatusCode::UNAUTHORIZED =>
@@ -678,14 +617,6 @@ where
                                     })?
                             }
                         };
-
-                        for (ip, error) in e.failed_ips() {
-                            if self.resolved_addresses.remove(&ip) {
-                                tracing::debug!(%ip, "Discarding failed IP: {error}");
-                            }
-                        }
-
-                        self.state = State::Reconnect { backoff };
 
                         return Poll::Ready(Ok(Event::Hiccup {
                             backoff,
@@ -962,17 +893,6 @@ where
     fn reconnect_on_transient_error(&mut self, e: InternalError) {
         self.state = State::Connecting(future::ready(Err(e)).boxed())
     }
-
-    fn socket_addresses(&self) -> Vec<SocketAddr> {
-        let (host, port) = self.url_prototype.host_and_port();
-
-        self.resolved_addresses
-            .iter()
-            .copied()
-            .chain(host.parse::<IpAddr>().ok())
-            .map(|ip| SocketAddr::new(ip, port))
-            .collect()
-    }
 }
 
 fn make_control_message<TInitReq>(
@@ -1034,11 +954,6 @@ pub enum Event<TInboundMsg> {
         max_elapsed_time: Option<Duration>,
         error: anyhow::Error,
     },
-    /// We don't have any addresses to connect to.
-    ///
-    /// Upon receiving this event, you should re-resolve the [`host`](PhoenixChannel::host)
-    /// and provide new IPs for it via [`PhoenixChannel::update_ips`].
-    NoAddresses,
     /// The connection was closed successfully.
     Closed,
     /// The WebSocket connection was established.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -551,6 +551,7 @@ where
                 pending_messages,
                 next_request_id,
             } = match &mut self.state {
+                State::Connected(stream) => stream,
                 State::Closed => return Poll::Ready(Ok(Event::Closed)),
                 State::Closing(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(())) => {
@@ -568,7 +569,6 @@ where
                     }
                     Poll::Pending => return Poll::Pending,
                 },
-                State::Connected(stream) => stream,
                 State::Connecting(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(stream)) => {
                         self.state = State::Connected(Connected {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -399,11 +399,9 @@ where
         }
     }
 
-    /// Join the provided room.
-    ///
-    /// If successful, a [`Event::JoinedRoom`] event will be emitted.
-    fn join(&mut self, topic: impl Into<String>, payload: TInitReq) {
-        let topic = topic.into();
+    /// Join our room.
+    fn join_room(&mut self) {
+        let topic = self.login.to_owned();
 
         let State::Connected(Connected {
             pending_joins,
@@ -419,7 +417,7 @@ where
         let (request_id, msg) = make_control_message(
             next_request_id,
             topic,
-            EgressControlMessage::PhxJoin(payload),
+            EgressControlMessage::PhxJoin(self.init_req.clone()),
         );
 
         pending_joins.push_back(msg);
@@ -590,7 +588,7 @@ where
                         let (host, _) = self.url_prototype.host_and_port();
 
                         tracing::info!(%host, "Connected to portal");
-                        self.join(self.login, self.init_req.clone());
+                        self.join_room();
 
                         return Poll::Ready(Ok(Event::Connected));
                     }
@@ -786,7 +784,7 @@ where
                                 ErrorReply::UnmatchedTopic if message.topic == self.login => {
                                     tracing::debug!(topic = %self.login, "We are no longer part of our room, rejoining");
 
-                                    self.join(self.login, self.init_req.clone());
+                                    self.join_room();
                                     continue;
                                 }
                                 ErrorReply::UnmatchedTopic

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -710,16 +710,13 @@ where
                     // Grab ownership of the `stream`.
                     let mut stream = match std::mem::replace(&mut self.state, State::Closed) {
                         State::Connected(Connected { stream, .. }) => stream,
-                        State::Reconnect { .. }
-                        | State::Connecting(_)
-                        | State::Closing(_)
-                        | State::Closed => {
+                        State::Connecting(_) | State::Closing(_) | State::Closed => {
                             // Defense-in-depth: This should not happen but never know what kind of bugs we might introduce in the future.
                             debug_assert!(
                                 false,
                                 "Should be in Connected after receiving Close frame"
                             );
-                            self.reconnect_on_transient_error(InternalError::WsClose(frame));
+                            self.handle_internal_error(InternalError::WsClose(frame));
                             continue;
                         }
                     };

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -555,7 +555,6 @@ where
                 State::Closing(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(())) => {
                         tracing::info!("Closed websocket connection to portal");
-
                         self.state = State::Closed;
 
                         return Poll::Ready(Ok(Event::Closed));

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -196,7 +196,7 @@ pub enum Error {
     )]
     MaxRetriesReached { final_error: String },
     #[error("Failed to login with portal: {0}")]
-    LoginFailed(ErrorReply),
+    LoginFailed(String),
     #[error("Fatal IO error: {0}")]
     FatalIo(io::Error),
 }
@@ -402,7 +402,7 @@ where
     /// Join the provided room.
     ///
     /// If successful, a [`Event::JoinedRoom`] event will be emitted.
-    pub fn join(&mut self, topic: impl Into<String>, payload: TInitReq) {
+    fn join(&mut self, topic: impl Into<String>, payload: TInitReq) {
         let topic = topic.into();
 
         let State::Connected(Connected {
@@ -779,14 +779,25 @@ where
                             if message.topic == self.login
                                 && pending_join_requests.contains_key(&req_id)
                             {
-                                return Poll::Ready(Err(Error::LoginFailed(reason)));
+                                return Poll::Ready(Err(Error::LoginFailed(reason.to_string())));
                             }
 
-                            return Poll::Ready(Ok(Event::ErrorResponse {
-                                topic: message.topic,
-                                req_id,
-                                res: reason,
-                            }));
+                            match reason {
+                                ErrorReply::UnmatchedTopic if message.topic == self.login => {
+                                    tracing::debug!(topic = %self.login, "We are no longer part of our room, rejoining");
+
+                                    self.join(self.login, self.init_req.clone());
+                                    continue;
+                                }
+                                ErrorReply::UnmatchedTopic
+                                | ErrorReply::InvalidVersion
+                                | ErrorReply::Disabled
+                                | ErrorReply::Other => {
+                                    tracing::debug!(%req_id, %reason, "Received error reply");
+                                }
+                            }
+
+                            continue;
                         }
                         (Payload::Reply(Reply::Ok(OkReply::Message(()))), Some(_)) => {
                             // We don't use the reply feature of phoenix-channel.
@@ -929,11 +940,6 @@ fn make_initial_backoff() -> ExponentialBackoff {
 
 #[derive(Debug)]
 pub enum Event<TInboundMsg> {
-    ErrorResponse {
-        topic: String,
-        req_id: OutboundRequestId,
-        res: ErrorReply,
-    },
     JoinedRoom {
         topic: String,
     },
@@ -1002,7 +1008,7 @@ enum OkReply<T> {
 /// This represents the info we have about the error
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum ErrorReply {
+enum ErrorReply {
     #[serde(rename = "unmatched topic")]
     UnmatchedTopic,
     InvalidVersion,

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -572,8 +572,6 @@ where
                 State::Connected(stream) => stream,
                 State::Connecting(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(stream)) => {
-                        self.backoff = None; // TODO: Should we only reset this once we have joined the room?
-                        self.was_connected = true;
                         self.state = State::Connected(Connected {
                             stream,
                             heartbeat: tokio::time::interval(HEARTBEAT_INTERVAL),
@@ -808,6 +806,9 @@ where
 
                             if pending_join_requests.remove(&req_id).is_some() {
                                 if message.topic == self.login {
+                                    self.backoff = None;
+                                    self.was_connected = true;
+
                                     let (host, _) = self.url_prototype.host_and_port();
                                     tracing::info!(%host, "Connected to portal");
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -585,12 +585,11 @@ where
                             next_request_id: 0,
                         });
 
-                        let (host, _) = self.url_prototype.host_and_port();
+                        tracing::debug!("WebSocket connection established");
 
-                        tracing::info!(%host, "Connected to portal");
                         self.join_room();
 
-                        return Poll::Ready(Ok(Event::Connected));
+                        continue;
                     }
                     Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(r))))
                         if r.status() == StatusCode::UNAUTHORIZED =>
@@ -802,17 +801,19 @@ where
                             continue;
                         }
                         (Payload::Reply(Reply::Ok(OkReply::NoMessage(Empty {}))), Some(req_id)) => {
-                            if pending_join_requests.remove(&req_id).is_some() {
-                                tracing::debug!("Joined {} room on portal", message.topic);
-
-                                // For `phx_join` requests, `reply` is empty so we can safely ignore it.
-                                return Poll::Ready(Ok(Event::JoinedRoom {
-                                    topic: message.topic,
-                                }));
-                            }
-
                             if inflight_heartbeats.remove(&req_id) {
                                 tracing::trace!(%req_id, "Received heartbeat reply");
+                                continue;
+                            }
+
+                            if pending_join_requests.remove(&req_id).is_some() {
+                                if message.topic == self.login {
+                                    let (host, _) = self.url_prototype.host_and_port();
+                                    tracing::info!(%host, "Connected to portal");
+
+                                    return Poll::Ready(Ok(Event::Connected));
+                                }
+
                                 continue;
                             }
 
@@ -938,9 +939,6 @@ fn make_initial_backoff() -> ExponentialBackoff {
 
 #[derive(Debug)]
 pub enum Event<TInboundMsg> {
-    JoinedRoom {
-        topic: String,
-    },
     HeartbeatSent,
     /// The server sent us a message, most likely this is a broadcast to all connected clients.
     InboundMessage {
@@ -954,7 +952,9 @@ pub enum Event<TInboundMsg> {
     },
     /// The connection was closed successfully.
     Closed,
-    /// The WebSocket connection was established.
+    /// The portal connection was established.
+    ///
+    /// This includes successfully joining the room on the portal end.
     Connected,
 }
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -619,8 +619,7 @@ where
                                 .backoff
                                 .as_ref()
                                 .and_then(|b| b.max_elapsed_time),
-                            error: anyhow::Error::new(e)
-                                .context("Reconnecting to portal on transient error"),
+                            error: anyhow::Error::new(e).context("Connection hiccup"),
                         }));
                     }
                     Poll::Pending => {

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -475,6 +475,7 @@ where
             addresses
                 .into_iter()
                 .chain(self.host().parse::<IpAddr>().ok())
+                .unique()
                 .map(|ip| SocketAddr::new(ip, self.port()))
                 .collect(),
             self.host(),

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -485,7 +485,7 @@ where
         );
         self.last_url = Some(url);
 
-        // 3. In case we were already re-connecting, we need to wake the suspended task.
+        // In case we were already re-connecting, we need to wake the suspended task.
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }
@@ -553,21 +553,19 @@ where
             } = match &mut self.state {
                 State::Connected(stream) => stream,
                 State::Closed => return Poll::Ready(Ok(Event::Closed)),
-                State::Closing(future) => match future.poll_unpin(cx) {
-                    Poll::Ready(Ok(())) => {
+                State::Closing(future) => match std::task::ready!(future.poll_unpin(cx)) {
+                    Ok(()) => {
                         tracing::info!("Closed websocket connection to portal");
                         self.state = State::Closed;
 
                         return Poll::Ready(Ok(Event::Closed));
                     }
-                    Poll::Ready(Err(e)) => {
+                    Err(e) => {
                         tracing::info!("Error while closing websocket connection to portal: {e:#}");
-
                         self.state = State::Closed;
 
                         return Poll::Ready(Ok(Event::Closed));
                     }
-                    Poll::Pending => return Poll::Pending,
                 },
                 State::Connecting(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(stream)) => {
@@ -591,6 +589,7 @@ where
                     Poll::Ready(Err(InternalError::WebSocket(tungstenite::Error::Http(r))))
                         if r.status() == StatusCode::UNAUTHORIZED =>
                     {
+                        self.state = State::Closed;
                         return Poll::Ready(Err(Error::InvalidToken));
                     }
                     Poll::Ready(Err(e)) => {
@@ -611,6 +610,7 @@ where
                                     })?
                             }
                         };
+                        self.state = State::Closed;
 
                         return Poll::Ready(Ok(Event::Hiccup {
                             backoff,

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -763,7 +763,7 @@ where
 
                     match (message.payload, message.reference) {
                         (Payload::Message(msg), _) => {
-                            return Poll::Ready(Ok(Event::InboundMessage {
+                            return Poll::Ready(Ok(Event::Message {
                                 topic: message.topic,
                                 msg,
                             }));
@@ -939,8 +939,8 @@ fn make_initial_backoff() -> ExponentialBackoff {
 
 #[derive(Debug)]
 pub enum Event<TInboundMsg> {
-    /// The server sent us a message, most likely this is a broadcast to all connected clients.
-    InboundMessage { topic: String, msg: TInboundMsg },
+    /// The server sent us a message.
+    Message { topic: String, msg: TInboundMsg },
     Hiccup {
         backoff: Duration,
         max_elapsed_time: Option<Duration>,

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -231,7 +231,7 @@ async fn replies_with_close_frame_upon_close() {
     let (server, port) = spawn_websocket_server(|text| {
         match text {
             r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
             }
             other => panic!("Unexpected message: {other}"),
         }
@@ -268,7 +268,7 @@ async fn replies_with_close_frame_upon_close() {
 
     assert_eq!(
         format!("{client_result:#}"),
-        "Reconnecting to portal on transient error: portal sent empty websocket close frame"
+        "Connection hiccup: portal sent empty websocket close frame"
     );
 }
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -70,7 +70,11 @@ async fn client_does_not_pipeline_messages() {
     let mut channel = make_test_channel("localhost", server_addr.port());
 
     let client = async move {
-        channel.connect(PublicKeyParam([0u8; 32]));
+        channel.connect(
+            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+            Duration::ZERO,
+            PublicKeyParam([0u8; 32]),
+        );
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
@@ -85,9 +89,6 @@ async fn client_does_not_pipeline_messages() {
                     ..
                 } => {
                     channel.close().unwrap();
-                }
-                phoenix_channel::Event::NoAddresses => {
-                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Hiccup { error, .. } => {
                     panic!("Unexpected hiccup: {error:?}")
@@ -136,7 +137,11 @@ async fn client_deduplicates_messages() {
     let mut num_responses = 0;
 
     let client = async {
-        channel.connect(PublicKeyParam([0u8; 32]));
+        channel.connect(
+            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+            Duration::ZERO,
+            PublicKeyParam([0u8; 32]),
+        );
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
@@ -159,9 +164,6 @@ async fn client_deduplicates_messages() {
                 }
                 phoenix_channel::Event::Hiccup { error, .. } => {
                     panic!("Unexpected hiccup: {error:?}")
-                }
-                phoenix_channel::Event::NoAddresses => {
-                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Closed => break,
                 phoenix_channel::Event::Connected => {}
@@ -203,7 +205,11 @@ async fn client_clears_local_message_on_connect() {
 
     let client = async {
         channel.send("test", OutboundMsg::Bar).unwrap_err();
-        channel.connect(PublicKeyParam([0u8; 32]));
+        channel.connect(
+            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+            Duration::ZERO,
+            PublicKeyParam([0u8; 32]),
+        );
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
@@ -223,9 +229,6 @@ async fn client_clears_local_message_on_connect() {
                 }
                 phoenix_channel::Event::Hiccup { error, .. } => {
                     panic!("Unexpected hiccup: {error:?}")
-                }
-                phoenix_channel::Event::NoAddresses => {
-                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
                 }
                 phoenix_channel::Event::Closed => break,
                 phoenix_channel::Event::Connected => {}
@@ -326,7 +329,11 @@ async fn times_out_after_missed_heartbeats() {
     let mut channel = make_test_channel("localhost", port);
 
     let client = async {
-        channel.connect(PublicKeyParam([0u8; 32]));
+        channel.connect(
+            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+            Duration::ZERO,
+            PublicKeyParam([0u8; 32]),
+        );
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
@@ -338,9 +345,6 @@ async fn times_out_after_missed_heartbeats() {
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => break error,
-                phoenix_channel::Event::NoAddresses => {
-                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
-                }
                 phoenix_channel::Event::Closed => {
                     panic!("Channel closed")
                 }
@@ -375,7 +379,11 @@ async fn http_429_triggers_retry() {
     let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -395,7 +403,12 @@ async fn http_408_triggers_retry() {
     let port = http_status_server(http::StatusCode::REQUEST_TIMEOUT).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -415,7 +428,12 @@ async fn http_400_returns_client_error() {
     let port = http_status_server(http::StatusCode::BAD_REQUEST).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -434,7 +452,12 @@ async fn http_401_returns_invalid_token() {
     let port = http_status_server(http::StatusCode::UNAUTHORIZED).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -449,67 +472,45 @@ async fn http_401_returns_invalid_token() {
 }
 
 #[tokio::test]
-async fn discards_failed_ips_on_hiccup() {
-    let mut channel = make_test_channel("localhost", 443); // Use a hostname so we run out of IPs
-    channel.update_ips(vec![
-        IpAddr::from(Ipv4Addr::from([127, 0, 0, 1])),
-        IpAddr::from(Ipv4Addr::from([127, 0, 0, 10])),
-        IpAddr::from(Ipv4Addr::from([127, 0, 0, 111])),
-    ]);
-    channel.connect(PublicKeyParam([0u8; 32]));
+async fn includes_ip_from_hostname() {
+    use phoenix_channel::PublicKeyParam;
 
-    let event = tokio::time::timeout(Duration::from_secs(6), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
+    let _guard = logging::test("debug,wire::api=trace");
+
+    let (server, port) = spawn_websocket_server(|text| {
+        match text {
+            r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
+                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+            }
+            other => panic!("Unexpected message: {other}"),
+        }
     })
-    .await
-    .expect("should not timeout")
-    .expect("should not error");
+    .await;
 
-    let phoenix_channel::Event::Hiccup { .. } = event else {
-        panic!("Expected `Hiccup`")
+    let mut channel = make_test_channel("127.0.0.1", port);
+    channel.connect(vec![], Duration::ZERO, PublicKeyParam([0u8; 32]));
+
+    let client = async {
+        loop {
+            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+                phoenix_channel::Event::SuccessResponse { .. } => {}
+                phoenix_channel::Event::ErrorResponse { res, .. } => {
+                    panic!("Unexpected error: {res:?}")
+                }
+                phoenix_channel::Event::JoinedRoom { .. } => {}
+                phoenix_channel::Event::HeartbeatSent => {}
+                phoenix_channel::Event::InboundMessage { .. } => {}
+                phoenix_channel::Event::Hiccup { error, .. } => panic!("{error:#}"),
+                phoenix_channel::Event::Closed => {
+                    panic!("Channel closed")
+                }
+                phoenix_channel::Event::Connected => break,
+            }
+        }
     };
 
-    let result = tokio::time::timeout(Duration::from_secs(2), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    assert!(
-        matches!(result, Ok(phoenix_channel::Event::NoAddresses)),
-        "expected Event::NoAddresses, got {result:?}"
-    );
-}
-
-#[tokio::test]
-async fn emits_no_addresses_when_no_ips() {
-    let mut channel = make_test_channel("localhost", 443); // Use a hostname so we run out of IPs
-    channel.connect(PublicKeyParam([0u8; 32]));
-
-    let result = tokio::time::timeout(Duration::from_secs(5), async {
-        future::poll_fn(|cx| channel.poll(cx)).await
-    })
-    .await
-    .expect("should not timeout");
-
-    assert!(
-        matches!(result, Ok(phoenix_channel::Event::NoAddresses)),
-        "expected Event::NoAddresses, got {result:?}"
-    );
-}
-
-#[tokio::test]
-async fn does_not_clear_address_from_url_on_hiccup() {
-    let mut channel = make_test_channel("127.0.0.1", 443);
-    channel.connect(PublicKeyParam([0u8; 32]));
-
-    loop {
-        match std::future::poll_fn(|cx| channel.poll(cx)).await {
-            Ok(phoenix_channel::Event::Hiccup { .. }) => continue,
-            Err(phoenix_channel::Error::MaxRetriesReached { .. }) => break,
-            other => panic!("Unexpected event: {other:?}"), // This line ensures we never receive `Event::NoAddresses` which means we keep retrying.
-        }
-    }
+    client.await;
+    server.abort();
 }
 
 /// Spawns a WebSocket server that responds to requests using a handler function.
@@ -675,7 +676,12 @@ async fn http_503_triggers_retry() {
     let port = http_status_server(http::StatusCode::SERVICE_UNAVAILABLE).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -695,7 +701,12 @@ async fn http_429_with_retry_after_uses_header_value() {
     let port = http_status_server_with_retry_after(429, "Too Many Requests", 30).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -721,7 +732,12 @@ async fn http_503_with_retry_after_uses_header_value() {
     let port = http_status_server_with_retry_after(503, "Service Unavailable", 60).await;
 
     let mut channel = make_test_channel("127.0.0.1", port);
-    channel.connect(PublicKeyParam([0u8; 32]));
+
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         future::poll_fn(|cx| channel.poll(cx)).await
@@ -750,8 +766,11 @@ async fn initial_connection_uses_constant_1s_backoff() {
     let _guard = logging::test("debug");
 
     let mut channel = make_test_channel("127.0.0.1", 1);
-
-    channel.connect(PublicKeyParam([0u8; 32]));
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
 
     let mut hiccups = Vec::new();
     let start = std::time::Instant::now();
@@ -764,9 +783,12 @@ async fn initial_connection_uses_constant_1s_backoff() {
                 ..
             }) => {
                 hiccups.push((backoff, max_elapsed_time));
-            }
-            Ok(phoenix_channel::Event::NoAddresses) => {
-                channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
+
+                channel.connect(
+                    vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+                    backoff,
+                    PublicKeyParam([0u8; 32]),
+                );
             }
             Err(Error::MaxRetriesReached { .. }) => break,
             other => panic!("Unexpected event: {other:?}"),

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -772,7 +772,6 @@ async fn initial_connection_uses_constant_1s_backoff() {
         PublicKeyParam([0u8; 32]),
     );
 
-    let mut hiccups = Vec::new();
     let start = std::time::Instant::now();
 
     loop {
@@ -782,7 +781,8 @@ async fn initial_connection_uses_constant_1s_backoff() {
                 max_elapsed_time,
                 ..
             }) => {
-                hiccups.push((backoff, max_elapsed_time));
+                assert_eq!(max_elapsed_time, Some(Duration::from_secs(15)));
+                assert_eq!(backoff, Duration::from_secs(1));
 
                 channel.connect(
                     vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
@@ -801,11 +801,4 @@ async fn initial_connection_uses_constant_1s_backoff() {
         elapsed < Duration::from_secs(20),
         "Expected to complete within 20s, but took {elapsed:?}"
     );
-
-    for (i, (backoff, max_elapsed_time)) in hiccups.iter().enumerate() {
-        assert_eq!(*max_elapsed_time, Some(Duration::from_secs(15)));
-        if i > 0 {
-            assert_eq!(*backoff, Duration::from_secs(1));
-        }
-    }
 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -78,7 +78,6 @@ async fn client_does_not_pipeline_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
                     ..
@@ -140,7 +139,6 @@ async fn client_deduplicates_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
                     ..
@@ -203,7 +201,6 @@ async fn client_clears_local_message_on_connect() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
                     ..
@@ -322,7 +319,6 @@ async fn times_out_after_missed_heartbeats() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => break error,
                 phoenix_channel::Event::Closed => {
@@ -473,7 +469,6 @@ async fn includes_ip_from_hostname() {
     let client = async {
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => panic!("{error:#}"),
                 phoenix_channel::Event::Closed => {

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -78,9 +78,6 @@ async fn client_does_not_pipeline_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::ErrorResponse { res, .. } => {
-                    panic!("Unexpected error: {res:?}")
-                }
                 phoenix_channel::Event::JoinedRoom { .. } => {}
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
@@ -144,9 +141,6 @@ async fn client_deduplicates_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::ErrorResponse { res, .. } => {
-                    panic!("Unexpected error: {res:?}")
-                }
                 phoenix_channel::Event::JoinedRoom { .. } => {
                     channel.send("test", OutboundMsg::Bar).unwrap();
                     channel.send("test", OutboundMsg::Bar).unwrap();
@@ -211,9 +205,6 @@ async fn client_clears_local_message_on_connect() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::ErrorResponse { res, .. } => {
-                    panic!("Unexpected error: {res:?}")
-                }
                 phoenix_channel::Event::JoinedRoom { .. } => {
                     channel.send("test", OutboundMsg::Bar).unwrap();
                 }
@@ -334,9 +325,6 @@ async fn times_out_after_missed_heartbeats() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::ErrorResponse { res, .. } => {
-                    panic!("Unexpected error: {res:?}")
-                }
                 phoenix_channel::Event::JoinedRoom { .. } => {}
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}
@@ -489,9 +477,6 @@ async fn includes_ip_from_hostname() {
     let client = async {
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::ErrorResponse { res, .. } => {
-                    panic!("Unexpected error: {res:?}")
-                }
                 phoenix_channel::Event::JoinedRoom { .. } => {}
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -334,7 +334,7 @@ async fn times_out_after_missed_heartbeats() {
 
     assert_eq!(
         format!("{error:#}"),
-        "Reconnecting to portal on transient error: too many heartbeats were unanswered"
+        "Connection hiccup: too many heartbeats were unanswered"
     );
 }
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -46,7 +46,7 @@ async fn client_does_not_pipeline_messages() {
                         }
 
                         ws.send(Message::text(
-                            r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#,
+                            r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#,
                         )).await.unwrap();
                     }
                     r#"{"topic":"test","event":"bar","ref":1}"# => {
@@ -115,7 +115,7 @@ async fn client_deduplicates_messages() {
     let (server, port) = spawn_websocket_server(|text| {
         match text {
             r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
             }
             // We only handle the message with `ref: 1` and thus guarantee that not more than 1 is received
             r#"{"topic":"test","event":"bar","ref":1}"# => {
@@ -178,7 +178,7 @@ async fn client_clears_local_message_on_connect() {
     let (server, port) = spawn_websocket_server(|text| {
         match text {
             r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
             }
             // We only handle the message with `ref: 1` and thus guarantee that the first one is not received.
             r#"{"topic":"test","event":"bar","ref":1}"# => {
@@ -288,7 +288,7 @@ async fn times_out_after_missed_heartbeats() {
     let (server, port) = spawn_websocket_server(|text| {
         match text {
             r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
             }
             // We send a bogus reply (bad `ref`) to ensure the implementation matches those up correctly.
             r#"{"topic":"phoenix","event":"heartbeat","payload":{},"ref":1}"# => {
@@ -456,7 +456,7 @@ async fn includes_ip_from_hostname() {
     let (server, port) = spawn_websocket_server(|text| {
         match text {
             r#"{"topic":"test","event":"phx_join","payload":null,"ref":0}"# => {
-                r#"{"event":"phx_reply","ref":0,"topic":"client","payload":{"status":"ok","response":{}}}"#
+                r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#
             }
             other => panic!("Unexpected message: {other}"),
         }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -744,35 +744,12 @@ async fn http_503_with_retry_after_uses_header_value() {
 
 #[tokio::test]
 async fn initial_connection_uses_constant_1s_backoff() {
-    use std::{str::FromStr, sync::Arc, time::Duration};
-
-    use phoenix_channel::{DeviceInfo, Error, LoginUrl, PhoenixChannel, PublicKeyParam};
-    use secrecy::SecretString;
-    use url::Url;
+    use phoenix_channel::{Error, PublicKeyParam};
+    use std::time::Duration;
 
     let _guard = logging::test("debug");
 
-    let login_url = LoginUrl::client(
-        Url::from_str("ws://127.0.0.1:1").unwrap(),
-        String::new(),
-        None,
-        DeviceInfo::default(),
-    )
-    .unwrap();
-
-    let mut channel = PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
-        login_url,
-        SecretString::from("secret"),
-        "test/1.0.0".to_owned(),
-        "test",
-        (),
-        || {
-            backoff::ExponentialBackoffBuilder::default()
-                .with_max_elapsed_time(Some(Duration::from_secs(3600)))
-                .build()
-        },
-        Arc::new(socket_factory::tcp),
-    );
+    let mut channel = make_test_channel("127.0.0.1", 1);
 
     channel.connect(PublicKeyParam([0u8; 32]));
 

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -78,7 +78,6 @@ async fn client_does_not_pipeline_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::SuccessResponse { .. } => {}
                 phoenix_channel::Event::ErrorResponse { res, .. } => {
                     panic!("Unexpected error: {res:?}")
                 }
@@ -145,7 +144,6 @@ async fn client_deduplicates_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::SuccessResponse { .. } => {}
                 phoenix_channel::Event::ErrorResponse { res, .. } => {
                     panic!("Unexpected error: {res:?}")
                 }
@@ -213,7 +211,6 @@ async fn client_clears_local_message_on_connect() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::SuccessResponse { .. } => {}
                 phoenix_channel::Event::ErrorResponse { res, .. } => {
                     panic!("Unexpected error: {res:?}")
                 }
@@ -337,7 +334,6 @@ async fn times_out_after_missed_heartbeats() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::SuccessResponse { .. } => {}
                 phoenix_channel::Event::ErrorResponse { res, .. } => {
                     panic!("Unexpected error: {res:?}")
                 }
@@ -493,7 +489,6 @@ async fn includes_ip_from_hostname() {
     let client = async {
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::SuccessResponse { .. } => {}
                 phoenix_channel::Event::ErrorResponse { res, .. } => {
                     panic!("Unexpected error: {res:?}")
                 }

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -78,7 +78,7 @@ async fn client_does_not_pipeline_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::InboundMessage {
+                phoenix_channel::Event::Message {
                     msg: InboundMsg::Foo,
                     ..
                 } => {
@@ -139,7 +139,7 @@ async fn client_deduplicates_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::InboundMessage {
+                phoenix_channel::Event::Message {
                     msg: InboundMsg::Foo,
                     ..
                 } => {
@@ -201,7 +201,7 @@ async fn client_clears_local_message_on_connect() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::InboundMessage {
+                phoenix_channel::Event::Message {
                     msg: InboundMsg::Foo,
                     ..
                 } => {
@@ -319,7 +319,7 @@ async fn times_out_after_missed_heartbeats() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::InboundMessage { .. } => {}
+                phoenix_channel::Event::Message { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => break error,
                 phoenix_channel::Event::Closed => {
                     panic!("Channel closed")
@@ -469,7 +469,7 @@ async fn includes_ip_from_hostname() {
     let client = async {
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::InboundMessage { .. } => {}
+                phoenix_channel::Event::Message { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => panic!("{error:#}"),
                 phoenix_channel::Event::Closed => {
                     panic!("Channel closed")

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -78,7 +78,6 @@ async fn client_does_not_pipeline_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::JoinedRoom { .. } => {}
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
@@ -141,12 +140,6 @@ async fn client_deduplicates_messages() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::JoinedRoom { .. } => {
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                }
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
@@ -158,7 +151,12 @@ async fn client_deduplicates_messages() {
                     panic!("Unexpected hiccup: {error:?}")
                 }
                 phoenix_channel::Event::Closed => break,
-                phoenix_channel::Event::Connected => {}
+                phoenix_channel::Event::Connected => {
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                }
             }
         }
     };
@@ -205,9 +203,6 @@ async fn client_clears_local_message_on_connect() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::JoinedRoom { .. } => {
-                    channel.send("test", OutboundMsg::Bar).unwrap();
-                }
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage {
                     msg: InboundMsg::Foo,
@@ -219,7 +214,9 @@ async fn client_clears_local_message_on_connect() {
                     panic!("Unexpected hiccup: {error:?}")
                 }
                 phoenix_channel::Event::Closed => break,
-                phoenix_channel::Event::Connected => {}
+                phoenix_channel::Event::Connected => {
+                    channel.send("test", OutboundMsg::Bar).unwrap();
+                }
             }
         }
     };
@@ -325,7 +322,6 @@ async fn times_out_after_missed_heartbeats() {
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::JoinedRoom { .. } => {}
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => break error,
@@ -477,7 +473,6 @@ async fn includes_ip_from_hostname() {
     let client = async {
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::JoinedRoom { .. } => {}
                 phoenix_channel::Event::HeartbeatSent => {}
                 phoenix_channel::Event::InboundMessage { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => panic!("{error:#}"),

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -67,7 +67,7 @@ async fn client_does_not_pipeline_messages() {
         }
     });
 
-    let mut channel = make_websocket_test_channel(server_addr.port());
+    let mut channel = make_test_channel("localhost", server_addr.port());
 
     let client = async move {
         channel.connect(PublicKeyParam([0u8; 32]));
@@ -131,7 +131,7 @@ async fn client_deduplicates_messages() {
     })
     .await;
 
-    let mut channel = make_websocket_test_channel(port);
+    let mut channel = make_test_channel("localhost", port);
 
     let mut num_responses = 0;
 
@@ -199,7 +199,7 @@ async fn client_clears_local_message_on_connect() {
     })
     .await;
 
-    let mut channel = make_websocket_test_channel(port);
+    let mut channel = make_test_channel("localhost", port);
 
     let client = async {
         channel.send("test", OutboundMsg::Bar).unwrap_err();
@@ -323,7 +323,7 @@ async fn times_out_after_missed_heartbeats() {
     })
     .await;
 
-    let mut channel = make_websocket_test_channel(port);
+    let mut channel = make_test_channel("localhost", port);
 
     let client = async {
         channel.connect(PublicKeyParam([0u8; 32]));
@@ -581,40 +581,10 @@ impl ServerHandle {
     }
 }
 
-fn make_websocket_test_channel(
+fn make_test_channel(
+    host: &str,
     port: u16,
 ) -> PhoenixChannel<(), OutboundMsg, InboundMsg, PublicKeyParam> {
-    use std::{str::FromStr, sync::Arc, time::Duration};
-
-    use backoff::ExponentialBackoffBuilder;
-    use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel};
-    use secrecy::SecretString;
-    use url::Url;
-
-    let login_url = LoginUrl::client(
-        Url::from_str(&format!("ws://localhost:{}", port)).unwrap(),
-        String::new(),
-        None,
-        DeviceInfo::default(),
-    )
-    .unwrap();
-
-    PhoenixChannel::<(), OutboundMsg, InboundMsg, _>::disconnected(
-        login_url,
-        SecretString::from("secret"),
-        "test/1.0.0".to_owned(),
-        "test",
-        (),
-        || {
-            ExponentialBackoffBuilder::default()
-                .with_initial_interval(Duration::from_secs(1))
-                .build()
-        },
-        Arc::new(socket_factory::tcp),
-    )
-}
-
-fn make_test_channel(host: &str, port: u16) -> PhoenixChannel<(), (), (), PublicKeyParam> {
     let url = LoginUrl::client(
         format!("ws://{host}:{port}").as_str(),
         "test-device-id".to_string(),

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -238,35 +238,28 @@ async fn replies_with_close_frame_upon_close() {
     })
     .await;
 
-    let mut channel = make_websocket_test_channel(port);
+    let mut channel = make_test_channel("localhost", port);
 
-    let (mut join_tx, mut join_rx) = futures::channel::mpsc::channel(1);
+    let (mut connected_tx, mut connected_rx) = futures::channel::mpsc::channel(1);
 
     let client = tokio::spawn(async move {
-        channel.connect(PublicKeyParam([0u8; 32]));
+        channel.connect(
+            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+            Duration::ZERO,
+            PublicKeyParam([0u8; 32]),
+        );
 
         loop {
             match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
-                phoenix_channel::Event::SuccessResponse { .. } => {}
-                phoenix_channel::Event::ErrorResponse { res, .. } => {
-                    panic!("Unexpected error: {res:?}")
-                }
-                phoenix_channel::Event::JoinedRoom { .. } => {
-                    join_tx.send(()).await.unwrap();
-                }
-                phoenix_channel::Event::HeartbeatSent => {}
-                phoenix_channel::Event::InboundMessage { .. } => {}
                 phoenix_channel::Event::Hiccup { error, .. } => break error,
-                phoenix_channel::Event::NoAddresses => {
-                    channel.update_ips(vec![IpAddr::from(Ipv4Addr::LOCALHOST)]);
-                }
                 phoenix_channel::Event::Closed => panic!("Should not close"),
-                phoenix_channel::Event::Connected => {}
+                phoenix_channel::Event::Message { .. } => {}
+                phoenix_channel::Event::Connected => connected_tx.send(()).await.unwrap(),
             }
         }
     });
 
-    join_rx.recv().await.unwrap(); // Wait for successful join.
+    connected_rx.recv().await.unwrap(); // Wait for successful connection.
 
     let server_result = server.stop().await;
     let client_result = client.await.unwrap();

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -16,7 +16,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use secrecy::{ExposeSecret, SecretString};
 use std::borrow::Cow;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -766,8 +766,8 @@ async fn phoenix_channel_event_loop(
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     is_connected: Arc<AtomicBool>,
 ) {
-    update_portal_host_ips(&mut portal).await;
-    portal.connect(NoParams);
+    let ips = resolve_portal_host_ips(portal.host()).await;
+    portal.connect(ips, Duration::ZERO, NoParams);
 
     loop {
         match std::future::poll_fn(|cx| portal.poll(cx)).await {
@@ -792,7 +792,6 @@ async fn phoenix_channel_event_loop(
                 is_connected.store(false, Ordering::Relaxed);
                 break;
             }
-            Ok(Event::NoAddresses) => update_portal_host_ips(&mut portal).await,
             Ok(Event::Hiccup {
                 backoff,
                 max_elapsed_time,
@@ -800,6 +799,9 @@ async fn phoenix_channel_event_loop(
             }) => {
                 is_connected.store(false, Ordering::Relaxed);
                 tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}");
+
+                let ips = resolve_portal_host_ips(portal.host()).await;
+                portal.connect(ips, backoff, NoParams);
             }
             Ok(Event::Connected) => {}
             Err(e) => {
@@ -812,23 +814,13 @@ async fn phoenix_channel_event_loop(
     }
 }
 
-async fn update_portal_host_ips(
-    portal: &mut PhoenixChannel<JoinMessage, (), IngressMessages, NoParams>,
-) {
-    let host = portal.host();
-
-    let ips = match tokio::net::lookup_host(format!("{host}:0"))
+async fn resolve_portal_host_ips(host: String) -> Vec<IpAddr> {
+    tokio::net::lookup_host(format!("{host}:0"))
         .await
         .context("Failed to lookup portal host")
-    {
-        Ok(sockets) => sockets.map(|s| s.ip()),
-        Err(e) => {
-            tracing::warn!(%host, "{e:#}");
-            return;
-        }
-    };
-
-    portal.update_ips(ips);
+        .inspect_err(|e| tracing::debug!(%host, "{e:#}"))
+        .map(|ips| ips.map(|s| s.ip()).collect())
+        .unwrap_or_default()
 }
 
 fn fmt_human_throughput(mut throughput: f64) -> String {

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -775,9 +775,6 @@ async fn phoenix_channel_event_loop(
                 tracing::info!(target: "relay", "Successfully joined room '{topic}'");
                 is_connected.store(true, Ordering::Relaxed);
             }
-            Ok(Event::ErrorResponse { topic, req_id, res }) => {
-                tracing::warn!(target: "relay", "Request with ID {req_id} on topic {topic} failed: {res:?}");
-            }
             Ok(Event::HeartbeatSent) => {
                 tracing::debug!(target: "relay", "Heartbeat sent to portal");
             }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -771,10 +771,6 @@ async fn phoenix_channel_event_loop(
 
     loop {
         match std::future::poll_fn(|cx| portal.poll(cx)).await {
-            Ok(Event::JoinedRoom { topic }) => {
-                tracing::info!(target: "relay", "Successfully joined room '{topic}'");
-                is_connected.store(true, Ordering::Relaxed);
-            }
             Ok(Event::HeartbeatSent) => {
                 tracing::debug!(target: "relay", "Heartbeat sent to portal");
             }
@@ -799,7 +795,9 @@ async fn phoenix_channel_event_loop(
                 let ips = resolve_portal_host_ips(portal.host()).await;
                 portal.connect(ips, backoff, NoParams);
             }
-            Ok(Event::Connected) => {}
+            Ok(Event::Connected) => {
+                is_connected.store(true, Ordering::Relaxed);
+            }
             Err(e) => {
                 is_connected.store(false, Ordering::Relaxed);
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -771,7 +771,7 @@ async fn phoenix_channel_event_loop(
 
     loop {
         match std::future::poll_fn(|cx| portal.poll(cx)).await {
-            Ok(Event::InboundMessage { msg, .. }) => {
+            Ok(Event::Message { msg, .. }) => {
                 if event_tx.send(Ok(msg)).await.is_err() {
                     tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
                     break;

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -771,7 +771,6 @@ async fn phoenix_channel_event_loop(
 
     loop {
         match std::future::poll_fn(|cx| portal.poll(cx)).await {
-            Ok(Event::SuccessResponse { .. }) => {}
             Ok(Event::JoinedRoom { topic }) => {
                 tracing::info!(target: "relay", "Successfully joined room '{topic}'");
                 is_connected.store(true, Ordering::Relaxed);

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -771,9 +771,6 @@ async fn phoenix_channel_event_loop(
 
     loop {
         match std::future::poll_fn(|cx| portal.poll(cx)).await {
-            Ok(Event::HeartbeatSent) => {
-                tracing::debug!(target: "relay", "Heartbeat sent to portal");
-            }
             Ok(Event::InboundMessage { msg, .. }) => {
                 if event_tx.send(Ok(msg)).await.is_err() {
                     tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");


### PR DESCRIPTION
The `PhoenixChannel` component has gone through many different designs. We always needed some kind of reconnect mechanism and the different consumers (Client, Gateway & Relay) at times had different needs here.

With the recent removal of the legacy connection scheme and more learnings as to what we need from this component, we can simplify the API here and encapsulate its behaviour better. The high-level summary here is:

- Remove the notion of success and error replies: The way we use the phoenix-protocol, these messages don't matter. Even though the portal does acknowledge our messages with a `phx_reply`, all of connlib is built around application-level ACKs. For example, we expect an inbound message for the same resource ID after a `create_flow`, regardless of whether the portal has sent us a `phx_reply`.
- Remove the ability to join arbitrary rooms: We only ever join a single room, there is not need to expose this.
- Only emit `Connected` once we have joined our designated room.
- Only reset the reconnect backoff once we have joined the room.
- And last but not least: Do not automatically reconnect using the previous IPs. Instead, the caller must call `connect` after receiving a `Hiccup` event.

These design decisions allow us to re-query DNS on every hiccup without muddling the internal state. `PhoenixChannel` now does not implicitly reconnect and thus requires a new set of IPs on every `connect` call.