### PR TITLE
build(rust): bump str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7151,7 +7151,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.16.2"
-source = "git+https://github.com/algesten/str0m?branch=main#29000b1c6452ab8009f24171ba737f7428348d08"
+source = "git+https://github.com/algesten/str0m?branch=main#e339fa41e59916b704c4684609013a9691cef14f"
 dependencies = [
  "arrayvec",
  "combine",
@@ -7168,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "str0m-proto"
 version = "0.1.2"
-source = "git+https://github.com/algesten/str0m?branch=main#29000b1c6452ab8009f24171ba737f7428348d08"
+source = "git+https://github.com/algesten/str0m?branch=main#e339fa41e59916b704c4684609013a9691cef14f"
 dependencies = [
  "base64ct",
  "dimpl",

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1974,7 +1974,7 @@ mod tests {
 
         IceConfig::client_default().apply(&mut agent);
 
-        assert_eq!(agent.ice_timeout(), Duration::from_millis(15250))
+        assert_eq!(agent.ice_timeout(), Duration::from_millis(16500))
     }
 
     #[test]
@@ -1992,7 +1992,7 @@ mod tests {
 
         IceConfig::server_default().apply(&mut agent);
 
-        assert_eq!(agent.ice_timeout(), Duration::from_millis(600_750))
+        assert_eq!(agent.ice_timeout(), Duration::from_millis(615_500))
     }
 
     #[test]


### PR DESCRIPTION
Latest version of str0m includes a fix for the computation of the ICE timeout. This does not change anything functionally but it makes it clearer, what the ICE timeout really is (for an established connection). The previous value was only valid for a not-yet established connection.