### PR TITLE
chore: Allow Claude to review dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,3 +26,4 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          allowed_bots: "dependabot[bot]"


### PR DESCRIPTION
Add dependabot[bot] to allowed_bots in workflow to enable automated code reviews on dependency update pull requests

Otherwise CI fails on dependabot-created PRs, as we don't filter out Claude CI job for them.
