### PR TITLE
fix(portal): use GenServer.call for channel coms

### DIFF
--- a/elixir/lib/portal/channels.ex
+++ b/elixir/lib/portal/channels.ex
@@ -1,10 +1,10 @@
 defmodule Portal.Channels do
   @moduledoc """
-  Targeted message delivery to client and gateway channel processes using `:pg` process groups.
+  Targeted message delivery to client and gateway channel processes using `:pg` as a registry.
 
   Replaces the previous `PubSub.Account.broadcast` pattern which sent messages to every
   channel in an account. Instead, processes register under their specific ID and messages
-  are sent directly to the registered processes.
+  are delivered directly via `GenServer.call/2`.
 
   `:pg` works natively across distributed Erlang clusters, auto-deregisters dead processes,
   and handles netsplits by removing unreachable members from the local view.
@@ -14,32 +14,34 @@ defmodule Portal.Channels do
   Registers the calling process as a client channel for the given client ID.
   """
   def register_client(client_id) do
-    :ok = :pg.join(group(:client, client_id), self())
+    :ok = :pg.join(pg_key(:client, client_id), self())
   end
 
   @doc """
   Registers the calling process as a gateway channel for the given gateway ID.
   """
   def register_gateway(gateway_id) do
-    :ok = :pg.join(group(:gateway, gateway_id), self())
+    :ok = :pg.join(pg_key(:gateway, gateway_id), self())
   end
 
   @doc """
-  Sends a message to all processes registered for the given client ID.
+  Calls the registered client channel process with the given message.
 
-  Returns `:ok` if at least one process is registered, `{:error, :not_found}` otherwise.
+  Returns `:ok` if the process handled the call, `{:error, :not_found}` if no process
+  is registered or the process exits or times out.
   """
   def send_to_client(client_id, message) do
-    send_to_group(group(:client, client_id), message)
+    call_channel(pg_key(:client, client_id), message)
   end
 
   @doc """
-  Sends a message to all processes registered for the given gateway ID.
+  Calls the registered gateway channel process with the given message.
 
-  Returns `:ok` if at least one process is registered, `{:error, :not_found}` otherwise.
+  Returns `:ok` if the process handled the call, `{:error, :not_found}` if no process
+  is registered or the process exits or times out.
   """
   def send_to_gateway(gateway_id, message) do
-    send_to_group(group(:gateway, gateway_id), message)
+    call_channel(pg_key(:gateway, gateway_id), message)
   end
 
   @doc """
@@ -52,16 +54,18 @@ defmodule Portal.Channels do
     send_to_gateway(gateway_id, {:reject_access, client_id, resource_id})
   end
 
-  defp send_to_group(group, message) do
-    case :pg.get_members(group) do
+  defp call_channel(pg_key, message) do
+    case :pg.get_members(pg_key) do
       [] ->
         {:error, :not_found}
 
-      pids ->
-        Enum.each(pids, &send(&1, message))
+      [pid] ->
+        GenServer.call(pid, message)
         :ok
     end
+  catch
+    :exit, _ -> {:error, :not_found}
   end
 
-  defp group(type, id), do: {__MODULE__, type, id}
+  defp pg_key(type, id), do: {__MODULE__, type, id}
 end

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -238,29 +238,6 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
-  #############################################################
-  ##### Forwarding replies from the gateway to the client #####
-  #############################################################
-
-  # This the list of ICE candidates gathered by the gateway and relayed to the client
-  def handle_info({:ice_candidates, gateway_id, candidates}, socket) do
-    push(socket, "ice_candidates", %{
-      gateway_id: gateway_id,
-      candidates: candidates
-    })
-
-    {:noreply, socket}
-  end
-
-  def handle_info({:invalidate_ice_candidates, gateway_id, candidates}, socket) do
-    push(socket, "invalidate_ice_candidates", %{
-      gateway_id: gateway_id,
-      candidates: candidates
-    })
-
-    {:noreply, socket}
-  end
-
   # DEPRECATED IN 1.4
   # This message is sent by the gateway when it is ready to accept the connection from the client
   def handle_info(
@@ -331,6 +308,30 @@ defmodule PortalAPI.Client.Channel do
 
   # Catch-all for messages we don't handle
   def handle_info(_message, socket), do: {:noreply, socket}
+
+  #############################################################
+  ##### Forwarding replies from the gateway to the client #####
+  #############################################################
+
+  # This the list of ICE candidates gathered by the gateway and relayed to the client
+  @impl true
+  def handle_call({:ice_candidates, gateway_id, candidates}, _from, socket) do
+    push(socket, "ice_candidates", %{
+      gateway_id: gateway_id,
+      candidates: candidates
+    })
+
+    {:reply, :ok, socket}
+  end
+
+  def handle_call({:invalidate_ice_candidates, gateway_id, candidates}, _from, socket) do
+    push(socket, "invalidate_ice_candidates", %{
+      gateway_id: gateway_id,
+      candidates: candidates
+    })
+
+    {:reply, :ok, socket}
+  end
 
   ####################################
   ##### Client-initiated actions #####

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -209,29 +209,33 @@ defmodule PortalAPI.Gateway.Channel do
     end
   end
 
+  # Catch-all for messages we don't handle
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   ###########################
   #### Connection setup #####
   ###########################
 
-  def handle_info({:ice_candidates, client_id, candidates}, socket) do
+  @impl true
+  def handle_call({:ice_candidates, client_id, candidates}, _from, socket) do
     push(socket, "ice_candidates", %{
       client_id: client_id,
       candidates: candidates
     })
 
-    {:noreply, socket}
+    {:reply, :ok, socket}
   end
 
-  def handle_info({:invalidate_ice_candidates, client_id, candidates}, socket) do
+  def handle_call({:invalidate_ice_candidates, client_id, candidates}, _from, socket) do
     push(socket, "invalidate_ice_candidates", %{
       client_id: client_id,
       candidates: candidates
     })
 
-    {:noreply, socket}
+    {:reply, :ok, socket}
   end
 
-  def handle_info({:authorize_policy, {channel_pid, socket_ref}, payload}, socket) do
+  def handle_call({:authorize_policy, {channel_pid, socket_ref}, payload}, _from, socket) do
     %{
       client: client,
       subject: subject,
@@ -272,11 +276,11 @@ defmodule PortalAPI.Gateway.Channel do
         authorization_expires_at
       )
 
-    {:noreply, assign(socket, cache: cache)}
+    {:reply, :ok, assign(socket, cache: cache)}
   end
 
   # DEPRECATED IN 1.4
-  def handle_info({:allow_access, {channel_pid, socket_ref}, attrs}, socket) do
+  def handle_call({:allow_access, {channel_pid, socket_ref}, attrs}, _from, socket) do
     %{
       client_id: client_id,
       client_ipv4: client_ipv4,
@@ -289,7 +293,7 @@ defmodule PortalAPI.Gateway.Channel do
 
     case Resource.adapt_resource_for_version(resource, socket.assigns.session.version) do
       nil ->
-        {:noreply, socket}
+        {:reply, :ok, socket}
 
       resource ->
         ref =
@@ -317,12 +321,12 @@ defmodule PortalAPI.Gateway.Channel do
             authorization_expires_at
           )
 
-        {:noreply, assign(socket, cache: cache)}
+        {:reply, :ok, assign(socket, cache: cache)}
     end
   end
 
   # DEPRECATED IN 1.4
-  def handle_info({:request_connection, {channel_pid, socket_ref}, attrs}, socket) do
+  def handle_call({:request_connection, {channel_pid, socket_ref}, attrs}, _from, socket) do
     %{
       client: client,
       resource: %Cache.Cacheable.Resource{} = resource,
@@ -332,7 +336,7 @@ defmodule PortalAPI.Gateway.Channel do
 
     case Resource.adapt_resource_for_version(resource, socket.assigns.session.version) do
       nil ->
-        {:noreply, socket}
+        {:reply, :ok, socket}
 
       resource ->
         ref =
@@ -357,17 +361,14 @@ defmodule PortalAPI.Gateway.Channel do
             authorization_expires_at
           )
 
-        {:noreply, assign(socket, cache: cache)}
+        {:reply, :ok, assign(socket, cache: cache)}
     end
   end
 
-  def handle_info({:reject_access, client_id, resource_id}, socket) do
+  def handle_call({:reject_access, client_id, resource_id}, _from, socket) do
     push(socket, "reject_access", %{client_id: client_id, resource_id: resource_id})
-    {:noreply, socket}
+    {:reply, :ok, socket}
   end
-
-  # Catch-all for messages we don't handle
-  def handle_info(_message, socket), do: {:noreply, socket}
 
   @impl true
   def handle_in("flow_authorized", %{"ref" => signed_ref}, socket) do

--- a/elixir/test/portal/channels_test.exs
+++ b/elixir/test/portal/channels_test.exs
@@ -2,56 +2,22 @@ defmodule Portal.ChannelsTest do
   use ExUnit.Case, async: true
   alias Portal.Channels
 
-  describe "register_client/1 and send_to_client/2" do
-    test "delivers message to a registered client process" do
-      client_id = Ecto.UUID.generate()
-      Channels.register_client(client_id)
+  for {type, register, deliver} <- [
+        {:client, &Channels.register_client/1, &Channels.send_to_client/2},
+        {:gateway, &Channels.register_gateway/1, &Channels.send_to_gateway/2}
+      ] do
+    @register register
+    @deliver deliver
 
-      assert :ok = Channels.send_to_client(client_id, :hello)
-      assert_receive :hello
+    test "delivers message to registered #{type} process" do
+      id = Ecto.UUID.generate()
+      spawn_call_receiver(fn -> @register.(id) end)
+      assert :ok = @deliver.(id, :hello)
+      assert_receive {:received, _pid, :hello}
     end
 
-    test "delivers message to multiple registered processes" do
-      client_id = Ecto.UUID.generate()
-      parent = self()
-
-      pids =
-        for _ <- 1..3 do
-          spawn(fn ->
-            Channels.register_client(client_id)
-            send(parent, {:registered, self()})
-
-            receive do
-              msg -> send(parent, {:received, self(), msg})
-            end
-          end)
-        end
-
-      for pid <- pids, do: assert_receive({:registered, ^pid})
-
-      assert :ok = Channels.send_to_client(client_id, :broadcast)
-
-      for pid <- pids, do: assert_receive({:received, ^pid, :broadcast})
-    end
-
-    test "returns {:error, :not_found} when no process is registered" do
-      client_id = Ecto.UUID.generate()
-      assert {:error, :not_found} = Channels.send_to_client(client_id, :hello)
-    end
-  end
-
-  describe "register_gateway/1 and send_to_gateway/2" do
-    test "delivers message to a registered gateway process" do
-      gateway_id = Ecto.UUID.generate()
-      Channels.register_gateway(gateway_id)
-
-      assert :ok = Channels.send_to_gateway(gateway_id, :hello)
-      assert_receive :hello
-    end
-
-    test "returns {:error, :not_found} when no process is registered" do
-      gateway_id = Ecto.UUID.generate()
-      assert {:error, :not_found} = Channels.send_to_gateway(gateway_id, :hello)
+    test "returns {:error, :not_found} when no #{type} is registered" do
+      assert {:error, :not_found} = @deliver.(Ecto.UUID.generate(), :hello)
     end
   end
 
@@ -66,23 +32,20 @@ defmodule Portal.ChannelsTest do
           send(parent, :registered)
 
           receive do
-            :stop -> :ok
+            {:"$gen_call", from, _message} ->
+              GenServer.reply(from, :ok)
+              receive do: (:stop -> :ok)
           end
         end)
 
       assert_receive :registered
-
-      # Confirm delivery works while process is alive
       assert :ok = Channels.send_to_client(client_id, :ping)
 
-      # Stop the process and wait for :pg to clean up
       Process.monitor(pid)
       send(pid, :stop)
       assert_receive {:DOWN, _, :process, ^pid, :normal}
 
-      # :pg cleanup is async; give it a moment
       Process.sleep(50)
-
       assert {:error, :not_found} = Channels.send_to_client(client_id, :ping)
     end
   end
@@ -93,15 +56,37 @@ defmodule Portal.ChannelsTest do
       client_id = Ecto.UUID.generate()
       resource_id = Ecto.UUID.generate()
 
-      Channels.register_gateway(gateway_id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway_id) end)
 
       assert :ok = Channels.reject_access(gateway_id, client_id, resource_id)
-      assert_receive {:reject_access, ^client_id, ^resource_id}
+      assert_receive {:received, _pid, {:reject_access, ^client_id, ^resource_id}}
     end
 
     test "returns {:error, :not_found} when gateway is not registered" do
-      gateway_id = Ecto.UUID.generate()
-      assert {:error, :not_found} = Channels.reject_access(gateway_id, "c", "r")
+      assert {:error, :not_found} = Channels.reject_access(Ecto.UUID.generate(), "c", "r")
+    end
+  end
+
+  defp spawn_call_receiver(register_fn) do
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        register_fn.()
+        send(parent, {:registered, self()})
+        call_receiver_loop(parent)
+      end)
+
+    assert_receive {:registered, ^pid}
+    pid
+  end
+
+  defp call_receiver_loop(parent) do
+    receive do
+      {:"$gen_call", from, message} ->
+        GenServer.reply(from, :ok)
+        send(parent, {:received, self(), message})
+        call_receiver_loop(parent)
     end
   end
 end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -2290,7 +2290,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       candidates = ["foo", "bar"]
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:ice_candidates, gateway.id, candidates}
       )
@@ -2313,7 +2313,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       candidates = ["foo", "bar"]
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:invalidate_ice_candidates, gateway.id, candidates}
       )
@@ -2488,7 +2488,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       :ok = Portal.Presence.Relays.connect(global_relay)
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       :ok = PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
 
@@ -2552,7 +2552,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       :ok = Portal.Presence.Relays.connect(global_relay)
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       gateway = Repo.preload(gateway, :site)
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
@@ -2610,7 +2610,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       :ok = Portal.Presence.Relays.connect(global_relay)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: System.unique_integer([:positive, :monotonic]),
@@ -2746,7 +2746,7 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: System.unique_integer([:positive, :monotonic]),
@@ -2802,7 +2802,7 @@ defmodule PortalAPI.Client.ChannelTest do
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       {:ok, _reply, socket} =
         PortalAPI.Client.Socket
@@ -2848,7 +2848,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       push(socket, "create_flow", %{
         "resource_id" => resource.id,
@@ -2891,8 +2891,8 @@ defmodule PortalAPI.Client.ChannelTest do
 
       :ok = connect_gateway_presence(gateway2, gateway_token.id)
 
-      :ok = Channels.register_gateway(gateway1.id)
-      :ok = Channels.register_gateway(gateway2.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway1.id) end)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway2.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: System.unique_integer([:positive, :monotonic]),
@@ -2955,7 +2955,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       :ok = Portal.Presence.Relays.connect(global_relay)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
 
       send(socket.channel_pid, %Changes.Change{
@@ -3002,7 +3002,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       :ok = Portal.Presence.Relays.connect(global_relay)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
 
       send(socket.channel_pid, %Changes.Change{
@@ -3062,7 +3062,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       socket = join_channel(client, subject)
       :ok = Portal.Presence.Relays.connect(global_relay)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
 
       send(socket.channel_pid, %Changes.Change{
@@ -3283,7 +3283,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
@@ -3597,7 +3597,7 @@ defmodule PortalAPI.Client.ChannelTest do
       gateway = Repo.preload(gateway, :site)
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: System.unique_integer([:positive, :monotonic]),
@@ -3688,7 +3688,7 @@ defmodule PortalAPI.Client.ChannelTest do
       gateway = Repo.preload(gateway, :site)
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
@@ -3791,7 +3791,7 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       Phoenix.PubSub.subscribe(PubSub, Portal.Sockets.socket_id(gateway_token.id))
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: System.unique_integer([:positive, :monotonic]),
@@ -3953,7 +3953,7 @@ defmodule PortalAPI.Client.ChannelTest do
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
@@ -4020,7 +4020,7 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       attrs = %{
         "resource_id" => resource.id,
@@ -4100,7 +4100,7 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       Phoenix.PubSub.subscribe(PubSub, Portal.Sockets.socket_id(gateway_token.id))
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       push(socket, "request_connection", %{
         "resource_id" => resource.id,
@@ -4151,7 +4151,7 @@ defmodule PortalAPI.Client.ChannelTest do
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
 
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       push(socket, "broadcast_ice_candidates", attrs)
 
@@ -4197,7 +4197,7 @@ defmodule PortalAPI.Client.ChannelTest do
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
       :ok = PubSub.subscribe(Portal.Sockets.socket_id(gateway_token.id))
-      :ok = Channels.register_gateway(gateway.id)
+      spawn_call_receiver(fn -> Channels.register_gateway(gateway.id) end)
 
       push(socket, "broadcast_invalidated_ice_candidates", attrs)
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -209,7 +209,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         gateway: %{username: "C", password: "D"}
       }
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:authorize_policy, {channel_pid, socket_ref},
          %{
@@ -298,7 +298,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         gateway: %{username: "C", password: "D"}
       }
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:authorize_policy, {channel_pid, socket_ref},
          %{
@@ -321,7 +321,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert_push "authorize_flow", _payload
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:authorize_policy, {channel_pid, socket_ref},
          %{
@@ -499,7 +499,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       :ok = Portal.Presence.Relays.connect(relay)
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -572,7 +572,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       # Consume the relays_presence message from relay connection
       assert_push "relays_presence", _relays_presence
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -647,7 +647,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
           group: group
         )
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -663,7 +663,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert_push "allow_access", %{}
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -759,7 +759,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         "expires_at" => policy_authorization.expires_at
       }
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -850,7 +850,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         )
 
       # Build up policy authorization cache
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -866,7 +866,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert_push "allow_access", %{}
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -882,7 +882,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert_push "allow_access", %{}
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -997,7 +997,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       client_payload = "RTC_SD_or_DNS_Q"
       :ok = Portal.Presence.Relays.connect(relay)
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -1066,7 +1066,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       :ok = PubSub.Changes.subscribe(account.id)
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -1146,7 +1146,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
       client_payload = "RTC_SD_or_DNS_Q"
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:allow_access, {channel_pid, socket_ref},
          %{
@@ -1550,7 +1550,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       candidates = ["foo", "bar"]
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:ice_candidates, client.id, candidates}
       )
@@ -1573,7 +1573,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       candidates = ["foo", "bar"]
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:invalidate_ice_candidates, client.id, candidates}
       )
@@ -1617,7 +1617,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       :ok = Portal.Presence.Relays.connect(relay)
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:request_connection, {channel_pid, socket_ref},
          %{
@@ -1697,7 +1697,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
           group: group
         )
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:request_connection, {channel_pid, socket_ref},
          %{
@@ -1772,7 +1772,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         gateway: %{username: "C", password: "D"}
       }
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:authorize_policy, {channel_pid, socket_ref},
          %{
@@ -1871,7 +1871,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
           group: group
         )
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:authorize_policy, {channel_pid, socket_ref},
          %{
@@ -1967,7 +1967,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         gateway: %{username: "C", password: "D"}
       }
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:authorize_policy, {channel_pid, socket_ref},
          %{
@@ -2056,7 +2056,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       :ok = Portal.Presence.Relays.connect(relay)
 
-      send(
+      GenServer.call(
         socket.channel_pid,
         {:request_connection, {channel_pid, socket_ref},
          %{
@@ -2156,7 +2156,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         "client_ids" => [client.id]
       }
 
-      :ok = Channels.register_client(client.id)
+      spawn_call_receiver(fn -> Channels.register_client(client.id) end)
 
       push(socket, "broadcast_ice_candidates", attrs)
 
@@ -2201,7 +2201,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         "client_ids" => [client.id]
       }
 
-      :ok = Channels.register_client(client.id)
+      spawn_call_receiver(fn -> Channels.register_client(client.id) end)
 
       push(socket, "broadcast_invalidated_ice_candidates", attrs)
 

--- a/elixir/test/support/channel_case.ex
+++ b/elixir/test/support/channel_case.ex
@@ -73,6 +73,38 @@ defmodule PortalAPI.ChannelCase do
     }
   end
 
+  @doc """
+  Spawns a process that calls `register_fn`, signals the parent, then loops
+  handling GenServer.call protocol. Used to avoid deadlocks when tests register
+  themselves as a client/gateway and Portal.Channels uses GenServer.call.
+  """
+  def spawn_call_receiver(register_fn) do
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        register_fn.()
+        send(parent, {:registered, self()})
+        call_receiver_loop(parent)
+      end)
+
+    assert_receive {:registered, ^pid}
+    pid
+  end
+
+  @doc """
+  Loops handling GenServer.call protocol by replying :ok and forwarding the
+  unwrapped message to parent.
+  """
+  def call_receiver_loop(parent) do
+    receive do
+      {:"$gen_call", from, message} ->
+        GenServer.reply(from, :ok)
+        send(parent, message)
+        call_receiver_loop(parent)
+    end
+  end
+
   setup tags do
     # Isolate relay presence per test to prevent interference between async tests
     Portal.Config.put_env_override(


### PR DESCRIPTION
When sending connection setup messages from client to gateway and vice-versa, we used `Process.send` which is fire-and-forget. This means that during brief netsplits or state divergence, the message would be lost. In most cases the client will re-attempt to establish a flow, but instead of relying on that to happen, we update these messages to use `GenServer.call` which will raise an exception if the other process does not handle the call.

If the call fails, we then respond to the caller appropriately so that `:offline` can be pushed down the channel.
