### PR TITLE
chore: skip claude workflow for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,4 +27,3 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          allowed_bots: "dependabot[bot]"


### PR DESCRIPTION
Dependabot runs in a restricted context without access to repository secrets, causing the workflow to fail on missing CLAUDE_CODE_OAUTH_TOKEN. Skip the job entirely instead.

Fixes #12229 
