### PR TITLE
ci: prevent pipeline failures if Coveralls is down

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -53,6 +53,7 @@ jobs:
           format: lcov
           flag-name: portal
           parallel: true
+          fail-on-error: false
 
   type-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -151,6 +151,7 @@ jobs:
           format: lcov
           flag-name: rust-test-${{ runner.os }}
           parallel: true
+          fail-on-error: false
 
   tunnel_test:
     name: tunnel-test
@@ -228,6 +229,7 @@ jobs:
           format: lcov
           flag-name: rust-tunnel-test
           parallel: true
+          fail-on-error: false
 
   fuzz:
     name: fuzz

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -98,3 +98,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+          fail-on-error: false


### PR DESCRIPTION
We shouldn't fail whole CI if for some reason we cannot upload code coverage data; coveralls is a 3rd-party service that experiences outages at times.

We already had it for some jobs (e.g. Swift), but it was not rolled out everywhere.