### PR TITLE
test(portal): use 10ms debounce timeout

### DIFF
--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -908,7 +908,7 @@ defmodule PortalAPI.Client.ChannelTest do
     } do
       # Use a non-zero debounce to prevent race condition where the 0ms debounce
       # timer fires before the test process has called connect() after disconnect()
-      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 50)
+      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 10)
 
       # Connect relay BEFORE client joins so it's included in init
       relay1 = connect_relay(%{lat: 37.0, lon: -120.0})
@@ -938,6 +938,10 @@ defmodule PortalAPI.Client.ChannelTest do
       client: client,
       subject: subject
     } do
+      # Use a non-zero debounce so both disconnect and reconnect presence_diff events
+      # are captured in the same window and delivered as one combined message.
+      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 10)
+
       # Connect relay BEFORE client joins so it's included in init
       relay1 = connect_relay(%{lat: 37.0, lon: -120.0})
 
@@ -1240,8 +1244,8 @@ defmodule PortalAPI.Client.ChannelTest do
       client: client,
       subject: subject
     } do
-      # Set debounce to 50ms so the test is fast but we can still observe coalescing
-      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 50)
+      # Set debounce to 10ms so the test is fast but we can still observe coalescing
+      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 10)
 
       _socket = join_channel(client, subject)
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -2259,6 +2259,10 @@ defmodule PortalAPI.Gateway.ChannelTest do
       site: site,
       token: token
     } do
+      # Use a non-zero debounce so both disconnect and reconnect presence_diff events
+      # are captured in the same window and delivered as one combined message.
+      Portal.Config.put_env_override(:portal, :relay_presence_debounce_ms, 10)
+
       relay1 = relay_fixture(%{lat: 37.0, lon: -120.0})
 
       :ok = Portal.Presence.Relays.connect(relay1)


### PR DESCRIPTION
Need some kind of debounce timeout to prevent races in the channel presence unit tests. Previously this was 0.

Fixes #12282
