### PR TITLE
fix(portal): separate ops check origin port

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -371,7 +371,7 @@ if config_env() == :prod do
       signing_salt: env_var_to_config!(:ops_live_view_signing_salt)
     ],
     check_origin: [
-      "//#{env_var_to_config!(:ops_websocket_origin)}:#{env_var_to_config!(:phoenix_http_ops_port)}"
+      "//#{env_var_to_config!(:ops_websocket_origin)}:#{env_var_to_config!(:ops_websocket_port)}"
     ]
 
   ###############################

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -188,6 +188,25 @@ defmodule Portal.Config.Definitions do
   defconfig(:ops_websocket_origin, :string, default: "localhost")
 
   @doc """
+  The external port used in WebSocket origin checks for the ops endpoint.
+
+  This should be the stable ingress port (e.g. 1080) rather than the internal
+  blue/green listen port, so that `check_origin` passes when traffic is
+  redirected via iptables.
+
+  Maps to the `OPS_WEBSOCKET_PORT` environment variable.
+  """
+  defconfig(:ops_websocket_port, :integer,
+    default: 13_002,
+    changeset: fn changeset, key ->
+      Ecto.Changeset.validate_number(changeset, key,
+        greater_than: 0,
+        less_than_or_equal_to: 65_535
+      )
+    end
+  )
+
+  @doc """
   Allows to override Bandit HTTP/1.1 server options.
 
   These options are passed to Bandit's `http_1_options`. Keep in mind that changing


### PR DESCRIPTION
The port the ops services are accessed on is different from the listen port because we remap them with iptables to provide a consistent service port on blue/green deploys.