### PR TITLE
fix(portal): evict stale pids on channel join

### DIFF
--- a/elixir/lib/portal/channels.ex
+++ b/elixir/lib/portal/channels.ex
@@ -12,16 +12,24 @@ defmodule Portal.Channels do
 
   @doc """
   Registers the calling process as a client channel for the given client ID.
+
+  Uses upsert semantics: any previously registered processes for this client ID
+  are evicted from the group before the calling process joins. This ensures only
+  one process per client ID is ever registered (e.g. on reconnection).
   """
   def register_client(client_id) do
-    :ok = :pg.join(group(:client, client_id), self())
+    upsert_group(group(:client, client_id))
   end
 
   @doc """
   Registers the calling process as a gateway channel for the given gateway ID.
+
+  Uses upsert semantics: any previously registered processes for this gateway ID
+  are evicted from the group before the calling process joins. This ensures only
+  one process per gateway ID is ever registered (e.g. on reconnection).
   """
   def register_gateway(gateway_id) do
-    :ok = :pg.join(group(:gateway, gateway_id), self())
+    upsert_group(group(:gateway, gateway_id))
   end
 
   @doc """
@@ -50,6 +58,12 @@ defmodule Portal.Channels do
   """
   def reject_access(gateway_id, client_id, resource_id) do
     send_to_gateway(gateway_id, {:reject_access, client_id, resource_id})
+  end
+
+  defp upsert_group(group) do
+    others = group |> :pg.get_members() |> Enum.reject(&(&1 == self()))
+    unless others == [], do: :pg.leave(group, others)
+    :pg.join(group, self())
   end
 
   defp send_to_group(group, message) do

--- a/elixir/lib/portal/channels.ex
+++ b/elixir/lib/portal/channels.ex
@@ -61,8 +61,11 @@ defmodule Portal.Channels do
   end
 
   defp upsert_group(group) do
-    others = group |> :pg.get_members() |> Enum.reject(&(&1 == self()))
-    unless others == [], do: :pg.leave(group, others)
+    case :pg.get_members(group) do
+      [] -> :ok
+      members -> :pg.leave(group, members)
+    end
+
     :pg.join(group, self())
   end
 

--- a/elixir/test/portal/channels_test.exs
+++ b/elixir/test/portal/channels_test.exs
@@ -11,27 +11,31 @@ defmodule Portal.ChannelsTest do
       assert_receive :hello
     end
 
-    test "delivers message to multiple registered processes" do
+    test "re-registration replaces the previous process" do
       client_id = Ecto.UUID.generate()
       parent = self()
 
-      pids =
-        for _ <- 1..3 do
-          spawn(fn ->
-            Channels.register_client(client_id)
-            send(parent, {:registered, self()})
+      old_pid =
+        spawn(fn ->
+          Channels.register_client(client_id)
+          send(parent, :registered)
 
-            receive do
-              msg -> send(parent, {:received, self(), msg})
-            end
-          end)
-        end
+          receive do
+            msg -> send(parent, {:old_received, msg})
+          end
+        end)
 
-      for pid <- pids, do: assert_receive({:registered, ^pid})
+      assert_receive :registered
 
-      assert :ok = Channels.send_to_client(client_id, :broadcast)
+      # New process (self) registers for the same client_id — should evict old_pid
+      Channels.register_client(client_id)
 
-      for pid <- pids, do: assert_receive({:received, ^pid, :broadcast})
+      assert :ok = Channels.send_to_client(client_id, :hello)
+      assert_receive :hello
+      refute_receive {:old_received, :hello}
+
+      # Cleanup
+      Process.exit(old_pid, :kill)
     end
 
     test "returns {:error, :not_found} when no process is registered" do

--- a/elixir/test/portal/channels_test.exs
+++ b/elixir/test/portal/channels_test.exs
@@ -53,6 +53,33 @@ defmodule Portal.ChannelsTest do
       assert_receive :hello
     end
 
+    test "re-registration replaces the previous process" do
+      gateway_id = Ecto.UUID.generate()
+      parent = self()
+
+      old_pid =
+        spawn(fn ->
+          Channels.register_gateway(gateway_id)
+          send(parent, :registered)
+
+          receive do
+            msg -> send(parent, {:old_received, msg})
+          end
+        end)
+
+      assert_receive :registered
+
+      # New process (self) registers for the same gateway_id — should evict old_pid
+      Channels.register_gateway(gateway_id)
+
+      assert :ok = Channels.send_to_gateway(gateway_id, :hello)
+      assert_receive :hello
+      refute_receive {:old_received, :hello}
+
+      # Cleanup
+      Process.exit(old_pid, :kill)
+    end
+
     test "returns {:error, :not_found} when no process is registered" do
       gateway_id = Ecto.UUID.generate()
       assert {:error, :not_found} = Channels.send_to_gateway(gateway_id, :hello)


### PR DESCRIPTION
When the client or gateway roam or some other network partition occurs, it's possible that when they reconnect, the old channel pid will still be alive.

To prevent that, we remove the old pid from the process group when the same client id or gateway id join.
