### PR TITLE
fix(portal): add gui/headless client for autoredirect

### DIFF
--- a/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
+++ b/elixir/lib/portal_web/plugs/auto_redirect_default_provider.ex
@@ -24,11 +24,12 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProvider do
   # Only redirect from the base sign-in page, not from provider-specific routes
   def call(
         %{
-          params: %{"as" => "client", "account_id_or_slug" => account_id_or_slug},
+          params: %{"as" => as, "account_id_or_slug" => account_id_or_slug},
           path_info: [_account]
         } = conn,
         _opts
-      ) do
+      )
+      when as in ["client", "gui-client", "headless-client"] do
     with %Account{} = account <- Database.get_account_by_id_or_slug(account_id_or_slug),
          provider when is_struct(provider) <- Database.get_default_provider_for_account(account) do
       redirect_path = redirect_path(account, provider)

--- a/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
+++ b/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
@@ -1,0 +1,258 @@
+defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.AuthProviderFixtures
+
+  alias PortalWeb.Plugs.AutoRedirectDefaultProvider
+
+  setup do
+    account = account_fixture()
+    {:ok, account: account}
+  end
+
+  describe "call/2" do
+    for as_value <- ["client", "headless-client", "gui-client"] do
+      test "redirects to default OIDC provider when as=#{as_value}", %{
+        conn: conn,
+        account: account
+      } do
+        as_value = unquote(as_value)
+        provider = oidc_provider_fixture(account: account, is_default: true)
+
+        conn =
+          conn
+          |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
+          |> Map.put(:path_info, [account.slug])
+          |> Map.put(:query_string, "as=#{as_value}&state=test-state")
+          |> AutoRedirectDefaultProvider.call([])
+
+        assert conn.halted
+        location = redirected_to(conn)
+        assert location =~ "/sign_in/oidc/#{provider.id}"
+        assert location =~ "as=#{as_value}"
+        assert location =~ "state=test-state"
+      end
+
+      test "redirects to default Google provider when as=#{as_value}", %{
+        conn: conn,
+        account: account
+      } do
+        as_value = unquote(as_value)
+        provider = google_provider_fixture(account: account, is_default: true)
+
+        conn =
+          conn
+          |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
+          |> Map.put(:path_info, [account.slug])
+          |> Map.put(:query_string, "as=#{as_value}")
+          |> AutoRedirectDefaultProvider.call([])
+
+        assert conn.halted
+        location = redirected_to(conn)
+        assert location =~ "/sign_in/google/#{provider.id}"
+      end
+
+      test "redirects to default Entra provider when as=#{as_value}", %{
+        conn: conn,
+        account: account
+      } do
+        as_value = unquote(as_value)
+        provider = entra_provider_fixture(account: account, is_default: true)
+
+        conn =
+          conn
+          |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
+          |> Map.put(:path_info, [account.slug])
+          |> Map.put(:query_string, "as=#{as_value}")
+          |> AutoRedirectDefaultProvider.call([])
+
+        assert conn.halted
+        location = redirected_to(conn)
+        assert location =~ "/sign_in/entra/#{provider.id}"
+      end
+
+      test "redirects to default Okta provider when as=#{as_value}", %{
+        conn: conn,
+        account: account
+      } do
+        as_value = unquote(as_value)
+        provider = okta_provider_fixture(account: account, is_default: true)
+
+        conn =
+          conn
+          |> Map.put(:params, %{"as" => as_value, "account_id_or_slug" => account.slug})
+          |> Map.put(:path_info, [account.slug])
+          |> Map.put(:query_string, "as=#{as_value}")
+          |> AutoRedirectDefaultProvider.call([])
+
+        assert conn.halted
+        location = redirected_to(conn)
+        assert location =~ "/sign_in/okta/#{provider.id}"
+      end
+    end
+
+    test "does not redirect when as is not a client type", %{conn: conn, account: account} do
+      _provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "browser", "account_id_or_slug" => account.slug})
+        |> Map.put(:path_info, [account.slug])
+        |> AutoRedirectDefaultProvider.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect when as param is missing", %{conn: conn, account: account} do
+      _provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"account_id_or_slug" => account.slug})
+        |> Map.put(:path_info, [account.slug])
+        |> AutoRedirectDefaultProvider.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect when no default provider exists", %{conn: conn, account: account} do
+      _provider = oidc_provider_fixture(account: account, is_default: false)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => account.slug})
+        |> Map.put(:path_info, [account.slug])
+        |> AutoRedirectDefaultProvider.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect when provider is disabled", %{conn: conn, account: account} do
+      _provider = oidc_provider_fixture(account: account, is_default: true, is_disabled: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => account.slug})
+        |> Map.put(:path_info, [account.slug])
+        |> AutoRedirectDefaultProvider.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect when account is not found", %{conn: conn} do
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => "nonexistent-slug"})
+        |> Map.put(:path_info, ["nonexistent-slug"])
+        |> AutoRedirectDefaultProvider.call([])
+
+      refute conn.halted
+    end
+
+    test "does not redirect when path_info has more than one segment", %{
+      conn: conn,
+      account: account
+    } do
+      _provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => account.slug})
+        |> Map.put(:path_info, [account.slug, "sign_in"])
+        |> AutoRedirectDefaultProvider.call([])
+
+      refute conn.halted
+    end
+
+    test "redirects without query string when query_string is empty", %{
+      conn: conn,
+      account: account
+    } do
+      provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => account.slug})
+        |> Map.put(:path_info, [account.slug])
+        |> Map.put(:query_string, "")
+        |> AutoRedirectDefaultProvider.call([])
+
+      assert conn.halted
+      location = redirected_to(conn)
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+      refute location =~ "?"
+    end
+
+    test "looks up account by ID when account_id_or_slug is a UUID", %{
+      conn: conn,
+      account: account
+    } do
+      provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn =
+        conn
+        |> Map.put(:params, %{"as" => "client", "account_id_or_slug" => account.id})
+        |> Map.put(:path_info, [account.id])
+        |> AutoRedirectDefaultProvider.call([])
+
+      assert conn.halted
+      location = redirected_to(conn)
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+    end
+  end
+
+  describe "integration" do
+    test "as=client auto-redirects to default OIDC provider with params preserved", %{
+      conn: conn,
+      account: account
+    } do
+      provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn = get(conn, ~p"/#{account.slug}?as=client&nonce=test-nonce&state=test-state")
+
+      location = redirected_to(conn)
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+      assert location =~ "as=client"
+      assert location =~ "nonce=test-nonce"
+      assert location =~ "state=test-state"
+    end
+
+    test "as=headless-client auto-redirects to default OIDC provider with params preserved", %{
+      conn: conn,
+      account: account
+    } do
+      provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn = get(conn, ~p"/#{account.slug}?as=headless-client&state=test-state")
+
+      location = redirected_to(conn)
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+      assert location =~ "as=headless-client"
+      assert location =~ "state=test-state"
+    end
+
+    test "as=gui-client auto-redirects to default OIDC provider with params preserved", %{
+      conn: conn,
+      account: account
+    } do
+      provider = oidc_provider_fixture(account: account, is_default: true)
+
+      conn = get(conn, ~p"/#{account.slug}?as=gui-client&nonce=test-nonce&state=test-state")
+
+      location = redirected_to(conn)
+      assert location =~ "/sign_in/oidc/#{provider.id}"
+      assert location =~ "as=gui-client"
+      assert location =~ "nonce=test-nonce"
+      assert location =~ "state=test-state"
+    end
+
+    test "does not redirect when no default provider", %{conn: conn, account: account} do
+      _provider = oidc_provider_fixture(account: account, is_default: false)
+
+      conn = get(conn, ~p"/#{account.slug}?as=client&state=test-state")
+
+      assert html_response(conn, 200) =~ "Sign In"
+    end
+  end
+end


### PR DESCRIPTION
We added new params to differentiate types of clients (see #11799) but this now broke auto redirect for those clients.
