### PR TITLE
fix(phoenix-channel): don't reset heartbeat on send

### DIFF
--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -38,7 +38,7 @@ tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 hostname = "0.4.2"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "tracing"] }
+tokio = { workspace = true, features = ["macros", "rt", "test-util", "tracing"] }
 
 [lints]
 workspace = true

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -572,7 +572,10 @@ where
                     Poll::Ready(Ok(stream)) => {
                         self.state = State::Connected(Connected {
                             stream,
-                            heartbeat: tokio::time::interval(HEARTBEAT_INTERVAL),
+                            heartbeat: tokio::time::interval_at(
+                                tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+                                HEARTBEAT_INTERVAL,
+                            ),
                             inflight_heartbeats: Default::default(),
                             pending_heartbeat: Default::default(),
                             pending_joins: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
@@ -656,8 +659,6 @@ where
                         match stream.start_send_unpin(Message::Text(join.clone().into())) {
                             Ok(()) => {
                                 tracing::trace!(target: "wire::api::send", %join);
-
-                                heartbeat.reset()
                             }
                             Err(e) => {
                                 pending_joins.push_front(join);
@@ -679,8 +680,6 @@ where
                             {
                                 Ok(()) => {
                                     tracing::trace!(target: "wire::api::send", msg = %serialized_msg);
-
-                                    heartbeat.reset()
                                 }
                                 Err(e) => {
                                     pending_messages.push_front(msg);

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -721,6 +721,114 @@ async fn http_503_with_retry_after_uses_header_value() {
     }
 }
 
+/// Regression test for <https://github.com/firezone/firezone/pull/12309>.
+///
+/// The original bug reset the heartbeat timer on every message send, meaning a
+/// busy client that was continuously exchanging data with the portal would
+/// never actually send a heartbeat, causing the portal to silently drop the
+/// connection.
+#[tokio::test(start_paused = true)]
+async fn heartbeat_not_reset_by_message_sends() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use futures::StreamExt as _;
+    use phoenix_channel::PublicKeyParam;
+    use tokio_tungstenite::tungstenite::Message;
+
+    // 10 seconds, matching the private HEARTBEAT_INTERVAL constant in lib.rs.
+    const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+    let _guard = logging::test("debug,wire::api=trace");
+
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let heartbeat_received = Arc::new(AtomicBool::new(false));
+    let heartbeat_received_server = heartbeat_received.clone();
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        while let Some(Ok(msg)) = ws.next().await {
+            match msg {
+                Message::Text(text) if text.contains("phx_join") => {
+                    ws.send(Message::text(
+                        r#"{"event":"phx_reply","ref":0,"topic":"test","payload":{"status":"ok","response":{}}}"#,
+                    ))
+                    .await
+                    .unwrap();
+                }
+                Message::Text(text) if text.contains(r#""heartbeat""#) => {
+                    heartbeat_received_server.store(true, Ordering::SeqCst);
+                }
+                Message::Close(_) | Message::Text(_) => break,
+                _ => {}
+            }
+        }
+    });
+
+    let mut channel = make_test_channel("localhost", server_addr.port());
+    channel.connect(
+        vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+        Duration::ZERO,
+        PublicKeyParam([0u8; 32]),
+    );
+
+    // Drive the channel until connected.
+    loop {
+        match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+            phoenix_channel::Event::Connected => break,
+            _ => {}
+        }
+    }
+
+    // Send several messages to simulate a busy client.  With the regression
+    // (heartbeat.reset() being called on each send), these sends would keep
+    // resetting the heartbeat timer so it could never fire.
+    for _ in 0..10 {
+        let _ = channel.send("test", OutboundMsg::Bar);
+    }
+
+    // Advance time past the heartbeat interval.  With the bug, the timer would
+    // have been reset by the last message send and this advance would NOT cross
+    // a heartbeat deadline.  Without the bug, the timer runs independently and
+    // this advance DOES cross the deadline.
+    tokio::time::advance(HEARTBEAT_INTERVAL + Duration::from_millis(100)).await;
+
+    // Poll the channel until it has nothing left to process.  This sends the
+    // pending messages and, after the heartbeat tick fires, also queues and
+    // sends the heartbeat message.
+    loop {
+        match std::future::poll_fn(|cx| match channel.poll(cx) {
+            std::task::Poll::Ready(r) => std::task::Poll::Ready(Some(r)),
+            std::task::Poll::Pending => std::task::Poll::Ready(None),
+        })
+        .await
+        {
+            Some(Ok(_)) => {} // Got an event; keep draining.
+            Some(Err(_)) | None => break,
+        }
+    }
+
+    // Yield to let the server task process the heartbeat message it received.
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+
+    assert!(
+        heartbeat_received.load(Ordering::SeqCst),
+        "No heartbeat was sent after passing the heartbeat interval while \
+         messages were being sent.  This indicates heartbeat.reset() is being \
+         called on message sends (regression of PR #12309)."
+    );
+
+    server.abort();
+}
+
 #[tokio::test]
 async fn initial_connection_uses_constant_1s_backoff() {
     use phoenix_channel::{Error, PublicKeyParam};

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -23,7 +23,7 @@ use stun_codec::{
         attributes::{
             ErrorCode, MessageIntegrity, Nonce, Realm, Software, Username, XorMappedAddress,
         },
-        errors::{StaleNonce, Unauthorized, UnknownAttribute},
+        errors::{BadRequest, StaleNonce, Unauthorized, UnknownAttribute},
         methods::BINDING,
     },
     rfc5766::{

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,11 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12309">
+          Fixes an issue where a busy Client continuously sending data to the
+          portal could be silently disconnected due to heartbeats never being
+          sent.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,11 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12309">
+          Fixes an issue where a busy Client continuously sending data to the
+          portal could be silently disconnected due to heartbeats never being
+          sent.
+        </ChangeItem>
         <ChangeItem pull="12236">
           Fixes an issue on macOS where the app could get stuck on the loading
           spinner if the system extension was not ready at startup.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,11 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12309">
+          Fixes an issue where a busy Client continuously sending data to the
+          portal could be silently disconnected due to heartbeats never being
+          sent.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -23,6 +23,11 @@ export default function Gateway() {
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
+        <ChangeItem pull="12309">
+          Fixes an issue where a busy Gateway continuously sending data to the
+          portal could be silently disconnected due to heartbeats never being
+          sent.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,11 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12309">
+          Fixes an issue where a busy Client continuously sending data to the
+          portal could be silently disconnected due to heartbeats never being
+          sent.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.


### PR DESCRIPTION
In https://github.com/firezone/firezone/commits/e7f1497eff we made a seemingly irrelevant change that reset the heartbeat interval on each wire::api send. This meant that "busy" clients/gateways that are sending and receiving control plane data will never send an actual phoenix-channel heartbeat, causing the connection to be cut.

--- 

Fixes #12312 