### PR TITLE
fix(portal): handle 3-tuple sync errors

### DIFF
--- a/elixir/lib/portal/entra/error_handler.ex
+++ b/elixir/lib/portal/entra/error_handler.ex
@@ -48,6 +48,7 @@ defmodule Portal.Entra.ErrorHandler do
   defp classify({tag, _}) when tag in [:validation, :scopes, :circuit_breaker, :consent_revoked],
     do: :client_error
 
+  defp classify({_tag, _msg, _body}), do: :transient
   defp classify(nil), do: :transient
   defp classify(msg) when is_binary(msg), do: :transient
 
@@ -110,6 +111,7 @@ defmodule Portal.Entra.ErrorHandler do
     format(%Req.Response{status: status, body: body})
   end
 
+  defp format({_tag, msg, _body}) when is_binary(msg), do: msg
   defp format({_tag, msg}) when is_binary(msg), do: msg
   defp format(nil), do: "Unknown error occurred"
   defp format(msg) when is_binary(msg), do: msg

--- a/elixir/lib/portal/google/error_handler.ex
+++ b/elixir/lib/portal/google/error_handler.ex
@@ -36,6 +36,7 @@ defmodule Portal.Google.ErrorHandler do
   defp classify({tag, _}) when tag in [:validation, :scopes, :circuit_breaker],
     do: :client_error
 
+  defp classify({_tag, _msg, _body}), do: :transient
   defp classify(nil), do: :transient
   defp classify(msg) when is_binary(msg), do: :transient
 
@@ -71,6 +72,7 @@ defmodule Portal.Google.ErrorHandler do
   end
 
   defp format(%Req.Response{status: status}), do: "Google API returned HTTP #{status}"
+  defp format({_tag, msg, _body}) when is_binary(msg), do: msg
   defp format({_tag, msg}) when is_binary(msg), do: msg
   defp format(nil), do: "Unknown error occurred"
   defp format(msg) when is_binary(msg), do: msg

--- a/elixir/lib/portal/okta/error_handler.ex
+++ b/elixir/lib/portal/okta/error_handler.ex
@@ -36,6 +36,7 @@ defmodule Portal.Okta.ErrorHandler do
   defp classify({tag, _}) when tag in [:validation, :scopes, :circuit_breaker],
     do: :client_error
 
+  defp classify({_tag, _msg, _body}), do: :transient
   defp classify(nil), do: :transient
   defp classify(msg) when is_binary(msg), do: :transient
 
@@ -55,6 +56,7 @@ defmodule Portal.Okta.ErrorHandler do
     Okta.ErrorCodes.format_error(status, nil)
   end
 
+  defp format({_tag, msg, _body}) when is_binary(msg), do: msg
   defp format({_tag, msg}) when is_binary(msg), do: msg
   defp format(nil), do: "Unknown error occurred"
   defp format(msg) when is_binary(msg), do: msg


### PR DESCRIPTION
Some sync errors are returned in a 3-tuple format (for example, invalid API responses from Google) and we need to handle these to prevent the Oban error handler from detaching which causes the error to fail to stick on the directory.
