### PR TITLE
feat(portal): google group filtering

### DIFF
--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -1,4 +1,6 @@
 defmodule Portal.Google.APIClient do
+  require Logger
+
   def get_access_token(impersonation_email, key) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
     token_endpoint = config[:token_endpoint]
@@ -52,6 +54,22 @@ defmodule Portal.Google.APIClient do
   def get_customer(access_token) do
     "/admin/directory/v1/customers/my_customer"
     |> get(access_token)
+  end
+
+  @doc """
+  Fetches a single group by group key (Google group ID or email).
+
+  Returns `{:ok, group_map}` on success, or `{:error, reason}` on failure.
+  A 404 response returns `{:error, :not_found}`.
+  """
+  @spec get_group(String.t(), String.t()) :: {:ok, map()} | {:error, :not_found | term()}
+  def get_group(access_token, group_key) do
+    case get("/admin/directory/v1/groups/#{URI.encode(group_key)}", access_token) do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: 404}} -> {:error, :not_found}
+      {:ok, %Req.Response{} = response} -> {:error, response}
+      {:error, _} = error -> error
+    end
   end
 
   @doc """
@@ -125,29 +143,38 @@ defmodule Portal.Google.APIClient do
   @doc """
   Streams groups from the Google Workspace directory.
   Returns a stream that yields pages of groups.
+
+  ## Options
+
+    * `:query` - optional query string passed directly to the API `query` parameter
+      (e.g. `"email:firezone-sync*"` to filter by email prefix server-side)
   """
-  def stream_groups(access_token, domain) do
-    query =
-      URI.encode_query(%{
-        "customer" => "my_customer",
-        "domain" => domain,
-        "maxResults" => "200"
-      })
+  def stream_groups(access_token, domain, opts \\ []) do
+    params = %{
+      "customer" => "my_customer",
+      "domain" => domain,
+      "maxResults" => "200"
+    }
+
+    params =
+      case Keyword.get(opts, :query) do
+        nil -> params
+        q -> Map.put(params, "query", q)
+      end
 
     path = "/admin/directory/v1/groups"
-    stream_pages(path, query, access_token, "groups")
+    stream_pages(path, URI.encode_query(params), access_token, "groups")
   end
 
   @doc """
   Streams members of a specific group.
   Returns a stream that yields pages of members.
-  Uses includeDerivedMembership to fetch transitive memberships.
+  Fetches direct memberships only.
   """
   def stream_group_members(access_token, group_key) do
     query =
       URI.encode_query(%{
-        "maxResults" => "200",
-        "includeDerivedMembership" => "true"
+        "maxResults" => "200"
       })
 
     path = "/admin/directory/v1/groups/#{group_key}/members"
@@ -166,6 +193,195 @@ defmodule Portal.Google.APIClient do
 
     path = "/admin/directory/v1/customer/my_customer/orgunits"
     stream_pages(path, query, access_token, "organizationUnits")
+  end
+
+  # Google allows up to 1000 sub-requests per batch call. We use 100 to stay well
+  # within limits and keep individual batch request sizes reasonable.
+  @default_batch_endpoint "https://www.googleapis.com/batch/admin/directory/v1"
+  @batch_size 100
+
+  @doc """
+  Fetches multiple users by Google user ID using the Google API Batch endpoint.
+
+  Chunks `user_ids` into groups of #{@batch_size} and issues one multipart HTTP POST
+  per chunk. Users that return 404 (deleted from Google Workspace) are silently
+  skipped. Returns `{:ok, [user_map]}` or `{:error, reason}` on transport/HTTP failure.
+  """
+  @spec batch_get_users(String.t(), [String.t()]) :: {:ok, [map()]} | {:error, term()}
+  def batch_get_users(_access_token, []), do: {:ok, []}
+
+  def batch_get_users(access_token, user_ids) do
+    result =
+      user_ids
+      |> Enum.chunk_every(@batch_size)
+      |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc_chunks} ->
+        case do_batch_get_users(access_token, chunk) do
+          {:ok, users} -> {:cont, {:ok, [users | acc_chunks]}}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, chunks} -> {:ok, chunks |> Enum.reverse() |> List.flatten()}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp do_batch_get_users(access_token, user_ids) do
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    req_opts = config[:req_opts] || []
+    batch_endpoint = config[:batch_endpoint] || @default_batch_endpoint
+    boundary = "batch_#{System.unique_integer([:positive])}"
+
+    body =
+      user_ids
+      |> Enum.with_index(1)
+      |> Enum.map_join("", fn {user_id, idx} ->
+        "--#{boundary}\r\nContent-Type: application/http\r\nContent-ID: <item#{idx}@batch>\r\n\r\nGET /admin/directory/v1/users/#{URI.encode(user_id)}\r\n\r\n"
+      end)
+      |> Kernel.<>("--#{boundary}--")
+
+    case Req.post(
+           batch_endpoint,
+           [
+             headers: [
+               {"Authorization", "Bearer #{access_token}"},
+               {"Content-Type", "multipart/mixed; boundary=#{boundary}"}
+             ],
+             body: body
+           ] ++ req_opts
+         ) do
+      {:ok, %Req.Response{status: 200, body: resp_body, headers: resp_headers}} ->
+        content_type =
+          resp_headers
+          |> Map.get("content-type", [])
+          |> List.first("")
+
+        parse_batch_user_response(resp_body, content_type)
+
+      {:ok, response} ->
+        {:error, response}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp parse_batch_user_response(body, content_type) do
+    body = IO.iodata_to_binary(body)
+    boundary = extract_multipart_boundary(content_type)
+
+    body
+    |> String.split("--#{boundary}")
+    # Skip preamble (index 0) and the closing "--" delimiter (last element)
+    |> Enum.slice(1..-2//1)
+    |> Enum.reduce_while({:ok, []}, fn part, {:ok, acc} ->
+      case parse_batch_part(part) do
+        {:ok, users} ->
+          {:cont, {:ok, Enum.reverse(users, acc)}}
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, users} -> {:ok, Enum.reverse(users)}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp extract_multipart_boundary(content_type) do
+    case Regex.run(~r/boundary=(?:\"?([^\";\s,]+)\"?)/, content_type) do
+      [_, boundary] when is_binary(boundary) and boundary != "" ->
+        boundary
+
+      _ ->
+        raise "Could not extract multipart boundary from Content-Type: #{content_type}"
+    end
+  end
+
+  defp parse_batch_part(part) do
+    # Each part is:
+    #   \r\n<outer headers>\r\n\r\n<nested HTTP response>
+    # where <nested HTTP response> is:
+    #   HTTP/1.1 200 OK\r\n<response headers>\r\n\r\n<JSON body>
+    with [_outer_headers, nested] <- String.split(part, "\r\n\r\n", parts: 2),
+         [status_and_headers, json_body] <- String.split(nested, "\r\n\r\n", parts: 2),
+         status when status in [200, 404] <- extract_http_status(status_and_headers) do
+      case status do
+        404 ->
+          {:ok, []}
+
+        200 ->
+          case JSON.decode(String.trim(json_body)) do
+            {:ok, user} ->
+              {:ok, [user]}
+
+            {:error, decode_error} ->
+              log_batch_parse_issue(
+                "Failed to decode JSON in batch users response part",
+                error: inspect(decode_error),
+                snippet: snippet(json_body)
+              )
+
+              {:error,
+               %Req.Response{
+                 status: 502,
+                 body: %{"error" => "Invalid JSON in batch users response part"}
+               }}
+          end
+      end
+    else
+      status when is_integer(status) and status not in [200, 404] ->
+        log_batch_parse_issue("Skipping batch users response part with unexpected status",
+          status: status
+        )
+
+        normalized_status = if(status > 0, do: status, else: 502)
+
+        {:error,
+         %Req.Response{status: normalized_status, body: %{"error" => "Batch users part failed"}}}
+
+      # Anything else (parse failure, unexpected status) — skip this part
+      malformed ->
+        log_batch_parse_issue("Skipping malformed batch users response part",
+          detail: inspect(malformed),
+          snippet: snippet(part)
+        )
+
+        {:error,
+         %Req.Response{
+           status: 502,
+           body: %{"error" => "Malformed batch users response part"}
+         }}
+    end
+  end
+
+  defp log_batch_parse_issue(message, metadata) do
+    Logger.warning(fn ->
+      [
+        message,
+        " ",
+        Enum.map_join(metadata, " ", fn {k, v} -> "#{k}=#{v}" end)
+      ]
+    end)
+  end
+
+  defp snippet(value, max_len \\ 160) do
+    value = if is_binary(value), do: value, else: inspect(value)
+    String.slice(value, 0, max_len)
+  end
+
+  defp extract_http_status(status_line_and_headers) do
+    status_line =
+      status_line_and_headers
+      |> String.split("\r\n", parts: 2)
+      |> List.first("")
+
+    case Regex.run(~r/HTTP\/\d+\.\d+\s+(\d+)/, status_line) do
+      [_, code] -> String.to_integer(code)
+      _ -> 0
+    end
   end
 
   @doc """
@@ -209,9 +425,6 @@ defmodule Portal.Google.APIClient do
         nil ->
           {:halt, nil}
 
-        {:error, _reason} = error ->
-          {[error], nil}
-
         {current_path, current_query} ->
           fetch_page(current_path, current_query, access_token, result_key)
       end,
@@ -236,8 +449,9 @@ defmodule Portal.Google.APIClient do
     end
   end
 
-  # Google's API omits these keys entirely when the collection is empty
-  @optional_result_keys ~w[members organizationUnits]
+  # Google's API omits these keys entirely when the collection is empty.
+  # This includes `groups` when a filtered query (e.g. `email:firezone-sync*`) matches nothing.
+  @optional_result_keys ~w[groups members organizationUnits]
 
   defp parse_page_response(body, current_path, current_query, result_key) do
     case Map.fetch(body, result_key) do

--- a/elixir/lib/portal/google/directory.ex
+++ b/elixir/lib/portal/google/directory.ex
@@ -26,6 +26,8 @@ defmodule Portal.Google.Directory do
     field :error_email_count, :integer, default: 0, read_after_writes: true
     field :is_verified, :boolean, default: false, read_after_writes: true
     field :legacy_service_account_key, :map, redact: true
+    field :group_sync_mode, Ecto.Enum, values: [:all, :filtered, :disabled], default: :all
+    field :orgunit_sync_enabled, :boolean, default: false
 
     timestamps()
   end
@@ -37,6 +39,7 @@ defmodule Portal.Google.Directory do
     |> validate_length(:domain, min: 1, max: 255)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_number(:error_email_count, greater_than_or_equal_to: 0)
+    |> check_constraint(:group_sync_mode, name: :group_sync_mode_values)
     |> assoc_constraint(:account)
     |> assoc_constraint(:directory)
     |> unique_constraint(:domain,

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -1,6 +1,19 @@
 defmodule Portal.Google.Sync do
   @moduledoc """
   Oban worker for syncing users, groups, and memberships from Google Workspace.
+
+  Sync runs in four phases:
+  1. Upsert seed groups (based on group_sync_mode), collect group idp_ids.
+  2. Upsert org units (if orgunit_sync_enabled), collect {idp_id, path} pairs.
+  3. Org unit member sync: per org unit, fetch users, upsert identities directly
+     from the users payload (deduped via seen_user_ids), and upsert memberships.
+  4. BFS group member sync: for each group, fetch direct members, upsert identities,
+     discover GROUP-type members as sub-groups (fetching each via get_group for its
+     display name), upsert them, and recurse. We collect direct user memberships and
+     the group graph during traversal, then compute flattened memberships in-memory
+     and upsert them in batches. A `seen_user_ids` set is threaded through to skip
+     redundant batch_get_users calls for users already fetched in an earlier group.
+  Finally, delete everything with a stale last_synced_at.
   """
   use Oban.Worker,
     queue: :google_sync,
@@ -14,6 +27,7 @@ defmodule Portal.Google.Sync do
   alias Portal.Google
   alias __MODULE__.Database
   require Logger
+  @db_batch_size 500
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"directory_id" => directory_id}}) do
@@ -126,72 +140,90 @@ defmodule Portal.Google.Sync do
 
       _ ->
         config = Portal.Config.fetch_env!(:portal, Google.APIClient)
-        config[:service_account_key] |> JSON.decode!()
+
+        case config[:service_account_key] do
+          key when is_binary(key) ->
+            JSON.decode!(key)
+
+          _ ->
+            raise Google.SyncError,
+              error: "service account key is not configured",
+              directory_id: directory.id,
+              step: :service_account_key
+        end
     end
   end
 
+  # Phase orchestration
+
   defp fetch_and_sync_all(directory, access_token, synced_at) do
-    # Sync users first
-    sync_users(directory, access_token, synced_at)
+    # Phase 1: Upsert seed groups (based on group_sync_mode), collect idp_ids
+    group_idp_ids = sync_groups_phase(directory, access_token, synced_at)
 
-    # Then sync groups and their members
-    sync_groups(directory, access_token, synced_at)
+    # Phase 2: Upsert org units (if enabled), collect {idp_id, path} pairs
+    org_unit_entries = sync_org_units_phase(directory, access_token, synced_at)
 
-    # Finally sync organization units
-    sync_org_units(directory, access_token, synced_at)
+    # Phase 3: Org unit member sync.
+    # Per org unit: fetch users → upsert identities directly from user payload (deduped)
+    # → upsert memberships. Returns the set of user IDs already synced.
+    seen_user_ids =
+      sync_org_unit_members_phase(
+        directory,
+        access_token,
+        synced_at,
+        org_unit_entries,
+        MapSet.new()
+      )
+
+    # Phase 4: BFS group member sync.
+    # For each group: fetch direct members → batch_get_users only for unseen users
+    # → upsert identities → discover GROUP-type sub-groups → recurse.
+    sync_group_members_bfs(
+      directory,
+      access_token,
+      synced_at,
+      group_idp_ids,
+      seen_user_ids
+    )
 
     :ok
   end
 
-  defp sync_users(directory, access_token, synced_at) do
-    Logger.debug("Streaming users", google_directory_id: directory.id)
+  # Phase 1: groups
 
-    Google.APIClient.stream_users(access_token, directory.domain)
-    |> Stream.each(fn
-      {:error, error} ->
-        Logger.debug("Failed to stream users",
-          google_directory_id: directory.id,
-          error: inspect(error)
-        )
+  @firezone_sync_prefix "firezone-sync"
 
-        raise Google.SyncError,
-          error: error,
-          directory_id: directory.id,
-          step: :stream_users
+  defp sync_groups_phase(directory, access_token, synced_at) do
+    case directory.group_sync_mode do
+      :disabled ->
+        []
 
-      users when is_list(users) ->
-        Logger.debug("Received users page",
-          google_directory_id: directory.id,
-          count: length(users)
-        )
+      :all ->
+        upsert_groups(directory, access_token, synced_at)
 
-        # Build identities for these users - validate required fields
-        identities =
-          Enum.map(users, fn user ->
-            # Ensure critical fields exist
-            unless user["id"] do
-              raise Google.SyncError,
-                error: {:validation, "user missing 'id' field"},
-                directory_id: directory.id,
-                step: :process_user
-            end
+      :filtered ->
+        # Google's query language does not support OR, so we issue two queries and
+        # rely on idempotent upserts to deduplicate groups that match both.
+        ids1 =
+          upsert_groups(directory, access_token, synced_at,
+            query: "email:#{@firezone_sync_prefix}*"
+          )
 
-            map_user_to_identity(user, directory.id)
-          end)
+        ids2 =
+          upsert_groups(directory, access_token, synced_at,
+            query: "name:[#{@firezone_sync_prefix}]*"
+          )
 
-        unless Enum.empty?(identities) do
-          batch_upsert_identities(directory, synced_at, identities)
-        end
-    end)
-    |> Stream.run()
+        Enum.uniq(ids1 ++ ids2)
+    end
   end
 
-  defp sync_groups(directory, access_token, synced_at) do
+  defp upsert_groups(directory, access_token, synced_at, opts \\ []) do
     Logger.debug("Streaming groups", google_directory_id: directory.id)
 
-    Google.APIClient.stream_groups(access_token, directory.domain)
-    |> Stream.each(fn
-      {:error, error} ->
+    Google.APIClient.stream_groups(access_token, directory.domain, opts)
+    |> Enum.reduce([], fn
+      {:error, error}, _acc ->
         Logger.debug("Failed to stream groups",
           google_directory_id: directory.id,
           error: inspect(error)
@@ -202,16 +234,14 @@ defmodule Portal.Google.Sync do
           directory_id: directory.id,
           step: :stream_groups
 
-      groups when is_list(groups) ->
+      groups, acc when is_list(groups) ->
         Logger.debug("Received groups page",
           google_directory_id: directory.id,
           count: length(groups)
         )
 
-        # Build and sync groups - validate required fields are present
         group_attrs =
           Enum.map(groups, fn group ->
-            # Ensure critical fields exist - if Google returns incomplete data, we must fail
             unless group["id"] do
               raise Google.SyncError,
                 error: {:validation, "group missing 'id' field"},
@@ -228,7 +258,8 @@ defmodule Portal.Google.Sync do
 
             %{
               idp_id: group["id"],
-              name: group["name"] || group["email"]
+              name: group["name"] || group["email"],
+              email: group["email"]
             }
           end)
 
@@ -236,79 +267,28 @@ defmodule Portal.Google.Sync do
           batch_upsert_groups(directory, synced_at, group_attrs)
         end
 
-        # For each group, stream and sync members
-        Enum.each(groups, fn group ->
-          sync_group_members(directory, access_token, synced_at, group)
-        end)
+        group_ids = Enum.map(groups, & &1["id"])
+        Enum.reverse(group_ids, acc)
     end)
-    |> Stream.run()
+    |> Enum.reverse()
   end
 
-  defp sync_group_members(directory, access_token, synced_at, group) do
-    group_key = group["id"]
-    group_name = group["name"] || group["email"]
+  # Phase 2: org units
 
-    Logger.debug("Streaming members for group",
-      google_directory_id: directory.id,
-      group_key: group_key,
-      group_name: group_name
-    )
-
-    Google.APIClient.stream_group_members(access_token, group_key)
-    |> Stream.each(fn
-      {:error, error} ->
-        Logger.error("Failed to fetch members for group",
-          group_key: group_key,
-          group_name: group_name,
-          error: inspect(error),
-          google_directory_id: directory.id
-        )
-
-        raise Google.SyncError,
-          error: error,
-          directory_id: directory.id,
-          step: :stream_group_members
-
-      members when is_list(members) ->
-        process_group_members_page(directory, synced_at, group_key, group_name, members)
-    end)
-    |> Stream.run()
-  end
-
-  defp process_group_members_page(directory, synced_at, group_key, group_name, members) do
-    Logger.debug("Received members page",
-      google_directory_id: directory.id,
-      group_key: group_key,
-      count: length(members)
-    )
-
-    # Filter only user members (not groups or other types)
-    user_members = Enum.filter(members, fn member -> member["type"] == "USER" end)
-
-    # Build memberships (group_idp_id, user_idp_id) - validate required fields
-    memberships =
-      Enum.map(user_members, fn member ->
-        unless member["id"] do
-          raise Google.SyncError,
-            error: {:validation, "member missing 'id' field in group #{group_name}"},
-            directory_id: directory.id,
-            step: :process_member
-        end
-
-        {group_key, member["id"]}
-      end)
-
-    unless Enum.empty?(memberships) do
-      batch_upsert_memberships(directory, synced_at, memberships)
+  defp sync_org_units_phase(directory, access_token, synced_at) do
+    if directory.orgunit_sync_enabled do
+      upsert_org_units(directory, access_token, synced_at)
+    else
+      []
     end
   end
 
-  defp sync_org_units(directory, access_token, synced_at) do
+  defp upsert_org_units(directory, access_token, synced_at) do
     Logger.debug("Streaming organization units", google_directory_id: directory.id)
 
     Google.APIClient.stream_organization_units(access_token)
-    |> Stream.each(fn
-      {:error, error} ->
+    |> Enum.reduce([], fn
+      {:error, error}, _acc ->
         Logger.debug("Failed to stream organization units",
           google_directory_id: directory.id,
           error: inspect(error)
@@ -319,13 +299,12 @@ defmodule Portal.Google.Sync do
           directory_id: directory.id,
           step: :stream_org_units
 
-      org_units when is_list(org_units) ->
+      org_units, acc when is_list(org_units) ->
         Logger.debug("Received organization units page",
           google_directory_id: directory.id,
           count: length(org_units)
         )
 
-        # Build org unit attrs - validate required fields
         org_unit_attrs =
           Enum.map(org_units, fn org_unit ->
             unless org_unit["orgUnitId"] do
@@ -352,7 +331,8 @@ defmodule Portal.Google.Sync do
 
             %{
               idp_id: org_unit["orgUnitId"],
-              name: org_unit["name"]
+              name: org_unit["name"],
+              email: nil
             }
           end)
 
@@ -360,33 +340,370 @@ defmodule Portal.Google.Sync do
           batch_upsert_org_units(directory, synced_at, org_unit_attrs)
         end
 
-        # For each org unit, stream and sync members
-        Enum.each(org_units, fn org_unit ->
-          sync_org_unit_members(directory, access_token, synced_at, org_unit)
-        end)
+        entries = Enum.map(org_units, fn ou -> {ou["orgUnitId"], ou["orgUnitPath"]} end)
+        Enum.reverse(entries, acc)
     end)
-    |> Stream.run()
+    |> Enum.reverse()
   end
 
-  defp sync_org_unit_members(directory, access_token, synced_at, org_unit) do
-    org_unit_id = org_unit["orgUnitId"]
-    org_unit_name = org_unit["name"]
-    org_unit_path = org_unit["orgUnitPath"]
+  # Phase 3: BFS group member sync
 
-    Logger.debug("Streaming members for organization unit",
-      google_directory_id: directory.id,
-      org_unit_id: org_unit_id,
-      org_unit_name: org_unit_name,
-      org_unit_path: org_unit_path
+  defp sync_group_members_bfs(
+         directory,
+         access_token,
+         synced_at,
+         seed_group_idp_ids,
+         seen_user_ids
+       ) do
+    visited = MapSet.new(seed_group_idp_ids)
+    queue = :queue.from_list(seed_group_idp_ids)
+
+    initial_state = %{
+      seen_user_ids: seen_user_ids,
+      direct_users_by_group: %{},
+      children_by_group: %{}
+    }
+
+    final_state = do_bfs(directory, access_token, synced_at, queue, visited, initial_state)
+
+    upsert_flattened_group_memberships(
+      directory,
+      synced_at,
+      final_state.children_by_group,
+      final_state.direct_users_by_group
     )
 
-    Google.APIClient.stream_organization_unit_members(access_token, org_unit_path)
-    |> Stream.each(fn
+    final_state.seen_user_ids
+  end
+
+  defp do_bfs(directory, access_token, synced_at, queue, visited, state) do
+    case :queue.out(queue) do
+      {:empty, _} ->
+        state
+
+      {{:value, group_idp_id}, remaining_queue} ->
+        {next_queue, next_visited, next_state} =
+          process_group_bfs_node(
+            directory,
+            access_token,
+            synced_at,
+            group_idp_id,
+            remaining_queue,
+            visited,
+            state
+          )
+
+        do_bfs(directory, access_token, synced_at, next_queue, next_visited, next_state)
+    end
+  end
+
+  defp process_group_bfs_node(
+         directory,
+         access_token,
+         synced_at,
+         group_idp_id,
+         remaining_queue,
+         visited,
+         state
+       ) do
+    {user_tuples, sub_group_ids} = fetch_group_members(directory, access_token, group_idp_id)
+    direct_user_ids = user_ids_set_from_memberships(user_tuples)
+
+    next_seen_user_ids =
+      sync_new_user_identities(
+        directory,
+        access_token,
+        synced_at,
+        direct_user_ids,
+        state.seen_user_ids
+      )
+
+    next_state =
+      state
+      |> put_group_direct_users(group_idp_id, direct_user_ids)
+      |> put_group_children(group_idp_id, sub_group_ids)
+      |> Map.put(:seen_user_ids, next_seen_user_ids)
+
+    {next_queue, next_visited} =
+      enqueue_discovered_sub_groups(
+        directory,
+        access_token,
+        synced_at,
+        sub_group_ids,
+        remaining_queue,
+        visited
+      )
+
+    {next_queue, next_visited, next_state}
+  end
+
+  defp put_group_direct_users(state, group_idp_id, direct_user_ids) do
+    %{
+      state
+      | direct_users_by_group: Map.put(state.direct_users_by_group, group_idp_id, direct_user_ids)
+    }
+  end
+
+  defp put_group_children(state, group_idp_id, sub_group_ids) do
+    children_set = MapSet.new(sub_group_ids)
+    %{state | children_by_group: Map.put(state.children_by_group, group_idp_id, children_set)}
+  end
+
+  defp user_ids_set_from_memberships(memberships) do
+    memberships
+    |> Enum.map(fn {_, user_id} -> user_id end)
+    |> MapSet.new()
+  end
+
+  defp upsert_flattened_group_memberships(
+         _directory,
+         _synced_at,
+         children_by_group,
+         direct_users_by_group
+       )
+       when map_size(children_by_group) == 0 and map_size(direct_users_by_group) == 0,
+       do: :ok
+
+  defp upsert_flattened_group_memberships(
+         directory,
+         synced_at,
+         children_by_group,
+         direct_users_by_group
+       ) do
+    children_group_ids =
+      children_by_group
+      |> Map.values()
+      |> Enum.flat_map(&MapSet.to_list/1)
+
+    group_ids =
+      (Map.keys(children_by_group) ++ Map.keys(direct_users_by_group) ++ children_group_ids)
+      |> MapSet.new()
+      |> MapSet.to_list()
+
+    flattened_users_by_group =
+      group_ids
+      |> Enum.reduce(%{}, fn group_id, acc ->
+        Map.put(acc, group_id, Map.get(direct_users_by_group, group_id, MapSet.new()))
+      end)
+      |> expand_flattened_users_until_stable(group_ids, children_by_group)
+
+    memberships =
+      flattened_users_by_group
+      |> Enum.flat_map(fn {group_id, user_ids} ->
+        Enum.map(user_ids, fn user_id -> {group_id, user_id} end)
+      end)
+
+    upsert_membership_batches(directory, synced_at, memberships)
+  end
+
+  defp expand_flattened_users_until_stable(flattened_users_by_group, group_ids, children_by_group) do
+    {next, changed?} =
+      Enum.reduce(group_ids, {flattened_users_by_group, false}, fn group_id, {acc, changed?} ->
+        current_users = Map.get(acc, group_id, MapSet.new())
+
+        expanded_users =
+          Map.get(children_by_group, group_id, MapSet.new())
+          |> Enum.reduce(current_users, fn child_group_id, users_acc ->
+            MapSet.union(users_acc, Map.get(acc, child_group_id, MapSet.new()))
+          end)
+
+        if MapSet.equal?(current_users, expanded_users) do
+          {acc, changed?}
+        else
+          {Map.put(acc, group_id, expanded_users), true}
+        end
+      end)
+
+    if changed? do
+      expand_flattened_users_until_stable(next, group_ids, children_by_group)
+    else
+      next
+    end
+  end
+
+  defp maybe_enqueue_sub_group(directory, access_token, synced_at, sub_id, {q, v}) do
+    if MapSet.member?(v, sub_id) do
+      {q, v}
+    else
+      case fetch_and_upsert_discovered_group(directory, access_token, synced_at, sub_id) do
+        :ok -> {:queue.in(sub_id, q), MapSet.put(v, sub_id)}
+        :skip -> {q, MapSet.put(v, sub_id)}
+      end
+    end
+  end
+
+  defp enqueue_discovered_sub_groups(
+         directory,
+         access_token,
+         synced_at,
+         sub_group_ids,
+         queue,
+         visited
+       ) do
+    Enum.reduce(sub_group_ids, {queue, visited}, fn sub_id, acc ->
+      maybe_enqueue_sub_group(directory, access_token, synced_at, sub_id, acc)
+    end)
+  end
+
+  # Fetches and upserts a sub-group discovered during BFS by calling get_group to
+  # retrieve its display name and email. Returns :ok on success or :skip if the
+  # group no longer exists in Google (404).
+  defp fetch_and_upsert_discovered_group(directory, access_token, synced_at, group_id) do
+    Logger.debug("Fetching discovered sub-group",
+      google_directory_id: directory.id,
+      group_id: group_id
+    )
+
+    case Google.APIClient.get_group(access_token, group_id) do
+      {:ok, group} ->
+        unless group["id"] do
+          raise Google.SyncError,
+            error: {:validation, "discovered group missing 'id' field"},
+            directory_id: directory.id,
+            step: :get_group
+        end
+
+        unless group["name"] || group["email"] do
+          raise Google.SyncError,
+            error: {:validation, "discovered group '#{group_id}' missing 'name' field"},
+            directory_id: directory.id,
+            step: :get_group
+        end
+
+        attrs = [
+          %{
+            idp_id: group["id"],
+            name: group["name"] || group["email"],
+            email: group["email"]
+          }
+        ]
+
+        batch_upsert_groups(directory, synced_at, attrs)
+        :ok
+
+      {:error, :not_found} ->
+        Logger.debug("Discovered sub-group no longer exists in Google, skipping",
+          google_directory_id: directory.id,
+          group_id: group_id
+        )
+
+        :skip
+
       {:error, error} ->
+        raise Google.SyncError,
+          error: error,
+          directory_id: directory.id,
+          step: :get_group
+    end
+  end
+
+  # Returns {user_membership_tuples, sub_group_idp_ids}:
+  # - user_membership_tuples: [{group_idp_id, user_idp_id}] for type=USER members
+  # - sub_group_idp_ids: [idp_id] for type=GROUP members (to be discovered via BFS)
+  defp fetch_group_members(directory, access_token, group_idp_id) do
+    Logger.debug("Streaming members for group",
+      google_directory_id: directory.id,
+      group_key: group_idp_id
+    )
+
+    Google.APIClient.stream_group_members(access_token, group_idp_id)
+    |> Enum.reduce({[], []}, fn
+      {:error, error}, _acc ->
+        Logger.error("Failed to fetch members for group",
+          group_key: group_idp_id,
+          error: inspect(error),
+          google_directory_id: directory.id
+        )
+
+        raise Google.SyncError,
+          error: error,
+          directory_id: directory.id,
+          step: :stream_group_members
+
+      members, {user_acc, sub_group_acc} when is_list(members) ->
+        Logger.debug("Received members page",
+          google_directory_id: directory.id,
+          group_key: group_idp_id,
+          count: length(members)
+        )
+
+        user_members = Enum.filter(members, fn m -> m["type"] == "USER" end)
+        group_members = Enum.filter(members, fn m -> m["type"] == "GROUP" end)
+
+        user_tuples =
+          Enum.map(user_members, fn member ->
+            unless member["id"] do
+              raise Google.SyncError,
+                error: {:validation, "member missing 'id' field in group #{group_idp_id}"},
+                directory_id: directory.id,
+                step: :process_member
+            end
+
+            {group_idp_id, member["id"]}
+          end)
+
+        sub_group_ids =
+          Enum.flat_map(group_members, fn member ->
+            case member["id"] do
+              nil -> []
+              id -> [id]
+            end
+          end)
+
+        {Enum.reverse(user_tuples, user_acc), Enum.reverse(sub_group_ids, sub_group_acc)}
+    end)
+    |> then(fn {user_acc, sub_group_acc} ->
+      {Enum.reverse(user_acc), Enum.reverse(sub_group_acc)}
+    end)
+  end
+
+  # Phase 3: org unit member sync
+
+  defp sync_org_unit_members_phase(
+         directory,
+         access_token,
+         synced_at,
+         org_unit_entries,
+         seen_user_ids
+       ) do
+    Enum.reduce(org_unit_entries, seen_user_ids, fn {ou_idp_id, ou_path}, seen ->
+      sync_single_org_unit(directory, access_token, synced_at, ou_idp_id, ou_path, seen)
+    end)
+  end
+
+  defp sync_single_org_unit(directory, access_token, synced_at, ou_idp_id, ou_path, seen_user_ids) do
+    {user_tuples, users_by_id} =
+      fetch_org_unit_memberships(directory, access_token, ou_idp_id, ou_path)
+
+    user_ids = user_ids_from_membership_tuples(user_tuples)
+
+    new_user_ids =
+      user_ids
+      |> Enum.reject(&MapSet.member?(seen_user_ids, &1))
+
+    new_users =
+      new_user_ids
+      |> Enum.map(&Map.fetch!(users_by_id, &1))
+
+    sync_identities_for_user_payloads(directory, synced_at, new_users)
+    upsert_membership_batches(directory, synced_at, user_tuples)
+
+    Enum.reduce(user_ids, seen_user_ids, &MapSet.put(&2, &1))
+  end
+
+  defp fetch_org_unit_memberships(directory, access_token, ou_idp_id, ou_path) do
+    Logger.debug("Streaming members for organization unit",
+      google_directory_id: directory.id,
+      org_unit_id: ou_idp_id,
+      org_unit_path: ou_path
+    )
+
+    Google.APIClient.stream_organization_unit_members(access_token, ou_path)
+    |> Enum.reduce({[], %{}}, fn
+      {:error, error}, _acc ->
         Logger.error("Failed to fetch users for organization unit",
-          org_unit_id: org_unit_id,
-          org_unit_name: org_unit_name,
-          org_unit_path: org_unit_path,
+          org_unit_id: ou_idp_id,
+          org_unit_path: ou_path,
           error: inspect(error),
           google_directory_id: directory.id
         )
@@ -396,38 +713,165 @@ defmodule Portal.Google.Sync do
           directory_id: directory.id,
           step: :stream_org_unit_members
 
-      users when is_list(users) ->
-        process_org_unit_members_page(directory, synced_at, org_unit_id, org_unit_name, users)
+      users, {tuple_acc, users_by_id_acc} when is_list(users) ->
+        Logger.debug("Received users page for organization unit",
+          google_directory_id: directory.id,
+          org_unit_id: ou_idp_id,
+          count: length(users)
+        )
+
+        tuples =
+          Enum.map(users, fn user ->
+            unless user["id"] do
+              raise Google.SyncError,
+                error: {:validation, "user missing 'id' field in org unit #{ou_idp_id}"},
+                directory_id: directory.id,
+                step: :process_org_unit_member
+            end
+
+            {ou_idp_id, user["id"]}
+          end)
+
+        users_by_id =
+          Enum.reduce(users, users_by_id_acc, fn user, acc ->
+            Map.put(acc, user["id"], user)
+          end)
+
+        {Enum.reverse(tuples, tuple_acc), users_by_id}
     end)
-    |> Stream.run()
+    |> then(fn {tuple_acc, users_by_id} ->
+      {Enum.reverse(tuple_acc), users_by_id}
+    end)
   end
 
-  defp process_org_unit_members_page(directory, synced_at, org_unit_id, org_unit_name, users) do
-    Logger.debug("Received users page for organization unit",
-      google_directory_id: directory.id,
-      org_unit_id: org_unit_id,
-      count: length(users)
+  # Identity sync (shared by group BFS and org unit phases)
+
+  defp sync_identities_for_users(_directory, _access_token, _synced_at, []), do: :ok
+
+  defp sync_identities_for_users(directory, access_token, synced_at, user_idp_ids) do
+    Logger.debug("Fetching user details for #{length(user_idp_ids)} users via batch API",
+      google_directory_id: directory.id
     )
 
-    # Build memberships (org_unit_idp_id, user_idp_id) - validate required fields
-    memberships =
-      Enum.map(users, fn user ->
-        unless user["id"] do
+    users =
+      case Google.APIClient.batch_get_users(access_token, user_idp_ids) do
+        {:ok, users} ->
+          users
+
+        {:error, error} ->
           raise Google.SyncError,
-            error: {:validation, "user missing 'id' field in org unit #{org_unit_name}"},
+            error: error,
             directory_id: directory.id,
-            step: :process_org_unit_member
-        end
+            step: :batch_get_users
+      end
 
-        {org_unit_id, user["id"]}
-      end)
+    identities = Enum.map(users, &map_user_to_identity(&1, directory.id))
 
-    unless Enum.empty?(memberships) do
-      batch_upsert_memberships(directory, synced_at, memberships)
-    end
+    identities
+    |> Enum.chunk_every(@db_batch_size)
+    |> Enum.each(&batch_upsert_identities(directory, synced_at, &1))
   end
 
-  defp batch_upsert_identities(directory, synced_at, identities) do
+  defp sync_identities_for_user_payloads(_directory, _synced_at, []), do: :ok
+
+  defp sync_identities_for_user_payloads(directory, synced_at, users) do
+    identities = Enum.map(users, &map_user_to_identity(&1, directory.id))
+
+    identities
+    |> Enum.chunk_every(@db_batch_size)
+    |> Enum.each(&batch_upsert_identities(directory, synced_at, &1))
+  end
+
+  defp sync_new_user_identities(directory, access_token, synced_at, user_ids, seen_user_ids) do
+    new_user_idp_ids =
+      user_ids
+      |> Enum.reject(&MapSet.member?(seen_user_ids, &1))
+
+    sync_identities_for_users(directory, access_token, synced_at, new_user_idp_ids)
+
+    Enum.reduce(new_user_idp_ids, seen_user_ids, &MapSet.put(&2, &1))
+  end
+
+  defp user_ids_from_membership_tuples(user_tuples) do
+    user_tuples
+    |> Enum.map(fn {_, user_id} -> user_id end)
+    |> Enum.uniq()
+  end
+
+  defp upsert_membership_batches(_directory, _synced_at, []), do: :ok
+
+  defp upsert_membership_batches(directory, synced_at, memberships) do
+    memberships
+    |> Enum.chunk_every(@db_batch_size)
+    |> Enum.each(&batch_upsert_memberships(directory, synced_at, &1))
+  end
+
+  defp map_user_to_identity(user, directory_id) do
+    primary_email = user["primaryEmail"]
+
+    unless primary_email do
+      raise Google.SyncError,
+        error: {:validation, "user '#{user["id"]}' missing 'primaryEmail' field"},
+        directory_id: directory_id,
+        step: :process_user
+    end
+
+    full_name =
+      user
+      |> Map.get("name", %{})
+      |> Map.get("fullName")
+
+    %{
+      idp_id: user["id"],
+      email: primary_email,
+      name: full_name || primary_email,
+      given_name: Map.get(user, "name", %{}) |> Map.get("givenName"),
+      family_name: Map.get(user, "name", %{}) |> Map.get("familyName"),
+      preferred_username: primary_email,
+      picture: Map.get(user, "thumbnailPhotoUrl")
+    }
+  end
+
+  # Cleanup
+
+  defp delete_unsynced(directory, synced_at) do
+    account_id = directory.account_id
+    directory_id = directory.id
+
+    # Delete memberships before groups (memberships reference groups via FK)
+    {count, _} = Database.delete_unsynced_memberships(account_id, directory_id, synced_at)
+
+    Logger.debug("Deleted unsynced memberships",
+      google_directory_id: directory.id,
+      count: count
+    )
+
+    {count, _} = Database.delete_unsynced_groups(account_id, directory_id, synced_at)
+
+    Logger.debug("Deleted unsynced groups and org units",
+      google_directory_id: directory.id,
+      count: count
+    )
+
+    {count, _} = Database.delete_unsynced_identities(account_id, directory_id, synced_at)
+
+    Logger.debug("Deleted unsynced identities",
+      google_directory_id: directory.id,
+      count: count
+    )
+
+    {count, _} = Database.delete_actors_without_identities(account_id, directory_id)
+
+    Logger.debug("Deleted actors without identities",
+      google_directory_id: directory.id,
+      count: count
+    )
+  end
+
+  # Batch DB helpers
+
+  @doc false
+  def batch_upsert_identities(directory, synced_at, identities) do
     account_id = directory.account_id
     directory_id = directory.id
 
@@ -458,7 +902,8 @@ defmodule Portal.Google.Sync do
     :ok
   end
 
-  defp batch_upsert_memberships(directory, synced_at, memberships) do
+  @doc false
+  def batch_upsert_memberships(directory, synced_at, memberships) do
     account_id = directory.account_id
     directory_id = directory.id
 
@@ -474,7 +919,10 @@ defmodule Portal.Google.Sync do
           google_directory_id: directory.id
         )
 
-        :error
+        raise Google.SyncError,
+          error: {:database, "failed to upsert memberships: #{inspect(reason)}"},
+          directory_id: directory.id,
+          step: :batch_upsert_memberships
     end
   end
 
@@ -487,70 +935,6 @@ defmodule Portal.Google.Sync do
 
     Logger.debug("Upserted #{count} organization units", google_directory_id: directory.id)
     :ok
-  end
-
-  defp delete_unsynced(directory, synced_at) do
-    account_id = directory.account_id
-    directory_id = directory.id
-
-    # Delete groups that weren't synced
-    {deleted_groups_count, _} =
-      Database.delete_unsynced_groups(account_id, directory_id, synced_at)
-
-    Logger.debug("Deleted unsynced groups",
-      google_directory_id: directory.id,
-      count: deleted_groups_count
-    )
-
-    # Delete identities that weren't synced
-    {deleted_identities_count, _} =
-      Database.delete_unsynced_identities(account_id, directory_id, synced_at)
-
-    Logger.debug("Deleted unsynced identities",
-      google_directory_id: directory.id,
-      count: deleted_identities_count
-    )
-
-    # Delete memberships that weren't synced
-    {deleted_memberships_count, _} =
-      Database.delete_unsynced_memberships(account_id, directory_id, synced_at)
-
-    Logger.debug("Deleted unsynced group memberships",
-      google_directory_id: directory.id,
-      count: deleted_memberships_count
-    )
-
-    # Delete actors that no longer have any identities and were created by this directory
-    {deleted_actors_count, _} =
-      Database.delete_actors_without_identities(account_id, directory_id)
-
-    Logger.debug("Deleted actors without identities",
-      google_directory_id: directory.id,
-      count: deleted_actors_count
-    )
-  end
-
-  defp map_user_to_identity(user, directory_id) do
-    # Map Google Workspace user fields to our identity schema
-    # Validate that critical fields are present
-    primary_email = user["primaryEmail"]
-
-    unless primary_email do
-      raise Google.SyncError,
-        error: {:validation, "user '#{user["id"]}' missing 'primaryEmail' field"},
-        directory_id: directory_id,
-        step: :process_user
-    end
-
-    %{
-      idp_id: user["id"],
-      email: primary_email,
-      name: Map.get(user, "name", %{}) |> Map.get("fullName"),
-      given_name: Map.get(user, "name", %{}) |> Map.get("givenName"),
-      family_name: Map.get(user, "name", %{}) |> Map.get("familyName"),
-      preferred_username: primary_email,
-      picture: Map.get(user, "thumbnailPhotoUrl")
-    }
   end
 
   defmodule Database do
@@ -732,7 +1116,6 @@ defmodule Portal.Google.Sync do
       do: {:ok, %{upserted_groups: 0}}
 
     def batch_upsert_groups(account_id, directory_id, last_synced_at, group_attrs, entity_type) do
-      # Convert to raw SQL to support conditional updates based on last_synced_at
       query = build_group_upsert_query(length(group_attrs))
 
       params =
@@ -754,30 +1137,31 @@ defmodule Portal.Google.Sync do
     end
 
     defp build_group_upsert_query(count) do
-      # Each group has 2 fields: idp_id, name
+      # Each group has 3 fields: idp_id, name, email
       values_clause =
-        for i <- 1..count, base = (i - 1) * 2 do
-          "($#{base + 1}, $#{base + 2})"
+        for i <- 1..count, base = (i - 1) * 3 do
+          "($#{base + 1}, $#{base + 2}, $#{base + 3})"
         end
         |> Enum.join(", ")
 
-      offset = count * 2
+      offset = count * 3
       account_id = offset + 1
       directory_id = offset + 2
       last_synced_at = offset + 3
       entity_type = offset + 4
 
       """
-      WITH input_data (idp_id, name) AS (
+      WITH input_data (idp_id, name, email) AS (
         VALUES #{values_clause}
       )
       INSERT INTO groups (
-        id, name, directory_id, idp_id, account_id,
+        id, name, email, directory_id, idp_id, account_id,
         inserted_at, updated_at, type, entity_type, last_synced_at
       )
       SELECT
         uuid_generate_v4(),
         id.name,
+        id.email,
         $#{directory_id},
         id.idp_id,
         $#{account_id},
@@ -793,6 +1177,11 @@ defmodule Portal.Google.Sync do
           WHEN groups.last_synced_at IS NULL OR groups.last_synced_at < EXCLUDED.last_synced_at
           THEN EXCLUDED.name
           ELSE groups.name
+        END,
+        email = CASE
+          WHEN groups.last_synced_at IS NULL OR groups.last_synced_at < EXCLUDED.last_synced_at
+          THEN EXCLUDED.email
+          ELSE groups.email
         END,
         directory_id = CASE
           WHEN groups.last_synced_at IS NULL OR groups.last_synced_at < EXCLUDED.last_synced_at
@@ -822,10 +1211,9 @@ defmodule Portal.Google.Sync do
       group_params =
         group_attrs
         |> Enum.flat_map(fn attrs ->
-          [attrs.idp_id, attrs.name]
+          [attrs.idp_id, attrs.name, Map.get(attrs, :email)]
         end)
 
-      # Properly cast UUIDs to binary
       group_params ++
         [
           Ecto.UUID.dump!(account_id),
@@ -844,7 +1232,14 @@ defmodule Portal.Google.Sync do
       params =
         build_membership_upsert_params(account_id, directory_id, last_synced_at, tuples)
 
-      case Safe.unscoped() |> Safe.query(query, params) do
+      result =
+        try do
+          Safe.unscoped() |> Safe.query(query, params)
+        rescue
+          error in DBConnection.EncodeError -> {:error, error}
+        end
+
+      case result do
         {:ok, %Postgrex.Result{num_rows: num_rows}} -> {:ok, %{upserted_memberships: num_rows}}
         {:error, reason} -> {:error, reason}
       end
@@ -930,7 +1325,6 @@ defmodule Portal.Google.Sync do
     end
 
     def delete_unsynced_memberships(account_id, directory_id, synced_at) do
-      # Delete memberships for groups in this directory that haven't been synced
       query =
         from(m in Portal.Membership,
           join: g in Portal.Group,

--- a/elixir/lib/portal/group.ex
+++ b/elixir/lib/portal/group.ex
@@ -12,6 +12,7 @@ defmodule Portal.Group do
     field :id, :binary_id, primary_key: true, autogenerate: true
 
     field :name, :string
+    field :email, :string
     field :type, Ecto.Enum, values: ~w[managed static]a, default: :static
     field :entity_type, Ecto.Enum, values: ~w[group org_unit]a, default: :group
 

--- a/elixir/lib/portal_api/controllers/google_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/google_directory_json.ex
@@ -22,6 +22,8 @@ defmodule PortalAPI.GoogleDirectoryJSON do
       synced_at: directory.synced_at,
       error_message: directory.error_message,
       errored_at: directory.errored_at,
+      group_sync_mode: directory.group_sync_mode,
+      orgunit_sync_enabled: directory.orgunit_sync_enabled,
       inserted_at: directory.inserted_at,
       updated_at: directory.updated_at
     }

--- a/elixir/lib/portal_api/controllers/group_json.ex
+++ b/elixir/lib/portal_api/controllers/group_json.ex
@@ -23,6 +23,7 @@ defmodule PortalAPI.GroupJSON do
     %{
       id: group.id,
       name: group.name,
+      email: group.email,
       entity_type: group.entity_type,
       directory_id: group.directory_id,
       idp_id: group.idp_id,

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -25,6 +25,15 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
           format: :datetime,
           description: "Error email timestamp"
         },
+        group_sync_mode: %Schema{
+          type: :string,
+          enum: ["all", "filtered", "disabled"],
+          description: "Group sync mode"
+        },
+        orgunit_sync_enabled: %Schema{
+          type: :boolean,
+          description: "Whether org unit sync is enabled"
+        },
         inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
         updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
       },

--- a/elixir/lib/portal_api/schemas/group_schema.ex
+++ b/elixir/lib/portal_api/schemas/group_schema.ex
@@ -12,6 +12,11 @@ defmodule PortalAPI.Schemas.Group do
       properties: %{
         id: %Schema{type: :string, description: "Group ID"},
         name: %Schema{type: :string, description: "Group Name"},
+        email: %Schema{
+          type: :string,
+          description: "Group email address for synced groups",
+          nullable: true
+        },
         entity_type: %Schema{
           type: :string,
           enum: ["group", "org_unit"],
@@ -48,6 +53,7 @@ defmodule PortalAPI.Schemas.Group do
       example: %{
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "Engineering",
+        "email" => nil,
         "entity_type" => "group",
         "directory_id" => nil,
         "idp_id" => nil,
@@ -95,6 +101,7 @@ defmodule PortalAPI.Schemas.Group do
         "data" => %{
           "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
           "name" => "Engineering",
+          "email" => nil,
           "entity_type" => "group",
           "directory_id" => nil,
           "idp_id" => nil,
@@ -124,6 +131,7 @@ defmodule PortalAPI.Schemas.Group do
           %{
             "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
             "name" => "Engineering",
+            "email" => nil,
             "entity_type" => "group",
             "directory_id" => nil,
             "idp_id" => nil,
@@ -133,7 +141,8 @@ defmodule PortalAPI.Schemas.Group do
           },
           %{
             "id" => "4ae929a7-1973-43f2-a1a8-9221b91a4c0e",
-            "name" => "Finance",
+            "name" => "firezone-sync-admins",
+            "email" => "firezone-sync-admins@example.com",
             "entity_type" => "group",
             "directory_id" => "6b4e3a2c-1234-5678-9abc-def012345678",
             "idp_id" => "google-workspace-group-123",

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -471,6 +471,12 @@ defmodule PortalWeb.Groups do
                   {get_idp_id(@group.idp_id)}
                 </p>
               </div>
+              <div :if={@group.email}>
+                <p class="text-xs font-medium text-neutral-500 uppercase">Email</p>
+                <p class="text-sm text-neutral-900 truncate" title={@group.email}>
+                  {@group.email}
+                </p>
+              </div>
             </div>
           </div>
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -27,7 +27,8 @@ defmodule PortalWeb.Settings.DirectorySync do
 
   @fields %{
     Entra.Directory => @common_fields ++ ~w[tenant_id sync_all_groups]a,
-    Google.Directory => @common_fields ++ ~w[domain impersonation_email]a,
+    Google.Directory =>
+      @common_fields ++ ~w[domain impersonation_email group_sync_mode orgunit_sync_enabled]a,
     Okta.Directory => @common_fields ++ ~w[okta_domain client_id private_key_jwk kid]a
   }
 
@@ -935,10 +936,10 @@ defmodule PortalWeb.Settings.DirectorySync do
           </p>
         </div>
 
-        <div :if={@type == "entra"}>
-          <label class="block text-sm font-medium text-neutral-700 mb-3">
+        <fieldset :if={@type == "entra"}>
+          <legend class="block text-sm font-medium text-neutral-700 mb-3">
             Group sync mode
-          </label>
+          </legend>
           <% sync_all_groups = get_field(@form.source, :sync_all_groups) %>
           <div class="grid gap-4 md:grid-cols-2">
             <label class={[
@@ -992,7 +993,7 @@ defmodule PortalWeb.Settings.DirectorySync do
               </span>
             </label>
           </div>
-        </div>
+        </fieldset>
 
         <div :if={@type == "google"}>
           <.input
@@ -1006,6 +1007,110 @@ defmodule PortalWeb.Settings.DirectorySync do
           />
           <p class="mt-1 text-xs text-neutral-600">
             Enter the admin email address to impersonate for directory sync.
+          </p>
+        </div>
+
+        <fieldset :if={@type == "google"}>
+          <legend class="block text-sm font-medium text-neutral-700 mb-3">
+            Group sync mode
+          </legend>
+          <% group_sync_mode = get_field(@form.source, :group_sync_mode) %>
+          <div class="grid gap-4 md:grid-cols-3">
+            <label class={[
+              "flex flex-col p-4 border-2 rounded-md cursor-pointer transition-all",
+              if(group_sync_mode == :all,
+                do: "border-accent-500 bg-accent-50",
+                else: "border-neutral-200 hover:border-neutral-300"
+              )
+            ]}>
+              <input
+                type="radio"
+                name={@form[:group_sync_mode].name}
+                value="all"
+                checked={group_sync_mode == :all}
+                class="sr-only"
+              />
+              <div class="mb-2">
+                <span class="text-base font-semibold text-neutral-900">
+                  All groups
+                </span>
+              </div>
+              <span class="text-sm text-neutral-600">
+                All groups from your directory will be synced.
+                <strong class="block mt-1">Default.</strong>
+              </span>
+            </label>
+
+            <label class={[
+              "flex flex-col p-4 border-2 rounded-md cursor-pointer transition-all",
+              if(group_sync_mode == :filtered,
+                do: "border-accent-500 bg-accent-50",
+                else: "border-neutral-200 hover:border-neutral-300"
+              )
+            ]}>
+              <input
+                type="radio"
+                name={@form[:group_sync_mode].name}
+                value="filtered"
+                checked={group_sync_mode == :filtered}
+                class="sr-only"
+              />
+              <div class="mb-2">
+                <span class="text-base font-semibold text-neutral-900">
+                  Filtered groups
+                </span>
+              </div>
+              <span class="text-sm text-neutral-600">
+                Only groups whose name starts with
+                <code class="text-xs"><strong>[firezone-sync]</strong></code>
+                or email starts with <code class="text-xs"><strong>firezone-sync</strong></code>
+                will be synced.
+              </span>
+            </label>
+
+            <label class={[
+              "flex flex-col p-4 border-2 rounded-md cursor-pointer transition-all",
+              if(group_sync_mode == :disabled,
+                do: "border-accent-500 bg-accent-50",
+                else: "border-neutral-200 hover:border-neutral-300"
+              )
+            ]}>
+              <input
+                type="radio"
+                name={@form[:group_sync_mode].name}
+                value="disabled"
+                checked={group_sync_mode == :disabled}
+                class="sr-only"
+              />
+              <div class="mb-2">
+                <span class="text-base font-semibold text-neutral-900">
+                  Disabled
+                </span>
+              </div>
+              <span class="text-sm text-neutral-600">
+                No groups will be synced from your directory.
+              </span>
+            </label>
+          </div>
+        </fieldset>
+
+        <div :if={@type == "google"} class="mt-4">
+          <label class="flex items-center gap-3 cursor-pointer">
+            <input type="hidden" name={@form[:orgunit_sync_enabled].name} value="false" />
+            <input
+              type="checkbox"
+              name={@form[:orgunit_sync_enabled].name}
+              value="true"
+              checked={get_field(@form.source, :orgunit_sync_enabled)}
+              class="w-4 h-4 text-accent-600 border-neutral-300 rounded"
+            />
+            <span class="text-sm font-medium text-neutral-700">
+              Sync Organization Units
+            </span>
+          </label>
+          <p class="mt-1 ml-7 text-xs text-neutral-600">
+            Sync Google Workspace organizational units as groups. <strong>Note:</strong>
+            When enabled, all org units and active users will be synced.
           </p>
         </div>
 
@@ -1348,15 +1453,19 @@ defmodule PortalWeb.Settings.DirectorySync do
     changeset = socket.assigns.form.source
     impersonation_email = get_field(changeset, :impersonation_email)
     config = Portal.Config.fetch_env!(:portal, Google.APIClient)
-    key = config[:service_account_key] |> JSON.decode!()
 
     result =
-      with {:ok, %Req.Response{status: 200, body: %{"access_token" => access_token}}} <-
+      with key_json when is_binary(key_json) <- config[:service_account_key],
+           key = JSON.decode!(key_json),
+           {:ok, %Req.Response{status: 200, body: %{"access_token" => access_token}}} <-
              Google.APIClient.get_access_token(impersonation_email, key),
            {:ok, %Req.Response{status: 200, body: body}} <-
              Google.APIClient.get_customer(access_token),
            :ok <- Google.APIClient.test_connection(access_token, body["customerDomain"]) do
         {:ok, body["customerDomain"]}
+      else
+        nil -> {:error, :service_account_not_configured}
+        other -> other
       end
 
     case result do
@@ -1527,6 +1636,10 @@ defmodule PortalWeb.Settings.DirectorySync do
     Logger.info("Transport error while verifying Google directory", error: inspect(reason))
 
     "Transport error while attempting to connect to Google.  We're looking into this"
+  end
+
+  defp parse_google_verification_error({:error, :service_account_not_configured}) do
+    "No service account key is configured for this deployment. Please contact your administrator."
   end
 
   defp parse_google_verification_error({:error, reason}) when is_exception(reason) do

--- a/elixir/priv/repo/migrations/20260224120000_add_group_sync_mode_to_google_directories.exs
+++ b/elixir/priv/repo/migrations/20260224120000_add_group_sync_mode_to_google_directories.exs
@@ -1,0 +1,18 @@
+defmodule Portal.Repo.Migrations.AddGroupSyncModeToGoogleDirectories do
+  use Ecto.Migration
+
+  def change do
+    alter table(:google_directories) do
+      add(:group_sync_mode, :string, null: false, default: "all")
+      add(:orgunit_sync_enabled, :boolean, null: false, default: false)
+    end
+
+    execute("UPDATE google_directories SET orgunit_sync_enabled = TRUE")
+
+    create(
+      constraint(:google_directories, :group_sync_mode_values,
+        check: "group_sync_mode IN ('all', 'filtered', 'disabled')"
+      )
+    )
+  end
+end

--- a/elixir/priv/repo/migrations/20260225120000_add_email_to_groups.exs
+++ b/elixir/priv/repo/migrations/20260225120000_add_email_to_groups.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.AddEmailToGroups do
+  use Ecto.Migration
+
+  def change do
+    alter table(:groups) do
+      add(:email, :string, null: true)
+    end
+  end
+end

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -120,6 +120,49 @@ defmodule Portal.Google.APIClientTest do
     end
   end
 
+  describe "get_group/2" do
+    test "returns group body for 200 response" do
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/admin/directory/v1/groups/group123"
+        Req.Test.json(conn, %{"id" => "group123", "name" => "Engineering"})
+      end)
+
+      assert {:ok, %{"id" => "group123", "name" => "Engineering"}} =
+               APIClient.get_group(@test_access_token, "group123")
+    end
+
+    test "returns :not_found for 404 response" do
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(404)
+        |> Req.Test.json(%{"error" => "not found"})
+      end)
+
+      assert {:error, :not_found} = APIClient.get_group(@test_access_token, "missing-group")
+    end
+
+    test "returns response error for non-404 non-200 response" do
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => "server error"})
+      end)
+
+      assert {:error, %Req.Response{status: 500}} =
+               APIClient.get_group(@test_access_token, "group123")
+    end
+
+    test "returns transport error unchanged" do
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.transport_error(conn, :econnrefused)
+      end)
+
+      assert {:error, %Req.TransportError{reason: :econnrefused}} =
+               APIClient.get_group(@test_access_token, "group123")
+    end
+  end
+
   describe "test_connection/2" do
     test "returns :ok when all endpoints are accessible" do
       Req.Test.expect(APIClient, 3, fn conn ->
@@ -401,7 +444,7 @@ defmodule Portal.Google.APIClientTest do
       assert [[%{"id" => "group1"}], [%{"id" => "group2"}]] = result
     end
 
-    test "returns error when groups key is missing" do
+    test "returns empty list when groups key is missing (e.g. filtered query with no matches)" do
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{})
       end)
@@ -410,13 +453,12 @@ defmodule Portal.Google.APIClientTest do
         APIClient.stream_groups(@test_access_token, @test_domain)
         |> Enum.to_list()
 
-      assert [{:error, {:missing_key, message, _body}}] = result
-      assert message =~ "groups"
+      assert [[]] = result
     end
   end
 
   describe "stream_group_members/2" do
-    test "streams a single page of members with includeDerivedMembership" do
+    test "streams a single page of direct members" do
       test_pid = self()
       group_key = "group123"
 
@@ -443,7 +485,7 @@ defmodule Portal.Google.APIClientTest do
       assert_receive {:members_request, conn}
       assert_authorization_header(conn, @test_access_token)
       assert conn.query_params["maxResults"] == "200"
-      assert conn.query_params["includeDerivedMembership"] == "true"
+      refute Map.has_key?(conn.query_params, "includeDerivedMembership")
     end
 
     test "streams multiple pages of members" do
@@ -476,11 +518,11 @@ defmodule Portal.Google.APIClientTest do
       assert [[%{"id" => "user1"}], [%{"id" => "user2"}]] = result
 
       assert_receive {:members_page, 0, page1_params}
-      assert page1_params["includeDerivedMembership"] == "true"
+      refute Map.has_key?(page1_params, "includeDerivedMembership")
       refute Map.has_key?(page1_params, "pageToken")
 
       assert_receive {:members_page, 1, page2_params}
-      assert page2_params["includeDerivedMembership"] == "true"
+      refute Map.has_key?(page2_params, "includeDerivedMembership")
       assert page2_params["pageToken"] == "page2"
     end
 
@@ -694,6 +736,242 @@ defmodule Portal.Google.APIClientTest do
     end
   end
 
+  describe "batch_get_users/2" do
+    test "returns empty list when user_ids is empty" do
+      assert {:ok, []} = APIClient.batch_get_users(@test_access_token, [])
+    end
+
+    test "uses configured batch endpoint when provided" do
+      original_config = Application.get_env(:portal, APIClient)
+
+      custom_endpoint = "https://batch.googleapis.test/custom-batch"
+
+      Application.put_env(
+        :portal,
+        APIClient,
+        Keyword.put(original_config, :batch_endpoint, custom_endpoint)
+      )
+
+      on_exit(fn ->
+        Application.put_env(:portal, APIClient, original_config)
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.host == "batch.googleapis.test"
+        assert conn.request_path == "/custom-batch"
+
+        boundary = "custom_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, [%{"id" => "user1", "primaryEmail" => "user1@example.com"}]} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "parses multipart responses with quoted boundary values" do
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        boundary = "quoted_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=\"#{boundary}\"")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, [%{"id" => "user1", "primaryEmail" => "user1@example.com"}]} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "returns error for parts with malformed HTTP status line" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "malformed_status_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"NOT-HTTP", JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 502}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "skips 404 users in batch response" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "not_found_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 404 Not Found", JSON.encode!(%{"error" => %{"message" => "not found"}})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, []} = APIClient.batch_get_users(@test_access_token, ["deleted-user"])
+    end
+
+    test "handles iodata response body for multipart parsing" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "iodata_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, [body])
+      end)
+
+      assert {:ok, [%{"id" => "user1", "primaryEmail" => "user1@example.com"}]} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "returns error for non-200 batch response" do
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => "server error"})
+      end)
+
+      assert {:error, %Req.Response{status: 500}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "returns error for non-404 per-part status in batch response" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "forbidden_part_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 403 Forbidden", JSON.encode!(%{"error" => %{"message" => "forbidden"}})}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 403}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "returns transport error for batch request failure" do
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.transport_error(conn, :timeout)
+      end)
+
+      assert {:error, %Req.TransportError{reason: :timeout}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "halts on chunk error after first successful chunk" do
+      counter = :atomics.new(1, [])
+
+      Req.Test.expect(APIClient, 2, fn conn ->
+        call_idx = :atomics.get(counter, 1)
+        :atomics.put(counter, 1, call_idx + 1)
+
+        case call_idx do
+          0 ->
+            boundary = "first_chunk"
+
+            body =
+              build_batch_body(boundary, [
+                {"HTTP/1.1 200 OK",
+                 JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+              ])
+
+            conn
+            |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+            |> Plug.Conn.send_resp(200, body)
+
+          _ ->
+            conn
+            |> Plug.Conn.put_status(503)
+            |> Req.Test.json(%{"error" => "unavailable"})
+        end
+      end)
+
+      user_ids = Enum.map(1..101, &"user-#{&1}")
+
+      assert {:error, %Req.Response{status: 503}} =
+               APIClient.batch_get_users(@test_access_token, user_ids)
+    end
+
+    test "raises when multipart boundary is missing from content type" do
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed")
+        |> Plug.Conn.send_resp(200, "--irrelevant--")
+      end)
+
+      assert_raise RuntimeError, ~r/Could not extract multipart boundary/, fn ->
+        APIClient.batch_get_users(@test_access_token, ["user1"])
+      end
+    end
+
+    test "returns error for malformed multipart parts" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "malformed_part_boundary"
+
+        body =
+          "--#{boundary}\r\nContent-Type: application/http\r\n\r\nmalformed\r\n--#{boundary}--"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 502}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+
+    test "returns error for batch parts with invalid JSON payload" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "invalid_json_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK", "not-json"}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:error, %Req.Response{status: 502}} =
+               APIClient.batch_get_users(@test_access_token, ["user1"])
+    end
+  end
+
   describe "pagination edge cases" do
     test "handles empty result list correctly for users" do
       Req.Test.expect(APIClient, fn conn ->
@@ -775,6 +1053,15 @@ defmodule Portal.Google.APIClientTest do
   end
 
   # Helper functions
+
+  defp build_batch_body(boundary, parts) do
+    encoded_parts =
+      Enum.map(parts, fn {status_line, json_body} ->
+        "--#{boundary}\r\nContent-Type: application/http\r\n\r\n#{status_line}\r\nContent-Type: application/json\r\n\r\n#{json_body}\r\n"
+      end)
+
+    Enum.join(encoded_parts, "") <> "--#{boundary}--"
+  end
 
   defp assert_authorization_header(conn, expected_token) do
     auth_header =

--- a/elixir/test/portal/google/directory_test.exs
+++ b/elixir/test/portal/google/directory_test.exs
@@ -205,6 +205,47 @@ defmodule Portal.Google.DirectoryTest do
       assert Ecto.Changeset.get_field(changeset, :is_disabled) == false
       assert Ecto.Changeset.get_field(changeset, :error_email_count) == 0
       assert Ecto.Changeset.get_field(changeset, :is_verified) == false
+      assert Ecto.Changeset.get_field(changeset, :group_sync_mode) == :all
+      assert Ecto.Changeset.get_field(changeset, :orgunit_sync_enabled) == false
+    end
+
+    test "accepts all valid group_sync_mode values", %{account: account} do
+      for mode <- [:all, :filtered, :disabled] do
+        changeset =
+          %Directory{account_id: account.id}
+          |> Ecto.Changeset.cast(
+            %{
+              name: "Test Directory",
+              domain: "example.com",
+              impersonation_email: "admin@example.com",
+              is_verified: true,
+              group_sync_mode: mode
+            },
+            [:name, :domain, :impersonation_email, :is_verified, :group_sync_mode]
+          )
+          |> Directory.changeset()
+
+        assert changeset.valid?, "Expected group_sync_mode #{inspect(mode)} to be valid"
+        assert Ecto.Changeset.get_field(changeset, :group_sync_mode) == mode
+      end
+    end
+
+    test "rejects invalid group_sync_mode value", %{account: account} do
+      changeset =
+        %Directory{account_id: account.id}
+        |> Ecto.Changeset.cast(
+          %{
+            name: "Test Directory",
+            domain: "example.com",
+            impersonation_email: "admin@example.com",
+            is_verified: true,
+            group_sync_mode: :invalid_mode
+          },
+          [:name, :domain, :impersonation_email, :is_verified, :group_sync_mode]
+        )
+        |> Directory.changeset()
+
+      refute changeset.valid?
     end
 
     test "allows synced and errored timestamps to be set", %{account: account} do

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -4,9 +4,11 @@ defmodule Portal.Google.SyncTest do
 
   import Portal.AccountFixtures
   import Portal.GoogleDirectoryFixtures
+  import Portal.ResourceFixtures
   import ExUnit.CaptureLog
 
   alias Portal.Google.{Sync, SyncError, APIClient}
+  alias Portal.Google.Sync.Database
 
   @test_private_key """
   -----BEGIN RSA PRIVATE KEY-----
@@ -38,10 +40,30 @@ defmodule Portal.Google.SyncTest do
   -----END RSA PRIVATE KEY-----
   """
 
+  # Builds a valid multipart/mixed batch response and sends it via the conn.
+  # `users` is a list of user maps to include as 200 OK parts.
+  defp respond_with_batch_users(conn, users) do
+    boundary = "test_batch_response_boundary"
+
+    parts =
+      Enum.map(users, fn user ->
+        json = JSON.encode!(user)
+
+        "--#{boundary}\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n#{json}\r\n"
+      end)
+
+    body = Enum.join(parts, "") <> "--#{boundary}--"
+
+    conn
+    |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+    |> Plug.Conn.send_resp(200, body)
+  end
+
   describe "perform/1" do
     setup do
       # Set up test configuration for API client
       original_config = Application.get_env(:portal, APIClient)
+      original_log_level = Logger.level()
 
       test_config = [
         endpoint: "https://test.googleapis.com",
@@ -63,6 +85,7 @@ defmodule Portal.Google.SyncTest do
       ]
 
       Application.put_env(:portal, APIClient, test_config)
+      Logger.configure(level: :debug)
 
       # Set up default stub
       Req.Test.stub(APIClient, fn conn ->
@@ -70,6 +93,7 @@ defmodule Portal.Google.SyncTest do
       end)
 
       on_exit(fn ->
+        Logger.configure(level: original_log_level)
         Application.put_env(:portal, APIClient, original_config)
       end)
 
@@ -121,19 +145,43 @@ defmodule Portal.Google.SyncTest do
       assert log =~ directory.id
     end
 
-    test "performs successful sync with users, groups, and org units" do
+    test "performs successful sync with groups, org units, and user identity sync" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock access token request
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         assert conn.request_path == "/token"
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock users API
+      # 2. Groups API
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups")
+        refute String.contains?(conn.request_path, "/members")
+
+        Req.Test.json(conn, %{
+          "groups" => [
+            %{"id" => "group1", "name" => "DevOps", "email" => "devops@example.com"}
+          ]
+        })
+      end)
+
+      # 3. Org units API
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/orgunits")
+
+        Req.Test.json(conn, %{
+          "organizationUnits" => [
+            %{"orgUnitId" => "ou1", "name" => "Engineering", "orgUnitPath" => "/Engineering"}
+          ]
+        })
+      end)
+
+      # 4. Org unit members for /Engineering (now synced before group BFS)
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/users")
+        assert String.contains?(conn.query_string || "", "orgUnitPath")
 
         Req.Test.json(conn, %{
           "users" => [
@@ -146,48 +194,13 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # Mock groups API
-      Req.Test.expect(APIClient, fn conn ->
-        assert String.contains?(conn.request_path, "/groups")
-        refute String.contains?(conn.request_path, "/members")
-
-        Req.Test.json(conn, %{
-          "groups" => [
-            %{"id" => "group1", "name" => "DevOps", "email" => "devops@example.com"}
-          ]
-        })
-      end)
-
-      # Mock group members API
+      # 5. Group members for group1 (BFS phase)
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.request_path, "/groups/group1/members")
 
         Req.Test.json(conn, %{
           "members" => [
             %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"}
-          ]
-        })
-      end)
-
-      # Mock org units API
-      Req.Test.expect(APIClient, fn conn ->
-        assert String.contains?(conn.request_path, "/orgunits")
-
-        Req.Test.json(conn, %{
-          "organizationUnits" => [
-            %{"orgUnitId" => "ou1", "name" => "Engineering", "orgUnitPath" => "/Engineering"}
-          ]
-        })
-      end)
-
-      # Mock org unit users API
-      Req.Test.expect(APIClient, fn conn ->
-        assert String.contains?(conn.request_path, "/users")
-        assert String.contains?(conn.query_string || "", "orgUnitPath")
-
-        Req.Test.json(conn, %{
-          "users" => [
-            %{"id" => "user1", "primaryEmail" => "user1@example.com"}
           ]
         })
       end)
@@ -201,7 +214,7 @@ defmodule Portal.Google.SyncTest do
       assert updated_directory.error_email_count == 0
       assert updated_directory.is_disabled == false
 
-      # Verify identities were created
+      # Verify identity was created
       identities = Repo.all(Portal.ExternalIdentity)
       assert length(identities) == 1
       identity = hd(identities)
@@ -212,11 +225,11 @@ defmodule Portal.Google.SyncTest do
       groups = Repo.all(Portal.Group)
       assert length(groups) == 2
 
-      # Verify we have one group and one org unit
       group_by_type = Enum.group_by(groups, & &1.entity_type)
       assert length(group_by_type[:group]) == 1
       assert length(group_by_type[:org_unit]) == 1
       assert hd(group_by_type[:group]).name == "DevOps"
+      assert hd(group_by_type[:group]).email == "devops@example.com"
       assert hd(group_by_type[:org_unit]).name == "Engineering"
 
       # Verify memberships were created (one for group, one for org unit)
@@ -240,42 +253,16 @@ defmodule Portal.Google.SyncTest do
       end
     end
 
-    test "raises SyncError when users API returns error" do
-      account = account_fixture()
-      directory = google_directory_fixture(account: account, domain: "example.com")
-
-      # Mock successful access token
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
-      end)
-
-      # Mock users API to fail
-      Req.Test.expect(APIClient, fn conn ->
-        conn
-        |> Plug.Conn.put_status(403)
-        |> Req.Test.json(%{"error" => "insufficient_permissions"})
-      end)
-
-      assert_raise SyncError, ~r/at stream_users: HTTP 403/, fn ->
-        perform_job(Sync, %{"directory_id" => directory.id})
-      end
-    end
-
     test "raises SyncError when groups API returns error" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock groups API to fail
+      # 2. Groups API fails
       Req.Test.expect(APIClient, fn conn ->
         conn
         |> Plug.Conn.put_status(500)
@@ -291,22 +278,17 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock successful groups API
+      # 2. Groups API succeeds (empty)
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"groups" => []})
       end)
 
-      # Mock org units API to fail
+      # 3. Org units API fails
       Req.Test.expect(APIClient, fn conn ->
         conn
         |> Plug.Conn.put_status(403)
@@ -318,45 +300,79 @@ defmodule Portal.Google.SyncTest do
       end
     end
 
-    test "raises SyncError when user is missing id field" do
+    test "raises SyncError when group member is missing id field" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock users API with missing id
+      # 2. Groups API returns group1
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
-          "users" => [
-            %{"primaryEmail" => "user@example.com", "name" => %{"fullName" => "User"}}
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      # 3. Org units
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. Group members — member is missing "id" field
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"type" => "USER", "email" => "user@example.com"}
           ]
         })
       end)
 
-      assert_raise SyncError, ~r/user missing 'id' field/, fn ->
+      assert_raise SyncError, ~r/member missing 'id' field/, fn ->
         perform_job(Sync, %{"directory_id" => directory.id})
       end
     end
 
-    test "raises SyncError when user is missing primaryEmail field" do
+    test "raises SyncError when get_user returns user missing primaryEmail field" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock users API with missing primaryEmail
+      # 2. Groups API returns group1
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
-          "users" => [
-            %{"id" => "user1", "name" => %{"fullName" => "User"}}
-          ]
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
         })
+      end)
+
+      # 3. Org units
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. Group members returns user1
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "user1", "type" => "USER", "email" => "user1@example.com"}]
+        })
+      end)
+
+      # 5. batch_get_users returns user without primaryEmail
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{"id" => "user1", "name" => %{"fullName" => "User"}}
+        ])
       end)
 
       assert_raise SyncError, ~r/user .* missing 'primaryEmail' field/, fn ->
@@ -368,17 +384,12 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock groups API with missing id
+      # 2. Groups API returns group without id
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "groups" => [
@@ -396,17 +407,12 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock groups API with missing name and email
+      # 2. Groups API returns group with only id
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "groups" => [
@@ -424,22 +430,17 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock successful groups API
+      # 2. Groups API
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"groups" => []})
       end)
 
-      # Mock org units API with missing orgUnitId
+      # 3. Org units API with missing orgUnitId
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "organizationUnits" => [
@@ -457,22 +458,17 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock successful groups API
+      # 2. Groups API
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"groups" => []})
       end)
 
-      # Mock org units API with missing name
+      # 3. Org units API with missing name
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "organizationUnits" => [
@@ -490,22 +486,17 @@ defmodule Portal.Google.SyncTest do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock successful users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => []})
-      end)
-
-      # Mock successful groups API
+      # 2. Groups API
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"groups" => []})
       end)
 
-      # Mock org units API with missing orgUnitPath
+      # 3. Org units API with missing orgUnitPath
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "organizationUnits" => [
@@ -519,32 +510,31 @@ defmodule Portal.Google.SyncTest do
       end
     end
 
-    test "handles empty user list" do
+    test "handles empty groups and org units" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock successful access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock empty users, groups, and org units
-      Req.Test.expect(APIClient, 3, fn conn ->
-        cond do
-          String.contains?(conn.request_path, "/users") ->
-            Req.Test.json(conn, %{"users" => []})
-
-          String.contains?(conn.request_path, "/groups") ->
-            Req.Test.json(conn, %{"groups" => []})
-
-          String.contains?(conn.request_path, "/orgunits") ->
-            Req.Test.json(conn, %{"organizationUnits" => []})
-        end
+      # 2. Groups → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups")
+        Req.Test.json(conn, %{"groups" => []})
       end)
+
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/orgunits")
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # No group members, no org unit members, no get_user calls
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
 
-      # Verify sync completed successfully with no data
       updated_directory = Repo.get!(Portal.Google.Directory, directory.id)
       assert updated_directory.synced_at != nil
       assert updated_directory.error_message == nil
@@ -579,31 +569,42 @@ defmodule Portal.Google.SyncTest do
         }
         |> Repo.insert()
 
-      # Mock successful sync with new user
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
+      # 2. Groups → group1 with new_user as member
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
-          "users" => [
-            %{
-              "id" => "new_user",
-              "primaryEmail" => "new@example.com",
-              "name" => %{"fullName" => "New User"}
-            }
-          ]
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
         })
       end)
 
-      Req.Test.expect(APIClient, 2, fn conn ->
-        cond do
-          String.contains?(conn.request_path, "/groups") ->
-            Req.Test.json(conn, %{"groups" => []})
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
 
-          String.contains?(conn.request_path, "/orgunits") ->
-            Req.Test.json(conn, %{"organizationUnits" => []})
-        end
+      # 4. Group members → new_user
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "new_user", "type" => "USER", "email" => "new@example.com"}]
+        })
+      end)
+
+      # 5. batch_get_users for new_user
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "new_user",
+            "primaryEmail" => "new@example.com",
+            "name" => %{"fullName" => "New User"}
+          }
+        ])
       end)
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
@@ -633,30 +634,30 @@ defmodule Portal.Google.SyncTest do
         google_directory_fixture(
           account: account,
           domain: "example.com",
-          legacy_service_account_key: legacy_key
+          legacy_service_account_key: nil
         )
+
+      Repo.update!(Ecto.Changeset.change(directory, legacy_service_account_key: legacy_key))
 
       test_pid = self()
 
-      # Mock access token request and capture the request
+      # 1. Token — capture the request to verify legacy key was used
       Req.Test.expect(APIClient, fn conn ->
         {:ok, body, _conn} = Plug.Conn.read_body(conn)
         send(test_pid, {:token_request, body})
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock empty responses for API calls
-      Req.Test.expect(APIClient, 3, fn conn ->
-        cond do
-          String.contains?(conn.request_path, "/users") ->
-            Req.Test.json(conn, %{"users" => []})
+      # 2. Groups → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups")
+        Req.Test.json(conn, %{"groups" => []})
+      end)
 
-          String.contains?(conn.request_path, "/groups") ->
-            Req.Test.json(conn, %{"groups" => []})
-
-          String.contains?(conn.request_path, "/orgunits") ->
-            Req.Test.json(conn, %{"organizationUnits" => []})
-        end
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/orgunits")
+        Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
@@ -665,60 +666,67 @@ defmodule Portal.Google.SyncTest do
       assert_receive {:token_request, body}
       params = URI.decode_query(body)
       assert params["assertion"]
-      # The JWT would be signed with the legacy key's client_email
     end
 
-    test "handles multiple pages of users" do
+    test "handles multiple pages of group members" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock paginated users API
-      page_counter = :counters.new(1, [:atomics])
-
-      Req.Test.expect(APIClient, 2, fn conn ->
-        current_page = :counters.get(page_counter, 1)
-        :counters.add(page_counter, 1, 1)
-
-        case current_page do
-          0 ->
-            Req.Test.json(conn, %{
-              "users" => [
-                %{
-                  "id" => "user1",
-                  "primaryEmail" => "user1@example.com",
-                  "name" => %{"fullName" => "User One"}
-                }
-              ],
-              "nextPageToken" => "page2"
-            })
-
-          1 ->
-            Req.Test.json(conn, %{
-              "users" => [
-                %{
-                  "id" => "user2",
-                  "primaryEmail" => "user2@example.com",
-                  "name" => %{"fullName" => "User Two"}
-                }
-              ]
-            })
-        end
+      # 2. Groups → group1
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
       end)
 
-      # Mock groups and org units
-      Req.Test.expect(APIClient, 2, fn conn ->
-        cond do
-          String.contains?(conn.request_path, "/groups") ->
-            Req.Test.json(conn, %{"groups" => []})
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
 
-          String.contains?(conn.request_path, "/orgunits") ->
-            Req.Test.json(conn, %{"organizationUnits" => []})
-        end
+      # 4. Group members — paginated: page 1 returns user1 with nextPageToken
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+        refute String.contains?(conn.query_string || "", "pageToken")
+
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "user1", "type" => "USER", "email" => "user1@example.com"}],
+          "nextPageToken" => "page2"
+        })
+      end)
+
+      # 5. Group members — page 2 returns user2
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+        assert String.contains?(conn.query_string || "", "pageToken")
+
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "user2", "type" => "USER", "email" => "user2@example.com"}]
+        })
+      end)
+
+      # 6. batch_get_users for user1 and user2 (both in a single batch call, accumulated from both pages)
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user1",
+            "primaryEmail" => "user1@example.com",
+            "name" => %{"fullName" => "User One"}
+          },
+          %{
+            "id" => "user2",
+            "primaryEmail" => "user2@example.com",
+            "name" => %{"fullName" => "User Two"}
+          }
+        ])
       end)
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
@@ -730,29 +738,16 @@ defmodule Portal.Google.SyncTest do
       assert idp_ids == ["user1", "user2"]
     end
 
-    test "filters non-USER members from group membership" do
+    test "discovers GROUP-type members as sub-groups and only creates USER-type memberships for the parent" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock user
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{
-          "users" => [
-            %{
-              "id" => "user1",
-              "primaryEmail" => "user1@example.com",
-              "name" => %{"fullName" => "User One"}
-            }
-          ]
-        })
-      end)
-
-      # Mock group
+      # 2. Groups → group1
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "groups" => [
@@ -761,8 +756,15 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # Mock group members with mixed types
+      # 3. Org units → empty
       Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. Group members for group1: USER user1, GROUP group2, EXTERNAL ext1
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
         Req.Test.json(conn, %{
           "members" => [
             %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"},
@@ -772,46 +774,620 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # Mock org units
+      # 5. batch_get_users for user1 only (GROUP and EXTERNAL do not become USER identities)
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user1",
+            "primaryEmail" => "user1@example.com",
+            "name" => %{"fullName" => "User One"}
+          }
+        ])
+      end)
+
+      # 6. get_group("group2") — BFS fetches full details for the discovered sub-group
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2")
+        refute String.contains?(conn.request_path, "/members")
+
+        Req.Test.json(conn, %{
+          "id" => "group2",
+          "name" => "Nested Team",
+          "email" => "nested@example.com"
+        })
+      end)
+
+      # 7. Group members for group2 (BFS continues into the discovered sub-group) → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2/members")
+        Req.Test.json(conn, %{"members" => []})
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # Verify group1 (seed) and group2 (discovered via BFS) both exist as portal groups
+      groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
+      assert length(groups) == 2
+
+      [g1, g2] = groups
+      assert g1.idp_id == "group1"
+      assert g1.name == "Engineering"
+      assert g1.email == "eng@example.com"
+      assert g2.idp_id == "group2"
+      assert g2.name == "Nested Team"
+      assert g2.email == "nested@example.com"
+
+      # Only user1 (USER type) created a membership in group1; group2 has no members
+      memberships = Repo.all(Portal.Membership)
+      assert length(memberships) == 1
+    end
+
+    test "syncs transitive sub-groups recursively and creates memberships at each level" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      # group1 (seed) → [GROUP group2] → [USER user2, GROUP group3] → [USER user3]
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Groups → group1 only (seed)
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Top Level", "email" => "top@example.com"}]
+        })
+      end)
+
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. group1 members: GROUP group2 (no direct USER members)
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "group2", "type" => "GROUP", "email" => "mid@example.com"}]
+        })
+      end)
+
+      # 5. get_group("group2")
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2")
+        refute String.contains?(conn.request_path, "/members")
+
+        Req.Test.json(conn, %{
+          "id" => "group2",
+          "name" => "Middle Level",
+          "email" => "mid@example.com"
+        })
+      end)
+
+      # 6. group2 members: USER user2 + GROUP group3
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "user2", "type" => "USER", "email" => "user2@example.com"},
+            %{"id" => "group3", "type" => "GROUP", "email" => "leaf@example.com"}
+          ]
+        })
+      end)
+
+      # 7. batch_get_users for user2 (new)
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user2",
+            "primaryEmail" => "user2@example.com",
+            "name" => %{"fullName" => "User Two"}
+          }
+        ])
+      end)
+
+      # 8. get_group("group3")
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group3")
+        refute String.contains?(conn.request_path, "/members")
+
+        Req.Test.json(conn, %{
+          "id" => "group3",
+          "name" => "Leaf Level",
+          "email" => "leaf@example.com"
+        })
+      end)
+
+      # 9. group3 members: USER user3
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group3/members")
+
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "user3", "type" => "USER", "email" => "user3@example.com"}]
+        })
+      end)
+
+      # 10. batch_get_users for user3 (new)
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user3",
+            "primaryEmail" => "user3@example.com",
+            "name" => %{"fullName" => "User Three"}
+          }
+        ])
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # All three portal groups were created
+      groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
+      assert Enum.map(groups, & &1.idp_id) == ["group1", "group2", "group3"]
+      assert Enum.map(groups, & &1.name) == ["Top Level", "Middle Level", "Leaf Level"]
+
+      # Flattened memberships:
+      # group1 -> user2,user3 ; group2 -> user2,user3 ; group3 -> user3
+      memberships =
+        Repo.all(Portal.Membership)
+        |> Repo.preload([:group, :actor])
+        |> Enum.map(fn m -> {m.group.idp_id, m.actor.name} end)
+        |> Enum.sort()
+
+      assert memberships == [
+               {"group1", "User Three"},
+               {"group1", "User Two"},
+               {"group2", "User Three"},
+               {"group2", "User Two"},
+               {"group3", "User Three"}
+             ]
+
+      identities = Repo.all(Portal.ExternalIdentity) |> Enum.sort_by(& &1.idp_id)
+      assert Enum.map(identities, & &1.idp_id) == ["user2", "user3"]
+    end
+
+    test "BFS stops when a sub-group has already been visited (cycle prevention)" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      # group1 (seed) → [GROUP group2]
+      # group2 → [USER user1, GROUP group1]  ← group1 already visited, stops here
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Groups → group1
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Group One", "email" => "g1@example.com"}]
+        })
+      end)
+
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. group1 members → GROUP group2 (no USER members)
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "group2", "type" => "GROUP", "email" => "g2@example.com"}]
+        })
+      end)
+
+      # 5. get_group("group2")
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2")
+        refute String.contains?(conn.request_path, "/members")
+
+        Req.Test.json(conn, %{
+          "id" => "group2",
+          "name" => "Group Two",
+          "email" => "g2@example.com"
+        })
+      end)
+
+      # 6. group2 members → USER user1 + GROUP group1 (cycle back to already-visited group1)
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"},
+            %{"id" => "group1", "type" => "GROUP", "email" => "g1@example.com"}
+          ]
+        })
+      end)
+
+      # 7. batch_get_users for user1
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user1",
+            "primaryEmail" => "user1@example.com",
+            "name" => %{"fullName" => "User One"}
+          }
+        ])
+      end)
+
+      # No get_group("group1") call — it's already in visited, BFS skips it
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
+      assert Enum.map(groups, & &1.idp_id) == ["group1", "group2"]
+
+      memberships =
+        Repo.all(Portal.Membership)
+        |> Repo.preload([:group, :actor])
+        |> Enum.map(fn m -> {m.group.idp_id, m.actor.name} end)
+        |> Enum.sort()
+
+      assert memberships == [
+               {"group1", "User One"},
+               {"group2", "User One"}
+             ]
+    end
+
+    test "BFS skips sub-groups that no longer exist in Google (404)" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Groups → group1
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Top", "email" => "top@example.com"}]
+        })
+      end)
+
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. group1 members → GROUP deleted_group
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "deleted_group", "type" => "GROUP", "email" => "gone@example.com"}
+          ]
+        })
+      end)
+
+      # 5. get_group("deleted_group") → 404
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/deleted_group")
+
+        conn
+        |> Plug.Conn.put_status(404)
+        |> Req.Test.json(%{"error" => %{"code" => 404, "message" => "Resource Not Found"}})
+      end)
+
+      # No group2 members call — it was skipped
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # Only group1 exists; deleted_group was silently skipped
+      groups = Repo.all(Portal.Group)
+      assert length(groups) == 1
+      assert hd(groups).idp_id == "group1"
+    end
+
+    test "group_sync_mode :filtered issues separate email and name prefix queries, then syncs members" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          group_sync_mode: :filtered
+        )
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. First groups call: email prefix query → group1
+      Req.Test.expect(APIClient, fn conn ->
+        refute String.contains?(conn.request_path, "/members")
+        assert String.contains?(conn.query_string, "email%3Afirezone-sync")
+
+        Req.Test.json(conn, %{
+          "groups" => [
+            %{
+              "id" => "group1",
+              "name" => "firezone-sync-admins",
+              "email" => "firezone-sync-admins@example.com"
+            }
+          ]
+        })
+      end)
+
+      # 3. Second groups call: name prefix query → group2
+      Req.Test.expect(APIClient, fn conn ->
+        refute String.contains?(conn.request_path, "/members")
+        assert String.contains?(conn.query_string, "name%3A%5Bfirezone-sync%5D")
+
+        Req.Test.json(conn, %{
+          "groups" => [
+            %{"id" => "group2", "name" => "[firezone-sync] ops", "email" => "ops@example.com"}
+          ]
+        })
+      end)
+
+      # 4. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 5. Group members for group1 → user1
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"}
+          ]
+        })
+      end)
+
+      # 6. batch_get_users for user1 (right after group1 members in BFS)
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user1",
+            "primaryEmail" => "user1@example.com",
+            "name" => %{"fullName" => "User One"}
+          }
+        ])
+      end)
+
+      # 7. Group members for group2 → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2/members")
+        Req.Test.json(conn, %{"members" => []})
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      groups = Repo.all(Portal.Group) |> Enum.sort_by(& &1.idp_id)
+      assert length(groups) == 2
+      assert Enum.map(groups, & &1.idp_id) == ["group1", "group2"]
+
+      memberships = Repo.all(Portal.Membership)
+      assert length(memberships) == 1
+    end
+
+    test "group_sync_mode :disabled skips group sync — stale groups are deleted" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          group_sync_mode: :disabled
+        )
+
+      # Pre-existing group with stale last_synced_at
+      old_synced_at = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+      {:ok, existing_group} =
+        %Portal.Group{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          directory_id: directory.id,
+          idp_id: "group-devops",
+          name: "DevOps",
+          type: :static,
+          entity_type: :group,
+          last_synced_at: old_synced_at
+        }
+        |> Repo.insert()
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # No groups API call expected (mode is :disabled)
+
+      # 2. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/orgunits")
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # Stale group was not synced this run — delete_unsynced removes it
+      refute Repo.get_by(Portal.Group, id: existing_group.id)
+    end
+
+    test "orgunit_sync_enabled false skips org unit sync — stale org units are deleted" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          orgunit_sync_enabled: false
+        )
+
+      old_synced_at = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+      {:ok, existing_ou} =
+        %Portal.Group{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          directory_id: directory.id,
+          idp_id: "ou-engineering",
+          name: "Engineering",
+          type: :static,
+          entity_type: :org_unit,
+          last_synced_at: old_synced_at
+        }
+        |> Repo.insert()
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Groups → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"groups" => []})
+      end)
+
+      # No org units API call expected (orgunit_sync_enabled: false)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # Stale org unit was not synced this run — delete_unsynced removes it
+      refute Repo.get_by(Portal.Group, id: existing_ou.id)
+    end
+
+    test "group_sync_mode :disabled and orgunit_sync_enabled false — all stale groups deleted" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          group_sync_mode: :disabled,
+          orgunit_sync_enabled: false
+        )
+
+      old_synced_at = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+      {:ok, existing_group} =
+        %Portal.Group{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          directory_id: directory.id,
+          idp_id: "group-devops",
+          name: "DevOps",
+          type: :static,
+          entity_type: :group,
+          last_synced_at: old_synced_at
+        }
+        |> Repo.insert()
+
+      {:ok, existing_ou} =
+        %Portal.Group{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          directory_id: directory.id,
+          idp_id: "ou-engineering",
+          name: "Engineering",
+          type: :static,
+          entity_type: :org_unit,
+          last_synced_at: old_synced_at
+        }
+        |> Repo.insert()
+
+      # 1. Token only — no groups or org units API calls
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # Both are stale — delete_unsynced removes them
+      refute Repo.get_by(Portal.Group, id: existing_group.id)
+      refute Repo.get_by(Portal.Group, id: existing_ou.id)
+    end
+
+    test "group_sync_mode :filtered deletes non-matching groups" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          group_sync_mode: :filtered
+        )
+
+      old_synced_at = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+      # A stale group that does NOT match the firezone-sync prefix
+      {:ok, non_matching_group} =
+        %Portal.Group{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          directory_id: directory.id,
+          idp_id: "group-devops",
+          name: "DevOps",
+          type: :static,
+          entity_type: :group,
+          last_synced_at: old_synced_at
+        }
+        |> Repo.insert()
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Both prefix queries return empty (no firezone-sync groups in Google)
+      Req.Test.expect(APIClient, 2, fn conn ->
+        Req.Test.json(conn, %{"groups" => []})
+      end)
+
+      # 3. Org units → empty
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"organizationUnits" => []})
       end)
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
 
-      # Verify only USER type member created a membership
-      memberships = Repo.all(Portal.Membership)
-      assert length(memberships) == 1
+      # Non-matching group is stale — delete_unsynced removes it
+      refute Repo.get_by(Portal.Group, id: non_matching_group.id)
     end
 
     test "syncs org unit with no members when users key is missing in response" do
       account = account_fixture()
       directory = google_directory_fixture(account: account, domain: "example.com")
 
-      # Mock access token
+      # 1. Token
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
       end)
 
-      # Mock users API
-      Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{
-          "users" => [
-            %{
-              "id" => "user1",
-              "primaryEmail" => "user1@example.com",
-              "name" => %{"fullName" => "User One"}
-            }
-          ]
-        })
-      end)
-
-      # Mock groups API
+      # 2. Groups → empty
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{"groups" => []})
       end)
 
-      # Mock org units API - return one org unit
+      # 3. Org units → ou1
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "organizationUnits" => [
@@ -820,12 +1396,13 @@ defmodule Portal.Google.SyncTest do
         })
       end)
 
-      # Mock org unit members API - return response WITHOUT "users" key (empty org unit)
-      # Google omits the "users" key entirely when no users match the query
+      # 4. Org unit members — Google omits "users" key for empty org units
       Req.Test.expect(APIClient, fn conn ->
         assert String.contains?(conn.query_string || "", "orgUnitPath")
         Req.Test.json(conn, %{"etag" => "\"p9q284efnuVA987\"", "kind" => "admin#directory#users"})
       end)
+
+      # No get_user calls — no members
 
       assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
 
@@ -839,6 +1416,479 @@ defmodule Portal.Google.SyncTest do
       # Verify no memberships were created for the empty org unit
       memberships = Repo.all(Portal.Membership)
       assert length(memberships) == 0
+    end
+
+    test "raises SyncError when access token transport fails" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.transport_error(conn, :econnrefused)
+      end)
+
+      assert_raise SyncError, ~r/get_access_token/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when access token response is missing access_token field" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"expires_in" => 3600})
+      end)
+
+      assert_raise SyncError, ~r/get_access_token/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when service account key is not configured and no legacy key exists" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account)
+
+      config = Application.get_env(:portal, APIClient)
+
+      Application.put_env(
+        :portal,
+        APIClient,
+        Keyword.put(config, :service_account_key, %{invalid: true})
+      )
+
+      assert_raise SyncError, ~r/service account key is not configured/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "logs reconnect count when orphaned policies are reconnected" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+      resource = resource_fixture(account: account)
+
+      policy =
+        Repo.insert!(%Portal.Policy{
+          account_id: account.id,
+          resource_id: resource.id,
+          group_id: nil,
+          group_idp_id: "group1",
+          description: "Orphaned policy awaiting group reconnection",
+          conditions: []
+        })
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"members" => []})
+      end)
+
+      log =
+        capture_log(fn ->
+          assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+        end)
+
+      assert log =~ "Reconnected 1 orphaned policies after sync"
+      assert Repo.get_by!(Portal.Policy, id: policy.id, account_id: account.id).group_id != nil
+    end
+
+    test "raises SyncError when discovered sub-group is missing both name and email" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Top", "email" => "top@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "group2", "type" => "GROUP", "email" => "group2@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"id" => "group2"})
+      end)
+
+      assert_raise SyncError, ~r/discovered group 'group2' missing 'name' field/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when discovered sub-group is missing id field" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Top", "email" => "top@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "group2", "type" => "GROUP", "email" => "group2@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"name" => "Nested Group", "email" => "group2@example.com"})
+      end)
+
+      assert_raise SyncError, ~r/discovered group missing 'id' field/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when discovered sub-group lookup returns non-404 error" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Top", "email" => "top@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "group2", "type" => "GROUP", "email" => "group2@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => "server error"})
+      end)
+
+      assert_raise SyncError, ~r/get_group/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when group members API returns error" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(403)
+        |> Req.Test.json(%{"error" => "forbidden"})
+      end)
+
+      assert_raise SyncError, ~r/at stream_group_members: HTTP 403/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when batch_get_users returns error response" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [%{"id" => "user1", "type" => "USER", "email" => "user1@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => "server error"})
+      end)
+
+      assert_raise SyncError, ~r/at batch_get_users: HTTP 500/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "ignores GROUP members with nil id while still syncing valid USER members" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "user1", "type" => "USER", "email" => "user1@example.com"},
+            %{"id" => nil, "type" => "GROUP", "email" => "unknown@example.com"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "user1",
+            "primaryEmail" => "user1@example.com",
+            "name" => %{"fullName" => "User One"}
+          }
+        ])
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert Repo.aggregate(Portal.Group, :count, :id) == 1
+      assert Repo.aggregate(Portal.Membership, :count, :id) == 1
+    end
+
+    test "raises SyncError when org unit members API returns error" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"groups" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "organizationUnits" => [
+            %{"orgUnitId" => "ou1", "name" => "Engineering", "orgUnitPath" => "/Engineering"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(403)
+        |> Req.Test.json(%{"error" => "forbidden"})
+      end)
+
+      assert_raise SyncError, ~r/at stream_org_unit_members: HTTP 403/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "raises SyncError when org unit user is missing id field" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"groups" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "organizationUnits" => [
+            %{"orgUnitId" => "ou1", "name" => "Engineering", "orgUnitPath" => "/Engineering"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"users" => [%{"primaryEmail" => "missing-id@example.com"}]})
+      end)
+
+      assert_raise SyncError, ~r/user missing 'id' field in org unit ou1/, fn ->
+        perform_job(Sync, %{"directory_id" => directory.id})
+      end
+    end
+
+    test "syncs identities for new org unit users not seen in group BFS" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"groups" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "organizationUnits" => [
+            %{"orgUnitId" => "ou1", "name" => "Engineering", "orgUnitPath" => "/Engineering"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "users" => [
+            %{
+              "id" => "ou_user_1",
+              "primaryEmail" => "ou1@example.com",
+              "name" => %{"fullName" => "OU User"}
+            }
+          ]
+        })
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+      assert Repo.aggregate(Portal.ExternalIdentity, :count, :id) == 1
+      assert Repo.aggregate(Portal.Membership, :count, :id) == 1
+    end
+
+    test "Database upsert helpers cover empty and error branches" do
+      now = DateTime.utc_now()
+      nonexistent_account_id = Ecto.UUID.generate()
+      nonexistent_directory_id = Ecto.UUID.generate()
+
+      assert {:ok, %{upserted_identities: 0}} =
+               Database.batch_upsert_identities(
+                 nonexistent_account_id,
+                 nonexistent_directory_id,
+                 now,
+                 []
+               )
+
+      assert {:ok, %{upserted_groups: 0}} =
+               Database.batch_upsert_groups(
+                 nonexistent_account_id,
+                 nonexistent_directory_id,
+                 now,
+                 [],
+                 :group
+               )
+
+      assert {:ok, %{upserted_memberships: 0}} =
+               Database.batch_upsert_memberships(
+                 nonexistent_account_id,
+                 nonexistent_directory_id,
+                 now,
+                 []
+               )
+
+      assert {:error, _reason} =
+               Database.batch_upsert_groups(
+                 nonexistent_account_id,
+                 nonexistent_directory_id,
+                 now,
+                 [%{idp_id: "group1", name: "Group 1", email: "group1@example.com"}],
+                 :group
+               )
+
+      assert {:error, _reason} =
+               Database.batch_upsert_identities(
+                 nonexistent_account_id,
+                 nonexistent_directory_id,
+                 now,
+                 [%{idp_id: "user1", email: "u1@example.com", name: "User 1"}]
+               )
+
+      assert {:error, _reason} =
+               Database.batch_upsert_memberships(
+                 nonexistent_account_id,
+                 nonexistent_directory_id,
+                 "not-a-datetime",
+                 [{"group1", "user1"}]
+               )
+    end
+
+    test "Sync batch upsert wrappers return :error and log on database failures" do
+      directory = %Portal.Google.Directory{
+        id: Ecto.UUID.generate(),
+        account_id: Ecto.UUID.generate()
+      }
+
+      identity_log =
+        capture_log(fn ->
+          assert :error ==
+                   Sync.batch_upsert_identities(directory, DateTime.utc_now(), [
+                     %{idp_id: "user1", email: "broken@example.com", name: "Broken User"}
+                   ])
+        end)
+
+      assert identity_log =~ "Failed to upsert identities"
+
+      memberships_log =
+        capture_log(fn ->
+          assert_raise SyncError, ~r/batch_upsert_memberships/, fn ->
+            Sync.batch_upsert_memberships(directory, "not-a-datetime", [
+              {"group1", "user1"}
+            ])
+          end
+        end)
+
+      assert memberships_log =~ "Failed to upsert memberships"
     end
   end
 end

--- a/elixir/test/portal_api/controllers/google_directory_controller_test.exs
+++ b/elixir/test/portal_api/controllers/google_directory_controller_test.exs
@@ -1,0 +1,61 @@
+defmodule PortalAPI.GoogleDirectoryControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.GoogleDirectoryFixtures
+
+  setup do
+    account = account_fixture()
+    actor = api_client_fixture(account: account)
+
+    %{account: account, actor: actor}
+  end
+
+  describe "index/2" do
+    test "returns error when not authorized", %{conn: conn} do
+      conn = get(conn, "/google_directories")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "lists all google directories", %{conn: conn, account: account, actor: actor} do
+      directory = google_directory_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/google_directories")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert Enum.any?(data, fn d -> d["id"] == directory.id end)
+    end
+  end
+
+  describe "show/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      directory = google_directory_fixture(account: account)
+      conn = get(conn, "/google_directories/#{directory.id}")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "shows a google directory with sync fields", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      directory = google_directory_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/google_directories/#{directory.id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert data["id"] == directory.id
+      assert data["group_sync_mode"] == "all"
+      assert data["orgunit_sync_enabled"] == true
+    end
+  end
+end

--- a/elixir/test/portal_api/controllers/group_controller_test.exs
+++ b/elixir/test/portal_api/controllers/group_controller_test.exs
@@ -103,6 +103,7 @@ defmodule PortalAPI.GroupControllerTest do
                "data" => %{
                  "id" => group.id,
                  "name" => group.name,
+                 "email" => nil,
                  "entity_type" => "group",
                  "directory_id" => nil,
                  "idp_id" => nil,
@@ -130,6 +131,7 @@ defmodule PortalAPI.GroupControllerTest do
                "data" => %{
                  "id" => group.id,
                  "name" => group.name,
+                 "email" => nil,
                  "entity_type" => "group",
                  "directory_id" => group.directory_id,
                  "idp_id" => group.idp_id,
@@ -295,6 +297,7 @@ defmodule PortalAPI.GroupControllerTest do
                "data" => %{
                  "id" => group.id,
                  "name" => group.name,
+                 "email" => nil,
                  "entity_type" => "group",
                  "directory_id" => nil,
                  "idp_id" => nil,

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -204,6 +204,8 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert html =~ "Name"
       assert html =~ "Impersonation Email"
       assert html =~ "Directory Verification"
+      assert html =~ "Note:"
+      assert html =~ "all org units and active users will be synced"
     end
 
     test "renders new Entra directory form", %{account: account, actor: actor, conn: conn} do
@@ -1332,6 +1334,14 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       html = render(lv)
       assert html =~ "Directory saved successfully"
       assert html =~ "New Google Directory"
+
+      directory =
+        Portal.Repo.get_by!(Portal.Google.Directory,
+          account_id: account.id,
+          name: "New Google Directory"
+        )
+
+      assert directory.orgunit_sync_enabled == false
     end
 
     test "creates new Okta directory successfully", %{account: account, actor: actor, conn: conn} do

--- a/elixir/test/support/fixtures/google_directory_fixtures.ex
+++ b/elixir/test/support/fixtures/google_directory_fixtures.ex
@@ -19,7 +19,8 @@ defmodule Portal.GoogleDirectoryFixtures do
       domain: "example#{unique_num}.com",
       name: "Google Directory #{unique_num}",
       impersonation_email: "admin#{unique_num}@example#{unique_num}.com",
-      is_verified: true
+      is_verified: true,
+      orgunit_sync_enabled: true
     })
   end
 
@@ -75,7 +76,9 @@ defmodule Portal.GoogleDirectoryFixtures do
         :is_disabled,
         :disabled_reason,
         :error_message,
-        :error_email_count
+        :error_email_count,
+        :group_sync_mode,
+        :orgunit_sync_enabled
       ])
       |> Portal.Google.Directory.changeset()
       |> Portal.Repo.insert()


### PR DESCRIPTION
Unlike Okta and Entra, unfortunately Google Workspace does not provide in-built "assignments" that we can query to determine which user/groups are assigned to Firezone in order to sync only those.

In light of that, we improve our Google sync engine to:

1. Add `orgunit_sync_enabled: bool` which controls whether org units and their resulting members are synced (default: `enabled`)
2. Add `group_sync_mode: all|filtered|disabled` to control the group syncing behavior (default: `all`)
3. Adds an `email` field to the `groups` table to save for syncing google groups. This is then shown the user in the group card and REST API if it's present.
4. When group sync mode is `filtered`:
  a. We only sync groups (and their nested members) that have a `name` starting with `[firezone-sync]` or an email starting with `firezone-sync`. Only prefix matching is supported by Google's API here, so unfortunately we can only query for prefix matches and not patterns that match anywhere.
  b. Due to limitations of the Google API when doing filtered queries, we need to individually fetch each nested group to retrieve its name property.
  c. Due to limitations again, we need to fetch users individually if we want to filter them by membership in the groups / org units we've fetched. This is however made efficient by batching them using the batch API (however, requires multipart request/response structure).

<img width="711" height="881" alt="Screenshot 2026-03-03 at 10 46 02 AM" src="https://github.com/user-attachments/assets/d84c3f8f-5c4a-483c-ac20-f85e24918cf2" />




---

Fixes #12190 