### PR TITLE
fix(relay): only allow a single allocation per username

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2577,6 +2577,7 @@ dependencies = [
  "aya-log",
  "backoff",
  "base64 0.22.1",
+ "bimap",
  "bin-shared",
  "bytecodec",
  "bytes",

--- a/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
@@ -340,7 +340,7 @@ impl StubPortal {
             .map(|(id, (ipv4, ipv6))| {
                 (
                     Just(*id),
-                    ref_client_host(Just(*ipv4), Just(*ipv6), system_dns.clone()),
+                    ref_client_host(*id, Just(*ipv4), Just(*ipv6), system_dns.clone()),
                 )
             })
             .collect::<Vec<_>>()

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio", "query"] }
 backoff = { workspace = true }
 base64 = { workspace = true }
+bimap = { workspace = true }
 bin-shared = { workspace = true }
 bytecodec = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
Some NAT devices out in the wild like to flip / flop our source port which is quite unexpected and causes problems for the TURN protocol as it uses the 3-tuple to uniquely identify a client. This can lead to the following sequence of events (all logs from a relay):

```
2026-02-25T16:34:52.605122Z INFO Refreshed channel binding allocation=54878 peer=$peer:52625 channel=17459
2026-02-25T16:35:59.263647Z INFO Refreshed allocation allocation=54878 sender=$sender:52625
2026-02-25T16:39:52.626651Z INFO Refreshed channel binding allocation=54878 peer=$peer:52625 channel=17459
2026-02-25T16:40:59.280659Z INFO Refreshed allocation allocation=54878 sender=$sender:52625
2026-02-25T16:43:16.559847Z INFO Handled BINDING request sender=$sender:52625
2026-02-25T16:43:21.224243Z INFO refresh failed with Allocation Mismatch: Sender doesn't have an allocation sender=$sender:44939
2026-02-25T16:43:21.240847Z INFO Created new allocation sender=$sender:44939 first_relay_address=20.223.192.97 second_relay_address=2603:1020:0:29::2c lifetime=600s
2026-02-25T16:43:21.259037Z INFO Successfully bound channel allocation=62203 peer=$peer:52625 channel=17479
2026-02-25T16:43:41.560519Z INFO Handled BINDING request sender=$sender:44939
2026-02-25T16:44:06.561254Z INFO Handled BINDING request sender=$sender:52625
2026-02-25T16:48:21.258572Z INFO Refreshed allocation allocation=54878 sender=$sender:52625
2026-02-25T16:48:21.346668Z WARN channel bind failed with Bad Request: Peer is already bound to another channel existing_channel=17459 allocation=54878 peer=$peer:52625 channel=17479
```

1. We start out in the state that `$sender` has an allocation on port 54878 and a channel binding to `$peer` in channel 17459.
2. Some time between 16:43:16 and 16:43:21, a NAT device between the Gateway and the Relay changes our source port from 52625 to 44939
3. The Relay doesn't recognise the Gateway and replies with an allocation mismatch
4. The Gateway tries to self-heal, discards its local state, creates a new allocation and rebinds the channel to `$peer` on channel 17479
5. Some time between 16:43:41 and 16:44:06, the NAT device restores our source port to 52625
6. At 16:48:21, 5 minutes after the initial channel binding, the Gateway attempts to refresh the channel but the relay doesn't allow it because the channel number is now different

We cannot control the network devices in the path between the Gateway and Relay. Therefore, the only sensible way of fixing this is to only allow a single allocation per TURN username. In the above scenario, the Gateway would have used the same credentials for both allocations and therefore, if this patch were already in place, the relay would have free'd up the first allocation as the 2nd one got created. After the change back to the other port, the relay would again have replied with an Allocation Mismatch, causing the Gateway to yet again clear its local state and start over.

Resolves: #12311