### PR TITLE
fix(phoenix-channel): always send heartbeats

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -656,8 +656,6 @@ where
                         match stream.start_send_unpin(Message::Text(join.clone().into())) {
                             Ok(()) => {
                                 tracing::trace!(target: "wire::api::send", %join);
-
-                                heartbeat.reset()
                             }
                             Err(e) => {
                                 pending_joins.push_front(join);
@@ -679,8 +677,6 @@ where
                             {
                                 Ok(()) => {
                                     tracing::trace!(target: "wire::api::send", msg = %serialized_msg);
-
-                                    heartbeat.reset()
                                 }
                                 Err(e) => {
                                     pending_messages.push_front(msg);

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -572,7 +572,10 @@ where
                     Poll::Ready(Ok(stream)) => {
                         self.state = State::Connected(Connected {
                             stream,
-                            heartbeat: tokio::time::interval(HEARTBEAT_INTERVAL),
+                            heartbeat: tokio::time::interval_at(
+                                tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+                                HEARTBEAT_INTERVAL,
+                            ),
                             inflight_heartbeats: Default::default(),
                             pending_heartbeat: Default::default(),
                             pending_joins: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -478,9 +478,10 @@ async fn includes_ip_from_hostname() {
 
 /// Spawns a WebSocket server that responds to requests using a handler function.
 /// Returns the server task handle and the port number.
-async fn spawn_websocket_server<F>(handler: F) -> (ServerHandle, u16)
+async fn spawn_websocket_server<F, R>(handler: F) -> (ServerHandle, u16)
 where
-    F: Fn(&str) -> &str + Send + 'static,
+    F: Fn(&str) -> R + Send + 'static,
+    R: Into<tokio_tungstenite::tungstenite::Utf8Bytes>,
 {
     use futures::{SinkExt, StreamExt};
     use tokio::net::TcpListener;

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unwrap_used)]
 
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::atomic::AtomicUsize;
 use std::{future, sync::Arc, time::Duration};
 
 use futures::SinkExt as _;
@@ -329,6 +330,78 @@ async fn times_out_after_missed_heartbeats() {
         format!("{error:#}"),
         "Connection hiccup: too many heartbeats were unanswered"
     );
+}
+
+#[tokio::test]
+async fn sends_heartbeats_regardless_of_messages() {
+    use phoenix_channel::PublicKeyParam;
+
+    let _guard = logging::test("debug,wire::api=trace");
+
+    let num_heartbeats = Arc::new(AtomicUsize::default());
+
+    let (server, port) = spawn_websocket_server({
+        let num_heartbeats = num_heartbeats.clone();
+
+        move |text| {
+            let msg = serde_json::from_str::<'_, serde_json::Value>(text).unwrap();
+            let reference = &msg["ref"];
+            let topic = msg["topic"].as_str().unwrap();
+
+            match msg["event"].as_str().unwrap() {
+                "phx_join" => {
+                    format!(r#"{{"event":"phx_reply","ref":{reference},"topic":"{topic}","payload":{{"status":"ok","response":{{}}}}}}"#)
+                }
+                "heartbeat" => {
+                    num_heartbeats.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                    format!(r#"{{"event":"phx_reply","ref":{reference},"topic":"phoenix","payload":{{"status":"ok","response":{{}}}}}}"#)
+                }
+                "bar" => {
+                    format!(r#"{{"event":"foo","ref":{reference},"topic":"{topic}","payload":null}}"#)
+                }
+                other => panic!("Unknown event: {other}")
+            }
+        }
+    })
+    .await;
+
+    let mut channel = make_test_channel("localhost", port);
+
+    let client = tokio::spawn(async move {
+        channel.connect(
+            vec![IpAddr::from(Ipv4Addr::LOCALHOST)],
+            Duration::ZERO,
+            PublicKeyParam([0u8; 32]),
+        );
+
+        let mut message_interval = tokio::time::interval(Duration::from_secs(3));
+
+        loop {
+            tokio::select! {
+                event = std::future::poll_fn(|cx| channel.poll(cx)) => {
+                    match event.unwrap() {
+                        phoenix_channel::Event::Message { .. } => {}
+                        phoenix_channel::Event::Hiccup { error, .. } => panic!("Connection failed: {error}"),
+                        phoenix_channel::Event::Closed => {
+                            panic!("Channel closed")
+                        }
+                        phoenix_channel::Event::Connected => {}
+                    }
+                }
+                _ = message_interval.tick() => {
+                    let _ = channel.send("test", OutboundMsg::Bar);
+                }
+            }
+        }
+    });
+
+    tokio::time::sleep(Duration::from_secs(25)).await;
+
+    assert_eq!(num_heartbeats.load(std::sync::atomic::Ordering::SeqCst), 3);
+
+    client.abort();
+    server.abort();
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -398,7 +398,7 @@ async fn sends_heartbeats_regardless_of_messages() {
 
     tokio::time::sleep(Duration::from_secs(25)).await;
 
-    assert_eq!(num_heartbeats.load(std::sync::atomic::Ordering::SeqCst), 3);
+    assert_eq!(num_heartbeats.load(std::sync::atomic::Ordering::SeqCst), 2);
 
     client.abort();
     server.abort();

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -78,6 +78,10 @@ export default function Android() {
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
+        <ChangeItem pull="12322">
+          Fixes an issue where the WebSocket connection to the control plane was
+          lost under load.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
         <ChangeItem pull="11077">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -52,6 +52,10 @@ export default function Apple() {
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
+        <ChangeItem pull="12322">
+          Fixes an issue where the WebSocket connection to the control plane was
+          lost under load.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.13" date={new Date("2026-01-30")}>
         <ChangeItem pull="11901">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -27,6 +27,10 @@ export default function GUI({ os }: { os: OS }) {
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
+        <ChangeItem pull="12322">
+          Fixes an issue where the WebSocket connection to the control plane was
+          lost under load.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.10" date={new Date("2026-02-02")}>
         <ChangeItem pull="11625">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -35,6 +35,10 @@ export default function Gateway() {
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
+        <ChangeItem pull="12322">
+          Fixes an issue where the WebSocket connection to the control plane was
+          lost under load.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.0" date={new Date("2026-02-02")}>
         <ChangeItem pull="11771">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -45,6 +45,10 @@ export default function Headless({ os }: { os: OS }) {
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
+        <ChangeItem pull="12322">
+          Fixes an issue where the WebSocket connection to the control plane was
+          lost under load.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.6" date={new Date("2026-01-06")}>
         <ChangeItem pull="11627">


### PR DESCRIPTION
Contrary to a prior belief, phoenix channel heartbeats need to be sent independently of other messages. Thus, the current behaviour of resetting the timer when we are sending another message is wrong and causes false-positive disconnects of the WebSocket when the connection is otherwise utilized, like on a busy Gateway with many connections.

Supersedes: #12309
Resolves: #12312