### PR TITLE
build(deps): bump `rtnetlink` and `netlink-packet-route`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4507,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -6186,8 +6186,7 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+source = "git+https://github.com/rust-netlink/rtnetlink?branch=main#eb685374ba7f7a1201754f6b2b40c491d3d50cb3"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -129,7 +129,7 @@ mio = "1.1.1"
 moka = "0.12.13"
 native-dialog = "0.9.0"
 netlink-packet-core = "0.8.1"
-netlink-packet-route = "0.28.0"
+netlink-packet-route = "0.29.0"
 network-types = "0.1.0"
 nix = "0.30.1"
 notify-rust = "4.12.0"
@@ -266,6 +266,7 @@ softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting 
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
+rtnetlink = { git = "https://github.com/rust-netlink/rtnetlink", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
The latest release of `netlink-packet-route` silences a warning that has been bugging us for a while in Sentry. See https://github.com/rust-netlink/netlink-packet-route/pull/226.