### PR TITLE
fix(portal): store address tuple vs address struct

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -64,8 +64,12 @@ defmodule PortalAPI.Client.Channel do
 
     # Track client's presence with session metadata for client-to-client signaling
     session_meta = %{
-      ipv4: socket.assigns.client.ipv4_address && socket.assigns.client.ipv4_address.address,
-      ipv6: socket.assigns.client.ipv6_address && socket.assigns.client.ipv6_address.address,
+      ipv4:
+        socket.assigns.client.ipv4_address &&
+          socket.assigns.client.ipv4_address.address.address,
+      ipv6:
+        socket.assigns.client.ipv6_address &&
+          socket.assigns.client.ipv6_address.address.address,
       public_key: socket.assigns.session.public_key,
       psk_base: socket.assigns.client.psk_base
     }


### PR DESCRIPTION
Stores the raw, inner address tuple in the presence meta for each connected client as opposed to the `Postgrex.INET` struct itself, which fixes a `not_found` error when attempting to lookup a connected client by account_id and address tuple.
