### PR TITLE
feat(connlib): process multiple TUN packets per scheduler wakeup

### DIFF
--- a/rust/libs/connlib/tun/src/unix.rs
+++ b/rust/libs/connlib/tun/src/unix.rs
@@ -19,22 +19,71 @@ where
         .context("Failed to create runtime")?
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, tokio::io::Interest::WRITABLE)?;
+            let mut pending_packets = Vec::with_capacity(128);
 
-            while let Some(packet) = outbound_rx.recv().await {
-                #[cfg(debug_assertions)]
-                tracing::trace!(target: "wire::dev::send", ?packet);
+            loop {
+                // Read a batch of packets.
+                let num_read = outbound_rx.recv_many(&mut pending_packets, 128).await;
 
-                if let Err(e) = fd
-                    .async_io(tokio::io::Interest::WRITABLE, |fd| {
-                        write(fd.as_raw_fd(), &packet)
-                    })
-                    .await
-                {
-                    tracing::warn!("Failed to write to TUN FD: {e}");
+                if num_read == 0 {
+                    return anyhow::Ok(());
                 }
-            }
 
-            anyhow::Ok(())
+                // Wait until fd is writable.
+                let mut guard = loop {
+                    match fd.writable().await {
+                        Ok(guard) => break guard,
+                        Err(e) => {
+                            tracing::warn!("Failed to await TUN fd writability: {e}");
+                        }
+                    }
+                };
+
+                let mut idx = 0;
+
+                'write: while idx < num_read {
+                    let Some(packet) = pending_packets.get(idx) else {
+                        tracing::warn!(
+                            idx,
+                            num_read,
+                            pending_packets_len = pending_packets.len(),
+                            "Missing pending packet while writing batch"
+                        );
+                        break 'write;
+                    };
+
+                    // Try and write the current packet.
+                    match guard.try_io(|fd| write(fd.as_raw_fd(), packet)) {
+                        Err(_would_block) => {
+                            // Renew the guard if fd is no longer writable.
+                            guard = match fd.writable().await {
+                                Ok(guard) => guard,
+                                Err(e) => {
+                                    // Temporary(?) IO error when waiting for writability.
+                                    // Loop around to try and write the same packet again.
+                                    // Most likely, we will end up in this branch again as a result.
+                                    tracing::warn!("Failed to await TUN fd writability: {e}");
+                                    continue 'write;
+                                }
+                            };
+                        }
+                        Ok(Ok(_bytes_written)) => {
+                            #[cfg(debug_assertions)]
+                            tracing::trace!(target: "wire::dev::send", ?packet);
+
+                            idx += 1; // We sent the packet, go to the next one.
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(?packet, "Failed to write to TUN FD: {e}");
+
+                            idx += 1; // We failed to send the packet, go to the next one.
+                        }
+                    }
+                }
+
+                // Clear the buffer for the next batch.
+                pending_packets.clear();
+            }
         })?;
 
     anyhow::Ok(())
@@ -56,51 +105,58 @@ where
             let fd = AsyncFd::with_interest(fd, tokio::io::Interest::READABLE)?;
 
             loop {
-                let next_inbound_packet = fd
-                    .async_io(tokio::io::Interest::READABLE, |fd| {
-                        let mut ip_packet_buf = IpPacketBuf::new();
-
-                        let len = read(fd.as_raw_fd(), &mut ip_packet_buf)?;
-
-                        if len == 0 {
-                            return Ok(None);
-                        }
-
-                        let packet = IpPacket::new(ip_packet_buf, len)
-                            .context("Failed to parse IP packet") // Add an extra layer to ensure any inner error is the `cause`
-                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-
-                        Ok(Some(packet))
-                    })
-                    .await;
-
-                match next_inbound_packet.context("Failed to read from TUN FD") {
-                    Ok(None) => bail!("TUN file descriptor is closed"),
-                    Ok(Some(packet)) => {
-                        #[cfg(debug_assertions)]
-                        tracing::trace!(target: "wire::dev::recv", ?packet);
-
-                        if inbound_tx.send(packet).await.is_err() {
-                            tracing::debug!("Inbound packet receiver gone, shutting down task");
-
-                            break;
-                        };
-                    }
-                    Err(e) if e.any_is::<ip_packet::Fragmented>() => {
-                        tracing::debug!("{e:#}"); // Log on debug to be less noisy.
-                        continue;
-                    }
+                let mut guard = match fd.readable().await {
+                    Ok(guard) => guard,
                     Err(e) => {
-                        tracing::warn!("{e:#}");
+                        tracing::warn!("Failed to await TUN fd readability: {e}");
                         continue;
+                    }
+                };
+
+                // `try_io` returns an `Err` only if the fd is not readable anymore.
+                // In that case we want to loop around and .await a new read guard.
+                while let Ok(res) = guard.try_io(|fd| read_packet(&read, fd.as_raw_fd())) {
+                    match res.context("Failed to read from TUN fd") {
+                        Ok(Some(packet)) => {
+                            #[cfg(debug_assertions)]
+                            tracing::trace!(target: "wire::dev::recv", ?packet);
+
+                            if inbound_tx.send(packet).await.is_err() {
+                                tracing::debug!("Inbound packet receiver gone, shutting down task");
+                                return anyhow::Ok(());
+                            }
+                        }
+                        Ok(None) => bail!("TUN file descriptor is closed"),
+                        Err(e) if e.any_is::<ip_packet::Fragmented>() => {
+                            tracing::debug!("{e:#}"); // Log on debug to be less noisy.
+                        }
+                        Err(e) => {
+                            tracing::warn!("{e:#}");
+                        }
                     }
                 }
             }
-
-            anyhow::Ok(())
         })?;
 
     anyhow::Ok(())
+}
+
+fn read_packet(
+    read: &impl Fn(i32, &mut IpPacketBuf) -> std::result::Result<usize, io::Error>,
+    raw_fd: i32,
+) -> std::result::Result<Option<IpPacket>, io::Error> {
+    let mut ip_packet_buf = IpPacketBuf::new();
+    let len = read(raw_fd, &mut ip_packet_buf)?;
+
+    if len == 0 {
+        return Ok(None);
+    }
+
+    let packet = IpPacket::new(ip_packet_buf, len)
+        .context("Failed to parse IP packet") // Add an extra layer to ensure any inner error is the `cause`
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+    Ok(Some(packet))
 }
 
 #[cfg(test)]

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull={12332}>
+          Processes TUN reads and writes in a hot loop until the file descriptor
+          would block, reducing per-packet scheduler wakeups.
+        </ChangeItem>
         <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull={12332}>
+          Processes TUN reads and writes in a hot loop until the file descriptor
+          would block, reducing per-packet scheduler wakeups.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.14" date={new Date("2026-03-17")}>
         <ChangeItem pull={12407}>
           Fixes update notification dismissal on macOS where dismissing one

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,14 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Linux && (
+          <ChangeItem pull={12332}>
+            Processes TUN reads and writes in a hot loop until the file
+            descriptor would block, reducing per-packet scheduler wakeups.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.5.11" date={new Date("2026-03-16")}>
         <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull={12332}>
+          Processes TUN reads and writes in a hot loop until the file descriptor
+          would block, reducing per-packet scheduler wakeups.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.1" date={new Date("2026-03-16")}>
         <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,14 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Linux && (
+          <ChangeItem pull={12332}>
+            Processes TUN reads and writes in a hot loop until the file
+            descriptor would block, reducing per-packet scheduler wakeups.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.5.7" date={new Date("2026-03-16")}>
         <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a


### PR DESCRIPTION
This change aims to reduce scheduler overhead in the TUN path by replacing per-packet async I/O calls with hot loops that keep reading and writing until the `fd` returns `WouldBlock`.

On the send side, we now batch up to 128 packets from the channel via `recv_many`, then write them in a tight `try_io` loop, retrying on `WouldBlock`. Intermediate `writable().await` errors are logged and retried instead of terminating the task.

On the receive side, we wait for readability once, then drain packets in a tight `try_io` loop. Intermediate `readable().await` errors are similarly logged and retried.

### Profile results

These were performed on a M2 Pro (10-core) Macbook Pro. Tests were run against staging Gateways (latest `main`) to speedtest.net using Internet Resource. No statistically relevant throughput changes were observed with these changes, however we see about a 25% total reduction in CPU usage under load.

Link to full trace: https://firezonehq.slack.com/archives/C04JR58F7ND/p1772296200081869

#### before

<img width="1840" height="1191" alt="Screenshot 2026-02-28 at 8 24 36 AM" src="https://github.com/user-attachments/assets/18a9897a-caa7-4390-9fb2-fbd9dc5c24e6" />

#### after

<img width="1840" height="1191" alt="Screenshot 2026-02-28 at 8 24 24 AM" src="https://github.com/user-attachments/assets/f4482f7a-3ade-42ca-bb65-f746bec5a6cc" />