### PR TITLE
chore(portal): Log when client/gateway channel times out

### DIFF
--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -1,5 +1,6 @@
 defmodule PortalAPI.Client.Socket do
   use Phoenix.Socket
+  defoverridable terminate: 2
   alias Portal.{Authentication, ClientSession, Version}
   alias Portal.Client
   alias __MODULE__.Database
@@ -11,6 +12,31 @@ defmodule PortalAPI.Client.Socket do
   ## Channels
 
   channel "client", PortalAPI.Client.Channel
+
+  ## Termination
+
+  @impl true
+  def terminate(:timeout, {_state, socket}) do
+    client = socket.assigns[:client]
+    subject = socket.assigns[:subject]
+    session = socket.assigns[:session]
+
+    if client do
+      Logger.info("Client missed heartbeat, connection will timeout",
+        client_id: client.id,
+        account_id: client.account_id,
+        account_slug: subject && subject.account.slug,
+        actor_id: subject && subject.actor.id,
+        token_id: subject && subject.credential.id,
+        session_remote_ip: session && session.remote_ip
+      )
+    end
+
+    :ok
+  end
+
+  @impl true
+  def terminate(_reason, _state), do: :ok
 
   ## Authentication
 

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -1,5 +1,6 @@
 defmodule PortalAPI.Gateway.Socket do
   use Phoenix.Socket
+  defoverridable terminate: 2
   alias Portal.Authentication
   alias Portal.{Gateway, GatewaySession, Version}
   alias __MODULE__.Database
@@ -11,6 +12,29 @@ defmodule PortalAPI.Gateway.Socket do
   ## Channels
 
   channel "gateway", PortalAPI.Gateway.Channel
+
+  ## Termination
+
+  @impl true
+  def terminate(:timeout, {_state, socket}) do
+    gateway = socket.assigns[:gateway]
+    session = socket.assigns[:session]
+
+    if gateway do
+      Logger.info("Gateway missed heartbeat, connection will timeout",
+        gateway_id: gateway.id,
+        site_id: gateway.site_id,
+        account_id: gateway.account_id,
+        token_id: socket.assigns[:token_id],
+        session_remote_ip: session && session.remote_ip
+      )
+    end
+
+    :ok
+  end
+
+  @impl true
+  def terminate(_reason, _state), do: :ok
 
   ## Authentication
 

--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -27,7 +27,8 @@ defmodule PortalAPI.Relay.Socket do
     :ok
   end
 
-  def terminate(reason, state), do: super(reason, state)
+  @impl true
+  def terminate(_reason, _state), do: :ok
 
   ## Authentication
 

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -1,6 +1,7 @@
 defmodule PortalAPI.Client.SocketTest do
   use PortalAPI.ChannelCase, async: true
 
+  import ExUnit.CaptureLog
   import PortalAPI.Client.Socket, only: [id: 1]
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -468,6 +469,54 @@ defmodule PortalAPI.Client.SocketTest do
       assert log =~ "Hardware ID mismatch"
       assert log =~ "device_serial"
       assert log =~ "device_uuid"
+    end
+  end
+
+  describe "terminate/2" do
+    test "logs when connection times out" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+      subject = subject_fixture(account: account, actor: %{type: :account_user})
+      session = %Portal.ClientSession{remote_ip: %Postgrex.INET{address: {127, 0, 0, 1}}}
+
+      socket =
+        socket(PortalAPI.Client.Socket, "", %{
+          client: client,
+          subject: subject,
+          session: session
+        })
+
+      log =
+        capture_log(fn ->
+          assert :ok = Socket.terminate(:timeout, {%{}, socket})
+        end)
+
+      assert log =~ "Client missed heartbeat"
+      assert log =~ client.id
+      assert log =~ subject.account.slug
+    end
+
+    test "does not log for other termination reasons" do
+      socket = socket(PortalAPI.Client.Socket, "", %{})
+
+      log =
+        capture_log(fn ->
+          assert :ok = Socket.terminate(:shutdown, {%{}, socket})
+        end)
+
+      refute log =~ "Client missed heartbeat"
+    end
+
+    test "does not log when client is not yet assigned" do
+      socket = socket(PortalAPI.Client.Socket, "", %{})
+
+      log =
+        capture_log(fn ->
+          assert :ok = Socket.terminate(:timeout, {%{}, socket})
+        end)
+
+      refute log =~ "Client missed heartbeat"
     end
   end
 

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -1,5 +1,6 @@
 defmodule PortalAPI.Gateway.SocketTest do
   use PortalAPI.ChannelCase, async: true
+  import ExUnit.CaptureLog
   import PortalAPI.Gateway.Socket, except: [connect: 3]
   import Portal.AccountFixtures
   import Portal.SiteFixtures
@@ -253,6 +254,54 @@ defmodule PortalAPI.Gateway.SocketTest do
       # Both connections with different tokens should succeed
       assert {:ok, _socket} = connect(Socket, attrs1, connect_info: connect_info_1)
       assert {:ok, _socket} = connect(Socket, attrs2, connect_info: connect_info_2)
+    end
+  end
+
+  describe "terminate/2" do
+    test "logs when connection times out" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      token_id = Ecto.UUID.generate()
+      session = %Portal.GatewaySession{remote_ip: %Postgrex.INET{address: {127, 0, 0, 1}}}
+
+      socket =
+        socket(PortalAPI.Gateway.Socket, "", %{
+          gateway: gateway,
+          session: session,
+          token_id: token_id
+        })
+
+      log =
+        capture_log(fn ->
+          assert :ok = Socket.terminate(:timeout, {%{}, socket})
+        end)
+
+      assert log =~ "Gateway missed heartbeat"
+      assert log =~ gateway.id
+      assert log =~ token_id
+    end
+
+    test "does not log for other termination reasons" do
+      socket = socket(PortalAPI.Gateway.Socket, "", %{})
+
+      log =
+        capture_log(fn ->
+          assert :ok = Socket.terminate(:shutdown, {%{}, socket})
+        end)
+
+      refute log =~ "Gateway missed heartbeat"
+    end
+
+    test "does not log when gateway is not yet assigned" do
+      socket = socket(PortalAPI.Gateway.Socket, "", %{})
+
+      log =
+        capture_log(fn ->
+          assert :ok = Socket.terminate(:timeout, {%{}, socket})
+        end)
+
+      refute log =~ "Gateway missed heartbeat"
     end
   end
 


### PR DESCRIPTION
<!-- Please describe what this PR does, why it's needed, and how it was tested. -->

---

<!-- Fixes / Resolves / Closes / Related issues, if any: -->
