### PR TITLE
fix(portal): fix seeds service account token

### DIFF
--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -301,15 +301,23 @@ defmodule Portal.Authentication do
     end
   end
 
-  defp verify_secret_hash(token, nonce, fragment) do
-    expected_hash = Portal.Crypto.hash(:sha3_256, nonce <> fragment <> token.secret_salt)
+  defp verify_secret_hash(
+         %{secret_salt: secret_salt, secret_hash: secret_hash},
+         nonce,
+         fragment
+       )
+       when is_binary(nonce) and is_binary(fragment) and is_binary(secret_salt) and
+              is_binary(secret_hash) do
+    expected_hash = Portal.Crypto.hash(:sha3_256, nonce <> fragment <> secret_salt)
 
-    if Plug.Crypto.secure_compare(expected_hash, token.secret_hash) do
+    if Plug.Crypto.secure_compare(expected_hash, secret_hash) do
       :ok
     else
       :error
     end
   end
+
+  defp verify_secret_hash(_token, _nonce, _fragment), do: :error
 
   # Authentication
 

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -703,19 +703,30 @@ defmodule Portal.Repo.Seeds do
       }
     }
 
+    backup_manager_nonce = "n"
+    backup_manager_secret_fragment = Crypto.random_token(32, encoder: :hex32)
+    backup_manager_secret_salt = Crypto.random_token(16)
+
+    backup_manager_secret_hash =
+      Crypto.hash(
+        :sha3_256,
+        backup_manager_nonce <> backup_manager_secret_fragment <> backup_manager_secret_salt
+      )
+
     service_account_token =
       %ClientToken{
         id: "7da7d1cd-111c-44a7-b5ac-4027b9d230e5",
         account_id: service_account_actor.account_id,
         actor_id: service_account_actor.id,
-        secret_salt: "kKKA7dtf3TJk0-1O2D9N1w",
-        secret_hash: "5c1d6795ea1dd08b6f4fd331eeaffc12032ba171d227f328446f2d26b96437e5",
+        secret_fragment: backup_manager_secret_fragment,
+        secret_salt: backup_manager_secret_salt,
+        secret_hash: backup_manager_secret_hash,
         expires_at: DateTime.utc_now() |> DateTime.add(365, :day)
       }
       |> Repo.insert!()
 
     service_account_actor_encoded_token =
-      "n" <> Authentication.encode_fragment!(service_account_token)
+      backup_manager_nonce <> Authentication.encode_fragment!(service_account_token)
 
     # Email tokens are generated during sign-in flow, not pre-generated
     unprivileged_actor_email_token = "<generated during sign-in>"

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -194,6 +194,18 @@ defmodule Portal.AuthenticationTest do
       assert authenticate(".invalid", context) == {:error, :invalid_token}
     end
 
+    test "returns error when token payload contains nil fragment" do
+      token = client_token_fixture()
+      context = build_context(type: :client)
+
+      config = Portal.Config.fetch_env!(:portal, Portal.Tokens)
+      key_base = Keyword.fetch!(config, :key_base)
+      salt = Keyword.fetch!(config, :salt) <> "client"
+      encoded_fragment = Plug.Crypto.sign(key_base, salt, {token.account_id, token.id, nil})
+
+      assert authenticate("n." <> encoded_fragment, context) == {:error, :invalid_token}
+    end
+
     test "returns error for empty token" do
       context = build_context(type: :client)
       assert authenticate("", context) == {:error, :invalid_token}


### PR DESCRIPTION
- Adds a function head to gracefully handle invalid tokens missing salt/nonce.
- Fixes a bug with the seeds service account token that incorrectly generated the token.
