### PR TITLE
fix(phoenix-channel): skip missed heartbeat ticks

### DIFF
--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -84,7 +84,7 @@ struct Connected<TOutboundMsg> {
 
     heartbeat: tokio::time::Interval,
     inflight_heartbeats: HashSet<OutboundRequestId>,
-    pending_heartbeat: Option<(OutboundRequestId, String)>,
+    pending_heartbeat: Option<String>,
 
     pending_joins: VecDeque<String>,
     pending_join_requests: BTreeMap<OutboundRequestId, Instant>,
@@ -643,11 +643,9 @@ where
             // Priority 2: Keep local buffers small and send pending messages.
             match stream.poll_ready_unpin(cx) {
                 Poll::Ready(Ok(())) => {
-                    if let Some((hb_id, heartbeat)) = pending_heartbeat.take() {
+                    if let Some(heartbeat) = pending_heartbeat.take() {
                         match stream.start_send_unpin(Message::Text(heartbeat.clone().into())) {
                             Ok(()) => {
-                                // Only track the heartbeat as inflight once it is actually sent.
-                                inflight_heartbeats.insert(hb_id);
                                 tracing::trace!(target: "wire::api::send", %heartbeat);
                             }
                             Err(e) => {
@@ -877,11 +875,8 @@ where
                         EgressControlMessage::<()>::Heartbeat(Empty {}),
                     );
 
-                    // Store the ID alongside the message. The ID is only moved into
-                    // inflight_heartbeats when the message is actually sent (Priority 2).
-                    // This prevents orphaned IDs accumulating when the sink is backpressured
-                    // and pending_heartbeat gets replaced by subsequent ticks.
-                    pending_heartbeat.replace((id, heartbeat));
+                    pending_heartbeat.replace(heartbeat);
+                    inflight_heartbeats.insert(id);
 
                     continue;
                 }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -84,7 +84,7 @@ struct Connected<TOutboundMsg> {
 
     heartbeat: tokio::time::Interval,
     inflight_heartbeats: HashSet<OutboundRequestId>,
-    pending_heartbeat: Option<String>,
+    pending_heartbeat: Option<(OutboundRequestId, String)>,
 
     pending_joins: VecDeque<String>,
     pending_join_requests: BTreeMap<OutboundRequestId, Instant>,
@@ -565,10 +565,18 @@ where
                     Poll::Ready(Ok(stream)) => {
                         self.state = State::Connected(Connected {
                             stream,
-                            heartbeat: tokio::time::interval_at(
-                                tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
-                                HEARTBEAT_INTERVAL,
-                            ),
+                            heartbeat: {
+                                let mut interval = tokio::time::interval_at(
+                                    tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+                                    HEARTBEAT_INTERVAL,
+                                );
+                                // If we were busy and missed ticks, don't burst-fire to catch up.
+                                // Deliver at most one tick and reschedule from now.
+                                interval.set_missed_tick_behavior(
+                                    tokio::time::MissedTickBehavior::Delay,
+                                );
+                                interval
+                            },
                             inflight_heartbeats: Default::default(),
                             pending_heartbeat: Default::default(),
                             pending_joins: VecDeque::with_capacity(MAX_BUFFERED_MESSAGES),
@@ -635,9 +643,11 @@ where
             // Priority 2: Keep local buffers small and send pending messages.
             match stream.poll_ready_unpin(cx) {
                 Poll::Ready(Ok(())) => {
-                    if let Some(heartbeat) = pending_heartbeat.take() {
+                    if let Some((hb_id, heartbeat)) = pending_heartbeat.take() {
                         match stream.start_send_unpin(Message::Text(heartbeat.clone().into())) {
                             Ok(()) => {
+                                // Only track the heartbeat as inflight once it is actually sent.
+                                inflight_heartbeats.insert(hb_id);
                                 tracing::trace!(target: "wire::api::send", %heartbeat);
                             }
                             Err(e) => {
@@ -867,8 +877,11 @@ where
                         EgressControlMessage::<()>::Heartbeat(Empty {}),
                     );
 
-                    pending_heartbeat.replace(heartbeat);
-                    inflight_heartbeats.insert(id);
+                    // Store the ID alongside the message. The ID is only moved into
+                    // inflight_heartbeats when the message is actually sent (Priority 2).
+                    // This prevents orphaned IDs accumulating when the sink is backpressured
+                    // and pending_heartbeat gets replaced by subsequent ticks.
+                    pending_heartbeat.replace((id, heartbeat));
 
                     continue;
                 }


### PR DESCRIPTION
When the event loop is busy, Tokio’s interval can deliver accumulated heartbeat ticks back-to-back; that can create artificial heartbeat bursts that contend with normal control-plane traffic and make liveness behavior noisier than intended. This change sets the heartbeat timer to MissedTickBehavior::Delay, so missed ticks are not replayed in a burst and heartbeats resume at a steady cadence from “now.”