### PR TITLE
fix(portal): evict other node's channel pid

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -365,6 +365,11 @@ defmodule PortalAPI.Client.Channel do
     {:noreply, socket}
   end
 
+  def handle_info({:pg_group_evicted, group}, socket) do
+    Channels.handle_eviction(group)
+    {:noreply, socket}
+  end
+
   # Catch-all for messages we don't handle
   def handle_info(_message, socket), do: {:noreply, socket}
 

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -366,6 +366,11 @@ defmodule PortalAPI.Gateway.Channel do
     {:noreply, socket}
   end
 
+  def handle_info({:pg_group_evicted, group}, socket) do
+    Channels.handle_eviction(group)
+    {:noreply, socket}
+  end
+
   # Catch-all for messages we don't handle
   def handle_info(_message, socket), do: {:noreply, socket}
 


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/12303 we introduced logic that evicted stale pids on channel join to prevent two clients connecting with the same FIREZONE_ID from receiving ICE messages.

That introduced a bug in a multi-node cluster because `:pg.leave/2` does not work if called on a node other than where the target pid is running.

To fix this, we introduce a simple `{:pg_group_evicted, group}` message which we send to the other members of the group which then handle and leave themselves.

---

Fixes #12338 