### PR TITLE
chore(relay): demote Hiccup log to INFO

### DIFF
--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -797,7 +797,7 @@ async fn phoenix_channel_event_loop(
                 error,
             }) => {
                 is_connected.store(false, Ordering::Relaxed);
-                tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}");
+                tracing::info!(?backoff, ?max_elapsed_time, "{error:#}");
 
                 let ips = resolve_portal_host_ips(portal.host()).await;
                 portal.connect(ips, backoff, NoParams);


### PR DESCRIPTION
With the improved WebSocket close handling we can demote this log to `INFO` as it will occur under normal circumstances.

```
Connection hiccup: portal sent websocket close frame:  (1012)
```

We will still have these logs to search if needed, we just won't sent them to Sentry.
