### PR TITLE
fix(portal): validate UUID in path params

### DIFF
--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -132,15 +132,15 @@ defmodule Portal.Safe do
     fun.()
   rescue
     error in Ecto.Query.CastError ->
-      Logger.error("Query cast error", error: error)
+      Logger.info("Query cast error", error: error)
       nil
 
     error in Ecto.CastError ->
-      Logger.error("Cast error", error: error)
+      Logger.info("Cast error", error: error)
       nil
 
     error in ArgumentError ->
-      Logger.error("Argument error", error: error)
+      Logger.info("Argument error", error: error)
       nil
   end
 
@@ -148,15 +148,15 @@ defmodule Portal.Safe do
     fun.()
   rescue
     error in Ecto.Query.CastError ->
-      Logger.error("Query cast error", error: error)
+      Logger.info("Query cast error", error: error)
       reraise Ecto.NoResultsError, [queryable: queryable], __STACKTRACE__
 
     error in Ecto.CastError ->
-      Logger.error("Cast error", error: error)
+      Logger.info("Cast error", error: error)
       reraise Ecto.NoResultsError, [queryable: queryable], __STACKTRACE__
 
     error in ArgumentError ->
-      Logger.error("Argument error", error: error)
+      Logger.info("Argument error", error: error)
       reraise Ecto.NoResultsError, [queryable: queryable], __STACKTRACE__
   end
 

--- a/elixir/lib/portal_api/plugs/validate_uuid_params.ex
+++ b/elixir/lib/portal_api/plugs/validate_uuid_params.ex
@@ -1,0 +1,22 @@
+defmodule PortalAPI.Plugs.ValidateUUIDParams do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    invalid? =
+      conn.path_params
+      |> Enum.filter(fn {key, _} -> key == "id" or String.ends_with?(key, "_id") end)
+      |> Enum.any?(fn {_, value} -> Ecto.UUID.cast(value) == :error end)
+
+    if invalid? do
+      conn
+      |> put_status(:bad_request)
+      |> Phoenix.Controller.put_view(json: PortalAPI.ErrorJSON)
+      |> Phoenix.Controller.render(:"400")
+      |> halt()
+    else
+      conn
+    end
+  end
+end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -10,6 +10,7 @@ defmodule PortalAPI.Router do
     plug :accepts, ["json"]
     plug PortalAPI.Plugs.Auth
     plug PortalAPI.Plugs.RateLimit
+    plug PortalAPI.Plugs.ValidateUUIDParams
   end
 
   pipeline :public do

--- a/elixir/test/portal_api/controllers/gateway_controller_test.exs
+++ b/elixir/test/portal_api/controllers/gateway_controller_test.exs
@@ -25,6 +25,16 @@ defmodule PortalAPI.GatewayControllerTest do
       assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
     end
 
+    test "returns 400 for invalid UUID site_id", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/sites/null/gateways")
+
+      assert json_response(conn, 400) == %{"error" => %{"reason" => "Bad Request"}}
+    end
+
     test "lists all gateways for a site", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_api/controllers/site_controller_test.exs
+++ b/elixir/test/portal_api/controllers/site_controller_test.exs
@@ -90,6 +90,16 @@ defmodule PortalAPI.SiteControllerTest do
       assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
     end
 
+    test "returns 400 for invalid UUID id", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/sites/null")
+
+      assert json_response(conn, 400) == %{"error" => %{"reason" => "Bad Request"}}
+    end
+
     test "returns a single site", %{conn: conn, account: account, actor: actor} do
       site = site_fixture(account: account)
 

--- a/elixir/test/portal_api/plugs/validate_uuid_params_test.exs
+++ b/elixir/test/portal_api/plugs/validate_uuid_params_test.exs
@@ -1,0 +1,72 @@
+defmodule PortalAPI.Plugs.ValidateUUIDParamsTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+  import Plug.Conn
+
+  alias PortalAPI.Plugs.ValidateUUIDParams
+
+  @valid_uuid "00000000-0000-0000-0000-000000000000"
+  @opts ValidateUUIDParams.init([])
+
+  defp build_conn(path_params) do
+    conn(:get, "/test")
+    |> put_private(:phoenix_endpoint, PortalAPI.Endpoint)
+    |> put_private(:phoenix_format, "json")
+    |> Map.put(:path_params, path_params)
+  end
+
+  describe "call/2" do
+    test "passes through when no path params are present" do
+      conn = build_conn(%{})
+      result = ValidateUUIDParams.call(conn, @opts)
+      refute result.halted
+    end
+
+    test "passes through when non-id params have any value" do
+      conn = build_conn(%{"name" => "null", "type" => "not-a-uuid"})
+      result = ValidateUUIDParams.call(conn, @opts)
+      refute result.halted
+    end
+
+    test "passes through when id param is a valid UUID" do
+      conn = build_conn(%{"id" => @valid_uuid})
+      result = ValidateUUIDParams.call(conn, @opts)
+      refute result.halted
+    end
+
+    test "passes through when all _id params are valid UUIDs" do
+      conn = build_conn(%{"site_id" => @valid_uuid, "id" => @valid_uuid})
+      result = ValidateUUIDParams.call(conn, @opts)
+      refute result.halted
+    end
+
+    test "halts with 400 when id is the literal string null" do
+      conn = build_conn(%{"id" => "null"})
+      result = ValidateUUIDParams.call(conn, @opts)
+      assert result.halted
+      assert result.status == 400
+    end
+
+    test "halts with 400 when id is an arbitrary non-UUID string" do
+      conn = build_conn(%{"id" => "not-a-uuid"})
+      result = ValidateUUIDParams.call(conn, @opts)
+      assert result.halted
+      assert result.status == 400
+    end
+
+    test "halts with 400 when a _id param is invalid" do
+      conn = build_conn(%{"site_id" => "null", "id" => @valid_uuid})
+      result = ValidateUUIDParams.call(conn, @opts)
+      assert result.halted
+      assert result.status == 400
+    end
+
+    test "halts with 400 when id is an empty string" do
+      conn = build_conn(%{"id" => ""})
+      result = ValidateUUIDParams.call(conn, @opts)
+      assert result.halted
+      assert result.status == 400
+    end
+  end
+end


### PR DESCRIPTION
If a user sends a missing or invalid UUID in their REST API request, we would log an error and return a `404`. This spams Sentry and also is not quite correct behavior - instead, we validate that all `*id` path params are valid UUIDs before allowing the pipeline to continue further.

---

Fixes #12339 
