### PR TITLE
chore(portal): demote transport logs to warning

### DIFF
--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -30,7 +30,7 @@ defmodule PortalAPI.Endpoint do
 
   socket "/gateway", PortalAPI.Gateway.Socket,
     websocket: [
-      transport_log: :debug,
+      transport_log: :warning,
       check_origin: :conn,
       connect_info: [:trace_context_headers, :user_agent, :peer_data, :x_headers],
       error_handler: {PortalAPI.Sockets, :handle_error, []},
@@ -41,7 +41,7 @@ defmodule PortalAPI.Endpoint do
 
   socket "/client", PortalAPI.Client.Socket,
     websocket: [
-      transport_log: :debug,
+      transport_log: :warning,
       check_origin: :conn,
       connect_info: [:trace_context_headers, :user_agent, :peer_data, :x_headers],
       error_handler: {PortalAPI.Sockets, :handle_error, []},
@@ -52,7 +52,7 @@ defmodule PortalAPI.Endpoint do
 
   socket "/relay", PortalAPI.Relay.Socket,
     websocket: [
-      transport_log: :debug,
+      transport_log: :warning,
       check_origin: :conn,
       connect_info: [:trace_context_headers, :user_agent, :peer_data, :x_headers],
       error_handler: {PortalAPI.Sockets, :handle_error, []},


### PR DESCRIPTION
These constitute the bulk of our logs, which themselves constitute the bulk of our cloud cost.
