### PR TITLE
fix(portal): rollback sign_up on Stripe failure

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -77,25 +77,8 @@ jobs:
       - name: Compile Application
         run: mix compile --warnings-as-errors
 
-      - name: Restore PLT cache
-        id: plt_cache
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: elixir/priv/plts
-          key: plt-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('elixir/mix.lock') }}
-          # This will make sure that we can incrementally build the PLT from older cache and save it under a new key
-          restore-keys: plt-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
-
       - name: Create PLTs
-        # Always run to incrementally update PLT if restored from cache with different mix.lock
         run: mix dialyzer --plt
-
-      - name: Save PLT cache
-        if: github.ref_name == 'main'
-        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          key: ${{ steps.plt_cache.outputs.cache-primary-key }}
-          path: elixir/priv/plts
 
       - name: Run Dialyzer
         run: mix dialyzer --format dialyxir

--- a/elixir/lib/portal/billing/event_handler.ex
+++ b/elixir/lib/portal/billing/event_handler.ex
@@ -664,7 +664,7 @@ defmodule Portal.Billing.EventHandler do
 
     def slug_exists?(slug) do
       from(a in Portal.Account, where: a.slug == ^slug)
-      |> Safe.unscoped()
+      |> Safe.unscoped(:replica)
       |> Safe.exists?()
     end
 


### PR DESCRIPTION
When an account is created via the sign up flow, we reach out to stripe to provision a customer on the Starter plan. Unfortunately, if that fails, we continue without rollback and the account remains in a quasi-provisioned state.

To prevent this, we make the following changes to help with atomicity:

0. Pre-generate a random account ID so it's known for both Stripe and the DB.
1. No more storing the account slug in Stripe. This is not needed since we'll have the account ID.
2. Try to create the Stripe customer first, if that fails, we show a transient error to the user and ask them to try again.
3. If it succeeds, we take the returned Stripe metadata and use it to provision the account.
