### PR TITLE
fix(portal): reject emails without a '.'

### DIFF
--- a/elixir/lib/portal/changeset.ex
+++ b/elixir/lib/portal/changeset.ex
@@ -338,7 +338,7 @@ defmodule Portal.Changeset do
     Enum.any?(cidrs, &Portal.Types.CIDR.contains?(&1, inet))
   end
 
-  @email_regex ~r/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+  @email_regex ~r/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
 
   def validate_email(%Ecto.Changeset{} = changeset, field) do
     changeset

--- a/elixir/test/portal/actor_test.exs
+++ b/elixir/test/portal/actor_test.exs
@@ -24,6 +24,17 @@ defmodule Portal.ActorTest do
       changeset = build_changeset(%{name: String.duplicate("a", 256)})
       assert %{name: ["should be at most 255 character(s)"]} = errors_on(changeset)
     end
+
+    test "rejects email host without a dot" do
+      changeset =
+        build_changeset(%{
+          name: "Test Actor",
+          type: :account_user,
+          email: "user@localhost"
+        })
+
+      assert %{email: ["is an invalid email address"]} = errors_on(changeset)
+    end
   end
 
   describe "changeset/1 association constraints" do

--- a/elixir/test/portal/google/directory_test.exs
+++ b/elixir/test/portal/google/directory_test.exs
@@ -295,6 +295,7 @@ defmodule Portal.Google.DirectoryTest do
         "not-an-email",
         "@example.com",
         "user@",
+        "user@localhost",
         "user name@example.com"
       ]
 

--- a/elixir/test/portal_api/controllers/actor_controller_test.exs
+++ b/elixir/test/portal_api/controllers/actor_controller_test.exs
@@ -252,6 +252,29 @@ defmodule PortalAPI.ActorControllerTest do
       assert resp["data"]["email"] == attrs["email"]
       assert resp["data"]["type"] == attrs["type"]
     end
+
+    test "returns validation error when email host has no dot", %{conn: conn, actor: api_actor} do
+      attrs = %{
+        "name" => "Test User",
+        "email" => "test_user@localhost",
+        "type" => "account_user"
+      }
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/actors", actor: attrs)
+
+      assert %{
+               "error" => %{
+                 "reason" => "Unprocessable Content",
+                 "validation_errors" => %{
+                   "email" => ["is an invalid email address"]
+                 }
+               }
+             } = json_response(conn, 422)
+    end
   end
 
   describe "update/2" do

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -58,6 +58,17 @@ defmodule PortalWeb.SignUpTest do
       assert %{email: ["is an invalid email address"]} = errors_on(changeset)
     end
 
+    test "requires at least one dot in email host" do
+      changeset =
+        PortalWeb.SignUp.Registration.changeset(%{
+          email: "user@localhost",
+          email_confirmation: "user@localhost"
+        })
+
+      refute changeset.valid?
+      assert %{email: ["is an invalid email address"]} = errors_on(changeset)
+    end
+
     test "validates email confirmation" do
       changeset =
         PortalWeb.SignUp.Registration.changeset(%{


### PR DESCRIPTION
Noticed that while technically valid, emails without a period in the host aren't really routable and are sometimes typo'd during signup for some users, causing Stripe provision issues and other issues down the road.
