### PR TITLE
feat(connlib): read multiple UDP packet batches at once

### DIFF
--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -260,6 +260,7 @@ impl ThreadedUdpSocket {
                 };
 
                 let socket = Arc::new(socket);
+                const PACKETS_PER_YIELD: usize = 16;
 
                 let send = runtime.spawn({
                     let io_error_counter = io_error_counter.clone();
@@ -267,9 +268,8 @@ impl ThreadedUdpSocket {
                     let socket = socket.clone();
 
                     async move {
+                        let mut packets_since_yield = 0;
                         while let Some(datagram) = outbound_rx.recv().await {
-                            tokio::task::yield_now().await;
-
                             if let Err(e) = socket.send(datagram).await {
                                 if let Some(io) = e.any_downcast_ref::<io::Error>() {
                                     io_error_counter.add(
@@ -291,6 +291,12 @@ impl ThreadedUdpSocket {
                                     break;
                                 }
                             };
+
+                            packets_since_yield += 1;
+                            if packets_since_yield >= PACKETS_PER_YIELD {
+                                tokio::task::yield_now().await;
+                                packets_since_yield = 0;
+                            }
                         }
 
                         tracing::debug!(
@@ -299,9 +305,8 @@ impl ThreadedUdpSocket {
                     }
                 });
                 let receive = runtime.spawn(async move {
+                    let mut packets_since_yield = 0;
                     loop {
-                        tokio::task::yield_now().await;
-
                         let result = socket.recv_from().await;
 
                         if let Some(io) = result
@@ -325,6 +330,12 @@ impl ThreadedUdpSocket {
                                 "Channel for inbound datagrams closed; exiting UDP thread"
                             );
                             break;
+                        }
+
+                        packets_since_yield += 1;
+                        if packets_since_yield >= PACKETS_PER_YIELD {
+                            tokio::task::yield_now().await;
+                            packets_since_yield = 0;
                         }
                     }
                 });

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -268,75 +268,72 @@ impl ThreadedUdpSocket {
                     let socket = socket.clone();
 
                     async move {
-                        let mut packets_since_yield = 0;
-                        while let Some(datagram) = outbound_rx.recv().await {
-                            if let Err(e) = socket.send(datagram).await {
-                                if let Some(io) = e.any_downcast_ref::<io::Error>() {
-                                    io_error_counter.add(
-                                        1,
-                                        &[
-                                            otel::attr::network_io_direction_transmit(),
-                                            otel::attr::network_type_for_addr(preferred_addr),
-                                            otel::attr::io_error_type(io),
-                                            otel::attr::io_error_code(io),
-                                        ],
-                                    );
-                                }
-
-                                // We use the inbound_tx channel to send the error back to the main thread.
-                                if inbound_tx.send(Err(e)).await.is_err() {
+                        'recv: loop {
+                            for _ in 0..PACKETS_PER_YIELD {
+                                let Some(datagram) = outbound_rx.recv().await else {
                                     tracing::debug!(
-                                        "Channel for inbound datagrams closed; exiting UDP thread"
+                                        "Channel for outbound datagrams closed; exiting UDP thread"
                                     );
-                                    break;
-                                }
-                            };
+                                    break 'recv;
+                                };
 
-                            packets_since_yield += 1;
-                            if packets_since_yield >= PACKETS_PER_YIELD {
-                                tokio::task::yield_now().await;
-                                packets_since_yield = 0;
+                                if let Err(e) = socket.send(datagram).await {
+                                    if let Some(io) = e.any_downcast_ref::<io::Error>() {
+                                        io_error_counter.add(
+                                            1,
+                                            &[
+                                                otel::attr::network_io_direction_transmit(),
+                                                otel::attr::network_type_for_addr(preferred_addr),
+                                                otel::attr::io_error_type(io),
+                                                otel::attr::io_error_code(io),
+                                            ],
+                                        );
+                                    }
+
+                                    // We use the inbound_tx channel to send the error back to the main thread.
+                                    if inbound_tx.send(Err(e)).await.is_err() {
+                                        tracing::debug!(
+                                            "Channel for inbound datagrams closed; exiting UDP thread"
+                                        );
+                                        break 'recv;
+                                    }
+                                };
                             }
-                        }
 
-                        tracing::debug!(
-                            "Channel for outbound datagrams closed; exiting UDP thread"
-                        );
+                            tokio::task::yield_now().await;
+                        };
                     }
                 });
                 let receive = runtime.spawn(async move {
-                    let mut packets_since_yield = 0;
-                    loop {
-                        let result = socket.recv_from().await;
+                    'send: loop {
+                        for _ in 0..PACKETS_PER_YIELD {
+                            let result = socket.recv_from().await;
 
-                        if let Some(io) = result
-                            .as_ref()
-                            .err()
-                            .and_then(|e| e.any_downcast_ref::<io::Error>())
-                        {
-                            io_error_counter.add(
-                                1,
-                                &[
-                                    otel::attr::network_io_direction_receive(),
-                                    otel::attr::network_type_for_addr(preferred_addr),
-                                    otel::attr::io_error_type(io),
-                                    otel::attr::io_error_code(io),
-                                ],
-                            );
+                            if let Some(io) = result
+                                .as_ref()
+                                .err()
+                                .and_then(|e| e.any_downcast_ref::<io::Error>())
+                            {
+                                io_error_counter.add(
+                                    1,
+                                    &[
+                                        otel::attr::network_io_direction_receive(),
+                                        otel::attr::network_type_for_addr(preferred_addr),
+                                        otel::attr::io_error_type(io),
+                                        otel::attr::io_error_code(io),
+                                    ],
+                                );
+                            }
+
+                            if inbound_tx.send(result).await.is_err() {
+                                tracing::debug!(
+                                    "Channel for inbound datagrams closed; exiting UDP thread"
+                                );
+                                break 'send;
+                            }
                         }
 
-                        if inbound_tx.send(result).await.is_err() {
-                            tracing::debug!(
-                                "Channel for inbound datagrams closed; exiting UDP thread"
-                            );
-                            break;
-                        }
-
-                        packets_since_yield += 1;
-                        if packets_since_yield >= PACKETS_PER_YIELD {
-                            tokio::task::yield_now().await;
-                            packets_since_yield = 0;
-                        }
+                        tokio::task::yield_now().await;
                     }
                 });
 

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -269,10 +269,8 @@ impl ThreadedUdpSocket {
                     let mut pending_datagrams = Vec::with_capacity(BATCHES_PER_YIELD);
 
                     async move {
-                        let mut batches_since_yield = 0;
                         'recv: loop {
-                            let num_batches =
-                                outbound_rx.recv_many(&mut pending_datagrams, BATCHES_PER_YIELD).await;
+                            let num_batches = outbound_rx.recv_many(&mut pending_datagrams, BATCHES_PER_YIELD).await;
 
                             if num_batches == 0 {
                                 break 'recv;
@@ -302,11 +300,7 @@ impl ThreadedUdpSocket {
                                 };
                             }
 
-                            batches_since_yield += num_batches;
-                            if batches_since_yield >= BATCHES_PER_YIELD {
-                                tokio::task::yield_now().await;
-                                batches_since_yield -= BATCHES_PER_YIELD;
-                            }
+                            tokio::task::yield_now().await;
                         };
                     }
                 });

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -277,7 +277,7 @@ impl ThreadedUdpSocket {
                                 tracing::debug!(
                                     "Channel for outbound datagrams closed; exiting UDP send task"
                                 );
-                                break;
+                                return;
                             }
 
                             for datagram in pending_datagrams.drain(..) {
@@ -299,7 +299,7 @@ impl ThreadedUdpSocket {
                                         tracing::debug!(
                                             "Channel for inbound datagrams closed; exiting UDP send task"
                                         );
-                                        break;
+                                        return;
                                     }
                                 };
                             }
@@ -330,7 +330,7 @@ impl ThreadedUdpSocket {
                             tracing::debug!(
                                 "Channel for inbound datagrams closed; exiting UDP recv task"
                             );
-                            break;
+                            return;
                         }
                     }
                 });

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -266,17 +266,17 @@ impl ThreadedUdpSocket {
                     let io_error_counter = io_error_counter.clone();
                     let inbound_tx = inbound_tx.clone();
                     let socket = socket.clone();
+                    let mut pending_datagrams = Vec::with_capacity(PACKETS_PER_YIELD);
 
                     async move {
                         'recv: loop {
-                            for _ in 0..PACKETS_PER_YIELD {
-                                let Some(datagram) = outbound_rx.recv().await else {
-                                    tracing::debug!(
-                                        "Channel for outbound datagrams closed; exiting UDP thread"
-                                    );
-                                    break 'recv;
-                                };
+                            let num_packets = outbound_rx.recv_many(&mut pending_datagrams, PACKETS_PER_YIELD).await;
 
+                            if num_packets == 0 {
+                                break 'recv;
+                            }
+
+                            for datagram in pending_datagrams.drain(..) {
                                 if let Err(e) = socket.send(datagram).await {
                                     if let Some(io) = e.any_downcast_ref::<io::Error>() {
                                         io_error_counter.add(

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -18,6 +18,7 @@ use tokio_util::sync::PollSender;
 const DEFAULT_LISTEN_PORT: u16 = EPHEMERAL_PORT_RANGE_START + FIRE;
 const EPHEMERAL_PORT_RANGE_START: u16 = 49152;
 const FIRE: u16 = 3473; // "FIRE" when typed on a phone pad.
+const UDP_SEND_BATCH_LIMIT: usize = 16;
 
 const UNSPECIFIED_V4_SOCKET: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_LISTEN_PORT);
@@ -266,12 +267,13 @@ impl ThreadedUdpSocket {
                     let inbound_tx = inbound_tx.clone();
                     let socket = socket.clone();
 
-                    let mut pending_datagrams = Vec::with_capacity(16);
-                    let limit = pending_datagrams.capacity();
+                    let mut pending_datagrams = Vec::with_capacity(UDP_SEND_BATCH_LIMIT);
 
                     async move {
                         loop {
-                            let num_batches = outbound_rx.recv_many(&mut pending_datagrams, limit).await;
+                            let num_batches = outbound_rx
+                                .recv_many(&mut pending_datagrams, UDP_SEND_BATCH_LIMIT)
+                                .await;
 
                             if num_batches == 0 {
                                 tracing::debug!(

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -260,19 +260,21 @@ impl ThreadedUdpSocket {
                 };
 
                 let socket = Arc::new(socket);
-                const PACKETS_PER_YIELD: usize = 16;
+                const BATCHES_PER_YIELD: usize = 16;
 
                 let send = runtime.spawn({
                     let io_error_counter = io_error_counter.clone();
                     let inbound_tx = inbound_tx.clone();
                     let socket = socket.clone();
-                    let mut pending_datagrams = Vec::with_capacity(PACKETS_PER_YIELD);
+                    let mut pending_datagrams = Vec::with_capacity(BATCHES_PER_YIELD);
 
                     async move {
+                        let mut batches_since_yield = 0;
                         'recv: loop {
-                            let num_packets = outbound_rx.recv_many(&mut pending_datagrams, PACKETS_PER_YIELD).await;
+                            let num_batches =
+                                outbound_rx.recv_many(&mut pending_datagrams, BATCHES_PER_YIELD).await;
 
-                            if num_packets == 0 {
+                            if num_batches == 0 {
                                 break 'recv;
                             }
 
@@ -300,13 +302,17 @@ impl ThreadedUdpSocket {
                                 };
                             }
 
-                            tokio::task::yield_now().await;
+                            batches_since_yield += num_batches;
+                            if batches_since_yield >= BATCHES_PER_YIELD {
+                                tokio::task::yield_now().await;
+                                batches_since_yield -= BATCHES_PER_YIELD;
+                            }
                         };
                     }
                 });
                 let receive = runtime.spawn(async move {
                     'send: loop {
-                        for _ in 0..PACKETS_PER_YIELD {
+                        for _ in 0..BATCHES_PER_YIELD {
                             let result = socket.recv_from().await;
 
                             if let Some(io) = result

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -260,17 +260,18 @@ impl ThreadedUdpSocket {
                 };
 
                 let socket = Arc::new(socket);
-                const BATCHES_PER_YIELD: usize = 16;
 
                 let send = runtime.spawn({
                     let io_error_counter = io_error_counter.clone();
                     let inbound_tx = inbound_tx.clone();
                     let socket = socket.clone();
-                    let mut pending_datagrams = Vec::with_capacity(BATCHES_PER_YIELD);
+
+                    let mut pending_datagrams = Vec::with_capacity(16);
+                    let limit = pending_datagrams.capacity();
 
                     async move {
                         loop {
-                            let num_batches = outbound_rx.recv_many(&mut pending_datagrams, BATCHES_PER_YIELD).await;
+                            let num_batches = outbound_rx.recv_many(&mut pending_datagrams, limit).await;
 
                             if num_batches == 0 {
                                 tracing::debug!(

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -269,11 +269,11 @@ impl ThreadedUdpSocket {
                     let mut pending_datagrams = Vec::with_capacity(BATCHES_PER_YIELD);
 
                     async move {
-                        'recv: loop {
+                        loop {
                             let num_batches = outbound_rx.recv_many(&mut pending_datagrams, BATCHES_PER_YIELD).await;
 
                             if num_batches == 0 {
-                                break 'recv;
+                                break;
                             }
 
                             for datagram in pending_datagrams.drain(..) {
@@ -295,45 +295,39 @@ impl ThreadedUdpSocket {
                                         tracing::debug!(
                                             "Channel for inbound datagrams closed; exiting UDP thread"
                                         );
-                                        break 'recv;
+                                        break;
                                     }
                                 };
                             }
-
-                            tokio::task::yield_now().await;
                         };
                     }
                 });
                 let receive = runtime.spawn(async move {
-                    'send: loop {
-                        for _ in 0..BATCHES_PER_YIELD {
-                            let result = socket.recv_from().await;
+                    loop {
+                        let result = socket.recv_from().await;
 
-                            if let Some(io) = result
-                                .as_ref()
-                                .err()
-                                .and_then(|e| e.any_downcast_ref::<io::Error>())
-                            {
-                                io_error_counter.add(
-                                    1,
-                                    &[
-                                        otel::attr::network_io_direction_receive(),
-                                        otel::attr::network_type_for_addr(preferred_addr),
-                                        otel::attr::io_error_type(io),
-                                        otel::attr::io_error_code(io),
-                                    ],
-                                );
-                            }
-
-                            if inbound_tx.send(result).await.is_err() {
-                                tracing::debug!(
-                                    "Channel for inbound datagrams closed; exiting UDP thread"
-                                );
-                                break 'send;
-                            }
+                        if let Some(io) = result
+                            .as_ref()
+                            .err()
+                            .and_then(|e| e.any_downcast_ref::<io::Error>())
+                        {
+                            io_error_counter.add(
+                                1,
+                                &[
+                                    otel::attr::network_io_direction_receive(),
+                                    otel::attr::network_type_for_addr(preferred_addr),
+                                    otel::attr::io_error_type(io),
+                                    otel::attr::io_error_code(io),
+                                ],
+                            );
                         }
 
-                        tokio::task::yield_now().await;
+                        if inbound_tx.send(result).await.is_err() {
+                            tracing::debug!(
+                                "Channel for inbound datagrams closed; exiting UDP thread"
+                            );
+                            break;
+                        }
                     }
                 });
 

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -273,6 +273,9 @@ impl ThreadedUdpSocket {
                             let num_batches = outbound_rx.recv_many(&mut pending_datagrams, BATCHES_PER_YIELD).await;
 
                             if num_batches == 0 {
+                                tracing::debug!(
+                                    "Channel for outbound datagrams closed; exiting UDP send task"
+                                );
                                 break;
                             }
 
@@ -293,7 +296,7 @@ impl ThreadedUdpSocket {
                                     // We use the inbound_tx channel to send the error back to the main thread.
                                     if inbound_tx.send(Err(e)).await.is_err() {
                                         tracing::debug!(
-                                            "Channel for inbound datagrams closed; exiting UDP thread"
+                                            "Channel for inbound datagrams closed; exiting UDP send task"
                                         );
                                         break;
                                     }
@@ -324,7 +327,7 @@ impl ThreadedUdpSocket {
 
                         if inbound_tx.send(result).await.is_err() {
                             tracing::debug!(
-                                "Channel for inbound datagrams closed; exiting UDP thread"
+                                "Channel for inbound datagrams closed; exiting UDP recv task"
                             );
                             break;
                         }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12355">
+          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          yielding to the scheduler.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -22,7 +22,7 @@ export default function Android() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          Reduces CPU overhead by processing up to 16 UDP datagram batches before
           yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -22,8 +22,8 @@ export default function Android() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches
-          before yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches at a
+          time.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -22,8 +22,8 @@ export default function Android() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches before
-          yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches
+          before yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -26,7 +26,7 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          Reduces CPU overhead by processing up to 16 UDP datagram batches before
           yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12236">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -26,8 +26,8 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches before
-          yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches
+          before yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12236">
           Fixes an issue on macOS where the app could get stuck on the loading

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12355">
+          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          yielding to the scheduler.
+        </ChangeItem>
         <ChangeItem pull="12236">
           Fixes an issue on macOS where the app could get stuck on the loading
           spinner if the system extension was not ready at startup.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -26,8 +26,8 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches
-          before yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches at a
+          time.
         </ChangeItem>
         <ChangeItem pull="12236">
           Fixes an issue on macOS where the app could get stuck on the loading

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -12,8 +12,8 @@ export default function GUI({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches
-          before yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches at a
+          time.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -12,8 +12,8 @@ export default function GUI({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches before
-          yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches
+          before yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -12,7 +12,7 @@ export default function GUI({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          Reduces CPU overhead by processing up to 16 UDP datagram batches before
           yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,10 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12355">
+          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          yielding to the scheduler.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,7 +24,7 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          Reduces CPU overhead by processing up to 16 UDP datagram batches before
           yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,8 +24,8 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches
-          before yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches at a
+          time.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -23,6 +23,10 @@ export default function Gateway() {
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
+        <ChangeItem pull="12355">
+          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          yielding to the scheduler.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,8 +24,8 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches before
-          yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches
+          before yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,8 +11,8 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches before
-          yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches
+          before yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,7 +11,7 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          Reduces CPU overhead by processing up to 16 UDP datagram batches before
           yielding to the scheduler.
         </ChangeItem>
         <ChangeItem pull="12251">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,10 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12355">
+          Reduces CPU overhead by processing UDP packets in batches of 64 before
+          yielding to the scheduler.
+        </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,8 +11,8 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="12355">
-          Reduces CPU overhead by processing up to 16 UDP datagram batches
-          before yielding to the scheduler.
+          Reduces CPU overhead by processing up to 16 UDP datagram batches at a
+          time.
         </ChangeItem>
         <ChangeItem pull="12251">
           Gracefully handles WebSocket closes from the portal instead of logging


### PR DESCRIPTION
In our UDP reading and writing paths, on most platforms we already batch multiple packets together to read / write them in a one go with different kinds of kernel APIs, i.e. GSO/GRO on Linux or `sendmsg_x`/`recvmsg_x` on Darwin.

Both the send and recv task for UDP packets run on the same thread and therefore compete for CPU time with each other. Previously, we tried to make this more fair by adding explicit yield points. Tokio however already builds such fairness scheduling into its channels which we use here. See https://docs.rs/tokio/latest/tokio/task/coop/fn.cooperative.html for details.

Therefore, we don't need any extra yield points. What we can do however is read entire an entire batch of packets from the tokio channel and send those over in a tight loop.

### Profile results

CPU usage dropped by about 25%, and throughput about a 10% sustained bump, and much less jittery overall.