### PR TITLE
feat(connlib): reduce allocations when building packets

### DIFF
--- a/rust/libs/connlib/ip-packet/src/lib.rs
+++ b/rust/libs/connlib/ip-packet/src/lib.rs
@@ -1021,14 +1021,9 @@ mod tests {
 
     #[test]
     fn udp_packet_payload() {
-        let udp_packet = crate::make::udp_packet(
-            Ipv4Addr::LOCALHOST,
-            Ipv4Addr::LOCALHOST,
-            0,
-            0,
-            b"foobar".to_vec(),
-        )
-        .unwrap();
+        let udp_packet =
+            crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, b"foobar")
+                .unwrap();
 
         let ip_payload = udp_packet.payload();
         let udp_payload = &ip_payload[etherparse::UdpHeader::LEN..];
@@ -1038,8 +1033,8 @@ mod tests {
 
     #[test]
     fn ipv4_ecn() {
-        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
-            .unwrap();
+        let p =
+            crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[]).unwrap();
 
         assert_eq!(p.clone().with_ecn(Ecn::NonEct).ecn(), Ecn::NonEct);
         assert_eq!(p.clone().with_ecn(Ecn::Ect0).ecn(), Ecn::Ect0);
@@ -1049,8 +1044,8 @@ mod tests {
 
     #[test]
     fn ipv6_ecn() {
-        let p = crate::make::udp_packet(Ipv6Addr::LOCALHOST, Ipv6Addr::LOCALHOST, 0, 0, vec![])
-            .unwrap();
+        let p =
+            crate::make::udp_packet(Ipv6Addr::LOCALHOST, Ipv6Addr::LOCALHOST, 0, 0, &[]).unwrap();
 
         assert_eq!(p.clone().with_ecn(Ecn::NonEct).ecn(), Ecn::NonEct);
         assert_eq!(p.clone().with_ecn(Ecn::Ect1).ecn(), Ecn::Ect1);
@@ -1060,8 +1055,8 @@ mod tests {
 
     #[test]
     fn ip4_checksum_after_ecn_is_correct() {
-        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
-            .unwrap();
+        let p =
+            crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[]).unwrap();
 
         let p_with_ecn = p.with_ecn(Ecn::Ect0);
         let ip4_header = p_with_ecn.ipv4_header().unwrap();
@@ -1074,7 +1069,7 @@ mod tests {
 
     #[test]
     fn ecn_from_transport_happy_path() {
-        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[])
             .unwrap()
             .with_ecn(Ecn::Ect0);
 
@@ -1085,7 +1080,7 @@ mod tests {
 
     #[test]
     fn ecn_from_transport_no_clear_ect() {
-        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[])
             .unwrap()
             .with_ecn(Ecn::Ect0);
 
@@ -1103,8 +1098,8 @@ mod tests {
     /// One possibility for the future might be to use dedicated `Error` types.
     #[test]
     fn all_as_functions_should_return_option() {
-        let mut p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
-            .unwrap();
+        let mut p =
+            crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[]).unwrap();
 
         let _: Option<_> = p.as_udp();
         let _: Option<_> = p.as_udp_mut();
@@ -1119,8 +1114,8 @@ mod tests {
 
     #[test]
     fn src_is_updated() {
-        let mut p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
-            .unwrap();
+        let mut p =
+            crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[]).unwrap();
 
         p.set_src(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))).unwrap();
 
@@ -1129,8 +1124,8 @@ mod tests {
 
     #[test]
     fn dst_is_updated() {
-        let mut p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
-            .unwrap();
+        let mut p =
+            crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[]).unwrap();
 
         p.set_dst(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))).unwrap();
 

--- a/rust/libs/connlib/ip-packet/src/make.rs
+++ b/rust/libs/connlib/ip-packet/src/make.rs
@@ -38,15 +38,16 @@ pub fn fz_p2p_control(header: [u8; 8], control_payload: &[u8]) -> Result<IpPacke
 
     let mut packet_buf = IpPacketBuf::new();
 
-    let mut payload_buf = vec![0u8; 8 + control_payload.len()];
+    // Assemble header + payload on the stack, bounded by the already-checked `MAX_IP_SIZE`.
+    let mut payload_buf = [0u8; MAX_IP_SIZE];
     payload_buf[..8].copy_from_slice(&header);
-    payload_buf[8..].copy_from_slice(control_payload);
+    payload_buf[8..ip_payload_size].copy_from_slice(control_payload);
 
     builder
         .write(
             &mut std::io::Cursor::new(packet_buf.buf()),
             crate::fz_p2p_control::IP_NUMBER,
-            &payload_buf,
+            &payload_buf[..ip_payload_size],
         )
         .with_context(|| {
             format!("Buffer should be big enough; ip_payload_size={ip_payload_size}")
@@ -110,7 +111,7 @@ pub fn tcp_packet<IP>(
     sport: u16,
     dport: u16,
     flags: TcpFlags,
-    payload: Vec<u8>,
+    payload: &[u8],
 ) -> Result<IpPacket>
 where
     IP: Into<IpAddr>,
@@ -152,7 +153,7 @@ pub fn udp_packet<SIP, DIP>(
     daddr: DIP,
     sport: u16,
     dport: u16,
-    payload: Vec<u8>,
+    payload: &[u8],
 ) -> Result<IpPacket>
 where
     SIP: Into<IpAddr>,
@@ -284,7 +285,7 @@ mod tests {
             Ipv4Addr::LOCALHOST,
             0,
             0,
-            payload,
+            &payload,
         )
         .unwrap();
 
@@ -307,7 +308,7 @@ mod tests {
             Ipv6Addr::LOCALHOST,
             0,
             0,
-            payload,
+            &payload,
         )
         .unwrap();
 

--- a/rust/libs/connlib/ip-packet/src/proptest.rs
+++ b/rust/libs/connlib/ip-packet/src/proptest.rs
@@ -5,10 +5,10 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 pub fn udp_packet() -> impl Strategy<Value = IpPacket> {
     prop_oneof![
         (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
-            crate::make::udp_packet(saddr, daddr, sport, dport, Vec::new()).unwrap()
+            crate::make::udp_packet(saddr, daddr, sport, dport, &[]).unwrap()
         }),
         (ip6_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
-            crate::make::udp_packet(saddr, daddr, sport, dport, Vec::new()).unwrap()
+            crate::make::udp_packet(saddr, daddr, sport, dport, &[]).unwrap()
         }),
     ]
 }
@@ -19,12 +19,12 @@ pub fn tcp_packet(
     prop_oneof![
         (ip4_tuple(), any::<u16>(), any::<u16>(), flags.clone()).prop_map(
             |((saddr, daddr), sport, dport, flags)| {
-                crate::make::tcp_packet(saddr, daddr, sport, dport, flags, Vec::new()).unwrap()
+                crate::make::tcp_packet(saddr, daddr, sport, dport, flags, &[]).unwrap()
             }
         ),
         (ip6_tuple(), any::<u16>(), any::<u16>(), flags).prop_map(
             |((saddr, daddr), sport, dport, flags)| {
-                crate::make::tcp_packet(saddr, daddr, sport, dport, flags, Vec::new()).unwrap()
+                crate::make::tcp_packet(saddr, daddr, sport, dport, flags, &[]).unwrap()
             }
         ),
     ]

--- a/rust/libs/connlib/l3-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l3-udp-dns-client/lib.rs
@@ -94,7 +94,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         let payload = message.into_bytes();
 
         let ip_packet =
-            ip_packet::make::udp_packet(local_ip, server.ip(), local_port, server.port(), payload)
+            ip_packet::make::udp_packet(local_ip, server.ip(), local_port, server.port(), &payload)
                 .context("Failed to make IP packet")?;
 
         self.scheduled_queries.push_back(ip_packet);

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1379,12 +1379,13 @@ impl ClientState {
                 self.dns_resource_nat.recreate(message.domain());
                 self.update_dns_resource_nat(now, iter::empty());
 
+                let response_bytes = response.into_bytes(MAX_UDP_PAYLOAD);
                 let maybe_packet = ip_packet::make::udp_packet(
                     packet.destination(),
                     packet.source(),
                     datagram.destination_port(),
                     datagram.source_port(),
-                    response.into_bytes(MAX_UDP_PAYLOAD),
+                    &response_bytes,
                 )
                 .inspect_err(|e| {
                     tracing::debug!("Failed to create LLMNR DNS response packet: {e:#}");
@@ -1972,15 +1973,10 @@ fn into_udp_dns_packet(
     dst: SocketAddr,
     message: dns_types::Response,
 ) -> Option<IpPacket> {
-    ip_packet::make::udp_packet(
-        from.ip(),
-        dst.ip(),
-        from.port(),
-        dst.port(),
-        message.into_bytes(MAX_UDP_PAYLOAD),
-    )
-    .inspect_err(|e| tracing::warn!("Failed to create IP packet for DNS response: {e:#}"))
-    .ok()
+    let bytes = message.into_bytes(MAX_UDP_PAYLOAD);
+    ip_packet::make::udp_packet(from.ip(), dst.ip(), from.port(), dst.port(), &bytes)
+        .inspect_err(|e| tracing::warn!("Failed to create IP packet for DNS response: {e:#}"))
+        .ok()
 }
 
 pub struct IpProvider {

--- a/rust/libs/connlib/tunnel/src/client/dns_resource_nat.rs
+++ b/rust/libs/connlib/tunnel/src/client/dns_resource_nat.rs
@@ -372,7 +372,7 @@ mod tests {
 
         // Should buffer packets if we are coming from `Failed`.
         let packet =
-            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[])
                 .unwrap();
 
         let maybe_packet =
@@ -397,7 +397,7 @@ mod tests {
             .unwrap();
 
         let packet =
-            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[])
                 .unwrap();
 
         let maybe_packet = dns_resource_nat.handle_outgoing(
@@ -457,7 +457,7 @@ mod tests {
             .unwrap();
 
         let app_packet =
-            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[])
                 .unwrap();
 
         let maybe_packet = dns_resource_nat.handle_outgoing(
@@ -535,7 +535,7 @@ mod tests {
         now += Duration::from_secs(2);
 
         let app_packet =
-            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+            ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, &[])
                 .unwrap();
 
         let maybe_packet =

--- a/rust/libs/connlib/tunnel/src/client/pending_device_access.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_device_access.rs
@@ -134,7 +134,7 @@ mod tests {
             Ipv4Addr::LOCALHOST,
             1,
             1,
-            vec![payload], // We need to vary the payload because identical packets don't get buffered.
+            &[payload], // We need to vary the payload because identical packets don't get buffered.
         )
         .unwrap()
     }

--- a/rust/libs/connlib/tunnel/src/client/pending_flows.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_flows.rs
@@ -219,7 +219,7 @@ mod tests {
             Ipv4Addr::LOCALHOST,
             1,
             1,
-            vec![payload], // We need to vary the payload because identical packets don't get buffered.
+            &[payload], // We need to vary the payload because identical packets don't get buffered.
         )
         .unwrap()
     }

--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -744,7 +744,7 @@ mod tests {
             5401,
             80,
             TcpFlags::default(),
-            vec![0; 100],
+            &[0u8; 100],
         )
         .unwrap();
 
@@ -753,7 +753,7 @@ mod tests {
             cidr_v4_resource().hosts().next().unwrap(),
             5401,
             80,
-            vec![0; 100],
+            &[0u8; 100],
         )
         .unwrap();
 
@@ -806,7 +806,7 @@ mod tests {
             5401,
             80,
             TcpFlags::default(),
-            vec![0; 100],
+            &[0u8; 100],
         )
         .unwrap();
 
@@ -816,7 +816,7 @@ mod tests {
             80,
             5401,
             TcpFlags::default(),
-            vec![0; 100],
+            &[0u8; 100],
         )
         .unwrap();
 
@@ -852,7 +852,7 @@ mod tests {
             bar_contained_ip(),
             1,
             bar_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -863,7 +863,7 @@ mod tests {
             bar_contained_ip(),
             1,
             foo_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -877,7 +877,7 @@ mod tests {
             proxy_ip4_1(),
             1,
             bar_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -891,7 +891,7 @@ mod tests {
             proxy_ip4_1(),
             1,
             foo_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -921,7 +921,7 @@ mod tests {
             proxy_ip4_1(),
             1,
             foo_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -932,7 +932,7 @@ mod tests {
             proxy_ip4_1(),
             1,
             600,
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -946,7 +946,7 @@ mod tests {
             "1.1.1.1".parse::<Ipv4Addr>().unwrap(),
             1,
             600,
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -977,7 +977,7 @@ mod tests {
             proxy_ip4_1(),
             1,
             foo_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -993,7 +993,7 @@ mod tests {
             client_tun_ipv4(),
             foo_allowed_port(),
             1,
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -1007,7 +1007,7 @@ mod tests {
             client_tun_ipv4(),
             foo_allowed_port(),
             1,
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -1051,7 +1051,7 @@ mod tests {
                 proxy_ip4_1(),
                 1,
                 foo_allowed_port(),
-                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 0, 0, 0, 0, 0, 0],
             )
             .unwrap();
 
@@ -1076,7 +1076,7 @@ mod tests {
                 client_tun_ipv4(),
                 foo_allowed_port(),
                 1,
-                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 0, 0, 0, 0, 0, 0],
             )
             .unwrap();
 
@@ -1089,7 +1089,7 @@ mod tests {
                 proxy_ip4_1(),
                 2, // Using a new source port
                 foo_allowed_port(),
-                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 0, 0, 0, 0, 0, 0],
             )
             .unwrap();
 
@@ -1110,7 +1110,7 @@ mod tests {
                 client_tun_ipv4(),
                 foo_allowed_port(),
                 2,
-                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 0, 0, 0, 0, 0, 0],
             )
             .unwrap();
 
@@ -1145,7 +1145,7 @@ mod tests {
             proxy_ip4_1(),
             1,
             foo_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -1201,7 +1201,7 @@ mod tests {
             proxy_ip6_1(),
             1,
             foo_allowed_port(),
-            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
         )
         .unwrap();
 
@@ -1233,7 +1233,7 @@ mod tests {
         );
 
         let icmp_unreachable = ip_packet::make::icmp_dest_unreachable_network(
-            &ip_packet::make::udp_packet(proxy_ip4_1(), client_tun_ipv4(), 443, 50000, vec![])
+            &ip_packet::make::udp_packet(proxy_ip4_1(), client_tun_ipv4(), 443, 50000, &[])
                 .unwrap(),
         )
         .unwrap();
@@ -1453,15 +1453,10 @@ mod proptests {
             };
 
             let packet = match protocol {
-                Protocol::Tcp { dport } => tcp_packet(
-                    src,
-                    *dest,
-                    sport,
-                    *dport,
-                    TcpFlags::default(),
-                    payload.clone(),
-                ),
-                Protocol::Udp { dport } => udp_packet(src, *dest, sport, *dport, payload.clone()),
+                Protocol::Tcp { dport } => {
+                    tcp_packet(src, *dest, sport, *dport, TcpFlags::default(), &payload)
+                }
+                Protocol::Udp { dport } => udp_packet(src, *dest, sport, *dport, &payload),
                 Protocol::Icmp => icmp_request_packet(src, *dest, 1, 0, &[]),
             }
             .unwrap();
@@ -1516,15 +1511,10 @@ mod proptests {
 
         for (_, protocol) in protocol_config {
             let packet = match protocol {
-                Protocol::Tcp { dport } => tcp_packet(
-                    src,
-                    dest,
-                    sport,
-                    dport,
-                    TcpFlags::default(),
-                    payload.clone(),
-                ),
-                Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
+                Protocol::Tcp { dport } => {
+                    tcp_packet(src, dest, sport, dport, TcpFlags::default(), &payload)
+                }
+                Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, &payload),
                 Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
             }
             .unwrap();
@@ -1566,9 +1556,9 @@ mod proptests {
         );
         let packet = match protocol {
             Protocol::Tcp { dport } => {
-                tcp_packet(src, dest, sport, dport, TcpFlags::default(), payload)
+                tcp_packet(src, dest, sport, dport, TcpFlags::default(), &payload)
             }
-            Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload),
+            Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, &payload),
             Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
         }
         .unwrap();
@@ -1624,24 +1614,19 @@ mod proptests {
         );
 
         let packet_allowed = match protocol_allowed {
-            Protocol::Tcp { dport } => tcp_packet(
-                src,
-                dest,
-                sport,
-                dport,
-                TcpFlags::default(),
-                payload.clone(),
-            ),
-            Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
+            Protocol::Tcp { dport } => {
+                tcp_packet(src, dest, sport, dport, TcpFlags::default(), &payload)
+            }
+            Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, &payload),
             Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
         }
         .unwrap();
 
         let packet_rejected = match protocol_removed {
             Protocol::Tcp { dport } => {
-                tcp_packet(src, dest, sport, dport, TcpFlags::default(), payload)
+                tcp_packet(src, dest, sport, dport, TcpFlags::default(), &payload)
             }
-            Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload),
+            Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, &payload),
             Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
         }
         .unwrap();

--- a/rust/libs/connlib/tunnel/src/tests/dns_server_resource.rs
+++ b/rust/libs/connlib/tunnel/src/tests/dns_server_resource.rs
@@ -59,6 +59,7 @@ impl UdpDnsServerResource {
             let query = dns_types::Query::parse(udp.payload()).unwrap();
 
             let response = handle_dns_query(&query, global_dns_records, now);
+            let response_bytes = response.into_bytes(MAX_UDP_PAYLOAD);
 
             self.outbound_packets.push_back(
                 ip_packet::make::udp_packet(
@@ -66,7 +67,7 @@ impl UdpDnsServerResource {
                     packet.source(),
                     udp.destination_port(),
                     udp.source_port(),
-                    response.into_bytes(MAX_UDP_PAYLOAD),
+                    &response_bytes,
                 )
                 .expect("src and dst are retrieved from the same packet"),
             )

--- a/rust/libs/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sim_client.rs
@@ -184,8 +184,9 @@ impl SimClient {
 
         match dns_transport {
             DnsTransport::Udp { local_port } => {
+                let query_bytes = query.into_bytes();
                 let packet =
-                    ip_packet::make::udp_packet(src, sentinel, local_port, 53, query.into_bytes())
+                    ip_packet::make::udp_packet(src, sentinel, local_port, 53, &query_bytes)
                         .unwrap();
 
                 self.sent_udp_dns_queries

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -290,14 +290,9 @@ impl TunnelTest {
             } => {
                 let dst = address_from_destination(&dst, &state, &src, client_id);
 
-                let packet = ip_packet::make::udp_packet(
-                    src,
-                    dst,
-                    sport.0,
-                    dport.0,
-                    payload.to_be_bytes().to_vec(),
-                )
-                .unwrap();
+                let packet =
+                    ip_packet::make::udp_packet(src, dst, sport.0, dport.0, &payload.to_be_bytes())
+                        .unwrap();
 
                 let client = state.clients.get_mut(&client_id).unwrap();
                 let transmit = client.exec_mut(|sim| sim.encapsulate(packet, now));

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn/checksum.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn/checksum.rs
@@ -157,7 +157,7 @@ mod tests {
             old_dst_ip,
             old_src_port,
             old_dst_port,
-            old_udp_payload.to_vec(),
+            &old_udp_payload,
         )
         .unwrap();
         let incoming_checksum = incoming_ip_packet.as_udp().unwrap().checksum();
@@ -175,7 +175,7 @@ mod tests {
             new_dst_ip,
             new_src_port,
             new_dst_port,
-            new_udp_payload.to_vec(),
+            &new_udp_payload,
         )
         .unwrap();
         let outgoing_checksum = outgoing_ip_packet.as_udp().unwrap().checksum();


### PR DESCRIPTION
Previously, connlib performed redundant work on every packet: `IpPacket::new()` parsed UDP/TCP headers twice (once eagerly to capture for error messages, once to validate), `make::fz_p2p_control` heap-allocated a temporary buffer to assemble its payload, and `make::udp_packet`/`make::tcp_packet` accepted `Vec<u8>` payloads despite only ever borrowing them.

This PR eliminates the double-parse by deferring address extraction into lazy error closures, replaces the heap allocation in `fz_p2p_control` with a stack-allocated `[u8; MAX_IP_SIZE]` (already bounded by an existing `ensure!`), and changes the packet factory functions to take `&[u8]`, consistent with the existing `icmp_*` functions.