### PR TITLE
feat(apple): support streaming Swift logs to Sentry

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -639,6 +639,12 @@ pub fn hash_device_id(id: String) -> String {
     telemetry::hash_device_id(id)
 }
 
+/// Returns whether log streaming is currently active.
+#[uniffi::export]
+pub fn is_log_streaming_active() -> bool {
+    telemetry::feature_flags::stream_logs_active()
+}
+
 impl From<connlib_model::ResourceView> for Resource {
     fn from(resource: connlib_model::ResourceView) -> Self {
         match resource {

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -42,6 +42,12 @@ pub fn stream_logs(metadata: &Metadata<'_>) -> bool {
     FEATURE_FLAGS.stream_logs(metadata)
 }
 
+/// Returns whether log streaming is currently active (i.e. `stream_logs` flag is on
+/// and has non-empty directives).
+pub fn stream_logs_active() -> bool {
+    !FEATURE_FLAGS.stream_logs.read().directives.is_empty()
+}
+
 pub fn icmp_error_unreachable_prohibited_create_new_flow() -> bool {
     FEATURE_FLAGS.icmp_error_unreachable_prohibited_create_new_flow()
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -6,22 +6,62 @@
 
 import Foundation
 import OSLog
+import Sentry
 import SystemPackage
 
 public final class Log {
-  private static let logger: Logger = {
-    switch Bundle.main.bundleIdentifier {
-    case "dev.firezone.firezone":
-      return Logger(subsystem: "dev.firezone.firezone", category: "app")
-    case "dev.firezone.firezone.network-extension":
-      return Logger(subsystem: "dev.firezone.firezone", category: "tunnel")
-    default:
-      // Test environment or unknown bundle - use generic logger with "unknown" category
-      let bundleId = Bundle.main.bundleIdentifier ?? "nil"
-      Logger(subsystem: "dev.firezone.firezone", category: "unknown")
-        .warning("Unknown bundle identifier: \(bundleId). Using generic logger.")
-      return Logger(subsystem: "dev.firezone.firezone", category: "unknown")
+  private static let sentryLock = NSLock()
+  nonisolated(unsafe) private static var _streamingActive = false
+  nonisolated(unsafe) private static var _sentryAttributes: [String: Any] = [
+    "process": processName
+  ]
+
+  public static var isStreamingActive: Bool {
+    sentryLock.withLock { _streamingActive }
+  }
+
+  public static func setStreamingActive(_ active: Bool) {
+    let changed = sentryLock.withLock {
+      let old = _streamingActive
+      _streamingActive = active
+      return old != active
     }
+    if changed {
+      // The flag is already flipped, so the "enabled" message is
+      // itself streamed to Sentry, but "disabled" is not.
+      debug("Log streaming \(active ? "enabled" : "disabled")")
+    }
+  }
+
+  public static func setUser(firezoneId: String, accountSlug: String) {
+    sentryLock.withLock {
+      _sentryAttributes["user.id"] = firezoneId
+      _sentryAttributes["user.account_slug"] = accountSlug
+    }
+  }
+
+  public static func setEnvironment(_ environment: String) {
+    sentryLock.withLock {
+      _sentryAttributes["environment"] = environment
+    }
+  }
+
+  private static let processName: String = {
+    switch Bundle.main.bundleIdentifier {
+    case "dev.firezone.firezone": return "app"
+    case "dev.firezone.firezone.network-extension": return "tunnel"
+    default: return "unknown"
+    }
+  }()
+
+  private static let logger: Logger = {
+    let category = processName
+    if category == "unknown" {
+      let bundleId = Bundle.main.bundleIdentifier ?? "nil"
+      Logger(subsystem: "dev.firezone.firezone", category: category)
+        .warning("Unknown bundle identifier: \(bundleId). Using generic logger.")
+    }
+    return Logger(subsystem: "dev.firezone.firezone", category: category)
   }()
 
   private static let logWriter: LogWriter? = {
@@ -38,6 +78,21 @@ public final class Log {
     return LogWriter(folderURL: folderURL, logger: logger)
   }()
 
+  private static func sentryLog(severity: LogWriter.Severity, message: String) {
+    let attrs = sentryLock.withLock {
+      guard _streamingActive else { return nil as [String: Any]? }
+      return _sentryAttributes
+    }
+    guard let attrs else { return }
+    switch severity {
+    case .trace: return  // we don't bother sending trace-level logs to Sentry
+    case .debug: SentrySDK.logger.debug(message, attributes: attrs)
+    case .info: SentrySDK.logger.info(message, attributes: attrs)
+    case .warning: SentrySDK.logger.warn(message, attributes: attrs)
+    case .error: SentrySDK.logger.error(message, attributes: attrs)
+    }
+  }
+
   public static func log(_ message: String) {
     debug(message)
   }
@@ -45,26 +100,35 @@ public final class Log {
   public static func trace(_ message: String) {
     logger.trace("\(message, privacy: .public)")
     logWriter?.write(severity: .trace, message: message)
+    sentryLog(severity: .trace, message: message)
   }
 
   public static func debug(_ message: String) {
     self.logger.debug("\(message, privacy: .public)")
     logWriter?.write(severity: .debug, message: message)
+    sentryLog(severity: .debug, message: message)
   }
 
   public static func info(_ message: String) {
     logger.info("\(message, privacy: .public)")
     logWriter?.write(severity: .info, message: message)
+    sentryLog(severity: .info, message: message)
   }
 
   public static func warning(_ message: String) {
     logger.warning("\(message, privacy: .public)")
     logWriter?.write(severity: .warning, message: message)
+    sentryLog(severity: .warning, message: message)
+  }
+
+  public static func error(_ message: String) {
+    self.logger.error("\(message, privacy: .public)")
+    logWriter?.write(severity: .error, message: message)
+    sentryLog(severity: .error, message: message)
   }
 
   public static func error(_ err: Error) {
-    self.logger.error("\(err.localizedDescription, privacy: .public)")
-    logWriter?.write(severity: .error, message: err.localizedDescription)
+    error(err.localizedDescription)
 
     if shouldCaptureError(err) {
       Telemetry.capture(err)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -79,11 +79,11 @@ public final class Log {
   }()
 
   private static func sentryLog(severity: LogWriter.Severity, message: String) {
-    let attrs = sentryLock.withLock {
-      guard _streamingActive else { return nil as [String: Any]? }
+    let attrs: [String: Any] = sentryLock.withLock {
+      guard _streamingActive else { return [:] }
       return _sentryAttributes
     }
-    guard let attrs else { return }
+    guard !attrs.isEmpty else { return }
     switch severity {
     case .trace: return  // we don't bother sending trace-level logs to Sentry
     case .debug: SentrySDK.logger.debug(message, attributes: attrs)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -7,8 +7,10 @@
 import Sentry
 
 public enum Telemetry {
-  /// Sets the Sentry user from the firezone device ID and account slug.
+  /// Sets the Sentry user on both the scope (for error events) and log attributes.
   public static func setUser(firezoneId: String, accountSlug: String) {
+    Log.info("Configuring Sentry user: firezone_id=\(firezoneId), account_slug=\(accountSlug)")
+    Log.setUser(firezoneId: firezoneId, accountSlug: accountSlug)
     SentrySDK.configureScope { scope in
       let user = User(userId: firezoneId)
       user.data = ["account_slug": accountSlug]
@@ -24,6 +26,7 @@ public enum Telemetry {
       options.releaseName = releaseName()
       options.dist = distributionType()
       options.enableAppHangTracking = enableAppHangTracking
+      options.enableLogs = true
     }
   }
 
@@ -44,6 +47,7 @@ public enum Telemetry {
       return
     }
 
+    Log.setEnvironment(environment)
     SentrySDK.configureScope { configuration in
       configuration.setEnvironment(environment)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
@@ -29,23 +29,24 @@ public struct ConnlibState: Encodable, Decodable {
   private static let encoder = PropertyListEncoder()
   private static let decoder = PropertyListDecoder()
 
-  /// Decodes a ConnlibState from data and returns the fields and hash
+  public struct DecodedState {
+    public let resources: [FirezoneKit.Resource]?  // swiftlint:disable:this discouraged_optional_collection
+    public let unreachableResources: [UnreachableResource]
+    public let isLogStreamingActive: Bool
+    public let hash: Data
+  }
+
+  /// Decodes a ConnlibState from data and returns the fields and hash.
   /// - Parameter data: The encoded data to decode
-  /// - Returns: A tuple containing the resources, unreachable resources, log streaming flag, and hash
   /// - Throws: If decoding fails
-  public static func decode(
-    from data: Data
-  ) throws -> (
-    resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
-    unreachableResources: [UnreachableResource],
-    isLogStreamingActive: Bool,
-    hash: Data
-  ) {
+  public static func decode(from data: Data) throws -> DecodedState {
     let hash = Data(SHA256.hash(data: data))
     let state = try Self.decoder.decode(ConnlibState.self, from: data)
-    return (
-      resources: state.resources, unreachableResources: state.unreachableResources,
-      isLogStreamingActive: state.isLogStreamingActive, hash: hash
+    return DecodedState(
+      resources: state.resources,
+      unreachableResources: state.unreachableResources,
+      isLogStreamingActive: state.isLogStreamingActive,
+      hash: hash
     )
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct ConnlibState: Encodable, Decodable {
   // swiftlint:disable:next discouraged_optional_collection
-  private let resources: [FirezoneKit.Resource]?
-  private let unreachableResources: [UnreachableResource]
-  private let isLogStreamingActive: Bool
+  public let resources: [FirezoneKit.Resource]?
+  public let unreachableResources: [UnreachableResource]
+  public let isLogStreamingActive: Bool
 
   private enum CodingKeys: String, CodingKey {
     case resources
@@ -19,35 +19,36 @@ public struct ConnlibState: Encodable, Decodable {
     case isLogStreamingActive
   }
 
+  private init(
+    resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
+    unreachableResources: [UnreachableResource],
+    isLogStreamingActive: Bool
+  ) {
+    self.resources = resources
+    self.unreachableResources = unreachableResources
+    self.isLogStreamingActive = isLogStreamingActive
+  }
+
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     resources = try container.decodeIfPresent([FirezoneKit.Resource].self, forKey: .resources)
-    unreachableResources = try container.decode([UnreachableResource].self, forKey: .unreachableResources)
-    isLogStreamingActive = try container.decodeIfPresent(Bool.self, forKey: .isLogStreamingActive) ?? false
+    unreachableResources = try container.decode(
+      [UnreachableResource].self, forKey: .unreachableResources)
+    isLogStreamingActive =
+      try container.decodeIfPresent(Bool.self, forKey: .isLogStreamingActive) ?? false
   }
 
   private static let encoder = PropertyListEncoder()
   private static let decoder = PropertyListDecoder()
 
-  public struct DecodedState {
-    public let resources: [FirezoneKit.Resource]?  // swiftlint:disable:this discouraged_optional_collection
-    public let unreachableResources: [UnreachableResource]
-    public let isLogStreamingActive: Bool
-    public let hash: Data
-  }
-
-  /// Decodes a ConnlibState from data and returns the fields and hash.
+  /// Decodes a ConnlibState from data and returns the state and its SHA256 hash.
   /// - Parameter data: The encoded data to decode
+  /// - Returns: A tuple of the decoded state and its hash
   /// - Throws: If decoding fails
-  public static func decode(from data: Data) throws -> DecodedState {
+  public static func decode(from data: Data) throws -> (ConnlibState, Data) {
     let hash = Data(SHA256.hash(data: data))
     let state = try Self.decoder.decode(ConnlibState.self, from: data)
-    return DecodedState(
-      resources: state.resources,
-      unreachableResources: state.unreachableResources,
-      isLogStreamingActive: state.isLogStreamingActive,
-      hash: hash
-    )
+    return (state, hash)
   }
 
   /// Creates a ConnlibState from resources and returns encoded data only if different from currentHash

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
@@ -11,25 +11,41 @@ public struct ConnlibState: Encodable, Decodable {
   // swiftlint:disable:next discouraged_optional_collection
   private let resources: [FirezoneKit.Resource]?
   private let unreachableResources: [UnreachableResource]
+  private let isLogStreamingActive: Bool
+
+  private enum CodingKeys: String, CodingKey {
+    case resources
+    case unreachableResources
+    case isLogStreamingActive
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    resources = try container.decodeIfPresent([FirezoneKit.Resource].self, forKey: .resources)
+    unreachableResources = try container.decode([UnreachableResource].self, forKey: .unreachableResources)
+    isLogStreamingActive = try container.decodeIfPresent(Bool.self, forKey: .isLogStreamingActive) ?? false
+  }
 
   private static let encoder = PropertyListEncoder()
   private static let decoder = PropertyListDecoder()
 
   /// Decodes a ConnlibState from data and returns the fields and hash
   /// - Parameter data: The encoded data to decode
-  /// - Returns: A tuple containing the resources, unreachable resources, and hash
+  /// - Returns: A tuple containing the resources, unreachable resources, log streaming flag, and hash
   /// - Throws: If decoding fails
   public static func decode(
     from data: Data
   ) throws -> (
     resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
     unreachableResources: [UnreachableResource],
+    isLogStreamingActive: Bool,
     hash: Data
   ) {
     let hash = Data(SHA256.hash(data: data))
     let state = try Self.decoder.decode(ConnlibState.self, from: data)
     return (
-      resources: state.resources, unreachableResources: state.unreachableResources, hash: hash
+      resources: state.resources, unreachableResources: state.unreachableResources,
+      isLogStreamingActive: state.isLogStreamingActive, hash: hash
     )
   }
 
@@ -37,15 +53,19 @@ public struct ConnlibState: Encodable, Decodable {
   /// - Parameters:
   ///   - resources: Optional array of resources
   ///   - unreachableResources: Set of unreachable resources
+  ///   - isLogStreamingActive: Whether the NE has log streaming enabled
   ///   - currentHash: The hash to compare against
   /// - Returns: The encoded data if the hash differs, nil otherwise
   /// - Throws: If encoding fails
   public static func encodeIfChanged(
     resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
     unreachableResources: [UnreachableResource],
+    isLogStreamingActive: Bool,
     comparedTo currentHash: Data
   ) throws -> Data? {
-    let state = ConnlibState(resources: resources, unreachableResources: unreachableResources)
+    let state = ConnlibState(
+      resources: resources, unreachableResources: unreachableResources,
+      isLogStreamingActive: isLogStreamingActive)
     let encodedData = try Self.encoder.encode(state)
     let newHash = Data(SHA256.hash(data: encodedData))
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -436,8 +436,8 @@ public final class Store: ObservableObject {
   // MARK: Private functions
 
   private func fetchAndCacheFirezoneId() {
-    // Skip IPC if we already have a cached Firezone ID for this session
-    if userDefaults.string(forKey: "encodedFirezoneId") != nil {
+    if let firezoneId = userDefaults.string(forKey: "encodedFirezoneId") {
+      Telemetry.setUser(firezoneId: firezoneId, accountSlug: configuration.accountSlug)
       return
     }
 
@@ -514,6 +514,7 @@ public final class Store: ObservableObject {
     resourceList = ResourceList.loading
     connlibStateHash = Data()
     unreachableResources.removeAll()
+    Log.setStreamingActive(false)
   }
 
   /// Fetches state from the tunnel provider, using hash-based optimisation.
@@ -534,10 +535,14 @@ public final class Store: ObservableObject {
     }
 
     // Decode state and compute hash
-    let (resources, unreachableResources, hash) = try ConnlibState.decode(from: data)
+    let (resources, unreachableResources, isLogStreamingActive, hash) =
+      try ConnlibState.decode(from: data)
 
     // Update both hash and resource list
     self.connlibStateHash = hash
+
+    // Propagate log streaming state from the NE to the main app process
+    Log.setStreamingActive(isLogStreamingActive)
 
     if let resources = resources {
       resourceList = ResourceList.loaded(resources)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -535,26 +535,27 @@ public final class Store: ObservableObject {
     }
 
     // Decode state and compute hash
-    let decoded = try ConnlibState.decode(from: data)
+    let (state, hash) = try ConnlibState.decode(from: data)
 
     // Update both hash and resource list
-    self.connlibStateHash = decoded.hash
+    self.connlibStateHash = hash
 
     // Propagate log streaming state from the NE to the main app process
-    Log.setStreamingActive(decoded.isLogStreamingActive)
+    Log.setStreamingActive(state.isLogStreamingActive)
 
-    if let resources = decoded.resources {
+    if let resources = state.resources {
       resourceList = ResourceList.loaded(resources)
     }
 
-    let newlyUnreachableResources = Set(decoded.unreachableResources).subtracting(self.unreachableResources)
+    let newlyUnreachableResources = Set(state.unreachableResources).subtracting(
+      self.unreachableResources)
 
     await showNotificationsForUnreachableResources(
       unreachableResources: newlyUnreachableResources,
-      resources: decoded.resources ?? []
+      resources: state.resources ?? []
     )
 
-    self.unreachableResources = Set(decoded.unreachableResources)
+    self.unreachableResources = Set(state.unreachableResources)
   }
 
   private func showNotificationsForUnreachableResources(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -535,27 +535,26 @@ public final class Store: ObservableObject {
     }
 
     // Decode state and compute hash
-    let (resources, unreachableResources, isLogStreamingActive, hash) =
-      try ConnlibState.decode(from: data)
+    let decoded = try ConnlibState.decode(from: data)
 
     // Update both hash and resource list
-    self.connlibStateHash = hash
+    self.connlibStateHash = decoded.hash
 
     // Propagate log streaming state from the NE to the main app process
-    Log.setStreamingActive(isLogStreamingActive)
+    Log.setStreamingActive(decoded.isLogStreamingActive)
 
-    if let resources = resources {
+    if let resources = decoded.resources {
       resourceList = ResourceList.loaded(resources)
     }
 
-    let newlyUnreachableResources = Set(unreachableResources).subtracting(self.unreachableResources)
+    let newlyUnreachableResources = Set(decoded.unreachableResources).subtracting(self.unreachableResources)
 
     await showNotificationsForUnreachableResources(
       unreachableResources: newlyUnreachableResources,
-      resources: resources ?? []
+      resources: decoded.resources ?? []
     )
 
-    self.unreachableResources = Set(unreachableResources)
+    self.unreachableResources = Set(decoded.unreachableResources)
   }
 
   private func showNotificationsForUnreachableResources(

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -23,11 +23,12 @@ struct ConnlibStateTests {
     let data = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [unreachable],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let unwrappedData = try #require(data)
-    let (resources, unreachableResources, hash) = try ConnlibState.decode(from: unwrappedData)
+    let (resources, unreachableResources, _, hash) = try ConnlibState.decode(from: unwrappedData)
 
     #expect(hash.count == 32)  // SHA256 hash size
     #expect(resources?.count == 1)
@@ -42,19 +43,21 @@ struct ConnlibStateTests {
     let data1 = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let data2 = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let unwrappedData1 = try #require(data1)
     let unwrappedData2 = try #require(data2)
-    let (_, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
-    let (_, _, hash2) = try ConnlibState.decode(from: unwrappedData2)
+    let (_, _, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
+    let (_, _, _, hash2) = try ConnlibState.decode(from: unwrappedData2)
 
     #expect(hash1 == hash2)
   }
@@ -67,19 +70,21 @@ struct ConnlibStateTests {
     let data1 = try ConnlibState.encodeIfChanged(
       resources: [resource1],
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let data2 = try ConnlibState.encodeIfChanged(
       resources: [resource2],
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let unwrappedData1 = try #require(data1)
     let unwrappedData2 = try #require(data2)
-    let (_, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
-    let (_, _, hash2) = try ConnlibState.decode(from: unwrappedData2)
+    let (_, _, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
+    let (_, _, _, hash2) = try ConnlibState.decode(from: unwrappedData2)
 
     #expect(hash1 != hash2)
   }
@@ -95,16 +100,18 @@ struct ConnlibStateTests {
     let data = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [unreachable],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let unwrappedData = try #require(data)
-    let (_, _, hash) = try ConnlibState.decode(from: unwrappedData)
+    let (_, _, _, hash) = try ConnlibState.decode(from: unwrappedData)
 
     // Now try to encode again with the same hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [unreachable],
+      isLogStreamingActive: false,
       comparedTo: hash
     )
 
@@ -120,23 +127,25 @@ struct ConnlibStateTests {
     let data1 = try ConnlibState.encodeIfChanged(
       resources: [resource1],
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     let unwrappedData1 = try #require(data1)
-    let (_, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
+    let (_, _, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
 
     // Try to encode different state with first hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource2],
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: hash1
     )
 
     #expect(result != nil)
 
     let unwrappedResult = try #require(result)
-    let (resources, _, _) = try ConnlibState.decode(from: unwrappedResult)
+    let (resources, _, _, _) = try ConnlibState.decode(from: unwrappedResult)
     #expect(resources?.count == 1)
     #expect(resources?[0].id == "2")
   }
@@ -146,15 +155,56 @@ struct ConnlibStateTests {
     let result = try ConnlibState.encodeIfChanged(
       resources: nil,
       unreachableResources: [],
+      isLogStreamingActive: false,
       comparedTo: Data()
     )
 
     #expect(result != nil)
 
     let unwrappedResult = try #require(result)
-    let (resources, unreachableResources, _) = try ConnlibState.decode(from: unwrappedResult)
+    let (resources, unreachableResources, _, _) = try ConnlibState.decode(from: unwrappedResult)
     #expect(resources == nil)
     #expect(unreachableResources.isEmpty)
+  }
+
+  // MARK: - isLogStreamingActive Tests
+
+  @Test("decode() round-trips isLogStreamingActive = true")
+  func decodeRoundTripsLogStreamingActive() throws {
+    let data = try ConnlibState.encodeIfChanged(
+      resources: nil,
+      unreachableResources: [],
+      isLogStreamingActive: true,
+      comparedTo: Data()
+    )
+
+    let unwrapped = try #require(data)
+    let (_, _, isActive, _) = try ConnlibState.decode(from: unwrapped)
+
+    #expect(isActive == true)
+  }
+
+  @Test("encodeIfChanged() detects isLogStreamingActive change")
+  func encodeIfChangedDetectsLogStreamingChange() throws {
+    let data = try ConnlibState.encodeIfChanged(
+      resources: nil,
+      unreachableResources: [],
+      isLogStreamingActive: false,
+      comparedTo: Data()
+    )
+
+    let unwrapped = try #require(data)
+    let (_, _, _, hash) = try ConnlibState.decode(from: unwrapped)
+
+    // Same resources, different streaming flag — should return data
+    let result = try ConnlibState.encodeIfChanged(
+      resources: nil,
+      unreachableResources: [],
+      isLogStreamingActive: true,
+      comparedTo: hash
+    )
+
+    #expect(result != nil)
   }
 
   // MARK: - Helper Functions

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -28,12 +28,12 @@ struct ConnlibStateTests {
     )
 
     let unwrappedData = try #require(data)
-    let decoded = try ConnlibState.decode(from: unwrappedData)
+    let (state, hash) = try ConnlibState.decode(from: unwrappedData)
 
-    #expect(decoded.hash.count == 32)  // SHA256 hash size
-    #expect(decoded.resources?.count == 1)
-    #expect(decoded.resources?[0].id == "1")
-    #expect(decoded.unreachableResources.count == 1)
+    #expect(hash.count == 32)  // SHA256 hash size
+    #expect(state.resources?.count == 1)
+    #expect(state.resources?[0].id == "1")
+    #expect(state.unreachableResources.count == 1)
   }
 
   @Test("decode() produces same hash for identical content")
@@ -56,10 +56,10 @@ struct ConnlibStateTests {
 
     let unwrappedData1 = try #require(data1)
     let unwrappedData2 = try #require(data2)
-    let decoded1 = try ConnlibState.decode(from: unwrappedData1)
-    let decoded2 = try ConnlibState.decode(from: unwrappedData2)
+    let (_, hash1) = try ConnlibState.decode(from: unwrappedData1)
+    let (_, hash2) = try ConnlibState.decode(from: unwrappedData2)
 
-    #expect(decoded1.hash == decoded2.hash)
+    #expect(hash1 == hash2)
   }
 
   @Test("decode() produces different hash for different content")
@@ -83,10 +83,10 @@ struct ConnlibStateTests {
 
     let unwrappedData1 = try #require(data1)
     let unwrappedData2 = try #require(data2)
-    let decoded1 = try ConnlibState.decode(from: unwrappedData1)
-    let decoded2 = try ConnlibState.decode(from: unwrappedData2)
+    let (_, hash1) = try ConnlibState.decode(from: unwrappedData1)
+    let (_, hash2) = try ConnlibState.decode(from: unwrappedData2)
 
-    #expect(decoded1.hash != decoded2.hash)
+    #expect(hash1 != hash2)
   }
 
   // MARK: - encodeIfChanged() Tests
@@ -105,14 +105,14 @@ struct ConnlibStateTests {
     )
 
     let unwrappedData = try #require(data)
-    let decoded = try ConnlibState.decode(from: unwrappedData)
+    let (_, hash) = try ConnlibState.decode(from: unwrappedData)
 
     // Now try to encode again with the same hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [unreachable],
       isLogStreamingActive: false,
-      comparedTo: decoded.hash
+      comparedTo: hash
     )
 
     #expect(result == nil)
@@ -132,22 +132,22 @@ struct ConnlibStateTests {
     )
 
     let unwrappedData1 = try #require(data1)
-    let decoded1 = try ConnlibState.decode(from: unwrappedData1)
+    let (_, hash1) = try ConnlibState.decode(from: unwrappedData1)
 
     // Try to encode different state with first hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource2],
       unreachableResources: [],
       isLogStreamingActive: false,
-      comparedTo: decoded1.hash
+      comparedTo: hash1
     )
 
     #expect(result != nil)
 
     let unwrappedResult = try #require(result)
-    let decoded = try ConnlibState.decode(from: unwrappedResult)
-    #expect(decoded.resources?.count == 1)
-    #expect(decoded.resources?[0].id == "2")
+    let (state, _) = try ConnlibState.decode(from: unwrappedResult)
+    #expect(state.resources?.count == 1)
+    #expect(state.resources?[0].id == "2")
   }
 
   @Test("encodeIfChanged() handles nil resources")
@@ -162,9 +162,9 @@ struct ConnlibStateTests {
     #expect(result != nil)
 
     let unwrappedResult = try #require(result)
-    let decoded = try ConnlibState.decode(from: unwrappedResult)
-    #expect(decoded.resources == nil)
-    #expect(decoded.unreachableResources.isEmpty)
+    let (state, _) = try ConnlibState.decode(from: unwrappedResult)
+    #expect(state.resources == nil)
+    #expect(state.unreachableResources.isEmpty)
   }
 
   // MARK: - isLogStreamingActive Tests
@@ -179,9 +179,9 @@ struct ConnlibStateTests {
     )
 
     let unwrapped = try #require(data)
-    let decoded = try ConnlibState.decode(from: unwrapped)
+    let (state, _) = try ConnlibState.decode(from: unwrapped)
 
-    #expect(decoded.isLogStreamingActive == true)
+    #expect(state.isLogStreamingActive == true)
   }
 
   @Test("encodeIfChanged() detects isLogStreamingActive change")
@@ -194,14 +194,14 @@ struct ConnlibStateTests {
     )
 
     let unwrapped = try #require(data)
-    let decoded = try ConnlibState.decode(from: unwrapped)
+    let (_, hash) = try ConnlibState.decode(from: unwrapped)
 
     // Same resources, different streaming flag — should return data
     let result = try ConnlibState.encodeIfChanged(
       resources: nil,
       unreachableResources: [],
       isLogStreamingActive: true,
-      comparedTo: decoded.hash
+      comparedTo: hash
     )
 
     #expect(result != nil)

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -28,12 +28,12 @@ struct ConnlibStateTests {
     )
 
     let unwrappedData = try #require(data)
-    let (resources, unreachableResources, _, hash) = try ConnlibState.decode(from: unwrappedData)
+    let decoded = try ConnlibState.decode(from: unwrappedData)
 
-    #expect(hash.count == 32)  // SHA256 hash size
-    #expect(resources?.count == 1)
-    #expect(resources?[0].id == "1")
-    #expect(unreachableResources.count == 1)
+    #expect(decoded.hash.count == 32)  // SHA256 hash size
+    #expect(decoded.resources?.count == 1)
+    #expect(decoded.resources?[0].id == "1")
+    #expect(decoded.unreachableResources.count == 1)
   }
 
   @Test("decode() produces same hash for identical content")
@@ -56,10 +56,10 @@ struct ConnlibStateTests {
 
     let unwrappedData1 = try #require(data1)
     let unwrappedData2 = try #require(data2)
-    let (_, _, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
-    let (_, _, _, hash2) = try ConnlibState.decode(from: unwrappedData2)
+    let decoded1 = try ConnlibState.decode(from: unwrappedData1)
+    let decoded2 = try ConnlibState.decode(from: unwrappedData2)
 
-    #expect(hash1 == hash2)
+    #expect(decoded1.hash == decoded2.hash)
   }
 
   @Test("decode() produces different hash for different content")
@@ -83,10 +83,10 @@ struct ConnlibStateTests {
 
     let unwrappedData1 = try #require(data1)
     let unwrappedData2 = try #require(data2)
-    let (_, _, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
-    let (_, _, _, hash2) = try ConnlibState.decode(from: unwrappedData2)
+    let decoded1 = try ConnlibState.decode(from: unwrappedData1)
+    let decoded2 = try ConnlibState.decode(from: unwrappedData2)
 
-    #expect(hash1 != hash2)
+    #expect(decoded1.hash != decoded2.hash)
   }
 
   // MARK: - encodeIfChanged() Tests
@@ -105,14 +105,14 @@ struct ConnlibStateTests {
     )
 
     let unwrappedData = try #require(data)
-    let (_, _, _, hash) = try ConnlibState.decode(from: unwrappedData)
+    let decoded = try ConnlibState.decode(from: unwrappedData)
 
     // Now try to encode again with the same hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource],
       unreachableResources: [unreachable],
       isLogStreamingActive: false,
-      comparedTo: hash
+      comparedTo: decoded.hash
     )
 
     #expect(result == nil)
@@ -132,22 +132,22 @@ struct ConnlibStateTests {
     )
 
     let unwrappedData1 = try #require(data1)
-    let (_, _, _, hash1) = try ConnlibState.decode(from: unwrappedData1)
+    let decoded1 = try ConnlibState.decode(from: unwrappedData1)
 
     // Try to encode different state with first hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource2],
       unreachableResources: [],
       isLogStreamingActive: false,
-      comparedTo: hash1
+      comparedTo: decoded1.hash
     )
 
     #expect(result != nil)
 
     let unwrappedResult = try #require(result)
-    let (resources, _, _, _) = try ConnlibState.decode(from: unwrappedResult)
-    #expect(resources?.count == 1)
-    #expect(resources?[0].id == "2")
+    let decoded = try ConnlibState.decode(from: unwrappedResult)
+    #expect(decoded.resources?.count == 1)
+    #expect(decoded.resources?[0].id == "2")
   }
 
   @Test("encodeIfChanged() handles nil resources")
@@ -162,9 +162,9 @@ struct ConnlibStateTests {
     #expect(result != nil)
 
     let unwrappedResult = try #require(result)
-    let (resources, unreachableResources, _, _) = try ConnlibState.decode(from: unwrappedResult)
-    #expect(resources == nil)
-    #expect(unreachableResources.isEmpty)
+    let decoded = try ConnlibState.decode(from: unwrappedResult)
+    #expect(decoded.resources == nil)
+    #expect(decoded.unreachableResources.isEmpty)
   }
 
   // MARK: - isLogStreamingActive Tests
@@ -179,9 +179,9 @@ struct ConnlibStateTests {
     )
 
     let unwrapped = try #require(data)
-    let (_, _, isActive, _) = try ConnlibState.decode(from: unwrapped)
+    let decoded = try ConnlibState.decode(from: unwrapped)
 
-    #expect(isActive == true)
+    #expect(decoded.isLogStreamingActive == true)
   }
 
   @Test("encodeIfChanged() detects isLogStreamingActive change")
@@ -194,14 +194,14 @@ struct ConnlibStateTests {
     )
 
     let unwrapped = try #require(data)
-    let (_, _, _, hash) = try ConnlibState.decode(from: unwrapped)
+    let decoded = try ConnlibState.decode(from: unwrapped)
 
     // Same resources, different streaming flag — should return data
     let result = try ConnlibState.encodeIfChanged(
       resources: nil,
       unreachableResources: [],
       isLogStreamingActive: true,
-      comparedTo: hash
+      comparedTo: decoded.hash
     )
 
     #expect(result != nil)

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -43,8 +43,8 @@ actor Adapter {
 
   /// How often the NE polls Rust for the log-streaming feature flag.
   /// Shorter than `RE_EVAL_DURATION` (5 min) on the Rust side so the NE
-  /// picks up a flag change within ~1 minute of PostHog re-evaluation.
-  private static let featureFlagPollInterval: Duration = .seconds(60)
+  /// picks up a flag change soon after PostHog re-evaluation.
+  private static let featureFlagPollInterval: Duration = .seconds(5)
 
   // Our local copy of the accountSlug
   private let accountSlug: String

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -39,6 +39,12 @@ actor Adapter {
   private var eventLoopTask: CancellableTask?
   private var eventConsumerTask: CancellableTask?
   private var pathMonitorTask: CancellableTask?
+  private var featureFlagPollTask: CancellableTask?
+
+  /// How often the NE polls Rust for the log-streaming feature flag.
+  /// Shorter than `RE_EVAL_DURATION` (5 min) on the Rust side so the NE
+  /// picks up a flag change within ~1 minute of PostHog re-evaluation.
+  private static let featureFlagPollInterval: Duration = .seconds(60)
 
   // Our local copy of the accountSlug
   private let accountSlug: String
@@ -238,6 +244,15 @@ actor Adapter {
       }
     }
 
+    // Poll Rust feature flag to enable/disable native Swift log streaming to Sentry
+    featureFlagPollTask = CancellableTask { @Sendable in
+      while !Task.isCancelled {
+        let active = isLogStreamingActive()
+        Log.setStreamingActive(active)
+        try? await Task.sleep(for: Adapter.featureFlagPollInterval)
+      }
+    }
+
     // Wait for tunnel to be ready (first tunInterfaceUpdated event)
     try await withTaskCancellationHandler {
       try await withCheckedThrowingContinuation { continuation in
@@ -274,6 +289,10 @@ actor Adapter {
     // -> onTermination -> monitor.cancel()
     pathMonitorTask = nil
 
+    // Stop feature flag polling and disable log streaming
+    featureFlagPollTask = nil
+    Log.setStreamingActive(false)
+
     // Tasks will finish naturally after disconnect command is processed
     // No need to cancel them here - they'll clean up via their defer blocks
   }
@@ -287,6 +306,7 @@ actor Adapter {
       return try ConnlibState.encodeIfChanged(
         resources: self.resources?.map { self.convertResource($0) },
         unreachableResources: self.unreachableResources,
+        isLogStreamingActive: Log.isStreamingActive,
         comparedTo: hash
       )
     } catch {


### PR DESCRIPTION
This adds Sentry structured log forwarding for Swift-native logs, gated behind the `stream_logs` PostHog feature flag. Each log entry carries the environment, Firezone ID and account slug as attributes — structured logs have a separate dictionary and required separate configuration.

At the same time, add "process" attribute to denote whether it's the main app ("app") or NE process ("tunnel").

Rust side:
- Expose `stream_logs_active()` in telemetry feature_flags
- Add `is_log_streaming_active()` UniFFI-exported function

Swift side:
- Enable Sentry structured logs transport (like we do in Rust)
- Forward debug-level and above to Sentry (trace filtered out via severity check to avoid overwhelming the ingest budget)
- Thread-safe `Log.setUser()` propagates firezone_id and account_slug into every log entry's attributes
- `Telemetry.setUser()` now calls `Log.setUser()` so both error events and structured logs carry the same identity
- Fix: always call `Telemetry.setUser()` when a cached Firezone ID exists, not only when fetched fresh via IPC — previously a restart would leave Sentry with no user context until the next IPC round-trip
- Propagate the streaming flag from the Network Extension to the main app via `ConnlibState` IPC (NE polls FFI every 60s; app reads on state update)
- Disable streaming on VPN disconnect in both processes

Fixes #12289 