### PR TITLE
refactor(apple): inject UserDefaults for testability

### DIFF
--- a/swift/apple/.swiftlint.yml
+++ b/swift/apple/.swiftlint.yml
@@ -155,7 +155,7 @@ custom_rules:
     severity: error
   no_userdefaults_standard:
     name: "Prefer injected UserDefaults"
-    regex: 'UserDefaults\.standard'
+    regex: '(UserDefaults\.standard|:\s*UserDefaults\s*=\s*\.standard)'
     message: "Use injected userDefaults instead of .standard for testability. If this is a DI entry point or view code, add swiftlint:disable:next."
     severity: error
 

--- a/swift/apple/.swiftlint.yml
+++ b/swift/apple/.swiftlint.yml
@@ -153,5 +153,10 @@ custom_rules:
     regex: '(handle|fileHandle)\.write\((?!contentsOf:)'
     message: "'write' can throw uncatchable NSExceptions  - prefer `.write(contentsOf:)`"
     severity: error
+  no_userdefaults_standard:
+    name: "Prefer injected UserDefaults"
+    regex: 'UserDefaults\.standard'
+    message: "Use injected userDefaults instead of .standard for testability. If this is a DI entry point or view code, add swiftlint:disable:next."
+    severity: error
 
 reporter: xcode

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -108,6 +108,7 @@ public final class VPNConfigurationManager {
     let configuration = Configuration.shared
 
     if let actorName = legacyConfiguration["actorName"] {
+      // swiftlint:disable:next no_userdefaults_standard - legacy migration, runs before DI is available
       UserDefaults.standard.set(actorName, forKey: "actorName")
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -119,6 +119,7 @@ public class Configuration: ObservableObject {
 
   private var defaults: UserDefaults
 
+  // swiftlint:disable:next no_userdefaults_standard - DI entry point
   init(userDefaults: UserDefaults = UserDefaults.standard) {
     defaults = userDefaults
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
@@ -3,9 +3,11 @@ import Foundation
 public final class Favorites: ObservableObject {
   private static let key = "favoriteResourceIDs"
   private var ids: Set<String>
+  private let userDefaults: UserDefaults
 
-  public init() {
-    ids = Favorites.load()
+  public init(userDefaults: UserDefaults) {
+    self.userDefaults = userDefaults
+    ids = Self.load(from: userDefaults)
   }
 
   func contains(_ id: String) -> Bool {
@@ -37,11 +39,11 @@ public final class Favorites: ObservableObject {
   private func save() {
     // It's a run-time exception if we pass the `Set` directly here
     let ids = Array(ids)
-    UserDefaults.standard.set(ids, forKey: Favorites.key)
+    userDefaults.set(ids, forKey: Favorites.key)
   }
 
-  private static func load() -> Set<String> {
-    if let ids = UserDefaults.standard.stringArray(forKey: key) {
+  private static func load(from userDefaults: UserDefaults) -> Set<String> {
+    if let ids = userDefaults.stringArray(forKey: key) {
       return Set(ids)
     }
     return []

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -69,6 +69,7 @@ public final class Store: ObservableObject {
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
+      // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
@@ -85,6 +86,7 @@ public final class Store: ObservableObject {
     public init(
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
+      // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -18,7 +18,7 @@ import UserNotifications
 // TODO: Move some state logic to view models
 public final class Store: ObservableObject {
   @Published private(set) var actorName: String
-  @Published private(set) var favorites = Favorites()
+  @Published private(set) var favorites: Favorites
   @Published private(set) var resourceList: ResourceList = .loading
 
   // Encapsulate Tunnel status here to make it easier for other components to observe
@@ -58,6 +58,9 @@ public final class Store: ObservableObject {
   // Track which unreachable resource notifications we have already shown
   private var unreachableResources: Set<UnreachableResource> = []
 
+  /// UserDefaults instance for persisting GUI state.
+  let userDefaults: UserDefaults
+
   // Task consuming VPN status updates; its presence means observers are active.
   private var vpnStatusTask: CancellableTask?
 
@@ -65,25 +68,31 @@ public final class Store: ObservableObject {
     public init(
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
-      systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil
+      systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
+      userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
-      self.updateChecker = UpdateChecker(configuration: configuration)
+      self.updateChecker = UpdateChecker(configuration: configuration, userDefaults: userDefaults)
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
-      self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
-      self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
+      self.userDefaults = userDefaults
+      self.favorites = Favorites(userDefaults: userDefaults)
+      self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
+      self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
     }
   #else
     public init(
       configuration: Configuration? = nil,
-      sessionNotification: SessionNotificationProtocol = SessionNotification()
+      sessionNotification: SessionNotificationProtocol = SessionNotification(),
+      userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
       self.sessionNotification = sessionNotification
-      self.actorName = UserDefaults.standard.string(forKey: "actorName") ?? "Unknown user"
-      self.shownAlertIds = Set(UserDefaults.standard.stringArray(forKey: "shownAlertIds") ?? [])
+      self.userDefaults = userDefaults
+      self.favorites = Favorites(userDefaults: userDefaults)
+      self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
+      self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
     }
   #endif
@@ -385,7 +394,7 @@ public final class Store: ObservableObject {
 
     // This is only shown in the GUI, cache it here
     self.actorName = actorName
-    UserDefaults.standard.set(actorName, forKey: "actorName")
+    userDefaults.set(actorName, forKey: "actorName")
 
     configuration.accountSlug = accountSlug
 
@@ -393,7 +402,7 @@ public final class Store: ObservableObject {
 
     // Clear shown alerts when starting a new session so user can see new errors
     shownAlertIds.removeAll()
-    UserDefaults.standard.removeObject(forKey: "shownAlertIds")
+    userDefaults.removeObject(forKey: "shownAlertIds")
 
     // Clear notified unreachable resources for fresh session
     unreachableResources.removeAll()
@@ -426,7 +435,7 @@ public final class Store: ObservableObject {
 
   private func fetchAndCacheFirezoneId() {
     // Skip IPC if we already have a cached Firezone ID for this session
-    if UserDefaults.standard.string(forKey: "encodedFirezoneId") != nil {
+    if userDefaults.string(forKey: "encodedFirezoneId") != nil {
       return
     }
 
@@ -436,7 +445,7 @@ public final class Store: ObservableObject {
           let firezoneId = try await IPCClient.fetchEncodedFirezoneId(session: session)
         else { return }
 
-        UserDefaults.standard.set(firezoneId, forKey: "encodedFirezoneId")
+        userDefaults.set(firezoneId, forKey: "encodedFirezoneId")
         Telemetry.setUser(firezoneId: firezoneId, accountSlug: configuration.accountSlug)
       } catch {
         Log.error(error)
@@ -446,7 +455,7 @@ public final class Store: ObservableObject {
 
   private func markAlertAsShown(_ id: String) {
     shownAlertIds.insert(id)
-    UserDefaults.standard.set(Array(shownAlertIds), forKey: "shownAlertIds")
+    userDefaults.set(Array(shownAlertIds), forKey: "shownAlertIds")
   }
 
   // Network Extensions don't have a 2-way binding up to the GUI process,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -39,7 +39,9 @@ public struct AppView: View {
           }
 
           // Close window for day to day use
-          if vpnStatus != .invalid && systemExtensionStatus == .installed && launchedBefore() {
+          if vpnStatus != .invalid && systemExtensionStatus == .installed
+            && launchedBefore(userDefaults: store.userDefaults)
+          {
             WindowDefinition.main.window()?.close()
           }
         })
@@ -79,9 +81,9 @@ public struct AppView: View {
       }
     }
 
-    private static func launchedBefore() -> Bool {
-      let bool = UserDefaults.standard.bool(forKey: "launchedBefore")
-      UserDefaults.standard.set(true, forKey: "launchedBefore")
+    private static func launchedBefore(userDefaults: UserDefaults) -> Bool {
+      let bool = userDefaults.bool(forKey: "launchedBefore")
+      userDefaults.set(true, forKey: "launchedBefore")
 
       return bool
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -24,17 +24,20 @@
     }
 
     private var timerCancellable: AnyCancellable?
-    private let notificationAdapter: NotificationAdapter = NotificationAdapter()
+    private let notificationAdapter: NotificationAdapter
     private let versionCheckUrl: URL
     private let marketingVersion: SemanticVersion
     private let configuration: Configuration
+    private let userDefaults: UserDefaults
 
     private var cancellables: Set<AnyCancellable> = []
 
     @Published private(set) var updateAvailable: Bool = false
 
-    init(configuration: Configuration? = nil) {
+    init(configuration: Configuration? = nil, userDefaults: UserDefaults) {
       self.configuration = configuration ?? Configuration.shared
+      self.userDefaults = userDefaults
+      self.notificationAdapter = NotificationAdapter(userDefaults: userDefaults)
 
       guard let versionCheckUrl = URL(string: "https://www.firezone.dev/api/releases"),
         let versionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
@@ -105,7 +108,8 @@
             await MainActor.run {
               self.updateAvailable = true
 
-              if let lastDismissedVersion = getLastDismissedVersion(),
+              if let lastDismissedVersion = getLastDismissedVersion(
+                userDefaults: self.userDefaults),
                 lastDismissedVersion >= latestVersion
               {
                 return
@@ -131,7 +135,10 @@
     static let notificationIdentifier = "UPDATE_CATEGORY"
     static let dismissIdentifier = "DISMISS_ACTION"
 
-    override public init() {
+    let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults) {
+      self.userDefaults = userDefaults
       super.init()
 
       let notificationCenter = UNUserNotificationCenter.current()
@@ -169,7 +176,7 @@
 
     @MainActor func showUpdateNotification(version: SemanticVersion) {
       let content = UNMutableNotificationContent()
-      setLastNotifiedVersion(version: version)
+      setLastNotifiedVersion(version: version, userDefaults: userDefaults)
       content.title = "Update Firezone"
       content.body = "New version available"
       content.sound = .default
@@ -195,9 +202,9 @@
     ) {
       if response.actionIdentifier == NotificationAdapter.dismissIdentifier {
         // User dismissed this notification
-        if let lastNotifiedVersion = getLastNotifiedVersion() {
+        if let lastNotifiedVersion = getLastNotifiedVersion(userDefaults: userDefaults) {
           // Don't notify them again for this version
-          setLastDismissedVersion(version: lastNotifiedVersion)
+          setLastDismissedVersion(version: lastNotifiedVersion, userDefaults: userDefaults)
         }
 
         completionHandler()
@@ -237,37 +244,37 @@
   private let lastDismissedVersionKey = "lastDismissedVersion"
   private let lastNotifiedVersionKey = "lastNotifiedVersion"
 
-  private func setLastDismissedVersion(version: SemanticVersion) {
-    setVersion(key: lastDismissedVersionKey, version: version)
+  private func setLastDismissedVersion(version: SemanticVersion, userDefaults: UserDefaults) {
+    setVersion(key: lastDismissedVersionKey, version: version, userDefaults: userDefaults)
   }
 
-  private func setLastNotifiedVersion(version: SemanticVersion) {
-    setVersion(key: lastNotifiedVersionKey, version: version)
+  private func setLastNotifiedVersion(version: SemanticVersion, userDefaults: UserDefaults) {
+    setVersion(key: lastNotifiedVersionKey, version: version, userDefaults: userDefaults)
   }
 
-  private func getLastDismissedVersion() -> SemanticVersion? {
-    loadVersion(key: lastDismissedVersionKey)
+  private func getLastDismissedVersion(userDefaults: UserDefaults) -> SemanticVersion? {
+    loadVersion(key: lastDismissedVersionKey, userDefaults: userDefaults)
   }
 
-  private func getLastNotifiedVersion() -> SemanticVersion? {
-    loadVersion(key: lastNotifiedVersionKey)
+  private func getLastNotifiedVersion(userDefaults: UserDefaults) -> SemanticVersion? {
+    loadVersion(key: lastNotifiedVersionKey, userDefaults: userDefaults)
   }
 
-  func setVersion(key: String, version: SemanticVersion) {
+  func setVersion(key: String, version: SemanticVersion, userDefaults: UserDefaults) {
     let encoder = PropertyListEncoder()
 
     do {
       let data = try encoder.encode(version)
-      UserDefaults.standard.setValue(data, forKey: key)
+      userDefaults.setValue(data, forKey: key)
     } catch {
       Log.error(error)
     }
   }
 
-  func loadVersion(key: String) -> SemanticVersion? {
+  func loadVersion(key: String, userDefaults: UserDefaults) -> SemanticVersion? {
     let decoder = PropertyListDecoder()
 
-    guard let data = UserDefaults.standard.object(forKey: lastDismissedVersionKey) as? Data
+    guard let data = userDefaults.object(forKey: lastDismissedVersionKey) as? Data
     else { return nil }
 
     do {

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/FavoritesTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/FavoritesTests.swift
@@ -1,0 +1,128 @@
+//
+//  FavoritesTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Combine
+import Foundation
+import Testing
+
+@testable import FirezoneKit
+
+@Suite("Favorites Tests")
+struct FavoritesTests {
+
+  // MARK: - Core Operations
+
+  @Test("Starts empty when no prior data exists")
+  func startsEmpty() {
+    let defaults = makeTestDefaults()
+    let favorites = Favorites(userDefaults: defaults)
+
+    #expect(favorites.isEmpty())
+  }
+
+  @Test("Add makes resource ID contained")
+  func addMakesContained() {
+    let defaults = makeTestDefaults()
+    let favorites = Favorites(userDefaults: defaults)
+
+    favorites.add("resource-1")
+
+    #expect(favorites.contains("resource-1"))
+    #expect(!favorites.isEmpty())
+  }
+
+  @Test("Adding same ID twice is idempotent")
+  func addIdempotent() {
+    let defaults = makeTestDefaults()
+    let favorites = Favorites(userDefaults: defaults)
+
+    favorites.add("resource-1")
+    favorites.add("resource-1")
+
+    #expect(favorites.contains("resource-1"))
+    // Remove once - should be gone (not still there from double-add)
+    favorites.remove("resource-1")
+    #expect(!favorites.contains("resource-1"))
+  }
+
+  @Test("Remove makes resource ID no longer contained")
+  func removeWorks() {
+    let defaults = makeTestDefaults()
+    let favorites = Favorites(userDefaults: defaults)
+
+    favorites.add("resource-1")
+    favorites.remove("resource-1")
+
+    #expect(!favorites.contains("resource-1"))
+    #expect(favorites.isEmpty())
+  }
+
+  @Test("Reset clears all favorites")
+  func resetClearsAll() {
+    let defaults = makeTestDefaults()
+    let favorites = Favorites(userDefaults: defaults)
+
+    favorites.add("resource-1")
+    favorites.add("resource-2")
+    favorites.add("resource-3")
+    favorites.reset()
+
+    #expect(favorites.isEmpty())
+    #expect(!favorites.contains("resource-1"))
+    #expect(!favorites.contains("resource-2"))
+    #expect(!favorites.contains("resource-3"))
+  }
+
+  // MARK: - Persistence
+
+  @Test("Favorites persist across instances")
+  func favoritesPersistedAcrossInstances() {
+    let defaults = makeTestDefaults()
+
+    // First instance adds favorites
+    let favorites1 = Favorites(userDefaults: defaults)
+    favorites1.add("resource-1")
+    favorites1.add("resource-2")
+
+    // Second instance should load them
+    let favorites2 = Favorites(userDefaults: defaults)
+    #expect(favorites2.contains("resource-1"))
+    #expect(favorites2.contains("resource-2"))
+  }
+
+  // MARK: - ObservableObject Behavior
+
+  @Test("Add triggers objectWillChange")
+  @MainActor
+  func addTriggersChange() async throws {
+    let defaults = makeTestDefaults()
+    let favorites = Favorites(userDefaults: defaults)
+
+    await confirmation("objectWillChange fires on add") { confirm in
+      let cancellable = favorites.objectWillChange.sink { _ in
+        confirm()
+      }
+
+      favorites.add("resource-1")
+
+      // Keep cancellable alive
+      _ = cancellable
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  /// Creates an isolated UserDefaults instance for each test.
+  private func makeTestDefaults() -> UserDefaults {
+    let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      fatalError("Failed to create UserDefaults with suite: \(suiteName)")
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+}

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -30,6 +30,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
   private var logExportState: LogExportState = .idle
   private var tunnelConfiguration: TunnelConfiguration?
+  // swiftlint:disable:next no_userdefaults_standard
   private let defaults = UserDefaults.standard
 
   override init() {
@@ -49,7 +50,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       "NetworkExtension starting - Version: \(version), Build: \(build), Bundle ID: \(bundleId)")
 
     migrateFirezoneId()
-    self.tunnelConfiguration = TunnelConfiguration.tryLoad()
+    self.tunnelConfiguration = TunnelConfiguration.tryLoad(from: defaults)
   }
 
   override func startTunnel(
@@ -76,7 +77,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let decoder = PropertyListDecoder()
         let configFromOptions = try decoder.decode(TunnelConfiguration.self, from: configData)
         // Save it for future fallback (e.g., system-initiated restarts)
-        configFromOptions.save()
+        configFromOptions.save(to: defaults)
         self.tunnelConfiguration = configFromOptions
       } catch {
         Log.error(error)
@@ -104,7 +105,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     handleTokenSave(token)
 
     // The firezone id should be initialized by now
-    guard let rawId = UserDefaults.standard.string(forKey: "firezoneId")
+    guard let rawId = defaults.string(forKey: "firezoneId")
     else {
       completionHandler(PacketTunnelProviderError.firezoneIdIsInvalid)
       return
@@ -217,7 +218,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       switch providerMessage {
 
       case .setConfiguration(let tunnelConfiguration):
-        tunnelConfiguration.save()
+        tunnelConfiguration.save(to: defaults)
         self.tunnelConfiguration = tunnelConfiguration
 
         let adapter = self.adapter
@@ -243,7 +244,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           completionHandler?(connlibState)
         }
       case .getEncodedFirezoneId:
-        guard let rawId = UserDefaults.standard.string(forKey: "firezoneId") else {
+        guard let rawId = defaults.string(forKey: "firezoneId") else {
           Log.error(PacketTunnelProviderError.firezoneIdIsInvalid)
           completionHandler?(nil)
           return
@@ -514,7 +515,7 @@ private final class PacketTunnelProviderActorBridge: @unchecked Sendable {
 
 // Increase usefulness of TunnelConfiguration now that we're over the IPC barrier
 extension TunnelConfiguration {
-  func save() {
+  func save(to userDefaults: UserDefaults) {
     let key = "configurationCache"
 
     let dict: [String: Any] = [
@@ -524,13 +525,13 @@ extension TunnelConfiguration {
       "internetResourceEnabled": internetResourceEnabled,
     ]
 
-    UserDefaults.standard.set(dict, forKey: key)
+    userDefaults.set(dict, forKey: key)
   }
 
-  static func tryLoad() -> TunnelConfiguration? {
+  static func tryLoad(from userDefaults: UserDefaults) -> TunnelConfiguration? {
     let key = "configurationCache"
 
-    guard let dict = UserDefaults.standard.dictionary(forKey: key)
+    guard let dict = userDefaults.dictionary(forKey: key)
     else {
       return nil
     }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -30,7 +30,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
   private var logExportState: LogExportState = .idle
   private var tunnelConfiguration: TunnelConfiguration?
-  // swiftlint:disable:next no_userdefaults_standard
+  // swiftlint:disable:next no_userdefaults_standard - NetworkExtension DI entry point uses shared UserDefaults store
   private let defaults = UserDefaults.standard
 
   override init() {


### PR DESCRIPTION
Replace all direct UserDefaults.standard access with constructor-injected instances throughout the Apple client. This enables isolated unit testing without polluting the shared defaults store.

- Store, Favorites, UpdateChecker, NotificationAdapter: accept injected UserDefaults, threaded from Store as the top-level DI entry point
- Add swiftlint custom rule `no_userdefaults_standard` to catch future direct access; only 3 legitimate DI entry points retain disable comments
- Add FavoritesTests with isolated UserDefaults per test
- Fix bug in loadVersion(key:) which ignored its key parameter, always reading lastDismissedVersionKey instead