### PR TITLE
feat(portal): rate-limit web endpoint

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -375,6 +375,10 @@ config :portal, PortalAPI.RateLimit,
   refill_rate: 10,
   capacity: 200
 
+config :portal, PortalWeb.RateLimit,
+  refill_rate: 10,
+  capacity: 200
+
 ###############################
 ##### Third-party configs #####
 ###############################

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -316,6 +316,10 @@ if config_env() == :prod do
         signing_salt: env_var_to_config!(:live_view_signing_salt)
       ]
 
+    config :portal, PortalWeb.RateLimit,
+      refill_rate: env_var_to_config!(:web_refill_rate),
+      capacity: env_var_to_config!(:web_capacity)
+
     config :portal, api_url_override: env_var_to_config!(:api_url_override)
   end
 

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -178,6 +178,13 @@ config :portal, PortalWeb.Endpoint,
   url: [port: 13_100],
   server: true
 
+# Keep the endpoint limiter effectively disabled in general tests to avoid
+# cross-test interference from shared localhost IPs. Dedicated rate-limit tests
+# override this config with strict values.
+config :portal, PortalWeb.RateLimit,
+  refill_rate: 100_000,
+  capacity: 1_000_000
+
 config :portal, PortalWeb.Plugs.PutCSPHeader,
   csp_policy: [
     "default-src 'self' 'nonce-${nonce}' https://firezone.statuspage.io",

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -59,7 +59,7 @@ defmodule Portal.Application do
     # 1) Portal.Cluster sends goodbye while DB/PubSub are healthy.
     # 2) Replication managers disconnect while BEAM is still fully alive.
     # 3) Endpoints drain and terminate channels while Presence/PubSub/Repo are alive.
-    # 4) PortalAPI.RateLimit stops after endpoint traffic has ceased.
+    # 4) Portal{API,Web}.RateLimit stops after endpoint traffic has ceased.
     base_children ++
       client_session_buffer() ++
       gateway_session_buffer() ++
@@ -159,7 +159,9 @@ defmodule Portal.Application do
 
   defp rate_limit do
     case Portal.Config.get_env(:portal, :node_type, "portal") do
-      type when type in ["api", "portal"] -> [PortalAPI.RateLimit]
+      "api" -> [PortalAPI.RateLimit]
+      "web" -> [PortalWeb.RateLimit]
+      "portal" -> [PortalAPI.RateLimit, PortalWeb.RateLimit]
       _ -> []
     end
   end

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -135,6 +135,16 @@ defmodule Portal.Config.Definitions do
   defconfig(:api_capacity, :integer, default: 200)
 
   @doc """
+  The Web rate limiter uses a token bucket algorithm. This field sets the rate the bucket is refilled.
+  """
+  defconfig(:web_refill_rate, :integer, default: 10)
+
+  @doc """
+  The Web rate limiter uses a token bucket algorithm. This field sets the capacity of the bucket.
+  """
+  defconfig(:web_capacity, :integer, default: 200)
+
+  @doc """
   Enable or disable requiring secure cookies. Required for HTTPS.
   """
   defconfig(:phoenix_secure_cookies, :boolean, default: true)

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -65,6 +65,8 @@ defmodule PortalWeb.Endpoint do
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
 
+  plug PortalWeb.Plugs.RateLimit
+
   plug Plug.Session, @session_cookie
 
   plug PortalWeb.Plugs.FetchUserAgent

--- a/elixir/lib/portal_web/plugs/rate_limit.ex
+++ b/elixir/lib/portal_web/plugs/rate_limit.ex
@@ -1,0 +1,38 @@
+defmodule PortalWeb.Plugs.RateLimit do
+  import Plug.Conn
+
+  @default_refill_rate 10
+  @default_capacity 200
+
+  def init(opts), do: opts
+
+  def call(conn, opts) do
+    refill_rate = Keyword.get(opts, :refill_rate, config(:refill_rate, @default_refill_rate))
+    capacity = Keyword.get(opts, :capacity, config(:capacity, @default_capacity))
+    cost = Keyword.get(opts, :cost, PortalWeb.RateLimit.default_cost())
+
+    key = "web:#{ip_to_string(conn.remote_ip)}"
+
+    case PortalWeb.RateLimit.hit(key, refill_rate, capacity, cost) do
+      {:allow, _count} ->
+        conn
+
+      {:deny, retry_after_ms} ->
+        conn
+        |> put_resp_header("retry-after", Integer.to_string(ceil(retry_after_ms / 1000)))
+        |> send_resp(429, "Too Many Requests")
+        |> halt()
+    end
+  end
+
+  defp config(key, default) do
+    Portal.Config.get_env(:portal, PortalWeb.RateLimit, [])
+    |> Keyword.get(key, default)
+  end
+
+  defp ip_to_string(ip) do
+    ip
+    |> :inet.ntoa()
+    |> to_string()
+  end
+end

--- a/elixir/lib/portal_web/rate_limit.ex
+++ b/elixir/lib/portal_web/rate_limit.ex
@@ -1,0 +1,66 @@
+defmodule PortalWeb.RateLimit do
+  @moduledoc """
+  Distributed, eventually consistent rate limiter for `PortalWeb` HTTP requests.
+  """
+
+  @default_cost 10
+
+  def default_cost do
+    @default_cost
+  end
+
+  def hit(key, refill_rate, capacity, cost \\ @default_cost) do
+    :ok = broadcast({:hit, key, refill_rate, capacity, cost, Node.self()})
+    PortalWeb.RateLimit.Local.hit(key, refill_rate, capacity, cost)
+  end
+
+  defmodule Local do
+    @moduledoc false
+    use Hammer, backend: :ets, algorithm: :token_bucket
+  end
+
+  defmodule Listener do
+    @moduledoc false
+    use GenServer
+
+    @doc false
+    def start_link(opts) do
+      topic = Keyword.fetch!(opts, :topic)
+      GenServer.start_link(__MODULE__, topic)
+    end
+
+    @impl true
+    def init(topic) do
+      :ok = Portal.PubSub.subscribe(topic)
+      {:ok, []}
+    end
+
+    @impl true
+    def handle_info({:hit, key, refill_rate, capacity, cost, node}, state) do
+      if node != Node.self() do
+        {_allow_deny, _int} = Local.hit(key, refill_rate, capacity, cost)
+      end
+
+      {:noreply, state}
+    end
+  end
+
+  @topic "__webratelimit"
+
+  defp broadcast(message) do
+    Portal.PubSub.broadcast(@topic, message)
+  end
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor
+    }
+  end
+
+  def start_link(opts) do
+    children = [{Local, opts}, {Listener, topic: @topic}]
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end

--- a/elixir/test/portal_web/rate_limit_test.exs
+++ b/elixir/test/portal_web/rate_limit_test.exs
@@ -1,0 +1,51 @@
+defmodule PortalWeb.RateLimitTest do
+  use PortalWeb.ConnCase, async: false
+
+  setup do
+    previous_config = Application.get_env(:portal, PortalWeb.RateLimit)
+
+    Application.put_env(:portal, PortalWeb.RateLimit,
+      refill_rate: 1,
+      capacity: PortalWeb.RateLimit.default_cost()
+    )
+
+    on_exit(fn ->
+      if previous_config do
+        Application.put_env(:portal, PortalWeb.RateLimit, previous_config)
+      else
+        Application.delete_env(:portal, PortalWeb.RateLimit)
+      end
+    end)
+
+    :ok
+  end
+
+  test "limits repeated requests from the same client IP", %{conn: conn} do
+    ip = unique_ip()
+
+    first_resp =
+      conn
+      |> put_ip(ip)
+      |> get("/browser/config.xml")
+
+    assert response(first_resp, 200)
+
+    second_resp =
+      conn
+      |> recycle()
+      |> put_ip(ip)
+      |> get("/browser/config.xml")
+
+    assert response(second_resp, 429) == "Too Many Requests"
+    assert [retry_after] = get_resp_header(second_resp, "retry-after")
+    assert String.to_integer(retry_after) >= 1
+  end
+
+  defp put_ip(conn, ip) do
+    %{conn | remote_ip: ip}
+  end
+
+  defp unique_ip do
+    {:rand.uniform(255), :rand.uniform(255), :rand.uniform(255), :rand.uniform(255)}
+  end
+end


### PR DESCRIPTION
Implements an application-layer fallback rate limit for the web endpoint.
