### PR TITLE
chore(portal): ignore expected warnings on deploy

### DIFF
--- a/elixir/lib/portal/telemetry/sentry.ex
+++ b/elixir/lib/portal/telemetry/sentry.ex
@@ -1,8 +1,9 @@
 defmodule Portal.Telemetry.Sentry do
-  @ignored_message_patterns [
+  @ignored_message_regexes [
     # This happens when libcluster loses connection to a node, which is normal during deploys.
-    "Node ~p not responding **~n** Removing (timedout) connection",
-    "[libcluster:default] unable to connect to"
+    ~r/Node ~p not responding \*\*~n\*\* Removing \(timedout\) connection/,
+    ~r/\[libcluster:default\] unable to connect to/,
+    ~r/^'global' at node '.+' disconnected node '.+' in order to prevent overlapping partitions$/
   ]
 
   def before_send(%{original_exception: %{skip_sentry: skip_sentry}}) when skip_sentry do
@@ -21,9 +22,12 @@ defmodule Portal.Telemetry.Sentry do
 
   def before_send(%{message: %{formatted: formatted_message}} = event)
       when is_binary(formatted_message) do
-    if Enum.any?(@ignored_message_patterns, fn p ->
-         String.contains?(formatted_message, p)
-       end) do
+    ignored_by_regex? =
+      Enum.any?(@ignored_message_regexes, fn regex ->
+        Regex.match?(regex, formatted_message)
+      end)
+
+    if ignored_by_regex? do
       nil
     else
       event

--- a/elixir/test/portal/telemetry/sentry_test.exs
+++ b/elixir/test/portal/telemetry/sentry_test.exs
@@ -1,0 +1,78 @@
+defmodule Portal.Telemetry.SentryTest do
+  use ExUnit.Case, async: true
+
+  describe "before_send/1" do
+    test "drops libcluster timeout warning messages" do
+      event = %{
+        message: %{
+          formatted: "Node ~p not responding **~n** Removing (timedout) connection"
+        }
+      }
+
+      assert Portal.Telemetry.Sentry.before_send(event) == nil
+    end
+
+    test "drops libcluster unable to connect warning messages" do
+      event = %{
+        message: %{
+          formatted: "[libcluster:default] unable to connect to :foo@127.0.0.1"
+        }
+      }
+
+      assert Portal.Telemetry.Sentry.before_send(event) == nil
+    end
+
+    test "drops libcluster global partition overlap warning messages" do
+      event = %{
+        message: %{
+          formatted:
+            "'global' at node 'worker@127.0.0.1' disconnected node 'worker@127.0.0.2' in order to prevent overlapping partitions"
+        }
+      }
+
+      assert Portal.Telemetry.Sentry.before_send(event) == nil
+    end
+
+    test "passes through unrelated messages" do
+      event = %{message: %{formatted: "some other warning"}}
+
+      assert Portal.Telemetry.Sentry.before_send(event) == event
+    end
+
+    test "does not drop partial global partition text" do
+      event = %{
+        message: %{
+          formatted: "'global' at node 'worker@127.0.0.1' saw partition overlap risk"
+        }
+      }
+
+      assert Portal.Telemetry.Sentry.before_send(event) == event
+    end
+
+    test "drops events with skip_sentry set on original exception" do
+      event = %{original_exception: %{skip_sentry: true}}
+
+      assert Portal.Telemetry.Sentry.before_send(event) == nil
+    end
+
+    test "drops Ecto.NoResultsError exceptions" do
+      event = %{original_exception: %Ecto.NoResultsError{}}
+
+      assert Portal.Telemetry.Sentry.before_send(event) == nil
+    end
+
+    test "drops invalid CSRF token exceptions" do
+      event = %{
+        original_exception: Plug.CSRFProtection.InvalidCSRFTokenError.exception([])
+      }
+
+      assert Portal.Telemetry.Sentry.before_send(event) == nil
+    end
+
+    test "passes through non-message events without ignored exceptions" do
+      event = %{foo: :bar}
+
+      assert Portal.Telemetry.Sentry.before_send(event) == event
+    end
+  end
+end


### PR DESCRIPTION
This happens on deploys and is no cause for alarm.

--- 

Fixes #12399 
