### PR TITLE
fix(connlib): `ensure!` on max packet size

### DIFF
--- a/rust/libs/connlib/ip-packet/src/make.rs
+++ b/rust/libs/connlib/ip-packet/src/make.rs
@@ -27,14 +27,14 @@ macro_rules! build {
 pub fn fz_p2p_control(header: [u8; 8], control_payload: &[u8]) -> Result<IpPacket> {
     let ip_payload_size = header.len() + control_payload.len();
 
-    anyhow::ensure!(ip_payload_size <= crate::MAX_IP_SIZE);
-
     let builder = etherparse::PacketBuilder::ipv6(
         crate::fz_p2p_control::ADDR.octets(),
         crate::fz_p2p_control::ADDR.octets(),
         0,
     );
     let packet_size = builder.size(ip_payload_size);
+
+    anyhow::ensure!(packet_size <= crate::MAX_IP_SIZE);
 
     let mut packet_buf = IpPacketBuf::new();
 


### PR DESCRIPTION
Copilot brought up this regression which seems to be valid feedback, but the PR merged before it could be addressed.

--- 

Related: https://github.com/firezone/firezone/pull/12357/changes#r2873249302
