### PR TITLE
fix(apple): correct loadVersion behavior

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SemanticVersion.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SemanticVersion.swift
@@ -60,4 +60,28 @@ struct SemanticVersion: Comparable, CustomStringConvertible, Codable {
   static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
     return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
   }
+
+  func save(to userDefaults: UserDefaults, forKey key: String) {
+    let encoder = PropertyListEncoder()
+
+    do {
+      let data = try encoder.encode(self)
+      userDefaults.setValue(data, forKey: key)
+    } catch {
+      Log.error(error)
+    }
+  }
+
+  init?(from userDefaults: UserDefaults, forKey key: String) {
+    guard let data = userDefaults.object(forKey: key) as? Data else { return nil }
+
+    let decoder = PropertyListDecoder()
+
+    do {
+      self = try decoder.decode(SemanticVersion.self, from: data)
+    } catch {
+      Log.error(error)
+      return nil
+    }
+  }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SemanticVersion.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SemanticVersion.swift
@@ -66,14 +66,14 @@ struct SemanticVersion: Comparable, CustomStringConvertible, Codable {
 
     do {
       let data = try encoder.encode(self)
-      userDefaults.setValue(data, forKey: key)
+      userDefaults.set(data, forKey: key)
     } catch {
       Log.error(error)
     }
   }
 
   init?(from userDefaults: UserDefaults, forKey key: String) {
-    guard let data = userDefaults.object(forKey: key) as? Data else { return nil }
+    guard let data = userDefaults.data(forKey: key) else { return nil }
 
     let decoder = PropertyListDecoder()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -245,47 +245,19 @@
   private let lastNotifiedVersionKey = "lastNotifiedVersion"
 
   private func setLastDismissedVersion(version: SemanticVersion, userDefaults: UserDefaults) {
-    setVersion(key: lastDismissedVersionKey, version: version, userDefaults: userDefaults)
+    version.save(to: userDefaults, forKey: lastDismissedVersionKey)
   }
 
   private func setLastNotifiedVersion(version: SemanticVersion, userDefaults: UserDefaults) {
-    setVersion(key: lastNotifiedVersionKey, version: version, userDefaults: userDefaults)
+    version.save(to: userDefaults, forKey: lastNotifiedVersionKey)
   }
 
   private func getLastDismissedVersion(userDefaults: UserDefaults) -> SemanticVersion? {
-    loadVersion(key: lastDismissedVersionKey, userDefaults: userDefaults)
+    SemanticVersion(from: userDefaults, forKey: lastDismissedVersionKey)
   }
 
   private func getLastNotifiedVersion(userDefaults: UserDefaults) -> SemanticVersion? {
-    loadVersion(key: lastNotifiedVersionKey, userDefaults: userDefaults)
-  }
-
-  func setVersion(key: String, version: SemanticVersion, userDefaults: UserDefaults) {
-    let encoder = PropertyListEncoder()
-
-    do {
-      let data = try encoder.encode(version)
-      userDefaults.setValue(data, forKey: key)
-    } catch {
-      Log.error(error)
-    }
-  }
-
-  func loadVersion(key: String, userDefaults: UserDefaults) -> SemanticVersion? {
-    let decoder = PropertyListDecoder()
-
-    guard let data = userDefaults.object(forKey: lastDismissedVersionKey) as? Data
-    else { return nil }
-
-    do {
-      let version = try decoder.decode(SemanticVersion.self, from: data)
-
-      return version
-    } catch {
-      Log.error(error)
-
-      return nil
-    }
+    SemanticVersion(from: userDefaults, forKey: lastNotifiedVersionKey)
   }
 
 #endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
@@ -13,23 +13,12 @@ import Testing
 @Suite("Configuration Tests")
 struct ConfigurationTests {
 
-  // Each call creates a unique suite for proper test isolation
-  private func makeTestDefaults() -> UserDefaults {
-    let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
-    guard let defaults = UserDefaults(suiteName: suiteName) else {
-      fatalError("Failed to create UserDefaults with suite: \(suiteName)")
-    }
-    // Clear any existing values (shouldn't be any with UUID-based name)
-    defaults.removePersistentDomain(forName: suiteName)
-    return defaults
-  }
-
   // MARK: - Default Values
 
   @Test("Returns default values when UserDefaults is empty")
   @MainActor
   func defaultValues() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     #expect(config.authURL == Configuration.defaultAuthURL)
@@ -48,7 +37,7 @@ struct ConfigurationTests {
   @Test("String defaults use fallback when key is missing")
   @MainActor
   func stringDefaultsFallback() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     // Verify the fallback logic works - string(forKey:) returns nil, so ?? kicks in
@@ -69,7 +58,7 @@ struct ConfigurationTests {
   @Test("String properties persist to UserDefaults")
   @MainActor
   func stringPropertiesPersist() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     config.authURL = "https://custom.auth.url"
@@ -95,7 +84,7 @@ struct ConfigurationTests {
   @Test("Boolean properties persist to UserDefaults")
   @MainActor
   func booleanPropertiesPersist() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     config.connectOnStart = true
@@ -126,7 +115,7 @@ struct ConfigurationTests {
   @Test("toTunnelConfiguration returns correct values")
   @MainActor
   func tunnelConfiguration() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     config.apiURL = "wss://test.api"
@@ -174,7 +163,7 @@ struct ConfigurationTests {
   @Test("Published properties initialized from UserDefaults")
   @MainActor
   func publishedPropertiesInitialized() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
 
     // Set values before creating Configuration
     defaults.set(true, forKey: "internetResourceEnabled")
@@ -194,7 +183,7 @@ struct ConfigurationTests {
   @Test("Published properties update when regular properties change")
   @MainActor
   func publishedPropertiesUpdateReactively() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     // Initially false
@@ -219,7 +208,7 @@ struct ConfigurationTests {
   @Test("Published properties update when UserDefaults changes externally")
   @MainActor
   func publishedPropertiesUpdateFromExternalChanges() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     // Initially false
@@ -245,7 +234,7 @@ struct ConfigurationTests {
   @Test("objectWillChange emits when properties change")
   @MainActor
   func objectWillChangeEmits() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
     // Wait for objectWillChange to emit and verify state changed correctly
@@ -273,7 +262,7 @@ struct ConfigurationTests {
   @Test("Configuration reads pre-existing UserDefaults values")
   @MainActor
   func readsPreExistingValues() async {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
 
     // Set values before creating Configuration
     defaults.set("https://preset.auth", forKey: "authURL")
@@ -297,7 +286,7 @@ struct ConfigurationTests {
   @Test("Multiple Configuration instances share same UserDefaults")
   @MainActor
   func sharedUserDefaults() async throws {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let config1 = Configuration(userDefaults: defaults)
     let config2 = Configuration(userDefaults: defaults)
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/FavoritesTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/FavoritesTests.swift
@@ -17,7 +17,7 @@ struct FavoritesTests {
 
   @Test("Starts empty when no prior data exists")
   func startsEmpty() {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let favorites = Favorites(userDefaults: defaults)
 
     #expect(favorites.isEmpty())
@@ -25,7 +25,7 @@ struct FavoritesTests {
 
   @Test("Add makes resource ID contained")
   func addMakesContained() {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let favorites = Favorites(userDefaults: defaults)
 
     favorites.add("resource-1")
@@ -36,7 +36,7 @@ struct FavoritesTests {
 
   @Test("Adding same ID twice is idempotent")
   func addIdempotent() {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let favorites = Favorites(userDefaults: defaults)
 
     favorites.add("resource-1")
@@ -50,7 +50,7 @@ struct FavoritesTests {
 
   @Test("Remove makes resource ID no longer contained")
   func removeWorks() {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let favorites = Favorites(userDefaults: defaults)
 
     favorites.add("resource-1")
@@ -62,7 +62,7 @@ struct FavoritesTests {
 
   @Test("Reset clears all favorites")
   func resetClearsAll() {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let favorites = Favorites(userDefaults: defaults)
 
     favorites.add("resource-1")
@@ -80,7 +80,7 @@ struct FavoritesTests {
 
   @Test("Favorites persist across instances")
   func favoritesPersistedAcrossInstances() {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
 
     // First instance adds favorites
     let favorites1 = Favorites(userDefaults: defaults)
@@ -98,7 +98,7 @@ struct FavoritesTests {
   @Test("Add triggers objectWillChange")
   @MainActor
   func addTriggersChange() async throws {
-    let defaults = makeTestDefaults()
+    let defaults = UserDefaults.makeTestDefaults()
     let favorites = Favorites(userDefaults: defaults)
 
     await confirmation("objectWillChange fires on add") { confirm in
@@ -111,18 +111,6 @@ struct FavoritesTests {
       // Keep cancellable alive
       _ = cancellable
     }
-  }
-
-  // MARK: - Private Helpers
-
-  /// Creates an isolated UserDefaults instance for each test.
-  private func makeTestDefaults() -> UserDefaults {
-    let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
-    guard let defaults = UserDefaults(suiteName: suiteName) else {
-      fatalError("Failed to create UserDefaults with suite: \(suiteName)")
-    }
-    defaults.removePersistentDomain(forName: suiteName)
-    return defaults
   }
 
 }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
@@ -1,0 +1,41 @@
+//
+//  SemanticVersionPersistenceTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+
+  import Foundation
+  import Testing
+
+  @testable import FirezoneKit
+
+  @Suite("SemanticVersion Persistence Tests")
+  struct SemanticVersionPersistenceTests {
+
+  private func makeTestDefaults() -> UserDefaults {
+    let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      fatalError("Failed to create UserDefaults with suite: \(suiteName)")
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  // BUG: loadVersion ignores its `key` parameter and always reads from
+  // `lastDismissedVersionKey`. This test documents that broken behaviour.
+  @Test("setVersion/loadVersion round-trip is broken — loadVersion ignores key")
+  func roundTripIsBroken() throws {
+    let defaults = makeTestDefaults()
+    let version = try SemanticVersion("1.2.3")
+
+    setVersion(key: "myKey", version: version, userDefaults: defaults)
+
+    // loadVersion should return `version` for "myKey", but it reads from the
+    // wrong key internally, so it returns nil.
+    let loaded = loadVersion(key: "myKey", userDefaults: defaults)
+    #expect(loaded == nil, "loadVersion ignores its key and reads lastDismissedVersionKey")
+  }
+
+#endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
@@ -14,19 +14,10 @@
   @Suite("SemanticVersion Persistence Tests")
   struct SemanticVersionPersistenceTests {
 
-  private func makeTestDefaults() -> UserDefaults {
-    let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
-    guard let defaults = UserDefaults(suiteName: suiteName) else {
-      fatalError("Failed to create UserDefaults with suite: \(suiteName)")
-    }
-    defaults.removePersistentDomain(forName: suiteName)
-    return defaults
-  }
-
-  @Test("save/init round-trips with the given key")
-  func roundTripsWithGivenKey() throws {
-    let defaults = makeTestDefaults()
-    let version = try SemanticVersion("1.2.3")
+    @Test("save/init round-trips with the given key")
+    func roundTripsWithGivenKey() throws {
+      let defaults = UserDefaults.makeTestDefaults()
+      let version = try SemanticVersion("1.2.3")
 
       version.save(to: defaults, forKey: "myKey")
 
@@ -34,11 +25,11 @@
       #expect(loaded == version)
     }
 
-  @Test("Different keys store independent values")
-  func differentKeysAreIndependent() throws {
-    let defaults = makeTestDefaults()
-    let versionA = try SemanticVersion("1.0.0")
-    let versionB = try SemanticVersion("2.0.0")
+    @Test("Different keys store independent values")
+    func differentKeysAreIndependent() throws {
+      let defaults = UserDefaults.makeTestDefaults()
+      let versionA = try SemanticVersion("1.0.0")
+      let versionB = try SemanticVersion("2.0.0")
 
       versionA.save(to: defaults, forKey: "keyA")
       versionB.save(to: defaults, forKey: "keyB")
@@ -47,9 +38,9 @@
       #expect(SemanticVersion(from: defaults, forKey: "keyB") == versionB)
     }
 
-  @Test("Returns nil for missing key")
-  func returnsNilForMissingKey() {
-    let defaults = makeTestDefaults()
+    @Test("Returns nil for missing key")
+    func returnsNilForMissingKey() {
+      let defaults = UserDefaults.makeTestDefaults()
 
       #expect(SemanticVersion(from: defaults, forKey: "nonexistent") == nil)
     }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
@@ -4,46 +4,42 @@
 //  LICENSE: Apache-2.0
 //
 
-#if os(macOS)
+import Foundation
+import Testing
 
-  import Foundation
-  import Testing
+@testable import FirezoneKit
 
-  @testable import FirezoneKit
+@Suite("SemanticVersion Persistence Tests")
+struct SemanticVersionPersistenceTests {
 
-  @Suite("SemanticVersion Persistence Tests")
-  struct SemanticVersionPersistenceTests {
+  @Test("save/init round-trips with the given key")
+  func roundTripsWithGivenKey() throws {
+    let defaults = UserDefaults.makeTestDefaults()
+    let version = try SemanticVersion("1.2.3")
 
-    @Test("save/init round-trips with the given key")
-    func roundTripsWithGivenKey() throws {
-      let defaults = UserDefaults.makeTestDefaults()
-      let version = try SemanticVersion("1.2.3")
+    version.save(to: defaults, forKey: "myKey")
 
-      version.save(to: defaults, forKey: "myKey")
-
-      let loaded = SemanticVersion(from: defaults, forKey: "myKey")
-      #expect(loaded == version)
-    }
-
-    @Test("Different keys store independent values")
-    func differentKeysAreIndependent() throws {
-      let defaults = UserDefaults.makeTestDefaults()
-      let versionA = try SemanticVersion("1.0.0")
-      let versionB = try SemanticVersion("2.0.0")
-
-      versionA.save(to: defaults, forKey: "keyA")
-      versionB.save(to: defaults, forKey: "keyB")
-
-      #expect(SemanticVersion(from: defaults, forKey: "keyA") == versionA)
-      #expect(SemanticVersion(from: defaults, forKey: "keyB") == versionB)
-    }
-
-    @Test("Returns nil for missing key")
-    func returnsNilForMissingKey() {
-      let defaults = UserDefaults.makeTestDefaults()
-
-      #expect(SemanticVersion(from: defaults, forKey: "nonexistent") == nil)
-    }
+    let loaded = SemanticVersion(from: defaults, forKey: "myKey")
+    #expect(loaded == version)
   }
 
-#endif
+  @Test("Different keys store independent values")
+  func differentKeysAreIndependent() throws {
+    let defaults = UserDefaults.makeTestDefaults()
+    let versionA = try SemanticVersion("1.0.0")
+    let versionB = try SemanticVersion("2.0.0")
+
+    versionA.save(to: defaults, forKey: "keyA")
+    versionB.save(to: defaults, forKey: "keyB")
+
+    #expect(SemanticVersion(from: defaults, forKey: "keyA") == versionA)
+    #expect(SemanticVersion(from: defaults, forKey: "keyB") == versionB)
+  }
+
+  @Test("Returns nil for missing key")
+  func returnsNilForMissingKey() {
+    let defaults = UserDefaults.makeTestDefaults()
+
+    #expect(SemanticVersion(from: defaults, forKey: "nonexistent") == nil)
+  }
+}

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/SemanticVersionPersistenceTests.swift
@@ -23,19 +23,36 @@
     return defaults
   }
 
-  // BUG: loadVersion ignores its `key` parameter and always reads from
-  // `lastDismissedVersionKey`. This test documents that broken behaviour.
-  @Test("setVersion/loadVersion round-trip is broken — loadVersion ignores key")
-  func roundTripIsBroken() throws {
+  @Test("save/init round-trips with the given key")
+  func roundTripsWithGivenKey() throws {
     let defaults = makeTestDefaults()
     let version = try SemanticVersion("1.2.3")
 
-    setVersion(key: "myKey", version: version, userDefaults: defaults)
+      version.save(to: defaults, forKey: "myKey")
 
-    // loadVersion should return `version` for "myKey", but it reads from the
-    // wrong key internally, so it returns nil.
-    let loaded = loadVersion(key: "myKey", userDefaults: defaults)
-    #expect(loaded == nil, "loadVersion ignores its key and reads lastDismissedVersionKey")
+      let loaded = SemanticVersion(from: defaults, forKey: "myKey")
+      #expect(loaded == version)
+    }
+
+  @Test("Different keys store independent values")
+  func differentKeysAreIndependent() throws {
+    let defaults = makeTestDefaults()
+    let versionA = try SemanticVersion("1.0.0")
+    let versionB = try SemanticVersion("2.0.0")
+
+      versionA.save(to: defaults, forKey: "keyA")
+      versionB.save(to: defaults, forKey: "keyB")
+
+      #expect(SemanticVersion(from: defaults, forKey: "keyA") == versionA)
+      #expect(SemanticVersion(from: defaults, forKey: "keyB") == versionB)
+    }
+
+  @Test("Returns nil for missing key")
+  func returnsNilForMissingKey() {
+    let defaults = makeTestDefaults()
+
+      #expect(SemanticVersion(from: defaults, forKey: "nonexistent") == nil)
+    }
   }
 
 #endif

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestSupport/UserDefaults+Testing.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/TestSupport/UserDefaults+Testing.swift
@@ -1,0 +1,21 @@
+//
+//  UserDefaults+Testing.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+
+extension UserDefaults {
+  /// Creates an ephemeral `UserDefaults` instance backed by a unique suite name.
+  ///
+  /// Each call returns a fresh, isolated store suitable for testing.
+  static func makeTestDefaults() -> UserDefaults {
+    let suiteName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+      fatalError("Failed to create UserDefaults with suite: \(suiteName)")
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+}

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,11 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12407">
+          Fixes update notification dismissal on macOS where dismissing one
+          version could be ignored due to reading from the wrong UserDefaults
+          key.
+        </ChangeItem>
         <ChangeItem pull="12355">
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.


### PR DESCRIPTION

`loadVersion(key:userDefaults:)` hardcoded `lastDismissedVersionKey`
instead of using the key parameter, so `getLastNotifiedVersion()` always
read from the wrong key. This confused update-notification dismissal
state on macOS.

First commit demonstrates the bug. Found during UserDefaults injection work,
separated out to be independently reviewed.