### PR TITLE
fix(android): bind input elements to current config

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/Config.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/model/Config.kt
@@ -2,10 +2,10 @@
 package dev.firezone.android.core.data.model
 
 data class Config(
-    var authUrl: String,
-    var apiUrl: String,
-    var logFilter: String,
-    var accountSlug: String,
-    var startOnLogin: Boolean,
-    var connectOnStart: Boolean,
+    val authUrl: String,
+    val apiUrl: String,
+    val logFilter: String,
+    val accountSlug: String,
+    val startOnLogin: Boolean,
+    val connectOnStart: Boolean,
 )

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
@@ -72,11 +72,9 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.configStateFlow.collect { config ->
-                        config?.let {
-                            binding.etAuthUrlInput.setText(it.authUrl)
-                            binding.etApiUrlInput.setText(it.apiUrl)
-                            binding.etLogFilterInput.setText(it.logFilter)
-                        }
+                        binding.etAuthUrlInput.setText(config.authUrl)
+                        binding.etApiUrlInput.setText(config.apiUrl)
+                        binding.etLogFilterInput.setText(config.logFilter)
                     }
                 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/AdvancedSettingsFragment.kt
@@ -70,28 +70,32 @@ class AdvancedSettingsFragment : Fragment(R.layout.fragment_settings_advanced) {
     private fun setupActionObservers() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.actionStateFlow.collect { action ->
-                    action?.let {
-                        viewModel.clearAction()
-                        when (it) {
-                            is SettingsViewModel.ViewAction.NavigateBack -> {
-                                requireActivity().finish()
-                            }
+                launch {
+                    viewModel.configStateFlow.collect { config ->
+                        config?.let {
+                            binding.etAuthUrlInput.setText(it.authUrl)
+                            binding.etApiUrlInput.setText(it.apiUrl)
+                            binding.etLogFilterInput.setText(it.logFilter)
+                        }
+                    }
+                }
 
-                            is SettingsViewModel.ViewAction.FillSettings -> {
-                                binding.etAuthUrlInput.apply {
-                                    setText(it.config.authUrl)
+                launch {
+                    viewModel.managedStatusStateFlow.collect { managedStatus ->
+                        managedStatus?.let {
+                            applyManagedStatus(it)
+                        }
+                    }
+                }
+
+                launch {
+                    viewModel.actionStateFlow.collect { action ->
+                        action?.let {
+                            viewModel.clearAction()
+                            when (it) {
+                                is SettingsViewModel.ViewAction.NavigateBack -> {
+                                    requireActivity().finish()
                                 }
-
-                                binding.etApiUrlInput.apply {
-                                    setText(it.config.apiUrl)
-                                }
-
-                                binding.etLogFilterInput.apply {
-                                    setText(it.config.logFilter)
-                                }
-
-                                applyManagedStatus(it.managedStatus)
                             }
                         }
                     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/GeneralSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/GeneralSettingsFragment.kt
@@ -61,28 +61,32 @@ class GeneralSettingsFragment : Fragment(R.layout.fragment_settings_general) {
     private fun setupActionObservers() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.actionStateFlow.collect { action ->
-                    action?.let {
-                        viewModel.clearAction()
-                        when (it) {
-                            is SettingsViewModel.ViewAction.NavigateBack -> {
-                                requireActivity().finish()
-                            }
+                launch {
+                    viewModel.configStateFlow.collect { config ->
+                        config?.let {
+                            binding.etAccountSlugInput.setText(it.accountSlug)
+                            binding.switchStartOnLogin.isChecked = it.startOnLogin
+                            binding.switchConnectOnStart.isChecked = it.connectOnStart
+                        }
+                    }
+                }
 
-                            is SettingsViewModel.ViewAction.FillSettings -> {
-                                binding.etAccountSlugInput.apply {
-                                    setText(it.config.accountSlug)
+                launch {
+                    viewModel.managedStatusStateFlow.collect { managedStatus ->
+                        managedStatus?.let {
+                            applyManagedStatus(it)
+                        }
+                    }
+                }
+
+                launch {
+                    viewModel.actionStateFlow.collect { action ->
+                        action?.let {
+                            viewModel.clearAction()
+                            when (it) {
+                                is SettingsViewModel.ViewAction.NavigateBack -> {
+                                    requireActivity().finish()
                                 }
-
-                                binding.switchStartOnLogin.apply {
-                                    isChecked = it.config.startOnLogin
-                                }
-
-                                binding.switchConnectOnStart.apply {
-                                    isChecked = it.config.connectOnStart
-                                }
-
-                                applyManagedStatus(it.managedStatus)
                             }
                         }
                     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/GeneralSettingsFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/GeneralSettingsFragment.kt
@@ -63,11 +63,9 @@ class GeneralSettingsFragment : Fragment(R.layout.fragment_settings_general) {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.configStateFlow.collect { config ->
-                        config?.let {
-                            binding.etAccountSlugInput.setText(it.accountSlug)
-                            binding.switchStartOnLogin.isChecked = it.startOnLogin
-                            binding.switchConnectOnStart.isChecked = it.connectOnStart
-                        }
+                        binding.etAccountSlugInput.setText(config.accountSlug)
+                        binding.switchStartOnLogin.isChecked = config.startOnLogin
+                        binding.switchConnectOnStart.isChecked = config.connectOnStart
                     }
                 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -39,7 +39,7 @@ internal class SettingsViewModel
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 
-        // Working config that gets modified during editing
+        // Working config that gets modified during editing using immutable copy
         private var config =
             Config(
                 authUrl = "",
@@ -51,8 +51,8 @@ internal class SettingsViewModel
             )
 
         // StateFlow that emits config only on load/reset, not during editing
-        private val _configStateFlow = MutableStateFlow<Config?>(null)
-        val configStateFlow: StateFlow<Config?> = _configStateFlow
+        private val _configStateFlow = MutableStateFlow(config)
+        val configStateFlow: StateFlow<Config> = _configStateFlow
 
         private val _managedStatusStateFlow = MutableStateFlow<ManagedConfigStatus?>(null)
         val managedStatusStateFlow: StateFlow<ManagedConfigStatus?> = _managedStatusStateFlow
@@ -96,32 +96,32 @@ internal class SettingsViewModel
         }
 
         fun onValidateAuthUrl(authUrl: String) {
-            this.config.authUrl = authUrl
+            config = config.copy(authUrl = authUrl)
             onFieldUpdated()
         }
 
         fun onValidateApiUrl(apiUrl: String) {
-            this.config.apiUrl = apiUrl
+            config = config.copy(apiUrl = apiUrl)
             onFieldUpdated()
         }
 
         fun onValidateLogFilter(logFilter: String) {
-            this.config.logFilter = logFilter
+            config = config.copy(logFilter = logFilter)
             onFieldUpdated()
         }
 
         fun onValidateAccountSlug(accountSlug: String) {
-            this.config.accountSlug = accountSlug
+            config = config.copy(accountSlug = accountSlug)
             onFieldUpdated()
         }
 
         fun onStartOnLoginChanged(isChecked: Boolean) {
-            this.config.startOnLogin = isChecked
+            config = config.copy(startOnLogin = isChecked)
             onFieldUpdated()
         }
 
         fun onConnectOnStartChanged(isChecked: Boolean) {
-            this.config.connectOnStart = isChecked
+            config = config.copy(connectOnStart = isChecked)
             onFieldUpdated()
         }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -39,6 +39,7 @@ internal class SettingsViewModel
         private val actionMutableStateFlow = MutableStateFlow<ViewAction?>(null)
         val actionStateFlow: StateFlow<ViewAction?> = actionMutableStateFlow
 
+        // Working config that gets modified during editing
         private var config =
             Config(
                 authUrl = "",
@@ -49,16 +50,20 @@ internal class SettingsViewModel
                 connectOnStart = false,
             )
 
+        // StateFlow that emits config only on load/reset, not during editing
+        private val _configStateFlow = MutableStateFlow<Config?>(null)
+        val configStateFlow: StateFlow<Config?> = _configStateFlow
+
+        private val _managedStatusStateFlow = MutableStateFlow<ManagedConfigStatus?>(null)
+        val managedStatusStateFlow: StateFlow<ManagedConfigStatus?> = _managedStatusStateFlow
+
         fun populateFieldsFromConfig() {
             viewModelScope.launch {
                 repo.getConfig().collect {
                     config = it
+                    _configStateFlow.value = it
+                    _managedStatusStateFlow.value = repo.getManagedStatus()
                     onFieldUpdated()
-                    actionMutableStateFlow.value =
-                        ViewAction.FillSettings(
-                            it,
-                            managedStatus = repo.getManagedStatus(),
-                        )
                 }
             }
         }
@@ -174,12 +179,9 @@ internal class SettingsViewModel
         fun resetSettingsToDefaults() {
             config = repo.getDefaultConfigSync()
             repo.resetFavorites()
+            _configStateFlow.value = config
+            _managedStatusStateFlow.value = repo.getManagedStatus()
             onFieldUpdated()
-            actionMutableStateFlow.value =
-                ViewAction.FillSettings(
-                    config = config,
-                    managedStatus = repo.getManagedStatus(),
-                )
         }
 
         fun clearAction() {
@@ -246,10 +248,5 @@ internal class SettingsViewModel
 
         internal sealed class ViewAction {
             data object NavigateBack : ViewAction()
-
-            data class FillSettings(
-                val config: Config,
-                val managedStatus: ManagedConfigStatus,
-            ) : ViewAction()
         }
     }


### PR DESCRIPTION
Instead of proactively filling the input elements in the settings screen with text, we need to expose a `MutableStateFlow` that holds the version of the config we want to display. The different fragments can then bind to this flow and update its values as they change.

In the current version, the text of the input elements is being set when the activity launches but at that point, the input elements for the advanced screen don't exist because they are on a different tab.