### PR TITLE
fix(portal): add missing replica scoping

### DIFF
--- a/elixir/lib/portal_web/components/layouts/app.html.heex
+++ b/elixir/lib/portal_web/components/layouts/app.html.heex
@@ -109,7 +109,7 @@
     Attempting to reconnect <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
   </.flash>
 
-  <% banner = Portal.Repo.one(Portal.Banner) %>
+  <% banner = Portal.Safe.unscoped(Portal.Banner, :replica) |> Portal.Safe.one() %>
   <div
     :if={banner}
     id="banner"

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -854,12 +854,12 @@ defmodule PortalWeb.Policies.Components do
         )
 
       # Combine all providers from different tables using Safe
-      (userpass_query |> Safe.scoped(subject) |> Safe.all()) ++
-        (email_otp_query |> Safe.scoped(subject) |> Safe.all()) ++
-        (oidc_query |> Safe.scoped(subject) |> Safe.all()) ++
-        (google_query |> Safe.scoped(subject) |> Safe.all()) ++
-        (entra_query |> Safe.scoped(subject) |> Safe.all()) ++
-        (okta_query |> Safe.scoped(subject) |> Safe.all())
+      (userpass_query |> Safe.scoped(subject, :replica) |> Safe.all()) ++
+        (email_otp_query |> Safe.scoped(subject, :replica) |> Safe.all()) ++
+        (oidc_query |> Safe.scoped(subject, :replica) |> Safe.all()) ++
+        (google_query |> Safe.scoped(subject, :replica) |> Safe.all()) ++
+        (entra_query |> Safe.scoped(subject, :replica) |> Safe.all()) ++
+        (okta_query |> Safe.scoped(subject, :replica) |> Safe.all())
     end
 
     # Inlined from PortalWeb.Groups.Components
@@ -938,7 +938,7 @@ defmodule PortalWeb.Policies.Components do
           query
         end
 
-      groups = query |> Safe.scoped(subject) |> Safe.all()
+      groups = query |> Safe.scoped(subject, :replica) |> Safe.all()
 
       # For metadata, we'll return a simple count
       metadata = %{limit: 25, count: length(groups)}

--- a/elixir/lib/portal_web/live/policies/edit.ex
+++ b/elixir/lib/portal_web/live/policies/edit.ex
@@ -291,7 +291,7 @@ defmodule PortalWeb.Policies.Edit do
 
     defp get_group_idp_id(group_id, subject) do
       from(g in Group, where: g.id == ^group_id, select: g.idp_id)
-      |> Safe.scoped(subject)
+      |> Safe.scoped(subject, :replica)
       |> Safe.one()
     end
 

--- a/elixir/lib/portal_web/live/sign_in/email.ex
+++ b/elixir/lib/portal_web/live/sign_in/email.ex
@@ -205,7 +205,7 @@ defmodule PortalWeb.SignIn.Email do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one()
+      query |> Safe.unscoped(:replica) |> Safe.one()
     end
   end
 end

--- a/elixir/lib/portal_web/live_hooks/fetch_account.ex
+++ b/elixir/lib/portal_web/live_hooks/fetch_account.ex
@@ -24,7 +24,7 @@ defmodule PortalWeb.LiveHooks.FetchAccount do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one()
+      query |> Safe.unscoped(:replica) |> Safe.one()
     end
   end
 end

--- a/elixir/lib/portal_web/plugs/fetch_account.ex
+++ b/elixir/lib/portal_web/plugs/fetch_account.ex
@@ -28,7 +28,7 @@ defmodule PortalWeb.Plugs.FetchAccount do
           do: from(a in Account, where: a.id == ^id_or_slug or a.slug == ^id_or_slug),
           else: from(a in Account, where: a.slug == ^id_or_slug)
 
-      query |> Safe.unscoped() |> Safe.one()
+      query |> Safe.unscoped(:replica) |> Safe.one()
     end
   end
 end


### PR DESCRIPTION
Adds missing `:replica` scope to some places that were missing it, which should resolve some backed up query drop errors coming in for the public routes.
