### PR TITLE
test(portal): assert_push init to avoid flakiness

### DIFF
--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -1341,6 +1341,7 @@ defmodule PortalAPI.Client.ChannelTest do
       account: account
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       updated_account = %{account | config: %{account.config | search_domain: "new.example.com"}}
 
       change = %Changes.Change{
@@ -1382,6 +1383,7 @@ defmodule PortalAPI.Client.ChannelTest do
            subject: subject
          } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       group = group_fixture(account: account)
       identity_fixture(actor: actor, account: account)
 
@@ -1440,6 +1442,7 @@ defmodule PortalAPI.Client.ChannelTest do
            subject: subject
          } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       group = group_fixture(account: account)
       identity_fixture(actor: actor, account: account)
 
@@ -1495,6 +1498,7 @@ defmodule PortalAPI.Client.ChannelTest do
            subject: subject
          } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
 
       # Create two groups
       group_1 = group_fixture(account: account)
@@ -1712,6 +1716,7 @@ defmodule PortalAPI.Client.ChannelTest do
       actor: actor
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
       site = site_fixture(account: account)
@@ -1771,6 +1776,7 @@ defmodule PortalAPI.Client.ChannelTest do
       actor: actor
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -1823,6 +1829,7 @@ defmodule PortalAPI.Client.ChannelTest do
            actor: actor
          } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -1916,6 +1923,7 @@ defmodule PortalAPI.Client.ChannelTest do
       actor: actor
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -1971,6 +1979,7 @@ defmodule PortalAPI.Client.ChannelTest do
       actor: actor
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -2029,6 +2038,7 @@ defmodule PortalAPI.Client.ChannelTest do
            actor: actor
          } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -2103,6 +2113,7 @@ defmodule PortalAPI.Client.ChannelTest do
            actor: actor
          } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group_1 = group_fixture(account: account)
       group_2 = group_fixture(account: account)
@@ -2198,6 +2209,7 @@ defmodule PortalAPI.Client.ChannelTest do
       actor: actor
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -2256,6 +2268,7 @@ defmodule PortalAPI.Client.ChannelTest do
       actor: actor
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       identity_fixture(actor: actor, account: account)
       group = group_fixture(account: account)
 
@@ -2312,6 +2325,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       candidates = ["foo", "bar"]
 
       send(
@@ -2335,6 +2349,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       candidates = ["foo", "bar"]
 
       send(
@@ -2354,6 +2369,7 @@ defmodule PortalAPI.Client.ChannelTest do
   describe "handle_in/3 create_flow" do
     test "returns error when resource is not found", %{client: client, subject: subject} do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       resource_id = Ecto.UUID.generate()
 
       push(socket, "create_flow", %{
@@ -2371,6 +2387,7 @@ defmodule PortalAPI.Client.ChannelTest do
       global_relay: global_relay
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       :ok = Portal.Presence.Relays.connect(global_relay)
 
       push(socket, "create_flow", %{
@@ -2388,6 +2405,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       resource = resource_fixture(account: account)
 
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
@@ -2417,6 +2435,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
 
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
@@ -2482,6 +2501,7 @@ defmodule PortalAPI.Client.ChannelTest do
       dns_resource: resource
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       gateway = gateway_fixture(account: account) |> Repo.preload(:site)
       gateway_token = gateway_token_fixture(account: account, site: gateway.site)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
@@ -2633,6 +2653,7 @@ defmodule PortalAPI.Client.ChannelTest do
       global_relay: global_relay
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       :ok = Portal.Presence.Relays.connect(global_relay)
       :ok = Channels.register_gateway(gateway.id)
 
@@ -2978,6 +2999,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       :ok = Portal.Presence.Relays.connect(global_relay)
       :ok = Channels.register_gateway(gateway.id)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
@@ -3025,6 +3047,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       :ok = Portal.Presence.Relays.connect(global_relay)
       :ok = Channels.register_gateway(gateway.id)
       :ok = connect_gateway_presence(gateway, gateway_token.id)
@@ -3085,6 +3108,7 @@ defmodule PortalAPI.Client.ChannelTest do
       subject: subject
     } do
       socket = join_channel(client, subject)
+      assert_push "init", _init_payload
       :ok = Portal.Presence.Relays.connect(global_relay)
       :ok = Channels.register_gateway(gateway.id)
       :ok = connect_gateway_presence(gateway, gateway_token.id)

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -207,6 +207,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       expired_policy_authorization =
         policy_authorization_fixture(
@@ -284,6 +285,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       expired_policy_authorization =
         policy_authorization_fixture(
@@ -502,6 +504,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       policy_authorization =
         policy_authorization_fixture(
@@ -633,6 +636,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
            group: group
          } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       channel_pid = self()
       socket_ref = make_ref()
@@ -822,6 +826,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
            group: group
          } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       channel_pid = self()
       socket_ref = make_ref()
@@ -1003,6 +1008,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       policy_authorization =
         policy_authorization_fixture(
@@ -1070,6 +1076,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       channel_pid = self()
       socket_ref = make_ref()
@@ -1155,6 +1162,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       policy_authorization =
         policy_authorization_fixture(
@@ -1229,6 +1237,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       token: token
     } do
       _socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       # The resource is already connected to the gateway via the setup
       # No policy authorizations exist yet, so the resource isn't in the cache
@@ -1373,6 +1382,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       account: account
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       # Update the channel process state to use an old gateway version (< 1.2.0)
       :sys.replace_state(socket.channel_pid, fn state ->
@@ -1577,6 +1587,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       token: token
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       candidates = ["foo", "bar"]
 
@@ -1600,6 +1611,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       token: token
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       candidates = ["foo", "bar"]
 
@@ -1628,6 +1640,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       policy_authorization =
         policy_authorization_fixture(
@@ -1706,6 +1719,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
            group: group
          } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       channel_pid = self()
       socket_ref = make_ref()
@@ -1783,6 +1797,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       group: group
     } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       policy_authorization =
         policy_authorization_fixture(
@@ -1880,6 +1895,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
            group: group
          } do
       socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
 
       channel_pid = self()
       socket_ref = make_ref()


### PR DESCRIPTION
In the channel tests, it appears that adding an `assert_push "init"` can alleviate flakiness because it will consume those messages in the mailbox before the other mailbox messages are asserted upon.
