### PR TITLE
fix(connlib): clean up on `handle_device_access_denied`

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -578,15 +578,9 @@ impl Eventloop {
                 ipv4: client_ipv4,
                 reason,
             }) => {
-                tracing::debug!(%client_ipv4, "Failed to access device: {reason:?}");
-
-                match reason {
-                    FailReason::Offline => tunnel.state_mut().set_client_offline(client_ipv4),
-                    FailReason::NotFound => {}
-                    FailReason::VersionMismatch => {}
-                    FailReason::Forbidden => {}
-                    FailReason::Unknown => {}
-                }
+                tunnel
+                    .state_mut()
+                    .handle_client_device_access_denied(client_ipv4, reason);
             }
         }
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -578,9 +578,11 @@ impl Eventloop {
                 ipv4: client_ipv4,
                 reason,
             }) => {
-                tunnel
-                    .state_mut()
-                    .handle_client_device_access_denied(client_ipv4, reason);
+                tunnel.state_mut().handle_client_device_access_denied(
+                    client_ipv4,
+                    reason,
+                    Instant::now(),
+                );
             }
         }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -605,12 +605,12 @@ impl ClientState {
     ) -> Option<(ClientOrGatewayId, IpPacket)> {
         let dst = packet.destination();
 
-        if let Some(gateway) = self.gateways.peer_by_ip(dst) {
-            return Some((ClientOrGatewayId::Gateway(gateway.id()), packet));
+        if let Some((id, _)) = self.gateways.peer_by_ip(dst) {
+            return Some((ClientOrGatewayId::Gateway(id), packet));
         }
 
-        if let Some(client) = self.clients.peer_by_ip(dst) {
-            return Some((ClientOrGatewayId::Client(client.id()), packet));
+        if let Some((id, _)) = self.clients.peer_by_ip(dst) {
+            return Some((ClientOrGatewayId::Client(id), packet));
         }
 
         let ipv4_addr = match dst {
@@ -635,14 +635,14 @@ impl ClientState {
             return None;
         };
 
-        let Some(peer) =
+        let Some((gid, _)) =
             peer_by_resource_mut(&self.authorized_resources, &mut self.gateways, resource)
         else {
             self.on_not_connected_resource(resource, packet, now);
             return None;
         };
 
-        Some((ClientOrGatewayId::Gateway(peer.id()), packet))
+        Some((ClientOrGatewayId::Gateway(gid), packet))
     }
 
     pub fn add_ice_candidate(
@@ -714,7 +714,7 @@ impl ClientState {
 
         let peer = self
             .gateways
-            .upsert(gid, || GatewayOnClient::new(gid, gateway_tun));
+            .upsert(gid, || GatewayOnClient::new(gateway_tun));
 
         // Deal with buffered packets
 
@@ -796,8 +796,7 @@ impl ClientState {
             now,
         )?;
 
-        self.clients
-            .upsert(cid, || ClientOnClient::new(cid, client_tun));
+        self.clients.upsert(cid, || ClientOnClient::new(client_tun));
 
         if let Some(pending_client_access) = pending_device_access {
             for packet in pending_client_access.into_buffered_packets() {
@@ -1449,7 +1448,7 @@ impl ClientState {
                 });
             }
             dns::ResolveStrategy::RecurseSite(resource) => {
-                let Some(gateway) =
+                let Some((_, gateway)) =
                     peer_by_resource_mut(&self.authorized_resources, &mut self.gateways, resource)
                 else {
                     self.on_not_connected_resource(
@@ -1875,7 +1874,8 @@ impl ClientState {
 
         self.pending_flows.remove(&id);
 
-        let Some(peer) = peer_by_resource_mut(&self.authorized_resources, &mut self.gateways, id)
+        let Some((_, peer)) =
+            peer_by_resource_mut(&self.authorized_resources, &mut self.gateways, id)
         else {
             return;
         };
@@ -1964,11 +1964,11 @@ fn peer_by_resource_mut<'p>(
     resources_gateways: &HashMap<ResourceId, GatewayId>,
     peers: &'p mut PeerStore<GatewayId, GatewayOnClient>,
     resource: ResourceId,
-) -> Option<&'p mut GatewayOnClient> {
+) -> Option<(GatewayId, &'p mut GatewayOnClient)> {
     let gateway_id = resources_gateways.get(&resource)?;
     let peer = peers.peer_by_id_mut(gateway_id)?;
 
-    Some(peer)
+    Some((*gateway_id, peer))
 }
 
 fn into_udp_dns_packet(
@@ -2061,9 +2061,7 @@ mod tests {
             SiteId::from_u128(2),
             HashSet::from([GatewayId::from_u128(30), GatewayId::from_u128(40)]),
         );
-        state
-            .gateways
-            .upsert(GatewayId::from_u128(30), || peer(GatewayId::from_u128(30)));
+        state.gateways.upsert(GatewayId::from_u128(30), peer);
 
         let preferred_gateways = state.preferred_gateways(ResourceId::from_u128(100));
 
@@ -2089,9 +2087,7 @@ mod tests {
             SiteId::from_u128(2),
             HashSet::from([GatewayId::from_u128(30), GatewayId::from_u128(40)]),
         );
-        state
-            .gateways
-            .upsert(GatewayId::from_u128(30), || peer(GatewayId::from_u128(30)));
+        state.gateways.upsert(GatewayId::from_u128(30), peer);
         state
             .authorized_resources
             .insert(ResourceId::from_u128(100), GatewayId::from_u128(30));
@@ -2169,14 +2165,11 @@ mod tests {
         }
     }
 
-    fn peer(id: GatewayId) -> GatewayOnClient {
-        GatewayOnClient::new(
-            id,
-            IpConfig {
-                v4: Ipv4Addr::LOCALHOST,
-                v6: Ipv6Addr::LOCALHOST,
-            },
-        )
+    fn peer() -> GatewayOnClient {
+        GatewayOnClient::new(IpConfig {
+            v4: Ipv4Addr::LOCALHOST,
+            v6: Ipv6Addr::LOCALHOST,
+        })
     }
 }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -255,12 +255,23 @@ impl ClientState {
         self.resource_list.update(self.resources());
     }
 
-    pub fn handle_client_device_access_denied(&mut self, ipv4: Ipv4Addr, reason: FailReason) {
-        tracing::debug!(%ipv4, "Failed to access device: {reason:?}");
+    pub fn handle_client_device_access_denied(
+        &mut self,
+        ipv4: Ipv4Addr,
+        reason: FailReason,
+        now: Instant,
+    ) {
+        tracing::debug!(%ipv4, "Device access denied: {reason:?}");
 
         self.pending_device_access.remove(&ipv4);
-
         // TODO: Update resource list with offline client.
+
+        let Some((id, _)) = self.clients.peer_by_ip(ipv4) else {
+            return;
+        };
+        self.clients.remove(&id);
+        self.node
+            .close_connection(ClientOrGatewayId::Client(id), p2p_control::goodbye(), now);
     }
 
     pub(crate) fn public_key(&self) -> PublicKey {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -15,6 +15,7 @@ use crate::client::dns_config::DnsConfig;
 use crate::client::pending_device_access::PendingDeviceAccessRequests;
 use crate::client::pending_flows::{ConnectionTrigger, DnsQueryForSite, PendingFlows};
 use crate::client::tracked_state::TrackedState;
+use crate::messages::client::FailReason;
 use boringtun::x25519;
 #[cfg(all(feature = "proptest", test))]
 pub(crate) use resource::DnsResource;
@@ -254,7 +255,9 @@ impl ClientState {
         self.resource_list.update(self.resources());
     }
 
-    pub fn set_client_offline(&mut self, ipv4: Ipv4Addr) {
+    pub fn handle_client_device_access_denied(&mut self, ipv4: Ipv4Addr, reason: FailReason) {
+        tracing::debug!(%ipv4, "Failed to access device: {reason:?}");
+
         self.pending_device_access.remove(&ipv4);
 
         // TODO: Update resource list with offline client.

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -255,6 +255,12 @@ impl ClientState {
         self.resource_list.update(self.resources());
     }
 
+    /// Handles cases where access to a device is denied.
+    ///
+    /// This can happen in several cases:
+    ///
+    /// 1. During initial setup of the access, i.e. when we are trying to connect to another device.
+    /// 2. When access is revoked after it has been established.
     pub fn handle_client_device_access_denied(
         &mut self,
         ipv4: Ipv4Addr,

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -1,20 +1,13 @@
-use connlib_model::ClientId;
-
 use crate::IpConfig;
 
 /// The state of client on another client.
 pub(crate) struct ClientOnClient {
-    id: ClientId,
     remote_tun: IpConfig,
 }
 
 impl ClientOnClient {
-    pub(crate) fn new(id: ClientId, remote_tun: IpConfig) -> ClientOnClient {
-        ClientOnClient { id, remote_tun }
-    }
-
-    pub fn id(&self) -> ClientId {
-        self.id
+    pub(crate) fn new(remote_tun: IpConfig) -> ClientOnClient {
+        ClientOnClient { remote_tun }
     }
 
     pub(crate) fn remote_tun(&self) -> IpConfig {

--- a/rust/libs/connlib/tunnel/src/client/gateway_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/gateway_on_client.rs
@@ -3,7 +3,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use connlib_model::{GatewayId, ResourceId};
+use connlib_model::ResourceId;
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use ip_packet::IpPacket;
@@ -12,7 +12,6 @@ use crate::{IpConfig, NotAllowedResource};
 
 /// The state of one gateway on a client.
 pub(crate) struct GatewayOnClient {
-    id: GatewayId,
     gateway_tun: IpConfig,
     allowed_ips: IpNetworkTable<HashSet<ResourceId>>,
 }
@@ -63,9 +62,8 @@ impl GatewayOnClient {
 }
 
 impl GatewayOnClient {
-    pub(crate) fn new(id: GatewayId, gateway_tun: IpConfig) -> GatewayOnClient {
+    pub(crate) fn new(gateway_tun: IpConfig) -> GatewayOnClient {
         GatewayOnClient {
-            id,
             allowed_ips: IpNetworkTable::new(),
             gateway_tun,
         }
@@ -85,9 +83,5 @@ impl GatewayOnClient {
         }
 
         Ok(())
-    }
-
-    pub fn id(&self) -> GatewayId {
-        self.id
     }
 }

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -115,12 +115,10 @@ impl GatewayState {
 
         anyhow::ensure!(crate::is_peer(dst), UnroutablePacket::not_a_peer(&packet));
 
-        let peer = self
+        let (cid, peer) = self
             .peers
             .peer_by_ip_mut(dst)
             .with_context(|| UnroutablePacket::no_peer_state(&packet))?;
-
-        let cid = peer.id();
 
         flow_tracker::inbound_tun::record_client(cid);
 

--- a/rust/libs/connlib/tunnel/src/peer_store.rs
+++ b/rust/libs/connlib/tunnel/src/peer_store.rs
@@ -78,14 +78,18 @@ where
         self.peer_by_id.get_mut(id)
     }
 
-    pub(crate) fn peer_by_ip(&self, ip: IpAddr) -> Option<&P> {
+    pub(crate) fn peer_by_ip(&self, ip: impl Into<IpAddr>) -> Option<&P> {
+        let ip = ip.into();
+
         let id = self.id_by_ip.get(&ip)?;
         let peer = self.peer_by_id.get(id)?;
 
         Some(peer)
     }
 
-    pub(crate) fn peer_by_ip_mut(&mut self, ip: IpAddr) -> Option<&mut P> {
+    pub(crate) fn peer_by_ip_mut(&mut self, ip: impl Into<IpAddr>) -> Option<&mut P> {
+        let ip = ip.into();
+
         let id = self.id_by_ip.get(&ip)?;
         let peer = self.peer_by_id.get_mut(id)?;
 
@@ -179,13 +183,7 @@ mod tests {
             DummyPeer::new(0, Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
         });
 
-        assert_eq!(
-            peer_storage
-                .peer_by_ip(Ipv4Addr::LOCALHOST.into())
-                .unwrap()
-                .id,
-            0
-        );
+        assert_eq!(peer_storage.peer_by_ip(Ipv4Addr::LOCALHOST).unwrap().id, 0);
     }
 
     #[test]
@@ -197,11 +195,7 @@ mod tests {
         peer_storage.remove(&0);
 
         assert!(peer_storage.peer_by_id(&0).is_none());
-        assert!(
-            peer_storage
-                .peer_by_ip(Ipv4Addr::LOCALHOST.into())
-                .is_none()
-        )
+        assert!(peer_storage.peer_by_ip(Ipv4Addr::LOCALHOST).is_none())
     }
 
     #[test]
@@ -215,10 +209,6 @@ mod tests {
         });
 
         assert!(peer_storage.peer_by_id(&0).is_some());
-        assert!(
-            peer_storage
-                .peer_by_ip("1.1.1.1".parse().unwrap())
-                .is_none()
-        )
+        assert!(peer_storage.peer_by_ip(Ipv4Addr::new(1, 1, 1, 1)).is_none())
     }
 }

--- a/rust/libs/connlib/tunnel/src/peer_store.rs
+++ b/rust/libs/connlib/tunnel/src/peer_store.rs
@@ -78,22 +78,22 @@ where
         self.peer_by_id.get_mut(id)
     }
 
-    pub(crate) fn peer_by_ip(&self, ip: impl Into<IpAddr>) -> Option<&P> {
+    pub(crate) fn peer_by_ip(&self, ip: impl Into<IpAddr>) -> Option<(TId, &P)> {
         let ip = ip.into();
 
         let id = self.id_by_ip.get(&ip)?;
         let peer = self.peer_by_id.get(id)?;
 
-        Some(peer)
+        Some((*id, peer))
     }
 
-    pub(crate) fn peer_by_ip_mut(&mut self, ip: impl Into<IpAddr>) -> Option<&mut P> {
+    pub(crate) fn peer_by_ip_mut(&mut self, ip: impl Into<IpAddr>) -> Option<(TId, &mut P)> {
         let ip = ip.into();
 
         let id = self.id_by_ip.get(&ip)?;
         let peer = self.peer_by_id.get_mut(id)?;
 
-        Some(peer)
+        Some((*id, peer))
     }
 
     pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut P> {
@@ -146,14 +146,13 @@ mod tests {
     use super::*;
 
     struct DummyPeer {
-        id: u64,
         ipv4: Ipv4Addr,
         ipv6: Ipv6Addr,
     }
 
     impl DummyPeer {
-        fn new(id: u64, ipv4: Ipv4Addr, ipv6: Ipv6Addr) -> Self {
-            Self { id, ipv4, ipv6 }
+        fn new(ipv4: Ipv4Addr, ipv6: Ipv6Addr) -> Self {
+            Self { ipv4, ipv6 }
         }
     }
 
@@ -171,7 +170,7 @@ mod tests {
     fn can_insert_and_retrieve_peer() {
         let mut peer_storage = PeerStore::<u64, DummyPeer>::default();
         peer_storage.upsert(0, || {
-            DummyPeer::new(0, Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
+            DummyPeer::new(Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
         });
         assert!(peer_storage.peer_by_id(&0).is_some());
     }
@@ -180,17 +179,17 @@ mod tests {
     fn can_insert_and_retrieve_peer_by_ip() {
         let mut peer_storage = PeerStore::<u64, DummyPeer>::default();
         peer_storage.upsert(0, || {
-            DummyPeer::new(0, Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
+            DummyPeer::new(Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
         });
 
-        assert_eq!(peer_storage.peer_by_ip(Ipv4Addr::LOCALHOST).unwrap().id, 0);
+        assert_eq!(peer_storage.peer_by_ip(Ipv4Addr::LOCALHOST).unwrap().0, 0);
     }
 
     #[test]
     fn can_remove_peer() {
         let mut peer_storage = PeerStore::<u64, DummyPeer>::default();
         peer_storage.upsert(0, || {
-            DummyPeer::new(0, Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
+            DummyPeer::new(Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
         });
         peer_storage.remove(&0);
 
@@ -202,10 +201,10 @@ mod tests {
     fn inserting_peer_removes_previous_instances_of_same_id() {
         let mut peer_storage = PeerStore::<u64, DummyPeer>::default();
         peer_storage.upsert(0, || {
-            DummyPeer::new(0, Ipv4Addr::new(1, 1, 1, 1), Ipv6Addr::LOCALHOST)
+            DummyPeer::new(Ipv4Addr::new(1, 1, 1, 1), Ipv6Addr::LOCALHOST)
         });
         peer_storage.upsert(0, || {
-            DummyPeer::new(0, Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
+            DummyPeer::new(Ipv4Addr::LOCALHOST, Ipv6Addr::LOCALHOST)
         });
 
         assert!(peer_storage.peer_by_id(&0).is_some());

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1171,8 +1171,11 @@ impl TunnelTest {
                         .get_mut(&src)
                         .expect("unknown source client")
                         .exec_mut(|c| {
-                            c.sut
-                                .handle_client_device_access_denied(ipv4, FailReason::NotFound)
+                            c.sut.handle_client_device_access_denied(
+                                ipv4,
+                                FailReason::NotFound,
+                                now,
+                            )
                         }),
                 }
 

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -10,6 +10,7 @@ use super::stub_portal::StubPortal;
 use super::transition::{Destination, DnsQuery};
 use crate::client;
 use crate::dns::is_subdomain;
+use crate::messages::client::FailReason;
 use crate::messages::gateway::{Client, Subject};
 use crate::messages::{IceCredentials, Key, SecretKey};
 use crate::tests::assertions::*;
@@ -1169,7 +1170,10 @@ impl TunnelTest {
                         .clients
                         .get_mut(&src)
                         .expect("unknown source client")
-                        .exec_mut(|c| c.sut.set_client_offline(ipv4)),
+                        .exec_mut(|c| {
+                            c.sut
+                                .handle_client_device_access_denied(ipv4, FailReason::NotFound)
+                        }),
                 }
 
                 Ok(())


### PR DESCRIPTION
When a connection to another device is denied after it has already been established, we need to immediately disconnect from the device. Most likely, the other device is already gone by then anyway (i.e. had its token invalidated etc). Cleaning up the connection ensures that we do not need to wait for a timeout to clean things up.