### PR TITLE
refactor(apple): use DI protocols in Store

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -8,9 +8,8 @@ import Foundation
 @preconcurrency import NetworkExtension
 import SystemPackage
 
-// TODO: Use a more abstract IPC protocol to make this less terse
-
-enum IPCClient {
+@MainActor
+public final class IPCClient {
   enum Error: Swift.Error {
     case decodeIPCDataFailed
     case noIPCData
@@ -28,14 +27,15 @@ enum IPCClient {
     }
   }
 
-  // Encoder used to send messages to the tunnel
-  private static let encoder = PropertyListEncoder()
-  private static let decoder = PropertyListDecoder()
+  private let encoder = PropertyListEncoder()
+  private let decoder = PropertyListDecoder()
 
-  // Auto-connect
-  @MainActor
-  static func start(
-    session: NETunnelProviderSession, configuration: TunnelConfiguration
+  public init() {}
+
+  // MARK: - Public API
+
+  public func start(
+    session: TunnelSessionProtocol, configuration: TunnelConfiguration
   ) throws {
     let configData = try encoder.encode(configuration)
     let options: [String: NSObject] = [
@@ -44,141 +44,101 @@ enum IPCClient {
     try session.startTunnel(options: options)
   }
 
-  // Sign in
-  @MainActor
-  static func start(
-    session: NETunnelProviderSession, token: String, configuration: TunnelConfiguration
+  public func start(
+    session: TunnelSessionProtocol, token: String, configuration: TunnelConfiguration
   ) throws {
     let configData = try encoder.encode(configuration)
     let options: [String: NSObject] = [
       "token": token as NSObject,
       "configuration": configData as NSObject,
     ]
-
     try session.startTunnel(options: options)
   }
 
-  @MainActor
-  static func signOut(session: NETunnelProviderSession) async throws {
+  public func signOut(session: TunnelSessionProtocol) async throws {
     let message = ProviderMessage.signOut
     _ = try await sendProviderMessage(session: session, message: message)
-
     session.stopTunnel()
   }
 
-  @MainActor
-  static func fetchState(
-    session: NETunnelProviderSession, currentHash: Data
+  public func fetchState(
+    session: TunnelSessionProtocol, currentHash: Data
   ) async throws -> Data? {
     let message = ProviderMessage.getState(currentHash)
-
-    // Get data from the provider - if hash matches, provider returns nil
     return try await sendProviderMessage(session: session, message: message)
   }
 
-  @MainActor
-  static func setConfiguration(
-    session: NETunnelProviderSession, _ configuration: TunnelConfiguration
+  public func setConfiguration(
+    session: TunnelSessionProtocol, _ configuration: TunnelConfiguration
   ) async throws {
     let message = ProviderMessage.setConfiguration(configuration)
     _ = try await sendProviderMessage(session: session, message: message)
   }
 
-  // MARK: - Low-level IPC operations
-
-  @MainActor
-  static func clearLogs(session: NETunnelProviderSession) async throws {
+  public func clearLogs(session: TunnelSessionProtocol) async throws {
     let message = ProviderMessage.clearLogs
     _ = try await sendProviderMessage(session: session, message: message)
   }
 
-  @MainActor
-  static func getLogFolderSize(session: NETunnelProviderSession) async throws -> Int64 {
-    let message = ProviderMessage.getLogFolderSize
-    guard let data = try await sendProviderMessage(session: session, message: message)
-    else {
-      throw Error.noIPCData
-    }
-
-    return data.withUnsafeBytes { rawBuffer in
-      rawBuffer.load(as: Int64.self)
-    }
-  }
-
-  @MainActor
-  static func fetchEncodedFirezoneId(session: NETunnelProviderSession) async throws -> String? {
+  public func fetchEncodedFirezoneId(session: TunnelSessionProtocol) async throws -> String? {
     guard let data = try await sendProviderMessage(session: session, message: .getEncodedFirezoneId)
     else { return nil }
     return String(data: data, encoding: .utf8)
   }
 
-  @MainActor
-  static func exportLogs(session: NETunnelProviderSession, fd: FileDescriptor) async throws {
-    let isCycleStart = try await maybeCycleStart(session)
-    defer {
-      if isCycleStart { session.stopTunnel() }
-    }
+  #if os(macOS)
+    public func getLogFolderSize(session: TunnelSessionProtocol) async throws -> Int64 {
+      let message = ProviderMessage.getLogFolderSize
+      guard let data = try await sendProviderMessage(session: session, message: message)
+      else {
+        throw Error.noIPCData
+      }
 
-    let message = ProviderMessage.exportLogs
-    let encodedMessage = try encoder.encode(message)
-
-    func nextChunk() async throws -> LogChunk {
-      try await withCheckedThrowingContinuation { continuation in
-        do {
-          try session.sendProviderMessage(encodedMessage) { data in
-            guard let data else {
-              return continuation.resume(throwing: Error.noIPCData)
-            }
-            guard let chunk = try? decoder.decode(LogChunk.self, from: data) else {
-              return continuation.resume(throwing: Error.decodeIPCDataFailed)
-            }
-            continuation.resume(returning: chunk)
-          }
-        } catch {
-          continuation.resume(throwing: error)
-        }
+      return data.withUnsafeBytes { rawBuffer in
+        rawBuffer.load(as: Int64.self)
       }
     }
 
-    while true {
-      let chunk = try await nextChunk()
+    public func exportLogs(session: TunnelSessionProtocol, fd: FileDescriptor) async throws {
+      let isCycleStart = try await maybeCycleStart(session)
+      defer {
+        if isCycleStart { session.stopTunnel() }
+      }
 
-      try fd.writeAll(chunk.data)
+      let message = ProviderMessage.exportLogs
+      let encodedMessage = try encoder.encode(message)
 
-      if chunk.done { break }
-    }
-  }
-
-  /// Returns a stream of VPN status updates for the given session.
-  ///
-  /// Filters `NEVPNStatusDidChange` notifications to only those matching `session`.
-  /// The caller is responsible for consuming the stream in a task they manage.
-  static func vpnStatusUpdates(
-    session: NETunnelProviderSession
-  ) -> AsyncStream<NEVPNStatus> {
-    AsyncStream { continuation in
-      let task = Task {
-        for await notification in NotificationCenter.default.notifications(
-          named: .NEVPNStatusDidChange)
-        {
-          guard let notificationSession = notification.object as? NETunnelProviderSession
-          else {
-            return
-          }
-
-          if notificationSession === session {
-            continuation.yield(notificationSession.status)
+      func nextChunk() async throws -> LogChunk {
+        try await withCheckedThrowingContinuation { continuation in
+          do {
+            try session.sendProviderMessage(encodedMessage) { data in
+              guard let data else {
+                return continuation.resume(throwing: Error.noIPCData)
+              }
+              guard let chunk = try? self.decoder.decode(LogChunk.self, from: data) else {
+                return continuation.resume(throwing: Error.decodeIPCDataFailed)
+              }
+              continuation.resume(returning: chunk)
+            }
+          } catch {
+            continuation.resume(throwing: error)
           }
         }
-        continuation.finish()
       }
-      continuation.onTermination = { _ in task.cancel() }
-    }
-  }
 
-  private static func sendProviderMessage(
-    session: NETunnelProviderSession,
-    message: ProviderMessage,
+      while true {
+        let chunk = try await nextChunk()
+        try fd.writeAll(chunk.data)
+        if chunk.done { break }
+      }
+    }
+  #endif
+
+  // MARK: - Private
+
+  private func sendProviderMessage(
+    session: TunnelSessionProtocol,
+    message: ProviderMessage
   ) async throws -> Data? {
     let isCycleStart = try await maybeCycleStart(session)
 
@@ -200,7 +160,7 @@ enum IPCClient {
   /// On macOS, the tunnel needs to be in a connected, connecting, or reasserting state for the utun to be removed
   /// upon stopTunnel. We do this by ensuring the tunnel is "started" prior to any IPC call. If so, we return true
   /// so that the caller may stop the tunnel afterwards.
-  private static func maybeCycleStart(_ session: NETunnelProviderSession) async throws -> Bool {
+  private func maybeCycleStart(_ session: TunnelSessionProtocol) async throws -> Bool {
     if session.status == .invalid {
       throw Error.invalidStatus(session.status)
     }
@@ -221,5 +181,19 @@ enum IPCClient {
     #endif
 
     return false
+  }
+}
+
+// MARK: - Legacy static method for VPNConfigurationManager migration
+
+extension IPCClient {
+  /// Static convenience for use during legacy configuration migration only.
+  /// VPNConfigurationManager.maybeMigrateConfiguration() uses this because it operates
+  /// on a concrete NETunnelProviderSession before Store/DI is available.
+  @MainActor
+  static func setConfigurationForMigration(
+    session: NETunnelProviderSession, _ configuration: TunnelConfiguration
+  ) async throws {
+    try await IPCClient().setConfiguration(session: session, configuration)
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -6,7 +6,6 @@
 
 import AppleArchive
 import Foundation
-@preconcurrency import NetworkExtension
 import SystemPackage
 
 /// Convenience module for smoothing over the differences between exporting logs on macOS and iOS.
@@ -29,7 +28,7 @@ import SystemPackage
     @MainActor
     static func export(
       to archiveURL: URL,
-      session: NETunnelProviderSession
+      store: Store
     ) async throws {
       guard let logFolderURL = SharedAccess.logFolderURL
       else {
@@ -59,7 +58,7 @@ import SystemPackage
       defer { try? fd.close() }
 
       // 3. Await tunnel log export from tunnel process
-      try await IPCClient.exportLogs(session: session, fd: fd)
+      try await store.exportLogs(fd: fd)
 
       // 4. Create app log archive
       let appLogURL = sharedLogFolderURL.appendingPathComponent("app.zip")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/RealVPNConfigurationProvider.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/RealVPNConfigurationProvider.swift
@@ -1,0 +1,43 @@
+//
+//  RealVPNConfigurationProvider.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import NetworkExtension
+
+/// Production implementation of VPNConfigurationProtocol.
+///
+/// Thin wrapper around VPNConfigurationManager. Intentionally minimal
+/// so the untested delegation layer has almost no logic.
+@MainActor
+public final class RealVPNConfigurationProvider: VPNConfigurationProtocol {
+  private var vpnManager: VPNConfigurationManager?
+
+  public init() {}
+
+  public func loadConfiguration() async throws -> Bool {
+    if let manager = try await VPNConfigurationManager.load() {
+      try await manager.maybeMigrateConfiguration()
+      self.vpnManager = manager
+      return true
+    }
+    return false
+  }
+
+  public func installConfiguration() async throws {
+    self.vpnManager = try await VPNConfigurationManager()
+  }
+
+  public func enable() async throws {
+    guard let vpnManager else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try await vpnManager.enable()
+  }
+
+  public func session() -> TunnelSessionProtocol? {
+    vpnManager?.session()
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -16,7 +16,7 @@ enum VPNConfigurationManagerError: Error {
   var localizedDescription: String {
     switch self {
     case .managerNotInitialized:
-      return "NETunnelProviderManager is not yet initialized. Race condition?"
+      return "VPN configuration is not yet loaded. Is the tunnel session available?"
     }
   }
 }
@@ -27,9 +27,13 @@ enum VPNConfigurationManagerError: Error {
 public final class VPNConfigurationManager {
   let manager: NETunnelProviderManager
 
-  // App cannot run without bundle identifier - force unwrap is safe
-  // swiftlint:disable:next force_unwrapping
-  public static let bundleIdentifier: String = "\(Bundle.main.bundleIdentifier!).network-extension"
+  nonisolated public static var bundleIdentifier: String {
+    guard let mainBundleId = Bundle.main.bundleIdentifier else {
+      // Return a placeholder for test environment where main bundle has no identifier
+      return "dev.firezone.firezone.network-extension"
+    }
+    return "\(mainBundleId).network-extension"
+  }
   static let bundleDescription = "Firezone"
 
   // Initialize and save a new VPN configuration in system Preferences
@@ -136,7 +140,7 @@ public final class VPNConfigurationManager {
       configuration.internetResourceEnabled = internetResourceEnabled == "true"
     }
 
-    try await IPCClient.setConfiguration(session: session, configuration.toTunnelConfiguration())
+    try await IPCClient.setConfigurationForMigration(session: session, configuration.toTunnelConfiguration())
 
     // Remove fields to prevent confusion if the user sees these in System Settings and wonders why they're stale.
     if let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
@@ -1,0 +1,46 @@
+//
+//  TunnelSessionProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import NetworkExtension
+
+/// Abstracts NETunnelProviderSession for testing.
+public protocol TunnelSessionProtocol: AnyObject {
+  var status: NEVPNStatus { get }
+  var statusUpdates: AsyncStream<NEVPNStatus> { get }
+  func stopTunnel()
+  // swiftlint:disable:next discouraged_optional_collection - matches NETunnelProviderSession API
+  func startTunnel(options: [String: Any]?) throws
+  func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws
+
+  #if os(macOS)
+    /// Fetches the last disconnect error from the tunnel session.
+    /// NETunnelProviderSession already provides this, so conformance is free.
+    func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void)
+  #endif
+}
+
+// Default conformance for real session
+extension NETunnelProviderSession: TunnelSessionProtocol {
+  public var statusUpdates: AsyncStream<NEVPNStatus> {
+    // Capture ObjectIdentifier (Sendable) instead of self to satisfy Swift 6 concurrency.
+    // The session from the notification is used directly for reading status.
+    let identity = ObjectIdentifier(self)
+    return AsyncStream { continuation in
+      let task = Task {
+        for await notification in NotificationCenter.default.notifications(
+          named: .NEVPNStatusDidChange)
+        {
+          guard let session = notification.object as? NETunnelProviderSession,
+            ObjectIdentifier(session) == identity
+          else { continue }
+          continuation.yield(session.status)
+        }
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/UpdateCheckerProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/UpdateCheckerProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  UpdateCheckerProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import Combine
+
+  /// Abstracts update checking to support dependency injection.
+  @MainActor
+  public protocol UpdateCheckerProtocol: AnyObject, ObservableObject {
+    var updateAvailable: Bool { get }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/VPNConfigurationProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/VPNConfigurationProtocol.swift
@@ -1,0 +1,29 @@
+//
+//  VPNConfigurationProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import NetworkExtension
+
+/// Abstracts VPN configuration lifecycle for dependency injection.
+///
+/// Models the system API surface (NETunnelProviderManager) closely,
+/// keeping the delegating implementation thin and trivially correct.
+/// Production uses `RealVPNConfigurationProvider`, tests use `MockVPNConfigProvider`.
+@MainActor
+public protocol VPNConfigurationProtocol {
+  /// Loads an existing VPN configuration if available.
+  /// - Returns: `true` if a configuration was loaded, `false` if none exists.
+  func loadConfiguration() async throws -> Bool
+
+  /// Creates and installs a new VPN configuration.
+  func installConfiguration() async throws
+
+  /// Enables the VPN configuration (re-activates if another VPN was selected).
+  func enable() async throws
+
+  /// Returns the current tunnel session, or `nil` if no configuration is loaded.
+  func session() -> TunnelSessionProtocol?
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -7,6 +7,7 @@
 import Combine
 import NetworkExtension
 import OSLog
+import SystemPackage
 import UserNotifications
 
 #if os(macOS)
@@ -41,7 +42,7 @@ public final class Store: ObservableObject {
 
   private(set) var sessionNotification: SessionNotificationProtocol
   #if os(macOS)
-    let updateChecker: UpdateChecker
+    let updateChecker: any UpdateCheckerProtocol
     private let systemExtensionManager: any SystemExtensionManagerProtocol
   #endif
 
@@ -49,7 +50,6 @@ public final class Store: ObservableObject {
   private var stateUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
   private var lastSavedConfiguration: TunnelConfiguration?
-  private var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
 
   // Track which session expired alerts have been shown to prevent duplicates
@@ -61,19 +61,28 @@ public final class Store: ObservableObject {
   /// UserDefaults instance for persisting GUI state.
   let userDefaults: UserDefaults
 
+  private let vpnConfigProvider: VPNConfigurationProtocol
+
+  private let ipcClient = IPCClient()
+
+  var currentSession: TunnelSessionProtocol?
+
   // Task consuming VPN status updates; its presence means observers are active.
   private var vpnStatusTask: CancellableTask?
 
   #if os(macOS)
     public init(
       configuration: Configuration? = nil,
+      vpnConfigProvider: VPNConfigurationProtocol = RealVPNConfigurationProvider(),
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
+      updateChecker: (any UpdateCheckerProtocol)? = nil,
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
-      self.updateChecker = UpdateChecker(configuration: configuration, userDefaults: userDefaults)
+      self.updateChecker = updateChecker ?? UpdateChecker(configuration: configuration, userDefaults: userDefaults)
+      self.vpnConfigProvider = vpnConfigProvider
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
       self.userDefaults = userDefaults
@@ -85,11 +94,13 @@ public final class Store: ObservableObject {
   #else
     public init(
       configuration: Configuration? = nil,
+      vpnConfigProvider: VPNConfigurationProtocol = RealVPNConfigurationProvider(),
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
+      self.vpnConfigProvider = vpnConfigProvider
       self.sessionNotification = sessionNotification
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
@@ -103,37 +114,6 @@ public final class Store: ObservableObject {
     self.sessionNotification.signInHandler = {
       do { try await WebAuthSession.signIn(store: self) } catch { Log.error(error) }
     }
-
-    // We monitor for any configuration changes and tell the tunnel service about them
-    self.configuration.objectWillChange
-      .receive(on: DispatchQueue.main)
-      .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)  // These happen quite frequently
-      .sink(receiveValue: { [weak self] _ in
-        guard let self = self else { return }
-        let current = self.configuration.toTunnelConfiguration()
-
-        if self.vpnConfigurationManager == nil {
-          // No manager yet, nothing to update
-          return
-        }
-
-        if self.lastSavedConfiguration == current {
-          // No changes
-          return
-        }
-
-        self.lastSavedConfiguration = current
-
-        Task {
-          do {
-            guard let session = try self.manager().session() else { return }
-            try await IPCClient.setConfiguration(session: session, current)
-          } catch {
-            Log.error(error)
-          }
-        }
-      })
-      .store(in: &cancellables)
 
     // Forward favorites changes to Store's objectWillChange so SwiftUI redraws.
     // This is necessary because Favorites is a separate ObservableObject, and SwiftUI
@@ -158,12 +138,47 @@ public final class Store: ObservableObject {
       }
       .store(in: &cancellables)
 
-    // Load our state from the system. Based on what's loaded, we may need to ask the user for permission for things.
-    // When everything loads correctly, we attempt to start the tunnel if connectOnStart is enabled.
+    // Monitor configuration changes and propagate to tunnel service
+    setupConfigurationObserver()
+
+    // Run the startup sequence: configure telemetry, check system extension (macOS),
+    // load VPN configuration, set up observers, and auto-connect if enabled.
     Task {
       await startupSequence()
       await initNotifications()
     }
+  }
+
+  // MARK: - Configuration Observer
+
+  /// Sets up the configuration change observer with debouncing.
+  private func setupConfigurationObserver() {
+    self.configuration.objectWillChange
+      .receive(on: DispatchQueue.main)
+      .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)  // These happen quite frequently
+      .sink(receiveValue: { [weak self] _ in
+        guard let self = self else { return }
+        let current = self.configuration.toTunnelConfiguration()
+
+        if self.lastSavedConfiguration == current {
+          // No changes
+          return
+        }
+
+        self.lastSavedConfiguration = current
+
+        Task { [weak self] in
+          guard let self else { return }
+          do {
+            let session = try self.requireSession()
+            try await self.ipcClient.setConfiguration(session: session, current)
+          } catch {
+            // Session not ready yet - this is expected during startup
+            Log.debug("Config change ignored: \(error)")
+          }
+        }
+      })
+      .store(in: &cancellables)
   }
 
   #if os(macOS)
@@ -204,30 +219,6 @@ public final class Store: ObservableObject {
     }
   #endif
 
-  private func setupTunnelObservers() async throws {
-    guard vpnStatusTask == nil else {
-      Log.debug("Tunnel observers already set up, skipping")
-      return
-    }
-
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-
-    let statusStream = IPCClient.vpnStatusUpdates(session: session)
-
-    vpnStatusTask = CancellableTask { [weak self] in
-      for await status in statusStream {
-        do { try await self?.handleVPNStatusChange(newVPNStatus: status) } catch {
-          Log.error(error)
-        }
-      }
-    }
-
-    // Handle initial status to ensure resources start loading if already connected
-    try await handleVPNStatusChange(newVPNStatus: session.status)
-  }
-
   private func handleVPNStatusChange(newVPNStatus: NEVPNStatus) async throws {
     self.vpnStatus = newVPNStatus
 
@@ -242,25 +233,22 @@ public final class Store: ObservableObject {
       // On macOS we must show notifications from the UI process. On iOS, we've already initiated the notification
       // from the tunnel process, because the UI process is not guaranteed to be alive.
       if vpnStatus == .disconnected {
-        do {
-          try manager().session()?.fetchLastDisconnectError { error in
-            if let nsError = error as NSError?,
-              nsError.domain == ConnlibError.errorDomain,
-              nsError.code == 0,  // sessionExpired error code
-              let reason = nsError.userInfo["reason"] as? String,
-              let id = nsError.userInfo["id"] as? String
-            {
-              // Only show the alert if we haven't shown this specific error before
-              Task { @MainActor in
-                if !self.shownAlertIds.contains(id) {
-                  await self.sessionNotification.showSignedOutAlertMacOS(reason)
-                  self.markAlertAsShown(id)
-                }
+        currentSession?.fetchLastDisconnectError { [weak self] error in
+          guard let self = self else { return }
+          if let nsError = error as NSError?,
+            nsError.domain == ConnlibError.errorDomain,
+            nsError.code == 0,  // sessionExpired error code
+            let reason = nsError.userInfo["reason"] as? String,
+            let id = nsError.userInfo["id"] as? String
+          {
+            // Only show the alert if we haven't shown this specific error before
+            Task { @MainActor in
+              if !self.shownAlertIds.contains(id) {
+                await self.sessionNotification.showSignedOutAlertMacOS(reason)
+                self.markAlertAsShown(id)
               }
             }
           }
-        } catch {
-          Log.error(error)
         }
       }
 
@@ -292,7 +280,7 @@ public final class Store: ObservableObject {
         Log.debug("Startup: initVPNConfiguration")
         try await initVPNConfiguration()
         Log.debug("Startup: setupTunnelObservers")
-        try await setupTunnelObservers()
+        setupTunnelObservers()
         Log.debug("Startup: maybeAutoConnect")
         try await maybeAutoConnect()
         return
@@ -344,38 +332,53 @@ public final class Store: ObservableObject {
   }
 
   private func initVPNConfiguration() async throws {
-    // Try to load existing configuration
-    if let manager = try await VPNConfigurationManager.load() {
-      try await manager.maybeMigrateConfiguration()
-      self.vpnConfigurationManager = manager
+    let loaded = try await vpnConfigProvider.loadConfiguration()
+    if loaded {
+      self.currentSession = vpnConfigProvider.session()
     } else {
       self.vpnStatus = .invalid
     }
   }
 
+  /// Sets up VPN status observation. Must be called after initVPNConfiguration()
+  /// so that currentSession is available.
+  func setupTunnelObservers() {
+    guard vpnStatusTask == nil else {
+      Log.debug("Status observers already active, skipping")
+      return
+    }
+    guard let session = currentSession else { return }
+    let statusStream = session.statusUpdates
+    vpnStatusTask = CancellableTask { [weak self] in
+      for await status in statusStream {
+        do { try await self?.handleVPNStatusChange(newVPNStatus: status) } catch {
+          Log.error(error)
+        }
+      }
+    }
+
+    // Handle initial status to ensure resources start loading if already connected
+    let initialStatus = session.status
+    Task {
+      do {
+        try await handleVPNStatusChange(newVPNStatus: initialStatus)
+      } catch {
+        Log.error(error)
+      }
+    }
+  }
+
   private func maybeAutoConnect() async throws {
     if configuration.connectOnStart {
-      try await manager().enable()
-      guard let session = try manager().session() else {
-        throw VPNConfigurationManagerError.managerNotInitialized
-      }
-      try IPCClient.start(session: session, configuration: configuration.toTunnelConfiguration())
+      try await vpnConfigProvider.enable()
+      let session = try requireSession()
+      try ipcClient.start(session: session, configuration: configuration.toTunnelConfiguration())
     }
   }
+
   func installVPNConfiguration() async throws {
-    // Create a new VPN configuration in system settings.
-    self.vpnConfigurationManager = try await VPNConfigurationManager()
-
-    try await setupTunnelObservers()
-  }
-
-  func manager() throws -> VPNConfigurationManager {
-    guard let vpnConfigurationManager
-    else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-
-    return vpnConfigurationManager
+    try await vpnConfigProvider.installConfiguration()
+    self.currentSession = vpnConfigProvider.session()
   }
 
   func grantNotifications() async throws {
@@ -383,11 +386,7 @@ public final class Store: ObservableObject {
   }
 
   public func stop() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-
-    session.stopTunnel()
+    currentSession?.stopTunnel()
   }
 
   func signIn(authResponse: AuthResponse) async throws {
@@ -400,8 +399,6 @@ public final class Store: ObservableObject {
 
     configuration.accountSlug = accountSlug
 
-    try await manager().enable()
-
     // Clear shown alerts when starting a new session so user can see new errors
     shownAlertIds.removeAll()
     userDefaults.removeObject(forKey: "shownAlertIds")
@@ -409,28 +406,43 @@ public final class Store: ObservableObject {
     // Clear notified unreachable resources for fresh session
     unreachableResources.removeAll()
 
-    // Bring the tunnel up and send it a token and configuration to start
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try IPCClient.start(
+    // Enable and start the tunnel with the auth token
+    try await vpnConfigProvider.enable()
+    let session = try requireSession()
+    try ipcClient.start(
       session: session, token: authResponse.token,
-      configuration: configuration.toTunnelConfiguration()
-    )
+      configuration: configuration.toTunnelConfiguration())
   }
 
   func signOut() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.signOut(session: session)
+    let session = try requireSession()
+    try await ipcClient.signOut(session: session)
   }
 
   func clearLogs() async throws {
-    guard let session = try manager().session() else {
+    let session = try requireSession()
+    try await ipcClient.clearLogs(session: session)
+  }
+
+  #if os(macOS)
+    func getLogFolderSize() async throws -> Int64 {
+      let session = try requireSession()
+      return try await ipcClient.getLogFolderSize(session: session)
+    }
+
+    func exportLogs(fd: FileDescriptor) async throws {
+      let session = try requireSession()
+      try await ipcClient.exportLogs(session: session, fd: fd)
+    }
+  #endif
+
+  // MARK: - Session Management
+
+  func requireSession() throws -> TunnelSessionProtocol {
+    guard let currentSession else {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
-    try await IPCClient.clearLogs(session: session)
+    return currentSession
   }
 
   // MARK: Private functions
@@ -443,8 +455,8 @@ public final class Store: ObservableObject {
 
     Task {
       do {
-        guard let session = try manager().session(),
-          let firezoneId = try await IPCClient.fetchEncodedFirezoneId(session: session)
+        let session = try requireSession()
+        guard let firezoneId = try await ipcClient.fetchEncodedFirezoneId(session: session)
         else { return }
 
         userDefaults.set(firezoneId, forKey: "encodedFirezoneId")
@@ -469,16 +481,16 @@ public final class Store: ObservableObject {
       return
     }
 
-    // Define the Timer's closure
-    let updateState: @Sendable (Timer) -> Void = { _ in
+    // Note: Strong capture of self is intentional — timer is invalidated in endUpdatingState()
+    // when VPN disconnects, preventing retain cycles.
+    let updateState: @Sendable (Timer) -> Void = { [self] _ in
       Task {
         await MainActor.run {
           self.stateUpdateTask?.cancel()
           self.stateUpdateTask = Task {
             if !Task.isCancelled {
               do {
-                guard let session = try self.manager().session() else { return }
-                try await self.fetchState(session: session)
+                try await self.fetchResources()
               } catch let error as NSError {
                 // https://developer.apple.com/documentation/networkextension/nevpnerror-swift.struct/code
                 if error.domain == "NEVPNErrorDomain" && error.code == 1 {
@@ -521,15 +533,14 @@ public final class Store: ObservableObject {
   ///
   /// If the hash matches what the provider has, state is unchanged.
   /// Otherwise, fetches and caches the new state.
-  ///
-  /// - Parameter session: The tunnel provider session to communicate with
-  /// - Throws: IPCClient.Error if IPC communication fails
-  private func fetchState(session: NETunnelProviderSession) async throws {
+  /// Internal for `@testable` access.
+  func fetchResources() async throws {
     // Capture current hash before IPC call
     let currentHash = self.connlibStateHash
+    let session = try requireSession()
 
     // If no data returned, state hasn't changed - no update needed
-    guard let data = try await IPCClient.fetchState(session: session, currentHash: currentHash)
+    guard let data = try await ipcClient.fetchState(session: session, currentHash: currentHash)
     else {
       return
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -622,12 +622,9 @@ public struct SettingsView: View {
 
         Task {
           do {
-            guard let session = try store.manager().session() else {
-              throw VPNConfigurationManagerError.managerNotInitialized
-            }
             try await LogExporter.export(
               to: destinationURL,
-              session: session
+              store: store
             )
 
             window.contentViewController?.presentingViewController?.dismiss(self)
@@ -710,10 +707,7 @@ public struct SettingsView: View {
 
     do {
       #if os(macOS)
-        guard let session = try store.manager().session() else {
-          throw VPNConfigurationManagerError.managerNotInitialized
-        }
-        let providerLogFolderSize = try await IPCClient.getLogFolderSize(session: session)
+        let providerLogFolderSize = try await store.getLogFolderSize()
         let totalSize = logFolderSize + providerLogFolderSize
       #else
         let totalSize = logFolderSize

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -11,7 +11,7 @@
   import Cocoa
 
   @MainActor
-  class UpdateChecker {
+  class UpdateChecker: UpdateCheckerProtocol {
     enum UpdateError: Error {
       case invalidVersion(String)
 


### PR DESCRIPTION
Replace direct NETunnelProviderSession and VPNConfigurationManager usage in Store with injectable protocols:

- TunnelSessionProtocol: abstracts tunnel session operations
- VPNConfigurationProtocol: abstracts VPN config lifecycle
- UpdateCheckerProtocol: abstracts update checking (macOS)

Convert IPCClient from static enum to injectable class that delegates I/O through TunnelSessionProtocol. Store now owns session lifecycle via currentSession property.
