### PR TITLE
feat(swift): introduce DI for `VPNConfigurationManager`

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -10,6 +10,44 @@
 import Foundation
 import NetworkExtension
 
+// MARK: - Protocols
+
+@MainActor
+public protocol TunnelProviderManager: AnyObject {
+  var isEnabled: Bool { get set }
+  var localizedDescription: String? { get set }
+  var protocolConfiguration: NEVPNProtocol? { get set }
+  var connection: NEVPNConnection { get }
+
+  func saveToPreferences() async throws
+  func loadFromPreferences() async throws
+}
+
+@MainActor
+public protocol TunnelProviderManagerFactory {
+  func loadAllFromPreferences() async throws -> [any TunnelProviderManager]
+  func createManager() -> any TunnelProviderManager
+}
+
+// MARK: - NetworkExtension Conformances
+
+extension NETunnelProviderManager: TunnelProviderManager {}
+
+@MainActor
+public final class NETunnelProviderManagerFactory: TunnelProviderManagerFactory {
+  public init() {}
+
+  public func loadAllFromPreferences() async throws -> [any TunnelProviderManager] {
+    try await NETunnelProviderManager.loadAllFromPreferences()
+  }
+
+  public func createManager() -> any TunnelProviderManager {
+    NETunnelProviderManager()
+  }
+}
+
+// MARK: - VPNConfigurationManager
+
 enum VPNConfigurationManagerError: Error {
   case managerNotInitialized
 
@@ -25,7 +63,7 @@ enum VPNConfigurationManagerError: Error {
 // we isolate to @MainActor to align with this design.
 @MainActor
 public final class VPNConfigurationManager {
-  let manager: NETunnelProviderManager
+  let manager: any TunnelProviderManager
 
   // App cannot run without bundle identifier - force unwrap is safe
   // swiftlint:disable:next force_unwrapping
@@ -33,9 +71,8 @@ public final class VPNConfigurationManager {
   static let bundleDescription = "Firezone"
 
   // Initialize and save a new VPN configuration in system Preferences
-  init() async throws {
+  init(manager: any TunnelProviderManager) async throws {
     let protocolConfiguration = NETunnelProviderProtocol()
-    let manager = NETunnelProviderManager()
 
     protocolConfiguration.providerConfiguration = nil
     protocolConfiguration.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
@@ -49,7 +86,7 @@ public final class VPNConfigurationManager {
     self.manager = manager
   }
 
-  init(from manager: NETunnelProviderManager) {
+  init(from manager: any TunnelProviderManager) {
     self.manager = manager
   }
 
@@ -69,10 +106,12 @@ public final class VPNConfigurationManager {
     return providerConfiguration
   }
 
-  static func load() async throws -> VPNConfigurationManager? {
+  static func load(using factory: TunnelProviderManagerFactory) async throws
+    -> VPNConfigurationManager?
+  {
     // loadAllFromPreferences() returns list of VPN configurations created by our main app's bundle ID.
     // Since our bundle ID can change (by us), find the one that's current and ignore the others.
-    let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+    let managers = try await factory.loadAllFromPreferences()
 
     for manager in managers where manager.localizedDescription == bundleDescription {
       return VPNConfigurationManager(from: manager)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -89,7 +89,7 @@ public final class Store: ObservableObject {
     public init(
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
-      tunnelManagerFactory: TunnelProviderManagerFactory = NetworkExtensionManagerFactory(),
+      tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -51,6 +51,7 @@ public final class Store: ObservableObject {
   private var lastSavedConfiguration: TunnelConfiguration?
   private var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
+  private let tunnelManagerFactory: TunnelProviderManagerFactory
 
   // Track which session expired alerts have been shown to prevent duplicates
   private var shownAlertIds: Set<String>
@@ -69,6 +70,7 @@ public final class Store: ObservableObject {
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
       systemExtensionManager: (any SystemExtensionManagerProtocol)? = nil,
+      tunnelManagerFactory: TunnelProviderManagerFactory = NETunnelProviderManagerFactory(),
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
@@ -76,6 +78,7 @@ public final class Store: ObservableObject {
       self.updateChecker = UpdateChecker(configuration: configuration, userDefaults: userDefaults)
       self.sessionNotification = sessionNotification
       self.systemExtensionManager = systemExtensionManager ?? SystemExtensionManager()
+      self.tunnelManagerFactory = tunnelManagerFactory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
@@ -86,11 +89,13 @@ public final class Store: ObservableObject {
     public init(
       configuration: Configuration? = nil,
       sessionNotification: SessionNotificationProtocol = SessionNotification(),
+      tunnelManagerFactory: TunnelProviderManagerFactory = NetworkExtensionManagerFactory(),
       // swiftlint:disable:next no_userdefaults_standard
       userDefaults: UserDefaults = .standard
     ) {
       self.configuration = configuration ?? Configuration.shared
       self.sessionNotification = sessionNotification
+      self.tunnelManagerFactory = tunnelManagerFactory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
       self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
@@ -345,7 +350,7 @@ public final class Store: ObservableObject {
 
   private func initVPNConfiguration() async throws {
     // Try to load existing configuration
-    if let manager = try await VPNConfigurationManager.load() {
+    if let manager = try await VPNConfigurationManager.load(using: tunnelManagerFactory) {
       try await manager.maybeMigrateConfiguration()
       self.vpnConfigurationManager = manager
     } else {
@@ -364,7 +369,9 @@ public final class Store: ObservableObject {
   }
   func installVPNConfiguration() async throws {
     // Create a new VPN configuration in system settings.
-    self.vpnConfigurationManager = try await VPNConfigurationManager()
+    self.vpnConfigurationManager = try await VPNConfigurationManager(
+      manager: tunnelManagerFactory.createManager()
+    )
 
     try await setupTunnelObservers()
   }


### PR DESCRIPTION
Introduces two new protocols to the Swift codebase in an effort to make things more testable:

- `TunnelProviderManager`: Directly conforms to `NETunnelProviderManager`
- `TunnelProviderManagerFactory`: Allows creating new instances of `TunnelProviderManager` by either creating a new one or loading all existing ones from preferences and iterating through them

These two protocols are introduced at the lowest, possible boundary to the system and therefore allow us to pretty much cover all additional code on top of it with tests. For example, we can write a test that `VPNConfigurationManager.load` iterates through all `TunnelProviderManager`s and picks the one with the right `localizedDescription`.