### PR TITLE
fix(connlib): don't early-return from eventloop under pressure

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -22,7 +22,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
-    task::{Context, Poll, ready},
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 use tracing::Level;
@@ -264,9 +264,11 @@ impl Io {
             impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
         >,
     > {
-        if let Err(e) = ready!(self.flush(cx)) {
-            return Poll::Ready(Input::error(e));
-        }
+        let flush_pending = match self.flush(cx) {
+            Poll::Ready(Ok(())) => false,
+            Poll::Ready(Err(e)) => return Poll::Ready(Input::error(e)),
+            Poll::Pending => true,
+        };
 
         let mut error = TunnelError::default();
 
@@ -398,7 +400,8 @@ impl Io {
             self.timeout = None;
         }
 
-        if !timeout
+        if flush_pending
+            && !timeout
             && device.is_pending()
             && network.is_pending()
             && tcp_dns_queries.is_empty()

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12430">
+          Improves tunnel event-loop fairness so outbound backpressure no longer
+          starves inbound packet processing under latency.
+        </ChangeItem>
         <ChangeItem pull="12355">
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -30,6 +30,10 @@ export default function Apple() {
           version could be ignored due to reading from the wrong UserDefaults
           key.
         </ChangeItem>
+        <ChangeItem pull="12430">
+          Improves tunnel event-loop fairness so outbound backpressure no longer
+          starves inbound packet processing under latency.
+        </ChangeItem>
         <ChangeItem pull="12355">
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,10 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12430">
+          Improves tunnel event-loop fairness so outbound backpressure no longer
+          starves inbound packet processing under latency.
+        </ChangeItem>
         <ChangeItem pull="12355">
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -23,6 +23,10 @@ export default function Gateway() {
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
+        <ChangeItem pull="12430">
+          Improves tunnel event-loop fairness so outbound backpressure no longer
+          starves inbound packet processing under latency.
+        </ChangeItem>
         <ChangeItem pull="12355">
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,10 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="12430">
+          Improves tunnel event-loop fairness so outbound backpressure no longer
+          starves inbound packet processing under latency.
+        </ChangeItem>
         <ChangeItem pull="12355">
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.


### PR DESCRIPTION
This change fixes a fairness issue in the tunnel event loop where outbound backpressure could unintentionally block inbound progress. Before this patch, `Io::poll` started with `ready!(self.flush(cx))`, so when flushing the send path returned `Poll::Pending`, the function exited early and skipped polling other sources in that tick. That behavior let send pressure dominate scheduling under higher latency or queue pressure, which aligns with the upload/receive asymmetry we observed during testing.

The fix still polls `flush` first, but it no longer treats `Poll::Pending` as an immediate return. Instead, it records that flush is pending and continues polling network receive, device receive, DNS, and timer sources in the same iteration. `Io::poll` now returns `Poll::Pending` only when `flush` is pending *and* all other sources are also pending/empty. This preserves send backpressure while restoring receive-side fairness, and tests with simulated latency show the throughput regression disappears with this change.

Throughput benchmarks with this change show a ~3-4x increase in throughput on links with 100ms RTT latency: from roughly ~55 Mbps to ~175 - 250 Mbps.

On local LAN links (~2ms latency), we see about a ~20% increase in the receive-heavy path: ~2.5 Gbps -> ~3.1 Gbps (`iperf3 -R` from a client machine), and simply just more stable throughput in the send path (presumably because TUN readability is the bottleneck on macOS).
