### PR TITLE
fix(portal): restore pointer cursor

### DIFF
--- a/elixir/assets/css/main.css
+++ b/elixir/assets/css/main.css
@@ -6,7 +6,7 @@
 
 @layer base {
   button:not(:disabled),
-  [role="button"]:not(:disabled) {
+  [role="button"]:not([aria-disabled="true"]):not([disabled]) {
     cursor: pointer;
   }
 }

--- a/elixir/assets/css/main.css
+++ b/elixir/assets/css/main.css
@@ -4,6 +4,13 @@
 @plugin "flowbite/plugin";
 @import "./scrollbar.css";
 
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 @layer utilities {
   .scrollbar-gutter-stable {
     scrollbar-gutter: stable;


### PR DESCRIPTION
Tailwind v4 no longer applies the `pointer` cursor as the default for buttons, so we need an explicit global rule to restore this.

---

Related: https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor
