### PR TITLE
feat(portal): country code blocklist

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -314,6 +314,8 @@ config :portal,
   external_trusted_proxies: [],
   private_clients: [%{__struct__: Postgrex.INET, address: {172, 28, 0, 0}, netmask: 16}]
 
+config :portal, country_code_blocklist: []
+
 config :portal, PortalWeb.Plugs.PutCSPHeader,
   csp_policy: [
     "default-src 'self' 'nonce-${nonce}' https://firezone.statuspage.io",

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -164,6 +164,7 @@ if config_env() == :prod do
     internet_resource: env_var_to_config!(:feature_internet_resource_enabled)
 
   config :portal, sign_up_whitelisted_domains: env_var_to_config!(:sign_up_whitelisted_domains)
+  config :portal, country_code_blocklist: env_var_to_config!(:country_code_blocklist)
 
   config :portal,
     outbound_email_adapter_configured?: !!env_var_to_config!(:outbound_email_adapter)

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -700,6 +700,13 @@ defmodule Portal.Config.Definitions do
   """
   defconfig(:maxmind_city_db_path, :string, default: nil)
 
+  @doc """
+  Comma-separated list of ISO 3166-1 alpha-2 country codes to block at the endpoint.
+
+  Requests are denied with HTTP 403 when the resolved remote IP country matches one of these codes.
+  """
+  defconfig(:country_code_blocklist, {:array, ",", :string}, default: [])
+
   ##############################################
   ## Outbound Email Settings
   ##############################################

--- a/elixir/lib/portal/plugs/country_code_blocklist.ex
+++ b/elixir/lib/portal/plugs/country_code_blocklist.ex
@@ -1,0 +1,52 @@
+defmodule Portal.Plugs.CountryCodeBlocklist do
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @forbidden_body "Forbidden"
+
+  @impl true
+  def init(opts) do
+    blocked_country_codes =
+      Portal.Config.get_env(:portal, :country_code_blocklist, [])
+      |> normalize_country_codes()
+      |> MapSet.new()
+
+    Keyword.put(opts, :blocked_country_codes, blocked_country_codes)
+  end
+
+  @impl true
+  def call(conn, opts) do
+    blocked_country_codes = Keyword.fetch!(opts, :blocked_country_codes)
+
+    if blocked_country_code?(conn, blocked_country_codes), do: deny(conn), else: conn
+  end
+
+  defp blocked_country_code?(conn, blocked_country_codes) do
+    case resolved_country_code(conn) do
+      nil -> false
+      country_code -> MapSet.member?(blocked_country_codes, country_code)
+    end
+  end
+
+  defp resolved_country_code(conn) do
+    case Portal.Geo.locate(conn.remote_ip, conn.req_headers) do
+      {country_code, _city, _coords} when is_binary(country_code) -> String.upcase(country_code)
+      _other -> nil
+    end
+  end
+
+  defp deny(conn) do
+    conn
+    |> send_resp(:forbidden, @forbidden_body)
+    |> halt()
+  end
+
+  defp normalize_country_codes(country_codes) do
+    country_codes
+    |> Enum.map(&to_string/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.map(&String.upcase/1)
+  end
+end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -23,6 +23,8 @@ defmodule PortalAPI.Endpoint do
     proxies: {__MODULE__, :external_trusted_proxies, []},
     clients: {__MODULE__, :clients, []}
 
+  plug Portal.Plugs.CountryCodeBlocklist
+
   plug Plug.RequestId
   # TODO: Rework LoggerJSON to use Telemetry and integrate it
   # https://hexdocs.pm/phoenix/Phoenix.Logger.html

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -38,6 +38,8 @@ defmodule PortalWeb.Endpoint do
     proxies: {__MODULE__, :external_trusted_proxies, []},
     clients: {__MODULE__, :clients, []}
 
+  plug Portal.Plugs.CountryCodeBlocklist
+
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 

--- a/elixir/test/portal/plugs/country_code_blocklist_test.exs
+++ b/elixir/test/portal/plugs/country_code_blocklist_test.exs
@@ -1,0 +1,66 @@
+defmodule Portal.Plugs.CountryCodeBlocklistTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias Portal.Plugs.CountryCodeBlocklist
+
+  describe "call/2" do
+    test "passes through when blocklist is empty" do
+      Portal.Config.put_env_override(:country_code_blocklist, [])
+
+      conn =
+        conn(:get, "/")
+        |> put_req_header("x-azure-geo-country", "UA")
+        |> put_remote_ip({100, 64, 0, 1})
+        |> CountryCodeBlocklist.call(CountryCodeBlocklist.init([]))
+
+      refute conn.halted
+      assert conn.status == nil
+    end
+
+    test "halts with 403 when country is blocked" do
+      Portal.Config.put_env_override(:country_code_blocklist, ["UA", "RU"])
+
+      conn =
+        conn(:get, "/")
+        |> put_req_header("x-azure-geo-country", "UA")
+        |> put_remote_ip({100, 64, 0, 2})
+        |> CountryCodeBlocklist.call(CountryCodeBlocklist.init([]))
+
+      assert conn.halted
+      assert conn.status == 403
+      assert conn.resp_body == "Forbidden"
+    end
+
+    test "allows request when country is not blocked" do
+      Portal.Config.put_env_override(:country_code_blocklist, ["UA", "RU"])
+
+      conn =
+        conn(:get, "/")
+        |> put_req_header("x-azure-geo-country", "US")
+        |> put_remote_ip({100, 64, 0, 3})
+        |> CountryCodeBlocklist.call(CountryCodeBlocklist.init([]))
+
+      refute conn.halted
+      assert conn.status == nil
+    end
+
+    test "passes through when country cannot be resolved" do
+      Portal.Config.put_env_override(:country_code_blocklist, ["UA"])
+
+      conn =
+        conn(:get, "/")
+        |> put_remote_ip({100, 64, 0, 4})
+        |> CountryCodeBlocklist.call(CountryCodeBlocklist.init([]))
+
+      refute conn.halted
+      assert conn.status == nil
+    end
+  end
+
+  defp put_remote_ip(conn, ip) do
+    %{conn | remote_ip: ip}
+  end
+end


### PR DESCRIPTION
Unfortunately not all cloud providers expose a reliable means of blocking traffic from certain countries via their load balancers and we need an application-level fallback.
