### PR TITLE
fix(portal): reduce session flush interval to 5s

### DIFF
--- a/elixir/lib/portal/client_session/buffer.ex
+++ b/elixir/lib/portal/client_session/buffer.ex
@@ -4,7 +4,7 @@ defmodule Portal.ClientSession.Buffer do
   alias __MODULE__.Database
   require Logger
 
-  @flush_interval :timer.seconds(60)
+  @flush_interval :timer.seconds(5)
   @flush_threshold 1_000
 
   @drop_keys [:__struct__, :__meta__, :account, :client, :client_token]

--- a/elixir/lib/portal/gateway_session/buffer.ex
+++ b/elixir/lib/portal/gateway_session/buffer.ex
@@ -4,7 +4,7 @@ defmodule Portal.GatewaySession.Buffer do
   alias __MODULE__.Database
   require Logger
 
-  @flush_interval :timer.seconds(60)
+  @flush_interval :timer.seconds(5)
   @flush_threshold 1_000
 
   @drop_keys [:__struct__, :__meta__, :account, :gateway, :gateway_token]


### PR DESCRIPTION
Since these are eventually consistent, during this window if the client has signed in for the first time, some details won't appear in the clients list until the sessions is inserted.

To minimize the amount of time this persists, we reduce the flush interval from 60s to 5s.