### PR TITLE
chore(portal): remove acct delete from billing

### DIFF
--- a/elixir/lib/portal_web/live/settings/billing.ex
+++ b/elixir/lib/portal_web/live/settings/billing.ex
@@ -241,26 +241,6 @@ defmodule PortalWeb.Settings.Billing do
         </div>
       </:content>
     </.section>
-
-    <.section>
-      <:title>
-        Danger zone
-      </:title>
-      <:content>
-        <h3 class="ml-4 mb-4 font-medium text-neutral-900">
-          Terminate account
-        </h3>
-        <p class="ml-4 mb-4 text-neutral-600">
-          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" /> To
-          <span :if={Portal.Account.active?(@account)}>disable your account and</span>
-          schedule it for deletion, please <.link
-            class={link_style()}
-            target="_blank"
-            href={mailto_support(@account, @subject, "Account termination request: #{@account.name}")}
-          >contact support</.link>.
-        </p>
-      </:content>
-    </.section>
     """
   end
 

--- a/elixir/test/portal_web/live/settings/billing_test.exs
+++ b/elixir/test/portal_web/live/settings/billing_test.exs
@@ -376,21 +376,6 @@ defmodule PortalWeb.Settings.BillingTest do
       assert html =~ "Priority email and dedicated Slack support"
     end
 
-    test "renders danger zone section", %{
-      account: account,
-      actor: actor,
-      conn: conn
-    } do
-      {:ok, _lv, html} =
-        conn
-        |> authorize_conn(actor)
-        |> live(~p"/#{account}/settings/billing")
-
-      assert html =~ "Danger zone"
-      assert html =~ "Terminate account"
-      assert html =~ "contact support"
-    end
-
     test "renders Contact sales link", %{
       account: account,
       actor: actor,


### PR DESCRIPTION
This section is outdated and redundant with the section for this in /settings/account.
