### PR TITLE
feat(portal): search pool by actor name/email

### DIFF
--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -484,12 +484,15 @@ defmodule PortalWeb.Resources.Components do
 
       query =
         from(c in Portal.Client, as: :clients)
+        |> join(:inner, [clients: c], a in assoc(c, :actor), as: :actors)
         |> join(:left, [clients: c], ipv4 in assoc(c, :ipv4_address), as: :ipv4)
         |> join(:left, [clients: c], ipv6 in assoc(c, :ipv6_address), as: :ipv6)
         |> where([clients: c], c.id not in ^selected_ids)
         |> where(
-          [clients: c, ipv4: ipv4, ipv6: ipv6],
+          [clients: c, actors: a, ipv4: ipv4, ipv6: ipv6],
           ilike(c.name, ^pattern) or
+            ilike(a.name, ^pattern) or
+            ilike(coalesce(a.email, ""), ^pattern) or
             ilike(type(c.id, :string), ^pattern) or
             ilike(coalesce(c.external_id, ""), ^pattern) or
             ilike(coalesce(c.device_serial, ""), ^pattern) or

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -488,20 +488,7 @@ defmodule PortalWeb.Resources.Components do
         |> join(:left, [clients: c], ipv4 in assoc(c, :ipv4_address), as: :ipv4)
         |> join(:left, [clients: c], ipv6 in assoc(c, :ipv6_address), as: :ipv6)
         |> where([clients: c], c.id not in ^selected_ids)
-        |> where(
-          [clients: c, actors: a, ipv4: ipv4, ipv6: ipv6],
-          ilike(c.name, ^pattern) or
-            ilike(a.name, ^pattern) or
-            ilike(coalesce(a.email, ""), ^pattern) or
-            ilike(type(c.id, :string), ^pattern) or
-            ilike(coalesce(c.external_id, ""), ^pattern) or
-            ilike(coalesce(c.device_serial, ""), ^pattern) or
-            ilike(coalesce(c.device_uuid, ""), ^pattern) or
-            ilike(coalesce(c.identifier_for_vendor, ""), ^pattern) or
-            ilike(coalesce(c.firebase_installation_id, ""), ^pattern) or
-            ilike(type(ipv4.address, :string), ^pattern) or
-            ilike(type(ipv6.address, :string), ^pattern)
-        )
+        |> where(^client_search_filter(pattern))
         |> preload([:ipv4_address, :ipv6_address])
         |> limit(10)
 
@@ -514,6 +501,23 @@ defmodule PortalWeb.Resources.Components do
           |> Portal.Presence.Clients.preload_clients_presence()
           |> Enum.sort_by(&if &1.online?, do: 0, else: 1)
       end
+    end
+
+    defp client_search_filter(pattern) do
+      dynamic(
+        [clients: c, actors: a, ipv4: ipv4, ipv6: ipv6],
+        ilike(c.name, ^pattern) or
+          ilike(a.name, ^pattern) or
+          ilike(coalesce(a.email, ""), ^pattern) or
+          ilike(type(c.id, :string), ^pattern) or
+          ilike(coalesce(c.external_id, ""), ^pattern) or
+          ilike(coalesce(c.device_serial, ""), ^pattern) or
+          ilike(coalesce(c.device_uuid, ""), ^pattern) or
+          ilike(coalesce(c.identifier_for_vendor, ""), ^pattern) or
+          ilike(coalesce(c.firebase_installation_id, ""), ^pattern) or
+          ilike(type(ipv4.address, :string), ^pattern) or
+          ilike(type(ipv6.address, :string), ^pattern)
+      )
     end
 
     def validate_selected_clients([], _subject), do: {:ok, []}

--- a/elixir/test/portal_web/live/resources/edit_test.exs
+++ b/elixir/test/portal_web/live/resources/edit_test.exs
@@ -231,6 +231,34 @@ defmodule PortalWeb.Live.Resources.EditTest do
            })
   end
 
+  test "can search for clients in device pool picker by actor email", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    account = update_account(account, features: %{client_to_client: true})
+    existing_client = client_fixture(account: account, name: "ExistingDevice")
+
+    client_actor =
+      actor_fixture(account: account, name: "Jordan Device User", email: "jordan@example.com")
+
+    _client = client_fixture(account: account, actor: client_actor, name: "Phone-01")
+    resource = static_device_pool_resource_fixture(account: account, clients: [existing_client])
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/#{resource}/edit")
+
+    html =
+      lv
+      |> element("input[name='client_search']")
+      |> render_change(%{"client_search" => "jordan@example.com"})
+
+    assert html =~ "Phone-01"
+  end
+
   test "can remove a client from an existing device pool", %{
     account: account,
     actor: actor,

--- a/elixir/test/portal_web/live/resources/new_test.exs
+++ b/elixir/test/portal_web/live/resources/new_test.exs
@@ -266,6 +266,36 @@ defmodule PortalWeb.Live.Resources.NewTest do
     assert html =~ "MyLaptop"
   end
 
+  test "can search for clients in device pool picker by actor name", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    enable_feature(:client_to_client)
+    update_account(account, features: %{client_to_client: true})
+
+    client_actor =
+      actor_fixture(account: account, name: "Taylor Device User", email: "taylor@example.com")
+
+    _client = client_fixture(account: account, actor: client_actor, name: "Laptop-01")
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(actor)
+      |> live(~p"/#{account}/resources/new")
+
+    lv
+    |> form("form[phx-submit='submit']")
+    |> render_change(resource: %{type: :static_device_pool})
+
+    html =
+      lv
+      |> element("input[name='client_search']")
+      |> render_change(%{"client_search" => "Taylor Device User"})
+
+    assert html =~ "Laptop-01"
+  end
+
   test "can add a client to the device pool", %{
     account: account,
     actor: actor,


### PR DESCRIPTION
When searching for a client to add to a static device pool, it's helpful to be able to search by associated actor / email as well.

---

Related: #11143 
