### PR TITLE
feat(portal): configurable socket rate limits

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -379,6 +379,10 @@ config :portal, PortalAPI.RateLimit,
   refill_rate: 10,
   capacity: 200
 
+config :portal, PortalAPI.Sockets.RateLimit,
+  refill_rate: 1,
+  capacity: 1
+
 config :portal, PortalWeb.RateLimit,
   refill_rate: 10,
   capacity: 200

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -351,6 +351,10 @@ if config_env() == :prod do
       refill_rate: env_var_to_config!(:api_refill_rate),
       capacity: env_var_to_config!(:api_capacity)
 
+    config :portal, PortalAPI.Sockets.RateLimit,
+      refill_rate: env_var_to_config!(:api_socket_refill_rate),
+      capacity: env_var_to_config!(:api_socket_capacity)
+
     config :portal,
       api_external_url: api_external_url
   end

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -135,6 +135,16 @@ defmodule Portal.Config.Definitions do
   defconfig(:api_capacity, :integer, default: 200)
 
   @doc """
+  The API socket rate limiter uses a token bucket algorithm. This field sets the rate the bucket is refilled.
+  """
+  defconfig(:api_socket_refill_rate, :integer, default: 1)
+
+  @doc """
+  The API socket rate limiter uses a token bucket algorithm. This field sets the capacity of the bucket.
+  """
+  defconfig(:api_socket_capacity, :integer, default: 1)
+
+  @doc """
   The Web rate limiter uses a token bucket algorithm. This field sets the rate the bucket is refilled.
   """
   defconfig(:web_refill_rate, :integer, default: 10)

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -19,8 +19,8 @@ defmodule PortalAPI.Client.Socket do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "client.connect" do
-      with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
-           {:ok, token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
+      with {:ok, token} <- PortalAPI.Sockets.extract_token(attrs, connect_info),
+           :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: token) do
         do_connect(token, attrs, socket, connect_info)
       end
     end

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -19,8 +19,8 @@ defmodule PortalAPI.Gateway.Socket do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "gateway.connect" do
-      with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
-           {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
+      with {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info),
+           :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: encoded_token) do
         do_connect(encoded_token, attrs, socket, connect_info)
       end
     end

--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -36,8 +36,8 @@ defmodule PortalAPI.Relay.Socket do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "relay.connect" do
-      with :ok <- PortalAPI.Sockets.RateLimit.check(connect_info),
-           {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info) do
+      with {:ok, encoded_token} <- PortalAPI.Sockets.extract_token(attrs, connect_info),
+           :ok <- PortalAPI.Sockets.RateLimit.check(connect_info, token: encoded_token) do
         do_connect(encoded_token, attrs, socket, connect_info)
       end
     end

--- a/elixir/lib/portal_api/sockets/rate_limit.ex
+++ b/elixir/lib/portal_api/sockets/rate_limit.ex
@@ -2,25 +2,32 @@ defmodule PortalAPI.Sockets.RateLimit do
   @moduledoc """
   Rate limiting for WebSocket connections.
 
-  Limits connection attempts to 1 request per second per unique combination
-  of IP address and X-Authorization header value (hashed for security).
+  Connection attempts are limited per unique combination of client IP and token.
+  The refill rate and capacity are loaded at runtime from
+  `PortalAPI.Sockets.RateLimit` application config, which is backed by the
+  `api_socket_refill_rate` and `api_socket_capacity` config definitions.
   """
 
-  @refill_rate 1
-  @capacity 1
   @cost 1
   @retry_after_seconds 1
 
   @doc """
   Checks if a socket connection should be rate limited.
 
-  Uses the IP address and a hash of the X-Authorization header as a unique key.
+  Uses the IP address and a hash of the provided socket token as a unique key.
+  If `:token` is not provided in `opts`, it falls back to hashing the
+  `x-authorization` header when present, or `"none"` otherwise.
+
+  The token bucket parameters are loaded from runtime config on each call.
   Returns `:ok` if allowed, or `{:error, :rate_limit}` if rate limited.
   """
-  def check(connect_info) do
-    key = build_key(connect_info)
+  def check(connect_info, opts \\ []) when is_list(opts) do
+    key = build_key(connect_info, opts[:token])
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    refill_rate = Keyword.fetch!(config, :refill_rate)
+    capacity = Keyword.fetch!(config, :capacity)
 
-    case PortalAPI.RateLimit.hit(key, @refill_rate, @capacity, @cost) do
+    case PortalAPI.RateLimit.hit(key, refill_rate, capacity, @cost) do
       {:allow, _count} -> :ok
       {:deny, _refill_time} -> {:error, :rate_limit}
     end
@@ -31,9 +38,9 @@ defmodule PortalAPI.Sockets.RateLimit do
   """
   def retry_after_seconds, do: @retry_after_seconds
 
-  defp build_key(connect_info) do
+  defp build_key(connect_info, token) do
     ip = extract_ip(connect_info)
-    token_hash = hash_authorization(connect_info)
+    token_hash = hash_authorization(connect_info, token)
     "socket:#{ip_to_string(ip)}:#{token_hash}"
   end
 
@@ -44,7 +51,11 @@ defmodule PortalAPI.Sockets.RateLimit do
 
   defp extract_ip(%{peer_data: peer_data}), do: peer_data.address
 
-  defp hash_authorization(%{x_headers: x_headers}) when is_list(x_headers) do
+  defp hash_authorization(_connect_info, token) when is_binary(token) do
+    :crypto.hash(:sha256, token) |> Base.encode16(case: :lower) |> binary_part(0, 16)
+  end
+
+  defp hash_authorization(%{x_headers: x_headers}, _token) when is_list(x_headers) do
     case List.keyfind(x_headers, "x-authorization", 0) do
       {"x-authorization", value} ->
         :crypto.hash(:sha256, value) |> Base.encode16(case: :lower) |> binary_part(0, 16)
@@ -54,7 +65,7 @@ defmodule PortalAPI.Sockets.RateLimit do
     end
   end
 
-  defp hash_authorization(_connect_info), do: "none"
+  defp hash_authorization(_connect_info, _token), do: "none"
 
   defp ip_to_string(ip) when is_tuple(ip), do: :inet.ntoa(ip) |> to_string()
   defp ip_to_string(ip), do: to_string(ip)

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -302,6 +302,34 @@ defmodule PortalAPI.Client.SocketTest do
       assert rate_limited, "Expected at least one connection attempt to be rate limited"
     end
 
+    test "uses socket rate limit config overrides for repeated connection attempts" do
+      Portal.Config.put_env_override(:portal, PortalAPI.Sockets.RateLimit,
+        refill_rate: 1,
+        capacity: 3
+      )
+
+      token = client_token_fixture()
+      encoded_token = encode_token(token)
+
+      attrs = connect_attrs(token: encoded_token)
+      ip = unique_ip()
+      connect_info = build_connect_info(ip: ip, token: encoded_token)
+
+      # All 3 connections should succeed, proving capacity=3 is applied
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+
+      # Subsequent connections should be rate limited. Use Enum.any? to avoid
+      # flakiness from crossing second boundaries with the slow (1/s) refill rate.
+      rate_limited =
+        Enum.any?(1..3, fn _ ->
+          connect(Socket, attrs, connect_info: connect_info) == {:error, :rate_limit}
+        end)
+
+      assert rate_limited, "Expected at least one connection attempt to be rate limited"
+    end
+
     test "allows connections from different IPs with same token" do
       token = client_token_fixture()
       encoded_token = encode_token(token)

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -215,6 +215,34 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert rate_limited, "Expected at least one connection attempt to be rate limited"
     end
 
+    test "uses socket rate limit config overrides for repeated connection attempts" do
+      Portal.Config.put_env_override(:portal, PortalAPI.Sockets.RateLimit,
+        refill_rate: 1,
+        capacity: 3
+      )
+
+      token = gateway_token_fixture()
+      encrypted_secret = encode_gateway_token(token)
+
+      attrs = connect_attrs(token: encrypted_secret)
+      ip = unique_ip()
+      connect_info = build_connect_info(ip: ip, token: encrypted_secret)
+
+      # All 3 connections should succeed, proving capacity=3 is applied
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+      assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
+
+      # Subsequent connections should be rate limited. Use Enum.any? to avoid
+      # flakiness from crossing second boundaries with the slow (1/s) refill rate.
+      rate_limited =
+        Enum.any?(1..3, fn _ ->
+          connect(Socket, attrs, connect_info: connect_info) == {:error, :rate_limit}
+        end)
+
+      assert rate_limited, "Expected at least one connection attempt to be rate limited"
+    end
+
     test "allows connections from different IPs with same token" do
       token = gateway_token_fixture()
       encrypted_secret = encode_gateway_token(token)

--- a/elixir/test/portal_api/sockets/rate_limit_test.exs
+++ b/elixir/test/portal_api/sockets/rate_limit_test.exs
@@ -15,6 +15,26 @@ defmodule PortalAPI.Sockets.RateLimitTest do
       assert RateLimit.check(connect_info) == {:error, :rate_limit}
     end
 
+    test "uses runtime config overrides" do
+      Portal.Config.put_env_override(:portal, PortalAPI.Sockets.RateLimit,
+        refill_rate: 1,
+        capacity: 3
+      )
+
+      connect_info = unique_connect_info()
+
+      assert RateLimit.check(connect_info) == :ok
+      assert RateLimit.check(connect_info) == :ok
+      assert RateLimit.check(connect_info) == :ok
+
+      rate_limited =
+        Enum.any?(1..3, fn _ ->
+          RateLimit.check(connect_info) == {:error, :rate_limit}
+        end)
+
+      assert rate_limited, "Expected at least one request to be rate limited"
+    end
+
     test "allows requests from different IPs with same token" do
       token = unique_token()
 


### PR DESCRIPTION
When testing certain load scenarios, it's helpful to customize the default API socket connect limit used by the channel modules. To do this, we expose these limits via the usual `Portal.Config` system so they can be overridden at runtime.