### PR TITLE
feat(connlib): send `no_relays` message instead of reconnecting

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -914,6 +914,23 @@ defmodule PortalAPI.Client.Channel do
     {:noreply, socket}
   end
 
+  def handle_in("no_relays", _payload, socket) do
+    {:ok, relays} = select_relays(socket)
+    socket = cache_relays(socket, relays)
+
+    push(socket, "relays_presence", %{
+      disconnected_ids: [],
+      connected:
+        Views.Relay.render_many(
+          relays,
+          socket.assigns.session.public_key,
+          socket.assigns.subject.expires_at
+        )
+    })
+
+    {:noreply, socket}
+  end
+
   # Catch-all for unknown messages
   def handle_in(message, payload, socket) do
     Logger.error("Unknown client message", message: message, payload: payload)

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -468,6 +468,23 @@ defmodule PortalAPI.Gateway.Channel do
     {:noreply, socket}
   end
 
+  def handle_in("no_relays", _payload, socket) do
+    {:ok, relays} = select_relays(socket)
+    socket = cache_relays(socket, relays)
+
+    push(socket, "relays_presence", %{
+      disconnected_ids: [],
+      connected:
+        Views.Relay.render_many(
+          relays,
+          socket.assigns.session.public_key,
+          @relay_credentials_expire_at
+        )
+    })
+
+    {:noreply, socket}
+  end
+
   # Catch-all for unknown messages
   def handle_in(message, payload, socket) do
     Logger.error("Unknown gateway message", message: message, payload: payload)

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -4487,7 +4487,7 @@ defmodule PortalAPI.Client.ChannelTest do
                     connected: [relay_view | _] = relays
                   }
 
-      assert length(relays) == 2
+      assert length(relays) == 4
 
       assert %{
                addr: _,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -4468,6 +4468,57 @@ defmodule PortalAPI.Client.ChannelTest do
     end
   end
 
+  describe "handle_in/3 no_relays" do
+    test "sends relays_presence with 2 selected relays", %{
+      client: client,
+      subject: subject
+    } do
+      relay1 = connect_relay(%{lat: 37.0, lon: -120.0})
+      relay2 = connect_relay(%{lat: 38.0, lon: -121.0})
+
+      socket = join_channel(client, subject)
+      assert_push "init", %{relays: _}
+
+      push(socket, "no_relays", %{})
+
+      assert_push "relays_presence",
+                  %{
+                    disconnected_ids: [],
+                    connected: [relay_view | _] = relays
+                  }
+
+      assert length(relays) == 2
+
+      assert %{
+               addr: _,
+               expires_at: _,
+               id: _,
+               password: _,
+               type: _,
+               username: _
+             } = relay_view
+
+      relay_ids = Enum.map(relays, & &1.id) |> Enum.uniq() |> Enum.sort()
+      assert relay_ids == [relay1.id, relay2.id] |> Enum.sort()
+    end
+
+    test "sends relays_presence with empty connected when no relays are online", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", %{relays: []}
+
+      push(socket, "no_relays", %{})
+
+      assert_push "relays_presence",
+                  %{
+                    disconnected_ids: [],
+                    connected: []
+                  }
+    end
+  end
+
   describe "handle_in/3 for unknown message" do
     test "it doesn't crash", %{client: client, subject: subject} do
       socket = join_channel(client, subject)

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -2003,6 +2003,60 @@ defmodule PortalAPI.Gateway.ChannelTest do
       assert_reply ref, :error, %{reason: :unknown_message}
     end
 
+    test "no_relays sends relays_presence with 2 selected relays", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      relay1 = relay_fixture(%{lat: 37.0, lon: -120.0})
+      :ok = Portal.Presence.Relays.connect(relay1)
+
+      relay2 = relay_fixture(%{lat: 38.0, lon: -121.0})
+      :ok = Portal.Presence.Relays.connect(relay2)
+
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      push(socket, "no_relays", %{})
+
+      assert_push "relays_presence",
+                  %{
+                    disconnected_ids: [],
+                    connected: [relay_view | _] = relays
+                  }
+
+      assert length(relays) == 2
+
+      assert %{
+               addr: _,
+               expires_at: _,
+               id: _,
+               password: _,
+               type: _,
+               username: _
+             } = relay_view
+
+      relay_ids = Enum.map(relays, & &1.id) |> Enum.uniq() |> Enum.sort()
+      assert relay_ids == [relay1.id, relay2.id] |> Enum.sort()
+    end
+
+    test "no_relays sends relays_presence with empty connected when no relays are online", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: []}
+
+      push(socket, "no_relays", %{})
+
+      assert_push "relays_presence",
+                  %{
+                    disconnected_ids: [],
+                    connected: []
+                  }
+    end
+
     test "flow_authorized forwards reply to the client channel", %{
       client: client,
       account: account,

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -2025,7 +2025,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
                     connected: [relay_view | _] = relays
                   }
 
-      assert length(relays) == 2
+      assert length(relays) == 4
 
       assert %{
                addr: _,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -315,12 +315,10 @@ impl Eventloop {
                 ) {
                     tracing::debug!("Failed to authorise flow: No TURN servers available");
 
-                    // Re-connecting to the portal means we will receive another `init` and thus new TURN servers.
                     self.portal_cmd_tx
-                        .send(PortalCommand::Connect(PublicKeyParam(
-                            tunnel.public_key().to_bytes(),
-                        )))
-                        .await?;
+                        .send(PortalCommand::Send(EgressMessages::NoRelays))
+                        .await
+                        .context("Failed to connect phoenix-channel")?;
 
                     return Ok(());
                 };

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -317,7 +317,7 @@ impl Eventloop {
                     self.portal_cmd_tx
                         .send(PortalCommand::Send(EgressMessages::NoRelays))
                         .await
-                        .context("Failed to connect phoenix-channel")?;
+                        .context("Failed to send message to portal")?;
 
                     return Ok(());
                 };

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -52,7 +52,6 @@ pub struct Eventloop {
 
 enum PortalCommand {
     Send(EgressMessages),
-    Connect(PublicKeyParam),
     Close,
 }
 
@@ -523,7 +522,7 @@ impl Eventloop {
 
 async fn phoenix_channel_event_loop(
     mut portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
-    mut public_key: PublicKeyParam,
+    public_key: PublicKeyParam,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
     resolver: TokioResolver,
@@ -576,12 +575,6 @@ async fn phoenix_channel_event_loop(
                         tracing::debug!(?msg, "Failed to send message to portal: Not connected")
                     }
                 }
-            }
-            Either::Right((Some(PortalCommand::Connect(new_public_key)), _)) => {
-                public_key = new_public_key; // Important! Update the current public key so we can reuse on connection hiccups!
-
-                let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
-                portal.connect(ips, Duration::ZERO, public_key.clone());
             }
             Either::Right((Some(PortalCommand::Close), _)) => {
                 let _ = portal.close();

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -315,7 +315,7 @@ impl Eventloop {
                     tracing::debug!("Failed to authorise flow: No TURN servers available");
 
                     self.portal_cmd_tx
-                        .send(PortalCommand::Send(EgressMessages::NoRelays))
+                        .send(PortalCommand::Send(EgressMessages::NoRelays {}))
                         .await
                         .context("Failed to send message to portal")?;
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -500,7 +500,7 @@ impl Eventloop {
                         self.portal_cmd_tx
                             .send(PortalCommand::Send(EgressMessages::NoRelays))
                             .await
-                            .context("Failed to connect phoenix-channel")?;
+                            .context("Failed to send message to portal")?;
                     }
                     Err(e) => {
                         tracing::warn!("Failed to handle flow created: {e:#}");

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -497,11 +497,8 @@ impl Eventloop {
                     Ok(Err(e @ snownet::NoTurnServers {})) => {
                         tracing::debug!("Failed to handle flow created: {e}");
 
-                        // Re-connecting to the portal means we will receive another `init` and thus new TURN servers.
                         self.portal_cmd_tx
-                            .send(PortalCommand::Connect(PublicKeyParam(
-                                tunnel.public_key().to_bytes(),
-                            )))
+                            .send(PortalCommand::Send(EgressMessages::NoRelays))
                             .await
                             .context("Failed to connect phoenix-channel")?;
                     }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -498,7 +498,7 @@ impl Eventloop {
                         tracing::debug!("Failed to handle flow created: {e}");
 
                         self.portal_cmd_tx
-                            .send(PortalCommand::Send(EgressMessages::NoRelays))
+                            .send(PortalCommand::Send(EgressMessages::NoRelays {}))
                             .await
                             .context("Failed to send message to portal")?;
                     }

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -525,6 +525,15 @@ mod tests {
     }
 
     #[test]
+    fn serialize_no_relays_message() {
+        let message = EgressMessages::NoRelays {};
+        let expected_json = r#"{"event":"no_relays","payload":{}}"#;
+        let actual_json = serde_json::to_string(&message).unwrap();
+
+        assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
     fn faulty_candidate_get_skipped() {
         let bad_candidates = serde_json::json!({ "gateway_id": "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3", "candidates": ["foo", "bar", "baz", "candidate:fffeff6435be70ddbf995982 1 udp 1694498559 87.121.72.60 57114 typ srflx raddr 0.0.0.0 rport 0"] });
 

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -215,7 +215,7 @@ pub enum EgressMessages {
     RequestDeviceAccess {
         ipv4: Ipv4Addr,
     },
-    NoRelays,
+    NoRelays {},
     NewGatewayIceCandidates(GatewayIceCandidates),
     InvalidateGatewayIceCandidates(GatewayIceCandidates),
     NewClientIceCandidates(ClientIceCandidates),

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -215,6 +215,7 @@ pub enum EgressMessages {
     RequestDeviceAccess {
         ipv4: Ipv4Addr,
     },
+    NoRelays,
     NewGatewayIceCandidates(GatewayIceCandidates),
     InvalidateGatewayIceCandidates(GatewayIceCandidates),
     NewClientIceCandidates(ClientIceCandidates),

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -248,6 +248,7 @@ pub enum EgressMessages {
         #[serde(rename = "ref")]
         reference: String,
     },
+    NoRelays,
 }
 
 #[cfg(test)]

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -418,6 +418,15 @@ mod tests {
     }
 
     #[test]
+    fn serialize_no_relays_message() {
+        let message = EgressMessages::NoRelays {};
+        let expected_json = r#"{"event":"no_relays","payload":{}}"#;
+        let actual_json = serde_json::to_string(&message).unwrap();
+
+        assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
     fn faulty_candidate_get_skipped() {
         let bad_candidates = serde_json::json!({ "client_id": "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3", "candidates": ["foo", "bar", "baz", "candidate:fffeff6435be70ddbf995982 1 udp 1694498559 87.121.72.60 57114 typ srflx raddr 0.0.0.0 rport 0"] });
 

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -248,7 +248,7 @@ pub enum EgressMessages {
         #[serde(rename = "ref")]
         reference: String,
     },
-    NoRelays,
+    NoRelays {},
 }
 
 #[cfg(test)]

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -660,7 +660,6 @@ impl TunnelTest {
                     Err(ClientEventError::Client { id, error: e }) => {
                         tracing::debug!("Failed to handle ClientEvent: {e}");
 
-                        // Simulate WebSocket reconnect ...
                         let client = self.clients.get_mut(&id).unwrap();
                         client.exec_mut(|c| {
                             c.update_relays(iter::empty(), self.relays.iter(), now);
@@ -669,7 +668,6 @@ impl TunnelTest {
                     Err(ClientEventError::Gateway { id, error: e }) => {
                         tracing::debug!("Failed to handle GatewayEvent: {e}");
 
-                        // Simulate WebSocket reconnect ...
                         let gateway = self.gateways.get_mut(&id).unwrap();
                         gateway
                             .exec_mut(|g| g.update_relays(iter::empty(), self.relays.iter(), now))


### PR DESCRIPTION
When connlib disconnects from all its relays and we need to make a new connection, we force-reconnect the WebSocket in order to receive a new `init` message which contains a new set of relays. That is unnecessarily expensive on the portal end. Instead, we can just send a regular message that we don't have any local relays. The portal can then respond with a `relays_presence` message and send us a new set of relays.