### PR TITLE
fix(snownet): reset TURN keep-alive on channel-data traffic

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -695,6 +695,10 @@ impl Allocation {
             SocketAddr::V6(_) => self.ip6_socket()?,
         };
 
+        if let Some(socket) = self.active_socket.as_mut() {
+            socket.reset(now);
+        }
+
         tracing::trace!(%peer, ?socket, "Decapsulated channel-data message");
 
         Some((peer, payload, socket))
@@ -717,6 +721,8 @@ impl Allocation {
                 .as_mut()
                 .and_then(|a| a.handle_timeout(now))
         {
+            tracing::debug!("Sending STUN binding as keep-alive");
+
             self.queue(addr, make_binding_request(self.software.clone()), None, now);
         }
 
@@ -875,7 +881,7 @@ impl Allocation {
         buffer: &mut [u8],
         now: Instant,
     ) -> Option<EncodeOk> {
-        let active_socket = self.active_socket?.addr;
+        let active_socket = self.active_socket.as_mut()?;
         let payload_length = buffer.len() - 4;
 
         let connected_channel_to_peer = self.channel_bindings.connected_channel_to_peer(peer, now);
@@ -898,8 +904,10 @@ impl Allocation {
             payload_length,
         );
 
+        active_socket.reset(now);
+
         Some(EncodeOk {
-            socket: active_socket,
+            socket: active_socket.addr,
         })
     }
 
@@ -1204,9 +1212,15 @@ impl ActiveSocket {
             return None;
         }
 
-        self.next_binding = now + BINDING_INTERVAL;
+        self.reset(now);
 
         Some(self.addr)
+    }
+
+    fn reset(&mut self, now: Instant) {
+        tracing::trace!("Resetting keepalive binding");
+
+        self.next_binding = now + BINDING_INTERVAL;
     }
 }
 

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -2791,6 +2791,65 @@ mod tests {
         );
     }
 
+    #[test]
+    fn skips_binding_request_on_outbound_channel_data_message() {
+        let _guard = logging::test("trace");
+
+        let mut now = Instant::now();
+
+        let mut allocation = Allocation::for_test_ip4(now)
+            .with_binding_response(PEER1, now)
+            .with_allocate_response(&[RELAY_ADDR_IP4], now);
+
+        allocation.bind_channel(PEER2_IP4, now);
+        let channel_bind_msg = allocation.next_message().unwrap();
+        allocation.handle_test_input_ip4(channel_bind_success(&channel_bind_msg), now);
+
+        now += Duration::from_secs(10);
+
+        allocation
+            .encode_channel_data_header(PEER2_IP4, &mut [0u8; 10], now)
+            .unwrap();
+
+        now += Duration::from_secs(15);
+        allocation.handle_timeout(now);
+
+        let maybe_transmit = allocation.poll_transmit();
+        assert_eq!(maybe_transmit, None);
+    }
+
+    #[test]
+    fn skips_binding_request_on_inbound_channel_data_message() {
+        let _guard = logging::test("trace");
+
+        let mut now = Instant::now();
+
+        let mut allocation = Allocation::for_test_ip4(now)
+            .with_binding_response(PEER1, now)
+            .with_allocate_response(&[RELAY_ADDR_IP4], now);
+
+        allocation.bind_channel(PEER2_IP4, now);
+        let channel_bind_msg = allocation.next_message().unwrap();
+        allocation.handle_test_input_ip4(channel_bind_success(&channel_bind_msg), now);
+
+        now += Duration::from_secs(10);
+
+        let mut packet = vec![0; 4];
+        channel_data::encode_header_to_slice(&mut packet, 16384, 0);
+
+        allocation.decapsulate(
+            SocketAddr::V4(RELAY_V4),
+            channel_data::decode(&packet).unwrap(),
+            now,
+        );
+
+        now += Duration::from_secs(15);
+        allocation.handle_timeout(now);
+
+        let maybe_transmit = allocation.poll_transmit();
+        assert_eq!(maybe_transmit, None);
+    }
+
     fn ch(peer: SocketAddr, now: Instant) -> Channel {
         Channel {
             peer,

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -695,10 +695,6 @@ impl Allocation {
             SocketAddr::V6(_) => self.ip6_socket()?,
         };
 
-        if let Some(socket) = self.active_socket.as_mut() {
-            socket.reset(now);
-        }
-
         tracing::trace!(%peer, ?socket, "Decapsulated channel-data message");
 
         Some((peer, payload, socket))
@@ -2824,38 +2820,6 @@ mod tests {
         allocation
             .encode_channel_data_header(PEER2_IP4, &mut [0u8; 10], now)
             .unwrap();
-
-        now += Duration::from_secs(15);
-        allocation.handle_timeout(now);
-
-        let maybe_transmit = allocation.poll_transmit();
-        assert_eq!(maybe_transmit, None);
-    }
-
-    #[test]
-    fn skips_binding_request_on_inbound_channel_data_message() {
-        let _guard = logging::test("trace");
-
-        let mut now = Instant::now();
-
-        let mut allocation = Allocation::for_test_ip4(now)
-            .with_binding_response(PEER1, now)
-            .with_allocate_response(&[RELAY_ADDR_IP4], now);
-
-        allocation.bind_channel(PEER2_IP4, now);
-        let channel_bind_msg = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(channel_bind_success(&channel_bind_msg), now);
-
-        now += Duration::from_secs(10);
-
-        let mut packet = vec![0; 4];
-        channel_data::encode_header_to_slice(&mut packet, 16384, 0);
-
-        allocation.decapsulate(
-            SocketAddr::V4(RELAY_V4),
-            channel_data::decode(&packet).unwrap(),
-            now,
-        );
 
         now += Duration::from_secs(15);
         allocation.handle_timeout(now);

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull={12506}>
+          Fixes an issue where the Gateway would disconnect from a relay under
+          high-load.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.1" date={new Date("2026-03-16")}>
         <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a


### PR DESCRIPTION
In order to keep NAT bindings along the path to the TURN servers alive, we send a STUN binding request every 25s. Under high load to the TURN server, those binding requests can get lost, causing false-positive disconnects from the server because we think it is not responding.

To prevent that, we can reset the timer for the keep-alive message every time we send a channel-data message. The channel-data message is also just another UDP packet and will keep the NAT bindings alive just like the STUN binding request.