### PR TITLE
fix(connlib): only wakeup at most every 100ms

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -656,8 +656,8 @@ fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
 fn abs_duration_since(left: tokio::time::Instant, right: tokio::time::Instant) -> Duration {
     match left.cmp(&right) {
         std::cmp::Ordering::Less => right.duration_since(left),
-        std::cmp::Ordering::Equal => right.duration_since(left),
         std::cmp::Ordering::Greater => left.duration_since(right),
+        std::cmp::Ordering::Equal => Duration::ZERO,
     }
 }
 
@@ -675,6 +675,7 @@ mod tests {
 
         assert_eq!(abs_duration_since(one, two), Duration::from_secs(1));
         assert_eq!(abs_duration_since(two, one), Duration::from_secs(1));
+        assert_eq!(abs_duration_since(one, one), Duration::ZERO);
     }
 
     #[tokio::test]

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -512,7 +512,7 @@ impl Io {
             Some(_) => {}
             None => {
                 self.timeout = {
-                    tracing::trace!(?wakeup_in, %reason);
+                    tracing::trace!(wakeup_in, %reason);
 
                     Some(Box::pin(tokio::time::sleep_until(timeout)))
                 }

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -501,7 +501,10 @@ impl Io {
         let timeout = tokio::time::Instant::from_std(timeout);
 
         match self.timeout.as_mut() {
-            Some(existing_timeout) if existing_timeout.deadline() != timeout => {
+            Some(existing_timeout)
+                if abs_duration_since(existing_timeout.deadline(), timeout)
+                    >= Duration::from_millis(100) =>
+            {
                 tracing::trace!(wakeup_in, %reason);
 
                 existing_timeout.as_mut().reset(timeout)
@@ -650,12 +653,29 @@ fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
     true
 }
 
+fn abs_duration_since(left: tokio::time::Instant, right: tokio::time::Instant) -> Duration {
+    match left.cmp(&right) {
+        std::cmp::Ordering::Less => right.duration_since(left),
+        std::cmp::Ordering::Equal => right.duration_since(left),
+        std::cmp::Ordering::Greater => left.duration_since(right),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::task::noop_waker_ref;
     use std::{future::poll_fn, net::Ipv4Addr, ptr::addr_of_mut};
 
     use super::*;
+
+    #[test]
+    fn correct_abs_duration_since() {
+        let one = tokio::time::Instant::now();
+        let two = one + Duration::from_secs(1);
+
+        assert_eq!(abs_duration_since(one, two), Duration::from_secs(1));
+        assert_eq!(abs_duration_since(two, one), Duration::from_secs(1));
+    }
 
     #[tokio::test]
     async fn timer_is_reset_after_it_fires() {
@@ -746,6 +766,48 @@ mod tests {
         );
         assert!(io.udp_dns_server.is_empty());
         assert!(io.tcp_dns_server.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cannot_reset_less_than_100ms_earlier() {
+        let _guard = logging::test("debug");
+
+        let mut io = Io::for_test();
+        let now = Instant::now();
+
+        io.reset_timeout(now + Duration::from_millis(400), "test");
+        io.reset_timeout(now + Duration::from_millis(350), "test"); // Needs to be at least 100ms earlier to replace.
+
+        tokio::time::sleep(Duration::from_millis(350)).await;
+        let poll = io.poll_test();
+
+        assert!(poll.is_pending());
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let Poll::Ready(input) = io.poll_test() else {
+            panic!("Should be ready");
+        };
+
+        assert!(input.timeout);
+    }
+
+    #[tokio::test]
+    async fn cannot_reset_less_than_100ms_later() {
+        let _guard = logging::test("debug");
+
+        let mut io = Io::for_test();
+        let now = Instant::now();
+
+        io.reset_timeout(now + Duration::from_millis(350), "test");
+        io.reset_timeout(now + Duration::from_millis(400), "test"); // Needs to be at least 100ms later to replace.
+
+        tokio::time::sleep(Duration::from_millis(350)).await;
+
+        let Poll::Ready(input) = io.poll_test() else {
+            panic!("Should be ready");
+        };
+
+        assert!(input.timeout);
     }
 
     fn example_com_recursive_query() -> dns::RecursiveQuery {


### PR DESCRIPTION
The networking core of Firezone - connlib - operates in a sans-IO fashion. This means that we don't actually have any IO inside our application logic and instead, we just perform in-memory state updates. This also applies to all time-related actions. Those are expressed as deadlines in the form of `Instant`s. When a particular part of the state machine wants to do something at a later point, it sets its deadline to that `Instant`. Those get then aggregated via `poll_timeout` and the entire state machine is woken up at the earliest point.

As we add more connections to `snownet`, this presents itself as a scaling problem. Connections get added at different points in time but they all need to perform time-related actions with the same durations, like sending a STUN request every 1.5s. With more connections being managed by a single node, the exact points in time where each connection wants to send a STUN request gets spread out over e.g. those 1.5s. The result is that _something_ within in the state machine basically wants to get updated all the time, leading to lots of CPU cycles getting burnt by unnecessarily fine-granular timer updates.

To fix this, we limit timer updates to a 100ms granularity. This means, unless the time at which something needs to happen is at least 100ms off from the current one, we won't actually change the timer itself.