### PR TITLE
fix(connlib): explicitly migrate removed relays

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6999,6 +6999,7 @@ dependencies = [
  "ringbuffer",
  "sha1",
  "sha2",
+ "smallvec",
  "str0m",
  "stun_codec",
  "telemetry",

--- a/rust/libs/connlib/snownet/Cargo.toml
+++ b/rust/libs/connlib/snownet/Cargo.toml
@@ -23,6 +23,7 @@ rand = { workspace = true }
 ringbuffer = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
+smallvec = { workspace = true }
 str0m = { workspace = true }
 stun_codec = { workspace = true }
 telemetry = { workspace = true }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -610,7 +610,7 @@ where
 
         let removed_allocations = self.allocations.gc();
 
-        self.connections.maybe_migrate_relays(
+        self.connections.migrate_relays(
             removed_allocations,
             &self.allocations,
             &mut self.pending_events,
@@ -714,7 +714,7 @@ where
         }
 
         // Fourth, migrate existing connections away from removed relays.
-        self.connections.maybe_migrate_relays(
+        self.connections.migrate_relays(
             to_remove.into_iter(),
             &self.allocations,
             &mut self.pending_events,
@@ -777,10 +777,7 @@ where
             intent_sent_at,
             signalling_completed_at: now,
             remote_pub_key: remote,
-            relay: SelectedRelay {
-                id: relay,
-                sample_failure: false,
-            },
+            relay: SelectedRelay { id: relay },
             state: ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(128),
                 ip_buffer: AllocRingBuffer::new(128),
@@ -1254,8 +1251,6 @@ struct Connection<RId> {
 #[derive(Debug)]
 struct SelectedRelay<RId> {
     id: RId,
-    /// Whether we've already logged failure to sample a new relay.
-    sample_failure: bool,
 }
 
 impl<RId> Connection<RId>
@@ -1896,6 +1891,25 @@ where
 
     fn is_idle(&self) -> bool {
         matches!(self.state, ConnectionState::Idle { .. })
+    }
+
+    fn migrate_relay<TId>(
+        &mut self,
+        cid: TId,
+        new_relay: RId,
+        new_allocation: &Allocation,
+        pending_events: &mut VecDeque<Event<TId>>,
+        now: Instant,
+    ) where
+        TId: fmt::Display + Copy,
+    {
+        tracing::info!(%cid, old = %self.relay.id, new = %new_relay, "Attempting to migrate connection to new relay");
+
+        self.relay.id = new_relay;
+
+        for candidate in new_allocation.current_relay_candidates() {
+            self.add_local_candidate(cid, &candidate, pending_events, now);
+        }
     }
 }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -779,7 +779,7 @@ where
             remote_pub_key: remote,
             relay: SelectedRelay {
                 id: relay,
-                logged_sample_failure: false,
+                sample_failure: false,
             },
             state: ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(128),
@@ -1255,7 +1255,7 @@ struct Connection<RId> {
 struct SelectedRelay<RId> {
     id: RId,
     /// Whether we've already logged failure to sample a new relay.
-    logged_sample_failure: bool,
+    sample_failure: bool,
 }
 
 impl<RId> Connection<RId>

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -608,8 +608,10 @@ where
             }
         }
 
-        self.allocations.gc();
-        self.connections.check_relays_available(
+        let removed_allocations = self.allocations.gc();
+
+        self.connections.maybe_migrate_relays(
+            removed_allocations,
             &self.allocations,
             &mut self.pending_events,
             &mut self.rng,
@@ -710,6 +712,15 @@ where
         {
             previous_allocation.refresh(now);
         }
+
+        // Fourth, migrate existing connections away from removed relays.
+        self.connections.maybe_migrate_relays(
+            to_remove.into_iter(),
+            &self.allocations,
+            &mut self.pending_events,
+            &mut self.rng,
+            now,
+        );
     }
 
     #[must_use]

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -9,6 +9,7 @@ use bufferpool::BufferPool;
 use itertools::Itertools as _;
 use rand::{Rng, seq::IteratorRandom as _};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
+use smallvec::SmallVec;
 use str0m::Candidate;
 use stun_codec::rfc5389::attributes::{Realm, Username};
 
@@ -38,10 +39,6 @@ where
 
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.is_empty()
-    }
-
-    pub(crate) fn contains(&self, id: &RId) -> bool {
-        self.inner.contains_key(id)
     }
 
     pub(crate) fn get_by_id(&self, id: &RId) -> Option<&Allocation> {
@@ -188,19 +185,25 @@ where
             .next()
     }
 
-    pub(crate) fn gc(&mut self) {
+    /// Performs garbage-collection across all our allocations.
+    ///
+    /// This is zero-cost if we end up not making any changes because we will simply end up returning an empty iterator.
+    pub(crate) fn gc(&mut self) -> impl Iterator<Item = RId> + use<RId> {
         self.inner
-            .retain(|rid, allocation| match allocation.can_be_freed() {
+            .extract_if(.., |rid, allocation| match allocation.can_be_freed() {
                 Some(e) => {
                     tracing::info!(%rid, "Disconnecting from relay; {e}");
 
                     self.previous_relays_by_ip
                         .extend(server_addresses(allocation));
 
-                    false
+                    true
                 }
-                None => true,
-            });
+                None => false,
+            })
+            .map(|(rid, _)| rid)
+            .collect::<SmallVec<[_; 2]>>() // Typically, we are only connected to 2 relays. Using a `SmallVec` here avoids allocations.
+            .into_iter()
     }
 
     fn shared_candidates(&self) -> impl Iterator<Item = Candidate> {

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -187,7 +187,8 @@ where
 
     /// Performs garbage-collection across all our allocations.
     ///
-    /// This is zero-cost if we end up not making any changes because we will simply end up returning an empty iterator.
+    /// Handling the resulting iterator is zero-cost if we end up not making any changes
+    /// because we will simply end up returning an empty iterator.
     pub(crate) fn gc(&mut self) -> impl Iterator<Item = RId> + use<RId> {
         self.inner
             .extract_if(.., |rid, allocation| match allocation.can_be_freed() {

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -90,9 +90,9 @@ where
         rng: &mut impl Rng,
         now: Instant,
     ) {
-        for rid in removed_allocations {
-            for (cid, c) in self.iter_mut_by_relay(rid) {
-                let Some((rid, new_allocation)) = allocations.sample(rng) else {
+        for removed_relay in removed_allocations {
+            for (cid, c) in self.iter_mut_by_relay(removed_relay) {
+                let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
                     if !c.relay.logged_sample_failure {
                         tracing::debug!(%cid, "Failed to sample new relay for connection");
                     }
@@ -101,9 +101,9 @@ where
                     continue;
                 };
 
-                tracing::info!(%cid, old = %c.relay.id, new = %rid, "Attempting to migrate connection to new relay");
+                tracing::info!(%cid, old = %c.relay.id, new = %new_relay, "Attempting to migrate connection to new relay");
 
-                c.relay.id = rid;
+                c.relay.id = new_relay;
 
                 for candidate in new_allocation.current_relay_candidates() {
                     c.add_local_candidate(cid, &candidate, pending_events, now);

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -93,10 +93,10 @@ where
         for removed_relay in removed_allocations {
             for (cid, c) in self.iter_mut_by_relay(removed_relay) {
                 let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
-                    if !c.relay.logged_sample_failure {
+                    if !c.relay.sample_failure {
                         tracing::debug!(%cid, "Failed to sample new relay for connection");
                     }
-                    c.relay.logged_sample_failure = true;
+                    c.relay.sample_failure = true;
 
                     continue;
                 };
@@ -464,7 +464,7 @@ mod tests {
             last_proactive_handshake_sent_at: None,
             relay: SelectedRelay {
                 id: 0,
-                logged_sample_failure: false,
+                sample_failure: false,
             },
             state: crate::node::ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(1),

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -100,9 +100,9 @@ where
         for removed_relay in removed_allocations {
             for (cid, c) in self.iter_mut_by_relay(removed_relay) {
                 let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
-                    let was_present = connections_with_removed_relays.insert(cid);
+                    let was_inserted = connections_with_removed_relays.insert(cid);
 
-                    if !was_present {
+                    if was_inserted {
                         tracing::debug!(%cid, "Failed to sample new relay for connection");
                     }
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -82,33 +82,32 @@ where
         Some(connection)
     }
 
-    pub(crate) fn check_relays_available(
+    pub(crate) fn maybe_migrate_relays(
         &mut self,
+        removed_allocations: impl Iterator<Item = RId>,
         allocations: &Allocations<RId>,
         pending_events: &mut VecDeque<Event<TId>>,
         rng: &mut impl Rng,
         now: Instant,
     ) {
-        for (cid, c) in self.iter_established_mut() {
-            if allocations.contains(&c.relay.id) {
-                continue; // Our relay is still there, no problems.
-            }
+        for rid in removed_allocations {
+            for (cid, c) in self.iter_mut_by_relay(rid) {
+                let Some((rid, new_allocation)) = allocations.sample(rng) else {
+                    if !c.relay.logged_sample_failure {
+                        tracing::debug!(%cid, "Failed to sample new relay for connection");
+                    }
+                    c.relay.logged_sample_failure = true;
 
-            let Some((rid, allocation)) = allocations.sample(rng) else {
-                if !c.relay.logged_sample_failure {
-                    tracing::debug!(%cid, "Failed to sample new relay for connection");
+                    continue;
+                };
+
+                tracing::info!(%cid, old = %c.relay.id, new = %rid, "Attempting to migrate connection to new relay");
+
+                c.relay.id = rid;
+
+                for candidate in new_allocation.current_relay_candidates() {
+                    c.add_local_candidate(cid, &candidate, pending_events, now);
                 }
-                c.relay.logged_sample_failure = true;
-
-                continue;
-            };
-
-            tracing::info!(%cid, old = %c.relay.id, new = %rid, "Attempting to migrate connection to new relay");
-
-            c.relay.id = rid;
-
-            for candidate in allocation.current_relay_candidates() {
-                c.add_local_candidate(cid, &candidate, pending_events, now);
             }
         }
     }

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
     hash::Hash,
     iter,
@@ -23,6 +23,8 @@ pub struct Connections<TId, RId> {
     disconnected_ids: BTreeMap<TId, Instant>,
     disconnected_public_keys: BTreeMap<[u8; 32], Instant>,
     disconnected_session_indices: BTreeMap<usize, Instant>,
+
+    connections_with_removed_relays: BTreeSet<TId>,
 }
 
 impl<TId, RId> Default for Connections<TId, RId> {
@@ -33,6 +35,7 @@ impl<TId, RId> Default for Connections<TId, RId> {
             disconnected_ids: Default::default(),
             disconnected_public_keys: Default::default(),
             disconnected_session_indices: Default::default(),
+            connections_with_removed_relays: Default::default(),
         }
     }
 }
@@ -82,7 +85,7 @@ where
         Some(connection)
     }
 
-    pub(crate) fn maybe_migrate_relays(
+    pub(crate) fn migrate_relays(
         &mut self,
         removed_allocations: impl Iterator<Item = RId>,
         allocations: &Allocations<RId>,
@@ -90,25 +93,38 @@ where
         rng: &mut impl Rng,
         now: Instant,
     ) {
+        // Temporarily take ownership of buffer to satisfy borrow-checker.
+        let mut connections_with_removed_relays =
+            std::mem::take(&mut self.connections_with_removed_relays);
+
         for removed_relay in removed_allocations {
             for (cid, c) in self.iter_mut_by_relay(removed_relay) {
                 let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
-                    if !c.relay.sample_failure {
+                    let was_present = connections_with_removed_relays.insert(cid);
+
+                    if !was_present {
                         tracing::debug!(%cid, "Failed to sample new relay for connection");
                     }
-                    c.relay.sample_failure = true;
 
                     continue;
                 };
 
-                tracing::info!(%cid, old = %c.relay.id, new = %new_relay, "Attempting to migrate connection to new relay");
-
-                c.relay.id = new_relay;
-
-                for candidate in new_allocation.current_relay_candidates() {
-                    c.add_local_candidate(cid, &candidate, pending_events, now);
-                }
+                c.migrate_relay(cid, new_relay, new_allocation, pending_events, now);
             }
+        }
+
+        for cid in connections_with_removed_relays {
+            let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
+                self.connections_with_removed_relays.insert(cid);
+
+                continue;
+            };
+
+            let Ok(c) = self.get_mut(&cid, now) else {
+                continue;
+            };
+
+            c.migrate_relay(cid, new_relay, new_allocation, pending_events, now);
         }
     }
 
@@ -347,10 +363,13 @@ mod tests {
     use ringbuffer::AllocRingBuffer;
     use str0m::ice::IceAgent;
 
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
     use crate::{
-        IceConfig,
-        node::{ConnectionState, SelectedRelay},
+        IceConfig, RelaySocket,
+        node::{ConnectionState, SelectedRelay, SessionId, allocations::Allocations},
     };
+    use stun_codec::rfc5389::attributes::{Realm, Username};
 
     use super::*;
 
@@ -393,8 +412,70 @@ mod tests {
         assert_disconnected(&mut connections, id, idx, key, now, false);
     }
 
+    #[test]
+    fn can_make_u256_out_of_byte_array() {
+        let bytes = random();
+        let _num = into_u256(bytes);
+    }
+
+    #[test]
+    fn u256_renders_as_int() {
+        let num = into_u256([1; 32]);
+
+        assert_eq!(
+            num.to_string(),
+            "454086624460063511464984254936031011189294057512315937409637584344757371137"
+        );
+    }
+
+    #[test]
+    fn migrate_relay_retries_connections_that_previously_had_no_allocation() {
+        let mut connections: Connections<u32, u32> = Connections::default();
+        let mut allocations: Allocations<u32> = Allocations::default();
+        let now = Instant::now();
+        let mut rng = rand::thread_rng();
+
+        // Insert a connection that is using relay id 1.
+        let conn = new_connection(12345, 1, [1u8; 32]);
+        connections.insert_established(1, conn.index, conn);
+
+        // First call: relay 1 is removed but no allocations are available.
+        let mut pending_events = VecDeque::new();
+        connections.migrate_relays(
+            std::iter::once(1u32),
+            &allocations,
+            &mut pending_events,
+            &mut rng,
+            now,
+        );
+
+        // The connection still uses relay 1 because no new relay was available.
+        assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 1);
+
+        allocations.upsert(
+            2,
+            RelaySocket::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478)),
+            Username::new("user".to_owned()).unwrap(),
+            "pass".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+            SessionId::new(PublicKey::from([0u8; 32])),
+        );
+
+        connections.migrate_relays(
+            std::iter::empty(),
+            &allocations,
+            &mut pending_events,
+            &mut rng,
+            now,
+        );
+
+        // The connection should now be using the new relay (id 2).
+        assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 2);
+    }
+
     fn insert_dummy_connection(connections: &mut Connections<u32, u32>) -> (u32, Index, PublicKey) {
-        let conn = new_connection(12345, [1u8; 32]);
+        let conn = new_connection(12345, 0, [1u8; 32]);
         let id = 1;
         let idx = conn.index;
         let key = conn.tunnel.remote_static_public();
@@ -440,7 +521,7 @@ mod tests {
         assert_eq!(err.recently_disconnected(), is_recently_disconnected);
     }
 
-    fn new_connection(idx: u32, key: [u8; 32]) -> Connection<u32> {
+    fn new_connection(idx: u32, relay_id: u32, key: [u8; 32]) -> Connection<u32> {
         let private = StaticSecret::random_from_rng(rand::thread_rng());
         let new_local = Index::new_local(idx);
 
@@ -462,10 +543,7 @@ mod tests {
             remote_pub_key: PublicKey::from(rand::random::<[u8; 32]>()),
             next_wg_timer_update: Instant::now(),
             last_proactive_handshake_sent_at: None,
-            relay: SelectedRelay {
-                id: 0,
-                sample_failure: false,
-            },
+            relay: SelectedRelay { id: relay_id },
             state: crate::node::ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(1),
                 ip_buffer: AllocRingBuffer::new(1),
@@ -480,21 +558,5 @@ mod tests {
             default_ice_config: IceConfig::client_default(),
             idle_ice_config: IceConfig::client_idle(),
         }
-    }
-
-    #[test]
-    fn can_make_u256_out_of_byte_array() {
-        let bytes = random();
-        let _num = into_u256(bytes);
-    }
-
-    #[test]
-    fn u256_renders_as_int() {
-        let num = into_u256([1; 32]);
-
-        assert_eq!(
-            num.to_string(),
-            "454086624460063511464984254936031011189294057512315937409637584344757371137"
-        );
     }
 }


### PR DESCRIPTION
Instead of the current O(n) algorithm of ensuring all relays we are connected to are still alive, we introduce a more explicit functionality of only migrating the ones that have been removed.

This is more efficient because it ends up being zero-cost in cases where we have not removed any relays during the GC cycle.

Related: #12504