### PR TITLE
fix(connlib): don't call `handle_timeout` on candidates change

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -670,8 +670,6 @@ impl ClientState {
     ) {
         self.node
             .add_remote_candidate(conn_id.into(), ice_candidate.into(), now);
-        self.node.handle_timeout(now);
-        self.drain_node_events(now);
     }
 
     pub fn remove_ice_candidate(
@@ -682,8 +680,6 @@ impl ClientState {
     ) {
         self.node
             .remove_remote_candidate(conn_id.into(), ice_candidate.into(), now);
-        self.node.handle_timeout(now);
-        self.drain_node_events(now);
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(%rid))]

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -248,8 +248,6 @@ impl GatewayState {
     ) {
         self.node
             .add_remote_candidate(conn_id, ice_candidate.into(), now);
-        self.node.handle_timeout(now);
-        self.drain_node_events();
     }
 
     pub fn remove_ice_candidate(
@@ -260,8 +258,6 @@ impl GatewayState {
     ) {
         self.node
             .remove_remote_candidate(conn_id, ice_candidate.into(), now);
-        self.node.handle_timeout(now);
-        self.drain_node_events();
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(%rid, %cid))]


### PR DESCRIPTION
Explicitly calling `handle_timeout` after a change turns out to not be necessary, the time-related actions required as a result get triggered automatically as `poll_timeout` recomputes a new, earlier timeout if new candidate pairs have been created.

Related: #12504