### PR TITLE
fix(connlib): reduce allocations of `Vec`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6999,6 +6999,7 @@ dependencies = [
  "ringbuffer",
  "sha1",
  "sha2",
+ "smallvec",
  "str0m",
  "stun_codec",
  "telemetry",

--- a/rust/libs/connlib/snownet/Cargo.toml
+++ b/rust/libs/connlib/snownet/Cargo.toml
@@ -23,6 +23,7 @@ rand = { workspace = true }
 ringbuffer = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
+smallvec = { workspace = true }
 str0m = { workspace = true }
 stun_codec = { workspace = true }
 telemetry = { workspace = true }

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -10,6 +10,7 @@ use ip_packet::Ecn;
 use logging::err_with_src;
 use rand::random;
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
+use smallvec::SmallVec;
 use std::{
     collections::{BTreeMap, VecDeque},
     iter,
@@ -341,11 +342,15 @@ impl Allocation {
 
         if message.method() != BINDING && !passed_message_integrity_check {
             // We don't want to `remove` the message here otherwise an attacker could change our state with unauthenticated messages.
-            let request = self
-                .sent_requests
-                .get(&transaction_id)
-                .map(|(_, r, _)| r.attributes().map(display_attr).collect::<Vec<_>>());
-            let response = message.attributes().map(display_attr).collect::<Vec<_>>();
+            let request = self.sent_requests.get(&transaction_id).map(|(_, r, _)| {
+                r.attributes()
+                    .map(display_attr)
+                    .collect::<SmallVec<[_; 16]>>()
+            });
+            let response = message
+                .attributes()
+                .map(display_attr)
+                .collect::<SmallVec<[_; 16]>>();
 
             tracing::warn!(?request, ?response, "Message integrity check failed");
             return true; // The message still indicated that it was for this `Allocation`.
@@ -364,8 +369,11 @@ impl Allocation {
             let request = original_request
                 .attributes()
                 .map(display_attr)
-                .collect::<Vec<_>>();
-            let response = message.attributes().map(display_attr).collect::<Vec<_>>();
+                .collect::<SmallVec<[_; 16]>>();
+            let response = message
+                .attributes()
+                .map(display_attr)
+                .collect::<SmallVec<[_; 16]>>();
 
             tracing::debug!(target: "wire::turn", ?request, ?response);
         }
@@ -463,7 +471,7 @@ impl Allocation {
             }
 
             if error.code() == UnknownAttribute::CODEPOINT {
-                let attributes = message.unknown_attributes().collect::<Vec<_>>();
+                let attributes = message.unknown_attributes().collect::<SmallVec<[_; 16]>>();
 
                 tracing::warn!(
                     ?attributes,
@@ -770,7 +778,7 @@ impl Allocation {
                 tracing::debug!(%number, %peer, "Channel is due for a refresh");
             })
             .map(|(number, peer)| make_channel_bind_request(peer, number, self.software.clone()))
-            .collect::<Vec<_>>(); // Need to allocate here to satisfy borrow-checker. Number of channel refresh messages should be small so this shouldn't be a big impact.
+            .collect::<SmallVec<[_; 16]>>();
 
         for message in channel_refresh_messages {
             self.authenticate_and_queue(message, None, now);

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -27,6 +27,7 @@ use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use sha2::Digest;
+use smallvec::SmallVec;
 use std::collections::BTreeSet;
 use std::hash::Hash;
 use std::net::IpAddr;
@@ -282,7 +283,7 @@ where
                 .on_upsert(cid, &mut c.agent, c.default_ice_config, now);
 
             // Take all current candidates.
-            let current_candidates = c.agent.local_candidates().collect::<Vec<_>>();
+            let current_candidates = c.agent.local_candidates().collect::<SmallVec<[_; 16]>>();
 
             // Re-seed connection with all candidates.
             let new_candidates =
@@ -1095,7 +1096,7 @@ fn generate_optimistic_candidates(agent: &mut IceAgent) {
         })
         .filter(|c| !agent.remote_candidates().contains(c))
         .take(2)
-        .collect::<Vec<_>>();
+        .collect::<SmallVec<[_; 2]>>();
 
     for c in optimistic_candidates {
         tracing::debug!(candidate = ?c, "Adding optimistic candidate for remote");


### PR DESCRIPTION
Using `SmallVec` over `Vec` in certain places inside `snownet` helps us reduce allocations when we have a good idea, how many items we want to buffer temporarily. `SmallVec` uses a stack-allocated array to optimize the common case but spills to the heap in case the capacity of the array is not enough.

Related: #12504