### PR TITLE
fix(connlib): optimize timeout handling

### DIFF
--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -67,7 +67,7 @@ rand = { workspace = true }
 sha2 = { workspace = true }
 test-case = { workspace = true }
 test-strategy = { workspace = true }
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true, features = ["process", "test-util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]

--- a/rust/libs/connlib/tunnel/src/budget.rs
+++ b/rust/libs/connlib/tunnel/src/budget.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{KeyValue, metrics::Histogram};
-use std::{task::Waker, time::Instant};
+use std::{sync::OnceLock, task::Waker, time::Instant};
 
 /// Tracks progress and iteration budget for an event-loop.
 ///
@@ -13,7 +13,7 @@ pub(crate) struct Budget {
     remaining: u32,
     ready: bool,
     started_at: Instant,
-    histogram: Histogram<f64>,
+    name: &'static str,
 }
 
 pub(crate) struct Tick<'a>(&'a mut bool);
@@ -25,17 +25,13 @@ impl Tick<'_> {
 }
 
 impl Budget {
-    pub(crate) fn new(waker: Waker, budget: u32) -> Self {
+    pub(crate) fn new(waker: Waker, budget: u32, name: &'static str) -> Self {
         Self {
             waker,
             remaining: budget,
             ready: true, // Treat the first iteration as "ready" so we always enter the loop once.
             started_at: Instant::now(),
-            histogram: opentelemetry::global::meter("connlib")
-                .f64_histogram("eventloop.poll.duration")
-                .with_description("Duration of a single event-loop poll.")
-                .with_unit("s")
-                .build(),
+            name,
         }
     }
 
@@ -56,15 +52,43 @@ impl Drop for Budget {
         let exhausted = self.remaining == 0;
         let elapsed_s = self.started_at.elapsed().as_secs_f64();
 
-        self.histogram.record(
+        poll_duration_histogram().record(
             elapsed_s,
-            &[KeyValue::new("eventloop.exhausted", exhausted)],
+            &[
+                KeyValue::new("eventloop.exhausted", exhausted),
+                KeyValue::new("eventloop.name", self.name),
+            ],
         );
 
         if exhausted {
             self.waker.wake_by_ref();
         }
     }
+}
+
+fn poll_duration_histogram() -> &'static Histogram<f64> {
+    static STORAGE: OnceLock<Histogram<f64>> = OnceLock::new();
+
+    STORAGE.get_or_init(|| {
+        opentelemetry::global::meter("connlib")
+            .f64_histogram("eventloop.poll.duration")
+            .with_description("Duration of a single event-loop poll.")
+            .with_unit("s")
+            .with_boundaries(vec![
+                0.000_005, // 5µs
+                0.000_010, // 10µs
+                0.000_025, // 25µs
+                0.000_050, // 50µs
+                0.000_100, // 100µs
+                0.000_250, // 250µs
+                0.000_500, // 500µs
+                0.001_000, // 1ms
+                0.002_500, // 2.5ms
+                0.005_000, // 5ms
+                0.010_000, // 10ms
+            ])
+            .build()
+    })
 }
 
 #[cfg(test)]
@@ -82,7 +106,7 @@ mod tests {
     #[test]
     fn iterates_once_with_no_work_does_not_call_waker() {
         let (waker, wake_count) = counting_waker();
-        let mut budget = Budget::new(waker, 10);
+        let mut budget = Budget::new(waker, 10, "test");
 
         let mut iterations = 0usize;
         while let Some(_tick) = budget.next() {
@@ -96,7 +120,7 @@ mod tests {
     #[test]
     fn continues_as_long_as_want_continue_is_called() {
         let (waker, wake_count) = counting_waker();
-        let mut budget = Budget::new(waker, 10);
+        let mut budget = Budget::new(waker, 10, "test");
 
         let mut iterations = 0usize;
         while let Some(mut tick) = budget.next() {
@@ -113,7 +137,7 @@ mod tests {
     #[test]
     fn wakes_after_exhausting_budget() {
         let (waker, wake_count) = counting_waker();
-        let mut budget = Budget::new(waker, 10);
+        let mut budget = Budget::new(waker, 10, "test");
 
         while let Some(mut tick) = budget.next() {
             tick.want_continue();

--- a/rust/libs/connlib/tunnel/src/budget.rs
+++ b/rust/libs/connlib/tunnel/src/budget.rs
@@ -1,0 +1,165 @@
+use opentelemetry::{KeyValue, metrics::Histogram};
+use std::{task::Waker, time::Instant};
+
+/// Tracks progress and iteration budget for an event-loop.
+///
+/// Call [`Budget::next`] in a `while let` loop to drive the event loop.
+/// Each call yields a [`Tick`] guard; call [`Tick::want_continue`] to signal that work was done
+/// and another iteration should follow.
+/// When the budget is dropped, it wakes the waker if the budget was exhausted while still
+/// making progress, so the runtime reschedules the task instead of suspending it indefinitely.
+pub(crate) struct Budget {
+    waker: Waker,
+    remaining: u32,
+    ready: bool,
+    started_at: Instant,
+    histogram: Histogram<f64>,
+}
+
+pub(crate) struct Tick<'a>(&'a mut bool);
+
+impl Tick<'_> {
+    pub(crate) fn want_continue(&mut self) {
+        *self.0 = true;
+    }
+}
+
+impl Budget {
+    pub(crate) fn new(waker: Waker, budget: u32) -> Self {
+        Self {
+            waker,
+            remaining: budget,
+            ready: true, // Treat the first iteration as "ready" so we always enter the loop once.
+            started_at: Instant::now(),
+            histogram: opentelemetry::global::meter("connlib")
+                .f64_histogram("eventloop.poll.duration")
+                .with_description("Duration of a single event-loop poll.")
+                .with_unit("s")
+                .build(),
+        }
+    }
+
+    pub(crate) fn next(&mut self) -> Option<Tick<'_>> {
+        if !self.ready || self.remaining == 0 {
+            return None;
+        }
+
+        self.remaining -= 1;
+        self.ready = false;
+
+        Some(Tick(&mut self.ready))
+    }
+}
+
+impl Drop for Budget {
+    fn drop(&mut self) {
+        let exhausted = self.remaining == 0;
+        let elapsed_s = self.started_at.elapsed().as_secs_f64();
+
+        self.histogram.record(
+            elapsed_s,
+            &[KeyValue::new("eventloop.exhausted", exhausted)],
+        );
+
+        if exhausted {
+            self.waker.wake_by_ref();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{RawWaker, RawWakerVTable},
+    };
+
+    use super::*;
+
+    #[test]
+    fn iterates_once_with_no_work_does_not_call_waker() {
+        let (waker, wake_count) = counting_waker();
+        let mut budget = Budget::new(waker, 10);
+
+        let mut iterations = 0usize;
+        while let Some(_tick) = budget.next() {
+            iterations += 1;
+        }
+
+        assert_eq!(iterations, 1);
+        assert_eq!(wake_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn continues_as_long_as_want_continue_is_called() {
+        let (waker, wake_count) = counting_waker();
+        let mut budget = Budget::new(waker, 10);
+
+        let mut iterations = 0usize;
+        while let Some(mut tick) = budget.next() {
+            iterations += 1;
+            if iterations < 3 {
+                tick.want_continue();
+            }
+        }
+
+        assert_eq!(iterations, 3);
+        assert_eq!(wake_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn wakes_after_exhausting_budget() {
+        let (waker, wake_count) = counting_waker();
+        let mut budget = Budget::new(waker, 10);
+
+        while let Some(mut tick) = budget.next() {
+            tick.want_continue();
+        }
+
+        drop(budget);
+
+        assert_eq!(wake_count.load(Ordering::SeqCst), 1);
+    }
+
+    fn counting_waker() -> (Waker, Arc<AtomicUsize>) {
+        // Note: counting_waker is called multiple times per test in clone vtable, so Arc handles the ref-counting.
+        let count = Arc::new(AtomicUsize::new(0));
+        let waker = unsafe { Waker::from_raw(make_raw_waker(Arc::clone(&count))) };
+
+        (waker, count)
+    }
+
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(
+        // clone
+        |ptr| {
+            let arc = unsafe { Arc::from_raw(ptr as *const AtomicUsize) };
+            let cloned = Arc::clone(&arc);
+            std::mem::forget(arc);
+            make_raw_waker(cloned)
+        },
+        // wake (consumes the pointer)
+        |ptr| {
+            let arc = unsafe { Arc::from_raw(ptr as *const AtomicUsize) };
+            arc.fetch_add(1, Ordering::SeqCst);
+        },
+        // wake_by_ref
+        |ptr| {
+            let arc = unsafe { Arc::from_raw(ptr as *const AtomicUsize) };
+            arc.fetch_add(1, Ordering::SeqCst);
+            std::mem::forget(arc);
+        },
+        // drop
+        |ptr| {
+            drop(unsafe { Arc::from_raw(ptr as *const AtomicUsize) });
+        },
+    );
+
+    fn make_raw_waker(count: Arc<AtomicUsize>) -> RawWaker {
+        let ptr = Arc::into_raw(count) as *const ();
+
+        RawWaker::new(ptr, &VTABLE)
+    }
+}

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -46,6 +46,8 @@ const MAX_INBOUND_PACKET_BATCH: usize = {
     }
 };
 
+const DEFAULT_TIME_ADVANCE: Duration = Duration::from_secs(10);
+
 /// Bundles together all side-effects that connlib needs to have access to.
 pub struct Io {
     /// The UDP sockets used to send & receive packets from the network.
@@ -67,7 +69,7 @@ pub struct Io {
     doh_clients: BTreeMap<DoHUrl, HttpClient>,
     doh_clients_bootstrap: FuturesMap<DoHUrl, Result<HttpClient>>,
 
-    timeout: Option<Pin<Box<tokio::time::Sleep>>>,
+    timeout: Pin<Box<tokio::time::Sleep>>,
 
     tun: Device,
     packet_counter: opentelemetry::metrics::Counter<u64>,
@@ -165,7 +167,7 @@ impl Io {
         sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
 
         Self {
-            timeout: None,
+            timeout: Box::pin(tokio::time::sleep(DEFAULT_TIME_ADVANCE)),
             sockets,
             nameservers: NameserverSet::new(
                 nameservers,
@@ -268,6 +270,8 @@ impl Io {
         if let Err(e) = ready!(self.flush(cx)) {
             return Poll::Ready(Input::error(e));
         }
+
+        let now = Instant::now();
 
         let mut error = TunnelError::default();
 
@@ -389,14 +393,12 @@ impl Io {
             self.doh_clients.remove(server);
         }
 
-        let timeout = self
-            .timeout
-            .as_mut()
-            .map(|timeout| timeout.poll_unpin(cx).is_ready())
-            .unwrap_or(false);
+        let timeout = self.timeout.as_mut().poll_unpin(cx).is_ready();
 
         if timeout {
-            self.timeout = None;
+            self.timeout
+                .as_mut()
+                .reset(tokio::time::Instant::from_std(now) + DEFAULT_TIME_ADVANCE);
         }
 
         if !timeout
@@ -411,7 +413,7 @@ impl Io {
         }
 
         Poll::Ready(Input {
-            now: Instant::now(),
+            now,
             now_utc: Utc::now(),
             timeout,
             device: poll_result_to_option(device, &mut error),
@@ -487,20 +489,10 @@ impl Io {
             .map(tracing::field::debug);
         let timeout = tokio::time::Instant::from_std(timeout);
 
-        match self.timeout.as_mut() {
-            Some(existing_timeout) if existing_timeout.deadline() != timeout => {
-                tracing::trace!(wakeup_in, %reason);
+        if self.timeout.as_mut().deadline() != timeout {
+            tracing::trace!(wakeup_in, %reason);
 
-                existing_timeout.as_mut().reset(timeout)
-            }
-            Some(_) => {}
-            None => {
-                self.timeout = {
-                    tracing::trace!(?wakeup_in, %reason);
-
-                    Some(Box::pin(tokio::time::sleep_until(timeout)))
-                }
-            }
+            self.timeout.as_mut().reset(timeout);
         }
     }
 
@@ -509,12 +501,8 @@ impl Io {
         let now = tokio::time::Instant::from_std(now);
         let latest_wakeup = now + Duration::from_secs(1);
 
-        match self.timeout.as_mut() {
-            Some(existing_timeout) if existing_timeout.deadline() < latest_wakeup => {}
-            Some(existing_timeout) => {
-                existing_timeout.as_mut().reset(latest_wakeup);
-            }
-            None => self.timeout = Some(Box::pin(tokio::time::sleep_until(latest_wakeup))),
+        if self.timeout.as_mut().deadline() > latest_wakeup {
+            self.timeout.as_mut().reset(latest_wakeup);
         }
     }
 
@@ -669,12 +657,21 @@ mod tests {
 
         assert!(input.timeout);
         assert!(input.now >= deadline, "timer expire after deadline");
+        let last_now = input.now;
+
         drop(input);
 
         let poll = io.poll_test();
 
         assert!(poll.is_pending());
-        assert!(io.timeout.is_none());
+        assert_eq!(
+            io.timeout
+                .as_mut()
+                .deadline()
+                .into_std()
+                .duration_since(last_now),
+            DEFAULT_TIME_ADVANCE
+        );
     }
 
     #[tokio::test]

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -504,6 +504,20 @@ impl Io {
         }
     }
 
+    /// Schedules a wakeup in case one isn't registered yet.
+    pub fn schedule_timeout(&mut self, now: Instant) {
+        let now = tokio::time::Instant::from_std(now);
+        let latest_wakeup = now + Duration::from_secs(1);
+
+        match self.timeout.as_mut() {
+            Some(existing_timeout) if existing_timeout.deadline() < latest_wakeup => {}
+            Some(existing_timeout) => {
+                existing_timeout.as_mut().reset(latest_wakeup);
+            }
+            None => self.timeout = Some(Box::pin(tokio::time::sleep_until(latest_wakeup))),
+        }
+    }
+
     pub fn send_network(
         &mut self,
         src: Option<SocketAddr>,
@@ -707,6 +721,43 @@ mod tests {
                 dns_types::ResponseCode::NOERROR
             );
         }
+    }
+
+    #[tokio::test]
+    async fn schedule_timeout_shortens_deadline_when_current_is_too_far_away() {
+        let mut io = Io::for_test();
+
+        // The default deadline is DEFAULT_TIME_ADVANCE (10s) from now.
+        // schedule_timeout should pull it in to ~1s from now.
+        let now = Instant::now();
+        io.schedule_timeout(now);
+
+        let deadline = io.timeout.as_mut().deadline().into_std();
+        let wakeup_in = deadline.duration_since(now);
+
+        assert!(
+            wakeup_in <= Duration::from_secs(1),
+            "expected deadline within 1s, got {wakeup_in:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn schedule_timeout_does_not_postpone_an_already_close_deadline() {
+        let mut io = Io::for_test();
+
+        // Set a deadline that is already sooner than 1s.
+        let now = Instant::now();
+        let close_deadline = now + Duration::from_millis(100);
+        io.reset_timeout(close_deadline, "close deadline");
+
+        io.schedule_timeout(now);
+
+        let deadline = io.timeout.as_mut().deadline().into_std();
+
+        assert_eq!(
+            deadline, close_deadline,
+            "schedule_timeout must not push out a deadline that is already close"
+        );
     }
 
     #[tokio::test]

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -488,11 +488,7 @@ impl Io {
 
     /// Schedules a wakeup in case one isn't registered yet.
     pub fn schedule_timeout(&mut self, now: Instant) {
-        let latest_wakeup = now + Duration::from_secs(1);
-
-        if self.timeout.deadline() > latest_wakeup {
-            self.timeout.reset(latest_wakeup);
-        }
+        self.timeout.schedule(now + Duration::from_secs(1));
     }
 
     pub fn send_network(

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -476,7 +476,7 @@ impl Io {
 
     pub fn reset_timeout(&mut self, timeout: Instant, reason: &'static str) {
         let wakeup_in = tracing::event_enabled!(Level::TRACE)
-            .then(|| timeout.duration_since(Instant::now()))
+            .then(|| timeout.saturating_duration_since(Instant::now()))
             .map(tracing::field::debug);
 
         if self.timeout.deadline() != timeout {

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -3,15 +3,15 @@ mod doh;
 mod gso_queue;
 mod nameserver_set;
 mod tcp_dns;
+mod timeout;
 mod udp_dns;
 
 pub use device::{Device, TunChannelClosed};
 
-use crate::{TunnelError, dns, otel, sockets::Sockets};
+use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{Context as _, ErrorExt, Result};
 use chrono::{DateTime, Utc};
 use dns_types::DoHUrl;
-use futures::FutureExt as _;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
 use gat_lending_iterator::LendingIterator;
 use gso_queue::GsoQueue;
@@ -23,7 +23,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     io,
     net::{IpAddr, SocketAddr},
-    pin::Pin,
     sync::Arc,
     task::{Context, Poll, ready},
     time::{Duration, Instant},
@@ -69,7 +68,7 @@ pub struct Io {
     doh_clients: BTreeMap<DoHUrl, HttpClient>,
     doh_clients_bootstrap: FuturesMap<DoHUrl, Result<HttpClient>>,
 
-    timeout: Pin<Box<tokio::time::Sleep>>,
+    timeout: Timeout,
 
     tun: Device,
     packet_counter: opentelemetry::metrics::Counter<u64>,
@@ -167,7 +166,7 @@ impl Io {
         sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
 
         Self {
-            timeout: Box::pin(tokio::time::sleep(DEFAULT_TIME_ADVANCE)),
+            timeout: Timeout::new(DEFAULT_TIME_ADVANCE),
             sockets,
             nameservers: NameserverSet::new(
                 nameservers,
@@ -270,8 +269,6 @@ impl Io {
         if let Err(e) = ready!(self.flush(cx)) {
             return Poll::Ready(Input::error(e));
         }
-
-        let now = Instant::now();
 
         let mut error = TunnelError::default();
 
@@ -393,13 +390,7 @@ impl Io {
             self.doh_clients.remove(server);
         }
 
-        let timeout = self.timeout.as_mut().poll_unpin(cx).is_ready();
-
-        if timeout {
-            self.timeout
-                .as_mut()
-                .reset(tokio::time::Instant::from_std(now) + DEFAULT_TIME_ADVANCE);
-        }
+        let timeout = self.timeout.poll_tick(cx).is_ready();
 
         if !timeout
             && device.is_pending()
@@ -413,7 +404,7 @@ impl Io {
         }
 
         Poll::Ready(Input {
-            now,
+            now: Instant::now(),
             now_utc: Utc::now(),
             timeout,
             device: poll_result_to_option(device, &mut error),
@@ -487,22 +478,20 @@ impl Io {
         let wakeup_in = tracing::event_enabled!(Level::TRACE)
             .then(|| timeout.duration_since(Instant::now()))
             .map(tracing::field::debug);
-        let timeout = tokio::time::Instant::from_std(timeout);
 
-        if self.timeout.as_mut().deadline() != timeout {
+        if self.timeout.deadline() != timeout {
             tracing::trace!(wakeup_in, %reason);
 
-            self.timeout.as_mut().reset(timeout);
+            self.timeout.reset(timeout);
         }
     }
 
     /// Schedules a wakeup in case one isn't registered yet.
     pub fn schedule_timeout(&mut self, now: Instant) {
-        let now = tokio::time::Instant::from_std(now);
         let latest_wakeup = now + Duration::from_secs(1);
 
-        if self.timeout.as_mut().deadline() > latest_wakeup {
-            self.timeout.as_mut().reset(latest_wakeup);
+        if self.timeout.deadline() > latest_wakeup {
+            self.timeout.reset(latest_wakeup);
         }
     }
 
@@ -652,12 +641,13 @@ mod tests {
 
         let deadline = Instant::now() + Duration::from_secs(1);
         io.reset_timeout(deadline, "");
+        let scheduled_deadline = io.timeout.deadline();
 
         let input = io.next().await;
 
         assert!(input.timeout);
         assert!(input.now >= deadline, "timer expire after deadline");
-        let last_now = input.now;
+        assert_eq!(deadline, scheduled_deadline);
 
         drop(input);
 
@@ -665,11 +655,7 @@ mod tests {
 
         assert!(poll.is_pending());
         assert_eq!(
-            io.timeout
-                .as_mut()
-                .deadline()
-                .into_std()
-                .duration_since(last_now),
+            io.timeout.deadline().duration_since(scheduled_deadline),
             DEFAULT_TIME_ADVANCE
         );
     }
@@ -729,7 +715,7 @@ mod tests {
         let now = Instant::now();
         io.schedule_timeout(now);
 
-        let deadline = io.timeout.as_mut().deadline().into_std();
+        let deadline = io.timeout.deadline();
         let wakeup_in = deadline.duration_since(now);
 
         assert!(
@@ -749,7 +735,7 @@ mod tests {
 
         io.schedule_timeout(now);
 
-        let deadline = io.timeout.as_mut().deadline().into_std();
+        let deadline = io.timeout.deadline();
 
         assert_eq!(
             deadline, close_deadline,

--- a/rust/libs/connlib/tunnel/src/io/timeout.rs
+++ b/rust/libs/connlib/tunnel/src/io/timeout.rs
@@ -7,9 +7,21 @@ use std::{
 use futures::FutureExt as _;
 
 /// A dedicated timeout future that is always initialised and auto-advances by the given [`Duration`] as soon as it is ready.
+///
+/// There are two ways to set the deadline:
+///
+/// - [`Timeout::reset`]: moves the deadline to an arbitrary point in time.
+///   If a scheduled wakeup ceiling has been set via [`Timeout::schedule`], the effective
+///   deadline is clamped to that ceiling so a scheduled wakeup is never accidentally postponed.
+///
+/// - [`Timeout::schedule`]: records an upper-bound ("scheduled wakeup") and immediately
+///   clamps the current deadline to it.  The ceiling is cleared once the timer fires.
 pub struct Timeout {
     default_advance: Duration,
     inner: Pin<Box<tokio::time::Sleep>>,
+    /// Upper-bound imposed by [`Timeout::schedule`]. [`Timeout::reset`] will never move
+    /// the deadline beyond this value while it is set.
+    scheduled: Option<Instant>,
 }
 
 impl Timeout {
@@ -17,25 +29,56 @@ impl Timeout {
         Self {
             default_advance,
             inner: Box::pin(tokio::time::sleep(default_advance)),
+            scheduled: None,
         }
     }
 
     pub fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         ready!(self.inner.as_mut().poll_unpin(cx));
 
-        self.reset(self.deadline() + self.default_advance);
+        // Clear the scheduled ceiling — it has been honoured by firing.
+        self.scheduled = None;
+
+        self.set_deadline(self.deadline() + self.default_advance);
 
         Poll::Ready(())
     }
 
+    /// Moves the deadline to `deadline`, clamping it to the scheduled wakeup ceiling if one is set.
     pub fn reset(&mut self, deadline: Instant) {
-        self.inner
-            .as_mut()
-            .reset(tokio::time::Instant::from_std(deadline));
+        let effective = match self.scheduled {
+            Some(ceiling) => deadline.min(ceiling),
+            None => deadline,
+        };
+
+        self.set_deadline(effective);
+    }
+
+    /// Sets an upper-bound on the deadline and immediately applies it.
+    ///
+    /// Subsequent calls to [`Timeout::reset`] will never push the deadline past `ceiling`.
+    /// The ceiling is cleared once the timer fires via [`Timeout::poll_tick`].
+    pub fn schedule(&mut self, ceiling: Instant) {
+        self.scheduled = Some(match self.scheduled {
+            // Keep the tightest ceiling if schedule() is called more than once.
+            Some(existing) => ceiling.min(existing),
+            None => ceiling,
+        });
+
+        // Apply the ceiling to the current deadline immediately.
+        if self.deadline() > ceiling {
+            self.set_deadline(ceiling);
+        }
     }
 
     pub fn deadline(&self) -> Instant {
         self.inner.as_ref().deadline().into()
+    }
+
+    fn set_deadline(&mut self, deadline: Instant) {
+        self.inner
+            .as_mut()
+            .reset(tokio::time::Instant::from_std(deadline));
     }
 }
 
@@ -53,13 +96,78 @@ mod tests {
         let original_deadline = timeout.deadline();
 
         tokio::time::advance(advance).await;
-
         poll_fn(|cx| timeout.poll_tick(cx)).await;
 
-        assert_eq!(
-            timeout.deadline(),
-            original_deadline + advance,
-            "deadline should be old_deadline + default_advance, not based on wall-clock now"
-        );
+        assert_eq!(timeout.deadline(), original_deadline + advance);
+    }
+
+    #[tokio::test]
+    async fn reset_moves_deadline_freely_without_scheduled_ceiling() {
+        let mut timeout = Timeout::new(Duration::from_secs(10));
+        let now = Instant::now();
+
+        timeout.reset(now + Duration::from_secs(5));
+        assert_eq!(timeout.deadline(), now + Duration::from_secs(5));
+
+        timeout.reset(now + Duration::from_millis(100));
+        assert_eq!(timeout.deadline(), now + Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn reset_is_clamped_to_scheduled_ceiling() {
+        let mut timeout = Timeout::new(Duration::from_secs(10));
+        let now = Instant::now();
+        let ceiling = now + Duration::from_secs(1);
+
+        timeout.schedule(ceiling);
+        timeout.reset(now + Duration::from_secs(5));
+
+        assert_eq!(timeout.deadline(), ceiling);
+    }
+
+    #[tokio::test]
+    async fn reset_can_shorten_below_scheduled_ceiling() {
+        let mut timeout = Timeout::new(Duration::from_secs(10));
+        let now = Instant::now();
+
+        timeout.schedule(now + Duration::from_secs(1));
+        timeout.reset(now + Duration::from_millis(100));
+
+        assert_eq!(timeout.deadline(), now + Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn schedule_clamps_existing_deadline_and_keeps_tightest_on_repeated_calls() {
+        let mut timeout = Timeout::new(Duration::from_secs(10));
+        let now = Instant::now();
+
+        // First schedule pulls the deadline in from 10s to 2s.
+        timeout.schedule(now + Duration::from_secs(2));
+        assert_eq!(timeout.deadline(), now + Duration::from_secs(2));
+
+        // A tighter ceiling wins.
+        timeout.schedule(now + Duration::from_secs(1));
+        assert_eq!(timeout.deadline(), now + Duration::from_secs(1));
+
+        // A looser ceiling is ignored.
+        timeout.schedule(now + Duration::from_secs(5));
+        assert_eq!(timeout.deadline(), now + Duration::from_secs(1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ceiling_is_cleared_after_firing_allowing_reset_to_move_deadline_freely() {
+        let mut timeout = Timeout::new(Duration::from_secs(10));
+        let now = Instant::now();
+
+        timeout.schedule(now + Duration::from_secs(1));
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        poll_fn(|cx| timeout.poll_tick(cx)).await;
+
+        // Ceiling is gone — reset should now move the deadline freely past the old ceiling.
+        let far = Instant::now() + Duration::from_secs(20);
+        timeout.reset(far);
+
+        assert_eq!(timeout.deadline(), far);
     }
 }

--- a/rust/libs/connlib/tunnel/src/io/timeout.rs
+++ b/rust/libs/connlib/tunnel/src/io/timeout.rs
@@ -45,12 +45,14 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn deadline_auto_resets_to_old_deadline_plus_advance_after_firing() {
         let advance = Duration::from_secs(1);
         let mut timeout = Timeout::new(advance);
 
         let original_deadline = timeout.deadline();
+
+        tokio::time::advance(advance).await;
 
         poll_fn(|cx| timeout.poll_tick(cx)).await;
 

--- a/rust/libs/connlib/tunnel/src/io/timeout.rs
+++ b/rust/libs/connlib/tunnel/src/io/timeout.rs
@@ -1,0 +1,63 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll, ready},
+    time::{Duration, Instant},
+};
+
+use futures::FutureExt as _;
+
+/// A dedicated timeout future that is always initialised and auto-advances by the given [`Duration`] as soon as it is ready.
+pub struct Timeout {
+    default_advance: Duration,
+    inner: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl Timeout {
+    pub fn new(default_advance: Duration) -> Self {
+        Self {
+            default_advance,
+            inner: Box::pin(tokio::time::sleep(default_advance)),
+        }
+    }
+
+    pub fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        ready!(self.inner.as_mut().poll_unpin(cx));
+
+        self.reset(self.deadline() + self.default_advance);
+
+        Poll::Ready(())
+    }
+
+    pub fn reset(&mut self, deadline: Instant) {
+        self.inner
+            .as_mut()
+            .reset(tokio::time::Instant::from_std(deadline));
+    }
+
+    pub fn deadline(&self) -> Instant {
+        self.inner.as_ref().deadline().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::poll_fn;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn deadline_auto_resets_to_old_deadline_plus_advance_after_firing() {
+        let advance = Duration::from_secs(1);
+        let mut timeout = Timeout::new(advance);
+
+        let original_deadline = timeout.deadline();
+
+        poll_fn(|cx| timeout.poll_tick(cx)).await;
+
+        assert_eq!(
+            timeout.deadline(),
+            original_deadline + advance,
+            "deadline should be old_deadline + default_advance, not based on wall-clock now"
+        );
+    }
+}

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -236,7 +236,7 @@ impl ClientTunnel {
             {
                 if let Some(response) = dns_response {
                     self.role_state.handle_dns_response(response, now);
-                    self.role_state.handle_timeout(now);
+                    self.io.schedule_timeout(now);
 
                     ready = true;
                 }
@@ -257,9 +257,7 @@ impl ClientTunnel {
                                     transmit.ecn,
                                 );
                             }
-                            None => {
-                                self.role_state.handle_timeout(now);
-                            }
+                            None => self.io.schedule_timeout(now),
                         }
                     }
 
@@ -286,7 +284,7 @@ impl ClientTunnel {
                             Some(packet) => self
                                 .io
                                 .send_tun(packet.with_ecn_from_transport(received.ecn)),
-                            None => self.role_state.handle_timeout(now),
+                            None => self.io.schedule_timeout(now),
                         };
                     }
 
@@ -449,9 +447,7 @@ impl GatewayTunnel {
                                     transmit.ecn,
                                 );
                             }
-                            Ok(None) => {
-                                self.role_state.handle_timeout(now, Utc::now());
-                            }
+                            Ok(None) => self.io.schedule_timeout(now),
                             Err(e) => {
                                 let routing_error = e
                                     .any_downcast_ref::<gateway::UnroutablePacket>()
@@ -492,7 +488,7 @@ impl GatewayTunnel {
                             Ok(Some(packet)) => self
                                 .io
                                 .send_tun(packet.with_ecn_from_transport(received.ecn)),
-                            Ok(None) => self.role_state.handle_timeout(now, now_utc),
+                            Ok(None) => self.io.schedule_timeout(now),
                             Err(e) => error.push(e),
                         };
                     }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(test, allow(clippy::print_stderr))]
 
 use anyhow::{Context as _, ErrorExt as _, Result};
+use budget::Budget;
 use connlib_model::{
     ClientId, ClientOrGatewayId, GatewayId, IceCandidate, PublicKey, ResourceId, ResourceView,
 };
@@ -28,6 +29,7 @@ use std::{
 };
 use tun::Tun;
 
+mod budget;
 mod client;
 mod dns;
 mod expiring_map;
@@ -181,11 +183,9 @@ impl ClientTunnel {
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<ClientEvent> {
-        let mut ready = false;
+        let mut budget = Budget::new(cx.waker().clone(), MAX_EVENTLOOP_ITERS);
 
-        for _ in 0..MAX_EVENTLOOP_ITERS {
-            ready = false;
-
+        while let Some(mut tick) = budget.next() {
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
             // Pass up existing events.
@@ -206,20 +206,20 @@ impl ClientTunnel {
             // Drain all buffered IP packets.
             while let Some(packet) = self.role_state.poll_packets() {
                 self.io.send_tun(packet);
-                ready = true;
+                tick.want_continue();
             }
 
             // Drain all buffered transmits.
             while let Some(trans) = self.role_state.poll_transmit() {
                 self.io
                     .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
-                ready = true;
+                tick.want_continue();
             }
 
             // Drain all scheduled DNS queries.
             while let Some(query) = self.role_state.poll_dns_queries() {
                 self.io.send_dns_query(query);
-                ready = true;
+                tick.want_continue();
             }
 
             // Process all IO sources that are ready.
@@ -239,12 +239,12 @@ impl ClientTunnel {
                     self.role_state.handle_dns_response(response, now);
                     self.io.schedule_timeout(now);
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if timeout {
                     self.role_state.handle_timeout(now);
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if let Some(packets) = device {
@@ -262,7 +262,7 @@ impl ClientTunnel {
                         }
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if let Some(mut packets) = network {
@@ -289,26 +289,18 @@ impl ClientTunnel {
                         };
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if !error.is_empty() {
                     return Poll::Ready(ClientEvent::Error(error));
                 }
             }
-
-            if !ready {
-                break;
-            }
         }
 
         // Reset timer for time-based wakeup before we suspend.
         if let Some((timeout, reason)) = self.role_state.poll_timeout() {
             self.io.reset_timeout(timeout, reason);
-        }
-
-        if ready {
-            cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
         }
 
         Poll::Pending
@@ -370,9 +362,9 @@ impl GatewayTunnel {
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<GatewayEvent> {
-        for _ in 0..MAX_EVENTLOOP_ITERS {
-            let mut ready = false;
+        let mut budget = Budget::new(cx.waker().clone(), MAX_EVENTLOOP_ITERS);
 
+        while let Some(mut tick) = budget.next() {
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
             // Pass up existing events.
@@ -385,7 +377,7 @@ impl GatewayTunnel {
                 self.io
                     .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
 
-                ready = true;
+                tick.want_continue();
             }
 
             // Process all IO sources that are ready.
@@ -429,12 +421,12 @@ impl GatewayTunnel {
                         }
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if timeout {
                     self.role_state.handle_timeout(now, now_utc);
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if let Some(packets) = device {
@@ -466,7 +458,7 @@ impl GatewayTunnel {
                         }
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if let Some(mut packets) = network {
@@ -494,7 +486,7 @@ impl GatewayTunnel {
                         };
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 for query in udp_dns_queries {
@@ -520,7 +512,7 @@ impl GatewayTunnel {
                         }
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 for query in tcp_dns_queries {
@@ -546,27 +538,20 @@ impl GatewayTunnel {
                         }
                     }
 
-                    ready = true;
+                    tick.want_continue();
                 }
 
                 if !error.is_empty() {
                     return Poll::Ready(GatewayEvent::Error(error));
                 }
             }
-
-            if ready {
-                continue;
-            }
-
-            // Reset timer for time-based wakeup before we suspend.
-            if let Some((timeout, reason)) = self.role_state.poll_timeout() {
-                self.io.reset_timeout(timeout, reason);
-            }
-
-            return Poll::Pending;
         }
 
-        cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
+        // Reset timer for time-based wakeup before we suspend.
+        if let Some((timeout, reason)) = self.role_state.poll_timeout() {
+            self.io.reset_timeout(timeout, reason);
+        }
+
         Poll::Pending
     }
 }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -291,11 +291,6 @@ impl ClientTunnel {
                     ready = true;
                 }
 
-                // Reset timer for time-based wakeup.
-                if let Some((timeout, reason)) = self.role_state.poll_timeout() {
-                    self.io.reset_timeout(timeout, reason);
-                }
-
                 if !error.is_empty() {
                     return Poll::Ready(ClientEvent::Error(error));
                 }
@@ -303,6 +298,11 @@ impl ClientTunnel {
 
             if ready {
                 continue;
+            }
+
+            // Reset timer for time-based wakeup before we suspend.
+            if let Some((timeout, reason)) = self.role_state.poll_timeout() {
+                self.io.reset_timeout(timeout, reason);
             }
 
             return Poll::Pending;
@@ -548,11 +548,6 @@ impl GatewayTunnel {
                     ready = true;
                 }
 
-                // Reset timer for time-based wakeup.
-                if let Some((timeout, reason)) = self.role_state.poll_timeout() {
-                    self.io.reset_timeout(timeout, reason);
-                }
-
                 if !error.is_empty() {
                     return Poll::Ready(GatewayEvent::Error(error));
                 }
@@ -560,6 +555,11 @@ impl GatewayTunnel {
 
             if ready {
                 continue;
+            }
+
+            // Reset timer for time-based wakeup before we suspend.
+            if let Some((timeout, reason)) = self.role_state.poll_timeout() {
+                self.io.reset_timeout(timeout, reason);
             }
 
             return Poll::Pending;

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -183,7 +183,7 @@ impl ClientTunnel {
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<ClientEvent> {
-        let mut budget = Budget::new(cx.waker().clone(), MAX_EVENTLOOP_ITERS);
+        let mut budget = Budget::new(cx.waker().clone(), MAX_EVENTLOOP_ITERS, "client-tunnel");
 
         while let Some(mut tick) = budget.next() {
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
@@ -362,7 +362,7 @@ impl GatewayTunnel {
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<GatewayEvent> {
-        let mut budget = Budget::new(cx.waker().clone(), MAX_EVENTLOOP_ITERS);
+        let mut budget = Budget::new(cx.waker().clone(), MAX_EVENTLOOP_ITERS, "gateway-tunnel");
 
         while let Some(mut tick) = budget.next() {
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -181,8 +181,10 @@ impl ClientTunnel {
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<ClientEvent> {
+        let mut ready = false;
+
         for _ in 0..MAX_EVENTLOOP_ITERS {
-            let mut ready = false;
+            ready = false;
 
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
@@ -295,19 +297,20 @@ impl ClientTunnel {
                 }
             }
 
-            if ready {
-                continue;
+            if !ready {
+                break;
             }
-
-            // Reset timer for time-based wakeup before we suspend.
-            if let Some((timeout, reason)) = self.role_state.poll_timeout() {
-                self.io.reset_timeout(timeout, reason);
-            }
-
-            return Poll::Pending;
         }
 
-        cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
+        // Reset timer for time-based wakeup before we suspend.
+        if let Some((timeout, reason)) = self.role_state.poll_timeout() {
+            self.io.reset_timeout(timeout, reason);
+        }
+
+        if ready {
+            cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
+        }
+
         Poll::Pending
     }
 }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -8,7 +8,6 @@
 #![cfg_attr(test, allow(clippy::print_stderr))]
 
 use anyhow::{Context as _, ErrorExt as _, Result};
-use chrono::Utc;
 use connlib_model::{
     ClientId, ClientOrGatewayId, GatewayId, IceCandidate, PublicKey, ResourceId, ResourceView,
 };
@@ -308,7 +307,6 @@ impl ClientTunnel {
             return Poll::Pending;
         }
 
-        self.role_state.handle_timeout(Instant::now()); // Ensure time advances, even if we are busy handling packets.
         cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
         Poll::Pending
     }
@@ -565,7 +563,6 @@ impl GatewayTunnel {
             return Poll::Pending;
         }
 
-        self.role_state.handle_timeout(Instant::now(), Utc::now()); // Ensure time advances, even if we are busy handling packets.
         cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
         Poll::Pending
     }


### PR DESCRIPTION
Handling time in a sans-IO system like connlib is tricky. In order to know, when a time-sensitive action is due, we need to call into the state machine to compute said value (i.e. `poll_timeout`). As soon as there any state changes, the computed value is effectively stale and would have to be re-computed to be correct.

The trade-off we need to balance here is computing power vs timing correctness. Right now, connlib is designed to err on the side of correctness:

- We compute `poll_timeout` on every tick of the event-loop
- We call `handle_timeout` after every state change that did not immediately produce a result

Recent benchmarking has shown that this consumes a lot of CPU, especially as the number of connections increases because many algorithms within connlib are O(n) with the number of connections.

To improve this, we make the following changes to connlib's timeout handling in the event-loop:

- `poll_timeout` is only re-computed when we are about to suspend the event-loop. The budget here is at most 5000 ticks. As a result, we may be slightly less accurate in when time-based actions need to be taken but we do guarantee that it re-compute it.
- `handle_timeout` calls on mutations are scheduled instead of performed immediately. This reduces the number of times we call `handle_timeout`. The grace period here is 1 second.
- The new `Timeout` abstraction ensures we call `handle_timeout` _at least_ once every 10 seconds. This is a defense-in-depth strategy to ensure we don't miss time-related actions in case of scheduling bugs.

For better testability, we extract the event-loop budget handling into a new component. The added observability yielded the following data on my local system:

```
Metric #4
                Name         : eventloop.poll.duration
                Description  : Duration of a single event-loop poll.
                Unit         : s
                Type         : Histogram
                Temporality  : Cumulative
                StartTime    : 2026-03-12 01:01:07.251309
                EndTime      : 2026-03-12 01:02:07.241546
                Histogram DataPoints
                DataPoint #0
                        Count        : 43141
                        Sum          : 1.641520934000014
                        Min          : 8.72e-7
                        Max          : 0.001744628
                        Attributes   :
                                 ->  eventloop.exhausted: false
                        Buckets
                                 -inf to 0.000005 : 6727
                                 0.000005 to 0.00001 : 6336
                                 0.00001 to 0.000025 : 9196
                                 0.000025 to 0.00005 : 10219
                                 0.00005 to 0.0001 : 7644
                                 0.0001 to 0.00025 : 2626
                                 0.00025 to 0.0005 : 354
                                 0.0005 to 0.001 : 30
                                 0.001 to 0.0025 : 9
                                 0.0025 to 0.005 : 0
                                 0.005 to 0.01 : 0
                                0.01 to +Infinity : 0
```

The data-points are in seconds, meaning the majority of event-loop durations here finished in 25-50 microseconds. Only 9 of those took 1 millisecond or longer.

Using this data, it is safe to say that there is absolutely no need to re-compute `poll_timeout` at every tick and doing it at the very end is more than precise enough.