### PR TITLE
feat(snownet): fast-dispatch STUN message to ICE agent

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -637,6 +637,7 @@ where
         );
         self.connections
             .handle_timeout(&mut self.pending_events, now);
+        self.inflight_stun_requests.handle_timeout(now);
     }
 
     /// Returns buffered data that needs to be sent on the socket.
@@ -1519,9 +1520,10 @@ where
             let dst = transmit.destination;
             let stun_packet_bytes = Vec::from(transmit.contents);
             match StunMessage::parse(&stun_packet_bytes) {
-                Ok(msg) => {
-                    inflight_stun_requests.add(cid, msg.trans_id());
+                Ok(msg) if msg.is_binding_request() => {
+                    inflight_stun_requests.add(cid, msg.trans_id(), now);
                 }
+                Ok(_) => {}
                 Err(e) => {
                     tracing::warn!("str0m emitted invalid STUN message: {e}")
                 }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -226,6 +226,7 @@ where
 
         self.connections.clear();
         self.buffered_transmits.clear();
+        self.inflight_stun_requests.clear();
 
         self.private_key = StaticSecret::random_from_rng(&mut self.rng);
         self.public_key = (&self.private_key).into();

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1,6 +1,7 @@
 mod allocations;
 mod connection_state;
 mod connections;
+mod inflight_stun_requests;
 
 pub use connections::UnknownConnection;
 
@@ -9,6 +10,7 @@ use crate::index::IndexLfsr;
 use crate::node::allocations::Allocations;
 use crate::node::connection_state::{ConnectionState, PeerSocket};
 use crate::node::connections::Connections;
+use crate::node::inflight_stun_requests::InflightStunRequests;
 use crate::stats::{ConnectionStats, NodeStats};
 use crate::utils::channel_data_packet_buffer;
 use anyhow::{Context, Result, anyhow};
@@ -25,7 +27,7 @@ use ip_packet::{Ecn, IpPacket, IpPacketBuf};
 use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
-use ringbuffer::{AllocRingBuffer, RingBuffer as _};
+use ringbuffer::{AllocRingBuffer, RingBuffer};
 use sha2::Digest;
 use smallvec::SmallVec;
 use std::collections::BTreeSet;
@@ -92,6 +94,8 @@ pub struct Node<TId, RId> {
     allocations: Allocations<RId>,
 
     connections: Connections<TId, RId>,
+    inflight_stun_requests: InflightStunRequests<TId>,
+
     pending_events: VecDeque<Event<TId>>,
 
     stats: NodeStats,
@@ -184,6 +188,7 @@ where
             next_rate_limiter_reset: None,
             pending_events: VecDeque::default(),
             allocations: Default::default(),
+            inflight_stun_requests: Default::default(),
             connections: Default::default(),
             stats: Default::default(),
             buffer_pool: BufferPool::new(ip_packet::MAX_FZ_PAYLOAD, "snownet"),
@@ -553,7 +558,13 @@ where
     /// Returns a pending [`Event`] from the pool.
     #[must_use]
     pub fn poll_event(&mut self) -> Option<Event<TId>> {
-        self.pending_events.pop_front()
+        let event = self.pending_events.pop_front()?;
+
+        if let Event::ConnectionClosed(id) | Event::ConnectionFailed(id) = &event {
+            self.inflight_stun_requests.remove_by_conn_id(*id);
+        }
+
+        Some(event)
     }
 
     /// Returns, when [`Node::handle_timeout`] should be called next.
@@ -594,7 +605,13 @@ where
         self.allocations_drain_events(now);
 
         for (id, connection) in self.connections.iter_established_mut() {
-            connection.handle_timeout(id, now, &mut self.allocations, &mut self.buffered_transmits);
+            connection.handle_timeout(
+                id,
+                now,
+                &mut self.allocations,
+                &mut self.buffered_transmits,
+                &mut self.inflight_stun_requests,
+            );
         }
 
         if self.connections.all_idle() {
@@ -910,23 +927,30 @@ where
             return ControlFlow::Continue(());
         };
 
-        for (_, c) in self.connections.iter_mut() {
-            if c.agent.accepts_message(&message) {
-                c.agent.handle_packet(
-                    now,
-                    StunPacket {
-                        proto: Protocol::Udp,
-                        source: from,
-                        destination,
-                        message,
-                    },
-                );
+        let (_, c) = match self.connections.get_established_mut_for_stun_message(
+            &message,
+            &mut self.inflight_stun_requests,
+            now,
+        ) {
+            Ok(c) => c,
+            Err(e) => return ControlFlow::Break(Err(e)),
+        };
 
-                return ControlFlow::Break(Ok(()));
-            }
+        let handled = c.agent.handle_packet(
+            now,
+            StunPacket {
+                proto: Protocol::Udp,
+                source: from,
+                destination,
+                message,
+            },
+        );
+
+        if !handled {
+            tracing::debug!(
+                "Agent did not handle STUN packet assigned by local ufrag or STUN Transaction ID"
+            );
         }
-
-        tracing::trace!("Packet was a STUN message but no agent handled it. Already disconnected?");
 
         ControlFlow::Break(Ok(()))
     }
@@ -1303,6 +1327,7 @@ where
         now: Instant,
         allocations: &mut Allocations<RId>,
         transmits: &mut VecDeque<Transmit>,
+        inflight_stun_requests: &mut InflightStunRequests<TId>,
     ) where
         TId: Copy + Ord + fmt::Display,
         RId: Copy + Ord + fmt::Display,
@@ -1492,23 +1517,31 @@ where
         while let Some(transmit) = self.agent.poll_transmit() {
             let source = transmit.source;
             let dst = transmit.destination;
-            let stun_packet = transmit.contents;
+            let stun_packet_bytes = Vec::from(transmit.contents);
+            match StunMessage::parse(&stun_packet_bytes) {
+                Ok(msg) => {
+                    inflight_stun_requests.add(cid, msg.trans_id());
+                }
+                Err(e) => {
+                    tracing::warn!("str0m emitted invalid STUN message: {e}")
+                }
+            }
 
             // Check if `str0m` wants us to send from a "remote" socket, i.e. one that we allocated with a relay.
             let Some((relay, allocation)) = allocations.get_mut_by_allocation(source) else {
-                self.stats.stun_bytes_to_peer_direct += stun_packet.len();
+                self.stats.stun_bytes_to_peer_direct += stun_packet_bytes.len();
 
                 // `source` did not match any of our allocated sockets, must be a local one then!
                 transmits.push_back(Transmit {
                     src: Some(source),
                     dst,
-                    payload: self.buffer_pool.pull_initialised(&Vec::from(stun_packet)),
+                    payload: self.buffer_pool.pull_initialised(&stun_packet_bytes),
                     ecn: Ecn::NonEct,
                 });
                 continue;
             };
 
-            let mut data_channel_packet = channel_data_packet_buffer(&stun_packet);
+            let mut data_channel_packet = channel_data_packet_buffer(&stun_packet_bytes);
 
             // Payload should be sent from a "remote socket", let's wrap it in a channel data message!
             let Some(encode_ok) =

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -84,7 +84,8 @@ where
 
         self.established_by_wireguard_session_index
             .remove(&connection.index.global());
-        self.established_by_local_ufrag.retain(|_, c| c != id);
+        self.established_by_local_ufrag
+            .remove(&connection.agent.local_credentials().ufrag);
 
         self.disconnected_ids.insert(*id, now);
         self.disconnected_public_keys

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -6,25 +6,28 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use boringtun::noise::Index;
 use rand::Rng;
+use str0m::ice::{StunMessage, TransId};
 
 use crate::{
     ConnectionStats, Event,
-    node::{Connection, allocations::Allocations},
+    node::{Connection, allocations::Allocations, inflight_stun_requests::InflightStunRequests},
 };
 
 pub struct Connections<TId, RId> {
     established: BTreeMap<TId, Connection<RId>>,
 
     established_by_wireguard_session_index: BTreeMap<usize, TId>,
+    established_by_local_ufrag: BTreeMap<String, TId>,
 
     disconnected_ids: BTreeMap<TId, Instant>,
     disconnected_public_keys: BTreeMap<[u8; 32], Instant>,
     disconnected_session_indices: BTreeMap<usize, Instant>,
 
     connections_with_removed_relays: BTreeSet<TId>,
+    disconnected_ufrags: BTreeMap<String, Instant>,
 }
 
 impl<TId, RId> Default for Connections<TId, RId> {
@@ -32,10 +35,12 @@ impl<TId, RId> Default for Connections<TId, RId> {
         Self {
             established: Default::default(),
             established_by_wireguard_session_index: Default::default(),
+            established_by_local_ufrag: Default::default(),
             disconnected_ids: Default::default(),
             disconnected_public_keys: Default::default(),
             disconnected_session_indices: Default::default(),
             connections_with_removed_relays: Default::default(),
+            disconnected_ufrags: Default::default(),
         }
     }
 }
@@ -60,6 +65,8 @@ where
             self.disconnected_public_keys
                 .insert(conn.tunnel.remote_static_public().to_bytes(), now);
             self.disconnected_ids.insert(id, now);
+            self.disconnected_ufrags
+                .insert(conn.agent.local_credentials().ufrag.to_owned(), now);
         }
 
         self.disconnected_ids
@@ -68,6 +75,8 @@ where
             .retain(|_, v| now.duration_since(*v) < Self::RECENT_DISCONNECT_TIMEOUT);
         self.disconnected_session_indices
             .retain(|_, v| now.duration_since(*v) < Self::RECENT_DISCONNECT_TIMEOUT);
+        self.disconnected_ufrags
+            .retain(|_, v| now.duration_since(*v) < Self::RECENT_DISCONNECT_TIMEOUT);
     }
 
     pub(crate) fn remove_established(&mut self, id: &TId, now: Instant) -> Option<Connection<RId>> {
@@ -75,12 +84,15 @@ where
 
         self.established_by_wireguard_session_index
             .remove(&connection.index.global());
+        self.established_by_local_ufrag.retain(|_, c| c != id);
 
         self.disconnected_ids.insert(*id, now);
         self.disconnected_public_keys
             .insert(connection.tunnel.remote_static_public().to_bytes(), now);
         self.disconnected_session_indices
             .insert(connection.index.global(), now);
+        self.disconnected_ufrags
+            .insert(connection.agent.local_credentials().ufrag.to_owned(), now);
 
         Some(connection)
     }
@@ -138,6 +150,7 @@ where
         index: Index,
         connection: Connection<RId>,
     ) -> Option<Connection<RId>> {
+        let local_ufrag = connection.agent.local_credentials().ufrag.to_owned();
         let existing = self.established.insert(id, connection);
 
         // Remove previous mappings for connection.
@@ -145,6 +158,7 @@ where
             .retain(|_, c| c != &id);
         self.established_by_wireguard_session_index
             .insert(index.global(), id);
+        self.established_by_local_ufrag.insert(local_ufrag, id);
 
         existing
     }
@@ -209,6 +223,43 @@ where
             ))?;
 
         Ok((*id, conn))
+    }
+
+    pub(crate) fn get_established_mut_for_stun_message(
+        &mut self,
+        message: &StunMessage,
+        inflight_stun_requests: &mut InflightStunRequests<TId>,
+        now: Instant,
+    ) -> Result<(TId, &mut Connection<RId>)> {
+        if message.is_binding_request() {
+            let (ufrag, _) = message
+                .split_username()
+                .context("Binding request does not have a USERNAME attribute")?;
+            let id = self
+                .established_by_local_ufrag
+                .get(ufrag)
+                .ok_or(UnknownConnection::by_local_ufrag(
+                    ufrag,
+                    &self.disconnected_ufrags,
+                    now,
+                ))
+                .copied()?;
+            let conn = self.get_mut(&id, now)?;
+
+            return Ok((id, conn));
+        }
+
+        if message.is_successful_binding_response() {
+            let trans_id = message.trans_id();
+            let id = inflight_stun_requests
+                .remove(trans_id)
+                .ok_or(UnknownConnection::by_trans_id(trans_id))?;
+            let conn = self.get_mut(&id, now)?;
+
+            return Ok((id, conn));
+        }
+
+        bail!("STUN message is not a BINDING")
     }
 
     pub(crate) fn iter_established(&self) -> impl Iterator<Item = (TId, &Connection<RId>)> {
@@ -324,6 +375,28 @@ impl UnknownConnection {
             disconnected_for: disconnected_public_keys
                 .get(&key)
                 .map(|disconnected| now.duration_since(*disconnected)),
+        }
+    }
+
+    fn by_local_ufrag(
+        key: &str,
+        disconnected_ufrags: &BTreeMap<String, Instant>,
+        now: Instant,
+    ) -> Self {
+        Self {
+            id: key.to_owned(),
+            kind: "ufrag",
+            disconnected_for: disconnected_ufrags
+                .get(key)
+                .map(|disconnected| now.duration_since(*disconnected)),
+        }
+    }
+
+    fn by_trans_id(key: TransId) -> Self {
+        Self {
+            id: format!("{key:?}"),
+            kind: "STUN trans ID",
+            disconnected_for: None,
         }
     }
 

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -44,6 +44,10 @@ where
             .extract_if(|_, (_, expires_at)| now >= *expires_at)
         {}
     }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
 }
 
 #[cfg(test)]

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use str0m::ice::TransId;
+
+pub struct InflightStunRequests<TId> {
+    inner: HashMap<String, TId>,
+}
+
+impl<TId> Default for InflightStunRequests<TId> {
+    fn default() -> Self {
+        Self {
+            inner: HashMap::default(),
+        }
+    }
+}
+
+impl<TId> InflightStunRequests<TId>
+where
+    TId: PartialEq,
+{
+    pub fn add(&mut self, conn_id: TId, id: TransId) {
+        self.inner.insert(format!("{id:?}"), conn_id); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
+    }
+
+    pub fn remove(&mut self, id: TransId) -> Option<TId> {
+        self.inner.remove(&format!("{id:?}"))
+    }
+
+    pub fn remove_by_conn_id(&mut self, id: TId) {
+        self.inner.retain(|_, c| c != &id);
+    }
+}

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -1,9 +1,15 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use str0m::ice::TransId;
 
+/// For how long we will at most keep around an inflight STUN request ID.
+const TTL: Duration = Duration::from_secs(10);
+
 pub struct InflightStunRequests<TId> {
-    inner: HashMap<String, TId>,
+    inner: HashMap<String, (TId, Instant)>,
 }
 
 impl<TId> Default for InflightStunRequests<TId> {
@@ -18,15 +24,134 @@ impl<TId> InflightStunRequests<TId>
 where
     TId: PartialEq,
 {
-    pub fn add(&mut self, conn_id: TId, id: TransId) {
-        self.inner.insert(format!("{id:?}"), conn_id); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
+    pub fn add(&mut self, conn_id: TId, id: TransId, now: Instant) {
+        self.inner.insert(format!("{id:?}"), (conn_id, now + TTL)); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
     }
 
     pub fn remove(&mut self, id: TransId) -> Option<TId> {
-        self.inner.remove(&format!("{id:?}"))
+        let (id, _) = self.inner.remove(&format!("{id:?}"))?;
+
+        Some(id)
     }
 
     pub fn remove_by_conn_id(&mut self, id: TId) {
-        self.inner.retain(|_, c| c != &id);
+        for _ in self.inner.extract_if(|_, (c, _)| c == &id) {}
+    }
+
+    pub fn handle_timeout(&mut self, now: Instant) {
+        for _ in self
+            .inner
+            .extract_if(|_, (_, expires_at)| now >= *expires_at)
+        {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_remove_returns_conn_id() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id = TransId::new();
+
+        requests.add(42u32, id, now);
+        let result = requests.remove(id);
+
+        assert_eq!(result, Some(42u32));
+    }
+
+    #[test]
+    fn remove_unknown_id_returns_none() {
+        let mut requests = InflightStunRequests::<u32>::default();
+        let id = TransId::new();
+
+        let result = requests.remove(id);
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn remove_is_idempotent() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id = TransId::new();
+
+        requests.add(1u32, id, now);
+        assert_eq!(requests.remove(id), Some(1u32));
+        assert_eq!(requests.remove(id), None);
+    }
+
+    #[test]
+    fn entry_not_expired_before_ttl() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id = TransId::new();
+
+        requests.add(1u32, id, now);
+        requests.handle_timeout(now + TTL - Duration::from_millis(1));
+
+        assert_eq!(requests.remove(id), Some(1u32));
+    }
+
+    #[test]
+    fn entry_expired_after_ttl() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id = TransId::new();
+
+        requests.add(1u32, id, now);
+        requests.handle_timeout(now + TTL + Duration::from_millis(1));
+
+        assert_eq!(requests.remove(id), None);
+    }
+
+    #[test]
+    fn only_expired_entries_are_removed() {
+        let mut requests = InflightStunRequests::default();
+        let t0 = Instant::now();
+        let early_id = TransId::new();
+        let late_id = TransId::new();
+
+        requests.add(1u32, early_id, t0);
+        requests.add(2u32, late_id, t0 + Duration::from_secs(5));
+
+        // Advance past the TTL of the first entry only.
+        requests.handle_timeout(t0 + TTL + Duration::from_millis(1));
+
+        assert_eq!(requests.remove(early_id), None);
+        assert_eq!(requests.remove(late_id), Some(2u32));
+    }
+
+    #[test]
+    fn remove_by_conn_id_removes_all_matching_entries() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id_a = TransId::new();
+        let id_b = TransId::new();
+        let id_c = TransId::new();
+
+        requests.add(1u32, id_a, now);
+        requests.add(1u32, id_b, now);
+        requests.add(2u32, id_c, now);
+
+        requests.remove_by_conn_id(1u32);
+
+        assert_eq!(requests.remove(id_a), None);
+        assert_eq!(requests.remove(id_b), None);
+        assert_eq!(requests.remove(id_c), Some(2u32));
+    }
+
+    #[test]
+    fn remove_by_conn_id_is_noop_for_unknown_id() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id = TransId::new();
+
+        requests.add(1u32, id, now);
+        requests.remove_by_conn_id(99u32);
+
+        assert_eq!(requests.remove(id), Some(1u32));
     }
 }


### PR DESCRIPTION
Right now, dispatch of STUN messages to the relevant ICE agent uses an O(n) algorithm by simply searching through the list of connections for the appropriate agent. When handling large number of connections (500+) this is quite inefficient and ends consuming a significant amount of CPU as STUN messages are exchanged on a fairly high frequency of ~1.5s.

To improve this, we implement an O(1) algorithm finding the relevant connection for a particular STUN message.

1. For BINDING requests, we can look-up the connection by the local ICE credential ufrag.
2. For BINDING responses, we need to record the emitted `TransId` of a binding request and map it to the connection.

Related: #12504