### PR TITLE
feat(portal): email queue

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -88,6 +88,8 @@ config :portal, Portal.ChangeLogs.ReplicationConnection,
     client_tokens
     one_time_passcodes
     portal_sessions
+    outbound_emails
+    outbound_email_deliveries
     ipv4_addresses
     ipv6_addresses
     api_tokens
@@ -418,6 +420,13 @@ config :swoosh, :api_client, Swoosh.ApiClient.Req
 config :portal, Portal.Mailer,
   adapter: Portal.Mailer.NoopAdapter,
   from_email: "test@firez.one"
+
+config :portal, Portal.Mailer.Secondary,
+  adapter: Portal.Mailer.NoopAdapter,
+  from_email: "test@firez.one",
+  req_opts: [retry: :transient]
+
+config :portal, Portal.AzureCommunicationServices, event_grid_webhook_secret: nil
 
 config :esbuild,
   version: "0.25.4",

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -101,7 +101,8 @@ config :portal, Oban,
     google_sync: 5,
     okta_scheduler: 1,
     okta_sync: 5,
-    sync_error_notifications: 1
+    sync_error_notifications: 1,
+    outbound_emails: 1
   ],
   engine: Oban.Engines.Basic,
   repo: Portal.Repo
@@ -223,6 +224,7 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 config :portal, Portal.Mailer, adapter: Swoosh.Adapters.Local
+config :portal, Portal.Mailer.Secondary, adapter: Swoosh.Adapters.Local
 
 config :sentry,
   environment_name: :dev

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -271,7 +271,8 @@ if config_env() == :prod do
           google_sync: 5,
           okta_scheduler: 1,
           okta_sync: 5,
-          sync_error_notifications: 1
+          sync_error_notifications: 1,
+          outbound_emails: 1
         ],
         else: []
       ),
@@ -463,6 +464,17 @@ if config_env() == :prod do
            adapter: env_var_to_config!(:outbound_email_adapter),
            from_email: env_var_to_config!(:outbound_email_from)
          ] ++ env_var_to_config!(:outbound_email_adapter_opts)
+
+  config :portal,
+         Portal.Mailer.Secondary,
+         [
+           adapter: env_var_to_config!(:secondary_outbound_email_adapter),
+           from_email: env_var_to_config!(:outbound_email_from)
+         ] ++ env_var_to_config!(:secondary_outbound_email_adapter_opts)
+
+  config :portal,
+         Portal.AzureCommunicationServices,
+         event_grid_webhook_secret: env_var_to_config!(:acs_event_grid_webhook_secret)
 
   # Sentry
 

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -219,6 +219,7 @@ config :portal, relays_presence_debounce_timeout_ms: 100
 ##### Third-party configs #####
 ###############################
 config :portal, Portal.Mailer, adapter: Portal.Mailer.TestAdapter
+config :portal, Portal.Mailer.Secondary, adapter: Portal.Mailer.TestAdapter
 
 # Allow asserting on info logs and higher
 config :logger, level: :info

--- a/elixir/lib/portal/azure_communication_services.ex
+++ b/elixir/lib/portal/azure_communication_services.ex
@@ -1,0 +1,195 @@
+defmodule Portal.AzureCommunicationServices do
+  @moduledoc """
+  Handles ACS Event Grid delivery reports for recipient and message-level email state.
+  """
+
+  alias Portal.EmailSuppression
+  alias __MODULE__.Database
+
+  @ignored_delivery_statuses MapSet.new(["Queued", "OutForDelivery", "Expanded"])
+
+  def event_grid_webhook_secret do
+    Portal.Config.fetch_env!(:portal, __MODULE__)
+    |> Keyword.fetch!(:event_grid_webhook_secret)
+  end
+
+  def handle_event_grid_events(events) when is_list(events) do
+    Enum.reduce_while(events, :ok, fn event, :ok ->
+      case handle_event(event) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp handle_event(
+         %{"eventType" => "Microsoft.Communication.EmailDeliveryReportReceived"} = event
+       ) do
+    with {:ok, report} <- delivery_report(event),
+         {:ok, _result} <- Database.apply_delivery_report(report) do
+      :ok
+    end
+  end
+
+  defp handle_event(_event), do: :ok
+
+  defp delivery_report(%{"data" => data}) when is_map(data) do
+    with message_id when is_binary(message_id) <- data["messageId"],
+         recipient when is_binary(recipient) <- data["recipient"],
+         %{} = attrs <- report_update_attrs(data) do
+      {:ok,
+       Map.merge(attrs, %{
+         message_id: message_id,
+         email: EmailSuppression.normalize_email(recipient)
+       })}
+    else
+      nil -> :ok
+      :ignore -> :ok
+      _ -> {:error, :invalid_delivery_report}
+    end
+  end
+
+  defp delivery_report(_event), do: {:error, :invalid_delivery_report}
+
+  defp report_update_attrs(%{"deliveryStatus" => delivery_status} = data) do
+    if MapSet.member?(@ignored_delivery_statuses, delivery_status) do
+      :ignore
+    else
+      terminal_status_attrs(data)
+    end
+  end
+
+  defp terminal_status_attrs(%{"deliveryStatus" => "Delivered"}) do
+    %{status: :delivered, failure_code: nil, failure_message: nil, suppress?: false}
+  end
+
+  defp terminal_status_attrs(%{"deliveryStatus" => "Suppressed"} = data) do
+    %{
+      status: :suppressed,
+      failure_code: "Suppressed",
+      failure_message: data["deliveryStatusDetails"],
+      suppress?: true
+    }
+  end
+
+  defp terminal_status_attrs(%{"deliveryStatus" => "Bounced"} = data) do
+    %{
+      status: :bounced,
+      failure_code: "Bounced",
+      failure_message: data["deliveryStatusDetails"],
+      suppress?: true
+    }
+  end
+
+  defp terminal_status_attrs(%{"deliveryStatus" => delivery_status} = data) do
+    details = data["deliveryStatusDetails"]
+
+    cond do
+      suppression_text?(delivery_status) or suppression_text?(details) ->
+        %{
+          status: :suppressed,
+          failure_code: to_string(delivery_status),
+          failure_message: details,
+          suppress?: true
+        }
+
+      bounce_text?(delivery_status) or bounce_text?(details) ->
+        %{
+          status: :bounced,
+          failure_code: to_string(delivery_status),
+          failure_message: details,
+          suppress?: true
+        }
+
+      true ->
+        %{
+          status: :failed,
+          failure_code: to_string(delivery_status),
+          failure_message: details,
+          suppress?: false
+        }
+    end
+  end
+
+  defp suppression_text?(value) when is_binary(value),
+    do: String.contains?(String.downcase(value), "suppress")
+
+  defp suppression_text?(_value), do: false
+
+  defp bounce_text?(value) when is_binary(value),
+    do: String.contains?(String.downcase(value), "bounce")
+
+  defp bounce_text?(_value), do: false
+
+  defmodule Database do
+    import Ecto.Query
+
+    require Logger
+
+    alias Portal.Safe
+    alias Portal.{EmailSuppression, OutboundEmailDelivery, Repo}
+
+    @db_opts [timeout: 20_000, pool_timeout: 20_000]
+
+    def apply_delivery_report(report) do
+      Safe.transact(
+        fn ->
+          with {:ok, update_result} <- update_delivery(report),
+               :ok <- maybe_insert_suppression(update_result, report.suppress?, report.email) do
+            {:ok, update_result}
+          end
+        end,
+        @db_opts
+      )
+    end
+
+    defp update_delivery(report) do
+      {count, _} =
+        from(d in OutboundEmailDelivery,
+          where: d.message_id == ^report.message_id,
+          where: d.email == ^report.email,
+          where: d.status == :pending
+        )
+        |> Safe.unscoped(Repo)
+        |> Safe.update_all(
+          set: [
+            status: report.status,
+            failure_code: report.failure_code,
+            failure_message: report.failure_message,
+            updated_at: DateTime.utc_now()
+          ]
+        )
+
+      case count do
+        1 ->
+          {:ok, :updated}
+
+        0 ->
+          Logger.info("Ignored ACS delivery report; no pending delivery found",
+            message_id: report.message_id,
+            email: report.email
+          )
+
+          {:ok, :ignored}
+      end
+    end
+
+    defp maybe_insert_suppression(:ignored, _suppress?, _email), do: :ok
+    defp maybe_insert_suppression(_result, false, _email), do: :ok
+
+    defp maybe_insert_suppression(:updated, true, email) do
+      Safe.insert_all(
+        Repo,
+        EmailSuppression,
+        [%{email: email, inserted_at: DateTime.utc_now()}],
+        Keyword.merge(
+          @db_opts,
+          on_conflict: :nothing,
+          conflict_target: [:email]
+        )
+      )
+
+      :ok
+    end
+  end
+end

--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -37,6 +37,8 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
     "resources" => Portal.Resource,
     "sites" => Portal.Site,
     "client_tokens" => Portal.ClientToken,
+    "outbound_emails" => Portal.OutboundEmail,
+    "outbound_email_deliveries" => Portal.OutboundEmailDelivery,
     "userpass_auth_providers" => Portal.Userpass.AuthProvider
   }
 
@@ -57,6 +59,9 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
   # Ignore token writes for relays since these are not expected to have an account_id
   def on_write(state, _lsn, _op, "tokens", %{"type" => "relay"}, _data), do: state
   def on_write(state, _lsn, _op, "tokens", _old_data, %{"type" => "relay"}), do: state
+
+  # Global suppression rows are not account-scoped and should not enter account audit logs.
+  def on_write(state, _lsn, _op, "email_suppressions", _old_data, _data), do: state
 
   # Handle accounts specially
   def on_write(state, lsn, op, "accounts", %{"id" => account_id} = old_data, data) do

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -782,6 +782,62 @@ defmodule Portal.Config.Definitions do
     end
   )
 
+  @doc """
+  Method to use for sending queued outbound email.
+  If not set, queued emails will use the default no-op behaviour.
+  """
+  defconfig(
+    :secondary_outbound_email_adapter,
+    Ecto.ParameterizedType.init(Ecto.Enum,
+      values:
+        [
+          Swoosh.Adapters.AmazonSES,
+          Swoosh.Adapters.AzureCommunicationServices,
+          Swoosh.Adapters.CustomerIO,
+          Swoosh.Adapters.Dyn,
+          Swoosh.Adapters.ExAwsAmazonSES,
+          Swoosh.Adapters.Gmail,
+          Swoosh.Adapters.MailPace,
+          Swoosh.Adapters.Mailgun,
+          Swoosh.Adapters.Mailjet,
+          Swoosh.Adapters.Mandrill,
+          Swoosh.Adapters.Postmark,
+          Swoosh.Adapters.ProtonBridge,
+          Swoosh.Adapters.SMTP,
+          Swoosh.Adapters.SMTP2GO,
+          Swoosh.Adapters.Sendgrid,
+          Swoosh.Adapters.Sendinblue,
+          Swoosh.Adapters.Sendmail,
+          Swoosh.Adapters.SocketLabs,
+          Swoosh.Adapters.SparkPost
+        ] ++ @local_development_adapters
+    ),
+    default: nil
+  )
+
+  @doc """
+  Queued email adapter configuration.
+  """
+  defconfig(:secondary_outbound_email_adapter_opts, :map,
+    default: %{},
+    sensitive: true,
+    dump: fn map ->
+      Dumper.keyword(map)
+      |> Keyword.update(:tls_options, nil, &Dumper.dump_ssl_opts/1)
+      |> Keyword.update(:sockopts, [], &Dumper.dump_ssl_opts/1)
+    end
+  )
+
+  ##############################################
+  ## Outbound Email
+  ##############################################
+
+  @doc """
+  Shared secret expected on ACS Event Grid webhook notification requests.
+  Configure the webhook URL with `?secret=...` using this value.
+  """
+  defconfig(:acs_event_grid_webhook_secret, :string, sensitive: true, default: nil)
+
   ##############################################
   ## Billing flags
   ##############################################

--- a/elixir/lib/portal/email_suppression.ex
+++ b/elixir/lib/portal/email_suppression.ex
@@ -1,0 +1,25 @@
+defmodule Portal.EmailSuppression do
+  use Ecto.Schema
+  import Ecto.Changeset, only: [validate_required: 2, unique_constraint: 2]
+
+  @primary_key false
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "email_suppressions" do
+    field(:email, :string, primary_key: true)
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required([:email])
+    |> unique_constraint(:email)
+  end
+
+  def normalize_email(email) when is_binary(email) do
+    email
+    |> String.trim()
+    |> String.downcase()
+  end
+end

--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -1,11 +1,17 @@
 defmodule Portal.Mailer do
   alias Swoosh.Mailer
   alias Swoosh.Email
+  alias Portal.EmailSuppression
   alias Portal.Mailer.RateLimiter
+  alias Portal.Workers.OutboundEmail, as: OutboundEmailWorker
+  alias __MODULE__.Database
   require Logger
+
+  @recipient_fields [{"to", :to}, {"cc", :cc}, {"bcc", :bcc}]
 
   def deliver_with_rate_limit(email, config \\ []) do
     {key, config} = Keyword.pop(config, :rate_limit_key, {email.to, email.subject})
+
     {rate_limit, config} = Keyword.pop(config, :rate_limit, 10)
     {rate_limit_interval, config} = Keyword.pop(config, :rate_limit_interval, :timer.minutes(2))
 
@@ -32,6 +38,20 @@ defmodule Portal.Mailer do
     opts = Mailer.parse_config(:portal, __MODULE__, [], config)
     metadata = %{email: email, config: config, mailer: __MODULE__}
 
+    deliver_with_mailer_config(email, opts, metadata)
+  end
+
+  def deliver_secondary(email, config \\ []) do
+    opts =
+      Portal.Config.fetch_env!(:portal, Portal.Mailer.Secondary)
+      |> Keyword.merge(config)
+
+    metadata = %{email: email, config: config, mailer: Portal.Mailer.Secondary}
+
+    deliver_with_mailer_config(email, opts, metadata)
+  end
+
+  defp deliver_with_mailer_config(email, opts, metadata) do
     if opts[:adapter] do
       deliver_with_telemetry(email, opts, metadata)
     else
@@ -84,5 +104,193 @@ defmodule Portal.Mailer do
 
     Email.new()
     |> Email.from({"Firezone Notifications", from_email})
+  end
+
+  def with_account_id(%Email{} = email, account_id) when is_binary(account_id) do
+    Email.put_private(email, :account_id, account_id)
+  end
+
+  def bcc_recipients(%Email{} = email, recipients) when is_list(recipients) do
+    Enum.reduce(recipients, email, fn recipient, acc ->
+      Email.bcc(acc, recipient)
+    end)
+  end
+
+  @doc """
+  Enqueues an email for delivery via the secondary ACS adapter.
+
+  Checks the suppression table before inserting the Oban job. Returns
+  `{:ok, :suppressed}` if all recipients are suppressed.
+  """
+  def enqueue(%Email{} = email) do
+    account_id = require_account_id!(email)
+    request = serialize(email)
+
+    case drop_suppressed_recipients(request) do
+      {:ok, filtered_request} ->
+        %{"account_id" => account_id, "request" => filtered_request}
+        |> OutboundEmailWorker.new()
+        |> Oban.insert()
+
+      :fully_suppressed ->
+        Logger.info("Skipping queued email because all recipients are suppressed",
+          account_id: account_id,
+          subject: inspect(email.subject)
+        )
+
+        {:ok, :suppressed}
+    end
+  end
+
+  def insert_tracked_delivery(account_id, message_id, subject, recipients) do
+    Database.insert_tracked(account_id, message_id, subject, recipients)
+  end
+
+  defp require_account_id!(%Email{} = email) do
+    case email.private[:account_id] do
+      account_id when is_binary(account_id) -> account_id
+      _ -> raise ArgumentError, "call Portal.Mailer.with_account_id/2 before enqueue/1"
+    end
+  end
+
+  defp serialize(%Email{} = email) do
+    %{
+      "to" => serialize_addresses(email.to),
+      "cc" => serialize_addresses(email.cc),
+      "bcc" => serialize_addresses(email.bcc),
+      "from" =>
+        case email.from do
+          {name, addr} -> %{"name" => name, "address" => addr}
+          addr -> %{"name" => "", "address" => addr}
+        end,
+      "subject" => email.subject,
+      "html_body" => email.html_body,
+      "text_body" => email.text_body
+    }
+  end
+
+  defp serialize_addresses(addresses) do
+    addresses
+    |> List.wrap()
+    |> Enum.map(fn
+      {name, addr} -> %{"name" => name, "address" => addr}
+      addr when is_binary(addr) -> %{"name" => "", "address" => addr}
+    end)
+  end
+
+  defp drop_suppressed_recipients(request) do
+    suppressed_emails =
+      request
+      |> recipient_addresses()
+      |> Database.suppressed_recipient_addresses()
+
+    filtered_request =
+      Enum.reduce(@recipient_fields, request, fn {field, _kind}, acc ->
+        recipients = Map.get(acc, field, [])
+
+        Map.put(
+          acc,
+          field,
+          Enum.reject(recipients, fn %{"address" => address} ->
+            EmailSuppression.normalize_email(address) in suppressed_emails
+          end)
+        )
+      end)
+
+    case recipient_addresses(filtered_request) do
+      [] -> :fully_suppressed
+      _ -> {:ok, filtered_request}
+    end
+  end
+
+  defp recipient_addresses(request) do
+    Enum.flat_map(@recipient_fields, fn {field, _kind} ->
+      Enum.map(Map.get(request, field, []), fn %{"address" => address} -> address end)
+    end)
+  end
+
+  defmodule Database do
+    import Ecto.Query
+
+    alias Portal.Safe
+    alias Portal.{EmailSuppression, OutboundEmail, OutboundEmailDelivery, Repo}
+
+    @db_opts [timeout: 20_000, pool_timeout: 20_000]
+
+    def suppressed_recipient_addresses(recipients) do
+      addresses =
+        recipients
+        |> Enum.map(&EmailSuppression.normalize_email/1)
+
+      if addresses == [] do
+        []
+      else
+        from(s in EmailSuppression, where: s.email in ^addresses, select: s.email)
+        |> Safe.unscoped(:replica)
+        |> Safe.all()
+      end
+    end
+
+    def insert_tracked(account_id, message_id, subject, recipients) do
+      now = DateTime.utc_now()
+      recipients = normalize_recipients(recipients)
+
+      Safe.transact(
+        fn ->
+          with {:ok, entry} <- insert_entry(account_id, message_id, subject, recipients, now) do
+            Safe.insert_all(
+              Repo,
+              OutboundEmailDelivery,
+              delivery_rows(account_id, message_id, recipients, now),
+              @db_opts
+            )
+
+            {:ok, entry}
+          end
+        end,
+        @db_opts
+      )
+    end
+
+    defp normalize_recipients(recipients) do
+      recipients
+      |> Enum.map(&EmailSuppression.normalize_email/1)
+      |> Enum.uniq()
+    end
+
+    defp delivery_rows(account_id, message_id, recipients, now) do
+      Enum.map(recipients, fn email ->
+        %{
+          account_id: account_id,
+          message_id: message_id,
+          email: email,
+          status: :pending,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+    end
+
+    defp insert_entry(account_id, message_id, subject, recipients, now) do
+      attrs = %{
+        account_id: account_id,
+        message_id: message_id,
+        subject: subject,
+        recipients: recipients,
+        inserted_at: now,
+        updated_at: now
+      }
+
+      changeset =
+        %OutboundEmail{}
+        |> Ecto.Changeset.change(attrs)
+        |> OutboundEmail.changeset()
+
+      Safe.insert(
+        Repo,
+        changeset,
+        @db_opts
+      )
+    end
   end
 end

--- a/elixir/lib/portal/mailer/account_delete_email.ex
+++ b/elixir/lib/portal/mailer/account_delete_email.ex
@@ -12,6 +12,7 @@ defmodule Portal.Mailer.AccountDelete do
     default_email()
     |> subject("ACCOUNT DELETE REQUEST - #{account.id}")
     |> to("support@firezone.dev")
+    |> with_account_id(account.id)
     |> render_text_body(__MODULE__, :account_delete_request, account: account, subject: subject)
   end
 end

--- a/elixir/lib/portal/mailer/auth_email.ex
+++ b/elixir/lib/portal/mailer/auth_email.ex
@@ -22,6 +22,7 @@ defmodule Portal.Mailer.AuthEmail do
     default_email()
     |> subject("Welcome to Firezone")
     |> to(actor.email)
+    |> with_account_id(account.id)
     |> render_body(__MODULE__, :sign_up_link,
       account: account,
       sign_in_form_url: sign_in_form_url,
@@ -50,6 +51,7 @@ defmodule Portal.Mailer.AuthEmail do
     default_email()
     |> subject("Firezone sign in token")
     |> to(actor.email)
+    |> with_account_id(actor.account.id)
     |> render_body(__MODULE__, :sign_in_link,
       account: actor.account,
       client_sign_in: params["as"] == "client",
@@ -69,6 +71,7 @@ defmodule Portal.Mailer.AuthEmail do
     default_email()
     |> subject("Welcome to Firezone")
     |> to(actor.email)
+    |> with_account_id(account.id)
     |> render_body(__MODULE__, :new_user,
       account: account,
       actor: actor,

--- a/elixir/lib/portal/mailer/beta_email.ex
+++ b/elixir/lib/portal/mailer/beta_email.ex
@@ -12,6 +12,7 @@ defmodule Portal.Mailer.BetaEmail do
     default_email()
     |> subject("REST API Beta Request - #{account.id}")
     |> to("support@firezone.dev")
+    |> with_account_id(account.id)
     |> render_text_body(__MODULE__, :rest_api_request, account: account, subject: subject)
   end
 end

--- a/elixir/lib/portal/mailer/notifications.ex
+++ b/elixir/lib/portal/mailer/notifications.ex
@@ -11,13 +11,14 @@ defmodule Portal.Mailer.Notifications do
   embed_templates "notifications/*.html", suffix: "_html"
   embed_templates "notifications/*.text", suffix: "_text"
 
-  def outdated_gateway_email(account, gateways, incompatible_client_count, email) do
+  def outdated_gateway_email(account, gateways, incompatible_client_count, recipients) do
     params = %{clients_order_by: "latest_session:asc:version"}
     outdated_clients_url = url(~p"/#{account.id}/clients?#{params}")
 
     default_email()
     |> subject("Firezone Gateway Upgrade Available")
-    |> to(email)
+    |> put_recipients(recipients)
+    |> with_account_id(account.id)
     |> render_body(__MODULE__, :outdated_gateway,
       account: account,
       gateways: gateways,
@@ -27,13 +28,14 @@ defmodule Portal.Mailer.Notifications do
     )
   end
 
-  def limits_exceeded_email(account, warning, email) do
+  def limits_exceeded_email(account, warning, recipients) do
     billing_url = url(~p"/#{account.id}/settings/billing")
     plan_type = Portal.Billing.plan_type(account)
 
     default_email()
     |> subject("Firezone Account Limits Exceeded")
-    |> to(email)
+    |> put_recipients(recipients)
+    |> with_account_id(account.id)
     |> render_body(__MODULE__, :limits_exceeded,
       account: account,
       warning: warning,
@@ -41,4 +43,9 @@ defmodule Portal.Mailer.Notifications do
       plan_type: plan_type
     )
   end
+
+  defp put_recipients(email, recipients) when is_list(recipients),
+    do: bcc_recipients(email, recipients)
+
+  defp put_recipients(email, recipient), do: to(email, recipient)
 end

--- a/elixir/lib/portal/mailer/rate_limiter.ex
+++ b/elixir/lib/portal/mailer/rate_limiter.ex
@@ -28,7 +28,7 @@ defmodule Portal.Mailer.RateLimiter do
 
   @impl true
   def handle_info(:prune_expired_counters, %{prune_interval: prune_interval} = state) do
-    _ = prune_expired_counters()
+    prune_expired_counters()
     :ok = schedule_tick(prune_interval)
     {:noreply, state}
   end
@@ -47,7 +47,7 @@ defmodule Portal.Mailer.RateLimiter do
 
   @doc false
   def prune(ets_table_name \\ @default_ets_table_name) do
-    _ = :ets.delete_all_objects(ets_table_name)
+    :ets.delete_all_objects(ets_table_name)
     :ok
   end
 
@@ -82,7 +82,7 @@ defmodule Portal.Mailer.RateLimiter do
   end
 
   def reset_rate_limit(key, ets_table_name \\ @default_ets_table_name) do
-    _ = delete_counter(ets_table_name, key)
+    delete_counter(ets_table_name, key)
     :ok
   end
 

--- a/elixir/lib/portal/mailer/sync_email.ex
+++ b/elixir/lib/portal/mailer/sync_email.ex
@@ -11,16 +11,22 @@ defmodule Portal.Mailer.SyncEmail do
   embed_templates "sync_email/*.html", suffix: "_html"
   embed_templates "sync_email/*.text", suffix: "_text"
 
-  def sync_error_email(directory, email) do
+  def sync_error_email(directory, recipients) do
     settings_url = url(~p"/#{directory.account.slug}/settings/directory_sync")
 
     default_email()
     |> subject("Directory Sync Error - #{directory.name}")
-    |> to(email)
+    |> put_recipients(recipients)
+    |> with_account_id(directory.account.id)
     |> render_body(__MODULE__, :sync_error,
       account: directory.account,
       directory: directory,
       settings_url: settings_url
     )
   end
+
+  defp put_recipients(email, recipients) when is_list(recipients),
+    do: bcc_recipients(email, recipients)
+
+  defp put_recipients(email, recipient), do: to(email, recipient)
 end

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -1,6 +1,6 @@
 defmodule Portal.Ops do
   alias __MODULE__.Database
-  alias Portal.Banner
+  alias Portal.{Banner, Mailer}
 
   @doc """
   Counts presences grouped by topic prefix.
@@ -77,9 +77,31 @@ defmodule Portal.Ops do
     Database.delete_all(Banner)
   end
 
+  def queue_admin_email(subject, html_body, plaintext_body) do
+    queue_admin_email(:all, subject, html_body, plaintext_body)
+  end
+
+  def queue_admin_email(account_ids, subject, html_body, plaintext_body)
+      when account_ids == :all or is_list(account_ids) do
+    Database.get_account_admin_emails_by_account(account_ids)
+    |> Enum.each(fn {account_id, admin_emails} ->
+      if admin_emails != [] do
+        Mailer.default_email()
+        |> Swoosh.Email.subject(subject)
+        |> Mailer.bcc_recipients(admin_emails)
+        |> Swoosh.Email.html_body(html_body)
+        |> Swoosh.Email.text_body(plaintext_body)
+        |> Mailer.with_account_id(account_id)
+        |> Mailer.enqueue()
+      end
+    end)
+
+    :ok
+  end
+
   defmodule Database do
     import Ecto.Query
-    alias Portal.{Account, Safe}
+    alias Portal.{Account, Actor, Safe}
 
     def get_disabled_account!(id) do
       from(a in Account,
@@ -106,6 +128,29 @@ defmodule Portal.Ops do
       banner
       |> Safe.unscoped()
       |> Safe.delete()
+    end
+
+    def get_account_admin_emails_by_account(account_ids_or_all) do
+      Actor
+      |> where([a], a.type == :account_admin_user)
+      |> where([a], is_nil(a.disabled_at))
+      |> maybe_filter_account_ids(account_ids_or_all)
+      |> select([a], {a.account_id, a.email})
+      |> Safe.unscoped(:replica)
+      |> Safe.all()
+      |> Enum.group_by(fn {account_id, _email} -> account_id end, fn {_account_id, email} ->
+        email
+      end)
+    end
+
+    defp maybe_filter_account_ids(query, :all) do
+      join(query, :inner, [a], account in Account,
+        on: account.id == a.account_id and is_nil(account.disabled_at)
+      )
+    end
+
+    defp maybe_filter_account_ids(query, account_ids) when is_list(account_ids) do
+      where(query, [a], a.account_id in ^account_ids)
     end
   end
 end

--- a/elixir/lib/portal/outbound_email.ex
+++ b/elixir/lib/portal/outbound_email.ex
@@ -1,0 +1,30 @@
+defmodule Portal.OutboundEmail do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "outbound_emails" do
+    belongs_to(:account, Portal.Account, primary_key: true)
+    field(:message_id, :string, primary_key: true)
+
+    has_many(:deliveries, Portal.OutboundEmailDelivery,
+      references: :message_id,
+      foreign_key: :message_id
+    )
+
+    field(:subject, :string)
+    field(:recipients, {:array, :string})
+
+    timestamps()
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required([:message_id, :subject, :recipients])
+    |> assoc_constraint(:account)
+    |> unique_constraint([:account_id, :message_id], name: :outbound_emails_pkey)
+  end
+end

--- a/elixir/lib/portal/outbound_email_delivery.ex
+++ b/elixir/lib/portal/outbound_email_delivery.ex
@@ -1,0 +1,39 @@
+defmodule Portal.OutboundEmailDelivery do
+  @moduledoc """
+  Per-recipient delivery state for a tracked outbound email message.
+  Created when an email is accepted by ACS, updated by delivery report webhooks.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "outbound_email_deliveries" do
+    belongs_to(:account, Portal.Account, primary_key: true)
+    field(:message_id, :string, primary_key: true)
+    field(:email, :string, primary_key: true)
+
+    belongs_to(:outbound_email, Portal.OutboundEmail,
+      define_field: false,
+      references: :message_id,
+      foreign_key: :message_id,
+      type: :string
+    )
+
+    field(:status, Ecto.Enum, values: [:pending, :delivered, :bounced, :suppressed, :failed])
+
+    field(:failure_code, :string)
+    field(:failure_message, :string)
+
+    timestamps()
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:outbound_email)
+  end
+end

--- a/elixir/lib/portal/workers/check_account_limits.ex
+++ b/elixir/lib/portal/workers/check_account_limits.ex
@@ -136,30 +136,30 @@ defmodule Portal.Workers.CheckAccountLimits do
         )
 
       admins ->
-        Enum.each(admins, fn admin ->
-          send_limit_exceeded_email(account, admin, warning)
-        end)
+        send_limit_exceeded_email(account, admins, warning)
     end
   end
 
-  defp send_limit_exceeded_email(account, admin, warning) do
+  defp send_limit_exceeded_email(account, admins, warning) do
+    recipient_emails = Enum.map(admins, & &1.email)
+
     Logger.info("Sending limits exceeded email",
-      to: admin.email,
+      recipient_count: length(recipient_emails),
       account_id: account.id
     )
 
-    Notifications.limits_exceeded_email(account, warning, admin.email)
-    |> Mailer.deliver()
+    Notifications.limits_exceeded_email(account, warning, recipient_emails)
+    |> Mailer.enqueue()
     |> case do
       {:ok, _result} ->
-        Logger.info("Limits exceeded email sent successfully",
-          to: admin.email,
+        Logger.info("Limits exceeded email enqueued successfully",
+          recipient_count: length(recipient_emails),
           account_id: account.id
         )
 
       {:error, reason} ->
-        Logger.error("Failed to send limits exceeded email",
-          to: admin.email,
+        Logger.error("Failed to enqueue limits exceeded email",
+          recipient_count: length(recipient_emails),
           reason: inspect(reason),
           account_id: account.id
         )
@@ -186,7 +186,6 @@ defmodule Portal.Workers.CheckAccountLimits do
   defmodule Database do
     import Ecto.Query
     alias Portal.Safe
-    alias Portal.Account
     alias Portal.Actor
     alias Portal.Client
 

--- a/elixir/lib/portal/workers/outbound_email.ex
+++ b/elixir/lib/portal/workers/outbound_email.ex
@@ -3,7 +3,7 @@ defmodule Portal.Workers.OutboundEmail do
   Oban worker that submits a queued email using the secondary outbound adapter.
   """
 
-  use Oban.Worker, queue: :outbound_emails, max_attempts: 3
+  use Oban.Worker, queue: :outbound_emails, max_attempts: 1
 
   alias Portal.Mailer
   require Logger

--- a/elixir/lib/portal/workers/outbound_email.ex
+++ b/elixir/lib/portal/workers/outbound_email.ex
@@ -1,0 +1,108 @@
+defmodule Portal.Workers.OutboundEmail do
+  @moduledoc """
+  Oban worker that submits a queued email using the secondary outbound adapter.
+  """
+
+  use Oban.Worker, queue: :outbound_emails, max_attempts: 3
+
+  alias Portal.Mailer
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"account_id" => account_id, "request" => request}}) do
+    email = request |> deserialize() |> put_acs_client_options()
+    result = Mailer.deliver_secondary(email)
+    persist_delivery_result(result, account_id, email)
+  end
+
+  defp put_acs_client_options(%Swoosh.Email{} = email) do
+    req_opts = Portal.Config.fetch_env!(:portal, Portal.Mailer.Secondary)[:req_opts] || []
+
+    if req_opts == [] do
+      email
+    else
+      Swoosh.Email.put_private(email, :client_options, req_opts)
+    end
+  end
+
+  defp persist_delivery_result({:ok, response}, account_id, email) do
+    with message_id when is_binary(message_id) <- response_message_id(response),
+         {:ok, _} <-
+           Mailer.insert_tracked_delivery(
+             account_id,
+             message_id,
+             email.subject,
+             email_addresses(email)
+           ) do
+      :ok
+    else
+      nil ->
+        Logger.error("ACS queued email response did not include a message id",
+          account_id: account_id,
+          response: inspect(response)
+        )
+
+        {:discard, :missing_message_id}
+
+      {:error, reason} ->
+        Logger.error("Failed to persist tracked outbound email; email was already sent",
+          account_id: account_id,
+          message_id: response_message_id(response),
+          reason: inspect(reason)
+        )
+
+        {:discard, {:track_delivery, reason}}
+    end
+  end
+
+  defp persist_delivery_result({:error, reason}, account_id, _email) do
+    Logger.error("Queued email delivery failed",
+      account_id: account_id,
+      reason: inspect(reason)
+    )
+
+    {:discard, reason}
+  end
+
+  defp email_addresses(%Swoosh.Email{} = email) do
+    (List.wrap(email.to) ++ List.wrap(email.cc) ++ List.wrap(email.bcc))
+    |> Enum.map(fn
+      {_, addr} -> addr
+      addr -> addr
+    end)
+  end
+
+  defp deserialize(
+         %{
+           "from" => from,
+           "subject" => subject,
+           "html_body" => html_body,
+           "text_body" => text_body
+         } = request
+       ) do
+    Swoosh.Email.new()
+    |> maybe_put_recipients(:to, request["to"] || [])
+    |> maybe_put_recipients(:cc, request["cc"] || [])
+    |> maybe_put_recipients(:bcc, request["bcc"] || [])
+    |> Swoosh.Email.from({from["name"], from["address"]})
+    |> Swoosh.Email.subject(subject)
+    |> Swoosh.Email.html_body(html_body)
+    |> Swoosh.Email.text_body(text_body)
+  end
+
+  defp maybe_put_recipients(email, _field, []), do: email
+
+  defp maybe_put_recipients(email, field, recipients) do
+    mapped =
+      Enum.map(recipients, fn %{"name" => name, "address" => address} -> {name, address} end)
+
+    case field do
+      :to -> Swoosh.Email.to(email, mapped)
+      :cc -> Swoosh.Email.cc(email, mapped)
+      :bcc -> Swoosh.Email.bcc(email, mapped)
+    end
+  end
+
+  defp response_message_id(response) when is_map(response), do: response[:id] || response["id"]
+  defp response_message_id(_response), do: nil
+end

--- a/elixir/lib/portal/workers/outdated_gateways.ex
+++ b/elixir/lib/portal/workers/outdated_gateways.ex
@@ -49,8 +49,13 @@ defmodule Portal.Workers.OutdatedGateways do
   end
 
   defp send_notifications(gateways, account, incompatible_client_count) do
-    Database.all_admins_for_account!(account)
-    |> Enum.each(&send_email(account, gateways, incompatible_client_count, &1.email))
+    admin_emails =
+      Database.all_admins_for_account!(account)
+      |> Enum.map(& &1.email)
+
+    if admin_emails != [] do
+      send_email(account, gateways, incompatible_client_count, admin_emails)
+    end
 
     changeset =
       account_changeset(account, %{
@@ -66,14 +71,25 @@ defmodule Portal.Workers.OutdatedGateways do
     Database.update_account(changeset)
   end
 
-  defp send_email(account, gateways, incompatible_client_count, email) do
+  defp send_email(account, gateways, incompatible_client_count, emails) do
     Mailer.Notifications.outdated_gateway_email(
       account,
       gateways,
       incompatible_client_count,
-      email
+      emails
     )
-    |> Mailer.deliver_with_rate_limit()
+    |> Mailer.enqueue()
+    |> case do
+      {:ok, _result} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to enqueue outdated gateway email",
+          account_id: account.id,
+          recipient_count: length(emails),
+          reason: inspect(reason)
+        )
+    end
   end
 
   defp account_changeset(account, attrs) do

--- a/elixir/lib/portal/workers/sync_error_notification.ex
+++ b/elixir/lib/portal/workers/sync_error_notification.ex
@@ -77,16 +77,15 @@ defmodule Portal.Workers.SyncErrorNotification do
 
       admins ->
         increment_error_email_count(directory)
-
-        Enum.each(admins, fn admin ->
-          send_email_notification(admin, directory, frequency)
-        end)
+        send_email_notification(admins, directory, frequency)
     end
   end
 
-  defp send_email_notification(admin, directory, frequency) do
+  defp send_email_notification(admins, directory, frequency) do
+    recipient_emails = Enum.map(admins, & &1.email)
+
     Logger.info("Sending sync error email",
-      to: admin.email,
+      recipient_count: length(recipient_emails),
       directory_id: directory.id,
       directory_name: directory.name,
       frequency: frequency
@@ -94,19 +93,19 @@ defmodule Portal.Workers.SyncErrorNotification do
 
     # Attempt to send the email but log errors if it fails. Important not to raise here
     # otherwise we won't increment the error email count and potentially spam admins with emails.
-    Mailer.SyncEmail.sync_error_email(directory, admin.email)
-    |> Mailer.deliver()
+    Mailer.SyncEmail.sync_error_email(directory, recipient_emails)
+    |> Mailer.enqueue()
     |> case do
       {:ok, _result} ->
-        Logger.info("Sync error email sent successfully",
-          to: admin.email,
+        Logger.info("Sync error email enqueued successfully",
+          recipient_count: length(recipient_emails),
           directory_id: directory.id
         )
 
       {:error, reason} ->
-        Logger.error("Failed to send sync error email",
-          to: admin.email,
-          reason: reason,
+        Logger.error("Failed to enqueue sync error email",
+          recipient_count: length(recipient_emails),
+          reason: inspect(reason),
           directory_id: directory.id
         )
     end

--- a/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/azure_communication_services/webhook_controller.ex
@@ -1,0 +1,91 @@
+defmodule PortalAPI.Integrations.AzureCommunicationServices.WebhookController do
+  use PortalAPI, :controller
+
+  alias Portal.AzureCommunicationServices
+  require Logger
+
+  def handle_webhook(conn, _params) do
+    with [event_type] <- get_req_header(conn, "aeg-event-type"),
+         {:ok, body, conn} <- read_body(conn),
+         {:ok, events} <- decode_events(body) do
+      case dispatch_event_type(conn, event_type, events) do
+        {:error, :invalid_secret} ->
+          send_resp(conn, 401, "Unauthorized")
+
+        {:error, :invalid_validation_event} ->
+          send_resp(conn, 400, "Bad Request: invalid validation event")
+
+        {:error, reason} ->
+          Logger.error("ACS Event Grid webhook failed", reason: inspect(reason))
+          send_resp(conn, 500, "Internal Error")
+
+        conn ->
+          conn
+      end
+    else
+      [] ->
+        send_resp(conn, 400, "Bad Request: missing aeg-event-type header")
+
+      {:more, _, _} ->
+        send_resp(conn, 413, "Request Entity Too Large")
+
+      {:error, :invalid_json} ->
+        send_resp(conn, 400, "Bad Request: invalid JSON")
+
+      {:error, reason} ->
+        Logger.error("ACS Event Grid webhook failed", reason: inspect(reason))
+        send_resp(conn, 500, "Internal Error")
+    end
+  end
+
+  defp dispatch_event_type(conn, "SubscriptionValidation", events) do
+    case validation_code(events) do
+      {:ok, code} -> json(conn, %{validationResponse: code})
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp dispatch_event_type(conn, "Notification", events) do
+    with :ok <- verify_secret(conn),
+         :ok <- AzureCommunicationServices.handle_event_grid_events(events) do
+      send_resp(conn, 200, "")
+    end
+  end
+
+  defp dispatch_event_type(conn, "Unsubscribe", _events) do
+    send_resp(conn, 200, "")
+  end
+
+  defp dispatch_event_type(conn, _event_type, _events) do
+    send_resp(conn, 400, "Bad Request: unsupported aeg-event-type")
+  end
+
+  defp verify_secret(conn) do
+    case AzureCommunicationServices.event_grid_webhook_secret() do
+      nil ->
+        Logger.error("ACS Event Grid webhook secret is not configured")
+        {:error, :invalid_secret}
+
+      secret ->
+        conn = fetch_query_params(conn)
+
+        if Plug.Crypto.secure_compare(conn.params["secret"] || "", secret) do
+          :ok
+        else
+          {:error, :invalid_secret}
+        end
+    end
+  end
+
+  defp validation_code([%{"data" => %{"validationCode" => code}} | _]) when is_binary(code),
+    do: {:ok, code}
+
+  defp validation_code(_events), do: {:error, :invalid_validation_event}
+
+  defp decode_events(body) do
+    case JSON.decode(body) do
+      {:ok, events} -> {:ok, events}
+      {:error, _reason} -> {:error, :invalid_json}
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/integrations/stripe/webhook_controller.ex
+++ b/elixir/lib/portal_api/controllers/integrations/stripe/webhook_controller.ex
@@ -8,7 +8,7 @@ defmodule PortalAPI.Integrations.Stripe.WebhookController do
 
   def handle_webhook(conn, _params) do
     with [signature_header] <- get_req_header(conn, "stripe-signature"),
-         {:ok, body, conn} <- read_body(conn),
+         {:ok, body, conn} <- read_body(conn, length: 1_000_000),
          {:ok, {timestamp, signatures}} <- fetch_timestamp_and_signatures(signature_header),
          :ok <- verify_timestamp(timestamp, @tolerance),
          secret = Billing.fetch_webhook_signing_secret!(),
@@ -19,6 +19,9 @@ defmodule PortalAPI.Integrations.Stripe.WebhookController do
     else
       [] ->
         send_resp(conn, 400, "Bad Request: missing signature header")
+
+      {:error, :too_large} ->
+        send_resp(conn, 413, "Request Entity Too Large")
 
       {:error, :missing_timestamp} ->
         send_resp(conn, 400, "Bad Request: missing timestamp")

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -77,6 +77,10 @@ defmodule PortalAPI.Router do
   end
 
   scope "/integrations", PortalAPI.Integrations do
+    scope "/azure_communication_services", AzureCommunicationServices do
+      post "/webhooks", WebhookController, :handle_webhook
+    end
+
     scope "/stripe", Stripe do
       post "/webhooks", WebhookController, :handle_webhook
     end

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -119,9 +119,20 @@ defmodule PortalWeb.EmailOTPController do
             {actor.id, otp.id, nil}
           else
             {:error, :rate_limited} ->
+              Logger.info("Email OTP sign-in rate limited",
+                account_slug: account.slug,
+                auth_provider_id: auth_provider_id
+              )
+
               {Ecto.UUID.generate(), Ecto.UUID.generate(), :rate_limited}
 
-            _ ->
+            error ->
+              Logger.info("Email OTP sign-in email not sent",
+                account_slug: account.slug,
+                auth_provider_id: auth_provider_id,
+                error: inspect(error)
+              )
+
               # Generate dummy IDs to prevent oracle attacks
               {Ecto.UUID.generate(), Ecto.UUID.generate(), nil}
           end

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -114,7 +114,7 @@ defmodule PortalWeb.Settings.Account do
       socket.assigns.account,
       socket.assigns.subject
     )
-    |> Portal.Mailer.deliver()
+    |> Portal.Mailer.enqueue()
 
     socket =
       socket

--- a/elixir/lib/portal_web/live/settings/api_clients/beta.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/beta.ex
@@ -66,7 +66,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
       socket.assigns.account,
       socket.assigns.subject
     )
-    |> Portal.Mailer.deliver()
+    |> Portal.Mailer.enqueue()
 
     socket =
       socket

--- a/elixir/priv/repo/migrations/20260307000000_create_outbound_emails.exs
+++ b/elixir/priv/repo/migrations/20260307000000_create_outbound_emails.exs
@@ -1,0 +1,54 @@
+defmodule Portal.Repo.Migrations.CreateOutboundEmails do
+  use Ecto.Migration
+
+  def change do
+    create table(:outbound_emails, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:message_id, :text, null: false, primary_key: true)
+      add(:subject, :text, null: false)
+      add(:recipients, {:array, :text}, null: false, default: [])
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create table(:email_suppressions, primary_key: false) do
+      add(:email, :text, primary_key: true, null: false)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    # message_id is listed first so the PK index (message_id, account_id, email)
+    # supports efficient lookups by message_id + email in ACS webhook processing.
+    create table(:outbound_email_deliveries, primary_key: false) do
+      add(
+        :message_id,
+        references(:outbound_emails,
+          column: :message_id,
+          type: :text,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        ),
+        null: false,
+        primary_key: true
+      )
+
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:email, :text, null: false, primary_key: true)
+      add(:status, :string, null: false)
+      add(:failure_code, :text)
+      add(:failure_message, :text)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(index(:outbound_emails, [:inserted_at]))
+  end
+end

--- a/elixir/test/portal/azure_communication_services_test.exs
+++ b/elixir/test/portal/azure_communication_services_test.exs
@@ -1,0 +1,158 @@
+defmodule Portal.AzureCommunicationServicesTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Query
+  import Portal.AccountFixtures
+  import Portal.OutboundEmailFixtures
+
+  alias Portal.AzureCommunicationServices
+
+  describe "handle_event_grid_events/1" do
+    test "updates delivery status to :delivered" do
+      account = account_fixture()
+
+      entry =
+        outbound_email_fixture(account,
+          message_id: "message-1",
+          recipients: ["delivered@example.com"]
+        )
+
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event("message-1", "delivered@example.com", "Delivered")
+               ])
+
+      delivery = delivery!(entry, "delivered@example.com")
+      assert delivery.status == :delivered
+      assert is_nil(delivery.failure_code)
+      assert is_nil(delivery.failure_message)
+    end
+
+    test "marks a recipient bounced and inserts a suppression" do
+      account = account_fixture()
+
+      entry =
+        outbound_email_fixture(account,
+          message_id: "message-2",
+          recipients: ["bounced@example.com"]
+        )
+
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event(
+                   "message-2",
+                   "bounced@example.com",
+                   "Bounced",
+                   "Mailbox does not exist"
+                 )
+               ])
+
+      delivery = delivery!(entry, "bounced@example.com")
+      assert delivery.status == :bounced
+      assert delivery.failure_code == "Bounced"
+      assert delivery.failure_message == "Mailbox does not exist"
+
+      suppressed =
+        from(s in Portal.EmailSuppression, where: s.email == "bounced@example.com")
+        |> Repo.aggregate(:count, :email)
+
+      assert suppressed == 1
+    end
+
+    test "marks a recipient suppressed and inserts a suppression" do
+      account = account_fixture()
+
+      entry =
+        outbound_email_fixture(account,
+          message_id: "message-3",
+          recipients: ["suppressed@example.com"]
+        )
+
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event(
+                   "message-3",
+                   "suppressed@example.com",
+                   "Suppressed",
+                   "Recipient is on the suppression list"
+                 )
+               ])
+
+      delivery = delivery!(entry, "suppressed@example.com")
+      assert delivery.status == :suppressed
+
+      suppressed =
+        from(s in Portal.EmailSuppression, where: s.email == "suppressed@example.com")
+        |> Repo.aggregate(:count, :email)
+
+      assert suppressed == 1
+    end
+
+    test "ignores out-of-order delivery events (stale: already terminal)" do
+      account = account_fixture()
+
+      entry =
+        outbound_email_fixture(account,
+          message_id: "message-4",
+          recipients: ["ordered@example.com"]
+        )
+
+      # First event delivers the recipient
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event("message-4", "ordered@example.com", "Delivered")
+               ])
+
+      assert delivery!(entry, "ordered@example.com").status == :delivered
+
+      # Second event tries to bounce (out-of-order) — stale because status is no longer :pending
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event(
+                   "message-4",
+                   "ordered@example.com",
+                   "Bounced",
+                   "Old bounce"
+                 )
+               ])
+
+      delivery = delivery!(entry, "ordered@example.com")
+      assert delivery.status == :delivered
+
+      suppressed =
+        from(s in Portal.EmailSuppression, where: s.email == "ordered@example.com")
+        |> Repo.aggregate(:count, :email)
+
+      assert suppressed == 0
+    end
+
+    test "logs and returns ok for unknown message_id" do
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event("no-such-message", "anyone@example.com", "Delivered")
+               ])
+    end
+  end
+
+  defp delivery!(entry, email) do
+    Repo.get_by!(Portal.OutboundEmailDelivery,
+      account_id: entry.account_id,
+      message_id: entry.message_id,
+      email: email
+    )
+  end
+
+  defp delivery_report_event(message_id, recipient, status, details \\ nil) do
+    %{
+      "id" => Ecto.UUID.generate(),
+      "eventType" => "Microsoft.Communication.EmailDeliveryReportReceived",
+      "eventTime" => "2026-03-13T07:00:00Z",
+      "data" => %{
+        "messageId" => message_id,
+        "recipient" => recipient,
+        "deliveryStatus" => status,
+        "deliveryStatusDetails" => details
+      }
+    }
+  end
+end

--- a/elixir/test/portal/mailer_test.exs
+++ b/elixir/test/portal/mailer_test.exs
@@ -1,5 +1,7 @@
 defmodule Portal.MailerTest do
-  use ExUnit.Case, async: true
+  use Portal.DataCase, async: true
+
+  import Portal.AccountFixtures
   import Portal.Mailer
 
   describe "deliver_with_rate_limit/2" do
@@ -16,6 +18,227 @@ defmodule Portal.MailerTest do
 
       assert deliver_with_rate_limit(email, config) == {:error, :from_not_set}
       assert deliver_with_rate_limit(email, config) == {:error, :rate_limited}
+    end
+  end
+
+  describe "with_account_id/2" do
+    test "sets account_id in email private" do
+      email = Swoosh.Email.new()
+      account = account_fixture()
+
+      result = with_account_id(email, account.id)
+
+      assert result.private[:account_id] == account.id
+    end
+  end
+
+  describe "enqueue/1" do
+    test "raises when account_id is missing" do
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Missing Account")
+        |> Swoosh.Email.text_body("body")
+
+      assert_raise ArgumentError, ~r/with_account_id\/2/, fn ->
+        enqueue(email)
+      end
+    end
+
+    test "enqueues an Oban job without delivering" do
+      account = account_fixture()
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Test")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, job} = enqueue(email)
+
+      assert job.worker == "Portal.Workers.OutboundEmail"
+      assert job.args["account_id"] == account.id
+      assert job.args["request"]["subject"] == "Test"
+      assert job.args["request"]["to"] == [%{"name" => "", "address" => "recipient@example.com"}]
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+
+      refute_email_sent()
+    end
+
+    test "filters suppressed recipients before inserting the job" do
+      account = account_fixture()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("suppressed@example.com")
+      })
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "suppressed@example.com"})
+        |> Swoosh.Email.to({"", "allowed@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Filtered")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, job} = enqueue(email)
+      assert Enum.map(job.args["request"]["to"], & &1["address"]) == ["allowed@example.com"]
+    end
+
+    test "skips queueing when all recipients are suppressed" do
+      account = account_fixture()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("suppressed@example.com")
+      })
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "suppressed@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Suppressed")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, :suppressed} = enqueue(email)
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+      assert Repo.aggregate(Oban.Job, :count, :id) == 0
+    end
+
+    test "does not queue a later email when the recipient is in suppressions" do
+      account = account_fixture()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("recipient@example.com")
+      })
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", " Recipient@Example.com "})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Suppressed Recipient")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, :suppressed} = enqueue(email)
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+      assert Repo.aggregate(Oban.Job, :count, :id) == 0
+    end
+
+    test "filters suppressed bcc recipients before inserting the job" do
+      account = account_fixture()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("suppressed@example.com")
+      })
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.bcc({"", "suppressed@example.com"})
+        |> Swoosh.Email.bcc({"", "allowed@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Filtered BCC")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, job} = enqueue(email)
+      assert job.args["request"]["bcc"] == [%{"name" => "", "address" => "allowed@example.com"}]
+    end
+  end
+
+  describe "deliver/1" do
+    test "delivers email inline without creating a tracked row" do
+      account = account_fixture()
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Now Test")
+        |> Swoosh.Email.text_body("now body")
+        |> with_account_id(account.id)
+
+      assert {:ok, %{}} = deliver(email)
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+
+      assert_email_sent(subject: "Now Test")
+    end
+
+    test "returns delivery errors" do
+      account = account_fixture()
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.subject("Now Failed")
+        |> Swoosh.Email.text_body("now body")
+        |> with_account_id(account.id)
+
+      assert {:error, :from_not_set} = deliver(email)
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+
+    test "bypasses the suppression table" do
+      account = account_fixture()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("recipient@example.com")
+      })
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Bypass")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, %{}} = deliver(email)
+      assert_email_sent(subject: "Bypass")
+    end
+  end
+
+  describe "Database.insert_tracked/4" do
+    test "stores subject and recipients in the tracked row" do
+      account = account_fixture()
+
+      assert {:ok, entry} =
+               Portal.Mailer.Database.insert_tracked(
+                 account.id,
+                 "acs-message-123",
+                 "Tracked",
+                 ["recipient@example.com"]
+               )
+
+      assert entry.account_id == account.id
+      assert entry.message_id == "acs-message-123"
+      assert entry.subject == "Tracked"
+      assert entry.recipients == ["recipient@example.com"]
+    end
+
+    test "returns an error when the same message id is tracked twice" do
+      account = account_fixture()
+
+      assert {:ok, _entry} =
+               Portal.Mailer.Database.insert_tracked(
+                 account.id,
+                 "acs-message-duplicate",
+                 "Tracked",
+                 ["recipient@example.com"]
+               )
+
+      assert {:error, changeset} =
+               Portal.Mailer.Database.insert_tracked(
+                 account.id,
+                 "acs-message-duplicate",
+                 "Tracked",
+                 ["recipient@example.com"]
+               )
+
+      refute changeset.valid?
     end
   end
 end

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -3,6 +3,7 @@ defmodule Portal.OpsTest do
   import Portal.Ops
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.OutboundEmailTestHelpers
   import Portal.GroupFixtures
   import Portal.IdentityFixtures
   import Portal.ClientFixtures
@@ -100,6 +101,82 @@ defmodule Portal.OpsTest do
 
     test "succeeds even when no banners exist" do
       assert {0, nil} = clear_banner()
+    end
+  end
+
+  describe "queue_admin_email/4" do
+    test "queues one batched email per account with enabled admins" do
+      account1 = account_fixture()
+      account2 = account_fixture()
+
+      admin1 = admin_actor_fixture(account: account1)
+      disabled_admin = admin_actor_fixture(account: account1)
+      admin2 = admin_actor_fixture(account: account2)
+
+      disabled_admin
+      |> Ecto.Changeset.change(disabled_at: DateTime.utc_now())
+      |> Repo.update!()
+
+      assert :ok =
+               queue_admin_email(
+                 [account1.id, account2.id],
+                 "Admin Subject",
+                 "<p>Admin HTML</p>",
+                 "Admin Text"
+               )
+
+      assert collect_queued_emails(account1.id) == [
+               %{
+                 subject: "Admin Subject",
+                 html_body: "<p>Admin HTML</p>",
+                 text_body: "Admin Text",
+                 to: [],
+                 bcc: [{"", admin1.email}]
+               }
+             ]
+
+      assert collect_queued_emails(account2.id) == [
+               %{
+                 subject: "Admin Subject",
+                 html_body: "<p>Admin HTML</p>",
+                 text_body: "Admin Text",
+                 to: [],
+                 bcc: [{"", admin2.email}]
+               }
+             ]
+    end
+
+    test "skips disabled accounts when queuing for :all" do
+      enabled_account = account_fixture()
+      disabled_account = account_fixture()
+
+      enabled_admin = admin_actor_fixture(account: enabled_account)
+      _disabled_admin = admin_actor_fixture(account: disabled_account)
+
+      update_account(disabled_account, %{
+        disabled_at: DateTime.utc_now(),
+        disabled_reason: "Testing"
+      })
+
+      assert :ok =
+               queue_admin_email(
+                 :all,
+                 "Admin Subject",
+                 "<p>Admin HTML</p>",
+                 "Admin Text"
+               )
+
+      assert collect_queued_emails(enabled_account.id) == [
+               %{
+                 subject: "Admin Subject",
+                 html_body: "<p>Admin HTML</p>",
+                 text_body: "Admin Text",
+                 to: [],
+                 bcc: [{"", enabled_admin.email}]
+               }
+             ]
+
+      assert collect_queued_emails(disabled_account.id) == []
     end
   end
 end

--- a/elixir/test/portal/workers/check_account_limits_test.exs
+++ b/elixir/test/portal/workers/check_account_limits_test.exs
@@ -5,6 +5,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
   import ExUnit.CaptureLog
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.OutboundEmailTestHelpers
   import Portal.ClientSessionFixtures
 
   alias Portal.Workers.CheckAccountLimits
@@ -66,14 +67,14 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
       assert :ok = perform_job(CheckAccountLimits, %{})
 
       # Collect all sent emails
-      emails_sent = collect_sent_emails()
+      emails_sent = collect_queued_emails(account.id)
 
-      # All 3 admins should receive emails
-      assert length(emails_sent) == 3
+      # One batched email should be queued with all 3 admins in BCC
+      assert length(emails_sent) == 1
 
       email_recipients =
         emails_sent
-        |> Enum.flat_map(fn email -> email.to end)
+        |> Enum.flat_map(fn email -> email.bcc end)
         |> Enum.map(fn
           {_name, email} -> email
           email when is_binary(email) -> email
@@ -117,7 +118,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
       assert :ok = perform_job(CheckAccountLimits, %{})
 
       # No new emails should be sent
-      refute_email_sent()
+      refute_email_queued(account.id)
 
       # warning_last_sent_at should not be updated
       account = Repo.get!(Portal.Account, account.id)
@@ -144,7 +145,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
       assert :ok = perform_job(CheckAccountLimits, %{})
 
       # Email should be sent again
-      assert_email_sent(fn email ->
+      assert_email_queued(account.id, fn email ->
         assert email.subject == "Firezone Account Limits Exceeded"
       end)
 
@@ -190,7 +191,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
 
       account = Repo.get!(Portal.Account, account.id)
       refute Portal.Billing.any_limit_exceeded?(account)
-      refute_email_sent()
+      refute_email_queued(account.id)
     end
 
     test "does not process disabled accounts" do
@@ -213,7 +214,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
 
       account = Repo.get!(Portal.Account, account.id)
       refute Portal.Billing.any_limit_exceeded?(account)
-      refute_email_sent()
+      refute_email_queued(account.id)
     end
 
     test "only sends emails to enabled admin actors" do
@@ -239,14 +240,14 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
       assert :ok = perform_job(CheckAccountLimits, %{})
 
       # Collect all sent emails
-      emails_sent = collect_sent_emails()
+      emails_sent = collect_queued_emails(account.id)
 
-      # Only 2 enabled admins should receive emails
-      assert length(emails_sent) == 2
+      # One batched email should be queued with only the enabled admins in BCC
+      assert length(emails_sent) == 1
 
       email_recipients =
         emails_sent
-        |> Enum.flat_map(fn email -> email.to end)
+        |> Enum.flat_map(fn email -> email.bcc end)
         |> Enum.map(fn {_name, email} -> email end)
 
       assert admin1.email in email_recipients
@@ -274,7 +275,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
 
       assert :ok = perform_job(CheckAccountLimits, %{})
 
-      emails_sent = collect_sent_emails()
+      emails_sent = collect_queued_emails(account.id)
       [first_email | _] = emails_sent
 
       # Verify multiple limits with counts
@@ -291,7 +292,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
 
       assert :ok = perform_job(CheckAccountLimits, %{})
 
-      [first_email | _] = collect_sent_emails()
+      [first_email | _] = collect_queued_emails(account.id)
       assert first_email.text_body =~ "change your paid users"
       assert first_email.text_body =~ "Settings"
       assert first_email.text_body =~ "Billing"
@@ -307,7 +308,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
 
       assert :ok = perform_job(CheckAccountLimits, %{})
 
-      [first_email | _] = collect_sent_emails()
+      [first_email | _] = collect_queued_emails(account.id)
       assert first_email.text_body =~ "upgrade to Team"
       assert first_email.text_body =~ "Settings"
       assert first_email.text_body =~ "Billing"
@@ -322,7 +323,7 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
 
       assert :ok = perform_job(CheckAccountLimits, %{})
 
-      [first_email | _] = collect_sent_emails()
+      [first_email | _] = collect_queued_emails(account.id)
       assert first_email.text_body =~ "contact your account manager"
     end
 
@@ -399,17 +400,5 @@ defmodule Portal.Workers.CheckAccountLimitsTest do
     |> Ecto.Changeset.cast(%{metadata: %{stripe: stripe_attrs}}, [])
     |> Ecto.Changeset.cast_embed(:metadata)
     |> Repo.update!()
-  end
-
-  defp collect_sent_emails do
-    collect_sent_emails([])
-  end
-
-  defp collect_sent_emails(acc) do
-    receive do
-      {:email, email} -> collect_sent_emails([email | acc])
-    after
-      0 -> Enum.reverse(acc)
-    end
   end
 end

--- a/elixir/test/portal/workers/outbound_email_test.exs
+++ b/elixir/test/portal/workers/outbound_email_test.exs
@@ -1,0 +1,73 @@
+defmodule Portal.Workers.OutboundEmailTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Portal.AccountFixtures
+
+  alias Portal.Workers.OutboundEmail, as: Worker
+
+  describe "perform/1" do
+    test "delivers a queued job and inserts a running tracked row" do
+      account = account_fixture()
+      configure_acs_secondary()
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/emails:send"
+
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-message-123", "status" => "Running"})
+      end)
+
+      assert :ok = perform_job(Worker, queued_args(account.id))
+
+      db_entry =
+        Repo.get_by!(Portal.OutboundEmail, account_id: account.id, message_id: "acs-message-123")
+
+      assert db_entry.subject == "Test Subject"
+      assert db_entry.recipients == ["to@test.com"]
+    end
+
+    test "discards HTTP delivery failures without tracking a row" do
+      account = account_fixture()
+      configure_acs_secondary()
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/emails:send"
+
+        conn
+        |> Plug.Conn.put_status(422)
+        |> Req.Test.json(%{"error" => %{"message" => "invalid recipient"}})
+      end)
+
+      assert {:discard, {422, _body}} = perform_job(Worker, queued_args(account.id))
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+  end
+
+  defp queued_args(account_id) do
+    %{
+      "account_id" => account_id,
+      "request" => %{
+        "to" => [%{"name" => "", "address" => "to@test.com"}],
+        "cc" => [],
+        "bcc" => [],
+        "from" => %{"name" => "", "address" => "from@test.com"},
+        "subject" => "Test Subject",
+        "html_body" => nil,
+        "text_body" => "hello"
+      }
+    }
+  end
+
+  defp configure_acs_secondary do
+    Portal.Config.put_env_override(:portal, Portal.Mailer.Secondary,
+      adapter: Swoosh.Adapters.AzureCommunicationServices,
+      endpoint: "https://acs.example.com",
+      auth: "acs-token",
+      req_opts: [plug: {Req.Test, Portal.AzureCommunicationServices}, retry: false]
+    )
+  end
+end

--- a/elixir/test/portal/workers/outdated_gateways_test.exs
+++ b/elixir/test/portal/workers/outdated_gateways_test.exs
@@ -1,10 +1,14 @@
 defmodule Portal.Workers.OutdatedGatewaysTest do
   use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.ClientFixtures
   import Portal.ClientSessionFixtures
+  import Portal.GatewayFixtures
+  import Portal.OutboundEmailTestHelpers
+  import Portal.SiteFixtures
 
   alias Portal.Workers.OutdatedGateways
 
@@ -126,6 +130,46 @@ defmodule Portal.Workers.OutdatedGatewaysTest do
       )
 
       assert OutdatedGateways.Database.count_incompatible_for(account, "1.3.0") == 0
+    end
+  end
+
+  describe "perform/1" do
+    test "enqueues outdated gateway notifications instead of delivering inline" do
+      account =
+        account_fixture(
+          config: %{
+            notifications: %{
+              outdated_gateway: %{enabled: true}
+            }
+          }
+        )
+
+      admin = admin_actor_fixture(account: account)
+      site = site_fixture(account: account)
+
+      gateway =
+        gateway_fixture(
+          account: account,
+          site: site,
+          last_seen_version: "0.9.0"
+        )
+
+      assert :ok =
+               Portal.Presence.Gateways.connect(
+                 gateway,
+                 gateway.latest_session.gateway_token_id
+               )
+
+      assert Map.has_key?(Portal.Presence.Gateways.Site.list(site.id), gateway.id)
+
+      assert :ok = perform_job(OutdatedGateways, %{})
+
+      assert_email_queued(account.id, fn email ->
+        assert email.subject == "Firezone Gateway Upgrade Available"
+        assert email.bcc == [{"", admin.email}]
+      end)
+
+      refute_email_sent()
     end
   end
 end

--- a/elixir/test/portal_api/controllers/integrations/azure_communication_services/webhook_controller_test.exs
+++ b/elixir/test/portal_api/controllers/integrations/azure_communication_services/webhook_controller_test.exs
@@ -1,0 +1,109 @@
+defmodule PortalAPI.Integrations.AzureCommunicationServices.WebhookControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.OutboundEmailFixtures
+
+  setup do
+    Portal.Config.put_env_override(:portal, Portal.AzureCommunicationServices,
+      event_grid_webhook_secret: "acs-secret"
+    )
+
+    :ok
+  end
+
+  describe "handle_webhook/2" do
+    test "returns the validation response for subscription validation events", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("aeg-event-type", "SubscriptionValidation")
+        |> post(
+          "/integrations/azure_communication_services/webhooks",
+          validation_payload("abc123")
+        )
+
+      assert json_response(conn, 200) == %{"validationResponse" => "abc123"}
+    end
+
+    test "returns unauthorized when the webhook secret is invalid", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("aeg-event-type", "Notification")
+        |> post(
+          "/integrations/azure_communication_services/webhooks?secret=wrong",
+          notification_payload()
+        )
+
+      assert response(conn, 401) == "Unauthorized"
+    end
+
+    test "processes notification events", %{conn: conn} do
+      account = account_fixture()
+
+      entry =
+        outbound_email_fixture(account,
+          message_id: "message-1",
+          recipients: ["delivered@example.com"]
+        )
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("aeg-event-type", "Notification")
+        |> post(
+          "/integrations/azure_communication_services/webhooks?secret=acs-secret",
+          notification_payload()
+        )
+
+      assert response(conn, 200) == ""
+
+      delivery =
+        Repo.get_by!(Portal.OutboundEmailDelivery,
+          account_id: account.id,
+          message_id: entry.message_id,
+          email: "delivered@example.com"
+        )
+
+      assert delivery.status == :delivered
+    end
+
+    test "returns 200 for unknown message_id so Event Grid does not retry", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("aeg-event-type", "Notification")
+        |> post(
+          "/integrations/azure_communication_services/webhooks?secret=acs-secret",
+          notification_payload()
+        )
+
+      assert response(conn, 200) == ""
+    end
+  end
+
+  defp validation_payload(code) do
+    JSON.encode!([
+      %{
+        "eventType" => "Microsoft.EventGrid.SubscriptionValidationEvent",
+        "data" => %{"validationCode" => code}
+      }
+    ])
+  end
+
+  defp notification_payload do
+    JSON.encode!([
+      %{
+        "id" => Ecto.UUID.generate(),
+        "eventType" => "Microsoft.Communication.EmailDeliveryReportReceived",
+        "eventTime" => "2026-03-13T07:00:00Z",
+        "data" => %{
+          "messageId" => "message-1",
+          "recipient" => "delivered@example.com",
+          "deliveryStatus" => "Delivered"
+        }
+      }
+    ])
+  end
+end

--- a/elixir/test/portal_web/live/settings/account_test.exs
+++ b/elixir/test/portal_web/live/settings/account_test.exs
@@ -3,6 +3,7 @@ defmodule PortalWeb.Live.Settings.AccountTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.OutboundEmailTestHelpers
 
   setup do
     Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
@@ -93,7 +94,7 @@ defmodule PortalWeb.Live.Settings.AccountTest do
            |> render_click()
            |> element_to_text() =~ "A request has been sent to delete your account"
 
-    assert_email_sent(fn email ->
+    assert_email_queued(account.id, fn email ->
       assert email.subject == "ACCOUNT DELETE REQUEST - #{account.id}"
       assert email.text_body =~ "#{account.id}"
       assert email.text_body =~ "#{actor.id}"

--- a/elixir/test/portal_web/live/settings/api_clients/beta_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/beta_test.exs
@@ -3,6 +3,7 @@ defmodule PortalWeb.Live.Settings.ApiClients.BetaTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.OutboundEmailTestHelpers
 
   setup do
     account = account_fixture()
@@ -84,7 +85,7 @@ defmodule PortalWeb.Live.Settings.ApiClients.BetaTest do
            |> Floki.find(".flash-info")
            |> element_to_text() =~ "request to join"
 
-    assert_email_sent(fn email ->
+    assert_email_queued(account.id, fn email ->
       assert email.subject == "REST API Beta Request - #{account.id}"
       assert email.text_body =~ "REST API Beta Request"
       assert email.text_body =~ "#{account.id}"

--- a/elixir/test/support/fixtures/outbound_email_fixtures.ex
+++ b/elixir/test/support/fixtures/outbound_email_fixtures.ex
@@ -1,0 +1,35 @@
+defmodule Portal.OutboundEmailFixtures do
+  alias Portal.Repo
+
+  def outbound_email_fixture(account, attrs \\ []) do
+    defaults = [
+      account_id: account.id,
+      message_id: Ecto.UUID.generate(),
+      subject: "Test Subject",
+      recipients: ["to@test.com"]
+    ]
+
+    merged = Keyword.merge(defaults, attrs)
+    entry = Repo.insert!(struct(Portal.OutboundEmail, merged))
+
+    now = DateTime.utc_now()
+    account_id = entry.account_id
+    message_id = entry.message_id
+
+    delivery_rows =
+      Enum.map(entry.recipients, fn email ->
+        %{
+          account_id: account_id,
+          message_id: message_id,
+          email: email,
+          status: :pending,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    Repo.insert_all(Portal.OutboundEmailDelivery, delivery_rows)
+
+    entry
+  end
+end

--- a/elixir/test/support/outbound_email_helpers.ex
+++ b/elixir/test/support/outbound_email_helpers.ex
@@ -1,0 +1,48 @@
+defmodule Portal.OutboundEmailTestHelpers do
+  @moduledoc false
+
+  import Ecto.Query
+  import ExUnit.Assertions, only: [assert: 1]
+
+  alias Portal.Repo
+
+  def collect_queued_emails(account_id) do
+    from(j in Oban.Job,
+      where: j.worker == "Portal.Workers.OutboundEmail",
+      order_by: [asc: j.inserted_at]
+    )
+    |> Repo.all()
+    |> Enum.filter(&(&1.args["account_id"] == account_id))
+    |> Enum.map(&format_queued_email/1)
+  end
+
+  def assert_email_queued(account_id, fun) do
+    [email | _] = collect_queued_emails(account_id)
+    fun.(email)
+  end
+
+  def refute_email_queued(account_id) do
+    assert collect_queued_emails(account_id) == []
+  end
+
+  defp format_queued_email(job) do
+    request = job.args["request"] || %{}
+
+    %{
+      subject: request["subject"],
+      text_body: request["text_body"],
+      html_body: request["html_body"],
+      to: format_addresses(request["to"]),
+      bcc: format_addresses(request["bcc"])
+    }
+  end
+
+  defp format_addresses(nil), do: []
+
+  defp format_addresses(addresses) do
+    Enum.map(addresses, fn
+      %{"name" => name, "address" => address} -> {name, address}
+      %{"address" => address} -> {nil, address}
+    end)
+  end
+end


### PR DESCRIPTION
Adds outbound email tracking and delivery infrastructure via Azure Communication Services (ACS). Emails sent through the secondary ACS adapter are now enqueued as Oban jobs (`Workers.OutboundEmail`), which deliver via ACS and persist an `outbound_emails` record (with `message_id`, `subject`, `recipients`) plus per-recipient `outbound_email_deliveries` rows (starting as `:pending`). ACS Event Grid webhooks update delivery status to terminal states (`:delivered`, `:bounced`, `:suppressed`, `:failed`) and automatically populate an `email_suppressions` table for bounced/suppressed recipients. Future enqueued emails check suppressions before inserting the job, skipping fully-suppressed sends entirely.

  The design keeps the two tracking concerns independent: `outbound_emails` is a simple record of successful submission to ACS, while `outbound_email_deliveries` tracks per-recipient lifecycle driven by webhooks — no roll-up or status aggregation on the parent row. The primary mailer (`deliver/1`) remains unchanged for inline sends like OTP emails with no tracking overhead. Also includes the ACS webhook controller, config definitions for the secondary mailer and Event Grid secret, an `Ops.queue_admin_email/4` helper for bulk admin notifications, and updates all existing email callers to use the new `enqueue/1` API.