### PR TITLE
fix(portal): boot dupe pid on channel connect

### DIFF
--- a/elixir/lib/portal/changes/hooks/client_tokens.ex
+++ b/elixir/lib/portal/changes/hooks/client_tokens.ex
@@ -1,6 +1,6 @@
 defmodule Portal.Changes.Hooks.ClientTokens do
   @behaviour Portal.Changes.Hooks
-  alias Portal.PubSub
+  alias Portal.Channels
   import Portal.SchemaHelpers
 
   @impl true
@@ -12,19 +12,7 @@ defmodule Portal.Changes.Hooks.ClientTokens do
   @impl true
   def on_delete(_lsn, old_data) do
     token = struct_from_params(Portal.ClientToken, old_data)
-
-    # We don't need to broadcast deleted tokens since the disconnect_socket/1
-    # function will handle any disconnects for us directly.
-
-    # Disconnect all sockets using this token
-    disconnect_socket(token)
-  end
-
-  # This is a special message that disconnects all sockets using this token,
-  # such as for LiveViews.
-  defp disconnect_socket(token) do
-    topic = Portal.Sockets.socket_id(token.id)
-    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
-    PubSub.broadcast(topic, payload)
+    Channels.send_to_token(token.id, :disconnect)
+    :ok
   end
 end

--- a/elixir/lib/portal/changes/hooks/gateway_tokens.ex
+++ b/elixir/lib/portal/changes/hooks/gateway_tokens.ex
@@ -1,6 +1,6 @@
 defmodule Portal.Changes.Hooks.GatewayTokens do
   @behaviour Portal.Changes.Hooks
-  alias Portal.PubSub
+  alias Portal.Channels
   import Portal.SchemaHelpers
 
   @impl true
@@ -12,14 +12,7 @@ defmodule Portal.Changes.Hooks.GatewayTokens do
   @impl true
   def on_delete(_lsn, old_data) do
     token = struct_from_params(Portal.GatewayToken, old_data)
-
-    # Disconnect all sockets using this token
-    disconnect_socket(token)
-  end
-
-  defp disconnect_socket(token) do
-    topic = Portal.Sockets.socket_id(token.id)
-    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
-    PubSub.broadcast(topic, payload)
+    Channels.send_to_token(token.id, :disconnect)
+    :ok
   end
 end

--- a/elixir/lib/portal/channels.ex
+++ b/elixir/lib/portal/channels.ex
@@ -51,6 +51,23 @@ defmodule Portal.Channels do
   end
 
   @doc """
+  Registers the calling process under the given token ID.
+  Used to enable disconnect-by-token when a token is deleted.
+  """
+  def register_token(token_id) do
+    :pg.join(group(:token, token_id), self())
+  end
+
+  @doc """
+  Sends a message to the process registered for the given token ID.
+
+  Returns `:ok` if a process is registered, `{:error, :not_found}` otherwise.
+  """
+  def send_to_token(token_id, message) do
+    send_to_group(group(:token, token_id), message)
+  end
+
+  @doc """
   Tells a gateway to reject access for a client to a resource.
 
   This is the public API for triggering reject_access from outside the channel system
@@ -60,13 +77,8 @@ defmodule Portal.Channels do
     send_to_gateway(gateway_id, {:reject_access, client_id, resource_id})
   end
 
-  @doc false
-  def handle_eviction(group) do
-    :pg.leave(group, self())
-  end
-
   defp upsert_group(group) do
-    Enum.each(:pg.get_members(group), &send(&1, {:pg_group_evicted, group}))
+    Enum.each(:pg.get_members(group), &send(&1, :disconnect))
     :pg.join(group, self())
   end
 

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -46,6 +46,8 @@ defmodule PortalAPI.Client.Channel do
       @recompute_authorized_resources_every
     )
 
+    schedule_session_expiry(socket.assigns.subject.expires_at)
+
     # Get initial list of authorized resources, hydrating the cache
     {:ok, resources, [], cache} =
       Cache.Client.recompute_connectable_resources(
@@ -83,6 +85,7 @@ defmodule PortalAPI.Client.Channel do
 
     # Register for targeted messages from gateway channels
     :ok = Channels.register_client(socket.assigns.client.id)
+    :ok = Channels.register_token(socket.assigns.subject.credential.id)
     :ok = PubSub.Changes.subscribe(socket.assigns.client.account_id)
 
     push(socket, "init", %{
@@ -373,9 +376,11 @@ defmodule PortalAPI.Client.Channel do
     {:noreply, socket}
   end
 
-  def handle_info({:pg_group_evicted, group}, socket) do
-    Channels.handle_eviction(group)
-    {:noreply, socket}
+  def handle_info(:disconnect, socket) do
+    # Important: We push disconnect before closing the socket to prevent the client from
+    # attempting to immediately reconnect
+    push(socket, "disconnect", %{reason: "token_expired"})
+    {:stop, :shutdown, socket}
   end
 
   # Catch-all for messages we don't handle
@@ -1507,5 +1512,10 @@ defmodule PortalAPI.Client.Channel do
 
   defp flow_creation_timeout do
     Portal.Config.get_env(:portal, :flow_creation_timeout_ms, :timer.seconds(15))
+  end
+
+  defp schedule_session_expiry(expires_at) do
+    ms = DateTime.diff(expires_at, DateTime.utc_now(), :millisecond)
+    Process.send_after(self(), :disconnect, max(ms, 0))
   end
 end

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -67,6 +67,7 @@ defmodule PortalAPI.Gateway.Channel do
 
     # Register for targeted messages from client channels
     :ok = Channels.register_gateway(socket.assigns.gateway.id)
+    :ok = Channels.register_token(socket.assigns.token_id)
     :ok = PubSub.Changes.subscribe(socket.assigns.gateway.account_id)
 
     # Return all connected relays and subscribe to global relay presence
@@ -366,9 +367,11 @@ defmodule PortalAPI.Gateway.Channel do
     {:noreply, socket}
   end
 
-  def handle_info({:pg_group_evicted, group}, socket) do
-    Channels.handle_eviction(group)
-    {:noreply, socket}
+  def handle_info(:disconnect, socket) do
+    # Important: We push disconnect before closing the socket to prevent the gateway from
+    # attempting to immediately reconnect
+    push(socket, "disconnect", %{reason: "token_expired"})
+    {:stop, :shutdown, socket}
   end
 
   # Catch-all for messages we don't handle

--- a/elixir/test/portal/changes/hooks/tokens_test.exs
+++ b/elixir/test/portal/changes/hooks/tokens_test.exs
@@ -3,7 +3,8 @@ defmodule Portal.Changes.Hooks.TokensTest do
   import Portal.AccountFixtures
   import Portal.TokenFixtures
   alias Portal.Changes.Hooks.ClientTokens
-  alias Portal.PubSub
+  alias Portal.Changes.Hooks.GatewayTokens
+  alias Portal.Channels
 
   describe "ClientTokens.on_insert/2" do
     test "returns :ok" do
@@ -18,12 +19,11 @@ defmodule Portal.Changes.Hooks.TokensTest do
   end
 
   describe "ClientTokens.on_delete/2" do
-    test "broadcasts disconnect message on socket topic" do
+    test "sends :disconnect to registered token process" do
       account = account_fixture()
       token = client_token_fixture(account: account)
 
-      topic = Portal.Sockets.socket_id(token.id)
-      :ok = PubSub.subscribe(topic)
+      Channels.register_token(token.id)
 
       old_data = %{
         "id" => token.id,
@@ -32,11 +32,63 @@ defmodule Portal.Changes.Hooks.TokensTest do
       }
 
       assert :ok == ClientTokens.on_delete(0, old_data)
+      assert_receive :disconnect
+    end
 
-      assert_receive %Phoenix.Socket.Broadcast{
-        topic: ^topic,
-        event: "disconnect"
+    test "returns :ok when no process is registered for token" do
+      account = account_fixture()
+      token = client_token_fixture(account: account)
+
+      old_data = %{
+        "id" => token.id,
+        "account_id" => account.id,
+        "type" => "client"
       }
+
+      assert :ok == ClientTokens.on_delete(0, old_data)
+    end
+  end
+
+  describe "GatewayTokens.on_insert/2" do
+    test "returns :ok" do
+      assert :ok == GatewayTokens.on_insert(0, %{})
+    end
+  end
+
+  describe "GatewayTokens.on_update/3" do
+    test "returns :ok" do
+      assert :ok = GatewayTokens.on_update(0, %{}, %{})
+    end
+  end
+
+  describe "GatewayTokens.on_delete/2" do
+    test "sends :disconnect to registered token process" do
+      account = account_fixture()
+      token = gateway_token_fixture(account: account)
+
+      Channels.register_token(token.id)
+
+      old_data = %{
+        "id" => token.id,
+        "account_id" => account.id,
+        "type" => "gateway"
+      }
+
+      assert :ok == GatewayTokens.on_delete(0, old_data)
+      assert_receive :disconnect
+    end
+
+    test "returns :ok when no process is registered for token" do
+      account = account_fixture()
+      token = gateway_token_fixture(account: account)
+
+      old_data = %{
+        "id" => token.id,
+        "account_id" => account.id,
+        "type" => "gateway"
+      }
+
+      assert :ok == GatewayTokens.on_delete(0, old_data)
     end
   end
 end

--- a/elixir/test/portal/channels_test.exs
+++ b/elixir/test/portal/channels_test.exs
@@ -11,7 +11,7 @@ defmodule Portal.ChannelsTest do
       assert_receive :hello
     end
 
-    test "re-registration replaces the previous process" do
+    test "re-registration sends :disconnect to the previous process" do
       client_id = Ecto.UUID.generate()
       parent = self()
 
@@ -30,9 +30,10 @@ defmodule Portal.ChannelsTest do
       # New process (self) registers for the same client_id — should evict old_pid
       Channels.register_client(client_id)
 
+      assert_receive {:old_received, :disconnect}
+
       assert :ok = Channels.send_to_client(client_id, :hello)
       assert_receive :hello
-      refute_receive {:old_received, :hello}
 
       # Cleanup
       Process.exit(old_pid, :kill)
@@ -53,7 +54,7 @@ defmodule Portal.ChannelsTest do
       assert_receive :hello
     end
 
-    test "re-registration replaces the previous process" do
+    test "re-registration sends :disconnect to the previous process" do
       gateway_id = Ecto.UUID.generate()
       parent = self()
 
@@ -72,9 +73,10 @@ defmodule Portal.ChannelsTest do
       # New process (self) registers for the same gateway_id — should evict old_pid
       Channels.register_gateway(gateway_id)
 
+      assert_receive {:old_received, :disconnect}
+
       assert :ok = Channels.send_to_gateway(gateway_id, :hello)
       assert_receive :hello
-      refute_receive {:old_received, :hello}
 
       # Cleanup
       Process.exit(old_pid, :kill)
@@ -118,37 +120,18 @@ defmodule Portal.ChannelsTest do
     end
   end
 
-  describe "handle_eviction/1" do
-    test "removes the calling process from its registered group" do
-      client_id = Ecto.UUID.generate()
-      parent = self()
-      group = {Portal.Channels, :client, client_id}
+  describe "register_token/1 and send_to_token/2" do
+    test "delivers message to a registered process" do
+      token_id = Ecto.UUID.generate()
+      Channels.register_token(token_id)
 
-      pid =
-        spawn(fn ->
-          Channels.register_client(client_id)
-          send(parent, :registered)
+      assert :ok = Channels.send_to_token(token_id, :hello)
+      assert_receive :hello
+    end
 
-          receive do
-            {:pg_group_evicted, g} ->
-              Channels.handle_eviction(g)
-              send(parent, :evicted)
-          end
-
-          receive do
-            :stop -> :ok
-          end
-        end)
-
-      assert_receive :registered
-      assert :ok = Channels.send_to_client(client_id, :ping)
-
-      send(pid, {:pg_group_evicted, group})
-      assert_receive :evicted
-
-      assert {:error, :not_found} = Channels.send_to_client(client_id, :ping)
-
-      Process.exit(pid, :kill)
+    test "returns {:error, :not_found} when no process is registered" do
+      token_id = Ecto.UUID.generate()
+      assert {:error, :not_found} = Channels.send_to_token(token_id, :hello)
     end
   end
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -314,11 +314,11 @@ defmodule PortalAPI.Client.ChannelTest do
       refute_receive {:socket_close, _pid, _}
     end
 
-    test "send disconnect broadcast when the token is deleted", %{
+    test "pushes disconnect event and closes when the token is deleted", %{
       client: client,
       subject: subject
     } do
-      :ok = PubSub.subscribe(Portal.Sockets.socket_id(subject.credential.id))
+      Process.flag(:trap_exit, true)
 
       {:ok, _reply, _socket} =
         PortalAPI.Client.Socket
@@ -351,12 +351,8 @@ defmodule PortalAPI.Client.ChannelTest do
 
       Portal.Changes.Hooks.ClientTokens.on_delete(100, data)
 
-      assert_receive %Phoenix.Socket.Broadcast{
-        topic: topic,
-        event: "disconnect"
-      }
-
-      assert topic == Portal.Sockets.socket_id(token.id)
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
     end
 
     test "sends list of available resources after join", %{
@@ -847,22 +843,36 @@ defmodule PortalAPI.Client.ChannelTest do
     end
   end
 
-  describe "handle_info/2 pg_group_evicted" do
-    test "channel leaves pg group and stops receiving targeted messages", %{
+  describe "handle_info/2 :disconnect" do
+    test "pushes disconnect event and closes the channel", %{
       client: client,
       subject: subject
     } do
-      socket = join_channel(client, subject)
-      # Flush :after_join before asserting group membership
-      :sys.get_state(socket.channel_pid)
+      Process.flag(:trap_exit, true)
+      _socket = join_channel(client, subject)
 
-      assert :ok = Channels.send_to_client(client.id, :ping)
+      assert_push "init", _init_payload
 
-      group = {Portal.Channels, :client, client.id}
-      send(socket.channel_pid, {:pg_group_evicted, group})
-      :sys.get_state(socket.channel_pid)
+      Channels.send_to_client(client.id, :disconnect)
 
-      assert {:error, :not_found} = Channels.send_to_client(client.id, :ping)
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
+    end
+
+    test "duplicate connection evicts the first client", %{
+      client: client,
+      subject: subject
+    } do
+      Process.flag(:trap_exit, true)
+      _socket = join_channel(client, subject)
+
+      assert_push "init", _init_payload
+
+      # Simulate a second connection registering for the same client
+      Channels.register_client(client.id)
+
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
     end
   end
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -158,23 +158,38 @@ defmodule PortalAPI.Gateway.ChannelTest do
     end
   end
 
-  describe "handle_info/2 pg_group_evicted" do
-    test "channel leaves pg group and stops receiving targeted messages", %{
+  describe "handle_info/2 :disconnect" do
+    test "pushes disconnect event and closes the channel", %{
       gateway: gateway,
       site: site,
       token: token
     } do
-      socket = join_channel(gateway, site, token)
-      # Flush :after_join before asserting group membership
-      :sys.get_state(socket.channel_pid)
+      Process.flag(:trap_exit, true)
+      _socket = join_channel(gateway, site, token)
 
-      assert :ok = Channels.send_to_gateway(gateway.id, :ping)
+      assert_push "init", _init_payload
 
-      group = {Portal.Channels, :gateway, gateway.id}
-      send(socket.channel_pid, {:pg_group_evicted, group})
-      :sys.get_state(socket.channel_pid)
+      Channels.send_to_gateway(gateway.id, :disconnect)
 
-      assert {:error, :not_found} = Channels.send_to_gateway(gateway.id, :ping)
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
+    end
+
+    test "duplicate connection evicts the first gateway", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      Process.flag(:trap_exit, true)
+      _socket = join_channel(gateway, site, token)
+
+      assert_push "init", _init_payload
+
+      # Simulate a second connection registering for the same gateway
+      Channels.register_gateway(gateway.id)
+
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
     end
   end
 
@@ -434,20 +449,16 @@ defmodule PortalAPI.Gateway.ChannelTest do
       assert payload.account_slug == "new-slug"
     end
 
-    test "disconnects socket when token is deleted", %{
+    test "pushes disconnect event and closes when the token is deleted", %{
       account: account,
       gateway: gateway,
       site: site,
       token: token
     } do
+      Process.flag(:trap_exit, true)
       _socket = join_channel(gateway, site, token)
 
-      # Consume the init message from join
       assert_push "init", _init_payload
-
-      # Subscribe to the token's socket topic (Portal.Sockets.socket_id returns "tokens:#{id}")
-      socket_topic = Portal.Sockets.socket_id(token.id)
-      :ok = PubSub.subscribe(socket_topic)
 
       data = %{
         "id" => token.id,
@@ -457,12 +468,8 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       Changes.Hooks.GatewayTokens.on_delete(100, data)
 
-      assert_receive %Phoenix.Socket.Broadcast{
-        topic: topic,
-        event: "disconnect"
-      }
-
-      assert topic == socket_topic
+      assert_push "disconnect", %{reason: "token_expired"}
+      assert_receive {:EXIT, _pid, :shutdown}
     end
 
     test "disconnect socket when gateway is deleted", %{


### PR DESCRIPTION
When a client/gateway joins a channel, we register its pid in a global registry so that it can receive messages from its counterpart (client/gateway).

If a duplicate client/gateway joins (via FIREZONE_ID), we purposefully didn't boot the other one off in order to avoid a battle where they would continuously reconnect at the rate of their RTT to the portal node.

However, connlib has a `disconnect` message that will expressly shut the runtime down, and we can use this to prevent this scenario.

To accomplish this we introduce a `:disconnect` message handler that first pushes the connlib `disconnect` payload and then immediately kills the channel pid, taking the socket and transport with it.