### PR TITLE
feat(connlib): introduce timer granularity

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -162,12 +162,13 @@ impl Io {
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         nameservers: BTreeSet<IpAddr>,
+        now: Instant,
     ) -> Self {
         let mut sockets = Sockets::default();
         sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
 
         Self {
-            timeout: Timeout::new(DEFAULT_TIME_ADVANCE, TIMEOUT_GRANULARITY, Instant::now()),
+            timeout: Timeout::new(DEFAULT_TIME_ADVANCE, TIMEOUT_GRANULARITY, now),
             sockets,
             nameservers: NameserverSet::new(
                 nameservers,
@@ -634,9 +635,10 @@ mod tests {
 
     #[tokio::test]
     async fn timer_is_reset_after_it_fires() {
-        let mut io = Io::for_test();
+        let now = Instant::now();
+        let mut io = Io::for_test(now);
 
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let deadline = now + Duration::from_secs(1);
         io.reset_timeout(deadline, "");
         let scheduled_deadline = io.timeout.deadline();
 
@@ -660,7 +662,7 @@ mod tests {
     #[tokio::test]
     async fn emits_now_in_case_timeout_is_in_the_past() {
         let now = Instant::now();
-        let mut io = Io::for_test();
+        let mut io = Io::for_test(now);
 
         io.reset_timeout(now - Duration::from_secs(10), "");
 
@@ -674,7 +676,7 @@ mod tests {
     async fn bootstrap_doh() {
         let _guard = logging::test("debug");
 
-        let mut io = Io::for_test();
+        let mut io = Io::for_test(Instant::now());
         io.update_system_resolvers(vec![IpAddr::from([1, 1, 1, 1])]);
 
         {
@@ -705,11 +707,11 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_timeout_shortens_deadline_when_current_is_too_far_away() {
-        let mut io = Io::for_test();
+        let now = Instant::now();
+        let mut io = Io::for_test(now);
 
         // The default deadline is DEFAULT_TIME_ADVANCE (10s) from now.
         // schedule_timeout should pull it in to ~1s from now.
-        let now = Instant::now();
         io.schedule_timeout(now);
 
         let deadline = io.timeout.deadline();
@@ -723,10 +725,10 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_timeout_does_not_postpone_an_already_close_deadline() {
-        let mut io = Io::for_test();
+        let now = Instant::now();
+        let mut io = Io::for_test(now);
 
         // Set a deadline that is already sooner than 1s.
-        let now = Instant::now();
         let close_deadline = now + Duration::from_millis(100);
         io.reset_timeout(close_deadline, "close deadline");
 
@@ -744,7 +746,7 @@ mod tests {
     async fn rebind_dns_clears_all_servers_on_failure() {
         let _guard = logging::test("debug");
 
-        let mut io = Io::for_test();
+        let mut io = Io::for_test(Instant::now());
 
         let result = io.rebind_dns(vec![
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0), // This one will almost definitely work.
@@ -785,11 +787,12 @@ mod tests {
 
     /// Helper functions to make the test more concise.
     impl Io {
-        fn for_test() -> Io {
+        fn for_test(now: Instant) -> Io {
             let mut io = Io::new(
                 Arc::new(socket_factory::tcp),
                 Arc::new(socket_factory::udp),
                 BTreeSet::new(),
+                now,
             );
             io.set_tun(Box::new(DummyTun::new()));
 

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -46,6 +46,7 @@ const MAX_INBOUND_PACKET_BATCH: usize = {
 };
 
 const DEFAULT_TIME_ADVANCE: Duration = Duration::from_secs(10);
+const TIMEOUT_GRANULARITY: Duration = Duration::from_millis(50);
 
 /// Bundles together all side-effects that connlib needs to have access to.
 pub struct Io {
@@ -166,7 +167,7 @@ impl Io {
         sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
 
         Self {
-            timeout: Timeout::new(DEFAULT_TIME_ADVANCE),
+            timeout: Timeout::new(DEFAULT_TIME_ADVANCE, TIMEOUT_GRANULARITY, Instant::now()),
             sockets,
             nameservers: NameserverSet::new(
                 nameservers,

--- a/rust/libs/connlib/tunnel/src/io/timeout.rs
+++ b/rust/libs/connlib/tunnel/src/io/timeout.rs
@@ -8,28 +8,31 @@ use futures::FutureExt as _;
 
 /// A dedicated timeout future that is always initialised and auto-advances by the given [`Duration`] as soon as it is ready.
 ///
-/// There are two ways to set the deadline:
-///
-/// - [`Timeout::reset`]: moves the deadline to an arbitrary point in time.
-///   If a scheduled wakeup ceiling has been set via [`Timeout::schedule`], the effective
-///   deadline is clamped to that ceiling so a scheduled wakeup is never accidentally postponed.
-///
-/// - [`Timeout::schedule`]: records an upper-bound ("scheduled wakeup") and immediately
-///   clamps the current deadline to it.  The ceiling is cleared once the timer fires.
+/// Every deadline passed to [`Timeout::reset`] or [`Timeout::schedule`] is rounded **up**
+/// to the next multiple of `granularity` measured from an epoch fixed at construction time.
+/// This coalesces wakeups that fall within the same coarse tick, avoiding churn in the
+/// underlying OS timer when many small resets arrive in rapid succession.
 pub struct Timeout {
     default_advance: Duration,
     inner: Pin<Box<tokio::time::Sleep>>,
     /// Upper-bound imposed by [`Timeout::schedule`]. [`Timeout::reset`] will never move
     /// the deadline beyond this value while it is set.
     scheduled: Option<Instant>,
+    /// The granularity of our timer.
+    tick: Duration,
+    created_at: Instant,
 }
 
 impl Timeout {
-    pub fn new(default_advance: Duration) -> Self {
+    pub fn new(default_advance: Duration, tick: Duration, now: Instant) -> Self {
         Self {
             default_advance,
-            inner: Box::pin(tokio::time::sleep(default_advance)),
+            inner: Box::pin(tokio::time::sleep_until(
+                tokio::time::Instant::from_std(now) + default_advance,
+            )),
             scheduled: None,
+            tick,
+            created_at: now,
         }
     }
 
@@ -46,9 +49,11 @@ impl Timeout {
 
     /// Moves the deadline to `deadline`, clamping it to the scheduled wakeup ceiling if one is set.
     pub fn reset(&mut self, deadline: Instant) {
+        let coarse = self.round_up(deadline);
+
         let effective = match self.scheduled {
-            Some(ceiling) => deadline.min(ceiling),
-            None => deadline,
+            Some(ceiling) => coarse.min(ceiling),
+            None => coarse,
         };
 
         self.set_deadline(effective);
@@ -80,6 +85,21 @@ impl Timeout {
             .as_mut()
             .reset(tokio::time::Instant::from_std(deadline));
     }
+
+    fn round_up(&self, deadline: Instant) -> Instant {
+        if self.tick.is_zero() {
+            return deadline;
+        }
+
+        let offset = deadline.saturating_duration_since(self.created_at);
+        let remainder_nanos = offset.as_nanos() % self.tick.as_nanos();
+
+        if remainder_nanos == 0 {
+            deadline
+        } else {
+            deadline + (self.tick - Duration::from_nanos(remainder_nanos as u64))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -88,10 +108,13 @@ mod tests {
 
     use super::*;
 
+    const STEP: Duration = Duration::from_millis(50);
+
     #[tokio::test(start_paused = true)]
     async fn deadline_auto_resets_to_old_deadline_plus_advance_after_firing() {
+        let now = Instant::now();
         let advance = Duration::from_secs(1);
-        let mut timeout = Timeout::new(advance);
+        let mut timeout = Timeout::new(advance, STEP, now);
 
         let original_deadline = timeout.deadline();
 
@@ -103,8 +126,8 @@ mod tests {
 
     #[tokio::test]
     async fn reset_moves_deadline_freely_without_scheduled_ceiling() {
-        let mut timeout = Timeout::new(Duration::from_secs(10));
         let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
 
         timeout.reset(now + Duration::from_secs(5));
         assert_eq!(timeout.deadline(), now + Duration::from_secs(5));
@@ -115,8 +138,8 @@ mod tests {
 
     #[tokio::test]
     async fn reset_is_clamped_to_scheduled_ceiling() {
-        let mut timeout = Timeout::new(Duration::from_secs(10));
         let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
         let ceiling = now + Duration::from_secs(1);
 
         timeout.schedule(ceiling);
@@ -127,8 +150,8 @@ mod tests {
 
     #[tokio::test]
     async fn reset_can_shorten_below_scheduled_ceiling() {
-        let mut timeout = Timeout::new(Duration::from_secs(10));
         let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
 
         timeout.schedule(now + Duration::from_secs(1));
         timeout.reset(now + Duration::from_millis(100));
@@ -138,36 +161,123 @@ mod tests {
 
     #[tokio::test]
     async fn schedule_clamps_existing_deadline_and_keeps_tightest_on_repeated_calls() {
-        let mut timeout = Timeout::new(Duration::from_secs(10));
         let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
 
-        // First schedule pulls the deadline in from 10s to 2s.
         timeout.schedule(now + Duration::from_secs(2));
-        assert_eq!(timeout.deadline(), now + Duration::from_secs(2));
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_secs(2),
+            "first schedule should pull deadline in from 10s to 2s"
+        );
 
-        // A tighter ceiling wins.
         timeout.schedule(now + Duration::from_secs(1));
-        assert_eq!(timeout.deadline(), now + Duration::from_secs(1));
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_secs(1),
+            "tighter ceiling should win"
+        );
 
-        // A looser ceiling is ignored.
         timeout.schedule(now + Duration::from_secs(5));
-        assert_eq!(timeout.deadline(), now + Duration::from_secs(1));
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_secs(1),
+            "looser ceiling should be ignored"
+        );
     }
 
     #[tokio::test(start_paused = true)]
     async fn ceiling_is_cleared_after_firing_allowing_reset_to_move_deadline_freely() {
-        let mut timeout = Timeout::new(Duration::from_secs(10));
         let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
 
         timeout.schedule(now + Duration::from_secs(1));
 
         tokio::time::advance(Duration::from_secs(1)).await;
         poll_fn(|cx| timeout.poll_tick(cx)).await;
 
-        // Ceiling is gone — reset should now move the deadline freely past the old ceiling.
-        let far = Instant::now() + Duration::from_secs(20);
+        let far = now + Duration::from_secs(20);
         timeout.reset(far);
 
-        assert_eq!(timeout.deadline(), far);
+        assert_eq!(
+            timeout.deadline(),
+            far,
+            "ceiling should be cleared after firing, allowing reset to move deadline freely"
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_rounds_up_to_granularity_boundary() {
+        let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
+
+        timeout.reset(now + Duration::from_millis(10));
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_millis(50),
+            "10ms past epoch should round up to the 50ms boundary"
+        );
+
+        timeout.reset(now + Duration::from_millis(50));
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_millis(50),
+            "deadline exactly on a boundary should be unchanged"
+        );
+
+        timeout.reset(now + Duration::from_millis(51));
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_millis(100),
+            "51ms past epoch should round up to the 100ms boundary"
+        );
+    }
+
+    #[tokio::test]
+    async fn schedule_stores_ceiling_without_rounding() {
+        let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
+
+        let ceiling = now + Duration::from_millis(30);
+        timeout.schedule(ceiling);
+
+        assert_eq!(
+            timeout.deadline(),
+            ceiling,
+            "schedule should store and apply the ceiling as-is, without rounding"
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_rounded_up_value_is_still_clamped_by_ceiling() {
+        let now = Instant::now();
+        let mut timeout = Timeout::new(Duration::from_secs(10), STEP, now);
+
+        timeout.schedule(now + Duration::from_millis(30));
+        timeout.reset(now + Duration::from_millis(10));
+
+        assert_eq!(
+            timeout.deadline(),
+            now + Duration::from_millis(30),
+            "10ms rounds up to 50ms but ceiling is 30ms, so ceiling should win"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_advance_after_fire_is_not_rounded() {
+        let now = Instant::now();
+        let advance = Duration::from_secs(1);
+        let mut timeout = Timeout::new(advance, STEP, now);
+
+        let original_deadline = timeout.deadline();
+
+        tokio::time::advance(advance).await;
+        poll_fn(|cx| timeout.poll_tick(cx)).await;
+
+        assert_eq!(
+            timeout.deadline(),
+            original_deadline + advance,
+            "post-fire advance should be applied exactly, without rounding"
+        );
     }
 }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -118,17 +118,20 @@ impl ClientTunnel {
         records: BTreeSet<DnsResourceRecord>,
         is_internet_resource_active: bool,
     ) -> Self {
+        let now = Instant::now();
+
         Self {
             io: Io::new(
                 tcp_socket_factory,
                 udp_socket_factory.clone(),
                 BTreeSet::default(),
+                now,
             ),
             role_state: ClientState::new(
                 rand::random(),
                 records,
                 is_internet_resource_active,
-                Instant::now(),
+                now,
                 SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("Should be able to compute UNIX timestamp"),
@@ -314,12 +317,19 @@ impl GatewayTunnel {
         nameservers: BTreeSet<IpAddr>,
         flow_logs: bool,
     ) -> Self {
+        let now = Instant::now();
+
         Self {
-            io: Io::new(tcp_socket_factory, udp_socket_factory.clone(), nameservers),
+            io: Io::new(
+                tcp_socket_factory,
+                udp_socket_factory.clone(),
+                nameservers,
+                now,
+            ),
             role_state: GatewayState::new(
                 flow_logs,
                 rand::random(),
-                Instant::now(),
+                now,
                 SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("Should be able to compute UNIX timestamp"),


### PR DESCRIPTION
As the number of connections within a Firezone peer increase, so does the number of wake-up times for asynchronous actions. For example, each connection wants to send a STUN request every 1.5s. At 1000 connections, that is one STUN request every 1.5ms on average. However, when the timer wakes up, we don't know which particular connection wanted to get processed so we just run through all of them.

To fix this, we refactor our `Timeout` component to work on a given granularity. When the timer is reset, the `Instant` is rounded up to the next epoch defined by the granularity, thus forming time-based "buckets". Because everything within `snownet` operates on the time it is given, this should eventually align all internal timers to roughly fire in the same intervals.

I suspect this might lead to slightly more bursty behaviour but I think that might actually be a good thing. We can send up to 32 UDP packets to different hosts in a single syscall so having more of those ready at the same time could be beneficial.