### PR TITLE
feat(connlib): don't eagerly call `Connection::handle_timeout`

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -808,6 +808,7 @@ where
             first_handshake_completed_at: None,
             default_ice_config,
             idle_ice_config,
+            poll_timeout_cache: None,
         }
     }
 
@@ -1273,6 +1274,8 @@ struct Connection<RId> {
 
     #[debug(skip)]
     buffer_pool: BufferPool<Vec<u8>>,
+
+    poll_timeout_cache: Option<(Instant, &'static str)>,
 }
 
 #[derive(Debug)]
@@ -1290,7 +1293,7 @@ where
 
     #[must_use]
     fn poll_timeout(&mut self) -> Option<(Instant, &'static str)> {
-        iter::empty()
+        self.poll_timeout_cache = iter::empty()
             .chain(
                 self.agent
                     .poll_timeout()
@@ -1306,7 +1309,9 @@ where
                     .map(|instant| (instant, "disconnect timeout")),
             )
             .chain(self.state.poll_timeout(&self.agent))
-            .min_by_key(|(instant, _)| *instant)
+            .min_by_key(|(instant, _)| *instant);
+
+        self.poll_timeout_cache
     }
 
     fn candidate_timeout(&self) -> Option<Instant> {
@@ -1334,6 +1339,16 @@ where
         TId: Copy + Ord + fmt::Display,
         RId: Copy + Ord + fmt::Display,
     {
+        // Important: This just checks the cache. `poll_timeout()` re-computes on every call.
+        if self
+            .poll_timeout_cache
+            .is_some_and(|(timeout, _)| timeout > now)
+        {
+            return;
+        }
+
+        self.poll_timeout_cache = None;
+
         let _guard = tracing::info_span!("handle_timeout", %cid).entered();
 
         self.agent.handle_timeout(now);

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1342,12 +1342,11 @@ where
         // Important: This just checks the cache. `poll_timeout()` re-computes on every call.
         if self
             .poll_timeout_cache
-            .is_some_and(|(timeout, _)| timeout > now)
+            .take_if(|(timeout, _)| now >= *timeout)
+            .is_none()
         {
             return;
-        }
-
-        self.poll_timeout_cache = None;
+        };
 
         let _guard = tracing::info_span!("handle_timeout", %cid).entered();
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -2,6 +2,7 @@ mod allocations;
 mod connection_state;
 mod connections;
 mod inflight_stun_requests;
+mod timeout_cache;
 
 pub use connections::UnknownConnection;
 
@@ -11,6 +12,7 @@ use crate::node::allocations::Allocations;
 use crate::node::connection_state::{ConnectionState, PeerSocket};
 use crate::node::connections::Connections;
 use crate::node::inflight_stun_requests::InflightStunRequests;
+use crate::node::timeout_cache::TimeoutCache;
 use crate::stats::{ConnectionStats, NodeStats};
 use crate::utils::channel_data_packet_buffer;
 use anyhow::{Context, Result, anyhow};
@@ -808,7 +810,7 @@ where
             first_handshake_completed_at: None,
             default_ice_config,
             idle_ice_config,
-            poll_timeout_cache: None,
+            poll_timeout_cache: Default::default(),
         }
     }
 
@@ -1275,7 +1277,7 @@ struct Connection<RId> {
     #[debug(skip)]
     buffer_pool: BufferPool<Vec<u8>>,
 
-    poll_timeout_cache: Option<(Instant, &'static str)>,
+    poll_timeout_cache: TimeoutCache,
 }
 
 #[derive(Debug)]
@@ -1293,7 +1295,7 @@ where
 
     #[must_use]
     fn poll_timeout(&mut self) -> Option<(Instant, &'static str)> {
-        self.poll_timeout_cache = iter::empty()
+        let timeout = iter::empty()
             .chain(
                 self.agent
                     .poll_timeout()
@@ -1311,7 +1313,7 @@ where
             .chain(self.state.poll_timeout(&self.agent))
             .min_by_key(|(instant, _)| *instant);
 
-        self.poll_timeout_cache
+        self.poll_timeout_cache.update(timeout)
     }
 
     fn candidate_timeout(&self) -> Option<Instant> {
@@ -1339,13 +1341,9 @@ where
         TId: Copy + Ord + fmt::Display,
         RId: Copy + Ord + fmt::Display,
     {
-        // Important: This just checks the cache. `poll_timeout()` re-computes on every call.
-        if self
-            .poll_timeout_cache
-            .take_if(|(timeout, _)| now >= *timeout)
-            .is_none()
-        {
-            return;
+        match self.poll_timeout_cache.check(now) {
+            ControlFlow::Continue(()) => {}
+            ControlFlow::Break(()) => return,
         };
 
         let _guard = tracing::info_span!("handle_timeout", %cid).entered();

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -631,7 +631,7 @@ mod tests {
             buffer_pool: BufferPool::new(0, "test"),
             default_ice_config: IceConfig::client_default(),
             idle_ice_config: IceConfig::client_idle(),
-            poll_timeout_cache: None,
+            poll_timeout_cache: Default::default(),
         }
     }
 }

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -631,6 +631,7 @@ mod tests {
             buffer_pool: BufferPool::new(0, "test"),
             default_ice_config: IceConfig::client_default(),
             idle_ice_config: IceConfig::client_idle(),
+            poll_timeout_cache: None,
         }
     }
 }

--- a/rust/libs/connlib/snownet/src/node/timeout_cache.rs
+++ b/rust/libs/connlib/snownet/src/node/timeout_cache.rs
@@ -1,0 +1,74 @@
+use std::{ops::ControlFlow, time::Instant};
+
+#[derive(Debug, Default)]
+pub struct TimeoutCache {
+    inner: Option<(Instant, &'static str)>,
+}
+
+impl TimeoutCache {
+    pub fn update(
+        &mut self,
+        value: impl Into<Option<(Instant, &'static str)>>,
+    ) -> Option<(Instant, &'static str)> {
+        self.inner = value.into();
+
+        self.inner
+    }
+
+    pub fn check(&mut self, now: Instant) -> ControlFlow<()> {
+        let Some((timeout, _)) = self.inner else {
+            return ControlFlow::Break(());
+        };
+
+        if timeout > now {
+            return ControlFlow::Break(());
+        }
+
+        self.inner = None;
+
+        ControlFlow::Continue(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn check_returns_break_if_deadline_not_reached() {
+        let mut cache = TimeoutCache::default();
+        let now = Instant::now();
+
+        cache.update((now + Duration::from_secs(1), "test"));
+
+        assert_eq!(cache.check(now), ControlFlow::Break(()));
+    }
+
+    #[test]
+    fn check_returns_continue_if_deadline_reached() {
+        let mut cache = TimeoutCache::default();
+        let now = Instant::now();
+
+        cache.update((now + Duration::from_secs(1), "test"));
+
+        assert_eq!(
+            cache.check(now + Duration::from_secs(1)),
+            ControlFlow::Continue(())
+        );
+        assert_eq!(
+            cache.check(now + Duration::from_secs(1)),
+            ControlFlow::Break(()),
+            "subsequent check should return `Break`"
+        );
+    }
+
+    #[test]
+    fn empty_cache_returns_break() {
+        let mut cache = TimeoutCache::default();
+        let now = Instant::now();
+
+        assert_eq!(cache.check(now), ControlFlow::Break(()));
+    }
+}

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -625,12 +625,6 @@ impl TunnelTest {
                 now,
             );
 
-            if let Some((next, reason)) = self.poll_timeout()
-                && next < now
-            {
-                tracing::error!(?next, ?now, %reason, "State machine requested time in the past");
-            }
-
             for (id, gateway) in self.gateways.iter_mut() {
                 let Some(event) = gateway.exec_mut(|g| g.sut.poll_event()) else {
                     continue;


### PR DESCRIPTION
Right now, we always delegate to each `Connection` when `Node::handle_timeout` is called, regardless as to whether there is any actual work that needs to be done. This is wasteful and turns `handle_timeout` into O(n) complexity. We can optimize this with an early-return at the top of `Connection::handle_timeout` and bail out early if there is nothing to do. To make this even more efficient, we also cache the result of `Connection::poll_timeout` until we reach that deadline.

The early-return also skips the creation of the `tracing::Span` in the common case.

In order to ship this, we need to remove a condition from our test-suite. In particular, we can no longer assert that we never request a time that is in the past. This makes sense: A connection will now only get updated to the current time after it has surpassed its latest deadline instead of being eagerly updated. As a result, the wall-clock may move past the requested timestamp.

We do take care of this edge-case in our event-loop by always passing the current wall-clock time into the state machine instead of the deadline the timer fired at (which may be in the past if the timer doesn't get polled quickly enough).

Related: #12504