### PR TITLE
feat(connlib): optimize removing inflight STUN requests

### DIFF
--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -61,6 +61,7 @@ where
 
     pub fn clear(&mut self) {
         self.inner.clear();
+        self.expires_at.clear();
     }
 }
 

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -1,9 +1,8 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeSet, HashMap},
     time::{Duration, Instant},
 };
 
-use smallvec::SmallVec;
 use str0m::ice::TransId;
 
 /// For how long we will at most keep around an inflight STUN request ID.
@@ -11,7 +10,7 @@ const TTL: Duration = Duration::from_secs(10);
 
 pub struct InflightStunRequests<TId> {
     inner: HashMap<String, TId>,
-    expires_at: BTreeMap<Instant, SmallVec<[String; 4]>>,
+    expires_at: BTreeSet<(Instant, String)>,
 }
 
 impl<TId> Default for InflightStunRequests<TId> {
@@ -31,7 +30,7 @@ where
         let k = format!("{id:?}"); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
 
         self.inner.insert(k.clone(), conn_id);
-        self.expires_at.entry(now + TTL).or_default().push(k);
+        self.expires_at.insert((now + TTL, k));
     }
 
     pub fn remove(&mut self, id: TransId) -> Option<TId> {
@@ -49,16 +48,13 @@ where
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {
-        while let Some(entry) = self.expires_at.first_entry() {
-            if entry.key() > &now {
+        while let Some((expires, trans_id)) = self.expires_at.first() {
+            if expires > &now {
                 break;
             }
 
-            let trans_id = entry.remove();
-
-            for id in trans_id {
-                self.inner.remove(&id);
-            }
+            self.inner.remove(trans_id);
+            self.expires_at.pop_first();
         }
     }
 

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -36,11 +36,15 @@ where
     pub fn remove(&mut self, id: TransId) -> Option<TId> {
         let id = self.inner.remove(&format!("{id:?}"))?;
 
+        // We purposely don't clean up `expires_at` because it will get cleaned up in `handle_timeout` anyway.
+
         Some(id)
     }
 
     pub fn remove_by_conn_id(&mut self, id: TId) {
         for _ in self.inner.extract_if(|_, c| c == &id) {}
+
+        // We purposely don't clean up `expires_at` because it will get cleaned up in `handle_timeout` anyway.
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use smallvec::SmallVec;
 use str0m::ice::TransId;
 
 /// For how long we will at most keep around an inflight STUN request ID.
@@ -10,7 +11,7 @@ const TTL: Duration = Duration::from_secs(10);
 
 pub struct InflightStunRequests<TId> {
     inner: HashMap<String, TId>,
-    expires_at: BTreeMap<Instant, String>,
+    expires_at: BTreeMap<Instant, SmallVec<[String; 4]>>,
 }
 
 impl<TId> Default for InflightStunRequests<TId> {
@@ -30,7 +31,7 @@ where
         let k = format!("{id:?}"); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
 
         self.inner.insert(k.clone(), conn_id);
-        self.expires_at.insert(now + TTL, k);
+        self.expires_at.entry(now + TTL).or_default().push(k);
     }
 
     pub fn remove(&mut self, id: TransId) -> Option<TId> {
@@ -55,7 +56,9 @@ where
 
             let trans_id = entry.remove();
 
-            self.inner.remove(&trans_id);
+            for id in trans_id {
+                self.inner.remove(&id);
+            }
         }
     }
 

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -127,6 +127,21 @@ mod tests {
     }
 
     #[test]
+    fn entries_with_same_time_get_cleared_with_handle_timeout() {
+        let mut requests = InflightStunRequests::default();
+        let now = Instant::now();
+        let id1 = TransId::new();
+        let id2 = TransId::new();
+
+        requests.add(1u32, id1, now);
+        requests.add(2u32, id2, now);
+        requests.handle_timeout(now + TTL + Duration::from_millis(1));
+
+        assert_eq!(requests.remove(id1), None);
+        assert_eq!(requests.remove(id2), None);
+    }
+
+    #[test]
     fn only_expired_entries_are_removed() {
         let mut requests = InflightStunRequests::default();
         let t0 = Instant::now();

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     time::{Duration, Instant},
 };
 
@@ -9,13 +9,15 @@ use str0m::ice::TransId;
 const TTL: Duration = Duration::from_secs(10);
 
 pub struct InflightStunRequests<TId> {
-    inner: HashMap<String, (TId, Instant)>,
+    inner: HashMap<String, TId>,
+    expires_at: BTreeMap<Instant, String>,
 }
 
 impl<TId> Default for InflightStunRequests<TId> {
     fn default() -> Self {
         Self {
-            inner: HashMap::default(),
+            inner: Default::default(),
+            expires_at: Default::default(),
         }
     }
 }
@@ -25,24 +27,32 @@ where
     TId: PartialEq,
 {
     pub fn add(&mut self, conn_id: TId, id: TransId, now: Instant) {
-        self.inner.insert(format!("{id:?}"), (conn_id, now + TTL)); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
+        let k = format!("{id:?}"); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
+
+        self.inner.insert(k.clone(), conn_id);
+        self.expires_at.insert(now + TTL, k);
     }
 
     pub fn remove(&mut self, id: TransId) -> Option<TId> {
-        let (id, _) = self.inner.remove(&format!("{id:?}"))?;
+        let id = self.inner.remove(&format!("{id:?}"))?;
 
         Some(id)
     }
 
     pub fn remove_by_conn_id(&mut self, id: TId) {
-        for _ in self.inner.extract_if(|_, (c, _)| c == &id) {}
+        for _ in self.inner.extract_if(|_, c| c == &id) {}
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {
-        for _ in self
-            .inner
-            .extract_if(|_, (_, expires_at)| now >= *expires_at)
-        {}
+        while let Some(entry) = self.expires_at.first_entry() {
+            if entry.key() > &now {
+                break;
+            }
+
+            let trans_id = entry.remove();
+
+            self.inner.remove(&trans_id);
+        }
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
In #12516, we optimize the dispatching of STUN messages to the correct ICE agent by remembering the STUN transaction ID for each outbound request. The introduced `InflightStunRequests` data-structure has a safety net to prevent unbounded growth where entries are only kept around for at most 10s.

Whilst not wildly expensive, checking all entries as to whether they are expired is unnecessary. Time usually only moves forward and as such, the only thing we need to check is whether the "first" entry is past the current deadline. To be fully correct, we insert the deadlines into a dedicated `BTreeMap`. By design, the b-tree keeps a sorted list of keys and therefore the first entry will always be the earliest. If we don't need to remove that one, we don't need to remove any of the keys.

This turns the clean-up algorithm from O(n) to O(1) and optimizes for the happy-path where the entry most likely gets removed due to the binding request being answered and not due to a timeout.

Related: #12504 