### PR TITLE
fix(connlib): don't recompute `candidate_timeout`

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1304,7 +1304,7 @@ where
             )
             .chain(Some((self.next_wg_timer_update, "boringtun tunnel")))
             .chain(
-                self.candidate_timeout()
+                self.candidate_timeout
                     .map(|instant| (instant, "candidate timeout")),
             )
             .chain(
@@ -1315,10 +1315,6 @@ where
             .min_by_key(|(instant, _)| *instant);
 
         self.poll_timeout_cache.update(timeout)
-    }
-
-    fn candidate_timeout(&self) -> Option<Instant> {
-        self.candidate_timeout
     }
 
     fn disconnect_timeout(&self) -> Option<Instant> {
@@ -1349,10 +1345,7 @@ where
         self.state
             .handle_timeout(&mut self.agent, self.idle_ice_config, now);
 
-        if self
-            .candidate_timeout()
-            .is_some_and(|timeout| now >= timeout)
-        {
+        if self.candidate_timeout.is_some_and(|timeout| now >= timeout) {
             tracing::info!(state = %self.state, index = %self.index.global(), "Connection failed (no candidates received)");
             self.state = ConnectionState::Failed;
             return;

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -797,7 +797,6 @@ where
             stats: Default::default(),
             buffer: vec![0; ip_packet::MAX_FZ_PAYLOAD],
             intent_sent_at,
-            signalling_completed_at: now,
             remote_pub_key: remote,
             relay: SelectedRelay { id: relay },
             state: ConnectionState::Connecting {
@@ -811,6 +810,7 @@ where
             default_ice_config,
             idle_ice_config,
             poll_timeout_cache: Default::default(),
+            candidate_timeout: Some(now + CANDIDATE_TIMEOUT),
         }
     }
 
@@ -1266,7 +1266,8 @@ struct Connection<RId> {
 
     stats: ConnectionStats,
     intent_sent_at: Instant,
-    signalling_completed_at: Instant,
+    candidate_timeout: Option<Instant>,
+
     first_handshake_completed_at: Option<Instant>,
 
     buffer: Vec<u8>,
@@ -1317,11 +1318,7 @@ where
     }
 
     fn candidate_timeout(&self) -> Option<Instant> {
-        if self.agent.remote_candidates().count() > 0 {
-            return None;
-        }
-
-        Some(self.signalling_completed_at + CANDIDATE_TIMEOUT)
+        self.candidate_timeout
     }
 
     fn disconnect_timeout(&self) -> Option<Instant> {
@@ -1907,6 +1904,7 @@ where
         TId: fmt::Display,
     {
         self.agent.add_remote_candidate(candidate);
+        self.candidate_timeout = None;
 
         generate_optimistic_candidates(&mut self.agent);
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -625,7 +625,7 @@ mod tests {
             disconnected_at: None,
             stats: Default::default(),
             intent_sent_at: Instant::now(),
-            signalling_completed_at: Instant::now(),
+            candidate_timeout: None,
             first_handshake_completed_at: None,
             buffer: Default::default(),
             buffer_pool: BufferPool::new(0, "test"),


### PR DESCRIPTION
When we set up a new connection in `snownet`, we wait for 10s to see if we receive any candidates for it. If not, we deallocate the connection again. In the happy-path case, this timeout never gets hit, yet we recompute it a lot by counting the number of remote candidates that have been added.

We can optimize this by only computing it once and zeroing it out as soon as we receive the first candidate.

Related: #12504