### PR TITLE
fix(connlib): use `TransId` directly

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -1928,12 +1928,13 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.2.6"
-source = "git+https://github.com/algesten/dimpl?branch=main#97c9e9d83a7a7548f90cfb5cc99a8f23832e48be"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da42827f6904e69bf1cc78ddcb74fab007a2b476099ab0a42e8cacf1ea1f6c0"
 dependencies = [
  "arrayvec",
  "log",
- "nom 7.1.3",
+ "nom 8.0.0",
  "once_cell",
  "rand 0.9.1",
  "subtle",
@@ -6446,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57239be45f014795255107f85dfe3503791711e77c4995f936caf89a2afe0c16"
+checksum = "d2213ed8f5ff249a7cf15be660536310010f34a79495fe9f1aadf789495ede24"
 dependencies = [
  "bytes",
  "crc",
@@ -7153,7 +7154,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.16.2"
-source = "git+https://github.com/algesten/str0m?branch=main#e339fa41e59916b704c4684609013a9691cef14f"
+source = "git+https://github.com/algesten/str0m?branch=main#3e0bdbd56e565f6150c357c7c3dbcd91599b673b"
 dependencies = [
  "arrayvec",
  "combine",
@@ -7164,17 +7165,19 @@ dependencies = [
  "serde",
  "str0m-proto",
  "subtle",
+ "time",
  "tracing",
 ]
 
 [[package]]
 name = "str0m-proto"
 version = "0.1.2"
-source = "git+https://github.com/algesten/str0m?branch=main#e339fa41e59916b704c4684609013a9691cef14f"
+source = "git+https://github.com/algesten/str0m?branch=main#3e0bdbd56e565f6150c357c7c3dbcd91599b673b"
 dependencies = [
  "base64ct",
  "dimpl",
  "subtle",
+ "time",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -258,7 +258,6 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 [patch.crates-io]
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
-dimpl = { git = "https://github.com/algesten/dimpl", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.30" } # Waiting for release.

--- a/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
+++ b/rust/libs/connlib/snownet/src/node/inflight_stun_requests.rs
@@ -9,8 +9,8 @@ use str0m::ice::TransId;
 const TTL: Duration = Duration::from_secs(10);
 
 pub struct InflightStunRequests<TId> {
-    inner: HashMap<String, TId>,
-    expires_at: BTreeSet<(Instant, String)>,
+    inner: HashMap<TransId, TId>,
+    expires_at: BTreeSet<(Instant, TransId)>,
 }
 
 impl<TId> Default for InflightStunRequests<TId> {
@@ -27,14 +27,12 @@ where
     TId: PartialEq,
 {
     pub fn add(&mut self, conn_id: TId, id: TransId, now: Instant) {
-        let k = format!("{id:?}"); // TODO: Use debug formatting while we wait for https://github.com/algesten/str0m/pull/905
-
-        self.inner.insert(k.clone(), conn_id);
-        self.expires_at.insert((now + TTL, k));
+        self.inner.insert(id, conn_id);
+        self.expires_at.insert((now + TTL, id));
     }
 
     pub fn remove(&mut self, id: TransId) -> Option<TId> {
-        let id = self.inner.remove(&format!("{id:?}"))?;
+        let id = self.inner.remove(&id)?;
 
         // We purposely don't clean up `expires_at` because it will get cleaned up in `handle_timeout` anyway.
 


### PR DESCRIPTION
We've recently patched `str0m` to derive additional traits on the `TransId` type which now allows us to use it as a key in a `HashMap`. This futher improves performance because we don't need to allocate a new `String` for each entry.

Related: #12516
Related: #12504