### PR TITLE
fix(snownet): lazily create anyhow context

### DIFF
--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -181,7 +181,7 @@ where
         let connection = self
             .established
             .get_mut(id)
-            .context(UnknownConnection::by_id(*id, &self.disconnected_ids, now))?;
+            .with_context(|| UnknownConnection::by_id(*id, &self.disconnected_ids, now))?;
 
         Ok(connection)
     }
@@ -194,16 +194,14 @@ where
         let id = self
             .established_by_wireguard_session_index
             .get(&index.global())
-            .context(UnknownConnection::by_index(
-                index.global(),
-                &self.disconnected_session_indices,
-                now,
-            ))?;
+            .with_context(|| {
+                UnknownConnection::by_index(index.global(), &self.disconnected_session_indices, now)
+            })?;
 
         let connection = self
             .established
             .get_mut(id)
-            .context(UnknownConnection::by_id(*id, &self.disconnected_ids, now))?;
+            .with_context(|| UnknownConnection::by_id(*id, &self.disconnected_ids, now))?;
 
         Ok((*id, connection))
     }
@@ -217,11 +215,9 @@ where
             .established
             .iter_mut()
             .find(|(_, c)| c.tunnel.remote_static_public().as_bytes() == &key)
-            .context(UnknownConnection::by_public_key(
-                key,
-                &self.disconnected_public_keys,
-                now,
-            ))?;
+            .with_context(|| {
+                UnknownConnection::by_public_key(key, &self.disconnected_public_keys, now)
+            })?;
 
         Ok((*id, conn))
     }


### PR DESCRIPTION
These functions are in the hot-path of data routing and allocate a `String` every time only to then immediately drop it again if we can actually find the connection in our map. `anyhow` provides the `with_context` functions for this purpose which only gets evaluated in the case of an error. This reduces about 6% of CPU cycles on my test bed when running an iperf between two devices.