### PR TITLE
docs(changelog): remove duplicate hashtag

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -29,7 +29,7 @@ export default function Android() {
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="#12111">
+        <ChangeItem pull="12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,167 +21,167 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem pull="12355">
+        <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.
         </ChangeItem>
-        <ChangeItem pull="12251">
+        <ChangeItem pull={12251}>
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="12111">
+        <ChangeItem pull={12111}>
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>
-        <ChangeItem pull="11625">
+        <ChangeItem pull={11625}>
           Fails faster when the initial connection to the control plane cannot
           be established, allowing the user to retry sooner.
         </ChangeItem>
-        <ChangeItem pull="11584">
+        <ChangeItem pull={11584}>
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.
         </ChangeItem>
-        <ChangeItem pull="11627">
+        <ChangeItem pull={11627}>
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
-        <ChangeItem pull="11626">
+        <ChangeItem pull={11626}>
           Fixes an issue where reconnecting to the portal would fail if the DNS
           resolver list was empty due to a network reset or other edge case.
         </ChangeItem>
-        <ChangeItem pull="11595">
+        <ChangeItem pull={11595}>
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.
         </ChangeItem>
-        <ChangeItem pull="11594">
+        <ChangeItem pull={11594}>
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
-        <ChangeItem pull="11654">
+        <ChangeItem pull={11654}>
           Implements retry with exponential backoff for anything but 401
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
-        <ChangeItem pull="11804">
+        <ChangeItem pull={11804}>
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
-        <ChangeItem pull="11891">
+        <ChangeItem pull={11891}>
           Fixes an issue where cached IPv6 addresses for a resource got returned
           for IPv4-only DNS resources if the setting was only changed after a
           DNS query had already been processed.
         </ChangeItem>
-        <ChangeItem pull="12013">
+        <ChangeItem pull={12013}>
           Asks for notification permissions on launch.
         </ChangeItem>
-        <ChangeItem pull="11779">
+        <ChangeItem pull={11779}>
           Notifies the user when a connection to a resource cannot be
           established.
         </ChangeItem>
-        <ChangeItem pull="12248">
+        <ChangeItem pull={12248}>
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
-        <ChangeItem pull="12322">
+        <ChangeItem pull={12322}>
           Fixes an issue where the WebSocket connection to the control plane was
           lost under load.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-12-23")}>
-        <ChangeItem pull="11077">
+        <ChangeItem pull={11077}>
           Fixes an issue where the authentication link would not open in the
           correct app.
         </ChangeItem>
-        <ChangeItem pull="11115">
+        <ChangeItem pull={11115}>
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.7" date={new Date("2025-12-05")}>
-        <ChangeItem pull="10752">
+        <ChangeItem pull={10752}>
           Fixes an issue where the reported client version was out of date.
         </ChangeItem>
-        <ChangeItem pull="10773">
+        <ChangeItem pull={10773}>
           Fixes an issue where the order of upstream / system DNS resolvers was
           not respected.
         </ChangeItem>
-        <ChangeItem pull="10914">
+        <ChangeItem pull={10914}>
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.6" date={new Date("2025-10-28")}>
-        <ChangeItem pull="10667">
+        <ChangeItem pull={10667}>
           Fixes an issue where the Tunnel service would crash when trying to
           connect Firezone without an Internet connection.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.5" date={new Date("2025-10-18")}>
-        <ChangeItem pull="10509">
+        <ChangeItem pull={10509}>
           Fixes an issue where the Internet Resource could be briefly active on
           startup, despite it being disabled.
         </ChangeItem>
-        <ChangeItem pull="10533">
+        <ChangeItem pull={10533}>
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.4" date={new Date("2025-09-18")}>
-        <ChangeItem pull="10371">
+        <ChangeItem pull={10371}>
           Fixes a bug that could prevent sign-ins from completing successfully
           if Firefox is set as the default browser.
         </ChangeItem>
-        <ChangeItem pull="10104">
+        <ChangeItem pull={10104}>
           {
             "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.3" date={new Date("2025-08-05")}>
-        <ChangeItem pull="9985">
+        <ChangeItem pull={9985}>
           Fixes an issue where control plane messages could be stuck forever on
           flaky connections, requiring signing out and back in to recover.
         </ChangeItem>
-        <ChangeItem pull="9725">
+        <ChangeItem pull={9725}>
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.
         </ChangeItem>
-        <ChangeItem pull="9891">
+        <ChangeItem pull={9891}>
           Fixes an issue where connections would sometimes take up to 90s to
           establish.
         </ChangeItem>
-        <ChangeItem pull="9979">
+        <ChangeItem pull={9979}>
           Fixes an issue where connections in low-latency networks (between
           Client and Gateway) would fail to establish reliably.
         </ChangeItem>
-        <ChangeItem pull="9999">
+        <ChangeItem pull={9999}>
           Decreases connection setup time on flaky Internet connections in
           certain edge cases.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.2" date={new Date("2025-06-30")}>
-        <ChangeItem pull="9621">
+        <ChangeItem pull={9621}>
           {
             "Fixes an issue where the VPN permission screen wouldn't dismiss after granting the VPN permission."
           }
         </ChangeItem>
-        <ChangeItem pull="9564">
+        <ChangeItem pull={9564}>
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.1" date={new Date("2025-06-04")}>
-        <ChangeItem pull="9394">
+        <ChangeItem pull={9394}>
           Fixes a minor issue that would cause background service panic when
           signing out.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.0" date={new Date("2025-06-02")}>
-        <ChangeItem pull="9300">
+        <ChangeItem pull={9300}>
           Uses the new IP stack setting for DNS resources, which allows DNS
           resources to optionally return only A or AAAA records if configured by
           the administrator.
         </ChangeItem>
-        <ChangeItem pull="9227">
+        <ChangeItem pull={9227}>
           {
             "Adds full support for managed configurations to configure the client using your organization's MDM solution. See the "
           }
@@ -193,88 +193,88 @@ export default function Android() {
           </Link>{" "}
           for more details.
         </ChangeItem>
-        <ChangeItem pull="9014">
+        <ChangeItem pull={9014}>
           Fixes an issue where idle connections would be slow (~60s) in
           detecting changes to network connectivity.
         </ChangeItem>
-        <ChangeItem pull="9018">
+        <ChangeItem pull={9018}>
           Further improves performance of relayed connections on IPv4-only
           systems.
         </ChangeItem>
-        <ChangeItem pull="9093">
+        <ChangeItem pull={9093}>
           Fixes a rare panic when the DNS servers on the system would change
           while Firezone is connected.
         </ChangeItem>
-        <ChangeItem pull="9147">
+        <ChangeItem pull={9147}>
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
-        <ChangeItem pull="9366">
+        <ChangeItem pull={9366}>
           Fixes an issue where Firezone could not start if the operating system
           refused our request to increase the UDP socket buffer sizes.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.8" date={new Date("2025-04-30")}>
-        <ChangeItem pull="8920">
+        <ChangeItem pull={8920}>
           Improves connection reliability by maintaining the order of IP packets
           across GSO batches.
         </ChangeItem>
-        <ChangeItem pull="8926">
+        <ChangeItem pull={8926}>
           Rolls over to a new log-file as soon as logs are cleared.
         </ChangeItem>
-        <ChangeItem pull="8935">
+        <ChangeItem pull={8935}>
           Improves reliability for upload-intensive connections with many
           concurrent DNS queries.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.7" date={new Date("2025-04-21")}>
-        <ChangeItem pull="8798">
+        <ChangeItem pull={8798}>
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
-        <ChangeItem pull="8754">
+        <ChangeItem pull={8754}>
           Fixes a performance regression that could lead to packet drops under
           high load.
         </ChangeItem>
-        <ChangeItem pull="7590">
+        <ChangeItem pull={7590}>
           Improves performance by moving UDP sockets to a dedicated thread.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.5" date={new Date("2025-03-15")}>
-        <ChangeItem pull="8445">
+        <ChangeItem pull={8445}>
           {
             "Fixes a bug where search domains changes weren't applied if already signed in."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.4.4" date={new Date("2025-03-14")}>
-        <ChangeItem pull="8436">
+        <ChangeItem pull={8436}>
           Applies the search domain configured in the admin portal, if any.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-03-10")}>
-        <ChangeItem pull="8376">
+        <ChangeItem pull={8376}>
           Fixes a bug where UI controls could overlap with system controls on
           some devices.
         </ChangeItem>
-        <ChangeItem pull="8286">
+        <ChangeItem pull={8286}>
           Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.2" date={new Date("2025-02-16")}>
-        <ChangeItem pull="8117">
+        <ChangeItem pull={8117}>
           Fixes an upload speed performance regression.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.1" date={new Date("2025-01-28")}>
-        <ChangeItem pull="7891">
+        <ChangeItem pull={7891}>
           Substantially reduces memory usage when sending large amounts of data.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.0" date={new Date("2025-01-02")}>
-        <ChangeItem pull="7599">
+        <ChangeItem pull={7599}>
           The Android app is now distributed{" "}
           <Link
             href="https://www.github.com/firezone/firezone/releases"
@@ -284,11 +284,11 @@ export default function Android() {
           </Link>
           to the Google Play Store.
         </ChangeItem>
-        <ChangeItem pull="7334">
+        <ChangeItem pull={7334}>
           Fixes an issue where symmetric NATs would generate unnecessary
           candidate for hole-punching.
         </ChangeItem>
-        <ChangeItem pull="7210">
+        <ChangeItem pull={7210}>
           Adds support for GSO (Generic Segmentation Offload), delivering
           throughput improvements of up to 60%.
         </ChangeItem>
@@ -296,134 +296,134 @@ export default function Android() {
           Makes use of the new control protocol, delivering faster and more
           robust connection establishment.
         </ChangeItem>
-        <ChangeItem pull="7477">
+        <ChangeItem pull={7477}>
           Improves connection setup latency by buffering initial packets.
         </ChangeItem>
-        <ChangeItem pull="7551">
+        <ChangeItem pull={7551}>
           Fixes an issue where large DNS responses were incorrectly discarded.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.7" date={new Date("2024-11-08")}>
-        <ChangeItem pull="7263">
+        <ChangeItem pull={7263}>
           Mitigates a crash in case the maximum packet size is not respected.
         </ChangeItem>
-        <ChangeItem pull="7265">
+        <ChangeItem pull={7265}>
           Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
-        <ChangeItem pull="7288">
+        <ChangeItem pull={7288}>
           Fixes an issue where network roaming would cause Firezone to become
           unresponsive.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.6" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
-        <ChangeItem pull="7151">
+        <ChangeItem pull={7151}>
           Adds always-on error reporting using sentry.io.
         </ChangeItem>
-        <ChangeItem pull="7160">
+        <ChangeItem pull={7160}>
           Fixes an issue where notifications would sometimes not get delivered
           when Firezone was active.
         </ChangeItem>
-        <ChangeItem pull="7164">
+        <ChangeItem pull={7164}>
           Fixes an issue where Firezone would fail to establish connections to
           Gateways and the user had to sign-out and in again.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.5" date={new Date("2024-10-03")}>
-        <ChangeItem pull="6831">
+        <ChangeItem pull={6831}>
           {
             "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
           }
         </ChangeItem>
-        <ChangeItem pull="6845">
+        <ChangeItem pull={6845}>
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
         </ChangeItem>
-        <ChangeItem pull="6857">
+        <ChangeItem pull={6857}>
           Sends the Firebase Installation ID for device verification.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.4" date={new Date("2024-09-26")}>
-        <ChangeItem pull="6809">
+        <ChangeItem pull={6809}>
           Fixes a bug where non-wildcard DNS resources were not prioritised over
           wildcard ones (e.g. <code>app.example.com</code> vs{" "}
           <code>*.example.com</code>).
         </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-24")}>
-        <ChangeItem pull="6707">
+        <ChangeItem pull={6707}>
           Resetting the settings now resets the list of favorited Resources,
           too.
         </ChangeItem>
-        <ChangeItem pull="6765">
+        <ChangeItem pull={6765}>
           Fixes a bug where DNS PTR queries by the system did not get answered.
         </ChangeItem>
-        <ChangeItem pull="6722">
+        <ChangeItem pull={6722}>
           Fixes a routing bug when one of several overlapping CIDR resources
           gets disabled / removed.
         </ChangeItem>
-        <ChangeItem pull="6788">
+        <ChangeItem pull={6788}>
           Fixes an issue where some browsers may fail to route DNS Resources
           correctly.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-05")}>
-        <ChangeItem pull="6605">
+        <ChangeItem pull={6605}>
           Fixes another bug where the tunnel would immediately disconnect after
           connecting.
         </ChangeItem>
-        <ChangeItem pull="6518">
+        <ChangeItem pull={6518}>
           Minor improvements to the look of the internet resource and makes the
           Internet resource off by default.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-08-31")}>
-        <ChangeItem pull="6517">
+        <ChangeItem pull={6517}>
           Fixes a bug where the tunnel would immediately disconnect after
           connecting.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ChangeItem pull="6424">
+        <ChangeItem pull={6424}>
           Fixes a bug where packets would be lost when a connection is first
           established to a gateway, due to routes being updated with no actual
           change.
         </ChangeItem>
-        <ChangeItem pull="6405">
+        <ChangeItem pull={6405}>
           Shows the Git SHA corresponding to the build on the Settings -&gt;
           Advanced screen.
         </ChangeItem>
-        <ChangeItem pull="6495">
+        <ChangeItem pull={6495}>
           {
             "Fixes a bug where the Firezone tunnel wasn't shut down properly if you disconnect the VPN in system settings."
           }
         </ChangeItem>
-        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
+        <ChangeItem pull={6434}>Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ChangeItem pull="5901">
+        <ChangeItem pull={5901}>
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
-        <ChangeItem pull="6361">
+        <ChangeItem pull={6361}>
           {
             "Connections to Gateways are now sticky for the duration of the Client's session. This fixes potential issues maintaining long-lived TCP connections to Gateways in a high-availability setup."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.1.6" date={new Date("2024-08-13")}>
-        <ChangeItem pull="6276">
+        <ChangeItem pull={6276}>
           Fixes a bug where relayed connections failed to establish after an
           idle period.
         </ChangeItem>
-        <ChangeItem pull="6277">
+        <ChangeItem pull={6277}>
           Fixes a bug where restrictive NATs caused connectivity problems.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-10")}>
-        <ChangeItem pull="6107">
+        <ChangeItem pull={6107}>
           Adds the ability to mark Resources as favorites.
         </ChangeItem>
-        <ChangeItem pull="6181">
+        <ChangeItem pull={6181}>
           Improves reliability of DNS resolution of non-resources.
         </ChangeItem>
       </Entry>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,185 +25,185 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem pull="12407">
+        <ChangeItem pull={12407}>
           Fixes update notification dismissal on macOS where dismissing one
           version could be ignored due to reading from the wrong UserDefaults
           key.
         </ChangeItem>
-        <ChangeItem pull="12355">
+        <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.
         </ChangeItem>
-        <ChangeItem pull="12236">
+        <ChangeItem pull={12236}>
           Fixes an issue on macOS where the app could get stuck on the loading
           spinner if the system extension was not ready at startup.
         </ChangeItem>
-        <ChangeItem pull="12279">
+        <ChangeItem pull={12279}>
           Bumps minimum iOS version from 15.6 to 16.0 to enable SwiftUI
           NavigationStack and NavigationSplitView API.
         </ChangeItem>
-        <ChangeItem pull="12251">
+        <ChangeItem pull={12251}>
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="12016">
+        <ChangeItem pull={12016}>
           Uses the system{`'`}s DNS resolver ordering on macOS for more accurate
           DNS resolution behavior.
         </ChangeItem>
-        <ChangeItem pull="11988">
+        <ChangeItem pull={11988}>
           Fixes a crash if the currently active log file gets deleted.
         </ChangeItem>
-        <ChangeItem pull="11779">
+        <ChangeItem pull={11779}>
           Notifies the user when a connection to a resource cannot be
           established.
         </ChangeItem>
-        <ChangeItem pull="12248">
+        <ChangeItem pull={12248}>
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
-        <ChangeItem pull="12322">
+        <ChangeItem pull={12322}>
           Fixes an issue where the WebSocket connection to the control plane was
           lost under load.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.13" date={new Date("2026-01-30")}>
-        <ChangeItem pull="11901">
+        <ChangeItem pull={11901}>
           Fixes an issue where the tunnel may not come up after a fresh install
           of the Firezone client.
         </ChangeItem>
-        <ChangeItem pull="11892">
+        <ChangeItem pull={11892}>
           Exports logs in plain text format instead of JSONL for easier reading.
         </ChangeItem>
-        <ChangeItem pull="11834">
+        <ChangeItem pull={11834}>
           Fixes an issue where the tunnel might hang or crash on iOS immediately
           after signing in.
         </ChangeItem>
-        <ChangeItem pull="11659">
+        <ChangeItem pull={11659}>
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>
-        <ChangeItem pull="11804">
+        <ChangeItem pull={11804}>
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
-        <ChangeItem pull="11891">
+        <ChangeItem pull={11891}>
           Fixes an issue where cached IPv6 addresses for a resource got returned
           for IPv4-only DNS resources if the setting was only changed after a
           DNS query had already been processed.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.12" date={new Date("2026-01-20")}>
-        <ChangeItem pull="11735">
+        <ChangeItem pull={11735}>
           Fixes an issue on iOS where the system resolvers could not be reliably
           read, causing DNS queries to fail system-wide.
         </ChangeItem>
-        <ChangeItem pull="11625">
+        <ChangeItem pull={11625}>
           Fails faster when the initial connection to the control plane cannot
           be established, allowing the user to retry sooner.
         </ChangeItem>
-        <ChangeItem pull="11634">
+        <ChangeItem pull={11634}>
           Bumps minimum macOS version from 12.4 to 13.0 (Ventura) to enable
           SwiftUI MenuBarExtra API.
         </ChangeItem>
-        <ChangeItem pull="11584">
+        <ChangeItem pull={11584}>
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.
         </ChangeItem>
-        <ChangeItem pull="11627">
+        <ChangeItem pull={11627}>
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
-        <ChangeItem pull="11626">
+        <ChangeItem pull={11626}>
           Fixes an issue where reconnecting to the portal would fail if the DNS
           resolver list was empty due to a network reset or other edge case.
         </ChangeItem>
-        <ChangeItem pull="11595">
+        <ChangeItem pull={11595}>
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.
         </ChangeItem>
-        <ChangeItem pull="11594">
+        <ChangeItem pull={11594}>
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
-        <ChangeItem pull="11654">
+        <ChangeItem pull={11654}>
           Implements retry with exponential backoff for anything but 401
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.11" date={new Date("2025-12-23")}>
-        <ChangeItem pull="11141">
+        <ChangeItem pull={11141}>
           Fixes an issue where spurious resource updates would result in
           perceived network interruptions resulting in errors like{" "}
           <code>ERR_NETWORK_CHANGED</code> in Google Chrome.
         </ChangeItem>
-        <ChangeItem pull="11115">
+        <ChangeItem pull={11115}>
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.10" date={new Date("2025-12-04")}>
-        <ChangeItem pull="10986">
+        <ChangeItem pull={10986}>
           Fixes a minor race condition that could arise on sign out.
         </ChangeItem>
-        <ChangeItem pull="10855">
+        <ChangeItem pull={10855}>
           Fixes an issue on macOS where the <code>utun</code> index would
           auto-increment by itself on configuration updates.
         </ChangeItem>
-        <ChangeItem pull="10752">
+        <ChangeItem pull={10752}>
           Fixes an issue where the reported client version was out of date.
         </ChangeItem>
-        <ChangeItem pull="10773">
+        <ChangeItem pull={10773}>
           Fixes an issue where the order of upstream / system DNS resolvers was
           not respected.
         </ChangeItem>
-        <ChangeItem pull="10824">
+        <ChangeItem pull={10824}>
           Adds support for <code>hideResourceList</code> managed configuration
           key to hide the Resource List in the macOS and iOS apps.
         </ChangeItem>
-        <ChangeItem pull="10914">
+        <ChangeItem pull={10914}>
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
-        <ChangeItem pull="10965">
+        <ChangeItem pull={10965}>
           Fixes an issue where some packets would get dropped under high
           throughput scenarios.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.9" date={new Date("2025-10-20")}>
-        <ChangeItem pull="10603">
+        <ChangeItem pull={10603}>
           Fixes an issue on macOS where DNS resources might fail to be routed
           properly after many (150+) Firezone session restarts.
         </ChangeItem>
-        <ChangeItem pull="10509">
+        <ChangeItem pull={10509}>
           Fixes an issue where the Internet Resource could be briefly active on
           startup, despite it being disabled.
         </ChangeItem>
-        <ChangeItem pull="10533">
+        <ChangeItem pull={10533}>
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
-        <ChangeItem pull="10567">
+        <ChangeItem pull={10567}>
           Fixes an issue where the Resources menu would not populate when
           launching the app while already connected.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.8" date={new Date("2025-09-10")}>
-        <ChangeItem pull="10313">
+        <ChangeItem pull={10313}>
           Fixes an issue where multiple concurrent Firezone macOS clients could
           run simultaneously. We now enforce a single instance of the client.
         </ChangeItem>
-        <ChangeItem pull="10224">
+        <ChangeItem pull={10224}>
           Fixes a minor DNS cache bug where newly-added DNS resources may not
           resolve for a few seconds after showing up in the Resource List.
         </ChangeItem>
-        <ChangeItem pull="10104">
+        <ChangeItem pull={10104}>
           {
             "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.7" date={new Date("2025-08-07")}>
-        <ChangeItem pull="10143">
+        <ChangeItem pull={10143}>
           Fixes an issue on iOS 17 and below that caused the tunnel to crash
           after signing in. This was due to a change in how newer versions of
           Xcode handle linking against referenced libraries. iOS 18 and higher
@@ -211,97 +211,97 @@ export default function Apple() {
         </ChangeItem>
       </Entry>
       <Entry version="1.5.6" date={new Date("2025-08-02")}>
-        <ChangeItem pull="10075">
+        <ChangeItem pull={10075}>
           Fixes an issue on iOS where the tunnel may never fully come up after
           signing in due to a network connectivity reset loop.
         </ChangeItem>
-        <ChangeItem pull="10056">
+        <ChangeItem pull={10056}>
           Fixes an issue where connectivity could be lost for up to 20 seconds
           after waking from sleep.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.5" date={new Date("2025-07-28")}>
-        <ChangeItem pull="10022">
+        <ChangeItem pull={10022}>
           Fixes a bug on iOS where network connectivity changes (such as from
           WiFi to cellular) may result in the wrong default system DNS resolvers
           being read, which could prevent DNS resources from working correctly.
         </ChangeItem>
-        <ChangeItem pull="10019">
+        <ChangeItem pull={10019}>
           Fixes an issue on recent versions of iOS where the export logs sheet
           would open and then immediately close.
         </ChangeItem>
-        <ChangeItem pull="9991">
+        <ChangeItem pull={9991}>
           Fixes an issue where only the first system DNS resolver was used to
           forward queries instead of all found ones.
         </ChangeItem>
-        <ChangeItem pull="9985">
+        <ChangeItem pull={9985}>
           Fixes an issue where control plane messages could be stuck forever on
           flaky connections, requiring signing out and back in to recover.
         </ChangeItem>
-        <ChangeItem pull="9993">
+        <ChangeItem pull={9993}>
           Fixes an issue where DNS resolvers could be lost upon waking from
           sleep, leading to broken Internet connectivity.
         </ChangeItem>
-        <ChangeItem pull="9891">
+        <ChangeItem pull={9891}>
           Fixes an issue where connections would sometimes take up to 90s to
           establish.
         </ChangeItem>
-        <ChangeItem pull="9979">
+        <ChangeItem pull={9979}>
           Fixes an issue where connections in low-latency networks (between
           Client and Gateway) would fail to establish reliably.
         </ChangeItem>
-        <ChangeItem pull="9999">
+        <ChangeItem pull={9999}>
           Decreases connection setup time on flaky Internet connections in
           certain edge cases.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.4" date={new Date("2025-07-11")}>
-        <ChangeItem pull="9597">
+        <ChangeItem pull={9597}>
           Fixes an issue where certain log files would not be recreated after
           logs were cleared.
         </ChangeItem>
-        <ChangeItem pull="9536">
+        <ChangeItem pull={9536}>
           Uses <code>.zip</code> to compress logs instead of Apple Archive.
         </ChangeItem>
-        <ChangeItem pull="9725">
+        <ChangeItem pull={9725}>
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.3" date={new Date("2025-06-19")}>
-        <ChangeItem pull="9564">
+        <ChangeItem pull={9564}>
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.2" date={new Date("2025-06-03")}>
-        <ChangeItem pull="9300">
+        <ChangeItem pull={9300}>
           Uses the new IP stack setting for DNS resources, which allows DNS
           resources to optionally return only A or AAAA records if configured by
           the administrator.
         </ChangeItem>
-        <ChangeItem pull="9366">
+        <ChangeItem pull={9366}>
           Fixes an issue where Firezone could not start if the operating system
           refused our request to increase the UDP socket buffer sizes.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.1" date={new Date("2025-06-01")}>
-        <ChangeItem pull="9308">
+        <ChangeItem pull={9308}>
           Fixes an issue where the network extension could crash when viewing
           the diagnostic logs pane in app settings.
         </ChangeItem>
-        <ChangeItem pull="9308">
+        <ChangeItem pull={9308}>
           Fixes a minor issue where the network extension process could crash
           when signing out.
         </ChangeItem>
-        <ChangeItem pull="9242">
+        <ChangeItem pull={9242}>
           Fixes a rare bug that could prevent certain IPv6 DNS upstream
           resolvers from being used if they contained an interface scope
           specifier.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.0" date={new Date("2025-05-26")}>
-        <ChangeItem pull="9230">
+        <ChangeItem pull={9230}>
           Finalizes the managed configuration support for the macOS client. For
           details on how to configure this, see{" "}
           <Link
@@ -312,13 +312,13 @@ export default function Apple() {
           </Link>
           .
         </ChangeItem>
-        <ChangeItem pull="9231">
+        <ChangeItem pull={9231}>
           Fixes a minor bug where the app would report a minor error in the
           backend when quitting while signed out.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.15" date={new Date("2025-05-23")}>
-        <ChangeItem pull="9204">
+        <ChangeItem pull={9204}>
           Adds a
           <Link
             href={
@@ -331,170 +331,170 @@ export default function Apple() {
           for easily generating managed configuration files for the macOS app
           using the iMazing Profile Editor.
         </ChangeItem>
-        <ChangeItem pull="9196">
+        <ChangeItem pull={9196}>
           Adds managed configuration support for the macOS application. This
           allows applying using your MDM provider to configure the app on
           managed devices using <code>mobileconfig</code> files.
         </ChangeItem>
-        <ChangeItem pull="9168">
+        <ChangeItem pull={9168}>
           Adds a &quot;Connect on start&quot; setting, and another &quot;Start
           on login&quot; setting specific to just the macOS app.
         </ChangeItem>
-        <ChangeItem pull="9167">
+        <ChangeItem pull={9167}>
           Disables update checking and notifications for the App Store variant
           of the macOS client.
         </ChangeItem>
-        <ChangeItem pull="9119">
+        <ChangeItem pull={9119}>
           Automatically saves the account slug after the first sign in, and adds
           a new
           <code>General</code> tab in Settings to allow updating it.
         </ChangeItem>
-        <ChangeItem pull="9014">
+        <ChangeItem pull={9014}>
           Fixes an issue where idle connections would be slow (~60s) in
           detecting changes to network connectivity.
         </ChangeItem>
-        <ChangeItem pull="9018">
+        <ChangeItem pull={9018}>
           Further improves performance of relayed connections on IPv4-only
           systems.
         </ChangeItem>
-        <ChangeItem pull="9093">
+        <ChangeItem pull={9093}>
           Fixes a rare panic when the DNS servers on the system would change
           while Firezone is connected.
         </ChangeItem>
-        <ChangeItem pull="9147">
+        <ChangeItem pull={9147}>
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.14" date={new Date("2025-05-02")}>
-        <ChangeItem pull="9005">
+        <ChangeItem pull={9005}>
           Fixes an issue where the IP checksum was not updated when ECN bits
           were set. This caused packet loss on recent MacOS versions which
           default to using ECN.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.13" date={new Date("2025-04-30")}>
-        <ChangeItem pull="8731">
+        <ChangeItem pull={8731}>
           Improves throughput performance by requesting socket receive buffers
           of 10MB. The actual size of the buffers is capped by the operating
           system. You may need to adjust <code>kern.ipc.maxsockbuf</code> for
           this to take full effect.
         </ChangeItem>
-        <ChangeItem pull="8920">
+        <ChangeItem pull={8920}>
           Improves connection reliability by maintaining the order of IP packets
           across GSO batches.
         </ChangeItem>
-        <ChangeItem pull="8926">
+        <ChangeItem pull={8926}>
           Rolls over to a new log-file as soon as logs are cleared.
         </ChangeItem>
-        <ChangeItem pull="8935">
+        <ChangeItem pull={8935}>
           Improves reliability for upload-intensive connections with many
           concurrent DNS queries.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.12" date={new Date("2025-04-21")}>
-        <ChangeItem pull="8798">
+        <ChangeItem pull={8798}>
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.11" date={new Date("2025-04-18")}>
-        <ChangeItem pull="8814">
+        <ChangeItem pull={8814}>
           Fixes an issue where the app would hang on launch if another VPN app
           was connected.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.10" date={new Date("2025-04-17")}>
-        <ChangeItem pull="8795">
+        <ChangeItem pull={8795}>
           Publishes an installer package for macOS in addition to the DMG file.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.9" date={new Date("2025-04-15")}>
-        <ChangeItem pull="7590">
+        <ChangeItem pull={7590}>
           Improves performance by moving UDP sockets to a dedicated thread.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.8" date={new Date("2025-03-21")}>
-        <ChangeItem pull="8477">
+        <ChangeItem pull={8477}>
           Fixes an issue where the app would not auto-connect on launch.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.7" date={new Date("2025-03-14")}>
-        <ChangeItem pull="8421">
+        <ChangeItem pull={8421}>
           Applies the search domain configured in the admin portal, if any.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.6" date={new Date("2025-03-11")}>
-        <ChangeItem pull="8282">
+        <ChangeItem pull={8282}>
           Shows friendlier and more-human alert messages when something goes
           wrong.
         </ChangeItem>
-        <ChangeItem pull="8286">
+        <ChangeItem pull={8286}>
           Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.5" date={new Date("2025-02-24")}>
-        <ChangeItem pull="8251">
+        <ChangeItem pull={8251}>
           Fixes an issue where the update checker would not properly notify the
           user about new updates available on macOS.
         </ChangeItem>
-        <ChangeItem pull="8248">
+        <ChangeItem pull={8248}>
           Fixes a crash on macOS that could occur when an application update
           become available.
         </ChangeItem>
-        <ChangeItem pull="8249">
+        <ChangeItem pull={8249}>
           Fixes a regression that caused a crash if &quot;Open menu&quot; was
           clicked in the Welcome screen.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.4" date={new Date("2025-02-24")}>
-        <ChangeItem pull="8202">
+        <ChangeItem pull={8202}>
           Fixes a crash that occurred if the system reports invalid DNS servers.
         </ChangeItem>
-        <ChangeItem pull="8237">
+        <ChangeItem pull={8237}>
           Fixes a minor memory leak that would occur each time you sign in.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-02-16")}>
-        <ChangeItem pull="8122">
+        <ChangeItem pull={8122}>
           Fixes a rare crash that could occur when dismissing the update
           available notification.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.2" date={new Date("2025-02-13")}>
-        <ChangeItem pull="8104">
+        <ChangeItem pull={8104}>
           Fixes a minor memory leak that could occur after being unexpectedly
           disconnected.
         </ChangeItem>
-        <ChangeItem pull="8091">
+        <ChangeItem pull={8091}>
           Fixes a bug that prevented exporting logs from the macOS app more than
           once.
         </ChangeItem>
-        <ChangeItem pull="8090">
+        <ChangeItem pull={8090}>
           Improves app launch time by asynchronously loading icons upon app
           launch.
         </ChangeItem>
-        <ChangeItem pull="8066">
+        <ChangeItem pull={8066}>
           Improves MenuBar list responsiveness on macOS.
         </ChangeItem>
-        <ChangeItem pull="8064">
+        <ChangeItem pull={8064}>
           Fixes a bug that might cause the UI process to crash when the Resource
           list is updated.
         </ChangeItem>
-        <ChangeItem pull="7996">
+        <ChangeItem pull={7996}>
           No longer shows an error dialog if the sign in process is canceled.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.1" date={new Date("2025-01-29")}>
         <ChangeItem>Fixes a few minor UI hangs.</ChangeItem>
-        <ChangeItem pull="7890">
+        <ChangeItem pull={7890}>
           Fixes a minor memory leak that occurred when roaming networks.
         </ChangeItem>
-        <ChangeItem pull="8091">
+        <ChangeItem pull={8091}>
           Fixes a bug that prevented exporting logs from the macOS app more than
           once.
         </ChangeItem>
-        <ChangeItem pull="7891">
+        <ChangeItem pull={7891}>
           Substantially reduces the amount of memory usage when sending large
           amount of data to many different Gateways.
         </ChangeItem>
@@ -505,25 +505,25 @@ export default function Apple() {
         </ChangeItem>
       </Entry>
       <Entry version="1.4.0" date={new Date("2025-01-16")}>
-        <ChangeItem pull="7581">
+        <ChangeItem pull={7581}>
           Adds download links and CI configuration to publish the macOS app as a
           standalone package.
         </ChangeItem>
-        <ChangeItem pull="7344">
+        <ChangeItem pull={7344}>
           The macOS app now uses a System Extension instead of an App Extension
           for tunneling. This is needed for the app to be distributed outside of
           the Mac App Store.
         </ChangeItem>
-        <ChangeItem pull="7594">
+        <ChangeItem pull={7594}>
           Fixes a race condition that could cause the app to crash in rare
           circumstances if the VPN profile is removed from system settings while
           the app is running.
         </ChangeItem>
-        <ChangeItem pull="7593">
+        <ChangeItem pull={7593}>
           Fixes a bug where the VPN status would not properly update upon the
           first launch of the app.
         </ChangeItem>
-        <ChangeItem pull="7334">
+        <ChangeItem pull={7334}>
           Fixes an issue where certain NAT types would cause excessive signaling
           traffic which led to connectivity issues.
         </ChangeItem>
@@ -531,72 +531,72 @@ export default function Apple() {
           Makes use of the new control protocol, delivering faster and more
           robust connection establishment.
         </ChangeItem>
-        <ChangeItem pull="7477">
+        <ChangeItem pull={7477}>
           Improves connection setup latency by buffering initial packets.
         </ChangeItem>
-        <ChangeItem pull="7551">
+        <ChangeItem pull={7551}>
           Fixes an issue where large DNS responses were incorrectly discarded.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.9" date={new Date("2024-11-08")}>
-        <ChangeItem pull="7288">
+        <ChangeItem pull={7288}>
           Fixes an issue where network roaming would cause Firezone to become
           unresponsive.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.8" date={new Date("2024-11-05")}>
-        <ChangeItem pull="7263">
+        <ChangeItem pull={7263}>
           Mitigates a crash in case the maximum packet size is not respected.
         </ChangeItem>
-        <ChangeItem pull="7265">
+        <ChangeItem pull={7265}>
           Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.7" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
-        <ChangeItem pull="7152">
+        <ChangeItem pull={7152}>
           Adds always-on error reporting using sentry.io.
         </ChangeItem>
-        <ChangeItem pull="7164">
+        <ChangeItem pull={7164}>
           Fixes an issue where Firezone would fail to establish connections to
           Gateways and the user had to sign-out and in again.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.6" date={new Date("2024-10-02")}>
-        <ChangeItem pull="6831">
+        <ChangeItem pull={6831}>
           {
             "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
           }
         </ChangeItem>
-        <ChangeItem pull="6845">
+        <ChangeItem pull={6845}>
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
         </ChangeItem>
-        <ChangeItem pull="6857">
+        <ChangeItem pull={6857}>
           {"MacOS: sends hardware's UUID for device verification."}
         </ChangeItem>
-        <ChangeItem pull="6857">
+        <ChangeItem pull={6857}>
           iOS: sends Id for vendor for device verification.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.5" date={new Date("2024-09-26")}>
-        <ChangeItem pull="6809">
+        <ChangeItem pull={6809}>
           Fixes a bug where non-wildcard DNS resources were not prioritised over
           wildcard ones (e.g. <code>app.example.com</code> vs{" "}
           <code>*.example.com</code>).
         </ChangeItem>
       </Entry>
       <Entry version="1.3.4" date={new Date("2024-09-25")}>
-        <ChangeItem pull="6788">
+        <ChangeItem pull={6788}>
           Fixes an issue where some browsers may fail to route DNS Resources
           correctly.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-19")}>
-        <ChangeItem pull="6765">
+        <ChangeItem pull={6765}>
           Fixes a bug where DNS PTR queries by the system did not get answered.
         </ChangeItem>
-        <ChangeItem pull="6722">
+        <ChangeItem pull={6722}>
           Fixes a routing bug when one of several overlapping CIDR resources
           gets disabled / removed.
         </ChangeItem>
@@ -606,64 +606,64 @@ export default function Apple() {
         </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-18")}>
-        <ChangeItem pull="6632">
+        <ChangeItem pull={6632}>
           {
             "(macOS) Fixes a bug where the addressDescription wasn't fully displayed in the macOS menu bar if it exceeded a certain length."
           }
         </ChangeItem>
-        <ChangeItem pull="6679">
+        <ChangeItem pull={6679}>
           (macOS) Displays a notification when a new version is available.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ChangeItem pull="6521">
+        <ChangeItem pull={6521}>
           {
             "Gracefully handles cases where the device's local interface IPv4/IPv6 address or local network gateway changes while the client is connected."
           }
         </ChangeItem>
-        <ChangeItem pull="6518">
+        <ChangeItem pull={6518}>
           Minor improvements to the look of the internet resource and makes the
           Internet resource off by default.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
+        <ChangeItem pull={6434}>Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.1" date={new Date("2024-08-22")}>
-        <ChangeItem pull="6406">
+        <ChangeItem pull={6406}>
           Shows the Git SHA corresponding to the build on the Settings -&gt;
           Advanced screen.
         </ChangeItem>
-        <ChangeItem pull="6424">
+        <ChangeItem pull={6424}>
           Fixes a bug where packets would be lost when a connection is first
           established to a Gateway due to routes being updated with no actual
           change.
         </ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ChangeItem pull="5901">
+        <ChangeItem pull={5901}>
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
-        <ChangeItem pull="6186">
+        <ChangeItem pull={6186}>
           Adds the ability to mark Resources as favorites.
         </ChangeItem>
-        <ChangeItem pull="6361">
+        <ChangeItem pull={6361}>
           {
             "Connections to Gateways are now sticky for the duration of the Client's session. This fixes potential issues maintaining long-lived TCP connections to Gateways in a high-availability setup."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-13")}>
-        <ChangeItem pull="6276">
+        <ChangeItem pull={6276}>
           Fixes a bug where relayed connections failed to establish after an
           idle period.
         </ChangeItem>
-        <ChangeItem pull="6277">
+        <ChangeItem pull={6277}>
           Fixes a bug where restrictive NATs caused connectivity problems.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-08-10")}>
-        <ChangeItem pull="6181">
+        <ChangeItem pull={6181}>
           Improves reliability of DNS resolution of non-resources.
         </ChangeItem>
       </Entry>

--- a/website/src/components/Changelog/ChangeItem.tsx
+++ b/website/src/components/Changelog/ChangeItem.tsx
@@ -4,7 +4,7 @@ export default function ChangeItem({
   pull,
   children,
 }: {
-  pull?: string;
+  pull?: number;
   children: React.ReactNode;
 }) {
   return (

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -12,71 +12,71 @@ export default function GUI({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased></Unreleased>
       <Entry version="1.5.11" date={new Date("2026-03-16")}>
-        <ChangeItem pull="12355">
+        <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.
         </ChangeItem>
-        <ChangeItem pull="12251">
+        <ChangeItem pull={12251}>
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="12111">
+        <ChangeItem pull={12111}>
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>
-        <ChangeItem pull="11779">
+        <ChangeItem pull={11779}>
           Notifies the user when a connection to a resource cannot be
           established.
         </ChangeItem>
-        <ChangeItem pull="12248">
+        <ChangeItem pull={12248}>
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
-        <ChangeItem pull="12322">
+        <ChangeItem pull={12322}>
           Fixes an issue where the WebSocket connection to the control plane was
           lost under load.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.10" date={new Date("2026-02-02")}>
-        <ChangeItem pull="11625">
+        <ChangeItem pull={11625}>
           Fails faster when the initial connection to the control plane cannot
           be established, allowing the user to retry sooner.
         </ChangeItem>
-        <ChangeItem pull="11584">
+        <ChangeItem pull={11584}>
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.
         </ChangeItem>
-        <ChangeItem pull="11627">
+        <ChangeItem pull={11627}>
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
-        <ChangeItem pull="11626">
+        <ChangeItem pull={11626}>
           Fixes an issue where reconnecting to the portal would fail if the DNS
           resolver list was empty due to a network reset or other edge case.
         </ChangeItem>
-        <ChangeItem pull="11595">
+        <ChangeItem pull={11595}>
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.
         </ChangeItem>
-        <ChangeItem pull="11594">
+        <ChangeItem pull={11594}>
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
-        <ChangeItem pull="11654">
+        <ChangeItem pull={11654}>
           Implements retry with exponential backoff for anything but 401
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
-        <ChangeItem pull="11804">
+        <ChangeItem pull={11804}>
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
         {os == OS.Linux && (
-          <ChangeItem pull="11813">
+          <ChangeItem pull={11813}>
             Fixes an issue where notifications would not always be displayed.
           </ChangeItem>
         )}
-        <ChangeItem pull="11891">
+        <ChangeItem pull={11891}>
           Fixes an issue where cached IPv6 addresses for a resource got returned
           for IPv4-only DNS resources if the setting was only changed after a
           DNS query had already been processed.
@@ -84,30 +84,30 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.5.9" date={new Date("2025-12-23")}>
         {os == OS.Linux && (
-          <ChangeItem pull="10742">
+          <ChangeItem pull={10742}>
             Fixes an issue where CIDR/IP resources whose routes conflict with
             the local network were not routable.
           </ChangeItem>
         )}
-        <ChangeItem pull="10773">
+        <ChangeItem pull={10773}>
           Fixes an issue where the order of upstream / system DNS resolvers was
           not respected.
         </ChangeItem>
         {os == OS.Linux && (
-          <ChangeItem pull="10849">
+          <ChangeItem pull={10849}>
             Fixes some rendering issues on Wayland-only systems.
           </ChangeItem>
         )}
-        <ChangeItem pull="10914">
+        <ChangeItem pull={10914}>
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
-        <ChangeItem pull="11115">
+        <ChangeItem pull={11115}>
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
         {os == OS.Linux && (
-          <ChangeItem pull="11243">
+          <ChangeItem pull={11243}>
             Fixes an issue where upgrading from version 1.5.8 on Fedora fails
             due to a bad scriptlet. To uninstall version 1.5.8, use{" "}
             <code>
@@ -117,115 +117,115 @@ export default function GUI({ os }: { os: OS }) {
         )}
       </Entry>
       <Entry version="1.5.8" date={new Date("2025-10-16")}>
-        <ChangeItem pull="10509">
+        <ChangeItem pull={10509}>
           Fixes an issue where the Internet Resource could be briefly active on
           startup, despite it being disabled.
         </ChangeItem>
-        <ChangeItem pull="10533">
+        <ChangeItem pull={10533}>
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
         {os == OS.Linux && (
-          <ChangeItem pull="10539">
+          <ChangeItem pull={10539}>
             Fixes an issue where the Tunnel Service was not running after a
             version upgrade.
           </ChangeItem>
         )}
         {os == OS.Linux && (
-          <ChangeItem pull="10554">
+          <ChangeItem pull={10554}>
             Fixes an issue where local LAN traffic was dropped when the Internet
             Resource was active.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.5.7" date={new Date("2025-09-10")}>
-        <ChangeItem pull="10104">
+        <ChangeItem pull={10104}>
           {
             "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.6" date={new Date("2025-07-28")}>
-        <ChangeItem pull="9985">
+        <ChangeItem pull={9985}>
           Fixes an issue where control plane messages could be stuck forever on
           flaky connections, requiring signing out and back in to recover.
         </ChangeItem>
-        <ChangeItem pull="9891">
+        <ChangeItem pull={9891}>
           Fixes an issue where connections would sometimes take up to 90s to
           establish.
         </ChangeItem>
-        <ChangeItem pull="9979">
+        <ChangeItem pull={9979}>
           Fixes an issue where connections in low-latency networks (between
           Client and Gateway) would fail to establish reliably.
         </ChangeItem>
-        <ChangeItem pull="9999">
+        <ChangeItem pull={9999}>
           Decreases connection setup time on flaky Internet connections in
           certain edge cases.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.5" date={new Date("2025-07-09")}>
-        <ChangeItem pull="9779">Fixes a rare crash during sign-in.</ChangeItem>
-        <ChangeItem pull="9725">
+        <ChangeItem pull={9779}>Fixes a rare crash during sign-in.</ChangeItem>
+        <ChangeItem pull={9725}>
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="9696">
+          <ChangeItem pull={9696}>
             Establishes connections quicker by narrowing the set of network
             changes we react to.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.5.4" date={new Date("2025-06-19")}>
-        <ChangeItem pull="9564">
+        <ChangeItem pull={9564}>
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.3" date={new Date("2025-06-16")}>
-        <ChangeItem pull="9537">
+        <ChangeItem pull={9537}>
           Fixes an issue that caused increased CPU and memory consumption.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.2" date={new Date("2025-06-12")}>
-        <ChangeItem pull="8160">
+        <ChangeItem pull={8160}>
           Moves network change listening to the tunnel service for improved
           reliability.
         </ChangeItem>
-        <ChangeItem pull="9505">
+        <ChangeItem pull={9505}>
           Fixes minor visual inconsistencies in the main app window.
         </ChangeItem>
-        <ChangeItem pull="9443">
+        <ChangeItem pull={9443}>
           Fixes an issue where log directives applied via MDM would not be
           applied on startup.
         </ChangeItem>
-        <ChangeItem pull="9445">
+        <ChangeItem pull={9445}>
           Fixes an issue where disabling the update checker via MDM would cause
           the Client to hang upon sign-in.
         </ChangeItem>
-        <ChangeItem pull="9477">
+        <ChangeItem pull={9477}>
           Fixes an issue where disabling &quot;connect on start&quot; would
           incorrectly show the Client as &quot;Signed in&quot; on the next
           launch.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.1" date={new Date("2025-06-05")}>
-        <ChangeItem pull="9418">
+        <ChangeItem pull={9418}>
           Fixes an issue where advanced settings were not saved and loaded
           properly across restarts of the Client.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.0" date={new Date("2025-06-05")}>
-        <ChangeItem pull="9300">
+        <ChangeItem pull={9300}>
           Uses the new IP stack setting for DNS resources, which allows DNS
           resources to optionally return only A or AAAA records if configured by
           the administrator.
         </ChangeItem>
-        <ChangeItem pull="9211">
+        <ChangeItem pull={9211}>
           Fixes an issue where changing the Advanced settings would reset the
           favourited resources.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="9203">
+          <ChangeItem pull={9203}>
             Allows managing certain settings via an MDM provider such as
             Microsoft Intune. For more details on how to do this, see the{" "}
             <Link
@@ -237,78 +237,78 @@ export default function GUI({ os }: { os: OS }) {
             .
           </ChangeItem>
         )}
-        <ChangeItem pull="9366">
+        <ChangeItem pull={9366}>
           Fixes an issue where Firezone could not start if the operating system
           refused our request to increase the UDP socket buffer sizes.
         </ChangeItem>
-        <ChangeItem pull="9381">
+        <ChangeItem pull={9381}>
           Introduces &quot;General&quot; settings, allowing the user to manage
           autostart behaviour as well as the to-be-used account slug.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
-        <ChangeItem pull="9147">
+        <ChangeItem pull={9147}>
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
-        <ChangeItem pull="9136">
+        <ChangeItem pull={9136}>
           Launching Firezone while it is already running while now re-activate
           the &quot;Welcome&quot; screen, allowing the user to sign in and out.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="9154">
+          <ChangeItem pull={9154}>
             Renames the background service from{" "}
             <code>FirezoneClientIpcService</code>
             to <code>FirezoneClientTunnelService</code>.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="9154">
+          <ChangeItem pull={9154}>
             Renames the systemd service from{" "}
             <code>firezone-client-ipc.service</code> to
             <code>firezone-client-tunnel.service</code>.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="9181">
+          <ChangeItem pull={9181}>
             Increases minimum supported CentOS version to 10.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="9213">
+          <ChangeItem pull={9213}>
             Adds the Client to the winget repository. You can install it via
             <code>winget install Firezone.Client.GUI</code>.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.13" date={new Date("2025-05-14")}>
-        <ChangeItem pull="9014">
+        <ChangeItem pull={9014}>
           Fixes an issue where idle connections would be slow (~60s) in
           detecting changes to network connectivity.
         </ChangeItem>
-        <ChangeItem pull="9018">
+        <ChangeItem pull={9018}>
           Further improves performance of relayed connections on IPv4-only
           systems.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="9021">
+          <ChangeItem pull={9021}>
             Optimizes network change detection.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="9112">
+          <ChangeItem pull={9112}>
             Fixes a rare crash that could occur if the tray menu cannot be
             initialised.
           </ChangeItem>
         )}
-        <ChangeItem pull="9093">
+        <ChangeItem pull={9093}>
           Fixes a rare panic when the DNS servers on the system would change
           while Firezone is connected.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.12" date={new Date("2025-04-30")}>
         {os === OS.Linux && (
-          <ChangeItem pull="8731">
+          <ChangeItem pull={8731}>
             Improves throughput performance by requesting socket receive buffers
             of 10MB. The actual size of the buffers is capped by the operating
             system. You may need to adjust <code>net.core.rmem_max</code> for
@@ -316,73 +316,73 @@ export default function GUI({ os }: { os: OS }) {
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="8731">
+          <ChangeItem pull={8731}>
             Improves throughput performance by requesting socket receive buffers
             of 10MB.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="8920">
+          <ChangeItem pull={8920}>
             Improves connection reliability by maintaining the order of IP
             packets across GSO batches.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="8920">
+          <ChangeItem pull={8920}>
             Improves connection reliability by maintaining the order of IP
             packets.
           </ChangeItem>
         )}
-        <ChangeItem pull="8926">
+        <ChangeItem pull={8926}>
           Rolls over to a new log-file as soon as logs are cleared.
         </ChangeItem>
-        <ChangeItem pull="8935">
+        <ChangeItem pull={8935}>
           Improves reliability for upload-intensive connections with many
           concurrent DNS queries.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.11" date={new Date("2025-04-21")}>
-        <ChangeItem pull="8798">
+        <ChangeItem pull={8798}>
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.10" date={new Date("2025-04-15")}>
         {os === OS.Linux && (
-          <ChangeItem pull="8754">
+          <ChangeItem pull={8754}>
             Fixes a performance regression that could lead to packet drops under
             high load.
           </ChangeItem>
         )}
-        <ChangeItem pull="7590">
+        <ChangeItem pull={7590}>
           Improves performance by moving UDP sockets to a dedicated thread.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.9" date={new Date("2025-03-14")}>
         {os === OS.Windows && (
-          <ChangeItem pull="8422">
+          <ChangeItem pull={8422}>
             Applies the search domain configured in the admin portal, if any.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="8378">
+          <ChangeItem pull={8378}>
             Applies the search domain configured in the admin portal, if any.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.8" date={new Date("2025-03-10")}>
-        <ChangeItem pull="8286">
+        <ChangeItem pull={8286}>
           Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.7" date={new Date("2025-02-26")}>
         {os === OS.Linux && (
-          <ChangeItem pull="8219">
+          <ChangeItem pull={8219}>
             Configures the IPC service to log to journald.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="8268">
+          <ChangeItem pull={8268}>
             Fixes a hang that could occur after signing out which could prevent
             future sign ins and other actions, possibly with an{" "}
             <code>os error 231</code> code.
@@ -391,33 +391,33 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.4.6" date={new Date("2025-02-20")}>
         {os === OS.Linux && (
-          <ChangeItem pull="8117">
+          <ChangeItem pull={8117}>
             Fixes an upload speed performance regression.
           </ChangeItem>
         )}
-        <ChangeItem pull="8129">
+        <ChangeItem pull={8129}>
           Allows signing-in without access to the local keyring.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="8156">
+          <ChangeItem pull={8156}>
             Fixes a race condition that attempted to remove the WinTUN adapter
             twice upon shutdown.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.5" date={new Date("2025-02-12")}>
-        <ChangeItem pull="8105">
+        <ChangeItem pull={8105}>
           Fixes a visual regression where the Settings and About window lost
           their styling attributes.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.4" date={new Date("2025-02-11")}>
-        <ChangeItem pull="8035">
+        <ChangeItem pull={8035}>
           Shows a non-disruptive toast notification and quits the GUI client in
           case the IPC service gets shut down through the service manager.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="8083">
+          <ChangeItem pull={8083}>
             Fixes a regression introduced in 1.4.3 where Firezone would not work
             on systems with a disabled IPv6 stack.
           </ChangeItem>
@@ -425,42 +425,42 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-02-05")}>
         {os === OS.Windows && (
-          <ChangeItem pull="8003">
+          <ChangeItem pull={8003}>
             Removes dependency on <code>netsh</code>, making sign-in faster.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="7972">
+          <ChangeItem pull={7972}>
             Makes DNS configuration more resilient.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.2" date={new Date("2025-01-30")}>
         {os === OS.Windows && (
-          <ChangeItem pull="7912">
+          <ChangeItem pull={7912}>
             Fixes an issue where the tunnel device could not be created,
             resulting in an immediate sign-out after signing-in.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.1" date={new Date("2025-01-28")}>
-        <ChangeItem pull="7551">
+        <ChangeItem pull={7551}>
           Fixes an issue where large DNS responses were incorrectly discarded.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="7556">
+          <ChangeItem pull={7556}>
             Disables URO/GRO due to hardware / driver bugs.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="7822">
+          <ChangeItem pull={7822}>
             Makes the runtime dependency on <code>update-desktop-database</code>{" "}
             optional, thus improving compatibility on non-Ubuntu systems.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.0" date={new Date("2024-12-13")}>
-        <ChangeItem pull="7210">
+        <ChangeItem pull={7210}>
           Adds support for GSO (Generic Segmentation Offload), delivering
           throughput improvements of up to 60%.
         </ChangeItem>
@@ -469,67 +469,67 @@ export default function GUI({ os }: { os: OS }) {
           robust connection establishment.
         </ChangeItem>
         {os === OS.Linux && (
-          <ChangeItem pull="7449">
+          <ChangeItem pull={7449}>
             Uses multiple threads to read & write to the TUN device, greatly
             improving performance.
           </ChangeItem>
         )}
-        <ChangeItem pull="7477">
+        <ChangeItem pull={7477}>
           Improves connection setup latency by buffering initial packets.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.13" date={new Date("2024-11-15")}>
-        <ChangeItem pull="7334">
+        <ChangeItem pull={7334}>
           Fixes an issue where symmetric NATs would generate unnecessary
           candidate for hole-punching.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.12" date={new Date("2024-11-08")}>
-        <ChangeItem pull="7288">
+        <ChangeItem pull={7288}>
           Fixes an issue where network roaming would cause Firezone to become
           unresponsive.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.11" date={new Date("2024-11-05")}>
-        <ChangeItem pull="7263">
+        <ChangeItem pull={7263}>
           Mitigates a crash in case the maximum packet size is not respected.
         </ChangeItem>
-        <ChangeItem pull="7265">
+        <ChangeItem pull={7265}>
           Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.10" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="7009">
+          <ChangeItem pull={7009}>
             The IPC service <code>firezone-client-ipc.exe</code> is now signed.
           </ChangeItem>
         )}
-        <ChangeItem pull="7123">
+        <ChangeItem pull={7123}>
           Reports the version to the Portal correctly.
         </ChangeItem>
         {os === OS.Linux && (
-          <ChangeItem pull="6996">
+          <ChangeItem pull={6996}>
             Supports Ubuntu 24.04, no longer supports Ubuntu 20.04.
           </ChangeItem>
         )}
-        <ChangeItem pull="7164">
+        <ChangeItem pull={7164}>
           Fixes an issue where Firezone would fail to establish connections to
           Gateways and the user had to sign-out and in again.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.9" date={new Date("2024-10-09")}>
         {os === OS.Linux && (
-          <ChangeItem pull="6987">
+          <ChangeItem pull={6987}>
             Fixes a crash on startup caused by incorrect permissions on the ID
             file.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.3.8" date={new Date("2024-10-08")}>
-        <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
+        <ChangeItem pull={6874}>Fixes the GUI shutting down slowly.</ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="6931">
+          <ChangeItem pull={6931}>
             {"Mitigates an issue where "}
             <code>ipconfig</code>
             {
@@ -539,63 +539,63 @@ export default function GUI({ os }: { os: OS }) {
         )}
       </Entry>
       <Entry version="1.3.7" date={new Date("2024-10-02")}>
-        <ChangeItem pull="6831">
+        <ChangeItem pull={6831}>
           {
             "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
           }
         </ChangeItem>
-        <ChangeItem pull="6845">
+        <ChangeItem pull={6845}>
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
         </ChangeItem>
-        <ChangeItem pull="6782">
+        <ChangeItem pull={6782}>
           Adds always-on error reporting using sentry.io.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="6874">
+          <ChangeItem pull={6874}>
             Fixes a delay when closing the GUI.
           </ChangeItem>
         )}
-        <ChangeItem pull="6857">
+        <ChangeItem pull={6857}>
           {"Tries to send motherboard's hardware ID for device verification."}
         </ChangeItem>
       </Entry>
       <Entry version="1.3.6" date={new Date("2024-09-25")}>
-        <ChangeItem pull="6809">
+        <ChangeItem pull={6809}>
           Fixes a bug where non-wildcard DNS resources were not prioritised over
           wildcard ones (e.g. <code>app.example.com</code> vs{" "}
           <code>*.example.com</code>).
         </ChangeItem>
       </Entry>
       <Entry version="1.3.5" date={new Date("2024-09-25")}>
-        <ChangeItem pull="6788">
+        <ChangeItem pull={6788}>
           Fixes an issue where some browsers may fail to route DNS Resources
           correctly.
         </ChangeItem>
         {os === OS.Linux && (
-          <ChangeItem pull="6780">
+          <ChangeItem pull={6780}>
             {
               "Fixes a bug where the Linux Clients didn't work on ZFS filesystems."
             }
           </ChangeItem>
         )}
-        <ChangeItem pull="6795">
+        <ChangeItem pull={6795}>
           {
             'Fixes a bug where auto-sign-in with an expired token would cause a "Couldn\'t send Disconnect" error message.'
           }
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="6810">
+          <ChangeItem pull={6810}>
             Fixes a bug where roaming from Ethernet to WiFi would cause Firezone
             to fail to connect to the portal.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.3.4" date={new Date("2024-09-19")}>
-        <ChangeItem pull="6765">
+        <ChangeItem pull={6765}>
           Fixes a bug where DNS PTR queries by the system did not get answered.
         </ChangeItem>
-        <ChangeItem pull="6722">
+        <ChangeItem pull={6722}>
           Fixes a routing bug when one of several overlapping CIDR resources
           gets disabled / removed.
         </ChangeItem>
@@ -606,38 +606,38 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-13")}>
         {os === OS.Windows && (
-          <ChangeItem pull="6681">
+          <ChangeItem pull={6681}>
             Fixes a bug where sign-in fails if IPv6 is disabled.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-06")}>
-        <ChangeItem pull="6624">
+        <ChangeItem pull={6624}>
           Fixes a bug that took down the tunnel when internet resource was
           missing.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ChangeItem pull="6518">
+        <ChangeItem pull={6518}>
           Minor improvements to the look of the internet resource and makes the
           Internet resource off by default.
         </ChangeItem>
-        <ChangeItem pull="6584">
+        <ChangeItem pull={6584}>
           Prevents routing loops for some Windows installation when the Internet
           resource was on, taking down network connections.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
+        <ChangeItem pull={6434}>Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.2" date={new Date("2024-08-29")}>
-        <ChangeItem pull="6432">
+        <ChangeItem pull={6432}>
           Shows an orange dot on the tray icon when an update is ready to
           download.
         </ChangeItem>
-        <ChangeItem pull="6449">Checks for updates once a day</ChangeItem>
+        <ChangeItem pull={6449}>Checks for updates once a day</ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="6472">
+          <ChangeItem pull={6472}>
             {
               "Fixes an issue where Split DNS didn't work for domain-joined Windows machines"
             }
@@ -645,141 +645,141 @@ export default function GUI({ os }: { os: OS }) {
         )}
       </Entry>
       <Entry version="1.2.1" date={new Date("2024-08-27")}>
-        <ChangeItem pull="6414">
+        <ChangeItem pull={6414}>
           {
             "Waits for Internet to connect to Firezone if there's no Internet at startup and you're already signed in."
           }
         </ChangeItem>
-        <ChangeItem pull="6455">
+        <ChangeItem pull={6455}>
           Fixes a false positive warning log at startup about DNS interception
           being disabled.
         </ChangeItem>
-        <ChangeItem pull="6458">
+        <ChangeItem pull={6458}>
           Fixes a bug where we considered our own startup to be a network change
           event, which may interfere with access to DNS Resources.
         </ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ChangeItem pull="5901">
+        <ChangeItem pull={5901}>
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="6280">
+          <ChangeItem pull={6280}>
             Fixes a bug where the &quot;Clear Logs&quot; button did not clear
             the IPC service logs.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="6308">
+          <ChangeItem pull={6308}>
             Fixes a bug where the GUI could not run if the user is Administrator
           </ChangeItem>
         )}
-        <ChangeItem pull="6351">
+        <ChangeItem pull={6351}>
           The log filter on the IPC service is now reloaded immediately when you
           change the setting in the GUI.
         </ChangeItem>
-        <ChangeItem pull="6361">
+        <ChangeItem pull={6361}>
           {
             "Connections to Gateways are now sticky for the duration of the Client's session to fix issues with long-lived TCP connections."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.1.12" date={new Date("2024-08-13")}>
-        <ChangeItem pull="6226">
+        <ChangeItem pull={6226}>
           Fixes a bug where clearing the log files would delete the current
           logfile, preventing logs from being written.
         </ChangeItem>
-        <ChangeItem pull="6276">
+        <ChangeItem pull={6276}>
           Fixes a bug where relayed connections failed to establish after an
           idle period.
         </ChangeItem>
-        <ChangeItem pull="6277">
+        <ChangeItem pull={6277}>
           Fixes a bug where restrictive NATs caused connectivity problems.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.11" date={new Date("2024-08-09")}>
-        <ChangeItem pull="6233">
+        <ChangeItem pull={6233}>
           Fixes an issue where the IPC service can panic during DNS resolution.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.10" date={new Date("2024-08-08")}>
-        <ChangeItem pull="5923">
+        <ChangeItem pull={5923}>
           Adds the ability to mark Resources as favorites.
         </ChangeItem>
         {os === OS.Linux && (
-          <ChangeItem pull="6163">
+          <ChangeItem pull={6163}>
             Supports using <code>etc-resolv-conf</code> DNS control method, or
             disabling DNS control
           </ChangeItem>
         )}
-        <ChangeItem pull="6181">
+        <ChangeItem pull={6181}>
           Improves reliability of DNS resolution of non-resources.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="6163">Supports disabling DNS control</ChangeItem>
+          <ChangeItem pull={6163}>Supports disabling DNS control</ChangeItem>
         )}
-        <ChangeItem pull="6184">
+        <ChangeItem pull={6184}>
           Mitigates a bug where the IPC service can panic if an internal channel
           fills up
         </ChangeItem>
       </Entry>
       <Entry version="1.1.9" date={new Date("2024-08-02")}>
-        <ChangeItem pull="6143">
+        <ChangeItem pull={6143}>
           Fixes an issue where DNS queries could time out on some networks.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.8" date={new Date("2024-08-01")}>
         {os === OS.Linux && (
-          <ChangeItem pull="5978">Adds network roaming support.</ChangeItem>
+          <ChangeItem pull={5978}>Adds network roaming support.</ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="6051">
+          <ChangeItem pull={6051}>
             Fixes &quot;Element not found&quot; error when setting routes.
           </ChangeItem>
         )}
-        <ChangeItem pull="6017">
+        <ChangeItem pull={6017}>
           Removes keyboard accelerators, which were not working.
         </ChangeItem>
-        <ChangeItem pull="6071">
+        <ChangeItem pull={6071}>
           Puts angle brackets around hyperlinks in the menu.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.7" date={new Date("2024-07-17")}>
         {os === OS.Linux && (
-          <ChangeItem pull="5848">
+          <ChangeItem pull={5848}>
             Stops the GUI and prompts you to re-launch it if you update Firezone
             while the GUI is running.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="5375">
+          <ChangeItem pull={5375}>
             Improves sign-in speed and fixes a DNS leak
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.1.6" date={new Date("2024-07-12")}>
-        <ChangeItem pull="5795">
+        <ChangeItem pull={5795}>
           Unexpected IPC service stops are now reported as &quot;IPC connection
           closed&quot;.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="5827">
+          <ChangeItem pull={5827}>
             Fixes a bug where DNS could stop working when you sign out.
           </ChangeItem>
         )}
-        <ChangeItem pull="5817">
+        <ChangeItem pull={5817}>
           Shows different tray icons when signed out, signing in, and signed in.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-07-08")}>
         {os === OS.Linux && (
-          <ChangeItem pull="5793">
+          <ChangeItem pull={5793}>
             The Linux GUI Client is now built for both x86-64 and ARM64.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-07-05")}>
-        <ChangeItem pull="5700">
+        <ChangeItem pull={5700}>
           Fixes an issue where a stale DNS cache could prevent traffic from
           routing to DNS Resources if they were updated while the Client was
           signed in.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -20,7 +20,7 @@ export default function GUI({ os }: { os: OS }) {
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="#12111">
+        <ChangeItem pull="12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,102 +24,102 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased></Unreleased>
       <Entry version="1.5.1" date={new Date("2026-03-16")}>
-        <ChangeItem pull="12355">
+        <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.
         </ChangeItem>
-        <ChangeItem pull="12251">
+        <ChangeItem pull={12251}>
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="12134">
+        <ChangeItem pull={12134}>
           Fixes an issue where outdated and thus irrelevant candidates were sent
           to Clients, causing connectivity issues in rare situations.
         </ChangeItem>
-        <ChangeItem pull="12248">
+        <ChangeItem pull={12248}>
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
-        <ChangeItem pull="12322">
+        <ChangeItem pull={12322}>
           Fixes an issue where the WebSocket connection to the control plane was
           lost under load.
         </ChangeItem>
-        <ChangeItem pull="12504">
+        <ChangeItem pull={12504}>
           Greatly improves performance for cases where many Clients (100+) are
           connected to a single Gateway.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.0" date={new Date("2026-02-02")}>
-        <ChangeItem pull="11771">
+        <ChangeItem pull={11771}>
           BREAKING: Remove support for Firezone 1.3.x Clients and lower.
         </ChangeItem>
-        <ChangeItem pull="11770">
+        <ChangeItem pull={11770}>
           Enables detailed flow logs for tunneled TCP and UDP connections. Set
           `FIREZONE_FLOW_LOGS=true` or `--flow-logs` to enable.
         </ChangeItem>
-        <ChangeItem pull="11664">
+        <ChangeItem pull={11664}>
           Adds a <code>FIREZONE_MAX_PARTITION_TIME</code> environment variable
           to configure how long the Gateway will retry connecting to the portal
           before exiting. Accepts human-readable durations like <code>5m</code>,{" "}
           <code>1h</code>, or <code>30d</code>. Defaults to 24 hours.
         </ChangeItem>
-        <ChangeItem pull="11625">
+        <ChangeItem pull={11625}>
           Fails faster when the initial connection to the control plane cannot
           be established, allowing faster restarts by the process manager.
         </ChangeItem>
-        <ChangeItem pull="11584">
+        <ChangeItem pull={11584}>
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.
         </ChangeItem>
-        <ChangeItem pull="11627">
+        <ChangeItem pull={11627}>
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
-        <ChangeItem pull="11626">
+        <ChangeItem pull={11626}>
           Fixes an issue where reconnecting to the portal would fail if the DNS
           resolver list was empty due to a network reset or other edge case.
         </ChangeItem>
-        <ChangeItem pull="11595">
+        <ChangeItem pull={11595}>
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.
         </ChangeItem>
-        <ChangeItem pull="11594">
+        <ChangeItem pull={11594}>
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
-        <ChangeItem pull="11804">
+        <ChangeItem pull={11804}>
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.19" date={new Date("2025-12-23")}>
-        <ChangeItem pull="10972">
+        <ChangeItem pull={10972}>
           Fixes an issue where IPv6-only DNS resources could not be reached.
         </ChangeItem>
-        <ChangeItem pull="11115">
+        <ChangeItem pull={11115}>
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
-        <ChangeItem pull="11208">
+        <ChangeItem pull={11208}>
           Fixes an issue where the Gateway could reboot when the WebSocket
           connection to the portal got cut.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.18" date={new Date("2025-11-10")}>
-        <ChangeItem pull="10620">
+        <ChangeItem pull={10620}>
           Adds a `--log-format` CLI option to output logs as JSON.
         </ChangeItem>
-        <ChangeItem pull="10796">
+        <ChangeItem pull={10796}>
           Fixes an issue where packets for DNS resources would be routed to
           stale IPs after DNS record changes.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.17" date={new Date("2025-10-16")}>
-        <ChangeItem pull="10367">
+        <ChangeItem pull={10367}>
           Fixes a rare CPU-spike issue in case a Client connected with many
           possible IPv6 addresses.
         </ChangeItem>
-        <ChangeItem pull="10349">
+        <ChangeItem pull={10349}>
           Attempts to increase the system-wide parameters{" "}
           <code>core.rmem_max</code> to 128 MB and <code>core.wmem_max</code> to
           16 MB for improved performance. See the{" "}
@@ -131,184 +131,184 @@ export default function Gateway() {
           </Link>
           section for details.
         </ChangeItem>
-        <ChangeItem pull="10373">
+        <ChangeItem pull={10373}>
           Switches to user-space DNS resolution, allowing for accurate caching
           based on the TTL in the DNS response.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.16" date={new Date("2025-09-10")}>
-        <ChangeItem pull="10231">
+        <ChangeItem pull={10231}>
           Remove the FIREZONE_NUM_TUN_THREADS env variable. The Gateway will now
           always default to a single TUN thread. Using multiple threads can
           cause packet reordering which hurts TCP throughput performance.
         </ChangeItem>
-        <ChangeItem pull="10076">
+        <ChangeItem pull={10076}>
           Introduces graceful shutdown, allowing Clients to immediately switch
           over a new Gateway instead of waiting for the ICE timeout (~15s).
         </ChangeItem>
-        <ChangeItem pull="10310">
+        <ChangeItem pull={10310}>
           Fixes an issue where packets for DNS resources could get routed to the
           wrong address.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.15" date={new Date("2025-08-05")}>
-        <ChangeItem pull="10109">
+        <ChangeItem pull={10109}>
           Fixes an issue where connections would fail to establish in
           environments with a limited number of ports on the NAT.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.14" date={new Date("2025-07-28")}>
-        <ChangeItem pull="9986">
+        <ChangeItem pull={9986}>
           Fixes an issue where a Client could not establish a connection unless
           their first attempt succeeded.
         </ChangeItem>
-        <ChangeItem pull="9979">
+        <ChangeItem pull={9979}>
           Fixes an issue where connections in low-latency networks (between
           Client and Gateway) would fail to establish reliably.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.13" date={new Date("2025-07-22")}>
-        <ChangeItem pull="9834">
+        <ChangeItem pull={9834}>
           Excludes ICMP errors from the ICMP traffic filter. Those are now
           always routed back to the client.
         </ChangeItem>
-        <ChangeItem pull="9816">
+        <ChangeItem pull={9816}>
           Responds with ICMP errors for filtered packets.
         </ChangeItem>
-        <ChangeItem pull="9812">
+        <ChangeItem pull={9812}>
           Adds support for translating Time-Exceeded ICMP errors in the DNS
           resource NAT, allowing <code>tracepath</code> to work through a
           Firezone tunnel.
         </ChangeItem>
-        <ChangeItem pull="9891">
+        <ChangeItem pull={9891}>
           Fixes an issue where connections would sometimes take up to 90s to
           establish.
         </ChangeItem>
-        <ChangeItem pull="9896">
+        <ChangeItem pull={9896}>
           Fixes a potential security issue where prior resource authorizations
           would not get revoked if the Gateway was disconnected from the portal
           while access was removed.
         </ChangeItem>
-        <ChangeItem pull="9894">
+        <ChangeItem pull={9894}>
           Shuts down the Gateway after 15m of being disconnected from the
           portal.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.12" date={new Date("2025-06-30")}>
-        <ChangeItem pull="9657">
+        <ChangeItem pull={9657}>
           Fixes an issue where connections would fail to establish if the
           Gateway was under high load.
         </ChangeItem>
-        <ChangeItem pull="9725">
+        <ChangeItem pull={9725}>
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.
         </ChangeItem>
-        <ChangeItem pull="9655">
+        <ChangeItem pull={9655}>
           Allows long-lived TCP connections to remain open by increasing the NAT
           TTL to 2h.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.11" date={new Date("2025-06-19")}>
-        <ChangeItem pull="9564">
+        <ChangeItem pull={9564}>
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.10" date={new Date("2025-06-05")}>
-        <ChangeItem pull="9147">
+        <ChangeItem pull={9147}>
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
-        <ChangeItem pull="9366">
+        <ChangeItem pull={9366}>
           Fixes an issue where Firezone could not start if the operating system
           refused our request to increase the UDP socket buffer sizes.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.9" date={new Date("2025-05-14")}>
-        <ChangeItem pull="9059">
+        <ChangeItem pull={9059}>
           Fixes an issue where ICMP unreachable errors for large packets would
           not be sent.
         </ChangeItem>
-        <ChangeItem pull="9060">
+        <ChangeItem pull={9060}>
           {
             "Fixes an issue where service discovery for DNS resources would fail in case the Gateway's started up with no network connectivity."
           }
         </ChangeItem>
-        <ChangeItem pull="9088">
+        <ChangeItem pull={9088}>
           Fixes an issue where large batches of packets to the same Client got
           dropped under high load.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.8" date={new Date("2025-05-02")}>
-        <ChangeItem pull="9009">
+        <ChangeItem pull={9009}>
           Fixes an issue where ECN bits got erroneously cleared without updating
           the packet checksum. This caused packet loss on recent MacOS versions
           which attempt to use ECN.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.7" date={new Date("2025-04-30")}>
-        <ChangeItem pull="8798">
+        <ChangeItem pull={8798}>
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
-        <ChangeItem pull="8731">
+        <ChangeItem pull={8731}>
           Improves throughput performance by requesting socket receive buffers
           of 10MB. The actual size of the buffers is capped by the operating
           system. You may need to adjust <code>net.core.rmem_max</code> for this
           to take full effect.
         </ChangeItem>
-        <ChangeItem pull="8920">
+        <ChangeItem pull={8920}>
           Improves connection reliability by maintaining the order of IP packets
           across GSO batches.
         </ChangeItem>
-        <ChangeItem pull="8937">
+        <ChangeItem pull={8937}>
           Fixes an issue where connections to DNS resources which utilise
           round-robin DNS may be interrupted whenever the Client re-queried the
           DNS name.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
-        <ChangeItem pull="8383">
+        <ChangeItem pull={8383}>
           Deprecates the NAT64 functionality in favor of sending ICMP errors to
           hint to the calling application about which IP version to use.
         </ChangeItem>
-        <ChangeItem pull="8754">
+        <ChangeItem pull={8754}>
           Fixes a performance regression that could lead to packet drops under
           high load.
         </ChangeItem>
-        <ChangeItem pull="8765">
+        <ChangeItem pull={8765}>
           Improves performance on single-core systems by defaulting to only 1
           TUN thread if we have less than 4 cores.
         </ChangeItem>
-        <ChangeItem pull="7590">
+        <ChangeItem pull={7590}>
           Improves performance by moving UDP sockets to a dedicated thread.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.5" date={new Date("2025-03-10")}>
-        <ChangeItem pull="8124">
+        <ChangeItem pull={8124}>
           Fixes a bug in the routing of DNS resources that would lead to
           &quot;Source not allowed&quot; errors in the Client logs.
         </ChangeItem>
-        <ChangeItem pull="8225">
+        <ChangeItem pull={8225}>
           Caches successful DNS queries for DNS resource domains for 30 seconds.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.4" date={new Date("2025-02-11")}>
-        <ChangeItem pull="7944">
+        <ChangeItem pull={7944}>
           Fixes an edge case where a busy Gateway could experience a deadlock
           due to a busy or unresponsive TUN device.
         </ChangeItem>
-        <ChangeItem pull="8070">
+        <ChangeItem pull={8070}>
           Only write logs using ANSI-escape codes if the underlying output
           stream supports it.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-01-28")}>
-        <ChangeItem pull="7567">
+        <ChangeItem pull={7567}>
           {
             "Fixes an issue where ICMPv6's 'PacketTooBig' errors were not correctly translated by the NAT64 module."
           }
         </ChangeItem>
-        <ChangeItem pull="7565">
+        <ChangeItem pull={7565}>
           Fails early in case the binary is not started as <code>root</code> or
           with the
           <code>CAP_NET_ADMIN</code> capability. The check can be skipped with
@@ -316,92 +316,92 @@ export default function Gateway() {
         </ChangeItem>
       </Entry>
       <Entry version="1.4.2" date={new Date("2024-12-13")}>
-        <ChangeItem pull="7210">
+        <ChangeItem pull={7210}>
           Adds support for GSO (Generic Segmentation Offload), delivering
           throughput improvements of up to 60%.
         </ChangeItem>
-        <ChangeItem pull="7398">
+        <ChangeItem pull={7398}>
           Fixes cases where client applications such as ssh would fail to
           automatically determine the correct IP protocol version to use (4/6).
         </ChangeItem>
-        <ChangeItem pull="7449">
+        <ChangeItem pull={7449}>
           Uses multiple threads to read & write to the TUN device, greatly
           improving performance. The number of threads can be controlled with
           <code>FIREZONE_NUM_TUN_THREADS</code> and defaults to 2.
         </ChangeItem>
-        <ChangeItem pull="7479">
+        <ChangeItem pull={7479}>
           Fixes an issue where SSH connections involving NAT64 failed to
           establish.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.1" date={new Date("2024-11-15")}>
-        <ChangeItem pull="7263">
+        <ChangeItem pull={7263}>
           Mitigates a crash in case the maximum packet size is not respected.
         </ChangeItem>
-        <ChangeItem pull="7334">
+        <ChangeItem pull={7334}>
           Fixes an issue where symmetric NATs would generate unnecessary
           candidate for hole-punching.
         </ChangeItem>
-        <ChangeItem pull="7120">
+        <ChangeItem pull={7120}>
           Silences several unnecessary warnings from the WireGuard library.
         </ChangeItem>
-        <ChangeItem pull="7341">
+        <ChangeItem pull={7341}>
           Disconnects from non-compliant TURN servers.
         </ChangeItem>
-        <ChangeItem pull="7342">
+        <ChangeItem pull={7342}>
           Fixes a packet drop issue under high-load.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.0" date={new Date("2024-11-04")}>
-        <ChangeItem pull="6960">
+        <ChangeItem pull={6960}>
           Separates traffic restrictions between DNS Resources CIDR Resources,
           preventing them from interfering with each other.
         </ChangeItem>
-        <ChangeItem pull="6941">
+        <ChangeItem pull={6941}>
           Implements support for the new control protocol, delivering faster and
           more robust connection establishment.
         </ChangeItem>
-        <ChangeItem pull="7103">
+        <ChangeItem pull={7103}>
           Adds on-by-default error reporting using sentry.io. Disable by setting
           <code>FIREZONE_NO_TELEMETRY=true</code>.
         </ChangeItem>
-        <ChangeItem pull="7164">
+        <ChangeItem pull={7164}>
           Fixes an issue where the Gateway would fail to accept connections and
           had to be restarted.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-10-02")}>
-        <ChangeItem pull="6733">
+        <ChangeItem pull={6733}>
           {
             "Reduces log level of the \"Couldn't find connection by IP\" message so that it doesn't log each time a client disconnects."
           }
         </ChangeItem>
-        <ChangeItem pull="6845">
+        <ChangeItem pull={6845}>
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ChangeItem pull="6563">
+        <ChangeItem pull={6563}>
           Removes unnecessary packet buffers for a minor performance increase.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ChangeItem pull="6434">
+        <ChangeItem pull={6434}>
           Adds support for routing the Internet Resource for Clients.
         </ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ChangeItem pull="5901">
+        <ChangeItem pull={5901}>
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-13")}>
-        <ChangeItem pull="6276">
+        <ChangeItem pull={6276}>
           Fixes a bug where relayed connections failed to establish after an
           idle period.
         </ChangeItem>
-        <ChangeItem pull="6277">
+        <ChangeItem pull={6277}>
           Fixes a bug where restrictive NATs caused connectivity problems.
         </ChangeItem>
       </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,194 +11,194 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased></Unreleased>
       <Entry version="1.5.7" date={new Date("2026-03-16")}>
-        <ChangeItem pull="12355">
+        <ChangeItem pull={12355}>
           Reduces CPU overhead by processing up to 16 UDP datagram batches at a
           time.
         </ChangeItem>
-        <ChangeItem pull="12251">
+        <ChangeItem pull={12251}>
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="12111">
+        <ChangeItem pull={12111}>
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>
-        <ChangeItem pull="11882">
+        <ChangeItem pull={11882}>
           Adds the <code>sign-in</code> and <code>sign-out</code> commands to
           allow authenticating the Client as a normal user via browser-based
           authentication.
         </ChangeItem>
-        <ChangeItem pull="11625">
+        <ChangeItem pull={11625}>
           Fails faster when the initial connection to the control plane cannot
           be established, allowing the user to retry sooner.
         </ChangeItem>
-        <ChangeItem pull="11584">
+        <ChangeItem pull={11584}>
           Improves connection reliability on systems where certain UDP socket
           features are unavailable.
         </ChangeItem>
-        <ChangeItem pull="11654">
+        <ChangeItem pull={11654}>
           Implements retry with exponential backoff for anything but 401
           responses. For example, this allows Firezone to automatically sign-in
           even if Internet Access is gated by a captive portal.
         </ChangeItem>
-        <ChangeItem pull="11891">
+        <ChangeItem pull={11891}>
           Fixes an issue where cached IPv6 addresses for a resource got returned
           for IPv4-only DNS resources if the setting was only changed after a
           DNS query had already been processed.
         </ChangeItem>
-        <ChangeItem pull="12248">
+        <ChangeItem pull={12248}>
           Re-establishes the WebSocket connection to the control plane if it
           becomes unresponsive.
         </ChangeItem>
-        <ChangeItem pull="12322">
+        <ChangeItem pull={12322}>
           Fixes an issue where the WebSocket connection to the control plane was
           lost under load.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.6" date={new Date("2026-01-06")}>
-        <ChangeItem pull="11627">
+        <ChangeItem pull={11627}>
           Fixes an issue where reconnections would fail if the portal host is an
           IP address.
         </ChangeItem>
-        <ChangeItem pull="11626">
+        <ChangeItem pull={11626}>
           Fixes an issue where reconnecting to the portal would fail if the DNS
           resolver list was empty due to a network reset or other edge case.
         </ChangeItem>
-        <ChangeItem pull="11595">
+        <ChangeItem pull={11595}>
           Passes the authentication token in the x-authorization header instead
           of in the URL, improving rate limiting for users behind shared IPs.
         </ChangeItem>
-        <ChangeItem pull="11594">
+        <ChangeItem pull={11594}>
           Implements retry with exponential backoff on 429 (Too Many Requests)
           responses from the portal.
         </ChangeItem>
-        <ChangeItem pull="11804">
+        <ChangeItem pull={11804}>
           Fixes an issue where connections would flap between relayed and
           direct, causing WireGuard connection timeouts.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.5" date={new Date("2025-12-23")}>
         {os == OS.Linux && (
-          <ChangeItem pull="10742">
+          <ChangeItem pull={10742}>
             Fixes an issue where CIDR/IP resources whose routes conflict with
             the local network were not routable.
           </ChangeItem>
         )}
-        <ChangeItem pull="10773">
+        <ChangeItem pull={10773}>
           Fixes an issue where the order of upstream / system DNS resolvers was
           not respected.
         </ChangeItem>
-        <ChangeItem pull="10914">
+        <ChangeItem pull={10914}>
           Fixes an issue where concurrent DNS queries with the same ID would be
           dropped.
         </ChangeItem>
-        <ChangeItem pull="11115">
+        <ChangeItem pull={11115}>
           Fixes an issue where Firezone would not connect if an IPv6 interface
           is present but not routable.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.4" date={new Date("2025-10-16")}>
-        <ChangeItem pull="10533">
+        <ChangeItem pull={10533}>
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
-        <ChangeItem pull="10553">
+        <ChangeItem pull={10553}>
           Adds a CLI switch <code>--activate-internet-resource</code>. By
           default, the Internet Resource is now off.
         </ChangeItem>
         {os == OS.Linux && (
-          <ChangeItem pull="10554">
+          <ChangeItem pull={10554}>
             Fixes an issue where local LAN traffic was dropped when the Internet
             Resource was active.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.5.3" date={new Date("2025-09-10")}>
-        <ChangeItem pull="10126">
+        <ChangeItem pull={10126}>
           Sets <code>FIREZONE_DNS_CONTROL=etc-resolv-conf</code> by default in
           the headless client Docker image.
         </ChangeItem>
-        <ChangeItem pull="10104">
+        <ChangeItem pull={10104}>
           {
             "Fixes an issue where DNS resources would resolve to a different IP after signing out and back into Firezone. This would break connectivity for long-running services that don't re-resolve DNS, like SSH sessions or mongoose."
           }
         </ChangeItem>
       </Entry>
       <Entry version="1.5.2" date={new Date("2025-07-28")}>
-        <ChangeItem pull="9985">
+        <ChangeItem pull={9985}>
           Fixes an issue where control plane messages could be stuck forever on
           flaky connections, requiring signing out and back in to recover.
         </ChangeItem>
-        <ChangeItem pull="9891">
+        <ChangeItem pull={9891}>
           Fixes an issue where connections would sometimes take up to 90s to
           establish.
         </ChangeItem>
-        <ChangeItem pull="9979">
+        <ChangeItem pull={9979}>
           Fixes an issue where connections in low-latency networks (between
           Client and Gateway) would fail to establish reliably.
         </ChangeItem>
-        <ChangeItem pull="9999">
+        <ChangeItem pull={9999}>
           Decreases connection setup time on flaky Internet connections in
           certain edge cases.
         </ChangeItem>
       </Entry>
       <Entry version="1.5.1" date={new Date("2025-07-04")}>
-        <ChangeItem pull="9564">
+        <ChangeItem pull={9564}>
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.
         </ChangeItem>
-        <ChangeItem pull="9725">
+        <ChangeItem pull={9725}>
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="9696">
+          <ChangeItem pull={9696}>
             Establishes connections quicker by narrowing the set of network
             changes we react to.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.5.0" date={new Date("2025-06-05")}>
-        <ChangeItem pull="9300">
+        <ChangeItem pull={9300}>
           Uses the new IP stack setting for DNS resources, which allows DNS
           resources to optionally return only A or AAAA records if configured by
           the administrator.
         </ChangeItem>
-        <ChangeItem pull="9147">
+        <ChangeItem pull={9147}>
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
-        <ChangeItem pull="9366">
+        <ChangeItem pull={9366}>
           Fixes an issue where Firezone could not start if the operating system
           refused our request to increase the UDP socket buffer sizes.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.8" date={new Date("2025-05-14")}>
-        <ChangeItem pull="9014">
+        <ChangeItem pull={9014}>
           Fixes an issue where idle connections would be slow (~60s) in
           detecting changes to network connectivity.
         </ChangeItem>
-        <ChangeItem pull="9018">
+        <ChangeItem pull={9018}>
           Further improves performance of relayed connections on IPv4-only
           systems.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="9021">
+          <ChangeItem pull={9021}>
             Optimizes network change detection.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="9213">
+          <ChangeItem pull={9213}>
             Adds the Client to the winget repository. You can install it via
             <code>winget install Firezone.Client.Headless</code>.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.7" date={new Date("2025-04-30")}>
-        <ChangeItem pull="8798">
+        <ChangeItem pull={8798}>
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
         {os === OS.Linux && (
-          <ChangeItem pull="8731">
+          <ChangeItem pull={8731}>
             Improves throughput performance by requesting socket receive buffers
             of 10MB. The actual size of the buffers is capped by the operating
             system. You may need to adjust <code>net.core.rmem_max</code> for
@@ -206,81 +206,81 @@ export default function Headless({ os }: { os: OS }) {
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="8731">
+          <ChangeItem pull={8731}>
             Improves throughput performance by requesting socket receive buffers
             of 10MB.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="8914">
+          <ChangeItem pull={8914}>
             Reduces the number of TUN threads to 1 to match other platforms and
             mitigate packet reordering issues.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="8920">
+          <ChangeItem pull={8920}>
             Improves connection reliability by maintaining the order of IP
             packets across GSO batches.
           </ChangeItem>
         )}
         {os === OS.Windows && (
-          <ChangeItem pull="8920">
+          <ChangeItem pull={8920}>
             Improves connection reliability by maintaining the order of IP
             packets.
           </ChangeItem>
         )}
-        <ChangeItem pull="8935">
+        <ChangeItem pull={8935}>
           Improves reliability for upload-intensive connections with many
           concurrent DNS queries.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
         {os == OS.Linux && (
-          <ChangeItem pull="8754">
+          <ChangeItem pull={8754}>
             Fixes a performance regression that could lead to packet drops under
             high load.
           </ChangeItem>
         )}
-        <ChangeItem pull="7590">
+        <ChangeItem pull={7590}>
           Improves performance by moving UDP sockets to a dedicated thread.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.5" date={new Date("2025-03-14")}>
         {os === OS.Windows && (
-          <ChangeItem pull="8422">
+          <ChangeItem pull={8422}>
             Applies the search domain configured in the admin portal, if any.
           </ChangeItem>
         )}
         {os === OS.Linux && (
-          <ChangeItem pull="8378">
+          <ChangeItem pull={8378}>
             Applies the search domain configured in the admin portal, if any.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.4" date={new Date("2025-03-10")}>
         {os === OS.Linux && (
-          <ChangeItem pull="8117">
+          <ChangeItem pull={8117}>
             Fixes an upload speed performance regression.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-02-11")}>
-        <ChangeItem pull="8055">
+        <ChangeItem pull={8055}>
           Hides the <code>--check</code> and <code>--exit</code> CLI options
           from the help output. These are only used internally.
         </ChangeItem>
         {os === OS.Windows && (
-          <ChangeItem pull="8083">
+          <ChangeItem pull={8083}>
             Fixes a regression introduced in 1.4.2 where Firezone would not work
             on systems with a disabled IPv6 stack.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.2" date={new Date("2025-02-10")}>
-        <ChangeItem pull="8041">
+        <ChangeItem pull={8041}>
           Publishes the headless client for Windows.
         </ChangeItem>
-        <ChangeItem pull="8070">
+        <ChangeItem pull={8070}>
           Only write logs using ANSI-escape codes if the underlying output
           stream supports it.
         </ChangeItem>
@@ -290,22 +290,22 @@ export default function Headless({ os }: { os: OS }) {
       {os === OS.Linux && (
         <>
           <Entry version="1.4.1" date={new Date("2025-01-28")}>
-            <ChangeItem pull="7551">
+            <ChangeItem pull={7551}>
               Fixes an issue where large DNS responses were incorrectly
               discarded.
             </ChangeItem>
-            <ChangeItem pull="7770">
+            <ChangeItem pull={7770}>
               BREAKING: Removes the positional token argument on the CLI. Use
               <code>FIREZONE_TOKEN</code> or <code>FIREZONE_TOKEN_PATH</code>{" "}
               env variables instead.
             </ChangeItem>
           </Entry>
           <Entry version="1.4.0" date={new Date("2024-12-13")}>
-            <ChangeItem pull="7350">
+            <ChangeItem pull={7350}>
               Allows disabling telemetry by setting
               <code>FIREZONE_NO_TELEMETRY=true</code>.
             </ChangeItem>
-            <ChangeItem pull="7210">
+            <ChangeItem pull={7210}>
               Adds support for GSO (Generic Segmentation Offload), delivering
               throughput improvements of up to 60%.
             </ChangeItem>
@@ -313,138 +313,138 @@ export default function Headless({ os }: { os: OS }) {
               Makes use of the new control protocol, delivering faster and more
               robust connection establishment.
             </ChangeItem>
-            <ChangeItem pull="7449">
+            <ChangeItem pull={7449}>
               Uses multiple threads to read & write to the TUN device, greatly
               improving performance.
             </ChangeItem>
-            <ChangeItem pull="7477">
+            <ChangeItem pull={7477}>
               Improves connection setup latency by buffering initial packets.
             </ChangeItem>
           </Entry>
           <Entry version="1.3.7" date={new Date("2024-11-15")}>
-            <ChangeItem pull="7334">
+            <ChangeItem pull={7334}>
               Fixes an issue where symmetric NATs would generate unnecessary
               candidate for hole-punching.
             </ChangeItem>
           </Entry>
           <Entry version="1.3.6" date={new Date("2024-11-08")}>
-            <ChangeItem pull="7263">
+            <ChangeItem pull={7263}>
               Mitigates a crash in case the maximum packet size is not
               respected.
             </ChangeItem>
-            <ChangeItem pull="7265">
+            <ChangeItem pull={7265}>
               Prevents re-connections to the portal from hanging for longer than
               5s.
             </ChangeItem>
-            <ChangeItem pull="7288">
+            <ChangeItem pull={7288}>
               Fixes an issue where network roaming would cause Firezone to
               become unresponsive.
             </ChangeItem>
-            <ChangeItem pull="7287">
+            <ChangeItem pull={7287}>
               Fixes an issue where subsequent SIGHUP signals after the first one
               were ignored.
             </ChangeItem>
           </Entry>
           <Entry version="1.3.5" date={new Date("2024-10-31")}>
             <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
-            <ChangeItem pull="7164">
+            <ChangeItem pull={7164}>
               Fixes an issue where Firezone would fail to establish connections
               to Gateways and the client had to be restarted.
             </ChangeItem>
           </Entry>
           <Entry version="1.3.4" date={new Date("2024-10-02")}>
-            <ChangeItem pull="6831">
+            <ChangeItem pull={6831}>
               {
                 "Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is active."
               }
             </ChangeItem>
-            <ChangeItem pull="6845">
+            <ChangeItem pull={6845}>
               Fixes connectivity issues on idle connections by entering an
               always-on, low-power mode instead of closing them.
             </ChangeItem>
-            <ChangeItem pull="6782">
+            <ChangeItem pull={6782}>
               Adds always-on error reporting using sentry.io.
             </ChangeItem>
-            <ChangeItem pull="6857">
+            <ChangeItem pull={6857}>
               {"Sends the motherboard's hardware ID for device verification."}
             </ChangeItem>
           </Entry>
           <Entry version="1.3.3" date={new Date("2024-09-25")}>
-            <ChangeItem pull="6809">
+            <ChangeItem pull={6809}>
               Fixes a bug where non-wildcard DNS resources were not prioritised
               over wildcard ones (e.g. <code>app.example.com</code> vs{" "}
               <code>*.example.com</code>).
             </ChangeItem>
           </Entry>
           <Entry version="1.3.2" date={new Date("2024-09-25")}>
-            <ChangeItem pull="6765">
+            <ChangeItem pull={6765}>
               Fixes a bug where DNS PTR queries by the system did not get
               answered.
             </ChangeItem>
-            <ChangeItem pull="6722">
+            <ChangeItem pull={6722}>
               Fixes a routing bug when one of several overlapping CIDR resources
               gets disabled / removed.
             </ChangeItem>
-            <ChangeItem pull="6780">
+            <ChangeItem pull={6780}>
               {
                 "Fixes a bug where the Linux Clients didn't work on ZFS filesystems."
               }
             </ChangeItem>
-            <ChangeItem pull="6788">
+            <ChangeItem pull={6788}>
               Fixes an issue where some browsers may fail to route DNS Resources
               correctly.
             </ChangeItem>
           </Entry>
           <Entry version="1.3.1" date={new Date("2024-09-05")}>
-            <ChangeItem pull="6563">
+            <ChangeItem pull={6563}>
               Removes unnecessary packet buffers for a minor performance
               increase.
             </ChangeItem>
           </Entry>
           <Entry version="1.3.0" date={new Date("2024-08-30")}>
-            <ChangeItem pull="6434">
+            <ChangeItem pull={6434}>
               Adds the Internet Resource feature.
             </ChangeItem>
           </Entry>
           <Entry version="1.2.0" date={new Date("2024-08-21")}>
-            <ChangeItem pull="5901">
+            <ChangeItem pull={5901}>
               Implements glob-like matching of domains for DNS resources.
             </ChangeItem>
-            <ChangeItem pull="6361">
+            <ChangeItem pull={6361}>
               {
                 "Connections to Gateways are now sticky for the duration of the Client's session to fix issues with long-lived TCP connections."
               }
             </ChangeItem>
           </Entry>
           <Entry version="1.1.7" date={new Date("2024-08-13")}>
-            <ChangeItem pull="6276">
+            <ChangeItem pull={6276}>
               Fixes a bug where relayed connections failed to establish after an
               idle period.
             </ChangeItem>
-            <ChangeItem pull="6277">
+            <ChangeItem pull={6277}>
               Fixes a bug where restrictive NATs caused connectivity problems.
             </ChangeItem>
           </Entry>
           <Entry version="1.1.6" date={new Date("2024-08-09")}>
-            <ChangeItem pull="6233">
+            <ChangeItem pull={6233}>
               Fixes an issue where the IPC service can panic during DNS
               resolution.
             </ChangeItem>
           </Entry>
           <Entry version="1.1.5" date={new Date("2024-08-08")}>
-            <ChangeItem pull="6163">
+            <ChangeItem pull={6163}>
               Uses <code>systemd-resolved</code> DNS control by default on Linux
             </ChangeItem>
-            <ChangeItem pull="6184">
+            <ChangeItem pull={6184}>
               Mitigates a bug where the Client can panic if an internal channel
               fills up
             </ChangeItem>
-            <ChangeItem pull="6181">
+            <ChangeItem pull={6181}>
               Improves reliability of DNS resolution of non-resources.
             </ChangeItem>
           </Entry>
           <Entry version="1.1.4" date={new Date("2024-08-02")}>
-            <ChangeItem pull="6143">
+            <ChangeItem pull={6143}>
               Fixes an issue where DNS queries could time out on some networks.
             </ChangeItem>
           </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -19,7 +19,7 @@ export default function Headless({ os }: { os: OS }) {
           Gracefully handles WebSocket closes from the portal instead of logging
           a deserialization error.
         </ChangeItem>
-        <ChangeItem pull="#12111">
+        <ChangeItem pull="12111">
           Prevents unbounded log growth by enforcing a 100 MB log size cap with
           automatic cleanup of oldest files.
         </ChangeItem>


### PR DESCRIPTION
The hash-tag in the changelog is rendered automatically. To ensure this doesn't happen again, we change the type of `pull` to be a number.