### PR TITLE
refactor(rust): reuse `Budget` for relay event-loop

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2315,6 +2315,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventloop-budget"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2595,7 @@ dependencies = [
  "derive_more 2.1.1",
  "difference",
  "ebpf-shared",
+ "eventloop-budget",
  "futures",
  "hex",
  "logging",
@@ -8508,6 +8516,7 @@ dependencies = [
  "divan",
  "dns-over-tcp",
  "dns-types",
+ "eventloop-budget",
  "firezone-relay",
  "futures",
  "futures-bounded",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "libs/connlib/socket-factory",
     "libs/connlib/tun",
     "libs/connlib/tunnel",
+    "libs/eventloop-budget",
     "libs/http-client",
     "libs/known-dirs",
     "libs/logging",
@@ -88,6 +89,7 @@ either = "1.15.0"
 etc-hosts-dns-client = { path = "libs/connlib/etc-hosts-dns-client" }
 etherparse = { version = "0.19.0", default-features = false }
 etherparse-ext = { path = "libs/connlib/etherparse-ext" }
+eventloop-budget = { path = "libs/eventloop-budget" }
 filetime = "0.2.27"
 firezone-headless-client = { path = "headless-client" }
 firezone-relay = { path = "relay/server" }

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -21,6 +21,7 @@ derive_more = { workspace = true, features = ["debug", "from", "display"] }
 divan = { workspace = true, optional = true }
 dns-over-tcp = { workspace = true }
 dns-types = { workspace = true }
+eventloop-budget = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true, features = ["tokio"] }
 gat-lending-iterator = { workspace = true }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -8,11 +8,11 @@
 #![cfg_attr(test, allow(clippy::print_stderr))]
 
 use anyhow::{Context as _, ErrorExt as _, Result};
-use budget::Budget;
 use connlib_model::{
     ClientId, ClientOrGatewayId, GatewayId, IceCandidate, PublicKey, ResourceId, ResourceView,
 };
 use dns_types::DomainName;
+use eventloop_budget::Budget;
 use futures::{FutureExt, future::BoxFuture};
 use gat_lending_iterator::LendingIterator;
 use io::{Buffers, Io};
@@ -29,7 +29,6 @@ use std::{
 };
 use tun::Tun;
 
-mod budget;
 mod client;
 mod dns;
 mod expiring_map;

--- a/rust/libs/eventloop-budget/Cargo.toml
+++ b/rust/libs/eventloop-budget/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "eventloop-budget"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+opentelemetry = { workspace = true, features = ["metrics"] }
+
+[lints]
+workspace = true

--- a/rust/libs/eventloop-budget/src/lib.rs
+++ b/rust/libs/eventloop-budget/src/lib.rs
@@ -8,7 +8,7 @@ use std::{sync::OnceLock, task::Waker, time::Instant};
 /// and another iteration should follow.
 /// When the budget is dropped, it wakes the waker if the budget was exhausted while still
 /// making progress, so the runtime reschedules the task instead of suspending it indefinitely.
-pub(crate) struct Budget<'a> {
+pub struct Budget<'a> {
     waker: &'a Waker,
     remaining: u32,
     ready: bool,
@@ -16,16 +16,16 @@ pub(crate) struct Budget<'a> {
     name: &'static str,
 }
 
-pub(crate) struct Tick<'a>(&'a mut bool);
+pub struct Tick<'a>(&'a mut bool);
 
 impl Tick<'_> {
-    pub(crate) fn want_continue(&mut self) {
+    pub fn want_continue(&mut self) {
         *self.0 = true;
     }
 }
 
 impl<'a> Budget<'a> {
-    pub(crate) fn new(waker: &'a Waker, budget: u32, name: &'static str) -> Self {
+    pub fn new(waker: &'a Waker, budget: u32, name: &'static str) -> Self {
         Self {
             waker,
             remaining: budget,
@@ -35,7 +35,11 @@ impl<'a> Budget<'a> {
         }
     }
 
-    pub(crate) fn next(&mut self) -> Option<Tick<'_>> {
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "We cannot implement `Iterator` because we borrow from `self`."
+    )]
+    pub fn next(&mut self) -> Option<Tick<'_>> {
         if !self.ready || self.remaining == 0 {
             return None;
         }

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -18,6 +18,7 @@ bytecodec = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 derive_more = { workspace = true, features = ["from"] }
+eventloop-budget = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 logging = { workspace = true }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, bail};
 use backoff::ExponentialBackoffBuilder;
 use bin_shared::{http_health_check, signals};
 use clap::Parser;
+use eventloop_budget::Budget;
 use firezone_relay::sockets::Sockets;
 use firezone_relay::{
     AddressFamily, AllocationPort, ChannelData, ClientSocket, Command, IpStack, PeerSocket, Server,
@@ -515,9 +516,9 @@ where
     }
 
     fn poll(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<()>> {
-        for _ in 0..MAX_EVENTLOOP_ITERS {
-            let mut ready = false;
+        let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "relay");
 
+        while let Some(mut tick) = budget.next() {
             ready!(self.sockets.flush(cx))?;
 
             // Priority 1: Execute the pending commands of the server.
@@ -590,7 +591,7 @@ where
                     }
                 }
 
-                ready = true;
+                tick.want_continue();
             }
 
             // Priority 2: Read from our sockets.
@@ -640,7 +641,7 @@ where
                         }
                     };
 
-                    ready = true;
+                    tick.want_continue();
                 }
                 Poll::Ready(Ok(sockets::Received {
                     port, // Packets coming in on any other port are from peers.
@@ -667,12 +668,12 @@ where
                         };
                     };
 
-                    ready = true;
+                    tick.want_continue();
                 }
                 Poll::Ready(Err(sockets::Error::Io(e))) => {
                     tracing::warn!(target: "relay", "Error while receiving message: {}", err_with_src(&e));
 
-                    ready = true;
+                    tick.want_continue();
                 }
                 Poll::Ready(Err(sockets::Error::MioTaskCrashed(e))) => return Poll::Ready(Err(e)), // Fail the event-loop. We can't operate without the `mio` worker-task.
                 Poll::Pending => {}
@@ -681,20 +682,20 @@ where
             // Priority 3: Check when we need to next be woken. This needs to happen after all state modifications.
             if let Some(timeout) = self.server.poll_timeout() {
                 Pin::new(&mut self.sleep).reset(timeout);
-                // Purposely no `ready = true` because we just change the state of `sleep` and we poll it below.
+                // Purposely no `tick.want_continue()` because we just change the state of `sleep` and we poll it below.
             }
 
             // Priority 4: Handle time-sensitive tasks:
             if let Poll::Ready(deadline) = self.sleep.poll_unpin(cx) {
                 self.server.handle_timeout(deadline);
 
-                ready = true;
+                tick.want_continue();
             }
 
             // Priority 5: Handle portal messages
             match self.event_rx.poll_recv(cx) {
                 Poll::Ready(Some(Ok(IngressMessages::Init(Init {})))) => {
-                    ready = true;
+                    tick.want_continue();
                 }
                 Poll::Ready(Some(Err(e))) => {
                     return Poll::Ready(Err(
@@ -726,15 +727,10 @@ where
 
                 tracing::info!(target: "relay", "Allocations = {num_allocations} Channels = {num_channels} Throughput = {}", fmt_human_throughput(avg_throughput as f64));
 
-                ready = true;
-            }
-
-            if !ready {
-                return Poll::Pending;
+                tick.want_continue();
             }
         }
 
-        cx.waker().wake_by_ref(); // Schedule another wake-up with the runtime to avoid getting suspended forever.
         Poll::Pending
     }
 


### PR DESCRIPTION
The `Budget` abstraction is unit-tested, hence it makes sense to reuse this for the relay's event-loop as well.