### PR TITLE
build(deps): bump `quinn-udp` to `0.6.0`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3558,7 +3558,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5774,7 +5774,7 @@ dependencies = [
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.12",
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
@@ -5816,6 +5816,19 @@ dependencies = [
  "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53412bac6247548e2164c7d7f67854aa104ea7d5901efd99622fdf05205496f6"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7020,7 +7033,7 @@ dependencies = [
  "ip-packet",
  "libc",
  "opentelemetry",
- "quinn-udp",
+ "quinn-udp 0.6.0",
  "socket2 0.6.3",
  "tokio",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -148,7 +148,7 @@ png = "0.17.16"
 proc-macro2 = "1.0.106"
 proptest = "1.9.0"
 proptest-state-machine = "0.6.0"
-quinn-udp = { version = "0.5.12", features = ["fast-apple-datapath"] }
+quinn-udp = { version = "0.6.0", features = ["fast-apple-datapath"] }
 quote = "1.0.44"
 rand = "0.8.5"
 rand_core = "0.6.4"

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -200,6 +200,12 @@ impl UdpSocket {
         let quinn_ref = quinn_udp::UdpSockRef::from(&self.inner);
         let quinn_state = quinn_udp::UdpSocketState::new(quinn_ref)?;
 
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        // SAFETY: All versions of MacOS / iOS that we tested support these APIs.
+        unsafe {
+            quinn_state.set_apple_fast_path();
+        }
+
         Ok(PerfUdpSocket {
             inner: self.inner,
             state: quinn_state,
@@ -688,6 +694,7 @@ where
 #[cfg(test)]
 mod tests {
     use gat_lending_iterator::LendingIterator as _;
+    use quinn_udp::RecvMeta;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV6};
 
     use super::*;
@@ -704,20 +711,18 @@ mod tests {
                 DummyBuffer(b"".to_vec()),
             ],
             [
-                quinn_udp::RecvMeta {
-                    addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-                    dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-                    stride: 7,
-                    len: 38,
-                    ecn: None,
-                },
-                quinn_udp::RecvMeta {
-                    addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-                    dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-                    stride: 4,
-                    len: 23,
-                    ecn: None,
-                },
+                recv_meta(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    38,
+                    7,
+                ),
+                recv_meta(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    23,
+                    4,
+                ),
                 quinn_udp::RecvMeta::default(),
             ],
             0,
@@ -803,5 +808,15 @@ mod tests {
             err.to_string(),
             "An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full. (os error 10055)"
         );
+    }
+
+    fn recv_meta(addr: SocketAddr, dst_ip: IpAddr, len: usize, stride: usize) -> RecvMeta {
+        let mut meta = RecvMeta::default();
+        meta.addr = addr;
+        meta.dst_ip = Some(dst_ip);
+        meta.len = len;
+        meta.stride = stride;
+
+        meta
     }
 }


### PR DESCRIPTION
Recent fixes to `quinn-udp` contain make the GRO/GSO "enabled" state on Windows a per-socket state, meaning it resets every time we reset our sockets, i.e. during roaming. This may have positive impacts on performance for Windows users that roam between network connections that either do or don't support GRO/GSO in their driver.

Additionally, the support for Apple fast-path send via `sendmsg_x` and `recvmsg_x` has been gated behind a runtime feature flag that we need to explicitly enable.