### PR TITLE
fix(portal): validate openapi spec

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -121,6 +121,20 @@ jobs:
 
       - name: Check for unused deps
         run: mix deps.unlock --check-unused
+
+      - name: Validate OpenAPI spec
+        run: |
+          mix openapi.spec.yaml --spec PortalAPI.ApiSpec
+          result=$(curl --fail --show-error --silent \
+            --max-time 10 \
+            --retry 3 \
+            --retry-delay 1 \
+            --retry-connrefused \
+            --data-binary @openapi.yaml \
+            -H 'Content-Type:application/yaml' \
+            https://validator.swagger.io/validator/debug)
+          echo "$result"
+          echo "$result" | jq -e '.schemaValidationMessages | length == 0'
 # TODO: IDP-REFACTOR: Re-enable
 # acceptance-test:
 #   name: acceptance-test-${{ matrix.MIX_TEST_PARTITION }}

--- a/elixir/lib/portal_api/schemas/account_schema.ex
+++ b/elixir/lib/portal_api/schemas/account_schema.ex
@@ -45,7 +45,7 @@ defmodule PortalAPI.Schemas.Account do
       description: "Account schema",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         slug: %Schema{type: :string, description: "Account slug"},
         name: %Schema{type: :string, description: "Account name"},
         legal_name: %Schema{type: :string, description: "Account legal name"},

--- a/elixir/lib/portal_api/schemas/actor_schema.ex
+++ b/elixir/lib/portal_api/schemas/actor_schema.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Schemas.Actor do
       description: "Actor",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Actor ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Actor ID"},
         name: %Schema{
           type: :string,
           description: "Actor Name",
@@ -37,6 +37,7 @@ defmodule PortalAPI.Schemas.Actor do
         },
         created_by_directory_id: %Schema{
           type: :string,
+          format: :uuid,
           description: "Directory ID that created this actor",
           nullable: true
         },

--- a/elixir/lib/portal_api/schemas/client_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.Client do
       description: "Client",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Client ID"},
-        actor_id: %Schema{type: :string, description: "Actor ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Client ID"},
+        actor_id: %Schema{type: :string, format: :uuid, description: "Actor ID"},
         name: %Schema{
           type: :string,
           description: "Client Name"
@@ -34,6 +34,7 @@ defmodule PortalAPI.Schemas.Client do
         },
         device_uuid: %Schema{
           type: :string,
+          format: :uuid,
           description: "Device manufacturer UUID (unavailable for mobile devices)"
         },
         identifier_for_vendor: %Schema{

--- a/elixir/lib/portal_api/schemas/client_session_schema.ex
+++ b/elixir/lib/portal_api/schemas/client_session_schema.ex
@@ -10,9 +10,9 @@ defmodule PortalAPI.Schemas.ClientSession do
       description: "Client Session",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Client Session ID"},
-        client_id: %Schema{type: :string, description: "Client ID"},
-        client_token_id: %Schema{type: :string, description: "Client Token ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Client Session ID"},
+        client_id: %Schema{type: :string, format: :uuid, description: "Client ID"},
+        client_token_id: %Schema{type: :string, format: :uuid, description: "Client Token ID"},
         last_seen_user_agent: %Schema{
           type: :string,
           description: "User agent at time of session"

--- a/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/email_otp_auth_provider_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
       description: "Email OTP Auth Provider",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Provider ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Provider name"},
         issuer: %Schema{type: :string, description: "Issuer"},
         context: %Schema{
@@ -28,8 +28,12 @@ defmodule PortalAPI.Schemas.EmailOTPAuthProvider do
           description: "Portal session lifetime in seconds"
         },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
       description: "Entra Auth Provider",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Provider ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Provider name"},
         issuer: %Schema{type: :string, description: "Issuer"},
         context: %Schema{
@@ -29,8 +29,12 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
         },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -10,23 +10,31 @@ defmodule PortalAPI.Schemas.EntraDirectory do
       description: "Entra Directory",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Directory ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Directory name"},
-        tenant_id: %Schema{type: :string, description: "Microsoft Entra tenant ID"},
+        tenant_id: %Schema{type: :string, format: :uuid, description: "Microsoft Entra tenant ID"},
         error_count: %Schema{type: :integer, description: "Error count"},
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
         disabled_reason: %Schema{type: :string, description: "Reason for disabling"},
-        synced_at: %Schema{type: :string, format: :datetime, description: "Last sync timestamp"},
+        synced_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Last sync timestamp"
+        },
         error: %Schema{type: :string, description: "Last error message"},
         error_emailed_at: %Schema{
           type: :string,
-          format: :datetime,
+          format: :"date-time",
           description: "Error email timestamp"
         },
         sync_all_groups: %Schema{type: :boolean, description: "Sync all groups"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/external_identity_schema.ex
+++ b/elixir/lib/portal_api/schemas/external_identity_schema.ex
@@ -10,15 +10,19 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
       description: "External Identity",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "External Identity ID"},
-        actor_id: %Schema{type: :string, description: "Actor ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "External Identity ID"},
+        actor_id: %Schema{type: :string, format: :uuid, description: "Actor ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         issuer: %Schema{
           type: :string,
           description:
             "Identity issuer URL (e.g., 'https://accounts.google.com', 'https://company.okta.com')"
         },
-        directory_id: %Schema{type: :string, description: "Directory UUID reference"},
+        directory_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description: "Directory UUID reference"
+        },
         idp_id: %Schema{type: :string, description: "IDP-specific identifier for this identity"},
         name: %Schema{type: :string, description: "Full name"},
         given_name: %Schema{type: :string, description: "Given name"},
@@ -31,10 +35,14 @@ defmodule PortalAPI.Schemas.ExternalIdentity do
         firezone_avatar_url: %Schema{type: :string, description: "Firezone-hosted avatar URL"},
         last_synced_at: %Schema{
           type: :string,
-          format: :datetime,
+          format: :"date-time",
           description: "Last sync timestamp"
         },
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        }
       },
       required: [:id, :actor_id, :issuer, :idp_id],
       example: %{

--- a/elixir/lib/portal_api/schemas/gateway_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_schema.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Schemas.Gateway do
       description: "Gateway",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Gateway ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Gateway ID"},
         name: %Schema{
           type: :string,
           description: "Gateway Name",

--- a/elixir/lib/portal_api/schemas/gateway_session_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_session_schema.ex
@@ -10,9 +10,9 @@ defmodule PortalAPI.Schemas.GatewaySession do
       description: "Gateway Session",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Gateway Session ID"},
-        gateway_id: %Schema{type: :string, description: "Gateway ID"},
-        gateway_token_id: %Schema{type: :string, description: "Gateway Token ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Gateway Session ID"},
+        gateway_id: %Schema{type: :string, format: :uuid, description: "Gateway ID"},
+        gateway_token_id: %Schema{type: :string, format: :uuid, description: "Gateway Token ID"},
         last_seen_user_agent: %Schema{
           type: :string,
           description: "User agent at time of session"

--- a/elixir/lib/portal_api/schemas/gateway_token_schema.ex
+++ b/elixir/lib/portal_api/schemas/gateway_token_schema.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Schemas.GatewayToken do
       description: "Gateway Token",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Gateway Token ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Gateway Token ID"},
         token: %Schema{type: :string, description: "Gateway Token"}
       },
       required: [:id, :token],
@@ -53,7 +53,7 @@ defmodule PortalAPI.Schemas.GatewayToken do
         data: %Schema{
           type: :object,
           properties: %{
-            id: %Schema{type: :string, description: "Gateway Token ID"}
+            id: %Schema{type: :string, format: :uuid, description: "Gateway Token ID"}
           },
           required: [:id]
         }

--- a/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_auth_provider_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
       description: "Google Auth Provider",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Provider ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Provider name"},
         issuer: %Schema{type: :string, description: "Issuer"},
         context: %Schema{
@@ -29,8 +29,12 @@ defmodule PortalAPI.Schemas.GoogleAuthProvider do
         },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/google_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/google_directory_schema.ex
@@ -10,19 +10,23 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
       description: "Google Directory",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Directory ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Directory name"},
         domain: %Schema{type: :string, description: "Google Workspace domain"},
         impersonation_email: %Schema{type: :string, description: "Impersonation email"},
         error_count: %Schema{type: :integer, description: "Error count"},
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
         disabled_reason: %Schema{type: :string, description: "Reason for disabling"},
-        synced_at: %Schema{type: :string, format: :datetime, description: "Last sync timestamp"},
+        synced_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Last sync timestamp"
+        },
         error: %Schema{type: :string, description: "Last error message"},
         error_emailed_at: %Schema{
           type: :string,
-          format: :datetime,
+          format: :"date-time",
           description: "Error email timestamp"
         },
         group_sync_mode: %Schema{
@@ -34,8 +38,12 @@ defmodule PortalAPI.Schemas.GoogleDirectory do
           type: :boolean,
           description: "Whether org unit sync is enabled"
         },
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/group_schema.ex
+++ b/elixir/lib/portal_api/schemas/group_schema.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Schemas.Group do
       description: "Group",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Group ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Group ID"},
         name: %Schema{type: :string, description: "Group Name"},
         email: %Schema{
           type: :string,
@@ -24,6 +24,7 @@ defmodule PortalAPI.Schemas.Group do
         },
         directory_id: %Schema{
           type: :string,
+          format: :uuid,
           description: "Directory ID this group belongs to",
           nullable: true
         },

--- a/elixir/lib/portal_api/schemas/membership_schema.ex
+++ b/elixir/lib/portal_api/schemas/membership_schema.ex
@@ -12,7 +12,7 @@ defmodule PortalAPI.Schemas.Membership do
       items: %Schema{
         type: :object,
         properties: %{
-          id: %Schema{type: :string, description: "Actor ID"},
+          id: %Schema{type: :string, format: :uuid, description: "Actor ID"},
           name: %Schema{type: :string, description: "Actor Name"},
           type: %Schema{type: :string, description: "Actor Type"}
         }
@@ -43,12 +43,12 @@ defmodule PortalAPI.Schemas.Membership do
             add: %Schema{
               type: :array,
               description: "Array of Actor IDs",
-              items: %Schema{type: :string, description: "Actor ID"}
+              items: %Schema{type: :string, format: :uuid, description: "Actor ID"}
             },
             remove: %Schema{
               type: :array,
               description: "Array of Actor IDs",
-              items: %Schema{type: :string, description: "Actor ID"}
+              items: %Schema{type: :string, format: :uuid, description: "Actor ID"}
             }
           }
         }
@@ -81,7 +81,7 @@ defmodule PortalAPI.Schemas.Membership do
           items: %Schema{
             type: :object,
             properties: %{
-              actor_id: %Schema{type: :string, description: "Actor ID"}
+              actor_id: %Schema{type: :string, format: :uuid, description: "Actor ID"}
             }
           }
         }
@@ -152,7 +152,7 @@ defmodule PortalAPI.Schemas.Membership do
             actor_ids: %Schema{
               description: "Actor IDs",
               type: :array,
-              items: %Schema{type: :string, description: "Actor ID"}
+              items: %Schema{type: :string, format: :uuid, description: "Actor ID"}
             }
           }
         }

--- a/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
       description: "OIDC Auth Provider",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Provider ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Provider name"},
         issuer: %Schema{type: :string, description: "Issuer"},
         context: %Schema{
@@ -31,8 +31,12 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
         client_id: %Schema{type: :string, description: "Client ID"},
         discovery_document_uri: %Schema{type: :string, description: "Discovery document URI"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_auth_provider_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
       description: "Okta Auth Provider",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Provider ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Provider name"},
         issuer: %Schema{type: :string, description: "Issuer"},
         context: %Schema{
@@ -31,8 +31,12 @@ defmodule PortalAPI.Schemas.OktaAuthProvider do
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
         client_id: %Schema{type: :string, description: "Client ID"},
         okta_domain: %Schema{type: :string, description: "Okta domain"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/okta_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/okta_directory_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.OktaDirectory do
       description: "Okta Directory",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Directory ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Directory ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Directory name"},
         client_id: %Schema{type: :string, description: "Client ID"},
         kid: %Schema{type: :string, description: "Key ID"},
@@ -19,15 +19,23 @@ defmodule PortalAPI.Schemas.OktaDirectory do
         error_count: %Schema{type: :integer, description: "Error count"},
         is_disabled: %Schema{type: :boolean, description: "Whether directory is disabled"},
         disabled_reason: %Schema{type: :string, description: "Reason for disabling"},
-        synced_at: %Schema{type: :string, format: :datetime, description: "Last sync timestamp"},
+        synced_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Last sync timestamp"
+        },
         error: %Schema{type: :string, description: "Last error message"},
         error_emailed_at: %Schema{
           type: :string,
-          format: :datetime,
+          format: :"date-time",
           description: "Error email timestamp"
         },
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{

--- a/elixir/lib/portal_api/schemas/policy_schema.ex
+++ b/elixir/lib/portal_api/schemas/policy_schema.ex
@@ -10,9 +10,9 @@ defmodule PortalAPI.Schemas.Policy do
       description: "Policy",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Policy ID"},
-        group_id: %Schema{type: :string, description: "Group ID", nullable: true},
-        resource_id: %Schema{type: :string, description: "Resource ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Policy ID"},
+        group_id: %Schema{type: :string, format: :uuid, description: "Group ID", nullable: true},
+        resource_id: %Schema{type: :string, format: :uuid, description: "Resource ID"},
         description: %Schema{type: :string, description: "Policy Description", nullable: true}
       },
       required: [:id, :group_id, :resource_id, :description],

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Schemas.Resource do
       description: "Resource",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Resource ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Resource ID"},
         name: %Schema{type: :string, description: "Resource name"},
         address: %Schema{type: :string, description: "Resource address"},
         address_description: %Schema{type: :string, description: "Resource address description"},
@@ -25,10 +25,11 @@ defmodule PortalAPI.Schemas.Resource do
           enum: ["ipv4_only", "ipv6_only", "dual"]
         },
         site_id: %Schema{
-          title: "Site ID",
+          title: "SiteID",
           description:
             "Site to connect the Resource to. Required for all types except `static_device_pool`.",
-          type: :string
+          type: :string,
+          format: :uuid
         }
       },
       required: [:name, :type],

--- a/elixir/lib/portal_api/schemas/site_schema.ex
+++ b/elixir/lib/portal_api/schemas/site_schema.ex
@@ -10,7 +10,7 @@ defmodule PortalAPI.Schemas.Site do
       description: "Site",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Site ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Site ID"},
         name: %Schema{type: :string, description: "Site Name"}
       },
       required: [:id, :name],

--- a/elixir/lib/portal_api/schemas/userpass_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/userpass_auth_provider_schema.ex
@@ -10,8 +10,8 @@ defmodule PortalAPI.Schemas.UserpassAuthProvider do
       description: "Username & Password Auth Provider",
       type: :object,
       properties: %{
-        id: %Schema{type: :string, description: "Provider ID"},
-        account_id: %Schema{type: :string, description: "Account ID"},
+        id: %Schema{type: :string, format: :uuid, description: "Provider ID"},
+        account_id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         name: %Schema{type: :string, description: "Provider name"},
         issuer: %Schema{type: :string, description: "Issuer"},
         context: %Schema{
@@ -28,8 +28,12 @@ defmodule PortalAPI.Schemas.UserpassAuthProvider do
           description: "Portal session lifetime in seconds"
         },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
-        inserted_at: %Schema{type: :string, format: :datetime, description: "Creation timestamp"},
-        updated_at: %Schema{type: :string, format: :datetime, description: "Update timestamp"}
+        inserted_at: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Creation timestamp"
+        },
+        updated_at: %Schema{type: :string, format: :"date-time", description: "Update timestamp"}
       },
       required: [:id, :name],
       example: %{


### PR DESCRIPTION
- Adds `type: :uuid` to database id schemas
- Corrects `type: :datetime` to `type: :"date-time"`
- Adds a CI job to catch OpenAPI schema validation failures going forward

---

Related: https://github.com/firezone/firezone/pull/10045#issuecomment-4049129834