### PR TITLE
chore(portal): more consistent oidc fallback errors

### DIFF
--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -17,6 +17,8 @@ defmodule PortalWeb.Settings.Authentication do
 
   require Logger
 
+  @invalid_json_error_message "Discovery document contains invalid JSON. Please verify the Discovery Document URI returns valid OpenID Connect configuration."
+
   @context_options [
     {"Client Applications and Admin Portal", "clients_and_portal"},
     {"Client Applications Only", "clients_only"},
@@ -371,13 +373,16 @@ defmodule PortalWeb.Settings.Authentication do
     do: "Unable to fetch discovery document due to a network error."
 
   defp verification_start_error_message({:unexpected_end, _}),
-    do:
-      "Discovery document contains invalid JSON. Please verify the Discovery Document URI returns valid OpenID Connect configuration."
+    do: @invalid_json_error_message
 
   defp verification_start_error_message({tag, _, _})
        when tag in [:invalid_byte, :unexpected_sequence],
-       do:
-         "Discovery document contains invalid JSON. Please verify the Discovery Document URI returns valid OpenID Connect configuration."
+       do: @invalid_json_error_message
+
+  defp verification_start_error_message(reason) do
+    Logger.error("Unhandled verification start error", reason: inspect(reason))
+    "Failed to start verification."
+  end
 
   defp clear_verification_if_trigger_fields_changed(changeset) do
     schema = changeset.data.__struct__

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -349,8 +349,9 @@ defmodule PortalWeb.Settings.Authentication do
   defp verification_start_error_message({404, _body}),
     do: "Discovery document not found (HTTP 404). Please verify the Discovery Document URI."
 
-  defp verification_start_error_message({status, _body}) when status >= 500,
-    do: "Identity provider is unavailable (HTTP #{status}). Please try again shortly."
+  defp verification_start_error_message({status, _body})
+       when is_integer(status) and status >= 500,
+       do: "Identity provider is unavailable (HTTP #{status}). Please try again shortly."
 
   defp verification_start_error_message({status, _body}) when is_integer(status),
     do:
@@ -369,8 +370,14 @@ defmodule PortalWeb.Settings.Authentication do
   defp verification_start_error_message(%Req.TransportError{}),
     do: "Unable to fetch discovery document due to a network error."
 
-  defp verification_start_error_message(reason) when is_binary(reason), do: reason
-  defp verification_start_error_message(_reason), do: "Failed to start verification."
+  defp verification_start_error_message({:unexpected_end, _}),
+    do:
+      "Discovery document contains invalid JSON. Please verify the Discovery Document URI returns valid OpenID Connect configuration."
+
+  defp verification_start_error_message({tag, _, _})
+       when tag in [:invalid_byte, :unexpected_sequence],
+       do:
+         "Discovery document contains invalid JSON. Please verify the Discovery Document URI returns valid OpenID Connect configuration."
 
   defp clear_verification_if_trigger_fields_changed(changeset) do
     schema = changeset.data.__struct__

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -260,10 +260,6 @@ defmodule PortalWeb.OIDC do
     )
   end
 
-  def build_verification_uri(type, _config, _verifier, _state_token) do
-    {:error, "Unknown verification type: #{type}"}
-  end
-
   @doc """
   Returns the OIDC callback URL. Public so controllers can use it without
   duplicating the endpoint configuration.

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -8,6 +8,8 @@ defmodule PortalWeb.OIDC do
 
   alias Portal.{Google, Okta, Entra, OIDC}
 
+  require Logger
+
   @doc """
   Builds OpenIDConnect configuration for a provider.
   Supports Google, Okta, Entra, and generic OIDC providers.
@@ -228,6 +230,7 @@ defmodule PortalWeb.OIDC do
   Builds the IdP URI for the verification flow. For OIDC types this is an
   authorization URI with PKCE; for Entra types it is an admin consent URI.
   The state_token (from sign_verification_state/2) is passed through the IdP unchanged.
+  Accepts types: "google", "okta", "oidc", "entra", "entra_directory_sync".
   Returns {:ok, uri} or {:error, reason}.
   """
   def build_verification_uri(type, config, verifier, state_token)
@@ -258,6 +261,11 @@ defmodule PortalWeb.OIDC do
       state_token,
       "https://graph.microsoft.com/.default"
     )
+  end
+
+  def build_verification_uri(type, _config, _verifier, _state_token) do
+    Logger.error("Unknown verification type", type: type)
+    {:error, :unknown_verification_type}
   end
 
   @doc """

--- a/elixir/test/portal_web/settings/authentication_test.exs
+++ b/elixir/test/portal_web/settings/authentication_test.exs
@@ -3476,7 +3476,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       lv |> element("#verify-button") |> render_click()
 
       html = render(lv)
-      assert html =~ "discovery document"
+      assert html =~ "Discovery document contains invalid JSON"
     end
 
     test "handles JSON with invalid byte sequences", %{
@@ -3506,7 +3506,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       lv |> element("#verify-button") |> render_click()
 
       html = render(lv)
-      assert html =~ "Failed to start verification."
+      assert html =~ "Discovery document contains invalid JSON"
     end
 
     test "handles HTTP 401 error", %{


### PR DESCRIPTION
Adds more specific error matchers for the errors that can actually be hit and `Logger.error`'s them so we are aware.
