### PR TITLE
fix(connlib): handle ICMP errors in UDP & TCP DNS client

### DIFF
--- a/rust/libs/connlib/dns-over-tcp/src/client.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/client.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::codec;
 use anyhow::{Context as _, Result, anyhow, bail};
-use ip_packet::IpPacket;
+use ip_packet::{IpPacket, Layer4Protocol};
 use l3_tcp::{
     InMemoryDevice, Interface, PollResult, SocketSet, create_interface, create_tcp_socket,
 };
@@ -136,13 +136,6 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
     ///
     /// Only TCP packets originating from one of the connected DNS resolvers are accepted.
     pub fn accepts(&self, packet: &IpPacket) -> bool {
-        let Some(tcp) = packet.as_tcp() else {
-            #[cfg(debug_assertions)]
-            tracing::trace!(?packet, "Not a TCP packet");
-
-            return false;
-        };
-
         let Some((ipv4_source, ipv6_source)) = self.source_ips else {
             #[cfg(debug_assertions)]
             tracing::trace!("No source interface");
@@ -156,6 +149,22 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             IpAddr::V6(v6) if v6 != ipv6_source => return false,
             IpAddr::V4(_) | IpAddr::V6(_) => {}
         }
+
+        if let Ok(Some((failed_packet, _))) = packet.icmp_error()
+            && let Layer4Protocol::Tcp { dst, .. } = failed_packet.layer4_protocol()
+            && self
+                .sockets_by_remote
+                .contains_key(&SocketAddr::new(failed_packet.dst(), dst))
+        {
+            return true;
+        }
+
+        let Some(tcp) = packet.as_tcp() else {
+            #[cfg(debug_assertions)]
+            tracing::trace!(?packet, "Not a TCP packet");
+
+            return false;
+        };
 
         let remote = SocketAddr::new(packet.source(), tcp.source_port());
         let has_socket = self.sockets_by_remote.contains_key(&remote);
@@ -177,6 +186,42 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
     /// To actually process the packets in the buffer, [`Client::handle_timeout`] must be called.
     pub fn handle_inbound(&mut self, packet: IpPacket) {
         debug_assert!(self.accepts(&packet));
+
+        if let Ok(Some((failed_packet, icmp_error))) = packet.icmp_error()
+            && let Layer4Protocol::Tcp { dst, .. } = failed_packet.layer4_protocol()
+            && let server = SocketAddr::new(failed_packet.dst(), dst)
+            && let Some(handle) = self.sockets_by_remote.get(&server)
+            && let Some((ipv4_source, ipv6_source)) = self.source_ips
+        {
+            let socket = self.sockets.get_mut::<l3_tcp::Socket>(*handle);
+            socket.abort();
+
+            let local_port = *self
+                .local_ports_by_socket
+                .get(handle)
+                .expect("must always have a port for each socket");
+
+            let local_endpoint = local_endpoint(server, ipv4_source, ipv6_source, local_port);
+
+            let pending_queries = self
+                .pending_queries_by_remote_and_local
+                .entry((server, local_endpoint))
+                .or_default();
+            let sent_queries = self
+                .sent_queries_by_remote_and_local
+                .entry((server, local_endpoint))
+                .or_default();
+
+            self.query_results.extend(fail_all_queries(
+                &anyhow!("Received ICMP error for DNS query: {icmp_error}"),
+                server,
+                local_endpoint,
+                pending_queries,
+                sent_queries,
+            ));
+
+            return;
+        }
 
         self.device.receive(packet);
     }
@@ -456,4 +501,52 @@ fn try_recv_response(socket: &mut l3_tcp::Socket) -> Result<Option<dns_types::Re
     let maybe_response = codec::try_recv(socket)?;
 
     Ok(maybe_response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handles_icmp_error_for_pending_query() {
+        let _guard = logging::test("trace");
+
+        let now = Instant::now();
+        let mut client = create_test_client(now);
+        let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53);
+        let query = create_test_query();
+
+        let local = client.send_query(server, query.clone()).unwrap();
+        client.handle_timeout(now);
+        client.handle_timeout(now);
+
+        let packet = client.poll_outbound().unwrap();
+        let icmp_error_response = ip_packet::make::icmp_dest_unreachable_network(&packet).unwrap();
+
+        client.handle_inbound(icmp_error_response);
+
+        let query_result = client.poll_query_result().unwrap();
+
+        assert_eq!(query_result.query.id(), query.id());
+        assert_eq!(query_result.query.domain(), query.domain());
+        assert_eq!(query_result.local, local);
+        assert_eq!(query_result.server, server);
+        assert_eq!(
+            query_result.result.unwrap_err().to_string(),
+            "Received ICMP error for DNS query: Destination is unreachable (code: 0)"
+        );
+    }
+
+    fn create_test_client(now: Instant) -> Client {
+        let seed = [0u8; 32];
+        let mut client = Client::new(now, seed);
+        client.set_source_interface(Ipv4Addr::new(10, 0, 0, 1), Ipv6Addr::LOCALHOST);
+        client
+    }
+
+    fn create_test_query() -> dns_types::Query {
+        use std::str::FromStr;
+        let domain = dns_types::DomainName::from_str("example.com").unwrap();
+        dns_types::Query::new(domain, dns_types::RecordType::A)
+    }
 }

--- a/rust/libs/connlib/dns-over-tcp/src/lib.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 mod client;
 mod codec;
 mod server;

--- a/rust/libs/connlib/ip-packet/src/icmp_error.rs
+++ b/rust/libs/connlib/ip-packet/src/icmp_error.rs
@@ -1,4 +1,7 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::{
+    fmt,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
 
 use anyhow::{Context as _, Result, bail};
 use etherparse::{Icmpv4Type, Icmpv6Type, LaxIpv4Slice, LaxIpv6Slice, icmpv4, icmpv6};
@@ -56,6 +59,28 @@ impl IcmpError {
             self,
             V4Unreachable(FilterProhibited) | V6Unreachable(Prohibited)
         )
+    }
+}
+
+impl fmt::Display for IcmpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IcmpError::V4Unreachable(inner) => {
+                write!(f, "Destination is unreachable (code: {})", inner.code_u8())
+            }
+            IcmpError::V4TimeExceeded(inner) => {
+                write!(f, "Time exceeded (code: {})", inner.code_u8())
+            }
+            IcmpError::V6Unreachable(inner) => {
+                write!(f, "Destination is unreachable (code: {})", inner.code_u8())
+            }
+            IcmpError::V6PacketTooBig { mtu } => {
+                write!(f, "IPv6 packet exceeds allowed MTU ({mtu})")
+            }
+            IcmpError::V6TimeExceeded(inner) => {
+                write!(f, "Time exceeded (code: {})", inner.code_u8())
+            }
+        }
     }
 }
 

--- a/rust/libs/connlib/l3-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l3-udp-dns-client/lib.rs
@@ -1,13 +1,16 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{
+        HashMap, VecDeque,
+        hash_map::{Entry, OccupiedEntry},
+    },
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::{Duration, Instant},
 };
 
 use anyhow::{Context as _, Result, anyhow, bail};
-use ip_packet::IpPacket;
+use ip_packet::{FailedPacket, IpPacket, Layer4Protocol};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 const TIMEOUT: Duration = Duration::from_secs(30);
@@ -105,14 +108,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
     /// Checks whether this client can handle the given packet.
     ///
     /// Only UDP packets for pending DNS queries are accepted.
-    pub fn accepts(&self, packet: &IpPacket) -> bool {
-        let Some(udp) = packet.as_udp() else {
-            #[cfg(debug_assertions)]
-            tracing::trace!(?packet, "Not a UDP packet");
-
-            return false;
-        };
-
+    pub fn accepts(&mut self, packet: &IpPacket) -> bool {
         let Some((ipv4_source, ipv6_source)) = self.source_ips else {
             #[cfg(debug_assertions)]
             tracing::trace!("No source interface");
@@ -127,12 +123,39 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             IpAddr::V4(_) | IpAddr::V6(_) => {}
         }
 
+        if let Ok(Some((failed_packet, _))) = packet.icmp_error()
+            && self.entry_for_failed_packet(&failed_packet).is_some()
+        {
+            return true;
+        }
+
+        let Some(udp) = packet.as_udp() else {
+            #[cfg(debug_assertions)]
+            tracing::trace!(?packet, "Not a UDP packet");
+
+            return false;
+        };
+
         self.pending_queries_by_local_port
             .contains_key(&udp.destination_port())
     }
 
     pub fn handle_inbound(&mut self, packet: IpPacket) {
         debug_assert!(self.accepts(&packet));
+
+        if let Ok(Some((failed_packet, icmp_error))) = packet.icmp_error()
+            && let Some(entry) = self.entry_for_failed_packet(&failed_packet)
+        {
+            let pending_query = entry.remove();
+
+            self.query_results.push_back(QueryResult {
+                query: pending_query.message,
+                local: pending_query.local,
+                server: pending_query.server,
+                result: Err(anyhow!("Received ICMP error for DNS query: {icmp_error}")),
+            });
+            return;
+        }
 
         let Some(udp) = packet.as_udp() else {
             return;
@@ -248,6 +271,26 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             }
         }
     }
+
+    fn entry_for_failed_packet(
+        &mut self,
+        failed_packet: &FailedPacket,
+    ) -> Option<OccupiedEntry<'_, u16, PendingQuery>> {
+        let Layer4Protocol::Udp { src, dst } = failed_packet.layer4_protocol() else {
+            return None;
+        };
+
+        let dst_socket = SocketAddr::new(failed_packet.dst(), dst);
+        let Entry::Occupied(entry) = self.pending_queries_by_local_port.entry(src) else {
+            return None;
+        };
+
+        if entry.get().server != dst_socket {
+            return None;
+        };
+
+        Some(entry)
+    }
 }
 
 #[cfg(test)]
@@ -324,6 +367,32 @@ mod tests {
 
         // No pending queries, should return None
         assert!(client.poll_timeout().is_none());
+    }
+
+    #[test]
+    fn handles_icmp_error_for_pending_query() {
+        let mut client = create_test_client();
+        let now = Instant::now();
+        let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53);
+        let query = create_test_query();
+
+        let local = client.send_query(server, query.clone(), now).unwrap();
+
+        let packet = client.poll_outbound().unwrap();
+        let icmp_error_response = ip_packet::make::icmp_dest_unreachable_network(&packet).unwrap();
+
+        client.handle_inbound(icmp_error_response);
+
+        let query_result = client.poll_query_result().unwrap();
+
+        assert_eq!(query_result.query.id(), query.id());
+        assert_eq!(query_result.query.domain(), query.domain());
+        assert_eq!(query_result.local, local);
+        assert_eq!(query_result.server, server);
+        assert_eq!(
+            query_result.result.unwrap_err().to_string(),
+            "Received ICMP error for DNS query: Destination is unreachable (code: 0)"
+        );
     }
 
     fn create_test_client() -> Client {


### PR DESCRIPTION
When connlib needs to forward a DNS query to a server via the tunnel, we craft our own IP packets that use the TUN interface IPs as their source address. In other words, we basically create sockets on the TUN device but without involving the kernel. After all, we deal with layer 3 traffic directly.

As a result, we are also responsible for handling ICMP errors to those "sockets" and clean up any state accordingly if we e.g. receive a destination unreachable error. Right now, we don't do that and the ICMP error gets passed through to the TUN interface. The kernel has no knowledge of these sockets and therefore the ICMP error is a no-op.

To correctly handle these cases, we need to inspect inbound packets within the UDP and TCP DNS clients not only for their UDP / TCP payload but also check if they are ICMP errors for packets that originated from those clients. If they are, we need to clean up the state and emit a `QueryResult` with an error. These query results will then be handled by connlib by responding to the original DNS query with a SERVFAIL error.