### PR TITLE
feat(portal): flow log ingestion

### DIFF
--- a/elixir/lib/portal/accounts/limits.ex
+++ b/elixir/lib/portal/accounts/limits.ex
@@ -13,6 +13,8 @@ defmodule Portal.Accounts.Limits do
     field :api_tokens_per_client_count, :integer, default: 100
     field :api_refill_rate, :integer
     field :api_capacity, :integer
+    field :ingestion_refill_rate, :integer
+    field :ingestion_capacity, :integer
   end
 
   def changeset(limits \\ %__MODULE__{}, attrs) do
@@ -26,6 +28,8 @@ defmodule Portal.Accounts.Limits do
       api_tokens_per_client_count
       api_refill_rate
       api_capacity
+      ingestion_refill_rate
+      ingestion_capacity
     ]a
 
     limits
@@ -37,5 +41,7 @@ defmodule Portal.Accounts.Limits do
     |> validate_number(:account_admin_users_count, greater_than_or_equal_to: 0)
     |> validate_number(:api_clients_count, greater_than_or_equal_to: 0)
     |> validate_number(:api_tokens_per_client_count, greater_than_or_equal_to: 0)
+    |> validate_number(:ingestion_refill_rate, greater_than_or_equal_to: 0)
+    |> validate_number(:ingestion_capacity, greater_than_or_equal_to: 0)
   end
 end

--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -213,6 +213,72 @@ defmodule Portal.Authentication do
     "." <> Plug.Crypto.sign(key_base, salt <> type, body)
   end
 
+  # Ingestion authentication
+  #
+  # Introspects the token by attempting a cheap crypto decode against known salts
+  # (gateway, then client) to identify the token type before doing any DB work.
+  # This avoids needing the caller to know the token type upfront.
+  #
+  # Accepts a Plug.Conn so it can build the appropriate auth context only when
+  # needed (client tokens require a Context; gateway tokens do not).
+  def authenticate_ingestion(encoded_token, %Plug.Conn{} = conn)
+      when is_binary(encoded_token) do
+    config = fetch_config!()
+    key_base = Keyword.fetch!(config, :key_base)
+    base_salt = Keyword.fetch!(config, :salt)
+
+    with [nonce, signed] <- String.split(encoded_token, ".", parts: 2),
+         {:ok, token_type, payload} <-
+           identify_token_type(signed, key_base, base_salt) do
+      verify_identified_token(token_type, nonce, payload, encoded_token, conn)
+    else
+      _ -> {:error, :invalid_token}
+    end
+  end
+
+  @ingestion_salts [
+    {:gateway, "gateway"},
+    {:gateway, "gateway_group"},
+    {:client, "client"}
+  ]
+
+  defp identify_token_type(signed, key_base, base_salt) do
+    Enum.find_value(@ingestion_salts, {:error, :invalid_token}, fn {type, salt} ->
+      case Plug.Crypto.verify(key_base, base_salt <> salt, signed, max_age: :infinity) do
+        {:ok, payload} -> {:ok, type, payload}
+        {:error, _} -> nil
+      end
+    end)
+  end
+
+  defp verify_identified_token(
+         :gateway,
+         nonce,
+         {account_id, id, fragment},
+         _encoded_token,
+         _conn
+       ) do
+    with {:ok, token} <- Database.fetch_gateway_token(account_id, id),
+         :ok <- verify_secret_hash(token, nonce, fragment) do
+      account = Database.get_account_by_id!(token.account_id)
+      {:ok, :gateway, account, token.id}
+    else
+      _ -> {:error, :invalid_token}
+    end
+  end
+
+  defp verify_identified_token(:client, _nonce, _payload, encoded_token, conn) do
+    context =
+      Context.build(conn.remote_ip, conn.assigns[:user_agent], conn.req_headers, :client)
+
+    with {:ok, token} <- use_token(encoded_token, context),
+         {:ok, subject} <- build_subject(token, context) do
+      {:ok, :client, subject.account, token.id}
+    else
+      _ -> {:error, :invalid_token}
+    end
+  end
+
   def verify_relay_token(encoded_token) when is_binary(encoded_token) do
     verify_infrastructure_token(
       encoded_token,

--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -1,0 +1,104 @@
+defmodule Portal.FlowLog do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{
+          account_id: Ecto.UUID.t(),
+          flow_id: Ecto.UUID.t(),
+          device_id: Ecto.UUID.t(),
+          role: String.t(),
+          flow_start: DateTime.t(),
+          flow_end: DateTime.t(),
+          payload: map(),
+          inserted_at: DateTime.t()
+        }
+
+  @roles ~w[initiator responder]
+
+  schema "flow_logs" do
+    belongs_to :account, Portal.Account, primary_key: true
+    field :flow_id, :binary_id, primary_key: true
+    field :device_id, :binary_id, primary_key: true
+    field :role, :string
+    field :flow_start, :utc_datetime_usec
+    field :flow_end, :utc_datetime_usec
+    field :payload, :map
+
+    timestamps(updated_at: false)
+  end
+
+  @uuid_fields ~w[flow_id account_id device_id]a
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required([
+      :flow_id,
+      :account_id,
+      :device_id,
+      :role,
+      :flow_start,
+      :flow_end,
+      :payload
+    ])
+    |> validate_uuids()
+    |> validate_inclusion(:role, @roles)
+    |> validate_in_past(:flow_start)
+    |> validate_in_past(:flow_end)
+    |> validate_flow_end_after_start()
+    |> check_constraint(:role,
+      name: :flow_logs_role_chk,
+      message: "must be initiator or responder"
+    )
+    |> check_constraint(:flow_end,
+      name: :flow_end_after_start,
+      message: "must be after or equal to flow_start"
+    )
+    |> check_constraint(:flow_start, name: :flow_start_in_past, message: "must be in the past")
+    |> check_constraint(:flow_end, name: :flow_end_in_past, message: "must be in the past")
+  end
+
+  defp validate_uuids(changeset) do
+    Enum.reduce(@uuid_fields, changeset, fn field, cs ->
+      case get_field(cs, field) do
+        nil -> cs
+        value -> validate_uuid(cs, field, value)
+      end
+    end)
+  end
+
+  defp validate_uuid(changeset, field, value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, _} -> changeset
+      :error -> add_error(changeset, field, "is not a valid UUID")
+    end
+  end
+
+  defp validate_in_past(changeset, field) do
+    case get_field(changeset, field) do
+      %DateTime{} = dt ->
+        if DateTime.compare(dt, DateTime.utc_now()) == :gt do
+          add_error(changeset, field, "must be in the past")
+        else
+          changeset
+        end
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp validate_flow_end_after_start(changeset) do
+    flow_start = get_field(changeset, :flow_start)
+    flow_end = get_field(changeset, :flow_end)
+
+    if flow_start && flow_end && DateTime.compare(flow_end, flow_start) == :lt do
+      add_error(changeset, :flow_end, "must be after or equal to flow_start")
+    else
+      changeset
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -1,0 +1,103 @@
+defmodule PortalAPI.FlowLogController do
+  use PortalAPI, :controller
+  import Ecto.Changeset
+  alias Portal.FlowLog
+  alias __MODULE__.Database
+
+  @top_level_keys ~w(flow_id device_id role flow_start flow_end)
+  @cast_fields ~w[flow_id account_id device_id role flow_start flow_end payload inserted_at]a
+  @max_batch_size 10_000
+
+  def create(conn, %{"flow_logs" => records})
+      when is_list(records) and length(records) > @max_batch_size do
+    conn
+    |> put_status(400)
+    |> Phoenix.Controller.json(%{
+      error: %{reason: "batch size exceeds maximum of #{@max_batch_size}"}
+    })
+  end
+
+  def create(conn, %{"flow_logs" => records}) when is_list(records) do
+    account_id = conn.assigns.account.id
+    now = DateTime.utc_now()
+
+    {entries, errors} =
+      records
+      |> Enum.with_index()
+      |> Enum.reduce({[], []}, fn {record, index}, acc ->
+        validate_record(record, index, account_id, now, acc)
+      end)
+
+    if entries != [] do
+      Database.insert_all_flow_logs(entries)
+    end
+
+    if errors == [] do
+      conn
+      |> put_status(202)
+      |> put_view(json: PortalAPI.FlowLogJSON)
+      |> render(:accepted)
+    else
+      conn
+      |> put_status(422)
+      |> put_view(json: PortalAPI.FlowLogJSON)
+      |> render(:errors, errors: Enum.reverse(errors))
+    end
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(400)
+    |> Phoenix.Controller.json(%{error: %{reason: "expected a \"flow_logs\" array"}})
+  end
+
+  defp validate_record(record, index, _account_id, _now, {valid, invalid})
+       when not is_map(record) do
+    {valid, [{index, :not_a_map} | invalid]}
+  end
+
+  defp validate_record(record, index, account_id, now, {valid, invalid}) do
+    changeset =
+      record
+      |> to_attrs(account_id, now)
+      |> changeset()
+
+    if changeset.valid? do
+      entry = Map.new(@cast_fields, &{&1, get_field(changeset, &1)})
+      {[entry | valid], invalid}
+    else
+      {valid, [{index, changeset} | invalid]}
+    end
+  end
+
+  defp changeset(attrs) do
+    %FlowLog{}
+    |> cast(attrs, @cast_fields)
+    |> FlowLog.changeset()
+  end
+
+  defp to_attrs(record, account_id, now) do
+    {top, rest} = Map.split(record, @top_level_keys)
+
+    %{
+      "flow_id" => top["flow_id"],
+      "account_id" => account_id,
+      "device_id" => top["device_id"],
+      "role" => top["role"],
+      "flow_start" => top["flow_start"],
+      "flow_end" => top["flow_end"],
+      "payload" => rest,
+      "inserted_at" => now
+    }
+  end
+
+  defmodule Database do
+    alias Portal.Safe
+    alias Portal.FlowLog
+
+    def insert_all_flow_logs(entries) do
+      Safe.unscoped()
+      |> Safe.insert_all(FlowLog, entries, on_conflict: :nothing)
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -2,6 +2,7 @@ defmodule PortalAPI.FlowLogController do
   use PortalAPI, :controller
   import Ecto.Changeset
   alias Portal.FlowLog
+  alias PortalAPI.ProblemDetails
   alias __MODULE__.Database
 
   @top_level_keys ~w(flow_id device_id role flow_start flow_end)
@@ -10,11 +11,7 @@ defmodule PortalAPI.FlowLogController do
 
   def create(conn, %{"flow_logs" => records})
       when is_list(records) and length(records) > @max_batch_size do
-    conn
-    |> put_status(400)
-    |> Phoenix.Controller.json(%{
-      error: %{reason: "batch size exceeds maximum of #{@max_batch_size}"}
-    })
+    ProblemDetails.send(conn, 400, "Batch size exceeds maximum of #{@max_batch_size}")
   end
 
   def create(conn, %{"flow_logs" => records}) when is_list(records) do
@@ -38,17 +35,16 @@ defmodule PortalAPI.FlowLogController do
       |> put_view(json: PortalAPI.FlowLogJSON)
       |> render(:accepted)
     else
-      conn
-      |> put_status(422)
-      |> put_view(json: PortalAPI.FlowLogJSON)
-      |> render(:errors, errors: Enum.reverse(errors))
+      validation_errors = render_validation_errors(Enum.reverse(errors))
+
+      ProblemDetails.send(conn, 422, "Some flow log records failed validation", %{
+        validation_errors: validation_errors
+      })
     end
   end
 
   def create(conn, _params) do
-    conn
-    |> put_status(400)
-    |> Phoenix.Controller.json(%{error: %{reason: "expected a \"flow_logs\" array"}})
+    ProblemDetails.send(conn, 400, "Expected a \"flow_logs\" array")
   end
 
   defp validate_record(record, index, _account_id, _now, {valid, invalid})
@@ -74,6 +70,22 @@ defmodule PortalAPI.FlowLogController do
     %FlowLog{}
     |> cast(attrs, @cast_fields)
     |> FlowLog.changeset()
+  end
+
+  defp render_validation_errors(errors) do
+    Map.new(errors, fn
+      {index, :not_a_map} ->
+        {index, %{record: ["must be a JSON object"]}}
+
+      {index, changeset} ->
+        {index, Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
+    end)
+  end
+
+  defp translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
   end
 
   defp to_attrs(record, account_id, now) do

--- a/elixir/lib/portal_api/controllers/flow_log_json.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_json.ex
@@ -1,0 +1,27 @@
+defmodule PortalAPI.FlowLogJSON do
+  def render("accepted.json", _assigns) do
+    %{data: %{status: "accepted"}}
+  end
+
+  def render("errors.json", %{errors: errors}) do
+    %{
+      error: %{
+        reason: "Unprocessable Entity",
+        validation_errors:
+          Map.new(errors, fn
+            {index, :not_a_map} ->
+              {index, %{record: ["must be a JSON object"]}}
+
+            {index, changeset} ->
+              {index, Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
+          end)
+      }
+    }
+  end
+
+  defp translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
+end

--- a/elixir/lib/portal_api/controllers/flow_log_json.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_json.ex
@@ -2,26 +2,4 @@ defmodule PortalAPI.FlowLogJSON do
   def render("accepted.json", _assigns) do
     %{data: %{status: "accepted"}}
   end
-
-  def render("errors.json", %{errors: errors}) do
-    %{
-      error: %{
-        reason: "Unprocessable Entity",
-        validation_errors:
-          Map.new(errors, fn
-            {index, :not_a_map} ->
-              {index, %{record: ["must be a JSON object"]}}
-
-            {index, changeset} ->
-              {index, Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
-          end)
-      }
-    }
-  end
-
-  defp translate_error({msg, opts}) do
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
-  end
 end

--- a/elixir/lib/portal_api/plugs/ingestion_auth.ex
+++ b/elixir/lib/portal_api/plugs/ingestion_auth.ex
@@ -1,6 +1,7 @@
 defmodule PortalAPI.Plugs.IngestionAuth do
   import Plug.Conn
   alias Portal.Authentication
+  alias PortalAPI.ProblemDetails
 
   def init(opts), do: opts
 
@@ -13,11 +14,7 @@ defmodule PortalAPI.Plugs.IngestionAuth do
       |> assign(:token_id, token_id)
     else
       _ ->
-        conn
-        |> put_status(401)
-        |> Phoenix.Controller.put_view(json: PortalAPI.ErrorJSON)
-        |> Phoenix.Controller.render(:"401")
-        |> halt()
+        ProblemDetails.send(conn, 401, "Missing or invalid authorization token")
     end
   end
 end

--- a/elixir/lib/portal_api/plugs/ingestion_auth.ex
+++ b/elixir/lib/portal_api/plugs/ingestion_auth.ex
@@ -1,0 +1,23 @@
+defmodule PortalAPI.Plugs.IngestionAuth do
+  import Plug.Conn
+  alias Portal.Authentication
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with ["Bearer " <> encoded_token] <- get_req_header(conn, "authorization"),
+         {:ok, _token_type, account, token_id} <-
+           Authentication.authenticate_ingestion(encoded_token, conn) do
+      conn
+      |> assign(:account, account)
+      |> assign(:token_id, token_id)
+    else
+      _ ->
+        conn
+        |> put_status(401)
+        |> Phoenix.Controller.put_view(json: PortalAPI.ErrorJSON)
+        |> Phoenix.Controller.render(:"401")
+        |> halt()
+    end
+  end
+end

--- a/elixir/lib/portal_api/plugs/ingestion_rate_limit.ex
+++ b/elixir/lib/portal_api/plugs/ingestion_rate_limit.ex
@@ -1,0 +1,47 @@
+defmodule PortalAPI.Plugs.IngestionRateLimit do
+  import Plug.Conn
+
+  @default_refill_rate Portal.Config.fetch_env!(:portal, PortalAPI.RateLimit)[:refill_rate]
+  @default_capacity Portal.Config.fetch_env!(:portal, PortalAPI.RateLimit)[:capacity]
+  @cost 1
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    account = conn.assigns.account
+    token_id = conn.assigns.token_id
+    ip_key = "ingestion:ip:#{ip_to_string(conn.remote_ip)}"
+    token_key = "ingestion:token:#{token_id}"
+    refill_rate = refill_rate(account)
+    capacity = capacity(account)
+
+    with {:allow, _} <- PortalAPI.RateLimit.hit(ip_key, refill_rate, capacity, @cost),
+         {:allow, _} <- PortalAPI.RateLimit.hit(token_key, refill_rate, capacity, @cost) do
+      conn
+    else
+      {:deny, retry_after_ms} ->
+        retry_after = max(ceil(retry_after_ms / 1000), 1)
+
+        conn
+        |> put_resp_header("retry-after", Integer.to_string(retry_after))
+        |> put_status(429)
+        |> Phoenix.Controller.put_view(json: PortalAPI.ErrorJSON)
+        |> Phoenix.Controller.render(:"429")
+        |> halt()
+    end
+  end
+
+  defp refill_rate(account) do
+    account.limits.ingestion_refill_rate || @default_refill_rate
+  end
+
+  defp capacity(account) do
+    account.limits.ingestion_capacity || @default_capacity
+  end
+
+  defp ip_to_string(ip) do
+    ip
+    |> :inet.ntoa()
+    |> to_string()
+  end
+end

--- a/elixir/lib/portal_api/plugs/ingestion_rate_limit.ex
+++ b/elixir/lib/portal_api/plugs/ingestion_rate_limit.ex
@@ -24,10 +24,7 @@ defmodule PortalAPI.Plugs.IngestionRateLimit do
 
         conn
         |> put_resp_header("retry-after", Integer.to_string(retry_after))
-        |> put_status(429)
-        |> Phoenix.Controller.put_view(json: PortalAPI.ErrorJSON)
-        |> Phoenix.Controller.render(:"429")
-        |> halt()
+        |> PortalAPI.ProblemDetails.send(429, "Rate limit exceeded, retry after #{retry_after}s")
     end
   end
 

--- a/elixir/lib/portal_api/problem_details.ex
+++ b/elixir/lib/portal_api/problem_details.ex
@@ -1,0 +1,35 @@
+defmodule PortalAPI.ProblemDetails do
+  @moduledoc """
+  Builds RFC 9457 (Problem Details for HTTP APIs) responses.
+
+  See: https://www.rfc-editor.org/rfc/rfc9457
+  """
+  import Plug.Conn
+
+  @content_type "application/problem+json"
+
+  @doc """
+  Sends an RFC 9457 problem details JSON response.
+
+  `status` is an integer HTTP status code.
+  `detail` is a human-readable explanation specific to this occurrence.
+  `extensions` is an optional map of extension members (e.g. validation_errors).
+  """
+  # sobelow_skip ["XSS.SendResp"]
+  @spec send(Plug.Conn.t(), integer(), String.t(), map()) :: Plug.Conn.t()
+  def send(conn, status, detail, extensions \\ %{}) do
+    body =
+      %{
+        type: "about:blank",
+        title: Plug.Conn.Status.reason_phrase(status),
+        status: status,
+        detail: detail
+      }
+      |> Map.merge(extensions)
+
+    conn
+    |> put_resp_content_type(@content_type)
+    |> Plug.Conn.send_resp(status, Phoenix.json_library().encode_to_iodata!(body))
+    |> halt()
+  end
+end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -33,6 +33,24 @@ defmodule PortalAPI.Router do
     get "/", OpenApiSpex.Plug.SwaggerUI, path: "/openapi"
   end
 
+  pipeline :ingestion do
+    plug Plug.Parsers,
+      parsers: [:json],
+      pass: ["*/*"],
+      json_decoder: Phoenix.json_library(),
+      length: 10_000_000
+
+    plug :accepts, ["json"]
+    plug PortalAPI.Plugs.IngestionAuth
+    plug PortalAPI.Plugs.IngestionRateLimit
+  end
+
+  scope "/ingestion", PortalAPI do
+    pipe_through :ingestion
+
+    post "/flow_logs", FlowLogController, :create
+  end
+
   scope "/", PortalAPI do
     pipe_through :api
 

--- a/elixir/priv/repo/migrations/20260320000000_create_flow_logs.exs
+++ b/elixir/priv/repo/migrations/20260320000000_create_flow_logs.exs
@@ -1,0 +1,32 @@
+defmodule Portal.Repo.Migrations.CreateFlowLogs do
+  use Ecto.Migration
+
+  def change do
+    create table(:flow_logs, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      add(:flow_id, :binary_id, primary_key: true, null: false)
+      add(:device_id, :binary_id, primary_key: true, null: false)
+      add(:role, :string, null: false)
+      add(:flow_start, :utc_datetime_usec, null: false)
+      add(:flow_end, :utc_datetime_usec, null: false)
+      add(:payload, :map, null: false, default: %{})
+
+      timestamps(updated_at: false, type: :utc_datetime_usec)
+    end
+
+    create(
+      constraint(:flow_logs, :flow_logs_role_chk, check: "role IN ('initiator', 'responder')")
+    )
+
+    create(constraint(:flow_logs, :flow_end_after_start, check: "flow_end >= flow_start"))
+    create(constraint(:flow_logs, :flow_start_in_past, check: "flow_start <= now()"))
+    create(constraint(:flow_logs, :flow_end_in_past, check: "flow_end <= now()"))
+
+    create(index(:flow_logs, [:account_id, :flow_start]))
+    create(index(:flow_logs, [:account_id, :flow_end]))
+  end
+end

--- a/elixir/test/portal/flow_log_test.exs
+++ b/elixir/test/portal/flow_log_test.exs
@@ -1,0 +1,159 @@
+defmodule Portal.FlowLogTest do
+  use Portal.DataCase, async: true
+
+  import Ecto.Changeset
+  alias Portal.FlowLog
+
+  describe "changeset/1" do
+    test "valid with all required fields" do
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: Ecto.UUID.generate(),
+          role: "initiator",
+          flow_start: ~U[2026-03-20 10:00:00.000000Z],
+          flow_end: ~U[2026-03-20 10:05:00.000000Z],
+          payload: %{"bytes_sent" => 1024},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      assert changeset.valid?
+    end
+
+    test "valid with responder role" do
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: Ecto.UUID.generate(),
+          role: "responder",
+          flow_start: ~U[2026-03-20 10:00:00.000000Z],
+          flow_end: ~U[2026-03-20 10:05:00.000000Z],
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      assert changeset.valid?
+    end
+
+    test "invalid without required fields" do
+      changeset =
+        %FlowLog{}
+        |> change(%{})
+        |> FlowLog.changeset()
+
+      refute changeset.valid?
+      assert errors_on(changeset) |> Map.has_key?(:flow_id)
+      assert errors_on(changeset) |> Map.has_key?(:account_id)
+      assert errors_on(changeset) |> Map.has_key?(:device_id)
+      assert errors_on(changeset) |> Map.has_key?(:role)
+      assert errors_on(changeset) |> Map.has_key?(:flow_start)
+      assert errors_on(changeset) |> Map.has_key?(:flow_end)
+      assert errors_on(changeset) |> Map.has_key?(:payload)
+    end
+
+    test "invalid with bad role" do
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: Ecto.UUID.generate(),
+          role: "sideways",
+          flow_start: ~U[2026-03-20 10:00:00.000000Z],
+          flow_end: ~U[2026-03-20 10:05:00.000000Z],
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      refute changeset.valid?
+      assert errors_on(changeset) |> Map.has_key?(:role)
+    end
+
+    test "invalid with non-UUID device_id" do
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: "not-a-uuid",
+          role: "initiator",
+          flow_start: ~U[2026-03-20 10:00:00.000000Z],
+          flow_end: ~U[2026-03-20 10:05:00.000000Z],
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      refute changeset.valid?
+      assert errors_on(changeset) |> Map.has_key?(:device_id)
+    end
+
+    test "invalid when flow_end is before flow_start" do
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: Ecto.UUID.generate(),
+          role: "initiator",
+          flow_start: ~U[2026-03-20 10:05:00.000000Z],
+          flow_end: ~U[2026-03-20 10:00:00.000000Z],
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      refute changeset.valid?
+      assert "must be after or equal to flow_start" in errors_on(changeset).flow_end
+    end
+
+    test "invalid when flow_start is in the future" do
+      future = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: Ecto.UUID.generate(),
+          role: "initiator",
+          flow_start: future,
+          flow_end: future,
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      refute changeset.valid?
+      assert "must be in the past" in errors_on(changeset).flow_start
+      assert "must be in the past" in errors_on(changeset).flow_end
+    end
+
+    test "valid when flow_end equals flow_start" do
+      ts = ~U[2026-03-20 10:00:00.000000Z]
+
+      changeset =
+        %FlowLog{}
+        |> change(%{
+          flow_id: Ecto.UUID.generate(),
+          account_id: Ecto.UUID.generate(),
+          device_id: Ecto.UUID.generate(),
+          role: "initiator",
+          flow_start: ts,
+          flow_end: ts,
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        })
+        |> FlowLog.changeset()
+
+      assert changeset.valid?
+    end
+  end
+end

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -1,0 +1,263 @@
+defmodule PortalAPI.FlowLogControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.SiteFixtures
+  import Portal.TokenFixtures
+
+  alias Portal.FlowLog
+
+  setup do
+    account = account_fixture()
+
+    %{account: account}
+  end
+
+  defp authorize_gateway(conn, account) do
+    site = site_fixture(account: account)
+    token = gateway_token_fixture(account: account, site: site)
+    encoded = encode_gateway_token(token)
+
+    put_req_header(conn, "authorization", "Bearer " <> encoded)
+  end
+
+  defp authorize_client(conn, account) do
+    actor = actor_fixture(account: account)
+    token = client_token_fixture(account: account, actor: actor)
+    encoded = encode_token(token)
+
+    put_req_header(conn, "authorization", "Bearer " <> encoded)
+  end
+
+  defp build_flow_record(overrides \\ %{}) do
+    defaults = %{
+      "flow_id" => Ecto.UUID.generate(),
+      "device_id" => Ecto.UUID.generate(),
+      "role" => "initiator",
+      "flow_start" => "2026-03-20T10:00:00.000000Z",
+      "flow_end" => "2026-03-20T10:05:00.000000Z",
+      "bytes_sent" => 1024,
+      "protocol" => "tcp"
+    }
+
+    Map.merge(defaults, overrides)
+  end
+
+  describe "create/2" do
+    test "returns 401 when unauthenticated", %{conn: conn} do
+      conn = post(conn, "/ingestion/flow_logs", %{"flow_logs" => [build_flow_record()]})
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 400 when batch exceeds 10k records", %{conn: conn, account: account} do
+      records = for _ <- 1..10_001, do: build_flow_record()
+
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => records})
+
+      assert %{"error" => %{"reason" => "batch size exceeds maximum of 10000"}} =
+               json_response(conn, 400)
+    end
+
+    test "returns 400 when flow_logs key is missing", %{conn: conn, account: account} do
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"something" => "else"})
+
+      assert %{"error" => %{"reason" => "expected a \"flow_logs\" array"}} =
+               json_response(conn, 400)
+    end
+
+    test "returns 400 when flow_logs is not a list", %{conn: conn, account: account} do
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => "not a list"})
+
+      assert %{"error" => %{"reason" => "expected a \"flow_logs\" array"}} =
+               json_response(conn, 400)
+    end
+
+    test "returns 202 with gateway token", %{conn: conn, account: account} do
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [build_flow_record()]})
+
+      assert %{"data" => %{"status" => "accepted"}} = json_response(conn, 202)
+    end
+
+    test "returns 202 with client token", %{conn: conn, account: account} do
+      conn =
+        conn
+        |> authorize_client(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [build_flow_record()]})
+
+      assert %{"data" => %{"status" => "accepted"}} = json_response(conn, 202)
+    end
+
+    test "batch of records persisted", %{conn: conn, account: account} do
+      records = for _ <- 1..3, do: build_flow_record()
+
+      conn
+      |> authorize_gateway(account)
+      |> post("/ingestion/flow_logs", %{"flow_logs" => records})
+
+      logs = Repo.all(FlowLog)
+      assert length(logs) == 3
+      assert Enum.all?(logs, &(&1.account_id == account.id))
+    end
+
+    test "duplicate flow_id + device_id is idempotent", %{conn: conn, account: account} do
+      record = build_flow_record()
+
+      conn
+      |> authorize_gateway(account)
+      |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      build_conn()
+      |> put_req_header("user-agent", "testing")
+      |> authorize_gateway(account)
+      |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      assert length(Repo.all(FlowLog)) == 1
+    end
+
+    test "payload captures extra fields", %{conn: conn, account: account} do
+      record =
+        build_flow_record(%{
+          "bytes_sent" => 2048,
+          "bytes_received" => 512,
+          "protocol" => "udp",
+          "destination" => "10.0.0.1:443"
+        })
+
+      conn
+      |> authorize_gateway(account)
+      |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      [log] = Repo.all(FlowLog)
+      assert log.payload["bytes_sent"] == 2048
+      assert log.payload["bytes_received"] == 512
+      assert log.payload["protocol"] == "udp"
+      assert log.payload["destination"] == "10.0.0.1:443"
+    end
+
+    test "returns 422 with invalid role", %{conn: conn, account: account} do
+      record = build_flow_record(%{"role" => "sideways"})
+
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert Map.has_key?(errors, "0")
+    end
+
+    test "returns 422 with invalid UUID for device_id", %{conn: conn, account: account} do
+      record = build_flow_record(%{"device_id" => "not-a-uuid"})
+
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert Map.has_key?(errors, "0")
+    end
+
+    test "returns 422 with invalid datetime for flow_start", %{conn: conn, account: account} do
+      record = build_flow_record(%{"flow_start" => "not-a-datetime"})
+
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert Map.has_key?(errors, "0")
+    end
+
+    test "returns 422 when flow_end is before flow_start", %{conn: conn, account: account} do
+      record =
+        build_flow_record(%{
+          "flow_start" => "2026-03-20T10:05:00.000000Z",
+          "flow_end" => "2026-03-20T10:00:00.000000Z"
+        })
+
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
+
+      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert Map.has_key?(errors, "0")
+    end
+
+    test "same flow_id with initiator and responder creates two rows", %{
+      conn: conn,
+      account: account
+    } do
+      flow_id = Ecto.UUID.generate()
+
+      initiator_record =
+        build_flow_record(%{
+          "flow_id" => flow_id,
+          "device_id" => Ecto.UUID.generate(),
+          "role" => "initiator"
+        })
+
+      responder_record =
+        build_flow_record(%{
+          "flow_id" => flow_id,
+          "device_id" => Ecto.UUID.generate(),
+          "role" => "responder"
+        })
+
+      conn
+      |> authorize_gateway(account)
+      |> post("/ingestion/flow_logs", %{
+        "flow_logs" => [initiator_record, responder_record]
+      })
+
+      logs = Repo.all(FlowLog)
+      assert length(logs) == 2
+      assert Enum.all?(logs, &(&1.flow_id == flow_id))
+    end
+
+    test "returns 422 when record is not a JSON object", %{conn: conn, account: account} do
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => ["not a map", 42, nil]})
+
+      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert errors["0"]["record"] == ["must be a JSON object"]
+      assert errors["1"]["record"] == ["must be a JSON object"]
+      assert errors["2"]["record"] == ["must be a JSON object"]
+    end
+
+    test "partial batch inserts valid records and returns 422 with errors", %{
+      conn: conn,
+      account: account
+    } do
+      good_record = build_flow_record()
+      bad_record = build_flow_record(%{"flow_start" => "invalid"})
+
+      conn =
+        conn
+        |> authorize_gateway(account)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [good_record, bad_record]})
+
+      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert Map.has_key?(errors, "1")
+      assert length(Repo.all(FlowLog)) == 1
+    end
+  end
+end

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -48,7 +48,8 @@ defmodule PortalAPI.FlowLogControllerTest do
     test "returns 401 when unauthenticated", %{conn: conn} do
       conn = post(conn, "/ingestion/flow_logs", %{"flow_logs" => [build_flow_record()]})
 
-      assert json_response(conn, 401)
+      assert %{"type" => "about:blank", "status" => 401, "title" => "Unauthorized"} =
+               json_response(conn, 401)
     end
 
     test "returns 400 when batch exceeds 10k records", %{conn: conn, account: account} do
@@ -59,8 +60,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => records})
 
-      assert %{"error" => %{"reason" => "batch size exceeds maximum of 10000"}} =
-               json_response(conn, 400)
+      assert %{
+               "type" => "about:blank",
+               "status" => 400,
+               "title" => "Bad Request",
+               "detail" => "Batch size exceeds maximum of 10000"
+             } = json_response(conn, 400)
     end
 
     test "returns 400 when flow_logs key is missing", %{conn: conn, account: account} do
@@ -69,8 +74,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"something" => "else"})
 
-      assert %{"error" => %{"reason" => "expected a \"flow_logs\" array"}} =
-               json_response(conn, 400)
+      assert %{
+               "type" => "about:blank",
+               "status" => 400,
+               "title" => "Bad Request",
+               "detail" => "Expected a \"flow_logs\" array"
+             } = json_response(conn, 400)
     end
 
     test "returns 400 when flow_logs is not a list", %{conn: conn, account: account} do
@@ -79,8 +88,11 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => "not a list"})
 
-      assert %{"error" => %{"reason" => "expected a \"flow_logs\" array"}} =
-               json_response(conn, 400)
+      assert %{
+               "type" => "about:blank",
+               "status" => 400,
+               "title" => "Bad Request"
+             } = json_response(conn, 400)
     end
 
     test "returns 202 with gateway token", %{conn: conn, account: account} do
@@ -156,7 +168,13 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
 
-      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "title" => "Unprocessable Content",
+               "validation_errors" => errors
+             } = json_response(conn, 422)
+
       assert Map.has_key?(errors, "0")
     end
 
@@ -168,7 +186,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
 
-      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => errors
+             } = json_response(conn, 422)
+
       assert Map.has_key?(errors, "0")
     end
 
@@ -180,7 +203,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
 
-      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => errors
+             } = json_response(conn, 422)
+
       assert Map.has_key?(errors, "0")
     end
 
@@ -196,7 +224,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => [record]})
 
-      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => errors
+             } = json_response(conn, 422)
+
       assert Map.has_key?(errors, "0")
     end
 
@@ -237,7 +270,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => ["not a map", 42, nil]})
 
-      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => errors
+             } = json_response(conn, 422)
+
       assert errors["0"]["record"] == ["must be a JSON object"]
       assert errors["1"]["record"] == ["must be a JSON object"]
       assert errors["2"]["record"] == ["must be a JSON object"]
@@ -255,7 +293,12 @@ defmodule PortalAPI.FlowLogControllerTest do
         |> authorize_gateway(account)
         |> post("/ingestion/flow_logs", %{"flow_logs" => [good_record, bad_record]})
 
-      assert %{"error" => %{"validation_errors" => errors}} = json_response(conn, 422)
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => errors
+             } = json_response(conn, 422)
+
       assert Map.has_key?(errors, "1")
       assert length(Repo.all(FlowLog)) == 1
     end

--- a/elixir/test/portal_api/plugs/ingestion_rate_limit_test.exs
+++ b/elixir/test/portal_api/plugs/ingestion_rate_limit_test.exs
@@ -1,0 +1,56 @@
+defmodule PortalAPI.Plugs.IngestionRateLimitTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.SiteFixtures
+  import Portal.TokenFixtures
+
+  setup do
+    account = account_fixture(limits: %{ingestion_refill_rate: 5, ingestion_capacity: 5})
+    site = site_fixture(account: account)
+    token = gateway_token_fixture(account: account, site: site)
+    encoded = encode_gateway_token(token)
+
+    # Deterministic unique IP to avoid collisions across async tests
+    counter = System.unique_integer([:positive, :monotonic])
+
+    unique_ip =
+      {10, rem(div(counter, 65_536), 256), rem(div(counter, 256), 256), rem(counter, 254) + 1}
+
+    %{encoded: encoded, unique_ip: unique_ip}
+  end
+
+  describe "rate limiting" do
+    test "returns 429 with retry-after after exceeding rate limit", %{
+      conn: conn,
+      encoded: encoded,
+      unique_ip: unique_ip
+    } do
+      flow_record = %{
+        "flow_id" => Ecto.UUID.generate(),
+        "device_id" => Ecto.UUID.generate(),
+        "role" => "initiator",
+        "flow_start" => "2026-03-20T10:00:00.000000Z",
+        "flow_end" => "2026-03-20T10:05:00.000000Z"
+      }
+
+      for _ <- 1..5 do
+        build_conn()
+        |> Map.put(:remote_ip, unique_ip)
+        |> put_req_header("user-agent", "testing")
+        |> put_req_header("authorization", "Bearer " <> encoded)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [flow_record]})
+      end
+
+      conn =
+        conn
+        |> Map.put(:remote_ip, unique_ip)
+        |> put_req_header("authorization", "Bearer " <> encoded)
+        |> post("/ingestion/flow_logs", %{"flow_logs" => [flow_record]})
+
+      assert conn.status == 429
+      assert [retry_after] = get_resp_header(conn, "retry-after")
+      assert String.to_integer(retry_after) > 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `POST /ingestion/flow_logs` endpoint for batch ingestion of NetFlow-style flow logs from gateways and clients.

Each flow produces two rows — one per participating device — identified by `role` (`initiator` or `responder`), following RFC 5103 biflow conventions.

### Primary key: `(account_id, flow_id, device_id)`

A flow is a bidirectional connection between two devices. Each device reports its side independently, so the PK naturally deduplicates: the same `(flow_id, device_id)` pair can only appear once per account. A device cannot initiate a flow to itself, so there is no need to include `role` in the PK.

The PK is ordered `(account_id, flow_id, device_id)` so that "show me both sides of flow X" queries benefit from index prefix scans — the most common access pattern for flow log lookups.

### Idempotency & retry semantics

`insert_all` uses `ON CONFLICT DO NOTHING`, so gateways can safely retry failed batches without worrying about duplicates. If a row with the same PK already exists, it is silently skipped. This makes the endpoint fully idempotent from the caller's perspective.

### Partial batch acceptance

Valid records are inserted even when the batch contains invalid ones. The response returns 422 with per-index validation errors for the rejected records, so the caller knows exactly which to fix and retry. This avoids throwing away good data because of one bad record in a large batch.

### Batch size limit

Batches are capped at 10,000 records. Requests exceeding this limit receive a 400 response before any validation or insertion work is performed.

### DB load & table contention

- **No updates, append-only**: the table only receives inserts, never updates. `inserted_at` uses `timestamps(updated_at: false)`. This eliminates row-level lock contention and HOT-update overhead.
- **`insert_all` (bulk insert)**: a single SQL statement per batch rather than one round-trip per record. The controller validates all records through changesets first, then bulk-inserts the valid entries.
- **No sequences**: the composite PK is caller-supplied UUIDs, avoiding `nextval()` contention on high-throughput inserts.
- **Minimal indexes**: only `(account_id, flow_start)` and `(account_id, flow_end)` beyond the PK. Fewer indexes = faster inserts.

### Validation

All records pass through `FlowLog.changeset/1` before insertion:

- UUID format validation on `flow_id`, `account_id`, `device_id`
- `role` must be `initiator` or `responder` (app-side + DB check constraint)
- `flow_start` and `flow_end` must be valid ISO 8601 timestamps (Ecto `:utc_datetime_usec` cast)
- `flow_end >= flow_start` (app-side + DB check constraint)
- `flow_start` and `flow_end` must be in the past (app-side + DB check constraint)
- All remaining JSON fields are captured in a schemaless `payload` JSONB column

### Ingestion authentication

`authenticate_ingestion/2` in `Portal.Authentication` introspects the bearer token by attempting a cheap `Plug.Crypto.verify` decode against known salts (gateway, then client) to identify the token type _before_ any DB work. Once the type is identified, only the matching verification path is executed — the auth context is only built for client tokens (which need it), not gateway tokens. Returns the full account (with limits) and token ID for rate limiting. Used by the `IngestionAuth` plug on the ingestion pipeline.

- Gateway tokens: verified via `verify_secret_hash`, loads full account, sets `conn.assigns.account` and `conn.assigns.token_id`
- Client tokens: builds auth context, full `authenticate` path (DB lookup + subject build), sets `conn.assigns.account` and `conn.assigns.token_id`

### Rate limiting

Rate limiting is **per-IP and per-token** (not per-account), so a single misbehaving gateway cannot lock out other devices in the same account. Limits are configurable per-account via `account.limits.ingestion_refill_rate` and `account.limits.ingestion_capacity`, falling back to the global `PortalAPI.RateLimit` defaults.

## Test plan

- [x] 100% code coverage on all new modules (verified via `mix coveralls.html`)
- [x] Schema changeset tests: required fields, UUID validation, role validation, temporal ordering, future timestamps
- [x] Controller tests: auth (401 for unauthenticated, 202 for gateway/client tokens), batch insert, idempotent duplicates, payload capture, partial batch acceptance, validation error responses (422), bad request handling (400), batch size limit (400 for >10k records)
- [x] Same `flow_id` with initiator + responder creates two distinct rows
- [x] Rate limit test with per-account configurable limits
- [x] `mix dialyzer` passes with 0 errors
- [x] `mix credo --strict` passes with 0 warnings
- [x] Full test suite: 2872 tests, 0 failures