### PR TITLE
chore(rust): bump rustls-webpki to 0.103.10

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6329,9 +6329,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Related: https://rustsec.org/advisories/RUSTSEC-2026-0049
