### PR TITLE
feat(portal): add 6-char account key

### DIFF
--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -12,6 +12,7 @@ defmodule Portal.Account do
   schema "accounts" do
     field :name, :string
     field :slug, :string
+    field :key, :string
 
     field :legal_name, :string
 
@@ -80,8 +81,18 @@ defmodule Portal.Account do
     changeset
     |> validate_length(:name, min: 3, max: 64)
     |> validate_length(:slug, min: 3, max: 100)
+    |> validate_length(:key, is: 6)
+    |> validate_key_format()
     |> validate_length(:legal_name, min: 1, max: 255)
     |> unique_constraint(:slug, name: :accounts_slug_index)
+    |> unique_constraint(:key, name: :accounts_key_index)
+  end
+
+  @base36 ~c"abcdefghijklmnopqrstuvwxyz0123456789"
+
+  @doc "Generate a cryptographically random 6-character base-36 key."
+  def new_key do
+    for(_ <- 1..6, into: "", do: <<Enum.at(@base36, uniform(36))>>)
   end
 
   @spec active?(t()) :: boolean()
@@ -98,6 +109,22 @@ defmodule Portal.Account do
 
   defp account_feature_enabled?(account, feature) do
     Map.fetch!(account.features || %Portal.Accounts.Features{}, feature) || false
+  end
+
+  # Rejection sampling to avoid modulo bias.
+  # Largest multiple of 36 that fits in a byte is 252 (36 * 7).
+  defp uniform(n) do
+    <<byte>> = :crypto.strong_rand_bytes(1)
+
+    if byte < 252 do
+      rem(byte, n)
+    else
+      uniform(n)
+    end
+  end
+
+  defp validate_key_format(changeset) do
+    validate_format(changeset, :key, ~r/^[a-z0-9]+$/, message: "must be lowercase alphanumeric")
   end
 end
 

--- a/elixir/lib/portal/billing/event_handler.ex
+++ b/elixir/lib/portal/billing/event_handler.ex
@@ -472,7 +472,8 @@ defmodule Portal.Billing.EventHandler do
   # TODO: BILLING OVERHAUL
   # The DB operations should be wrapped in a transaction to ensure atomicity
   defp create_account_with_defaults(attrs, metadata, account_email) do
-    with {:ok, account} <- attrs |> create_account_changeset() |> Database.insert(),
+    with {:ok, account} <-
+           Database.insert_account_with_key_retry(fn -> create_account_changeset(attrs) end),
          {:ok, account} <- Billing.update_stripe_customer(account),
          {:ok, account} <- Portal.Billing.create_subscription(account),
          :ok <- setup_account_defaults(account, metadata, account_email) do
@@ -637,9 +638,10 @@ defmodule Portal.Billing.EventHandler do
     import Ecto.Changeset
 
     %Portal.Account{}
-    |> cast(attrs, [:name, :legal_name, :slug])
+    |> cast(attrs, [:name, :legal_name, :slug, :key])
+    |> put_change(:key, Portal.Account.new_key())
     |> cast_embed(:metadata)
-    |> validate_required([:name, :legal_name, :slug])
+    |> validate_required([:name, :legal_name, :slug, :key])
   end
 
   defmodule Database do
@@ -688,6 +690,28 @@ defmodule Portal.Billing.EventHandler do
     def insert(changeset) do
       Safe.unscoped(changeset)
       |> Safe.insert()
+    end
+
+    def insert_account_with_key_retry(changeset_fn, retries \\ 5) do
+      changeset_fn.()
+      |> Safe.unscoped()
+      |> Safe.insert()
+      |> case do
+        {:ok, account} ->
+          {:ok, account}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          if retries > 0 and key_taken?(changeset) do
+            insert_account_with_key_retry(changeset_fn, retries - 1)
+          else
+            {:error, changeset}
+          end
+      end
+    end
+
+    defp key_taken?(%Ecto.Changeset{errors: errors}) do
+      Keyword.has_key?(errors, :key) and
+        match?({"has already been taken", _}, Keyword.get(errors, :key))
     end
 
     def update_account_by_id(id, attrs) do

--- a/elixir/lib/portal_api/controllers/account_json.ex
+++ b/elixir/lib/portal_api/controllers/account_json.ex
@@ -12,6 +12,7 @@ defmodule PortalAPI.AccountJSON do
     %{
       id: account.id,
       slug: account.slug,
+      key: account.key,
       name: account.name,
       legal_name: account.legal_name,
       limits: build_limits(account)

--- a/elixir/lib/portal_api/schemas/account_schema.ex
+++ b/elixir/lib/portal_api/schemas/account_schema.ex
@@ -47,11 +47,17 @@ defmodule PortalAPI.Schemas.Account do
       properties: %{
         id: %Schema{type: :string, format: :uuid, description: "Account ID"},
         slug: %Schema{type: :string, description: "Account slug"},
+        key: %Schema{
+          type: :string,
+          description: "6-character account key",
+          minLength: 6,
+          maxLength: 6
+        },
         name: %Schema{type: :string, description: "Account name"},
         legal_name: %Schema{type: :string, description: "Account legal name"},
         limits: PortalAPI.Schemas.Account.LimitsSchema
       },
-      required: [:id, :slug, :name]
+      required: [:id, :slug, :key, :name]
     })
   end
 

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -43,6 +43,12 @@ defmodule PortalWeb.Settings.Account do
               <.copy id="account-slug">{@account.slug}</.copy>
             </:value>
           </.vertical_table_row>
+          <.vertical_table_row>
+            <:label>Account Key</:label>
+            <:value>
+              <.copy id="account-key">{@account.key}</.copy>
+            </:value>
+          </.vertical_table_row>
         </.vertical_table>
       </:content>
     </.section>

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -414,12 +414,13 @@ defmodule PortalWeb.SignUp do
     import Ecto.Changeset
 
     %Portal.Account{id: Map.get(attrs, :id)}
-    |> cast(attrs, [:name, :legal_name, :slug])
+    |> cast(attrs, [:name, :legal_name, :slug, :key])
     |> maybe_default_legal_name()
     |> maybe_generate_slug()
+    |> put_change(:key, Portal.Account.new_key())
     |> put_default_config()
     |> cast_embed(:metadata)
-    |> validate_required([:name, :legal_name, :slug])
+    |> validate_required([:name, :legal_name, :slug, :key])
     |> Portal.Account.changeset()
   end
 
@@ -579,13 +580,13 @@ defmodule PortalWeb.SignUp do
 
       Ecto.Multi.new()
       |> Ecto.Multi.run(:account, fn _repo, _changes ->
-        %{
+        attrs = %{
           id: account_id,
           name: registration.account.name,
           metadata: %{stripe: stripe_metadata}
         }
-        |> changeset_fns.account.()
-        |> insert()
+
+        insert_account_with_key_retry(attrs, changeset_fns.account)
       end)
       |> Ecto.Multi.run(:everyone_group, fn _repo, %{account: account} ->
         changeset_fns.everyone_group.(account)
@@ -682,6 +683,28 @@ defmodule PortalWeb.SignUp do
     def insert(changeset) do
       Safe.unscoped(changeset)
       |> Safe.insert()
+    end
+
+    def insert_account_with_key_retry(attrs, changeset_fn, retries \\ 5) do
+      changeset_fn.(attrs)
+      |> Safe.unscoped()
+      |> Safe.insert()
+      |> case do
+        {:ok, account} ->
+          {:ok, account}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          if retries > 0 and key_taken?(changeset) do
+            insert_account_with_key_retry(attrs, changeset_fn, retries - 1)
+          else
+            {:error, changeset}
+          end
+      end
+    end
+
+    defp key_taken?(%Ecto.Changeset{errors: errors}) do
+      Keyword.has_key?(errors, :key) and
+        match?({"has already been taken", _}, Keyword.get(errors, :key))
     end
 
     def slug_exists?(slug) do

--- a/elixir/priv/repo/manual_migrations/20260322000000_backfill_account_keys.exs
+++ b/elixir/priv/repo/manual_migrations/20260322000000_backfill_account_keys.exs
@@ -1,0 +1,26 @@
+defmodule Portal.Repo.Migrations.BackfillAccountKeys do
+  use Ecto.Migration
+
+  @chars "abcdefghijklmnopqrstuvwxyz0123456789"
+
+  def up do
+    execute("""
+    UPDATE accounts
+    SET key = (
+      SELECT string_agg(substr('#{@chars}', floor(random() * 36 + 1)::int, 1), '')
+      FROM generate_series(1, 6)
+    )
+    WHERE key IS NULL
+    """)
+
+    alter table(:accounts) do
+      modify(:key, :string, size: 6, null: false, from: {:string, size: 6, null: true})
+    end
+  end
+
+  def down do
+    alter table(:accounts) do
+      modify(:key, :string, size: 6, null: true, from: {:string, size: 6, null: false})
+    end
+  end
+end

--- a/elixir/priv/repo/migrations/20260321000000_add_key_to_accounts.exs
+++ b/elixir/priv/repo/migrations/20260321000000_add_key_to_accounts.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.AddKeyToAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      add(:key, :string, size: 6)
+    end
+  end
+end

--- a/elixir/priv/repo/migrations/20260321000001_add_key_unique_index_to_accounts.exs
+++ b/elixir/priv/repo/migrations/20260321000001_add_key_unique_index_to_accounts.exs
@@ -1,0 +1,11 @@
+defmodule Portal.Repo.Migrations.AddKeyUniqueIndexToAccounts do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    create_if_not_exists(
+      unique_index(:accounts, [:key], name: :accounts_key_index, concurrently: true)
+    )
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -249,11 +249,12 @@ defmodule Portal.Repo.Seeds do
           name: "Firezone Account",
           legal_name: "Firezone Account",
           slug: "firezone",
+          key: Account.new_key(),
           config: %{
             search_domain: "httpbin.search.test"
           }
         },
-        [:name, :legal_name, :slug]
+        [:name, :legal_name, :slug, :key]
       )
       |> cast_embed(:config)
       |> put_change(:id, "c89bcc8c-9392-4dae-a40d-888aef6d28e0")
@@ -289,9 +290,10 @@ defmodule Portal.Repo.Seeds do
         %{
           name: "Other Corp Account",
           legal_name: "Other Corp Account",
-          slug: "not_firezone"
+          slug: "not_firezone",
+          key: Account.new_key()
         },
-        [:name, :legal_name, :slug]
+        [:name, :legal_name, :slug, :key]
       )
       |> put_change(:id, "9b9290bf-e1bc-4dd3-b401-511908262690")
       |> Repo.insert!()

--- a/elixir/test/portal/account_test.exs
+++ b/elixir/test/portal/account_test.exs
@@ -6,9 +6,11 @@ defmodule Portal.AccountTest do
 
   alias Portal.Account
 
+  alias Portal.Repo
+
   defp build_changeset(attrs) do
     %Account{}
-    |> cast(attrs, [:name, :slug, :legal_name])
+    |> cast(attrs, [:name, :slug, :legal_name, :key])
     |> Account.changeset()
   end
 
@@ -41,6 +43,38 @@ defmodule Portal.AccountTest do
     test "rejects legal_name exceeding maximum length" do
       changeset = build_changeset(%{legal_name: String.duplicate("a", 256)})
       assert %{legal_name: ["should be at most 255 character(s)"]} = errors_on(changeset)
+    end
+  end
+
+  describe "new_key/0" do
+    test "returns a 6-character base-36 string" do
+      key = Account.new_key()
+      assert String.length(key) == 6
+      assert key =~ ~r/^[a-z0-9]{6}$/
+    end
+
+    test "returns different values on successive calls" do
+      keys = for _ <- 1..10, do: Account.new_key()
+      assert length(Enum.uniq(keys)) > 1
+    end
+  end
+
+  describe "changeset/1 key validations" do
+    test "rejects key with wrong length" do
+      changeset = build_changeset(%{key: "abc"})
+      assert %{key: ["should be 6 character(s)"]} = errors_on(changeset)
+    end
+
+    test "enforces unique constraint on key" do
+      account = account_fixture()
+
+      {:error, changeset} =
+        %Account{}
+        |> cast(valid_account_attrs(%{key: account.key}), [:name, :slug, :legal_name, :key])
+        |> Account.changeset()
+        |> Repo.insert()
+
+      assert %{key: ["has already been taken"]} = errors_on(changeset)
     end
   end
 end

--- a/elixir/test/portal_api/controllers/account_controller_test.exs
+++ b/elixir/test/portal_api/controllers/account_controller_test.exs
@@ -18,6 +18,7 @@ defmodule PortalAPI.AccountControllerTest do
                "data" => %{
                  "id" => account_id,
                  "slug" => slug,
+                 "key" => key,
                  "name" => name,
                  "legal_name" => legal_name,
                  "limits" => limits
@@ -26,6 +27,7 @@ defmodule PortalAPI.AccountControllerTest do
 
       assert account_id == account.id
       assert slug == account.slug
+      assert key == account.key
       assert name == account.name
       assert legal_name == account.legal_name
       assert is_map(limits)

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -582,6 +582,7 @@ defmodule PortalWeb.SignUpTest do
           |> Ecto.Changeset.cast(attrs, [:name])
           |> Ecto.Changeset.put_change(:legal_name, Map.get(attrs, :name))
           |> Ecto.Changeset.put_change(:slug, "test-#{System.unique_integer([:positive])}")
+          |> Ecto.Changeset.put_change(:key, Portal.Account.new_key())
         end,
         everyone_group: fn _account -> invalid_group_changeset end,
         site: fn _account, _attrs -> invalid_group_changeset end,

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -16,6 +16,7 @@ defmodule Portal.AccountFixtures do
       name: "Account #{unique_num}",
       legal_name: "Legal Account #{unique_num}",
       slug: "account_#{unique_num}",
+      key: Portal.Account.new_key(),
       config: %{
         clients_upstream_dns: %{
           type: :custom,
@@ -55,7 +56,7 @@ defmodule Portal.AccountFixtures do
     attrs = valid_account_attrs(attrs)
 
     %Portal.Account{}
-    |> cast(attrs, [:name, :legal_name, :slug])
+    |> cast(attrs, [:name, :legal_name, :slug, :key])
     |> cast_embed(:config)
     |> cast_embed(:features)
     |> cast_embed(:limits)
@@ -124,6 +125,7 @@ defmodule Portal.AccountFixtures do
       :name,
       :legal_name,
       :slug,
+      :key,
       :disabled_at,
       :disabled_reason,
       :users_limit_exceeded,


### PR DESCRIPTION
Accounts today contain a UUIDv4 (36 characters) and an account slug (varies, up to ~50 chars). Neither of these are suitable for use as a unique subdomain key to support device to device coms.

To support that feature instead, we create a unique 6-character `key` per account which will be used to form an FQDN for each connecting device:

e.g.

- Account key is `dr49as`
- Account FQDN is `dr49as.fz.internal`
- Device IP is `100.70.70.70`
- Full device FQDN within Firezone would be `100-70-70-70.dr49as.fz.internal`

---

Related: #11143 
Related: #12006 
