### PR TITLE
refactor(connlib): introduce `RoutingTable` component

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -174,7 +174,7 @@ impl ClientState {
 
         for record in &records {
             for ip in &record.ips {
-                routing_table.upsert_dns(*ip, record.resource);
+                routing_table.upsert_dns(*ip, record.resource, record.domain.clone());
             }
         }
 
@@ -324,13 +324,13 @@ impl ClientState {
         // Organise all buffered packets by gateway + domain.
         let mut buffered_packets_by_gateway_and_domain = buffered_packets
             .map(|packet| {
-                let (domain, resource) = self
-                    .stub_resolver
-                    .resolve_resource_by_ip(&packet.destination())
-                    .context("IP is not associated with a DNS resource domain")?;
+                let (resource, domain) = self
+                    .routing_table
+                    .matches_dns(packet.destination(), |_, _| Ordering::Equal)
+                    .context("IP is not associated with a DNS resource")?;
                 let gateway_id = self
                     .authorized_resources
-                    .get(resource)
+                    .get(&resource)
                     .context("No gateway for resource")?;
 
                 anyhow::Ok((*gateway_id, domain, packet))
@@ -366,7 +366,7 @@ impl ClientState {
             };
 
             let packets_for_domain = buffered_packets_by_gateway_and_domain
-                .remove(&(*gid, domain))
+                .remove(&(*gid, domain.clone()))
                 .unwrap_or_default();
 
             match self.dns_resource_nat.update(
@@ -617,12 +617,12 @@ impl ClientState {
             self.route_packet_to_resource(packet, now)?
         };
 
-        if let Some((domain, _)) = self.stub_resolver.resolve_resource_by_ip(&dst)
+        if let Some((_, domain)) = self.routing_table.matches_dns(dst, |_, _| Ordering::Equal)
             && let ClientOrGatewayId::Gateway(gid) = pid
         {
             packet = self
                 .dns_resource_nat
-                .handle_outgoing(gid, domain, packet, now)?;
+                .handle_outgoing(gid, &domain, packet, now)?;
         }
 
         let transmit = self
@@ -1030,8 +1030,9 @@ impl ClientState {
     fn get_resource_by_destination(&self, destination: IpAddr) -> Option<ResourceId> {
         let maybe_dns_resource_id = self.routing_table.matches_dns(destination, |_, _| Ordering::Equal)
             .inspect(
-                |rid| tracing::trace!(target: "tunnel_test_coverage", %destination, %rid, "Packet for DNS resource"),
-            );
+                |(rid, domain)| tracing::trace!(target: "tunnel_test_coverage", %destination, %rid, %domain, "Packet for DNS resource"),
+            )
+            .map(|(rid, _)| rid);
 
         // Tie-breaker function for preferring resources we are already connected to over other ones.
         let prefer_connected_cidr = |left, right| match (
@@ -1186,7 +1187,8 @@ impl ClientState {
         while let Some(dns::Event::RecordsChanged(records)) = self.stub_resolver.poll_event() {
             for record in &records {
                 for ip in &record.ips {
-                    self.routing_table.upsert_dns(*ip, record.resource);
+                    self.routing_table
+                        .upsert_dns(*ip, record.resource, record.domain.clone());
                 }
             }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -366,7 +366,7 @@ impl ClientState {
             };
 
             let packets_for_domain = buffered_packets_by_gateway_and_domain
-                .remove(&(*gid, domain.clone()))
+                .remove(&(*gid, domain))
                 .unwrap_or_default();
 
             match self.dns_resource_nat.update(
@@ -622,7 +622,7 @@ impl ClientState {
         {
             packet = self
                 .dns_resource_nat
-                .handle_outgoing(gid, &domain, packet, now)?;
+                .handle_outgoing(gid, domain, packet, now)?;
         }
 
         let transmit = self

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -6,6 +6,7 @@ mod gateway_on_client;
 mod pending_device_access;
 mod pending_flows;
 mod resource;
+mod routing_table;
 mod tracked_state;
 
 pub(crate) use crate::client::client_on_client::ClientOnClient;
@@ -14,12 +15,15 @@ pub(crate) use crate::client::gateway_on_client::GatewayOnClient;
 use crate::client::dns_config::DnsConfig;
 use crate::client::pending_device_access::PendingDeviceAccessRequests;
 use crate::client::pending_flows::{ConnectionTrigger, DnsQueryForSite, PendingFlows};
+use crate::client::routing_table::RoutingTable;
 use crate::client::tracked_state::TrackedState;
 use crate::messages::client::FailReason;
 use boringtun::x25519;
+#[cfg(test)]
+pub(crate) use resource::CidrResource;
 #[cfg(all(feature = "proptest", test))]
 pub(crate) use resource::DnsResource;
-pub(crate) use resource::{CidrResource, InternetResource, Resource};
+pub(crate) use resource::{InternetResource, Resource};
 
 use dns_resource_nat::DnsResourceNat;
 use dns_types::ResponseCode;
@@ -40,7 +44,6 @@ use connlib_model::{
 };
 use connlib_model::{Site, SiteId};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
-use ip_network_table::IpNetworkTable;
 use ip_packet::{IpPacket, MAX_UDP_PAYLOAD};
 use itertools::Itertools;
 use logging::{unwrap_or_debug, unwrap_or_warn};
@@ -127,8 +130,8 @@ pub struct ClientState {
     /// The online/offline status of a site, together with the timestamp when we set it.
     sites_status: BTreeMap<SiteId, (ResourceStatus, Instant)>,
 
-    /// All CIDR resources we know about, indexed by the IP range they cover (like `1.1.0.0/8`).
-    active_cidr_resources: IpNetworkTable<CidrResource>,
+    /// The routing table, mapping IPs to Resource IDs.
+    routing_table: RoutingTable,
     is_internet_resource_active: bool,
     /// All resources indexed by their ID.
     resources_by_id: BTreeMap<ResourceId, Resource>,
@@ -167,9 +170,17 @@ impl ClientState {
         now: Instant,
         unix_ts: Duration,
     ) -> Self {
+        let mut routing_table = RoutingTable::default();
+
+        for record in &records {
+            for ip in &record.ips {
+                routing_table.upsert_dns(*ip, record.resource);
+            }
+        }
+
         Self {
             authorized_resources: Default::default(),
-            active_cidr_resources: IpNetworkTable::new(),
+            routing_table,
             resources_by_id: Default::default(),
             gateways: Default::default(),
             clients: Default::default(),
@@ -854,10 +865,7 @@ impl ClientState {
             return Some(*server);
         }
 
-        self.active_cidr_resources
-            .longest_match(server.ip())
-            .is_some()
-            .then_some(*server)
+        self.routing_table.any_cidr(server.ip()).then_some(*server)
     }
 
     /// Handles UDP & TCP packets targeted at our stub resolver.
@@ -1002,7 +1010,7 @@ impl ClientState {
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {
         iter::empty()
-            .chain(self.active_cidr_resources.iter().map(|(ip, _)| ip))
+            .chain(self.routing_table.cidr_routes())
             .chain(iter::once(IPV4_TUNNEL.into()))
             .chain(iter::once(IPV6_TUNNEL.into()))
             .chain(iter::once(IPV4_RESOURCES.into()))
@@ -1020,20 +1028,22 @@ impl ClientState {
     }
 
     fn get_resource_by_destination(&self, destination: IpAddr) -> Option<ResourceId> {
-        // We need to filter disabled resources because we never remove resources from the stub_resolver
-        let maybe_dns_resource_id = self
-            .stub_resolver
-            .resolve_resource_by_ip(&destination)
-            .map(|(_, r)| *r)
+        let maybe_dns_resource_id = self.routing_table.matches_dns(destination, |_, _| Ordering::Equal)
             .inspect(
                 |rid| tracing::trace!(target: "tunnel_test_coverage", %destination, %rid, "Packet for DNS resource"),
             );
 
-        // We don't need to filter from here because resources are removed from the active_cidr_resources as soon as they are disabled.
-        let maybe_cidr_resource_id = self
-            .active_cidr_resources
-            .longest_match(destination)
-            .map(|(_, res)| res.id)
+        // Tie-breaker function for preferring resources we are already connected to over other ones.
+        let prefer_connected_cidr = |left, right| match (
+            self.is_cidr_resource_connected(&left),
+            self.is_cidr_resource_connected(&right),
+        ) {
+            (true, true) | (false, false) => Ordering::Equal,
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+        };
+
+        let maybe_cidr_resource_id = self.routing_table.matches_cidr(destination, prefer_connected_cidr)
             .inspect(
                 |rid| tracing::trace!(target: "tunnel_test_coverage", %destination, %rid, "Packet for CIDR resource"),
             );
@@ -1174,6 +1184,12 @@ impl ClientState {
         self.drain_node_events(now);
 
         while let Some(dns::Event::RecordsChanged(records)) = self.stub_resolver.poll_event() {
+            for record in &records {
+                for ip in &record.ips {
+                    self.routing_table.upsert_dns(*ip, record.resource);
+                }
+            }
+
             self.buffered_events
                 .push_back(ClientEvent::DnsRecordsChanged { records });
         }
@@ -1573,26 +1589,6 @@ impl ClientState {
         self.maybe_update_tun_config(new_tun_config);
     }
 
-    fn recalculate_active_cidr_resources(&self) -> IpNetworkTable<CidrResource> {
-        let mut active_cidr_resources = IpNetworkTable::<CidrResource>::new();
-
-        for resource in self.resources_by_id.values() {
-            let Resource::Cidr(resource) = resource else {
-                continue;
-            };
-
-            if let Some(active_resource) = active_cidr_resources.exact_match(resource.address)
-                && self.is_cidr_resource_connected(&active_resource.id)
-            {
-                continue;
-            }
-
-            active_cidr_resources.insert(resource.address, resource.clone());
-        }
-
-        active_cidr_resources
-    }
-
     fn maybe_update_tun_config(&mut self, new_tun_config: TunConfig) {
         if Some(&new_tun_config) == self.tun_config.current() {
             tracing::trace!(current = ?self.tun_config.current(), "TUN device configuration unchanged");
@@ -1777,7 +1773,6 @@ impl ClientState {
             self.add_resource(resource, now)
         }
 
-        self.active_cidr_resources = self.recalculate_active_cidr_resources();
         self.maybe_update_tun_routes();
         self.resource_list.update(self.resources());
     }
@@ -1815,33 +1810,12 @@ impl ClientState {
                 self.stub_resolver
                     .add_resource(dns.id, dns.address.clone(), dns.ip_stack)
             }
-            Resource::Cidr(cidr) => {
-                let existing = self.active_cidr_resources.exact_match(cidr.address);
-
-                match existing {
-                    Some(existing) => {
-                        // If we are "activating" the same resource, don't print a log to avoid spam.
-                        let is_different = existing.id != cidr.id;
-
-                        // If the current resource is routing traffic, we don't update the routing table, so don't print a log either.
-                        // See `recalculate_active_cidr_resources` for details.
-                        let existing_is_not_connected =
-                            self.is_cidr_resource_connected(&existing.id);
-
-                        is_different && existing_is_not_connected
-                    }
-                    None => true,
-                }
-            }
+            Resource::Cidr(cidr) => self.routing_table.upsert_cidr(cidr.address, cidr.id),
             Resource::Internet(_) => self.is_internet_resource_active,
         };
 
         if activated {
             self.log_activating_resource(&new_resource);
-        }
-
-        if matches!(new_resource, Resource::Cidr(_)) {
-            self.active_cidr_resources = self.recalculate_active_cidr_resources();
         }
 
         self.maybe_update_tun_routes();
@@ -1861,13 +1835,8 @@ impl ClientState {
     pub fn remove_resource(&mut self, id: ResourceId, now: Instant) {
         self.disable_resource(id, now);
 
-        if self
-            .resources_by_id
-            .remove(&id)
-            .is_some_and(|r| matches!(r, Resource::Cidr(_)))
-        {
-            self.active_cidr_resources = self.recalculate_active_cidr_resources();
-        };
+        self.resources_by_id.remove(&id);
+        self.routing_table.remove_by_resource(id);
 
         self.maybe_update_tun_routes();
         self.resource_list.update(self.resources());

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1001,9 +1001,8 @@ impl ClientState {
     }
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {
-        self.active_cidr_resources
-            .iter()
-            .map(|(ip, _)| ip)
+        iter::empty()
+            .chain(self.active_cidr_resources.iter().map(|(ip, _)| ip))
             .chain(iter::once(IPV4_TUNNEL.into()))
             .chain(iter::once(IPV6_TUNNEL.into()))
             .chain(iter::once(IPV4_RESOURCES.into()))

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1174,6 +1174,11 @@ impl ClientState {
         self.node.handle_timeout(now);
         self.drain_node_events(now);
 
+        while let Some(dns::Event::RecordsChanged(records)) = self.stub_resolver.poll_event() {
+            self.buffered_events
+                .push_back(ClientEvent::DnsRecordsChanged { records });
+        }
+
         self.advance_dns_clients_and_servers(now);
         self.send_dns_resource_nat_packets(now);
         self.reset_offline_site_status(now);
@@ -1708,13 +1713,7 @@ impl ClientState {
             return Some(ClientEvent::DeviceConnectionIntent { ipv4: client });
         }
 
-        self.buffered_events
-            .pop_front()
-            .or_else(|| match self.stub_resolver.poll_event()? {
-                dns::Event::RecordsChanged(records) => {
-                    Some(ClientEvent::DnsRecordsChanged { records })
-                }
-            })
+        self.buffered_events.pop_front()
     }
 
     pub(crate) fn reset(&mut self, now: Instant, reason: &str) {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1183,18 +1183,7 @@ impl ClientState {
     pub fn handle_timeout(&mut self, now: Instant) {
         self.node.handle_timeout(now);
         self.drain_node_events(now);
-
-        while let Some(dns::Event::RecordsChanged(records)) = self.stub_resolver.poll_event() {
-            for record in &records {
-                for ip in &record.ips {
-                    self.routing_table
-                        .upsert_dns(*ip, record.resource, record.domain.clone());
-                }
-            }
-
-            self.buffered_events
-                .push_back(ClientEvent::DnsRecordsChanged { records });
-        }
+        self.drain_stub_resolver_events();
 
         self.advance_dns_clients_and_servers(now);
         self.send_dns_resource_nat_packets(now);
@@ -1467,6 +1456,7 @@ impl ClientState {
             dns::ResolveStrategy::LocalResponse(response) => {
                 self.dns_resource_nat.recreate(message.domain());
                 self.update_dns_resource_nat(now, iter::empty());
+                self.drain_stub_resolver_events();
                 self.dns_cache.insert(message.domain(), &response, now);
 
                 return Some(response);
@@ -1663,6 +1653,20 @@ impl ClientState {
                     conn_id,
                     candidates,
                 })
+        }
+    }
+
+    fn drain_stub_resolver_events(&mut self) {
+        while let Some(dns::Event::RecordsChanged(records)) = self.stub_resolver.poll_event() {
+            for record in &records {
+                for ip in &record.ips {
+                    self.routing_table
+                        .upsert_dns(*ip, record.resource, record.domain.clone());
+                }
+            }
+
+            self.buffered_events
+                .push_back(ClientEvent::DnsRecordsChanged { records });
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/client/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/client/routing_table.rs
@@ -1,0 +1,312 @@
+use std::{cmp::Ordering, collections::BTreeSet, net::IpAddr};
+
+use connlib_model::ResourceId;
+use ip_network::IpNetwork;
+use ip_network_table::IpNetworkTable;
+use itertools::Itertools;
+
+#[derive(Debug, Default)]
+pub(crate) struct RoutingTable {
+    cidr: IpNetworkTable<BTreeSet<ResourceId>>,
+    dns: IpNetworkTable<BTreeSet<ResourceId>>,
+}
+
+impl RoutingTable {
+    /// Adds a new entry to the CIDR resource routing table.
+    ///
+    /// Returns `true` if the resource wasn't present before.
+    pub fn upsert_cidr(&mut self, network: IpNetwork, resource: ResourceId) -> bool {
+        upsert(&mut self.cidr, network, resource)
+    }
+
+    /// Adds a new entry to the DNS resource routing table.
+    ///
+    /// Returns `true` if the resource wasn't present before.
+    pub fn upsert_dns(&mut self, ip: IpAddr, resource: ResourceId) -> bool {
+        upsert(&mut self.dns, ip.into(), resource)
+    }
+
+    /// Finds the CIDR resource to which traffic to a certain IP should be routed.
+    ///
+    /// In case more than one resource is associated with this IP, the `tie_breaker` function is used to order them.
+    /// The one with the _greatest_ ordering is returned.
+    pub fn matches_cidr(
+        &self,
+        ip: IpAddr,
+        tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
+    ) -> Option<ResourceId> {
+        let (_, resources) = self.cidr.longest_match(ip)?;
+
+        resources
+            .iter()
+            .copied()
+            .sorted_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))
+            .next()
+    }
+
+    /// Finds the DNS resource to which traffic to a certain IP should be routed.
+    ///
+    /// In case more than one resource is associated with this IP, the `tie_breaker` function is used to order them.
+    /// The one with the _greatest_ ordering is returned.
+    pub fn matches_dns(
+        &self,
+        ip: IpAddr,
+        tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
+    ) -> Option<ResourceId> {
+        let (_, resources) = self.dns.longest_match(ip)?;
+
+        resources
+            .iter()
+            .copied()
+            .sorted_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))
+            .next()
+    }
+
+    pub fn any_cidr(&self, ip: IpAddr) -> bool {
+        self.cidr
+            .longest_match(ip)
+            .is_some_and(|(_, r)| !r.is_empty())
+    }
+
+    pub fn remove_by_resource(&mut self, resource: ResourceId) {
+        remove_by_resource(&mut self.cidr, resource);
+        remove_by_resource(&mut self.dns, resource);
+    }
+
+    pub fn cidr_routes(&self) -> impl Iterator<Item = IpNetwork> {
+        self.cidr.iter().map(|(n, _)| n)
+    }
+}
+
+fn upsert(
+    table: &mut IpNetworkTable<BTreeSet<ResourceId>>,
+    network: IpNetwork,
+    resource: ResourceId,
+) -> bool {
+    match table.exact_match_mut(network) {
+        Some(resources) => resources.insert(resource),
+        None => {
+            table.insert(network, BTreeSet::from_iter([resource]));
+
+            true
+        }
+    }
+}
+
+fn remove_by_resource(table: &mut IpNetworkTable<BTreeSet<ResourceId>>, resource: ResourceId) {
+    for (_, resources) in table.iter_mut() {
+        resources.remove(&resource);
+    }
+
+    table.retain(|_, resources| !resources.is_empty());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    const R1: ResourceId = ResourceId::from_u128(1);
+    const R2: ResourceId = ResourceId::from_u128(2);
+    const R3: ResourceId = ResourceId::from_u128(3);
+
+    #[test]
+    fn cidr_upsert() {
+        let mut t = RoutingTable::default();
+        let net = "10.0.0.0/8".parse().unwrap();
+
+        assert!(t.upsert_cidr(net, R1), "first upsert should return true");
+        assert!(!t.upsert_cidr(net, R1), "second upsert should return false");
+        assert!(
+            t.upsert_cidr(net, R2),
+            "same network upsert of different resource should return true"
+        );
+    }
+
+    #[test]
+    fn dns_upsert() {
+        let mut t = RoutingTable::default();
+        let ip = "192.168.1.1".parse().unwrap();
+
+        assert!(t.upsert_dns(ip, R1), "first upsert should return true");
+        assert!(!t.upsert_dns(ip, R1), "second upsert should return false");
+        assert!(
+            t.upsert_dns(ip, R2),
+            "same network upsert of different resource should return true"
+        );
+    }
+
+    #[test]
+    fn matches_cidr_resource_by_ip() {
+        let mut t = RoutingTable::default();
+        t.upsert_cidr("10.0.0.0/8".parse().unwrap(), R1);
+
+        assert_eq!(
+            t.matches_cidr("10.1.2.3".parse().unwrap(), no_tiebreak),
+            Some(R1)
+        );
+    }
+
+    #[test]
+    fn matches_dns_resource_by_ip() {
+        let mut t = RoutingTable::default();
+        let ip = "1.2.3.4".parse().unwrap();
+        t.upsert_dns(ip, R1);
+
+        assert_eq!(t.matches_dns(ip, no_tiebreak), Some(R1));
+    }
+
+    #[test]
+    fn matches_returns_none_for_unrouted_ip() {
+        let t = RoutingTable::default();
+
+        assert_eq!(
+            t.matches_cidr("10.0.0.1".parse().unwrap(), no_tiebreak),
+            None
+        );
+        assert_eq!(
+            t.matches_dns("10.0.0.1".parse().unwrap(), no_tiebreak),
+            None
+        );
+    }
+
+    #[test]
+    fn matches_longest_prefix_wins() {
+        let mut t = RoutingTable::default();
+        t.upsert_cidr("10.0.0.0/8".parse().unwrap(), R1);
+        t.upsert_cidr("10.20.0.0/16".parse().unwrap(), R2);
+
+        // Falls inside the /16 – more specific match should win.
+        assert_eq!(
+            t.matches_cidr("10.20.0.1".parse().unwrap(), no_tiebreak),
+            Some(R2)
+        );
+        // Only covered by the /8.
+        assert_eq!(
+            t.matches_cidr("10.99.0.1".parse().unwrap(), no_tiebreak),
+            Some(R1)
+        );
+    }
+
+    #[test]
+    fn matches_cidr_tie_breaker_controls_winner() {
+        let mut t = RoutingTable::default();
+        let net = "10.0.0.0/8".parse().unwrap();
+        t.upsert_cidr(net, R1);
+        t.upsert_cidr(net, R2);
+
+        let ip = "10.1.2.3".parse().unwrap();
+
+        let prefer_r1 = |a: ResourceId, b: ResourceId| match (a == R1, b == R1) {
+            (true, _) => Ordering::Greater,
+            (_, true) => Ordering::Less,
+            _ => a.cmp(&b),
+        };
+        assert_eq!(t.matches_cidr(ip, prefer_r1), Some(R1));
+
+        let prefer_r2 = |a: ResourceId, b: ResourceId| match (a == R2, b == R2) {
+            (true, _) => Ordering::Greater,
+            (_, true) => Ordering::Less,
+            _ => a.cmp(&b),
+        };
+        assert_eq!(t.matches_cidr(ip, prefer_r2), Some(R2));
+    }
+
+    #[test]
+    fn any_returns_true_for_covered_ip() {
+        let mut t = RoutingTable::default();
+        t.upsert_cidr("172.16.0.0/12".parse().unwrap(), R1);
+
+        assert!(t.any_cidr("172.16.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn any_returns_false_for_uncovered_ip() {
+        let mut t = RoutingTable::default();
+        t.upsert_cidr("172.16.0.0/12".parse().unwrap(), R1);
+
+        assert!(!t.any_cidr("192.168.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn remove_by_resource_stops_matching() {
+        let mut t = RoutingTable::default();
+        let net = "10.0.0.0/8".parse().unwrap();
+        t.upsert_cidr(net, R1);
+
+        t.remove_by_resource(R1);
+
+        assert_eq!(
+            t.matches_cidr("10.1.2.3".parse().unwrap(), no_tiebreak),
+            None
+        );
+    }
+
+    #[test]
+    fn remove_by_resource_leaves_other_resources_intact() {
+        let mut t = RoutingTable::default();
+        let net = "10.0.0.0/8".parse().unwrap();
+        t.upsert_cidr(net, R1);
+        t.upsert_cidr(net, R2);
+
+        t.remove_by_resource(R1);
+
+        assert_eq!(
+            t.matches_cidr("10.1.2.3".parse().unwrap(), no_tiebreak),
+            Some(R2)
+        );
+    }
+
+    #[test]
+    fn remove_by_resource_removes_from_dns_table() {
+        let mut t = RoutingTable::default();
+        let ip = "1.2.3.4".parse().unwrap();
+        t.upsert_dns(ip, R1);
+
+        t.remove_by_resource(R1);
+
+        assert_eq!(t.matches_cidr(ip, no_tiebreak), None);
+    }
+
+    #[test]
+    fn remove_nonexistent_resource_is_noop() {
+        let mut t = RoutingTable::default();
+        t.upsert_cidr("10.0.0.0/8".parse().unwrap(), R1);
+
+        t.remove_by_resource(R3); // R3 was never inserted
+
+        assert_eq!(
+            t.matches_cidr("10.1.2.3".parse().unwrap(), no_tiebreak),
+            Some(R1)
+        );
+    }
+
+    #[test]
+    fn cidr_routes_yields_all_inserted_networks() {
+        let mut t = RoutingTable::default();
+        let net1: IpNetwork = "10.0.0.0/8".parse().unwrap();
+        let net2: IpNetwork = "172.16.0.0/12".parse().unwrap();
+        t.upsert_cidr(net1, R1);
+        t.upsert_cidr(net2, R2);
+
+        let mut routes = t.cidr_routes().collect::<Vec<_>>();
+        routes.sort_by_key(|n| n.to_string());
+
+        assert!(routes.contains(&net1));
+        assert!(routes.contains(&net2));
+        assert_eq!(routes.len(), 2);
+    }
+
+    #[test]
+    fn cidr_routes_does_not_include_dns_entries() {
+        let mut t = RoutingTable::default();
+        let ip = "1.2.3.4".parse().unwrap();
+        t.upsert_dns(ip, R1);
+
+        assert_eq!(t.cidr_routes().count(), 0);
+    }
+
+    fn no_tiebreak(a: ResourceId, b: ResourceId) -> Ordering {
+        a.cmp(&b)
+    }
+}

--- a/rust/libs/connlib/tunnel/src/client/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/client/routing_table.rs
@@ -40,7 +40,7 @@ impl RoutingTable {
         let id = resources
             .iter()
             .copied()
-            .max_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))?;
+            .max_by(|left, right| tie_breaker(*left, *right).then(left.cmp(right)))?;
 
         Some(id)
     }
@@ -55,9 +55,9 @@ impl RoutingTable {
         tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
     ) -> Option<(ResourceId, &DomainName)> {
         let (_, resources) = self.dns.longest_match(ip)?;
-        let (id, domain) = resources.iter().max_by(|(left, _), (right, _)| {
-            tie_breaker(*left, *right).reverse().then(left.cmp(right))
-        })?;
+        let (id, domain) = resources
+            .iter()
+            .max_by(|(left, _), (right, _)| tie_breaker(*left, *right).then(left.cmp(right)))?;
 
         Some((*id, domain))
     }
@@ -214,14 +214,14 @@ mod tests {
         let prefer_r1 = |a: ResourceId, b: ResourceId| match (a == R1, b == R1) {
             (true, _) => Ordering::Greater,
             (_, true) => Ordering::Less,
-            _ => a.cmp(&b),
+            _ => Ordering::Equal,
         };
         assert_eq!(t.matches_cidr(ip, prefer_r1), Some(R1));
 
         let prefer_r2 = |a: ResourceId, b: ResourceId| match (a == R2, b == R2) {
             (true, _) => Ordering::Greater,
             (_, true) => Ordering::Less,
-            _ => a.cmp(&b),
+            _ => Ordering::Equal,
         };
         assert_eq!(t.matches_cidr(ip, prefer_r2), Some(R2));
     }

--- a/rust/libs/connlib/tunnel/src/client/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/client/routing_table.rs
@@ -4,7 +4,6 @@ use connlib_model::ResourceId;
 use dns_types::DomainName;
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
-use itertools::Itertools;
 
 #[derive(Debug, Default)]
 pub(crate) struct RoutingTable {
@@ -37,18 +36,11 @@ impl RoutingTable {
         tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
     ) -> Option<ResourceId> {
         let (_, resources) = self.cidr.longest_match(ip)?;
-        let first = resources.first()?;
-
-        // Fast-path for the case where no sorting is needed.
-        if resources.len() == 1 {
-            return Some(*first);
-        }
 
         let id = resources
             .iter()
             .copied()
-            .sorted_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))
-            .next()?;
+            .max_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))?;
 
         Some(id)
     }
@@ -63,18 +55,9 @@ impl RoutingTable {
         tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
     ) -> Option<(ResourceId, &DomainName)> {
         let (_, resources) = self.dns.longest_match(ip)?;
-        let (id, domain) = resources.first()?;
-
-        if resources.len() == 1 {
-            return Some((*id, domain));
-        }
-
-        let (id, domain) = resources
-            .iter()
-            .sorted_by(|(left, _), (right, _)| {
-                tie_breaker(*left, *right).reverse().then(left.cmp(right))
-            })
-            .next()?;
+        let (id, domain) = resources.iter().max_by(|(left, _), (right, _)| {
+            tie_breaker(*left, *right).reverse().then(left.cmp(right))
+        })?;
 
         Some((*id, domain))
     }

--- a/rust/libs/connlib/tunnel/src/client/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/client/routing_table.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, collections::BTreeSet, net::IpAddr};
 
 use connlib_model::ResourceId;
+use dns_types::DomainName;
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use itertools::Itertools;
@@ -8,7 +9,7 @@ use itertools::Itertools;
 #[derive(Debug, Default)]
 pub(crate) struct RoutingTable {
     cidr: IpNetworkTable<BTreeSet<ResourceId>>,
-    dns: IpNetworkTable<BTreeSet<ResourceId>>,
+    dns: IpNetworkTable<BTreeSet<(ResourceId, DomainName)>>,
 }
 
 impl RoutingTable {
@@ -22,8 +23,8 @@ impl RoutingTable {
     /// Adds a new entry to the DNS resource routing table.
     ///
     /// Returns `true` if the resource wasn't present before.
-    pub fn upsert_dns(&mut self, ip: IpAddr, resource: ResourceId) -> bool {
-        upsert(&mut self.dns, ip.into(), resource)
+    pub fn upsert_dns(&mut self, ip: IpAddr, resource: ResourceId, domain: DomainName) -> bool {
+        upsert(&mut self.dns, ip.into(), (resource, domain))
     }
 
     /// Finds the CIDR resource to which traffic to a certain IP should be routed.
@@ -52,14 +53,16 @@ impl RoutingTable {
         &self,
         ip: IpAddr,
         tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
-    ) -> Option<ResourceId> {
+    ) -> Option<(ResourceId, DomainName)> {
         let (_, resources) = self.dns.longest_match(ip)?;
 
         resources
             .iter()
-            .copied()
-            .sorted_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))
+            .sorted_by(|(left, _), (right, _)| {
+                tie_breaker(*left, *right).reverse().then(left.cmp(right))
+            })
             .next()
+            .cloned()
     }
 
     pub fn any_cidr(&self, ip: IpAddr) -> bool {
@@ -69,8 +72,8 @@ impl RoutingTable {
     }
 
     pub fn remove_by_resource(&mut self, resource: ResourceId) {
-        remove_by_resource(&mut self.cidr, resource);
-        remove_by_resource(&mut self.dns, resource);
+        remove_by_resource(&mut self.cidr, |c| c == &resource);
+        remove_by_resource(&mut self.dns, |(c, _)| c == &resource);
     }
 
     pub fn cidr_routes(&self) -> impl Iterator<Item = IpNetwork> {
@@ -78,24 +81,30 @@ impl RoutingTable {
     }
 }
 
-fn upsert(
-    table: &mut IpNetworkTable<BTreeSet<ResourceId>>,
-    network: IpNetwork,
-    resource: ResourceId,
-) -> bool {
+fn upsert<T>(table: &mut IpNetworkTable<BTreeSet<T>>, network: IpNetwork, element: T) -> bool
+where
+    T: Ord,
+{
     match table.exact_match_mut(network) {
-        Some(resources) => resources.insert(resource),
+        Some(elements) => elements.insert(element),
         None => {
-            table.insert(network, BTreeSet::from_iter([resource]));
+            table.insert(network, BTreeSet::from_iter([element]));
 
             true
         }
     }
 }
 
-fn remove_by_resource(table: &mut IpNetworkTable<BTreeSet<ResourceId>>, resource: ResourceId) {
+fn remove_by_resource<T>(
+    table: &mut IpNetworkTable<BTreeSet<T>>,
+    predicate: impl Fn(&T) -> bool + Copy,
+) where
+    T: Ord,
+{
     for (_, resources) in table.iter_mut() {
-        resources.remove(&resource);
+        for el in resources.extract_if(.., predicate) {
+            drop(el)
+        }
     }
 
     table.retain(|_, resources| !resources.is_empty());
@@ -127,11 +136,18 @@ mod tests {
     fn dns_upsert() {
         let mut t = RoutingTable::default();
         let ip = "192.168.1.1".parse().unwrap();
+        let domain = "example.com".parse::<DomainName>().unwrap();
 
-        assert!(t.upsert_dns(ip, R1), "first upsert should return true");
-        assert!(!t.upsert_dns(ip, R1), "second upsert should return false");
         assert!(
-            t.upsert_dns(ip, R2),
+            t.upsert_dns(ip, R1, domain.clone()),
+            "first upsert should return true"
+        );
+        assert!(
+            !t.upsert_dns(ip, R1, domain.clone()),
+            "second upsert should return false"
+        );
+        assert!(
+            t.upsert_dns(ip, R2, domain),
             "same network upsert of different resource should return true"
         );
     }
@@ -151,9 +167,10 @@ mod tests {
     fn matches_dns_resource_by_ip() {
         let mut t = RoutingTable::default();
         let ip = "1.2.3.4".parse().unwrap();
-        t.upsert_dns(ip, R1);
+        let domain = "example.com".parse::<DomainName>().unwrap();
+        t.upsert_dns(ip, R1, domain.clone());
 
-        assert_eq!(t.matches_dns(ip, no_tiebreak), Some(R1));
+        assert_eq!(t.matches_dns(ip, no_tiebreak), Some((R1, domain)));
     }
 
     #[test]
@@ -261,7 +278,8 @@ mod tests {
     fn remove_by_resource_removes_from_dns_table() {
         let mut t = RoutingTable::default();
         let ip = "1.2.3.4".parse().unwrap();
-        t.upsert_dns(ip, R1);
+        let domain = "example.com".parse::<DomainName>().unwrap();
+        t.upsert_dns(ip, R1, domain);
 
         t.remove_by_resource(R1);
 
@@ -301,7 +319,8 @@ mod tests {
     fn cidr_routes_does_not_include_dns_entries() {
         let mut t = RoutingTable::default();
         let ip = "1.2.3.4".parse().unwrap();
-        t.upsert_dns(ip, R1);
+        let domain = "example.com".parse::<DomainName>().unwrap();
+        t.upsert_dns(ip, R1, domain);
 
         assert_eq!(t.cidr_routes().count(), 0);
     }

--- a/rust/libs/connlib/tunnel/src/client/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/client/routing_table.rs
@@ -37,12 +37,20 @@ impl RoutingTable {
         tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
     ) -> Option<ResourceId> {
         let (_, resources) = self.cidr.longest_match(ip)?;
+        let first = resources.first()?;
 
-        resources
+        // Fast-path for the case where no sorting is needed.
+        if resources.len() == 1 {
+            return Some(*first);
+        }
+
+        let id = resources
             .iter()
             .copied()
             .sorted_by(|left, right| tie_breaker(*left, *right).reverse().then(left.cmp(right)))
-            .next()
+            .next()?;
+
+        Some(id)
     }
 
     /// Finds the DNS resource to which traffic to a certain IP should be routed.
@@ -53,16 +61,22 @@ impl RoutingTable {
         &self,
         ip: IpAddr,
         tie_breaker: impl Fn(ResourceId, ResourceId) -> Ordering,
-    ) -> Option<(ResourceId, DomainName)> {
+    ) -> Option<(ResourceId, &DomainName)> {
         let (_, resources) = self.dns.longest_match(ip)?;
+        let (id, domain) = resources.first()?;
 
-        resources
+        if resources.len() == 1 {
+            return Some((*id, domain));
+        }
+
+        let (id, domain) = resources
             .iter()
             .sorted_by(|(left, _), (right, _)| {
                 tie_breaker(*left, *right).reverse().then(left.cmp(right))
             })
-            .next()
-            .cloned()
+            .next()?;
+
+        Some((*id, domain))
     }
 
     pub fn any_cidr(&self, ip: IpAddr) -> bool {
@@ -170,7 +184,7 @@ mod tests {
         let domain = "example.com".parse::<DomainName>().unwrap();
         t.upsert_dns(ip, R1, domain.clone());
 
-        assert_eq!(t.matches_dns(ip, no_tiebreak), Some((R1, domain)));
+        assert_eq!(t.matches_dns(ip, no_tiebreak), Some((R1, &domain)));
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/client/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/client/routing_table.rs
@@ -280,7 +280,7 @@ mod tests {
 
         t.remove_by_resource(R1);
 
-        assert_eq!(t.matches_cidr(ip, no_tiebreak), None);
+        assert_eq!(t.matches_dns(ip, no_tiebreak), None);
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/dns.rs
+++ b/rust/libs/connlib/tunnel/src/dns.rs
@@ -167,17 +167,6 @@ impl StubResolver {
         }
     }
 
-    /// Attempts to resolve an IP to a given resource.
-    ///
-    /// Semantically, this is like a PTR query, i.e. we check whether we handed out this IP as part of answering a DNS query for one of our resources.
-    /// This is in the hot-path of packet routing and must be fast!
-    pub(crate) fn resolve_resource_by_ip(
-        &self,
-        ip: &IpAddr,
-    ) -> Option<&(dns_types::DomainName, ResourceId)> {
-        self.ips_to_fqdn.get(ip)
-    }
-
     pub(crate) fn resolved_resources(
         &self,
     ) -> impl Iterator<Item = (&dns_types::DomainName, &ResourceId, &Vec<IpAddr>)> + '_ {


### PR DESCRIPTION
Routing packets to the correct resource is one of the primary features of Firezone. Right now, conflicting or overlapping resources are handled in a way where the more specific resource wins, i.e. for CIDR ranges the one with the higher bitmask and for wildcard DNS resources, the one with more labels. Two resources with exactly the same range or domain name are not really supported. For CIDR ranges, we prefer the one we are already connected to and for DNS resources, we order them by their internal ID and match the first one.

This presents an issue when customers define the same resource multiple times but with different traffic filters. Those are not taken into account on the Client.

In preparation for doing that, we introduce a `RoutingTable` component to connlib. The primary change here is that we also store the assigned IP addresses of DNS resources instead of looking them up within the `StubResolver`. Internally, the `RoutingTable` already supports associating multiple resources with the same IP address. A "tie-breaker" function is used at the time of matching to decide between two resources that both match the same IP.

We use this functionality to implement the already present feature of preferring an already connected CIDR resource in case of an exact duplicate.

Another, minor change here is that we will now print "Adding resource" for an exact duplicate CIDR range even if we already have it. Previously, this was not the case if we were already connected to the other one.

Related: #4789 