### PR TITLE
fix(portal): don't evict token_id pids

### DIFF
--- a/elixir/lib/portal/pg.ex
+++ b/elixir/lib/portal/pg.ex
@@ -27,6 +27,16 @@ defmodule Portal.PG do
   end
 
   @doc """
+  Joins the calling process to the group under `key` without disconnecting existing members.
+
+  Use this for keys where multiple processes can legitimately coexist
+  (e.g. a credential shared by many clients).
+  """
+  def join(key) do
+    :pg.join(scope(), key, self())
+  end
+
+  @doc """
   Delivers `message` to all processes registered under `key`.
 
   Returns `:ok` if at least one process is registered, `{:error, :not_found}` otherwise.

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -1538,7 +1538,7 @@ defmodule PortalAPI.Client.Channel do
       new_pid ->
         Process.monitor(new_pid)
         :ok = PG.register(socket.assigns.client.id)
-        :ok = PG.register(socket.assigns.subject.credential.id)
+        :ok = PG.join(socket.assigns.subject.credential.id)
         {:noreply, assign(socket, :pg_scope_pid, new_pid)}
     end
   end

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -752,7 +752,7 @@ defmodule PortalAPI.Gateway.Channel do
       new_pid ->
         Process.monitor(new_pid)
         :ok = PG.register(socket.assigns.gateway.id)
-        :ok = PG.register(socket.assigns.token_id)
+        :ok = PG.join(socket.assigns.token_id)
         {:noreply, assign(socket, :pg_scope_pid, new_pid)}
     end
   end

--- a/elixir/test/portal/pg_test.exs
+++ b/elixir/test/portal/pg_test.exs
@@ -145,6 +145,90 @@ defmodule Portal.PGTest do
     end
   end
 
+  describe "join/1 (credential/token shared by multiple clients)" do
+    test "multiple processes can join the same key without disconnecting each other", %{
+      scope: scope
+    } do
+      credential_id = Ecto.UUID.generate()
+      parent = self()
+
+      pids =
+        for i <- 1..10 do
+          spawn(fn ->
+            Portal.Config.put_env_override(:portal, :pg_scope, scope)
+            PG.join(credential_id)
+            send(parent, {:joined, i})
+
+            receive do
+              msg -> send(parent, {:received, i, msg})
+            end
+          end)
+        end
+
+      for i <- 1..10, do: assert_receive({:joined, ^i})
+
+      # All 10 processes should receive the message — none were disconnected
+      assert :ok = PG.deliver(credential_id, :hello)
+
+      for i <- 1..10, do: assert_receive({:received, ^i, :hello})
+
+      Enum.each(pids, &Process.exit(&1, :kill))
+    end
+
+    test "join does not disconnect processes registered with register/1", %{scope: scope} do
+      key = Ecto.UUID.generate()
+      parent = self()
+
+      pid =
+        spawn(fn ->
+          Portal.Config.put_env_override(:portal, :pg_scope, scope)
+          PG.register(key)
+          send(parent, :registered)
+
+          receive do
+            msg -> send(parent, {:first, msg})
+          end
+        end)
+
+      assert_receive :registered
+
+      # join should NOT send :disconnect to the existing process
+      PG.join(key)
+
+      # Deliver should reach both the registered process and self
+      assert :ok = PG.deliver(key, :hello)
+      assert_receive {:first, :hello}
+      assert_receive :hello
+
+      Process.exit(pid, :kill)
+    end
+
+    test "register/1 disconnects joined processes but join/1 does not", %{scope: scope} do
+      key = Ecto.UUID.generate()
+      parent = self()
+
+      joined_pid =
+        spawn(fn ->
+          Portal.Config.put_env_override(:portal, :pg_scope, scope)
+          PG.join(key)
+          send(parent, :joined)
+
+          receive do
+            msg -> send(parent, {:joined_received, msg})
+          end
+        end)
+
+      assert_receive :joined
+
+      # register/1 should disconnect the joined process
+      PG.register(key)
+
+      assert_receive {:joined_received, :disconnect}
+
+      Process.exit(joined_pid, :kill)
+    end
+  end
+
   describe "scope_pid/0" do
     test "returns the pid of the running pg scope" do
       assert is_pid(PG.scope_pid())

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -948,6 +948,35 @@ defmodule PortalAPI.Client.ChannelTest do
     end
   end
 
+  describe "handle_info/2 :disconnect regression — shared credential" do
+    test "multiple clients sharing a credential are not disconnected by each other", %{
+      account: account,
+      actor: actor,
+      subject: subject
+    } do
+      Process.flag(:trap_exit, true)
+
+      # Create two different clients that share the same credential (token)
+      client1 = client_fixture(account: account, actor: actor)
+      client2 = client_fixture(account: account, actor: actor)
+
+      socket1 = join_channel(client1, subject)
+      assert_push "init", _
+
+      socket2 = join_channel(client2, subject)
+      assert_push "init", _
+
+      # Both channels should still be alive — sharing a credential must not
+      # cause one to evict the other (regression: PG.register on credential.id
+      # used to send :disconnect to all existing members)
+      assert Process.alive?(socket1.channel_pid)
+      assert Process.alive?(socket2.channel_pid)
+
+      # Neither channel should have received a disconnect push
+      refute_push "disconnect", _
+    end
+  end
+
   describe "handle_info/2 recompute_authorized_resources" do
     test "sends resource_created_or_updated for new connectable_resources", %{
       account: account,

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -334,6 +334,34 @@ defmodule PortalAPI.Gateway.ChannelTest do
     end
   end
 
+  describe "handle_info/2 :disconnect regression — shared token" do
+    test "multiple gateways sharing a token are not disconnected by each other", %{
+      account: account,
+      site: site,
+      token: token
+    } do
+      Process.flag(:trap_exit, true)
+
+      gateway1 = gateway_fixture(account: account, site: site)
+      gateway2 = gateway_fixture(account: account, site: site)
+
+      socket1 = join_channel(gateway1, site, token)
+      assert_push "init", _
+
+      socket2 = join_channel(gateway2, site, token)
+      assert_push "init", _
+
+      # Both channels should still be alive — sharing a token must not
+      # cause one to evict the other (regression: PG.register on token_id
+      # used to send :disconnect to all existing members)
+      assert Process.alive?(socket1.channel_pid)
+      assert Process.alive?(socket2.channel_pid)
+
+      # Neither channel should have received a disconnect push
+      refute_push "disconnect", _
+    end
+  end
+
   describe "handle_info/2" do
     test "ignores out of order %Change{}", %{
       gateway: gateway,


### PR DESCRIPTION
In a recent refactor we enforced stricter pg group memberships based on client/gateway id. Unfortunately the token id got swept up in this as well, and want to allow multiple pids to register to those.