### PR TITLE
chore(rust): bump str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7174,8 +7174,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.16.2"
-source = "git+https://github.com/algesten/str0m?branch=main#3e0bdbd56e565f6150c357c7c3dbcd91599b673b"
+version = "0.17.0"
+source = "git+https://github.com/algesten/str0m?branch=main#da92bfa3b7449228db8449dd529d4681c8b83c8c"
 dependencies = [
  "arrayvec",
  "combine",
@@ -7192,8 +7192,8 @@ dependencies = [
 
 [[package]]
 name = "str0m-proto"
-version = "0.1.2"
-source = "git+https://github.com/algesten/str0m?branch=main#3e0bdbd56e565f6150c357c7c3dbcd91599b673b"
+version = "0.2.0"
+source = "git+https://github.com/algesten/str0m?branch=main#da92bfa3b7449228db8449dd529d4681c8b83c8c"
 dependencies = [
  "base64ct",
  "dimpl",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -183,7 +183,7 @@ socket-factory = { path = "libs/connlib/socket-factory" }
 socket2 = { version = "0.6.3" }
 specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
-str0m = { version = "0.16.2", default-features = false }
+str0m = { version = "0.17.0", default-features = false }
 strum = { version = "0.27.2", features = ["derive"] }
 stun_codec = "0.4.0"
 subprocess = "1.0.0"


### PR DESCRIPTION
This update brings in a fix in the ICE agent that can trigger a disconnect during the initial connection setup in a very specific race-condition when STUN messages arrive faster at the remote than the actual candidates and thus, a previously peer-reflexive candidate gets replaced just as it is about to be confirmed as the nominated candidate.

Related: https://github.com/algesten/str0m/pull/908