### PR TITLE
fix(connlib): don't starve recv

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -24,7 +24,7 @@ use std::{
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
-    task::{Context, Poll, ready},
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 use tracing::Level;
@@ -266,7 +266,7 @@ impl Io {
             impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
         >,
     > {
-        if let Err(e) = ready!(self.flush(cx)) {
+        if let Poll::Ready(Err(e)) = self.flush(cx) {
             return Poll::Ready(Input::error(e));
         }
 


### PR DESCRIPTION
## Summary

- Replaces `ready!(self.flush(cx))` with `if let Poll::Ready(Err(e)) = self.flush(cx)` in the tunnel event loop
- The `ready!` macro caused the entire poll to early-return `Pending` when flush was backpressured, starving inbound packet processing
- Now we call flush (registering wakers, handling errors) but continue polling device, network, and DNS sources regardless of flush state

Split out from #12332 for independent testing.

## Test plan

- [ ] Run throughput tests under load to verify inbound packets aren't starved when outbound is backpressured
- [ ] Verify no busy-loop CPU regression when all sources are idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)