### PR TITLE
feat(connlib): eagerly flush GSO queue after encrypting

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -419,7 +419,7 @@ impl Io {
     pub fn flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let mut any_pending = false;
 
-        if self.flush_gso_queue(cx).is_pending() {
+        if self.flush_gso_queue(cx)?.is_pending() {
             any_pending = true
         }
 

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -417,20 +417,10 @@ impl Io {
     }
 
     pub fn flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        let mut datagrams = self.gso_queue.datagrams();
         let mut any_pending = false;
 
-        loop {
-            if self.sockets.poll_send_ready(cx)?.is_pending() {
-                any_pending = true;
-                break;
-            }
-
-            let Some(datagram) = datagrams.next() else {
-                break;
-            };
-
-            self.sockets.send(datagram)?;
+        if self.flush_gso_queue(cx).is_pending() {
+            any_pending = true
         }
 
         if self.tun.poll_flush(cx)?.is_pending() {
@@ -439,6 +429,22 @@ impl Io {
 
         if any_pending {
             return Poll::Pending;
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    pub fn flush_gso_queue(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let mut datagrams = self.gso_queue.datagrams();
+
+        loop {
+            ready!(self.sockets.poll_send_ready(cx)?);
+
+            let Some(datagram) = datagrams.next() else {
+                break;
+            };
+
+            self.sockets.send(datagram)?;
         }
 
         Poll::Ready(Ok(()))

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -231,7 +231,7 @@ impl ClientTunnel {
                 udp_dns_queries: _,
                 device,
                 network,
-                error,
+                mut error,
             }) = self.io.poll(cx, &mut self.buffers)
             {
                 if let Some(response) = dns_response {
@@ -259,6 +259,11 @@ impl ClientTunnel {
                             }
                             None => self.io.schedule_timeout(now),
                         }
+                    }
+
+                    // Eagerly flush GSO queue.
+                    if let Poll::Ready(Err(e)) = self.io.flush_gso_queue(cx) {
+                        error.push(e);
                     }
 
                     tick.want_continue();
@@ -455,6 +460,11 @@ impl GatewayTunnel {
                                 error.push(e);
                             }
                         }
+                    }
+
+                    // Eagerly flush GSO queue.
+                    if let Poll::Ready(Err(e)) = self.io.flush_gso_queue(cx) {
+                        error.push(e);
                     }
 
                     tick.want_continue();


### PR DESCRIPTION
In a node that is busy with sending and receiving packets at the same time, the current architecture of the tunnel's event-loop delays the flushing of UDP packets to the IO thread until all inbound packets of the current event-loop tick have been decrypted. Given that encryption and decryption is the dominant consumer of CPU time of this thread, this unnecessarily delays the sending of these UDP packets.

To fix this, we insert a dedicated `flush_gso_queue` function call after the hot-loop that encrypted the current batch of packets from the TUN device. Flushing these packets to the channel is something that needs to happen anyway. Doing it earlier allows the UDP IO thread to already send them out via the socket whilst the main thread is decrypting the next batch.