### PR TITLE
fix(portal): gen new key on backfill

### DIFF
--- a/elixir/priv/repo/manual_migrations/20260322000000_backfill_account_keys.exs
+++ b/elixir/priv/repo/manual_migrations/20260322000000_backfill_account_keys.exs
@@ -9,6 +9,7 @@ defmodule Portal.Repo.Migrations.BackfillAccountKeys do
     SET key = (
       SELECT string_agg(substr('#{@chars}', floor(random() * 36 + 1)::int, 1), '')
       FROM generate_series(1, 6)
+      WHERE accounts.id IS NOT NULL
     )
     WHERE key IS NULL
     """)


### PR DESCRIPTION
In #12612 we introduced a manual backfill but it turns out Postgres tries to be too smart and only generates the key once for the entire update. By including one of the columns in the subquery we force Postgres to generate a new key for each row, preventing a collision error when the manual migration is run.
