### PR TITLE
ci: use explicit write perms for workflows

### DIFF
--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      security-events: write
+      security-events: write # upload CodeQL results
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:

--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -9,8 +9,8 @@ on:
         default: ${{ github.sha }}
 
 permissions:
-  id-token: write
-  packages: write
+  id-token: write # OIDC auth
+  packages: write # push Docker images to GHCR
 
 jobs:
   control-plane:

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -62,10 +62,9 @@ on:
         value: ${{ jobs.data-plane-linux.outputs.http_test_server_image }}
 
 permissions:
-  # write permission is required to create a github release
-  contents: write
-  id-token: write
-  packages: write
+  contents: write # create/update GitHub releases
+  id-token: write # OIDC auth
+  packages: write # push Docker images to GHCR
 
 jobs:
   update-release-draft:

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -9,7 +9,7 @@ jobs:
       run:
         working-directory: ./elixir
     permissions:
-      checks: write
+      checks: write # dorny/test-reporter
     env:
       MIX_ENV: test
       POSTGRES_HOST: localhost

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -61,8 +61,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write
-      pull-requests: write
+      id-token: write # OIDC auth
+      pull-requests: write # post test result comments
     env:
       PORTAL_IMAGE: ${{ inputs.portal_image }}
       PORTAL_TAG: ${{ inputs.portal_tag }}

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -9,7 +9,7 @@ defaults:
 
 permissions:
   contents: "read"
-  id-token: "write"
+  id-token: "write" # OIDC auth
 
 jobs:
   static-analysis:
@@ -45,7 +45,7 @@ jobs:
   build_release:
     permissions:
       contents: write # for uploading artifacts to the release
-      id-token: write
+      id-token: write # OIDC auth
     name: build-release-${{ matrix.package-type }}
     needs: update-release-draft
     if: "${{ github.event_name == 'workflow_dispatch' }}"

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+  id-token: write # OIDC auth for Azure Storage uploads
 
 jobs:
   loadtest:

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write
-      pull-requests: write
+      id-token: write # OIDC auth
+      pull-requests: write # post perf result comments
     env:
       PORTAL_IMAGE: "ghcr.io/firezone/portal"
       PORTAL_TAG: ${{ github.sha }}
@@ -130,9 +130,9 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write
-      pull-requests: write
-      checks: write
+      id-token: write # OIDC auth
+      pull-requests: write # post Bencher PR comments
+      checks: write # Bencher check annotations
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: bencherdev/bencher@8151077aa7b1bceaac11c4b308265417cae60e2b # v0.5.10

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -9,7 +9,7 @@ defaults:
 
 permissions:
   contents: "read"
-  id-token: "write"
+  id-token: "write" # OIDC auth
 
 env:
   RUSTFLAGS: "--cfg tokio_unstable --deny warnings"

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -10,6 +10,8 @@ jobs:
   update-release-draft:
     name: update-release-draft
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # release-drafter needs to create/update releases
     env:
       # mark:next-apple-version
       RELEASE_NAME: macos-client-1.5.15
@@ -70,7 +72,7 @@ jobs:
       MISE_EXPERIMENTAL: "1"
     permissions:
       contents: write # for attaching the build artifacts to the release
-      id-token: write
+      id-token: write # OIDC auth
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -12,13 +12,13 @@ env:
 
 permissions:
   contents: "read"
-  id-token: "write"
+  id-token: "write" # OIDC auth
 
 jobs:
   update-release-draft:
     permissions:
       contents: write # for updating the release draft
-      id-token: write
+      id-token: write # OIDC auth
     name: update-release-draft
     runs-on: ubuntu-24.04
     env:
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: write # for attaching the build artifacts to the release
-      id-token: write
+      id-token: write # OIDC auth
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,12 +6,19 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   # Builds images that match what's default in docker-compose.yml for
   # local development.
   data-plane-dev-images:
     uses: ./.github/workflows/_data-plane.yml
     secrets: inherit
+    permissions:
+      contents: write # create/update GitHub releases
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
     with:
       image_prefix: "dev"
       stage: "debug"
@@ -21,6 +28,10 @@ jobs:
   data-plane-test-images:
     uses: ./.github/workflows/_data-plane.yml
     secrets: inherit
+    permissions:
+      contents: write # create/update GitHub releases
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
     with:
       image_prefix: "debug"
       stage: "debug"
@@ -30,6 +41,10 @@ jobs:
   data-plane-prod-images:
     uses: ./.github/workflows/_data-plane.yml
     secrets: inherit
+    permissions:
+      contents: write # create/update GitHub releases
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
     with:
       profile: "release"
       stage: "release"
@@ -38,6 +53,10 @@ jobs:
   data-plane-perf-images:
     uses: ./.github/workflows/_data-plane.yml
     secrets: inherit
+    permissions:
+      contents: write # create/update GitHub releases
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
     with:
       image_prefix: "perf"
       profile: "release"
@@ -47,11 +66,17 @@ jobs:
   control-plane-images:
     uses: ./.github/workflows/_control-plane.yml
     secrets: inherit
+    permissions:
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
 
   # Build loadtest binaries for QA environment.
   loadtest-binaries:
     uses: ./.github/workflows/_loadtest.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth for Azure Storage uploads
 
   notify:
     needs: [data-plane-prod-images, control-plane-images, loadtest-binaries]
@@ -73,20 +98,33 @@ jobs:
     needs: [data-plane-perf-images, control-plane-images]
     uses: ./.github/workflows/_perf_tests.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth
+      pull-requests: write # post perf result comments
+      checks: write # Bencher check annotations
 
   # To have proper test coverage, we need to run `rust` and `elixir` on `main`.
 
   rust:
     uses: ./.github/workflows/_rust.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth
 
   elixir:
     uses: ./.github/workflows/_elixir.yml
     secrets: inherit
+    permissions:
+      checks: write # dorny/test-reporter
 
   swift:
     uses: ./.github/workflows/_swift.yml
     secrets: inherit
+    permissions:
+      contents: write # release draft and build artifact uploads
+      id-token: write # OIDC auth
 
   coverage-finish:
     name: coverage-finish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ concurrency:
   group: "ci-${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
 
+permissions:
+  contents: read
+
 env:
   GH_TOKEN: ${{ github.token }}
 
@@ -160,11 +163,16 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'kotlin')
     uses: ./.github/workflows/_kotlin.yml
     secrets: inherit
+    permissions:
+      contents: write # release draft and build artifact uploads
+      id-token: write # OIDC auth
 
   monitor-kotlin:
     needs: [kotlin]
     if: "!cancelled() && needs.kotlin.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -174,11 +182,16 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'swift')
     uses: ./.github/workflows/_swift.yml
     secrets: inherit
+    permissions:
+      contents: write # release draft and build artifact uploads
+      id-token: write # OIDC auth
 
   monitor-swift:
     needs: [swift]
     if: "!cancelled() && needs.swift.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -188,11 +201,15 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'elixir')
     uses: ./.github/workflows/_elixir.yml
     secrets: inherit
+    permissions:
+      checks: write # dorny/test-reporter
 
   monitor-elixir:
     needs: [elixir]
     if: "!cancelled() && needs.elixir.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -202,11 +219,16 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'rust')
     uses: ./.github/workflows/_rust.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth
 
   monitor-rust:
     needs: [rust]
     if: "!cancelled() && needs.rust.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -216,11 +238,16 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'tauri')
     uses: ./.github/workflows/_tauri.yml
     secrets: inherit
+    permissions:
+      contents: write # release draft and build artifact uploads
+      id-token: write # OIDC auth
 
   monitor-tauri:
     needs: [tauri]
     if: "!cancelled() && needs.tauri.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -230,11 +257,17 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'codeql')
     uses: ./.github/workflows/_codeql.yml
     secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      security-events: write # upload CodeQL results
 
   monitor-codeql:
     needs: [codeql]
     if: "!cancelled() && needs.codeql.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -244,11 +277,16 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'control-plane')
     uses: ./.github/workflows/_control-plane.yml
     secrets: inherit
+    permissions:
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
 
   monitor-control-plane:
     needs: [control-plane]
     if: "!cancelled() && needs.control-plane.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -258,6 +296,10 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'data-plane')
     uses: ./.github/workflows/_data-plane.yml
     secrets: inherit
+    permissions:
+      contents: write # create/update GitHub releases
+      id-token: write # OIDC auth
+      packages: write # push Docker images to GHCR
     with:
       # Build debug/ on PRs and merge group, no prefix for production release images
       image_prefix: ${{ ((github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'debug') || '' }}
@@ -268,6 +310,8 @@ jobs:
     needs: [data-plane]
     if: "!cancelled() && needs.data-plane.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -277,11 +321,16 @@ jobs:
     if: contains(needs.planner.outputs.jobs_to_run, 'loadtest')
     uses: ./.github/workflows/_loadtest.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth for Azure Storage uploads
 
   monitor-loadtest:
     needs: [loadtest]
     if: "!cancelled() && needs.loadtest.result == 'failure' && github.event_name == 'merge_group'"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # gh run cancel
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh run cancel ${{ github.run_id }}
@@ -290,6 +339,10 @@ jobs:
     uses: ./.github/workflows/_integration_tests.yml
     needs: [control-plane, data-plane]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth
+      pull-requests: write # post test result comments
     with:
       gateway_image: ${{ needs.data-plane.outputs.gateway_image }}
       client_image: ${{ needs.data-plane.outputs.client_image }}
@@ -318,6 +371,10 @@ jobs:
     uses: ./.github/workflows/_integration_tests.yml
     needs: [control-plane, data-plane]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write # OIDC auth
+      pull-requests: write # post test result comments
     with:
       gateway_image: ${{ matrix.gateway.image }}
       gateway_tag: ${{ matrix.gateway.tag }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,15 +4,21 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write # post review comments
+  issues: read
+  id-token: write # OIDC auth
+
 jobs:
   claude-review:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # post review comments
       issues: read
-      id-token: write
+      id-token: write # OIDC auth
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,13 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: write # push commits to PR branches
+  pull-requests: write # create/update PRs and post comments
+  issues: write # comment on and close issues
+  id-token: write # OIDC auth
+  actions: read
+
 jobs:
   claude:
     if: |
@@ -27,10 +34,10 @@ jobs:
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
+      contents: write # push commits to PR branches
+      pull-requests: write # create/update PRs and post comments
+      issues: write # comment on and close issues
+      id-token: write # OIDC auth
       actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,8 +23,7 @@ jobs:
       }}
     runs-on: ubuntu-24.04
     permissions:
-      # Needed to upload artifacts to a release
-      packages: write
+      packages: write # push promoted Docker images to GHCR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
In light of recent supply chain news, we're updating our token perms to explicitly request write perms only when needed. The defaults have been changed to reduce default token perms.
