### PR TITLE
fix(apple): fallback to public resolvers when empty

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -477,13 +477,16 @@ actor Adapter {
         if ipv4Address.isWithinSentinelRange() {
           Log.warning(
             "Not adding fetched system resolver because it's within sentinel range: \(ipv4Address)")
-        } else if ipv4Address.isNonRoutable() {
-          Log.debug(
-            "Not adding fetched system resolver because it's non-routable: \(ipv4Address)")
-        } else {
-          parsedResolvers.append("\(ipv4Address)")
+          continue
         }
 
+        if ipv4Address.isNonRoutable() {
+          Log.debug(
+            "Not adding fetched system resolver because it's non-routable: \(ipv4Address)")
+          continue
+        }
+
+        parsedResolvers.append("\(ipv4Address)")
         continue
       }
 
@@ -491,13 +494,16 @@ actor Adapter {
         if ipv6Address.isWithinSentinelRange() {
           Log.warning(
             "Not adding fetched system resolver because it's within sentinel range: \(ipv6Address)")
-        } else if ipv6Address.isNonRoutable() {
-          Log.debug(
-            "Not adding fetched system resolver because it's non-routable: \(ipv6Address)")
-        } else {
-          parsedResolvers.append("\(ipv6Address)")
+          continue
         }
 
+        if ipv6Address.isNonRoutable() {
+          Log.debug(
+            "Not adding fetched system resolver because it's non-routable: \(ipv6Address)")
+          continue
+        }
+
+        parsedResolvers.append("\(ipv6Address)")
         continue
       }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -467,7 +467,9 @@ actor Adapter {
     let resolvers = ScopedResolvers.getDefaultDNSServers(
       interfaceName: path.availableInterfaces.first?.name)
 
-    // Step 2: Validate addresses and filter out sentinel ranges
+    Log.debug("System DNS resolvers before filtering: \(resolvers)")
+
+    // Step 2: Validate addresses and filter out sentinel ranges and non-routable addresses
     var parsedResolvers: [String] = []
 
     for stringAddress in resolvers {
@@ -475,6 +477,9 @@ actor Adapter {
         if ipv4Address.isWithinSentinelRange() {
           Log.warning(
             "Not adding fetched system resolver because it's within sentinel range: \(ipv4Address)")
+        } else if ipv4Address.isNonRoutable() {
+          Log.debug(
+            "Not adding fetched system resolver because it's non-routable: \(ipv4Address)")
         } else {
           parsedResolvers.append("\(ipv4Address)")
         }
@@ -486,6 +491,9 @@ actor Adapter {
         if ipv6Address.isWithinSentinelRange() {
           Log.warning(
             "Not adding fetched system resolver because it's within sentinel range: \(ipv6Address)")
+        } else if ipv6Address.isNonRoutable() {
+          Log.debug(
+            "Not adding fetched system resolver because it's non-routable: \(ipv6Address)")
         } else {
           parsedResolvers.append("\(ipv6Address)")
         }
@@ -496,7 +504,15 @@ actor Adapter {
       Log.warning("IP address \(stringAddress) did not parse as either IPv4 or IPv6")
     }
 
-    // Step 3: Send to connlib
+    // Step 3: Fall back to Cloudflare DNS if no usable resolvers remain
+    if parsedResolvers.isEmpty {
+      parsedResolvers = ["1.1.1.1", "2606:4700:4700::1111"]
+      Log.debug(
+        "No usable system DNS resolvers found after filtering; using fallback resolvers: \(parsedResolvers)"
+      )
+    }
+
+    // Step 4: Send to connlib
     Log.log("Sending resolvers to connlib: \(parsedResolvers)")
     sendCommand(.setDns(parsedResolvers))
   }
@@ -573,10 +589,25 @@ extension IPv4Address {
   func isWithinSentinelRange() -> Bool {
     return "\(self)".hasPrefix("100.100.111.")
   }
+
+  /// 127.0.0.0/8 (loopback) or 169.254.0.0/16 (link-local)
+  func isNonRoutable() -> Bool {
+    let bytes = rawValue
+    return bytes[bytes.startIndex] == 127
+      || (bytes[bytes.startIndex] == 169 && bytes[bytes.startIndex + 1] == 254)
+  }
 }
 
 extension IPv6Address {
   func isWithinSentinelRange() -> Bool {
     return "\(self)".hasPrefix("fd00:2021:1111:8000:100:100:111:")
+  }
+
+  /// ::1/128 (loopback) or fe80::/10 (link-local)
+  func isNonRoutable() -> Bool {
+    let bytes = Array(rawValue)
+    let isLoopback = bytes == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    let isLinkLocal = bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80
+    return isLoopback || isLinkLocal
   }
 }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,13 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull={12657}>
+          Falls back to public DNS resolvers when the system provides only
+          non-routable addresses (loopback, link-local), preventing tunnel
+          bootstrap failures.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.14" date={new Date("2026-03-17")}>
         <ChangeItem pull={12407}>
           Fixes update notification dismissal on macOS where dismissing one


### PR DESCRIPTION
## Summary

- Filters non-routable DNS resolvers (loopback `127.0.0.0/8`, link-local `169.254.0.0/16`, `::1`, `fe80::/10`) from the system-provided list on macOS/iOS before passing them to connlib
- Falls back to `1.1.1.1` and `2606:4700:4700::1111` when no usable resolvers remain, so the tunnel can still bootstrap
- Logs found resolvers at debug level before filtering for diagnosability

## Context

On some systems (suspected to be related to ProtonVPN or similar software), the system resolvers read via `dns_configuration_copy()` are link-local addresses. NECP prevents the tunnel from reaching these, causing DNS to fail entirely during the bootstrap phase before Firezone's own upstream resolvers are configured.

The fallback resolvers are only used temporarily — once Firezone initializes, the portal-configured upstream resolvers take over.

Related: https://firezonehq.slack.com/archives/C06RMP7569G/p1773836567851889

## Test plan

- [x] Verify on macOS/iOS that normal (routable) system resolvers are passed through unchanged
- [x] Simulate link-local-only resolvers and confirm fallback to `1.1.1.1` / `2606:4700:4700::1111`
- [x] Check debug logs show the pre-filter resolver list

🤖 Generated with [Claude Code](https://claude.com/claude-code)