### PR TITLE
ci: skip macOS alert tests

### DIFF
--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/MacOSAlertTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/MacOSAlertTests.swift
@@ -10,7 +10,7 @@
 
   @testable import FirezoneKit
 
-  @Suite("MacOSAlert Tests", .requiresAppKit)
+  @Suite("MacOSAlert Tests", .requiresAppKit, .disabled("Hangs on headless CI runners"))
   struct MacOSAlertTests {
     /// Waits for an alert's sheet to become visible before interacting with it.
     /// This is more reliable than arbitrary sleep delays as it polls for actual window state.


### PR DESCRIPTION
Skips macOS alert tests which seem to hang indefinitely in CI.

Red `main` prevents prod deploys - we ensure all checks are green before rolling to prod for safety.

---

Related: #12659 
Related: https://github.com/firezone/infra/actions/runs/23507310439/job/68418616321
