### PR TITLE
chore(portal): remove unused /healthz endpoint

### DIFF
--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -1,6 +1,6 @@
 defmodule Portal.Health do
   @moduledoc """
-  Health check plug that handles liveness and readiness probes.
+  Health check plug that handles readiness probes.
 
   - `/readyz` - Readiness check, returns 200 when endpoints are ready,
                 503 when draining or starting

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -2,7 +2,6 @@ defmodule Portal.Health do
   @moduledoc """
   Health check plug that handles liveness and readiness probes.
 
-  - `/healthz` - Liveness check, always returns 200 OK
   - `/readyz` - Readiness check, returns 200 when endpoints are ready,
                 503 when draining or starting
 
@@ -44,13 +43,6 @@ defmodule Portal.Health do
   def init(opts), do: opts
 
   @impl true
-  def call(%Plug.Conn{request_path: "/healthz", method: "GET"} = conn, _opts) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(200, JSON.encode!(%{status: :ok}))
-    |> halt()
-  end
-
   def call(%Plug.Conn{request_path: "/readyz", method: "GET"} = conn, _opts) do
     conn
     |> put_resp_content_type("application/json")

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -18,15 +18,6 @@ defmodule Portal.HealthTest do
   end
 
   describe "PortalWeb.Endpoint integration" do
-    test "GET /healthz returns 200" do
-      conn =
-        Plug.Test.conn(:get, "/healthz")
-        |> PortalWeb.Endpoint.call([])
-
-      assert conn.status == 200
-      assert JSON.decode!(conn.resp_body) == %{"status" => "ok"}
-    end
-
     test "GET /readyz returns 200 when ready" do
       conn =
         Plug.Test.conn(:get, "/readyz")
@@ -39,15 +30,6 @@ defmodule Portal.HealthTest do
   end
 
   describe "PortalAPI.Endpoint integration" do
-    test "GET /healthz returns 200" do
-      conn =
-        Plug.Test.conn(:get, "/healthz")
-        |> PortalAPI.Endpoint.call([])
-
-      assert conn.status == 200
-      assert JSON.decode!(conn.resp_body) == %{"status" => "ok"}
-    end
-
     test "GET /readyz returns 200 when ready" do
       conn =
         Plug.Test.conn(:get, "/readyz")
@@ -56,18 +38,6 @@ defmodule Portal.HealthTest do
       assert conn.status == 200
       assert %{"status" => "ready", "version" => version} = JSON.decode!(conn.resp_body)
       assert is_binary(version)
-    end
-  end
-
-  describe "GET /healthz" do
-    test "returns 200 with status ok" do
-      conn =
-        :get
-        |> conn("/healthz")
-        |> Portal.Health.call([])
-
-      assert conn.status == 200
-      assert JSON.decode!(conn.resp_body) == %{"status" => "ok"}
     end
   end
 


### PR DESCRIPTION
This endpoint is no longer used anywhere - the /readyz is used by infra monitoring instead.
