### PR TITLE
fix(portal): 503 on unavailable DB

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -174,6 +174,8 @@ config :portal, Portal.Health,
   web_endpoint: PortalWeb.Endpoint,
   api_endpoint: PortalAPI.Endpoint,
   ops_endpoint: PortalOps.Endpoint,
+  repo: Portal.Repo,
+  replica_repo: Portal.Repo.Replica,
   # TODO: Remove draining_file_path after Azure migration is complete
   draining_file_path: "/var/run/firezone/draining"
 

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -4,7 +4,7 @@ defmodule Portal.Health do
 
   - `/healthz` - Liveness check, always returns 200 OK
   - `/readyz` - Readiness check, returns 200 when endpoints are ready,
-                503 when draining or starting
+                503 when draining, database unavailable or starting
 
   Can be used in two ways:
 

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -71,6 +71,9 @@ defmodule Portal.Health do
       not endpoints_ready?() ->
         send_resp(conn, 503, JSON.encode!(%{status: :starting, version: version}))
 
+      not repos_ready?() ->
+        send_resp(conn, 503, JSON.encode!(%{status: :database_unavailable, version: version}))
+
       true ->
         send_resp(conn, 200, JSON.encode!(%{status: :ready, version: version}))
     end
@@ -79,6 +82,20 @@ defmodule Portal.Health do
   defp draining? do
     Portal.Config.fetch_env!(:portal, Portal.Health)[:draining_file_path]
     |> File.exists?()
+  end
+
+  defp repos_ready? do
+    config = Portal.Config.fetch_env!(:portal, Portal.Health)
+    repo = Keyword.fetch!(config, :repo)
+    replica_repo = Keyword.fetch!(config, :replica_repo)
+
+    try do
+      %{num_rows: 1} = Ecto.Adapters.SQL.query!(repo, "SELECT 1", [])
+      %{num_rows: 1} = Ecto.Adapters.SQL.query!(replica_repo, "SELECT 1", [])
+      true
+    rescue
+      _ -> false
+    end
   end
 
   defp endpoints_ready? do

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -98,6 +98,48 @@ defmodule Portal.HealthTest do
       assert is_binary(version)
     end
 
+    test "returns 503 with status database_unavailable when repo is unreachable", %{
+      draining_file_path: draining_file_path
+    } do
+      Portal.Config.put_env_override(:portal, Portal.Health,
+        draining_file_path: draining_file_path,
+        repo: :nonexistent_repo
+      )
+
+      conn =
+        :get
+        |> conn("/readyz")
+        |> Portal.Health.call([])
+
+      assert conn.status == 503
+
+      assert %{"status" => "database_unavailable", "version" => version} =
+               JSON.decode!(conn.resp_body)
+
+      assert is_binary(version)
+    end
+
+    test "returns 503 with status database_unavailable when replica repo is unreachable", %{
+      draining_file_path: draining_file_path
+    } do
+      Portal.Config.put_env_override(:portal, Portal.Health,
+        draining_file_path: draining_file_path,
+        replica_repo: :nonexistent_repo
+      )
+
+      conn =
+        :get
+        |> conn("/readyz")
+        |> Portal.Health.call([])
+
+      assert conn.status == 503
+
+      assert %{"status" => "database_unavailable", "version" => version} =
+               JSON.decode!(conn.resp_body)
+
+      assert is_binary(version)
+    end
+
     test "returns 503 with status starting when an endpoint is not ready", %{
       draining_file_path: draining_file_path
     } do


### PR DESCRIPTION
While nearly every endpoint will 500 without a valid repo connection, it would be better to explicitly return a 503 at `/readyz` when the repo(s) are unavailable.

---

Fixes #12590

