### PR TITLE
fix(rust): patch correct version of `quinn-udp`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5816,7 +5816,8 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.12"
-source = "git+https://github.com/quinn-rs/quinn?branch=main#06995454f44171d4164753b95e0bce900089a9a7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5829,8 +5830,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53412bac6247548e2164c7d7f67854aa104ea7d5901efd99622fdf05205496f6"
+source = "git+https://github.com/quinn-rs/quinn?branch=main#8acb578f10b02986050bc600e629f56f40162266"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -264,7 +264,7 @@ ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "mas
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.30" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
-quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
+quinn-udp = { git = "https://github.com/quinn-rs/quinn", version = "0.6.0", branch = "main" } # Waiting for release.
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 rtnetlink = { git = "https://github.com/rust-netlink/rtnetlink", branch = "main" } # Waiting for release.


### PR DESCRIPTION
We depend on two versions of `quinn-udp`, once directly and once indirectly through `reqwest`. With our current manifest, we are actually patching the wrong one with the latest tip of `main`.

This also fixes the regression of not automatically disabling GSO on Linux systems with network drivers that don't support it.