### PR TITLE
fix(ci): add mise action with pinned version and retries

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,36 @@
+---
+name: "Setup mise"
+description: "Installs mise with a pinned version and retry logic"
+inputs:
+  version:
+    description: "mise version to install"
+    required: false
+    default: "2026.3.10"
+  install_args:
+    description: "Arguments to pass to `mise install`"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      id: mise-1
+      continue-on-error: true
+      with:
+        version: ${{ inputs.version }}
+        install_args: ${{ inputs.install_args }}
+
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      if: ${{ steps.mise-1.outcome == 'failure' }}
+      id: mise-2
+      continue-on-error: true
+      with:
+        version: ${{ inputs.version }}
+        install_args: ${{ inputs.install_args }}
+
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      if: ${{ steps.mise-2.outcome == 'failure' }}
+      with:
+        version: ${{ inputs.version }}
+        install_args: ${{ inputs.install_args }}

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -62,7 +62,7 @@ jobs:
       MISE_EXPERIMENTAL: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: ./.github/actions/setup-mise
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         name: Restore pip cache
         id: pip-cache

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: sudo xcode-select --switch "$(find /Applications -maxdepth 1 -name "Xcode*${XCODE_VERSION}*.app" | sort -V | tail -n 1)"
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: ./.github/actions/setup-mise
         with:
           install_args: --cd swift/apple swiftlint
       - run: mise run //swift/apple:test-coverage
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: sudo xcode-select --switch "$(find /Applications -maxdepth 1 -name "Xcode*${XCODE_VERSION}*.app" | sort -V | tail -n 1)"
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: ./.github/actions/setup-mise
         with:
           install_args: --cd swift/apple swiftlint
       - name: Check Swift formatting and linting
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: ./.github/actions/setup-mise
         with:
           install_args: --cd swift/apple swiftlint
       - uses: ./.github/actions/setup-rust-stable


### PR DESCRIPTION
Create a shared `.github/actions/setup-mise` composite action that wraps `jdx/mise-action` and replaces all 4 direct call sites in `_swift.yml` and `_static-analysis.yml`.

Two improvements:

- Pin mise to an explicit version (2026.3.10) rather than fetching the latest on every run. This makes version bumps intentional and improves GitHub Actions cache hit rates since the cache key no longer changes with every upstream mise release.

- Retry up to 3 times on download failure. The GitHub Releases CDN has been intermittently returning 504s, causing spurious CI failures. The retry logic mirrors the existing `setup-rust-stable` pattern.
