### PR TITLE
chore(relay): remove `GoogleCloud` logging configuration

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,10 +7,6 @@ name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "actix-codec"
@@ -2622,7 +2618,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-opentelemetry",
- "tracing-stackdriver",
  "tracing-subscriber",
  "trackable",
  "url",
@@ -8396,22 +8391,6 @@ checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-stackdriver"
-version = "0.12.0"
-source = "git+https://github.com/thomaseizinger/tracing-stackdriver?branch=bump-otel-0.30#0b86826d6229cefca4d567c04dce4ff18aaf534b"
-dependencies = [
- "Inflector",
- "opentelemetry",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "tracing-core",
- "tracing-opentelemetry",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -220,7 +220,6 @@ tracing-journald = "0.3.2"
 tracing-log = "0.2.0"
 tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
 tracing-opentelemetry = "0.31.0"
-tracing-stackdriver = "0.12.0"
 tracing-subscriber = { version = "0.3.22", features = ["parking_lot"] }
 trackable = "1.3.0"
 tun = { path = "libs/connlib/tun" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -262,7 +262,6 @@ str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
-tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.30" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", version = "0.6.0", branch = "main" } # Waiting for release.
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -44,7 +44,6 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "tim
 tracing = { workspace = true, features = ["log"] }
 tracing-core = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-tracing-stackdriver = { workspace = true, features = ["opentelemetry"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"] }
 trackable = { workspace = true }
 url = { workspace = true }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -82,13 +82,6 @@ struct Args {
     #[arg(long, env, hide = true)]
     otlp_grpc_endpoint: Option<String>,
 
-    /// The Google Project ID to embed in spans.
-    ///
-    /// Set this if you are running on Google Cloud but using the OTLP trace collector.
-    /// OTLP is vendor-agnostic but for spans to be correctly recognised by Google Cloud, they need the project ID to be set.
-    #[arg(long, env, hide = true)]
-    google_cloud_project_id: Option<String>,
-
     /// Enable offloading of TURN traffic to an eBPF program.
     ///
     /// Requires the name of the network interface the XDP program should be loaded onto.
@@ -393,11 +386,11 @@ fn log_layer<T>(args: &Args) -> Box<dyn Layer<T> + Send + Sync>
 where
     T: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
 {
-    match (args.log_format, args.google_cloud_project_id.clone()) {
-        (LogFormat::Human, _) => tracing_subscriber::fmt::layer()
+    match args.log_format {
+        LogFormat::Human => tracing_subscriber::fmt::layer()
             .with_ansi(logging::stdout_supports_ansi())
             .boxed(),
-        (LogFormat::Json, _) => tracing_subscriber::fmt::layer().json().boxed(),
+        LogFormat::Json => tracing_subscriber::fmt::layer().json().boxed(),
     }
 }
 

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -28,7 +28,6 @@ use telemetry::{RELAY_DSN, Telemetry};
 use tokio::sync::mpsc;
 use tracing::Subscriber;
 use tracing_core::Dispatch;
-use tracing_stackdriver::CloudTraceConfiguration;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 use url::Url;
 
@@ -132,7 +131,6 @@ struct Args {
 enum LogFormat {
     Human,
     Json,
-    GoogleCloud,
 }
 
 fn main() {
@@ -400,14 +398,6 @@ where
             .with_ansi(logging::stdout_supports_ansi())
             .boxed(),
         (LogFormat::Json, _) => tracing_subscriber::fmt::layer().json().boxed(),
-        (LogFormat::GoogleCloud, None) => {
-            tracing::warn!(target: "relay", "Emitting logs in Google Cloud format but without the project ID set. Spans will be emitted without IDs!");
-
-            tracing_stackdriver::layer().boxed()
-        }
-        (LogFormat::GoogleCloud, Some(project_id)) => tracing_stackdriver::layer()
-            .with_cloud_trace(CloudTraceConfiguration { project_id })
-            .boxed(),
     }
 }
 


### PR DESCRIPTION
Our relays are no longer hosted on GoogleCloud so this can be removed, along with the dependency on `tracing-stackdriver`.