### PR TITLE
refactor(portal): replace node type with dynamic pools

### DIFF
--- a/elixir/.credo/check/warning/unsafe_repo_usage.ex
+++ b/elixir/.credo/check/warning/unsafe_repo_usage.ex
@@ -89,6 +89,25 @@ defmodule Credo.Check.Warning.UnsafeRepoUsage do
     {ast, issues}
   end
 
+  # Allow Portal.Repo.put_dynamic_repo - pool routing, not a database operation
+  defp traverse(
+         {{:., _meta, [{:__aliases__, _, [:Portal, :Repo]}, :put_dynamic_repo]}, _, _} = ast,
+         issues,
+         _issue_meta
+       ) do
+    {ast, issues}
+  end
+
+  # Allow Portal.Repo.Replica.put_dynamic_repo
+  defp traverse(
+         {{:., _meta, [{:__aliases__, _, [:Portal, :Repo, :Replica]}, :put_dynamic_repo]}, _, _} =
+           ast,
+         issues,
+         _issue_meta
+       ) do
+    {ast, issues}
+  end
+
   # Check for direct Portal.Repo calls
   defp traverse(
          {{:., meta, [{:__aliases__, _, [:Portal, :Repo]}, _]}, _, _} = ast,

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -46,6 +46,40 @@ config :portal, Portal.Repo.Replica,
   queue_interval: 1000,
   parameters: [application_name: "replica"]
 
+# Isolated primary connection pools (web/api)
+for {repo, app_name} <- [
+      {Portal.Repo.Web, "web"},
+      {Portal.Repo.Api, "api"}
+    ] do
+  config :portal, repo,
+    hostname: "localhost",
+    username: "postgres",
+    password: "postgres",
+    database: "firezone_dev",
+    show_sensitive_data_on_connection_error: true,
+    pool_size: :erlang.system_info(:logical_processors_available) * 2,
+    queue_target: 500,
+    queue_interval: 1000,
+    parameters: [application_name: app_name]
+end
+
+# Isolated replica connection pools (web/api)
+for {repo, app_name} <- [
+      {Portal.Repo.Replica.Web, "replica-web"},
+      {Portal.Repo.Replica.Api, "replica-api"}
+    ] do
+  config :portal, repo,
+    hostname: "localhost",
+    username: "postgres",
+    password: "postgres",
+    database: "firezone_dev",
+    show_sensitive_data_on_connection_error: true,
+    pool_size: :erlang.system_info(:logical_processors_available) * 2,
+    queue_target: 500,
+    queue_interval: 1000,
+    parameters: [application_name: app_name]
+end
+
 config :portal, Portal.ChangeLogs.ReplicationConnection,
   replication_slot_name: "change_logs_slot",
   publication_name: "change_logs_publication",
@@ -174,8 +208,6 @@ config :portal, Portal.Health,
   web_endpoint: PortalWeb.Endpoint,
   api_endpoint: PortalAPI.Endpoint,
   ops_endpoint: PortalOps.Endpoint,
-  repo: Portal.Repo,
-  replica_repo: Portal.Repo.Replica,
   # TODO: Remove draining_file_path after Azure migration is complete
   draining_file_path: "/var/run/firezone/draining"
 

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -27,6 +27,10 @@ db_opts = [
 
 config :portal, Portal.Repo, db_opts
 config :portal, Portal.Repo.Replica, db_opts
+config :portal, Portal.Repo.Web, db_opts
+config :portal, Portal.Repo.Api, db_opts
+config :portal, Portal.Repo.Replica.Web, db_opts
+config :portal, Portal.Repo.Replica.Api, db_opts
 
 config :portal, Portal.ChangeLogs.ReplicationConnection,
   replication_slot_name: db_opts[:database] <> "_clog_slot",

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -42,8 +42,7 @@ if config_env() == :prod do
            {:queue_target, env_var_to_config!(:database_queue_target)},
            {:queue_interval, env_var_to_config!(:database_queue_interval)},
            {:ssl, env_var_to_config!(:database_ssl)},
-           {:parameters, env_var_to_config!(:database_parameters)},
-           {:hostname, env_var_to_config!(:database_host_replica)}
+           {:parameters, env_var_to_config!(:database_parameters)}
          ] ++
            if(env_var_to_config!(:database_socket_options) != [],
              do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
@@ -52,7 +51,85 @@ if config_env() == :prod do
            if(env_var_to_config(:database_password),
              do: [{:password, env_var_to_config!(:database_password)}],
              else: []
+           ) ++
+           if(env_var_to_config(:database_socket_dir),
+             do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
+             else: [{:hostname, env_var_to_config!(:database_host_replica)}]
            )
+
+  # Shared connection options for isolated primary pools
+  primary_pool_base_opts =
+    [
+      {:database, env_var_to_config!(:database_name)},
+      {:username, env_var_to_config!(:database_user)},
+      {:port, env_var_to_config!(:database_port)},
+      {:queue_target, env_var_to_config!(:database_queue_target)},
+      {:queue_interval, env_var_to_config!(:database_queue_interval)},
+      {:ssl, env_var_to_config!(:database_ssl)}
+    ] ++
+      if(env_var_to_config!(:database_socket_options) != [],
+        do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
+        else: []
+      ) ++
+      if(env_var_to_config(:database_password),
+        do: [{:password, env_var_to_config!(:database_password)}],
+        else: []
+      ) ++
+      if(env_var_to_config(:database_socket_dir),
+        do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
+        else: [{:hostname, env_var_to_config!(:database_host)}]
+      )
+
+  # Shared connection options for isolated replica pools
+  replica_pool_base_opts =
+    [
+      {:database, env_var_to_config!(:database_name)},
+      {:username, env_var_to_config!(:database_user)},
+      {:port, env_var_to_config!(:database_port)},
+      {:queue_target, env_var_to_config!(:database_queue_target)},
+      {:queue_interval, env_var_to_config!(:database_queue_interval)},
+      {:ssl, env_var_to_config!(:database_ssl)}
+    ] ++
+      if(env_var_to_config!(:database_socket_options) != [],
+        do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
+        else: []
+      ) ++
+      if(env_var_to_config(:database_password),
+        do: [{:password, env_var_to_config!(:database_password)}],
+        else: []
+      ) ++
+      if(env_var_to_config(:database_socket_dir),
+        do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
+        else: [{:hostname, env_var_to_config!(:database_host_replica)}]
+      )
+
+  database_parameters = env_var_to_config!(:database_parameters)
+
+  # Isolated primary connection pools
+  for {repo, pool_size_key, app_name} <- [
+        {Portal.Repo.Web, :database_pool_size_web, "web"},
+        {Portal.Repo.Api, :database_pool_size_api, "api"}
+      ] do
+    config :portal,
+           repo,
+           [
+             {:pool_size, env_var_to_config!(pool_size_key)},
+             {:parameters, Keyword.merge(database_parameters, application_name: app_name)}
+           ] ++ primary_pool_base_opts
+  end
+
+  # Isolated replica connection pools
+  for {repo, pool_size_key, app_name} <- [
+        {Portal.Repo.Replica.Web, :database_pool_size_web_replica, "replica-web"},
+        {Portal.Repo.Replica.Api, :database_pool_size_api_replica, "replica-api"}
+      ] do
+    config :portal,
+           repo,
+           [
+             {:pool_size, env_var_to_config!(pool_size_key)},
+             {:parameters, Keyword.merge(database_parameters, application_name: app_name)}
+           ] ++ replica_pool_base_opts
+  end
 
   config :portal, Portal.ChangeLogs.ReplicationConnection,
     enabled: env_var_to_config!(:change_logs_replication_enabled),
@@ -148,7 +225,6 @@ if config_env() == :prod do
            )
 
   config :portal, region: env_var_to_config!(:region)
-  config :portal, node_type: env_var_to_config!(:node_type)
 
   config :portal, Portal.Cluster,
     adapter: env_var_to_config!(:erlang_cluster_adapter),
@@ -186,8 +262,6 @@ if config_env() == :prod do
 
   # Oban has its own config validation that prevents overriding config in runtime.exs,
   # so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
-  background_jobs_enabled = env_var_to_config!(:background_jobs_enabled)
-
   oban_crontab = [
     # Delete expired policy_authorizations every minute
     {"* * * * *", Portal.Workers.DeleteExpiredPolicyAuthorizations},
@@ -248,34 +322,23 @@ if config_env() == :prod do
   ]
 
   config :portal, Oban,
-    # Disable peer election and plugins on web/api nodes to avoid DB row-lock
-    # contention during blue/green deploys. With pool_size=2, Oban.Peers.Database
-    # transactions competing for the oban_peers lock can starve the connection pool.
-    peer: if(background_jobs_enabled, do: Oban.Peers.Database, else: false),
-    plugins:
-      if(background_jobs_enabled,
-        do: [
-          {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
-          {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(120)},
-          {Oban.Plugins.Cron, crontab: oban_crontab}
-        ],
-        else: []
-      ),
-    queues:
-      if(background_jobs_enabled,
-        do: [
-          default: 10,
-          entra_scheduler: 1,
-          entra_sync: 5,
-          google_scheduler: 1,
-          google_sync: 5,
-          okta_scheduler: 1,
-          okta_sync: 5,
-          sync_error_notifications: 1,
-          outbound_emails: 1
-        ],
-        else: []
-      ),
+    peer: Oban.Peers.Database,
+    plugins: [
+      {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+      {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(120)},
+      {Oban.Plugins.Cron, crontab: oban_crontab}
+    ],
+    queues: [
+      default: 10,
+      entra_scheduler: 1,
+      entra_sync: 5,
+      google_scheduler: 1,
+      google_sync: 5,
+      okta_scheduler: 1,
+      okta_sync: 5,
+      sync_error_notifications: 1,
+      outbound_emails: 1
+    ],
     engine: Oban.Engines.Basic,
     repo: Portal.Repo
 
@@ -404,7 +467,7 @@ if config_env() == :prod do
       resource_detectors: [:otel_resource_env_var, :otel_resource_app_env],
       resource: %{
         service: %{
-          name: System.get_env("NODE_TYPE", "portal"),
+          name: "portal",
           namespace: "firezone",
           version: System.get_env("RELEASE_VSN"),
           instance: %{id: System.get_env("NODE_NAME")}

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -30,6 +30,18 @@ config :portal, Portal.Repo.Replica,
   pool: Ecto.Adapters.SQL.Sandbox,
   queue_target: 1000
 
+for repo <- [
+      Portal.Repo.Web,
+      Portal.Repo.Api,
+      Portal.Repo.Replica.Web,
+      Portal.Repo.Replica.Api
+    ] do
+  config :portal, repo,
+    database: "firezone_test#{partition_suffix}",
+    pool: Ecto.Adapters.SQL.Sandbox,
+    queue_target: 1000
+end
+
 # Oban has its own config validation that prevents overriding config in runtime.exs,
 # so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
 config :portal, Oban,

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -15,6 +15,10 @@ defmodule Portal.Application do
     :ok = OpentelemetryLoggerMetadata.setup()
     :ok = OpentelemetryEcto.setup([:portal, :repo])
     :ok = OpentelemetryEcto.setup([:portal, :repo, :replica])
+    :ok = OpentelemetryEcto.setup([:portal, :repo, :web])
+    :ok = OpentelemetryEcto.setup([:portal, :repo, :api])
+    :ok = OpentelemetryEcto.setup([:portal, :repo, :replica, :web])
+    :ok = OpentelemetryEcto.setup([:portal, :repo, :replica, :api])
     :ok = OpentelemetryBandit.setup()
     :ok = OpentelemetryPhoenix.setup(adapter: :bandit)
     :ok = OpentelemetryOban.setup()
@@ -35,6 +39,11 @@ defmodule Portal.Application do
       # Core services
       Portal.Repo,
       Portal.Repo.Replica,
+      # Isolated connection pools (web/api)
+      Portal.Repo.Web,
+      Portal.Repo.Api,
+      Portal.Repo.Replica.Web,
+      Portal.Repo.Replica.Api,
       # Default pg scope for distributed process discovery (used by replication)
       %{id: :pg, start: {:pg, :start_link, []}},
       # Named pg scope for Portal.PG, isolated so a crash here does not affect replication
@@ -160,12 +169,7 @@ defmodule Portal.Application do
   end
 
   defp rate_limit do
-    case Portal.Config.get_env(:portal, :node_type, "portal") do
-      "api" -> [PortalAPI.RateLimit]
-      "web" -> [PortalWeb.RateLimit]
-      "portal" -> [PortalAPI.RateLimit, PortalWeb.RateLimit]
-      _ -> []
-    end
+    [PortalAPI.RateLimit, PortalWeb.RateLimit]
   end
 
   defp verify_geolix_databases do

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -46,24 +46,12 @@ defmodule Portal.Config.Definitions do
   ##############################################
 
   @doc """
-  Enabled or disable background job workers (eg. syncing IdP directory) for the app instance.
-  """
-  defconfig(:background_jobs_enabled, :boolean, default: false)
-
-  @doc """
   Region identifier used to target direct_broadcast! to web/api nodes.
 
   In a multi-region deployment, this ensures change events are only sent to
   web and api nodes in the same region. Maps to the `REGION` env var.
   """
   defconfig(:region, :string, default: "")
-
-  @doc """
-  Role of this node in the deployment.
-
-  Used to conditionally enable node-specific services.
-  """
-  defconfig(:node_type, :string, default: "portal")
 
   @doc """
   Enable or disable the Changes (CDC) replication consumer for this app instance.
@@ -319,6 +307,26 @@ defmodule Portal.Config.Definitions do
   defconfig(:database_pool_size, :integer,
     default: fn -> :erlang.system_info(:logical_processors_available) * 2 end
   )
+
+  @doc """
+  Size of the primary connection pool for PortalWeb (HTTP + LiveView) queries.
+  """
+  defconfig(:database_pool_size_web, :integer, default: 2)
+
+  @doc """
+  Size of the primary connection pool for PortalAPI (REST + Sockets) queries.
+  """
+  defconfig(:database_pool_size_api, :integer, default: 5)
+
+  @doc """
+  Size of the replica connection pool for PortalWeb (HTTP + LiveView) queries.
+  """
+  defconfig(:database_pool_size_web_replica, :integer, default: 2)
+
+  @doc """
+  Size of the replica connection pool for PortalAPI (REST + Sockets) queries.
+  """
+  defconfig(:database_pool_size_api_replica, :integer, default: 5)
 
   @doc """
   The target threshold for the length of time in milliseconds that a query should wait in the queue

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -76,18 +76,29 @@ defmodule Portal.Health do
     |> File.exists?()
   end
 
+  @repos [
+    Portal.Repo,
+    Portal.Repo.Replica,
+    Portal.Repo.Web,
+    Portal.Repo.Api,
+    Portal.Repo.Replica.Web,
+    Portal.Repo.Replica.Api
+  ]
+
+  # sobelow_skip ["SQL.Query"]
   defp repos_ready? do
     config = Portal.Config.fetch_env!(:portal, Portal.Health)
-    repo = Keyword.fetch!(config, :repo)
-    replica_repo = Keyword.fetch!(config, :replica_repo)
+    repos = Keyword.get(config, :repos, @repos)
+    query = Keyword.get(config, :repo_check_query, "SELECT 1")
 
-    try do
-      %{num_rows: 1} = Ecto.Adapters.SQL.query!(repo, "SELECT 1", [])
-      %{num_rows: 1} = Ecto.Adapters.SQL.query!(replica_repo, "SELECT 1", [])
-      true
-    rescue
-      _ -> false
-    end
+    Enum.all?(repos, fn repo ->
+      try do
+        %{num_rows: 1} = Ecto.Adapters.SQL.query!(repo, query, [])
+        true
+      rescue
+        _ -> false
+      end
+    end)
   end
 
   defp endpoints_ready? do

--- a/elixir/lib/portal/repo.ex
+++ b/elixir/lib/portal/repo.ex
@@ -7,6 +7,28 @@ defmodule Portal.Repo do
   alias Portal.Repo.Paginator
   require Ecto.Query
 
+  defoverridable get_dynamic_repo: 0
+
+  @doc """
+  Overrides `Ecto.Repo.get_dynamic_repo/0` to walk the process hierarchy
+  (`$callers` then `$ancestors`) when the current process has no dynamic repo set.
+
+  This allows child processes (channels, tasks, GenServers) to automatically
+  inherit the pool repo (e.g. `Portal.Repo.Web`) from their parent without
+  explicit propagation at each spawn boundary.
+  """
+  def get_dynamic_repo do
+    case Process.get({__MODULE__, :dynamic_repo}) do
+      nil ->
+        repo = Portal.Repo.DynamicRepoResolver.inherit(__MODULE__)
+        if repo != __MODULE__, do: put_dynamic_repo(repo)
+        repo
+
+      repo ->
+        repo
+    end
+  end
+
   def valid_uuid?(binary) when is_binary(binary),
     do: match?(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>>, binary)
 

--- a/elixir/lib/portal/repo/api.ex
+++ b/elixir/lib/portal/repo/api.ex
@@ -1,0 +1,5 @@
+defmodule Portal.Repo.Api do
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/elixir/lib/portal/repo/dynamic_repo_resolver.ex
+++ b/elixir/lib/portal/repo/dynamic_repo_resolver.ex
@@ -1,0 +1,42 @@
+defmodule Portal.Repo.DynamicRepoResolver do
+  @moduledoc """
+  Walks the process hierarchy (`$callers` then `$ancestors`) to find and
+  inherit a parent's dynamic repo setting.
+
+  Used by `Portal.Repo.get_dynamic_repo/0` and `Portal.Repo.Replica.get_dynamic_repo/0`
+  so that child processes (channels, tasks, GenServers) automatically route
+  queries to the same pool as their parent.
+  """
+
+  @spec inherit(module()) :: module()
+  def inherit(repo_module) do
+    callers = Process.get(:"$callers", [])
+    ancestors = Process.get(:"$ancestors", [])
+
+    find_in_hierarchy(repo_module, callers ++ ancestors)
+  end
+
+  defp find_in_hierarchy(repo_module, []) do
+    repo_module
+  end
+
+  defp find_in_hierarchy(repo_module, [pid | rest]) when is_pid(pid) do
+    case :erlang.process_info(pid, :dictionary) do
+      {:dictionary, dict} ->
+        case List.keyfind(dict, {repo_module, :dynamic_repo}, 0) do
+          {_, repo} -> repo
+          nil -> find_in_hierarchy(repo_module, rest)
+        end
+
+      :undefined ->
+        find_in_hierarchy(repo_module, rest)
+    end
+  end
+
+  defp find_in_hierarchy(repo_module, [name | rest]) when is_atom(name) do
+    case Process.whereis(name) do
+      nil -> find_in_hierarchy(repo_module, rest)
+      pid -> find_in_hierarchy(repo_module, [pid | rest])
+    end
+  end
+end

--- a/elixir/lib/portal/repo/replica.ex
+++ b/elixir/lib/portal/repo/replica.ex
@@ -6,6 +6,20 @@ defmodule Portal.Repo.Replica do
 
   alias Portal.Repo.{List, Paginator}
 
+  defoverridable get_dynamic_repo: 0
+
+  def get_dynamic_repo do
+    case Process.get({__MODULE__, :dynamic_repo}) do
+      nil ->
+        repo = Portal.Repo.DynamicRepoResolver.inherit(__MODULE__)
+        if repo != __MODULE__, do: put_dynamic_repo(repo)
+        repo
+
+      repo ->
+        repo
+    end
+  end
+
   @spec list(
           queryable :: Ecto.Queryable.t(),
           query_module :: module(),

--- a/elixir/lib/portal/repo/replica/api.ex
+++ b/elixir/lib/portal/repo/replica/api.ex
@@ -1,0 +1,6 @@
+defmodule Portal.Repo.Replica.Api do
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres,
+    read_only: true
+end

--- a/elixir/lib/portal/repo/replica/web.ex
+++ b/elixir/lib/portal/repo/replica/web.ex
@@ -1,0 +1,6 @@
+defmodule Portal.Repo.Replica.Web do
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres,
+    read_only: true
+end

--- a/elixir/lib/portal/repo/web.ex
+++ b/elixir/lib/portal/repo/web.ex
@@ -1,0 +1,5 @@
+defmodule Portal.Repo.Web do
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/elixir/lib/portal/telemetry.ex
+++ b/elixir/lib/portal/telemetry.ex
@@ -246,8 +246,7 @@ defmodule Portal.Telemetry do
 
     # Common attributes for all metrics to enable splitting by node in Azure Monitor
     node_attrs = %{
-      "node_name" => System.get_env("NODE_NAME", to_string(node())),
-      "node_type" => System.get_env("NODE_TYPE", "unknown")
+      "node_name" => System.get_env("NODE_NAME", to_string(node()))
     }
 
     # Observable gauges for BEAM health

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -16,6 +16,11 @@ defmodule PortalAPI.Client.Socket do
 
   @impl true
   def connect(attrs, socket, connect_info) do
+    unless Application.get_env(:portal, :sql_sandbox) do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Api)
+    end
+
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "client.connect" do

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -26,6 +26,7 @@ defmodule PortalAPI.Endpoint do
   plug Portal.Plugs.CountryCodeBlocklist
 
   plug Plug.RequestId
+  plug PortalAPI.Plugs.PutDynamicRepo
   # TODO: Rework LoggerJSON to use Telemetry and integrate it
   # https://hexdocs.pm/phoenix/Phoenix.Logger.html
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -16,6 +16,11 @@ defmodule PortalAPI.Gateway.Socket do
 
   @impl true
   def connect(attrs, socket, connect_info) do
+    unless Application.get_env(:portal, :sql_sandbox) do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Api)
+    end
+
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "gateway.connect" do

--- a/elixir/lib/portal_api/plugs/put_dynamic_repo.ex
+++ b/elixir/lib/portal_api/plugs/put_dynamic_repo.ex
@@ -1,0 +1,18 @@
+defmodule PortalAPI.Plugs.PutDynamicRepo do
+  @behaviour Plug
+
+  @sandbox Application.compile_env(:portal, :sql_sandbox)
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    unless @sandbox do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Api)
+    end
+
+    conn
+  end
+end

--- a/elixir/lib/portal_api/relay/socket.ex
+++ b/elixir/lib/portal_api/relay/socket.ex
@@ -33,6 +33,11 @@ defmodule PortalAPI.Relay.Socket do
 
   @impl true
   def connect(attrs, socket, connect_info) do
+    unless Application.get_env(:portal, :sql_sandbox) do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Api)
+    end
+
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "relay.connect" do

--- a/elixir/lib/portal_web/endpoint.ex
+++ b/elixir/lib/portal_web/endpoint.ex
@@ -41,6 +41,7 @@ defmodule PortalWeb.Endpoint do
   plug Portal.Plugs.CountryCodeBlocklist
 
   plug Plug.RequestId
+  plug PortalWeb.Plugs.PutDynamicRepo
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/elixir/lib/portal_web/live_hooks/put_dynamic_repo.ex
+++ b/elixir/lib/portal_web/live_hooks/put_dynamic_repo.ex
@@ -1,0 +1,12 @@
+defmodule PortalWeb.LiveHooks.PutDynamicRepo do
+  @sandbox Application.compile_env(:portal, :sql_sandbox)
+
+  def on_mount(:default, _params, _session, socket) do
+    unless @sandbox do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Web)
+    end
+
+    {:cont, socket}
+  end
+end

--- a/elixir/lib/portal_web/plugs/put_dynamic_repo.ex
+++ b/elixir/lib/portal_web/plugs/put_dynamic_repo.ex
@@ -1,0 +1,18 @@
+defmodule PortalWeb.Plugs.PutDynamicRepo do
+  @behaviour Plug
+
+  @sandbox Application.compile_env(:portal, :sql_sandbox)
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    unless @sandbox do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Web)
+    end
+
+    conn
+  end
+end

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -59,17 +59,18 @@ defmodule PortalWeb.Router do
     end
   end
 
-  scope "/sign_up", PortalWeb do
+  scope "/", PortalWeb do
     pipe_through :public
 
-    live "/", SignUp
-  end
-
-  # Maintained from the LaunchHN - show SignUp form
-  scope "/try", PortalWeb do
-    pipe_through :public
-
-    live "/", SignUp
+    live_session :public_sign_up,
+      on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
+        PortalWeb.LiveHooks.AllowEctoSandbox
+      ] do
+      live "/sign_up", SignUp
+      # Maintained from the LaunchHN - show SignUp form
+      live "/try", SignUp
+    end
   end
 
   scope "/auth", PortalWeb do
@@ -112,6 +113,7 @@ defmodule PortalWeb.Router do
 
     live_session :redirect_if_user_is_authenticated,
       on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
         PortalWeb.LiveHooks.AllowEctoSandbox,
         PortalWeb.LiveHooks.FetchAccount,
         PortalWeb.LiveHooks.FetchSubject,
@@ -123,6 +125,7 @@ defmodule PortalWeb.Router do
     live_session :email_otp_verify,
       session: {PortalWeb.Cookie.EmailOTP, :fetch_state, []},
       on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
         PortalWeb.LiveHooks.AllowEctoSandbox,
         PortalWeb.LiveHooks.FetchAccount,
         PortalWeb.LiveHooks.FetchSubject,
@@ -169,6 +172,7 @@ defmodule PortalWeb.Router do
 
     live_session :ensure_authenticated,
       on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
         PortalWeb.LiveHooks.AllowEctoSandbox,
         PortalWeb.LiveHooks.FetchAccount,
         PortalWeb.LiveHooks.FetchSubject,

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -68,12 +68,12 @@ defmodule Portal.HealthTest do
       assert is_binary(version)
     end
 
-    test "returns 503 with status database_unavailable when repo is unreachable", %{
+    test "returns 503 when repo check query raises", %{
       draining_file_path: draining_file_path
     } do
       Portal.Config.put_env_override(:portal, Portal.Health,
         draining_file_path: draining_file_path,
-        repo: :nonexistent_repo
+        repo_check_query: "INVALID SQL"
       )
 
       conn =
@@ -83,18 +83,23 @@ defmodule Portal.HealthTest do
 
       assert conn.status == 503
 
-      assert %{"status" => "database_unavailable", "version" => version} =
+      assert %{"status" => "database_unavailable", "version" => _} =
                JSON.decode!(conn.resp_body)
-
-      assert is_binary(version)
     end
 
-    test "returns 503 with status database_unavailable when replica repo is unreachable", %{
+    test "returns 200 when all configured repos are reachable", %{
       draining_file_path: draining_file_path
     } do
       Portal.Config.put_env_override(:portal, Portal.Health,
         draining_file_path: draining_file_path,
-        replica_repo: :nonexistent_repo
+        repos: [
+          Portal.Repo,
+          Portal.Repo.Replica,
+          Portal.Repo.Web,
+          Portal.Repo.Api,
+          Portal.Repo.Replica.Web,
+          Portal.Repo.Replica.Api
+        ]
       )
 
       conn =
@@ -102,12 +107,8 @@ defmodule Portal.HealthTest do
         |> conn("/readyz")
         |> Portal.Health.call([])
 
-      assert conn.status == 503
-
-      assert %{"status" => "database_unavailable", "version" => version} =
-               JSON.decode!(conn.resp_body)
-
-      assert is_binary(version)
+      assert conn.status == 200
+      assert %{"status" => "ready"} = JSON.decode!(conn.resp_body)
     end
 
     test "returns 503 with status starting when an endpoint is not ready", %{

--- a/elixir/test/portal/repo/dynamic_repo_resolver_test.exs
+++ b/elixir/test/portal/repo/dynamic_repo_resolver_test.exs
@@ -1,0 +1,237 @@
+defmodule Portal.Repo.DynamicRepoResolverTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Repo.DynamicRepoResolver
+
+  describe "inherit/1" do
+    test "returns the repo module itself when no hierarchy exists" do
+      assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo
+    end
+
+    test "returns the repo module when hierarchy has no dynamic repo set" do
+      parent =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      Process.put(:"$callers", [parent])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo
+      after
+        Process.put(:"$callers", [])
+        Process.exit(parent, :kill)
+      end
+    end
+
+    test "inherits dynamic repo from $callers" do
+      test_pid = self()
+
+      parent =
+        spawn(fn ->
+          Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+
+          send(test_pid, :ready)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive :ready
+
+      Process.put(:"$callers", [parent])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo.Web
+      after
+        Process.put(:"$callers", [])
+        Process.exit(parent, :kill)
+      end
+    end
+
+    test "inherits dynamic repo from $ancestors" do
+      test_pid = self()
+
+      parent =
+        spawn(fn ->
+          Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+
+          send(test_pid, :ready)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive :ready
+
+      Process.put(:"$ancestors", [parent])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo.Api
+      after
+        Process.put(:"$ancestors", [])
+        Process.exit(parent, :kill)
+      end
+    end
+
+    test "prefers $callers over $ancestors" do
+      test_pid = self()
+
+      caller =
+        spawn(fn ->
+          Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+          send(test_pid, {:ready, :caller})
+          receive do: (:stop -> :ok)
+        end)
+
+      ancestor =
+        spawn(fn ->
+          Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+          send(test_pid, {:ready, :ancestor})
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive {:ready, :caller}
+      assert_receive {:ready, :ancestor}
+
+      Process.put(:"$callers", [caller])
+      Process.put(:"$ancestors", [ancestor])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo.Web
+      after
+        Process.put(:"$callers", [])
+        Process.put(:"$ancestors", [])
+        Process.exit(caller, :kill)
+        Process.exit(ancestor, :kill)
+      end
+    end
+
+    test "skips dead processes in the hierarchy" do
+      test_pid = self()
+
+      dead =
+        spawn(fn ->
+          send(test_pid, :dead_ready)
+        end)
+
+      assert_receive :dead_ready
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}
+
+      alive =
+        spawn(fn ->
+          Portal.Repo.put_dynamic_repo(Portal.Repo.Job)
+          send(test_pid, :alive_ready)
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive :alive_ready
+
+      Process.put(:"$callers", [dead, alive])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo.Job
+      after
+        Process.put(:"$callers", [])
+        Process.exit(alive, :kill)
+      end
+    end
+
+    test "resolves registered names in $ancestors" do
+      test_pid = self()
+
+      {:ok, pid} =
+        Agent.start(
+          fn ->
+            Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+            send(test_pid, :ready)
+            :ok
+          end,
+          name: :"#{__MODULE__}.test_registered_name"
+        )
+
+      assert_receive :ready
+
+      Process.put(:"$ancestors", [:"#{__MODULE__}.test_registered_name"])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo.Web
+      after
+        Process.put(:"$ancestors", [])
+        Agent.stop(pid)
+      end
+    end
+
+    test "skips unregistered names in $ancestors" do
+      Process.put(:"$ancestors", [:nonexistent_process_name])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo) == Portal.Repo
+      after
+        Process.put(:"$ancestors", [])
+      end
+    end
+
+    test "works with Portal.Repo.Replica module" do
+      test_pid = self()
+
+      parent =
+        spawn(fn ->
+          Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Web)
+          send(test_pid, :ready)
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive :ready
+
+      Process.put(:"$callers", [parent])
+
+      try do
+        assert DynamicRepoResolver.inherit(Portal.Repo.Replica) == Portal.Repo.Replica.Web
+      after
+        Process.put(:"$callers", [])
+        Process.exit(parent, :kill)
+      end
+    end
+
+    test "inherits through Task.async" do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+
+      try do
+        task =
+          Task.async(fn ->
+            DynamicRepoResolver.inherit(Portal.Repo)
+          end)
+
+        assert Task.await(task) == Portal.Repo.Web
+      after
+        Portal.Repo.put_dynamic_repo(Portal.Repo)
+      end
+    end
+
+    test "inherits through nested Task.async" do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+
+      try do
+        task =
+          Task.async(fn ->
+            inner_task =
+              Task.async(fn ->
+                DynamicRepoResolver.inherit(Portal.Repo)
+              end)
+
+            Task.await(inner_task)
+          end)
+
+        assert Task.await(task) == Portal.Repo.Api
+      after
+        Portal.Repo.put_dynamic_repo(Portal.Repo)
+      end
+    end
+  end
+end

--- a/elixir/test/portal/repo/get_dynamic_repo_test.exs
+++ b/elixir/test/portal/repo/get_dynamic_repo_test.exs
@@ -1,0 +1,93 @@
+defmodule Portal.Repo.GetDynamicRepoTest do
+  use ExUnit.Case, async: true
+
+  describe "Portal.Repo.get_dynamic_repo/0" do
+    test "returns Portal.Repo when no dynamic repo is set and no hierarchy" do
+      assert Portal.Repo.get_dynamic_repo() == Portal.Repo
+    end
+
+    test "returns explicitly set dynamic repo" do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Web)
+
+      try do
+        assert Portal.Repo.get_dynamic_repo() == Portal.Repo.Web
+      after
+        Portal.Repo.put_dynamic_repo(Portal.Repo)
+      end
+    end
+
+    test "inherits from parent process via $callers" do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Api)
+
+      try do
+        task =
+          Task.async(fn ->
+            Portal.Repo.get_dynamic_repo()
+          end)
+
+        assert Task.await(task) == Portal.Repo.Api
+      after
+        Portal.Repo.put_dynamic_repo(Portal.Repo)
+      end
+    end
+
+    test "caches inherited repo in child process" do
+      Portal.Repo.put_dynamic_repo(Portal.Repo.Job)
+
+      try do
+        task =
+          Task.async(fn ->
+            Portal.Repo.get_dynamic_repo()
+
+            assert Process.get({Portal.Repo, :dynamic_repo}) == Portal.Repo.Job
+          end)
+
+        Task.await(task)
+      after
+        Portal.Repo.put_dynamic_repo(Portal.Repo)
+      end
+    end
+
+    test "does not cache when falling back to self" do
+      task =
+        Task.async(fn ->
+          Portal.Repo.get_dynamic_repo()
+
+          refute Process.get({Portal.Repo, :dynamic_repo})
+        end)
+
+      Task.await(task)
+    end
+  end
+
+  describe "Portal.Repo.Replica.get_dynamic_repo/0" do
+    test "returns Portal.Repo.Replica when no dynamic repo is set" do
+      assert Portal.Repo.Replica.get_dynamic_repo() == Portal.Repo.Replica
+    end
+
+    test "returns explicitly set dynamic repo" do
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Web)
+
+      try do
+        assert Portal.Repo.Replica.get_dynamic_repo() == Portal.Repo.Replica.Web
+      after
+        Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica)
+      end
+    end
+
+    test "inherits from parent process via $callers" do
+      Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica.Api)
+
+      try do
+        task =
+          Task.async(fn ->
+            Portal.Repo.Replica.get_dynamic_repo()
+          end)
+
+        assert Task.await(task) == Portal.Repo.Replica.Api
+      after
+        Portal.Repo.Replica.put_dynamic_repo(Portal.Repo.Replica)
+      end
+    end
+  end
+end

--- a/elixir/test/portal_api/plugs/put_dynamic_repo_test.exs
+++ b/elixir/test/portal_api/plugs/put_dynamic_repo_test.exs
@@ -1,0 +1,31 @@
+defmodule PortalAPI.Plugs.PutDynamicRepoTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+
+  alias PortalAPI.Plugs.PutDynamicRepo
+
+  describe "init/1" do
+    test "passes options through" do
+      assert PutDynamicRepo.init([]) == []
+      assert PutDynamicRepo.init(foo: :bar) == [foo: :bar]
+    end
+  end
+
+  describe "call/2" do
+    test "returns conn unchanged" do
+      conn = conn(:get, "/")
+      result = PutDynamicRepo.call(conn, [])
+
+      assert result == conn
+      refute result.halted
+    end
+
+    test "does not crash on POST requests" do
+      conn = conn(:post, "/test", "body")
+      result = PutDynamicRepo.call(conn, [])
+
+      assert result == conn
+    end
+  end
+end

--- a/elixir/test/portal_web/live_hooks/put_dynamic_repo_test.exs
+++ b/elixir/test/portal_web/live_hooks/put_dynamic_repo_test.exs
@@ -1,0 +1,21 @@
+defmodule PortalWeb.LiveHooks.PutDynamicRepoTest do
+  use ExUnit.Case, async: true
+
+  alias PortalWeb.LiveHooks.PutDynamicRepo
+
+  defp build_socket do
+    %Phoenix.LiveView.Socket{
+      assigns: %{__changed__: %{}},
+      endpoint: PortalWeb.Endpoint,
+      router: PortalWeb.Router
+    }
+  end
+
+  describe "on_mount/4" do
+    test "continues with socket unchanged" do
+      socket = build_socket()
+
+      assert {:cont, ^socket} = PutDynamicRepo.on_mount(:default, %{}, %{}, socket)
+    end
+  end
+end

--- a/elixir/test/portal_web/plugs/put_dynamic_repo_test.exs
+++ b/elixir/test/portal_web/plugs/put_dynamic_repo_test.exs
@@ -1,0 +1,31 @@
+defmodule PortalWeb.Plugs.PutDynamicRepoTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+
+  alias PortalWeb.Plugs.PutDynamicRepo
+
+  describe "init/1" do
+    test "passes options through" do
+      assert PutDynamicRepo.init([]) == []
+      assert PutDynamicRepo.init(foo: :bar) == [foo: :bar]
+    end
+  end
+
+  describe "call/2" do
+    test "returns conn unchanged" do
+      conn = conn(:get, "/")
+      result = PutDynamicRepo.call(conn, [])
+
+      assert result == conn
+      refute result.halted
+    end
+
+    test "does not crash on POST requests" do
+      conn = conn(:post, "/test", "body")
+      result = PutDynamicRepo.call(conn, [])
+
+      assert result == conn
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Removes `NODE_TYPE` and `BACKGROUND_JOBS_ENABLED` environment variables ("node coloring"), collapsing all node types into a single type. This lets us run fewer VMs and reduce unnecessary cluster size — every node now runs everything instead of needing separate web, API, and worker nodes.

Since all processes now share the same VM, we introduce **two isolated DB connection pools** to prevent noisy-neighbor effects between web and API workloads:

- **Web** (`Portal.Repo.Web` / `Portal.Repo.Replica.Web`) — PortalWeb HTTP requests and LiveViews
- **Api** (`Portal.Repo.Api` / `Portal.Repo.Replica.Api`) — PortalAPI REST endpoints and channel/socket connections

Oban workers use the default `Portal.Repo` / `Portal.Repo.Replica` pool — no separate Job pool needed.

Each pool has independent primary and replica repos (4 total), with configurable pool sizes via new env vars.

### How pool routing works

Pool selection happens at process boundaries via `put_dynamic_repo/1`:

| Boundary | Mechanism | Pool |
|---|---|---|
| PortalWeb HTTP requests | `PortalWeb.Plugs.PutDynamicRepo` plug | Web |
| PortalWeb LiveViews | `PortalWeb.LiveHooks.PutDynamicRepo` on_mount hook | Web |
| PortalAPI HTTP requests | `PortalAPI.Plugs.PutDynamicRepo` plug | Api |
| PortalAPI sockets | `connect/3` in each socket module | Api |
| Oban workers | (none — uses default `Portal.Repo`) | Default |

All DB access goes through `Portal.Safe` → `Portal.Repo` → Ecto's `get_dynamic_repo/0`, which transparently dispatches to whichever pool was set for the current process.

### Process hierarchy inheritance

Child processes (channel servers, tasks, GenServers) automatically inherit their parent's pool via an overridden `get_dynamic_repo/0` on `Portal.Repo` and `Portal.Repo.Replica`. This walks `$callers` and `$ancestors` using `:erlang.process_info(pid, :dictionary)` to find the parent's dynamic repo setting, then caches it locally. No explicit propagation needed at spawn sites.

### What's preserved

- **Region-specific ReplicationConnections** — unchanged, one per region
- **`CHANGE_LOGS_REPLICATION_ENABLED`** — still controls change_logs replication (centralus only)
- **Oban** — always enabled now (no longer gated by `BACKGROUND_JOBS_ENABLED`)

### Infra changes needed

Both `PortalWeb.Endpoint` and `PortalAPI.Endpoint` now start on every node. Load balancers need to be updated to route web traffic (`PHOENIX_HTTP_WEB_PORT`) and API traffic (`PHOENIX_HTTP_API_PORT`) to all nodes instead of specific node types.

### New env vars

| Variable | Default | Description |
|---|---|---|
| `DATABASE_POOL_SIZE_WEB` | 2 | Primary pool size for web requests |
| `DATABASE_POOL_SIZE_API` | 5 | Primary pool size for API requests |
| `DATABASE_POOL_SIZE_WEB_REPLICA` | 2 | Replica pool size for web requests |
| `DATABASE_POOL_SIZE_API_REPLICA` | 5 | Replica pool size for API requests |

### Removed env vars

- `NODE_TYPE` — no longer needed, all nodes run all workloads
- `BACKGROUND_JOBS_ENABLED` — Oban is always enabled

## Test plan

- [x] All 2908 tests pass (26 new tests for pool routing and hierarchy inheritance)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] `mix dialyzer` clean
- [x] `mix sobelow --skip` clean
- [ ] Update LB config to route both web and API traffic to all nodes
- [ ] Verify pool isolation in staging with representative load
- [ ] Confirm Oban jobs execute on all nodes
- [ ] Validate pool size tuning under production traffic patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)