### PR TITLE
fix(portal): suppress failed email deliveries

### DIFF
--- a/elixir/lib/portal/azure_communication_services.ex
+++ b/elixir/lib/portal/azure_communication_services.ex
@@ -99,7 +99,7 @@ defmodule Portal.AzureCommunicationServices do
       status: :failed,
       failure_code: to_string(status),
       failure_message: details,
-      suppress?: false
+      suppress?: true
     }
   end
 

--- a/elixir/test/portal/azure_communication_services_test.exs
+++ b/elixir/test/portal/azure_communication_services_test.exs
@@ -148,6 +148,37 @@ defmodule Portal.AzureCommunicationServicesTest do
       assert suppressed == 1
     end
 
+    test "marks a recipient failed and inserts a suppression for unknown status" do
+      account = account_fixture()
+
+      entry =
+        outbound_email_fixture(account,
+          message_id: "message-failed",
+          recipients: ["failed@example.com"]
+        )
+
+      assert :ok =
+               AzureCommunicationServices.handle_event_grid_events([
+                 delivery_report_event(
+                   "message-failed",
+                   "failed@example.com",
+                   "Failed",
+                   "Unknown delivery failure"
+                 )
+               ])
+
+      delivery = delivery!(entry, "failed@example.com")
+      assert delivery.status == :failed
+      assert delivery.failure_code == "Failed"
+      assert delivery.failure_message == "Unknown delivery failure"
+
+      suppressed =
+        from(s in Portal.EmailSuppression, where: s.email == "failed@example.com")
+        |> Repo.aggregate(:count, :email)
+
+      assert suppressed == 1
+    end
+
     test "ignores out-of-order delivery events (stale: already terminal)" do
       account = account_fixture()
 


### PR DESCRIPTION
Suppresses email delivery failures so that they don't get retried and ding our sender reputation.