### PR TITLE
fix(portal): check limits for actor promotion

### DIFF
--- a/elixir/lib/portal_api/controllers/actor_controller.ex
+++ b/elixir/lib/portal_api/controllers/actor_controller.ex
@@ -119,6 +119,17 @@ defmodule PortalAPI.ActorController do
 
   defp check_billing_limits(_account, _type), do: :ok
 
+  defp check_role_promotion_limits(account, actor, changeset) do
+    new_type = get_change(changeset, :type)
+
+    if actor.type != :account_admin_user and new_type == :account_admin_user and
+         not Billing.can_create_admin_users?(account) do
+      {:error, :forbidden, reason: "Admins limit reached"}
+    else
+      :ok
+    end
+  end
+
   operation :update,
     summary: "Update an Actor",
     parameters: [
@@ -138,9 +149,11 @@ defmodule PortalAPI.ActorController do
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update(conn, %{"id" => id, "actor" => params}) do
     subject = conn.assigns.subject
+    account = subject.account
 
     with {:ok, actor} <- Database.fetch_actor(id, subject),
          changeset <- actor_changeset(actor, params),
+         :ok <- check_role_promotion_limits(account, actor, changeset),
          {:ok, actor} <- Database.update_actor(changeset, subject) do
       render(conn, :show, actor: actor)
     else

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -313,35 +313,12 @@ defmodule PortalWeb.Actors do
     actor = socket.assigns.actor
     changeset = changeset(actor, attrs)
 
-    # Prevent changing the last admin to account_user
-    new_type = get_change(changeset, :type)
+    case validate_role_change(changeset, actor, socket) do
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
 
-    if actor.type == :account_admin_user and new_type == :account_user and
-         not other_enabled_admins_exist?(actor, socket.assigns.subject) do
-      changeset =
-        add_error(
-          changeset,
-          :type,
-          "Cannot change role. At least one admin must remain in the account."
-        )
-
-      {:noreply, assign(socket, form: to_form(changeset))}
-    else
-      case Database.update(changeset, socket.assigns.subject) do
-        {:ok, actor} ->
-          socket =
-            socket
-            |> put_flash(:success_inline, "Actor updated successfully")
-            |> reload_live_table!("actors")
-            |> push_patch(
-              to: ~p"/#{socket.assigns.account}/actors/#{actor.id}?#{socket.assigns.query_params}"
-            )
-
-          {:noreply, socket}
-
-        {:error, changeset} ->
-          {:noreply, assign(socket, form: to_form(changeset))}
-      end
+      :ok ->
+        save_actor(changeset, socket)
     end
   end
 
@@ -556,6 +533,62 @@ defmodule PortalWeb.Actors do
       end
     else
       {:noreply, put_flash(socket, :error, "Cannot send welcome email to this actor")}
+    end
+  end
+
+  defp validate_role_change(changeset, actor, socket) do
+    new_type = get_change(changeset, :type)
+
+    cond do
+      # Prevent changing the last admin to account_user
+      actor.type == :account_admin_user and new_type == :account_user and
+          not other_enabled_admins_exist?(actor, socket.assigns.subject) ->
+        changeset =
+          changeset
+          |> add_error(
+            :type,
+            "Cannot change role. At least one admin must remain in the account."
+          )
+          |> Map.put(:action, :validate)
+
+        {:error, changeset}
+
+      # Prevent promoting to admin when admin limit is reached
+      actor.type != :account_admin_user and new_type == :account_admin_user and
+          not Portal.Billing.can_create_admin_users?(
+            Database.fetch_account(socket.assigns.account.id)
+          ) ->
+        changeset =
+          changeset
+          |> add_error(
+            :type,
+            "Admin user limit reached for your account"
+          )
+          |> Map.put(:action, :validate)
+
+        {:error, changeset}
+
+      # Role change allowed
+      true ->
+        :ok
+    end
+  end
+
+  defp save_actor(changeset, socket) do
+    case Database.update(changeset, socket.assigns.subject) do
+      {:ok, actor} ->
+        socket =
+          socket
+          |> put_flash(:success_inline, "Actor updated successfully")
+          |> reload_live_table!("actors")
+          |> push_patch(
+            to: ~p"/#{socket.assigns.account}/actors/#{actor.id}?#{socket.assigns.query_params}"
+          )
+
+        {:noreply, socket}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
 
@@ -1952,6 +1985,12 @@ defmodule PortalWeb.Actors do
       all()
       |> Safe.scoped(subject, :replica)
       |> Safe.list(__MODULE__, opts)
+    end
+
+    def fetch_account(account_id) do
+      from(a in Portal.Account, where: a.id == ^account_id)
+      |> Safe.unscoped(:replica)
+      |> Safe.one!(fallback_to_primary: true)
     end
 
     def get_actor(id, subject) do

--- a/elixir/test/portal_api/controllers/actor_controller_test.exs
+++ b/elixir/test/portal_api/controllers/actor_controller_test.exs
@@ -315,6 +315,170 @@ defmodule PortalAPI.ActorControllerTest do
       assert resp["data"]["name"] == actor.name
       assert resp["data"]["type"] == attrs["type"]
     end
+
+    test "returns error when promoting to admin and admin limit reached", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_user)
+
+      # Create an admin to fill the limit
+      actor_fixture(account: account, type: :account_admin_user)
+
+      # Set admin limit to 1 (the existing admin already fills it)
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 1}
+      )
+      |> Repo.update!()
+
+      attrs = %{"type" => "account_admin_user"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert resp = json_response(conn, 403)
+      assert resp == %{"error" => %{"reason" => "Admins limit reached"}}
+    end
+
+    test "allows promoting to admin when under the limit", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_user)
+
+      # Set admin limit to 5 (plenty of room)
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 5}
+      )
+      |> Repo.update!()
+
+      attrs = %{"type" => "account_admin_user"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert json_response(conn, 200)
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: actor.id).type ==
+               :account_admin_user
+    end
+
+    test "allows promoting to admin when limit is nil", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_user)
+
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: nil}
+      )
+      |> Repo.update!()
+
+      attrs = %{"type" => "account_admin_user"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert json_response(conn, 200)
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: actor.id).type ==
+               :account_admin_user
+    end
+
+    test "allows demoting admin to user even when admin limit is reached", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      admin = actor_fixture(account: account, type: :account_admin_user)
+
+      # Create a second admin so the first can be demoted
+      actor_fixture(account: account, type: :account_admin_user)
+
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 1}
+      )
+      |> Repo.update!()
+
+      attrs = %{"type" => "account_user"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{admin.id}", actor: attrs)
+
+      assert json_response(conn, 200)
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: admin.id).type ==
+               :account_user
+    end
+
+    test "returns error when creating admin user and admin limit reached", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      # Create an admin to fill the limit
+      actor_fixture(account: account, type: :account_admin_user)
+
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 1}
+      )
+      |> Repo.update!()
+
+      attrs = %{
+        "name" => "New Admin",
+        "email" => "new-admin@example.com",
+        "type" => "account_admin_user"
+      }
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/actors", actor: attrs)
+
+      assert resp = json_response(conn, 403)
+      assert resp == %{"error" => %{"reason" => "Admins limit reached"}}
+    end
+
+    test "allows creating admin user when under the limit", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 5}
+      )
+      |> Repo.update!()
+
+      attrs = %{
+        "name" => "New Admin",
+        "email" => "new-admin@example.com",
+        "type" => "account_admin_user"
+      }
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/actors", actor: attrs)
+
+      assert json_response(conn, 201)
+    end
   end
 
   describe "delete/2" do

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -478,6 +478,202 @@ defmodule PortalWeb.Live.ActorsTest do
       # Form should show a validation error or remain on the edit page
       assert html =~ "actor-form"
     end
+
+    test "prevents promoting user to admin when admin limit is reached", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      other_actor = actor_fixture(account: account, type: :account_user)
+
+      # Set admin limit to 1 (the setup admin already counts)
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 1}
+      )
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor.id}/edit")
+
+      lv
+      |> form("#actor-form",
+        actor: %{
+          "name" => other_actor.name,
+          "email" => other_actor.email,
+          "type" => "account_admin_user"
+        }
+      )
+      |> render_submit()
+
+      # The error should be visible in the rendered LV
+      html = render(lv)
+      assert html =~ "Admin user limit reached for your account"
+
+      updated = Repo.get_by!(Portal.Actor, account_id: account.id, id: other_actor.id)
+      assert updated.type == :account_user
+    end
+
+    test "allows promoting user to admin when under the limit", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      other_actor = actor_fixture(account: account, type: :account_user)
+
+      # Set admin limit to 5 (plenty of room)
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 5}
+      )
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor.id}/edit")
+
+      lv
+      |> form("#actor-form",
+        actor: %{
+          "name" => other_actor.name,
+          "email" => other_actor.email,
+          "type" => "account_admin_user"
+        }
+      )
+      |> render_submit()
+
+      updated = Repo.get_by!(Portal.Actor, account_id: account.id, id: other_actor.id)
+      assert updated.type == :account_admin_user
+    end
+
+    test "allows promoting user to admin when limit is nil", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      other_actor = actor_fixture(account: account, type: :account_user)
+
+      # nil limit means unlimited
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: nil}
+      )
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor.id}/edit")
+
+      lv
+      |> form("#actor-form",
+        actor: %{
+          "name" => other_actor.name,
+          "email" => other_actor.email,
+          "type" => "account_admin_user"
+        }
+      )
+      |> render_submit()
+
+      updated = Repo.get_by!(Portal.Actor, account_id: account.id, id: other_actor.id)
+      assert updated.type == :account_admin_user
+    end
+
+    test "allows demoting admin to user even when admin limit is reached", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      other_admin = actor_fixture(account: account, type: :account_admin_user)
+
+      # Set admin limit to 1 — both admins are over the limit
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 1}
+      )
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_admin.id}/edit")
+
+      lv
+      |> form("#actor-form",
+        actor: %{
+          "name" => other_admin.name,
+          "email" => other_admin.email,
+          "type" => "account_user"
+        }
+      )
+      |> render_submit()
+
+      updated = Repo.get_by!(Portal.Actor, account_id: account.id, id: other_admin.id)
+      assert updated.type == :account_user
+    end
+  end
+
+  describe "handle_event create_user admin limits" do
+    test "prevents creating admin user when admin limit is reached", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      # Set admin limit to 1 (the setup admin already counts)
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 1}
+      )
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/add_user")
+
+      html =
+        lv
+        |> form("#user-form",
+          actor: %{
+            "name" => "New Admin",
+            "email" => "new-admin@example.com",
+            "type" => "account_admin_user",
+            "allow_email_otp_sign_in" => "true"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "Admin user limit reached for your account"
+      refute Repo.get_by(Portal.Actor, account_id: account.id, email: "new-admin@example.com")
+    end
+
+    test "allows creating admin user when under the limit", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      # Set admin limit to 5 (plenty of room)
+      Ecto.Changeset.change(account,
+        limits: %Portal.Accounts.Limits{account_admin_users_count: 5}
+      )
+      |> Repo.update!()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/add_user")
+
+      lv
+      |> form("#user-form",
+        actor: %{
+          "name" => "New Admin",
+          "email" => "new-admin@example.com",
+          "type" => "account_admin_user",
+          "allow_email_otp_sign_in" => "true"
+        }
+      )
+      |> render_submit()
+
+      assert Repo.get_by(Portal.Actor, account_id: account.id, email: "new-admin@example.com")
+    end
   end
 
   describe "handle_event delete (extended)" do


### PR DESCRIPTION
Fixes code paths where we did not properly check account limits before promoting an actor to admin user, and adds associated regression tests.
