### PR TITLE
chore(rust): export `tracing_macros::trace_dbg`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4266,6 +4266,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-log",
+ "tracing-macros",
  "tracing-subscriber",
  "windows",
 ]
@@ -8363,6 +8364,14 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-macros"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=main#412986fb2fcfcd231844eb14cf66665936c6ecfc"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -218,7 +218,7 @@ tracing-appender = "0.2.4"
 tracing-core = "0.1.36"
 tracing-journald = "0.3.2"
 tracing-log = "0.2.0"
-tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
+tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "main" } # Contains `dbg!` but for `tracing`.
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3.22", features = ["parking_lot"] }
 trackable = "1.3.0"

--- a/rust/libs/logging/Cargo.toml
+++ b/rust/libs/logging/Cargo.toml
@@ -19,6 +19,7 @@ time = { workspace = true, features = ["formatting"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-log = { workspace = true }
+tracing-macros = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -39,6 +39,7 @@ pub use capturing_writer::CapturingWriter;
 pub use display_btree_set::DisplayBTreeSet;
 pub use err_with_sources::{ErrorWithSources, err_with_src};
 pub use format::Format;
+pub use tracing_macros::trace_dbg as dbg;
 
 /// Registers a global subscriber with stdout logging and `additional_layer`
 pub fn setup_global_subscriber<L>(


### PR DESCRIPTION
The Rust standard library offers the `dbg` macro as a way of quickly adding some logging to a piece of code for introspection of expressions. The `trace_dbg` macro is the equivalent from the `tracing` ecosystem but it honors the subscriber setup of the current context, i.e. prints to files / stdout or whatever is configured instead of always printing to stderr like the `std::dbg` macro does.

This is especially useful for debugging the proptests where the logs are written to a dedicated file for each test run.