### PR TITLE
chore(portal): remove health endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       portal-router:
         condition: "service_healthy"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f localhost:4000/readyz"]
+      test: ["CMD-SHELL", "curl -f localhost:8080/readyz"]
       <<: *health-check
     networks:
       app-internal:

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -204,7 +204,6 @@ config :portal, Portal.Telemetry,
   enabled: true
 
 config :portal, Portal.Health,
-  health_port: 4000,
   web_endpoint: PortalWeb.Endpoint,
   api_endpoint: PortalAPI.Endpoint,
   ops_endpoint: PortalOps.Endpoint,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -504,8 +504,6 @@ if config_env() == :prod do
       ]
   end
 
-  config :portal, Portal.Health, health_port: env_var_to_config!(:health_port)
-
   config :portal, Portal.Telemetry,
     metrics_reporter: env_var_to_config!(:telemetry_metrics_reporter)
 

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -15,9 +15,6 @@ config :portal, sql_sandbox: true
 # Replica is not used in tests; use the primary DB instead
 config :portal, replica_repo: Portal.Repo
 
-# Use ephemeral port for health server to avoid conflicts between test runs
-config :portal, Portal.Health, health_port: 0
-
 config :portal, run_manual_migrations: true
 
 config :portal, Portal.Repo,

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -53,9 +53,7 @@ defmodule Portal.Application do
       # Application services
       Portal.Presence,
       Portal.Mailer.RateLimiter,
-      Portal.ComponentVersions,
-      # Health check server (always enabled)
-      Portal.Health
+      Portal.ComponentVersions
     ]
 
     endpoint_children = [

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -641,19 +641,6 @@ defmodule Portal.Config.Definitions do
   ##############################################
 
   @doc """
-  The port for the internal health endpoint.
-  """
-  defconfig(:health_port, :integer,
-    default: 4000,
-    changeset: fn changeset, key ->
-      Ecto.Changeset.validate_number(changeset, key,
-        greater_than: 0,
-        less_than_or_equal_to: 65_535
-      )
-    end
-  )
-
-  @doc """
   Path to the file that signals the service is draining.
 
   When this file exists, the `/readyz` endpoint will return 503 with status "draining".

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -5,39 +5,13 @@ defmodule Portal.Health do
   - `/readyz` - Readiness check, returns 200 when endpoints are ready,
                 503 when draining, database unavailable or starting
 
-  Can be used in two ways:
-
-  1. As a plug in Phoenix endpoints (passes through non-health routes):
+  Used as a plug in Phoenix endpoints (passes through non-health routes):
 
       plug Portal.Health
-
-  2. As a standalone server on a dedicated port (returns 404 for unknown routes):
-
-      children = [Portal.Health]
   """
   import Plug.Conn
 
   @behaviour Plug
-
-  def child_spec(_opts) do
-    config = Portal.Config.fetch_env!(:portal, Portal.Health)
-    port = Keyword.fetch!(config, :health_port)
-
-    %{
-      id: __MODULE__,
-      start:
-        {Bandit, :start_link,
-         [
-           [
-             plug: Portal.Health.Server,
-             scheme: :http,
-             port: port,
-             thousand_island_options: [num_acceptors: 2]
-           ]
-         ]},
-      type: :supervisor
-    }
-  end
 
   @impl true
   def init(opts), do: opts
@@ -109,18 +83,5 @@ defmodule Portal.Health do
 
     Process.whereis(web_endpoint) != nil and Process.whereis(api_endpoint) != nil and
       Process.whereis(ops_endpoint) != nil
-  end
-end
-
-defmodule Portal.Health.Server do
-  @moduledoc false
-  # Wrapper for standalone health server that returns 404 for unknown routes
-  use Plug.Builder
-
-  plug Portal.Health
-  plug :not_found
-
-  defp not_found(conn, _opts) do
-    Plug.Conn.send_resp(conn, 404, "Not found")
   end
 end

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -141,14 +141,5 @@ defmodule Portal.HealthTest do
       refute conn.halted
       assert conn.status == nil
     end
-
-    test "returns 404 when used as standalone server" do
-      conn =
-        :get
-        |> conn("/unknown")
-        |> Portal.Health.Server.call([])
-
-      assert conn.status == 404
-    end
   end
 end


### PR DESCRIPTION
This is no longer used now that we serve `/readyz` over both API and Web endpoints.
