### PR TITLE
fix(portal): monitor presence pids for crashes

### DIFF
--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -9,8 +9,8 @@ defmodule Portal.Presence do
 
   defmodule Clients do
     def connect(%Client{} = client, token_id, session_meta \\ %{}) do
-      with {:ok, _} <- __MODULE__.Account.track(client.account_id, client.id, session_meta),
-           {:ok, _} <- __MODULE__.Actor.track(client.actor_id, client.id, token_id) do
+      with :ok <- __MODULE__.Account.track(client.account_id, client.id, session_meta),
+           :ok <- __MODULE__.Actor.track(client.actor_id, client.id, token_id) do
         :ok
       end
     end
@@ -51,12 +51,16 @@ defmodule Portal.Presence do
 
     defmodule Account do
       def track(account_id, client_id, session_meta \\ %{}) do
-        Portal.Presence.track(
-          self(),
-          topic(account_id),
-          client_id,
-          Map.merge(session_meta, %{online_at: System.system_time(:second)})
-        )
+        meta = Map.merge(session_meta, %{online_at: System.system_time(:second)})
+
+        case Portal.Presence.track(self(), topic(account_id), client_id, meta) do
+          {:ok, _} ->
+            :ok
+
+          {:error, {:already_tracked, _, _, _}} ->
+            Portal.Presence.update(self(), topic(account_id), client_id, meta)
+            :ok
+        end
       end
 
       def subscribe(account_id) do
@@ -92,12 +96,16 @@ defmodule Portal.Presence do
 
     defmodule Actor do
       def track(actor_id, client_id, token_id) do
-        Portal.Presence.track(
-          self(),
-          topic(actor_id),
-          client_id,
-          %{token_id: token_id}
-        )
+        meta = %{token_id: token_id}
+
+        case Portal.Presence.track(self(), topic(actor_id), client_id, meta) do
+          {:ok, _} ->
+            :ok
+
+          {:error, {:already_tracked, _, _, _}} ->
+            Portal.Presence.update(self(), topic(actor_id), client_id, meta)
+            :ok
+        end
       end
 
       def get(actor_id, client_id) do
@@ -196,8 +204,8 @@ defmodule Portal.Presence do
       # Site must be tracked before Account so that when the Account presence
       # broadcast fires and the LiveView reloads, site presence is already
       # visible via Portal.Presence.Gateways.Site.list/1.
-      with {:ok, _} <- __MODULE__.Site.track(gateway.site_id, gateway.id, token_id),
-           {:ok, _} <- __MODULE__.Account.track(gateway.account_id, gateway.id, session_meta) do
+      with :ok <- __MODULE__.Site.track(gateway.site_id, gateway.id, token_id),
+           :ok <- __MODULE__.Account.track(gateway.account_id, gateway.id, session_meta) do
         :ok
       end
     end
@@ -269,12 +277,16 @@ defmodule Portal.Presence do
 
     defmodule Account do
       def track(account_id, gateway_id, session_meta \\ %{}) do
-        Portal.Presence.track(
-          self(),
-          topic(account_id),
-          gateway_id,
-          Map.merge(session_meta, %{online_at: System.system_time(:second)})
-        )
+        meta = Map.merge(session_meta, %{online_at: System.system_time(:second)})
+
+        case Portal.Presence.track(self(), topic(account_id), gateway_id, meta) do
+          {:ok, _} ->
+            :ok
+
+          {:error, {:already_tracked, _, _, _}} ->
+            Portal.Presence.update(self(), topic(account_id), gateway_id, meta)
+            :ok
+        end
       end
 
       def subscribe(account_id) do
@@ -302,12 +314,16 @@ defmodule Portal.Presence do
 
     defmodule Site do
       def track(site_id, gateway_id, token_id) do
-        Portal.Presence.track(
-          self(),
-          topic(site_id),
-          gateway_id,
-          %{token_id: token_id}
-        )
+        meta = %{token_id: token_id}
+
+        case Portal.Presence.track(self(), topic(site_id), gateway_id, meta) do
+          {:ok, _} ->
+            :ok
+
+          {:error, {:already_tracked, _, _, _}} ->
+            Portal.Presence.update(self(), topic(site_id), gateway_id, meta)
+            :ok
+        end
       end
 
       def subscribe(site_id) do

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -64,25 +64,8 @@ defmodule PortalAPI.Client.Channel do
     # Cache relay IDs and stamp secrets for tracking
     socket = cache_relays(socket, relays)
 
-    # Track client's presence with session metadata for client-to-client signaling
-    session_meta = %{
-      ipv4:
-        socket.assigns.client.ipv4_address &&
-          socket.assigns.client.ipv4_address.address.address,
-      ipv6:
-        socket.assigns.client.ipv6_address &&
-          socket.assigns.client.ipv6_address.address.address,
-      name: socket.assigns.client.name,
-      public_key: socket.assigns.session.public_key,
-      psk_base: socket.assigns.client.psk_base
-    }
-
-    :ok =
-      Presence.Clients.connect(
-        socket.assigns.client,
-        socket.assigns.subject.credential.id,
-        session_meta
-      )
+    # Track client's presence and monitor tracker shard processes for crash recovery
+    socket = track_presence(socket)
 
     :ok = PubSub.Changes.subscribe(socket.assigns.client.account_id)
 
@@ -384,17 +367,26 @@ defmodule PortalAPI.Client.Channel do
     {:stop, :shutdown, socket}
   end
 
-  # The pg scope crashed and restarted — re-register so targeted messages keep working.
-  # pid-matching against pg_scope_pid ensures we only react to the pg scope we monitored.
-  def handle_info(
-        {:DOWN, _ref, :process, pid, _reason},
-        %{assigns: %{pg_scope_pid: pid}} = socket
-      ) do
-    register(socket)
+  # A monitored process crashed — determine which subsystem it belongs to and recover.
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, socket) do
+    cond do
+      pid == socket.assigns[:pg_scope_pid] ->
+        register(socket)
+
+      Enum.any?(socket.assigns[:presence_monitors] || [], fn {p, _ref} -> p == pid end) ->
+        {:noreply, track_presence(socket)}
+
+      true ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(:register, socket) do
     register(socket)
+  end
+
+  def handle_info(:track_presence, socket) do
+    {:noreply, track_presence(socket)}
   end
 
   # Catch-all for messages we don't handle
@@ -1341,77 +1333,6 @@ defmodule PortalAPI.Client.Channel do
     {:noreply, assign(socket, cache: cache)}
   end
 
-  defmodule Database do
-    import Ecto.Query, only: [from: 2]
-
-    alias Portal.Features
-
-    def client_to_client_enabled?(account) do
-      query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
-
-      account_feature_enabled? = account.features.client_to_client == true
-
-      Portal.Safe.unscoped(query, :replica) |> Portal.Safe.exists?() and account_feature_enabled?
-    end
-
-    def all_compatible_gateways_for_client_and_resource(
-          client_version,
-          resource,
-          account_id
-        ) do
-      resource_site_id = site_id_from_resource(resource)
-
-      site_gateways =
-        Presence.Gateways.all_connected_gateways(account_id)
-        |> Enum.filter(&(&1.site_id == resource_site_id))
-
-      compatible_gateways =
-        filter_compatible_gateways(site_gateways, resource, client_version)
-
-      cond do
-        compatible_gateways != [] ->
-          {:ok, compatible_gateways}
-
-        site_gateways != [] ->
-          {:error, :version_mismatch}
-
-        true ->
-          {:ok, []}
-      end
-    end
-
-    # Filters gateways by the resource type, gateway version, and client version.
-    defp filter_compatible_gateways(gateways, _resource, nil), do: gateways
-
-    defp filter_compatible_gateways(gateways, resource, client_version) do
-      case Version.parse(client_version) do
-        {:ok, version} ->
-          Enum.filter(gateways, &compatible_gateway?(&1, resource, version))
-
-        :error ->
-          []
-      end
-    end
-
-    defp compatible_gateway?(gateway, resource, version) do
-      gateway_version_str = gateway.latest_session && gateway.latest_session.version
-
-      case gateway_version_str && Version.parse(gateway_version_str) do
-        {:ok, gateway_version} ->
-          Version.match?(gateway_version, ">= #{version.major}.#{version.minor - 1}.0") and
-            Version.match?(gateway_version, "< #{version.major}.#{version.minor + 2}.0") and
-            not is_nil(Portal.Resource.adapt_resource_for_version(resource, gateway_version_str))
-
-        _ ->
-          false
-      end
-    end
-
-    defp site_id_from_resource(%Portal.Cache.Cacheable.Resource{site: site}) do
-      Ecto.UUID.load!(site.id)
-    end
-  end
-
   defp load_balance_relays({lat, lon}, relays) when is_nil(lat) or is_nil(lon) do
     relays
     |> Enum.shuffle()
@@ -1485,8 +1406,7 @@ defmodule PortalAPI.Client.Channel do
   def do_create_policy_authorization(attrs, subject) do
     changeset = create_policy_authorization_changeset(attrs)
 
-    Portal.Safe.scoped(changeset, subject)
-    |> Portal.Safe.insert()
+    Database.insert_policy_authorization(changeset, subject)
     |> case do
       {:ok, _} ->
         :ok
@@ -1573,6 +1493,124 @@ defmodule PortalAPI.Client.Channel do
         :ok = PG.register(socket.assigns.client.id)
         :ok = PG.join(socket.assigns.subject.credential.id)
         {:noreply, assign(socket, :pg_scope_pid, new_pid)}
+    end
+  end
+
+  # Tracks client presence and monitors Presence tracker shard processes so we
+  # can re-track if any crash. Monitoring the supervisor alone is insufficient
+  # because individual shard crashes under :one_for_one don't kill the supervisor.
+  defp track_presence(socket) do
+    case Process.whereis(Portal.Presence) do
+      nil ->
+        Process.send_after(self(), :track_presence, 50)
+        socket
+
+      sup_pid ->
+        session_meta = %{
+          ipv4:
+            socket.assigns.client.ipv4_address &&
+              socket.assigns.client.ipv4_address.address.address,
+          ipv6:
+            socket.assigns.client.ipv6_address &&
+              socket.assigns.client.ipv6_address.address.address,
+          name: socket.assigns.client.name,
+          public_key: socket.assigns.session.public_key,
+          psk_base: socket.assigns.client.psk_base
+        }
+
+        :ok =
+          Presence.Clients.connect(
+            socket.assigns.client,
+            socket.assigns.subject.credential.id,
+            session_meta
+          )
+
+        for {_pid, ref} <- socket.assigns[:presence_monitors] || [] do
+          Process.demonitor(ref, [:flush])
+        end
+
+        monitors =
+          for {_, pid, _, _} <- Supervisor.which_children(sup_pid), is_pid(pid) do
+            {pid, Process.monitor(pid)}
+          end
+
+        assign(socket, presence_monitors: monitors)
+    end
+  end
+
+  defmodule Database do
+    import Ecto.Query, only: [from: 2]
+
+    alias Portal.Features
+
+    def client_to_client_enabled?(account) do
+      query = from(f in Features, where: f.feature == :client_to_client and f.enabled == true)
+
+      account_feature_enabled? = account.features.client_to_client == true
+
+      Portal.Safe.unscoped(query, :replica) |> Portal.Safe.exists?() and account_feature_enabled?
+    end
+
+    def all_compatible_gateways_for_client_and_resource(
+          client_version,
+          resource,
+          account_id
+        ) do
+      resource_site_id = site_id_from_resource(resource)
+
+      site_gateways =
+        Portal.Presence.Gateways.all_connected_gateways(account_id)
+        |> Enum.filter(&(&1.site_id == resource_site_id))
+
+      compatible_gateways =
+        filter_compatible_gateways(site_gateways, resource, client_version)
+
+      cond do
+        compatible_gateways != [] ->
+          {:ok, compatible_gateways}
+
+        site_gateways != [] ->
+          {:error, :version_mismatch}
+
+        true ->
+          {:ok, []}
+      end
+    end
+
+    def insert_policy_authorization(changeset, subject) do
+      Portal.Safe.scoped(changeset, subject)
+      |> Portal.Safe.insert()
+    end
+
+    # Filters gateways by the resource type, gateway version, and client version.
+    defp filter_compatible_gateways(gateways, _resource, nil), do: gateways
+
+    defp filter_compatible_gateways(gateways, resource, client_version) do
+      case Version.parse(client_version) do
+        {:ok, version} ->
+          Enum.filter(gateways, &compatible_gateway?(&1, resource, version))
+
+        :error ->
+          []
+      end
+    end
+
+    defp compatible_gateway?(gateway, resource, version) do
+      gateway_version_str = gateway.latest_session && gateway.latest_session.version
+
+      case gateway_version_str && Version.parse(gateway_version_str) do
+        {:ok, gateway_version} ->
+          Version.match?(gateway_version, ">= #{version.major}.#{version.minor - 1}.0") and
+            Version.match?(gateway_version, "< #{version.major}.#{version.minor + 2}.0") and
+            not is_nil(Portal.Resource.adapt_resource_for_version(resource, gateway_version_str))
+
+        _ ->
+          false
+      end
+    end
+
+    defp site_id_from_resource(%Portal.Cache.Cacheable.Resource{site: site}) do
+      Ecto.UUID.load!(site.id)
     end
   end
 end

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -51,19 +51,8 @@ defmodule PortalAPI.Gateway.Channel do
       token_id: socket.assigns.token_id
     )
 
-    session = socket.assigns.session
-
-    session_meta = %{
-      site_id: gateway.site_id,
-      public_key: session.public_key,
-      psk_base: gateway.psk_base,
-      version: session.version,
-      remote_ip: session.remote_ip,
-      remote_ip_location_lat: session.remote_ip_location_lat,
-      remote_ip_location_lon: session.remote_ip_location_lon
-    }
-
-    :ok = Presence.Gateways.connect(gateway, socket.assigns.token_id, session_meta)
+    # Track gateway presence and monitor tracker shard processes for crash recovery
+    socket = track_presence(socket)
 
     :ok = PubSub.Changes.subscribe(socket.assigns.gateway.account_id)
 
@@ -373,17 +362,26 @@ defmodule PortalAPI.Gateway.Channel do
     {:stop, :shutdown, socket}
   end
 
-  # The pg scope crashed and restarted — re-register so targeted messages keep working.
-  # pid-matching against pg_scope_pid ensures we only react to the pg scope we monitored.
-  def handle_info(
-        {:DOWN, _ref, :process, pid, _reason},
-        %{assigns: %{pg_scope_pid: pid}} = socket
-      ) do
-    register(socket)
+  # A monitored process crashed — determine which subsystem it belongs to and recover.
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, socket) do
+    cond do
+      pid == socket.assigns[:pg_scope_pid] ->
+        register(socket)
+
+      Enum.any?(socket.assigns[:presence_monitors] || [], fn {p, _ref} -> p == pid end) ->
+        {:noreply, track_presence(socket)}
+
+      true ->
+        {:noreply, socket}
+    end
   end
 
   def handle_info(:register, socket) do
     register(socket)
+  end
+
+  def handle_info(:track_presence, socket) do
+    {:noreply, track_presence(socket)}
   end
 
   # Catch-all for messages we don't handle
@@ -771,6 +769,44 @@ defmodule PortalAPI.Gateway.Channel do
         :ok = PG.register(socket.assigns.gateway.id)
         :ok = PG.join(socket.assigns.token_id)
         {:noreply, assign(socket, :pg_scope_pid, new_pid)}
+    end
+  end
+
+  # Tracks gateway presence and monitors Presence tracker shard processes so we
+  # can re-track if any crash. Monitoring the supervisor alone is insufficient
+  # because individual shard crashes under :one_for_one don't kill the supervisor.
+  defp track_presence(socket) do
+    case Process.whereis(Portal.Presence) do
+      nil ->
+        Process.send_after(self(), :track_presence, 50)
+        socket
+
+      sup_pid ->
+        gateway = socket.assigns.gateway
+        session = socket.assigns.session
+
+        session_meta = %{
+          site_id: gateway.site_id,
+          public_key: session.public_key,
+          psk_base: gateway.psk_base,
+          version: session.version,
+          remote_ip: session.remote_ip,
+          remote_ip_location_lat: session.remote_ip_location_lat,
+          remote_ip_location_lon: session.remote_ip_location_lon
+        }
+
+        :ok = Presence.Gateways.connect(gateway, socket.assigns.token_id, session_meta)
+
+        for {_pid, ref} <- socket.assigns[:presence_monitors] || [] do
+          Process.demonitor(ref, [:flush])
+        end
+
+        monitors =
+          for {_, pid, _, _} <- Supervisor.which_children(sup_pid), is_pid(pid) do
+            {pid, Process.monitor(pid)}
+          end
+
+        assign(socket, presence_monitors: monitors)
     end
   end
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -916,6 +916,66 @@ defmodule PortalAPI.Client.ChannelTest do
     end
   end
 
+  describe "handle_info/2 presence shard crash" do
+    test "re-tracks presence when it receives :DOWN from a monitored presence pid", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _init_payload
+
+      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+
+      # Simulate a Presence shard crash by sending a :DOWN for one of the
+      # monitored presence pids. We can't kill real shards in async tests
+      # because they're shared across all tests.
+      channel_state = :sys.get_state(socket.channel_pid)
+      [{shard_pid, _ref} | _] = channel_state.assigns.presence_monitors
+      send(socket.channel_pid, {:DOWN, make_ref(), :process, shard_pid, :killed})
+      :sys.get_state(socket.channel_pid)
+
+      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+    end
+
+    test "retries tracking when Presence supervisor name is temporarily unregistered", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _init_payload
+
+      # Temporarily unregister the Presence name so track_presence hits the nil branch
+      presence_pid = Process.whereis(Portal.Presence)
+      Process.unregister(Portal.Presence)
+
+      send(socket.channel_pid, :track_presence)
+      :sys.get_state(socket.channel_pid)
+
+      # Re-register before the 50ms retry fires
+      Process.register(presence_pid, Portal.Presence)
+
+      # Wait for the retry to fire and succeed
+      Process.sleep(100)
+      :sys.get_state(socket.channel_pid)
+
+      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+    end
+
+    test "re-tracks presence when already tracked (idempotent)", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _init_payload
+
+      # Send :track_presence while already tracked — should not crash
+      send(socket.channel_pid, :track_presence)
+      :sys.get_state(socket.channel_pid)
+
+      assert Presence.Clients.Account.list(client.account_id) |> Map.has_key?(client.id)
+    end
+  end
+
   describe "handle_info/2 :disconnect" do
     test "pushes disconnect event and closes the channel", %{
       client: client,

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -300,6 +300,73 @@ defmodule PortalAPI.Gateway.ChannelTest do
     end
   end
 
+  describe "handle_info/2 presence shard crash" do
+    test "re-tracks presence when it receives :DOWN from a monitored presence pid", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
+
+      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+             |> Map.has_key?(gateway.id)
+
+      # Simulate a Presence shard crash by sending a :DOWN for one of the
+      # monitored presence pids. We can't kill real shards in async tests
+      # because they're shared across all tests.
+      channel_state = :sys.get_state(socket.channel_pid)
+      [{shard_pid, _ref} | _] = channel_state.assigns.presence_monitors
+      send(socket.channel_pid, {:DOWN, make_ref(), :process, shard_pid, :killed})
+      :sys.get_state(socket.channel_pid)
+
+      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+             |> Map.has_key?(gateway.id)
+    end
+
+    test "retries tracking when Presence supervisor name is temporarily unregistered", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
+
+      # Temporarily unregister the Presence name so track_presence hits the nil branch
+      presence_pid = Process.whereis(Portal.Presence)
+      Process.unregister(Portal.Presence)
+
+      send(socket.channel_pid, :track_presence)
+      :sys.get_state(socket.channel_pid)
+
+      # Re-register before the 50ms retry fires
+      Process.register(presence_pid, Portal.Presence)
+
+      # Wait for the retry to fire and succeed
+      Process.sleep(100)
+      :sys.get_state(socket.channel_pid)
+
+      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+             |> Map.has_key?(gateway.id)
+    end
+
+    test "re-tracks presence when already tracked (idempotent)", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
+
+      # Send :track_presence while already tracked — should not crash
+      send(socket.channel_pid, :track_presence)
+      :sys.get_state(socket.channel_pid)
+
+      assert Portal.Presence.Gateways.Account.list(gateway.account_id)
+             |> Map.has_key?(gateway.id)
+    end
+  end
+
   describe "handle_info/2 :disconnect" do
     test "pushes disconnect event and closes the channel", %{
       gateway: gateway,


### PR DESCRIPTION
Similar to the fix in #12578, if a Presence shard crashes it takes all local CRDT state with it. The state of tracked pids is lost, causing clients/gateways that were connected to that node to show offline even though they have active Channel connections.

This state persists indefinitely until either the client/gateway is restarted or the app supervision tree is restarted.

To fix this we employ a similar fix using `Process.monitor` which will notify us if the presence pids have gone down, at which point we make sure to retrack.
