### PR TITLE
fix(portal): remove aboutMe from Entra dir sync queries

### DIFF
--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -101,7 +101,7 @@ defmodule Portal.Entra.APIClient do
     query =
       URI.encode_query(%{
         "$top" => "999",
-        "$select" => "id,displayName,mail,userPrincipalName,givenName,surname,aboutMe"
+        "$select" => "id,displayName,mail,userPrincipalName,givenName,surname"
       })
 
     path = "/v1.0/groups/#{group_id}/transitiveMembers"
@@ -123,7 +123,7 @@ defmodule Portal.Entra.APIClient do
           id: Integer.to_string(index),
           method: "GET",
           url:
-            "/users/#{user_id}?$select=id,displayName,mail,userPrincipalName,givenName,surname,aboutMe"
+            "/users/#{user_id}?$select=id,displayName,mail,userPrincipalName,givenName,surname"
         }
       end)
 

--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -122,8 +122,7 @@ defmodule Portal.Entra.APIClient do
         %{
           id: Integer.to_string(index),
           method: "GET",
-          url:
-            "/users/#{user_id}?$select=id,displayName,mail,userPrincipalName,givenName,surname"
+          url: "/users/#{user_id}?$select=id,displayName,mail,userPrincipalName,givenName,surname"
         }
       end)
 

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -732,8 +732,7 @@ defmodule Portal.Entra.Sync do
       name: user["displayName"],
       given_name: user["givenName"],
       family_name: user["surname"],
-      preferred_username: user["userPrincipalName"],
-      profile: user["aboutMe"]
+      preferred_username: user["userPrincipalName"]
     }
   end
 

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -732,7 +732,8 @@ defmodule Portal.Entra.Sync do
       name: user["displayName"],
       given_name: user["givenName"],
       family_name: user["surname"],
-      preferred_username: user["userPrincipalName"]
+      preferred_username: user["userPrincipalName"],
+      profile: nil
     }
   end
 

--- a/elixir/test/portal/entra/api_client_test.exs
+++ b/elixir/test/portal/entra/api_client_test.exs
@@ -319,7 +319,7 @@ defmodule Portal.Entra.APIClientTest do
       assert query_params["$top"] == "999"
 
       assert query_params["$select"] ==
-               "id,displayName,mail,userPrincipalName,givenName,surname,aboutMe"
+               "id,displayName,mail,userPrincipalName,givenName,surname"
     end
 
     test "streams multiple pages of members" do

--- a/elixir/test/portal/entra/api_client_test.exs
+++ b/elixir/test/portal/entra/api_client_test.exs
@@ -296,8 +296,7 @@ defmodule Portal.Entra.APIClientTest do
               "mail" => "user1@example.com",
               "userPrincipalName" => "user1@example.com",
               "givenName" => "User",
-              "surname" => "One",
-              "aboutMe" => "Test user"
+              "surname" => "One"
             },
             %{
               "id" => "user2",
@@ -414,8 +413,14 @@ defmodule Portal.Entra.APIClientTest do
 
       assert_receive {:batch_request, batch_request}
       assert length(batch_request["requests"]) == 3
-      assert Enum.at(batch_request["requests"], 0)["method"] == "GET"
-      assert Enum.at(batch_request["requests"], 0)["url"] =~ "/users/user1"
+      expected_select = "id,displayName,mail,userPrincipalName,givenName,surname"
+
+      Enum.zip(batch_request["requests"], user_ids)
+      |> Enum.each(fn {request, user_id} ->
+        assert request["method"] == "GET"
+        assert request["url"] == "/users/#{user_id}?$select=#{expected_select}"
+        refute request["url"] =~ "aboutMe"
+      end)
     end
 
     test "handles partial failures in batch request" do


### PR DESCRIPTION
This PR removes the SharePoint-backed aboutMe field from our Entra Microsoft Graph sync requests. We no longer request aboutMe in the Entra API client and no longer map it into external_identities.profile during sync.

The change was made to avoid Microsoft Graph failures like "Tenant does not have a SPO license", which are likely triggered when Graph API tries to resolve SharePoint Online profile data for tenants without SPO licensing. The only user-facing impact is that Entra-synced identities will no longer populate the optional profile/bio field.