### PR TITLE
feat(portal): expose claim field for entra auth/sync

### DIFF
--- a/elixir/lib/portal/changeset.ex
+++ b/elixir/lib/portal/changeset.ex
@@ -339,11 +339,17 @@ defmodule Portal.Changeset do
   end
 
   @email_regex ~r/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
+  @email_max_length 160
+
+  def valid_email?(value) when is_binary(value),
+    do: String.length(value) <= @email_max_length and Regex.match?(@email_regex, value)
+
+  def valid_email?(_), do: false
 
   def validate_email(%Ecto.Changeset{} = changeset, field) do
     changeset
     |> validate_format(field, @email_regex, message: "is an invalid email address")
-    |> validate_length(field, max: 160)
+    |> validate_length(field, max: @email_max_length)
   end
 
   def normalize_url(%Ecto.Changeset{} = changeset, field) do

--- a/elixir/lib/portal/entra/auth_provider.ex
+++ b/elixir/lib/portal/entra/auth_provider.ex
@@ -40,6 +40,7 @@ defmodule Portal.Entra.AuthProvider do
     field :is_default, :boolean, read_after_writes: true, default: false
 
     field :name, :string, default: "Entra"
+    field :email_claim, :string, default: "upn"
 
     timestamps()
   end
@@ -68,6 +69,7 @@ defmodule Portal.Entra.AuthProvider do
       name: :entra_auth_providers_account_id_name_index,
       message: "An Entra authentication provider with this name already exists."
     )
+    |> validate_inclusion(:email_claim, ~w[email upn preferred_username])
     |> check_constraint(:context, name: :context_must_be_valid)
   end
 

--- a/elixir/lib/portal/entra/directory.ex
+++ b/elixir/lib/portal/entra/directory.ex
@@ -24,6 +24,7 @@ defmodule Portal.Entra.Directory do
     field :error_email_count, :integer, default: 0, read_after_writes: true
     field :sync_all_groups, :boolean, default: false, read_after_writes: true
     field :is_verified, :boolean, default: false, read_after_writes: true
+    field :email_field, :string, default: "userPrincipalName"
 
     timestamps()
   end
@@ -34,6 +35,7 @@ defmodule Portal.Entra.Directory do
     |> validate_length(:tenant_id, min: 1, max: 255)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_number(:error_email_count, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:email_field, ~w[mail userPrincipalName])
     |> assoc_constraint(:account)
     |> assoc_constraint(:directory)
     |> unique_constraint(:tenant_id,

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -359,7 +359,9 @@ defmodule Portal.Entra.Sync do
           fetched_count: length(users)
         )
 
-        Enum.map(users, fn user -> map_user_to_identity(user, directory.id) end)
+        Enum.map(users, fn user ->
+          map_user_to_identity(user, directory.id, directory.email_field)
+        end)
 
       {:error, error} ->
         raise Entra.SyncError,
@@ -443,7 +445,9 @@ defmodule Portal.Entra.Sync do
 
     # Build identities for these members
     identities =
-      Enum.map(user_members, fn member -> map_user_to_identity(member, directory.id) end)
+      Enum.map(user_members, fn member ->
+        map_user_to_identity(member, directory.id, directory.email_field)
+      end)
 
     # Build memberships (group_idp_id, user_idp_id)
     memberships = Enum.map(user_members, fn member -> {group_id, member["id"]} end)
@@ -576,7 +580,9 @@ defmodule Portal.Entra.Sync do
 
     # Build identities for these members
     identities =
-      Enum.map(user_members, fn member -> map_user_to_identity(member, directory.id) end)
+      Enum.map(user_members, fn member ->
+        map_user_to_identity(member, directory.id, directory.email_field)
+      end)
 
     # Build memberships (group_idp_id, user_idp_id)
     memberships = Enum.map(user_members, fn member -> {group_id, member["id"]} end)
@@ -696,12 +702,7 @@ defmodule Portal.Entra.Sync do
     )
   end
 
-  defp map_user_to_identity(user, directory_id) do
-    # Map Microsoft Graph user fields to our identity schema
-    # Note: 'mail' is the primary email, userPrincipalName is the UPN (user@domain.com)
-    # We prefer 'mail' but fall back to userPrincipalName if mail is null
-    #
-    # Validate that critical fields are present
+  defp map_user_to_identity(user, directory_id, email_field) do
     unless user["id"] do
       raise Entra.SyncError,
         error: {:validation, "user missing 'id' field"},
@@ -709,11 +710,11 @@ defmodule Portal.Entra.Sync do
         step: :process_user
     end
 
-    primary_email = user["mail"] || user["userPrincipalName"]
+    primary_email = user[email_field]
 
-    unless primary_email do
+    unless Portal.Changeset.valid_email?(primary_email) do
       raise Entra.SyncError,
-        error: {:validation, "user '#{user["id"]}' missing 'mail' field"},
+        error: {:validation, "user '#{user["id"]}' has no valid email in '#{email_field}' field"},
         directory_id: directory_id,
         step: :process_user
     end

--- a/elixir/lib/portal_api/controllers/entra_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/entra_auth_provider_json.ex
@@ -18,6 +18,7 @@ defmodule PortalAPI.EntraAuthProviderJSON do
       context: provider.context,
       client_session_lifetime_secs: provider.client_session_lifetime_secs,
       portal_session_lifetime_secs: provider.portal_session_lifetime_secs,
+      email_claim: provider.email_claim,
       is_disabled: provider.is_disabled,
       is_default: provider.is_default,
       inserted_at: provider.inserted_at,

--- a/elixir/lib/portal_api/controllers/entra_directory_json.ex
+++ b/elixir/lib/portal_api/controllers/entra_directory_json.ex
@@ -21,6 +21,7 @@ defmodule PortalAPI.EntraDirectoryJSON do
       synced_at: directory.synced_at,
       error_message: directory.error_message,
       errored_at: directory.errored_at,
+      email_field: directory.email_field,
       sync_all_groups: directory.sync_all_groups,
       inserted_at: directory.inserted_at,
       updated_at: directory.updated_at

--- a/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_auth_provider_schema.ex
@@ -27,6 +27,11 @@ defmodule PortalAPI.Schemas.EntraAuthProvider do
           type: :integer,
           description: "Portal session lifetime in seconds"
         },
+        email_claim: %Schema{
+          type: :string,
+          description: "OIDC claim to use as email",
+          enum: ["email", "upn", "preferred_username"]
+        },
         is_disabled: %Schema{type: :boolean, description: "Whether provider is disabled"},
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
         inserted_at: %Schema{

--- a/elixir/lib/portal_api/schemas/entra_directory_schema.ex
+++ b/elixir/lib/portal_api/schemas/entra_directory_schema.ex
@@ -28,6 +28,11 @@ defmodule PortalAPI.Schemas.EntraDirectory do
           format: :"date-time",
           description: "Error email timestamp"
         },
+        email_field: %Schema{
+          type: :string,
+          description: "Graph API user field to use as email",
+          enum: ["mail", "userPrincipalName"]
+        },
         sync_all_groups: %Schema{type: :boolean, description: "Sync all groups"},
         inserted_at: %Schema{
           type: :string,

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -112,7 +112,7 @@ defmodule PortalWeb.OIDCController do
          {:ok, tokens} <- PortalWeb.OIDC.exchange_code(provider, code, verifier),
          {:ok, claims} <- PortalWeb.OIDC.verify_token(provider, tokens["id_token"]),
          userinfo = fetch_userinfo(provider, tokens["access_token"]),
-         {:ok, identity} <- upsert_identity(account, claims, userinfo),
+         {:ok, identity} <- upsert_identity(account, provider, claims, userinfo),
          :ok <- check_admin(identity, context_type),
          {:ok, session_or_token} <-
            create_session_or_token(conn, identity, provider, params) do
@@ -247,8 +247,11 @@ defmodule PortalWeb.OIDCController do
     end
   end
 
-  defp upsert_identity(account, claims, userinfo) do
-    with {:ok, identity_profile} <- IdentityProfile.build(claims, userinfo, account.id) do
+  defp upsert_identity(account, provider, claims, userinfo) do
+    email_claim = Map.get(provider, :email_claim)
+
+    with {:ok, identity_profile} <-
+           IdentityProfile.build(claims, userinfo, account.id, email_claim: email_claim) do
       maybe_log_unverified_email(account, identity_profile)
 
       Database.upsert_identity(

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -40,7 +40,7 @@ defmodule PortalWeb.Settings.Authentication do
     EmailOTP.AuthProvider => @common_fields,
     Userpass.AuthProvider => @common_fields,
     Google.AuthProvider => @common_fields ++ ~w[is_verified]a,
-    Entra.AuthProvider => @common_fields ++ ~w[is_verified]a,
+    Entra.AuthProvider => @common_fields ++ ~w[is_verified email_claim]a,
     Okta.AuthProvider => @common_fields ++ ~w[okta_domain client_id client_secret is_verified]a,
     OIDC.AuthProvider =>
       @common_fields ++ ~w[discovery_document_uri client_id client_secret is_verified is_legacy]a
@@ -922,6 +922,23 @@ defmodule PortalWeb.Settings.Authentication do
               Session lifetime for Client applications (1 hour to 90 days). Default: 7 days (604800).
             </p>
           </div>
+        </div>
+
+        <div :if={@type == "entra"}>
+          <.input
+            field={@form[:email_claim]}
+            type="select"
+            label="Email Claim"
+            options={[
+              {"UPN (upn)", "upn"},
+              {"Email (email)", "email"},
+              {"Preferred Username (preferred_username)", "preferred_username"}
+            ]}
+            required
+          />
+          <p class="mt-1 text-xs text-neutral-600">
+            The OIDC claim to use as the user's email address during sign-in.
+          </p>
         </div>
 
         <div :if={@type == "okta"}>

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -26,7 +26,7 @@ defmodule PortalWeb.Settings.DirectorySync do
   @common_fields ~w[name is_disabled disabled_reason is_verified error_message]a
 
   @fields %{
-    Entra.Directory => @common_fields ++ ~w[tenant_id sync_all_groups]a,
+    Entra.Directory => @common_fields ++ ~w[tenant_id sync_all_groups email_field]a,
     Google.Directory =>
       @common_fields ++ ~w[domain impersonation_email group_sync_mode orgunit_sync_enabled]a,
     Okta.Directory => @common_fields ++ ~w[okta_domain client_id private_key_jwk kid]a
@@ -1011,6 +1011,22 @@ defmodule PortalWeb.Settings.DirectorySync do
             </label>
           </div>
         </fieldset>
+
+        <div :if={@type == "entra"}>
+          <.input
+            field={@form[:email_field]}
+            type="select"
+            label="Email Field"
+            options={[
+              {"User Principal Name (userPrincipalName)", "userPrincipalName"},
+              {"Mail (mail)", "mail"}
+            ]}
+            required
+          />
+          <p class="mt-1 text-xs text-neutral-600">
+            The Microsoft Graph user field to use as the primary email during directory sync.
+          </p>
+        </div>
 
         <div :if={@type == "google"}>
           <.input

--- a/elixir/lib/portal_web/oidc/identity_profile.ex
+++ b/elixir/lib/portal_web/oidc/identity_profile.ex
@@ -27,17 +27,21 @@ defmodule PortalWeb.OIDC.IdentityProfile do
           email_verified: boolean()
         }
 
-  @spec build(map(), map(), Ecto.UUID.t()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
-  def build(claims, userinfo, account_id) do
-    email = claims["email"]
+  @spec build(map(), map(), Ecto.UUID.t(), keyword()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def build(claims, userinfo, account_id, opts \\ []) do
+    email = resolve_email(claims, Keyword.get(opts, :email_claim))
     idp_id = claims["oid"] || claims["sub"]
     issuer = claims["iss"]
-    profile_attrs = extract_profile_attrs(claims, userinfo)
+
+    profile_attrs =
+      claims
+      |> extract_profile_attrs(userinfo)
+      |> Map.put("email", email)
+      |> maybe_populate_name()
 
     attrs =
       profile_attrs
       |> Map.put("account_id", account_id)
-      |> Map.put("email", email)
       |> Map.put("issuer", issuer)
       |> Map.put("idp_id", idp_id)
 
@@ -65,7 +69,6 @@ defmodule PortalWeb.OIDC.IdentityProfile do
     %ExternalIdentity{}
     |> cast(attrs, @idp_fields ++ ~w[account_id actor_id]a)
     |> validate_required(~w[email issuer idp_id name account_id]a)
-    |> validate_length(:email, max: 255)
     |> validate_length(:issuer, max: 2048)
     |> validate_length(:idp_id, max: 255)
     |> validate_length(:name, max: 255)
@@ -76,7 +79,11 @@ defmodule PortalWeb.OIDC.IdentityProfile do
     |> validate_length(:preferred_username, max: 255)
     |> validate_length(:profile, max: 2048)
     |> validate_length(:picture, max: 2048)
+    |> Portal.Changeset.validate_email(:email)
   end
+
+  defp resolve_email(claims, nil), do: claims["email"]
+  defp resolve_email(claims, email_claim), do: claims[email_claim]
 
   defp extract_profile_attrs(claims, userinfo) do
     Map.merge(claims, userinfo)
@@ -92,7 +99,6 @@ defmodule PortalWeb.OIDC.IdentityProfile do
       "picture"
     ])
     |> sanitize_string_fields()
-    |> maybe_populate_name()
   end
 
   # Ensure all profile fields are strings or nil - some IdPs may return unexpected types

--- a/elixir/priv/repo/migrations/20260408000000_add_email_claim_to_entra.exs
+++ b/elixir/priv/repo/migrations/20260408000000_add_email_claim_to_entra.exs
@@ -1,0 +1,31 @@
+defmodule Portal.Repo.Migrations.AddEmailClaimToEntra do
+  use Ecto.Migration
+
+  def up do
+    # Default existing rows to "email"/"mail" to preserve current behavior
+    alter table(:entra_auth_providers) do
+      add(:email_claim, :string, null: false, default: "email")
+    end
+
+    alter table(:entra_directories) do
+      add(:email_field, :string, null: false, default: "mail")
+    end
+
+    # Change DB defaults for future inserts to stronger claims
+    execute("ALTER TABLE entra_auth_providers ALTER COLUMN email_claim SET DEFAULT 'upn'")
+
+    execute(
+      "ALTER TABLE entra_directories ALTER COLUMN email_field SET DEFAULT 'userPrincipalName'"
+    )
+  end
+
+  def down do
+    alter table(:entra_auth_providers) do
+      remove(:email_claim)
+    end
+
+    alter table(:entra_directories) do
+      remove(:email_field)
+    end
+  end
+end

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1050,7 +1050,7 @@ defmodule PortalWeb.OIDCControllerTest do
     # Test length validation for profile fields
     # Format: {field_name, claim_name, limit}
     for {field, claim, limit} <- [
-          {"email", "email", 255},
+          {"email", "email", 160},
           {"issuer", "iss", 2048},
           {"idp_id", "sub", 255},
           {"name", "name", 255},
@@ -1067,7 +1067,14 @@ defmodule PortalWeb.OIDCControllerTest do
         %{field: field, claim: claim, limit: limit} = ctx
 
         actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
-        long_value = String.duplicate("a", limit + 1)
+
+        long_value =
+          if claim == "email" do
+            suffix = "@example.com"
+            String.duplicate("a", limit + 1 - String.length(suffix)) <> suffix
+          else
+            String.duplicate("a", limit + 1)
+          end
 
         overrides = %{claim => long_value}
 
@@ -1115,7 +1122,7 @@ defmodule PortalWeb.OIDCControllerTest do
 
         assert log =~ "OIDC profile validation failed"
         assert log =~ "field=#{field}"
-        assert log =~ "length=#{limit + 1}"
+        assert log =~ "length=#{String.length(long_value)}"
       end
     end
   end

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -2996,6 +2996,35 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       assert updated.name == "Updated Entra Name"
     end
 
+    test "allows changing email_field for Entra directory", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      directory = entra_directory_fixture(account: account, name: "Entra Test", is_verified: true)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync/entra/#{directory.id}/edit")
+
+      assert html =~ "Email Field"
+
+      lv
+      |> form("#directory-form", %{
+        "directory" => %{"email_field" => "userPrincipalName"}
+      })
+      |> render_change()
+
+      lv |> form("#directory-form") |> render_submit()
+
+      html = render(lv)
+      assert html =~ "Directory saved successfully"
+
+      updated = Portal.Repo.get!(Entra.Directory, directory.id)
+      assert updated.email_field == "userPrincipalName"
+    end
+
     test "editing Okta directory does not clear legacy_service_account_key", %{
       account: account,
       actor: actor,

--- a/elixir/test/portal_web/oidc/identity_profile_test.exs
+++ b/elixir/test/portal_web/oidc/identity_profile_test.exs
@@ -1,0 +1,116 @@
+defmodule PortalWeb.OIDC.IdentityProfileTest do
+  use ExUnit.Case, async: true
+
+  alias PortalWeb.OIDC.IdentityProfile
+
+  @account_id Ecto.UUID.generate()
+
+  @valid_claims %{
+    "email" => "user@example.com",
+    "email_verified" => true,
+    "oid" => "object-id-123",
+    "sub" => "sub-id-456",
+    "iss" => "https://login.microsoftonline.com/tenant/v2.0",
+    "name" => "Test User",
+    "aud" => "client-id",
+    "exp" => 9_999_999_999
+  }
+
+  describe "build/4 without email_claim (non-Entra providers)" do
+    test "uses email claim when present and valid" do
+      assert {:ok, profile} = IdentityProfile.build(@valid_claims, %{}, @account_id)
+      assert profile.email == "user@example.com"
+    end
+
+    test "returns error when email is nil" do
+      claims = Map.delete(@valid_claims, "email")
+
+      assert {:error, changeset} = IdentityProfile.build(claims, %{}, @account_id)
+      assert "can't be blank" in errors_on(changeset).email
+    end
+
+    test "returns error when email is not a valid email" do
+      claims = Map.put(@valid_claims, "email", "not-an-email")
+
+      assert {:error, changeset} = IdentityProfile.build(claims, %{}, @account_id)
+      assert "is an invalid email address" in errors_on(changeset).email
+    end
+  end
+
+  describe "build/4 with email_claim (Entra providers)" do
+    test "uses configured upn claim" do
+      claims = Map.put(@valid_claims, "upn", "user@contoso.com")
+
+      assert {:ok, profile} =
+               IdentityProfile.build(claims, %{}, @account_id, email_claim: "upn")
+
+      assert profile.email == "user@contoso.com"
+    end
+
+    test "uses configured email claim" do
+      assert {:ok, profile} =
+               IdentityProfile.build(@valid_claims, %{}, @account_id, email_claim: "email")
+
+      assert profile.email == "user@example.com"
+    end
+
+    test "uses configured preferred_username claim" do
+      claims = Map.put(@valid_claims, "preferred_username", "user@contoso.com")
+
+      assert {:ok, profile} =
+               IdentityProfile.build(claims, %{}, @account_id, email_claim: "preferred_username")
+
+      assert profile.email == "user@contoso.com"
+    end
+
+    test "returns error when configured claim is missing" do
+      claims = Map.delete(@valid_claims, "upn")
+
+      assert {:error, changeset} =
+               IdentityProfile.build(claims, %{}, @account_id, email_claim: "upn")
+
+      assert "can't be blank" in errors_on(changeset).email
+    end
+
+    test "returns error when configured claim is not a valid email" do
+      claims = Map.put(@valid_claims, "upn", "jsmith_partner.com#EXT#@tenant")
+
+      assert {:error, changeset} =
+               IdentityProfile.build(claims, %{}, @account_id, email_claim: "upn")
+
+      assert "is an invalid email address" in errors_on(changeset).email
+    end
+
+    test "does not fall back to other claims when configured claim is invalid" do
+      claims =
+        @valid_claims
+        |> Map.put("upn", "not-valid")
+        |> Map.put("email", "valid@example.com")
+
+      assert {:error, _changeset} =
+               IdentityProfile.build(claims, %{}, @account_id, email_claim: "upn")
+    end
+  end
+
+  describe "build/4 idp_id" do
+    test "prefers oid over sub" do
+      assert {:ok, profile} = IdentityProfile.build(@valid_claims, %{}, @account_id)
+      assert profile.idp_id == "object-id-123"
+    end
+
+    test "falls back to sub when oid is nil" do
+      claims = Map.delete(@valid_claims, "oid")
+
+      assert {:ok, profile} = IdentityProfile.build(claims, %{}, @account_id)
+      assert profile.idp_id == "sub-id-456"
+    end
+  end
+
+  defp errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end

--- a/elixir/test/portal_web/settings/authentication_test.exs
+++ b/elixir/test/portal_web/settings/authentication_test.exs
@@ -799,6 +799,32 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Edit Test Entra"
       assert html =~ "Provider Verification"
     end
+
+    test "allows changing email_claim", %{account: account, actor: actor, conn: conn} do
+      provider =
+        entra_provider_fixture(account: account, name: "Test Entra", is_verified: true)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication/entra/#{provider.id}/edit")
+
+      assert html =~ "Email Claim"
+
+      lv
+      |> form("#auth-provider-form", %{
+        "auth_provider" => %{"email_claim" => "email"}
+      })
+      |> render_change()
+
+      lv |> form("#auth-provider-form") |> render_submit()
+
+      html = render(lv)
+      assert html =~ "saved"
+
+      updated = Portal.Repo.get!(Portal.Entra.AuthProvider, provider.id)
+      assert updated.email_claim == "email"
+    end
   end
 
   describe "edit okta provider" do

--- a/elixir/test/support/fixtures/entra_directory_fixtures.ex
+++ b/elixir/test/support/fixtures/entra_directory_fixtures.ex
@@ -74,7 +74,8 @@ defmodule Portal.EntraDirectoryFixtures do
         :disabled_reason,
         :error_message,
         :error_email_count,
-        :sync_all_groups
+        :sync_all_groups,
+        :email_field
       ])
       |> Portal.Entra.Directory.changeset()
       |> Portal.Repo.insert()


### PR DESCRIPTION
## Summary

Adds a configurable `email_claim` field to Entra auth providers and `email_field` to Entra directories, allowing admins to choose which OIDC claim or Graph API field is used as the email source during sign-in and directory sync.

- **Auth providers**: New `email_claim` column (default `upn`) with options: `upn`, `email`, `preferred_username`
- **Directory sync**: New `email_field` column (default `userPrincipalName`) with options: `userPrincipalName`, `mail`
- No fallback chain — the configured claim/field is the single source of truth. If it's missing or invalid, sign-in fails with a clear error
- Non-Entra OIDC providers continue to use `claims["email"]` only
- LiveView settings forms expose the new fields for Entra providers

## Why

The `mail` field in Entra can be null or stale depending on tenant configuration, causing sign-in failures. The `upn` claim is a stronger default since it's always present and not self-editable by users, but some tenants may need flexibility to use a different claim depending on their IdP setup.
