### PR TITLE
fix(portal): don't send to firezone.invalid emails

### DIFF
--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -193,7 +193,8 @@ defmodule Portal.Mailer do
           acc,
           field,
           Enum.reject(recipients, fn %{"address" => address} ->
-            EmailSuppression.normalize_email(address) in suppressed_emails
+            undeliverable_address?(address) or
+              EmailSuppression.normalize_email(address) in suppressed_emails
           end)
         )
       end)
@@ -202,6 +203,12 @@ defmodule Portal.Mailer do
       [] -> :fully_suppressed
       _ -> {:ok, filtered_request}
     end
+  end
+
+  defp undeliverable_address?(address) do
+    address
+    |> String.downcase()
+    |> String.ends_with?("@firezone.invalid")
   end
 
   defp recipient_addresses(request) do

--- a/elixir/test/portal/mailer_test.exs
+++ b/elixir/test/portal/mailer_test.exs
@@ -150,6 +150,38 @@ defmodule Portal.MailerTest do
       assert "other@example.com" in bcc_addresses
     end
 
+    test "filters @firezone.invalid recipients before inserting the job" do
+      account = account_fixture()
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "missing-email-123@firezone.invalid"})
+        |> Swoosh.Email.to({"", "allowed@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Invalid Filtered")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, job} = enqueue(email)
+      assert Enum.map(job.args["request"]["to"], & &1["address"]) == ["allowed@example.com"]
+    end
+
+    test "skips queueing when all recipients are @firezone.invalid" do
+      account = account_fixture()
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "missing-email-123@firezone.invalid"})
+        |> Swoosh.Email.bcc({"", "missing-email-456@Firezone.Invalid"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("All Invalid")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, :suppressed} = enqueue(email)
+      assert Repo.aggregate(Oban.Job, :count, :id) == 0
+    end
+
     test "filters suppressed bcc recipients before inserting the job" do
       account = account_fixture()
 


### PR DESCRIPTION
Upon checking our failed emails table it appears a lot of them are to these `firezone.invalid` domains from when we needed to migrate actors to this email.

To prevent failures we skip sending to these undeliverable domains to prevent dinging our sender reputation.
