### PR TITLE
fix(portal): skip forbidden groups in google sync

### DIFF
--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -62,10 +62,12 @@ defmodule Portal.Google.APIClient do
   Returns `{:ok, group_map}` on success, or `{:error, reason}` on failure.
   A 404 response returns `{:error, :not_found}`.
   """
-  @spec get_group(String.t(), String.t()) :: {:ok, map()} | {:error, :not_found | term()}
+  @spec get_group(String.t(), String.t()) ::
+          {:ok, map()} | {:error, :not_found | :forbidden | term()}
   def get_group(access_token, group_key) do
     case get("/admin/directory/v1/groups/#{URI.encode(group_key)}", access_token) do
       {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: 403}} -> {:error, :forbidden}
       {:ok, %Req.Response{status: 404}} -> {:error, :not_found}
       {:ok, %Req.Response{} = response} -> {:error, response}
       {:error, _} = error -> error

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -515,7 +515,8 @@ defmodule Portal.Google.Sync do
 
   # Fetches and upserts a sub-group discovered during BFS by calling get_group to
   # retrieve its display name and email. Returns :ok on success or :skip if the
-  # group no longer exists in Google (404).
+  # group no longer exists (404) or is inaccessible (403, e.g. external groups
+  # from another domain).
   defp fetch_and_upsert_discovered_group(directory, access_token, synced_at, group_id) do
     Logger.debug("Fetching discovered sub-group",
       google_directory_id: directory.id,
@@ -551,6 +552,14 @@ defmodule Portal.Google.Sync do
 
       {:error, :not_found} ->
         Logger.debug("Discovered sub-group no longer exists in Google, skipping",
+          google_directory_id: directory.id,
+          group_id: group_id
+        )
+
+        :skip
+
+      {:error, :forbidden} ->
+        Logger.debug("Discovered sub-group is not accessible (external group?), skipping",
           google_directory_id: directory.id,
           group_id: group_id
         )

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -1173,6 +1173,59 @@ defmodule Portal.Google.SyncTest do
       assert hd(groups).idp_id == "group1"
     end
 
+    test "BFS skips sub-groups that are inaccessible (403, e.g. external domain groups)" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      # 1. Token
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      # 2. Groups → group1
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Top", "email" => "top@example.com"}]
+        })
+      end)
+
+      # 3. Org units → empty
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      # 4. group1 members → GROUP from external domain
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "external_group", "type" => "GROUP", "email" => "team@otherdomain.com"}
+          ]
+        })
+      end)
+
+      # 5. get_group("external_group") → 403
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/external_group")
+
+        conn
+        |> Plug.Conn.put_status(403)
+        |> Req.Test.json(%{
+          "error" => %{"code" => 403, "message" => "Not Authorized to access this resource/api"}
+        })
+      end)
+
+      # No members call for external_group — it was skipped
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      # Only group1 exists; external_group was silently skipped
+      groups = Repo.all(Portal.Group)
+      assert length(groups) == 1
+      assert hd(groups).idp_id == "group1"
+    end
+
     test "group_sync_mode :filtered issues separate email and name prefix queries, then syncs members" do
       account = account_fixture()
 


### PR DESCRIPTION
Some groups may show up in the list of groups associated to an organization, but are unable to be fetched because they actually belong to a different workspace / domain.

Instead of failing the whole sync it would be more graceful to simply skip the problematic groups, debug log, and continue.

--- 

Fixes #12772 