### PR TITLE
fix(ci): use direct alpine version ref

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,9 +1,7 @@
-ARG ALPINE_VERSION="3.20"
-
 ARG PACKAGE
 
 # Base image which is used to run the application binary
-FROM alpine:${ALPINE_VERSION} AS runtime_base
+FROM alpine:3.23 AS runtime_base
 
 ENV LANG=C.UTF-8 \
     TERM=xterm \

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -119,12 +119,14 @@ function expect_error() {
 
 # Extract flow logs from gateway for a given protocol
 # Returns flow log lines (use with readarray)
+# Filters out zero-byte RST'd flows from Happy Eyeballs connection racing
 # Usage: readarray -t flows < <(get_flow_logs "tcp")
 function get_flow_logs() {
     local protocol="$1"
 
     docker compose logs gateway --since 30s 2>/dev/null |
-        grep "flow_logs::${protocol}.*flow completed" || true
+        grep "flow_logs::${protocol}.*flow completed" |
+        grep -v "rx_bytes=0 tx_bytes=0" || true
 }
 
 # Extract a field value from a flow log line


### PR DESCRIPTION
Fixes an issue where dependabot is not able to bump our rust alpine base image because it is indirected by a var.
