### PR TITLE
fix(tests): don't count RST towards completed flows

### DIFF
--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -119,12 +119,14 @@ function expect_error() {
 
 # Extract flow logs from gateway for a given protocol
 # Returns flow log lines (use with readarray)
+# Filters out zero-byte RST'd flows from Happy Eyeballs connection racing
 # Usage: readarray -t flows < <(get_flow_logs "tcp")
 function get_flow_logs() {
     local protocol="$1"
 
     docker compose logs gateway --since 30s 2>/dev/null |
-        grep "flow_logs::${protocol}.*flow completed" || true
+        grep "flow_logs::${protocol}.*flow completed" |
+        grep -v "rx_bytes=0 tx_bytes=0" || true
 }
 
 # Extract a field value from a flow log line


### PR DESCRIPTION
In Happy eyeballs v2, which newer versions of curl use, all IPs are attempted 200ms apart.

This causes 4 connections to be tried since we return 4 IPv4s. The other 3 RST, but the test erroneously counts these as completed flows.

To fix this, we filter out RST connections to make sure the test is grabbing one completed flow only.

---

Related: https://github.com/firezone/firezone/actions/runs/24217617138/job/70702050781?pr=12802
