### PR TITLE
chore(ci): upgrade pkgs in alpine images

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -11,7 +11,8 @@ ENV LANG=C.UTF-8 \
 WORKDIR /bin
 
 ## curl is needed to run tests (`main` runs CI against `release` images) and `firezone-relay` needs `curl` in its entry script.
-RUN apk add --no-cache --update curl
+RUN apk add --no-cache --update curl \
+    && apk upgrade --no-cache
 
 # Gateway specific runtime base image
 FROM runtime_base AS runtime_firezone-gateway

--- a/scripts/router/Dockerfile
+++ b/scripts/router/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.23
 
-RUN apk add --no-cache iproute2 nftables jq bash
+RUN apk add --no-cache iproute2 nftables jq bash \
+    && apk upgrade --no-cache
 
 HEALTHCHECK --interval=1s --timeout=1s --retries=5 CMD [ "sh", "-c", "test $(cat /tmp/setup_done) = 1" ]
 


### PR DESCRIPTION
Adds `apk upgrade` to our Dockerfiles so that we're patched with the latest updates for all included patches when building Docker images.