### PR TITLE
refactor(portal): fix channel test flakes

### DIFF
--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -240,15 +240,19 @@ config :geolix,
     %{id: :city, adapter: Geolix.Adapter.Fake, data: %{}}
   ]
 
-ex_unit_config =
-  [
-    formatters: [JUnitFormatter, ExUnit.CLIFormatter],
-    capture_log: true
-  ] ++
-    case System.get_env("CI_ASSERT_RECEIVE_TIMEOUT_MS") do
-      nil -> []
-      timeout -> [assert_receive_timeout: String.to_integer(timeout)]
-    end
+default_assert_receive_timeout = 1_000
+
+assert_receive_timeout =
+  case System.get_env("CI_ASSERT_RECEIVE_TIMEOUT_MS") do
+    nil -> default_assert_receive_timeout
+    timeout -> max(String.to_integer(timeout), default_assert_receive_timeout)
+  end
+
+ex_unit_config = [
+  formatters: [JUnitFormatter, ExUnit.CLIFormatter],
+  capture_log: true,
+  assert_receive_timeout: assert_receive_timeout
+]
 
 config :ex_unit, ex_unit_config
 

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -61,15 +61,17 @@ defmodule PortalAPI.Client.Channel do
     {:ok, relays} = select_relays(socket)
     :ok = Presence.Relays.Global.subscribe()
 
-    # Cache relay IDs and stamp secrets for tracking
-    socket = cache_relays(socket, relays)
-
-    # Track client's presence and monitor tracker shard processes for crash recovery
-    socket = track_presence(socket)
+    socket =
+      socket
+      # Cache relay IDs and stamp secrets for tracking
+      |> cache_relays(relays)
+      |> assign(cache: cache, pending_flows: %{})
+      # Track client's presence and monitor tracker shard processes for crash recovery
+      |> track_presence()
 
     :ok = PubSub.Changes.subscribe(socket.assigns.client.account_id)
 
-    send(self(), :register)
+    {:noreply, socket} = register(socket)
 
     push(socket, "init", %{
       # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
@@ -92,7 +94,7 @@ defmodule PortalAPI.Client.Channel do
         })
     })
 
-    {:noreply, assign(socket, cache: cache, pending_flows: %{})}
+    {:noreply, socket}
   end
 
   ####################################

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -56,7 +56,7 @@ defmodule PortalAPI.Gateway.Channel do
 
     :ok = PubSub.Changes.subscribe(socket.assigns.gateway.account_id)
 
-    send(self(), :register)
+    {:noreply, socket} = register(socket)
 
     # Return all connected relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -54,12 +54,6 @@ defmodule PortalAPI.Client.ChannelTest do
       })
       |> subscribe_and_join(PortalAPI.Client.Channel, "client")
 
-    # Flush the channel's mailbox so :register is processed before returning.
-    # after_join sends `send(self(), :register)` then pushes "init"; by the time
-    # the caller receives "init" via assert_push, :register is still pending in the
-    # channel's mailbox. This ensures PG registration is complete.
-    :sys.get_state(socket.channel_pid)
-
     socket
   end
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -36,12 +36,6 @@ defmodule PortalAPI.Gateway.ChannelTest do
       })
       |> subscribe_and_join(PortalAPI.Gateway.Channel, "gateway")
 
-    # Flush the channel's mailbox so :register is processed before returning.
-    # after_join sends `send(self(), :register)` then pushes "init"; by the time
-    # the caller receives "init" via assert_push, :register is still pending in the
-    # channel's mailbox. This ensures PG registration is complete.
-    :sys.get_state(socket.channel_pid)
-
     socket
   end
 


### PR DESCRIPTION
Occasionally there is a race in the tests when a client/gateway joins and we send messages through the channels. This aims to clean that up by ensuring we're registered before sending the init to the client/gateway.
