### PR TITLE
fix(portal): handle :rollback in service account creation

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -12,6 +12,8 @@ defmodule PortalWeb.Actors do
   import Ecto.Changeset
   import PortalWeb.Clients.Components, only: [client_os_icon_name: 1]
 
+  require Logger
+
   def mount(_params, _session, socket) do
     socket =
       socket
@@ -279,7 +281,7 @@ defmodule PortalWeb.Actors do
         )
 
       case result do
-        {:ok, {actor, {:ok, nil}}} ->
+        {:ok, {actor, nil}} ->
           socket =
             socket
             |> reload_live_table!("actors")
@@ -289,7 +291,7 @@ defmodule PortalWeb.Actors do
 
           {:noreply, socket}
 
-        {:ok, {actor, {:ok, {_token, encoded_token}}}} ->
+        {:ok, {actor, {_token, encoded_token}}} ->
           socket =
             socket
             |> reload_live_table!("actors")
@@ -300,8 +302,22 @@ defmodule PortalWeb.Actors do
 
           {:noreply, socket}
 
-        {:error, changeset} ->
+        {:error, %Ecto.Changeset{} = changeset} ->
           {:noreply, assign(socket, form: to_form(changeset))}
+
+        {:error, reason} ->
+          Logger.error("Failed to create service account",
+            reason: inspect(reason),
+            account_id: account.id,
+            subject_actor_id: socket.assigns.subject.actor.id
+          )
+
+          {:noreply,
+           put_flash(
+             socket,
+             :error,
+             "A temporary error occurred while creating the service account. Please try again."
+           )}
       end
     else
       {:noreply,
@@ -2179,7 +2195,7 @@ defmodule PortalWeb.Actors do
     def create_service_account_with_token(changeset, token_expiration, subject, token_creator_fn) do
       Safe.transact(fn ->
         with {:ok, actor} <- create(changeset, subject),
-             token_result <- token_creator_fn.(actor, token_expiration, subject) do
+             {:ok, token_result} <- token_creator_fn.(actor, token_expiration, subject) do
           {:ok, {actor, token_result}}
         end
       end)

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -403,6 +403,71 @@ defmodule PortalWeb.Live.ActorsTest do
              )
     end
 
+    test "creates a new service account without a token when expiration is blank", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      unique_num = System.unique_integer([:positive, :monotonic])
+      sa_name = "My Service Account #{unique_num}"
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/add_service_account")
+
+      result =
+        lv
+        |> form("#service-account-form", actor: %{"name" => sa_name})
+        |> render_submit(%{"token_expiration" => ""})
+
+      case result do
+        {:error, {:live_redirect, %{to: path}}} ->
+          assert path =~ "/actors/"
+
+        html when is_binary(html) ->
+          assert html =~ sa_name
+      end
+
+      created_actor =
+        Repo.get_by!(Portal.Actor,
+          account_id: account.id,
+          name: sa_name,
+          type: :service_account
+        )
+        |> Repo.preload(:client_tokens)
+
+      assert created_actor.client_tokens == []
+    end
+
+    test "re-renders the form when service account attrs are invalid", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      invalid_name = String.duplicate("a", 256)
+      expiration = Date.utc_today() |> Date.add(30) |> Date.to_iso8601()
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/add_service_account")
+
+      html =
+        lv
+        |> form("#service-account-form", actor: %{"name" => invalid_name})
+        |> render_submit(%{"token_expiration" => expiration})
+
+      assert html =~ "Add Service Account"
+      assert html =~ "service-account-form"
+
+      refute Repo.get_by(Portal.Actor,
+               account_id: account.id,
+               name: invalid_name,
+               type: :service_account
+             )
+    end
+
     test "shows temporary-error flash when token creation fails with non-changeset error", %{
       account: account,
       actor: actor,

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -402,6 +402,37 @@ defmodule PortalWeb.Live.ActorsTest do
                type: :service_account
              )
     end
+
+    test "shows temporary-error flash when token creation fails with non-changeset error", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      unique_num = System.unique_integer([:positive, :monotonic])
+      sa_name = "My Service Account #{unique_num}"
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/add_service_account")
+
+      # An unparseable date causes create_actor_token/3 to return
+      # {:error, :invalid_date} — a non-changeset error tuple — which previously
+      # crashed the LV via to_form(:invalid_date).
+      html =
+        lv
+        |> form("#service-account-form", actor: %{"name" => sa_name})
+        |> render_submit(%{"token_expiration" => "not-a-date"})
+
+      assert html =~ "A temporary error occurred"
+      assert html =~ "Please try again"
+
+      refute Repo.get_by(Portal.Actor,
+               account_id: account.id,
+               name: sa_name,
+               type: :service_account
+             )
+    end
   end
 
   describe "edit actor" do

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -416,7 +416,7 @@ defmodule PortalWeb.Live.ActorsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/actors/add_service_account")
 
-      # An unparseable date causes create_actor_token/3 to return
+      # An unparsable date causes create_actor_token/3 to return
       # {:error, :invalid_date} — a non-changeset error tuple — which previously
       # crashed the LV via to_form(:invalid_date).
       html =


### PR DESCRIPTION
Service account creation in the actors LiveView was crashing with a `Phoenix.HTML.FormData` protocol error in Sentry. The case statement assumed any `{:error, _}` was a changeset and passed it straight to `to_form/1`, but the function can also return non-changeset errors — for example the bare atom `:rollback` from a commit-time `DBConnection` failure (statement timeout, killed connection, etc.), or `{:error, :invalid_date}` from the token helper when the user submits an unparsable date.

The fix guards the changeset branch and adds a fallback that logs the failure with account context and shows the user a retry-friendly flash. I also fixed a latent bug in `create_service_account_with_token` where a bare variable in a `with` clause was silently wrapping token errors instead of propagating them.

I verified every constraint on `actors` and `client_tokens` is already mapped in `changeset/1`, so unmapped constraints aren't the source. The new log line should give us enough context to chase down the real cause if it recurs.