### PR TITLE
feat(portal): dedicated client sign in error page

### DIFF
--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -163,10 +163,12 @@ defmodule PortalWeb.OIDCController do
     )
 
     error = authorization_error_message(reason)
+    log_sign_in_redirect_error(account.id, error)
+    path = error_path_for_context(account.slug, params, error)
 
     conn
     |> put_flash(:error, error)
-    |> redirect(to: error_path(account.slug, params))
+    |> redirect(to: path)
   end
 
   defp authorization_error_reason(%Req.TransportError{reason: reason}), do: inspect(reason)
@@ -488,13 +490,17 @@ defmodule PortalWeb.OIDCController do
 
   defp fetch_error_context(conn) do
     case conn.assigns[:oidc_error_context] do
-      %{account_slug: slug, params: params} -> {slug, params || %{}}
-      nil -> {"", %{}}
+      %{account_id: account_id, account_slug: slug, params: params} ->
+        {account_id, slug, params || %{}}
+
+      nil ->
+        {nil, "", %{}}
     end
   end
 
   defp put_oidc_error_context(conn, %Cookie.AuthenticationState{} = cookie) do
     Plug.Conn.assign(conn, :oidc_error_context, %{
+      account_id: cookie.account_id,
       account_slug: cookie.account_slug,
       params: cookie.params || %{},
       auth_provider_id: cookie.auth_provider_id
@@ -621,15 +627,44 @@ defmodule PortalWeb.OIDCController do
   end
 
   defp redirect_with_error_context(conn, error) do
-    {account_slug, original_params} = fetch_error_context(conn)
-    redirect_for_error(conn, error, error_path(account_slug, original_params))
+    {account_id, account_slug, original_params} = fetch_error_context(conn)
+    log_sign_in_redirect_error(account_id, error)
+    redirect_for_error(conn, error, error_path_for_context(account_slug, original_params, error))
+  end
+
+  defp log_sign_in_redirect_error(nil, _error), do: :ok
+
+  defp log_sign_in_redirect_error(account_id, error) do
+    Logger.info("OIDC sign-in redirecting with error",
+      account_id: account_id,
+      error: error
+    )
   end
 
   defp error_path(account_slug, params), do: ~p"/#{account_slug}?#{sanitize(params)}"
 
+  defp error_path_for_context(account_slug, params, error) do
+    if client_context?(params) and account_slug != "" do
+      ~p"/#{account_slug}/sign_in/client_auth_error?#{client_error_params(params, error)}"
+    else
+      error_path(account_slug, params)
+    end
+  end
+
+  defp client_error_params(params, error) do
+    params
+    |> sanitize()
+    |> Map.put("error", error)
+  end
+
   defp sanitize(params) do
     Map.take(params, ["as", "redirect_to", "state", "nonce"])
   end
+
+  defp client_context?(%{"as" => as}) when as in ["client", "gui-client", "headless-client"],
+    do: true
+
+  defp client_context?(_params), do: false
 
   defmodule Database do
     import Ecto.Query

--- a/elixir/lib/portal_web/controllers/sign_in_controller.ex
+++ b/elixir/lib/portal_web/controllers/sign_in_controller.ex
@@ -1,6 +1,8 @@
 defmodule PortalWeb.SignInController do
   use PortalWeb, :controller
 
+  @default_client_auth_error "Please close this window and start the sign in process again."
+
   def client_redirect(conn, _params) do
     account = conn.assigns.account
 
@@ -24,12 +26,24 @@ defmodule PortalWeb.SignInController do
         redirect(conn, external: "#{scheme}://#{url}?#{query}")
 
       nil ->
-        redirect(conn, to: ~p"/#{account}/sign_in/client_auth_error")
+        redirect(conn, to: client_auth_error_path(account, %{}, @default_client_auth_error))
     end
   end
 
-  def client_auth_error(conn, _params) do
-    render(conn, :client_auth_error, layout: false)
+  def client_auth_error(conn, params) do
+    account = conn.assigns.account
+    retry_params = PortalWeb.Authentication.take_sign_in_params(params)
+
+    error =
+      params["error"] ||
+        Phoenix.Flash.get(conn.assigns[:flash] || %{}, :error) ||
+        @default_client_auth_error
+
+    render(conn, :client_auth_error,
+      layout: false,
+      error: error,
+      retry_path: retry_path(account, retry_params)
+    )
   end
 
   defp format_redirect_url(raw_client_handler) do
@@ -39,4 +53,16 @@ defmodule PortalWeb.SignInController do
 
     {uri.scheme, "#{maybe_host}handle_client_sign_in_callback"}
   end
+
+  defp client_auth_error_path(account, params, error) do
+    query =
+      params
+      |> PortalWeb.Authentication.take_sign_in_params()
+      |> Map.put("error", error)
+
+    ~p"/#{account}/sign_in/client_auth_error?#{query}"
+  end
+
+  defp retry_path(account, params) when map_size(params) == 0, do: ~p"/#{account}"
+  defp retry_path(account, params), do: ~p"/#{account}?#{params}"
 end

--- a/elixir/lib/portal_web/controllers/sign_in_html.ex
+++ b/elixir/lib/portal_web/controllers/sign_in_html.ex
@@ -70,7 +70,15 @@ defmodule PortalWeb.SignInHTML do
                   Sign in error!
                 </span>
               </h1>
-              <p class="text-center">Please close this window and start the sign in process again.</p>
+              <p class="text-center text-neutral-700">{@error}</p>
+              <div class="flex justify-center">
+                <.link
+                  href={@retry_path}
+                  class="inline-flex items-center justify-center rounded-sm bg-accent-500 px-4 py-2 text-sm font-medium text-white hover:bg-accent-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-accent-500"
+                >
+                  Return to sign in
+                </.link>
+              </div>
             </div>
           </div>
         </div>

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -642,6 +642,43 @@ defmodule PortalWeb.OIDCControllerTest do
       assert flash(conn, :error) ==
                "Identity provider returned an error (HTTP 418). Please try again."
     end
+
+    test "redirects client sign-in errors to the dedicated client auth error page", %{
+      conn: conn,
+      account: account,
+      provider: provider
+    } do
+      Mocks.OIDC.set_token_error(400, %{"error" => "invalid_grant"})
+
+      auth_state = build_oidc_auth_state(account, provider, params: client_params())
+
+      log =
+        capture_log(fn ->
+          conn = perform_callback(conn, auth_state)
+
+          location = redirected_to(conn)
+          assert String.starts_with?(location, "/#{account.slug}/sign_in/client_auth_error?")
+
+          query =
+            location
+            |> URI.parse()
+            |> Map.fetch!(:query)
+            |> URI.decode_query()
+
+          assert query["as"] == "client"
+          assert query["state"] == "client-state"
+          assert query["nonce"] == "client-nonce"
+
+          assert query["error"] ==
+                   "The authorization code has expired or was already used. Please try signing in again."
+        end)
+
+      assert log =~ "OIDC sign-in redirecting with error"
+      assert log =~ "account_id=#{account.id}"
+
+      assert log =~
+               "The authorization code has expired or was already used. Please try signing in again."
+    end
   end
 
   describe "callback/2 successful authentication" do
@@ -1586,7 +1623,7 @@ defmodule PortalWeb.OIDCControllerTest do
       conn: conn
     } do
       account = account_fixture()
-      %{provider: provider} = setup_oidc_provider(account)
+      %{provider: provider} = setup_oidc_provider(account, is_default: true)
 
       for params <- [
             %{
@@ -1611,7 +1648,7 @@ defmodule PortalWeb.OIDCControllerTest do
         failed_conn = get(conn, "/#{account.id}/sign_in/oidc/#{provider.id}", params)
         failed_location = redirected_to(failed_conn)
 
-        assert String.starts_with?(failed_location, "/#{account.slug}?")
+        assert String.starts_with?(failed_location, "/#{account.slug}/sign_in/client_auth_error?")
 
         failed_query = failed_location |> URI.parse() |> Map.get(:query) |> URI.decode_query()
 
@@ -1619,23 +1656,75 @@ defmodule PortalWeb.OIDCControllerTest do
         assert failed_query["state"] == params["state"]
         assert failed_query["nonce"] == params["nonce"]
         assert failed_query["redirect_to"] == params["redirect_to"]
+        assert failed_query["error"] =~ "Unable to fetch discovery document"
 
         Mocks.OIDC.stub_discovery_document()
+
+        retry_params = Map.drop(failed_query, ["error"])
 
         retry_conn =
           get(
             recycle(conn),
-            "/#{account.id}/sign_in/oidc/#{provider.id}",
-            failed_query
+            "/#{account.slug}",
+            retry_params
           )
 
-        assert redirected_to(retry_conn) =~ "/authorize"
-        cookie = oidc_cookie_from_response(retry_conn)
+        provider_retry_path = redirected_to(retry_conn)
+        assert provider_retry_path =~ "/sign_in/oidc/#{provider.id}"
+
+        provider_conn =
+          get(
+            recycle(conn),
+            provider_retry_path
+          )
+
+        assert redirected_to(provider_conn) =~ "/authorize"
+        cookie = oidc_cookie_from_response(provider_conn)
         assert cookie.params["as"] == params["as"]
         assert cookie.params["state"] == params["state"]
         assert cookie.params["nonce"] == params["nonce"]
         assert cookie.params["redirect_to"] == params["redirect_to"]
       end
+    end
+
+    test "redirects client authorization errors to the dedicated client auth error page", %{
+      conn: conn
+    } do
+      account = account_fixture()
+      Mocks.OIDC.stub_connection_refused()
+      %{provider: provider} = setup_oidc_provider(account)
+
+      log =
+        capture_log(fn ->
+          conn =
+            get(conn, "/#{account.id}/sign_in/oidc/#{provider.id}", %{
+              "as" => "client",
+              "state" => "client-state",
+              "nonce" => "client-nonce"
+            })
+
+          location = redirected_to(conn)
+          assert String.starts_with?(location, "/#{account.slug}/sign_in/client_auth_error?")
+
+          query =
+            location
+            |> URI.parse()
+            |> Map.fetch!(:query)
+            |> URI.decode_query()
+
+          assert query["as"] == "client"
+          assert query["state"] == "client-state"
+          assert query["nonce"] == "client-nonce"
+
+          assert query["error"] ==
+                   "Unable to fetch discovery document: Connection refused. The identity provider may be down."
+        end)
+
+      assert log =~ "OIDC sign-in redirecting with error"
+      assert log =~ "account_id=#{account.id}"
+
+      assert log =~
+               "Unable to fetch discovery document: Connection refused. The identity provider may be down."
     end
   end
 

--- a/elixir/test/portal_web/controllers/sign_in_controller_test.exs
+++ b/elixir/test/portal_web/controllers/sign_in_controller_test.exs
@@ -49,12 +49,56 @@ defmodule PortalWeb.SignInControllerTest do
       account: account
     } do
       conn = get(conn, ~p"/#{account}/sign_in/client_redirect")
-      assert redirected_to(conn, 302) =~ ~p"/#{account}/sign_in/client_auth_error"
+      redirect_path = redirected_to(conn, 302)
+      assert redirect_path =~ ~p"/#{account}/sign_in/client_auth_error"
+
+      query =
+        redirect_path
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+
+      assert query["error"] == "Please close this window and start the sign in process again."
     end
 
     test "displays account name on client auth error page", %{conn: conn, account: account} do
       conn = get(conn, ~p"/#{account}/sign_in/client_auth_error")
       assert html_response(conn, 200) =~ account.name
+    end
+
+    test "displays the error and retry link with params preserved", %{
+      conn: conn,
+      account: account
+    } do
+      conn =
+        get(
+          conn,
+          ~p"/#{account}/sign_in/client_auth_error?#{%{"as" => "client", "state" => "retry-state", "nonce" => "retry-nonce", "error" => "The authorization code has expired or was already used. Please try signing in again."}}"
+        )
+
+      html = html_response(conn, 200)
+
+      assert html =~
+               "The authorization code has expired or was already used. Please try signing in again."
+
+      [retry_path] =
+        Regex.run(
+          ~r/<a href="([^"]+)"[^>]*>\s*Return to sign in\s*<\/a>/s,
+          html,
+          capture: :all_but_first
+        )
+
+      query =
+        retry_path
+        |> String.replace("&amp;", "&")
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+
+      assert String.starts_with?(retry_path, ~s(/#{account.slug}?))
+      assert query["as"] == "client"
+      assert query["state"] == "retry-state"
+      assert query["nonce"] == "retry-nonce"
     end
   end
 end


### PR DESCRIPTION
Adds a dedicated error page for failed client authentication. This prevents a potential redirect loop that could occur if the account had a default auth provider configured.


#### Error log

```
[info] GET /auth/oidc/callback
[info] OIDC sign-in redirecting with error error="This authentication method is not available for your sign-in context." account_id="c89bcc8c-9392-4dae-a40d-888aef6d28e0"
```

#### User visible error

<img width="642" height="443" alt="Screenshot 2026-04-10 at 3 14 16 PM" src="https://github.com/user-attachments/assets/bc2baa9f-f5b7-449c-9b1d-99c359d325ef" />
