### PR TITLE
fix(portal): idempotent email queueing

### DIFF
--- a/elixir/lib/portal/workers/outbound_email.ex
+++ b/elixir/lib/portal/workers/outbound_email.ex
@@ -3,14 +3,19 @@ defmodule Portal.Workers.OutboundEmail do
   Oban worker that submits a queued email using the secondary outbound adapter.
   """
 
-  use Oban.Worker, queue: :outbound_emails, max_attempts: 1
+  use Oban.Worker, queue: :outbound_emails, max_attempts: 3
 
   alias Portal.Mailer
   require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"account_id" => account_id, "request" => request}}) do
-    email = request |> deserialize() |> put_acs_client_options()
+  def perform(%Oban.Job{id: job_id, args: %{"account_id" => account_id, "request" => request}}) do
+    email =
+      request
+      |> deserialize()
+      |> put_acs_client_options()
+      |> put_operation_id(job_id)
+
     result = Mailer.deliver_secondary(email)
     persist_delivery_result(result, account_id, email)
   end
@@ -61,7 +66,7 @@ defmodule Portal.Workers.OutboundEmail do
       reason: inspect(reason)
     )
 
-    {:discard, reason}
+    {:error, reason}
   end
 
   defp email_addresses(%Swoosh.Email{} = email) do
@@ -105,4 +110,13 @@ defmodule Portal.Workers.OutboundEmail do
 
   defp response_message_id(response) when is_map(response), do: response[:id] || response["id"]
   defp response_message_id(_response), do: nil
+
+  defp put_operation_id(%Swoosh.Email{} = email, job_id) do
+    Swoosh.Email.put_provider_option(email, :operation_id, job_operation_id(job_id))
+  end
+
+  defp job_operation_id(job_id) do
+    {:ok, uuid} = Ecto.UUID.load(<<0::64, job_id::64>>)
+    uuid
+  end
 end

--- a/elixir/test/portal/workers/outbound_email_test.exs
+++ b/elixir/test/portal/workers/outbound_email_test.exs
@@ -29,7 +29,7 @@ defmodule Portal.Workers.OutboundEmailTest do
       assert db_entry.recipients == ["to@test.com"]
     end
 
-    test "discards HTTP delivery failures without tracking a row" do
+    test "returns error on HTTP delivery failures without tracking a row" do
       account = account_fixture()
       configure_acs_secondary()
 
@@ -42,8 +42,68 @@ defmodule Portal.Workers.OutboundEmailTest do
         |> Req.Test.json(%{"error" => %{"message" => "invalid recipient"}})
       end)
 
-      assert {:discard, {422, _body}} = perform_job(Worker, queued_args(account.id))
+      assert {:error, {422, _body}} = perform_job(Worker, queued_args(account.id))
       assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+
+    test "returns error for 401 so Oban retries" do
+      account = account_fixture()
+      configure_acs_secondary()
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/emails:send"
+
+        conn
+        |> Plug.Conn.put_status(401)
+        |> Req.Test.json(%{"error" => %{"message" => "Unauthorized"}})
+      end)
+
+      assert {:error, {401, _body}} = perform_job(Worker, queued_args(account.id))
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+
+    test "returns error for 403 so Oban retries" do
+      account = account_fixture()
+      configure_acs_secondary()
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/emails:send"
+
+        conn
+        |> Plug.Conn.put_status(403)
+        |> Req.Test.json(%{"error" => %{"message" => "Forbidden"}})
+      end)
+
+      assert {:error, {403, _body}} = perform_job(Worker, queued_args(account.id))
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+
+    test "sets deterministic Operation-Id header derived from job id" do
+      account = account_fixture()
+      configure_acs_secondary()
+
+      test_pid = self()
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        operation_id =
+          Enum.find_value(conn.req_headers, fn
+            {"operation-id", value} -> value
+            _ -> nil
+          end)
+
+        send(test_pid, {:operation_id, operation_id})
+
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-msg-opid", "status" => "Running"})
+      end)
+
+      job = %Oban.Job{id: 42, args: queued_args(account.id)}
+      assert :ok = Worker.perform(job)
+
+      assert_received {:operation_id, "00000000-0000-0000-0000-00000000002a"}
     end
   end
 


### PR DESCRIPTION
Azure's email API appears to, on rare occasions, return a non-sensical `401` response about time drift. After triple-checking all of our VM clocks, and codepaths related to timestamping here, the bug appears to be a small race window in Azure's backend somewhere, causing it to temporarily return 401 here.

Previously, we took a very defensive approach and bailed all outbound email failures to avoid the possibility of sending dupes. This was done because had no idempotency built into our send logic.

However, if we supply an `operationId`, a UUID, Azure will essentially treat this as an idempotency key and not queue duplicate emails to be sent.

Based on this logic, we can configure Oban's built-in retry semantics to safely retry as follows:

- `401` or `403` - return `{:error, reason}` to trigger Oban retry mechanism
- Use the Oban Job ID (an integer) to create a deterministic UUID to use for the Azure operationId so that we can retry the job safely

With Req's retries and our own job retries here, it should provide a pretty safe outbound email job worker that does not send duplicates.


---

Fixes #12834 