### PR TITLE
fix(portal): check repo health in parallel

### DIFF
--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -59,20 +59,26 @@ defmodule Portal.Health do
     Portal.Repo.Replica.Api
   ]
 
-  # sobelow_skip ["SQL.Query"]
   defp repos_ready? do
     config = Portal.Config.fetch_env!(:portal, Portal.Health)
     repos = Keyword.get(config, :repos, @repos)
     query = Keyword.get(config, :repo_check_query, "SELECT 1")
 
-    Enum.all?(repos, fn repo ->
-      try do
-        %{num_rows: 1} = Ecto.Adapters.SQL.query!(repo, query, [])
-        true
-      rescue
-        _ -> false
-      end
+    repos
+    |> Task.async_stream(&repo_ready?(&1, query),
+      max_concurrency: max(length(repos), 1),
+      ordered: false,
+      timeout: :infinity
+    )
+    |> Enum.all?(fn
+      {:ok, true} -> true
+      _ -> false
     end)
+  end
+
+  # sobelow_skip ["SQL.Query"]
+  defp repo_ready?(repo, query) do
+    match?({:ok, %{num_rows: 1}}, Ecto.Adapters.SQL.query(repo, query, []))
   end
 
   defp endpoints_ready? do

--- a/elixir/test/portal/health_test.exs
+++ b/elixir/test/portal/health_test.exs
@@ -111,6 +111,31 @@ defmodule Portal.HealthTest do
       assert %{"status" => "ready"} = JSON.decode!(conn.resp_body)
     end
 
+    test "checks repos in parallel", %{draining_file_path: draining_file_path} do
+      Portal.Config.put_env_override(:portal, Portal.Health,
+        draining_file_path: draining_file_path,
+        repos: [
+          Portal.Repo,
+          Portal.Repo.Replica,
+          Portal.Repo.Web,
+          Portal.Repo.Api,
+          Portal.Repo.Replica.Web,
+          Portal.Repo.Replica.Api
+        ],
+        repo_check_query: "SELECT 1 FROM pg_sleep(0.25)"
+      )
+
+      {duration_us, conn} =
+        :timer.tc(fn ->
+          :get
+          |> conn("/readyz")
+          |> Portal.Health.call([])
+        end)
+
+      assert conn.status == 200
+      assert div(duration_us, 1_000) < 900
+    end
+
     test "returns 503 with status starting when an endpoint is not ready", %{
       draining_file_path: draining_file_path
     } do


### PR DESCRIPTION
For portal instances far away from the write master, the healthcheck can take longer than 1s to return because it queries each of the repo connection pools in serial.

To speed this up and allow for tighter health probing, we can do all of these in parallel.