### PR TITLE
chore(rust): update cargo-deny advisory allowlist

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -55,6 +55,16 @@ jobs:
         name: cargo doc
         shell: bash
       - run: cargo fmt -- --check
+      - name: Guard RUSTSEC-2026-0097 allowlist assumption
+        run: |
+          # RUSTSEC-2026-0097 is allowlisted because rand's `log` feature is not enabled,
+          # meaning the vulnerable re-entrant ThreadRng code path is compiled out.
+          # If a dependency ever enables rand/log, the allowlist is no longer valid.
+          if cargo tree -e features 2>/dev/null | grep -q 'rand feature "log"'; then
+            echo "::error::rand's 'log' feature is now enabled — RUSTSEC-2026-0097 allowlist in deny.toml is no longer safe to keep"
+            exit 1
+          fi
+        shell: bash
       - run: cargo deny check --hide-inclusion-graph --deny unnecessary-skip
         shell: bash
 

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -112,6 +112,12 @@ ignore = [
 
     "RUSTSEC-2025-0057", # `fxhash` is unmaintained, used by transitive dependencies. See #10297.
 
+    # `rand` unsoundness via re-entrant ThreadRng access from a custom logger (GHSA-cq8v-f236-94qc).
+    # Not exploitable: rand's `log` feature is not enabled (verified via `cargo tree -e features`),
+    # so the log!() call sites in rand's reseeding path are compiled out entirely.
+    # Upgrading to rand 0.9 is blocked by x25519-dalek requiring rand_core 0.6.
+    "RUSTSEC-2026-0097",
+
     # `rust-unic` crates are unmaintained but still pulled in via tauri.
     "RUSTSEC-2025-0075",
     "RUSTSEC-2025-0080",


### PR DESCRIPTION
Allowlist RUSTSEC-2026-0097 (rand unsoundness via re-entrant ThreadRng access from a custom logger). Not exploitable: rand's `log` feature is not enabled so the vulnerable code path is compiled out entirely. Upgrading to rand 0.9 is blocked by x25519-dalek requiring rand_core 0.6.

Add a CI step that fails if rand's `log` feature ever becomes enabled, invalidating the allowlist assumption.