### PR TITLE
chore(mise): disable auto_install in subdir configs

### DIFF
--- a/kotlin/android/mise.toml
+++ b/kotlin/android/mise.toml
@@ -3,6 +3,9 @@
 # Tasks are auto-discovered from mise-tasks/ directory.
 # Task names match filenames (e.g., mise-tasks/format.sh -> //kotlin/android:format)
 
+[settings]
+auto_install = false
+
 [task_config]
 includes = ["mise-tasks"]
 

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -2,6 +2,9 @@
 #
 # Usage: mise run <task> (from this directory) or mise //rust:<task> (from repo root)
 
+[settings]
+auto_install = false
+
 [env]
 # Match CI environment - enables tokio unstable features and denies warnings
 RUSTFLAGS = "--cfg tokio_unstable"

--- a/swift/apple/mise.toml
+++ b/swift/apple/mise.toml
@@ -6,6 +6,9 @@
 #
 # Requires: MISE_EXPERIMENTAL=1 for monorepo task discovery
 
+[settings]
+auto_install = false
+
 [task_config]
 includes = ["mise-tasks"]
 


### PR DESCRIPTION
Prevents mise from automatically installing unrelated tools inherited from the root .tool-versions when running subdirectory tasks. This helps avoid GitHub rate limiting from aqua, which downloads tools without authentication (60 req/hour limit). At the same time, it allows us to tighten the scope of what is available in CI context.

All tools can still be installed with `mise install` (which then can be tailored to install only subset if needed, as in our swift CI config)
