### PR TITLE
chore(connlib): Add proptest for dynamic device pools

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -25,6 +25,8 @@ use boringtun::x25519;
 pub(crate) use resource::CidrResource;
 #[cfg(all(feature = "proptest", test))]
 pub(crate) use resource::DnsResource;
+#[cfg(all(feature = "proptest", test))]
+pub(crate) use resource::DynamicDevicePoolResource;
 pub(crate) use resource::{InternetResource, Resource};
 
 use dns_resource_nat::DnsResourceNat;

--- a/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     iter,
     net::{Ipv4Addr, SocketAddr},
     time::{Duration, Instant},
@@ -39,7 +39,7 @@ pub struct DeviceStubResolver {
     /// Keyed by `(ResourceId, domain)` — the same pair the portal includes in its response.
     /// If multiple queries arrive for the same domain while waiting, we keep only the latest.
     /// Entries expire after [`QUERY_TIMEOUT`] if the portal never responds.
-    pending: HashMap<(ResourceId, String), PendingQuery>,
+    pending: BTreeMap<(ResourceId, String), PendingQuery>,
 }
 
 pub struct PendingQuery {

--- a/rust/libs/connlib/tunnel/src/proptest.rs
+++ b/rust/libs/connlib/tunnel/src/proptest.rs
@@ -11,7 +11,9 @@ use std::{
     ops::Range,
 };
 
-use crate::client::{CidrResource, DnsResource, InternetResource, Resource};
+use crate::client::{
+    CidrResource, DnsResource, DynamicDevicePoolResource, InternetResource, Resource,
+};
 
 pub fn resource(
     sites: impl Strategy<Value = Vec<Site>> + Clone + 'static,
@@ -77,6 +79,16 @@ pub fn internet_resource(
         name: "Internet Resource".to_string(),
         id,
         sites,
+    })
+}
+
+pub fn dynamic_device_pool_resource() -> impl Strategy<Value = DynamicDevicePoolResource> {
+    (resource_id(), resource_name(), domain_name(2..4)).prop_map(|(id, name, base_domain)| {
+        DynamicDevicePoolResource {
+            id,
+            name,
+            address: format!("*.{base_domain}"),
+        }
     })
 }
 

--- a/rust/libs/connlib/tunnel/src/tests/ref_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/ref_client.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     ClientState,
-    client::{CidrResource, DnsResource, InternetResource, Resource},
+    client::{CidrResource, DnsResource, DynamicDevicePoolResource, InternetResource, Resource},
     dns,
     messages::{Interface, UpstreamDo53, UpstreamDoH},
 };
@@ -162,7 +162,12 @@ impl RefClient {
         }
 
         let Some(site) = self.site_for_resource(*resource) else {
-            tracing::error!(%resource, "No site for resource");
+            // Device pool resources have no site, so this is expected for them.
+            if !self.resources.iter().any(|r| {
+                matches!(r, Resource::DynamicDevicePool(dp) if dp.id == *resource)
+            }) {
+                tracing::error!(%resource, "No site for resource");
+            }
             return;
         };
 
@@ -321,6 +326,19 @@ impl RefClient {
         }
     }
 
+    pub(crate) fn add_dynamic_device_pool_resource(&mut self, r: DynamicDevicePoolResource) {
+        let r = Resource::DynamicDevicePool(r);
+        let rid = r.id();
+
+        if let Some(existing) = self.resources.iter().find(|existing| existing.id() == rid)
+            && existing.has_different_address(&r)
+        {
+            self.remove_resource(&existing.id());
+        }
+
+        self.resources.push(r);
+    }
+
     /// Re-adds all resources in the order they have been initially added.
     pub(crate) fn readd_all_resources(&mut self) {
         self.cidr_resources = IpNetworkTable::new();
@@ -330,7 +348,10 @@ impl RefClient {
                 Resource::Dns(d) => self.add_dns_resource(d),
                 Resource::Cidr(c) => self.add_cidr_resource(c),
                 Resource::Internet(i) => self.add_internet_resource(i),
-                Resource::StaticDevicePool(_) | Resource::DynamicDevicePool(_) => {}
+                Resource::StaticDevicePool(_) => {}
+                Resource::DynamicDevicePool(d) => {
+                    self.add_dynamic_device_pool_resource(d);
+                }
             }
         }
     }
@@ -368,9 +389,8 @@ impl RefClient {
         self.resources
             .iter()
             .filter_map(move |r| {
-                maybe_online_sites
-                    .contains(r.site().unwrap())
-                    .then_some(r.id())
+                let site = r.site().ok()?;
+                maybe_online_sites.contains(site).then_some(r.id())
             })
             .collect()
     }
@@ -564,6 +584,12 @@ impl RefClient {
             }
         }
 
+        // Device pool queries are answered locally by the client and never
+        // forwarded to a gateway, so they must not trigger resource connections.
+        if self.matches_device_pool(&query.domain) {
+            return;
+        }
+
         if let Some(resource) = self.is_site_specific_dns_query(query) {
             self.set_resource_online(resource);
             self.connected_dns_resources.insert(resource);
@@ -574,6 +600,12 @@ impl RefClient {
             self.connect_to_internet_or_cidr_resource(resource);
             self.set_resource_online(resource);
         }
+    }
+
+    fn matches_device_pool(&self, domain: &DomainName) -> bool {
+        self.resources.iter().any(|r| {
+            matches!(r, Resource::DynamicDevicePool(dp) if dns::is_subdomain(domain, &dp.address))
+        })
     }
 
     pub(crate) fn ipv4_cidr_resource_dsts(&self) -> Vec<Ipv4Network> {

--- a/rust/libs/connlib/tunnel/src/tests/reference.rs
+++ b/rust/libs/connlib/tunnel/src/tests/reference.rs
@@ -461,6 +461,47 @@ impl ReferenceState {
                 },
             )
             .with_if_not_empty(
+                2,
+                (
+                    state.device_pool_resources_on_client(),
+                    state.reachable_dns_servers(),
+                ),
+                |(device_pools, dns_servers)| {
+                    (
+                        sample::select(device_pools),
+                        sample::select(dns_servers),
+                    )
+                        .prop_flat_map(
+                            |((client_id, resource), (dns_client_id, dns_server))| {
+                                if client_id != dns_client_id {
+                                    return Just(Transition::SendDnsQueries(Vec::new())).boxed();
+                                }
+
+                                let base = resource
+                                    .address
+                                    .trim_start_matches("*.")
+                                    .to_owned();
+
+                                dns_queries(
+                                    (
+                                        domain_label().prop_map(move |label| {
+                                            format!("{label}.{base}").parse().unwrap()
+                                        }),
+                                        Just(vec![RecordType::A]),
+                                    ),
+                                    Just(dns_server),
+                                )
+                                .prop_map(move |queries| {
+                                    Transition::SendDnsQueries(
+                                        queries.into_iter().map(|q| (client_id, q)).collect(),
+                                    )
+                                })
+                                .boxed()
+                            },
+                        )
+                },
+            )
+            .with_if_not_empty(
                 1,
                 state.resolved_ip4_for_non_resources(&state.global_dns_records, now),
                 |values| {
@@ -568,8 +609,10 @@ impl ReferenceState {
                         }
                         client::Resource::Cidr(r) => client.add_cidr_resource(r.clone()),
                         client::Resource::Internet(r) => client.add_internet_resource(r.clone()),
-                        client::Resource::StaticDevicePool(_)
-                        | client::Resource::DynamicDevicePool(_) => {}
+                        client::Resource::StaticDevicePool(_) => {}
+                        client::Resource::DynamicDevicePool(r) => {
+                            client.add_dynamic_device_pool_resource(r.clone());
+                        }
                     });
                 }
             }
@@ -1488,6 +1531,33 @@ impl ReferenceState {
 
     fn all_client_ids(&self) -> Vec<ClientId> {
         self.clients.keys().copied().collect()
+    }
+
+    fn device_pool_resources_on_client(
+        &self,
+    ) -> Vec<(ClientId, client::DynamicDevicePoolResource)> {
+        let device_pool_resources = self
+            .portal
+            .all_resources()
+            .into_iter()
+            .filter_map(|r| match r {
+                client::Resource::DynamicDevicePool(r) => Some(r),
+                client::Resource::Dns(_)
+                | client::Resource::Cidr(_)
+                | client::Resource::Internet(_)
+                | client::Resource::StaticDevicePool(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        self.clients
+            .iter()
+            .flat_map(|(client_id, client)| {
+                device_pool_resources
+                    .iter()
+                    .filter(|r| client.inner().has_resource(r.id))
+                    .map(move |r| (*client_id, r.clone()))
+            })
+            .collect()
     }
 
     /// Generates a list of Client ID <> TUN IPv4 tuples without the entries of each ID's own IP.

--- a/rust/libs/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/libs/connlib/tunnel/src/tests/strategies.rs
@@ -2,8 +2,8 @@ use super::dns_records::DnsRecords;
 use super::icmp_error_hosts::IcmpErrorHosts;
 use super::{sim_net::Host, sim_relay::ref_relay_host, stub_portal::StubPortal};
 use crate::client::{
-    CidrResource, DNS_SENTINELS_V4, DNS_SENTINELS_V6, DnsResource, IPV4_RESOURCES, IPV6_RESOURCES,
-    InternetResource,
+    CidrResource, DNS_SENTINELS_V4, DNS_SENTINELS_V6, DnsResource, IPV4_RESOURCES,
+    IPV6_RESOURCES, InternetResource,
 };
 use crate::messages::{UpstreamDo53, UpstreamDoH};
 use crate::{IPV4_TUNNEL, IPV6_TUNNEL, proptest::*};
@@ -97,6 +97,8 @@ pub(crate) fn stub_portal() -> impl Strategy<Value = StubPortal> {
                 ],
                 1..5,
             );
+            let device_pool_resources =
+                collection::btree_set(dynamic_device_pool_resource(), 0..=2);
             let internet_resource = internet_resource(Just(internet_site.clone()));
 
             // Assign between 1 and 3 gateways to each site.
@@ -116,6 +118,7 @@ pub(crate) fn stub_portal() -> impl Strategy<Value = StubPortal> {
                 gateways_by_site,
                 cidr_resources,
                 dns_resources,
+                device_pool_resources,
                 internet_resource,
                 gateway_selector,
                 upstream_do53_servers,
@@ -123,22 +126,25 @@ pub(crate) fn stub_portal() -> impl Strategy<Value = StubPortal> {
             )
         })
         .prop_flat_map(
+            #[allow(clippy::type_complexity)]
             |(
                 clients,
                 gateways_by_site,
                 cidr_resources,
                 dns_resources,
+                device_pool_resources,
                 internet_resource,
                 gateway_selector,
                 upstream_do53_servers,
                 upstream_doh_servers,
-            )| {
+            )|{
                 (
                     Just(clients),
                     Just(gateways_by_site),
                     Just(cidr_resources),
                     search_domain(dns_resources.clone()),
                     Just(dns_resources),
+                    Just(device_pool_resources),
                     Just(internet_resource),
                     Just(gateway_selector),
                     Just(upstream_do53_servers),
@@ -153,6 +159,7 @@ pub(crate) fn stub_portal() -> impl Strategy<Value = StubPortal> {
                 cidr_resources,
                 search_domain,
                 dns_resources,
+                device_pool_resources,
                 internet_resource,
                 gateway_selector,
                 upstream_do53_servers,
@@ -164,6 +171,7 @@ pub(crate) fn stub_portal() -> impl Strategy<Value = StubPortal> {
                     gateway_selector,
                     cidr_resources,
                     dns_resources,
+                    device_pool_resources,
                     internet_resource,
                     search_domain,
                     upstream_do53_servers,

--- a/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
@@ -28,6 +28,8 @@ use std::{
     time::Instant,
 };
 
+use crate::client::DynamicDevicePoolResource;
+
 /// Stub implementation of the portal.
 #[derive(Clone, derive_more::Debug)]
 pub(crate) struct StubPortal {
@@ -40,6 +42,7 @@ pub(crate) struct StubPortal {
     // TODO: Maybe these should use the `messages` types to cover the conversions and to model that that is what we receive from the portal?
     cidr_resources: BTreeMap<ResourceId, client::CidrResource>,
     dns_resources: BTreeMap<ResourceId, client::DnsResource>,
+    device_pool_resources: BTreeMap<ResourceId, DynamicDevicePoolResource>,
     internet_resource: client::InternetResource,
 
     search_domain: Option<DomainName>,
@@ -57,6 +60,7 @@ impl StubPortal {
         gateway_selector: Selector,
         cidr_resources: BTreeSet<client::CidrResource>,
         dns_resources: BTreeSet<client::DnsResource>,
+        device_pool_resources: BTreeSet<DynamicDevicePoolResource>,
         internet_resource: client::InternetResource,
         search_domain: Option<DomainName>,
         upstream_do53: Vec<UpstreamDo53>,
@@ -67,6 +71,10 @@ impl StubPortal {
             .map(|r| (r.id, r))
             .collect::<BTreeMap<_, _>>();
         let dns_resources = dns_resources
+            .into_iter()
+            .map(|r| (r.id, r))
+            .collect::<BTreeMap<_, _>>();
+        let device_pool_resources = device_pool_resources
             .into_iter()
             .map(|r| (r.id, r))
             .collect::<BTreeMap<_, _>>();
@@ -140,6 +148,7 @@ impl StubPortal {
             ),
             cidr_resources,
             dns_resources,
+            device_pool_resources,
             internet_resource,
             search_domain,
             upstream_do53,
@@ -157,6 +166,12 @@ impl StubPortal {
                     .values()
                     .cloned()
                     .map(client::Resource::Dns),
+            )
+            .chain(
+                self.device_pool_resources
+                    .values()
+                    .cloned()
+                    .map(client::Resource::DynamicDevicePool),
             )
             .chain(iter::once(client::Resource::Internet(
                 self.internet_resource.clone(),

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1214,7 +1214,33 @@ impl TunnelTest {
                 Ok(())
             }
             ClientEvent::Error(_) => unreachable!("ClientState never emits `TunnelError`"),
-            ClientEvent::DevicePoolDomainResolveIntent { .. } => Ok(()),
+            ClientEvent::DevicePoolDomainResolveIntent {
+                resource_id,
+                domain,
+            } => {
+                let tunnel_ips = self
+                    .clients
+                    .iter()
+                    .filter(|(id, _)| **id != src)
+                    .map(|(_, c)| c.inner().sut.tunnel_ip_config().unwrap().v4)
+                    .collect::<Vec<_>>();
+
+                if let Some(ipv4) = tunnel_ips.first().copied() {
+                    let client = self.clients.get_mut(&src).unwrap();
+                    client.exec_mut(|c| {
+                        c.sut.handle_device_pool_domain_resolved(
+                            crate::messages::client::DevicePoolDomainResolved {
+                                resource_id,
+                                domain,
+                                ipv4,
+                            },
+                            now,
+                        );
+                    });
+                }
+
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
Exercise the DynamicDevicePool DNS resolution flow in property-based tests:

- Generate 0-2 `DynamicDevicePoolResource` per test via `stub_portal`
- Track device pool resources in `RefClient` so add/remove transitions work
- Generate DNS queries (weight 2) targeting random subdomains that match device pool patterns
- Simulate the portal round-trip in the SUT by resolving `DevicePoolDomainResolveIntent` to another client's tunnel IPv4

Note: Only the happy path is tested with the proptest.