### PR TITLE
fix(apple): disable automatic termination for macOS app

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -123,9 +123,6 @@ struct FirezoneApp: App {
     func applicationWillFinishLaunching(_ notification: Notification) {
       // Enforce single instance BEFORE the app fully launches
       enforceSingleInstance()
-
-      // Prevent sudden termination for menu bar apps to allow cleanup
-      ProcessInfo.processInfo.disableSuddenTermination()
     }
 
     func applicationDidFinishLaunching(_: Notification) {

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -25,9 +25,9 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2025 Firezone, Inc. All rights reserved.</string>
 	<key>NSSupportsAutomaticTermination</key>
-	<true/>
+	<false/>
 	<key>NSSupportsSuddenTermination</key>
-	<true/>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -27,7 +27,7 @@
 	<key>NSSupportsAutomaticTermination</key>
 	<false/>
 	<key>NSSupportsSuddenTermination</key>
-	<false/>
+	<true/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,11 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull={12849}>
+          Fixes an issue on macOS where the app could be silently terminated by
+          the system under memory pressure, leaving the tunnel running without a
+          menu bar icon or session expiry notifications.
+        </ChangeItem>
         <ChangeItem pull={12657}>
           Falls back to public DNS resolvers when the system provides only
           non-routable addresses (loopback, link-local), preventing tunnel


### PR DESCRIPTION
macOS could sometimes auto-terminate the Firezone menu bar app under memory pressure because NSSupportsAutomaticTermination was set to true. This caused the tunnel to keep running (via the NE) while the menu bar icon disappeared, leaving users with no UI or session expiry notifications.
Whilst at there, disable NSSupportsSuddenTermination in the plist as well for consistency.