### PR TITLE
fix(portal): delete identities on suspend/inactive

### DIFF
--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -219,7 +219,7 @@ defmodule Portal.Entra.APIClient do
         enabled != false
 
       :error ->
-        Logger.warning("Skipping Entra user with missing accountEnabled field",
+        Logger.error("Skipping Entra user with missing accountEnabled field",
           entra_user_id: Map.get(user, "id", "unknown"),
           entra_user_email: Map.get(user, "mail", Map.get(user, "userPrincipalName", "unknown"))
         )

--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -5,6 +5,9 @@ defmodule Portal.Entra.APIClient do
 
   require Logger
 
+  @entra_user_select_fields "id,displayName,mail,userPrincipalName,givenName,surname,accountEnabled"
+  @advanced_query_headers [{"ConsistencyLevel", "eventual"}]
+
   @doc """
   Gets an access token using the OAuth2 client credentials flow.
   """
@@ -95,17 +98,20 @@ defmodule Portal.Entra.APIClient do
   Fetches user profile fields that map to our identity schema.
   """
   def stream_group_transitive_members(access_token, group_id) do
-    # Select only fields that we have in our identity schema:
-    # id -> idp_id, displayName -> name, mail/userPrincipalName -> email,
-    # givenName -> given_name, surname -> family_name, userPrincipalName -> preferred_username
+    # Use the user cast plus an accountEnabled filter so Graph excludes disabled
+    # users server-side before we build identities or memberships.
     query =
       URI.encode_query(%{
         "$top" => "999",
-        "$select" => "id,displayName,mail,userPrincipalName,givenName,surname"
+        "$count" => "true",
+        "$filter" => "accountEnabled eq true",
+        "$select" => @entra_user_select_fields
       })
 
-    path = "/v1.0/groups/#{group_id}/transitiveMembers"
-    stream_pages(path, query, access_token)
+    path = "/v1.0/groups/#{group_id}/transitiveMembers/microsoft.graph.user"
+
+    stream_pages(path, query, access_token, @advanced_query_headers)
+    |> Stream.map(&filter_active_entra_users_result/1)
   end
 
   @doc """
@@ -122,7 +128,7 @@ defmodule Portal.Entra.APIClient do
         %{
           id: Integer.to_string(index),
           method: "GET",
-          url: "/users/#{user_id}?$select=id,displayName,mail,userPrincipalName,givenName,surname"
+          url: "/users/#{user_id}?$select=#{@entra_user_select_fields}"
         }
       end)
 
@@ -191,10 +197,35 @@ defmodule Portal.Entra.APIClient do
       )
     end
 
-    users = Enum.map(successful, fn response -> response["body"] end)
+    users =
+      successful
+      |> Enum.map(fn response -> response["body"] end)
+      |> Enum.filter(&active_entra_user?/1)
+
     Logger.debug("Filtered users", count: length(users))
 
     {:ok, users}
+  end
+
+  defp filter_active_entra_users_result(users) when is_list(users) do
+    Enum.filter(users, &active_entra_user?/1)
+  end
+
+  defp filter_active_entra_users_result(other), do: other
+
+  defp active_entra_user?(user) do
+    case Map.fetch(user, "accountEnabled") do
+      {:ok, enabled} ->
+        enabled != false
+
+      :error ->
+        Logger.warning("Skipping Entra user with missing accountEnabled field",
+          entra_user_id: Map.get(user, "id", "unknown"),
+          entra_user_email: Map.get(user, "mail", Map.get(user, "userPrincipalName", "unknown"))
+        )
+
+        false
+    end
   end
 
   @doc """
@@ -252,18 +283,22 @@ defmodule Portal.Entra.APIClient do
     get("/v1.0/subscribedSkus", "", access_token)
   end
 
-  defp get(path, query, access_token) do
+  defp get(path, query, access_token, headers \\ []) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
     endpoint = config[:endpoint] || "https://graph.microsoft.com"
     req_opts = fetch_config(:req_opts) || []
 
     url = "#{endpoint}#{path}?#{query}"
-    Req.get(url, [headers: [{"Authorization", "Bearer #{access_token}"}]] ++ req_opts)
+
+    Req.get(
+      url,
+      [headers: [{"Authorization", "Bearer #{access_token}"} | headers]] ++ req_opts
+    )
   end
 
-  defp stream_pages(path, query, access_token) do
+  defp stream_pages(path, query, access_token, headers \\ []) do
     Stream.resource(
-      fn -> {path, query} end,
+      fn -> {path, query, headers} end,
       fn
         nil ->
           {:halt, nil}
@@ -272,17 +307,17 @@ defmodule Portal.Entra.APIClient do
           # Halt stream on error
           {[error], nil}
 
-        {current_path, current_query} ->
-          fetch_page(current_path, current_query, access_token)
+        {current_path, current_query, current_headers} ->
+          fetch_page(current_path, current_query, access_token, current_headers)
       end,
       fn _ -> :ok end
     )
   end
 
-  defp fetch_page(current_path, current_query, access_token) do
-    case get(current_path, current_query, access_token) do
+  defp fetch_page(current_path, current_query, access_token, headers) do
+    case get(current_path, current_query, access_token, headers) do
       {:ok, %Req.Response{status: 200, body: body}} ->
-        parse_page_response(body)
+        parse_page_response(body, headers)
 
       {:ok, %Req.Response{} = response} ->
         # Non-200 response
@@ -294,7 +329,7 @@ defmodule Portal.Entra.APIClient do
     end
   end
 
-  defp parse_page_response(body) do
+  defp parse_page_response(body, headers) do
     case Map.fetch(body, "value") do
       {:ok, list} when is_list(list) ->
         # Empty list is valid - it means no results for this page
@@ -308,7 +343,7 @@ defmodule Portal.Entra.APIClient do
               uri = URI.parse(next_link)
               next_path = String.replace(uri.path, "/v1.0", "")
               next_query = uri.query || ""
-              {next_path, next_query}
+              {next_path, next_query, headers}
           end
 
         {[list], next_state}

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -718,7 +718,7 @@ defmodule Portal.Entra.Sync do
         enabled != false
 
       :error ->
-        Logger.warning("Skipping Entra user with missing accountEnabled field",
+        Logger.error("Skipping Entra user with missing accountEnabled field",
           entra_directory_id: directory_id,
           entra_user_id: Map.get(user, "id", "unknown"),
           entra_user_email: Map.get(user, "mail", Map.get(user, "userPrincipalName", "unknown"))

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -354,12 +354,14 @@ defmodule Portal.Entra.Sync do
 
     case Entra.APIClient.batch_get_users(access_token, chunk) do
       {:ok, users} when is_list(users) ->
+        active_users = Enum.filter(users, &syncable_user?(&1, directory.id))
+
         Logger.debug("Fetched batch of users successfully",
           entra_directory_id: directory.id,
-          fetched_count: length(users)
+          fetched_count: length(active_users)
         )
 
-        Enum.map(users, fn user ->
+        Enum.map(active_users, fn user ->
           map_user_to_identity(user, directory.id, directory.email_field)
         end)
 
@@ -427,10 +429,11 @@ defmodule Portal.Entra.Sync do
       count: length(members)
     )
 
-    # Filter only users
+    # The API client already uses the microsoft.graph.user cast with
+    # accountEnabled=true filtering; keep a local guard as a safety net.
     user_members =
       Enum.filter(members, fn member ->
-        member["@odata.type"] == "#microsoft.graph.user"
+        graph_user_member?(member) and syncable_user?(member, directory.id)
       end)
 
     # Validate required fields for user members before processing
@@ -562,10 +565,11 @@ defmodule Portal.Entra.Sync do
       count: length(members)
     )
 
-    # Filter only users
+    # The API client already uses the microsoft.graph.user cast with
+    # accountEnabled=true filtering; keep a local guard as a safety net.
     user_members =
       Enum.filter(members, fn member ->
-        member["@odata.type"] == "#microsoft.graph.user"
+        graph_user_member?(member) and syncable_user?(member, directory.id)
       end)
 
     # Validate required fields for user members before processing
@@ -706,6 +710,30 @@ defmodule Portal.Entra.Sync do
       entra_directory_id: directory.id,
       count: deleted_actors_count
     )
+  end
+
+  defp syncable_user?(user, directory_id) do
+    case Map.fetch(user, "accountEnabled") do
+      {:ok, enabled} ->
+        enabled != false
+
+      :error ->
+        Logger.warning("Skipping Entra user with missing accountEnabled field",
+          entra_directory_id: directory_id,
+          entra_user_id: Map.get(user, "id", "unknown"),
+          entra_user_email: Map.get(user, "mail", Map.get(user, "userPrincipalName", "unknown"))
+        )
+
+        false
+    end
+  end
+
+  defp graph_user_member?(member) do
+    case Map.get(member, "@odata.type") do
+      nil -> true
+      "#microsoft.graph.user" -> true
+      _ -> false
+    end
   end
 
   defp map_user_to_identity(user, directory_id, email_field) do

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -126,20 +126,25 @@ defmodule Portal.Google.APIClient do
   end
 
   @doc """
-  Streams users from the Google Workspace directory.
+  Streams active users from the Google Workspace directory.
   Returns a stream that yields pages of users.
   """
+  @active_user_query "isSuspended=false isArchived=false"
+
   def stream_users(access_token, domain) do
     query =
       URI.encode_query(%{
         "customer" => "my_customer",
         "domain" => domain,
         "maxResults" => "500",
-        "projection" => "full"
+        "projection" => "full",
+        "query" => @active_user_query
       })
 
     path = "/admin/directory/v1/users"
+
     stream_pages(path, query, access_token, "users")
+    |> Stream.map(&filter_active_google_users_result/1)
   end
 
   @doc """
@@ -224,8 +229,11 @@ defmodule Portal.Google.APIClient do
       end)
 
     case result do
-      {:ok, chunks} -> {:ok, chunks |> Enum.reverse() |> List.flatten()}
-      {:error, _} = error -> error
+      {:ok, chunks} ->
+        {:ok, chunks |> Enum.reverse() |> List.flatten() |> Enum.filter(&active_google_user?/1)}
+
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -394,14 +402,14 @@ defmodule Portal.Google.APIClient do
   end
 
   @doc """
-  Streams users from a specific organization unit.
+  Streams active users from a specific organization unit.
   Returns a stream that yields pages of users in the given org unit.
   """
   def stream_organization_unit_members(access_token, org_unit_path) do
     query =
       URI.encode_query(%{
         "customer" => "my_customer",
-        "query" => "orgUnitPath='#{org_unit_path}'",
+        "query" => "orgUnitPath='#{org_unit_path}' #{@active_user_query}",
         "maxResults" => "500",
         "projection" => "full"
       })
@@ -409,14 +417,31 @@ defmodule Portal.Google.APIClient do
     path = "/admin/directory/v1/users"
 
     stream_pages(path, query, access_token, "users")
-    |> Stream.map(fn
-      # Org Unit with no members
-      {:error, {:missing_key, _msg, _body}} ->
-        []
+    |> Stream.map(&filter_org_unit_members_result/1)
+  end
 
-      other ->
-        other
-    end)
+  defp filter_org_unit_members_result({:error, {:missing_key, _msg, _body}}), do: []
+  defp filter_org_unit_members_result(result), do: filter_active_google_users_result(result)
+
+  defp filter_active_google_users_result(users) when is_list(users) do
+    Enum.filter(users, &active_google_user?/1)
+  end
+
+  defp filter_active_google_users_result(other), do: other
+
+  defp active_google_user?(user) do
+    case {Map.fetch(user, "suspended"), Map.fetch(user, "archived")} do
+      {{:ok, suspended}, {:ok, archived}} ->
+        suspended != true and archived != true
+
+      _ ->
+        Logger.warning("Skipping Google user with missing suspended/archived flags",
+          google_user_id: Map.get(user, "id", "unknown"),
+          google_user_email: Map.get(user, "primaryEmail", Map.get(user, "email", "unknown"))
+        )
+
+        false
+    end
   end
 
   defp get(path, access_token) do

--- a/elixir/lib/portal/google/api_client.ex
+++ b/elixir/lib/portal/google/api_client.ex
@@ -435,7 +435,7 @@ defmodule Portal.Google.APIClient do
         suspended != true and archived != true
 
       _ ->
-        Logger.warning("Skipping Google user with missing suspended/archived flags",
+        Logger.error("Skipping Google user with missing suspended/archived flags",
           google_user_id: Map.get(user, "id", "unknown"),
           google_user_email: Map.get(user, "primaryEmail", Map.get(user, "email", "unknown"))
         )

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -6,13 +6,14 @@ defmodule Portal.Google.Sync do
   1. Upsert seed groups (based on group_sync_mode), collect group idp_ids.
   2. Upsert org units (if orgunit_sync_enabled), collect {idp_id, path} pairs.
   3. Org unit member sync: per org unit, fetch users, upsert identities directly
-     from the users payload (deduped via seen_user_ids), and upsert memberships.
+     from the users payload (deduped via synced_user_ids), and upsert memberships.
   4. BFS group member sync: for each group, fetch direct members, upsert identities,
      discover GROUP-type members as sub-groups (fetching each via get_group for its
      display name), upsert them, and recurse. We collect direct user memberships and
      the group graph during traversal, then compute flattened memberships in-memory
-     and upsert them in batches. A `seen_user_ids` set is threaded through to skip
-     redundant batch_get_users calls for users already fetched in an earlier group.
+     and upsert them in batches. Separate `fetched_user_ids` and `synced_user_ids`
+     sets are threaded through traversal so users are fetched at most once even if
+     they are later filtered out as suspended or archived.
   Finally, delete everything with a stale last_synced_at.
   """
   use Oban.Worker,
@@ -165,8 +166,8 @@ defmodule Portal.Google.Sync do
 
     # Phase 3: Org unit member sync.
     # Per org unit: fetch users → upsert identities directly from user payload (deduped)
-    # → upsert memberships. Returns the set of user IDs already synced.
-    seen_user_ids =
+    # → upsert memberships. Returns the set of active user IDs already synced.
+    synced_user_ids =
       sync_org_unit_members_phase(
         directory,
         access_token,
@@ -183,7 +184,7 @@ defmodule Portal.Google.Sync do
       access_token,
       synced_at,
       group_idp_ids,
-      seen_user_ids
+      synced_user_ids
     )
 
     :ok
@@ -321,13 +322,14 @@ defmodule Portal.Google.Sync do
          access_token,
          synced_at,
          seed_group_idp_ids,
-         seen_user_ids
+         synced_user_ids
        ) do
     visited = MapSet.new(seed_group_idp_ids)
     queue = :queue.from_list(seed_group_idp_ids)
 
     initial_state = %{
-      seen_user_ids: seen_user_ids,
+      fetched_user_ids: synced_user_ids,
+      synced_user_ids: synced_user_ids,
       direct_users_by_group: %{},
       children_by_group: %{}
     }
@@ -341,7 +343,7 @@ defmodule Portal.Google.Sync do
       final_state.direct_users_by_group
     )
 
-    final_state.seen_user_ids
+    final_state.synced_user_ids
   end
 
   defp do_bfs(directory, access_token, synced_at, queue, visited, state) do
@@ -377,20 +379,22 @@ defmodule Portal.Google.Sync do
     {user_tuples, sub_group_ids} = fetch_group_members(directory, access_token, group_idp_id)
     direct_user_ids = user_ids_set_from_memberships(user_tuples)
 
-    next_seen_user_ids =
+    {next_fetched_user_ids, next_synced_user_ids, synced_direct_user_ids} =
       sync_new_user_identities(
         directory,
         access_token,
         synced_at,
         direct_user_ids,
-        state.seen_user_ids
+        state.fetched_user_ids,
+        state.synced_user_ids
       )
 
     next_state =
       state
-      |> put_group_direct_users(group_idp_id, direct_user_ids)
+      |> put_group_direct_users(group_idp_id, synced_direct_user_ids)
       |> put_group_children(group_idp_id, sub_group_ids)
-      |> Map.put(:seen_user_ids, next_seen_user_ids)
+      |> Map.put(:fetched_user_ids, next_fetched_user_ids)
+      |> Map.put(:synced_user_ids, next_synced_user_ids)
 
     {next_queue, next_visited} =
       enqueue_discovered_sub_groups(
@@ -756,14 +760,16 @@ defmodule Portal.Google.Sync do
           count: length(users)
         )
 
+        syncable_users = Enum.filter(users, &syncable_user?(&1, directory.id))
+
         tuples =
-          Enum.map(users, fn user ->
+          Enum.map(syncable_users, fn user ->
             validate_ou_member!(user, ou_idp_id, directory)
             {ou_idp_id, user["id"]}
           end)
 
         users_by_id =
-          Enum.reduce(users, users_by_id_acc, fn user, acc ->
+          Enum.reduce(syncable_users, users_by_id_acc, fn user, acc ->
             Map.put(acc, user["id"], user)
           end)
 
@@ -774,37 +780,11 @@ defmodule Portal.Google.Sync do
     end)
   end
 
-  # Identity sync (shared by group BFS and org unit phases)
-
-  defp sync_identities_for_users(_directory, _access_token, _synced_at, []), do: :ok
-
-  defp sync_identities_for_users(directory, access_token, synced_at, user_idp_ids) do
-    Logger.debug("Fetching user details for #{length(user_idp_ids)} users via batch API",
-      google_directory_id: directory.id
-    )
-
-    users =
-      case Google.APIClient.batch_get_users(access_token, user_idp_ids) do
-        {:ok, users} ->
-          users
-
-        {:error, error} ->
-          raise Google.SyncError,
-            error: error,
-            directory_id: directory.id,
-            step: :batch_get_users
-      end
-
-    identities = Enum.map(users, &map_user_to_identity(&1, directory.id))
-
-    identities
-    |> Enum.chunk_every(@db_batch_size)
-    |> Enum.each(&batch_upsert_identities(directory, synced_at, &1))
-  end
-
   defp sync_identities_for_user_payloads(_directory, _synced_at, []), do: :ok
 
   defp sync_identities_for_user_payloads(directory, synced_at, users) do
+    users = Enum.filter(users, &syncable_user?(&1, directory.id))
+
     identities = Enum.map(users, &map_user_to_identity(&1, directory.id))
 
     identities
@@ -812,14 +792,36 @@ defmodule Portal.Google.Sync do
     |> Enum.each(&batch_upsert_identities(directory, synced_at, &1))
   end
 
-  defp sync_new_user_identities(directory, access_token, synced_at, user_ids, seen_user_ids) do
+  defp sync_new_user_identities(
+         directory,
+         access_token,
+         synced_at,
+         user_ids,
+         fetched_user_ids,
+         synced_user_ids
+       ) do
+    already_synced_user_ids = MapSet.intersection(user_ids, synced_user_ids)
+
     new_user_idp_ids =
       user_ids
-      |> Enum.reject(&MapSet.member?(seen_user_ids, &1))
+      |> Enum.reject(&MapSet.member?(fetched_user_ids, &1))
 
-    sync_identities_for_users(directory, access_token, synced_at, new_user_idp_ids)
+    syncable_users = fetch_syncable_users(directory, access_token, new_user_idp_ids)
+    sync_identities_for_user_payloads(directory, synced_at, syncable_users)
 
-    Enum.reduce(new_user_idp_ids, seen_user_ids, &MapSet.put(&2, &1))
+    newly_synced_user_ids =
+      syncable_users
+      |> Enum.map(& &1["id"])
+      |> MapSet.new()
+
+    next_fetched_user_ids =
+      Enum.reduce(new_user_idp_ids, fetched_user_ids, &MapSet.put(&2, &1))
+
+    next_synced_user_ids =
+      Enum.reduce(newly_synced_user_ids, synced_user_ids, &MapSet.put(&2, &1))
+
+    {next_fetched_user_ids, next_synced_user_ids,
+     MapSet.union(already_synced_user_ids, newly_synced_user_ids)}
   end
 
   defp user_ids_from_membership_tuples(user_tuples) do
@@ -834,6 +836,40 @@ defmodule Portal.Google.Sync do
     memberships
     |> Enum.chunk_every(@db_batch_size)
     |> Enum.each(&batch_upsert_memberships(directory, synced_at, &1))
+  end
+
+  defp fetch_syncable_users(_directory, _access_token, []), do: []
+
+  defp fetch_syncable_users(directory, access_token, user_idp_ids) do
+    users =
+      case Google.APIClient.batch_get_users(access_token, user_idp_ids) do
+        {:ok, users} ->
+          users
+
+        {:error, error} ->
+          raise Google.SyncError,
+            error: error,
+            directory_id: directory.id,
+            step: :batch_get_users
+      end
+
+    Enum.filter(users, &syncable_user?(&1, directory.id))
+  end
+
+  defp syncable_user?(user, directory_id) do
+    case {Map.fetch(user, "suspended"), Map.fetch(user, "archived")} do
+      {{:ok, suspended}, {:ok, archived}} ->
+        suspended != true and archived != true
+
+      _ ->
+        Logger.warning("Skipping Google user with missing suspended/archived flags",
+          google_directory_id: directory_id,
+          google_user_id: Map.get(user, "id", "unknown"),
+          google_user_email: Map.get(user, "primaryEmail", Map.get(user, "email", "unknown"))
+        )
+
+        false
+    end
   end
 
   defp map_user_to_identity(user, directory_id) do

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -862,7 +862,7 @@ defmodule Portal.Google.Sync do
         suspended != true and archived != true
 
       _ ->
-        Logger.warning("Skipping Google user with missing suspended/archived flags",
+        Logger.error("Skipping Google user with missing suspended/archived flags",
           google_directory_id: directory_id,
           google_user_id: Map.get(user, "id", "unknown"),
           google_user_email: Map.get(user, "primaryEmail", Map.get(user, "email", "unknown"))

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -23,6 +23,7 @@ defmodule Portal.Okta.Sync do
     PROVISIONED
     RECOVERY
     PASSWORD_EXPIRED
+    LOCKED_OUT
   ]
 
   @impl Oban.Worker
@@ -445,7 +446,7 @@ defmodule Portal.Okta.Sync do
         if syncable_okta_user_status?(status), do: member["id"]
 
       :error ->
-        Logger.warning("Skipping Okta group member with missing status",
+        Logger.error("Skipping Okta group member with missing status",
           okta_directory_id: directory_id,
           okta_group_idp_id: group_idp_id,
           okta_user_id: Map.get(member, "id", "unknown")
@@ -461,7 +462,7 @@ defmodule Portal.Okta.Sync do
         syncable_okta_user_status?(status)
 
       :error ->
-        Logger.warning("Skipping Okta app user with missing status",
+        Logger.error("Skipping Okta app user with missing status",
           okta_directory_id: directory_id,
           okta_user_id: Map.get(user, "id", "unknown")
         )

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -17,6 +17,14 @@ defmodule Portal.Okta.Sync do
   require Logger
   require OpenTelemetry.Tracer
 
+  @syncable_okta_user_statuses ~w[
+    ACTIVE
+    STAGED
+    PROVISIONED
+    RECOVERY
+    PASSWORD_EXPIRED
+  ]
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"directory_id" => directory_id}}) do
     Logger.info("Starting Okta directory sync",
@@ -203,13 +211,8 @@ defmodule Portal.Okta.Sync do
   defp process_identity_batch!(batch, directory, synced_at) do
     # Extract successful users and check for errors
     {users, errors} =
-      Enum.reduce(batch, {[], []}, fn
-        {:ok, user_data}, {users, errors} ->
-          user = get_in(user_data, ["_embedded", "user"])
-          {[user | users], errors}
-
-        {:error, reason}, {users, errors} ->
-          {users, [reason | errors]}
+      Enum.reduce(batch, {[], []}, fn entry, acc ->
+        reduce_identity_batch_entry(entry, acc, directory.id)
       end)
 
     # If there are any errors in the batch, raise the first one
@@ -265,6 +268,24 @@ defmodule Portal.Okta.Sync do
     end
   end
 
+  defp reduce_identity_batch_entry({:ok, user_data}, {users, errors}, directory_id) do
+    case fetch_embedded_map(user_data, ["_embedded", "user"], "user") do
+      {:ok, user} ->
+        if syncable_app_user?(user, directory_id) do
+          {[user | users], errors}
+        else
+          {users, errors}
+        end
+
+      {:error, reason} ->
+        {users, [reason | errors]}
+    end
+  end
+
+  defp reduce_identity_batch_entry({:error, reason}, {users, errors}, _directory_id) do
+    {users, [reason | errors]}
+  end
+
   # Stream and batch-insert groups for a specific app
   defp sync_app_groups_streaming!(app_id, client, token, directory, synced_at) do
     Logger.debug("Streaming app groups",
@@ -285,8 +306,10 @@ defmodule Portal.Okta.Sync do
     {groups, errors} =
       Enum.reduce(batch, {[], []}, fn
         {:ok, group_data}, {groups, errors} ->
-          group = get_in(group_data, ["_embedded", "group"])
-          {[group | groups], errors}
+          case fetch_embedded_map(group_data, ["_embedded", "group"], "group") do
+            {:ok, group} -> {[group | groups], errors}
+            {:error, reason} -> {groups, [reason | errors]}
+          end
 
         {:error, reason}, {groups, errors} ->
           {groups, [reason | errors]}
@@ -402,10 +425,9 @@ defmodule Portal.Okta.Sync do
     Okta.APIClient.stream_group_members(group_idp_id, client, token)
     |> Enum.reduce([], fn
       {:ok, member}, acc ->
-        if member["status"] == "ACTIVE" do
-          [member["id"] | acc]
-        else
-          acc
+        case syncable_group_member_id(member, group_idp_id, directory_id) do
+          nil -> acc
+          member_id -> [member_id | acc]
         end
 
       {:error, reason}, _acc ->
@@ -415,6 +437,59 @@ defmodule Portal.Okta.Sync do
           step: :stream_group_members
     end)
     |> Enum.reverse()
+  end
+
+  defp syncable_group_member_id(member, group_idp_id, directory_id) do
+    case Map.fetch(member, "status") do
+      {:ok, status} ->
+        if syncable_okta_user_status?(status), do: member["id"]
+
+      :error ->
+        Logger.warning("Skipping Okta group member with missing status",
+          okta_directory_id: directory_id,
+          okta_group_idp_id: group_idp_id,
+          okta_user_id: Map.get(member, "id", "unknown")
+        )
+
+        nil
+    end
+  end
+
+  defp syncable_app_user?(user, directory_id) do
+    case Map.fetch(user, "status") do
+      {:ok, status} ->
+        syncable_okta_user_status?(status)
+
+      :error ->
+        Logger.warning("Skipping Okta app user with missing status",
+          okta_directory_id: directory_id,
+          okta_user_id: Map.get(user, "id", "unknown")
+        )
+
+        false
+    end
+  end
+
+  defp syncable_okta_user_status?(status) do
+    status in @syncable_okta_user_statuses
+  end
+
+  defp fetch_embedded_map(data, path, entity_name) do
+    assignment_id = Map.get(data, "id", "unknown")
+
+    case get_in(data, path) do
+      value when is_map(value) ->
+        {:ok, value}
+
+      nil ->
+        {:error,
+         {:validation, "assignment '#{assignment_id}' missing '_embedded.#{entity_name}' payload"}}
+
+      other ->
+        {:error,
+         {:validation,
+          "assignment '#{assignment_id}' has invalid '_embedded.#{entity_name}' payload: #{inspect(other)}"}}
+    end
   end
 
   # Helper to build issuer URL

--- a/elixir/test/portal/entra/api_client_test.exs
+++ b/elixir/test/portal/entra/api_client_test.exs
@@ -1,5 +1,6 @@
 defmodule Portal.Entra.APIClientTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
 
   alias Portal.Entra.APIClient
 
@@ -283,27 +284,31 @@ defmodule Portal.Entra.APIClientTest do
       Req.Test.expect(APIClient, fn conn ->
         # Verify the transitive members endpoint is being called
         assert conn.method == "GET"
-        assert conn.request_path == "/v1.0/groups/#{group_id}/transitiveMembers"
+
+        assert conn.request_path ==
+                 "/v1.0/groups/#{group_id}/transitiveMembers/microsoft.graph.user"
+
+        assert {"consistencylevel", "eventual"} in conn.req_headers
 
         conn = Plug.Conn.fetch_query_params(conn)
         send(test_pid, {:members_request, conn.query_params})
 
         Req.Test.json(conn, %{
           "value" => [
-            %{
+            active_entra_user(%{
               "id" => "user1",
               "displayName" => "User One",
               "mail" => "user1@example.com",
               "userPrincipalName" => "user1@example.com",
               "givenName" => "User",
               "surname" => "One"
-            },
-            %{
+            }),
+            active_entra_user(%{
               "id" => "user2",
               "displayName" => "User Two",
               "mail" => "user2@example.com",
               "userPrincipalName" => "user2@example.com"
-            }
+            })
           ]
         })
       end)
@@ -315,10 +320,12 @@ defmodule Portal.Entra.APIClientTest do
       assert [[%{"id" => "user1"}, %{"id" => "user2"}]] = result
 
       assert_receive {:members_request, query_params}
+      assert query_params["$count"] == "true"
+      assert query_params["$filter"] == "accountEnabled eq true"
       assert query_params["$top"] == "999"
 
       assert query_params["$select"] ==
-               "id,displayName,mail,userPrincipalName,givenName,surname"
+               "id,displayName,mail,userPrincipalName,givenName,surname,accountEnabled"
     end
 
     test "streams multiple pages of members" do
@@ -336,13 +343,13 @@ defmodule Portal.Entra.APIClientTest do
           case current_page do
             0 ->
               %{
-                "value" => [%{"id" => "user1"}],
+                "value" => [active_entra_user(%{"id" => "user1"})],
                 "@odata.nextLink" =>
-                  "https://graph.microsoft.com/v1.0/groups/#{group_id}/transitiveMembers?$skiptoken=xyz"
+                  "https://graph.microsoft.com/v1.0/groups/#{group_id}/transitiveMembers/microsoft.graph.user?$skiptoken=xyz"
               }
 
             1 ->
-              %{"value" => [%{"id" => "user2"}]}
+              %{"value" => [active_entra_user(%{"id" => "user2"})]}
           end
 
         Req.Test.json(conn, response)
@@ -353,6 +360,55 @@ defmodule Portal.Entra.APIClientTest do
         |> Enum.to_list()
 
       assert [[%{"id" => "user1"}], [%{"id" => "user2"}]] = result
+    end
+
+    test "filters disabled users from transitive member pages" do
+      group_id = "group_123"
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "value" => [
+            %{"id" => "user1", "accountEnabled" => true},
+            %{"id" => "user2", "accountEnabled" => false}
+          ]
+        })
+      end)
+
+      result =
+        APIClient.stream_group_transitive_members(@test_access_token, group_id)
+        |> Enum.to_list()
+
+      assert [[%{"id" => "user1"}]] = result
+    end
+
+    test "logs and skips transitive members missing accountEnabled" do
+      group_id = "group_123"
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "value" => [
+            %{"id" => "user1", "displayName" => "User One", "mail" => "user1@example.com"},
+            %{
+              "id" => "user2",
+              "displayName" => "User Two",
+              "mail" => "user2@example.com",
+              "accountEnabled" => true
+            }
+          ]
+        })
+      end)
+
+      log =
+        capture_log(fn ->
+          result =
+            APIClient.stream_group_transitive_members(@test_access_token, group_id)
+            |> Enum.to_list()
+
+          assert [[%{"id" => "user2", "accountEnabled" => true}]] = result
+        end)
+
+      assert log =~ "Skipping Entra user with missing accountEnabled field"
+      assert log =~ "user1"
     end
   end
 
@@ -377,7 +433,8 @@ defmodule Portal.Entra.APIClientTest do
               "body" => %{
                 "id" => "user1",
                 "displayName" => "User One",
-                "mail" => "user1@example.com"
+                "mail" => "user1@example.com",
+                "accountEnabled" => true
               }
             },
             %{
@@ -386,7 +443,8 @@ defmodule Portal.Entra.APIClientTest do
               "body" => %{
                 "id" => "user2",
                 "displayName" => "User Two",
-                "mail" => "user2@example.com"
+                "mail" => "user2@example.com",
+                "accountEnabled" => true
               }
             },
             %{
@@ -395,7 +453,8 @@ defmodule Portal.Entra.APIClientTest do
               "body" => %{
                 "id" => "user3",
                 "displayName" => "User Three",
-                "mail" => "user3@example.com"
+                "mail" => "user3@example.com",
+                "accountEnabled" => true
               }
             }
           ]
@@ -413,7 +472,7 @@ defmodule Portal.Entra.APIClientTest do
 
       assert_receive {:batch_request, batch_request}
       assert length(batch_request["requests"]) == 3
-      expected_select = "id,displayName,mail,userPrincipalName,givenName,surname"
+      expected_select = "id,displayName,mail,userPrincipalName,givenName,surname,accountEnabled"
 
       Enum.zip(batch_request["requests"], user_ids)
       |> Enum.each(fn {request, user_id} ->
@@ -435,7 +494,8 @@ defmodule Portal.Entra.APIClientTest do
               "body" => %{
                 "id" => "user1",
                 "displayName" => "User One",
-                "mail" => "user1@example.com"
+                "mail" => "user1@example.com",
+                "accountEnabled" => true
               }
             },
             %{
@@ -452,6 +512,85 @@ defmodule Portal.Entra.APIClientTest do
       assert {:ok, users} = APIClient.batch_get_users(@test_access_token, user_ids)
       assert length(users) == 1
       assert Enum.at(users, 0)["id"] == "user1"
+    end
+
+    test "filters disabled users from successful batch results" do
+      user_ids = ["user1", "user2"]
+
+      Req.Test.expect(APIClient, fn conn ->
+        batch_response = %{
+          "responses" => [
+            %{
+              "id" => "1",
+              "status" => 200,
+              "body" => %{
+                "id" => "user1",
+                "displayName" => "User One",
+                "mail" => "user1@example.com",
+                "accountEnabled" => true
+              }
+            },
+            %{
+              "id" => "2",
+              "status" => 200,
+              "body" => %{
+                "id" => "user2",
+                "displayName" => "User Two",
+                "mail" => "user2@example.com",
+                "accountEnabled" => false
+              }
+            }
+          ]
+        }
+
+        Req.Test.json(conn, batch_response)
+      end)
+
+      assert {:ok, users} = APIClient.batch_get_users(@test_access_token, user_ids)
+      assert Enum.map(users, & &1["id"]) == ["user1"]
+    end
+
+    test "logs and skips batch users missing accountEnabled" do
+      user_ids = ["user1", "user2"]
+
+      Req.Test.expect(APIClient, fn conn ->
+        batch_response = %{
+          "responses" => [
+            %{
+              "id" => "1",
+              "status" => 200,
+              "body" => %{
+                "id" => "user1",
+                "displayName" => "User One",
+                "mail" => "user1@example.com",
+                "userPrincipalName" => "user1@example.com"
+              }
+            },
+            %{
+              "id" => "2",
+              "status" => 200,
+              "body" => %{
+                "id" => "user2",
+                "displayName" => "User Two",
+                "mail" => "user2@example.com",
+                "userPrincipalName" => "user2@example.com",
+                "accountEnabled" => true
+              }
+            }
+          ]
+        }
+
+        Req.Test.json(conn, batch_response)
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, users} = APIClient.batch_get_users(@test_access_token, user_ids)
+          assert Enum.map(users, & &1["id"]) == ["user2"]
+        end)
+
+      assert log =~ "Skipping Entra user with missing accountEnabled field"
+      assert log =~ "user1"
     end
 
     test "returns error when all batch requests fail" do
@@ -646,5 +785,9 @@ defmodule Portal.Entra.APIClientTest do
 
       assert [{:error, %Req.TransportError{reason: :timeout}}] = result
     end
+  end
+
+  defp active_entra_user(attrs) do
+    Map.put_new(attrs, "accountEnabled", true)
   end
 end

--- a/elixir/test/portal/entra/sync_test.exs
+++ b/elixir/test/portal/entra/sync_test.exs
@@ -95,7 +95,8 @@ defmodule Portal.Entra.SyncTest do
                     "mail" => "direct@example.com",
                     "userPrincipalName" => "direct@example.com",
                     "givenName" => "Direct",
-                    "surname" => "User"
+                    "surname" => "User",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -104,7 +105,7 @@ defmodule Portal.Entra.SyncTest do
           String.contains?(path, "transitiveMembers") ->
             Req.Test.json(conn, %{
               "value" => [
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_alice_123",
                   "displayName" => "Alice Smith",
@@ -112,14 +113,14 @@ defmodule Portal.Entra.SyncTest do
                   "userPrincipalName" => "alice@example.com",
                   "givenName" => "Alice",
                   "surname" => "Smith"
-                },
-                %{
+                }),
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_bob_123",
                   "displayName" => "Bob Jones",
                   "mail" => "bob@example.com",
                   "userPrincipalName" => "bob@example.com"
-                }
+                })
               ]
             })
 
@@ -186,26 +187,26 @@ defmodule Portal.Entra.SyncTest do
           String.contains?(path, "group_sales_123/transitiveMembers") ->
             Req.Test.json(conn, %{
               "value" => [
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_carol_123",
                   "displayName" => "Carol Davis",
                   "mail" => "carol@example.com",
                   "userPrincipalName" => "carol@example.com"
-                }
+                })
               ]
             })
 
           String.contains?(path, "group_eng_123/transitiveMembers") ->
             Req.Test.json(conn, %{
               "value" => [
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_dave_123",
                   "displayName" => "Dave Wilson",
                   "mail" => "dave@example.com",
                   "userPrincipalName" => "dave@example.com"
-                }
+                })
               ]
             })
 
@@ -233,6 +234,207 @@ defmodule Portal.Entra.SyncTest do
       # Verify memberships created (2 memberships)
       memberships = Repo.all(Membership)
       assert length(memberships) == 2
+    end
+
+    test "skips disabled users from direct assignments and group memberships" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account, sync_all_groups: false)
+
+      api_client_config = Portal.Config.get_env(:portal, Portal.Entra.APIClient)
+      directory_sync_client_id = api_client_config[:client_id]
+
+      auth_provider_config = Portal.Config.get_env(:portal, Portal.Entra.AuthProvider)
+      auth_provider_client_id = auth_provider_config[:client_id]
+
+      Req.Test.expect(APIClient, 20, fn %{request_path: path, query_string: query} = conn ->
+        cond do
+          String.ends_with?(path, "/oauth2/v2.0/token") ->
+            Req.Test.json(conn, %{
+              "access_token" => "test_token",
+              "token_type" => "Bearer",
+              "expires_in" => 3600
+            })
+
+          path == "/v1.0/servicePrincipals" ->
+            params = URI.decode_query(query)
+            filter = params["$filter"]
+
+            cond do
+              String.contains?(filter, directory_sync_client_id) ->
+                Req.Test.json(conn, %{
+                  "value" => [
+                    %{"id" => @test_service_principal_id, "appId" => directory_sync_client_id}
+                  ]
+                })
+
+              String.contains?(filter, auth_provider_client_id) ->
+                Req.Test.json(conn, %{"value" => []})
+
+              true ->
+                Req.Test.json(conn, %{"value" => []})
+            end
+
+          String.contains?(path, "appRoleAssignedTo") ->
+            Req.Test.json(conn, %{
+              "value" => [
+                %{
+                  "id" => "assignment1",
+                  "principalId" => "user_direct_active",
+                  "principalType" => "User",
+                  "principalDisplayName" => "Direct Active"
+                },
+                %{
+                  "id" => "assignment2",
+                  "principalId" => "user_direct_disabled",
+                  "principalType" => "User",
+                  "principalDisplayName" => "Direct Disabled"
+                },
+                %{
+                  "id" => "assignment3",
+                  "principalId" => "group_eng_123",
+                  "principalType" => "Group",
+                  "principalDisplayName" => "Engineering"
+                }
+              ]
+            })
+
+          String.ends_with?(path, "/$batch") ->
+            Req.Test.json(conn, %{
+              "responses" => [
+                %{
+                  "id" => "1",
+                  "status" => 200,
+                  "body" => %{
+                    "id" => "user_direct_active",
+                    "displayName" => "Direct Active",
+                    "mail" => "active-direct@example.com",
+                    "userPrincipalName" => "active-direct@example.com",
+                    "givenName" => "Direct",
+                    "surname" => "Active",
+                    "accountEnabled" => true
+                  }
+                },
+                %{
+                  "id" => "2",
+                  "status" => 200,
+                  "body" => %{
+                    "id" => "user_direct_disabled",
+                    "displayName" => "Direct Disabled",
+                    "mail" => "disabled-direct@example.com",
+                    "userPrincipalName" => "disabled-direct@example.com",
+                    "givenName" => "Direct",
+                    "surname" => "Disabled",
+                    "accountEnabled" => false
+                  }
+                }
+              ]
+            })
+
+          String.contains?(path, "transitiveMembers") ->
+            Req.Test.json(conn, %{
+              "value" => [
+                %{
+                  "@odata.type" => "#microsoft.graph.user",
+                  "id" => "user_group_active",
+                  "displayName" => "Group Active",
+                  "mail" => "group-active@example.com",
+                  "userPrincipalName" => "group-active@example.com",
+                  "givenName" => "Group",
+                  "surname" => "Active",
+                  "accountEnabled" => true
+                },
+                %{
+                  "@odata.type" => "#microsoft.graph.user",
+                  "id" => "user_group_disabled",
+                  "displayName" => "Group Disabled",
+                  "mail" => "group-disabled@example.com",
+                  "userPrincipalName" => "group-disabled@example.com",
+                  "givenName" => "Group",
+                  "surname" => "Disabled",
+                  "accountEnabled" => false
+                }
+              ]
+            })
+
+          true ->
+            Req.Test.json(conn, %{"error" => "unexpected: #{path}"})
+        end
+      end)
+
+      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+
+      identities = Repo.all(ExternalIdentity)
+      identity_emails = Enum.map(identities, & &1.email) |> Enum.sort()
+      assert identity_emails == ["active-direct@example.com", "group-active@example.com"]
+
+      memberships = Repo.all(Membership)
+      assert length(memberships) == 1
+    end
+
+    test "deletes previously synced disabled users on a later sync" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account, sync_all_groups: false)
+
+      expect_entra_direct_assignment_sync([
+        %{
+          "id" => "user_active_123",
+          "displayName" => "Active User",
+          "mail" => "active@example.com",
+          "userPrincipalName" => "active@example.com",
+          "givenName" => "Active",
+          "surname" => "User",
+          "accountEnabled" => true
+        },
+        %{
+          "id" => "user_disable_123",
+          "displayName" => "Disable Me",
+          "mail" => "disable-me@example.com",
+          "userPrincipalName" => "disable-me@example.com",
+          "givenName" => "Disable",
+          "surname" => "Me",
+          "accountEnabled" => true
+        }
+      ])
+
+      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+
+      disabled_identity =
+        Repo.get_by!(ExternalIdentity,
+          directory_id: directory.id,
+          idp_id: "user_disable_123"
+        )
+
+      disabled_actor = Repo.get_by!(Actor, id: disabled_identity.actor_id)
+
+      expect_entra_direct_assignment_sync([
+        %{
+          "id" => "user_active_123",
+          "displayName" => "Active User",
+          "mail" => "active@example.com",
+          "userPrincipalName" => "active@example.com",
+          "givenName" => "Active",
+          "surname" => "User",
+          "accountEnabled" => true
+        },
+        %{
+          "id" => "user_disable_123",
+          "displayName" => "Disable Me",
+          "mail" => "disable-me@example.com",
+          "userPrincipalName" => "disable-me@example.com",
+          "givenName" => "Disable",
+          "surname" => "Me",
+          "accountEnabled" => false
+        }
+      ])
+
+      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+
+      identities = Repo.all(ExternalIdentity)
+      assert Enum.map(identities, & &1.email) == ["active@example.com"]
+      assert Repo.all(Membership) == []
+
+      refute Repo.get_by(ExternalIdentity, id: disabled_identity.id)
+      refute Repo.get_by(Actor, id: disabled_actor.id)
     end
 
     test "handles missing directory gracefully" do
@@ -337,7 +539,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "new_user_123",
                     "displayName" => "New User",
                     "mail" => "new@example.com",
-                    "userPrincipalName" => "new@example.com"
+                    "userPrincipalName" => "new@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -433,13 +636,13 @@ defmodule Portal.Entra.SyncTest do
             Req.Test.json(conn, %{
               "value" => [
                 # This user should be included
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_123",
                   "displayName" => "Test User",
                   "mail" => "user@example.com",
                   "userPrincipalName" => "user@example.com"
-                },
+                }),
                 # This group should be filtered out
                 %{
                   "@odata.type" => "#microsoft.graph.group",
@@ -521,7 +724,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_123",
                     "displayName" => "Test User",
                     "mail" => nil,
-                    "userPrincipalName" => "testuser@example.onmicrosoft.com"
+                    "userPrincipalName" => "testuser@example.onmicrosoft.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -598,7 +802,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user1_123",
                     "displayName" => "User One",
                     "mail" => "user1@example.com",
-                    "userPrincipalName" => "user1@example.com"
+                    "userPrincipalName" => "user1@example.com",
+                    "accountEnabled" => true
                   }
                 },
                 %{
@@ -727,11 +932,11 @@ defmodule Portal.Entra.SyncTest do
         if String.contains?(path, "transitiveMembers") do
           Req.Test.json(conn, %{
             "value" => [
-              %{
+              active_entra_user(%{
                 "@odata.type" => "#microsoft.graph.user",
                 "displayName" => "User Without ID",
                 "mail" => "user@example.com"
-              }
+              })
             ]
           })
         else
@@ -861,7 +1066,8 @@ defmodule Portal.Entra.SyncTest do
                         "id" => "user_dir_sync_123",
                         "displayName" => "Directory Sync User",
                         "mail" => "dirsync@example.com",
-                        "userPrincipalName" => "dirsync@example.com"
+                        "userPrincipalName" => "dirsync@example.com",
+                        "accountEnabled" => true
                       }
                     }
 
@@ -873,7 +1079,8 @@ defmodule Portal.Entra.SyncTest do
                         "id" => "user_auth_123",
                         "displayName" => "Auth Provider User",
                         "mail" => "authprovider@example.com",
-                        "userPrincipalName" => "authprovider@example.com"
+                        "userPrincipalName" => "authprovider@example.com",
+                        "accountEnabled" => true
                       }
                     }
 
@@ -979,7 +1186,7 @@ defmodule Portal.Entra.SyncTest do
           String.contains?(path, "group_engineering_123/transitiveMembers") ->
             Req.Test.json(conn, %{
               "value" => [
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_alice_123",
                   "displayName" => "Alice Engineer",
@@ -987,8 +1194,8 @@ defmodule Portal.Entra.SyncTest do
                   "userPrincipalName" => "alice@example.com",
                   "givenName" => "Alice",
                   "surname" => "Engineer"
-                },
-                %{
+                }),
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_bob_123",
                   "displayName" => "Bob Engineer",
@@ -996,7 +1203,7 @@ defmodule Portal.Entra.SyncTest do
                   "userPrincipalName" => "bob@example.com",
                   "givenName" => "Bob",
                   "surname" => "Engineer"
-                }
+                })
               ]
             })
 
@@ -1004,7 +1211,7 @@ defmodule Portal.Entra.SyncTest do
           String.contains?(path, "group_sales_123/transitiveMembers") ->
             Req.Test.json(conn, %{
               "value" => [
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "id" => "user_carol_123",
                   "displayName" => "Carol Sales",
@@ -1012,7 +1219,7 @@ defmodule Portal.Entra.SyncTest do
                   "userPrincipalName" => "carol@example.com",
                   "givenName" => "Carol",
                   "surname" => "Sales"
-                }
+                })
               ]
             })
 
@@ -1118,7 +1325,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_legacy_123",
                     "displayName" => "Legacy User",
                     "mail" => "legacy@example.com",
-                    "userPrincipalName" => "legacy@example.com"
+                    "userPrincipalName" => "legacy@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -1295,7 +1503,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_123",
                     "displayName" => "Test User",
                     "mail" => "test@example.com",
-                    "userPrincipalName" => "test@example.com"
+                    "userPrincipalName" => "test@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -1823,12 +2032,12 @@ defmodule Portal.Entra.SyncTest do
           String.contains?(path, "group_123/transitiveMembers") ->
             Req.Test.json(conn, %{
               "value" => [
-                %{
+                active_entra_user(%{
                   "@odata.type" => "#microsoft.graph.user",
                   "displayName" => "User Without ID",
                   "mail" => "user@example.com",
                   "userPrincipalName" => "user@example.com"
-                }
+                })
               ]
             })
 
@@ -1890,7 +2099,8 @@ defmodule Portal.Entra.SyncTest do
                   "body" => %{
                     "displayName" => "Test User",
                     "mail" => "test@example.com",
-                    "userPrincipalName" => "test@example.com"
+                    "userPrincipalName" => "test@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -1958,7 +2168,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_123",
                     "displayName" => "Test User",
                     "mail" => "not-an-email",
-                    "userPrincipalName" => "test@example.com"
+                    "userPrincipalName" => "test@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -2076,20 +2287,22 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_123",
                     "displayName" => "Direct User",
                     "mail" => "direct@example.com",
-                    "userPrincipalName" => "direct@example.com"
+                    "userPrincipalName" => "direct@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
             })
 
           String.contains?(path, "group_123/transitiveMembers") ->
-            duplicate_member = %{
-              "@odata.type" => "#microsoft.graph.user",
-              "id" => "user_123",
-              "displayName" => "Direct User",
-              "mail" => "direct@example.com",
-              "userPrincipalName" => "direct@example.com"
-            }
+            duplicate_member =
+              active_entra_user(%{
+                "@odata.type" => "#microsoft.graph.user",
+                "id" => "user_123",
+                "displayName" => "Direct User",
+                "mail" => "direct@example.com",
+                "userPrincipalName" => "direct@example.com"
+              })
 
             Req.Test.json(conn, %{"value" => [duplicate_member, duplicate_member]})
 
@@ -2156,7 +2369,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_123",
                     "displayName" => "User One",
                     "mail" => "shared@example.com",
-                    "userPrincipalName" => "shared@example.com"
+                    "userPrincipalName" => "shared@example.com",
+                    "accountEnabled" => true
                   }
                 },
                 %{
@@ -2166,7 +2380,8 @@ defmodule Portal.Entra.SyncTest do
                     "id" => "user_456",
                     "displayName" => "User Two",
                     "mail" => "shared@example.com",
-                    "userPrincipalName" => "shared@example.com"
+                    "userPrincipalName" => "shared@example.com",
+                    "accountEnabled" => true
                   }
                 }
               ]
@@ -2266,6 +2481,75 @@ defmodule Portal.Entra.SyncTest do
     {api_client_config[:client_id], auth_provider_config[:client_id]}
   end
 
+  defp expect_entra_direct_assignment_sync(batch_users) do
+    {directory_sync_client_id, auth_provider_client_id} = entra_client_ids()
+
+    Req.Test.expect(APIClient, 5, fn %{request_path: path, query_string: query} = conn ->
+      cond do
+        String.ends_with?(path, "/oauth2/v2.0/token") ->
+          Req.Test.json(conn, %{
+            "access_token" => "test_token",
+            "token_type" => "Bearer",
+            "expires_in" => 3600
+          })
+
+        path == "/v1.0/servicePrincipals" ->
+          params = URI.decode_query(query)
+          filter = params["$filter"]
+
+          cond do
+            String.contains?(filter, directory_sync_client_id) ->
+              Req.Test.json(conn, %{
+                "value" => [
+                  %{"id" => @test_service_principal_id, "appId" => directory_sync_client_id}
+                ]
+              })
+
+            String.contains?(filter, auth_provider_client_id) ->
+              Req.Test.json(conn, %{"value" => []})
+
+            true ->
+              Req.Test.json(conn, %{"value" => []})
+          end
+
+        String.contains?(path, "appRoleAssignedTo") ->
+          Req.Test.json(conn, %{
+            "value" => [
+              %{
+                "id" => "assignment1",
+                "principalId" => "user_active_123",
+                "principalType" => "User",
+                "principalDisplayName" => "Active User"
+              },
+              %{
+                "id" => "assignment2",
+                "principalId" => "user_disable_123",
+                "principalType" => "User",
+                "principalDisplayName" => "Disable Me"
+              }
+            ]
+          })
+
+        String.ends_with?(path, "/$batch") ->
+          responses =
+            batch_users
+            |> Enum.with_index(1)
+            |> Enum.map(fn {user, index} ->
+              %{
+                "id" => Integer.to_string(index),
+                "status" => 200,
+                "body" => active_entra_user(user)
+              }
+            end)
+
+          Req.Test.json(conn, %{"responses" => responses})
+
+        true ->
+          Req.Test.json(conn, %{"error" => "unexpected: #{path}"})
+      end
+    end)
+  end
+
   # Helper to receive all messages of a given type
   defp receive_all_messages(tag, acc \\ []) do
     receive do
@@ -2273,5 +2557,9 @@ defmodule Portal.Entra.SyncTest do
     after
       0 -> acc
     end
+  end
+
+  defp active_entra_user(attrs) do
+    Map.put_new(attrs, "accountEnabled", true)
   end
 end

--- a/elixir/test/portal/google/api_client_test.exs
+++ b/elixir/test/portal/google/api_client_test.exs
@@ -1,5 +1,6 @@
 defmodule Portal.Google.APIClientTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
 
   alias Portal.Google.APIClient
 
@@ -266,8 +267,8 @@ defmodule Portal.Google.APIClientTest do
         Req.Test.json(conn, %{
           "kind" => "admin#directory#users",
           "users" => [
-            %{"id" => "user1", "primaryEmail" => "user1@example.com"},
-            %{"id" => "user2", "primaryEmail" => "user2@example.com"}
+            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
+            active_google_user(%{"id" => "user2", "primaryEmail" => "user2@example.com"})
           ]
         })
       end)
@@ -284,6 +285,7 @@ defmodule Portal.Google.APIClientTest do
       assert conn.query_params["domain"] == @test_domain
       assert conn.query_params["maxResults"] == "500"
       assert conn.query_params["projection"] == "full"
+      assert conn.query_params["query"] == "isSuspended=false isArchived=false"
     end
 
     test "streams multiple pages using nextPageToken" do
@@ -300,18 +302,18 @@ defmodule Portal.Google.APIClientTest do
           case current_page do
             0 ->
               %{
-                "users" => [%{"id" => "user1"}],
+                "users" => [active_google_user(%{"id" => "user1"})],
                 "nextPageToken" => "page2_token"
               }
 
             1 ->
               %{
-                "users" => [%{"id" => "user2"}],
+                "users" => [active_google_user(%{"id" => "user2"})],
                 "nextPageToken" => "page3_token"
               }
 
             2 ->
-              %{"users" => [%{"id" => "user3"}]}
+              %{"users" => [active_google_user(%{"id" => "user3"})]}
           end
 
         Req.Test.json(conn, response)
@@ -328,12 +330,15 @@ defmodule Portal.Google.APIClientTest do
              ] = result
 
       assert_receive {:users_page, 0, page1_params}
+      assert page1_params["query"] == "isSuspended=false isArchived=false"
       refute Map.has_key?(page1_params, "pageToken")
 
       assert_receive {:users_page, 1, page2_params}
+      assert page2_params["query"] == "isSuspended=false isArchived=false"
       assert page2_params["pageToken"] == "page2_token"
 
       assert_receive {:users_page, 2, page3_params}
+      assert page3_params["query"] == "isSuspended=false isArchived=false"
       assert page3_params["pageToken"] == "page3_token"
     end
 
@@ -387,6 +392,51 @@ defmodule Portal.Google.APIClientTest do
         |> Enum.to_list()
 
       assert [{:error, %Req.TransportError{reason: :econnrefused}}] = result
+    end
+
+    test "filters suspended and archived users from returned pages" do
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "users" => [
+            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
+            %{"id" => "user2", "primaryEmail" => "user2@example.com", "suspended" => true},
+            %{"id" => "user3", "primaryEmail" => "user3@example.com", "archived" => true}
+          ]
+        })
+      end)
+
+      result =
+        APIClient.stream_users(@test_access_token, @test_domain)
+        |> Enum.to_list()
+
+      assert [[%{"id" => "user1"}]] = result
+    end
+
+    test "logs and skips users missing suspended or archived flags" do
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "kind" => "admin#directory#users",
+          "users" => [
+            %{"id" => "user1", "primaryEmail" => "user1@example.com"},
+            active_google_user(%{
+              "id" => "user2",
+              "primaryEmail" => "user2@example.com"
+            })
+          ]
+        })
+      end)
+
+      log =
+        capture_log(fn ->
+          result =
+            APIClient.stream_users(@test_access_token, @test_domain)
+            |> Enum.to_list()
+
+          assert [[%{"id" => "user2"}]] = result
+        end)
+
+      assert log =~ "Skipping Google user with missing suspended/archived flags"
+      assert log =~ "user1"
     end
   end
 
@@ -654,8 +704,8 @@ defmodule Portal.Google.APIClientTest do
         Req.Test.json(conn, %{
           "kind" => "admin#directory#users",
           "users" => [
-            %{"id" => "user1", "primaryEmail" => "user1@example.com"},
-            %{"id" => "user2", "primaryEmail" => "user2@example.com"}
+            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
+            active_google_user(%{"id" => "user2", "primaryEmail" => "user2@example.com"})
           ]
         })
       end)
@@ -669,7 +719,10 @@ defmodule Portal.Google.APIClientTest do
       assert_receive {:org_unit_users_request, conn}
       assert_authorization_header(conn, @test_access_token)
       assert conn.query_params["customer"] == "my_customer"
-      assert conn.query_params["query"] == "orgUnitPath='/Engineering'"
+
+      assert conn.query_params["query"] ==
+               "orgUnitPath='/Engineering' isSuspended=false isArchived=false"
+
       assert conn.query_params["maxResults"] == "500"
       assert conn.query_params["projection"] == "full"
     end
@@ -686,12 +739,12 @@ defmodule Portal.Google.APIClientTest do
           case current_page do
             0 ->
               %{
-                "users" => [%{"id" => "user1"}],
+                "users" => [active_google_user(%{"id" => "user1"})],
                 "nextPageToken" => "next_page"
               }
 
             1 ->
-              %{"users" => [%{"id" => "user2"}]}
+              %{"users" => [active_google_user(%{"id" => "user2"})]}
           end
 
         Req.Test.json(conn, response)
@@ -734,6 +787,24 @@ defmodule Portal.Google.APIClientTest do
 
       assert [{:error, %Req.Response{status: 403}}] = result
     end
+
+    test "filters suspended and archived org unit users from returned pages" do
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "users" => [
+            active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"}),
+            %{"id" => "user2", "primaryEmail" => "user2@example.com", "suspended" => true},
+            %{"id" => "user3", "primaryEmail" => "user3@example.com", "archived" => true}
+          ]
+        })
+      end)
+
+      result =
+        APIClient.stream_organization_unit_members(@test_access_token, "/Engineering")
+        |> Enum.to_list()
+
+      assert [[%{"id" => "user1"}]] = result
+    end
   end
 
   describe "batch_get_users/2" do
@@ -757,7 +828,9 @@ defmodule Portal.Google.APIClientTest do
         body =
           build_batch_body(boundary, [
             {"HTTP/1.1 200 OK",
-             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+             JSON.encode!(
+               active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
+             )}
           ])
 
         conn
@@ -779,7 +852,9 @@ defmodule Portal.Google.APIClientTest do
         body =
           build_batch_body(boundary, [
             {"HTTP/1.1 200 OK",
-             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+             JSON.encode!(
+               active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
+             )}
           ])
 
         conn
@@ -833,7 +908,9 @@ defmodule Portal.Google.APIClientTest do
         body =
           build_batch_body(boundary, [
             {"HTTP/1.1 200 OK",
-             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+             JSON.encode!(
+               active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
+             )}
           ])
 
         conn
@@ -883,6 +960,70 @@ defmodule Portal.Google.APIClientTest do
                APIClient.batch_get_users(@test_access_token, ["user1"])
     end
 
+    test "filters suspended and archived users from batch results" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "filtered_users_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(
+               active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
+             )},
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(%{
+               "id" => "user2",
+               "primaryEmail" => "user2@example.com",
+               "suspended" => true
+             })},
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(%{
+               "id" => "user3",
+               "primaryEmail" => "user3@example.com",
+               "archived" => true
+             })}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      assert {:ok, users} =
+               APIClient.batch_get_users(@test_access_token, ["user1", "user2", "user3"])
+
+      assert Enum.map(users, & &1["id"]) == ["user1"]
+    end
+
+    test "logs and skips batch users missing suspended or archived flags" do
+      Req.Test.expect(APIClient, fn conn ->
+        boundary = "missing_flags_boundary"
+
+        body =
+          build_batch_body(boundary, [
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})},
+            {"HTTP/1.1 200 OK",
+             JSON.encode!(
+               active_google_user(%{"id" => "user2", "primaryEmail" => "user2@example.com"})
+             )}
+          ])
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "multipart/mixed; boundary=#{boundary}")
+        |> Plug.Conn.send_resp(200, body)
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, users} = APIClient.batch_get_users(@test_access_token, ["user1", "user2"])
+          assert Enum.map(users, & &1["id"]) == ["user2"]
+        end)
+
+      assert log =~ "Skipping Google user with missing suspended/archived flags"
+      assert log =~ "user1"
+    end
+
     test "halts on chunk error after first successful chunk" do
       counter = :atomics.new(1, [])
 
@@ -897,7 +1038,9 @@ defmodule Portal.Google.APIClientTest do
             body =
               build_batch_body(boundary, [
                 {"HTTP/1.1 200 OK",
-                 JSON.encode!(%{"id" => "user1", "primaryEmail" => "user1@example.com"})}
+                 JSON.encode!(
+                   active_google_user(%{"id" => "user1", "primaryEmail" => "user1@example.com"})
+                 )}
               ])
 
             conn
@@ -988,7 +1131,7 @@ defmodule Portal.Google.APIClientTest do
         case current_page do
           0 ->
             Req.Test.json(conn, %{
-              "users" => [%{"id" => "user1"}],
+              "users" => [active_google_user(%{"id" => "user1"})],
               "nextPageToken" => "page2"
             })
 
@@ -1018,8 +1161,14 @@ defmodule Portal.Google.APIClientTest do
 
         response =
           case current_page do
-            0 -> %{"users" => [%{"id" => "user1"}], "nextPageToken" => "token123"}
-            1 -> %{"users" => [%{"id" => "user2"}]}
+            0 ->
+              %{
+                "users" => [active_google_user(%{"id" => "user1"})],
+                "nextPageToken" => "token123"
+              }
+
+            1 ->
+              %{"users" => [active_google_user(%{"id" => "user2"})]}
           end
 
         Req.Test.json(conn, response)
@@ -1033,6 +1182,7 @@ defmodule Portal.Google.APIClientTest do
       assert page1_params["domain"] == @test_domain
       assert page1_params["maxResults"] == "500"
       assert page1_params["projection"] == "full"
+      assert page1_params["query"] == "isSuspended=false isArchived=false"
       refute Map.has_key?(page1_params, "pageToken")
 
       assert_receive {:page_params, 1, page2_params}
@@ -1040,6 +1190,7 @@ defmodule Portal.Google.APIClientTest do
       assert page2_params["domain"] == @test_domain
       assert page2_params["maxResults"] == "500"
       assert page2_params["projection"] == "full"
+      assert page2_params["query"] == "isSuspended=false isArchived=false"
       assert page2_params["pageToken"] == "token123"
     end
   end
@@ -1053,6 +1204,12 @@ defmodule Portal.Google.APIClientTest do
       end)
 
     Enum.join(encoded_parts, "") <> "--#{boundary}--"
+  end
+
+  defp active_google_user(attrs) do
+    attrs
+    |> Map.put_new("suspended", false)
+    |> Map.put_new("archived", false)
   end
 
   defp assert_authorization_header(conn, expected_token) do

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -47,7 +47,7 @@ defmodule Portal.Google.SyncTest do
 
     parts =
       Enum.map(users, fn user ->
-        json = JSON.encode!(user)
+        json = user |> active_google_user() |> JSON.encode!()
 
         "--#{boundary}\r\nContent-Type: application/http\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n#{json}\r\n"
       end)
@@ -185,11 +185,11 @@ defmodule Portal.Google.SyncTest do
 
         Req.Test.json(conn, %{
           "users" => [
-            %{
+            active_google_user(%{
               "id" => "user1",
               "primaryEmail" => "user1@example.com",
               "name" => %{"fullName" => "User One", "givenName" => "User", "familyName" => "One"}
-            }
+            })
           ]
         })
       end)
@@ -656,6 +656,228 @@ defmodule Portal.Google.SyncTest do
       new_identities = Repo.all(Portal.ExternalIdentity)
       assert length(new_identities) == 1
       assert hd(new_identities).idp_id == "new_user"
+    end
+
+    test "skips suspended and archived users and removes their stale identities" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+      old_synced_at = DateTime.utc_now() |> DateTime.add(-3600, :second)
+
+      for {email, idp_id} <- [
+            {"suspended@example.com", "suspended_user"},
+            {"archived@example.com", "archived_user"}
+          ] do
+        {:ok, actor} =
+          %Portal.Actor{
+            type: :account_user,
+            account_id: account.id,
+            email: email,
+            name: email,
+            created_by_directory_id: directory.id
+          }
+          |> Repo.insert()
+
+        {:ok, _identity} =
+          %Portal.ExternalIdentity{
+            account_id: account.id,
+            actor_id: actor.id,
+            directory_id: directory.id,
+            idp_id: idp_id,
+            email: email,
+            issuer: "https://accounts.google.com",
+            last_synced_at: old_synced_at
+          }
+          |> Repo.insert()
+      end
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "active_user", "type" => "USER", "email" => "active@example.com"},
+            %{"id" => "suspended_user", "type" => "USER", "email" => "suspended@example.com"},
+            %{"id" => "archived_user", "type" => "USER", "email" => "archived@example.com"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "active_user",
+            "primaryEmail" => "active@example.com",
+            "name" => %{"fullName" => "Active User"}
+          },
+          %{
+            "id" => "suspended_user",
+            "primaryEmail" => "suspended@example.com",
+            "name" => %{"fullName" => "Suspended User"},
+            "suspended" => true
+          },
+          %{
+            "id" => "archived_user",
+            "primaryEmail" => "archived@example.com",
+            "name" => %{"fullName" => "Archived User"},
+            "archived" => true
+          }
+        ])
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      identities = Repo.all(Portal.ExternalIdentity)
+      assert Enum.map(identities, & &1.email) == ["active@example.com"]
+
+      memberships = Repo.all(Portal.Membership)
+      assert length(memberships) == 1
+
+      refute Repo.get_by(Portal.Actor, email: "suspended@example.com")
+      refute Repo.get_by(Portal.Actor, email: "archived@example.com")
+    end
+
+    test "deletes previously synced suspended users on a later sync" do
+      account = account_fixture()
+
+      directory =
+        google_directory_fixture(
+          account: account,
+          domain: "example.com",
+          group_sync_mode: :all,
+          orgunit_sync_enabled: false
+        )
+
+      expect_google_group_sync_round(
+        [
+          %{"id" => "active_user", "type" => "USER", "email" => "active@example.com"},
+          %{"id" => "user_to_suspend", "type" => "USER", "email" => "suspend-me@example.com"}
+        ],
+        [
+          %{
+            "id" => "active_user",
+            "primaryEmail" => "active@example.com",
+            "name" => %{"fullName" => "Active User"}
+          },
+          %{
+            "id" => "user_to_suspend",
+            "primaryEmail" => "suspend-me@example.com",
+            "name" => %{"fullName" => "Suspend Me"}
+          }
+        ]
+      )
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      suspended_identity =
+        Repo.get_by!(Portal.ExternalIdentity,
+          directory_id: directory.id,
+          idp_id: "user_to_suspend"
+        )
+
+      suspended_actor = Repo.get_by!(Portal.Actor, id: suspended_identity.actor_id)
+
+      expect_google_group_sync_round(
+        [
+          %{"id" => "active_user", "type" => "USER", "email" => "active@example.com"},
+          %{"id" => "user_to_suspend", "type" => "USER", "email" => "suspend-me@example.com"}
+        ],
+        [
+          %{
+            "id" => "active_user",
+            "primaryEmail" => "active@example.com",
+            "name" => %{"fullName" => "Active User"}
+          },
+          %{
+            "id" => "user_to_suspend",
+            "primaryEmail" => "suspend-me@example.com",
+            "name" => %{"fullName" => "Suspend Me"},
+            "suspended" => true
+          }
+        ]
+      )
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      identities = Repo.all(Portal.ExternalIdentity)
+      assert Enum.map(identities, & &1.email) == ["active@example.com"]
+      assert length(Repo.all(Portal.Membership)) == 1
+
+      refute Repo.get_by(Portal.ExternalIdentity, id: suspended_identity.id)
+      refute Repo.get_by(Portal.Actor, id: suspended_actor.id)
+    end
+
+    test "does not refetch suspended users that appear in multiple groups" do
+      account = account_fixture()
+      directory = google_directory_fixture(account: account, domain: "example.com")
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{
+          "groups" => [
+            %{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"},
+            %{"id" => "group2", "name" => "Operations", "email" => "ops@example.com"}
+          ]
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        Req.Test.json(conn, %{"organizationUnits" => []})
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group1/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "suspended_user", "type" => "USER", "email" => "suspended@example.com"}
+          ]
+        })
+      end)
+
+      # The suspended user should only be fetched once across both groups.
+      Req.Test.expect(APIClient, fn conn ->
+        assert conn.method == "POST"
+        assert String.contains?(conn.request_path, "/batch")
+
+        respond_with_batch_users(conn, [
+          %{
+            "id" => "suspended_user",
+            "primaryEmail" => "suspended@example.com",
+            "name" => %{"fullName" => "Suspended User"},
+            "suspended" => true
+          }
+        ])
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        assert String.contains?(conn.request_path, "/groups/group2/members")
+
+        Req.Test.json(conn, %{
+          "members" => [
+            %{"id" => "suspended_user", "type" => "USER", "email" => "suspended@example.com"}
+          ]
+        })
+      end)
+
+      assert :ok = perform_job(Sync, %{"directory_id" => directory.id})
+
+      assert Repo.all(Portal.ExternalIdentity) == []
+      assert Repo.all(Portal.Membership) == []
     end
 
     test "uses legacy service account key when present" do
@@ -1927,7 +2149,9 @@ defmodule Portal.Google.SyncTest do
       end)
 
       Req.Test.expect(APIClient, fn conn ->
-        Req.Test.json(conn, %{"users" => [%{"primaryEmail" => "missing-id@example.com"}]})
+        Req.Test.json(conn, %{
+          "users" => [active_google_user(%{"primaryEmail" => "missing-id@example.com"})]
+        })
       end)
 
       assert_raise SyncError, ~r/user missing 'id' field in org unit ou1/, fn ->
@@ -1958,11 +2182,11 @@ defmodule Portal.Google.SyncTest do
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.json(conn, %{
           "users" => [
-            %{
+            active_google_user(%{
               "id" => "ou_user_1",
               "primaryEmail" => "ou1@example.com",
               "name" => %{"fullName" => "OU User"}
-            }
+            })
           ]
         })
       end)
@@ -2056,5 +2280,35 @@ defmodule Portal.Google.SyncTest do
 
       assert memberships_log =~ "Failed to upsert memberships"
     end
+  end
+
+  defp expect_google_group_sync_round(group_members, batch_users) do
+    Req.Test.expect(APIClient, fn conn ->
+      Req.Test.json(conn, %{"access_token" => "test_token", "expires_in" => 3600})
+    end)
+
+    Req.Test.expect(APIClient, fn conn ->
+      Req.Test.json(conn, %{
+        "groups" => [%{"id" => "group1", "name" => "Engineering", "email" => "eng@example.com"}]
+      })
+    end)
+
+    Req.Test.expect(APIClient, fn conn ->
+      assert String.contains?(conn.request_path, "/groups/group1/members")
+      Req.Test.json(conn, %{"members" => group_members})
+    end)
+
+    Req.Test.expect(APIClient, fn conn ->
+      assert conn.method == "POST"
+      assert String.contains?(conn.request_path, "/batch")
+
+      respond_with_batch_users(conn, batch_users)
+    end)
+  end
+
+  defp active_google_user(attrs) do
+    attrs
+    |> Map.put_new("suspended", false)
+    |> Map.put_new("archived", false)
   end
 end

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -265,7 +265,13 @@ defmodule Portal.Okta.SyncTest do
 
       identities = Repo.all(ExternalIdentity)
       identity_emails = Enum.map(identities, & &1.email) |> Enum.sort()
-      assert identity_emails == ["active@example.com", "provisioned@example.com"]
+
+      assert identity_emails == [
+               "active@example.com",
+               "locked-out@example.com",
+               "provisioned@example.com"
+             ]
+
       assert Repo.all(Group) == []
       assert Repo.all(Membership) == []
       assert log =~ "Skipping Okta app user with missing status"
@@ -1219,7 +1225,7 @@ defmodule Portal.Okta.SyncTest do
         end)
 
       memberships = Repo.all(Membership)
-      assert length(memberships) == 2
+      assert length(memberships) == 3
       assert log =~ "Skipping Okta group member with missing status"
       assert log =~ "user_missing_status"
     end

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -3,6 +3,7 @@ defmodule Portal.Okta.SyncTest do
   use Oban.Testing, repo: Portal.Repo
 
   import Ecto.Query
+  import ExUnit.CaptureLog
   import Portal.AccountFixtures
   import Portal.OktaDirectoryFixtures
 
@@ -81,6 +82,7 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{
                       "email" => "alice@example.com",
                       "firstName" => "Alice",
@@ -144,6 +146,205 @@ defmodule Portal.Okta.SyncTest do
       assert updated_directory.error_message == nil
     end
 
+    test "filters app users by syncable Okta status" do
+      account = account_fixture(features: %{idp_sync: true})
+
+      directory =
+        okta_directory_fixture(
+          account: account,
+          private_key_jwk: @test_private_key_jwk,
+          kid: "test_kid"
+        )
+
+      Req.Test.expect(APIClient, 100, fn %{request_path: path} = conn ->
+        cond do
+          String.ends_with?(path, "/oauth2/v1/token") ->
+            Req.Test.json(conn, %{
+              "access_token" => @test_access_token,
+              "token_type" => "DPoP",
+              "expires_in" => 3600
+            })
+
+          String.ends_with?(path, "/oauth2/v1/introspect") ->
+            Req.Test.json(conn, %{
+              "active" => true,
+              "scope" => "okta.apps.read okta.users.read okta.groups.read"
+            })
+
+          String.ends_with?(path, "/apps") and not String.contains?(path, "/users") and
+              not String.contains?(path, "/groups") ->
+            Req.Test.json(conn, [
+              %{"id" => "app_123", "label" => "Test App"}
+            ])
+
+          String.contains?(path, "/apps/app_123/users") ->
+            Req.Test.json(conn, [
+              %{
+                "id" => "appuser_1",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_active",
+                    "status" => "ACTIVE",
+                    "profile" => %{
+                      "email" => "active@example.com",
+                      "firstName" => "Active",
+                      "lastName" => "User"
+                    }
+                  }
+                }
+              },
+              %{
+                "id" => "appuser_2",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_provisioned",
+                    "status" => "PROVISIONED",
+                    "profile" => %{
+                      "email" => "provisioned@example.com",
+                      "firstName" => "Provisioned",
+                      "lastName" => "User"
+                    }
+                  }
+                }
+              },
+              %{
+                "id" => "appuser_3",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_locked_out",
+                    "status" => "LOCKED_OUT",
+                    "profile" => %{
+                      "email" => "locked-out@example.com",
+                      "firstName" => "Locked",
+                      "lastName" => "Out"
+                    }
+                  }
+                }
+              },
+              %{
+                "id" => "appuser_4",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_suspended",
+                    "status" => "SUSPENDED",
+                    "profile" => %{
+                      "email" => "suspended@example.com",
+                      "firstName" => "Suspended",
+                      "lastName" => "User"
+                    }
+                  }
+                }
+              },
+              %{
+                "id" => "appuser_5",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_missing_status",
+                    "profile" => %{
+                      "email" => "missing-status@example.com",
+                      "firstName" => "Missing",
+                      "lastName" => "Status"
+                    }
+                  }
+                }
+              }
+            ])
+
+          String.contains?(path, "/apps/app_123/groups") ->
+            Req.Test.json(conn, [])
+
+          true ->
+            Req.Test.json(conn, %{"error" => "unexpected: #{path}"})
+        end
+      end)
+
+      log =
+        capture_log(fn ->
+          assert :ok = perform_job(Sync, %{directory_id: directory.id})
+        end)
+
+      identities = Repo.all(ExternalIdentity)
+      identity_emails = Enum.map(identities, & &1.email) |> Enum.sort()
+      assert identity_emails == ["active@example.com", "provisioned@example.com"]
+      assert Repo.all(Group) == []
+      assert Repo.all(Membership) == []
+      assert log =~ "Skipping Okta app user with missing status"
+      assert log =~ "user_missing_status"
+    end
+
+    test "deletes previously synced suspended users on a later sync" do
+      account = account_fixture(features: %{idp_sync: true})
+
+      directory =
+        okta_directory_fixture(
+          account: account,
+          private_key_jwk: @test_private_key_jwk,
+          kid: "test_kid"
+        )
+
+      expect_okta_identity_sync([
+        %{
+          "id" => "user_active",
+          "status" => "ACTIVE",
+          "profile" => %{
+            "email" => "active@example.com",
+            "firstName" => "Active",
+            "lastName" => "User"
+          }
+        },
+        %{
+          "id" => "user_suspend_later",
+          "status" => "ACTIVE",
+          "profile" => %{
+            "email" => "suspend-me@example.com",
+            "firstName" => "Suspend",
+            "lastName" => "Me"
+          }
+        }
+      ])
+
+      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+
+      suspended_identity =
+        Repo.get_by!(ExternalIdentity,
+          directory_id: directory.id,
+          idp_id: "user_suspend_later"
+        )
+
+      suspended_actor = Repo.get_by!(Portal.Actor, id: suspended_identity.actor_id)
+
+      expect_okta_identity_sync([
+        %{
+          "id" => "user_active",
+          "status" => "ACTIVE",
+          "profile" => %{
+            "email" => "active@example.com",
+            "firstName" => "Active",
+            "lastName" => "User"
+          }
+        },
+        %{
+          "id" => "user_suspend_later",
+          "status" => "SUSPENDED",
+          "profile" => %{
+            "email" => "suspend-me@example.com",
+            "firstName" => "Suspend",
+            "lastName" => "Me"
+          }
+        }
+      ])
+
+      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+
+      identities = Repo.all(ExternalIdentity)
+      assert Enum.map(identities, & &1.email) == ["active@example.com"]
+      assert Repo.all(Group) == []
+      assert Repo.all(Membership) == []
+
+      refute Repo.get_by(ExternalIdentity, id: suspended_identity.id)
+      refute Repo.get_by(Portal.Actor, id: suspended_actor.id)
+    end
+
     test "reconnects orphaned policies after sync" do
       account = account_fixture(features: %{idp_sync: true})
 
@@ -201,6 +402,7 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{
                       "email" => "alice@example.com",
                       "firstName" => "Alice",
@@ -319,6 +521,7 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{
                       # email is missing!
                       "firstName" => "Alice",
@@ -383,6 +586,7 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{
                       "email" => nil,
                       "firstName" => "Alice",
@@ -442,6 +646,7 @@ defmodule Portal.Okta.SyncTest do
               "_embedded" => %{
                 "user" => %{
                   "id" => "user_123",
+                  "status" => "ACTIVE",
                   "profile" => %{
                     "email" => "alice@example.com",
                     "firstName" => "Alice",
@@ -505,6 +710,7 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{
                       "email" => "alice@example.com",
                       "firstName" => "Alice",
@@ -777,6 +983,48 @@ defmodule Portal.Okta.SyncTest do
       assert error.step == :stream_app_users
     end
 
+    test "raises SyncError when app user payload is missing _embedded.user" do
+      account = account_fixture(features: %{idp_sync: true})
+
+      directory =
+        okta_directory_fixture(
+          account: account,
+          private_key_jwk: @test_private_key_jwk,
+          kid: "test_kid"
+        )
+
+      Req.Test.expect(APIClient, 10, fn %{request_path: path} = conn ->
+        cond do
+          String.ends_with?(path, "/oauth2/v1/token") ->
+            Req.Test.json(conn, %{"access_token" => @test_access_token})
+
+          String.ends_with?(path, "/oauth2/v1/introspect") ->
+            Req.Test.json(conn, %{
+              "active" => true,
+              "scope" => "okta.apps.read okta.users.read okta.groups.read"
+            })
+
+          String.ends_with?(path, "/apps") and not String.contains?(path, "/users") and
+              not String.contains?(path, "/groups") ->
+            Req.Test.json(conn, [%{"id" => "app_123"}])
+
+          String.contains?(path, "/apps/app_123/users") ->
+            Req.Test.json(conn, [%{"id" => "appuser_1", "_embedded" => %{}}])
+
+          true ->
+            Req.Test.json(conn, %{"error" => "unexpected: #{path}"})
+        end
+      end)
+
+      error =
+        assert_raise SyncError, fn ->
+          perform_job(Sync, %{directory_id: directory.id})
+        end
+
+      assert error.step == :stream_app_users
+      assert Exception.message(error) =~ "missing '_embedded.user' payload"
+    end
+
     test "raises SyncError when app group streaming yields an error" do
       account = account_fixture(features: %{idp_sync: true})
 
@@ -823,7 +1071,52 @@ defmodule Portal.Okta.SyncTest do
       assert error.step == :stream_app_groups
     end
 
-    test "ignores inactive group members" do
+    test "raises SyncError when app group payload is missing _embedded.group" do
+      account = account_fixture(features: %{idp_sync: true})
+
+      directory =
+        okta_directory_fixture(
+          account: account,
+          private_key_jwk: @test_private_key_jwk,
+          kid: "test_kid"
+        )
+
+      Req.Test.expect(APIClient, 10, fn %{request_path: path} = conn ->
+        cond do
+          String.ends_with?(path, "/oauth2/v1/token") ->
+            Req.Test.json(conn, %{"access_token" => @test_access_token})
+
+          String.ends_with?(path, "/oauth2/v1/introspect") ->
+            Req.Test.json(conn, %{
+              "active" => true,
+              "scope" => "okta.apps.read okta.users.read okta.groups.read"
+            })
+
+          String.ends_with?(path, "/apps") and not String.contains?(path, "/users") and
+              not String.contains?(path, "/groups") ->
+            Req.Test.json(conn, [%{"id" => "app_123"}])
+
+          String.contains?(path, "/apps/app_123/users") ->
+            Req.Test.json(conn, [])
+
+          String.contains?(path, "/apps/app_123/groups") ->
+            Req.Test.json(conn, [%{"id" => "appgroup_1", "_embedded" => %{}}])
+
+          true ->
+            Req.Test.json(conn, %{"error" => "unexpected: #{path}"})
+        end
+      end)
+
+      error =
+        assert_raise SyncError, fn ->
+          perform_job(Sync, %{directory_id: directory.id})
+        end
+
+      assert error.step == :stream_app_groups
+      assert Exception.message(error) =~ "missing '_embedded.group' payload"
+    end
+
+    test "filters group members by syncable Okta status" do
       account = account_fixture(features: %{idp_sync: true})
 
       directory =
@@ -855,10 +1148,39 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{
                       "email" => "alice@example.com",
                       "firstName" => "Alice",
                       "lastName" => "Smith"
+                    }
+                  }
+                }
+              },
+              %{
+                "id" => "appuser_2",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_456",
+                    "status" => "PASSWORD_EXPIRED",
+                    "profile" => %{
+                      "email" => "bob@example.com",
+                      "firstName" => "Bob",
+                      "lastName" => "Jones"
+                    }
+                  }
+                }
+              },
+              %{
+                "id" => "appuser_3",
+                "_embedded" => %{
+                  "user" => %{
+                    "id" => "user_789",
+                    "status" => "ACTIVE",
+                    "profile" => %{
+                      "email" => "charlie@example.com",
+                      "firstName" => "Charlie",
+                      "lastName" => "Brown"
                     }
                   }
                 }
@@ -881,7 +1203,9 @@ defmodule Portal.Okta.SyncTest do
           String.contains?(path, "/groups/group_123/users") ->
             Req.Test.json(conn, [
               %{"id" => "user_123", "status" => "ACTIVE"},
-              %{"id" => "user_456", "status" => "SUSPENDED"}
+              %{"id" => "user_456", "status" => "PASSWORD_EXPIRED"},
+              %{"id" => "user_789", "status" => "LOCKED_OUT"},
+              %{"id" => "user_missing_status"}
             ])
 
           true ->
@@ -889,10 +1213,15 @@ defmodule Portal.Okta.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Sync, %{directory_id: directory.id})
+      log =
+        capture_log(fn ->
+          assert :ok = perform_job(Sync, %{directory_id: directory.id})
+        end)
 
       memberships = Repo.all(Membership)
-      assert length(memberships) == 1
+      assert length(memberships) == 2
+      assert log =~ "Skipping Okta group member with missing status"
+      assert log =~ "user_missing_status"
     end
 
     test "raises SyncError when group member streaming yields an error" do
@@ -997,6 +1326,7 @@ defmodule Portal.Okta.SyncTest do
                 "_embedded" => %{
                   "user" => %{
                     "id" => "user_123",
+                    "status" => "ACTIVE",
                     "profile" => %{"firstName" => "Alice", "lastName" => "Smith"}
                   }
                 }
@@ -1263,6 +1593,7 @@ defmodule Portal.Okta.SyncTest do
                   "_embedded" => %{
                     "user" => %{
                       "id" => "okta_user_#{i}",
+                      "status" => "ACTIVE",
                       "profile" => %{
                         "email" => "user#{i}@example.com",
                         "firstName" => "User",
@@ -1361,6 +1692,7 @@ defmodule Portal.Okta.SyncTest do
                   "_embedded" => %{
                     "user" => %{
                       "id" => "okta_user_#{i}",
+                      "status" => "ACTIVE",
                       "profile" => %{
                         "email" => "user#{i}@example.com",
                         "firstName" => "User",
@@ -1509,5 +1841,48 @@ defmodule Portal.Okta.SyncTest do
                  [{"group1", "user1"}, {"group1", "user1"}]
                )
     end
+  end
+
+  defp expect_okta_identity_sync(app_users) do
+    Req.Test.expect(APIClient, 5, fn %{request_path: path} = conn ->
+      cond do
+        String.ends_with?(path, "/oauth2/v1/token") ->
+          Req.Test.json(conn, %{
+            "access_token" => @test_access_token,
+            "token_type" => "DPoP",
+            "expires_in" => 3600
+          })
+
+        String.ends_with?(path, "/oauth2/v1/introspect") ->
+          Req.Test.json(conn, %{
+            "active" => true,
+            "scope" => "okta.apps.read okta.users.read okta.groups.read"
+          })
+
+        String.ends_with?(path, "/apps") and not String.contains?(path, "/users") and
+            not String.contains?(path, "/groups") ->
+          Req.Test.json(conn, [
+            %{"id" => "app_123", "label" => "Test App"}
+          ])
+
+        String.contains?(path, "/apps/app_123/users") ->
+          users =
+            Enum.with_index(app_users, 1)
+            |> Enum.map(fn {user, index} ->
+              %{
+                "id" => "appuser_#{index}",
+                "_embedded" => %{"user" => user}
+              }
+            end)
+
+          Req.Test.json(conn, users)
+
+        String.contains?(path, "/apps/app_123/groups") ->
+          Req.Test.json(conn, [])
+
+        true ->
+          Req.Test.json(conn, %{"error" => "unexpected: #{path}"})
+      end
+    end)
   end
 end

--- a/website/src/app/kb/directory-sync/entra/readme.mdx
+++ b/website/src/app/kb/directory-sync/entra/readme.mdx
@@ -101,6 +101,24 @@ Directory sync runs automatically every 2 hours. To trigger a sync immediately,
 click the **Sync Now** button on the directory card in
 `Settings -> Directory Sync`.
 
+## Disabled and deleted users
+
+Firezone removes deleted Entra users on the next sync. It also filters out
+users where Microsoft Entra marks `accountEnabled` as `false`.
+
+- **API-side filtering:** When Firezone streams group members from Microsoft
+  Graph, it requests only users where `accountEnabled eq true`.
+- **Defense in depth:** Firezone also re-checks `accountEnabled` after
+  receiving user payloads, including batched lookups for directly assigned
+  users.
+- **Defensive handling:** If Microsoft Graph omits `accountEnabled`
+  unexpectedly, Firezone logs the event and skips that user instead of treating
+  them as active.
+
+Once a synced Entra user is deleted or disabled, their Firezone identity is
+removed on the next sync. This signs them out of Firezone and prevents new
+sign-ins through the synced Entra identity.
+
 ## Troubleshooting
 
 ### "Unauthorized" or "Access Denied" error

--- a/website/src/app/kb/directory-sync/google/readme.mdx
+++ b/website/src/app/kb/directory-sync/google/readme.mdx
@@ -137,6 +137,23 @@ Directory sync runs automatically every 2 hours. To trigger a sync immediately,
 click the **Sync Now** button on the directory card in
 `Settings -> Directory Sync`.
 
+## Deleted, suspended, and archived users
+
+Firezone removes deleted Google Workspace users on the next sync. It also
+filters out users marked as **suspended** or **archived**.
+
+- **API-side filtering:** Firezone requests active users with
+  `isSuspended=false isArchived=false`.
+- **Defense in depth:** Firezone also re-checks the `suspended` and `archived`
+  flags after receiving user payloads, including batch lookups used when
+  syncing group memberships.
+- **Defensive handling:** If Google omits either flag unexpectedly, Firezone
+  logs the event and skips that user instead of treating them as active.
+
+Once a synced Google user is deleted, suspended, or archived, their Firezone
+identity is removed on the next sync. This signs them out of Firezone and
+prevents new sign-ins through the synced Google identity.
+
 ## Troubleshooting
 
 ### "Not Authorized" or "Access Denied" error

--- a/website/src/app/kb/directory-sync/okta/readme.mdx
+++ b/website/src/app/kb/directory-sync/okta/readme.mdx
@@ -351,9 +351,9 @@ Firezone removes deleted Okta users on the next sync. It also filters users by
 their Okta `status`.
 
 - **Synced states:** `ACTIVE`, `STAGED`, `PROVISIONED`, `RECOVERY`, and
-  `PASSWORD_EXPIRED`
+  `PASSWORD_EXPIRED`, and `LOCKED_OUT`
 - **Filtered-out states:** Firezone excludes all other Okta states, including
-  `LOCKED_OUT`, `SUSPENDED`, and `DEPROVISIONED`.
+  `SUSPENDED` and `DEPROVISIONED`.
 - **Defense in depth:** Firezone re-checks `status` after receiving both app
   user and group member payloads.
 - **Defensive handling:** If Okta omits `status` unexpectedly, Firezone logs

--- a/website/src/app/kb/directory-sync/okta/readme.mdx
+++ b/website/src/app/kb/directory-sync/okta/readme.mdx
@@ -345,6 +345,24 @@ Directory sync runs automatically every 2 hours. To trigger a sync immediately,
 click the **Sync Now** button on the directory card in
 `Settings -> Directory Sync`.
 
+## Deleted users and Okta user states
+
+Firezone removes deleted Okta users on the next sync. It also filters users by
+their Okta `status`.
+
+- **Synced states:** `ACTIVE`, `STAGED`, `PROVISIONED`, `RECOVERY`, and
+  `PASSWORD_EXPIRED`
+- **Filtered-out states:** Firezone excludes all other Okta states, including
+  `LOCKED_OUT`, `SUSPENDED`, and `DEPROVISIONED`.
+- **Defense in depth:** Firezone re-checks `status` after receiving both app
+  user and group member payloads.
+- **Defensive handling:** If Okta omits `status` unexpectedly, Firezone logs
+  the event and skips that user instead of treating them as active.
+
+Once a synced Okta user is deleted or transitions to a filtered-out state,
+their Firezone identity is removed on the next sync. This signs them out of
+Firezone and prevents new sign-ins through the synced Okta identity.
+
 ## Troubleshooting
 
 ### "Unauthorized" or "Forbidden" error

--- a/website/src/app/kb/directory-sync/readme.mdx
+++ b/website/src/app/kb/directory-sync/readme.mdx
@@ -1,6 +1,7 @@
 import Alert from "@/components/DocsAlert";
 import PlanBadge from "@/components/PlanBadge";
 import SupportOptions from "@/components/SupportOptions";
+import { TabsGroup, TabsItem } from "@/components/Tabs";
 
 <PlanBadge plans={["enterprise"]}>
 
@@ -47,6 +48,52 @@ immediately **signed out of all Client and admin portal sessions**.
 
 This ensures terminated employees will have all Firezone access revoked upon the
 next sync after deleting or suspending them in your identity provider.
+
+<TabsGroup>
+<TabsItem title="Google Workspace" active>
+
+Firezone treats **suspended**, **archived**, and **deleted** Google Workspace
+users as inactive for directory sync.
+
+- **API-side filtering:** User list queries include
+  `isSuspended=false isArchived=false`.
+- **Defense in depth:** Firezone also re-checks the `suspended` and `archived`
+  flags after receiving user payloads, including batch lookups used for group
+  membership sync.
+- **Defensive handling:** If Google omits either flag unexpectedly, Firezone
+  logs the event and skips that user.
+
+</TabsItem>
+<TabsItem title="Microsoft Entra ID">
+
+Firezone treats **disabled** and **deleted** Entra users as inactive for
+directory sync.
+
+- **API-side filtering:** When Firezone streams group members from Microsoft
+  Graph, it requests only users where `accountEnabled eq true`.
+- **Defense in depth:** Firezone also re-checks `accountEnabled` after
+  receiving user payloads, including batched user lookups for direct
+  assignments.
+- **Defensive handling:** If Microsoft Graph omits `accountEnabled`
+  unexpectedly, Firezone logs the event and skips that user.
+
+</TabsItem>
+<TabsItem title="Okta">
+
+Firezone treats **deleted** users and users in non-syncable Okta states as
+inactive for directory sync.
+
+- **Synced states:** `ACTIVE`, `STAGED`, `PROVISIONED`, `RECOVERY`, and
+  `PASSWORD_EXPIRED`
+- **Filtered-out states:** Firezone excludes all other Okta states, including
+  `LOCKED_OUT`, `SUSPENDED`, and `DEPROVISIONED`.
+- **Defense in depth:** Firezone re-checks `status` for both app users and
+  group members after receiving each response.
+- **Defensive handling:** If Okta omits `status` unexpectedly, Firezone logs
+  the event and skips that user.
+
+</TabsItem>
+</TabsGroup>
 
 ### Deleting a group or organizational unit
 

--- a/website/src/app/kb/directory-sync/readme.mdx
+++ b/website/src/app/kb/directory-sync/readme.mdx
@@ -84,9 +84,9 @@ Firezone treats **deleted** users and users in non-syncable Okta states as
 inactive for directory sync.
 
 - **Synced states:** `ACTIVE`, `STAGED`, `PROVISIONED`, `RECOVERY`, and
-  `PASSWORD_EXPIRED`
+  `PASSWORD_EXPIRED`, and `LOCKED_OUT`
 - **Filtered-out states:** Firezone excludes all other Okta states, including
-  `LOCKED_OUT`, `SUSPENDED`, and `DEPROVISIONED`.
+  `SUSPENDED` and `DEPROVISIONED`.
 - **Defense in depth:** Firezone re-checks `status` for both app users and
   group members after receiving each response.
 - **Defensive handling:** If Okta omits `status` unexpectedly, Firezone logs


### PR DESCRIPTION
Fixes an issue where identities that have been suspended or archived at the IdP were not being deleted on the Firezone side.

Tested manually by syncing Google/Entra users, suspending / disabling them, then re-enabling.

Credit to @Intuinewin for the finding.