### PR TITLE
feat(apple): keep app running

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		8DCC022A28D512AE007E12D2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8DCC022928D512AE007E12D2 /* Preview Assets.xcassets */; };
 		8DE452A82CE6C194004CEDF9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5047E82CE6A8F4009802E9 /* main.swift */; };
 		8DFDEAC72D2CEBA500615095 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8DA12C322BB7DA04007D91EB /* PrivacyInfo.xcprivacy */; };
+		9A1000012F10000100BEEF01 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000042F10000100BEEF01 /* main.swift */; };
 		C1892134991C462C8E137DE3 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C09DC14A4A04715A37BC04C /* Channel.swift */; };
 		C4B08E1145E04823BC25E00D /* SessionEventLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */; };
 		CCC04BEF428B758D9BB5F842 /* connlib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2847ACC9D73EA6F356F2DEE1 /* connlib.swift */; };
@@ -59,6 +60,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8D5047E22CE6A8F4009802E9;
 			remoteInfo = FirezoneNetworkExtensionmacOS;
+		};
+		9A10000B2F10000100BEEF01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8DCC021128D512AC007E12D2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A1000082F10000100BEEF01;
+			remoteInfo = KeepFirezoneRunning;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -119,6 +127,10 @@
 		8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = xcconfig/config.xcconfig; sourceTree = "<group>"; };
 		8DE1077A2D2313EB00DB5A45 /* Info.iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.iOS.plist; sourceTree = "<group>"; };
 		8DE1077B2D2313EB00DB5A45 /* Info.macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.macOS.plist; sourceTree = "<group>"; };
+		9A1000022F10000100BEEF01 /* KeepFirezoneRunning.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KeepFirezoneRunning.entitlements; sourceTree = "<group>"; };
+		9A1000032F10000100BEEF01 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A1000042F10000100BEEF01 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		9A1000052F10000100BEEF01 /* KeepFirezoneRunning.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeepFirezoneRunning.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E14DC5E933BD4F63A844A8A6 /* SessionEventLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionEventLoop.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -150,6 +162,13 @@
 			files = (
 				05D3BB2128FDE9C000BC3727 /* NetworkExtension.framework in Frameworks */,
 				79756C6629704A7A0018E2D5 /* FirezoneKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A1000072F10000100BEEF01 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,12 +224,23 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9A1000062F10000100BEEF01 /* KeepFirezoneRunning */ = {
+			isa = PBXGroup;
+			children = (
+				9A1000022F10000100BEEF01 /* KeepFirezoneRunning.entitlements */,
+				9A1000032F10000100BEEF01 /* Info.plist */,
+				9A1000042F10000100BEEF01 /* main.swift */,
+			);
+			path = KeepFirezoneRunning;
+			sourceTree = "<group>";
+		};
 		8DCC021028D512AC007E12D2 = {
 			isa = PBXGroup;
 			children = (
 				8DA12C322BB7DA04007D91EB /* PrivacyInfo.xcprivacy */,
 				8DD2C4C2297B37BA00F984BF /* Packages */,
 				8DCC021B28D512AC007E12D2 /* Firezone */,
+				9A1000062F10000100BEEF01 /* KeepFirezoneRunning */,
 				05833DF928F73B070008FAB0 /* FirezoneNetworkExtension */,
 				8DCC021A28D512AC007E12D2 /* Products */,
 				8D3F90C328D64FAD00980124 /* Frameworks */,
@@ -222,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				8DCC021928D512AC007E12D2 /* Firezone.app */,
+				9A1000052F10000100BEEF01 /* KeepFirezoneRunning.app */,
 				05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */,
 				8D5047E32CE6A8F4009802E9 /* dev.firezone.firezone.network-extension.systemextension */,
 			);
@@ -311,12 +342,14 @@
 				8DCC021528D512AC007E12D2 /* Sources */,
 				8DCC021628D512AC007E12D2 /* Frameworks */,
 				8DCC021728D512AC007E12D2 /* Resources */,
+				8D0F0A012E9A000100BEEF01 /* Bundle keep app running agent */,
 				8DC169A32CFF77D1006801B5 /* Embed Foundation Extensions */,
 				8DC169A42CFF77D1006801B5 /* Embed System Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				9A10000C2F10000100BEEF01 /* PBXTargetDependency */,
 				8DC1699F2CFF77D1006801B5 /* PBXTargetDependency */,
 				8DC169A22CFF77D1006801B5 /* PBXTargetDependency */,
 			);
@@ -326,6 +359,25 @@
 			);
 			productName = Firezone;
 			productReference = 8DCC021928D512AC007E12D2 /* Firezone.app */;
+			productType = "com.apple.product-type.application";
+		};
+		9A1000082F10000100BEEF01 /* KeepFirezoneRunning */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A1000102F10000100BEEF01 /* Build configuration list for PBXNativeTarget "KeepFirezoneRunning" */;
+			buildPhases = (
+				9A10000A2F10000100BEEF01 /* Sources */,
+				9A1000072F10000100BEEF01 /* Frameworks */,
+				9A1000092F10000100BEEF01 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KeepFirezoneRunning;
+			packageProductDependencies = (
+			);
+			productName = KeepFirezoneRunning;
+			productReference = 9A1000052F10000100BEEF01 /* KeepFirezoneRunning.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -349,6 +401,9 @@
 						CreatedOnToolsVersion = 14.0;
 						LastSwiftMigration = 1400;
 					};
+					9A1000082F10000100BEEF01 = {
+						CreatedOnToolsVersion = 16.4;
+					};
 				};
 			};
 			buildConfigurationList = 8DCC021428D512AC007E12D2 /* Build configuration list for PBXProject "Firezone" */;
@@ -365,6 +420,7 @@
 			projectRoot = "";
 			targets = (
 				8DCC021828D512AC007E12D2 /* Firezone */,
+				9A1000082F10000100BEEF01 /* KeepFirezoneRunning */,
 				05CF1CEF290B1CEE00CF4755 /* FirezoneNetworkExtensioniOS */,
 				8D5047E22CE6A8F4009802E9 /* FirezoneNetworkExtensionmacOS */,
 			);
@@ -396,9 +452,38 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9A1000092F10000100BEEF01 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		8D0F0A012E9A000100BEEF01 /* Bundle keep app running agent */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/KeepFirezoneRunning.app",
+				"$(SRCROOT)/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template",
+			);
+			name = "Bundle keep app running agent";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LoginItems/KeepFirezoneRunning.app",
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LaunchAgents/$(PRODUCT_BUNDLE_IDENTIFIER).keep-app-running.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nif [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then\n  exit 0\nfi\nhelper_src=\"${BUILT_PRODUCTS_DIR}/KeepFirezoneRunning.app\"\nhelper_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LoginItems\"\nhelper_dst=\"${helper_dir}/KeepFirezoneRunning.app\"\nplist_template=\"${SRCROOT}/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template\"\nplist_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchAgents\"\nplist_dst=\"${plist_dir}/${PRODUCT_BUNDLE_IDENTIFIER}.keep-app-running.plist\"\nmkdir -p \"${helper_dir}\" \"${plist_dir}\"\nrm -rf \"${helper_dst}\"\n/usr/bin/ditto \"${helper_src}\" \"${helper_dst}\"\n/usr/bin/sed \"s#__PRODUCT_BUNDLE_IDENTIFIER__#${PRODUCT_BUNDLE_IDENTIFIER}#g\" \"${plist_template}\" > \"${plist_dst}\"\n";
+		};
 		8D40C0B72DD1335C00ACF8D7 /* Generate build number */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -524,6 +609,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9A10000A2F10000100BEEF01 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A1000012F10000100BEEF01 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -540,6 +633,14 @@
 			);
 			target = 8D5047E22CE6A8F4009802E9 /* FirezoneNetworkExtensionmacOS */;
 			targetProxy = 8DC169A12CFF77D1006801B5 /* PBXContainerItemProxy */;
+		};
+		9A10000C2F10000100BEEF01 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				macos,
+			);
+			target = 9A1000082F10000100BEEF01 /* KeepFirezoneRunning */;
+			targetProxy = 9A10000B2F10000100BEEF01 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1192,6 +1293,80 @@
 			};
 			name = Profile;
 		};
+		9A10000D2F10000100BEEF01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = KeepFirezoneRunning/KeepFirezoneRunning.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
+				CURRENT_PROJECT_VERSION = "$(inherited)";
+				DEVELOPMENT_TEAM = "$(inherited)";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KeepFirezoneRunning/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = dev.firezone.keep-firezone-running;
+				PRODUCT_NAME = KeepFirezoneRunning;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.2;
+			};
+			name = Debug;
+		};
+		9A10000E2F10000100BEEF01 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = KeepFirezoneRunning/KeepFirezoneRunning.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
+				CURRENT_PROJECT_VERSION = "$(inherited)";
+				DEVELOPMENT_TEAM = "$(inherited)";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KeepFirezoneRunning/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = dev.firezone.keep-firezone-running;
+				PRODUCT_NAME = KeepFirezoneRunning;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 6.2;
+			};
+			name = Release;
+		};
+		9A10000F2F10000100BEEF01 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8DDD0E8B2ADC6657001FA7E9 /* config.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = KeepFirezoneRunning/KeepFirezoneRunning.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
+				CURRENT_PROJECT_VERSION = "$(inherited)";
+				DEVELOPMENT_TEAM = "$(inherited)";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KeepFirezoneRunning/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = dev.firezone.keep-firezone-running;
+				PRODUCT_NAME = KeepFirezoneRunning;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.2;
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1231,6 +1406,16 @@
 				8DCC024428D512AE007E12D2 /* Debug */,
 				8DCC024528D512AE007E12D2 /* Release */,
 				A1B2C3D728D512AE007E12D2 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A1000102F10000100BEEF01 /* Build configuration list for PBXNativeTarget "KeepFirezoneRunning" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A10000D2F10000100BEEF01 /* Debug */,
+				9A10000E2F10000100BEEF01 /* Release */,
+				9A10000F2F10000100BEEF01 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -81,6 +81,14 @@ struct FirezoneApp: App {
         }
       }
       .menuBarExtraStyle(.menu)
+      .commands {
+        CommandGroup(replacing: .appTermination) {
+          Button(store.quitMenuTitle) {
+            store.quitApp()
+          }
+          .keyboardShortcut("q")
+        }
+      }
     #endif
   }
 

--- a/swift/apple/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template
+++ b/swift/apple/Firezone/LaunchAgents/dev.firezone.firezone.keep-app-running.plist.template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>__PRODUCT_BUNDLE_IDENTIFIER__.keep-app-running</string>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>__PRODUCT_BUNDLE_IDENTIFIER__</string>
+	</array>
+	<key>BundleProgram</key>
+	<string>Contents/Library/LoginItems/KeepFirezoneRunning.app/Contents/MacOS/KeepFirezoneRunning</string>
+	<key>KeepAlive</key>
+	<true/>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>Aqua</string>
+	</array>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist>

--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -1,6 +1,7 @@
 // Apple Developer account-specific configuration
 DEVELOPMENT_TEAM = 47R2M6779T
 PRODUCT_BUNDLE_IDENTIFIER = dev.firezone.firezone
+MAIN_APP_BUNDLE_ID = dev.firezone.firezone
 APP_GROUP_ID[sdk=macosx*] = 47R2M6779T.dev.firezone.firezone
 APP_GROUP_ID_PRE_1_4_0[sdk=macosx*] = 47R2M6779T.group.dev.firezone.firezone
 APP_GROUP_ID[sdk=iphoneos*] = group.dev.firezone.firezone

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -7,12 +7,26 @@
 import Foundation
 
 public struct SharedAccess {
+  private static let applicationSupportFolderName = "Application Support"
+  private static let keepAppRunningSentinelFileName = ".running"
+
   public static var baseFolderURL: URL {
     guard
       let url = FileManager.default.containerURL(
         forSecurityApplicationGroupIdentifier: BundleHelper.appGroupId)
     else {
       fatalError("Shared folder unavailable")
+    }
+    return url
+  }
+
+  public static var applicationSupportFolderURL: URL? {
+    let url =
+      baseFolderURL
+      .appendingPathComponent("Library")
+      .appendingPathComponent(applicationSupportFolderName)
+    guard ensureDirectoryExists(at: url.path) else {
+      return nil
     }
     return url
   }
@@ -71,6 +85,37 @@ public struct SharedAccess {
 
   public static var providerStopReasonURL: URL {
     baseFolderURL.appendingPathComponent("reason")
+  }
+
+  public static var keepAppRunningSentinelURL: URL? {
+    applicationSupportFolderURL?.appendingPathComponent(keepAppRunningSentinelFileName)
+  }
+
+  @discardableResult
+  public static func markAppRunning() -> Bool {
+    guard let sentinelURL = keepAppRunningSentinelURL else { return false }
+    do {
+      try Data().write(to: sentinelURL, options: .atomic)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  @discardableResult
+  public static func clearAppRunning() -> Bool {
+    guard let sentinelURL = keepAppRunningSentinelURL else { return false }
+
+    guard FileManager.default.fileExists(atPath: sentinelURL.path) else {
+      return true
+    }
+
+    do {
+      try FileManager.default.removeItem(at: sentinelURL)
+      return true
+    } catch {
+      return false
+    }
   }
 
   public static func ensureDirectoryExists(at path: String) -> Bool {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LaunchServicesManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LaunchServicesManager.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+  import Foundation
+  import ServiceManagement
+  import Sentry
+
+  extension SMAppService.Status {
+    var isRegistered: Bool {
+      switch self {
+      case .enabled, .requiresApproval:
+        return true
+      case .notRegistered, .notFound:
+        return false
+      @unknown default:
+        return false
+      }
+    }
+  }
+
+  enum LaunchServicesManager {
+    private static var keepAppRunningService: SMAppService {
+      let bundleIdentifier = Bundle.main.bundleIdentifier ?? "dev.firezone.firezone"
+      return SMAppService.agent(plistName: "\(bundleIdentifier).keep-app-running.plist")
+    }
+
+    static func sync(forceReregistration: Bool = false) async throws {
+      // Getting these statuses appears to be blocking sometimes.
+      SentrySDK.pauseAppHangTracking()
+      defer { SentrySDK.resumeAppHangTracking() }
+
+      try await syncKeepAppRunningService(
+        status: keepAppRunningService.status,
+        forceReregistration: forceReregistration
+      )
+    }
+
+    private static func syncKeepAppRunningService(
+      status: SMAppService.Status,
+      forceReregistration: Bool
+    ) async throws {
+      guard !forceReregistration || status != .enabled else {
+        try await keepAppRunningService.unregister()
+        try keepAppRunningService.register()
+        return
+      }
+
+      guard !status.isRegistered else {
+        return
+      }
+
+      try keepAppRunningService.register()
+    }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LoginItemManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LoginItemManager.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+#if os(macOS)
+  import Sentry
+  import ServiceManagement
+#endif
+
+enum LoginItemManager {
+  static func sync(startOnLogin: Bool) async throws {
+    #if os(macOS)
+      SentrySDK.pauseAppHangTracking()
+      defer { SentrySDK.resumeAppHangTracking() }
+      let status = SMAppService.mainApp.status
+
+      if !startOnLogin, status == .enabled {
+        try await SMAppService.mainApp.unregister()
+        return
+      }
+
+      if startOnLogin, status != .enabled {
+        try SMAppService.mainApp.register()
+      }
+    #endif
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -7,11 +7,6 @@
 
 import Combine
 import Foundation
-import Sentry
-
-#if os(macOS)
-  import ServiceManagement
-#endif
 
 @MainActor
 public class Configuration: ObservableObject {
@@ -144,30 +139,8 @@ public class Configuration: ObservableObject {
     )
   }
 
-  #if os(macOS)
-    // Register / unregister our launch service based on configuration.
-    func updateAppService() async throws {
-      // Getting the status initially appears to be blocking sometimes
-      SentrySDK.pauseAppHangTracking()
-      defer { SentrySDK.resumeAppHangTracking() }
-      let status = SMAppService.mainApp.status
-
-      if !startOnLogin, status == .enabled {
-        try await SMAppService.mainApp.unregister()
-        return
-      }
-
-      if startOnLogin, status != .enabled {
-        try SMAppService.mainApp.register()
-      }
-    }
-  #endif
-
   private func handleUserDefaultsChanged() {
-    #if os(macOS)
-      // This is idempotent
-      Task { do { try await updateAppService() } }
-    #endif
+    Task { do { try await LoginItemManager.sync(startOnLogin: startOnLogin) } }
 
     // Update published properties
     self.publishedInternetResourceEnabled = internetResourceEnabled

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -11,7 +11,6 @@ import UserNotifications
 
 #if os(macOS)
   import AppKit
-  import ServiceManagement
 #endif
 
 @MainActor
@@ -180,6 +179,14 @@ public final class Store: ObservableObject {
       } catch {
         Log.error(error)
       }
+
+      #if os(macOS)
+        do {
+          try await LaunchServicesManager.sync(forceReregistration: true)
+        } catch {
+          Log.error(error)
+        }
+      #endif
 
       await startupSequence()
       await initNotifications()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -37,6 +37,15 @@ public final class Store: ObservableObject {
     // Set to true to request the menu bar be opened programmatically.
     // The UI layer observes this and resets it after handling.
     @Published public var menuBarOpenRequested = false
+
+    public var quitMenuTitle: String {
+      switch vpnStatus {
+      case .connected, .connecting:
+        return "Disconnect and Quit"
+      default:
+        return "Quit"
+      }
+    }
   #endif
 
   private(set) var sessionNotification: SessionNotificationProtocol
@@ -181,6 +190,13 @@ public final class Store: ObservableObject {
     /// The UI layer observes `menuBarOpenRequested` and handles the actual opening.
     public func requestOpenMenuBar() {
       menuBarOpenRequested = true
+    }
+
+    public func quitApp() {
+      Task {
+        do { try await stop() } catch { Log.error(error) }
+        NSApp.terminate(nil)
+      }
     }
 
     /// Returns the appropriate icon name from asset catalog for the given state

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -175,6 +175,12 @@ public final class Store: ObservableObject {
     // Load our state from the system. Based on what's loaded, we may need to ask the user for permission for things.
     // When everything loads correctly, we attempt to start the tunnel if connectOnStart is enabled.
     Task {
+      do {
+        try await LoginItemManager.sync(startOnLogin: configuration.startOnLogin)
+      } catch {
+        Log.error(error)
+      }
+
       await startupSequence()
       await initNotifications()
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -199,6 +199,7 @@ public final class Store: ObservableObject {
     }
 
     public func quitApp() {
+      SharedAccess.clearAppRunning()
       Task {
         do { try await stop() } catch { Log.error(error) }
         NSApp.terminate(nil)
@@ -375,6 +376,7 @@ public final class Store: ObservableObject {
     if let manager = try await VPNConfigurationManager.load(using: tunnelManagerFactory) {
       try await manager.maybeMigrateConfiguration()
       self.vpnConfigurationManager = manager
+      SharedAccess.markAppRunning()
     } else {
       self.vpnStatus = .invalid
     }
@@ -396,6 +398,7 @@ public final class Store: ObservableObject {
     )
 
     try await setupTunnelObservers()
+    SharedAccess.markAppRunning()
   }
 
   func manager() throws -> VPNConfigurationManager {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
@@ -85,9 +85,7 @@ class SettingsViewModel: ObservableObject {
     configuration.connectOnStart = connectOnStart
     configuration.startOnLogin = startOnLogin
 
-    #if os(macOS)
-      try await configuration.updateAppService()
-    #endif
+    try await LoginItemManager.sync(startOnLogin: startOnLogin)
 
     updateDerivedState()
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
@@ -209,17 +209,8 @@
     @EnvironmentObject var store: Store
 
     var body: some View {
-      Button(quitTitle) {
-        NSApp.terminate(nil)
-      }
-    }
-
-    var quitTitle: String {
-      switch store.vpnStatus {
-      case .connected, .connecting:
-        return "Disconnect and Quit"
-      default:
-        return "Quit"
+      Button(store.quitMenuTitle) {
+        store.quitApp()
       }
     }
   }

--- a/swift/apple/KeepFirezoneRunning/Info.plist
+++ b/swift/apple/KeepFirezoneRunning/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>FirezoneAppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>FirezoneMainAppBundleIdentifier</key>
+	<string>$(MAIN_APP_BUNDLE_ID)</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/swift/apple/KeepFirezoneRunning/Info.plist
+++ b/swift/apple/KeepFirezoneRunning/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FirezoneAppGroupIdentifier</key>
+	<string>$(APP_GROUP_ID)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/swift/apple/KeepFirezoneRunning/KeepFirezoneRunning.entitlements
+++ b/swift/apple/KeepFirezoneRunning/KeepFirezoneRunning.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_ID)</string>
+	</array>
+</dict>
+</plist>

--- a/swift/apple/KeepFirezoneRunning/main.swift
+++ b/swift/apple/KeepFirezoneRunning/main.swift
@@ -1,0 +1,212 @@
+import AppKit
+import Foundation
+
+private enum Constants {
+  static let appGroupIdentifierInfoKey = "FirezoneAppGroupIdentifier"
+  static let applicationSupportFolderName = "Application Support"
+  static let keepAppRunningSentinelFileName = ".running"
+  static let mainAppPathEnvironmentVariable = "KEEP_FIREZONE_RUNNING_MAIN_APP_PATH"
+  static let relaunchInterval: TimeInterval = 5
+}
+
+private struct MainApp {
+  let url: URL
+  let bundleIdentifier: String
+}
+
+final class KeepFirezoneRunningAppDelegate: NSObject, NSApplicationDelegate {
+  private var didLogRunningSentinelResolutionFailure = false
+  private var timer: Timer?
+
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    NSLog(
+      "[KeepFirezoneRunning] launched helper bundle=%@",
+      Bundle.main.bundleURL.path
+    )
+    launchMainAppIfNeeded(trigger: "launch")
+
+    timer = Timer.scheduledTimer(
+      timeInterval: Constants.relaunchInterval,
+      target: self,
+      selector: #selector(handleTimer),
+      userInfo: nil,
+      repeats: true
+    )
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    timer?.invalidate()
+  }
+
+  @objc private func handleTimer() {
+    launchMainAppIfNeeded(trigger: "timer")
+  }
+
+  private func launchMainAppIfNeeded(trigger: String) {
+    guard shouldRelaunchMainApp else {
+      return
+    }
+
+    guard let mainApp = resolveMainApp(trigger: trigger) else {
+      return
+    }
+
+    let runningApplications = NSRunningApplication.runningApplications(
+      withBundleIdentifier: mainApp.bundleIdentifier
+    )
+
+    guard runningApplications.isEmpty else {
+      return
+    }
+
+    launch(mainApp, trigger: trigger)
+  }
+
+  private var shouldRelaunchMainApp: Bool {
+    guard let runningSentinelURL else {
+      if !didLogRunningSentinelResolutionFailure {
+        didLogRunningSentinelResolutionFailure = true
+        NSLog("[KeepFirezoneRunning] failed to resolve running sentinel location")
+      }
+      return false
+    }
+
+    return FileManager.default.fileExists(atPath: runningSentinelURL.path)
+  }
+
+  private func resolveMainApp(trigger: String) -> MainApp? {
+    guard let mainAppURL = mainAppURL else {
+      NSLog(
+        "[KeepFirezoneRunning] %@: failed to resolve main app URL from helper bundle=%@",
+        trigger,
+        Bundle.main.bundleURL.path
+      )
+      return nil
+    }
+
+    guard let bundleIdentifier = mainAppBundleIdentifier else {
+      NSLog(
+        "[KeepFirezoneRunning] %@: failed to resolve main app bundle identifier for %@",
+        trigger,
+        mainAppURL.path
+      )
+      return nil
+    }
+
+    return MainApp(url: mainAppURL, bundleIdentifier: bundleIdentifier)
+  }
+
+  private func launch(_ mainApp: MainApp, trigger: String) {
+    let configuration = NSWorkspace.OpenConfiguration()
+    configuration.activates = false
+
+    NSWorkspace.shared.openApplication(at: mainApp.url, configuration: configuration) {
+      runningApplication,
+      error in
+      if let error {
+        NSLog(
+          "[KeepFirezoneRunning] %@: failed to launch %@: %@",
+          trigger,
+          mainApp.url.path,
+          error.localizedDescription
+        )
+        return
+      }
+
+      if let runningApplication {
+        NSLog(
+          "[KeepFirezoneRunning] %@: launched %@ pid=%d",
+          trigger,
+          mainApp.url.path,
+          runningApplication.processIdentifier
+        )
+      } else {
+        NSLog(
+          "[KeepFirezoneRunning] %@: launch completed without app instance for %@",
+          trigger,
+          mainApp.url.path
+        )
+      }
+    }
+  }
+
+  private var mainAppURL: URL? {
+    if let mainAppPath = ProcessInfo.processInfo.environment[
+      Constants.mainAppPathEnvironmentVariable],
+      !mainAppPath.isEmpty
+    {
+      return URL(fileURLWithPath: mainAppPath)
+    }
+
+    let helperBundleURL = Bundle.main.bundleURL
+    guard helperBundleURL.lastPathComponent == "KeepFirezoneRunning.app" else {
+      return nil
+    }
+
+    return
+      helperBundleURL
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+
+  private var mainAppBundleIdentifier: String? {
+    guard let mainAppURL else {
+      return nil
+    }
+
+    return Bundle(url: mainAppURL)?.bundleIdentifier
+  }
+
+  private var runningSentinelURL: URL? {
+    guard
+      let appGroupIdentifier = Bundle.main.object(
+        forInfoDictionaryKey: Constants.appGroupIdentifierInfoKey
+      ) as? String,
+      !appGroupIdentifier.isEmpty,
+      let containerURL = FileManager.default.containerURL(
+        forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+    else {
+      return nil
+    }
+
+    let applicationSupportURL =
+      containerURL
+      .appendingPathComponent("Library")
+      .appendingPathComponent(Constants.applicationSupportFolderName)
+
+    guard ensureDirectoryExists(at: applicationSupportURL) else {
+      return nil
+    }
+
+    return applicationSupportURL.appendingPathComponent(Constants.keepAppRunningSentinelFileName)
+  }
+
+  private func ensureDirectoryExists(at url: URL) -> Bool {
+    let fileManager = FileManager.default
+
+    do {
+      var isDirectory: ObjCBool = false
+      if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+        return isDirectory.boolValue
+      }
+
+      try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+      return true
+    } catch {
+      NSLog(
+        "[KeepFirezoneRunning] failed to ensure directory exists at %@: %@",
+        url.path,
+        error.localizedDescription
+      )
+      return false
+    }
+  }
+}
+
+let application = NSApplication.shared
+let delegate = KeepFirezoneRunningAppDelegate()
+application.setActivationPolicy(.prohibited)
+application.delegate = delegate
+application.run()

--- a/swift/apple/KeepFirezoneRunning/main.swift
+++ b/swift/apple/KeepFirezoneRunning/main.swift
@@ -152,6 +152,10 @@ final class KeepFirezoneRunningAppDelegate: NSObject, NSApplicationDelegate {
       .deletingLastPathComponent()
   }
 
+  // The bundle identifier of the main app.
+  //
+  // This is loaded from our own plist and embedded at compile-time
+  // so we can test this using a debug build from XCode as well.
   private var mainAppBundleIdentifier: String? {
     Bundle.main.object(forInfoDictionaryKey: Constants.mainAppBundleIdentifierInfoKey) as? String
   }

--- a/swift/apple/KeepFirezoneRunning/main.swift
+++ b/swift/apple/KeepFirezoneRunning/main.swift
@@ -3,6 +3,7 @@ import Foundation
 
 private enum Constants {
   static let appGroupIdentifierInfoKey = "FirezoneAppGroupIdentifier"
+  static let mainAppBundleIdentifierInfoKey = "FirezoneMainAppBundleIdentifier"
   static let applicationSupportFolderName = "Application Support"
   static let keepAppRunningSentinelFileName = ".running"
   static let mainAppPathEnvironmentVariable = "KEEP_FIREZONE_RUNNING_MAIN_APP_PATH"
@@ -152,11 +153,7 @@ final class KeepFirezoneRunningAppDelegate: NSObject, NSApplicationDelegate {
   }
 
   private var mainAppBundleIdentifier: String? {
-    guard let mainAppURL else {
-      return nil
-    }
-
-    return Bundle(url: mainAppURL)?.bundleIdentifier
+    Bundle.main.object(forInfoDictionaryKey: Constants.mainAppBundleIdentifierInfoKey) as? String
   }
 
   private var runningSentinelURL: URL? {

--- a/website/src/app/kb/client-apps/macos-client/readme.mdx
+++ b/website/src/app/kb/client-apps/macos-client/readme.mdx
@@ -235,6 +235,12 @@ Normal system DNS:
 ;; MSG SIZE  rcvd: 57
 ```
 
+### Firezone keeps reappearing if stopped via the Actitity Monitor
+
+Firezone installs a Launch Agent called `KeepFirezoneRunning`.
+This Launch Agent restarts the application whenever it terminates non-gracefully.
+To quit Firezone without it being restarted, use the "Quit" entry from the menu bar.
+
 ## Known issues
 
 - [**Authentication will not use Firefox even if it is the default browser**](https://github.com/firezone/firezone/issues/7072):

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -30,6 +30,10 @@ export default function Apple() {
           the system under memory pressure, leaving the tunnel running without a
           menu bar icon or session expiry notifications.
         </ChangeItem>
+        <ChangeItem pull={12853}>
+          Adds a macOS LaunchAgent helper that relaunches Firezone after
+          unexpected exits.
+        </ChangeItem>
         <ChangeItem pull={12657}>
           Falls back to public DNS resolvers when the system provides only
           non-routable addresses (loopback, link-local), preventing tunnel


### PR DESCRIPTION
macOS will occasionally SIGTERM our app during certain system resource constraint conditions such as low disk space, where it kills our app with the `0xbaddd15c` error code.

See https://developer.apple.com/documentation/xcode/sigkill

Since there isn't really much we can do to prevent that, we introduce a dedicated launch agent that checks every 5s whether the app is still running. If it is not and our `.running` sentinel file is still there, we re-launch the application. The `.running` file is only cleared when the user purposely quits the app, preventing a restart loop when the user's intent is to actually quit Firezone.