### PR TITLE
feat(snownet): introduce `ice_restart`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3848,8 +3848,7 @@ dependencies = [
 [[package]]
 name = "is"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cf23944e1280f3b2959321a1ef776c14503af8e1e5efca32147a9136a5f8dc"
+source = "git+https://github.com/algesten/str0m?branch=main#81691436c7b5255f43420f3a2eb6eaab6c5182e4"
 dependencies = [
  "crc",
  "hmac",
@@ -7164,8 +7163,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m-proto"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a6a5a946631a167c1b0282846bfa33b0f8098b8dd565237809735656ed63f"
+source = "git+https://github.com/algesten/str0m?branch=main#81691436c7b5255f43420f3a2eb6eaab6c5182e4"
 dependencies = [
  "base64ct",
  "fastrand",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -257,6 +257,7 @@ type_complexity = "allow" # Don't care.
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.
 
 [patch.crates-io]
+is = { git = "https://github.com/algesten/str0m", branch = "main" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -296,17 +296,14 @@ where
             // Take all current candidates.
             let current_candidates = c.agent.local_candidates().collect::<SmallVec<[_; 16]>>();
 
-            // Re-seed connection with all candidates.
-            let new_candidates =
-                seed_agent_with_local_candidates(c.relay.id, &mut c.agent, &self.allocations);
-
             // Tell the remote about all of them.
             self.pending_events.extend(
-                std::iter::empty()
-                    .chain(current_candidates)
-                    .chain(new_candidates)
+                current_candidates
+                    .into_iter()
                     .map(|candidate| new_ice_candidate_event(cid, candidate)),
             );
+
+            c.ice_restart();
 
             // Initiate a new WG session.
             //
@@ -1069,20 +1066,6 @@ where
 
         Ok(rid)
     }
-}
-
-/// Seeds the agent with all local candidates, returning an iterator of all candidates that should be signalled to the remote.
-fn seed_agent_with_local_candidates<'a, RId>(
-    selected_relay: RId,
-    agent: &'a mut IceAgent,
-    allocations: &Allocations<RId>,
-) -> impl Iterator<Item = Candidate> + use<'a, RId>
-where
-    RId: Ord + fmt::Display + Copy,
-{
-    allocations
-        .candidates_for_relay(&selected_relay)
-        .filter_map(move |c| agent.add_local_candidate(c).cloned())
 }
 
 /// Generate optimistic candidates based on the ones we have already received.

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1899,6 +1899,20 @@ where
     where
         TId: fmt::Display,
     {
+        if let Some(c) = self
+            .agent
+            .remote_candidates()
+            .filter(|c| c.kind() == candidate.kind())
+            .filter(|c| c.addr().is_ipv4() == candidate.addr().is_ipv4())
+            .max_by_key(|c| c.prio())
+            && c.prio() < candidate.prio()
+        {
+            // This heuristic is not 100% fool-proof but restarting ICE is idempotent.
+
+            tracing::debug!("Remote likely advanced ICE epoch");
+            self.ice_restart();
+        }
+
         self.agent.add_remote_candidate(candidate);
         self.candidate_timeout = None;
 
@@ -1953,6 +1967,29 @@ where
         for candidate in new_allocation.current_relay_candidates() {
             self.add_local_candidate(cid, &candidate, pending_events, now);
         }
+    }
+
+    /// Our flavour of "ICE restart".
+    ///
+    /// Typically during an ICE restart, the remote credentials and candidates are cleared.
+    /// This however would require the remote to resend those to us again.
+    /// In Firezone, ICE credentials are deterministically assigned based on parties' session keys.
+    /// Those should never change during a given Firezone session.
+    ///
+    /// The candidates may be the same in case the roaming event was triggered erroneously.
+    /// Even if they are not, recreating the candidate pairs just clears the internal nomination state
+    /// and therefore both new and old candidates are considered equal and the new best one will win.
+    fn ice_restart(&mut self) {
+        if self.agent.state() == IceConnectionState::Checking {
+            tracing::trace!("Agent is already checking candidates, skipping ICE restart");
+            return;
+        }
+
+        self.agent.recreate_candidate_pairs();
+
+        self.first_handshake_completed_at = None;
+        self.last_proactive_handshake_sent_at = None;
+        self.poll_timeout_cache = TimeoutCache::default();
     }
 }
 


### PR DESCRIPTION
This PR represents part 1 for the new "soft ICE" connectivity layer in Firezone. In general, the idea of soft ICE is to only use the ICE agent for the initial connection setup and delegate the measure of connection health to the WireGuard state machine. As a result, an ICE disconnect does not tear down the tunnel.

This is a significant shift in how we treat ICE and needs to be coordinated across both Clients and Gateways and cannot be shipped in a single PR. Instead, we have to first ship this PR and release Gateway 1.6.0 before we can land the actual soft ICE layer across Clients and Gateways.

The core feature here is a new API exposed by `is` (formely `str0m`) that allows an agent to re-evaluate all candidate pairs and therefore immediately switch over to a new candidate pair without having to wait for an ICE timeout of the currently nominated pair.