### PR TITLE
feat(snownet): reset allocations instead of clearing them

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -270,6 +270,7 @@ impl Allocation {
         self.allocation_lifetime = None;
         self.channel_bindings.clear();
         self.buffered_channel_bindings.clear();
+        self.explicit_failure = None;
 
         self.send_binding_requests(now);
     }

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -256,6 +256,24 @@ impl Allocation {
         allocation
     }
 
+    pub fn reset(&mut self, now: Instant) {
+        self.active_socket = None;
+        self.ip4_host_candidate = None;
+        self.ip6_host_candidate = None;
+        self.ip4_srflx_candidate = None;
+        self.ip6_srflx_candidate = None;
+        self.ip4_allocation = None;
+        self.ip6_allocation = None;
+        self.buffered_transmits.clear();
+        self.events.clear();
+        self.sent_requests.clear();
+        self.allocation_lifetime = None;
+        self.channel_bindings.clear();
+        self.buffered_channel_bindings.clear();
+
+        self.send_binding_requests(now);
+    }
+
     pub fn host_and_server_reflexive_candidates(&self) -> impl Iterator<Item = Candidate> + use<> {
         [
             self.ip4_host_candidate.clone(),

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -214,8 +214,7 @@ where
     ///
     /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::reset`].
     pub fn reset(&mut self, now: Instant) {
-        self.allocations.clear();
-
+        self.allocations.reset(now);
         self.buffered_transmits.clear();
 
         self.pending_events.clear();

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -202,17 +202,6 @@ where
         }
     }
 
-    /// Resets this [`Node`].
-    ///
-    /// # Implementation note
-    ///
-    /// This also clears all [`Allocation`]s.
-    /// An [`Allocation`] on a TURN server is identified by the client's 3-tuple (IP, port, protocol).
-    /// Thus, clearing the [`Allocation`]'s state here without closing it means we won't be able to make a new one until:
-    /// - it times out
-    /// - we change our IP or port
-    ///
-    /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::reset`].
     pub fn reset(&mut self, now: Instant) {
         self.allocations.reset(now);
         self.buffered_transmits.clear();

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -30,10 +30,9 @@ impl<RId> Allocations<RId>
 where
     RId: Ord + fmt::Display + Copy,
 {
-    pub(crate) fn clear(&mut self) {
-        for (_, allocation) in std::mem::take(&mut self.inner) {
-            self.previous_relays_by_ip
-                .extend(server_addresses(&allocation));
+    pub(crate) fn reset(&mut self, now: Instant) {
+        for allocation in self.inner.values_mut() {
+            allocation.reset(now);
         }
     }
 
@@ -279,27 +278,6 @@ mod tests {
         );
 
         allocations.remove_by_id(&1);
-
-        assert!(matches!(
-            allocations.get_mut_by_server(SERVER_V4),
-            MutAllocationRef::Disconnected
-        ));
-    }
-
-    #[test]
-    fn clear_remembers_address() {
-        let mut allocations = Allocations::default();
-        allocations.upsert(
-            1,
-            RelaySocket::from(SERVER_V4),
-            Username::new("test".to_owned()).unwrap(),
-            "password".to_owned(),
-            Realm::new("firezone".to_owned()).unwrap(),
-            Instant::now(),
-            SessionId::new(PublicKey::from([0u8; 32])),
-        );
-
-        allocations.clear();
 
         assert!(matches!(
             allocations.get_mut_by_server(SERVER_V4),


### PR DESCRIPTION
When a Firezone client detects a network roam, it completely clears the local memory of the allocations with the assigned relays and waits for new relays to be assigned through the `init` message sent by the portal. This creates a delay of however long it takes to reconnect to the portal's WebSocket endpoint until which connlib cannot form new candidates and re-create connections to Gateways.

Instead of clearing the allocations, we now _reset_ them. In other words, we keep the IP, port and credentials around but throw away everything else. This allows connlib to recreate those candidates in parallel to the WebSocket connection. Additional relays sent down from the portal are then simply added to the current set. This should speed up roaming by however long it takes to recreate the WebSocket connection. A TCP + TLS handshake needs at least 3 RTTs + the single latency of sending the `init` message plus however long the portal needs to verify the token and create the `init` message, meaning for a typical latency of ~40ms, this is an improvement of ~150 - 200ms.

In most cases, these relays will be the exact same set unless the user travels big geographic distances. For direct connections, even that part does not matter because the resolved server-reflexive address is the same. With #12899 merged, we will now also prefer relays with a lower RTT which means it should not matter as much if a user ends up being connected to more relays spread across geographic regions.