### PR TITLE
feat: include `TriggerKind` in `create_flow` message

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -319,11 +319,13 @@ impl Eventloop {
             ClientEvent::ResourceConnectionIntent {
                 preferred_gateways,
                 resource,
+                trigger,
             } => {
                 self.portal_cmd_tx
                     .send(PortalCommand::Send(EgressMessages::CreateFlow {
                         resource_id: resource,
                         preferred_gateways,
+                        trigger,
                     }))
                     .await
                     .context("Failed to send message to portal")?;

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1727,10 +1727,11 @@ impl ClientState {
             return Some(ClientEvent::ResourcesChanged { resources });
         }
 
-        if let Some(resource) = self.pending_flows.poll_connection_intents() {
+        if let Some(i) = self.pending_flows.poll_connection_intents() {
             return Some(ClientEvent::ResourceConnectionIntent {
-                resource,
-                preferred_gateways: self.preferred_gateways(resource),
+                resource: i.resource,
+                preferred_gateways: self.preferred_gateways(i.resource),
+                trigger: i.trigger,
             });
         }
 

--- a/rust/libs/connlib/tunnel/src/client/pending_flows.rs
+++ b/rust/libs/connlib/tunnel/src/client/pending_flows.rs
@@ -5,16 +5,24 @@ use std::{
 };
 
 use connlib_model::ResourceId;
-use ip_packet::IpPacket;
+use ip_packet::{IpPacket, UnsupportedProtocol};
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 
-use crate::{client::Resource, dns, unique_packet_buffer::UniquePacketBuffer};
+use crate::{
+    client::Resource, dns, messages::client::TriggerKind, unique_packet_buffer::UniquePacketBuffer,
+};
 
 #[derive(Default)]
 pub struct PendingFlows {
     inner: HashMap<ResourceId, PendingFlow>,
 
-    connection_intents: VecDeque<ResourceId>,
+    connection_intents: VecDeque<ResourceConnectionIntent>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ResourceConnectionIntent {
+    pub resource: ResourceId,
+    pub trigger: TriggerKind,
 }
 
 impl PendingFlows {
@@ -28,6 +36,13 @@ impl PendingFlows {
     ) {
         let trigger = trigger.into();
         let trigger_name = trigger.name();
+        let trigger_kind = match trigger.kind() {
+            Ok(trigger_kind) => trigger_kind,
+            Err(e) => {
+                tracing::debug!("Failed to compute trigger kind: {e}");
+                return;
+            }
+        };
 
         if !resources_by_id.contains_key(&rid) {
             tracing::debug!(%rid, "Resource not found, skipping connection intent");
@@ -51,14 +66,17 @@ impl PendingFlows {
         tracing::debug!(trigger = %trigger_name, "Sending connection intent");
 
         pending_flow.last_intent_sent_at = now;
-        self.connection_intents.push_back(rid);
+        self.connection_intents.push_back(ResourceConnectionIntent {
+            resource: rid,
+            trigger: trigger_kind,
+        });
     }
 
     pub fn remove(&mut self, rid: &ResourceId) -> Option<PendingFlow> {
         self.inner.remove(rid)
     }
 
-    pub fn poll_connection_intents(&mut self) -> Option<ResourceId> {
+    pub fn poll_connection_intents(&mut self) -> Option<ResourceConnectionIntent> {
         self.connection_intents.pop_front()
     }
 }
@@ -137,6 +155,22 @@ impl ConnectionTrigger {
             }
         }
     }
+
+    fn kind(&self) -> Result<TriggerKind, UnsupportedProtocol> {
+        let trigger_kind = match self {
+            ConnectionTrigger::PacketForResource(ip_packet) => {
+                match ip_packet.destination_protocol()? {
+                    ip_packet::Protocol::Tcp(port) => TriggerKind::TcpPacket { port },
+                    ip_packet::Protocol::Udp(port) => TriggerKind::UdpPacket { port },
+                    ip_packet::Protocol::IcmpEcho(_) => TriggerKind::IcmpPacket,
+                }
+            }
+            ConnectionTrigger::DnsQueryForSite(_) => TriggerKind::DnsQueryForSite,
+            ConnectionTrigger::IcmpDestinationUnreachableProhibited => TriggerKind::IcmpProhibited,
+        };
+
+        Ok(trigger_kind)
+    }
 }
 
 impl From<IpPacket> for ConnectionTrigger {
@@ -170,7 +204,13 @@ mod tests {
         let resources = BTreeMap::from([(rid, ipv4_localhost_resource())]);
 
         pending_flows.on_not_connected_resource(rid, trigger(1), &resources, now);
-        assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
+        assert_eq!(
+            pending_flows.poll_connection_intents(),
+            Some(ResourceConnectionIntent {
+                resource: rid,
+                trigger: TriggerKind::UdpPacket { port: 1 }
+            })
+        );
 
         now += Duration::from_secs(1);
 
@@ -186,12 +226,24 @@ mod tests {
         let resources = BTreeMap::from([(rid, ipv4_localhost_resource())]);
 
         pending_flows.on_not_connected_resource(rid, trigger(1), &resources, now);
-        assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
+        assert_eq!(
+            pending_flows.poll_connection_intents(),
+            Some(ResourceConnectionIntent {
+                resource: rid,
+                trigger: TriggerKind::UdpPacket { port: 1 }
+            })
+        );
 
         now += Duration::from_secs(3);
 
         pending_flows.on_not_connected_resource(rid, trigger(2), &resources, now);
-        assert_eq!(pending_flows.poll_connection_intents(), Some(rid));
+        assert_eq!(
+            pending_flows.poll_connection_intents(),
+            Some(ResourceConnectionIntent {
+                resource: rid,
+                trigger: TriggerKind::UdpPacket { port: 1 }
+            })
+        );
     }
 
     #[test]
@@ -208,9 +260,21 @@ mod tests {
         ]);
 
         pending_flows.on_not_connected_resource(rid1, trigger(1), &resources, now);
-        assert_eq!(pending_flows.poll_connection_intents(), Some(rid1));
+        assert_eq!(
+            pending_flows.poll_connection_intents(),
+            Some(ResourceConnectionIntent {
+                resource: rid1,
+                trigger: TriggerKind::UdpPacket { port: 1 }
+            })
+        );
         pending_flows.on_not_connected_resource(rid2, trigger(2), &resources, now);
-        assert_eq!(pending_flows.poll_connection_intents(), Some(rid2));
+        assert_eq!(
+            pending_flows.poll_connection_intents(),
+            Some(ResourceConnectionIntent {
+                resource: rid2,
+                trigger: TriggerKind::UdpPacket { port: 1 }
+            })
+        );
     }
 
     fn trigger(payload: u8) -> IpPacket {

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -18,6 +18,7 @@ use gat_lending_iterator::LendingIterator;
 use io::{Buffers, Io};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use logging::DisplayBTreeSet;
+use messages::client::TriggerKind;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,
@@ -580,6 +581,7 @@ pub enum ClientEvent {
     ResourceConnectionIntent {
         resource: ResourceId,
         preferred_gateways: Vec<GatewayId>,
+        trigger: TriggerKind,
     },
     DeviceConnectionIntent {
         ipv4: Ipv4Addr,

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -238,6 +238,7 @@ pub enum EgressMessages {
         resource_id: ResourceId,
         #[serde(rename = "connected_gateway_ids")]
         preferred_gateways: Vec<GatewayId>,
+        trigger: TriggerKind,
     },
     RequestDeviceAccess {
         ipv4: Ipv4Addr,
@@ -247,6 +248,16 @@ pub enum EgressMessages {
     InvalidateGatewayIceCandidates(GatewayIceCandidates),
     NewClientIceCandidates(ClientIceCandidates),
     InvalidateClientIceCandidates(ClientIceCandidates),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum TriggerKind {
+    TcpPacket { port: u16 },
+    UdpPacket { port: u16 },
+    IcmpPacket,
+    DnsQueryForSite,
+    IcmpProhibited,
 }
 
 #[cfg(test)]
@@ -540,12 +551,65 @@ mod tests {
     }
 
     #[test]
-    fn serialize_create_flow_message() {
+    fn serialize_create_flow_message_tcp() {
         let message = EgressMessages::CreateFlow {
             resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
             preferred_gateways: Vec::new(),
+            trigger: TriggerKind::TcpPacket { port: 22 },
         };
-        let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[]}}"#;
+        let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[],"trigger":{"kind":"tcp_packet","port":22}}}"#;
+        let actual_json = serde_json::to_string(&message).unwrap();
+
+        assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
+    fn serialize_create_flow_message_udp() {
+        let message = EgressMessages::CreateFlow {
+            resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
+            preferred_gateways: Vec::new(),
+            trigger: TriggerKind::UdpPacket { port: 22 },
+        };
+        let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[],"trigger":{"kind":"udp_packet","port":22}}}"#;
+        let actual_json = serde_json::to_string(&message).unwrap();
+
+        assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
+    fn serialize_create_flow_message_icmp() {
+        let message = EgressMessages::CreateFlow {
+            resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
+            preferred_gateways: Vec::new(),
+            trigger: TriggerKind::IcmpPacket,
+        };
+        let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[],"trigger":{"kind":"icmp_packet"}}}"#;
+        let actual_json = serde_json::to_string(&message).unwrap();
+
+        assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
+    fn serialize_create_flow_message_dns_query_for_site() {
+        let message = EgressMessages::CreateFlow {
+            resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
+            preferred_gateways: Vec::new(),
+            trigger: TriggerKind::DnsQueryForSite,
+        };
+        let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[],"trigger":{"kind":"dns_query_for_site"}}}"#;
+        let actual_json = serde_json::to_string(&message).unwrap();
+
+        assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
+    fn serialize_create_flow_message_icmp_prohibited() {
+        let message = EgressMessages::CreateFlow {
+            resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
+            preferred_gateways: Vec::new(),
+            trigger: TriggerKind::IcmpProhibited,
+        };
+        let expected_json = r#"{"event":"create_flow","payload":{"resource_id":"f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3","connected_gateway_ids":[],"trigger":{"kind":"icmp_prohibited"}}}"#;
         let actual_json = serde_json::to_string(&message).unwrap();
 
         assert_eq!(actual_json, expected_json);

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1052,6 +1052,7 @@ impl TunnelTest {
             ClientEvent::ResourceConnectionIntent {
                 resource: resource_id,
                 preferred_gateways,
+                trigger: _,
             } => {
                 let (gateway_id, site_id) =
                     portal.handle_connection_intent(resource_id, preferred_gateways);


### PR DESCRIPTION
At present, `connlib` will only send the resource ID it wants to connect to to the portal. The underlying trigger is only known to connlib itself.

With this PR, we expose this trigger to the portal which allows us to decide there, whether to even authorize this connection. For example, if the Client tries to connect a resource on TCP port 22 but the provided resource does not allow this traffic, the portal can directly reject it.

Resolves: #12847 