### PR TITLE
chore(rust): downgrade tunnel warnings

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -292,7 +292,7 @@ impl Eventloop {
                 return Err(e);
             }
 
-            tracing::warn!("Tunnel error: {e:#}");
+            tracing::debug!("Tunnel error: {e:#}");
         }
 
         Ok(())

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -392,7 +392,7 @@ impl Eventloop {
                 return Err(e);
             }
 
-            tracing::warn!("Tunnel error: {e:#}");
+            tracing::debug!("Tunnel error: {e:#}");
         }
 
         Ok(())


### PR DESCRIPTION
Anything that can potentially happen per-packet is too noisy to report to Sentry. As a stop-gap measure until we can fix this, downgrade these warnings to debug logs.