### PR TITLE
feat(connlib): bias towards relays with low RTT

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -97,6 +97,10 @@ pub struct Allocation {
 
     explicit_failure: Option<FreeReason>,
 
+    /// Smoothed round-trip time to the relay, computed via an exponential moving
+    /// average over response times. `None` until we receive the first response.
+    rtt: Option<Duration>,
+
     buffer_pool: BufferPool<Vec<u8>>,
 }
 
@@ -248,6 +252,7 @@ impl Allocation {
             software: Software::new(format!("snownet; session={session_id}"))
                 .expect("description has less then 128 chars"),
             explicit_failure: Default::default(),
+            rtt: None,
             buffer_pool,
         };
 
@@ -364,6 +369,8 @@ impl Allocation {
 
         let rtt = now.duration_since(backoff.start_time());
         Span::current().record("rtt", field::debug(rtt));
+
+        self.update_rtt(rtt);
 
         if tracing::enabled!(target: "wire::turn", tracing::Level::DEBUG) {
             let request = original_request
@@ -949,6 +956,26 @@ impl Allocation {
 
     pub fn matches_socket(&self, socket: &RelaySocket) -> bool {
         &self.server == socket
+    }
+
+    /// The smoothed round-trip time to the relay.
+    ///
+    /// Returns `None` if we haven't received a response yet.
+    pub fn rtt(&self) -> Option<Duration> {
+        self.rtt
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_rtt(&mut self, rtt: Duration) {
+        self.rtt = Some(rtt);
+    }
+
+    fn update_rtt(&mut self, sample: Duration) {
+        // RFC 6298 SRTT-style EMA: srtt = 7/8 * srtt + 1/8 * sample.
+        self.rtt = Some(match self.rtt {
+            None => sample,
+            Some(srtt) => srtt * 7 / 8 + sample / 8,
+        });
     }
 
     fn log_update(&self, now: Instant) {
@@ -2665,6 +2692,40 @@ mod tests {
 
         assert!(socket.matches(SocketAddr::V4(RELAY_V4)));
         assert!(socket.matches(SocketAddr::V6(RELAY_V6)));
+    }
+
+    #[test]
+    fn rtt_is_tracked_after_response() {
+        let start = Instant::now();
+        let mut allocation = Allocation::for_test_ip4(start);
+
+        assert_eq!(allocation.rtt(), None);
+
+        let binding = allocation.next_message().unwrap();
+        let recv_at = start + Duration::from_millis(40);
+        allocation.handle_test_input_ip4(binding_response(&binding, PEER1), recv_at);
+
+        assert_eq!(allocation.rtt(), Some(Duration::from_millis(40)));
+    }
+
+    #[test]
+    fn rtt_is_smoothed_over_multiple_responses() {
+        let start = Instant::now();
+        let mut allocation = Allocation::for_test_ip4(start);
+
+        // First response: BINDING (40ms)
+        let binding = allocation.next_message().unwrap();
+        let mut now = start + Duration::from_millis(40);
+        allocation.handle_test_input_ip4(binding_response(&binding, PEER1), now);
+        assert_eq!(allocation.rtt(), Some(Duration::from_millis(40)));
+
+        // Second response: ALLOCATE (200ms after the request was sent)
+        let allocate = allocation.next_message().unwrap();
+        now += Duration::from_millis(200);
+        allocation.handle_test_input_ip4(allocate_response(&allocate, &[RELAY_ADDR_IP4]), now);
+
+        // EMA: 7/8 * 40ms + 1/8 * 200ms = 35ms + 25ms = 60ms
+        assert_eq!(allocation.rtt(), Some(Duration::from_millis(60)));
     }
 
     #[test]

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, btree_map::Entry},
     fmt,
     net::{IpAddr, SocketAddr},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use bufferpool::BufferPool;
@@ -152,10 +152,30 @@ where
         }
     }
 
+    /// Sample an allocation for a new connection, biased towards low RTT.
+    ///
+    /// We compute an inclusion threshold from the observed RTT distribution
+    /// (see [`inclusion_threshold`]) and uniformly sample among the relays at
+    /// or below it. Allocations without an RTT measurement are skipped: we
+    /// don't know whether they are healthy yet.
     pub(crate) fn sample(&self, rng: &mut impl Rng) -> Option<(RId, &Allocation)> {
-        let (id, a) = self.inner.iter().choose(rng)?;
+        let candidates = self
+            .inner
+            .iter()
+            .filter_map(|(id, a)| Some((*id, a, a.rtt()?)))
+            .collect::<SmallVec<[_; 8]>>();
 
-        Some((*id, a))
+        let rtts = candidates
+            .iter()
+            .map(|(_, _, rtt)| *rtt)
+            .collect::<SmallVec<[_; 8]>>();
+        let threshold = inclusion_threshold(&rtts)?;
+
+        candidates
+            .iter()
+            .filter(|(_, _, rtt)| *rtt <= threshold)
+            .choose(rng)
+            .map(|(id, a, _)| (*id, *a))
     }
 
     pub(crate) fn poll_timeout(&mut self) -> Option<(Instant, &'static str)> {
@@ -221,6 +241,48 @@ pub(crate) enum MutAllocationRef<'a, RId> {
     Connected(RId, &'a mut Allocation),
 }
 
+/// Maximum RTT (inclusive) for a relay to be considered when sampling.
+///
+/// For 1-2 relays, MAD-based outlier detection degenerates (with two
+/// samples the median sits exactly between them and MAD = gap/2, so neither is
+/// ever an outlier). For those small-N cases we fall back to a relative
+/// tolerance from the leader. For 3+ relays we use the standard `median + 3·MAD`
+/// outlier rule, which adapts to whatever spread the data shows.
+fn inclusion_threshold(rtts: &[Duration]) -> Option<Duration> {
+    let min = rtts.iter().copied().min()?;
+
+    if rtts.len() <= 2 {
+        // Include relays within 1.5x of the leader.
+        return Some(min * 3 / 2);
+    }
+
+    let mut sorted = rtts.iter().copied().collect::<SmallVec<[_; 8]>>();
+    sorted.sort();
+    let med = median(&sorted);
+
+    let mut deviations = sorted
+        .iter()
+        .map(|r| r.abs_diff(med))
+        .collect::<SmallVec<[_; 8]>>();
+    deviations.sort();
+    let mad = median(&deviations);
+
+    Some(med + 3 * mad)
+}
+
+/// Median of a sorted slice.
+///
+/// For even-length slices, returns the average of the two middle elements.
+fn median(sorted: &[Duration]) -> Duration {
+    let n = sorted.len();
+
+    if n.is_multiple_of(2) {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    } else {
+        sorted[n / 2]
+    }
+}
+
 fn server_addresses(allocation: &Allocation) -> impl Iterator<Item = IpAddr> {
     std::iter::empty()
         .chain(
@@ -262,6 +324,7 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
 
     use boringtun::x25519::PublicKey;
+    use rand::SeedableRng as _;
 
     use super::*;
 
@@ -336,6 +399,197 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn inclusion_threshold_falls_back_to_relative_for_small_n() {
+        // n=1: just the single relay; threshold is 1.5x its RTT.
+        assert_eq!(inclusion_threshold(&[ms(40)]), Some(ms(60)));
+
+        // n=2: 1.5x of the leader.
+        assert_eq!(inclusion_threshold(&[ms(40), ms(60)]), Some(ms(60)));
+    }
+
+    #[test]
+    fn inclusion_threshold_uses_mad_for_three_or_more_relays() {
+        // Tightly clustered: median=35, MAD=5, threshold=50; all kept.
+        assert_eq!(inclusion_threshold(&[ms(30), ms(35), ms(40)]), Some(ms(50)));
+
+        // One clear outlier: median=35, MAD=5, threshold=50; 200ms excluded.
+        assert_eq!(
+            inclusion_threshold(&[ms(30), ms(35), ms(200)]),
+            Some(ms(50))
+        );
+
+        // Many fast + one slow: outlier identified.
+        let threshold = inclusion_threshold(&[ms(30), ms(32), ms(35), ms(40), ms(200)]).unwrap();
+        assert!(threshold < ms(100));
+        assert!(threshold >= ms(40));
+    }
+
+    #[test]
+    fn inclusion_threshold_averages_two_middle_elements_for_even_n() {
+        // n=4 sorted = [30, 40, 50, 60]
+        // median = (40 + 50) / 2 = 45
+        // deviations from 45 = [15, 5, 5, 15] sorted = [5, 5, 15, 15]
+        // MAD = (5 + 15) / 2 = 10
+        // threshold = 45 + 3 * 10 = 75
+        assert_eq!(
+            inclusion_threshold(&[ms(30), ms(40), ms(50), ms(60)]),
+            Some(ms(75))
+        );
+    }
+
+    #[test]
+    fn sample_excludes_outlier_relay_among_many_fast_ones() {
+        let now = Instant::now();
+        let mut allocations = Allocations::default();
+
+        for (rid, port, rtt_ms) in [
+            (1u32, 11111u16, 30),
+            (2, 22222, 32),
+            (3, 33333, 35),
+            (4, 44444, 40),
+            (5, 55555, 200),
+        ] {
+            allocations.upsert(
+                rid,
+                RelaySocket::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)),
+                Username::new("test".to_owned()).unwrap(),
+                "password".to_owned(),
+                Realm::new("firezone".to_owned()).unwrap(),
+                now,
+                SessionId::new(PublicKey::from([0u8; 32])),
+            );
+            allocations
+                .get_mut_by_id(&rid)
+                .unwrap()
+                .set_rtt(Duration::from_millis(rtt_ms));
+        }
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        for _ in 0..1000 {
+            let (rid, _) = allocations.sample(&mut rng).unwrap();
+            assert_ne!(rid, 5, "outlier relay must not be selected");
+        }
+    }
+
+    #[test]
+    fn sample_distributes_load_across_similar_rtt_relays() {
+        let now = Instant::now();
+        let mut allocations = Allocations::default();
+
+        // 1ms apart: both relays should be picked roughly equally (uniform within bucket).
+        for (rid, port, rtt_ms) in [(1u32, 11111u16, 30), (2, 22222, 31)] {
+            allocations.upsert(
+                rid,
+                RelaySocket::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)),
+                Username::new("test".to_owned()).unwrap(),
+                "password".to_owned(),
+                Realm::new("firezone".to_owned()).unwrap(),
+                now,
+                SessionId::new(PublicKey::from([0u8; 32])),
+            );
+            allocations
+                .get_mut_by_id(&rid)
+                .unwrap()
+                .set_rtt(Duration::from_millis(rtt_ms));
+        }
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let mut counts = [0u32; 2];
+
+        for _ in 0..10_000 {
+            let (rid, _) = allocations.sample(&mut rng).unwrap();
+            counts[(rid - 1) as usize] += 1;
+        }
+
+        let ratio = counts[0] as f64 / counts[1] as f64;
+        assert!(
+            (0.9..=1.1).contains(&ratio),
+            "expected near-even split, got ratio {ratio}"
+        );
+    }
+
+    #[test]
+    fn sample_excludes_n2_relay_when_much_slower() {
+        let now = Instant::now();
+        let mut allocations = Allocations::default();
+
+        // 30ms vs 200ms with n=2 ⇒ 200ms is 6.7x the leader, well outside 1.5x.
+        for (rid, port, rtt_ms) in [(1u32, 11111u16, 30), (2, 22222, 200)] {
+            allocations.upsert(
+                rid,
+                RelaySocket::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)),
+                Username::new("test".to_owned()).unwrap(),
+                "password".to_owned(),
+                Realm::new("firezone".to_owned()).unwrap(),
+                now,
+                SessionId::new(PublicKey::from([0u8; 32])),
+            );
+            allocations
+                .get_mut_by_id(&rid)
+                .unwrap()
+                .set_rtt(Duration::from_millis(rtt_ms));
+        }
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        for _ in 0..100 {
+            let (rid, _) = allocations.sample(&mut rng).unwrap();
+            assert_eq!(rid, 1);
+        }
+    }
+
+    #[test]
+    fn sample_falls_back_to_only_remaining_relay_even_if_high_rtt() {
+        let now = Instant::now();
+        let mut allocations = Allocations::default();
+
+        allocations.upsert(
+            1,
+            RelaySocket::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 11111)),
+            Username::new("test".to_owned()).unwrap(),
+            "password".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+            SessionId::new(PublicKey::from([0u8; 32])),
+        );
+        allocations
+            .get_mut_by_id(&1)
+            .unwrap()
+            .set_rtt(Duration::from_millis(500));
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        let (rid, _) = allocations.sample(&mut rng).unwrap();
+        assert_eq!(rid, 1);
+    }
+
+    #[test]
+    fn sample_excludes_allocations_without_rtt() {
+        let now = Instant::now();
+        let mut allocations = Allocations::default();
+
+        allocations.upsert(
+            1,
+            RelaySocket::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 11111)),
+            Username::new("test".to_owned()).unwrap(),
+            "password".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+            SessionId::new(PublicKey::from([0u8; 32])),
+        );
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        assert_eq!(allocations.get_by_id(&1).unwrap().rtt(), None);
+        assert!(allocations.sample(&mut rng).is_none());
+    }
+
     const SERVER_V4: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 11111));
     const SERVER2_V4: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 22222));
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
 }

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -265,10 +265,16 @@ fn inclusion_threshold(rtts: &[Duration]) -> Option<Duration> {
         .map(|r| r.abs_diff(med))
         .collect::<SmallVec<[_; 8]>>();
     deviations.sort();
-    let mad = median(&deviations);
+    // Floor the MAD so that tightly-clustered relays don't collapse the
+    // threshold to a sub-millisecond window. A relay that is only a few ms
+    // slower than the leader should still be eligible.
+    let mad = median(&deviations).max(MAD_FLOOR);
 
     Some(med + 3 * mad)
 }
+
+/// Minimum effective MAD used when computing the inclusion threshold.
+const MAD_FLOOR: Duration = Duration::from_millis(2);
 
 /// Median of a sorted slice.
 ///
@@ -423,6 +429,17 @@ mod tests {
         let threshold = inclusion_threshold(&[ms(30), ms(32), ms(35), ms(40), ms(200)]).unwrap();
         assert!(threshold < ms(100));
         assert!(threshold >= ms(40));
+    }
+
+    #[test]
+    fn inclusion_threshold_floors_mad_so_tightly_clustered_relays_stay_in() {
+        // sorted = [30, 30, 30, 31] ⇒ median = 30, deviations = [0, 0, 0, 1].
+        // Raw MAD = 0, but the 2ms floor lifts the threshold to 30 + 3*2 = 36ms,
+        // keeping the 31ms relay in the pool.
+        assert_eq!(
+            inclusion_threshold(&[ms(30), ms(30), ms(30), ms(31)]),
+            Some(ms(36))
+        );
     }
 
     #[test]

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -530,6 +530,11 @@ mod tests {
             now,
             SessionId::new(PublicKey::from([0u8; 32])),
         );
+        // Simulate a successful response so the relay is eligible for sampling.
+        allocations
+            .get_mut_by_id(&2)
+            .unwrap()
+            .set_rtt(Duration::from_millis(20));
 
         connections.migrate_relays(
             std::iter::empty(),


### PR DESCRIPTION
Currently, connlib selects one of the available relays at random for every new connection. If multiple relays are available, it is possible that we select one with a higher RTT despite one with a lower RTT also being available. Purely selecting based on the RTT is also not fair however as we do want to spread the load across all relays given to us.

To resolve this, we resort to a MAD-based (median absolute deviation) approach with a dedicated handling of the special case where N=2. Using MAD, we can implement an approach of identifying outliers as 3*MAD from the median. For the case of N=2, we simply define the cut-off as 1.5 the RTT of the faster relay.

This approach allows connlib to uniformly select from all available relays in a way that always biases the closest ones but evenly distributes across those whilst excluding ones that are clear outliers compared to the others.

With this feature implemented, we can send more relays down from the portal and let connlib select the best ones for a given connection instead of the geo-IP based approach implemented in the portal.

Even with this approach implemented, connlib will still make an allocation on all of these relays. In a follow-up, we should consider making that an explicit step rather than an implicit one and only trigger it once we have assigned the relay to a connection.

Related: #6109