### PR TITLE
chore(snownet): remove `SessionId`

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -1,7 +1,7 @@
 use crate::{
     backoff::{self, ExponentialBackoff},
     channel_data,
-    node::{SessionId, Transmit},
+    node::Transmit,
 };
 use bufferpool::BufferPool;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
@@ -225,7 +225,6 @@ impl Allocation {
         password: String,
         realm: Realm,
         now: Instant,
-        session_id: SessionId,
         buffer_pool: BufferPool<Vec<u8>>,
     ) -> Self {
         let mut allocation = Self {
@@ -249,7 +248,7 @@ impl Allocation {
             allocation_lifetime: Default::default(),
             channel_bindings: Default::default(),
             buffered_channel_bindings: AllocRingBuffer::new(100),
-            software: Software::new(format!("snownet; session={session_id}"))
+            software: Software::new("snownet".to_owned())
                 .expect("description has less then 128 chars"),
             explicit_failure: Default::default(),
             rtt: None,
@@ -2997,7 +2996,6 @@ mod tests {
                 "baz".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 start,
-                SessionId::default(),
                 BufferPool::new(500, "test"),
             )
         }
@@ -3012,7 +3010,6 @@ mod tests {
                 "baz".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 start,
-                SessionId::default(),
                 BufferPool::new(500, "test"),
             )
         }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -24,7 +24,6 @@ use boringtun::x25519::{self, PublicKey};
 use boringtun::{noise::rate_limiter::RateLimiter, x25519::StaticSecret};
 use bufferpool::{Buffer, BufferPool};
 use core::fmt;
-use hex_display::HexDisplayExt;
 use ip_packet::{Ecn, IpPacket, IpPacketBuf};
 use is::stun::{StunMessage, StunPacket};
 use is::{Candidate, CandidateKind, IceConnectionState};
@@ -33,7 +32,6 @@ use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
-use sha2::Digest;
 use smallvec::SmallVec;
 use std::collections::BTreeSet;
 use std::hash::Hash;
@@ -87,7 +85,6 @@ const WG_REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(20);
 pub struct Node<TId, RId> {
     private_key: StaticSecret,
     public_key: PublicKey,
-    session_id: SessionId,
 
     index: IndexLfsr,
     rate_limiter: Arc<RateLimiter>,
@@ -184,7 +181,6 @@ where
 
         Self {
             rng,
-            session_id: SessionId::new(*public_key),
             private_key,
             public_key: *public_key,
             index,
@@ -240,7 +236,6 @@ where
             HANDSHAKE_RATE_LIMIT,
             now,
         ));
-        self.session_id = SessionId::new(self.public_key);
 
         tracing::debug!(%num_connections, "Closed all connections as part of reconnecting");
     }
@@ -697,15 +692,10 @@ where
                 continue;
             };
 
-            match self.allocations.upsert(
-                *rid,
-                *server,
-                username,
-                password.clone(),
-                realm,
-                now,
-                self.session_id.clone(),
-            ) {
+            match self
+                .allocations
+                .upsert(*rid, *server, username, password.clone(), realm, now)
+            {
                 allocations::UpsertResult::Added => {
                     tracing::info!(%rid, address = ?server, "Added new TURN server")
                 }
@@ -2006,28 +1996,6 @@ fn new_agent(role: IceRole) -> IceAgent {
     agent.set_timing_advance(Duration::ZERO);
 
     agent
-}
-
-/// A session ID is constant for as long as a [`Node`] is operational.
-#[derive(Debug, Default, Clone)]
-pub(crate) struct SessionId([u8; 32]);
-
-impl SessionId {
-    /// Construct a new session ID by hashing the node's public key with a domain-separator.
-    fn new(key: PublicKey) -> Self {
-        Self(
-            sha2::Sha256::new_with_prefix(b"SESSION-ID")
-                .chain_update(key.as_bytes())
-                .finalize()
-                .into(),
-        )
-    }
-}
-
-impl fmt::Display for SessionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", &self.0.hex())
-    }
 }
 
 #[cfg(test)]

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -16,7 +16,6 @@ use stun_codec::rfc5389::attributes::{Realm, Username};
 use crate::{
     RelaySocket, Transmit,
     allocation::{self, Allocation},
-    node::SessionId,
 };
 
 pub(crate) struct Allocations<RId> {
@@ -109,7 +108,6 @@ where
         password: String,
         realm: Realm,
         now: Instant,
-        session_id: SessionId,
     ) -> UpsertResult {
         match self.inner.entry(rid) {
             Entry::Vacant(v) => {
@@ -119,7 +117,6 @@ where
                     password,
                     realm,
                     now,
-                    session_id,
                     self.buffer_pool.clone(),
                 ));
 
@@ -140,7 +137,6 @@ where
                     password,
                     realm,
                     now,
-                    session_id,
                     self.buffer_pool.clone(),
                 ));
 
@@ -329,7 +325,6 @@ impl<RId> Default for Allocations<RId> {
 mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
 
-    use boringtun::x25519::PublicKey;
     use rand::SeedableRng as _;
 
     use super::*;
@@ -344,7 +339,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
 
         allocations.remove_by_id(&1);
@@ -365,7 +359,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
 
         allocations.clear();
@@ -386,7 +379,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
 
         allocations.upsert(
@@ -396,7 +388,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
 
         assert!(matches!(
@@ -474,7 +465,6 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                SessionId::new(PublicKey::from([0u8; 32])),
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -504,7 +494,6 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                SessionId::new(PublicKey::from([0u8; 32])),
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -541,7 +530,6 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                SessionId::new(PublicKey::from([0u8; 32])),
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -569,7 +557,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
         allocations
             .get_mut_by_id(&1)
@@ -594,7 +581,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
 
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -436,7 +436,7 @@ mod tests {
 
     use crate::{
         IceConfig, RelaySocket,
-        node::{ConnectionState, SelectedRelay, SessionId, allocations::Allocations},
+        node::{ConnectionState, SelectedRelay, allocations::Allocations},
     };
     use stun_codec::rfc5389::attributes::{Realm, Username};
 
@@ -528,7 +528,6 @@ mod tests {
             "pass".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            SessionId::new(PublicKey::from([0u8; 32])),
         );
         // Simulate a successful response so the relay is eligible for sampling.
         allocations


### PR DESCRIPTION
The `SessionId` was originally introduced to differentiate TURN clients within relay logs. We barely ever look at relay logs for any kind of debugging and socket addresses and STUN transaction IDs work just equally well for this.