### PR TITLE
chore: eliminate redirects to https://www.firezone.dev

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -123,7 +123,7 @@ jobs:
           identifier: ${{ matrix.identifier }}
           version: ${{ steps.get-version.outputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
-          release-notes-url: https://firezone.dev/changelog
+          release-notes-url: https://www.firezone.dev/changelog
           release-tag: ${{ inputs.release_name || github.event.release.tag_name || github.ref_name }}
 
   create-publish-pr:

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -18,7 +18,7 @@ jobs:
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private --max-concurrency 1 --retry-wait-time 60 --base https://firezone.dev --accept 100..=103,200..=399,429 .
+          args: --verbose --no-progress --exclude-all-private --max-concurrency 1 --retry-wait-time 60 --base https://www.firezone.dev --accept 100..=103,200..=399,429 .
           workingDirectory: website
 
       - name: Create Issue From File

--- a/elixir/lib/portal/mailer/auth_email/new_user.html.eex
+++ b/elixir/lib/portal/mailer/auth_email/new_user.html.eex
@@ -57,7 +57,7 @@
                 class="sm-my-8"
                 style="margin-top: 48px; margin-bottom: 48px; text-align: center"
               >
-                <a href="https://firezone.dev?utm_source=email">
+                <a href="https://www.firezone.dev?utm_source=email">
                   <div>
                     <img
                       class="logo-light"

--- a/elixir/lib/portal/mailer/auth_email/sign_in_link.html.eex
+++ b/elixir/lib/portal/mailer/auth_email/sign_in_link.html.eex
@@ -65,7 +65,7 @@
                 class="sm-my-8"
                 style="margin-top: 48px; margin-bottom: 48px; text-align: center"
               >
-                <a href="https://firezone.dev?utm_source=email">
+                <a href="https://www.firezone.dev?utm_source=email">
                   <div>
                     <img
                       class="logo-light"

--- a/elixir/lib/portal/mailer/auth_email/sign_up_link.html.eex
+++ b/elixir/lib/portal/mailer/auth_email/sign_up_link.html.eex
@@ -65,7 +65,7 @@
                 class="sm-my-8"
                 style="margin-top: 48px; margin-bottom: 48px; text-align: center"
               >
-                <a href="https://firezone.dev?utm_source=email">
+                <a href="https://www.firezone.dev?utm_source=email">
                   <div>
                     <img
                       class="logo-light"

--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
@@ -57,7 +57,7 @@
         <tr>
           <td style="width: 552px; max-width: 100%">
             <div class="sm-my-8" style="margin-top: 48px; margin-bottom: 48px; text-align: center">
-              <a href="https://firezone.dev">
+              <a href="https://www.firezone.dev">
                 <div>
                   <img class="logo-light" src="https://www.firezone.dev/images/logo-lockup.png" width="250" alt="Firezone logo" style="max-width: 100%; vertical-align: middle; line-height: 1">
                   <img class="logo-dark" src="https://www.firezone.dev/images/logo-text-dark.svg" width="250" alt="Firezone logo" style="display: none; max-width: 100%; vertical-align: middle; line-height: 1">

--- a/elixir/lib/portal/mailer/notifications/outdated_gateway.html.eex
+++ b/elixir/lib/portal/mailer/notifications/outdated_gateway.html.eex
@@ -57,7 +57,7 @@
         <tr>
           <td style="width: 552px; max-width: 100%">
             <div class="sm-my-8" style="margin-top: 48px; margin-bottom: 48px; text-align: center">
-              <a href="https://firezone.dev">
+              <a href="https://www.firezone.dev">
                 <div>
                   <img class="logo-light" src="https://www.firezone.dev/images/logo-lockup.png" width="250" alt="Firezone logo" style="max-width: 100%; vertical-align: middle; line-height: 1">
                   <img class="logo-dark" src="https://www.firezone.dev/images/logo-text-dark.svg" width="250" alt="Firezone logo" style="display: none; max-width: 100%; vertical-align: middle; line-height: 1">

--- a/elixir/lib/portal/mailer/sync_email/sync_error.html.eex
+++ b/elixir/lib/portal/mailer/sync_email/sync_error.html.eex
@@ -54,7 +54,7 @@
 					<tr>
 						<td style="width: 552px; max-width: 100%">
 							<div class="sm-my-8" style="margin-top: 48px; margin-bottom: 48px; text-align: center">
-								<a href="https://firezone.dev">
+								<a href="https://www.firezone.dev">
 									<div>
 										<img class="logo-light" src="https://www.firezone.dev/images/logo-lockup.png" width="250" alt="Firezone logo" style="max-width: 100%; vertical-align: middle; line-height: 1">
 										<img class="logo-dark" src="https://www.firezone.dev/images/logo-text-dark.svg" width="250" alt="Firezone logo" style="display: none; max-width: 100%; vertical-align: middle; line-height: 1">

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -1143,7 +1143,7 @@ defmodule Portal.Repo.Seeds do
           type: :dns,
           name: "*.firezone.dev",
           address: "*.firezone.dev",
-          address_description: "https://firezone.dev/",
+          address_description: "https://www.firezone.dev/",
           site_id: site.id,
           filters: []
         },

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -96,7 +96,7 @@ public class Configuration: ObservableObject {
   #endif
 
   static let defaultAccountSlug = ""
-  static let defaultSupportURL = "https://firezone.dev/support"
+  static let defaultSupportURL = "https://www.firezone.dev/support"
 
   // Bools are always default false
   static let defaultConnectOnStart = false

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
@@ -44,7 +44,7 @@ struct ConfigurationTests {
     // These assertions verify the actual values, not just self-comparison
     #expect(config.authURL.starts(with: "https://app.fire"))
     #expect(config.apiURL.starts(with: "wss://api.fire"))
-    #expect(config.supportURL == "https://firezone.dev/support")
+    #expect(config.supportURL == "https://www.firezone.dev/support")
     #expect(config.accountSlug.isEmpty)
 
     // Confirm nothing was written to UserDefaults (defaults are computed, not stored)

--- a/website/src/app/blog/2025-12-06-scheduled-maintenance/readme.mdx
+++ b/website/src/app/blog/2025-12-06-scheduled-maintenance/readme.mdx
@@ -18,6 +18,6 @@ This maintenance will deliver major enhancements to:
 
 ## Need help?
 
-If you experience any issues outside of the scheduled maintenance window, please don't hesitate to [contact our support team](https://firezone.dev/support).
+If you experience any issues outside of the scheduled maintenance window, please don't hesitate to [contact our support team](https://www.firezone.dev/support).
 
 Thank you for your patience as we work to improve Firezone for everyone.

--- a/website/src/app/blog/sep-2024-update/readme.mdx
+++ b/website/src/app/blog/sep-2024-update/readme.mdx
@@ -67,4 +67,4 @@ Improved wildcard matching requires Client and Gateway **v1.2.0** or later.
 ## End
 
 That's all for now. [Sign up](https://app.firezone.dev/sign_up) for a free starter account to try out all of the above. If you're interested in using Firezone
-for your organization, [contact us](https://firezone.dev/contact/sales) for a customized demo.
+for your organization, [contact us](https://www.firezone.dev/contact/sales) for a customized demo.


### PR DESCRIPTION
These just add noise to the Link Checker Report.
