### PR TITLE
test(connlib): introduce proptest seed harvester

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -176,63 +176,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tool: ripgrep,cargo-llvm-cov
+          tool: cargo-llvm-cov
       - uses: taiki-e/install-action@b9c5db3aef04caffaf95a1d03931de10fb2a140f # v2.65.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tool: bpf-linker
       - name: Tunnel proptest
+        id: proptest
         shell: bash
-        run: cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test transitions_and_state_are_deterministic
+        run: cargo llvm-cov --features proptest --package tunnel --lcov --output-path lcov.info -- --nocapture tunnel_test transitions_and_state_are_deterministic 2>&1 | tee proptest.log
         env:
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
           PROPTEST_CASES: 256
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
-      - name: Check coverage
+          TUNNEL_TEST_ENFORCE_COVERAGE: 1 # Fail the test if we don't hit all intended codepaths.
+
+      - name: Extract missing coverage patterns
+        id: missing
+        if: failure()
         shell: bash
         run: |
-          # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
-          patterns=(
-            "SendIcmpPacket"
-            "SendUdpPacket"
-            "ConnectTcp"
-            "SendDnsQueries"
-            "Packet for DNS resource"
-            "Packet for CIDR resource"
-            "Packet for Internet resource"
-            "Truncating DNS response"
-            "ICMP Error error=V4Unreachable"
-            "ICMP Error error=V6Unreachable"
-            "ICMP Error error=V4TimeExceeded"
-            "ICMP Error error=V6TimeExceeded"
-            "Forwarding query for DNS resource to corresponding site"
-            "Revoking resource authorization"
-            "Re-seeding records for DNS resources"
-            "Resource is known but its addressability changed"
-            "No A / AAAA records for domain"
-            "State change \(got new possible\): Disconnected -> Checking"
-            "Initiating graceful shutdown"
-            "Connection closed proactively \(sent goodbye\)"
-            "New device access authorized"
-            "Malicious client: ignoring resource filter"
-          )
-
-          missing_patterns=$(
-            for pattern in "${patterns[@]}"; do
-              if ! rg --quiet --no-ignore "$pattern" "$TESTCASES_DIR"; then
-                echo "$pattern"
-              fi
-            done
-          )
-
-          if [ -n "$missing_patterns" ]; then
-            echo "Error: Some required patterns were not found in test logs:"
-            echo "$missing_patterns"
-            exit 1
+          missing=$(sed -n '/^TUNNEL_TEST_MISSING_PATTERNS_BEGIN$/,/^TUNNEL_TEST_MISSING_PATTERNS_END$/p' proptest.log | sed '1d;$d')
+          if [ -n "$missing" ]; then
+            {
+              echo "patterns<<EOF"
+              echo "$missing"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Missing coverage patterns:" >&2
+            echo "$missing" >&2
           fi
+
+      - name: Harvest regression seeds for missing coverage
+        if: failure() && steps.missing.outputs.patterns != ''
+        timeout-minutes: 25
+        shell: bash
         env:
-          TESTCASES_DIR: "libs/connlib/tunnel/testcases"
+          PROPTEST_VERBOSE: 0
+        run: |
+          mapfile -t patterns <<< "${{ steps.missing.outputs.patterns }}"
+          cargo run -p tunnel-proptest-harvester -- "${patterns[@]}"
+      - name: Upload harvested seeds
+        if: failure() && steps.missing.outputs.patterns != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: proptest-harvest-seeds
+          path: rust/libs/connlib/tunnel/harvest-output/
+          if-no-files-found: warn
 
       - uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3280,6 +3280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,6 +4752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5567,7 +5583,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.44",
  "tracing",
@@ -8571,6 +8587,21 @@ dependencies = [
  "tun",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "tunnel-proptest-harvester"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "clap",
+ "futures",
+ "humantime",
+ "nix",
+ "num_cpus",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8601,7 +8601,6 @@ dependencies = [
  "num_cpus",
  "tokio",
  "tokio-stream",
- "tokio-util",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "tests/gui-smoke-test",
     "tests/http-test-server",
     "tests/loadtest",
+    "tests/tunnel-proptest-harvester",
     "tools/uniffi-bindgen",
 ]
 

--- a/rust/libs/connlib/tunnel/.gitignore
+++ b/rust/libs/connlib/tunnel/.gitignore
@@ -1,1 +1,2 @@
 testcases/
+harvest-output/

--- a/rust/libs/connlib/tunnel/src/tests.rs
+++ b/rust/libs/connlib/tunnel/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::tests::{flux_capacitor::FluxCapacitor, sut::TunnelTest};
+use crate::tests::{coverage::Coverage, flux_capacitor::FluxCapacitor, sut::TunnelTest};
 use assertions::PanicOnErrorEvents;
 use chrono::Utc;
 use core::fmt;
@@ -22,6 +22,7 @@ mod assertions;
 mod buffered_transmits;
 mod coin;
 mod composite_strategy;
+mod coverage;
 mod dns_records;
 mod dns_server_resource;
 mod flux_capacitor;
@@ -43,10 +44,22 @@ type QueryId = u16;
 
 #[test]
 fn tunnel_test() {
-    let config = Config {
+    let run_coverage = Coverage::new();
+    let harvest_target = coverage::harvest_target();
+
+    let mut config = Config {
         source_file: Some(file!()),
         ..Default::default()
     };
+
+    // In harvest mode, swap out the file-based regression persistence
+    // for one that (1) does not replay existing seeds and (2) echoes
+    // any newly-discovered seed to stderr tagged with the pattern being
+    // hunted, where the driver script can pick it up.
+    if let Some(target) = harvest_target {
+        config.failure_persistence =
+            Some(Box::new(coverage::HarvestPersistence::for_target(target)));
+    }
 
     let test_index = AtomicU32::new(0);
 
@@ -73,10 +86,16 @@ fn tunnel_test() {
     let result = test_runner.run(
         &strategy,
         |(mut ref_state, transitions, mut seen_counter)| {
+            let case_coverage = Coverage::new();
             let test_index = test_index.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
             flux_capacitor.reset();
-            let _guard = init_logging(flux_capacitor.clone(), test_index);
+
+            let _guard = init_logging(
+                flux_capacitor.clone(),
+                test_index,
+                run_coverage.clone(),
+                case_coverage.clone(),
+            );
 
             std::fs::write(
                 format!("testcases/{test_index}.state"),
@@ -126,6 +145,17 @@ fn tunnel_test() {
 
                 // Check the invariants after the transition is applied
                 TunnelTest::check_invariants(&sut, &ref_state);
+
+                // In harvest mode, fail the case as soon as the hunted
+                // pattern has fired so proptest shrinks and persists the
+                // seed via `HarvestPersistence`.
+                if let Some(target) = harvest_target
+                    && case_coverage.seen(target)
+                {
+                    return Err(TestCaseError::fail(format!(
+                        "harvest: pattern `{target}` fired"
+                    )));
+                }
             }
 
             Ok(())
@@ -134,18 +164,17 @@ fn tunnel_test() {
 
     println!("TestRunner stats: \n\n{test_runner}");
 
-    let Err(e) = result else {
-        return;
-    };
+    match result {
+        Ok(()) => run_coverage.assert_all_patterns_seen(),
+        Err(e) => match e {
+            TestError::Abort(msg) => panic!("Test aborted: {msg}"),
+            TestError::Fail(msg, (ref_state, transitions, _)) => {
+                eprintln!("{ref_state:#?}");
+                eprintln!("{transitions:#?}");
 
-    match e {
-        TestError::Abort(msg) => panic!("Test aborted: {msg}"),
-        TestError::Fail(msg, (ref_state, transitions, _)) => {
-            eprintln!("{ref_state:#?}");
-            eprintln!("{transitions:#?}");
-
-            panic!("{msg}")
-        }
+                panic!("{msg}")
+            }
+        },
     }
 }
 
@@ -211,6 +240,8 @@ where
 fn init_logging(
     flux_capacitor: FluxCapacitor,
     test_index: u32,
+    run_coverage: Coverage,
+    case_coverage: Coverage,
 ) -> tracing::subscriber::DefaultGuard {
     tracing_subscriber::registry()
         .with(
@@ -223,6 +254,22 @@ fn init_logging(
             tracing_subscriber::fmt::layer()
                 .with_writer(std::fs::File::create(format!("testcases/{test_index}.log")).unwrap())
                 .with_timer(flux_capacitor)
+                .with_ansi(false)
+                .with_filter(log_file_filter()),
+        )
+        // Feed two more fmt layers into `Coverage` handles. The stock
+        // formatter renders each event once per layer; we just scan the
+        // bytes. `with_ansi(false)` avoids escape sequences corrupting
+        // the substring search.
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(run_coverage)
+                .with_ansi(false)
+                .with_filter(log_file_filter()),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(case_coverage)
                 .with_ansi(false)
                 .with_filter(log_file_filter()),
         )

--- a/rust/libs/connlib/tunnel/src/tests.rs
+++ b/rust/libs/connlib/tunnel/src/tests.rs
@@ -44,7 +44,7 @@ type QueryId = u16;
 
 #[test]
 fn tunnel_test() {
-    let run_coverage = Coverage::new();
+    let run_coverage = coverage::run_coverage();
     let harvest_target = coverage::harvest_target();
 
     let mut config = Config {
@@ -86,7 +86,7 @@ fn tunnel_test() {
     let result = test_runner.run(
         &strategy,
         |(mut ref_state, transitions, mut seen_counter)| {
-            let case_coverage = Coverage::new();
+            let case_coverage = harvest_target.map(|_| Coverage::new());
             let test_index = test_index.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             flux_capacitor.reset();
 
@@ -150,7 +150,8 @@ fn tunnel_test() {
                 // pattern has fired so proptest shrinks and persists the
                 // seed via `HarvestPersistence`.
                 if let Some(target) = harvest_target
-                    && case_coverage.seen(target)
+                    && let Some(cov) = case_coverage.as_ref()
+                    && cov.seen(target)
                 {
                     return Err(TestCaseError::fail(format!(
                         "harvest: pattern `{target}` fired"
@@ -165,7 +166,11 @@ fn tunnel_test() {
     println!("TestRunner stats: \n\n{test_runner}");
 
     match result {
-        Ok(()) => run_coverage.assert_all_patterns_seen(),
+        Ok(()) => {
+            if let Some(cov) = &run_coverage {
+                cov.assert_all_patterns_seen();
+            }
+        }
         Err(e) => match e {
             TestError::Abort(msg) => panic!("Test aborted: {msg}"),
             TestError::Fail(msg, (ref_state, transitions, _)) => {
@@ -240,8 +245,8 @@ where
 fn init_logging(
     flux_capacitor: FluxCapacitor,
     test_index: u32,
-    run_coverage: Coverage,
-    case_coverage: Coverage,
+    run_coverage: Option<Coverage>,
+    case_coverage: Option<Coverage>,
 ) -> tracing::subscriber::DefaultGuard {
     tracing_subscriber::registry()
         .with(
@@ -257,22 +262,18 @@ fn init_logging(
                 .with_ansi(false)
                 .with_filter(log_file_filter()),
         )
-        // Feed two more fmt layers into `Coverage` handles. The stock
-        // formatter renders each event once per layer; we just scan the
-        // bytes. `with_ansi(false)` avoids escape sequences corrupting
-        // the substring search.
-        .with(
+        .with(run_coverage.map(|cov| {
             tracing_subscriber::fmt::layer()
-                .with_writer(run_coverage)
+                .with_writer(cov)
                 .with_ansi(false)
-                .with_filter(log_file_filter()),
-        )
-        .with(
+                .with_filter(log_file_filter())
+        }))
+        .with(case_coverage.map(|cov| {
             tracing_subscriber::fmt::layer()
-                .with_writer(case_coverage)
+                .with_writer(cov)
                 .with_ansi(false)
-                .with_filter(log_file_filter()),
-        )
+                .with_filter(log_file_filter())
+        }))
         .with(PanicOnErrorEvents::new(test_index))
         .set_default()
 }

--- a/rust/libs/connlib/tunnel/src/tests/coverage.rs
+++ b/rust/libs/connlib/tunnel/src/tests/coverage.rs
@@ -1,0 +1,246 @@
+//! Log-pattern coverage check for the `tunnel_test` proptest suite.
+//!
+//! [`Coverage`] is a minimal observer: a bitmap of [`REQUIRED_PATTERNS`]
+//! that flips bits as matching tracing events go by. Its [`MakeWriter`]
+//! impl plugs into a standard `tracing_subscriber::fmt::layer()` so the
+//! stock formatter does the rendering and we scan the resulting bytes
+//! line by line.
+
+use std::fmt;
+use std::io::{self, Write as _};
+use std::sync::{Arc, Mutex};
+
+use proptest::test_runner::{FailurePersistence, PersistedSeed};
+use tracing_subscriber::fmt::MakeWriter;
+
+/// Log patterns that every `tunnel_test` run must cover.
+///
+/// Each entry is a substring that must appear in at least one formatted
+/// event during the run.
+pub(crate) const REQUIRED_PATTERNS: &[&str] = &[
+    "SendIcmpPacket",
+    "SendUdpPacket",
+    "ConnectTcp",
+    "SendDnsQueries",
+    "Packet for DNS resource",
+    "Packet for CIDR resource",
+    "Packet for Internet resource",
+    "Truncating DNS response",
+    "ICMP Error error=V4Unreachable",
+    "ICMP Error error=V6Unreachable",
+    "ICMP Error error=V4TimeExceeded",
+    "ICMP Error error=V6TimeExceeded",
+    "Forwarding query for DNS resource to corresponding site",
+    "Revoking resource authorization",
+    "Re-seeding records for DNS resources",
+    "Resource is known but its addressability changed",
+    "No A / AAAA records for domain",
+    "State change (got new possible): Disconnected -> Checking",
+    "Initiating graceful shutdown",
+    "Connection closed proactively (sent goodbye)",
+    "New device access authorized",
+    "Malicious client: ignoring resource filter",
+];
+
+const ENFORCE_ENV_VAR: &str = "TUNNEL_TEST_ENFORCE_COVERAGE";
+const HARVEST_TARGET_ENV_VAR: &str = "TUNNEL_TEST_HARVEST_TARGET";
+const MISSING_BEGIN: &str = "TUNNEL_TEST_MISSING_PATTERNS_BEGIN";
+const MISSING_END: &str = "TUNNEL_TEST_MISSING_PATTERNS_END";
+
+/// Stderr marker prefixing each harvested seed. The driver script
+/// extracts seeds from worker logs by grepping for this prefix and
+/// assembles the final `tests.txt` block using the harvest target
+/// that was passed in via `TUNNEL_TEST_HARVEST_TARGET`.
+const HARVESTED_SEED_MARKER: &str = "TUNNEL_TEST_HARVESTED_SEED";
+
+/// Resolve the harvest target from `TUNNEL_TEST_HARVEST_TARGET`, once, at
+/// the top of the test runner. Panics if the env var is set to a value
+/// that does not match any entry in [`REQUIRED_PATTERNS`] — almost
+/// always a typo in the driver script.
+pub(crate) fn harvest_target() -> Option<&'static str> {
+    let raw = std::env::var(HARVEST_TARGET_ENV_VAR).ok()?;
+    let matched = REQUIRED_PATTERNS.iter().find(|p| **p == raw).copied();
+    if matched.is_none() {
+        panic!(
+            "{HARVEST_TARGET_ENV_VAR}={raw:?} does not match any entry \
+             in `REQUIRED_PATTERNS`. Pass one of: {:?}",
+            REQUIRED_PATTERNS,
+        );
+    }
+    matched
+}
+
+/// Shared pattern-observation bitmap.
+#[derive(Clone)]
+pub(crate) struct Coverage {
+    seen: Arc<Mutex<[bool; REQUIRED_PATTERNS.len()]>>,
+}
+
+impl Coverage {
+    pub(crate) fn new() -> Self {
+        Self {
+            seen: Arc::new(Mutex::new([false; REQUIRED_PATTERNS.len()])),
+        }
+    }
+
+    /// `true` iff at least one tracing event observed by this `Coverage`
+    /// contained `pattern` as a substring.
+    pub(crate) fn seen(&self, pattern: &str) -> bool {
+        let Some(idx) = index_of(pattern) else {
+            return false;
+        };
+        self.seen.lock().unwrap()[idx]
+    }
+
+    /// Panic listing every [`REQUIRED_PATTERNS`] entry that was not
+    /// observed through this `Coverage`, if `TUNNEL_TEST_ENFORCE_COVERAGE=1`.
+    pub(crate) fn assert_all_patterns_seen(&self) {
+        if std::env::var_os(ENFORCE_ENV_VAR).is_none_or(|v| v != "1") {
+            return;
+        }
+
+        let missing = REQUIRED_PATTERNS
+            .iter()
+            .copied()
+            .filter(|p| !self.seen(p))
+            .collect::<Vec<_>>();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        // Machine-readable block consumed by `scripts/harvest-seeds.sh`.
+        // Emit before the panic message so it always reaches stderr.
+        eprintln!("{MISSING_BEGIN}");
+        for pattern in &missing {
+            eprintln!("{pattern}");
+        }
+        eprintln!("{MISSING_END}");
+
+        let list = missing
+            .iter()
+            .map(|p| format!("  - {p}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        panic!(
+            "Coverage check failed: the following log patterns were not observed \
+             during the proptest run:\n{list}\n\n\
+             Run the `tunnel-proptest-harvest` task to generate regression seeds \
+             for the missing patterns and append them to \
+             `proptest-regressions/tests.txt`.",
+        );
+    }
+
+    fn observe(&self, line: &str) {
+        let mut seen = self.seen.lock().unwrap();
+        for (i, pattern) in REQUIRED_PATTERNS.iter().enumerate() {
+            if seen[i] {
+                continue;
+            }
+            if line.contains(pattern) {
+                seen[i] = true;
+            }
+        }
+    }
+}
+
+fn index_of(pattern: &str) -> Option<usize> {
+    REQUIRED_PATTERNS.iter().position(|p| *p == pattern)
+}
+
+// Plug `Coverage` into a `tracing_subscriber::fmt::layer()` so we reuse
+// the stock event formatter. The fmt layer terminates each rendered
+// event with a newline; the `Writer` buffers incoming bytes and flushes
+// each complete line to `observe` as soon as it arrives.
+impl<'a> MakeWriter<'a> for Coverage {
+    type Writer = Writer;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        Writer {
+            coverage: self.clone(),
+            pending: Vec::new(),
+        }
+    }
+}
+
+pub(crate) struct Writer {
+    coverage: Coverage,
+    /// Bytes from a partial line that haven't been terminated yet.
+    pending: Vec<u8>,
+}
+
+impl io::Write for Writer {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.pending.extend_from_slice(data);
+
+        let mut scan_start = 0;
+        while let Some(nl_offset) = self.pending[scan_start..].iter().position(|b| *b == b'\n') {
+            let line_end = scan_start + nl_offset + 1;
+            if let Ok(line) = std::str::from_utf8(&self.pending[scan_start..line_end]) {
+                self.coverage.observe(line);
+            }
+            scan_start = line_end;
+        }
+        self.pending.drain(..scan_start);
+
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Custom [`FailurePersistence`] used while harvesting regression seeds.
+///
+/// - `load_persisted_failures2` returns `[]` so the RNG is not biased by
+///   replaying seeds that already pass the current test.
+/// - `save_persisted_failure2` prints the shrunken seed to stderr
+///   prefixed with [`HARVESTED_SEED_MARKER`]. The driver script reads
+///   the seed out of the worker's captured log and pairs it up with the
+///   harvest target it passed in, so no output-path coordination
+///   between the runner and the driver is required.
+#[derive(Debug, Clone)]
+pub(crate) struct HarvestPersistence {
+    target: &'static str,
+}
+
+impl HarvestPersistence {
+    pub(crate) fn for_target(target: &'static str) -> Self {
+        Self { target }
+    }
+}
+
+impl FailurePersistence for HarvestPersistence {
+    fn load_persisted_failures2(&self, _source_file: Option<&'static str>) -> Vec<PersistedSeed> {
+        Vec::new()
+    }
+
+    fn save_persisted_failure2(
+        &mut self,
+        _source_file: Option<&'static str>,
+        seed: PersistedSeed,
+        _shrunken_value: &dyn fmt::Debug,
+    ) {
+        // The driver already knows which pattern this worker hunted
+        // (it set `TUNNEL_TEST_HARVEST_TARGET`), so the marker line only
+        // needs to carry the seed.
+        let _ = writeln!(io::stderr().lock(), "{HARVESTED_SEED_MARKER} {seed}");
+    }
+
+    fn box_clone(&self) -> Box<dyn FailurePersistence> {
+        Box::new(self.clone())
+    }
+
+    fn eq(&self, other: &dyn FailurePersistence) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|o| o.target == self.target)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/rust/libs/connlib/tunnel/src/tests/coverage.rs
+++ b/rust/libs/connlib/tunnel/src/tests/coverage.rs
@@ -109,7 +109,7 @@ impl Coverage {
             return;
         }
 
-        // Machine-readable block consumed by `scripts/harvest-seeds.sh`.
+        // Machine-readable block consumed by `tunnel-proptest-harvester`.
         // Emit before the panic message so it always reaches stderr.
         eprintln!("{MISSING_BEGIN}");
         for pattern in &missing {
@@ -126,7 +126,7 @@ impl Coverage {
         panic!(
             "Coverage check failed: the following log patterns were not observed \
              during the proptest run:\n{list}\n\n\
-             Run the `tunnel-proptest-harvest` task to generate regression seeds \
+             Run the `tunnel-proptest-harvester` binary to generate regression seeds \
              for the missing patterns and append them to \
              `proptest-regressions/tests.txt`.",
         );

--- a/rust/libs/connlib/tunnel/src/tests/coverage.rs
+++ b/rust/libs/connlib/tunnel/src/tests/coverage.rs
@@ -47,6 +47,13 @@ const HARVEST_TARGET_ENV_VAR: &str = "TUNNEL_TEST_HARVEST_TARGET";
 const MISSING_BEGIN: &str = "TUNNEL_TEST_MISSING_PATTERNS_BEGIN";
 const MISSING_END: &str = "TUNNEL_TEST_MISSING_PATTERNS_END";
 
+/// `Some(Coverage)` iff `TUNNEL_TEST_ENFORCE_COVERAGE=1`.
+pub(crate) fn run_coverage() -> Option<Coverage> {
+    std::env::var_os(ENFORCE_ENV_VAR)
+        .is_some_and(|v| v == "1")
+        .then(Coverage::new)
+}
+
 /// Stderr marker prefixing each harvested seed. The driver script
 /// extracts seeds from worker logs by grepping for this prefix and
 /// assembles the final `tests.txt` block using the harvest target
@@ -93,12 +100,8 @@ impl Coverage {
     }
 
     /// Panic listing every [`REQUIRED_PATTERNS`] entry that was not
-    /// observed through this `Coverage`, if `TUNNEL_TEST_ENFORCE_COVERAGE=1`.
+    /// observed through this `Coverage`.
     pub(crate) fn assert_all_patterns_seen(&self) {
-        if std::env::var_os(ENFORCE_ENV_VAR).is_none_or(|v| v != "1") {
-            return;
-        }
-
         let missing = REQUIRED_PATTERNS
             .iter()
             .copied()

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -50,46 +50,6 @@ env = { CARGO_PROFILE_TEST_OPT_LEVEL = "1", PROPTEST_CASES = "10000", PROPTEST_M
 raw = true
 run = "cargo test tunnel_test --features proptest -- --nocapture"
 
-# This task is particularly useful to purposely find a regression seed for a certain failure scenario that
-# we want to hit. The corresponding CI job performs a log-based coverage check to ensure that.
-[tasks.tunnel-proptest-x16]
-description = "Run tunnel-proptest 16 times in parallel, aborting all on first failure"
-dir = "libs/connlib/tunnel"
-env = { CARGO_PROFILE_TEST_OPT_LEVEL = "1", PROPTEST_CASES = "10000", PROPTEST_MAX_SHRINK_ITERS = "100" }
-raw = true
-run = """
-#!/usr/bin/env bash
-# `set -m` puts each `&`-backgrounded cargo in its own process group so we can
-# signal the whole subtree (cargo + test binary) via `kill -TERM -$pgid`.
-set -muo pipefail
-
-mv proptest-regressions/tests.txt proptest-regressions/tests.txt.bak
-
-# Build once up-front so the 16 parallel `cargo test` invocations don't
-# serialize on the target-dir lock.
-cargo test tunnel_test --features proptest --no-run
-
-pids=()
-
-cleanup() {
-    for pid in "${pids[@]}"; do
-        kill -TERM -"$pid" 2>/dev/null || true
-    done
-    wait 2>/dev/null || true
-}
-trap cleanup EXIT
-trap 'exit 130' INT TERM
-
-for _ in $(seq 16); do
-    cargo test tunnel_test --features proptest -- --nocapture &
-    pids+=($!)
-done
-
-for _ in "${pids[@]}"; do
-    wait -n || exit 1
-done
-"""
-
 # =============================================================================
 # Composite tasks
 # =============================================================================

--- a/rust/tests/tunnel-proptest-harvester/Cargo.toml
+++ b/rust/tests/tunnel-proptest-harvester/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "tunnel-proptest-harvester"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+description = "Parallel harvester for tunnel proptest regression seeds"
+
+[[bin]]
+name = "tunnel-proptest-harvester"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+futures = { workspace = true }
+humantime = { workspace = true }
+num_cpus = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt-multi-thread",
+    "macros",
+    "process",
+    "signal",
+    "sync",
+    "time",
+    "io-util",
+    "fs",
+] }
+tokio-stream = { workspace = true, features = ["io-util"] }
+tokio-util = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["signal"] }
+
+[lints]
+workspace = true

--- a/rust/tests/tunnel-proptest-harvester/Cargo.toml
+++ b/rust/tests/tunnel-proptest-harvester/Cargo.toml
@@ -26,7 +26,6 @@ tokio = { workspace = true, features = [
     "fs",
 ] }
 tokio-stream = { workspace = true, features = ["io-util"] }
-tokio-util = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["signal"] }

--- a/rust/tests/tunnel-proptest-harvester/src/main.rs
+++ b/rust/tests/tunnel-proptest-harvester/src/main.rs
@@ -128,7 +128,7 @@ async fn dry_pass() -> Result<Vec<Pattern>> {
     // Regression seeds only; novel case generation is the worker's job.
     .env("PROPTEST_CASES", "0")
     .env("CARGO_PROFILE_TEST_OPT_LEVEL", "1")
-    .stdout(Stdio::piped())
+    .stdout(Stdio::null())
     .stderr(Stdio::piped());
 
     let mut child = ProcessGroup::spawn(cmd).context("spawn cargo (dry pass)")?;

--- a/rust/tests/tunnel-proptest-harvester/src/main.rs
+++ b/rust/tests/tunnel-proptest-harvester/src/main.rs
@@ -1,0 +1,483 @@
+#![expect(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "CLI tool streams worker output and the final seed block"
+)]
+
+//! Hunt for regression seeds that cover tunnel-proptest log patterns
+//! missing from `proptest-regressions/tests.txt`. With no args, a dry
+//! pass first discovers which patterns the current suite misses.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use futures::future::{Either, select};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::task::{AbortHandle, JoinSet};
+use tokio_stream::StreamExt as _;
+
+use crate::process_group::ProcessGroup;
+use crate::slot_pool::{Slot, SlotPool};
+
+mod process_group;
+mod slot_pool;
+
+/// Resolved at compile time so the binary runs from anywhere.
+const TUNNEL_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../libs/connlib/tunnel");
+
+const HARVESTED_SEED_MARKER: &str = "TUNNEL_TEST_HARVESTED_SEED";
+const MISSING_BEGIN: &str = "TUNNEL_TEST_MISSING_PATTERNS_BEGIN";
+const MISSING_END: &str = "TUNNEL_TEST_MISSING_PATTERNS_END";
+const OUT_DIR: &str = "harvest-output";
+const WORKER_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// Safety net for impossible / mistyped patterns; never reached in practice.
+const MAX_ATTEMPTS_PER_PATTERN: usize = 20;
+
+const PROPTEST_CASES: u64 = 100_000;
+const PROPTEST_MAX_SHRINK_ITERS: u64 = 100;
+
+#[derive(Parser, Debug)]
+#[command(
+    about = "Harvest regression seeds for missing tunnel-proptest coverage patterns",
+    long_about = None,
+)]
+struct Args {
+    /// Patterns to hunt for. Omit to auto-discover via a dry pass.
+    patterns: Vec<Pattern>,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // On Ctrl-C, dropping `harvest` cascades Drop through `Pool` → tasks
+    // → `ProcessGroup` → SIGKILL; no cancellation tokens needed.
+    let harvest = std::pin::pin!(harvest(args.patterns));
+    let ctrl_c = std::pin::pin!(tokio::signal::ctrl_c());
+    match select(harvest, ctrl_c).await {
+        Either::Left((result, _)) => result,
+        Either::Right((_, _)) => {
+            eprintln!("\nreceived Ctrl-C, shutting down...");
+            std::process::exit(1)
+        }
+    }
+}
+
+async fn harvest(patterns: Vec<Pattern>) -> Result<()> {
+    let tunnel_dir = Path::new(TUNNEL_DIR)
+        .canonicalize()
+        .with_context(|| format!("resolving tunnel crate at {TUNNEL_DIR}"))?;
+    std::env::set_current_dir(&tunnel_dir)
+        .with_context(|| format!("cd {}", tunnel_dir.display()))?;
+
+    let max_workers = num_cpus::get().saturating_sub(1).max(1);
+
+    let patterns = if patterns.is_empty() {
+        let discovered = dry_pass().await?;
+        if discovered.is_empty() {
+            eprintln!("All coverage patterns are already hit by the existing suite.");
+            return Ok(());
+        }
+        discovered
+    } else {
+        patterns
+    };
+
+    eprintln!("Patterns to harvest ({}):", patterns.len());
+    for p in &patterns {
+        eprintln!("  - {p}");
+    }
+
+    eprintln!("Building test binary...");
+    let mut build = Command::new("cargo");
+    build.args(["test", "tunnel_test", "--features", "proptest", "--no-run"]);
+    run_passthrough(build)
+        .await
+        .context("cargo test --no-run failed")?;
+
+    let config = Arc::new(PoolConfig {
+        max_workers,
+        max_pattern_len: patterns.iter().map(|p| p.as_str().len()).max().unwrap_or(0),
+        max_slot_digits: max_workers.saturating_sub(1).to_string().len().max(1),
+    });
+
+    let seeds = Pool::new(patterns, config).run().await;
+    print_summary(&seeds);
+    Ok(())
+}
+
+async fn dry_pass() -> Result<Vec<Pattern>> {
+    eprintln!("Running dry pass to discover missing patterns...");
+
+    let mut cmd = Command::new("cargo");
+    cmd.args([
+        "test",
+        "tunnel_test",
+        "--features",
+        "proptest",
+        "--",
+        "--nocapture",
+    ])
+    .env("TUNNEL_TEST_ENFORCE_COVERAGE", "1")
+    // Regression seeds only; novel case generation is the worker's job.
+    .env("PROPTEST_CASES", "0")
+    .env("CARGO_PROFILE_TEST_OPT_LEVEL", "1")
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+    let mut child = ProcessGroup::spawn(cmd).context("spawn cargo (dry pass)")?;
+    let mut lines = child.stderr();
+
+    let mut in_marker_block = false;
+    let mut missing = Vec::new();
+
+    while let Some(line) = lines.next().await {
+        let Ok(line) = line else { continue };
+        if line == MISSING_BEGIN {
+            in_marker_block = true;
+            continue;
+        }
+        if line == MISSING_END {
+            in_marker_block = false;
+            continue;
+        }
+        if in_marker_block {
+            missing.push(Pattern::from(line));
+            continue;
+        }
+        if line.starts_with("Running test case") {
+            eprintln!("[dry] {line}");
+        }
+    }
+
+    let _ = child.wait().await;
+    Ok(missing)
+}
+
+async fn run_passthrough(mut cmd: Command) -> Result<()> {
+    cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    let mut child = ProcessGroup::spawn(cmd).context("spawn")?;
+    let status = child.wait().await?;
+    if !status.success() {
+        bail!("command exited with {status}");
+    }
+    Ok(())
+}
+
+struct Pool {
+    patterns: Vec<Pattern>,
+    config: Arc<PoolConfig>,
+    pattern_states: BTreeMap<Pattern, PatternState>,
+    slots: SlotPool,
+    tasks: JoinSet<TaskReport>,
+}
+
+struct PoolConfig {
+    max_workers: usize,
+    max_pattern_len: usize,
+    max_slot_digits: usize,
+}
+
+impl Pool {
+    fn new(patterns: Vec<Pattern>, config: Arc<PoolConfig>) -> Self {
+        let slots = SlotPool::new(config.max_workers);
+        let pattern_states = patterns
+            .iter()
+            .map(|p| (p.clone(), PatternState::default()))
+            .collect();
+
+        Self {
+            patterns,
+            config,
+            pattern_states,
+            slots,
+            tasks: JoinSet::new(),
+        }
+    }
+
+    async fn run(mut self) -> BTreeMap<Pattern, Seed> {
+        let _ = tokio::fs::remove_dir_all(OUT_DIR).await;
+        let _ = tokio::fs::create_dir_all(OUT_DIR).await;
+
+        eprintln!(
+            "Keeping up to {} workers busy across {} pattern(s) (per-worker timeout: {}, max {MAX_ATTEMPTS_PER_PATTERN} attempts per pattern)...",
+            self.config.max_workers,
+            self.patterns.len(),
+            humantime::format_duration(WORKER_TIMEOUT),
+        );
+
+        self.refill();
+
+        while let Some(reap) = self.tasks.join_next_with_id().await {
+            self.handle_reap(reap);
+            self.refill();
+        }
+
+        self.pattern_states
+            .into_iter()
+            .filter_map(|(k, v)| v.seed.map(|s| (k, s)))
+            .collect()
+    }
+
+    fn pick_next_pattern(&self) -> Option<Pattern> {
+        self.patterns
+            .iter()
+            .filter(|p| self.pattern_states[*p].can_spawn())
+            .min_by_key(|p| self.pattern_states[*p].active())
+            .cloned()
+    }
+
+    fn refill(&mut self) {
+        while let Some(pattern) = self.pick_next_pattern() {
+            let Some(slot) = self.slots.try_take() else {
+                break;
+            };
+            let state = self
+                .pattern_states
+                .get_mut(&pattern)
+                .expect("state entry exists for every pattern");
+            let attempt = state.attempts;
+            state.attempts += 1;
+
+            let abort = self.tasks.spawn(run_worker(
+                slot,
+                pattern.clone(),
+                attempt,
+                self.config.clone(),
+            ));
+            state.handles.push(abort);
+        }
+    }
+
+    fn handle_reap(&mut self, reap: Result<(tokio::task::Id, TaskReport), tokio::task::JoinError>) {
+        let report = match reap {
+            Ok((_, r)) => r,
+            Err(e) if e.is_cancelled() => return,
+            Err(e) => {
+                eprintln!("[panic ] task {:?}: {e}", e.id());
+                return;
+            }
+        };
+        let state = self
+            .pattern_states
+            .get_mut(&report.pattern)
+            .expect("state entry exists for every pattern");
+        // Keep `active()` honest.
+        state.handles.retain(|h| !h.is_finished());
+
+        let p = self.config.max_pattern_len;
+        match report.outcome {
+            TaskOutcome::Found(seed) => {
+                eprintln!(
+                    "[found ] {:<p$} (cases={})",
+                    report.pattern.as_str(),
+                    report.cases,
+                );
+                if state.seed.is_none() {
+                    state.seed = Some(seed);
+                    for abort in state.handles.drain(..) {
+                        abort.abort();
+                    }
+                }
+            }
+            TaskOutcome::Missed => {
+                eprintln!(
+                    "[missed] {:<p$} (cases={})",
+                    report.pattern.as_str(),
+                    report.cases,
+                );
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct PatternState {
+    /// Doubles as the next worker's log-file index.
+    attempts: usize,
+    /// Live worker count (after `retain(!is_finished)`); drained to
+    /// abort siblings when a seed arrives.
+    handles: Vec<AbortHandle>,
+    seed: Option<Seed>,
+}
+
+impl PatternState {
+    fn active(&self) -> usize {
+        self.handles.len()
+    }
+
+    fn is_done(&self) -> bool {
+        self.seed.is_some()
+    }
+
+    fn can_spawn(&self) -> bool {
+        !self.is_done() && self.attempts < MAX_ATTEMPTS_PER_PATTERN
+    }
+}
+
+async fn run_worker(
+    slot: Slot,
+    pattern: Pattern,
+    attempt: usize,
+    config: Arc<PoolConfig>,
+) -> TaskReport {
+    let p = config.max_pattern_len;
+    eprintln!("[start ] {:<p$} (slot {slot})", pattern.as_str());
+
+    let log_path =
+        PathBuf::from(OUT_DIR).join(format!("{}.{attempt}.log", sanitize(pattern.as_str())));
+    let mut log_file = tokio::fs::File::create(&log_path).await.ok();
+
+    let prefix = format!("[{slot:0>w$}]: {pattern:<p$} |", w = config.max_slot_digits);
+
+    let mut cmd = Command::new("cargo");
+    cmd.args([
+        "test",
+        "tunnel_test",
+        "--features",
+        "proptest",
+        "--",
+        "--nocapture",
+    ])
+    .env("TUNNEL_TEST_HARVEST_TARGET", pattern.as_str())
+    .env("PROPTEST_CASES", PROPTEST_CASES.to_string())
+    .env(
+        "PROPTEST_MAX_SHRINK_ITERS",
+        PROPTEST_MAX_SHRINK_ITERS.to_string(),
+    )
+    .env("CARGO_PROFILE_TEST_OPT_LEVEL", "1")
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+
+    let mut child = match ProcessGroup::spawn(cmd) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[error ] {:<p$} (slot {slot}): {e}", pattern.as_str());
+            return TaskReport {
+                pattern,
+                outcome: TaskOutcome::Missed,
+                cases: 0,
+            };
+        }
+    };
+
+    let mut lines = child.stdout_stderr();
+
+    let mut cases = 0;
+    let seed = tokio::time::timeout(WORKER_TIMEOUT, async {
+        while let Some(next) = lines.next().await {
+            let Ok(line) = next else { continue };
+            eprintln!("{prefix} {line}");
+            if let Some(file) = log_file.as_mut() {
+                let _ = file.write_all(line.as_bytes()).await;
+                let _ = file.write_all(b"\n").await;
+            }
+            if line.starts_with("Running test case") {
+                cases += 1;
+            }
+            if let Some(rest) = line.strip_prefix(HARVESTED_SEED_MARKER) {
+                let s = rest.trim();
+                if !s.is_empty() {
+                    return Some(Seed(s.to_owned()));
+                }
+            }
+        }
+        None
+    })
+    .await
+    .ok()
+    .flatten();
+
+    let outcome = match seed {
+        Some(s) => TaskOutcome::Found(s),
+        None => TaskOutcome::Missed,
+    };
+
+    TaskReport {
+        pattern,
+        outcome,
+        cases,
+    }
+}
+
+enum TaskOutcome {
+    Found(Seed),
+    Missed,
+}
+
+struct TaskReport {
+    pattern: Pattern,
+    outcome: TaskOutcome,
+    cases: usize,
+}
+
+fn print_summary(seeds: &BTreeMap<Pattern, Seed>) {
+    if seeds.is_empty() {
+        eprintln!("\nNo seeds harvested.");
+        return;
+    }
+
+    eprintln!("\nHarvested seeds (append to proptest-regressions/tests.txt):");
+    eprintln!("===========================================================");
+    for seed in seeds.values() {
+        println!("{seed}");
+    }
+    eprintln!("===========================================================");
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Pattern(String);
+
+impl Pattern {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for Pattern {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl std::str::FromStr for Pattern {
+    type Err = std::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl std::fmt::Display for Pattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(&self.0)
+    }
+}
+
+/// Verbatim `cc <hex>` line, ready to paste into `tests.txt`.
+#[derive(Clone, Debug)]
+struct Seed(String);
+
+impl std::fmt::Display for Seed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/rust/tests/tunnel-proptest-harvester/src/main.rs
+++ b/rust/tests/tunnel-proptest-harvester/src/main.rs
@@ -62,12 +62,11 @@ async fn main() -> Result<()> {
     let harvest = std::pin::pin!(harvest(args.patterns));
     let ctrl_c = std::pin::pin!(tokio::signal::ctrl_c());
     match select(harvest, ctrl_c).await {
-        Either::Left((result, _)) => result,
-        Either::Right((_, _)) => {
-            eprintln!("\nreceived Ctrl-C, shutting down...");
-            std::process::exit(1)
-        }
+        Either::Left((result, _)) => result?,
+        Either::Right((_, _)) => eprintln!("\nreceived Ctrl-C, shutting down..."),
     }
+
+    Ok(())
 }
 
 async fn harvest(patterns: Vec<Pattern>) -> Result<()> {

--- a/rust/tests/tunnel-proptest-harvester/src/process_group.rs
+++ b/rust/tests/tunnel-proptest-harvester/src/process_group.rs
@@ -1,0 +1,75 @@
+//! `Child` guard that SIGKILLs the whole process group on drop. Tokio's
+//! `kill_on_drop` only targets cargo's own pid, which leaves the test
+//! binary and rustc orphaned; `killpg` covers the subtree.
+
+use std::ops::{Deref, DerefMut};
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio_stream::wrappers::LinesStream;
+use tokio_stream::{Stream, StreamExt as _};
+
+pub(crate) struct ProcessGroup(Child);
+
+impl ProcessGroup {
+    pub(crate) fn spawn(mut cmd: Command) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        cmd.process_group(0);
+        // Our `Drop` covers the whole group; skip tokio's per-pid kill.
+        cmd.kill_on_drop(false);
+        Ok(Self(cmd.spawn()?))
+    }
+
+    /// Panics if called twice: stdout/stderr can only be taken once.
+    pub(crate) fn stdout_stderr(
+        &mut self,
+    ) -> impl Stream<Item = std::io::Result<String>> + Unpin + use<> {
+        self.stdout().merge(self.stderr())
+    }
+
+    /// Panics if called twice: stdout can only be taken once.
+    pub(crate) fn stdout(&mut self) -> impl Stream<Item = std::io::Result<String>> + Unpin + use<> {
+        let stdout = self
+            .0
+            .stdout
+            .take()
+            .expect("child was spawned with Stdio::piped() for stdout");
+
+        LinesStream::new(BufReader::new(stdout).lines())
+    }
+
+    /// Panics if called twice: stderr can only be taken once.
+    pub(crate) fn stderr(&mut self) -> impl Stream<Item = std::io::Result<String>> + Unpin + use<> {
+        let stderr = self
+            .0
+            .stderr
+            .take()
+            .expect("child was spawned with Stdio::piped() for stderr");
+
+        LinesStream::new(BufReader::new(stderr).lines())
+    }
+}
+
+impl Drop for ProcessGroup {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(pid) = self.0.id() {
+            use nix::sys::signal::{Signal, killpg};
+            use nix::unistd::Pid;
+            let _ = killpg(Pid::from_raw(pid as i32), Signal::SIGKILL);
+        }
+    }
+}
+
+impl Deref for ProcessGroup {
+    type Target = Child;
+    fn deref(&self) -> &Child {
+        &self.0
+    }
+}
+
+impl DerefMut for ProcessGroup {
+    fn deref_mut(&mut self) -> &mut Child {
+        &mut self.0
+    }
+}

--- a/rust/tests/tunnel-proptest-harvester/src/slot_pool.rs
+++ b/rust/tests/tunnel-proptest-harvester/src/slot_pool.rs
@@ -1,0 +1,44 @@
+//! Fixed-size pool of stable worker-slot IDs. `Slot`'s `Drop` returns
+//! the ID even on panic or abort, so slots never leak.
+
+use tokio::sync::mpsc;
+
+pub(crate) struct Slot {
+    id: usize,
+    sender: mpsc::UnboundedSender<usize>,
+}
+
+impl std::fmt::Display for Slot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.id.fmt(f)
+    }
+}
+
+impl Drop for Slot {
+    fn drop(&mut self) {
+        let _ = self.sender.send(self.id);
+    }
+}
+
+pub(crate) struct SlotPool {
+    sender: mpsc::UnboundedSender<usize>,
+    receiver: mpsc::UnboundedReceiver<usize>,
+}
+
+impl SlotPool {
+    pub(crate) fn new(size: usize) -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        for i in 0..size {
+            let _ = sender.send(i);
+        }
+        Self { sender, receiver }
+    }
+
+    pub(crate) fn try_take(&mut self) -> Option<Slot> {
+        let id = self.receiver.try_recv().ok()?;
+        Some(Slot {
+            id,
+            sender: self.sender.clone(),
+        })
+    }
+}

--- a/rust/tests/tunnel-proptest-harvester/src/slot_pool.rs
+++ b/rust/tests/tunnel-proptest-harvester/src/slot_pool.rs
@@ -1,5 +1,5 @@
 //! Fixed-size pool of stable worker-slot IDs. `Slot`'s `Drop` returns
-//! the ID even on panic or abort, so slots never leak.
+//! the ID even on panic or task cancellation, so slots never leak.
 
 use tokio::sync::mpsc;
 


### PR DESCRIPTION
The proptest suite of connlib is one of the most important parts of our QA process. It uses deterministic randomness to generate different kinds of initial states, applies a series of transitions to it and checks if certain assumptions hold at all times.

Due to connlib's complexity, it can be quite tricky to hit certain codepaths with this approach. To ensure that we are not accidentally regressing behaviour through blind-spots in our test suite, we currently employ a very simple coverage scheme: We grep the log files of all test runs for specific patterns and fail CI if they don't occur.

This works but is cumbersome to maintain because which specific test case gets generated from a particular seed changes as soon as the sampling code changes. In other words, any change to the proptests results in different test cases being generated from the regression seeds. It is only by the sheer volume of test cases that we run that most of the patterns we are interested in actually get it.

There are a few specific ones, mostly around ICMP errors, that are very tricky to hit and where we have to "grind" for a particular seed to ensure it gets hit. To make this process easier, this PR does two things:

1. It moves the coverage checking into Rust via an integration directly with `tracing`
2. It introduces the `tunnel-proptest-harvester`. A binary that can - in parallel - search for regression seeds for a particular pattern.

This makes the searching for all missing seeds as simple as: `cargo run -p tunnel-proptest-harvester`. Once finished, the new seeds only need to be copied into the `tests.txt` regression seed file.