### PR TITLE
ci(rust): turn of backtrace for `tunnel_test`

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -188,6 +188,7 @@ jobs:
         env:
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
           PROPTEST_CASES: 256
+          RUST_BACKTRACE: 0
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
       - name: Check coverage
         shell: bash


### PR DESCRIPTION
This makes CI output a bit more manageable.