### PR TITLE
fix(portal): add cascade delete to devices

### DIFF
--- a/elixir/priv/repo/migrations/20260426160000_cascade_parent_delete_to_devices.exs
+++ b/elixir/priv/repo/migrations/20260426160000_cascade_parent_delete_to_devices.exs
@@ -1,0 +1,45 @@
+defmodule Portal.Repo.Migrations.CascadeParentDeleteToDevices do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER TABLE devices DROP CONSTRAINT devices_actor_id_fkey")
+
+    execute("""
+    ALTER TABLE devices
+    ADD CONSTRAINT devices_actor_id_fkey
+    FOREIGN KEY (account_id, actor_id)
+    REFERENCES actors(account_id, id)
+    ON DELETE CASCADE
+    """)
+
+    execute("ALTER TABLE devices DROP CONSTRAINT devices_site_id_fkey")
+
+    execute("""
+    ALTER TABLE devices
+    ADD CONSTRAINT devices_site_id_fkey
+    FOREIGN KEY (account_id, site_id)
+    REFERENCES sites(account_id, id)
+    ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    execute("ALTER TABLE devices DROP CONSTRAINT devices_actor_id_fkey")
+
+    execute("""
+    ALTER TABLE devices
+    ADD CONSTRAINT devices_actor_id_fkey
+    FOREIGN KEY (account_id, actor_id)
+    REFERENCES actors(account_id, id)
+    """)
+
+    execute("ALTER TABLE devices DROP CONSTRAINT devices_site_id_fkey")
+
+    execute("""
+    ALTER TABLE devices
+    ADD CONSTRAINT devices_site_id_fkey
+    FOREIGN KEY (account_id, site_id)
+    REFERENCES sites(account_id, id)
+    """)
+  end
+end

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -4,6 +4,7 @@ defmodule PortalWeb.ActorsTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
+  import Portal.ClientFixtures
   import Portal.GroupFixtures
   import Portal.IdentityFixtures
   import Portal.MembershipFixtures
@@ -770,6 +771,25 @@ defmodule PortalWeb.ActorsTest do
 
       html = render(lv)
       refute html =~ other_actor.name
+    end
+
+    test "deletes actor with client devices without crashing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: other_actor)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}")
+
+      render_click(lv, "delete", %{"id" => other_actor.id})
+
+      assert is_nil(Portal.Repo.get_by(Portal.Actor, account_id: account.id, id: other_actor.id))
+      assert is_nil(Portal.Repo.get_by(Portal.Device, account_id: account.id, id: client.id))
     end
   end
 end

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -1,7 +1,7 @@
 defmodule PortalWeb.SitesTest do
   use PortalWeb.ConnCase, async: true
 
-  alias Portal.{Repo, Resource, Site}
+  alias Portal.{Device, Repo, Resource, Site}
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -291,6 +291,28 @@ defmodule PortalWeb.SitesTest do
 
       assert_patch(lv, ~p"/#{account}/sites")
       assert is_nil(Repo.get_by(Site, account_id: account.id, id: site.id))
+    end
+
+    test "deletes a site with gateway devices without crashing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}")
+
+      render_click(lv, "confirm_delete_site")
+      html = render_click(lv, "delete_site")
+
+      assert html =~ "Site #{site.name} deleted successfully."
+      assert_patch(lv, ~p"/#{account}/sites")
+      assert is_nil(Repo.get_by(Site, account_id: account.id, id: site.id))
+      assert is_nil(Repo.get_by(Device, account_id: account.id, id: gateway.id))
     end
 
     test "hides account-only actions for system-managed sites", %{


### PR DESCRIPTION
Missed a couple cascade deletes on the new devices table constraints.

Migration has been run manually on staging + prod to fix issue there. Running this again is harmless.

---


Fixes #12961
