### PR TITLE
fix(portal): use font specified in app.js

### DIFF
--- a/elixir/assets/css/main.css
+++ b/elixir/assets/css/main.css
@@ -6,6 +6,17 @@
 
 /* Start: This may not be needed after UI refactor */
 @layer base {
+  body {
+    @apply font-sans;
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    @apply font-mono;
+  }
+
   button:not(:disabled),
   [role="button"]:not([aria-disabled="true"]):not([disabled]) {
     cursor: pointer;

--- a/elixir/assets/tailwind.config.js
+++ b/elixir/assets/tailwind.config.js
@@ -7,6 +7,8 @@ const path = require("path");
 const defaultTheme = require("tailwindcss/defaultTheme");
 const colors = require("tailwindcss/colors");
 
+const depsDir = process.env.MIX_DEPS_PATH || path.join(__dirname, "../deps");
+
 const firezoneColors = {
   // See our brand palette in Figma.
   // These have been reversed to match Tailwind's default order.
@@ -66,8 +68,12 @@ module.exports = {
   ],
   theme: {
     fontFamily: {
-      sans: ["Inter Variable", ...defaultTheme.fontFamily.sans],
-      mono: ["JetBrains Mono Variable", ...defaultTheme.fontFamily.mono],
+      sans: ["Roboto Variable", "Roboto", ...defaultTheme.fontFamily.sans],
+      mono: [
+        "Roboto Mono Variable",
+        "Roboto Mono",
+        ...defaultTheme.fontFamily.mono,
+      ],
     },
     extend: {
       colors: {
@@ -104,7 +110,7 @@ module.exports = {
     // Icons are sourced from the remixicons dep (deps/remixicons/icons/).
     // Use any icon with the `ri-` prefix, e.g. `ri-settings-3-line`.
     plugin(function ({ matchComponents, theme }) {
-      let iconsDir = path.join(__dirname, "../deps/remixicons/icons");
+      let iconsDir = path.join(depsDir, "remixicons/icons");
       let values = {};
       function scanDir(dir) {
         fs.readdirSync(dir, { withFileTypes: true }).forEach((entry) => {


### PR DESCRIPTION
- Updates tailwind config and css selectors so that our font import from app.js is used throughout the app.
- Fixes a small issue where remix icons wouldn't load in dev due to hardcoding the deps path to `../deps`



### Before

<img width="1840" height="1191" alt="Screenshot 2026-04-26 at 11 15 18 AM" src="https://github.com/user-attachments/assets/a6632a20-7f0f-4020-ac95-31f94dd1d4e9" />



### After

<img width="1840" height="1191" alt="Screenshot 2026-04-26 at 11 15 14 AM" src="https://github.com/user-attachments/assets/ba8bf509-724e-4721-8cf1-768a7651ab37" />
