### PR TITLE
fix(portal): No 'Upgrade Plan' btn for enterprise accts

### DIFF
--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -65,8 +65,27 @@ defmodule PortalWeb.Settings.Account do
             >
               This account has not had billing provisioned.
             </p>
+            <div
+              :if={@billing_provisioned and Billing.plan_type(@account) == :enterprise}
+              class="pt-2 border-t border-[var(--border)]"
+            >
+              <div class="rounded-lg border border-violet-200 bg-violet-50 dark:border-violet-800 dark:bg-violet-950/30 p-3 flex gap-2.5 items-start">
+                <.icon
+                  name="ri-customer-service-2-line"
+                  class="w-4 h-4 shrink-0 text-violet-500 dark:text-violet-400 mt-0.5"
+                />
+                <div>
+                  <p class="text-xs font-medium text-violet-700 dark:text-violet-300">
+                    Enterprise Plan
+                  </p>
+                  <p class="text-xs text-violet-600 dark:text-violet-400 mt-0.5">
+                    Contact your account manager for plan changes.
+                  </p>
+                </div>
+              </div>
+            </div>
             <button
-              :if={@billing_provisioned}
+              :if={@billing_provisioned and Billing.plan_type(@account) != :enterprise}
               phx-click="redirect_to_billing_portal"
               class="w-full mt-1 px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-strong)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-emphasis)] bg-[var(--surface)] transition-colors"
             >

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -14,6 +14,7 @@ defmodule PortalWeb.Settings.Account do
       assign(socket,
         page_title: "Account",
         billing_provisioned: Billing.account_provisioned?(account),
+        billing_plan_type: Billing.plan_type(account),
         error: nil,
         slug_confirmation: "",
         confirm_delete_account: false,
@@ -66,7 +67,7 @@ defmodule PortalWeb.Settings.Account do
               This account has not had billing provisioned.
             </p>
             <div
-              :if={@billing_provisioned and Billing.plan_type(@account) == :enterprise}
+              :if={@billing_provisioned and @billing_plan_type == :enterprise}
               class="pt-2 border-t border-[var(--border)]"
             >
               <div class="rounded-lg border border-violet-200 bg-violet-50 dark:border-violet-800 dark:bg-violet-950/30 p-3 flex gap-2.5 items-start">
@@ -85,7 +86,7 @@ defmodule PortalWeb.Settings.Account do
               </div>
             </div>
             <button
-              :if={@billing_provisioned and Billing.plan_type(@account) != :enterprise}
+              :if={@billing_provisioned and @billing_plan_type != :enterprise}
               phx-click="redirect_to_billing_portal"
               class="w-full mt-1 px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-strong)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-emphasis)] bg-[var(--surface)] transition-colors"
             >

--- a/elixir/test/portal_web/live/settings/account_test.exs
+++ b/elixir/test/portal_web/live/settings/account_test.exs
@@ -24,6 +24,60 @@ defmodule PortalWeb.Settings.AccountTest do
     end
   end
 
+  describe "billing plan UI" do
+    test "shows upgrade button for non-enterprise provisioned account", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test", product_name: "Team"}}
+        })
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      assert html =~ "Upgrade plan"
+      refute html =~ "Contact your account manager for plan changes."
+    end
+
+    test "shows contact message instead of upgrade button for enterprise provisioned account", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      account =
+        update_account(account, %{
+          metadata: %{stripe: %{customer_id: "cus_test", product_name: "Enterprise"}}
+        })
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      refute html =~ "Upgrade plan"
+      assert html =~ "Contact your account manager for plan changes."
+    end
+
+    test "shows neither upgrade button nor contact message for unprovisioned account", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/account")
+
+      refute html =~ "Upgrade plan"
+      refute html =~ "Contact your account manager for plan changes."
+    end
+  end
+
   describe "index (default action)" do
     test "renders account settings page with account slug", %{
       conn: conn,


### PR DESCRIPTION
Enterprise accounts don't need to see the "Upgrade Plan" button as they are already on the highest tier plan.

Fixes #12959