### PR TITLE
feat(connlib): introduce raptor V2 aka soft ICE

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3703,8 +3703,7 @@ dependencies = [
 [[package]]
 name = "is"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cf23944e1280f3b2959321a1ef776c14503af8e1e5efca32147a9136a5f8dc"
+source = "git+https://github.com/algesten/str0m?branch=feat%2Frole-conflict#ddbd8caaa5d9c0595cffef0571e322a9ef4650ca"
 dependencies = [
  "crc",
  "hmac",
@@ -7008,8 +7007,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m-proto"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a6a5a946631a167c1b0282846bfa33b0f8098b8dd565237809735656ed63f"
+source = "git+https://github.com/algesten/str0m?branch=feat%2Frole-conflict#ddbd8caaa5d9c0595cffef0571e322a9ef4650ca"
 dependencies = [
  "base64ct",
  "fastrand",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8384,6 +8384,7 @@ dependencies = [
  "logging",
  "lru",
  "opentelemetry",
+ "phoenix-channel",
  "proptest",
  "proptest-state-machine",
  "rand 0.8.5",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -259,6 +259,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
+is = { git = "https://github.com/algesten/str0m", branch = "feat/role-conflict" } # Waiting for release with role-conflict detection.
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -40,6 +40,31 @@ pub use tokio_tungstenite::tungstenite::http::StatusCode;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
 
+/// Bound for the persistent queue used by must-queue messages (see [`MustQueue`]).
+///
+/// Persistent messages survive reconnects, so the queue can grow while we're
+/// disconnected. We cap it to avoid unbounded growth; if the cap is exceeded
+/// the oldest entry is dropped.
+const MAX_PERSISTENT_MESSAGES: usize = 32;
+
+/// Outbound messages that the channel must not silently drop on disconnect.
+///
+/// Messages whose [`MustQueue::must_queue`] returns `true` are placed on a
+/// persistent queue inside [`PhoenixChannel`] and re-sent on the next
+/// successful join. Messages where it returns `false` use the existing
+/// best-effort [`PhoenixChannel::send`] path: they are queued only while
+/// connected and dropped if the channel disconnects before they reach the
+/// wire.
+pub trait MustQueue {
+    fn must_queue(&self) -> bool;
+}
+
+impl MustQueue for () {
+    fn must_queue(&self) -> bool {
+        false
+    }
+}
+
 const INITIAL_CONNECT_MAX_ELAPSED_TIME: Duration = Duration::from_secs(15);
 const INITIAL_CONNECT_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -65,6 +90,13 @@ pub struct PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish> {
     make_reconnect_backoff: Box<dyn Fn() -> ExponentialBackoff + Send>,
     backoff: Option<ExponentialBackoff>,
     was_connected: bool,
+
+    /// Messages that must survive reconnects.
+    ///
+    /// Lives at the channel level (rather than inside `Connected`) so we keep
+    /// it across `State` transitions. Drained into the active connection's
+    /// `pending_messages` once we've rejoined.
+    pending_persistent: VecDeque<(String, TOutboundMsg)>,
 
     login: &'static str,
     init_req: TInitReq,
@@ -352,7 +384,7 @@ impl<TInitReq, TOutboundMsg, TInboundMsg, TFinish>
     PhoenixChannel<TInitReq, TOutboundMsg, TInboundMsg, TFinish>
 where
     TInitReq: Serialize + Clone,
-    TOutboundMsg: Serialize + PartialEq + fmt::Debug,
+    TOutboundMsg: Serialize + PartialEq + fmt::Debug + MustQueue,
     TInboundMsg: DeserializeOwned,
     TFinish: IntoIterator<Item = (&'static str, String)>,
 {
@@ -385,6 +417,7 @@ where
             login,
             init_req,
             last_url: None,
+            pending_persistent: VecDeque::new(),
         }
     }
 
@@ -414,12 +447,38 @@ where
     }
 
     /// Send a message to a topic.
+    ///
+    /// Messages whose [`MustQueue::must_queue`] returns `true` are placed on
+    /// the persistent queue and re-sent across reconnects. Other messages are
+    /// queued only while the channel is connected and rejected with
+    /// [`NotConnected`] otherwise.
     pub fn send(
         &mut self,
         topic: impl Into<String>,
         message: TOutboundMsg,
     ) -> Result<(), NotConnected<TOutboundMsg>> {
         let topic = topic.into();
+
+        if message.must_queue() {
+            if self.pending_persistent.iter().any(|(_, m)| m == &message) {
+                tracing::debug!(?message, "Refusing to queue exact duplicate");
+                return Ok(());
+            }
+
+            if self.pending_persistent.len() >= MAX_PERSISTENT_MESSAGES
+                && let Some((_, dropped)) = self.pending_persistent.pop_front()
+            {
+                tracing::warn!(?dropped, "Persistent queue full; dropping oldest message");
+            }
+
+            self.pending_persistent.push_back((topic, message));
+
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+
+            return Ok(());
+        }
 
         let State::Connected(Connected {
             pending_messages,
@@ -531,8 +590,41 @@ where
         Ok(())
     }
 
+    /// Drain the persistent queue into the active connection's pending
+    /// messages. No-op while we're disconnected or waiting for a join reply
+    /// (we want our room to exist before we send into it).
+    fn drain_persistent_into_pending(&mut self) {
+        let Self {
+            state,
+            pending_persistent,
+            ..
+        } = self;
+        let State::Connected(connected) = state else {
+            return;
+        };
+        if !connected.pending_join_requests.is_empty() {
+            return;
+        }
+
+        for (topic, message) in pending_persistent.drain(..) {
+            let request_id = fetch_add_request_id(&mut connected.next_request_id);
+            connected
+                .pending_messages
+                .push_back(PhoenixMessage::new_message(
+                    topic,
+                    message,
+                    Some(request_id),
+                ));
+        }
+    }
+
     pub fn poll(&mut self, cx: &mut Context) -> Poll<Result<Event<TInboundMsg>, Error>> {
         loop {
+            // Drain the persistent queue before doing anything else this
+            // iteration so messages we held across reconnects get a request
+            // ID and join the regular send path.
+            self.drain_persistent_into_pending();
+
             // First, check if we are connected.
             let Connected {
                 stream,

--- a/rust/libs/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/tests/lib.rs
@@ -416,6 +416,12 @@ enum OutboundMsg {
     Bar,
 }
 
+impl phoenix_channel::MustQueue for OutboundMsg {
+    fn must_queue(&self) -> bool {
+        false
+    }
+}
+
 #[tokio::test]
 async fn http_429_triggers_retry() {
     let port = http_status_server(http::StatusCode::TOO_MANY_REQUESTS).await;

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -260,6 +260,25 @@ impl Allocation {
         allocation
     }
 
+    pub fn reset(&mut self, now: Instant) {
+        self.active_socket = None;
+        self.ip4_host_candidate = None;
+        self.ip6_host_candidate = None;
+        self.ip4_srflx_candidate = None;
+        self.ip6_srflx_candidate = None;
+        self.ip4_allocation = None;
+        self.ip6_allocation = None;
+        self.buffered_transmits.clear();
+        self.events.clear();
+        self.sent_requests.clear();
+        self.allocation_lifetime = None;
+        self.channel_bindings.clear();
+        self.buffered_channel_bindings.clear();
+        self.explicit_failure = None;
+
+        self.send_binding_requests(now);
+    }
+
     pub fn host_and_server_reflexive_candidates(&self) -> impl Iterator<Item = Candidate> + use<> {
         [
             self.ip4_host_candidate.clone(),

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -12,9 +12,7 @@ mod stats;
 mod utils;
 
 pub use allocation::RelaySocket;
-pub use node::{
-    Credentials, Event, IceConfig, IceRole, NoTurnServers, Node, Transmit, UnknownConnection,
-};
+pub use node::{Credentials, Event, IceRole, NoTurnServers, Node, Transmit, UnknownConnection};
 pub use stats::{ConnectionStats, NodeStats};
 
 pub fn is_wireguard(payload: &[u8]) -> bool {

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -198,46 +198,27 @@ where
         }
     }
 
-    /// Resets this [`Node`].
+    /// Resets this [`Node`] in response to a network change on the local side.
     ///
-    /// # Implementation note
+    /// Unlike a full teardown, this preserves state that survives a roam:
+    /// - the WireGuard private key (so existing sessions can continue),
+    /// - established [`Connection`]s (their `IceAgent`s are restarted in place),
+    /// - the remote candidates and ICE credentials we already know.
     ///
-    /// This also clears all [`Allocation`]s.
-    /// An [`Allocation`] on a TURN server is identified by the client's 3-tuple (IP, port, protocol).
-    /// Thus, clearing the [`Allocation`]'s state here without closing it means we won't be able to make a new one until:
-    /// - it times out
-    /// - we change our IP or port
-    ///
-    /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::reset`].
-    pub fn reset(&mut self, now: Instant) {
+    /// What does get reset:
+    /// - each connection's candidate epoch is bumped so newly added local
+    ///   candidates strictly outrank candidates from the previous network,
+    /// - each connection's ICE candidate-pair list is re-formed, clearing
+    ///   any prior nomination state,
+    /// - [`Allocation`]s are cleared — upper layers MUST rebind the sockets
+    ///   they use for ICE and re-register TURN servers afterwards.
+    pub fn reset(&mut self) {
         self.allocations.clear();
-
         self.buffered_transmits.clear();
-
         self.pending_events.clear();
-
-        let closed_connections = self
-            .connections
-            .iter_ids()
-            .map(Event::ConnectionClosed)
-            .collect::<Vec<_>>();
-        let num_connections = closed_connections.len();
-
-        self.pending_events.extend(closed_connections);
-
-        self.connections.clear();
-        self.buffered_transmits.clear();
         self.inflight_stun_requests.clear();
 
-        self.private_key = StaticSecret::random_from_rng(&mut self.rng);
-        self.public_key = (&self.private_key).into();
-        self.rate_limiter = Arc::new(RateLimiter::new_at(
-            &self.public_key,
-            HANDSHAKE_RATE_LIMIT,
-            now,
-        ));
-
-        tracing::debug!(%num_connections, "Closed all connections as part of reconnecting");
+        self.connections.ice_restart();
     }
 
     pub fn num_connections(&self) -> usize {
@@ -1943,6 +1924,31 @@ where
         for candidate in new_allocation.current_relay_candidates() {
             self.add_local_candidate(cid, &candidate, pending_events, now);
         }
+    }
+
+    /// Re-form all ICE candidate pairs in place without tearing anything down.
+    ///
+    /// The existing local and remote candidates stay; only the candidate-pair
+    /// list and Firezone-level handshake bookkeeping are cleared. The
+    /// underlying WireGuard session is left alone, and the candidate epoch
+    /// is NOT bumped — that decision belongs to the caller, since the right
+    /// side to bump the epoch on depends on which side's candidates are
+    /// superseding the others.
+    fn ice_restart(&mut self) {
+        // If the ICE agent is already checking candidates, recreating the
+        // pair list would abort those in-flight checks for no benefit — the
+        // agent is already on the path we'd restart it on.
+        if self.agent.state() == IceConnectionState::Checking {
+            tracing::trace!("Agent is already checking candidates, skipping ICE restart");
+            return;
+        }
+
+        self.agent.recreate_candidate_pairs();
+
+        self.first_handshake_completed_at = None;
+        self.last_proactive_handshake_sent_at = None;
+        self.disconnected_at = None;
+        self.poll_timeout_cache = TimeoutCache::default();
     }
 }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -48,9 +48,6 @@ const HANDSHAKE_RATE_LIMIT: u64 = 100;
 /// How long we will at most wait for a candidate from the remote.
 const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Grace-period for when we will act on an ICE disconnect.
-const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(2);
-
 /// For how long we will at most try to re-key a WireGuard tunnel.
 const WG_REKEY_ATTEMPT_TIME: Duration = Duration::from_secs(20);
 
@@ -777,7 +774,6 @@ where
                 wg_buffer: AllocRingBuffer::new(128),
                 ip_buffer: AllocRingBuffer::new(128),
             },
-            disconnected_at: None,
             buffer_pool: self.buffer_pool.clone(),
             last_proactive_handshake_sent_at: None,
             first_handshake_completed_at: None,
@@ -1236,7 +1232,6 @@ struct Connection<RId> {
     relay: SelectedRelay<RId>,
 
     state: ConnectionState,
-    disconnected_at: Option<Instant>,
 
     stats: ConnectionStats,
     intent_sent_at: Instant,
@@ -1281,20 +1276,10 @@ where
                 self.candidate_timeout
                     .map(|instant| (instant, "candidate timeout")),
             )
-            .chain(
-                self.disconnect_timeout()
-                    .map(|instant| (instant, "disconnect timeout")),
-            )
             .chain(self.state.poll_timeout(&self.agent))
             .min_by_key(|(instant, _)| *instant);
 
         self.poll_timeout_cache.update(timeout)
-    }
-
-    fn disconnect_timeout(&self) -> Option<Instant> {
-        let disconnected_at = self.disconnected_at?;
-
-        Some(disconnected_at + DISCONNECT_TIMEOUT)
     }
 
     fn handle_timeout<TId>(
@@ -1325,15 +1310,6 @@ where
             return;
         }
 
-        if self
-            .disconnect_timeout()
-            .is_some_and(|timeout| now >= timeout)
-        {
-            tracing::info!(state = %self.state, index = %self.index.global(), "Connection failed (ICE timeout)");
-            self.state = ConnectionState::Failed;
-            return;
-        }
-
         self.handle_tunnel_timeout(now, allocations, transmits);
 
         // If this was a scheduled update, hop to the next interval.
@@ -1351,21 +1327,14 @@ where
         while let Some(event) = self.agent.poll_event() {
             match event {
                 IceAgentEvent::DiscoveredRecv { .. } => {}
-                IceAgentEvent::IceConnectionStateChange(IceConnectionState::Disconnected) => {
-                    tracing::debug!(grace_period = ?DISCONNECT_TIMEOUT, "Received ICE disconnect");
-
-                    self.disconnected_at = Some(now);
-                }
-                IceAgentEvent::IceConnectionStateChange(
-                    IceConnectionState::Checking | IceConnectionState::Connected,
-                ) => {
-                    let existing = self.disconnected_at.take();
-
-                    if let Some(disconnected_at) = existing {
-                        let offline = now.duration_since(disconnected_at);
-
-                        tracing::debug!(?offline, "ICE agent reconnected");
-                    }
+                // ICE connection-state transitions no longer drive connection
+                // teardown. Liveness is governed by the WireGuard state
+                // machine (via `REKEY_ATTEMPT_TIME`); an ICE `Disconnected`
+                // state is transient and recoverable as new candidates or
+                // STUN checks succeed, so tearing the connection down on it
+                // was an over-reaction. We still trace it for visibility.
+                IceAgentEvent::IceConnectionStateChange(state) => {
+                    tracing::debug!(?state, "ICE state change");
                 }
                 IceAgentEvent::NominatedSend {
                     destination,
@@ -1488,7 +1457,7 @@ where
                         self.initiate_wg_session(allocations, transmits, now);
                     }
                 }
-                IceAgentEvent::IceRestart(_) | IceAgentEvent::IceConnectionStateChange(_) => {}
+                IceAgentEvent::IceRestart(_) => {}
             }
         }
 
@@ -1947,7 +1916,6 @@ where
 
         self.first_handshake_completed_at = None;
         self.last_proactive_handshake_sent_at = None;
-        self.disconnected_at = None;
         self.poll_timeout_cache = TimeoutCache::default();
     }
 }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -156,14 +156,12 @@ where
     /// - the remote candidates and ICE credentials we already know.
     ///
     /// What does get reset:
-    /// - each connection's candidate epoch is bumped so newly added local
-    ///   candidates strictly outrank candidates from the previous network,
     /// - each connection's ICE candidate-pair list is re-formed, clearing
     ///   any prior nomination state,
-    /// - [`Allocation`]s are cleared — upper layers MUST rebind the sockets
+    /// - [`Allocation`]s are reset — upper layers MUST rebind the sockets
     ///   they use for ICE and re-register TURN servers afterwards.
     pub fn reset(&mut self, now: Instant) {
-        self.allocations.clear();
+        self.allocations.reset(now);
         self.buffered_transmits.clear();
         self.pending_events.clear();
         self.inflight_stun_requests.clear();

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -215,6 +215,20 @@ where
         self.pending_events.clear();
         self.inflight_stun_requests.clear();
 
+        // Tell peers to drop the candidates we previously signalled. The
+        // candidate epoch already makes the new candidates win locally and
+        // for any peer running this version; this is a backwards-compat
+        // nudge for peers that don't grade candidates by epoch yet.
+        for (cid, c) in self.connections.iter_established() {
+            for candidate in c.agent.local_candidates() {
+                self.pending_events
+                    .push_back(Event::InvalidateIceCandidate {
+                        connection: cid,
+                        candidate,
+                    });
+            }
+        }
+
         self.connections.ice_restart();
     }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -162,7 +162,7 @@ where
     ///   any prior nomination state,
     /// - [`Allocation`]s are cleared — upper layers MUST rebind the sockets
     ///   they use for ICE and re-register TURN servers afterwards.
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self, now: Instant) {
         self.allocations.clear();
         self.buffered_transmits.clear();
         self.pending_events.clear();
@@ -182,7 +182,7 @@ where
             }
         }
 
-        self.connections.ice_restart();
+        self.connections.ice_restart(self.unix_ms(now));
     }
 
     /// Returns the current Unix time in milliseconds, derived from the
@@ -1901,11 +1901,8 @@ where
     ///
     /// The existing local and remote candidates stay; only the candidate-pair
     /// list and Firezone-level handshake bookkeeping are cleared. The
-    /// underlying WireGuard session is left alone, and the candidate epoch
-    /// is NOT bumped — that decision belongs to the caller, since the right
-    /// side to bump the epoch on depends on which side's candidates are
-    /// superseding the others.
-    fn ice_restart(&mut self) {
+    /// underlying WireGuard session is left alone.
+    fn ice_restart(&mut self, unix_ms: u64) {
         // If the ICE agent is already checking candidates, recreating the
         // pair list would abort those in-flight checks for no benefit — the
         // agent is already on the path we'd restart it on.
@@ -1913,6 +1910,17 @@ where
             tracing::trace!("Agent is already checking candidates, skipping ICE restart");
             return;
         }
+
+        // Take the controlling role with a monotonically-increasing
+        // tiebreaker, so the next binding request to the peer triggers a
+        // role conflict (RFC 8445 §7.3.1.1) that the just-roamed side wins.
+        // Combined with `peer_socket_override`, this gives us — the side
+        // that knows it has new candidates — unilateral authority to
+        // nominate a new pair, which is what we need in c2c where the
+        // previously-controlled side could otherwise never drive a path
+        // swap.
+        self.agent.set_controlling(true);
+        self.agent.set_control_tie_breaker(unix_ms);
 
         self.agent.recreate_candidate_pairs();
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -953,14 +953,14 @@ where
             now,
         );
 
+        let decap_ok = matches!(&control_flow, ControlFlow::Break(Ok(())));
         let is_handshake = matches!(
             parsed_packet,
             Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
         );
-        let handshake_decapsulated_ok =
-            is_handshake && matches!(&control_flow, ControlFlow::Break(Ok(())));
+        let is_handshake_init = matches!(parsed_packet, Packet::HandshakeInit(_));
 
-        if handshake_decapsulated_ok && conn.first_handshake_completed_at.is_none() {
+        if decap_ok && is_handshake && conn.first_handshake_completed_at.is_none() {
             conn.first_handshake_completed_at = Some(now);
 
             tracing::debug!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
@@ -969,7 +969,10 @@ where
                 .push_back(Event::ConnectionEstablished(cid))
         }
 
-        if handshake_decapsulated_ok {
+        // Only `HandshakeInit` reflects the peer's choice of send-from
+        // socket; a `HandshakeResponse` just confirms wherever we sent the
+        // matching init from and would race ICE re-nominations.
+        if decap_ok && is_handshake_init {
             conn.maybe_override_peer_socket(cid, observed_peer_socket);
         }
 
@@ -1848,7 +1851,12 @@ where
     }
 
     /// Set or update the `peer_socket_override` on `Connected` based on the
-    /// source of an authenticated WG handshake.
+    /// source of an authenticated WG `HandshakeInit`.
+    ///
+    /// Caller must only invoke this for a `HandshakeInit`, never for a
+    /// `HandshakeResponse`: an init is the peer's choice of send-from
+    /// socket, while a response just confirms wherever we sent the matching
+    /// init from.
     ///
     /// The override applies only once we have an ICE-nominated socket to
     /// deviate from; during `Connecting` ICE hasn't picked anything yet and
@@ -1876,7 +1884,7 @@ where
             %cid,
             current = %effective.fmt(self.relay.id),
             new = %observed.fmt(self.relay.id),
-            "Overriding peer_socket from authenticated WG handshake"
+            "Overriding peer_socket from authenticated WG handshake init"
         );
 
         *peer_socket_override = Some(observed);

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -113,53 +113,6 @@ pub struct Node<TId, RId> {
 pub struct NoTurnServers {}
 
 #[derive(Debug, Clone, Copy)]
-pub struct IceConfig {
-    max_retrans: usize,
-    max_rto: Duration,
-    initial_rto: Duration,
-}
-
-impl IceConfig {
-    pub fn server_default() -> Self {
-        Self {
-            max_retrans: 45,
-            max_rto: Duration::from_millis(15_000),
-            initial_rto: Duration::from_millis(250),
-        }
-    }
-
-    pub fn server_idle() -> Self {
-        IceConfig {
-            max_retrans: 40,
-            max_rto: Duration::from_secs(25),
-            initial_rto: Duration::from_secs(25),
-        }
-    }
-
-    pub fn client_default() -> Self {
-        Self {
-            max_retrans: 12,
-            max_rto: Duration::from_millis(1500),
-            initial_rto: Duration::from_millis(250),
-        }
-    }
-
-    pub fn client_idle() -> Self {
-        Self {
-            max_retrans: 4,
-            max_rto: Duration::from_secs(25),
-            initial_rto: Duration::from_secs(25),
-        }
-    }
-
-    fn apply(&self, agent: &mut IceAgent) {
-        agent.set_max_stun_retransmits(self.max_retrans);
-        agent.set_max_stun_rto(self.max_rto);
-        agent.set_initial_stun_rto(self.initial_rto)
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
 pub enum IceRole {
     Controlling,
     Controlled,
@@ -249,8 +202,6 @@ where
         local_creds: Credentials,
         remote_creds: Credentials,
         ice_role: IceRole,
-        default_ice_config: IceConfig,
-        idle_ice_config: IceConfig,
         now: Instant,
     ) -> Result<(), NoTurnServers> {
         let local_creds = local_creds.into();
@@ -276,9 +227,6 @@ where
             && c.agent.controlling() == matches!(ice_role, IceRole::Controlling)
         {
             tracing::info!(local = ?local_creds, "Reusing existing connection");
-
-            c.state
-                .on_upsert(cid, &mut c.agent, c.default_ice_config, now);
 
             // Take all current candidates.
             let current_candidates = c.agent.local_candidates().collect::<SmallVec<[_; 16]>>();
@@ -320,7 +268,6 @@ where
         }
 
         let mut agent = new_agent(ice_role);
-        default_ice_config.apply(&mut agent);
         agent.set_local_credentials(local_creds);
         agent.set_remote_credentials(remote_creds);
 
@@ -342,8 +289,6 @@ where
             preshared_key,
             selected_relay,
             index,
-            default_ice_config,
-            idle_ice_config,
             now,
             now,
         );
@@ -377,8 +322,7 @@ where
         };
 
         let peer_socket = match connection.state {
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => peer_socket,
+            ConnectionState::Connected { peer_socket, .. } => peer_socket,
             ConnectionState::Connecting { .. } => {
                 tracing::info!("Connection closed during ICE");
                 return;
@@ -388,7 +332,7 @@ where
 
         self.pending_events.push_back(Event::ConnectionClosed(cid));
 
-        match connection.encapsulate(cid, peer_socket, &goodbye, now, &mut self.allocations) {
+        match connection.encapsulate(peer_socket, &goodbye, now, &mut self.allocations) {
             Ok(Some(transmit)) => {
                 tracing::info!("Connection closed proactively (sent goodbye)");
 
@@ -433,7 +377,7 @@ where
             return;
         };
 
-        c.add_remote_candidate(cid, candidate.clone(), now);
+        c.add_remote_candidate(candidate.clone());
 
         match candidate.kind() {
             CandidateKind::Host => {
@@ -463,7 +407,7 @@ where
             return;
         };
 
-        c.remove_remote_candidate(cid, candidate, now);
+        c.remove_remote_candidate(candidate, now);
     }
 
     /// Decapsulate an incoming packet.
@@ -540,7 +484,6 @@ where
             return Ok(None);
         }
 
-        let override_socket = conn.peer_socket_override;
         let socket = match &mut conn.state {
             ConnectionState::Connecting { ip_buffer, .. } => {
                 ip_buffer.enqueue(packet.clone());
@@ -550,17 +493,17 @@ where
 
                 return Ok(None);
             }
-            ConnectionState::Connected { peer_socket, .. } => {
-                override_socket.unwrap_or(*peer_socket)
-            }
-            ConnectionState::Idle { peer_socket } => override_socket.unwrap_or(*peer_socket),
+            ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+            } => peer_socket_override.unwrap_or(*peer_socket),
             ConnectionState::Failed => {
                 return Err(anyhow!("Connection {cid} failed"));
             }
         };
 
         let maybe_transmit = conn
-            .encapsulate(cid, socket, packet, now, &mut self.allocations)
+            .encapsulate(socket, packet, now, &mut self.allocations)
             .with_context(|| format!("cid={cid}"))?;
 
         Ok(maybe_transmit)
@@ -613,7 +556,7 @@ where
     pub fn handle_timeout(&mut self, now: Instant) {
         self.allocations.handle_timeout(now);
 
-        self.allocations_drain_events(now);
+        self.allocations_drain_events();
 
         for (id, connection) in self.connections.iter_established_mut() {
             connection.handle_timeout(
@@ -625,16 +568,11 @@ where
             );
         }
 
-        if self.connections.all_idle() {
-            // If all connections are idle, there is no point in resetting the rate limiter.
-            self.next_rate_limiter_reset = None;
-        } else {
-            let next_reset = *self.next_rate_limiter_reset.get_or_insert(now);
+        let next_reset = *self.next_rate_limiter_reset.get_or_insert(now);
 
-            if now >= next_reset {
-                self.rate_limiter.reset_count_at(now);
-                self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
-            }
+        if now >= next_reset {
+            self.rate_limiter.reset_count_at(now);
+            self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
         }
 
         let removed_allocations = self.allocations.gc();
@@ -757,8 +695,6 @@ where
         key: x25519::StaticSecret,
         relay: RId,
         index: Index,
-        default_ice_config: IceConfig,
-        idle_ice_config: IceConfig,
         intent_sent_at: Instant,
         now: Instant,
     ) -> Connection<RId> {
@@ -806,12 +742,9 @@ where
                 wg_buffer: AllocRingBuffer::new(128),
                 ip_buffer: AllocRingBuffer::new(128),
             },
-            peer_socket_override: None,
             buffer_pool: self.buffer_pool.clone(),
             last_proactive_handshake_sent_at: None,
             first_handshake_completed_at: None,
-            default_ice_config,
-            idle_ice_config,
             poll_timeout_cache: Default::default(),
             candidate_timeout: Some(now + CANDIDATE_TIMEOUT),
         }
@@ -1024,8 +957,8 @@ where
             parsed_packet,
             Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
         );
-        let handshake_decapsulated_ok = is_handshake
-            && matches!(&control_flow, ControlFlow::Break(Ok(())));
+        let handshake_decapsulated_ok =
+            is_handshake && matches!(&control_flow, ControlFlow::Break(Ok(())));
 
         if handshake_decapsulated_ok && conn.first_handshake_completed_at.is_none() {
             conn.first_handshake_completed_at = Some(now);
@@ -1045,14 +978,14 @@ where
             .map_break(|b| b.with_context(|| format!("cid={cid} length={}", packet.len())))
     }
 
-    fn allocations_drain_events(&mut self, now: Instant) {
+    fn allocations_drain_events(&mut self) {
         while let Some((rid, event)) = self.allocations.poll_event() {
             tracing::trace!(%rid, ?event);
 
             match event {
                 allocation::Event::New(candidate) => {
                     for (cid, c) in self.connections.iter_mut_by_relay(rid) {
-                        c.add_local_candidate(cid, &candidate, &mut self.pending_events, now);
+                        c.add_local_candidate(cid, &candidate, &mut self.pending_events);
                     }
                 }
                 allocation::Event::Invalid(candidate) => {
@@ -1272,16 +1205,6 @@ struct Connection<RId> {
 
     state: ConnectionState,
 
-    /// Temporary override for the outbound `PeerSocket`, set when we observe
-    /// an authenticated WireGuard handshake from a source that doesn't match
-    /// our current ICE nomination. Cleared by the next `NominatedSend` event
-    /// from ICE.
-    ///
-    /// This lets outgoing WG traffic follow the peer across cross-kind
-    /// path shifts (direct↔relay) that the controlled side of ICE can't
-    /// re-nominate without `USE-CANDIDATE` from the controlling side.
-    peer_socket_override: Option<PeerSocket>,
-
     stats: ConnectionStats,
     intent_sent_at: Instant,
     candidate_timeout: Option<Instant>,
@@ -1289,9 +1212,6 @@ struct Connection<RId> {
     first_handshake_completed_at: Option<Instant>,
 
     buffer: Vec<u8>,
-
-    default_ice_config: IceConfig,
-    idle_ice_config: IceConfig,
 
     #[debug(skip)]
     buffer_pool: BufferPool<Vec<u8>>,
@@ -1325,7 +1245,6 @@ where
                 self.candidate_timeout
                     .map(|instant| (instant, "candidate timeout")),
             )
-            .chain(self.state.poll_timeout(&self.agent))
             .min_by_key(|(instant, _)| *instant);
 
         self.poll_timeout_cache.update(timeout)
@@ -1350,8 +1269,6 @@ where
         let _guard = tracing::info_span!("handle_timeout", %cid).entered();
 
         self.agent.handle_timeout(now);
-        self.state
-            .handle_timeout(&mut self.agent, self.idle_ice_config, now);
 
         if self.candidate_timeout.is_some_and(|timeout| now >= timeout) {
             tracing::info!(state = %self.state, index = %self.index.global(), "Connection failed (no candidates received)");
@@ -1420,13 +1337,6 @@ where
                     // control back to it by dropping any WG-handshake-driven
                     // peer_socket override. The override was only there to
                     // bridge the window until this event arrived.
-                    if self.peer_socket_override.take().is_some() {
-                        tracing::debug!(
-                            %cid,
-                            "Clearing peer_socket override; ICE has re-nominated"
-                        );
-                    }
-
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
                         ConnectionState::Connecting {
                             wg_buffer,
@@ -1455,7 +1365,7 @@ where
                             );
                             transmits.extend(ip_buffer.into_iter().flat_map(|packet| {
                                 let transmit = self
-                                    .encapsulate(cid, remote_socket, &packet, now, allocations)
+                                    .encapsulate(remote_socket, &packet, now, allocations)
                                     .inspect_err(|e| {
                                         tracing::debug!(
                                             "Failed to encapsulate buffered IP packet: {e:#}"
@@ -1468,35 +1378,42 @@ where
 
                             self.state = ConnectionState::Connected {
                                 peer_socket: remote_socket,
-                                last_activity: now,
+                                peer_socket_override: None,
                             };
                             None
                         }
                         ConnectionState::Connected {
                             peer_socket,
-                            last_activity,
+                            peer_socket_override,
                         } if peer_socket == remote_socket => {
+                            // ICE re-nominated the same path. Drop any
+                            // override so we go back to following ICE.
+                            if peer_socket_override.is_some() {
+                                tracing::debug!(
+                                    %cid,
+                                    "Clearing peer_socket override; ICE has re-nominated"
+                                );
+                            }
                             self.state = ConnectionState::Connected {
                                 peer_socket,
-                                last_activity,
+                                peer_socket_override: None,
                             };
 
                             continue; // If we re-nominate the same socket, don't just continue. TODO: Should this be fixed upstream?
                         }
                         ConnectionState::Connected {
                             peer_socket,
-                            last_activity,
+                            peer_socket_override,
                         } => {
+                            if peer_socket_override.is_some() {
+                                tracing::debug!(
+                                    %cid,
+                                    "Clearing peer_socket override; ICE has re-nominated"
+                                );
+                            }
                             self.state = ConnectionState::Connected {
                                 peer_socket: remote_socket,
-                                last_activity,
-                            };
-
-                            Some(peer_socket)
-                        }
-                        ConnectionState::Idle { peer_socket } => {
-                            self.state = ConnectionState::Idle {
-                                peer_socket: remote_socket,
+                                peer_socket_override: None,
                             };
 
                             Some(peer_socket)
@@ -1614,20 +1531,13 @@ where
         };
     }
 
-    fn encapsulate<TId>(
+    fn encapsulate(
         &mut self,
-        cid: TId,
         socket: PeerSocket,
         packet: &IpPacket,
         now: Instant,
         allocations: &mut Allocations<RId>,
-    ) -> Result<Option<Transmit>>
-    where
-        TId: fmt::Display,
-    {
-        self.state
-            .on_outgoing(cid, &mut self.agent, self.default_ice_config, packet, now);
-
+    ) -> Result<Option<Transmit>> {
         let packet_start = if socket.send_from_relay() { 4 } else { 0 };
 
         let mut buffer = self.buffer_pool.pull();
@@ -1700,7 +1610,7 @@ where
     {
         let mut ip_packet = IpPacketBuf::new();
 
-        let control_flow = match self
+        match self
             .tunnel
             .decapsulate_at(Some(src), packet, ip_packet.buf(), now)
         {
@@ -1744,7 +1654,6 @@ where
             // This should be fairly rare which is why we just allocate these and return them from `poll_transmit` instead.
             // Overall, this results in a much nicer API for our caller and should not affect performance.
             TunnResult::WriteToNetwork(bytes) => {
-                let override_socket = self.peer_socket_override;
                 match &mut self.state {
                     ConnectionState::Connecting { wg_buffer, .. } => {
                         tracing::debug!(%cid, "No socket has been nominated yet, buffering WG packet");
@@ -1758,9 +1667,11 @@ where
                             wg_buffer.enqueue(packet.to_owned());
                         }
                     }
-                    ConnectionState::Connected { peer_socket, .. }
-                    | ConnectionState::Idle { peer_socket } => {
-                        let peer_socket = override_socket.unwrap_or(*peer_socket);
+                    ConnectionState::Connected {
+                        peer_socket,
+                        peer_socket_override,
+                    } => {
+                        let peer_socket = peer_socket_override.unwrap_or(*peer_socket);
                         transmits.extend(make_owned_transmit(
                             self.relay.id,
                             peer_socket,
@@ -1789,14 +1700,7 @@ where
 
                 ControlFlow::Break(Ok(()))
             }
-        };
-
-        if let ControlFlow::Continue(packet) = &control_flow {
-            self.state
-                .on_incoming(cid, &mut self.agent, self.default_ice_config, packet, now);
         }
-
-        control_flow
     }
 
     fn initiate_wg_session(
@@ -1858,16 +1762,12 @@ where
         cid: TId,
         candidate: &Candidate,
         pending_events: &mut VecDeque<Event<TId>>,
-        now: Instant,
     ) where
         TId: fmt::Display + Copy,
     {
         if let Some(candidate) = self.agent.add_local_candidate(candidate.clone()).cloned() {
             pending_events.push_back(new_ice_candidate_event(cid, candidate));
         }
-
-        self.state
-            .on_candidate(cid, &mut self.agent, self.default_ice_config, now);
     }
 
     fn remove_local_candidate<TId>(
@@ -1897,45 +1797,30 @@ where
         }
     }
 
-    fn add_remote_candidate<TId>(&mut self, cid: TId, candidate: Candidate, now: Instant)
-    where
-        TId: fmt::Display,
-    {
+    fn add_remote_candidate(&mut self, candidate: Candidate) {
         self.agent.add_remote_candidate(candidate);
         self.candidate_timeout = None;
 
         generate_optimistic_candidates(&mut self.agent);
-
-        // Make sure we move out of idle mode when we add new candidates.
-        self.state
-            .on_candidate(cid, &mut self.agent, self.default_ice_config, now);
     }
 
-    fn remove_remote_candidate<TId>(&mut self, cid: TId, candidate: Candidate, now: Instant)
-    where
-        TId: fmt::Display,
-    {
+    fn remove_remote_candidate(&mut self, candidate: Candidate, now: Instant) {
         self.agent.invalidate_candidate(&candidate);
         self.agent.handle_timeout(now); // We may have invalidated the last candidate, ensure we check our nomination state.
-
-        self.state
-            .on_candidate(cid, &mut self.agent, self.default_ice_config, now)
     }
 
     /// The socket outgoing WireGuard traffic should use.
     ///
-    /// If [`Connection::peer_socket_override`] is set, it takes precedence
-    /// over the ICE-nominated `peer_socket`: we've observed an authenticated
-    /// handshake from a source different from what ICE nominated, and until
-    /// ICE catches up we trust the crypto signal.
+    /// If a `peer_socket_override` is set on the `Connected` state it takes
+    /// precedence over the ICE-nominated `peer_socket`: we've observed an
+    /// authenticated handshake from a source different from what ICE
+    /// nominated, and until ICE catches up we trust the crypto signal.
     fn socket(&self) -> Option<PeerSocket> {
-        if let Some(s) = self.peer_socket_override {
-            return Some(s);
-        }
-
         match self.state {
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => Some(peer_socket),
+            ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+            } => Some(peer_socket_override.unwrap_or(peer_socket)),
             ConnectionState::Connecting { .. } | ConnectionState::Failed => None,
         }
     }
@@ -1944,17 +1829,12 @@ where
         matches!(self.state, ConnectionState::Failed)
     }
 
-    fn is_idle(&self) -> bool {
-        matches!(self.state, ConnectionState::Idle { .. })
-    }
-
     fn migrate_relay<TId>(
         &mut self,
         cid: TId,
         new_relay: RId,
         new_allocation: &Allocation,
         pending_events: &mut VecDeque<Event<TId>>,
-        now: Instant,
     ) where
         TId: fmt::Display + Copy,
     {
@@ -1963,12 +1843,12 @@ where
         self.relay.id = new_relay;
 
         for candidate in new_allocation.current_relay_candidates() {
-            self.add_local_candidate(cid, &candidate, pending_events, now);
+            self.add_local_candidate(cid, &candidate, pending_events);
         }
     }
 
-    /// Set or update [`Connection::peer_socket_override`] based on the source
-    /// of an authenticated WG handshake.
+    /// Set or update the `peer_socket_override` on `Connected` based on the
+    /// source of an authenticated WG handshake.
     ///
     /// The override applies only once we have an ICE-nominated socket to
     /// deviate from; during `Connecting` ICE hasn't picked anything yet and
@@ -1979,13 +1859,15 @@ where
     where
         TId: fmt::Display,
     {
-        let current = match self.state {
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => peer_socket,
-            ConnectionState::Connecting { .. } | ConnectionState::Failed => return,
+        let ConnectionState::Connected {
+            peer_socket,
+            peer_socket_override,
+        } = &mut self.state
+        else {
+            return;
         };
 
-        let effective = self.peer_socket_override.unwrap_or(current);
+        let effective = peer_socket_override.unwrap_or(*peer_socket);
         if effective == observed {
             return;
         }
@@ -1997,7 +1879,7 @@ where
             "Overriding peer_socket from authenticated WG handshake"
         );
 
-        self.peer_socket_override = Some(observed);
+        *peer_socket_override = Some(observed);
     }
 
     /// Re-form all ICE candidate pairs in place without tearing anything down.
@@ -2073,6 +1955,13 @@ fn new_agent(role: IceRole) -> IceAgent {
     let mut agent = IceAgent::new(is::IceCreds::new());
     agent.set_controlling(matches!(role, IceRole::Controlling));
     agent.set_timing_advance(Duration::ZERO);
+    // 25 s keeps NAT bindings open with consistent STUN traffic regardless of
+    // whether the connection is currently carrying app data. We previously
+    // toggled an "idle" config to relax this once a connection had been
+    // nominated, but a quieter STUN cadence let path-validation lag and
+    // hurt roam recovery, so we now run at the active interval all the
+    // time.
+    agent.set_max_stun_rto(Duration::from_secs(25));
 
     agent
 }
@@ -2082,53 +1971,6 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
     use super::*;
-
-    #[test]
-    fn client_default_ice_timeout() {
-        let mut agent = new_agent(IceRole::Controlling);
-
-        IceConfig::client_default().apply(&mut agent);
-
-        assert_eq!(agent.ice_timeout(), Duration::from_millis(16500))
-    }
-
-    // Our WireGuard rekey attempt time must be greater than the ICE timeout,
-    // otherwise we cannot migrate an existing tunnel to a new candidate pair.
-    #[test]
-    fn client_default_ice_timeout_less_than_wg_rekey_attempt_time() {
-        let mut agent = new_agent(IceRole::Controlling);
-
-        IceConfig::client_default().apply(&mut agent);
-
-        assert!(agent.ice_timeout() < WG_REKEY_ATTEMPT_TIME)
-    }
-
-    #[test]
-    fn client_idle_ice_timeout() {
-        let mut agent = new_agent(IceRole::Controlling);
-
-        IceConfig::client_idle().apply(&mut agent);
-
-        assert_eq!(agent.ice_timeout(), Duration::from_secs(100))
-    }
-
-    #[test]
-    fn server_default_ice_timeout() {
-        let mut agent = new_agent(IceRole::Controlling);
-
-        IceConfig::server_default().apply(&mut agent);
-
-        assert_eq!(agent.ice_timeout(), Duration::from_millis(615_500))
-    }
-
-    #[test]
-    fn server_idle_ice_timeout() {
-        let mut agent = new_agent(IceRole::Controlling);
-
-        IceConfig::server_idle().apply(&mut agent);
-
-        assert_eq!(agent.ice_timeout(), Duration::from_secs(1000))
-    }
 
     #[test]
     fn generates_correct_optimistic_candidates() {

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -185,6 +185,13 @@ where
         self.connections.ice_restart();
     }
 
+    /// Returns the current Unix time in milliseconds, derived from the
+    /// `unix_ts`/`unix_now` anchors captured at `Node::new` plus the elapsed
+    /// `Instant` delta — pure with respect to wall-clock time.
+    fn unix_ms(&self, now: Instant) -> u64 {
+        (self.unix_ts + now.saturating_duration_since(self.unix_now)).as_millis() as u64
+    }
+
     pub fn num_connections(&self) -> usize {
         self.connections.len()
     }
@@ -267,7 +274,7 @@ where
             tracing::info!(local = ?local_creds, remote = ?remote_creds, %index, "Creating new connection");
         }
 
-        let mut agent = new_agent(ice_role);
+        let mut agent = new_agent(ice_role, self.unix_ms(now));
         agent.set_local_credentials(local_creds);
         agent.set_remote_credentials(remote_creds);
 
@@ -1959,9 +1966,13 @@ where
     Some(transmit)
 }
 
-fn new_agent(role: IceRole) -> IceAgent {
+fn new_agent(role: IceRole, unix_ms: u64) -> IceAgent {
     let mut agent = IceAgent::new(is::IceCreds::new());
     agent.set_controlling(matches!(role, IceRole::Controlling));
+    // Seed the tiebreaker from a Unix-ms timestamp so role-conflict
+    // comparisons (RFC 8445 §7.3.1.1) between peers are over a comparable
+    // monotonic range.
+    agent.set_control_tie_breaker(unix_ms);
     agent.set_timing_advance(Duration::ZERO);
     // 25 s keeps NAT bindings open with consistent STUN traffic regardless of
     // whether the connection is currently carrying app data. We previously

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -494,11 +494,26 @@ where
             ControlFlow::Break(Err(e)) => return Err(e),
         };
 
-        let (id, packet) = match self.connections_try_handle(from, packet, now) {
-            ControlFlow::Continue(c) => c,
-            ControlFlow::Break(Ok(())) => return Ok(None),
-            ControlFlow::Break(Err(e)) => return Err(e),
+        // Reconstruct the `PeerSocket` that matches how we would send back
+        // to the peer given what we just observed: the same path kind (direct
+        // or via this relay) and the peer's currently-observed source as the
+        // destination. Used by `connections_try_handle` to set a temporary
+        // `peer_socket_override` if this turns out to be an authenticated
+        // handshake from a non-nominated path.
+        let observed_peer_socket = match relayed {
+            None => PeerSocket::PeerToPeer {
+                source: local,
+                dest: from,
+            },
+            Some(_) => PeerSocket::RelayToPeer { dest: from },
         };
+
+        let (id, packet) =
+            match self.connections_try_handle(from, observed_peer_socket, packet, now) {
+                ControlFlow::Continue(c) => c,
+                ControlFlow::Break(Ok(())) => return Ok(None),
+                ControlFlow::Break(Err(e)) => return Err(e),
+            };
 
         Ok(Some((id, packet)))
     }
@@ -525,6 +540,7 @@ where
             return Ok(None);
         }
 
+        let override_socket = conn.peer_socket_override;
         let socket = match &mut conn.state {
             ConnectionState::Connecting { ip_buffer, .. } => {
                 ip_buffer.enqueue(packet.clone());
@@ -534,8 +550,10 @@ where
 
                 return Ok(None);
             }
-            ConnectionState::Connected { peer_socket, .. } => *peer_socket,
-            ConnectionState::Idle { peer_socket } => *peer_socket,
+            ConnectionState::Connected { peer_socket, .. } => {
+                override_socket.unwrap_or(*peer_socket)
+            }
+            ConnectionState::Idle { peer_socket } => override_socket.unwrap_or(*peer_socket),
             ConnectionState::Failed => {
                 return Err(anyhow!("Connection {cid} failed"));
             }
@@ -788,6 +806,7 @@ where
                 wg_buffer: AllocRingBuffer::new(128),
                 ip_buffer: AllocRingBuffer::new(128),
             },
+            peer_socket_override: None,
             buffer_pool: self.buffer_pool.clone(),
             last_proactive_handshake_sent_at: None,
             first_handshake_completed_at: None,
@@ -947,6 +966,7 @@ where
     fn connections_try_handle(
         &mut self,
         from: SocketAddr,
+        observed_peer_socket: PeerSocket,
         packet: &[u8],
         now: Instant,
     ) -> ControlFlow<Result<()>, (TId, IpPacket)> {
@@ -1000,19 +1020,24 @@ where
             now,
         );
 
-        if let ControlFlow::Break(Ok(())) = &control_flow
-            && conn.first_handshake_completed_at.is_none()
-            && matches!(
-                parsed_packet,
-                Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
-            )
-        {
+        let is_handshake = matches!(
+            parsed_packet,
+            Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
+        );
+        let handshake_decapsulated_ok = is_handshake
+            && matches!(&control_flow, ControlFlow::Break(Ok(())));
+
+        if handshake_decapsulated_ok && conn.first_handshake_completed_at.is_none() {
             conn.first_handshake_completed_at = Some(now);
 
             tracing::debug!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
 
             self.pending_events
                 .push_back(Event::ConnectionEstablished(cid))
+        }
+
+        if handshake_decapsulated_ok {
+            conn.maybe_override_peer_socket(cid, observed_peer_socket);
         }
 
         control_flow
@@ -1247,6 +1272,16 @@ struct Connection<RId> {
 
     state: ConnectionState,
 
+    /// Temporary override for the outbound `PeerSocket`, set when we observe
+    /// an authenticated WireGuard handshake from a source that doesn't match
+    /// our current ICE nomination. Cleared by the next `NominatedSend` event
+    /// from ICE.
+    ///
+    /// This lets outgoing WG traffic follow the peer across cross-kind
+    /// path shifts (direct↔relay) that the controlled side of ICE can't
+    /// re-nominate without `USE-CANDIDATE` from the controlling side.
+    peer_socket_override: Option<PeerSocket>,
+
     stats: ConnectionStats,
     intent_sent_at: Instant,
     candidate_timeout: Option<Instant>,
@@ -1380,6 +1415,17 @@ where
                         (Some(_), false) => PeerSocket::RelayToPeer { dest: destination },
                         (Some(_), true) => PeerSocket::RelayToRelay { dest: destination },
                     };
+
+                    // ICE has made a deliberate nomination decision; hand
+                    // control back to it by dropping any WG-handshake-driven
+                    // peer_socket override. The override was only there to
+                    // bridge the window until this event arrived.
+                    if self.peer_socket_override.take().is_some() {
+                        tracing::debug!(
+                            %cid,
+                            "Clearing peer_socket override; ICE has re-nominated"
+                        );
+                    }
 
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
                         ConnectionState::Connecting {
@@ -1698,6 +1744,7 @@ where
             // This should be fairly rare which is why we just allocate these and return them from `poll_transmit` instead.
             // Overall, this results in a much nicer API for our caller and should not affect performance.
             TunnResult::WriteToNetwork(bytes) => {
+                let override_socket = self.peer_socket_override;
                 match &mut self.state {
                     ConnectionState::Connecting { wg_buffer, .. } => {
                         tracing::debug!(%cid, "No socket has been nominated yet, buffering WG packet");
@@ -1713,9 +1760,10 @@ where
                     }
                     ConnectionState::Connected { peer_socket, .. }
                     | ConnectionState::Idle { peer_socket } => {
+                        let peer_socket = override_socket.unwrap_or(*peer_socket);
                         transmits.extend(make_owned_transmit(
                             self.relay.id,
-                            *peer_socket,
+                            peer_socket,
                             bytes,
                             &self.buffer_pool,
                             allocations,
@@ -1728,7 +1776,7 @@ where
                         {
                             transmits.extend(make_owned_transmit(
                                 self.relay.id,
-                                *peer_socket,
+                                peer_socket,
                                 packet,
                                 &self.buffer_pool,
                                 allocations,
@@ -1874,7 +1922,17 @@ where
             .on_candidate(cid, &mut self.agent, self.default_ice_config, now)
     }
 
+    /// The socket outgoing WireGuard traffic should use.
+    ///
+    /// If [`Connection::peer_socket_override`] is set, it takes precedence
+    /// over the ICE-nominated `peer_socket`: we've observed an authenticated
+    /// handshake from a source different from what ICE nominated, and until
+    /// ICE catches up we trust the crypto signal.
     fn socket(&self) -> Option<PeerSocket> {
+        if let Some(s) = self.peer_socket_override {
+            return Some(s);
+        }
+
         match self.state {
             ConnectionState::Connected { peer_socket, .. }
             | ConnectionState::Idle { peer_socket } => Some(peer_socket),
@@ -1907,6 +1965,39 @@ where
         for candidate in new_allocation.current_relay_candidates() {
             self.add_local_candidate(cid, &candidate, pending_events, now);
         }
+    }
+
+    /// Set or update [`Connection::peer_socket_override`] based on the source
+    /// of an authenticated WG handshake.
+    ///
+    /// The override applies only once we have an ICE-nominated socket to
+    /// deviate from; during `Connecting` ICE hasn't picked anything yet and
+    /// during `Failed` the connection is going away. If the observed socket
+    /// already matches the path we're effectively using, the override is a
+    /// no-op.
+    fn maybe_override_peer_socket<TId>(&mut self, cid: TId, observed: PeerSocket)
+    where
+        TId: fmt::Display,
+    {
+        let current = match self.state {
+            ConnectionState::Connected { peer_socket, .. }
+            | ConnectionState::Idle { peer_socket } => peer_socket,
+            ConnectionState::Connecting { .. } | ConnectionState::Failed => return,
+        };
+
+        let effective = self.peer_socket_override.unwrap_or(current);
+        if effective == observed {
+            return;
+        }
+
+        tracing::info!(
+            %cid,
+            current = %effective.fmt(self.relay.id),
+            new = %observed.fmt(self.relay.id),
+            "Overriding peer_socket from authenticated WG handshake"
+        );
+
+        self.peer_socket_override = Some(observed);
     }
 
     /// Re-form all ICE candidate pairs in place without tearing anything down.

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -29,10 +29,9 @@ impl<RId> Allocations<RId>
 where
     RId: Ord + fmt::Display + Copy,
 {
-    pub(crate) fn clear(&mut self) {
-        for (_, allocation) in std::mem::take(&mut self.inner) {
-            self.previous_relays_by_ip
-                .extend(server_addresses(&allocation));
+    pub(crate) fn reset(&mut self, now: Instant) {
+        for allocation in self.inner.values_mut() {
+            allocation.reset(now);
         }
     }
 
@@ -342,26 +341,6 @@ mod tests {
         );
 
         allocations.remove_by_id(&1);
-
-        assert!(matches!(
-            allocations.get_mut_by_server(SERVER_V4),
-            MutAllocationRef::Disconnected
-        ));
-    }
-
-    #[test]
-    fn clear_remembers_address() {
-        let mut allocations = Allocations::default();
-        allocations.upsert(
-            1,
-            RelaySocket::from(SERVER_V4),
-            Username::new("test".to_owned()).unwrap(),
-            "password".to_owned(),
-            Realm::new("firezone".to_owned()).unwrap(),
-            Instant::now(),
-        );
-
-        allocations.clear();
 
         assert!(matches!(
             allocations.get_mut_by_server(SERVER_V4),

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -25,9 +25,14 @@ pub(crate) enum ConnectionState {
 
         /// A socket override applied on top of `peer_socket`.
         ///
-        /// Set when an authenticated WireGuard handshake arrives from a
-        /// source different from the ICE-nominated path (typically because
-        /// the peer migrated and we got the WG signal before ICE caught up).
+        /// Set when an authenticated WireGuard `HandshakeInit` arrives from
+        /// a source different from the ICE-nominated path: an init is the
+        /// peer's choice of send-from socket, so it tells us where the peer
+        /// wants future traffic to go. We deliberately ignore
+        /// `HandshakeResponse` here — a response just confirms wherever we
+        /// sent the matching init from, which would falsely look like a
+        /// peer-side path change if ICE re-nominated in between.
+        ///
         /// Cleared once ICE catches up via a fresh `NominatedSend`. Only
         /// meaningful while we are `Connected` — `Connecting` has nothing to
         /// override and `Failed` is going away — which is why it lives here

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -1,15 +1,7 @@
-use std::{
-    fmt,
-    net::SocketAddr,
-    time::{Duration, Instant},
-};
+use std::{fmt, net::SocketAddr};
 
 use ip_packet::IpPacket;
-use is::IceAgent;
-use is::IceConnectionState;
 use ringbuffer::AllocRingBuffer;
-
-use crate::IceConfig;
 
 #[derive(Debug)]
 pub(crate) enum ConnectionState {
@@ -31,199 +23,24 @@ pub(crate) enum ConnectionState {
         /// Our nominated socket.
         peer_socket: PeerSocket,
 
-        last_activity: Instant,
-    },
-    /// We haven't seen application packets in a while.
-    Idle {
-        /// Our nominated socket.
-        peer_socket: PeerSocket,
+        /// A socket override applied on top of `peer_socket`.
+        ///
+        /// Set when an authenticated WireGuard handshake arrives from a
+        /// source different from the ICE-nominated path (typically because
+        /// the peer migrated and we got the WG signal before ICE caught up).
+        /// Cleared once ICE catches up via a fresh `NominatedSend`. Only
+        /// meaningful while we are `Connected` — `Connecting` has nothing to
+        /// override and `Failed` is going away — which is why it lives here
+        /// instead of as a sibling field on the connection.
+        peer_socket_override: Option<PeerSocket>,
     },
     /// The connection failed in an unrecoverable way and will be GC'd.
     Failed,
 }
 
 impl ConnectionState {
-    pub(crate) fn poll_timeout(&self, agent: &IceAgent) -> Option<(Instant, &'static str)> {
-        if agent.state() != IceConnectionState::Connected {
-            return None;
-        }
-
-        match self {
-            ConnectionState::Connected { last_activity, .. } => {
-                Some((idle_at(*last_activity), "idle transition"))
-            }
-            ConnectionState::Connecting { .. }
-            | ConnectionState::Idle { .. }
-            | ConnectionState::Failed => None,
-        }
-    }
-
-    pub(crate) fn handle_timeout(
-        &mut self,
-        agent: &mut IceAgent,
-        idle_ice_config: IceConfig,
-        now: Instant,
-    ) {
-        let Self::Connected {
-            last_activity,
-            peer_socket,
-        } = self
-        else {
-            return;
-        };
-
-        if idle_at(*last_activity) > now {
-            return;
-        }
-
-        if agent.state() != IceConnectionState::Connected {
-            return;
-        }
-
-        let peer_socket = *peer_socket;
-
-        self.transition_to_idle(peer_socket, agent, idle_ice_config);
-    }
-
-    pub(crate) fn on_upsert<TId>(
-        &mut self,
-        cid: TId,
-        agent: &mut IceAgent,
-        default_ice_config: IceConfig,
-        now: Instant,
-    ) where
-        TId: fmt::Display,
-    {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
-            Self::Connected { last_activity, .. } => {
-                *last_activity = now;
-                return;
-            }
-            Self::Failed | Self::Connecting { .. } => return,
-        };
-
-        self.transition_to_connected(cid, peer_socket, agent, default_ice_config, "upsert", now);
-    }
-
-    pub(crate) fn on_candidate<TId>(
-        &mut self,
-        cid: TId,
-        agent: &mut IceAgent,
-        default_ice_config: IceConfig,
-        now: Instant,
-    ) where
-        TId: fmt::Display,
-    {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
-            Self::Connected { last_activity, .. } => {
-                *last_activity = now;
-                return;
-            }
-            Self::Failed | Self::Connecting { .. } => return,
-        };
-
-        self.transition_to_connected(
-            cid,
-            peer_socket,
-            agent,
-            default_ice_config,
-            "candidates changed",
-            now,
-        );
-    }
-
-    pub(crate) fn on_outgoing<TId>(
-        &mut self,
-        cid: TId,
-        agent: &mut IceAgent,
-        default_ice_config: IceConfig,
-        packet: &IpPacket,
-        now: Instant,
-    ) where
-        TId: fmt::Display,
-    {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
-            Self::Connected { last_activity, .. } => {
-                *last_activity = now;
-                return;
-            }
-            Self::Failed | Self::Connecting { .. } => return,
-        };
-
-        self.transition_to_connected(
-            cid,
-            peer_socket,
-            agent,
-            default_ice_config,
-            tracing::field::debug(packet),
-            now,
-        );
-    }
-
-    pub(crate) fn on_incoming<TId>(
-        &mut self,
-        cid: TId,
-        agent: &mut IceAgent,
-        default_ice_config: IceConfig,
-        packet: &IpPacket,
-        now: Instant,
-    ) where
-        TId: fmt::Display,
-    {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
-            Self::Connected { last_activity, .. } => {
-                *last_activity = now;
-                return;
-            }
-            Self::Failed | Self::Connecting { .. } => return,
-        };
-
-        self.transition_to_connected(
-            cid,
-            peer_socket,
-            agent,
-            default_ice_config,
-            tracing::field::debug(packet),
-            now,
-        );
-    }
-
-    fn transition_to_idle(
-        &mut self,
-        peer_socket: PeerSocket,
-        agent: &mut IceAgent,
-        idle_ice_config: IceConfig,
-    ) {
-        tracing::debug!("Connection is idle");
-        *self = Self::Idle { peer_socket };
-        idle_ice_config.apply(agent);
-    }
-
-    fn transition_to_connected<TId>(
-        &mut self,
-        cid: TId,
-        peer_socket: PeerSocket,
-        agent: &mut IceAgent,
-        default_ice_config: IceConfig,
-        trigger: impl tracing::Value,
-        now: Instant,
-    ) where
-        TId: fmt::Display,
-    {
-        tracing::debug!(trigger, %cid, "Connection resumed");
-        *self = Self::Connected {
-            peer_socket,
-            last_activity: now,
-        };
-        default_ice_config.apply(agent);
-    }
-
     pub(crate) fn has_nominated_socket(&self) -> bool {
-        matches!(self, Self::Connected { .. } | Self::Idle { .. })
+        matches!(self, Self::Connected { .. })
     }
 }
 
@@ -234,16 +51,9 @@ impl fmt::Display for ConnectionState {
             ConnectionState::Connected { peer_socket, .. } => {
                 write!(f, "Connected({})", peer_socket.kind())
             }
-            ConnectionState::Idle { peer_socket } => write!(f, "Idle({})", peer_socket.kind()),
             ConnectionState::Failed => write!(f, "Failed"),
         }
     }
-}
-
-fn idle_at(last_activity: Instant) -> Instant {
-    const MAX_IDLE: Duration = Duration::from_secs(20); // Must be longer than the ICE timeout otherwise we might not detect a failed connection early enough.
-
-    last_activity + MAX_IDLE
 }
 
 /// The socket of the peer we are connected to.

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -629,7 +629,6 @@ mod tests {
                 wg_buffer: AllocRingBuffer::new(1),
                 ip_buffer: AllocRingBuffer::new(1),
             },
-            disconnected_at: None,
             stats: Default::default(),
             intent_sent_at: Instant::now(),
             candidate_timeout: None,

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -277,10 +277,11 @@ where
     ///
     /// Candidates, ICE credentials, and the underlying
     /// [`boringtun::noise::Tunn`] are left alone so WireGuard sessions
-    /// survive.
-    pub(crate) fn ice_restart(&mut self) {
+    /// survive. The tiebreaker refresh happens inside
+    /// `Connection::ice_restart`.
+    pub(crate) fn ice_restart(&mut self, unix_ms: u64) {
         for c in self.established.values_mut() {
-            c.ice_restart();
+            c.ice_restart(unix_ms);
         }
     }
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -122,7 +122,7 @@ where
                     continue;
                 };
 
-                c.migrate_relay(cid, new_relay, new_allocation, pending_events, now);
+                c.migrate_relay(cid, new_relay, new_allocation, pending_events);
             }
         }
 
@@ -137,7 +137,7 @@ where
                 continue;
             };
 
-            c.migrate_relay(cid, new_relay, new_allocation, pending_events, now);
+            c.migrate_relay(cid, new_relay, new_allocation, pending_events);
         }
     }
 
@@ -288,10 +288,6 @@ where
         self.established.keys().copied()
     }
 
-    pub(crate) fn all_idle(&self) -> bool {
-        self.established.values().all(|c| c.is_idle())
-    }
-
     pub(crate) fn poll_timeout(&mut self) -> Option<(Instant, &'static str)> {
         iter::empty()
             .chain(
@@ -434,14 +430,14 @@ mod tests {
         x25519::{PublicKey, StaticSecret},
     };
     use bufferpool::BufferPool;
-    use is::{Candidate, IceAgent, IceCreds};
+    use is::IceAgent;
     use rand::random;
     use ringbuffer::AllocRingBuffer;
 
     use std::net::{Ipv4Addr, SocketAddrV4};
 
     use crate::{
-        IceConfig, RelaySocket,
+        RelaySocket,
         node::{ConnectionState, SelectedRelay, allocations::Allocations},
     };
     use stun_codec::rfc5389::attributes::{Realm, Username};
@@ -627,15 +623,12 @@ mod tests {
                 wg_buffer: AllocRingBuffer::new(1),
                 ip_buffer: AllocRingBuffer::new(1),
             },
-            peer_socket_override: None,
             stats: Default::default(),
             intent_sent_at: Instant::now(),
             candidate_timeout: None,
             first_handshake_completed_at: None,
             buffer: Default::default(),
             buffer_pool: BufferPool::new(0, "test"),
-            default_ice_config: IceConfig::client_default(),
-            idle_ice_config: IceConfig::client_idle(),
             poll_timeout_cache: Default::default(),
         }
     }

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -627,6 +627,7 @@ mod tests {
                 wg_buffer: AllocRingBuffer::new(1),
                 ip_buffer: AllocRingBuffer::new(1),
             },
+            peer_socket_override: None,
             stats: Default::default(),
             intent_sent_at: Instant::now(),
             candidate_timeout: None,

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -273,9 +273,17 @@ where
         self.established.len()
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.established.clear();
-        self.established_by_wireguard_session_index.clear();
+    /// Restart ICE on every established connection without tearing anything down.
+    ///
+    /// Each connection's candidate epoch is bumped before its ICE pair list
+    /// is re-formed. Candidates, ICE credentials, and the underlying
+    /// [`boringtun::noise::Tunn`] are left alone so WireGuard sessions
+    /// survive.
+    pub(crate) fn ice_restart(&mut self) {
+        for c in self.established.values_mut() {
+            c.candidate_epoch.inc();
+            c.ice_restart();
+        }
     }
 
     pub(crate) fn iter_ids(&self) -> impl Iterator<Item = TId> + '_ {

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -275,13 +275,11 @@ where
 
     /// Restart ICE on every established connection without tearing anything down.
     ///
-    /// Each connection's candidate epoch is bumped before its ICE pair list
-    /// is re-formed. Candidates, ICE credentials, and the underlying
+    /// Candidates, ICE credentials, and the underlying
     /// [`boringtun::noise::Tunn`] are left alone so WireGuard sessions
     /// survive.
     pub(crate) fn ice_restart(&mut self) {
         for c in self.established.values_mut() {
-            c.candidate_epoch.inc();
             c.ice_restart();
         }
     }
@@ -436,7 +434,7 @@ mod tests {
         x25519::{PublicKey, StaticSecret},
     };
     use bufferpool::BufferPool;
-    use is::IceAgent;
+    use is::{Candidate, IceAgent, IceCreds};
     use rand::random;
     use ringbuffer::AllocRingBuffer;
 

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -39,6 +39,7 @@ l4-udp-dns-server = { workspace = true }
 logging = { workspace = true }
 lru = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
+phoenix-channel = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 rangemap = { workspace = true }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1821,7 +1821,7 @@ impl ClientState {
     pub(crate) fn reset(&mut self, now: Instant, reason: &str) {
         tracing::info!("Resetting network state ({reason})");
 
-        self.node.reset(now); // Clear all network connections.
+        self.node.reset();
         self.gateways.clear(); // Clear all state associated with Gateways.
         self.clients.clear(); // Clear all state associated with Clients.
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1822,10 +1822,6 @@ impl ClientState {
         tracing::info!("Resetting network state ({reason})");
 
         self.node.reset();
-        self.gateways.clear(); // Clear all state associated with Gateways.
-        self.clients.clear(); // Clear all state associated with Clients.
-
-        self.dns_resource_nat.clear(); // Clear all state related to DNS resource NATs.
         self.drain_node_events(now);
 
         // Resetting the client will trigger a failed `QueryResult` for each one that is in-progress.

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -752,8 +752,6 @@ impl ClientState {
             client_ice.into(),
             gateway_ice.into(),
             snownet::IceRole::Controlling,
-            snownet::IceConfig::client_default(),
-            snownet::IceConfig::client_idle(),
             now,
         ) {
             Ok(()) => {}
@@ -845,8 +843,6 @@ impl ClientState {
             local_client_ice.into(),
             remote_client_ice.into(),
             ice_role.into(),
-            snownet::IceConfig::client_default(),
-            snownet::IceConfig::client_default(),
             now,
         )?;
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1817,7 +1817,7 @@ impl ClientState {
     pub(crate) fn reset(&mut self, now: Instant, reason: &str) {
         tracing::info!("Resetting network state ({reason})");
 
-        self.node.reset();
+        self.node.reset(now);
         self.drain_node_events(now);
 
         // Resetting the client will trigger a failed `QueryResult` for each one that is in-progress.

--- a/rust/libs/connlib/tunnel/src/client/dns_resource_nat.rs
+++ b/rust/libs/connlib/tunnel/src/client/dns_resource_nat.rs
@@ -224,10 +224,6 @@ impl DnsResourceNat {
         {}
     }
 
-    pub fn clear(&mut self) {
-        self.inner.clear();
-    }
-
     pub(crate) fn on_domain_status(
         &mut self,
         gid: GatewayId,

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -18,7 +18,7 @@ use connlib_model::{ClientId, IceCandidate, RelayId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::ExposeSecret as _;
-use snownet::{IceConfig, IceRole, NoTurnServers, Node, RelaySocket, Transmit};
+use snownet::{IceRole, NoTurnServers, Node, RelaySocket, Transmit};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
 use std::net::{IpAddr, SocketAddr};
@@ -296,8 +296,6 @@ impl GatewayState {
             gateway_ice.into(),
             client_ice.into(),
             IceRole::Controlled,
-            IceConfig::server_default(),
-            IceConfig::server_idle(),
             now,
         )?;
 

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -269,6 +269,25 @@ pub enum EgressMessages {
     InvalidateClientIceCandidates(ClientIceCandidates),
 }
 
+impl phoenix_channel::MustQueue for EgressMessages {
+    fn must_queue(&self) -> bool {
+        match self {
+            // Invalidations need to reach the peer for it to drop superseded
+            // candidates; if we drop them on a portal hiccup the peer can
+            // hold on to a stale candidate that "wins" priority and stick a
+            // dead path. Persist them across reconnects.
+            EgressMessages::InvalidateGatewayIceCandidates(_)
+            | EgressMessages::InvalidateClientIceCandidates(_) => true,
+            EgressMessages::CreateFlow { .. }
+            | EgressMessages::RequestDeviceAccess { .. }
+            | EgressMessages::ResolveDevicePoolDomain { .. }
+            | EgressMessages::NoRelays {}
+            | EgressMessages::NewGatewayIceCandidates(_)
+            | EgressMessages::NewClientIceCandidates(_) => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -221,6 +221,21 @@ pub enum EgressMessages {
     NoRelays {},
 }
 
+impl phoenix_channel::MustQueue for EgressMessages {
+    fn must_queue(&self) -> bool {
+        match self {
+            // Invalidations need to reach the peer for it to drop superseded
+            // candidates; if we drop them on a portal hiccup the peer can
+            // hold on to a stale candidate that "wins" priority and stick a
+            // dead path. Persist them across reconnects.
+            EgressMessages::BroadcastInvalidatedIceCandidates(_) => true,
+            EgressMessages::BroadcastIceCandidates(_)
+            | EgressMessages::FlowAuthorized { .. }
+            | EgressMessages::NoRelays {} => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::messages::PortRange;

--- a/rust/libs/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/libs/connlib/tunnel/src/tests/assertions.rs
@@ -322,7 +322,7 @@ fn assert_packets_properties<T, U>(
     }
 
     for (dst_client_id, expected_handshakes) in &all_expected_client_handshakes {
-        let mut num_expected_handshakes = expected_handshakes.len();
+        let num_expected_handshakes = expected_handshakes.len();
 
         let received_requests_for_client = received_requests_by_client.get(dst_client_id).unwrap();
 
@@ -330,10 +330,8 @@ fn assert_packets_properties<T, U>(
             let _guard = make_span(*t, *u).entered();
 
             let src_ref_client = ref_clients.get(src_client_id).unwrap();
-            let dst_ref_client = ref_clients.get(dst_client_id).unwrap();
 
-            let Some((sent_at, client_sent_request)) =
-                all_sent_requests.get(&(*src_client_id, (*t, *u)))
+            let Some((_, client_sent_request)) = all_sent_requests.get(&(*src_client_id, (*t, *u)))
             else {
                 tracing::error!(target: "assertions", %src_client_id, "❌ Missing {packet_protocol} request on client");
                 continue;
@@ -341,13 +339,6 @@ fn assert_packets_properties<T, U>(
             let Some(client_received_reply) =
                 all_received_replies_on_client.get(&(*src_client_id, (*t, *u).reply_to()))
             else {
-                // If the request was made after we reset our connections, missing a reply is okay.
-                if dst_ref_client.has_reset_connections_within_ice_timeout(*sent_at) {
-                    tracing::debug!(target: "assertions", %dst_client_id, "Destination client reset its connections and packet got lost");
-                    num_expected_handshakes -= 1;
-                    continue;
-                }
-
                 tracing::error!(target: "assertions", %src_client_id, "❌ Missing {packet_protocol} reply on client");
                 continue;
             };

--- a/rust/libs/connlib/tunnel/src/tests/ref_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/ref_client.rs
@@ -29,7 +29,7 @@ use std::{
     iter, mem,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     num::NonZeroU16,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 /// Reference state for a particular client.
@@ -114,9 +114,6 @@ pub struct RefClient {
     /// The expected TCP DNS handshakes.
     #[debug(skip)]
     pub(crate) expected_tcp_dns_handshakes: VecDeque<(dns::Upstream, QueryId)>,
-
-    #[debug(skip)]
-    connection_resets: Vec<Instant>,
 }
 
 impl RefClient {
@@ -232,21 +229,16 @@ impl RefClient {
             )
     }
 
-    pub(crate) fn restart(&mut self, key: PrivateKey, now: Instant) {
+    pub(crate) fn restart(&mut self, key: PrivateKey) {
         self.routes.clear();
 
         self.key = key;
 
-        self.reset_connections(now);
-        self.readd_all_resources();
-    }
-
-    pub(crate) fn reset_connections(&mut self, now: Instant) {
-        self.connection_resets.push(now);
-
         self.connected_cidr_resources.clear();
         self.connected_dns_resources.clear();
         self.connected_internet_resource = false;
+
+        self.readd_all_resources();
 
         for status in self.site_status.values_mut() {
             *status = ResourceStatus::Unknown;
@@ -1031,16 +1023,6 @@ impl RefClient {
             .find_map(|((_, _, sport, dport), res)| (resource == *res).then_some((*sport, *dport)))
     }
 
-    /// Checks whether the given instant falls within a time period T .. T + ICE_TIMEOUT where T marks every point in time where we reset all our connections.
-    pub(crate) fn has_reset_connections_within_ice_timeout(&self, at: Instant) -> bool {
-        let ice_timeout = Duration::from_millis(22_000); // TODO: Figure out why this isn't exactly ICE timeout but longer?
-
-        self.connection_resets
-            .iter()
-            .copied()
-            .any(|t| (t..t + ice_timeout).contains(&at))
-    }
-
     pub(crate) fn clear_packets(&mut self) {
         self.expected_gateway_icmp_handshakes.clear();
         self.expected_client_icmp_handshakes.clear();
@@ -1229,7 +1211,6 @@ fn ref_client(
                     resources: Default::default(),
                     routes: Default::default(),
                     site_status: Default::default(),
-                    connection_resets: Default::default(),
                 }
             },
         )

--- a/rust/libs/connlib/tunnel/src/tests/reference.rs
+++ b/rust/libs/connlib/tunnel/src/tests/reference.rs
@@ -836,10 +836,7 @@ impl ReferenceState {
                 debug_assert!(state.network.add_host(*client_id, client));
 
                 // When roaming, we are not connected to any resource and wait for the next packet to re-establish a connection.
-                client.exec_mut(|client| {
-                    client.reset_connections(now);
-                    client.readd_all_resources()
-                });
+                client.exec_mut(|client| client.readd_all_resources());
             }
             Transition::ReconnectPortal { client_id } => {
                 // Reconnecting to the portal should have no noticeable impact on the data plane.
@@ -855,13 +852,7 @@ impl ReferenceState {
                 state.deploy_new_relays(new_relays)
             }
             Transition::Idle => {}
-            Transition::PartitionRelaysFromPortal => {
-                if state.drop_direct_client_traffic {
-                    for client in state.clients.values_mut() {
-                        client.exec_mut(|c| c.reset_connections(now));
-                    }
-                }
-            }
+            Transition::PartitionRelaysFromPortal => {}
             Transition::DeauthorizeWhileGatewayIsPartitioned(resource) => {
                 for client in state.clients.values_mut() {
                     client.exec_mut(|client| client.remove_resource(resource))
@@ -869,7 +860,7 @@ impl ReferenceState {
             }
             Transition::RestartClient { client_id, key } => {
                 state.clients.get_mut(client_id).unwrap().exec_mut(|c| {
-                    c.restart(*key, now);
+                    c.restart(*key);
                 })
             }
             Transition::UpdateDnsRecords { domain, records } => {

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -473,13 +473,9 @@ impl TunnelTest {
                         g.update_relays(state.relays.keys().copied(), iter::empty(), now)
                     });
                 }
-
-                // 2. Advance state to ensure this is reflected.
-                state.advance(ref_state, &mut buffered_transmits);
-
                 let now = state.flux_capacitor.now();
 
-                // 3. Reconnect all relays.
+                // 2. Reconnect all relays.
                 for client in state.clients.values_mut() {
                     client.exec_mut(|c| c.update_relays(iter::empty(), state.relays.iter(), now));
                 }


### PR DESCRIPTION
Today, when a client roams (Wi-Fi → cellular, suspend/resume, etc.), the client tears down its tunnels and re-establishes them from scratch. Connection setup is expensive — STUN/TURN candidate gathering, ICE checks, full WireGuard handshake — and during that window the user sees their app traffic stall or fail. This branch reshapes how ICE and WireGuard cooperate so a roam recovers in seconds, in place, without dropping connection state.

The core idea is to decouple ICE from connection liveness. The WireGuard session is the source of truth for "is this connection alive"; ICE's job is "what's the best path to send on right now." A network change becomes a path renegotiation on the existing connection rather than a teardown.

The design to achieve this relies on several pieces:

1. `Node::reset` preserves state. The `IceAgent`, `Tunn`, established remote candidates, peer state, and the in-progress message queue all survive. What gets reset is the parts that are genuinely tied to the old network: allocations (sockets the OS just yanked), in-flight transmits, pending events, in-flight STUN. The agent runs `recreate_candidate_pairs` in place; the WireGuard session keeps going.

1. ICE Disconnected no longer fails the connection. Liveness is governed by WireGuard's rekey-attempt timer. A blip in ICE during a roam is normal and now harmless — the path is briefly unknown, but the session isn't dead.

1. Authenticated WireGuard handshakes drive opportunistic path detection. When we receive a valid `HandshakeInit` from a source different from the ICE-nominated path, we apply a `peer_socket_override` on top of the nominated socket. Init only — `HandshakeResponse` doesn't count, since a response just confirms wherever we sent the matching init from and would race ICE re-nominations. Override clears as soon as ICE catches up with a fresh nomination.

1. Role-conflict-driven re-nomination on roam. This is important for client <> client connections where either side can roam. The previously-controlled side of a c2c connection can never nominate a new pair on its own, so it can't trigger the path swap when it's the side that roamed. On every `ice_restart`, the just-roamed agent now flips itself to controlling and bumps its tiebreaker to a Unix-millisecond timestamp. The next binding request triggers an RFC 8445 §7.3.1.1 role conflict, which the just-roamed side wins (highest timestamp), giving it unilateral authority to nominate. This required upstreaming role-conflict support to the `is` crate (feat/role-conflict branch). Tiebreakers are seeded from Unix-ms at agent construction too, so peer comparisons are always over the same monotonic range.

1. Backwards-compat candidate invalidation. New peers that grade candidates by epoch don't need this, but older peers do — `Node::reset` emits `InvalidateIceCandidate` events for the now-stale local candidates so the peer prunes them. This is the bit that makes all of this backwards-compatible with older nodes.

1. Persistent message queue in `phoenix-channel`. Some control-plane messages (notably the `InvalidateGatewayIceCandidates` / `InvalidateClientIceCandidates` that come out of a roam) must survive a websocket reconnect. A `MustQueue` trait marks them; the channel keeps a bounded persistent queue across reconnects. Discardable messages still get dropped on reconnect as before.

How the pieces interact during a roam:

1. OS reports a network change. Tunnel calls `Node::reset(now)`.
2. Allocations are cleared; upper layer rebinds sockets and re-registers TURN.
3. For each connection: role flips to controlling with a fresh Unix-ms tiebreaker, ICE candidate pairs are re-formed, Firezone-level handshake bookkeeping clears. The WG Tunn is untouched.
4. Invalidation events are emitted to the peer (legacy compat); must-queue control messages survive any control-plane reconnect.
5. New local candidates flow in and ICE checks resume.
6. The first binding request hits the peer, triggers a role conflict, our side wins, nominates a path.
7. Nominating a new path triggers a WireGuard handshake on the controlling side but most likely, the controlled side is still hung up on the previously nominated pair. ICE attempts to not path-hop too much and therefore needs to wait for the previous pair to timeout.
8. The `HandshakeInit` on the newly nominated pair gets sent regardless and the controlled side installs a temporary `peer_socket_override` that allows WireGuard traffic to flow until ICE catches up.

The net effect: a roam looks like "ICE gets a new set of candidates, WireGuard keeps running, the path swap happens within an RTT or two of either side noticing." No teardown, no full handshake, no app-visible stall beyond the path-swap window.