### PR TITLE
refactor(portal): update group/membership multi-select inputs

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1126,11 +1126,26 @@ defmodule PortalWeb.Actors do
       Database.remove_group_member(group_id, actor, subject)
     end)
 
-    groups = Database.get_groups_for_actor(actor.id, subject)
+    groups =
+      updated_groups(
+        socket.assigns.actor_related.groups,
+        socket.assigns.actor_group_membership.pending_group_additions,
+        socket.assigns.actor_group_membership.pending_group_removals
+      )
 
     socket
     |> assign(actor_group_membership: actor_group_membership_state())
     |> merge_state(:actor_related, groups: groups)
+  end
+
+  defp updated_groups(current_groups, pending_additions, pending_removals) do
+    remove_ids = MapSet.new(pending_removals)
+
+    current_groups
+    |> Enum.reject(&MapSet.member?(remove_ids, &1.id))
+    |> Kernel.++(pending_additions)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.sort_by(&String.downcase(&1.name || ""))
   end
 
   # Helper functions
@@ -1543,7 +1558,9 @@ defmodule PortalWeb.Actors do
       |> Safe.one(fallback_to_primary: true)
     end
 
-    def get_groups_for_actor(actor_id, subject) do
+    def get_groups_for_actor(actor_id, subject, opts \\ []) do
+      repo = Keyword.get(opts, :repo, :replica)
+
       from(g in Portal.Group, as: :groups)
       |> join(:inner, [groups: g], m in Portal.Membership,
         on: m.group_id == g.id and m.account_id == g.account_id,
@@ -1571,7 +1588,7 @@ defmodule PortalWeb.Actors do
         }
       )
       |> order_by([groups: g], asc: g.name)
-      |> Safe.scoped(subject, :replica)
+      |> Safe.scoped(subject, repo)
       |> Safe.all()
     end
 

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1126,7 +1126,11 @@ defmodule PortalWeb.Actors do
       Database.remove_group_member(group_id, actor, subject)
     end)
 
-    assign(socket, actor_group_membership: actor_group_membership_state())
+    groups = Database.get_groups_for_actor(actor.id, subject)
+
+    socket
+    |> assign(actor_group_membership: actor_group_membership_state())
+    |> merge_state(:actor_related, groups: groups)
   end
 
   # Helper functions

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -1399,122 +1399,170 @@ defmodule PortalWeb.Actors.Components do
   attr :account, :any, required: true
 
   defp actor_group_picker(assigns) do
+    current_groups =
+      if Enum.empty?(assigns.pending_removals) do
+        assigns.current_groups
+      else
+        remove_ids = MapSet.new(assigns.pending_removals)
+        Enum.reject(assigns.current_groups, &MapSet.member?(remove_ids, &1.id))
+      end
+
+    removed_groups =
+      if Enum.empty?(assigns.pending_removals) do
+        []
+      else
+        remove_ids = MapSet.new(assigns.pending_removals)
+        Enum.filter(assigns.current_groups, &MapSet.member?(remove_ids, &1.id))
+      end
+
+    assigns =
+      assigns
+      |> assign(:current_groups, current_groups)
+      |> assign(:removed_groups, removed_groups)
+
     ~H"""
     <div>
       <% visible_count =
-        length(@current_groups) - length(@pending_removals) + length(@pending_additions) %>
+        length(@current_groups) + length(@pending_additions) %>
       <h3 class="text-sm font-medium text-[var(--text-secondary)] mb-2">
         Groups ({visible_count})
       </h3>
-      <div class="border border-[var(--border)] rounded-md overflow-hidden">
-        <div
-          class="p-3 bg-[var(--surface-raised)] border-b border-[var(--border)] relative"
-          phx-click-away="blur_group_search"
-        >
-          <div class="relative">
-            <.icon
-              name="ri-search-line"
-              class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-[var(--text-tertiary)] pointer-events-none"
-            />
-            <input
-              type="text"
-              name="value"
-              placeholder="Search to add groups..."
-              phx-change="search_actor_groups"
-              phx-focus="focus_group_search"
-              phx-debounce="300"
-              autocomplete="off"
-              data-1p-ignore
-              class="w-full pl-7 pr-3 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--control-focus)] focus:ring-1 focus:ring-[var(--control-focus)]/30 transition-colors"
-            />
-          </div>
-          <div
-            :if={@search_results != nil}
-            class="absolute z-10 left-3 right-3 mt-1 bg-[var(--surface-overlay)] border border-[var(--border)] rounded-lg shadow-lg max-h-48 overflow-y-auto"
-          >
-            <button
-              :for={group <- @search_results}
-              type="button"
-              phx-click="add_pending_group"
-              phx-value-group_id={group.id}
-              class="w-full text-left px-3 py-2 hover:bg-[var(--surface-raised)] border-b border-[var(--border)] last:border-b-0 transition-colors text-xs text-[var(--text-primary)]"
-            >
-              {group.name}
-            </button>
-            <div
-              :if={@search_results == []}
-              class="px-3 py-4 text-center text-xs text-[var(--text-tertiary)]"
-            >
-              No static groups found
-            </div>
-          </div>
+      <div
+        class="p-3 bg-[var(--surface-raised)] border border-[var(--border)] rounded-md relative"
+        phx-click-away="blur_group_search"
+      >
+        <div class="relative">
+          <.icon
+            name="ri-search-line"
+            class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-[var(--text-tertiary)] pointer-events-none"
+          />
+          <input
+            type="text"
+            name="value"
+            placeholder="Search to add groups..."
+            phx-change="search_actor_groups"
+            phx-focus="focus_group_search"
+            phx-debounce="300"
+            autocomplete="off"
+            data-1p-ignore
+            class="w-full pl-7 pr-3 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--control-focus)] focus:ring-1 focus:ring-[var(--control-focus)]/30 transition-colors"
+          />
         </div>
-        <ul class="divide-y divide-[var(--border)] max-h-48 overflow-y-auto">
-          <li
-            :for={group <- @current_groups}
-            class="px-3 py-2.5 flex items-center justify-between group"
-          >
-            <p class="text-xs font-medium text-[var(--text-primary)] flex-1 min-w-0 truncate">
-              {group.name}
-            </p>
-            <div class="ml-4 flex items-center gap-2 shrink-0">
-              <span
-                :if={group.id not in @pending_removals}
-                class="text-xs text-[var(--text-tertiary)]"
-              >
-                Current
-              </span>
-              <span :if={group.id in @pending_removals} class="text-xs text-red-600 font-medium">
-                To Remove
-              </span>
-              <button
-                :if={group.id not in @pending_removals}
-                type="button"
-                phx-click="add_pending_group_removal"
-                phx-value-group_id={group.id}
-                class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
-              >
-                <.icon name="ri-user-minus-line" class="w-4 h-4" />
-              </button>
-              <button
-                :if={group.id in @pending_removals}
-                type="button"
-                phx-click="undo_pending_group_removal"
-                phx-value-group_id={group.id}
-                class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
-              >
-                <.icon name="ri-arrow-go-back-line" class="w-4 h-4" />
-              </button>
-            </div>
-          </li>
-          <li
-            :for={group <- @pending_additions}
-            class="px-3 py-2.5 flex items-center justify-between group"
-          >
-            <p class="text-xs font-medium text-[var(--text-primary)] flex-1 min-w-0 truncate">
-              {group.name}
-            </p>
-            <div class="ml-4 flex items-center gap-2 shrink-0">
-              <span class="text-xs text-green-600 font-medium">To Add</span>
-              <button
-                type="button"
-                phx-click="remove_pending_group_addition"
-                phx-value-group_id={group.id}
-                class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
-              >
-                <.icon name="ri-user-minus-line" class="w-4 h-4" />
-              </button>
-            </div>
-          </li>
-        </ul>
         <div
-          :if={@current_groups == [] and @pending_additions == []}
-          class="px-3 py-4 text-center text-xs text-[var(--text-tertiary)]"
+          :if={@search_results != nil}
+          class="absolute z-10 left-3 right-3 mt-1 bg-[var(--surface-overlay)] border border-[var(--border)] rounded-lg shadow-lg max-h-48 overflow-y-auto"
         >
-          No groups added yet.
+          <button
+            :for={group <- @search_results}
+            type="button"
+            phx-click="add_pending_group"
+            phx-value-group_id={group.id}
+            class="w-full text-left px-3 py-2 hover:bg-[var(--surface-raised)] border-b border-[var(--border)] last:border-b-0 transition-colors text-xs text-[var(--text-primary)]"
+          >
+            {group.name}
+          </button>
+          <div
+            :if={@search_results == []}
+            class="px-3 py-4 text-center text-xs text-[var(--text-tertiary)]"
+          >
+            No static groups found
+          </div>
         </div>
       </div>
+      <div class="grid gap-2 mt-2 lg:grid-cols-3">
+        <.group_bucket
+          title="Current"
+          count={length(@current_groups)}
+          groups={@current_groups}
+          empty_message="No current groups."
+        >
+          <:actions :let={group}>
+            <button
+              type="button"
+              phx-click="add_pending_group_removal"
+              phx-value-group_id={group.id}
+              class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
+              title="Remove from current groups"
+            >
+              <.icon name="ri-close-line" class="w-4 h-4" />
+            </button>
+          </:actions>
+        </.group_bucket>
+
+        <.group_bucket
+          title="To Add"
+          title_class="text-green-700"
+          count={length(@pending_additions)}
+          groups={@pending_additions}
+          empty_message="No pending additions."
+        >
+          <:actions :let={group}>
+            <button
+              type="button"
+              phx-click="remove_pending_group_addition"
+              phx-value-group_id={group.id}
+              class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
+              title="Remove from pending additions"
+            >
+              <.icon name="ri-close-line" class="w-4 h-4" />
+            </button>
+          </:actions>
+        </.group_bucket>
+
+        <.group_bucket
+          title="To Remove"
+          title_class="text-red-700"
+          count={length(@removed_groups)}
+          groups={@removed_groups}
+          empty_message="No pending removals."
+        >
+          <:actions :let={group}>
+            <button
+              type="button"
+              phx-click="undo_pending_group_removal"
+              phx-value-group_id={group.id}
+              class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+              title="Remove from pending removals"
+            >
+              <.icon name="ri-close-line" class="w-4 h-4" />
+            </button>
+          </:actions>
+        </.group_bucket>
+      </div>
     </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :count, :integer, required: true
+  attr :groups, :list, required: true
+  attr :title_class, :string, default: nil
+  attr :empty_message, :string, required: true
+  slot :actions
+
+  defp group_bucket(assigns) do
+    ~H"""
+    <section class="min-w-0 rounded border border-[var(--border)] bg-[var(--surface)] overflow-hidden">
+      <div class="flex items-center justify-between px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--surface-raised)] shrink-0">
+        <h4 class={["text-[10px] font-semibold uppercase tracking-wider", @title_class || "text-[var(--text-tertiary)]"]}>
+          {@title}
+        </h4>
+        <span class="text-[10px] text-[var(--text-muted)]">{@count}</span>
+      </div>
+      <ul :if={@groups != []} class="h-48 overflow-y-auto px-2 py-1.5 space-y-0.5">
+        <li :for={group <- @groups}>
+          <div class="flex items-center gap-2 px-2 py-1.5 w-full rounded text-left hover:bg-[var(--surface)] transition-colors group">
+            <span class="flex-1 text-xs text-[var(--text-primary)] truncate">{group.name}</span>
+            {render_slot(@actions, group)}
+          </div>
+        </li>
+      </ul>
+      <div :if={@groups == []} class="flex items-center justify-center h-16 px-3 text-center">
+        <p class="text-xs text-[var(--text-tertiary)]">
+          {@empty_message}
+        </p>
+      </div>
+    </section>
     """
   end
 

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -54,6 +54,7 @@ defmodule PortalWeb.Groups do
 
     if editable_group?(group) do
       changeset = changeset(group, %{})
+      resources = preserved_group_resources(socket, id)
 
       {:noreply,
        socket
@@ -61,7 +62,8 @@ defmodule PortalWeb.Groups do
        |> assign(base_group_assigns(socket))
        |> assign(
          group_panel: group_panel_state(view: :edit_form),
-         group_form: group_form_state(to_form(changeset))
+         group_form: group_form_state(to_form(changeset)),
+         group_resources: group_resources_state(resources: resources)
        )}
     else
       {:noreply,
@@ -73,22 +75,38 @@ defmodule PortalWeb.Groups do
 
   # Show Group Panel
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :show}} = socket) do
-    group = Database.get_group_with_actors!(id, socket.assigns.subject)
-    resources = Database.list_resources_for_group(group, socket.assigns.subject)
     socket = handle_live_tables_params(socket, params, uri)
+    tab = String.to_existing_atom(Map.get(params, "tab", "members"))
 
-    socket =
-      socket
-      |> assign(selected_group: group)
-      |> assign(base_group_assigns(socket))
-      |> assign(
-        group_panel:
-          group_panel_state(tab: String.to_existing_atom(Map.get(params, "tab", "members"))),
-        group_resources: group_resources_state(resources: resources)
-      )
-      |> load_panel_members()
+    if selected_group_matches?(socket, id) do
+      socket =
+        socket
+        |> assign(base_group_assigns(socket))
+        |> assign(
+          selected_group: socket.assigns.selected_group,
+          group_panel: group_panel_state(tab: tab),
+          group_resources:
+            group_resources_state(resources: socket.assigns.group_resources.resources)
+        )
+        |> load_panel_members_from_selected_group()
 
-    {:noreply, socket}
+      {:noreply, socket}
+    else
+      group = Database.get_group_with_actors!(id, socket.assigns.subject)
+      resources = Database.list_resources_for_group(group, socket.assigns.subject)
+
+      socket =
+        socket
+        |> assign(selected_group: group)
+        |> assign(base_group_assigns(socket))
+        |> assign(
+          group_panel: group_panel_state(tab: tab),
+          group_resources: group_resources_state(resources: resources)
+        )
+        |> load_panel_members()
+
+      {:noreply, socket}
+    end
   end
 
   # Default handler
@@ -661,8 +679,14 @@ defmodule PortalWeb.Groups do
 
     case Database.create(changeset, socket.assigns.subject) do
       {:ok, group} ->
+        group =
+          group
+          |> Map.put(:actors, Enum.sort_by(socket.assigns.group_form.members_to_add, &actor_sort_key/1))
+          |> Map.put(:memberships, build_memberships_for_group(group, socket.assigns.group_form.members_to_add))
+
         socket =
           socket
+          |> assign(selected_group: group)
           |> put_flash(:success, "Group created successfully")
           |> reload_live_table!("groups")
           |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{group.id}")
@@ -688,8 +712,17 @@ defmodule PortalWeb.Groups do
 
       case Database.update(changeset, socket.assigns.subject) do
         {:ok, group} ->
+          updated_group =
+            apply_member_updates_to_group(
+              socket.assigns.selected_group,
+              group,
+              socket.assigns.group_form.members_to_add,
+              socket.assigns.group_form.members_to_remove
+            )
+
           socket =
             socket
+            |> assign(selected_group: updated_group)
             |> put_flash(:success, "Group updated successfully")
             |> reload_live_table!("groups")
             |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{group.id}")
@@ -953,18 +986,49 @@ defmodule PortalWeb.Groups do
   defp editable_group?(%{idp_id: nil}), do: true
   defp editable_group?(_group), do: false
 
-  @spec load_panel_members(Phoenix.LiveView.Socket.t()) :: Phoenix.LiveView.Socket.t()
-  defp load_panel_members(socket) do
+  @spec load_panel_members(Phoenix.LiveView.Socket.t(), keyword()) :: Phoenix.LiveView.Socket.t()
+  defp load_panel_members(socket, opts \\ []) do
     group = socket.assigns.selected_group
     subject = socket.assigns.subject
     page = socket.assigns.group_panel.member_page
     filter = socket.assigns.group_panel.show_member_filter
+    repo = Keyword.get(opts, :repo, :replica)
 
     {members, total} =
-      Database.list_group_members(group, subject, page, @member_page_size, filter)
+      Database.list_group_members(group, subject, page, @member_page_size, filter, repo: repo)
 
     socket
     |> assign(group_members: group_members_state(panel_members: members))
+    |> merge_state(:group_panel,
+      member_total: total,
+      member_pages: max(1, ceil(total / @member_page_size))
+    )
+  end
+
+  defp load_panel_members_from_selected_group(socket) do
+    group = socket.assigns.selected_group
+    page = socket.assigns.group_panel.member_page
+    filter = socket.assigns.group_panel.show_member_filter
+
+    members =
+      group.actors
+      |> Enum.filter(fn actor ->
+        if filter == "" do
+          true
+        else
+          normalized = String.downcase(filter)
+          String.contains?(String.downcase(actor.name || ""), normalized) or
+            String.contains?(String.downcase(actor.email || ""), normalized)
+        end
+      end)
+      |> Enum.sort_by(&actor_sort_key/1)
+
+    total = length(members)
+    offset = max(page - 1, 0) * @member_page_size
+    paged_members = Enum.slice(members, offset, @member_page_size)
+
+    socket
+    |> assign(group_members: group_members_state(panel_members: paged_members))
     |> merge_state(:group_panel,
       member_total: total,
       member_pages: max(1, ceil(total / @member_page_size))
@@ -977,6 +1041,52 @@ defmodule PortalWeb.Groups do
 
   defp deletable_group?(%{name: "Everyone"}), do: false
   defp deletable_group?(_group), do: true
+
+  defp selected_group_matches?(socket, id) do
+    match?(%{id: ^id}, socket.assigns.selected_group)
+  end
+
+  defp preserved_group_resources(socket, id) do
+    if selected_group_matches?(socket, id) do
+      socket.assigns.group_resources.resources
+    else
+      []
+    end
+  end
+
+  defp apply_member_updates_to_group(existing_group, updated_group, members_to_add, members_to_remove) do
+    remove_ids = MapSet.new(members_to_remove, & &1.id)
+
+    actors =
+      existing_group.actors
+      |> Enum.reject(&MapSet.member?(remove_ids, &1.id))
+      |> Kernel.++(members_to_add)
+      |> uniq_by_id()
+      |> Enum.sort_by(&actor_sort_key/1)
+
+    memberships =
+      existing_group.memberships
+      |> Enum.reject(&MapSet.member?(remove_ids, &1.actor_id))
+      |> Kernel.++(build_memberships_for_group(updated_group, members_to_add))
+      |> Enum.uniq_by(& &1.actor_id)
+
+    updated_group
+    |> Map.put(:actors, actors)
+    |> Map.put(:memberships, memberships)
+  end
+
+  defp build_memberships_for_group(group, actors) do
+    Enum.map(actors, fn actor ->
+      %Portal.Membership{
+        account_id: group.account_id,
+        group_id: group.id,
+        actor_id: actor.id,
+        actor: actor
+      }
+    end)
+  end
+
+  defp actor_sort_key(actor), do: {String.downcase(actor.name || ""), actor.id}
 
   # Utility helpers
   defp has_content?(str), do: String.trim(str) != ""
@@ -1488,7 +1598,9 @@ defmodule PortalWeb.Groups do
       |> then(&(Safe.scoped(&1, subject) |> Safe.delete()))
     end
 
-    def list_group_members(group, subject, page, page_size, filter) do
+    def list_group_members(group, subject, page, page_size, filter, opts \\ []) do
+      repo = Keyword.get(opts, :repo, :replica)
+
       base =
         from(a in Portal.Actor, as: :actors)
         |> join(:inner, [actors: a], m in Portal.Membership,
@@ -1514,7 +1626,7 @@ defmodule PortalWeb.Groups do
         base
         |> exclude(:order_by)
         |> select([actors: a], count(a.id))
-        |> Safe.scoped(subject, :replica)
+        |> Safe.scoped(subject, repo)
         |> Safe.one()
         |> case do
           {:error, _} -> 0
@@ -1526,7 +1638,7 @@ defmodule PortalWeb.Groups do
         base
         |> limit(^page_size)
         |> offset(^((page - 1) * page_size))
-        |> Safe.scoped(subject, :replica)
+        |> Safe.scoped(subject, repo)
         |> Safe.all()
         |> case do
           {:error, _} -> []
@@ -1624,7 +1736,9 @@ defmodule PortalWeb.Groups do
       end
     end
 
-    def get_group_with_actors!(id, subject) do
+    def get_group_with_actors!(id, subject, opts \\ []) do
+      repo = Keyword.get(opts, :repo, :replica)
+
       query =
         from(g in Portal.Group, as: :groups)
         |> where([groups: groups], groups.id == ^id)
@@ -1660,7 +1774,7 @@ defmodule PortalWeb.Groups do
         )
         |> preload([memberships: m, actors: a], memberships: m, actors: a)
 
-      query |> Safe.scoped(subject, :replica) |> Safe.one!(fallback_to_primary: true)
+      query |> Safe.scoped(subject, repo) |> Safe.one!(fallback_to_primary: true)
     end
 
     def preloads do

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -79,10 +79,10 @@ defmodule PortalWeb.Groups.Components do
     assigns =
       assign(
         assigns,
-        :all_members,
+        :current_members,
         if(assigns.panel_view == :edit_form && assigns.group,
-          do: get_all_members_for_display(assigns.group, assigns.members_to_add),
-          else: assigns.members_to_add
+          do: current_members_for_display(assigns.group, assigns.members_to_remove),
+          else: []
         )
       )
 
@@ -133,56 +133,78 @@ defmodule PortalWeb.Groups.Components do
           <div>
             <h3 class="text-sm font-medium text-[var(--text-secondary)] mb-2">
               {if @panel_view == :edit_form,
-                do: "Members (#{get_member_count(@all_members, @members_to_remove)})",
+                do: "Members (#{length(@current_members) + length(@members_to_add)})",
                 else: "Members (#{length(@members_to_add)})"}
             </h3>
-            <div class="border border-[var(--border)] rounded-md overflow-hidden">
-              <.member_search_input form={@form} member_search_results={@member_search_results} />
-              <.member_list members={@all_members}>
+            <.member_search_input form={@form} member_search_results={@member_search_results} />
+            <div class="grid gap-2 mt-2 lg:grid-cols-3">
+              <.member_bucket
+                title="Current"
+                count={length(@current_members)}
+                members={@current_members}
+                empty_message="No current members."
+              >
                 <:badge :let={actor}>
                   <.actor_type_badge actor={actor} />
                 </:badge>
                 <:actions :let={actor}>
-                  <% is_current = current_member?(actor, @group)
-                  is_to_add = Enum.any?(@members_to_add, &(&1.id == actor.id))
-                  is_to_remove = Enum.any?(@members_to_remove, &(&1.id == actor.id)) %>
-                  <div class="ml-4 flex items-center gap-2">
-                    <span
-                      :if={is_current and not is_to_remove}
-                      class="text-xs text-[var(--text-tertiary)]"
-                    >
-                      Current
-                    </span>
-                    <span :if={is_to_add} class="text-xs text-green-600 font-medium">
-                      To Add
-                    </span>
-                    <span :if={is_to_remove} class="text-xs text-red-600 font-medium">
-                      To Remove
-                    </span>
-                    <button
-                      :if={is_to_remove}
-                      type="button"
-                      phx-click="undo_member_removal"
-                      phx-value-actor_id={actor.id}
-                      class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
-                    >
-                      <.icon name="ri-arrow-go-back-line" class="w-5 h-5" />
-                    </button>
-                    <button
-                      :if={not is_to_remove}
-                      type="button"
-                      phx-click="remove_member"
-                      phx-value-actor_id={actor.id}
-                      class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
-                    >
-                      <.icon name="ri-user-minus-line" class="w-5 h-5" />
-                    </button>
-                  </div>
+                  <button
+                    type="button"
+                    phx-click="remove_member"
+                    phx-value-actor_id={actor.id}
+                    class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
+                    title="Remove from current members"
+                  >
+                    <.icon name="ri-close-line" class="w-4 h-4" />
+                  </button>
                 </:actions>
-                <:empty_message>
-                  No members added yet.
-                </:empty_message>
-              </.member_list>
+              </.member_bucket>
+
+              <.member_bucket
+                title="To Add"
+                title_class="text-green-700"
+                count={length(@members_to_add)}
+                members={@members_to_add}
+                empty_message="No pending additions."
+              >
+                <:badge :let={actor}>
+                  <.actor_type_badge actor={actor} />
+                </:badge>
+                <:actions :let={actor}>
+                  <button
+                    type="button"
+                    phx-click="remove_member"
+                    phx-value-actor_id={actor.id}
+                    class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--status-error)] transition-colors"
+                    title="Remove from pending additions"
+                  >
+                    <.icon name="ri-close-line" class="w-4 h-4" />
+                  </button>
+                </:actions>
+              </.member_bucket>
+
+              <.member_bucket
+                title="To Remove"
+                title_class="text-red-700"
+                count={length(@members_to_remove)}
+                members={@members_to_remove}
+                empty_message="No pending removals."
+              >
+                <:badge :let={actor}>
+                  <.actor_type_badge actor={actor} />
+                </:badge>
+                <:actions :let={actor}>
+                  <button
+                    type="button"
+                    phx-click="undo_member_removal"
+                    phx-value-actor_id={actor.id}
+                    class="shrink-0 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+                    title="Remove from pending removals"
+                  >
+                    <.icon name="ri-close-line" class="w-4 h-4" />
+                  </button>
+                </:actions>
+              </.member_bucket>
             </div>
           </div>
         </div>
@@ -685,7 +707,7 @@ defmodule PortalWeb.Groups.Components do
                       </div>
                       <.icon
                         name="ri-close-line"
-                        class="w-3 h-3 text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 shrink-0 transition-opacity"
+                        class="w-3.5 h-3.5 text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 shrink-0 transition-opacity"
                       />
                     </button>
                   </li>
@@ -1126,8 +1148,39 @@ defmodule PortalWeb.Groups.Components do
   end
 
   attr :members, :list, required: true
+  attr :title, :string, required: true
+  attr :count, :integer, required: true
+  attr :title_class, :string, default: nil
+  attr :empty_message, :string, required: true
+  slot :badge
+  slot :actions
+
+  defp member_bucket(assigns) do
+    ~H"""
+    <section class="min-w-0 rounded border border-[var(--border)] bg-[var(--surface)] overflow-hidden">
+      <div class="flex items-center justify-between px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--surface-raised)] shrink-0">
+        <h4 class={["text-[10px] font-semibold uppercase tracking-wider", @title_class || "text-[var(--text-tertiary)]"]}>
+          {@title}
+        </h4>
+        <span class="text-[10px] text-[var(--text-muted)]">{@count}</span>
+      </div>
+      <.member_list
+        members={@members}
+        item_class="px-2 py-1.5 flex items-center justify-between gap-2 rounded group hover:bg-[var(--surface)] transition-colors"
+        list_class="h-48 overflow-y-auto px-2 py-1.5 space-y-0.5"
+        empty_class="flex items-center justify-center h-16"
+      >
+        <:badge :let={actor}>{render_slot(@badge, actor)}</:badge>
+        <:actions :let={actor}>{render_slot(@actions, actor)}</:actions>
+        <:empty_message>{@empty_message}</:empty_message>
+      </.member_list>
+    </section>
+    """
+  end
+
+  attr :members, :list, required: true
   attr :item_class, :string, default: "px-3 py-2.5 flex items-center justify-between group"
-  attr :list_class, :string, default: "divide-y divide-[var(--border)] h-64 overflow-y-auto"
+  attr :list_class, :string, default: "divide-y divide-[var(--border)] h-48 overflow-y-auto"
   attr :empty_class, :string, default: "flex items-center justify-center h-64"
   slot :badge
   slot :actions
@@ -1224,14 +1277,8 @@ defmodule PortalWeb.Groups.Components do
       (Enum.empty?(form.source.changes) and members_to_add == [] and members_to_remove == [])
   end
 
-  defp get_all_members_for_display(group, members_to_add) do
-    Enum.uniq_by(group.actors ++ members_to_add, & &1.id)
+  defp current_members_for_display(group, members_to_remove) do
+    remove_ids = MapSet.new(members_to_remove, & &1.id)
+    Enum.reject(group.actors, &MapSet.member?(remove_ids, &1.id))
   end
-
-  defp get_member_count(all_members, members_to_remove) do
-    length(all_members) - length(members_to_remove)
-  end
-
-  defp current_member?(_actor, nil), do: false
-  defp current_member?(actor, group), do: Enum.any?(group.actors, &(&1.id == actor.id))
 end

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1387,7 +1387,7 @@ defmodule PortalWeb.Resources.Components do
                       <span class="flex-1 text-xs text-[var(--text-primary)] truncate">{group.name}</span>
                       <.icon
                         name="ri-close-line"
-                        class="w-3 h-3 text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 shrink-0 transition-opacity"
+                        class="w-3.5 h-3.5 text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 shrink-0 transition-opacity"
                       />
                     </button>
                   </li>

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -778,11 +778,26 @@ defmodule PortalWeb.ServiceAccounts do
       Database.remove_group_member(group_id, actor, subject)
     end)
 
-    groups = Database.get_groups_for_actor(actor.id, subject)
+    groups =
+      updated_groups(
+        socket.assigns.actor_related.groups,
+        socket.assigns.actor_group_membership.pending_group_additions,
+        socket.assigns.actor_group_membership.pending_group_removals
+      )
 
     socket
     |> assign(actor_group_membership: actor_group_membership_state())
     |> merge_state(:actor_related, groups: groups)
+  end
+
+  defp updated_groups(current_groups, pending_additions, pending_removals) do
+    remove_ids = MapSet.new(pending_removals)
+
+    current_groups
+    |> Enum.reject(&MapSet.member?(remove_ids, &1.id))
+    |> Kernel.++(pending_additions)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.sort_by(&String.downcase(&1.name || ""))
   end
 
   defp parse_date_to_datetime(date_string) do
@@ -956,7 +971,9 @@ defmodule PortalWeb.ServiceAccounts do
       |> Safe.one(fallback_to_primary: true)
     end
 
-    def get_groups_for_actor(actor_id, subject) do
+    def get_groups_for_actor(actor_id, subject, opts \\ []) do
+      repo = Keyword.get(opts, :repo, :replica)
+
       from(g in Portal.Group, as: :groups)
       |> join(:inner, [groups: g], m in Portal.Membership,
         on: m.group_id == g.id and m.account_id == g.account_id,
@@ -964,7 +981,7 @@ defmodule PortalWeb.ServiceAccounts do
       )
       |> where([membership: m], m.actor_id == ^actor_id)
       |> order_by([groups: g], asc: g.name)
-      |> Safe.scoped(subject, :replica)
+      |> Safe.scoped(subject, repo)
       |> Safe.all()
     end
 

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -80,6 +80,7 @@ defmodule PortalWeb.ServiceAccounts do
     with {:ok, actor} <- Database.get_actor(id, socket.assigns.subject) do
       socket = handle_live_tables_params(socket, params, uri)
       changeset = changeset(actor, %{})
+      groups = Database.get_groups_for_actor(actor.id, socket.assigns.subject)
 
       {:noreply,
        socket
@@ -88,7 +89,7 @@ defmodule PortalWeb.ServiceAccounts do
        |> assign(
          actor_panel: actor_panel_state(view: :edit, is_last_admin: false),
          actor_form: actor_form_state(to_form(changeset)),
-         actor_related: actor_related_state(),
+         actor_related: actor_related_state(groups: groups),
          actor_group_membership: actor_group_membership_state()
        )}
     else
@@ -777,7 +778,11 @@ defmodule PortalWeb.ServiceAccounts do
       Database.remove_group_member(group_id, actor, subject)
     end)
 
-    assign(socket, actor_group_membership: actor_group_membership_state())
+    groups = Database.get_groups_for_actor(actor.id, subject)
+
+    socket
+    |> assign(actor_group_membership: actor_group_membership_state())
+    |> merge_state(:actor_related, groups: groups)
   end
 
   defp parse_date_to_datetime(date_string) do

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -522,7 +522,13 @@ defmodule PortalWeb.ActorsTest do
       assert html =~ "To Add"
 
       html = render_click(lv, "remove_pending_group_addition", %{"group_id" => group.id})
-      refute html =~ "To Add"
+
+      refute html =~ group.name
+
+      refute has_element?(
+               lv,
+               "button[phx-click='remove_pending_group_addition'][phx-value-group_id='#{group.id}']"
+             )
     end
 
     test "undoes pending group removal in edit form", %{
@@ -542,8 +548,17 @@ defmodule PortalWeb.ActorsTest do
       html = render_click(lv, "add_pending_group_removal", %{"group_id" => group.id})
       assert html =~ "To Remove"
 
-      html = render_click(lv, "undo_pending_group_removal", %{"group_id" => group.id})
-      refute html =~ "To Remove"
+      render_click(lv, "undo_pending_group_removal", %{"group_id" => group.id})
+
+      refute has_element?(
+               lv,
+               "button[phx-click='undo_pending_group_removal'][phx-value-group_id='#{group.id}']"
+             )
+
+      assert has_element?(
+               lv,
+               "button[phx-click='add_pending_group_removal'][phx-value-group_id='#{group.id}']"
+             )
 
       lv
       |> form("form[phx-submit='save']",
@@ -673,6 +688,55 @@ defmodule PortalWeb.ActorsTest do
                actor_id: other_actor.id,
                group_id: current_group.id
              )
+    end
+
+    test "shows updated group list without full refresh after saving edits", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_actor = actor_fixture(account: account)
+      current_group = group_fixture(account: account, name: "Current Group")
+      added_group = group_fixture(account: account, name: "Added Group")
+      membership_fixture(actor: other_actor, group: current_group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}?tab=groups")
+
+      assert render(lv) =~ current_group.name
+
+      render_click(lv, "open_actor_edit_form")
+      assert_patch(lv, ~p"/#{account}/actors/#{other_actor}/edit")
+
+      render_click(lv, "add_pending_group_removal", %{"group_id" => current_group.id})
+
+      html =
+        lv
+        |> element("input[placeholder='Search to add groups...']")
+        |> render_change(%{"value" => added_group.name})
+
+      assert html =~ added_group.name
+
+      render_click(lv, "add_pending_group", %{"group_id" => added_group.id})
+
+      lv
+      |> form("form[phx-submit='save']",
+        actor: %{
+          name: other_actor.name,
+          email: other_actor.email,
+          type: "account_user",
+          allow_email_otp_sign_in: "true"
+        }
+      )
+      |> render_submit()
+
+      render_click(lv, "change_tab", %{"tab" => "groups"})
+
+      html = render(lv)
+      assert html =~ added_group.name
+      refute html =~ current_group.name
     end
 
     test "redirects to actor list when actor does not exist", %{

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -493,8 +493,17 @@ defmodule PortalWeb.GroupsTest do
       html = render_click(lv, "remove_member", %{"actor_id" => member.id})
       assert html =~ "To Remove"
 
-      html = render_click(lv, "undo_member_removal", %{"actor_id" => member.id})
-      refute html =~ "To Remove"
+      render_click(lv, "undo_member_removal", %{"actor_id" => member.id})
+
+      refute has_element?(
+               lv,
+               "button[phx-click='undo_member_removal'][phx-value-actor_id='#{member.id}']"
+             )
+
+      assert has_element?(
+               lv,
+               "button[phx-click='remove_member'][phx-value-actor_id='#{member.id}']"
+             )
 
       lv
       |> form("#group-form", group: %{name: group.name, member_search: ""})

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -452,6 +452,48 @@ defmodule PortalWeb.GroupsTest do
       assert Repo.get_by!(Membership, group_id: group.id, actor_id: added_member.id)
       assert is_nil(Repo.get_by(Membership, group_id: group.id, actor_id: current_member.id))
     end
+
+    test "shows updated members without full refresh after saving edits", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      current_member = actor_fixture(account: account, name: "Current Member")
+      added_member = actor_fixture(account: account, name: "Added Member")
+      membership_fixture(account: account, actor: current_member, group: group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{group}")
+
+      assert render(lv) =~ current_member.name
+
+      lv
+      |> element("a[href='#{~p"/#{account}/groups/#{group}/edit"}']")
+      |> render_click()
+
+      assert_patch(lv, ~p"/#{account}/groups/#{group}/edit")
+
+      render_click(lv, "remove_member", %{"actor_id" => current_member.id})
+
+      html =
+        lv
+        |> form("#group-form", group: %{name: group.name, member_search: added_member.name})
+        |> render_change()
+
+      assert html =~ added_member.name
+      render_click(lv, "add_member", %{"actor_id" => added_member.id})
+
+      lv
+      |> form("#group-form", group: %{name: group.name, member_search: ""})
+      |> render_submit()
+
+      html = render(lv)
+      assert html =~ added_member.name
+      refute html =~ current_member.name
+    end
   end
 
   describe "confirm_delete_group event" do

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -1,0 +1,38 @@
+defmodule PortalWeb.ServiceAccountsTest do
+  use PortalWeb.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.GroupFixtures
+  import Portal.MembershipFixtures
+
+  setup do
+    account = account_fixture()
+    actor = admin_actor_fixture(account: account)
+    %{account: account, actor: actor}
+  end
+
+  describe ":edit action" do
+    test "shows current groups for a service account in the current column", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      service_account = actor_fixture(account: account, type: :service_account)
+      current_group = group_fixture(account: account, name: "Current Group")
+      membership_fixture(actor: service_account, group: current_group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}/edit")
+
+      assert render(lv) =~ current_group.name
+
+      assert has_element?(
+               lv,
+               "button[phx-click='add_pending_group_removal'][phx-value-group_id='#{current_group.id}']"
+             )
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the multi-select inputs when editing groups and when editing actors.  The new multi-select inputs match the multi-select inputs on the "Grant Access" form for resources.

Fixes: #12980

### Group membership edit form
<img width="1128" height="492" alt="Screenshot 2026-04-28 at 2 23 54 AM" src="https://github.com/user-attachments/assets/6dc6f91d-5f5f-415b-9203-83334df22071" />

### Actor edit form
<img width="1119" height="695" alt="Screenshot 2026-04-28 at 2 25 58 AM" src="https://github.com/user-attachments/assets/f4667d03-4fcb-4b13-bc3f-8d6efa207263" />

