### PR TITLE
fix(portal): don't search by devices.email

### DIFF
--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -592,10 +592,10 @@ defmodule PortalWeb.Clients do
     def filters do
       [
         %Portal.Repo.Filter{
-          name: :name,
+          name: :search,
           title: "Client or Actor",
           type: {:string, :websearch},
-          fun: &filter_by_name_or_email_fts/2
+          fun: &filter_by_search_fts/2
         },
         %Portal.Repo.Filter{
           name: :verification,
@@ -620,7 +620,7 @@ defmodule PortalWeb.Clients do
       ]
     end
 
-    def filter_by_name_or_email_fts(queryable, name_or_email) do
+    def filter_by_search_fts(queryable, search_term) do
       queryable =
         if has_named_binding?(queryable, :actors) do
           queryable
@@ -631,9 +631,9 @@ defmodule PortalWeb.Clients do
       {queryable,
        dynamic(
          [devices: devices, actors: actors],
-         fulltext_search(actors.name, ^name_or_email) or
-           fulltext_search(devices.name, ^name_or_email) or
-           fulltext_search(devices.email, ^name_or_email)
+         fulltext_search(actors.name, ^search_term) or
+           fulltext_search(devices.name, ^search_term) or
+           fulltext_search(actors.email, ^search_term)
        )}
     end
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -55,6 +55,26 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ client.name
     end
 
+    test "filters clients by client name or actor name/email", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      owner = actor_fixture(account: account, name: "Owner Person", email: "owner@example.com")
+      client = client_fixture(account: account, actor: owner, name: "Owner Laptop")
+      other_client = client_fixture(account: account, actor: actor, name: "Other Laptop")
+
+      conn = authorize_conn(conn, actor)
+
+      for search <- [client.name, owner.name, owner.email] do
+        {:ok, _lv, html} =
+          live(conn, ~p"/#{account}/clients?#{%{"clients_filter[search]" => search}}")
+
+        assert html =~ client.name
+        refute html =~ other_client.name
+      end
+    end
+
     test "renders verified and unverified client states", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
- Fixes a regression where the search input on the clients table was not working due to searching a nonexistent `devices.email` field.
- Renames the filter key to `search` instead of `name` to better reflect what this is.
- Adds regression test

--- 

Fixes #12987 
