### PR TITLE
fix(portal): update text for resources with no site

### DIFF
--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -11,6 +11,7 @@ defmodule PortalWeb.Resources do
   import PortalWeb.Resources.Components,
     only: [
       map_filters_form_attrs: 2,
+      nil_site_label: 1,
       panel_shell: 1,
       resource_details_panel: 1,
       resource_form_panel: 1,
@@ -474,7 +475,7 @@ defmodule PortalWeb.Resources do
               {resource.site.name}
             </.link>
             <span :if={is_nil(resource.site)} class="text-[var(--text-muted)] italic">
-              No Site Needed
+              {nil_site_label(resource)}
             </span>
           </:col>
           <:col :let={resource} label="Status" class="w-32">

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -62,6 +62,9 @@ defmodule PortalWeb.Resources.Components do
     {resource.id, resource.name, resource}
   end
 
+  def nil_site_label(%{type: :static_device_pool}), do: "No Site Needed"
+  def nil_site_label(_resource), do: "No Site Associated"
+
   def map_filters_form_attrs(attrs, account) do
     attrs =
       if Portal.Account.traffic_filters_enabled?(account) do
@@ -1055,7 +1058,9 @@ defmodule PortalWeb.Resources.Components do
                   {@resource.site.name}
                 </.link>
               <% else %>
-                <span class="text-xs italic text-[var(--text-muted)]">No Site Needed</span>
+                <span class="text-xs italic text-[var(--text-muted)]">
+                  {nil_site_label(@resource)}
+                </span>
               <% end %>
             </span>
           </div>
@@ -1568,29 +1573,29 @@ defmodule PortalWeb.Resources.Components do
           Infrastructure
         </h3>
         <dl class="space-y-2.5">
-          <div :if={@resource.type == :static_device_pool}>
+          <div :if={@resource.type != :internet}>
             <dt class="text-[10px] text-[var(--text-tertiary)] mb-1">Site</dt>
-            <dd class="text-xs italic text-[var(--text-muted)]">No Site Needed</dd>
-          </div>
-          <div :if={@resource.site && @resource.type != :static_device_pool}>
-            <dt class="text-[10px] text-[var(--text-tertiary)] mb-1">Site</dt>
-            <dd class="flex items-center gap-1.5 flex-wrap">
-              <.link
-                navigate={~p"/#{@account}/sites/#{@resource.site}"}
-                class="text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-              >
-                {@resource.site.name}
-              </.link>
-              <span
-                :if={resource_online?(@resource)}
-                class="relative flex items-center justify-center w-1.5 h-1.5"
-              >
-                <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-[var(--status-active)]">
+            <%= if @resource.site do %>
+              <dd class="flex items-center gap-1.5 flex-wrap">
+                <.link
+                  navigate={~p"/#{@account}/sites/#{@resource.site}"}
+                  class="text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  {@resource.site.name}
+                </.link>
+                <span
+                  :if={resource_online?(@resource)}
+                  class="relative flex items-center justify-center w-1.5 h-1.5"
+                >
+                  <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-[var(--status-active)]">
+                  </span>
+                  <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-active)]">
+                  </span>
                 </span>
-                <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-active)]">
-                </span>
-              </span>
-            </dd>
+              </dd>
+            <% else %>
+              <dd class="text-xs italic text-[var(--text-muted)]">{nil_site_label(@resource)}</dd>
+            <% end %>
           </div>
         </dl>
       </section>

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1573,7 +1573,7 @@ defmodule PortalWeb.Resources.Components do
           Infrastructure
         </h3>
         <dl class="space-y-2.5">
-          <div :if={@resource.type != :internet}>
+          <div>
             <dt class="text-[10px] text-[var(--text-tertiary)] mb-1">Site</dt>
             <%= if @resource.site do %>
               <dd class="flex items-center gap-1.5 flex-wrap">

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -592,7 +592,7 @@ defmodule PortalWeb.Sites.Components do
         class="rounded border border-[var(--status-error)]/20 bg-[var(--status-error-bg)] p-3 space-y-3"
       >
         <p class="text-xs text-[var(--status-error)]">
-          Delete this site? Gateways and resources will be detached.
+          Delete this site? Associated gateways and resources will be permanently deleted.
         </p>
         <div class="flex items-center gap-2">
           <button

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -651,8 +651,7 @@ defmodule PortalWeb.ResourcesTest do
 
   defp count_occurrences(haystack, needle) do
     haystack
-    |> String.split(needle)
+    |> :binary.matches(needle)
     |> length()
-    |> Kernel.-(1)
   end
 end

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -65,6 +65,40 @@ defmodule PortalWeb.ResourcesTest do
       assert_patch(lv, ~p"/#{account}/resources")
       refute render(lv) =~ "Add Resource"
     end
+
+    test "shows conventional nil-site copy in the resources table", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      assert html =~ resource.name
+      assert count_occurrences(html, "No Site Associated") == 1
+      refute html =~ "No Site Needed"
+    end
+
+    test "shows device pool nil-site copy in the resources table", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = static_device_pool_resource_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      assert html =~ resource.name
+      assert count_occurrences(html, "No Site Needed") == 1
+      refute html =~ "No Site Associated"
+    end
   end
 
   describe ":new action" do
@@ -274,6 +308,40 @@ defmodule PortalWeb.ResourcesTest do
 
       assert html =~ resource.name
       assert html =~ resource.address
+    end
+
+    test "shows conventional nil-site copy consistently in the selected resource panel", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert html =~ resource.name
+      assert count_occurrences(html, "No Site Associated") == 3
+      refute html =~ "No Site Needed"
+    end
+
+    test "shows device pool nil-site copy consistently in the selected resource panel", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = static_device_pool_resource_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert html =~ resource.name
+      assert count_occurrences(html, "No Site Needed") == 3
+      refute html =~ "No Site Associated"
     end
 
     test "opens grant access form, creates access, and returns to list", %{
@@ -579,5 +647,12 @@ defmodule PortalWeb.ResourcesTest do
       html = render_click(lv, "cancel_delete_resource")
       refute html =~ "Delete this resource?"
     end
+  end
+
+  defp count_occurrences(haystack, needle) do
+    haystack
+    |> String.split(needle)
+    |> length()
+    |> Kernel.-(1)
   end
 end

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -282,6 +282,7 @@ defmodule PortalWeb.SitesTest do
 
       html = render_click(lv, "confirm_delete_site")
       assert html =~ "Delete this site?"
+      assert html =~ "Associated gateways and resources will be permanently deleted."
 
       html = render_click(lv, "cancel_delete_site")
       refute html =~ "Delete this site?"


### PR DESCRIPTION
Update text shown for a conventional resource with a `site_id` of `NULL`.

Also, updated the confirmation text when deleting a site to make sure the user knows the Gateways and Resources associated with the Site will also be deleted.

Fixes #12983