### PR TITLE
feat(snownet): override `peer_socket` from WG handshakes

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1608,7 +1608,7 @@ where
         let source_relay = allocations.get_mut_by_allocation(source).map(|(r, _)| r);
 
         if source_relay.is_some_and(|r| self.relay.id != r) {
-            tracing::warn!("Nominated a relay different from what we set out to! Weird?");
+            tracing::warn!("Socket uses unexpected relay");
         }
 
         let dest_is_relay = self

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1043,9 +1043,9 @@ where
         // are we allowed to (temporarily) override the `PeerSocket` of this connection
         // with what we have observed.
         if decap_ok
+            && let Packet::HandshakeInit(_) = parsed_packet
             && let observed_peer_socket =
                 conn.peer_socket_for_tuple(&mut self.allocations, destination, from)
-            && let Packet::HandshakeInit(_) = parsed_packet
             && let ConnectionState::Connected {
                 peer_socket,
                 peer_socket_override,

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -509,21 +509,8 @@ where
             ControlFlow::Break(Err(e)) => return Err(e),
         };
 
-        // Reconstruct the `PeerSocket` that matches how we would send back
-        // to the peer given what we just observed: the same path kind (direct
-        // or via this relay) and the peer's currently-observed source as the
-        // destination. Used by `connections_try_handle` to set a temporary
-        // `peer_socket_override` if this turns out to be an authenticated
-        // handshake from a non-nominated path.
-        let observed_peer_socket = match relayed {
-            None => PeerSocket::PeerToPeer {
-                source: local,
-                dest: from,
-            },
-            Some(_) => PeerSocket::RelayToPeer { dest: from },
-        };
-
-        let (id, packet) = match self.connections_try_handle(observed_peer_socket, packet, now) {
+        // We pass `destination` in here instead of `local` so we can correctly construct the observed socket.
+        let (id, packet) = match self.connections_try_handle(destination, from, packet, now) {
             ControlFlow::Continue(c) => c,
             ControlFlow::Break(Ok(())) => return Ok(None),
             ControlFlow::Break(Err(e)) => return Err(e),
@@ -982,7 +969,8 @@ where
 
     fn connections_try_handle(
         &mut self,
-        observed_peer_socket: PeerSocket,
+        destination: SocketAddr,
+        from: SocketAddr,
         packet: &[u8],
         now: Instant,
     ) -> ControlFlow<Result<()>, (TId, IpPacket)> {
@@ -1029,7 +1017,7 @@ where
 
         let control_flow = conn.decapsulate(
             cid,
-            observed_peer_socket.dest().ip(),
+            from.ip(),
             packet,
             &mut self.allocations,
             &mut self.buffered_transmits,
@@ -1055,6 +1043,8 @@ where
         // are we allowed to (temporarily) override the `PeerSocket` of this connection
         // with what we have observed.
         if decap_ok
+            && let observed_peer_socket =
+                conn.peer_socket_for_tuple(&mut self.allocations, destination, from)
             && let Packet::HandshakeInit(_) = parsed_packet
             && let ConnectionState::Connected {
                 peer_socket,
@@ -1072,7 +1062,7 @@ where
                 %cid,
                 current = %effective.fmt(conn.relay.id),
                 new = %observed_peer_socket.fmt(conn.relay.id),
-                "Overriding peer_socket from authenticated WG handshake init"
+                "Overriding peer socket from authenticated WG handshake init"
             );
 
             *peer_socket_override = Some(observed_peer_socket);
@@ -1443,31 +1433,8 @@ where
                     source,
                     ..
                 } => {
-                    let source_relay = allocations.get_mut_by_allocation(source).map(|(r, _)| r);
-
-                    if source_relay.is_some_and(|r| self.relay.id != r) {
-                        tracing::warn!(
-                            "Nominated a relay different from what we set out to! Weird?"
-                        );
-                    }
-
-                    let dest_is_relay = self
-                        .agent
-                        .remote_candidates()
-                        .any(|c| c.addr() == destination && c.kind() == CandidateKind::Relayed);
-
-                    let remote_socket = match (source_relay, dest_is_relay) {
-                        (None, false) => PeerSocket::PeerToPeer {
-                            source,
-                            dest: destination,
-                        },
-                        (None, true) => PeerSocket::PeerToRelay {
-                            source,
-                            dest: destination,
-                        },
-                        (Some(_), false) => PeerSocket::RelayToPeer { dest: destination },
-                        (Some(_), true) => PeerSocket::RelayToRelay { dest: destination },
-                    };
+                    let remote_socket =
+                        self.peer_socket_for_tuple(allocations, source, destination);
 
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
                         ConnectionState::Connecting {
@@ -1634,6 +1601,37 @@ where
                 payload: self.buffer_pool.pull_initialised(&data_channel_packet),
                 ecn: Ecn::NonEct,
             });
+        }
+    }
+
+    fn peer_socket_for_tuple(
+        &self,
+        allocations: &mut Allocations<RId>,
+        source: SocketAddr,
+        destination: SocketAddr,
+    ) -> PeerSocket {
+        let source_relay = allocations.get_mut_by_allocation(source).map(|(r, _)| r);
+
+        if source_relay.is_some_and(|r| self.relay.id != r) {
+            tracing::warn!("Nominated a relay different from what we set out to! Weird?");
+        }
+
+        let dest_is_relay = self
+            .agent
+            .remote_candidates()
+            .any(|c| c.addr() == destination && c.kind() == CandidateKind::Relayed);
+
+        match (source_relay, dest_is_relay) {
+            (None, false) => PeerSocket::PeerToPeer {
+                source,
+                dest: destination,
+            },
+            (None, true) => PeerSocket::PeerToRelay {
+                source,
+                dest: destination,
+            },
+            (Some(_), false) => PeerSocket::RelayToPeer { dest: destination },
+            (Some(_), true) => PeerSocket::RelayToRelay { dest: destination },
         }
     }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1043,7 +1043,6 @@ where
             parsed_packet,
             Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
         );
-        let is_handshake_init = matches!(parsed_packet, Packet::HandshakeInit(_));
 
         if decap_ok && is_handshake && conn.first_handshake_completed_at.is_none() {
             conn.first_handshake_completed_at = Some(now);
@@ -1054,11 +1053,31 @@ where
                 .push_back(Event::ConnectionEstablished(cid))
         }
 
-        // Only `HandshakeInit` reflects the peer's choice of send-from
-        // socket; a `HandshakeResponse` just confirms wherever we sent the
-        // matching init from and would race ICE re-nominations.
-        if decap_ok && is_handshake_init {
-            conn.maybe_override_peer_socket(cid, observed_peer_socket);
+        // Iff we successfully processed a WireGuard `HandshakeInit` packet
+        // are we allowed to (temporarily) override the `PeerSocket` of this connection
+        // with what we have observed.
+        if decap_ok
+            && let Packet::HandshakeInit(_) = parsed_packet
+            && let ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+                ..
+            }
+            | ConnectionState::Idle {
+                peer_socket,
+                peer_socket_override,
+            } = &mut conn.state
+            && let effective = peer_socket_override.unwrap_or(*peer_socket)
+            && effective != observed_peer_socket
+        {
+            tracing::info!(
+                %cid,
+                current = %effective.fmt(conn.relay.id),
+                new = %observed_peer_socket.fmt(conn.relay.id),
+                "Overriding peer_socket from authenticated WG handshake init"
+            );
+
+            *peer_socket_override = Some(observed_peer_socket);
         }
 
         control_flow
@@ -2001,51 +2020,6 @@ where
 
         for candidate in new_allocation.current_relay_candidates() {
             self.add_local_candidate(cid, &candidate, pending_events, now);
-        }
-    }
-
-    /// Set or update the `peer_socket_override` on the current state based
-    /// on the source of an authenticated WG `HandshakeInit`.
-    ///
-    /// Caller must only invoke this for a `HandshakeInit`, never for a
-    /// `HandshakeResponse`: an init is the peer's choice of send-from
-    /// socket, while a response just confirms wherever we sent the matching
-    /// init from.
-    ///
-    /// The override applies only once we have an ICE-nominated socket to
-    /// deviate from; during `Connecting` ICE hasn't picked anything yet and
-    /// during `Failed` the connection is going away. If the observed socket
-    /// already matches the path we're effectively using, the override is a
-    /// no-op.
-    fn maybe_override_peer_socket<TId>(&mut self, cid: TId, observed: PeerSocket)
-    where
-        TId: fmt::Display,
-    {
-        match &mut self.state {
-            ConnectionState::Connecting { .. } | ConnectionState::Failed => {}
-            ConnectionState::Connected {
-                peer_socket,
-                peer_socket_override,
-                ..
-            }
-            | ConnectionState::Idle {
-                peer_socket,
-                peer_socket_override,
-            } => {
-                let effective = peer_socket_override.unwrap_or(*peer_socket);
-                if effective == observed {
-                    return;
-                }
-
-                tracing::info!(
-                    %cid,
-                    current = %effective.fmt(self.relay.id),
-                    new = %observed.fmt(self.relay.id),
-                    "Overriding peer_socket from authenticated WG handshake init"
-                );
-
-                *peer_socket_override = Some(observed);
-            }
         }
     }
 }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -817,7 +817,6 @@ where
             disconnected_at: None,
             peer_socket_override: None,
             buffer_pool: self.buffer_pool.clone(),
-            last_proactive_handshake_sent_at: None,
             first_handshake_completed_at: None,
             default_ice_config,
             idle_ice_config,
@@ -1273,8 +1272,6 @@ struct Connection<RId> {
     remote_pub_key: PublicKey,
     /// When to next update the [`Tunn`]'s timers.
     next_wg_timer_update: Instant,
-
-    last_proactive_handshake_sent_at: Option<Instant>,
 
     /// The relay we have selected for this connection.
     relay: SelectedRelay<RId>,
@@ -1848,19 +1845,6 @@ where
             return;
         };
 
-        // If we have sent a handshake in the last 20s, don't bother making a new session.
-        // Our re-key timeout is 15s, meaning if more than 20s have passed and we are still
-        // here, we have a working connection and can refresh it.
-        if let Some(last_handshake) = self
-            .last_proactive_handshake_sent_at
-            .map(|last_sent_at| now.duration_since(last_sent_at))
-            && last_handshake < Duration::from_secs(20)
-        {
-            tracing::debug!(?last_handshake, "Suppressing repeated handshake");
-
-            return;
-        }
-
         /// [`boringtun`] requires us to pass buffers in where it can construct its packets.
         ///
         /// When updating the timers, the largest packet that we may have to send is `148` bytes as per `HANDSHAKE_INIT_SZ` constant in [`boringtun`].
@@ -1870,14 +1854,12 @@ where
 
         let TunnResult::WriteToNetwork(bytes) = self
             .tunnel
-            .format_handshake_initiation_at(&mut buf, false, now)
+            .format_handshake_initiation_at(&mut buf, true, now)
         else {
             tracing::debug!("Another handshake is already in progress");
 
             return;
         };
-
-        self.last_proactive_handshake_sent_at = Some(now);
 
         transmits.extend(make_owned_transmit(
             self.relay.id,

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1028,14 +1028,14 @@ where
             now,
         );
 
+        let decap_ok = matches!(&control_flow, ControlFlow::Break(Ok(())));
         let is_handshake = matches!(
             parsed_packet,
             Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
         );
-        let handshake_decapsulated_ok = is_handshake
-            && matches!(&control_flow, ControlFlow::Break(Ok(())));
+        let is_handshake_init = matches!(parsed_packet, Packet::HandshakeInit(_));
 
-        if handshake_decapsulated_ok && conn.first_handshake_completed_at.is_none() {
+        if decap_ok && is_handshake && conn.first_handshake_completed_at.is_none() {
             conn.first_handshake_completed_at = Some(now);
 
             tracing::debug!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
@@ -1044,7 +1044,10 @@ where
                 .push_back(Event::ConnectionEstablished(cid))
         }
 
-        if handshake_decapsulated_ok {
+        // Only `HandshakeInit` reflects the peer's choice of send-from
+        // socket; a `HandshakeResponse` just confirms wherever we sent the
+        // matching init from and would race ICE re-nominations.
+        if decap_ok && is_handshake_init {
             conn.maybe_override_peer_socket(cid, observed_peer_socket);
         }
 
@@ -1986,7 +1989,12 @@ where
     }
 
     /// Set or update [`Connection::peer_socket_override`] based on the source
-    /// of an authenticated WG handshake.
+    /// of an authenticated WG `HandshakeInit`.
+    ///
+    /// Caller must only invoke this for a `HandshakeInit`, never for a
+    /// `HandshakeResponse`: an init is the peer's choice of send-from
+    /// socket, while a response just confirms wherever we sent the matching
+    /// init from.
     ///
     /// The override applies only once we have an ICE-nominated socket to
     /// deviate from; during `Connecting` ICE hasn't picked anything yet and
@@ -2012,7 +2020,7 @@ where
             %cid,
             current = %effective.fmt(self.relay.id),
             new = %observed.fmt(self.relay.id),
-            "Overriding peer_socket from authenticated WG handshake"
+            "Overriding peer_socket from authenticated WG handshake init"
         );
 
         self.peer_socket_override = Some(observed);

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -523,12 +523,11 @@ where
             Some(_) => PeerSocket::RelayToPeer { dest: from },
         };
 
-        let (id, packet) =
-            match self.connections_try_handle(from, observed_peer_socket, packet, now) {
-                ControlFlow::Continue(c) => c,
-                ControlFlow::Break(Ok(())) => return Ok(None),
-                ControlFlow::Break(Err(e)) => return Err(e),
-            };
+        let (id, packet) = match self.connections_try_handle(observed_peer_socket, packet, now) {
+            ControlFlow::Continue(c) => c,
+            ControlFlow::Break(Ok(())) => return Ok(None),
+            ControlFlow::Break(Err(e)) => return Err(e),
+        };
 
         Ok(Some((id, packet)))
     }
@@ -983,7 +982,6 @@ where
 
     fn connections_try_handle(
         &mut self,
-        from: SocketAddr,
         observed_peer_socket: PeerSocket,
         packet: &[u8],
         now: Instant,
@@ -1031,7 +1029,7 @@ where
 
         let control_flow = conn.decapsulate(
             cid,
-            from.ip(),
+            observed_peer_socket.dest().ip(),
             packet,
             &mut self.allocations,
             &mut self.buffered_transmits,

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1489,12 +1489,7 @@ where
                         } if peer_socket == remote_socket => {
                             self.state = ConnectionState::Connected {
                                 peer_socket,
-                                peer_socket_override: resolve_override(
-                                    cid,
-                                    peer_socket_override,
-                                    remote_socket,
-                                    self.relay.id,
-                                ),
+                                peer_socket_override,
                                 last_activity,
                             };
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -385,13 +385,20 @@ where
         };
 
         let peer_socket = match connection.state {
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => peer_socket,
             ConnectionState::Connecting { .. } => {
                 tracing::info!("Connection closed during ICE");
                 return;
             }
             ConnectionState::Failed => return,
+            ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+                ..
+            }
+            | ConnectionState::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => peer_socket_override.unwrap_or(peer_socket),
         };
 
         self.pending_events.push_back(Event::ConnectionClosed(cid));
@@ -548,7 +555,6 @@ where
             return Ok(None);
         }
 
-        let override_socket = conn.peer_socket_override;
         let socket = match &mut conn.state {
             ConnectionState::Connecting { ip_buffer, .. } => {
                 ip_buffer.enqueue(packet.clone());
@@ -558,13 +564,18 @@ where
 
                 return Ok(None);
             }
-            ConnectionState::Connected { peer_socket, .. } => {
-                override_socket.unwrap_or(*peer_socket)
-            }
-            ConnectionState::Idle { peer_socket } => override_socket.unwrap_or(*peer_socket),
             ConnectionState::Failed => {
                 return Err(anyhow!("Connection {cid} failed"));
             }
+            ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+                ..
+            }
+            | ConnectionState::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => peer_socket_override.unwrap_or(*peer_socket),
         };
 
         let maybe_transmit = conn
@@ -815,7 +826,6 @@ where
                 ip_buffer: AllocRingBuffer::new(128),
             },
             disconnected_at: None,
-            peer_socket_override: None,
             buffer_pool: self.buffer_pool.clone(),
             first_handshake_completed_at: None,
             default_ice_config,
@@ -1282,16 +1292,6 @@ struct Connection<RId> {
     state: ConnectionState,
     disconnected_at: Option<Instant>,
 
-    /// Temporary override for the outbound `PeerSocket`, set when we observe
-    /// an authenticated WireGuard handshake from a source that doesn't match
-    /// our current ICE nomination. Cleared by the next `NominatedSend` event
-    /// from ICE.
-    ///
-    /// This lets outgoing WG traffic follow the peer across cross-kind
-    /// path shifts (direct↔relay) that the controlled side of ICE can't
-    /// re-nominate without `USE-CANDIDATE` from the controlling side.
-    peer_socket_override: Option<PeerSocket>,
-
     stats: ConnectionStats,
     intent_sent_at: Instant,
     candidate_timeout: Option<Instant>,
@@ -1452,17 +1452,6 @@ where
                         (Some(_), true) => PeerSocket::RelayToRelay { dest: destination },
                     };
 
-                    // ICE has made a deliberate nomination decision; hand
-                    // control back to it by dropping any WG-handshake-driven
-                    // peer_socket override. The override was only there to
-                    // bridge the window until this event arrived.
-                    if self.peer_socket_override.take().is_some() {
-                        tracing::debug!(
-                            %cid,
-                            "Clearing peer_socket override; ICE has re-nominated"
-                        );
-                    }
-
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
                         ConnectionState::Connecting {
                             wg_buffer,
@@ -1504,16 +1493,24 @@ where
 
                             self.state = ConnectionState::Connected {
                                 peer_socket: remote_socket,
+                                peer_socket_override: None,
                                 last_activity: now,
                             };
                             None
                         }
                         ConnectionState::Connected {
                             peer_socket,
+                            peer_socket_override,
                             last_activity,
                         } if peer_socket == remote_socket => {
                             self.state = ConnectionState::Connected {
                                 peer_socket,
+                                peer_socket_override: resolve_override(
+                                    cid,
+                                    peer_socket_override,
+                                    remote_socket,
+                                    self.relay.id,
+                                ),
                                 last_activity,
                             };
 
@@ -1521,18 +1518,34 @@ where
                         }
                         ConnectionState::Connected {
                             peer_socket,
+                            peer_socket_override,
                             last_activity,
                         } => {
                             self.state = ConnectionState::Connected {
                                 peer_socket: remote_socket,
+                                peer_socket_override: resolve_override(
+                                    cid,
+                                    peer_socket_override,
+                                    remote_socket,
+                                    self.relay.id,
+                                ),
                                 last_activity,
                             };
 
                             Some(peer_socket)
                         }
-                        ConnectionState::Idle { peer_socket } => {
+                        ConnectionState::Idle {
+                            peer_socket,
+                            peer_socket_override,
+                        } => {
                             self.state = ConnectionState::Idle {
                                 peer_socket: remote_socket,
+                                peer_socket_override: resolve_override(
+                                    cid,
+                                    peer_socket_override,
+                                    remote_socket,
+                                    self.relay.id,
+                                ),
                             };
 
                             Some(peer_socket)
@@ -1780,7 +1793,6 @@ where
             // This should be fairly rare which is why we just allocate these and return them from `poll_transmit` instead.
             // Overall, this results in a much nicer API for our caller and should not affect performance.
             TunnResult::WriteToNetwork(bytes) => {
-                let override_socket = self.peer_socket_override;
                 match &mut self.state {
                     ConnectionState::Connecting { wg_buffer, .. } => {
                         tracing::debug!(%cid, "No socket has been nominated yet, buffering WG packet");
@@ -1794,9 +1806,16 @@ where
                             wg_buffer.enqueue(packet.to_owned());
                         }
                     }
-                    ConnectionState::Connected { peer_socket, .. }
-                    | ConnectionState::Idle { peer_socket } => {
-                        let peer_socket = override_socket.unwrap_or(*peer_socket);
+                    ConnectionState::Connected {
+                        peer_socket,
+                        peer_socket_override,
+                        ..
+                    }
+                    | ConnectionState::Idle {
+                        peer_socket,
+                        peer_socket_override,
+                    } => {
+                        let peer_socket = peer_socket_override.unwrap_or(*peer_socket);
                         transmits.extend(make_owned_transmit(
                             self.relay.id,
                             peer_socket,
@@ -1943,20 +1962,17 @@ where
             .on_candidate(cid, &mut self.agent, self.default_ice_config, now)
     }
 
-    /// The socket outgoing WireGuard traffic should use.
-    ///
-    /// If [`Connection::peer_socket_override`] is set, it takes precedence
-    /// over the ICE-nominated `peer_socket`: we've observed an authenticated
-    /// handshake from a source different from what ICE nominated, and until
-    /// ICE catches up we trust the crypto signal.
     fn socket(&self) -> Option<PeerSocket> {
-        if let Some(s) = self.peer_socket_override {
-            return Some(s);
-        }
-
         match self.state {
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => Some(peer_socket),
+            ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+                ..
+            }
+            | ConnectionState::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => Some(peer_socket_override.unwrap_or(peer_socket)),
             ConnectionState::Connecting { .. } | ConnectionState::Failed => None,
         }
     }
@@ -1988,8 +2004,8 @@ where
         }
     }
 
-    /// Set or update [`Connection::peer_socket_override`] based on the source
-    /// of an authenticated WG `HandshakeInit`.
+    /// Set or update the `peer_socket_override` on the current state based
+    /// on the source of an authenticated WG `HandshakeInit`.
     ///
     /// Caller must only invoke this for a `HandshakeInit`, never for a
     /// `HandshakeResponse`: an init is the peer's choice of send-from
@@ -2005,26 +2021,71 @@ where
     where
         TId: fmt::Display,
     {
-        let current = match self.state {
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => peer_socket,
-            ConnectionState::Connecting { .. } | ConnectionState::Failed => return,
-        };
+        match &mut self.state {
+            ConnectionState::Connecting { .. } | ConnectionState::Failed => {}
+            ConnectionState::Connected {
+                peer_socket,
+                peer_socket_override,
+                ..
+            }
+            | ConnectionState::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => {
+                let effective = peer_socket_override.unwrap_or(*peer_socket);
+                if effective == observed {
+                    return;
+                }
 
-        let effective = self.peer_socket_override.unwrap_or(current);
-        if effective == observed {
-            return;
+                tracing::info!(
+                    %cid,
+                    current = %effective.fmt(self.relay.id),
+                    new = %observed.fmt(self.relay.id),
+                    "Overriding peer_socket from authenticated WG handshake init"
+                );
+
+                *peer_socket_override = Some(observed);
+            }
         }
-
-        tracing::info!(
-            %cid,
-            current = %effective.fmt(self.relay.id),
-            new = %observed.fmt(self.relay.id),
-            "Overriding peer_socket from authenticated WG handshake init"
-        );
-
-        self.peer_socket_override = Some(observed);
     }
+}
+
+/// Decide what `peer_socket_override` should be after ICE has nominated `nominated`.
+///
+/// If ICE landed on the same socket the override pointed at, drop the
+/// override and hand control back to ICE — they agree, no reason to keep a
+/// parallel signal alive. If they disagree, keep the override: the WG
+/// handshake that set it is a fresher signal about where the peer is
+/// actually sending from than this nomination, and a later matching
+/// nomination will clear it.
+fn resolve_override<TId, RId>(
+    cid: TId,
+    current: Option<PeerSocket>,
+    nominated: PeerSocket,
+    relay: RId,
+) -> Option<PeerSocket>
+where
+    TId: fmt::Display,
+    RId: fmt::Display + Copy,
+{
+    let current = current?;
+
+    if current == nominated {
+        tracing::debug!(
+            %cid,
+            "Clearing peer_socket override; ICE re-nominated to the same socket"
+        );
+        return None;
+    }
+
+    tracing::debug!(
+        %cid,
+        override_socket = %current.fmt(relay),
+        nominated = %nominated.fmt(relay),
+        "Keeping peer_socket override; ICE nominated a different socket"
+    );
+
+    Some(current)
 }
 
 #[must_use]

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -502,11 +502,26 @@ where
             ControlFlow::Break(Err(e)) => return Err(e),
         };
 
-        let (id, packet) = match self.connections_try_handle(from, packet, now) {
-            ControlFlow::Continue(c) => c,
-            ControlFlow::Break(Ok(())) => return Ok(None),
-            ControlFlow::Break(Err(e)) => return Err(e),
+        // Reconstruct the `PeerSocket` that matches how we would send back
+        // to the peer given what we just observed: the same path kind (direct
+        // or via this relay) and the peer's currently-observed source as the
+        // destination. Used by `connections_try_handle` to set a temporary
+        // `peer_socket_override` if this turns out to be an authenticated
+        // handshake from a non-nominated path.
+        let observed_peer_socket = match relayed {
+            None => PeerSocket::PeerToPeer {
+                source: local,
+                dest: from,
+            },
+            Some(_) => PeerSocket::RelayToPeer { dest: from },
         };
+
+        let (id, packet) =
+            match self.connections_try_handle(from, observed_peer_socket, packet, now) {
+                ControlFlow::Continue(c) => c,
+                ControlFlow::Break(Ok(())) => return Ok(None),
+                ControlFlow::Break(Err(e)) => return Err(e),
+            };
 
         Ok(Some((id, packet)))
     }
@@ -533,6 +548,7 @@ where
             return Ok(None);
         }
 
+        let override_socket = conn.peer_socket_override;
         let socket = match &mut conn.state {
             ConnectionState::Connecting { ip_buffer, .. } => {
                 ip_buffer.enqueue(packet.clone());
@@ -542,8 +558,10 @@ where
 
                 return Ok(None);
             }
-            ConnectionState::Connected { peer_socket, .. } => *peer_socket,
-            ConnectionState::Idle { peer_socket } => *peer_socket,
+            ConnectionState::Connected { peer_socket, .. } => {
+                override_socket.unwrap_or(*peer_socket)
+            }
+            ConnectionState::Idle { peer_socket } => override_socket.unwrap_or(*peer_socket),
             ConnectionState::Failed => {
                 return Err(anyhow!("Connection {cid} failed"));
             }
@@ -797,6 +815,7 @@ where
                 ip_buffer: AllocRingBuffer::new(128),
             },
             disconnected_at: None,
+            peer_socket_override: None,
             buffer_pool: self.buffer_pool.clone(),
             last_proactive_handshake_sent_at: None,
             first_handshake_completed_at: None,
@@ -956,6 +975,7 @@ where
     fn connections_try_handle(
         &mut self,
         from: SocketAddr,
+        observed_peer_socket: PeerSocket,
         packet: &[u8],
         now: Instant,
     ) -> ControlFlow<Result<()>, (TId, IpPacket)> {
@@ -1009,19 +1029,24 @@ where
             now,
         );
 
-        if let ControlFlow::Break(Ok(())) = &control_flow
-            && conn.first_handshake_completed_at.is_none()
-            && matches!(
-                parsed_packet,
-                Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
-            )
-        {
+        let is_handshake = matches!(
+            parsed_packet,
+            Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
+        );
+        let handshake_decapsulated_ok = is_handshake
+            && matches!(&control_flow, ControlFlow::Break(Ok(())));
+
+        if handshake_decapsulated_ok && conn.first_handshake_completed_at.is_none() {
             conn.first_handshake_completed_at = Some(now);
 
             tracing::debug!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
 
             self.pending_events
                 .push_back(Event::ConnectionEstablished(cid))
+        }
+
+        if handshake_decapsulated_ok {
+            conn.maybe_override_peer_socket(cid, observed_peer_socket);
         }
 
         control_flow
@@ -1257,6 +1282,16 @@ struct Connection<RId> {
     state: ConnectionState,
     disconnected_at: Option<Instant>,
 
+    /// Temporary override for the outbound `PeerSocket`, set when we observe
+    /// an authenticated WireGuard handshake from a source that doesn't match
+    /// our current ICE nomination. Cleared by the next `NominatedSend` event
+    /// from ICE.
+    ///
+    /// This lets outgoing WG traffic follow the peer across cross-kind
+    /// path shifts (direct↔relay) that the controlled side of ICE can't
+    /// re-nominate without `USE-CANDIDATE` from the controlling side.
+    peer_socket_override: Option<PeerSocket>,
+
     stats: ConnectionStats,
     intent_sent_at: Instant,
     candidate_timeout: Option<Instant>,
@@ -1416,6 +1451,17 @@ where
                         (Some(_), false) => PeerSocket::RelayToPeer { dest: destination },
                         (Some(_), true) => PeerSocket::RelayToRelay { dest: destination },
                     };
+
+                    // ICE has made a deliberate nomination decision; hand
+                    // control back to it by dropping any WG-handshake-driven
+                    // peer_socket override. The override was only there to
+                    // bridge the window until this event arrived.
+                    if self.peer_socket_override.take().is_some() {
+                        tracing::debug!(
+                            %cid,
+                            "Clearing peer_socket override; ICE has re-nominated"
+                        );
+                    }
 
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
                         ConnectionState::Connecting {
@@ -1734,6 +1780,7 @@ where
             // This should be fairly rare which is why we just allocate these and return them from `poll_transmit` instead.
             // Overall, this results in a much nicer API for our caller and should not affect performance.
             TunnResult::WriteToNetwork(bytes) => {
+                let override_socket = self.peer_socket_override;
                 match &mut self.state {
                     ConnectionState::Connecting { wg_buffer, .. } => {
                         tracing::debug!(%cid, "No socket has been nominated yet, buffering WG packet");
@@ -1749,9 +1796,10 @@ where
                     }
                     ConnectionState::Connected { peer_socket, .. }
                     | ConnectionState::Idle { peer_socket } => {
+                        let peer_socket = override_socket.unwrap_or(*peer_socket);
                         transmits.extend(make_owned_transmit(
                             self.relay.id,
-                            *peer_socket,
+                            peer_socket,
                             bytes,
                             &self.buffer_pool,
                             allocations,
@@ -1764,7 +1812,7 @@ where
                         {
                             transmits.extend(make_owned_transmit(
                                 self.relay.id,
-                                *peer_socket,
+                                peer_socket,
                                 packet,
                                 &self.buffer_pool,
                                 allocations,
@@ -1910,7 +1958,17 @@ where
             .on_candidate(cid, &mut self.agent, self.default_ice_config, now)
     }
 
+    /// The socket outgoing WireGuard traffic should use.
+    ///
+    /// If [`Connection::peer_socket_override`] is set, it takes precedence
+    /// over the ICE-nominated `peer_socket`: we've observed an authenticated
+    /// handshake from a source different from what ICE nominated, and until
+    /// ICE catches up we trust the crypto signal.
     fn socket(&self) -> Option<PeerSocket> {
+        if let Some(s) = self.peer_socket_override {
+            return Some(s);
+        }
+
         match self.state {
             ConnectionState::Connected { peer_socket, .. }
             | ConnectionState::Idle { peer_socket } => Some(peer_socket),
@@ -1943,6 +2001,39 @@ where
         for candidate in new_allocation.current_relay_candidates() {
             self.add_local_candidate(cid, &candidate, pending_events, now);
         }
+    }
+
+    /// Set or update [`Connection::peer_socket_override`] based on the source
+    /// of an authenticated WG handshake.
+    ///
+    /// The override applies only once we have an ICE-nominated socket to
+    /// deviate from; during `Connecting` ICE hasn't picked anything yet and
+    /// during `Failed` the connection is going away. If the observed socket
+    /// already matches the path we're effectively using, the override is a
+    /// no-op.
+    fn maybe_override_peer_socket<TId>(&mut self, cid: TId, observed: PeerSocket)
+    where
+        TId: fmt::Display,
+    {
+        let current = match self.state {
+            ConnectionState::Connected { peer_socket, .. }
+            | ConnectionState::Idle { peer_socket } => peer_socket,
+            ConnectionState::Connecting { .. } | ConnectionState::Failed => return,
+        };
+
+        let effective = self.peer_socket_override.unwrap_or(current);
+        if effective == observed {
+            return;
+        }
+
+        tracing::info!(
+            %cid,
+            current = %effective.fmt(self.relay.id),
+            new = %observed.fmt(self.relay.id),
+            "Overriding peer_socket from authenticated WG handshake"
+        );
+
+        self.peer_socket_override = Some(observed);
     }
 }
 

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -31,12 +31,30 @@ pub(crate) enum ConnectionState {
         /// Our nominated socket.
         peer_socket: PeerSocket,
 
+        /// A socket override applied on top of `peer_socket`.
+        ///
+        /// Set when an authenticated WireGuard `HandshakeInit` arrives from
+        /// a source different from the ICE-nominated path: an init is the
+        /// peer's choice of send-from socket, so it tells us where the peer
+        /// wants future traffic to go. We deliberately ignore
+        /// `HandshakeResponse` here — a response just confirms wherever we
+        /// sent the matching init from, which would falsely look like a
+        /// peer-side path change if ICE re-nominated in between.
+        ///
+        /// Cleared once ICE re-nominates the same socket; if ICE picks a
+        /// different one the override stays in place — the WG handshake
+        /// is a fresher signal about where the peer is sending from.
+        peer_socket_override: Option<PeerSocket>,
+
         last_activity: Instant,
     },
     /// We haven't seen application packets in a while.
     Idle {
         /// Our nominated socket.
         peer_socket: PeerSocket,
+
+        /// See [`ConnectionState::Connected::peer_socket_override`].
+        peer_socket_override: Option<PeerSocket>,
     },
     /// The connection failed in an unrecoverable way and will be GC'd.
     Failed,
@@ -67,6 +85,7 @@ impl ConnectionState {
         let Self::Connected {
             last_activity,
             peer_socket,
+            peer_socket_override,
         } = self
         else {
             return;
@@ -81,8 +100,9 @@ impl ConnectionState {
         }
 
         let peer_socket = *peer_socket;
+        let peer_socket_override = *peer_socket_override;
 
-        self.transition_to_idle(peer_socket, agent, idle_ice_config);
+        self.transition_to_idle(peer_socket, peer_socket_override, agent, idle_ice_config);
     }
 
     pub(crate) fn on_upsert<TId>(
@@ -94,8 +114,11 @@ impl ConnectionState {
     ) where
         TId: fmt::Display,
     {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
+        let (peer_socket, peer_socket_override) = match self {
+            Self::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => (*peer_socket, *peer_socket_override),
             Self::Connected { last_activity, .. } => {
                 *last_activity = now;
                 return;
@@ -103,7 +126,15 @@ impl ConnectionState {
             Self::Failed | Self::Connecting { .. } => return,
         };
 
-        self.transition_to_connected(cid, peer_socket, agent, default_ice_config, "upsert", now);
+        self.transition_to_connected(
+            cid,
+            peer_socket,
+            peer_socket_override,
+            agent,
+            default_ice_config,
+            "upsert",
+            now,
+        );
     }
 
     pub(crate) fn on_candidate<TId>(
@@ -115,8 +146,11 @@ impl ConnectionState {
     ) where
         TId: fmt::Display,
     {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
+        let (peer_socket, peer_socket_override) = match self {
+            Self::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => (*peer_socket, *peer_socket_override),
             Self::Connected { last_activity, .. } => {
                 *last_activity = now;
                 return;
@@ -127,6 +161,7 @@ impl ConnectionState {
         self.transition_to_connected(
             cid,
             peer_socket,
+            peer_socket_override,
             agent,
             default_ice_config,
             "candidates changed",
@@ -144,8 +179,11 @@ impl ConnectionState {
     ) where
         TId: fmt::Display,
     {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
+        let (peer_socket, peer_socket_override) = match self {
+            Self::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => (*peer_socket, *peer_socket_override),
             Self::Connected { last_activity, .. } => {
                 *last_activity = now;
                 return;
@@ -156,6 +194,7 @@ impl ConnectionState {
         self.transition_to_connected(
             cid,
             peer_socket,
+            peer_socket_override,
             agent,
             default_ice_config,
             tracing::field::debug(packet),
@@ -173,8 +212,11 @@ impl ConnectionState {
     ) where
         TId: fmt::Display,
     {
-        let peer_socket = match self {
-            Self::Idle { peer_socket } => *peer_socket,
+        let (peer_socket, peer_socket_override) = match self {
+            Self::Idle {
+                peer_socket,
+                peer_socket_override,
+            } => (*peer_socket, *peer_socket_override),
             Self::Connected { last_activity, .. } => {
                 *last_activity = now;
                 return;
@@ -185,6 +227,7 @@ impl ConnectionState {
         self.transition_to_connected(
             cid,
             peer_socket,
+            peer_socket_override,
             agent,
             default_ice_config,
             tracing::field::debug(packet),
@@ -195,11 +238,15 @@ impl ConnectionState {
     fn transition_to_idle(
         &mut self,
         peer_socket: PeerSocket,
+        peer_socket_override: Option<PeerSocket>,
         agent: &mut IceAgent,
         idle_ice_config: IceConfig,
     ) {
         tracing::debug!("Connection is idle");
-        *self = Self::Idle { peer_socket };
+        *self = Self::Idle {
+            peer_socket,
+            peer_socket_override,
+        };
         idle_ice_config.apply(agent);
     }
 
@@ -207,6 +254,7 @@ impl ConnectionState {
         &mut self,
         cid: TId,
         peer_socket: PeerSocket,
+        peer_socket_override: Option<PeerSocket>,
         agent: &mut IceAgent,
         default_ice_config: IceConfig,
         trigger: impl tracing::Value,
@@ -217,6 +265,7 @@ impl ConnectionState {
         tracing::debug!(trigger, %cid, "Connection resumed");
         *self = Self::Connected {
             peer_socket,
+            peer_socket_override,
             last_activity: now,
         };
         default_ice_config.apply(agent);
@@ -234,7 +283,7 @@ impl fmt::Display for ConnectionState {
             ConnectionState::Connected { peer_socket, .. } => {
                 write!(f, "Connected({})", peer_socket.kind())
             }
-            ConnectionState::Idle { peer_socket } => write!(f, "Idle({})", peer_socket.kind()),
+            ConnectionState::Idle { peer_socket, .. } => write!(f, "Idle({})", peer_socket.kind()),
             ConnectionState::Failed => write!(f, "Failed"),
         }
     }

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -330,15 +330,6 @@ impl PeerSocket {
         }
     }
 
-    pub(crate) fn dest(&self) -> SocketAddr {
-        match self {
-            PeerSocket::PeerToPeer { dest, .. } => *dest,
-            PeerSocket::PeerToRelay { dest, .. } => *dest,
-            PeerSocket::RelayToPeer { dest } => *dest,
-            PeerSocket::RelayToRelay { dest } => *dest,
-        }
-    }
-
     fn kind(&self) -> &'static str {
         match self {
             PeerSocket::PeerToPeer { .. } => "PeerToPeer",

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -33,17 +33,8 @@ pub(crate) enum ConnectionState {
 
         /// A socket override applied on top of `peer_socket`.
         ///
-        /// Set when an authenticated WireGuard `HandshakeInit` arrives from
-        /// a source different from the ICE-nominated path: an init is the
-        /// peer's choice of send-from socket, so it tells us where the peer
-        /// wants future traffic to go. We deliberately ignore
-        /// `HandshakeResponse` here — a response just confirms wherever we
-        /// sent the matching init from, which would falsely look like a
-        /// peer-side path change if ICE re-nominated in between.
-        ///
-        /// Cleared once ICE re-nominates the same socket; if ICE picks a
-        /// different one the override stays in place — the WG handshake
-        /// is a fresher signal about where the peer is sending from.
+        /// Set when an authenticated WireGuard [`HandshakeInit`](boringtun::noise::HandshakeInit) arrives from a source different from the ICE-nominated path.
+        /// An init is the peer's choice of send-from socket, so it tells us where the peer wants future traffic to go.
         peer_socket_override: Option<PeerSocket>,
 
         last_activity: Instant,

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -330,6 +330,15 @@ impl PeerSocket {
         }
     }
 
+    pub(crate) fn dest(&self) -> SocketAddr {
+        match self {
+            PeerSocket::PeerToPeer { dest, .. } => *dest,
+            PeerSocket::PeerToRelay { dest, .. } => *dest,
+            PeerSocket::RelayToPeer { dest } => *dest,
+            PeerSocket::RelayToRelay { dest } => *dest,
+        }
+    }
+
     fn kind(&self) -> &'static str {
         match self {
             PeerSocket::PeerToPeer { .. } => "PeerToPeer",

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -615,7 +615,6 @@ mod tests {
             ),
             remote_pub_key: PublicKey::from(rand::random::<[u8; 32]>()),
             next_wg_timer_update: Instant::now(),
-            last_proactive_handshake_sent_at: None,
             relay: SelectedRelay { id: relay_id },
             state: crate::node::ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(1),

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -622,6 +622,7 @@ mod tests {
                 ip_buffer: AllocRingBuffer::new(1),
             },
             disconnected_at: None,
+            peer_socket_override: None,
             stats: Default::default(),
             intent_sent_at: Instant::now(),
             candidate_timeout: None,

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -621,7 +621,6 @@ mod tests {
                 ip_buffer: AllocRingBuffer::new(1),
             },
             disconnected_at: None,
-            peer_socket_override: None,
             stats: Default::default(),
             intent_sent_at: Instant::now(),
             candidate_timeout: None,


### PR DESCRIPTION
Introduces a temporary per-connection `PeerSocket` override, set when an authenticated WireGuard handshake init decapsulates successfully from a source that doesn't match the ICE-nominated peer_socket. Outbound WG traffic uses the override while it's set, falling back to the ICE-nominated socket otherwise.

If the remote peer sends us a `HandshakeInit` on a new path and it arrives at our node, we can take that as a strong signal that we should be using this path, regardless of what ICE told us. In `snownet`, only the controlling side of ICE sends WireGuard handshakes and in our configuration, this is only a Firezone Client. Thus, after a Client roams, it will select a new path via ICE and once it has nominated that, follow-up with a WireGuard handshake. The controlling side, i.e. the Gateway, may still be running ICE checks on a previous candidate pair. Righ now, these ICE checks need to time-out before the nomination hops over to the new one. That is the time-window we want to bridge with this patch. ICE will catch up eventually to the new path which is what allows us to clear this override.

To ensure this works correctly, we also now enforce that each newly nominated socket sends a new WireGuard handshake. ICE is known to hop through a few paths as it figures out the best one, thus we must always send a new handshake as soon as ICE discovers a better option. Sending a new handshake will invalidate the previous one so we cannot accidentally use that.