### PR TITLE
feat(portal): static device pools

### DIFF
--- a/elixir/lib/portal/cache/cacheable/resource.ex
+++ b/elixir/lib/portal/cache/cacheable/resource.ex
@@ -7,12 +7,19 @@ defmodule Portal.Cache.Cacheable.Resource do
     :address_description,
     :ip_stack,
     :filters,
+    :devices,
     :site
   ]
 
   @type filter :: %{
           protocol: :tcp | :udp | :icmp,
           ports: [String.t()]
+        }
+
+  @type pool_device :: %{
+          id: Ecto.UUID.t(),
+          ipv4: Postgrex.INET.t(),
+          ipv6: Postgrex.INET.t()
         }
 
   @type t :: %__MODULE__{
@@ -23,6 +30,7 @@ defmodule Portal.Cache.Cacheable.Resource do
           address_description: String.t(),
           ip_stack: atom(),
           filters: [filter()],
+          devices: [pool_device()] | nil,
           site: Portal.Cache.Cacheable.Site.t() | nil
         }
 end

--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -34,12 +34,24 @@ defmodule Portal.Cache.Client do
             site: %{
               name:string:(~1.25 bytes per char),
               id:uuidv4:16
-            } or nil
+            } or nil,
+            devices: [%{id: uuidv4:16, ipv4: inet, ipv6: inet}] or nil
           }},
 
           memberships: %{group_id:uuidv4:16 => membership_id:uuidv4:16},
 
-          connectable_resources: [Cache.Cacheable.Resource.t()]
+          connectable_resources: [Cache.Cacheable.Resource.t()],
+
+          # For each connectable static_device_pool resource, the set of member device IDs.
+          pool_members: %{resource_id:uuidv4:16 => MapSet<device_id:uuidv4:16>},
+
+          # Cached IPs for each device that appears in any connectable pool. Used both
+          # to render `addresses` on the pool resource and to authorize client_device_access
+          # requests by ipv4 or ipv6.
+          device_addresses: %{device_id:uuidv4:16 => {ipv4_tuple_or_nil, ipv6_tuple_or_nil}},
+
+          # IPv4 addresses of clients previously authorized to connect to this client.
+          authorized_device_ipv4s: MapSet<ipv4_tuple>
         }
 
 
@@ -70,23 +82,43 @@ defmodule Portal.Cache.Client do
     # The list resources the client can currently connect to. This is defined as:
     # 1. The resource is authorized based on policies and conditions
     # 2. The resource is compatible with the client (i.e. the client can connect to it)
-    # 3. The resource has at least one site associated with it
+    # 3. The resource has at least one site associated with it (or, for pools, no site is required)
     :connectable_resources,
 
-    # Map of client_id => IPv4 tuple for all clients in currently connectable static device pools.
-    :connectable_devices,
+    # Map of static_device_pool resource_id => MapSet of member device_ids for every
+    # currently connectable pool.
+    :pool_members,
+
+    # Map of device_id => {ipv4_tuple_or_nil, ipv6_tuple_or_nil} for every device appearing
+    # in any connectable pool.
+    :device_addresses,
 
     # IPv4 addresses of clients previously authorized to connect to this client.
     :authorized_device_ipv4s
   ]
+
+  @type ipv4_tuple :: {byte(), byte(), byte(), byte()}
+  @type ipv6_tuple ::
+          {char(), char(), char(), char(), char(), char(), char(), char()}
+  @type denied_addresses :: {ipv4_tuple(), ipv6_tuple()} | nil
+  @type pool_device :: %{
+          id: Ecto.UUID.t(),
+          ipv4: Postgrex.INET.t(),
+          ipv6: Postgrex.INET.t()
+        }
 
   @type t :: %__MODULE__{
           policies: %{Cache.Cacheable.uuid_binary() => Portal.Cache.Cacheable.Policy.t()},
           resources: %{Cache.Cacheable.uuid_binary() => Portal.Cache.Cacheable.Resource.t()},
           memberships: %{Cache.Cacheable.uuid_binary() => Cache.Cacheable.uuid_binary()},
           connectable_resources: [Cache.Cacheable.Resource.t()],
-          connectable_devices: %{Ecto.UUID.t() => {byte(), byte(), byte(), byte()}},
-          authorized_device_ipv4s: MapSet.t({byte(), byte(), byte(), byte()})
+          pool_members: %{
+            Cache.Cacheable.uuid_binary() => MapSet.t(Cache.Cacheable.uuid_binary())
+          },
+          device_addresses: %{
+            Cache.Cacheable.uuid_binary() => {ipv4_tuple(), ipv6_tuple()}
+          },
+          authorized_device_ipv4s: MapSet.t(ipv4_tuple())
         }
 
   @doc """
@@ -151,25 +183,49 @@ defmodule Portal.Cache.Client do
     end
   end
 
-  @spec authorize_device_access(t(), {byte(), byte(), byte(), byte()}) ::
-          :ok | {:error, :forbidden}
-  def authorize_device_access(cache, {_, _, _, _} = target_ipv4) do
-    if Enum.any?(cache.connectable_devices, fn {_, ipv4} -> ipv4 == target_ipv4 end),
-      do: :ok,
-      else: {:error, :forbidden}
+  @doc """
+    Returns the device_id of the member of the given connectable pool with the matching IPv4 or
+    IPv6 address, or `{:error, :forbidden}` if no such device is in this pool.
+  """
+  @spec authorize_device_access(
+          t(),
+          Ecto.UUID.t(),
+          {:ipv4, ipv4_tuple()} | {:ipv6, ipv6_tuple()}
+        ) ::
+          {:ok, Ecto.UUID.t()} | {:error, :forbidden}
+  def authorize_device_access(cache, resource_id, {family, target_address})
+      when family in [:ipv4, :ipv6] do
+    rid_bytes = dump!(resource_id)
+    device_set = Map.get(cache.pool_members, rid_bytes, MapSet.new())
+
+    device_set
+    |> Enum.find_value(fn did_bytes ->
+      case Map.get(cache.device_addresses, did_bytes) do
+        {ipv4, _} when family == :ipv4 and ipv4 == target_address ->
+          load!(did_bytes)
+
+        {_, ipv6} when family == :ipv6 and ipv6 == target_address ->
+          load!(did_bytes)
+
+        _ ->
+          nil
+      end
+    end)
+    |> case do
+      nil -> {:error, :forbidden}
+      device_id -> {:ok, device_id}
+    end
   end
 
-  @spec track_authorized_device_ipv4(t(), Postgrex.INET.t() | nil) :: t()
-  def track_authorized_device_ipv4(cache, nil), do: cache
-
+  @spec track_authorized_device_ipv4(t(), Postgrex.INET.t()) :: t()
   def track_authorized_device_ipv4(cache, %Postgrex.INET{address: ipv4_tuple}) do
     %{cache | authorized_device_ipv4s: MapSet.put(cache.authorized_device_ipv4s, ipv4_tuple)}
   end
 
-  @spec device_ipv4_relevant?(t(), {byte(), byte(), byte(), byte()}) :: boolean()
+  @spec device_ipv4_relevant?(t(), ipv4_tuple()) :: boolean()
   def device_ipv4_relevant?(cache, {_, _, _, _} = ipv4) do
     MapSet.member?(cache.authorized_device_ipv4s, ipv4) or
-      Enum.any?(cache.connectable_devices, fn {_, v} -> v == ipv4 end)
+      Enum.any?(cache.device_addresses, fn {_, {v4, _v6}} -> v4 == ipv4 end)
   end
 
   @doc """
@@ -197,10 +253,23 @@ defmodule Portal.Cache.Client do
   def recompute_connectable_resources(cache, client, session, subject, opts \\ []) do
     {toggle, _opts} = Keyword.pop(opts, :toggle, false)
 
-    connectable_resources =
+    raw_connectable =
       cache.policies
       |> conforming_resource_ids(client, session, subject.credential.auth_provider_id)
       |> adapted_resources(cache.resources, session)
+
+    {pool_members, device_addresses} = load_pool_state(raw_connectable, subject)
+
+    connectable_resources =
+      Enum.map(raw_connectable, fn resource ->
+        case resource.type do
+          :static_device_pool ->
+            %{resource | devices: render_pool_devices(resource.id, pool_members, device_addresses)}
+
+          _ ->
+            resource
+        end
+      end)
 
     added = connectable_resources -- cache.connectable_resources
 
@@ -214,16 +283,11 @@ defmodule Portal.Cache.Client do
         load!(r.id)
       end
 
-    connectable_devices =
-      connectable_resources
-      |> Enum.filter(&(&1.type == :static_device_pool))
-      |> Enum.map(&load!(&1.id))
-      |> Database.all_member_ipv4s(subject)
-
     cache = %{
       cache
       | connectable_resources: connectable_resources,
-        connectable_devices: connectable_devices
+        pool_members: pool_members,
+        device_addresses: device_addresses
     }
 
     {:ok, added, removed_ids, cache}
@@ -506,29 +570,160 @@ defmodule Portal.Cache.Client do
           t(),
           Portal.StaticDevicePoolMember.t(),
           Authentication.Subject.t()
-        ) :: {:ok, t()}
+        ) :: {:ok, [Cache.Cacheable.Resource.t()], [Ecto.UUID.t()], t()}
   def add_static_device_pool_member(cache, %Portal.StaticDevicePoolMember{} = member, subject) do
-    if connectable_resource?(cache, member.resource_id) do
-      ipv4 = Database.get_client_ipv4(member.device_id, subject)
+    rid_bytes = dump!(member.resource_id)
+    did_bytes = dump!(member.device_id)
 
-      updated =
-        if ipv4 do
-          Map.put(cache.connectable_devices, member.device_id, ipv4)
-        else
-          cache.connectable_devices
-        end
+    with true <- connectable_resource?(cache, member.resource_id),
+         {:ok, device_addresses} <- ensure_device_addresses(cache, did_bytes, member.device_id, subject) do
+      pool_members =
+        Map.update(
+          cache.pool_members,
+          rid_bytes,
+          MapSet.new([did_bytes]),
+          &MapSet.put(&1, did_bytes)
+        )
 
-      {:ok, %{cache | connectable_devices: updated}}
+      cache = %{cache | pool_members: pool_members, device_addresses: device_addresses}
+
+      {updated_pool, cache} = refresh_pool_devices(cache, rid_bytes)
+
+      added = if updated_pool, do: [updated_pool], else: []
+
+      {:ok, added, [], cache}
     else
-      {:ok, cache}
+      _ -> {:ok, [], [], cache}
+    end
+  end
+
+  defp ensure_device_addresses(cache, did_bytes, device_id, subject) do
+    case Map.fetch(cache.device_addresses, did_bytes) do
+      {:ok, _existing} ->
+        {:ok, cache.device_addresses}
+
+      :error ->
+        case Database.get_client_addresses(device_id, subject) do
+          nil -> :error
+          {_v4, _v6} = addresses -> {:ok, Map.put(cache.device_addresses, did_bytes, addresses)}
+        end
     end
   end
 
   @spec delete_static_device_pool_member(t(), Portal.StaticDevicePoolMember.t()) ::
-          {:ok, {byte(), byte(), byte(), byte()} | nil, t()}
+          {:ok, denied_addresses(), [Cache.Cacheable.Resource.t()], [Ecto.UUID.t()], t()}
   def delete_static_device_pool_member(cache, %Portal.StaticDevicePoolMember{} = member) do
-    {ipv4, updated} = Map.pop(cache.connectable_devices, member.device_id)
-    {:ok, ipv4, %{cache | connectable_devices: updated}}
+    rid_bytes = dump!(member.resource_id)
+    did_bytes = dump!(member.device_id)
+
+    addresses = Map.get(cache.device_addresses, did_bytes)
+
+    pool_members =
+      case Map.fetch(cache.pool_members, rid_bytes) do
+        {:ok, set} ->
+          updated = MapSet.delete(set, did_bytes)
+
+          if MapSet.size(updated) == 0,
+            do: Map.delete(cache.pool_members, rid_bytes),
+            else: Map.put(cache.pool_members, rid_bytes, updated)
+
+        :error ->
+          cache.pool_members
+      end
+
+    cache = %{cache | pool_members: pool_members}
+
+    # Only deny access to the device's IPs when it is no longer reachable
+    # through any other pool we have access to.
+    denied = if device_in_any_pool?(cache, did_bytes), do: nil, else: addresses
+
+    cache = garbage_collect_device_addresses(cache, did_bytes)
+
+    {updated_pool, cache} = refresh_pool_devices(cache, rid_bytes)
+
+    added = if updated_pool, do: [updated_pool], else: []
+
+    {:ok, denied, added, [], cache}
+  end
+
+  @doc """
+    Reacts to an update of a non-self client device. If the device is a member of any
+    connectable pool and its addresses changed, returns the affected pool resources for
+    the channel to push as `resource_created_or_updated`.
+  """
+  @spec handle_member_device_update(t(), Portal.Device.t(), Authentication.Subject.t()) ::
+          {:ok, [Cache.Cacheable.Resource.t()], [Ecto.UUID.t()], t()}
+  def handle_member_device_update(cache, %Portal.Device{type: :client} = device, _subject) do
+    did_bytes = dump!(device.id)
+    new_ipv4 = device.ipv4.address
+    new_ipv6 = device.ipv6.address
+
+    case Map.fetch(cache.device_addresses, did_bytes) do
+      :error ->
+        {:ok, [], [], cache}
+
+      {:ok, existing} when existing == {new_ipv4, new_ipv6} ->
+        {:ok, [], [], cache}
+
+      {:ok, _existing} ->
+        cache = %{
+          cache
+          | device_addresses: Map.put(cache.device_addresses, did_bytes, {new_ipv4, new_ipv6})
+        }
+
+        affected =
+          for {rid_bytes, members} <- cache.pool_members,
+              MapSet.member?(members, did_bytes),
+              do: rid_bytes
+
+        {updated, cache} = refresh_pools(cache, affected)
+        {:ok, updated, [], cache}
+    end
+  end
+
+  defp refresh_pools(cache, rid_bytes_list) do
+    Enum.reduce(rid_bytes_list, {[], cache}, fn rid_bytes, {acc, cache_acc} ->
+      {updated_pool, cache_acc} = refresh_pool_devices(cache_acc, rid_bytes)
+      acc = if updated_pool, do: [updated_pool | acc], else: acc
+      {acc, cache_acc}
+    end)
+  end
+
+  @doc """
+    Reacts to deletion of a non-self client device. Removes the device from every pool
+    it was a member of, recomputes affected pools' addresses, and returns the device's
+    last-known addresses so the channel can push `client_device_access_denied`.
+
+    Cascade `static_device_pool_members` delete events that arrive after this become
+    no-ops because the device is no longer in `pool_members`. If the cascade arrives
+    *before* this Device delete, that path already pushed the denial and this becomes
+    the no-op.
+  """
+  @spec handle_member_device_delete(t(), Portal.Device.t()) ::
+          {:ok, denied_addresses(), [Cache.Cacheable.Resource.t()], [Ecto.UUID.t()], t()}
+  def handle_member_device_delete(cache, %Portal.Device{type: :client} = device) do
+    did_bytes = dump!(device.id)
+    addresses = Map.get(cache.device_addresses, did_bytes)
+
+    affected_pool_ids =
+      for {rid_bytes, members} <- cache.pool_members,
+          MapSet.member?(members, did_bytes),
+          do: rid_bytes
+
+    pool_members =
+      cache.pool_members
+      |> Enum.map(fn {rid, members} -> {rid, MapSet.delete(members, did_bytes)} end)
+      |> Enum.reject(fn {_rid, members} -> MapSet.size(members) == 0 end)
+      |> Map.new()
+
+    cache = %{
+      cache
+      | pool_members: pool_members,
+        device_addresses: Map.delete(cache.device_addresses, did_bytes)
+    }
+
+    {updated, cache} = refresh_pools(cache, affected_pool_ids)
+    {:ok, addresses, updated, [], cache}
   end
 
   defp hydrate(client, subject) do
@@ -558,7 +753,8 @@ defmodule Portal.Cache.Client do
       cache
       |> Map.put(:memberships, memberships)
       |> Map.put(:connectable_resources, [])
-      |> Map.put(:connectable_devices, %{})
+      |> Map.put(:pool_members, %{})
+      |> Map.put(:device_addresses, %{})
       |> Map.put(:authorized_device_ipv4s, Database.authorized_ipv4s(client.id, subject))
     end
   end
@@ -586,7 +782,82 @@ defmodule Portal.Cache.Client do
   end
 
   defp adapt(resource, session) do
-    Resource.adapt_resource_for_version(resource, session.version)
+    Resource.adapt_resource_for_version(resource, session)
+  end
+
+  defp load_pool_state(connectable_resources, subject) do
+    pool_resource_ids =
+      for r <- connectable_resources, r.type == :static_device_pool, do: load!(r.id)
+
+    case pool_resource_ids do
+      [] ->
+        {%{}, %{}}
+
+      ids ->
+        rows = Database.all_member_ips(ids, subject)
+
+        Enum.reduce(rows, {%{}, %{}}, fn {rid_bytes, did_bytes, ipv4, ipv6},
+                                         {pool_members_acc, device_addresses_acc} ->
+          pool_members_acc =
+            Map.update(
+              pool_members_acc,
+              rid_bytes,
+              MapSet.new([did_bytes]),
+              &MapSet.put(&1, did_bytes)
+            )
+
+          device_addresses_acc = Map.put(device_addresses_acc, did_bytes, {ipv4, ipv6})
+          {pool_members_acc, device_addresses_acc}
+        end)
+    end
+  end
+
+  defp render_pool_devices(rid_bytes, pool_members, device_addresses) do
+    pool_members
+    |> Map.get(rid_bytes, MapSet.new())
+    |> Enum.flat_map(fn did_bytes ->
+      case Map.fetch(device_addresses, did_bytes) do
+        :error -> []
+        {:ok, {ipv4, ipv6}} -> [pool_device_entry(did_bytes, ipv4, ipv6)]
+      end
+    end)
+    |> Enum.sort_by(& &1.ipv4.address)
+  end
+
+  defp pool_device_entry(did_bytes, ipv4_tuple, ipv6_tuple) do
+    %{
+      id: load!(did_bytes),
+      ipv4: %Postgrex.INET{address: ipv4_tuple, netmask: 32},
+      ipv6: %Postgrex.INET{address: ipv6_tuple, netmask: 128}
+    }
+  end
+
+  defp refresh_pool_devices(cache, rid_bytes) do
+    devices = render_pool_devices(rid_bytes, cache.pool_members, cache.device_addresses)
+
+    {updated, connectable} =
+      Enum.map_reduce(cache.connectable_resources, nil, fn r, found ->
+        if r.id == rid_bytes and r.type == :static_device_pool do
+          new_r = %{r | devices: devices}
+          {new_r, new_r}
+        else
+          {r, found}
+        end
+      end)
+
+    {connectable, %{cache | connectable_resources: updated}}
+  end
+
+  defp garbage_collect_device_addresses(cache, did_bytes) do
+    if device_in_any_pool?(cache, did_bytes) do
+      cache
+    else
+      %{cache | device_addresses: Map.delete(cache.device_addresses, did_bytes)}
+    end
+  end
+
+  defp device_in_any_pool?(cache, did_bytes) do
+    Enum.any?(cache.pool_members, fn {_rid, set} -> MapSet.member?(set, did_bytes) end)
   end
 
   defp conforming_resource_ids(policies, client, session, auth_provider_id)
@@ -811,44 +1082,60 @@ defmodule Portal.Cache.Client do
       |> Safe.one()
     end
 
-    def all_member_ipv4s([], _subject), do: %{}
+    @doc """
+      Returns a list of `{resource_id_bytes, device_id_bytes, ipv4_tuple, ipv6_tuple}`
+      for every member of the given pool resources. Member device ipv4/ipv6 are NOT NULL.
+    """
+    def all_member_ips([], _subject), do: []
 
-    def all_member_ipv4s(resource_ids, subject) do
+    def all_member_ips(resource_ids, subject) do
       from(r in Portal.Resource, as: :resources)
       |> where([resources: r], r.id in ^resource_ids)
       |> join(:inner, [resources: r], m in assoc(r, :static_pool_members), as: :members)
       |> join(:inner, [members: m], c in assoc(m, :client), as: :clients)
       |> where([clients: c], c.type == :client)
-      |> select([members: m, clients: c], {m.device_id, c.ipv4})
+      |> select(
+        [resources: r, members: m, clients: c],
+        {r.id, m.device_id, c.ipv4, c.ipv6}
+      )
       |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> case do
         {:error, :unauthorized} ->
-          %{}
+          []
 
         rows ->
-          Map.new(rows, fn {device_id, ipv4} -> {Ecto.UUID.cast!(device_id), ipv4.address} end)
+          Enum.map(rows, fn {rid, did, %Postgrex.INET{address: v4}, %Postgrex.INET{address: v6}} ->
+            {Ecto.UUID.dump!(rid), Ecto.UUID.dump!(did), v4, v6}
+          end)
       end
     end
 
-    def get_client_ipv4(client_id, subject) do
+    @doc """
+      Fetches `{ipv4_tuple, ipv6_tuple}` for a single client device, or `nil` if the
+      device cannot be found or the read is unauthorized (e.g. a race with deletion).
+      Both addresses are NOT NULL when the device row exists.
+    """
+    def get_client_addresses(client_id, subject) do
       from(c in Portal.Device,
         where: c.type == :client,
         where: c.id == ^client_id
       )
-      |> select([c], c.ipv4)
       |> Safe.scoped(subject, :replica)
       |> Safe.one()
       |> case do
-        %Postgrex.INET{address: tuple} ->
-          tuple
+        %Portal.Device{
+          ipv4: %Postgrex.INET{address: v4},
+          ipv6: %Postgrex.INET{address: v6}
+        } ->
+          {v4, v6}
 
         nil ->
-          Logger.error("IPv4 address not found for client", client_id: client_id)
+          Logger.error("Addresses not found for client", client_id: client_id)
           nil
 
         {:error, reason} ->
-          Logger.error("Failed to fetch IPv4 for client",
+          Logger.error("Failed to fetch addresses for client",
             client_id: client_id,
             reason: inspect(reason)
           )

--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -33,6 +33,7 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
     "portal_sessions" => Portal.PortalSession,
     "resources" => Portal.Resource,
     "sites" => Portal.Site,
+    "static_device_pool_members" => Portal.StaticDevicePoolMember,
     "client_tokens" => Portal.ClientToken,
     "outbound_emails" => Portal.OutboundEmail,
     "outbound_email_deliveries" => Portal.OutboundEmailDelivery,

--- a/elixir/lib/portal/presence.ex
+++ b/elixir/lib/portal/presence.ex
@@ -88,6 +88,14 @@ defmodule Portal.Presence do
         end)
       end
 
+      def find_by_ipv6(account_id, ipv6_tuple) when is_tuple(ipv6_tuple) do
+        account_id
+        |> list()
+        |> Enum.find_value(fn {client_id, %{metas: [meta | _]}} ->
+          if meta.ipv6 == ipv6_tuple, do: {client_id, meta}
+        end)
+      end
+
       defp topic(account_id) do
         "presences:account_clients:" <> account_id
       end

--- a/elixir/lib/portal/resource.ex
+++ b/elixir/lib/portal/resource.ex
@@ -350,6 +350,21 @@ defmodule Portal.Resource do
   # Version can be nil when derive_version/1 fails to parse the user agent
   def adapt_resource_for_version(resource, nil), do: resource
 
+  def adapt_resource_for_version(
+        %{type: :static_device_pool} = resource,
+        %Portal.ClientSession{} = session
+      ) do
+    if Portal.Version.client_supports_static_device_pools?(session) do
+      adapt_resource_for_version(resource, session.version)
+    else
+      nil
+    end
+  end
+
+  def adapt_resource_for_version(resource, %Portal.ClientSession{version: version}) do
+    adapt_resource_for_version(resource, version)
+  end
+
   def adapt_resource_for_version(resource, client_or_gateway_version) do
     cond do
       # internet resources require client and gateway >= 1.3.0

--- a/elixir/lib/portal/version.ex
+++ b/elixir/lib/portal/version.ex
@@ -71,4 +71,45 @@ defmodule Portal.Version do
         latest_session: session
       }),
       do: resource_cannot_change_sites_on_client?(session)
+
+  # Static device pool resources require:
+  #   apple    >= 1.5.16
+  #   gui      >= 1.5.13 (windows / linux gui)
+  #   headless >= 1.5.9  (windows / linux headless)
+  #   android  -- not yet supported
+  def client_supports_static_device_pools?(%ClientSession{version: nil}), do: false
+
+  def client_supports_static_device_pools?(%ClientSession{user_agent: nil}), do: false
+
+  def client_supports_static_device_pools?(%ClientSession{} = session) do
+    if String.contains?(session.user_agent, "headless-client/") do
+      Version.compare(session.version, "1.5.9") != :lt
+    else
+      case ComponentVersions.get_component_type_from_user_agent(session.user_agent) do
+        :apple -> Version.compare(session.version, "1.5.16") != :lt
+        :gui -> Version.compare(session.version, "1.5.13") != :lt
+        :android -> false
+      end
+    end
+  end
+
+  def client_supports_static_device_pools?(%Device{
+        type: :client,
+        latest_session: nil
+      }),
+      do: false
+
+  def client_supports_static_device_pools?(%Device{
+        type: :client,
+        actor: %Portal.Actor{type: :service_account},
+        latest_session: %ClientSession{version: version}
+      })
+      when not is_nil(version),
+      do: Version.compare(version, "1.5.9") != :lt
+
+  def client_supports_static_device_pools?(%Device{
+        type: :client,
+        latest_session: session
+      }),
+      do: client_supports_static_device_pools?(session)
 end

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -120,13 +120,16 @@ defmodule PortalAPI.Client.Channel do
         socket.assigns.subject
       )
 
-    # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
     for resource_id <- removed_ids do
       push(socket, "resource_deleted", resource_id)
     end
 
-    for resource <- added_resources, resource.type != :static_device_pool do
-      push(socket, "resource_created_or_updated", Views.Resource.render(resource, socket.assigns.session))
+    for resource <- added_resources do
+      push(
+        socket,
+        "resource_created_or_updated",
+        Views.Resource.render(resource, socket.assigns.session)
+      )
     end
 
     {:noreply, assign(socket, cache: cache)}
@@ -385,110 +388,42 @@ defmodule PortalAPI.Client.Channel do
   ##### Client-initiated actions #####
   ####################################
 
-  # This message is sent to the client to request a network flow with a gateway that can serve given resource.
+  # This message is sent to the client to request a network flow with a gateway (or, for
+  # static_device_pool resources, a peer client) that can serve the given resource.
   #
-  # `connected_gateway_ids` is used to indicate that the client is already connected to some of the gateways,
-  # so the gateway can be reused by multiplexing the connection.
+  # For gateway-backed resources, `connected_gateway_ids` indicates that the client is already
+  # connected to some of the gateways, so the gateway can be reused by multiplexing the connection.
+  #
+  # For static_device_pool resources, the payload also carries `ipv4` or `ipv6` of the target
+  # member device.
   def handle_in(
         "create_flow",
-        %{
-          "resource_id" => resource_id,
-          "connected_gateway_ids" => connected_gateway_ids
-        },
+        %{"resource_id" => resource_id} = payload,
         socket
       ) do
-    with {:ok, resource, membership_id, policy_id, expires_at} <-
-           Cache.Client.authorize_resource(
-             socket.assigns.cache,
-             socket.assigns.client,
-             socket.assigns.session,
-             resource_id,
-             socket.assigns.subject
-           ),
-         {:ok, gateways} when gateways != [] <-
-           Database.all_compatible_gateways_for_client_and_resource(
-             socket.assigns.client_version,
-             resource,
-             socket.assigns.subject.account.id
-           ) do
-      location = {
-        socket.assigns.subject.context.remote_ip_location_lat,
-        socket.assigns.subject.context.remote_ip_location_lon
-      }
+    case Cache.Client.authorize_resource(
+           socket.assigns.cache,
+           socket.assigns.client,
+           socket.assigns.session,
+           resource_id,
+           socket.assigns.subject
+         ) do
+      {:ok, %Cache.Cacheable.Resource{type: :static_device_pool} = resource, _, _, _} ->
+        handle_create_pool_flow(resource_id, resource, payload, socket)
 
-      gateway = Device.load_balance_gateways(location, gateways, connected_gateway_ids)
-      gateway_public_key = gateway.latest_session.public_key
+      {:ok, resource, membership_id, policy_id, expires_at} ->
+        connected_gateway_ids = Map.get(payload, "connected_gateway_ids", [])
 
-      policy_authorization_id = Ecto.UUID.generate()
-
-      preshared_key =
-        generate_preshared_key(
-          socket.assigns.client,
-          socket.assigns.session.public_key,
-          gateway,
-          gateway_public_key
+        handle_create_gateway_flow(
+          resource_id,
+          resource,
+          membership_id,
+          policy_id,
+          expires_at,
+          connected_gateway_ids,
+          socket
         )
 
-      ice_credentials =
-        generate_ice_credentials(
-          socket.assigns.session.public_key,
-          socket.assigns.client,
-          gateway,
-          gateway_public_key
-        )
-
-      message =
-        {:authorize_policy, {self(), socket_ref(socket)},
-         %{
-           client:
-             PortalAPI.Gateway.Views.Client.render(
-               socket.assigns.client,
-               socket.assigns.session.public_key,
-               preshared_key,
-               socket.assigns.subject.context.user_agent
-             ),
-           subject: PortalAPI.Gateway.Views.Subject.render(socket.assigns.subject),
-           resource: PortalAPI.Gateway.Views.Resource.render(resource),
-           policy_authorization_id: policy_authorization_id,
-           authorization_expires_at: expires_at,
-           ice_credentials: ice_credentials,
-           preshared_key: preshared_key
-         }}
-
-      async_create_policy_authorization(
-        policy_authorization_id,
-        socket.assigns.client,
-        gateway,
-        resource_id,
-        policy_id,
-        membership_id,
-        socket.assigns.subject,
-        expires_at
-      )
-
-      case PG.deliver(gateway.id, message) do
-        :ok ->
-          timer_ref =
-            Process.send_after(
-              self(),
-              {:flow_creation_timeout, resource_id},
-              flow_creation_timeout()
-            )
-
-          socket =
-            assign(
-              socket,
-              :pending_flows,
-              Map.put(socket.assigns.pending_flows, resource_id, timer_ref)
-            )
-
-          {:noreply, socket}
-
-        {:error, :not_found} ->
-          push(socket, "flow_creation_failed", %{resource_id: resource_id, reason: :offline})
-          {:noreply, socket}
-      end
-    else
       {:error, :not_found} ->
         push(socket, "flow_creation_failed", %{
           resource_id: resource_id,
@@ -502,22 +437,6 @@ defmodule PortalAPI.Client.Channel do
           resource_id: resource_id,
           reason: :forbidden,
           violated_properties: violated_properties
-        })
-
-        {:noreply, socket}
-
-      {:ok, []} ->
-        push(socket, "flow_creation_failed", %{
-          resource_id: resource_id,
-          reason: :offline
-        })
-
-        {:noreply, socket}
-
-      {:error, :version_mismatch} ->
-        push(socket, "flow_creation_failed", %{
-          resource_id: resource_id,
-          reason: :version_mismatch
         })
 
         {:noreply, socket}
@@ -728,103 +647,6 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
-  def handle_in("request_device_access", %{"ipv4" => ipv4_string}, socket) do
-    account_id = socket.assigns.client.account_id
-
-    with true <- client_to_client_enabled?(socket.assigns.subject.account),
-         {:ok, ipv4_tuple} <- parse_ipv4(ipv4_string),
-         :ok <- Cache.Client.authorize_device_access(socket.assigns.cache, ipv4_tuple),
-         {:ok, target_client_id, target_meta} <-
-           find_online_client_by_ipv4(account_id, ipv4_tuple) do
-      client = socket.assigns.client
-      client_public_key = socket.assigns.session.public_key
-
-      target_client = %Portal.Device{
-        id: target_client_id,
-        psk_base: target_meta.psk_base,
-        type: :client
-      }
-
-      preshared_key =
-        Portal.Crypto.psk(
-          client,
-          client_public_key,
-          target_client,
-          target_meta.public_key
-        )
-
-      ice_credentials =
-        generate_ice_credentials(
-          client_public_key,
-          client,
-          target_client,
-          target_meta.public_key
-        )
-
-      account_key = socket.assigns.subject.account.key
-
-      PG.deliver(
-        target_client_id,
-        {:client_device_access_authorized,
-         %{
-           client_id: client.id,
-           client_name: client.name,
-           client_fqdns: client_fqdns(client.ipv4, account_key),
-           client_public_key: client_public_key,
-           client_ipv4: client.ipv4,
-           client_ipv6: client.ipv6,
-           preshared_key: preshared_key,
-           local_ice_credentials: ice_credentials.receiver,
-           remote_ice_credentials: ice_credentials.initiator,
-           ice_role: :controlled
-         }}
-      )
-
-      target_ipv4 = target_meta.ipv4 && %Postgrex.INET{address: target_meta.ipv4}
-
-      push(socket, "client_device_access_authorized", %{
-        client_id: target_client_id,
-        client_name: target_meta.name,
-        client_fqdns: client_fqdns(target_ipv4, account_key),
-        client_public_key: target_meta.public_key,
-        client_ipv4: target_ipv4,
-        client_ipv6: target_meta.ipv6 && %Postgrex.INET{address: target_meta.ipv6},
-        preshared_key: preshared_key,
-        local_ice_credentials: ice_credentials.initiator,
-        remote_ice_credentials: ice_credentials.receiver,
-        ice_role: :controlling
-      })
-
-      {:noreply, socket}
-    else
-      false ->
-        push(socket, "client_device_access_denied", %{
-          ipv4: ipv4_string,
-          reason: :disabled
-        })
-
-        {:noreply, socket}
-
-      {:error, :invalid_ipv4} ->
-        Logger.warning("Invalid IPv4 address provided for device access request",
-          client_id: socket.assigns.client.id,
-          account_id: socket.assigns.client.account_id,
-          account_slug: socket.assigns.subject.account.slug,
-          ipv4: ipv4_string
-        )
-
-        {:noreply, socket}
-
-      :offline ->
-        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :offline})
-        {:noreply, socket}
-
-      {:error, :forbidden} ->
-        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :forbidden})
-        {:noreply, socket}
-    end
-  end
-
   def handle_in(
         "new_gateway_ice_candidates",
         %{"candidates" => candidates, "gateway_id" => gateway_id},
@@ -963,24 +785,291 @@ defmodule PortalAPI.Client.Channel do
 
   defp client_to_client_enabled?(account), do: Database.client_to_client_enabled?(account)
 
-  defp parse_ipv4(ipv4_string) when is_binary(ipv4_string) do
+  defp parse_target_address(%{"ipv4" => ipv4, "ipv6" => ipv6})
+       when is_binary(ipv4) and is_binary(ipv6),
+       do: {:error, :ambiguous_address}
+
+  defp parse_target_address(%{"ipv4" => ipv4_string}) when is_binary(ipv4_string) do
     case :inet.parse_address(String.to_charlist(ipv4_string)) do
-      {:ok, {_, _, _, _} = tuple} -> {:ok, tuple}
-      _ -> {:error, :invalid_ipv4}
+      {:ok, {_, _, _, _} = tuple} -> {:ok, {:ipv4, tuple}}
+      _ -> {:error, :invalid_address}
     end
   end
+
+  defp parse_target_address(%{"ipv6" => ipv6_string}) when is_binary(ipv6_string) do
+    case :inet.parse_address(String.to_charlist(ipv6_string)) do
+      {:ok, {_, _, _, _, _, _, _, _} = tuple} -> {:ok, {:ipv6, tuple}}
+      _ -> {:error, :invalid_address}
+    end
+  end
+
+  defp parse_target_address(_), do: {:error, :missing_address}
 
   defp client_fqdns(%Postgrex.INET{address: {a, b, c, d}}, account_key) do
     ["#{a}-#{b}-#{c}-#{d}.#{account_key}.fz.internal"]
   end
 
-  defp client_fqdns(_, _), do: []
-
-  defp find_online_client_by_ipv4(account_id, ipv4_tuple) do
+  defp find_online_client_by_address(account_id, {:ipv4, ipv4_tuple}) do
     case Presence.Clients.Account.find_by_ipv4(account_id, ipv4_tuple) do
       {target_client_id, target_meta} -> {:ok, target_client_id, target_meta}
       nil -> :offline
     end
+  end
+
+  defp find_online_client_by_address(account_id, {:ipv6, ipv6_tuple}) do
+    case Presence.Clients.Account.find_by_ipv6(account_id, ipv6_tuple) do
+      {target_client_id, target_meta} -> {:ok, target_client_id, target_meta}
+      nil -> :offline
+    end
+  end
+
+  defp handle_create_gateway_flow(
+         resource_id,
+         resource,
+         membership_id,
+         policy_id,
+         expires_at,
+         connected_gateway_ids,
+         socket
+       ) do
+    case Database.all_compatible_gateways_for_client_and_resource(
+           socket.assigns.client_version,
+           resource,
+           socket.assigns.subject.account.id
+         ) do
+      {:ok, [_ | _] = gateways} ->
+        location = {
+          socket.assigns.subject.context.remote_ip_location_lat,
+          socket.assigns.subject.context.remote_ip_location_lon
+        }
+
+        gateway = Device.load_balance_gateways(location, gateways, connected_gateway_ids)
+        gateway_public_key = gateway.latest_session.public_key
+
+        policy_authorization_id = Ecto.UUID.generate()
+
+        preshared_key =
+          generate_preshared_key(
+            socket.assigns.client,
+            socket.assigns.session.public_key,
+            gateway,
+            gateway_public_key
+          )
+
+        ice_credentials =
+          generate_ice_credentials(
+            socket.assigns.session.public_key,
+            socket.assigns.client,
+            gateway,
+            gateway_public_key
+          )
+
+        message =
+          {:authorize_policy, {self(), socket_ref(socket)},
+           %{
+             client:
+               PortalAPI.Gateway.Views.Client.render(
+                 socket.assigns.client,
+                 socket.assigns.session.public_key,
+                 preshared_key,
+                 socket.assigns.subject.context.user_agent
+               ),
+             subject: PortalAPI.Gateway.Views.Subject.render(socket.assigns.subject),
+             resource: PortalAPI.Gateway.Views.Resource.render(resource),
+             policy_authorization_id: policy_authorization_id,
+             authorization_expires_at: expires_at,
+             ice_credentials: ice_credentials,
+             preshared_key: preshared_key
+           }}
+
+        async_create_policy_authorization(
+          policy_authorization_id,
+          socket.assigns.client,
+          gateway,
+          resource_id,
+          policy_id,
+          membership_id,
+          socket.assigns.subject,
+          expires_at
+        )
+
+        case PG.deliver(gateway.id, message) do
+          :ok ->
+            timer_ref =
+              Process.send_after(
+                self(),
+                {:flow_creation_timeout, resource_id},
+                flow_creation_timeout()
+              )
+
+            socket =
+              assign(
+                socket,
+                :pending_flows,
+                Map.put(socket.assigns.pending_flows, resource_id, timer_ref)
+              )
+
+            {:noreply, socket}
+
+          {:error, :not_found} ->
+            push(socket, "flow_creation_failed", %{resource_id: resource_id, reason: :offline})
+            {:noreply, socket}
+        end
+
+      {:ok, []} ->
+        push(socket, "flow_creation_failed", %{resource_id: resource_id, reason: :offline})
+        {:noreply, socket}
+
+      {:error, :version_mismatch} ->
+        push(socket, "flow_creation_failed", %{
+          resource_id: resource_id,
+          reason: :version_mismatch
+        })
+
+        {:noreply, socket}
+    end
+  end
+
+  defp handle_create_pool_flow(resource_id, _resource, payload, socket) do
+    account_id = socket.assigns.client.account_id
+
+    with true <- client_to_client_enabled?(socket.assigns.subject.account),
+         {:ok, target} <- parse_target_address(payload),
+         {:ok, _device_id} <-
+           Cache.Client.authorize_device_access(socket.assigns.cache, resource_id, target),
+         {:ok, target_client_id, target_meta} <-
+           find_online_client_by_address(account_id, target) do
+      send_client_device_access_authorized(target_client_id, target_meta, socket)
+      {:noreply, socket}
+    else
+      false ->
+        push(socket, "client_device_access_denied", %{
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"],
+          reason: :disabled
+        })
+
+        {:noreply, socket}
+
+      {:error, :ambiguous_address} ->
+        Logger.warning("create_flow for pool included both ipv4 and ipv6",
+          client_id: socket.assigns.client.id,
+          resource_id: resource_id
+        )
+
+        push(socket, "client_device_access_denied", %{
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"],
+          reason: :ambiguous_address
+        })
+
+        {:noreply, socket}
+
+      {:error, :missing_address} ->
+        push(socket, "client_device_access_denied", %{
+          resource_id: resource_id,
+          reason: :missing_address
+        })
+
+        {:noreply, socket}
+
+      {:error, :invalid_address} ->
+        Logger.warning("Invalid IP address provided for pool device access request",
+          client_id: socket.assigns.client.id,
+          account_id: socket.assigns.client.account_id,
+          account_slug: socket.assigns.subject.account.slug,
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"]
+        )
+
+        push(socket, "client_device_access_denied", %{
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"],
+          reason: :invalid_address
+        })
+
+        {:noreply, socket}
+
+      :offline ->
+        push(socket, "client_device_access_denied", %{
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"],
+          reason: :offline
+        })
+
+        {:noreply, socket}
+
+      {:error, :forbidden} ->
+        push(socket, "client_device_access_denied", %{
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"],
+          reason: :forbidden
+        })
+
+        {:noreply, socket}
+    end
+  end
+
+  defp send_client_device_access_authorized(target_client_id, target_meta, socket) do
+    client = socket.assigns.client
+    client_public_key = socket.assigns.session.public_key
+
+    target_client = %Portal.Device{
+      id: target_client_id,
+      psk_base: target_meta.psk_base,
+      type: :client
+    }
+
+    preshared_key =
+      Portal.Crypto.psk(
+        client,
+        client_public_key,
+        target_client,
+        target_meta.public_key
+      )
+
+    ice_credentials =
+      generate_ice_credentials(
+        client_public_key,
+        client,
+        target_client,
+        target_meta.public_key
+      )
+
+    account_key = socket.assigns.subject.account.key
+
+    PG.deliver(
+      target_client_id,
+      {:client_device_access_authorized,
+       %{
+         client_id: client.id,
+         client_name: client.name,
+         client_fqdns: client_fqdns(client.ipv4, account_key),
+         client_public_key: client_public_key,
+         client_ipv4: client.ipv4,
+         client_ipv6: client.ipv6,
+         preshared_key: preshared_key,
+         local_ice_credentials: ice_credentials.receiver,
+         remote_ice_credentials: ice_credentials.initiator,
+         ice_role: :controlled
+       }}
+    )
+
+    target_ipv4 = %Postgrex.INET{address: target_meta.ipv4}
+    target_ipv6 = %Postgrex.INET{address: target_meta.ipv6}
+
+    push(socket, "client_device_access_authorized", %{
+      client_id: target_client_id,
+      client_name: target_meta.name,
+      client_fqdns: client_fqdns(target_ipv4, account_key),
+      client_public_key: target_meta.public_key,
+      client_ipv4: target_ipv4,
+      client_ipv6: target_ipv6,
+      preshared_key: preshared_key,
+      local_ice_credentials: ice_credentials.initiator,
+      remote_ice_credentials: ice_credentials.receiver,
+      ice_role: :controlling
+    })
   end
 
   # TODO: Re-enable after verifying compatibility with older clients
@@ -1011,11 +1100,7 @@ defmodule PortalAPI.Client.Channel do
 
   defp init(socket, resources, relays) do
     push(socket, "init", %{
-      # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
-      resources:
-        resources
-        |> Enum.reject(&(&1.type == :static_device_pool))
-        |> Views.Resource.render_many(socket.assigns.session),
+      resources: Views.Resource.render_many(resources, socket.assigns.session),
       # TODO: Re-enable after verifying compatibility with older clients
       # authorized_ipv4s: render_ipv4s(cache.authorized_device_ipv4s),
       relays:
@@ -1321,34 +1406,67 @@ defmodule PortalAPI.Client.Channel do
          %Change{op: :insert, struct: %Portal.StaticDevicePoolMember{} = member},
          socket
        ) do
-    {:ok, cache} =
-      Cache.Client.add_static_device_pool_member(
-        socket.assigns.cache,
-        member,
-        socket.assigns.subject
-      )
-
-    {:noreply, assign(socket, cache: cache)}
+    Cache.Client.add_static_device_pool_member(
+      socket.assigns.cache,
+      member,
+      socket.assigns.subject
+    )
+    |> push_resource_updates(socket)
   end
 
   defp handle_change(
          %Change{op: :delete, old_struct: %Portal.StaticDevicePoolMember{} = member},
          socket
        ) do
-    {:ok, ipv4, cache} =
+    {:ok, denied, added, removed_ids, cache} =
       Cache.Client.delete_static_device_pool_member(socket.assigns.cache, member)
 
-    if ipv4 do
-      push(socket, "client_device_access_denied", %{
-        ipv4: to_string(:inet.ntoa(ipv4)),
-        reason: :forbidden
-      })
-    end
+    push_device_access_denied(socket, denied)
+    push_resource_updates({:ok, added, removed_ids, cache}, socket)
+  end
 
-    {:noreply, assign(socket, cache: cache)}
+  # NON-SELF CLIENT DEVICES (members of a pool we have access to)
+
+  defp handle_change(
+         %Change{
+           op: :update,
+           old_struct: %Portal.Device{type: :client},
+           struct: %Portal.Device{type: :client} = device
+         },
+         socket
+       ) do
+    Cache.Client.handle_member_device_update(
+      socket.assigns.cache,
+      device,
+      socket.assigns.subject
+    )
+    |> push_resource_updates(socket)
+  end
+
+  defp handle_change(
+         %Change{op: :delete, old_struct: %Portal.Device{type: :client} = device},
+         socket
+       ) do
+    {:ok, denied, added, removed_ids, cache} =
+      Cache.Client.handle_member_device_delete(socket.assigns.cache, device)
+
+    push_device_access_denied(socket, denied)
+    push_resource_updates({:ok, added, removed_ids, cache}, socket)
   end
 
   defp handle_change(%Change{}, socket), do: {:noreply, socket}
+
+  defp push_device_access_denied(_socket, nil), do: :ok
+
+  defp push_device_access_denied(socket, {ipv4_tuple, ipv6_tuple}) do
+    push(socket, "client_device_access_denied", %{
+      ipv4: to_string(:inet.ntoa(ipv4_tuple)),
+      ipv6: to_string(:inet.ntoa(ipv6_tuple)),
+      reason: :forbidden
+    })
+
+    :ok
+  end
 
   defp push_resource_updates({:ok, added_resources, removed_ids, cache}, socket) do
     # Currently, connlib doesn't handle resources changing sites, so we need to delete then create.
@@ -1359,9 +1477,12 @@ defmodule PortalAPI.Client.Channel do
       push(socket, "resource_deleted", resource_id)
     end
 
-    # TODO: Re-enable static_device_pool resources after verifying compatibility with older clients
-    for resource <- added_resources, resource.type != :static_device_pool do
-      push(socket, "resource_created_or_updated", Views.Resource.render(resource, socket.assigns.session))
+    for resource <- added_resources do
+      push(
+        socket,
+        "resource_created_or_updated",
+        Views.Resource.render(resource, socket.assigns.session)
+      )
     end
 
     {:noreply, assign(socket, cache: cache)}
@@ -1539,8 +1660,8 @@ defmodule PortalAPI.Client.Channel do
 
       sup_pid ->
         session_meta = %{
-          ipv4: socket.assigns.client.ipv4 && socket.assigns.client.ipv4.address,
-          ipv6: socket.assigns.client.ipv6 && socket.assigns.client.ipv6.address,
+          ipv4: socket.assigns.client.ipv4.address,
+          ipv6: socket.assigns.client.ipv6.address,
           name: socket.assigns.client.name,
           public_key: socket.assigns.session.public_key,
           psk_base: socket.assigns.client.psk_base

--- a/elixir/lib/portal_api/client/views/resource.ex
+++ b/elixir/lib/portal_api/client/views/resource.ex
@@ -44,14 +44,14 @@ defmodule PortalAPI.Client.Views.Resource do
     |> put_sites([Views.Site.render(resource.site)], site_key)
   end
 
-  defp render_resource(%{type: :static_device_pool} = resource, site_key) do
+  defp render_resource(%{type: :static_device_pool} = resource, _site_key) do
     %{
       id: resource.id,
       type: :static_device_pool,
       name: resource.name,
+      devices: render_devices(resource.devices),
       filters: Enum.flat_map(resource.filters, &render_filter/1)
     }
-    |> put_sites([], site_key)
   end
 
   defp render_resource(%{} = resource, site_key) do
@@ -122,5 +122,13 @@ defmodule PortalAPI.Client.Views.Resource do
 
   defp put_sites(attrs, sites, site_key) do
     Map.put(attrs, site_key, sites)
+  end
+
+  defp render_devices(nil), do: []
+
+  defp render_devices(devices) do
+    Enum.map(devices, fn %{id: id, ipv4: ipv4, ipv6: ipv6} ->
+      %{client_id: id, ipv4: ipv4, ipv6: ipv6}
+    end)
   end
 end

--- a/elixir/test/portal/cache/client_test.exs
+++ b/elixir/test/portal/cache/client_test.exs
@@ -251,11 +251,19 @@ defmodule Portal.Cache.ClientTest do
     end
   end
 
-  describe "authorize_device_access/2" do
-    test "allows access when target client belongs to an authorized static device pool" do
+  describe "authorize_device_access/3" do
+    test "allows access when target client belongs to the given static device pool by ipv4" do
       account = account_fixture()
       actor = actor_fixture(type: :account_admin_user, account: account)
-      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      subject =
+        subject_fixture(
+          account: account,
+          actor: actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
       client = client_fixture(account: account, actor: actor)
       target_actor = actor_fixture(account: account)
       target_client = client_fixture(account: account, actor: target_actor)
@@ -269,20 +277,69 @@ defmodule Portal.Cache.ClientTest do
         device_id: client.id,
         account_id: client.account_id,
         user_agent: subject.context.user_agent,
-        remote_ip: subject.context.remote_ip
+        remote_ip: subject.context.remote_ip,
+        version: "1.5.16"
       }
 
       cache = Cache.recompute_connectable_resources(nil, client, session, subject) |> elem(3)
 
       target_ipv4 = target_client.ipv4.address
+      target_id = target_client.id
 
-      assert :ok = Cache.authorize_device_access(cache, target_ipv4)
+      assert {:ok, ^target_id} =
+               Cache.authorize_device_access(cache, resource.id, {:ipv4, target_ipv4})
     end
 
-    test "rejects access when target client is not in an authorized static device pool" do
+    test "allows access by ipv6" do
       account = account_fixture()
       actor = actor_fixture(type: :account_admin_user, account: account)
-      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      subject =
+        subject_fixture(
+          account: account,
+          actor: actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      client = client_fixture(account: account, actor: actor)
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+
+      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: resource)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        version: "1.5.16"
+      }
+
+      cache = Cache.recompute_connectable_resources(nil, client, session, subject) |> elem(3)
+
+      target_ipv6 = target_client.ipv6.address
+      target_id = target_client.id
+
+      assert {:ok, ^target_id} =
+               Cache.authorize_device_access(cache, resource.id, {:ipv6, target_ipv6})
+    end
+
+    test "rejects access when target client is not in the given pool" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+
+      subject =
+        subject_fixture(
+          account: account,
+          actor: actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
       client = client_fixture(account: account, actor: actor)
       target_actor = actor_fixture(account: account)
       target_client = client_fixture(account: account, actor: target_actor)
@@ -291,14 +348,105 @@ defmodule Portal.Cache.ClientTest do
         device_id: client.id,
         account_id: client.account_id,
         user_agent: subject.context.user_agent,
-        remote_ip: subject.context.remote_ip
+        remote_ip: subject.context.remote_ip,
+        version: "1.5.16"
       }
 
       cache = Cache.recompute_connectable_resources(nil, client, session, subject) |> elem(3)
 
       target_ipv4 = target_client.ipv4.address
 
-      assert {:error, :forbidden} = Cache.authorize_device_access(cache, target_ipv4)
+      assert {:error, :forbidden} =
+               Cache.authorize_device_access(cache, Ecto.UUID.generate(), {:ipv4, target_ipv4})
+    end
+  end
+
+  describe "static_device_pool resource rendering" do
+    test "populates addresses on connectable pool resources" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+
+      subject =
+        subject_fixture(
+          account: account,
+          actor: actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      client = client_fixture(account: account, actor: actor)
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+
+      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: resource)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        version: "1.5.16"
+      }
+
+      {:ok, _added, _removed, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      pool =
+        Enum.find(cache.connectable_resources, &(&1.type == :static_device_pool))
+
+      assert pool != nil
+
+      target_id = target_client.id
+
+      assert [
+               %{
+                 id: ^target_id,
+                 ipv4: %Postgrex.INET{address: ipv4_address, netmask: 32},
+                 ipv6: %Postgrex.INET{address: ipv6_address, netmask: 128}
+               }
+             ] = pool.devices
+
+      assert ipv4_address == target_client.ipv4.address
+      assert ipv6_address == target_client.ipv6.address
+    end
+
+    test "older clients do not see static_device_pool resources" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+
+      subject =
+        subject_fixture(
+          account: account,
+          actor: actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.0"
+        )
+
+      client = client_fixture(account: account, actor: actor)
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+
+      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: resource)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        version: "1.5.0"
+      }
+
+      {:ok, _added, _removed, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      assert Enum.all?(cache.connectable_resources, &(&1.type != :static_device_pool))
+      refute Map.has_key?(cache.pool_members, Ecto.UUID.dump!(resource.id))
     end
   end
 end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5060,60 +5060,21 @@ defmodule PortalAPI.Client.ChannelTest do
     end
   end
 
-  describe "handle_in/3 request_device_access" do
-    test "sends denied with :disabled when client_to_client feature is off", %{
-      client: client,
-      subject: subject
-    } do
-      socket = join_channel(client, subject)
-      assert_push "init", _
-
-      push(socket, "request_device_access", %{"ipv4" => "100.64.0.2"})
-
-      assert_push "client_device_access_denied", %{ipv4: "100.64.0.2", reason: :disabled}
-    end
-
-    test "sends denied with :disabled when account feature is off even if global feature is on",
-         %{
-           account: account,
-           client: client,
-           subject: subject
-         } do
-      enable_feature(:client_to_client)
-      account = update_account(account, %{features: %{client_to_client: false}})
-      subject = %{subject | account: account}
-
-      socket = join_channel(client, subject)
-      assert_push "init", _
-
-      push(socket, "request_device_access", %{"ipv4" => "100.64.0.2"})
-
-      assert_push "client_device_access_denied", %{ipv4: "100.64.0.2", reason: :disabled}
-    end
-
-    test "sends denied with :forbidden when target IP is not authorized", %{
-      client: client,
-      subject: subject
-    } do
+  describe "handle_in/3 create_flow for static_device_pool" do
+    setup %{account: account, group: group, actor: actor, subject: subject} do
       enable_feature(:client_to_client)
 
-      socket = join_channel(client, subject)
-      assert_push "init", _
+      # Override the default subject's user_agent so static_device_pool resources
+      # are eligible for the connectable list (apple >= 1.5.16).
+      subject = %{
+        subject
+        | context: %{
+            subject.context
+            | user_agent: "Mac OS/14 apple-client/1.5.16"
+          }
+      }
 
-      # No other client is tracking this IP in presence
-      unknown_ip = "100.96.200.1"
-      push(socket, "request_device_access", %{"ipv4" => unknown_ip})
-
-      assert_push "client_device_access_denied", %{ipv4: ^unknown_ip, reason: :forbidden}
-    end
-
-    test "sends authorized to both clients when target IP is found in presence", %{
-      account: account,
-      client: client,
-      subject: subject,
-      group: group
-    } do
-      enable_feature(:client_to_client)
+      _ = actor
 
       target_actor = actor_fixture(account: account)
       target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
@@ -5123,12 +5084,31 @@ defmodule PortalAPI.Client.ChannelTest do
           account: account,
           actor: target_actor,
           type: :client,
-          user_agent: "Linux/24.04 connlib/1.3.0"
+          user_agent: "Mac OS/14 apple-client/1.5.16"
         )
 
-      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
-      policy_fixture(account: account, group: group, resource: resource)
+      pool_resource =
+        static_device_pool_resource_fixture(account: account, clients: [target_client])
 
+      policy_fixture(account: account, group: group, resource: pool_resource)
+
+      %{
+        subject: subject,
+        target_actor: target_actor,
+        target_client: target_client,
+        target_subject: target_subject,
+        pool_resource: pool_resource
+      }
+    end
+
+    test "sends authorized to both clients when target ipv4 is found in presence", %{
+      account: account,
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
+    } do
       initiating_socket = join_channel(client, subject)
       assert_push "init", _
 
@@ -5147,9 +5127,11 @@ defmodule PortalAPI.Client.ChannelTest do
       {a, b, c, d} = client.ipv4.address
       initiating_client_fqdns = ["#{a}-#{b}-#{c}-#{d}.#{account.key}.fz.internal"]
 
-      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
 
-      # Initiating client receives authorized as the controlling peer
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
         client_name: ^target_client_name,
@@ -5157,7 +5139,6 @@ defmodule PortalAPI.Client.ChannelTest do
         ice_role: :controlling
       }
 
-      # Target client receives authorized as the controlled peer
       assert_push "client_device_access_authorized", %{
         client_id: ^initiating_client_id,
         client_name: ^initiating_client_name,
@@ -5166,74 +5147,68 @@ defmodule PortalAPI.Client.ChannelTest do
       }
     end
 
-    test "sends denied with :forbidden when target is not in an authorized device pool", %{
-      account: account,
+    test "sends authorized when target ipv6 is found in presence", %{
       client: client,
-      subject: subject
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
     } do
-      enable_feature(:client_to_client)
-
-      target_actor = actor_fixture(account: account)
-      target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
-
-      target_subject =
-        subject_fixture(
-          account: account,
-          actor: target_actor,
-          type: :client,
-          user_agent: "Linux/24.04 connlib/1.3.0"
-        )
-
       initiating_socket = join_channel(client, subject)
       assert_push "init", _
 
       join_channel(target_client, target_subject)
       assert_push "init", _
 
-      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
-      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+      target_ipv6 = Portal.Types.INET.to_string(target_client.ipv6)
+      target_client_id = target_client.id
 
-      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :forbidden}
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv6" => target_ipv6
+      })
+
+      assert_push "client_device_access_authorized", %{
+        client_id: ^target_client_id,
+        ice_role: :controlling
+      }
     end
 
-    test "sends denied with :offline when authorized target is offline", %{
-      account: account,
+    test "sends denied with :offline when target is in pool but not online", %{
       client: client,
       subject: subject,
-      group: group
+      target_client: target_client,
+      pool_resource: pool_resource
     } do
-      enable_feature(:client_to_client)
-
-      target_actor = actor_fixture(account: account)
-      target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
-      resource = static_device_pool_resource_fixture(account: account, clients: [target_client])
-      policy_fixture(account: account, group: group, resource: resource)
-
       initiating_socket = join_channel(client, subject)
       assert_push "init", _
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
-      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
 
       assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :offline}
     end
 
-    test "does not find clients from other accounts", %{
-      client: client,
-      subject: subject
-    } do
-      enable_feature(:client_to_client)
-
-      other_account = account_fixture()
-      other_actor = actor_fixture(account: other_account)
-      other_client = client_fixture(account: other_account, actor: other_actor) |> fetch_device!()
+    test "sends denied with :forbidden when target ipv4 is not a member of the pool",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           pool_resource: pool_resource
+         } do
+      other_actor = actor_fixture(account: account)
+      other_client = client_fixture(account: account, actor: other_actor) |> fetch_device!()
 
       other_subject =
         subject_fixture(
-          account: other_account,
+          account: account,
           actor: other_actor,
           type: :client,
-          user_agent: "Linux/24.04 connlib/1.3.0"
+          user_agent: "Linux/24.04 gui-client/1.5.13"
         )
 
       initiating_socket = join_channel(client, subject)
@@ -5244,24 +5219,100 @@ defmodule PortalAPI.Client.ChannelTest do
 
       other_ip = Portal.Types.INET.to_string(other_client.ipv4)
 
-      push(initiating_socket, "request_device_access", %{"ipv4" => other_ip})
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => other_ip
+      })
 
       assert_push "client_device_access_denied", %{ipv4: ^other_ip, reason: :forbidden}
     end
 
-    test "does nothing for invalid IPv4 addresses", %{
-      client: client,
-      subject: subject
-    } do
-      enable_feature(:client_to_client)
+    test "sends flow_creation_failed with :not_found when actor has no membership in policy's group",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           target_client: target_client
+         } do
+      pool =
+        static_device_pool_resource_fixture(account: account, clients: [target_client])
 
+      # Create a policy in another group the actor is not a member of — the resource
+      # is therefore not in the actor's connectable_resources.
+      other_group = group_fixture(account: account)
+      policy_fixture(account: account, group: other_group, resource: pool)
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool.id,
+        "ipv4" => target_ip
+      })
+
+      assert_push "flow_creation_failed", %{reason: :not_found}
+    end
+
+    test "sends denied with :disabled when account feature is off", %{
+      account: account,
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      pool_resource: pool_resource
+    } do
+      account = update_account(account, %{features: %{client_to_client: false}})
+      subject = %{subject | account: account}
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
+
+      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :disabled}
+    end
+
+    test "sends denied with :ambiguous_address when both ipv4 and ipv6 are provided",
+         %{client: client, subject: subject, pool_resource: pool_resource} do
       socket = join_channel(client, subject)
       assert_push "init", _
 
-      # "::1" is an IPv6 address, not IPv4 — triggers {:error, :invalid_ipv4}
-      push(socket, "request_device_access", %{"ipv4" => "::1"})
+      push(socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => "100.65.0.1",
+        "ipv6" => "fd00::1"
+      })
 
-      refute_push "client_device_access_denied", _
+      assert_push "client_device_access_denied", %{reason: :ambiguous_address}
+    end
+
+    test "sends denied with :missing_address when neither ipv4 nor ipv6 is provided",
+         %{client: client, subject: subject, pool_resource: pool_resource} do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      push(socket, "create_flow", %{"resource_id" => pool_resource.id})
+
+      assert_push "client_device_access_denied", %{reason: :missing_address}
+    end
+
+    test "sends denied with :invalid_address when the IP string is malformed",
+         %{client: client, subject: subject, pool_resource: pool_resource} do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      push(socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => "not-an-ip"
+      })
+
+      assert_push "client_device_access_denied", %{reason: :invalid_address}
     end
   end
 
@@ -5326,7 +5377,19 @@ defmodule PortalAPI.Client.ChannelTest do
   end
 
   describe "handle_info/2 for StaticDevicePoolMember changes" do
-    test "tracks pool member insert in cache when resource is connectable", %{
+    setup %{subject: subject} do
+      subject = %{
+        subject
+        | context: %{
+            subject.context
+            | user_agent: "Mac OS/14 apple-client/1.5.16"
+          }
+      }
+
+      %{subject: subject}
+    end
+
+    test "tracks pool member insert in cache and pushes resource_created_or_updated", %{
       account: account,
       client: client,
       subject: subject,
@@ -5341,19 +5404,39 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", _
 
+      pool_id = pool_resource.id
+      target_id = target_client.id
+      target_did_bytes = Ecto.UUID.dump!(target_client.id)
+      pool_id_bytes = Ecto.UUID.dump!(pool_id)
+      target_ipv4 = target_client.ipv4.address
+      target_ipv6 = target_client.ipv6.address
+
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
         op: :insert,
         struct: %Portal.StaticDevicePoolMember{
           id: Ecto.UUID.generate(),
           account_id: account.id,
-          resource_id: pool_resource.id,
+          resource_id: pool_id,
           device_id: target_client.id
         }
       })
 
+      assert_push "resource_created_or_updated", %{
+        id: ^pool_id,
+        type: :static_device_pool,
+        devices: [
+          %{
+            client_id: ^target_id,
+            ipv4: %Postgrex.INET{address: ^target_ipv4, netmask: 32},
+            ipv6: %Postgrex.INET{address: ^target_ipv6, netmask: 128}
+          }
+        ]
+      }
+
       state = :sys.get_state(socket.channel_pid)
-      assert state.assigns.cache.connectable_devices[target_client.id]
+      assert MapSet.member?(state.assigns.cache.pool_members[pool_id_bytes], target_did_bytes)
+      assert {^target_ipv4, ^target_ipv6} = state.assigns.cache.device_addresses[target_did_bytes]
     end
 
     test "removes pool member from cache on delete without pushing denied", %{
@@ -5364,7 +5447,7 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", _
 
-      # Delete a member that was never in connectable_devices — ipv4 is nil, no push
+      # Delete a member we have no record of — ipv4 is nil, no push
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
         op: :delete,
@@ -5378,14 +5461,16 @@ defmodule PortalAPI.Client.ChannelTest do
 
       :sys.get_state(socket.channel_pid)
       refute_push "client_device_access_denied", _
+      refute_push "resource_created_or_updated", _
     end
 
-    test "pushes client_device_access_denied when a tracked authorized member is deleted", %{
-      account: account,
-      client: client,
-      subject: subject,
-      group: group
-    } do
+    test "pushes client_device_access_denied with both v4 and v6 on member delete",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           group: group
+         } do
       target_actor = actor_fixture(account: account)
       target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
 
@@ -5397,8 +5482,9 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", _
 
-      # connectable_devices is populated from DB during join for the static pool resource
-      :sys.get_state(socket.channel_pid)
+      pool_id = pool_resource.id
+      ipv4_string = Portal.Types.INET.to_string(target_client.ipv4)
+      ipv6_string = Portal.Types.INET.to_string(target_client.ipv6)
 
       send(socket.channel_pid, %Changes.Change{
         lsn: 100,
@@ -5406,12 +5492,258 @@ defmodule PortalAPI.Client.ChannelTest do
         old_struct: %Portal.StaticDevicePoolMember{
           id: Ecto.UUID.generate(),
           account_id: account.id,
-          resource_id: pool_resource.id,
+          resource_id: pool_id,
           device_id: target_client.id
         }
       })
 
+      assert_push "client_device_access_denied", %{
+        ipv4: ^ipv4_string,
+        ipv6: ^ipv6_string,
+        reason: :forbidden
+      }
+
+      assert_push "resource_created_or_updated", %{
+        id: ^pool_id,
+        type: :static_device_pool,
+        devices: []
+      }
+    end
+
+    test "does not push client_device_access_denied when device is still in another pool",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           group: group
+         } do
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
+
+      pool_a = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      pool_b = static_device_pool_resource_fixture(account: account, clients: [target_client])
+      policy_fixture(account: account, group: group, resource: pool_a)
+      policy_fixture(account: account, group: group, resource: pool_b)
+
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      pool_a_id = pool_a.id
+      target_did_bytes = Ecto.UUID.dump!(target_client.id)
+
+      # Remove the target only from pool_a — it's still a member of pool_b
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :delete,
+        old_struct: %Portal.StaticDevicePoolMember{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          resource_id: pool_a_id,
+          device_id: target_client.id
+        }
+      })
+
+      assert_push "resource_created_or_updated", %{id: ^pool_a_id, devices: []}
+      refute_push "client_device_access_denied", _
+
+      # device_addresses still has the device because it's in pool_b
+      state = :sys.get_state(socket.channel_pid)
+      assert Map.has_key?(state.assigns.cache.device_addresses, target_did_bytes)
+    end
+  end
+
+  describe "handle_info/2 for non-self Device changes affecting pool members" do
+    setup %{account: account, group: group, subject: subject} do
+      subject = %{
+        subject
+        | context: %{
+            subject.context
+            | user_agent: "Mac OS/14 apple-client/1.5.16"
+          }
+      }
+
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
+
+      pool_resource =
+        static_device_pool_resource_fixture(account: account, clients: [target_client])
+
+      policy_fixture(account: account, group: group, resource: pool_resource)
+
+      %{
+        subject: subject,
+        target_client: target_client,
+        pool_resource: pool_resource
+      }
+    end
+
+    test "pushes resource_created_or_updated when a member device's IP changes", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      pool_resource: pool_resource
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", %{resources: resources}
+
+      pool_id = pool_resource.id
+      assert Enum.any?(resources, &(&1.type == :static_device_pool and &1.id == pool_id))
+
+      new_ipv4 = %Postgrex.INET{address: {100, 64, 99, 99}}
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 200,
+        op: :update,
+        old_struct: %Portal.Device{
+          id: target_client.id,
+          account_id: target_client.account_id,
+          type: :client,
+          ipv4: target_client.ipv4,
+          ipv6: target_client.ipv6
+        },
+        struct: %Portal.Device{
+          id: target_client.id,
+          account_id: target_client.account_id,
+          type: :client,
+          ipv4: new_ipv4,
+          ipv6: target_client.ipv6
+        }
+      })
+
+      target_id = target_client.id
+
+      assert_push "resource_created_or_updated", %{
+        id: ^pool_id,
+        type: :static_device_pool,
+        devices: [
+          %{
+            client_id: ^target_id,
+            ipv4: %Postgrex.INET{address: {100, 64, 99, 99}, netmask: 32},
+            ipv6: %Postgrex.INET{netmask: 128}
+          }
+        ]
+      }
+    end
+
+    test "ignores updates for non-member devices", %{
+      account: account,
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      stranger_actor = actor_fixture(account: account)
+      stranger_client = client_fixture(account: account, actor: stranger_actor) |> fetch_device!()
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 200,
+        op: :update,
+        old_struct: %Portal.Device{
+          id: stranger_client.id,
+          account_id: stranger_client.account_id,
+          type: :client,
+          ipv4: stranger_client.ipv4,
+          ipv6: stranger_client.ipv6
+        },
+        struct: %Portal.Device{
+          id: stranger_client.id,
+          account_id: stranger_client.account_id,
+          type: :client,
+          ipv4: %Postgrex.INET{address: {100, 64, 1, 99}},
+          ipv6: stranger_client.ipv6
+        }
+      })
+
+      :sys.get_state(socket.channel_pid)
+      refute_push "resource_created_or_updated", _
+    end
+
+    test "pushes denial and clears device_addresses when a member device is deleted", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      pool_resource: pool_resource
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_did_bytes = Ecto.UUID.dump!(target_client.id)
+      ipv4_string = Portal.Types.INET.to_string(target_client.ipv4)
+      ipv6_string = Portal.Types.INET.to_string(target_client.ipv6)
+      pool_id = pool_resource.id
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 200,
+        op: :delete,
+        old_struct: %Portal.Device{
+          id: target_client.id,
+          account_id: target_client.account_id,
+          type: :client,
+          ipv4: target_client.ipv4,
+          ipv6: target_client.ipv6
+        }
+      })
+
+      assert_push "client_device_access_denied", %{
+        ipv4: ^ipv4_string,
+        ipv6: ^ipv6_string,
+        reason: :forbidden
+      }
+
+      assert_push "resource_created_or_updated", %{
+        id: ^pool_id,
+        type: :static_device_pool,
+        devices: []
+      }
+
+      state = :sys.get_state(socket.channel_pid)
+      refute Map.has_key?(state.assigns.cache.device_addresses, target_did_bytes)
+    end
+
+    test "Device delete arriving before cascade member deletes still pushes denial",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           target_client: target_client,
+           pool_resource: pool_resource
+         } do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      pool_id = pool_resource.id
+
+      # Simulate the Device delete arriving FIRST
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 200,
+        op: :delete,
+        old_struct: %Portal.Device{
+          id: target_client.id,
+          account_id: target_client.account_id,
+          type: :client,
+          ipv4: target_client.ipv4,
+          ipv6: target_client.ipv6
+        }
+      })
+
       assert_push "client_device_access_denied", %{reason: :forbidden}
+      assert_push "resource_created_or_updated", %{id: ^pool_id, devices: []}
+
+      # Now the cascade member-delete arrives — must NOT double-push the denial
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 201,
+        op: :delete,
+        old_struct: %Portal.StaticDevicePoolMember{
+          id: Ecto.UUID.generate(),
+          account_id: account.id,
+          resource_id: pool_id,
+          device_id: target_client.id
+        }
+      })
+
+      :sys.get_state(socket.channel_pid)
+      refute_push "client_device_access_denied", _
     end
   end
 

--- a/elixir/test/portal_api/client/views/resource_test.exs
+++ b/elixir/test/portal_api/client/views/resource_test.exs
@@ -1,0 +1,84 @@
+defmodule PortalAPI.Client.Views.ResourceTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Cache.Cacheable
+  alias PortalAPI.Client.Views.Resource
+
+  describe "render/1 for :static_device_pool" do
+    test "renders id, type, name, devices, and filters; no sites or gateway_groups key" do
+      id_bytes = Ecto.UUID.bingenerate()
+      id_string = Ecto.UUID.cast!(id_bytes)
+      device_id = Ecto.UUID.generate()
+
+      ipv4 = %Postgrex.INET{address: {100, 65, 0, 1}, netmask: 32}
+      ipv6 = %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}
+
+      cacheable = %Cacheable.Resource{
+        id: id_bytes,
+        type: :static_device_pool,
+        name: "Pool A",
+        devices: [%{id: device_id, ipv4: ipv4, ipv6: ipv6}],
+        filters: [%{protocol: :tcp, ports: ["443"]}]
+      }
+
+      rendered = Resource.render(cacheable)
+
+      assert rendered.id == id_string
+      assert rendered.type == :static_device_pool
+      assert rendered.name == "Pool A"
+      # The cache uses :id internally, but the wire shape uses :client_id.
+      assert rendered.devices == [%{client_id: device_id, ipv4: ipv4, ipv6: ipv6}]
+      assert [%{protocol: :tcp, port_range_start: 443, port_range_end: 443}] = rendered.filters
+
+      # Pools are not tied to a site, so neither the legacy gateway_groups nor the new
+      # sites key should appear in the payload.
+      refute Map.has_key?(rendered, :gateway_groups)
+      refute Map.has_key?(rendered, :sites)
+
+      refute Map.has_key?(rendered, :address)
+      refute Map.has_key?(rendered, :addresses)
+      refute Map.has_key?(rendered, :address_description)
+      refute Map.has_key?(rendered, :ip_stack)
+      refute Map.has_key?(rendered, :site)
+    end
+
+    test "JSON-encodes devices as objects with client_id, ipv4, ipv6 strings" do
+      device_id = Ecto.UUID.generate()
+
+      cacheable = %Cacheable.Resource{
+        id: Ecto.UUID.bingenerate(),
+        type: :static_device_pool,
+        name: "Pool A",
+        devices: [
+          %{
+            id: device_id,
+            ipv4: %Postgrex.INET{address: {100, 65, 0, 1}, netmask: 32},
+            ipv6: %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}
+          }
+        ],
+        filters: []
+      }
+
+      json = JSON.encode!(Resource.render(cacheable))
+      decoded = JSON.decode!(json)
+
+      assert [entry] = decoded["devices"]
+      assert entry["client_id"] == device_id
+      assert entry["ipv4"] == "100.65.0.1/32"
+      assert entry["ipv6"] == "fd00::1/128"
+      refute Map.has_key?(entry, "id")
+    end
+
+    test "renders empty devices list when nil" do
+      cacheable = %Cacheable.Resource{
+        id: Ecto.UUID.bingenerate(),
+        type: :static_device_pool,
+        name: "Empty pool",
+        devices: nil,
+        filters: []
+      }
+
+      assert %{devices: []} = Resource.render(cacheable)
+    end
+  end
+end

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "~16.2.4",
     "@next/third-parties": "^16.2.4",
-    "@tailwindcss/postcss": "^4.2.4",
+    "@tailwindcss/postcss": "^4.2.2",
     "@types/mdx": "^2.0.13",
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^16.2.4
         version: 16.2.4(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@tailwindcss/postcss':
-        specifier: ^4.2.4
-        version: 4.2.4
+        specifier: ^4.2.2
+        version: 4.2.2
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
@@ -941,65 +941,65 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tailwindcss/node@4.2.4':
-    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
-  '@tailwindcss/oxide-android-arm64@4.2.4':
-    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.4':
-    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.2.4':
-    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.4':
-    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
-    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
-    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
-    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
-    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
-    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
-    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -1010,24 +1010,24 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
-    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
-    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.2.4':
-    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/postcss@4.2.4':
-    resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
+  '@tailwindcss/postcss@4.2.2':
+    resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1557,8 +1557,8 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  enhanced-resolve@5.21.0:
-    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
   es-abstract@1.24.2:
@@ -2981,11 +2981,14 @@ packages:
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
-  tapable@2.3.3:
-    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
   third-party-capital@1.0.20:
@@ -3908,74 +3911,74 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/node@4.2.4':
+  '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.0
+      enhanced-resolve: 5.20.1
       jiti: 2.6.1
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.2.4
+      tailwindcss: 4.2.2
 
-  '@tailwindcss/oxide-android-arm64@4.2.4':
+  '@tailwindcss/oxide-android-arm64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.2.4':
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
     optional: true
 
-  '@tailwindcss/oxide@4.2.4':
+  '@tailwindcss/oxide@4.2.2':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.2.4
-      '@tailwindcss/oxide-darwin-arm64': 4.2.4
-      '@tailwindcss/oxide-darwin-x64': 4.2.4
-      '@tailwindcss/oxide-freebsd-x64': 4.2.4
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
-      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
-      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
-      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
-      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
-      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/postcss@4.2.4':
+  '@tailwindcss/postcss@4.2.2':
     dependencies:
       '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.2.4
-      '@tailwindcss/oxide': 4.2.4
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.10
-      tailwindcss: 4.2.4
+      tailwindcss: 4.2.2
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -4510,10 +4513,10 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  enhanced-resolve@5.21.0:
+  enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.3
+      tapable: 2.3.2
 
   es-abstract@1.24.2:
     dependencies:
@@ -6611,9 +6614,11 @@ snapshots:
 
   tailwind-merge@3.4.0: {}
 
+  tailwindcss@4.2.2: {}
+
   tailwindcss@4.2.4: {}
 
-  tapable@2.3.3: {}
+  tapable@2.3.2: {}
 
   third-party-capital@1.0.20: {}
 

--- a/website/src/app/kb/client-apps/ios-client/readme.mdx
+++ b/website/src/app/kb/client-apps/ios-client/readme.mdx
@@ -7,7 +7,7 @@ iOS app also works for iPad.
 
 ## Prerequisites
 
-- Any iOS device running **iOS 16** or higher
+- Any iOS device running **iOS 15** or higher
 
 ## Installation
 


### PR DESCRIPTION
This PR turns on client-to-client static device pools end-to-end. Pool resources are now rendered to compatible clients (apple ≥ 1.5.16, gui ≥ 1.5.13, headless ≥ 1.5.9 — older clients never see them), pool membership and member-IP changes are reflected live, and `create_flow` for a pool routes to the existing client-to-client device-access path.

## New resource shape

A `static_device_pool` resource is rendered to the client as:

```json
{
  "id": "<resource uuid>",
  "type": "static_device_pool",
  "name": "<pool name>",
  "devices": [
    {
      "id": "<member device uuid>",
      "ipv4": "100.65.0.1/32",
      "ipv6": "fd00:2021:1111::1/128"
    }
  ],
  "filters": [{"protocol": "tcp", "port_range_start": 443, "port_range_end": 443}]
}
```

`devices` is the list of pool members, each carrying its `id` and both CIDR-noted IP addresses. `ipv4` and `ipv6` are always present — `devices.ipv4` and `devices.ipv6` are `NOT NULL` in the schema. They are sent as `Postgrex.INET` structs internally and serialized via the existing `JSON.Encoder` impl, matching the wire format used by `client_ipv4`/`client_ipv6` elsewhere. Pools are not tied to a site, so the payload deliberately omits both the legacy `gateway_groups` key and the newer `sites` key — they would only ever be empty lists.

## Client channel API changes (client-to-client)

| Message                          | Status     | Notes                                                                                                  |
| -------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------ |
| `request_device_access`          | **removed** | Replaced by `create_flow` with a pool `resource_id`.                                                  |
| `create_flow`                    | extended   | Accepts `{resource_id, ipv4}` *or* `{resource_id, ipv6}` when the resource is a `static_device_pool`. |
| `client_device_access_authorized` | unchanged  | Still pushed to both initiator (`controlling`) and target (`controlled`).                              |
| `client_device_access_denied`    | extended   | Now always carries both `ipv4` and `ipv6` when known. New `reason` values: `:ambiguous_address` (both ipv4 and ipv6 sent), `:missing_address` (neither sent), `:invalid_address` (unparseable string). Existing `:disabled` / `:offline` / `:forbidden` are unchanged. |

## Pool-flow sequence

```mermaid
sequenceDiagram
  participant A as Initiator client
  participant P as Portal channel
  participant B as Target client

  A->>P: create_flow { resource_id (pool), ipv4 | ipv6 }
  P->>P: authorize_resource (policy + conditions)
  P->>P: authorize_device_access (in this pool's members?)
  P->>P: Presence.Clients.Account.find_by_ipv4 / find_by_ipv6
  P-->>B: :client_device_access_authorized (controlled)
  P-->>A: client_device_access_authorized (controlling)
  Note over A,B: ICE exchange via the existing<br/>new_client_ice_candidates flow
```

If any step fails, Portal pushes `client_device_access_denied` with the reason listed above (or `flow_creation_failed` if the resource itself isn't authorized).

## Reactive updates

The client receives `resource_created_or_updated` for a pool whenever its `devices` list changes:

- A `StaticDevicePoolMember` is added or removed (cascade-deleted member rows on device delete are handled too).
- A member device's `ipv4` or `ipv6` is updated.
- A member device is hard-deleted (the channel synthesizes the same effect from the `Device` delete event so the denial is pushed regardless of whether the parent or the cascade row arrives first in the WAL stream).

`resource_deleted` is pushed when the pool's last policy is removed or when policy conditions stop conforming, via the existing policy-cascade path.

## Cache footprint

`Portal.Cache.Client` (the per-channel materialized authorization cache) gets two new fields and drops one:

| Field                  | Shape                                                              | Purpose                                                                                                |
| ---------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
| `pool_members` (new)   | `%{resource_id<<16>> => MapSet<device_id<<16>>>}`                 | Members of each currently-connectable pool. Drives `devices` and authorizes `create_flow` lookups.     |
| `device_addresses` (new) | `%{device_id<<16>> => {ipv4_tuple, ipv6_tuple}}`                 | Cached IPs for every device referenced by `pool_members`. Avoids a DB roundtrip on every device-IP change event. |
| `connectable_devices` (removed) | `%{device_id => ipv4_tuple}`                              | Replaced — derivable from `pool_members` × `device_addresses`.                                         |

### Memory back-of-envelope

Existing cache is documented as ~1 MB per connected client at the upper end (1k policies, 500 resources, 100 memberships).

For pools, per actor:
- `pool_members`: ~16 B per pool key + ~24 B per member entry. 50 pools × 100 members ≈ **120 KB**.
- `device_addresses`: ~16 B key + ~24 B (v4 tuple) + ~64 B (v6 tuple) per entry ≈ ~104 B per unique device. 5,000 unique devices ≈ **520 KB**.

So we're looking at roughly **+0.6–1 MB worst case** per client when pools are heavily used, on top of the existing ~1 MB. Realistic deployments will be a fraction of that.

We're not optimizing this further today — current app nodes have substantial RAM headroom (well below 30% utilization at peak), and the cache is bounded per actor by their policy reach. If a single account starts driving cache size into hundreds of MB per node we'll revisit (likely by lazy-loading `device_addresses` on demand instead of eager-fetching during `recompute_connectable_resources`).

## Version gating

Pool resources are dropped from `connectable_resources` for clients below the supported versions, so older clients see no behavioral change at all (no init payload entries, no broadcasts, no `create_flow` routes). Gating lives in `Portal.Version.client_supports_static_device_pools?/1` and is applied uniformly via `Portal.Resource.adapt_resource_for_version/2`.
