### PR TITLE
refactor(portal): remove virtual fields on structs

### DIFF
--- a/elixir/lib/portal/group.ex
+++ b/elixir/lib/portal/group.ex
@@ -25,14 +25,6 @@ defmodule Portal.Group do
     has_many :policies, Portal.Policy, references: :id
     has_many :memberships, Portal.Membership, references: :id, on_replace: :delete
 
-    field :member_count, :integer, virtual: true
-    field :count, :integer, virtual: true
-    field :directory_name, :string, virtual: true
-    field :directory_type, :string, virtual: true
-    field :policy_id, :binary_id, virtual: true
-    field :policy_disabled_at, :utc_datetime_usec, virtual: true
-    field :policy_count, :integer, virtual: true
-
     has_many :actors, through: [:memberships, :actor]
 
     belongs_to :directory, Portal.Directory

--- a/elixir/lib/portal/membership.ex
+++ b/elixir/lib/portal/membership.ex
@@ -28,5 +28,6 @@ defmodule Portal.Membership do
     |> assoc_constraint(:actor)
     |> assoc_constraint(:group)
     |> assoc_constraint(:account)
+    |> unique_constraint([:actor_id, :group_id], name: :memberships_actor_id_group_id_index)
   end
 end

--- a/elixir/lib/portal/resource.ex
+++ b/elixir/lib/portal/resource.ex
@@ -49,9 +49,6 @@ defmodule Portal.Resource do
     has_many :groups, through: [:policies, :group]
     has_many :static_pool_members, Portal.StaticDevicePoolMember, references: :id
 
-    field :policy_id, :binary_id, virtual: true
-    field :policy_disabled_at, :utc_datetime_usec, virtual: true
-
     timestamps()
   end
 

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -253,7 +253,7 @@ defmodule PortalWeb.Actors do
   end
 
   def handle_event("add_pending_group", %{"group_id" => group_id}, socket) do
-    existing_group_ids = Enum.map(socket.assigns.actor_related.groups, & &1.id)
+    existing_group_ids = Enum.map(socket.assigns.actor_related.groups, & &1.group.id)
     pending_ids = Enum.map(socket.assigns.actor_group_membership.pending_group_additions, & &1.id)
 
     already_exists = group_id in existing_group_ids or group_id in pending_ids
@@ -1118,34 +1118,32 @@ defmodule PortalWeb.Actors do
   end
 
   defp apply_group_membership_changes(socket, actor, subject) do
-    Enum.each(socket.assigns.actor_group_membership.pending_group_additions, fn group ->
-      Database.add_group_member(group.id, actor, subject)
-    end)
+    addition_results =
+      Enum.map(socket.assigns.actor_group_membership.pending_group_additions, fn group ->
+        Database.add_group_member(group.id, actor, subject)
+      end)
 
-    Enum.each(socket.assigns.actor_group_membership.pending_group_removals, fn group_id ->
-      Database.remove_group_member(group_id, actor, subject)
-    end)
+    removal_results =
+      Enum.map(socket.assigns.actor_group_membership.pending_group_removals, fn group_id ->
+        Database.remove_group_member(group_id, actor, subject)
+      end)
 
-    groups =
-      updated_groups(
-        socket.assigns.actor_related.groups,
-        socket.assigns.actor_group_membership.pending_group_additions,
-        socket.assigns.actor_group_membership.pending_group_removals
-      )
+    groups = Database.get_groups_for_actor(actor.id, subject)
 
-    socket
-    |> assign(actor_group_membership: actor_group_membership_state())
-    |> merge_state(:actor_related, groups: groups)
-  end
+    errors =
+      (addition_results ++ removal_results)
+      |> Enum.filter(&match?({:error, _}, &1))
 
-  defp updated_groups(current_groups, pending_additions, pending_removals) do
-    remove_ids = MapSet.new(pending_removals)
+    socket =
+      socket
+      |> assign(actor_group_membership: actor_group_membership_state())
+      |> merge_state(:actor_related, groups: groups)
 
-    current_groups
-    |> Enum.reject(&MapSet.member?(remove_ids, &1.id))
-    |> Kernel.++(pending_additions)
-    |> Enum.uniq_by(& &1.id)
-    |> Enum.sort_by(&String.downcase(&1.name || ""))
+    if Enum.empty?(errors) do
+      socket
+    else
+      put_flash(socket, :error, "Failed to update some group memberships.")
+    end
   end
 
   # Helper functions
@@ -1580,9 +1578,10 @@ defmodule PortalWeb.Actors do
         as: :okta_directory
       )
       |> where([membership: m], m.actor_id == ^actor_id)
-      |> select_merge(
-        [directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
+      |> select(
+        [groups: g, directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
         %{
+          group: g,
           directory_type: d.type,
           directory_name: fragment("COALESCE(?, ?, ?)", gd.name, ed.name, od.name)
         }

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -786,16 +786,16 @@ defmodule PortalWeb.Actors.Components do
           Not a member of any groups.
         </div>
         <ul :if={@groups != []}>
-          <li :for={group <- @groups} class="border-b border-[var(--border)] transition-colors">
+          <li :for={row <- @groups} class="border-b border-[var(--border)] transition-colors">
             <.link
-              navigate={~p"/#{@account}/groups/#{group.id}"}
+              navigate={~p"/#{@account}/groups/#{row.group.id}"}
               class="flex items-center gap-3 px-5 py-3 flex-1 min-w-0 hover:bg-[var(--surface-raised)] group/item"
             >
               <div class="flex items-center justify-center w-7 h-7 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] shrink-0">
-                <.provider_icon type={provider_type_from_group(group)} class="w-4 h-4" />
+                <.provider_icon type={provider_type_from_group(row)} class="w-4 h-4" />
               </div>
               <span class="flex-1 text-sm font-medium text-[var(--text-primary)] group-hover/item:text-[var(--brand)] transition-colors truncate">
-                {group.name}
+                {row.group.name}
               </span>
               <.icon
                 name="ri-arrow-right-s-line"
@@ -1404,7 +1404,7 @@ defmodule PortalWeb.Actors.Components do
         assigns.current_groups
       else
         remove_ids = MapSet.new(assigns.pending_removals)
-        Enum.reject(assigns.current_groups, &MapSet.member?(remove_ids, &1.id))
+        Enum.reject(assigns.current_groups, &MapSet.member?(remove_ids, &1.group.id))
       end
 
     removed_groups =
@@ -1412,7 +1412,7 @@ defmodule PortalWeb.Actors.Components do
         []
       else
         remove_ids = MapSet.new(assigns.pending_removals)
-        Enum.filter(assigns.current_groups, &MapSet.member?(remove_ids, &1.id))
+        Enum.filter(assigns.current_groups, &MapSet.member?(remove_ids, &1.group.id))
       end
 
     assigns =
@@ -1428,7 +1428,7 @@ defmodule PortalWeb.Actors.Components do
         Groups ({visible_count})
       </h3>
       <div
-        class="p-3 bg-[var(--surface-raised)] border border-[var(--border)] rounded-md relative"
+        class="p-3 bg-[var(--surface-raised)] border-b border-[var(--border)] relative"
         phx-click-away="blur_group_search"
       >
         <div class="relative">
@@ -1473,7 +1473,7 @@ defmodule PortalWeb.Actors.Components do
         <.group_bucket
           title="Current"
           count={length(@current_groups)}
-          groups={@current_groups}
+          groups={Enum.map(@current_groups, & &1.group)}
           empty_message="No current groups."
         >
           <:actions :let={group}>
@@ -1513,7 +1513,7 @@ defmodule PortalWeb.Actors.Components do
           title="To Remove"
           title_class="text-red-700"
           count={length(@removed_groups)}
-          groups={@removed_groups}
+          groups={Enum.map(@removed_groups, & &1.group)}
           empty_message="No pending removals."
         >
           <:actions :let={group}>

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -282,7 +282,7 @@ defmodule PortalWeb.Groups do
   end
 
   def handle_event("open_grant_resource_form", _params, socket) do
-    existing_ids = Enum.map(socket.assigns.group_resources.resources, & &1.id)
+    existing_ids = Enum.map(socket.assigns.group_resources.resources, & &1.resource.id)
     available = Database.list_available_resources(existing_ids, socket.assigns.subject)
     providers = Database.list_providers(socket.assigns.subject)
 
@@ -792,25 +792,25 @@ defmodule PortalWeb.Groups do
         <.live_table
           id="groups"
           rows={@groups}
-          row_id={&"group-#{&1.id}"}
-          row_click={fn g -> ~p"/#{@account}/groups/#{g.id}?#{@query_params}" end}
-          row_selected={fn g -> not is_nil(@selected_group) and g.id == @selected_group.id end}
+          row_id={&"group-#{&1.group.id}"}
+          row_click={fn row -> ~p"/#{@account}/groups/#{row.group.id}?#{@query_params}" end}
+          row_selected={fn row -> not is_nil(@selected_group) and row.group.id == @selected_group.id end}
           filters={@filters_by_table_id["groups"]}
           filter={@filter_form_by_table_id["groups"]}
           ordered_by={@order_by_table_id["groups"]}
           metadata={@groups_metadata}
           class="flex-1 min-h-0"
         >
-          <:col :let={group} field={{:groups, :name}} label="Name" class="w-full">
+          <:col :let={row} field={{:groups, :name}} label="Name" class="w-full">
             <div class="flex items-center gap-3">
               <div class="flex items-center justify-center w-7 h-7 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] shrink-0">
-                <.provider_icon type={provider_type_from_group(group)} class="w-4 h-4" />
+                <.provider_icon type={provider_type_from_group(row)} class="w-4 h-4" />
               </div>
               <div class="min-w-0">
                 <div class="flex items-center gap-1.5 font-medium text-[var(--text-primary)] group-hover:text-[var(--brand)] transition-colors">
-                  <span class="truncate">{group.name}</span>
+                  <span class="truncate">{row.group.name}</span>
                   <span
-                    :if={group.entity_type == :org_unit}
+                    :if={row.group.entity_type == :org_unit}
                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--status-neutral-bg)] text-[var(--text-tertiary)] shrink-0"
                     title="Organizational Unit"
                   >
@@ -818,29 +818,29 @@ defmodule PortalWeb.Groups do
                   </span>
                 </div>
                 <div class="text-xs text-[var(--text-tertiary)] truncate">
-                  {directory_display_name(group)}
+                  {directory_display_name(row)}
                 </div>
               </div>
             </div>
           </:col>
-          <:col :let={group} field={{:member_counts, :count}} label="Members" class="w-40">
+          <:col :let={row} field={{:member_counts, :count}} label="Members" class="w-40">
             <div class="text-sm text-[var(--text-primary)] tabular-nums">
-              <span class="font-medium">{group.member_count}</span>
+              <span class="font-medium">{row.member_count}</span>
               <span class="text-xs text-[var(--text-tertiary)]">users</span>
             </div>
           </:col>
-          <:col :let={group} label="Resources" class="w-54">
+          <:col :let={row} label="Resources" class="w-54">
             <span class={[
               "inline-flex items-center justify-center w-6 h-6 rounded text-xs font-semibold tabular-nums",
-              if((group.policy_count || 0) > 0,
+              if((row.policy_count || 0) > 0,
                 do: "bg-[var(--brand-tertiary)] text-[var(--brand)]",
                 else: "bg-[var(--status-neutral-bg)] text-[var(--text-tertiary)]"
               )
             ]}>
-              {group.policy_count || 0}
+              {row.policy_count || 0}
             </span>
           </:col>
-          <:action :let={_group}></:action>
+          <:action :let={_row}></:action>
           <:empty>
             <div class="flex flex-col items-center gap-3 py-16">
               <div class="w-9 h-9 rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] flex items-center justify-center">
@@ -1296,15 +1296,14 @@ defmodule PortalWeb.Groups do
 
     defp hydrate_group_query(query) do
       query
-      |> select_merge([groups: g, member_counts: mc, policy_counts: pc, directory: d], %{
-        count: coalesce(mc.count, 0),
-        member_count: coalesce(mc.count, 0),
-        policy_count: coalesce(pc.count, 0),
-        directory_type: d.type
-      })
-      |> select_merge(
-        [google_directory: gd, entra_directory: ed, okta_directory: od],
+      |> select(
+        [groups: g, member_counts: mc, policy_counts: pc, directory: d,
+         google_directory: gd, entra_directory: ed, okta_directory: od],
         %{
+          group: g,
+          member_count: coalesce(mc.count, 0),
+          policy_count: coalesce(pc.count, 0),
+          directory_type: d.type,
           directory_name: fragment("COALESCE(?, ?, ?)", gd.name, ed.name, od.name)
         }
       )
@@ -1382,7 +1381,7 @@ defmodule PortalWeb.Groups do
         |> Safe.scoped(subject, :replica)
         |> Safe.all()
 
-      groups_by_id = Map.new(groups, &{&1.id, &1})
+      groups_by_id = Map.new(groups, &{&1.group.id, &1})
 
       Enum.map(group_ids, fn group_id ->
         Map.fetch!(groups_by_id, group_id)
@@ -1524,14 +1523,7 @@ defmodule PortalWeb.Groups do
 
     def get_group!(id, subject) do
       from(g in Portal.Group, as: :groups)
-      |> join(:left, [groups: g], d in Directory,
-        on: d.id == g.directory_id and d.account_id == g.account_id,
-        as: :directory
-      )
       |> where([groups: groups], groups.id == ^id)
-      |> select_merge([groups: g, directory: d], %{
-        directory_type: d.type
-      })
       |> Safe.scoped(subject, :replica)
       |> Safe.one!(fallback_to_primary: true)
     end
@@ -1723,7 +1715,8 @@ defmodule PortalWeb.Groups do
         on: p.resource_id == r.id and p.group_id == ^group.id,
         as: :policies
       )
-      |> select_merge([policies: p], %{
+      |> select([resources: r, policies: p], %{
+        resource: r,
         policy_id: p.id,
         policy_disabled_at: p.disabled_at
       })
@@ -1732,7 +1725,7 @@ defmodule PortalWeb.Groups do
       |> Safe.all()
       |> case do
         {:error, _} -> []
-        resources -> resources
+        rows -> rows
       end
     end
 
@@ -1743,9 +1736,6 @@ defmodule PortalWeb.Groups do
         from(g in Portal.Group, as: :groups)
         |> where([groups: groups], groups.id == ^id)
         |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
-        |> select_merge([groups: g, directory: d], %{
-          directory_type: d.type
-        })
         |> join(:left, [directory: d], gd in Portal.Google.Directory,
           on: gd.id == d.id and d.type == :google,
           as: :google_directory
@@ -1760,19 +1750,13 @@ defmodule PortalWeb.Groups do
         )
         |> join(:left, [groups: g], m in assoc(g, :memberships), as: :memberships)
         |> join(:left, [memberships: m], a in assoc(m, :actor), as: :actors)
-        |> select_merge(
-          [directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
-          %{
-            directory_name:
-              fragment(
-                "COALESCE(?, ?, ?)",
-                gd.name,
-                ed.name,
-                od.name
-              )
-          }
+        |> preload(
+          [memberships: m, actors: a, directory: d, google_directory: gd,
+           entra_directory: ed, okta_directory: od],
+          memberships: m,
+          actors: a,
+          directory: {d, google_directory: gd, entra_directory: ed, okta_directory: od}
         )
-        |> preload([memberships: m, actors: a], memberships: m, actors: a)
 
       query |> Safe.scoped(subject, repo) |> Safe.one!(fallback_to_primary: true)
     end

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -315,7 +315,7 @@ defmodule PortalWeb.Groups.Components do
                 OU
               </span>
               <span class="text-xs text-[var(--text-tertiary)]">
-                {directory_display_name(@group)}
+                {directory_display_name(@group.directory)}
               </span>
             </div>
           </div>
@@ -830,19 +830,19 @@ defmodule PortalWeb.Groups.Components do
       </div>
       <ul :if={@resources != []}>
         <li
-          :for={resource <- @resources}
+          :for={row <- @resources}
           class={[
             "border-b border-[var(--border)] transition-colors",
-            @confirm_remove_resource_access_id == resource.id &&
+            @confirm_remove_resource_access_id == row.resource.id &&
               "bg-[var(--status-error-bg,#fef2f2)] border-[var(--status-error)]/20"
           ]}
         >
           <div
-            :if={@confirm_remove_resource_access_id == resource.id}
+            :if={@confirm_remove_resource_access_id == row.resource.id}
             class="flex items-center justify-between gap-2 px-4 py-2.5"
           >
             <span class="text-xs text-[var(--text-secondary)] truncate">
-              Remove access to <span class="font-medium text-[var(--text-primary)]">{resource.name}</span>?
+              Remove access to <span class="font-medium text-[var(--text-primary)]">{row.resource.name}</span>?
               <span class="block text-[var(--text-tertiary)]">
                 All group members will immediately lose access.
               </span>
@@ -858,7 +858,7 @@ defmodule PortalWeb.Groups.Components do
               <button
                 type="button"
                 phx-click="remove_resource_access"
-                phx-value-resource_id={resource.id}
+                phx-value-resource_id={row.resource.id}
                 class="px-2 py-1 text-xs rounded border border-[var(--status-error)]/30 text-[var(--status-error)] hover:bg-[var(--status-error)]/10 bg-[var(--surface)] transition-colors"
               >
                 Remove
@@ -866,38 +866,38 @@ defmodule PortalWeb.Groups.Components do
             </div>
           </div>
           <div
-            :if={@confirm_remove_resource_access_id != resource.id}
+            :if={@confirm_remove_resource_access_id != row.resource.id}
             class={[
               "flex items-center gap-1 pr-4 hover:bg-[var(--surface-raised)] group/item",
-              @resource_access_actions_open_id == resource.id && "relative z-20"
+              @resource_access_actions_open_id == row.resource.id && "relative z-20"
             ]}
           >
             <.link
-              navigate={~p"/#{@account}/resources/#{resource.id}"}
+              navigate={~p"/#{@account}/resources/#{row.resource.id}"}
               class={[
                 "flex items-center gap-3 px-5 py-3 flex-1 min-w-0",
-                not is_nil(resource.policy_disabled_at) && "opacity-50 hover:opacity-75"
+                not is_nil(row.policy_disabled_at) && "opacity-50 hover:opacity-75"
               ]}
             >
               <div class="w-14 shrink-0 flex">
-                <span class={type_badge_class(resource.type)}>
-                  {resource.type}
+                <span class={type_badge_class(row.resource.type)}>
+                  {row.resource.type}
                 </span>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2">
                   <p class="text-sm font-medium text-[var(--text-primary)] group-hover/item:text-[var(--brand)] transition-colors truncate">
-                    {resource.name}
+                    {row.resource.name}
                   </p>
                   <span
-                    :if={not is_nil(resource.policy_disabled_at)}
+                    :if={not is_nil(row.policy_disabled_at)}
                     class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--status-neutral-bg)] text-[var(--text-tertiary)] shrink-0"
                   >
                     disabled
                   </span>
                 </div>
                 <span class="text-xs text-[var(--text-tertiary)] font-mono truncate block">
-                  {resource.address}
+                  {row.resource.address}
                 </span>
               </div>
             </.link>
@@ -905,31 +905,31 @@ defmodule PortalWeb.Groups.Components do
               <button
                 type="button"
                 phx-click="toggle_resource_access_actions"
-                phx-value-resource_id={resource.id}
+                phx-value-resource_id={row.resource.id}
                 class="flex items-center justify-center w-6 h-6 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
                 title="More actions"
               >
                 <.icon name="ri-more-2-line" class="w-3.5 h-3.5" />
               </button>
               <div
-                :if={@resource_access_actions_open_id == resource.id}
+                :if={@resource_access_actions_open_id == row.resource.id}
                 phx-click-away="close_resource_access_actions"
                 class="absolute right-0 top-full mt-1 w-44 rounded-md border border-[var(--border)] bg-[var(--surface-overlay)] shadow-lg z-10 py-1"
               >
                 <button
-                  :if={is_nil(resource.policy_disabled_at)}
+                  :if={is_nil(row.policy_disabled_at)}
                   type="button"
                   phx-click="disable_resource_access"
-                  phx-value-resource_id={resource.id}
+                  phx-value-resource_id={row.resource.id}
                   class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
                 >
                   <.icon name="ri-pause-line" class="w-3.5 h-3.5 shrink-0" /> Disable
                 </button>
                 <button
-                  :if={not is_nil(resource.policy_disabled_at)}
+                  :if={not is_nil(row.policy_disabled_at)}
                   type="button"
                   phx-click="enable_resource_access"
-                  phx-value-resource_id={resource.id}
+                  phx-value-resource_id={row.resource.id}
                   class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
                 >
                   <.icon name="ri-play-line" class="w-3.5 h-3.5 shrink-0" /> Enable
@@ -937,7 +937,7 @@ defmodule PortalWeb.Groups.Components do
                 <button
                   type="button"
                   phx-click="confirm_remove_resource_access"
-                  phx-value-resource_id={resource.id}
+                  phx-value-resource_id={row.resource.id}
                   class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--status-error)] hover:bg-[var(--surface-raised)] transition-colors"
                 >
                   <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Remove access
@@ -977,7 +977,7 @@ defmodule PortalWeb.Groups.Components do
           <div>
             <dt class="text-[10px] text-[var(--text-tertiary)] mb-0.5">Directory</dt>
             <dd class="text-xs text-[var(--text-secondary)]">
-              {directory_display_name(@group)}
+              {directory_display_name(@group.directory)}
             </dd>
           </div>
           <div :if={@group.entity_type == :org_unit}>
@@ -1237,9 +1237,14 @@ defmodule PortalWeb.Groups.Components do
   defp deletable_group?(%{name: "Everyone"}), do: false
   defp deletable_group?(_group), do: true
 
-  defp directory_display_name(%{directory_name: name}) when not is_nil(name), do: name
-  defp directory_display_name(%{idp_id: idp_id}) when not is_nil(idp_id), do: "Unknown"
-  defp directory_display_name(_), do: "Firezone"
+  defp directory_display_name(directory) do
+    case directory do
+      %{google_directory: %{name: name}} when not is_nil(name) -> name
+      %{entra_directory: %{name: name}} when not is_nil(name) -> name
+      %{okta_directory: %{name: name}} when not is_nil(name) -> name
+      _ -> "Firezone"
+    end
+  end
 
   defp type_badge_class(:dns),
     do:

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -989,7 +989,7 @@ defmodule PortalWeb.Policies do
     end
 
     def fetch_group_option(id, subject) do
-      group =
+      row =
         from(g in Group, as: :groups)
         |> where([groups: g], g.id == ^id)
         |> join(:left, [groups: g], d in assoc(g, :directory), as: :directory)
@@ -1005,9 +1005,10 @@ defmodule PortalWeb.Policies do
           on: od.id == d.id and d.type == :okta,
           as: :okta_directory
         )
-        |> select_merge(
-          [directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
+        |> select(
+          [groups: g, directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
           %{
+            group: g,
             directory_name: fragment("COALESCE(?, ?, ?)", gd.name, ed.name, od.name),
             directory_type: d.type
           }
@@ -1015,7 +1016,7 @@ defmodule PortalWeb.Policies do
         |> Safe.scoped(subject, :replica)
         |> Safe.one!(fallback_to_primary: true)
 
-      {:ok, {group.id, group.name, group}}
+      {:ok, {row.group.id, row.group.name, row}}
     end
 
     def list_group_options(search_query_or_nil, subject) do
@@ -1034,9 +1035,10 @@ defmodule PortalWeb.Policies do
           on: od.id == d.id and d.type == :okta,
           as: :okta_directory
         )
-        |> select_merge(
-          [directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
+        |> select(
+          [groups: g, directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
           %{
+            group: g,
             directory_name: fragment("COALESCE(?, ?, ?)", gd.name, ed.name, od.name),
             directory_type: d.type
           }
@@ -1048,28 +1050,28 @@ defmodule PortalWeb.Policies do
         if search_query_or_nil in ["", nil] do
           query
         else
-          from(g in query, where: fulltext_search(g.name, ^search_query_or_nil))
+          from([groups: g] in query, where: fulltext_search(g.name, ^search_query_or_nil))
         end
 
-      groups = query |> Safe.scoped(subject, :replica) |> Safe.all()
-      metadata = %{limit: 25, count: length(groups)}
+      rows = query |> Safe.scoped(subject, :replica) |> Safe.all()
+      metadata = %{limit: 25, count: length(rows)}
 
-      {:ok, grouped_select_options(groups), metadata}
+      {:ok, grouped_select_options(rows), metadata}
     end
 
-    defp grouped_select_options(groups) do
-      groups
+    defp grouped_select_options(rows) do
+      rows
       |> Enum.group_by(&option_group_label/1)
       |> Enum.sort_by(fn {{idx, _label}, _} -> idx end)
-      |> Enum.map(fn {{_idx, label}, grps} ->
-        {label, grps |> Enum.sort_by(& &1.name) |> Enum.map(&{&1.id, &1.name, &1})}
+      |> Enum.map(fn {{_idx, label}, rows} ->
+        {label, rows |> Enum.sort_by(& &1.group.name) |> Enum.map(&{&1.group.id, &1.group.name, &1})}
       end)
     end
 
-    defp option_group_label(group) do
+    defp option_group_label(row) do
       cond do
-        not is_nil(group.idp_id) -> {9, "Synced from #{directory_display_name(group)}"}
-        group.type == :managed -> {1, "Managed by Firezone"}
+        not is_nil(row.group.idp_id) -> {9, "Synced from #{directory_display_name(row)}"}
+        row.group.type == :managed -> {1, "Managed by Firezone"}
         true -> {2, "Manually managed"}
       end
     end

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -363,10 +363,10 @@ defmodule PortalWeb.Policies.Components do
       required
     >
       <:options_group :let={options_group}>{options_group}</:options_group>
-      <:option :let={group}>
+      <:option :let={row}>
         <div class="flex items-center gap-2">
-          <.provider_icon type={provider_type_from_group(group)} class="w-4 h-4 shrink-0" />
-          <span>{group.name}</span>
+          <.provider_icon type={provider_type_from_group(row)} class="w-4 h-4 shrink-0" />
+          <span>{row.group.name}</span>
         </div>
       </:option>
       <:no_options :let={name}>
@@ -2555,9 +2555,10 @@ defmodule PortalWeb.Policies.Components do
           on: od.id == d.id and d.type == :okta,
           as: :okta_directory
         )
-        |> select_merge(
-          [directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
+        |> select(
+          [groups: g, directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
           %{
+            group: g,
             directory_name:
               fragment(
                 "COALESCE(?, ?, ?, 'Firezone')",
@@ -2590,9 +2591,10 @@ defmodule PortalWeb.Policies.Components do
           on: od.id == d.id and d.type == :okta,
           as: :okta_directory
         )
-        |> select_merge(
-          [directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
+        |> select(
+          [groups: g, directory: d, google_directory: gd, entra_directory: ed, okta_directory: od],
           %{
+            group: g,
             directory_name:
               fragment(
                 "COALESCE(?, ?, ?, 'Firezone')",
@@ -2608,44 +2610,44 @@ defmodule PortalWeb.Policies.Components do
 
       query =
         if search_query_or_nil != "" and search_query_or_nil != nil do
-          from(g in query, where: fulltext_search(g.name, ^search_query_or_nil))
+          from([groups: g] in query, where: fulltext_search(g.name, ^search_query_or_nil))
         else
           query
         end
 
-      groups = query |> Safe.scoped(subject, :replica) |> Safe.all()
+      rows = query |> Safe.scoped(subject, :replica) |> Safe.all()
 
       # For metadata, we'll return a simple count
-      metadata = %{limit: 25, count: length(groups)}
+      metadata = %{limit: 25, count: length(rows)}
 
-      {:ok, grouped_select_options(groups), metadata}
+      {:ok, grouped_select_options(rows), metadata}
     end
 
-    defp grouped_select_options(groups) do
-      groups
+    defp grouped_select_options(rows) do
+      rows
       |> Enum.group_by(&option_groups_index_and_label/1)
-      |> Enum.sort_by(fn {{options_group_index, options_group_label}, _groups} ->
+      |> Enum.sort_by(fn {{options_group_index, options_group_label}, _rows} ->
         {options_group_index, options_group_label}
       end)
-      |> Enum.map(fn {{_options_group_index, options_group_label}, groups} ->
-        {options_group_label, groups |> Enum.sort_by(& &1.name) |> Enum.map(&group_option/1)}
+      |> Enum.map(fn {{_options_group_index, options_group_label}, rows} ->
+        {options_group_label, rows |> Enum.sort_by(& &1.group.name) |> Enum.map(&group_option/1)}
       end)
     end
 
-    defp option_groups_index_and_label(group) do
+    defp option_groups_index_and_label(row) do
       index =
         cond do
-          group_synced?(group) -> 9
-          group_managed?(group) -> 1
+          group_synced?(row.group) -> 9
+          group_managed?(row.group) -> 1
           true -> 2
         end
 
       label =
         cond do
-          group_synced?(group) ->
-            "Synced from #{group.directory_name}"
+          group_synced?(row.group) ->
+            "Synced from #{row.directory_name}"
 
-          group_managed?(group) ->
+          group_managed?(row.group) ->
             "Managed by Firezone"
 
           true ->
@@ -2655,8 +2657,8 @@ defmodule PortalWeb.Policies.Components do
       {index, label}
     end
 
-    defp group_option(group) do
-      {group.id, group.name, group}
+    defp group_option(row) do
+      {row.group.id, row.group.name, row}
     end
 
     # Inlined from Portal.Actors helpers

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -746,7 +746,7 @@ defmodule PortalWeb.Resources do
 
   def handle_event("open_grant_form", _params, socket) do
     resource = socket.assigns.selected_resource
-    existing_ids = Enum.map(socket.assigns.selected_groups, & &1.id)
+    existing_ids = Enum.map(socket.assigns.selected_groups, & &1.group.id)
     available = Database.list_available_groups(resource, existing_ids, socket.assigns.subject)
     providers = Database.list_providers(socket.assigns.subject)
 
@@ -1370,7 +1370,8 @@ defmodule PortalWeb.Resources do
         on: d.id == g.directory_id and d.account_id == g.account_id,
         as: :directory
       )
-      |> select_merge([groups: g, directory: d, policies: p], %{
+      |> select([groups: g, directory: d, policies: p], %{
+        group: g,
         directory_type: d.type,
         policy_id: p.id,
         policy_disabled_at: p.disabled_at
@@ -1380,7 +1381,7 @@ defmodule PortalWeb.Resources do
       |> Safe.all()
       |> case do
         {:error, _} -> []
-        groups -> groups
+        rows -> rows
       end
     end
 
@@ -1391,12 +1392,12 @@ defmodule PortalWeb.Resources do
         on: d.id == g.directory_id and d.account_id == g.account_id,
         as: :directory
       )
-      |> select_merge([groups: g, directory: d], %{directory_type: d.type})
+      |> select([groups: g, directory: d], %{group: g, directory_type: d.type})
       |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> case do
         {:error, _} -> []
-        groups -> groups
+        rows -> rows
       end
     end
 

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1112,18 +1112,18 @@ defmodule PortalWeb.Resources.Components do
     <div class="flex-1 overflow-y-auto">
       <ul>
         <li
-          :for={group <- @groups}
+          :for={row <- @groups}
           class={[
             "border-b border-[var(--border)] transition-colors",
-            if(@group_actions_open_id == group.id, do: "relative z-20", else: "")
+            if(@group_actions_open_id == row.group.id, do: "relative z-20", else: "")
           ]}
         >
           <div
-            :if={@confirm_remove_group_id == group.id}
+            :if={@confirm_remove_group_id == row.group.id}
             class="flex items-center justify-between gap-2 px-4 py-2.5 bg-[var(--surface-raised)]"
           >
             <span class="text-xs text-[var(--text-secondary)] truncate">
-              Remove <span class="font-medium text-[var(--text-primary)]">{group.name}</span>'s access?
+              Remove <span class="font-medium text-[var(--text-primary)]">{row.group.name}</span>'s access?
               <span class="block text-[var(--text-tertiary)]">
                 All group members will immediately lose access.
               </span>
@@ -1139,7 +1139,7 @@ defmodule PortalWeb.Resources.Components do
               <button
                 type="button"
                 phx-click="remove_group_access"
-                phx-value-group_id={group.id}
+                phx-value-group_id={row.group.id}
                 class="px-2 py-1 text-xs rounded border border-[var(--status-error)]/30 text-[var(--status-error)] hover:bg-[var(--status-error)]/10 bg-[var(--surface)] transition-colors"
               >
                 Remove
@@ -1147,28 +1147,28 @@ defmodule PortalWeb.Resources.Components do
             </div>
           </div>
           <div
-            :if={@confirm_remove_group_id != group.id}
+            :if={@confirm_remove_group_id != row.group.id}
             class={[
               "flex items-center gap-1 pr-4 hover:bg-[var(--surface-raised)] group/item",
-              if(not is_nil(group.policy_disabled_at),
+              if(not is_nil(row.policy_disabled_at),
                 do: "opacity-50 hover:opacity-75",
                 else: ""
               )
             ]}
           >
             <.link
-              navigate={~p"/#{@account}/groups/#{group.id}"}
+              navigate={~p"/#{@account}/groups/#{row.group.id}"}
               class="flex items-center gap-3 px-5 py-3 flex-1 min-w-0"
             >
               <div class="flex items-center justify-center w-7 h-7 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] shrink-0">
-                <.provider_icon type={provider_type_from_group(group)} class="w-4 h-4" />
+                <.provider_icon type={provider_type_from_group(row)} class="w-4 h-4" />
               </div>
               <div class="flex-1 min-w-0 flex items-center gap-2">
                 <p class="text-sm font-medium text-[var(--text-primary)] group-hover/item:text-[var(--brand)] transition-colors truncate">
-                  {group.name}
+                  {row.group.name}
                 </p>
                 <span
-                  :if={not is_nil(group.policy_disabled_at)}
+                  :if={not is_nil(row.policy_disabled_at)}
                   class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--status-neutral-bg)] text-[var(--text-tertiary)]"
                 >
                   disabled
@@ -1179,31 +1179,31 @@ defmodule PortalWeb.Resources.Components do
               <button
                 type="button"
                 phx-click="toggle_group_actions"
-                phx-value-group_id={group.id}
+                phx-value-group_id={row.group.id}
                 class="flex items-center justify-center w-6 h-6 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
                 title="More actions"
               >
                 <.icon name="ri-more-2-line" class="w-3.5 h-3.5" />
               </button>
               <div
-                :if={@group_actions_open_id == group.id}
+                :if={@group_actions_open_id == row.group.id}
                 phx-click-away="close_group_actions"
                 class="absolute right-0 top-full mt-1 w-40 rounded-md border border-[var(--border)] bg-[var(--surface-overlay)] shadow-lg z-10 py-1"
               >
                 <button
-                  :if={is_nil(group.policy_disabled_at)}
+                  :if={is_nil(row.policy_disabled_at)}
                   type="button"
                   phx-click="disable_policy"
-                  phx-value-group_id={group.id}
+                  phx-value-group_id={row.group.id}
                   class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
                 >
                   <.icon name="ri-pause-line" class="w-3.5 h-3.5 shrink-0" /> Disable Access
                 </button>
                 <button
-                  :if={not is_nil(group.policy_disabled_at)}
+                  :if={not is_nil(row.policy_disabled_at)}
                   type="button"
                   phx-click="enable_policy"
-                  phx-value-group_id={group.id}
+                  phx-value-group_id={row.group.id}
                   class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
                 >
                   <.icon name="ri-play-line" class="w-3.5 h-3.5 shrink-0" /> Enable Access
@@ -1211,7 +1211,7 @@ defmodule PortalWeb.Resources.Components do
                 <button
                   type="button"
                   phx-click="confirm_remove_group"
-                  phx-value-group_id={group.id}
+                  phx-value-group_id={row.group.id}
                   class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--status-error)] hover:bg-[var(--surface-raised)] transition-colors"
                 >
                   <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Remove access
@@ -1282,21 +1282,21 @@ defmodule PortalWeb.Resources.Components do
             </label>
             <% filtered_available =
               @available_groups
-              |> Enum.reject(&(&1.id in @grant_selected_group_ids))
+              |> Enum.reject(&(&1.group.id in @grant_selected_group_ids))
               |> then(fn groups ->
                 if @grant_search == "" do
                   groups
                 else
-                  Enum.filter(groups, fn g ->
+                  Enum.filter(groups, fn row ->
                     String.contains?(
-                      String.downcase(g.name),
+                      String.downcase(row.group.name),
                       String.downcase(@grant_search)
                     )
                   end)
                 end
               end)
               selected_groups =
-                Enum.filter(@available_groups, &(&1.id in @grant_selected_group_ids))
+                Enum.filter(@available_groups, &(&1.group.id in @grant_selected_group_ids))
               at_max = length(@grant_selected_group_ids) >= 5 %>
             <div class="flex gap-2 h-52">
               <div class="flex-1 flex flex-col min-w-0 rounded border border-[var(--border)] overflow-hidden">
@@ -1325,11 +1325,11 @@ defmodule PortalWeb.Resources.Components do
                   </div>
                 </div>
                 <ul class="flex-1 overflow-y-auto px-2 py-1.5 space-y-0.5">
-                  <li :for={group <- filtered_available}>
+                  <li :for={row <- filtered_available}>
                     <button
                       type="button"
                       phx-click="toggle_grant_group"
-                      phx-value-group_id={group.id}
+                      phx-value-group_id={row.group.id}
                       disabled={at_max}
                       class={[
                         "flex items-center gap-2 px-2 py-1.5 w-full rounded text-left transition-colors",
@@ -1341,9 +1341,9 @@ defmodule PortalWeb.Resources.Components do
                       ]}
                     >
                       <div class="flex items-center justify-center w-5 h-5 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] shrink-0">
-                        <.provider_icon type={provider_type_from_group(group)} class="w-3 h-3" />
+                        <.provider_icon type={provider_type_from_group(row)} class="w-3 h-3" />
                       </div>
-                      <span class="text-xs text-[var(--text-primary)] truncate">{group.name}</span>
+                      <span class="text-xs text-[var(--text-primary)] truncate">{row.group.name}</span>
                     </button>
                   </li>
                   <li
@@ -1376,17 +1376,17 @@ defmodule PortalWeb.Resources.Components do
                   </span>
                 </div>
                 <ul class="flex-1 overflow-y-auto px-2 py-1.5 space-y-0.5">
-                  <li :for={group <- selected_groups}>
+                  <li :for={row <- selected_groups}>
                     <button
                       type="button"
                       phx-click="toggle_grant_group"
-                      phx-value-group_id={group.id}
+                      phx-value-group_id={row.group.id}
                       class="flex items-center gap-2 px-2 py-1.5 w-full rounded text-left hover:bg-[var(--surface)] transition-colors cursor-pointer group"
                     >
                       <div class="flex items-center justify-center w-5 h-5 rounded-full bg-[var(--surface-raised)] border border-[var(--border)] shrink-0">
-                        <.provider_icon type={provider_type_from_group(group)} class="w-3 h-3" />
+                        <.provider_icon type={provider_type_from_group(row)} class="w-3 h-3" />
                       </div>
-                      <span class="flex-1 text-xs text-[var(--text-primary)] truncate">{group.name}</span>
+                      <span class="flex-1 text-xs text-[var(--text-primary)] truncate">{row.group.name}</span>
                       <.icon
                         name="ri-close-line"
                         class="w-3.5 h-3.5 text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 shrink-0 transition-opacity"

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -218,7 +218,7 @@ defmodule PortalWeb.ServiceAccounts do
   end
 
   def handle_event("add_pending_group", %{"group_id" => group_id}, socket) do
-    existing_group_ids = Enum.map(socket.assigns.actor_related.groups, & &1.id)
+    existing_group_ids = Enum.map(socket.assigns.actor_related.groups, & &1.group.id)
     pending_ids = Enum.map(socket.assigns.actor_group_membership.pending_group_additions, & &1.id)
     already_exists = group_id in existing_group_ids or group_id in pending_ids
 
@@ -770,34 +770,32 @@ defmodule PortalWeb.ServiceAccounts do
   end
 
   defp apply_group_membership_changes(socket, actor, subject) do
-    Enum.each(socket.assigns.actor_group_membership.pending_group_additions, fn group ->
-      Database.add_group_member(group.id, actor, subject)
-    end)
+    addition_results =
+      Enum.map(socket.assigns.actor_group_membership.pending_group_additions, fn group ->
+        Database.add_group_member(group.id, actor, subject)
+      end)
 
-    Enum.each(socket.assigns.actor_group_membership.pending_group_removals, fn group_id ->
-      Database.remove_group_member(group_id, actor, subject)
-    end)
+    removal_results =
+      Enum.map(socket.assigns.actor_group_membership.pending_group_removals, fn group_id ->
+        Database.remove_group_member(group_id, actor, subject)
+      end)
 
-    groups =
-      updated_groups(
-        socket.assigns.actor_related.groups,
-        socket.assigns.actor_group_membership.pending_group_additions,
-        socket.assigns.actor_group_membership.pending_group_removals
-      )
+    groups = Database.get_groups_for_actor(actor.id, subject)
 
-    socket
-    |> assign(actor_group_membership: actor_group_membership_state())
-    |> merge_state(:actor_related, groups: groups)
-  end
+    errors =
+      (addition_results ++ removal_results)
+      |> Enum.filter(&match?({:error, _}, &1))
 
-  defp updated_groups(current_groups, pending_additions, pending_removals) do
-    remove_ids = MapSet.new(pending_removals)
+    socket =
+      socket
+      |> assign(actor_group_membership: actor_group_membership_state())
+      |> merge_state(:actor_related, groups: groups)
 
-    current_groups
-    |> Enum.reject(&MapSet.member?(remove_ids, &1.id))
-    |> Kernel.++(pending_additions)
-    |> Enum.uniq_by(& &1.id)
-    |> Enum.sort_by(&String.downcase(&1.name || ""))
+    if Enum.empty?(errors) do
+      socket
+    else
+      put_flash(socket, :error, "Failed to update some group memberships.")
+    end
   end
 
   defp parse_date_to_datetime(date_string) do
@@ -981,6 +979,7 @@ defmodule PortalWeb.ServiceAccounts do
       )
       |> where([membership: m], m.actor_id == ^actor_id)
       |> order_by([groups: g], asc: g.name)
+      |> select([groups: g], %{group: g, directory_type: nil, directory_name: nil})
       |> Safe.scoped(subject, repo)
       |> Safe.all()
     end

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -739,6 +739,42 @@ defmodule PortalWeb.ActorsTest do
       refute html =~ current_group.name
     end
 
+    test "shows error flash when adding a group membership fails", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_actor = actor_fixture(account: account)
+      group = group_fixture(account: account, name: "Target Group")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}/edit")
+
+      lv
+      |> element("input[placeholder='Search to add groups...']")
+      |> render_change(%{"value" => group.name})
+
+      render_click(lv, "add_pending_group", %{"group_id" => group.id})
+
+      # Create the membership directly in the DB to cause a unique constraint failure on save
+      membership_fixture(actor: other_actor, group: group)
+
+      lv
+      |> form("form[phx-submit='save']",
+        actor: %{
+          name: other_actor.name,
+          email: other_actor.email,
+          type: "account_user",
+          allow_email_otp_sign_in: "true"
+        }
+      )
+      |> render_submit()
+
+      assert render(lv) =~ "Failed to update some group memberships."
+    end
+
     test "redirects to actor list when actor does not exist", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -34,5 +34,92 @@ defmodule PortalWeb.ServiceAccountsTest do
                "button[phx-click='add_pending_group_removal'][phx-value-group_id='#{current_group.id}']"
              )
     end
+
+    test "adds a group membership to a service account on save", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      service_account = actor_fixture(account: account, type: :service_account)
+      group = group_fixture(account: account, name: "New Group")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}/edit")
+
+      lv
+      |> element("input[placeholder='Search to add groups...']")
+      |> render_change(%{"value" => group.name})
+
+      render_click(lv, "add_pending_group", %{"group_id" => group.id})
+
+      lv
+      |> form("form[phx-submit='save']", actor: %{name: service_account.name})
+      |> render_submit()
+
+      assert Portal.Repo.get_by(Portal.Membership,
+               actor_id: service_account.id,
+               group_id: group.id
+             )
+
+      render_click(lv, "change_tab", %{"tab" => "groups"})
+      assert render(lv) =~ group.name
+    end
+
+    test "removes a group membership from a service account on save", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      service_account = actor_fixture(account: account, type: :service_account)
+      group = group_fixture(account: account, name: "Current Group")
+      membership_fixture(actor: service_account, group: group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}/edit")
+
+      render_click(lv, "add_pending_group_removal", %{"group_id" => group.id})
+
+      lv
+      |> form("form[phx-submit='save']", actor: %{name: service_account.name})
+      |> render_submit()
+
+      refute Portal.Repo.get_by(Portal.Membership,
+               actor_id: service_account.id,
+               group_id: group.id
+             )
+    end
+
+    test "shows error flash when adding a group membership to a service account fails", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      service_account = actor_fixture(account: account, type: :service_account)
+      group = group_fixture(account: account, name: "Target Group")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}/edit")
+
+      lv
+      |> element("input[placeholder='Search to add groups...']")
+      |> render_change(%{"value" => group.name})
+
+      render_click(lv, "add_pending_group", %{"group_id" => group.id})
+
+      # Create the membership directly in the DB to cause a unique constraint failure on save
+      membership_fixture(actor: service_account, group: group)
+
+      lv
+      |> form("form[phx-submit='save']", actor: %{name: service_account.name})
+      |> render_submit()
+
+      assert render(lv) =~ "Failed to update some group memberships."
+    end
   end
 end


### PR DESCRIPTION
This PR updates a few structs in the portal web app in order to remove virtual fields.  The fields were originally put in to facilitate JOIN queries, but it was later decided to just use maps for the queries and not pollute the struct definitions.