### PR TITLE
feat(connlib): resolve IPv6 device pools

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -644,6 +644,7 @@ impl Eventloop {
                 resource_id,
                 domain,
                 ipv4,
+                ipv6,
             }) => {
                 let Some(domain) = parse_portal_domain(&domain) else {
                     return Ok(());
@@ -651,7 +652,7 @@ impl Eventloop {
                 tunnel.state_mut().handle_device_pool_domain_resolved(
                     resource_id,
                     domain,
-                    Ok(ipv4),
+                    Ok((ipv4, ipv6)),
                 );
             }
             IngressMessages::DevicePoolDomainResolutionFailed(

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -405,7 +405,7 @@ impl ClientState {
         &mut self,
         resource_id: ResourceId,
         domain: DomainName,
-        result: Result<Ipv4Addr, FailReason>,
+        result: Result<(Ipv4Addr, Ipv6Addr), FailReason>,
     ) {
         self.device_stub_resolver
             .handle_device_domain_resolved(resource_id, domain, result);

--- a/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
@@ -9,10 +9,11 @@ use crate::{
 use connlib_model::ResourceId;
 use dns_types::DomainName;
 use logging::err_with_src;
+use smallvec::SmallVec;
 use std::{
     collections::{BTreeMap, VecDeque},
     iter,
-    net::{Ipv4Addr, SocketAddr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     time::{Duration, Instant},
 };
 
@@ -28,7 +29,7 @@ const DNS_TTL: u32 = 1;
 pub struct DeviceStubResolver {
     device_pools: BTreeMap<ResourceId, Pattern>,
     resolved: BTreeMap<DomainName, CachedResolution>,
-    pending: ExpiringMap<(ResourceId, DomainName), PendingQuery>,
+    pending: ExpiringMap<(ResourceId, DomainName, dns_types::RecordType), PendingQuery>,
 
     events: VecDeque<Event>,
 }
@@ -68,6 +69,7 @@ struct PendingQuery {
 struct CachedResolution {
     resource_id: ResourceId,
     ipv4: Ipv4Addr,
+    ipv6: Ipv6Addr,
 }
 
 impl DeviceStubResolver {
@@ -104,7 +106,7 @@ impl DeviceStubResolver {
 
         // Cancel any in-flight portal queries for this resource with SERVFAIL,
         // so clients waiting on them don't hang until the query timeout.
-        for ((_, domain), pending) in self.pending.extract_if(|(rid, _), _| *rid == id) {
+        for ((_, domain, _), pending) in self.pending.extract_if(|(rid, _, _), _| *rid == id) {
             tracing::debug!(%domain, "Pending device pool DNS query cancelled; returning SERVFAIL");
 
             self.events.push_back(Event::SendResponse {
@@ -130,10 +132,11 @@ impl DeviceStubResolver {
             return ResolveStrategy::Passthrough;
         };
 
-        // Device pools are IPv4-only; answer AAAA and other non-A queries
-        // immediately with NOERROR + no records (the name exists, we just
-        // don't have records of the requested type).
-        if query.qtype() != dns_types::RecordType::A {
+        let qtype = query.qtype();
+
+        // Only A and AAAA are answered from device pool resolutions; for any other
+        // qtype, the name exists but we have no records of that type (NOERROR + empty).
+        if qtype != dns_types::RecordType::A && qtype != dns_types::RecordType::AAAA {
             return ResolveStrategy::LocalResponse(
                 dns_types::ResponseBuilder::for_query(query, dns_types::ResponseCode::NOERROR)
                     .build(),
@@ -141,25 +144,40 @@ impl DeviceStubResolver {
         }
 
         if let Some(entry) = self.resolved.get(&domain) {
-            return ResolveStrategy::LocalResponse(build_response(query, domain, entry.ipv4));
+            return ResolveStrategy::LocalResponse(build_response(
+                query,
+                domain.clone(),
+                entry.ipv4,
+                entry.ipv6,
+            ));
         }
 
-        let is_new = self
-            .pending
-            .insert(
-                (resource_id, domain.clone()),
-                PendingQuery {
-                    local,
-                    remote,
-                    transport,
-                    query: query.clone(),
-                },
-                now,
-                QUERY_TIMEOUT,
-            )
-            .is_none();
+        // If a portal query for this (resource, domain) is already in flight under
+        // either A or AAAA, don't fire another — the response will populate the cache
+        // for both, and `handle_device_domain_resolved` drains all waiters for the
+        // domain regardless of qtype.
+        let portal_query_already_in_flight =
+            self.pending
+                .contains_key(&(resource_id, domain.clone(), dns_types::RecordType::A))
+                || self.pending.contains_key(&(
+                    resource_id,
+                    domain.clone(),
+                    dns_types::RecordType::AAAA,
+                ));
 
-        if is_new {
+        self.pending.insert(
+            (resource_id, domain.clone(), qtype),
+            PendingQuery {
+                local,
+                remote,
+                transport,
+                query: query.clone(),
+            },
+            now,
+            QUERY_TIMEOUT,
+        );
+
+        if !portal_query_already_in_flight {
             tracing::debug!(%domain, "Querying portal for device FQDN");
 
             self.events.push_back(Event::QueryDomain {
@@ -175,42 +193,57 @@ impl DeviceStubResolver {
         &mut self,
         resource_id: ResourceId,
         domain: DomainName,
-        result: Result<Ipv4Addr, FailReason>,
+        result: Result<(Ipv4Addr, Ipv6Addr), FailReason>,
     ) {
-        let Some(entry) = self.pending.remove(&(resource_id, domain.clone())) else {
-            tracing::debug!(%resource_id, %domain, ?result, "Received device pool resolution for unknown query");
+        let pending = self
+            .pending
+            .extract_if(|(rid, dom, _), _| *rid == resource_id && *dom == domain)
+            .map(|(_, p)| p)
+            .collect::<SmallVec<[PendingQuery; 2]>>();
+
+        if pending.is_empty() {
+            tracing::debug!(%resource_id, %domain, "Received device pool resolution for unknown query");
             return;
-        };
-        let pending = entry.value;
+        }
 
         tracing::debug!(%resource_id, %domain, ?result, "Device FQDN resolved");
 
-        let response = match result {
-            Ok(ipv4) => {
-                self.resolved
-                    .insert(domain, CachedResolution { resource_id, ipv4 });
+        if let Ok((ipv4, ipv6)) = result {
+            self.resolved.insert(
+                domain,
+                CachedResolution {
+                    resource_id,
+                    ipv4,
+                    ipv6,
+                },
+            );
+        }
 
-                build_response(&pending.query, pending.query.domain(), ipv4)
-            }
-            Err(FailReason::NotFound) => dns_types::Response::nxdomain(&pending.query),
-            Err(
-                FailReason::Offline
-                | FailReason::VersionMismatch
-                | FailReason::Forbidden
-                | FailReason::Disabled
-                | FailReason::AmbiguousAddress
-                | FailReason::MissingAddress
-                | FailReason::InvalidAddress
-                | FailReason::Unknown,
-            ) => dns_types::Response::servfail(&pending.query),
-        };
+        for pending in pending {
+            let response = match result {
+                Ok((ipv4, ipv6)) => {
+                    build_response(&pending.query, pending.query.domain(), ipv4, ipv6)
+                }
+                Err(FailReason::NotFound) => dns_types::Response::nxdomain(&pending.query),
+                Err(
+                    FailReason::Offline
+                    | FailReason::VersionMismatch
+                    | FailReason::Forbidden
+                    | FailReason::Disabled
+                    | FailReason::AmbiguousAddress
+                    | FailReason::MissingAddress
+                    | FailReason::InvalidAddress
+                    | FailReason::Unknown,
+                ) => dns_types::Response::servfail(&pending.query),
+            };
 
-        self.events.push_back(Event::SendResponse {
-            local: pending.local,
-            remote: pending.remote,
-            transport: pending.transport,
-            response,
-        });
+            self.events.push_back(Event::SendResponse {
+                local: pending.local,
+                remote: pending.remote,
+                transport: pending.transport,
+                response,
+            });
+        }
     }
 
     pub(crate) fn poll_event(&mut self) -> Option<Event> {
@@ -220,7 +253,7 @@ impl DeviceStubResolver {
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
         self.pending.handle_timeout(now);
         while let Some(expiring_map::Event::EntryExpired {
-            key: (_, domain),
+            key: (_, domain, _),
             value: pending,
         }) = self.pending.poll_event()
         {
@@ -258,11 +291,24 @@ fn build_response(
     query: &dns_types::Query,
     domain: dns_types::DomainName,
     ipv4: Ipv4Addr,
+    ipv6: Ipv6Addr,
 ) -> dns_types::Response {
-    let record = dns_types::records::a(ipv4);
-    dns_types::ResponseBuilder::for_query(query, dns_types::ResponseCode::NOERROR)
-        .with_records(iter::once((domain, DNS_TTL, record)))
-        .build()
+    let builder = dns_types::ResponseBuilder::for_query(query, dns_types::ResponseCode::NOERROR);
+
+    match query.qtype() {
+        dns_types::RecordType::A => builder
+            .with_records(iter::once((domain, DNS_TTL, dns_types::records::a(ipv4))))
+            .build(),
+        dns_types::RecordType::AAAA => builder
+            .with_records(iter::once((
+                domain,
+                DNS_TTL,
+                dns_types::records::aaaa(ipv6),
+            )))
+            .build(),
+        // The name exists but we don't have a record of the requested type.
+        _ => builder.build(),
+    }
 }
 
 #[cfg(test)]
@@ -274,6 +320,8 @@ mod tests {
     const REMOTE: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345);
     const POOL_PATTERN: &str = "*.pool.example.com";
     const POOL_DOMAIN: &str = "foo.pool.example.com";
+    const TEST_IPV4: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 42);
+    const TEST_IPV6: Ipv6Addr = Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 42);
 
     #[test]
     fn handle_returns_passthrough_for_unmatched_domain() {
@@ -293,12 +341,12 @@ mod tests {
     }
 
     #[test]
-    fn handle_answers_aaaa_with_empty_noerror() {
+    fn handle_answers_unsupported_qtypes_with_empty_noerror() {
         let mut resolver = DeviceStubResolver::default();
         resolver.add_resource(ResourceId::from_u128(1), POOL_PATTERN.to_owned());
 
         let s = resolver.handle_query(
-            &query(POOL_DOMAIN, dns_types::RecordType::AAAA),
+            &query(POOL_DOMAIN, dns_types::RecordType::TXT),
             LOCAL,
             REMOTE,
             dns::Transport::Udp,
@@ -314,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_emits_query_domain_event_on_first_query() {
+    fn handle_emits_query_domain_event_on_first_a_query() {
         let mut resolver = DeviceStubResolver::default();
         let rid = ResourceId::from_u128(1);
         resolver.add_resource(rid, POOL_PATTERN.to_owned());
@@ -338,6 +386,73 @@ mod tests {
         assert_eq!(resource_id, rid);
         assert_eq!(domain.to_string(), POOL_DOMAIN);
         assert!(resolver.poll_event().is_none());
+    }
+
+    #[test]
+    fn handle_emits_query_domain_event_on_first_aaaa_query() {
+        let mut resolver = DeviceStubResolver::default();
+        let rid = ResourceId::from_u128(1);
+        resolver.add_resource(rid, POOL_PATTERN.to_owned());
+
+        let s = resolver.handle_query(
+            &query(POOL_DOMAIN, dns_types::RecordType::AAAA),
+            LOCAL,
+            REMOTE,
+            dns::Transport::Udp,
+            Instant::now(),
+        );
+
+        assert!(matches!(s, ResolveStrategy::Pending));
+        let Some(Event::QueryDomain { .. }) = resolver.poll_event() else {
+            panic!("expected QueryDomain event")
+        };
+    }
+
+    #[test]
+    fn aaaa_followup_after_a_coalesces_into_single_portal_query() {
+        let mut resolver = DeviceStubResolver::default();
+        let rid = ResourceId::from_u128(1);
+        let now = Instant::now();
+        resolver.add_resource(rid, POOL_PATTERN.to_owned());
+
+        // First, an A query — fires a portal request.
+        resolver.handle_query(
+            &query(POOL_DOMAIN, dns_types::RecordType::A),
+            LOCAL,
+            REMOTE,
+            dns::Transport::Udp,
+            now,
+        );
+        assert!(matches!(
+            resolver.poll_event(),
+            Some(Event::QueryDomain { .. })
+        ));
+
+        // Then an AAAA query for the same domain — should coalesce.
+        let s = resolver.handle_query(
+            &query(POOL_DOMAIN, dns_types::RecordType::AAAA),
+            LOCAL,
+            REMOTE,
+            dns::Transport::Udp,
+            now,
+        );
+        assert!(matches!(s, ResolveStrategy::Pending));
+        assert!(resolver.poll_event().is_none(), "should not re-fire portal");
+
+        // Resolution responds to both waiters.
+        resolver.handle_device_domain_resolved(
+            rid,
+            POOL_DOMAIN.parse().unwrap(),
+            Ok((TEST_IPV4, TEST_IPV6)),
+        );
+
+        let responses = iter::from_fn(|| resolver.poll_event())
+            .filter_map(|e| match e {
+                Event::SendResponse { response, .. } => Some(response),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(responses.len(), 2);
     }
 
     #[test]
@@ -366,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn resolved_emits_send_response() {
+    fn resolved_a_query_emits_a_record() {
         let mut resolver = DeviceStubResolver::default();
         let rid = ResourceId::from_u128(1);
         let now = Instant::now();
@@ -384,13 +499,43 @@ mod tests {
         resolver.handle_device_domain_resolved(
             rid,
             POOL_DOMAIN.parse().unwrap(),
-            Ok(Ipv4Addr::new(100, 64, 0, 42)),
+            Ok((TEST_IPV4, TEST_IPV6)),
         );
 
         let Some(Event::SendResponse { response, .. }) = resolver.poll_event() else {
             panic!("expected SendResponse event")
         };
         assert_eq!(response.response_code(), dns_types::ResponseCode::NOERROR);
+        assert_eq!(response.records().count(), 1);
+    }
+
+    #[test]
+    fn resolved_aaaa_query_emits_aaaa_record() {
+        let mut resolver = DeviceStubResolver::default();
+        let rid = ResourceId::from_u128(1);
+        let now = Instant::now();
+
+        resolver.add_resource(rid, POOL_PATTERN.to_owned());
+        resolver.handle_query(
+            &query(POOL_DOMAIN, dns_types::RecordType::AAAA),
+            LOCAL,
+            REMOTE,
+            dns::Transport::Udp,
+            now,
+        );
+        resolver.poll_event();
+
+        resolver.handle_device_domain_resolved(
+            rid,
+            POOL_DOMAIN.parse().unwrap(),
+            Ok((TEST_IPV4, TEST_IPV6)),
+        );
+
+        let Some(Event::SendResponse { response, .. }) = resolver.poll_event() else {
+            panic!("expected SendResponse event")
+        };
+        assert_eq!(response.response_code(), dns_types::ResponseCode::NOERROR);
+        assert_eq!(response.records().count(), 1);
     }
 
     #[test]
@@ -469,12 +614,23 @@ mod tests {
         resolver.handle_device_domain_resolved(
             rid,
             POOL_DOMAIN.parse().unwrap(),
-            Ok(Ipv4Addr::new(100, 64, 0, 42)),
+            Ok((TEST_IPV4, TEST_IPV6)),
         );
         resolver.poll_event();
 
+        // Repeat A query hits the cache.
         let s = resolver.handle_query(
             &query(POOL_DOMAIN, dns_types::RecordType::A),
+            LOCAL,
+            REMOTE,
+            dns::Transport::Udp,
+            now,
+        );
+        assert!(matches!(s, ResolveStrategy::LocalResponse(_)));
+
+        // AAAA query for the same domain also hits the cache (no portal roundtrip).
+        let s = resolver.handle_query(
+            &query(POOL_DOMAIN, dns_types::RecordType::AAAA),
             LOCAL,
             REMOTE,
             dns::Transport::Udp,
@@ -502,7 +658,7 @@ mod tests {
         resolver.handle_device_domain_resolved(
             rid,
             POOL_DOMAIN.parse().unwrap(),
-            Ok(Ipv4Addr::new(100, 64, 0, 42)),
+            Ok((TEST_IPV4, TEST_IPV6)),
         );
         resolver.poll_event();
 
@@ -595,7 +751,7 @@ mod tests {
         resolver.handle_device_domain_resolved(
             rid,
             POOL_DOMAIN.parse().unwrap(),
-            Ok(Ipv4Addr::new(100, 64, 0, 42)),
+            Ok((TEST_IPV4, TEST_IPV6)),
         );
 
         assert!(resolver.poll_event().is_none());

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -240,12 +240,13 @@ pub struct ClientDeviceAccessDenied {
     pub reason: FailReason,
 }
 
-/// Portal's response when a dynamic device pool domain is resolved to a tunnel IPv4.
+/// Portal's response when a dynamic device pool domain is resolved.
 #[derive(Debug, Deserialize, Clone)]
 pub struct DevicePoolDomainResolved {
     pub resource_id: ResourceId,
     pub domain: String,
     pub ipv4: Ipv4Addr,
+    pub ipv6: Ipv6Addr,
 }
 
 /// Portal's response when a dynamic device pool domain cannot be resolved.
@@ -818,12 +819,20 @@ mod tests {
             "payload": {
                 "resource_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
                 "domain": "device-42.laptops.example.com",
-                "ipv4": "100.64.0.42"
+                "ipv4": "100.64.0.42",
+                "ipv6": "fd00:2021:1111::42"
             }
         });
 
         let msg: IngressMessages = serde_json::from_value(json).unwrap();
-        assert!(matches!(msg, IngressMessages::DevicePoolDomainResolved(_)));
+        let IngressMessages::DevicePoolDomainResolved(resolved) = msg else {
+            panic!("expected DevicePoolDomainResolved")
+        };
+        assert_eq!(resolved.ipv4, "100.64.0.42".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(
+            resolved.ipv6,
+            "fd00:2021:1111::42".parse::<Ipv6Addr>().unwrap()
+        );
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/libs/connlib/tunnel/src/tests/stub_portal.rs
@@ -187,8 +187,9 @@ impl StubPortal {
     }
 
     /// Resolves a device-pool domain (e.g. `device0.pool.example.com`) to the
-    /// tunnel IPv4 of the matching client, if the label corresponds to a known device.
-    pub(crate) fn resolve_device_pool_domain(&self, domain: &str) -> Option<Ipv4Addr> {
+    /// tunnel IPv4 + IPv6 of the matching client, if the label corresponds to a known
+    /// device.
+    pub(crate) fn resolve_device_pool_domain(&self, domain: &str) -> Option<(Ipv4Addr, Ipv6Addr)> {
         let label = domain.split_once('.')?.0;
 
         let client = self
@@ -196,7 +197,7 @@ impl StubPortal {
             .values()
             .find(|c| c.device_label.as_str() == label)?;
 
-        Some(client.ipv4)
+        Some((client.ipv4, client.ipv6))
     }
 
     pub(crate) fn all_resources(&self) -> Vec<client::Resource> {


### PR DESCRIPTION
Companion to #13016. Previously the connlib device stub resolver short-circuited AAAA queries against device pool patterns with empty NOERROR, even though the portal already materializes both an IPv4 and IPv6 address for every device. This PR extends `DevicePoolDomainResolved` with a mandatory `ipv6` field — matching the portal contract, since every client and gateway has both addresses on the tunnel today — synthesizes A/AAAA responses from whichever record type the OS asks for, and caches both so subsequent queries skip the portal roundtrip.

A and AAAA queries for the same name typically arrive back-to-back from the OS resolver. The pending map is now keyed on `(ResourceId, DomainName, RecordType)` so the two coalesce: only the first fires a portal request, the second registers as another waiter, and the response drains both. An alternative considered was making `ipv4`/`ipv6` optional to support partial portal responses, but that doesn't match the portal's actual shape and would have required reasoning about cache poisoning across rolling upgrades.