### PR TITLE
refactor(portal): update action popover menus

### DIFF
--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1101,6 +1101,35 @@ defmodule PortalWeb.CoreComponents do
   end
 
   @doc """
+  Renders an actions dropdown shell with a standard overflow trigger.
+  """
+  attr :open, :boolean, required: true
+  attr :close_event, :string, required: true
+  attr :button_class, :any,
+    default:
+      "flex items-center justify-center w-7 h-7 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
+  attr :menu_class, :any,
+    default:
+      "absolute right-0 top-full mt-1 w-44 rounded-md border border-[var(--border)] bg-[var(--surface-overlay)] shadow-lg z-10 py-1"
+  attr :icon_class, :string, default: "w-4 h-4"
+  attr :trigger_icon, :string, default: "ri-more-2-line"
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def actions_dropdown(assigns) do
+    ~H"""
+    <div class="relative shrink-0">
+      <button type="button" class={@button_class} {@rest}>
+        <.icon name={@trigger_icon} class={@icon_class} />
+      </button>
+      <div :if={@open} phx-click-away={@close_event} class={@menu_class}>
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
   Renders online or offline status using an `online?` field of the schema.
   """
   attr :schema, :any, required: true

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -901,49 +901,42 @@ defmodule PortalWeb.Groups.Components do
                 </span>
               </div>
             </.link>
-            <div class="relative shrink-0">
+            <.actions_dropdown
+              open={@resource_access_actions_open_id == resource.id}
+              close_event="close_resource_access_actions"
+              button_class="flex items-center justify-center w-6 h-6 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
+              icon_class="w-3.5 h-3.5"
+              phx-click="toggle_resource_access_actions"
+              phx-value-resource_id={resource.id}
+              title="More actions"
+            >
+              <button
+                :if={is_nil(resource.policy_disabled_at)}
+                type="button"
+                phx-click="disable_resource_access"
+                phx-value-resource_id={resource.id}
+                class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
+              >
+                <.icon name="ri-pause-line" class="w-3.5 h-3.5 shrink-0" /> Disable
+              </button>
+              <button
+                :if={not is_nil(resource.policy_disabled_at)}
+                type="button"
+                phx-click="enable_resource_access"
+                phx-value-resource_id={resource.id}
+                class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
+              >
+                <.icon name="ri-play-line" class="w-3.5 h-3.5 shrink-0" /> Enable
+              </button>
               <button
                 type="button"
-                phx-click="toggle_resource_access_actions"
-                phx-value-resource_id={row.resource.id}
-                class="flex items-center justify-center w-6 h-6 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
-                title="More actions"
+                phx-click="confirm_remove_resource_access"
+                phx-value-resource_id={resource.id}
+                class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--status-error)] hover:bg-[var(--surface-raised)] transition-colors"
               >
-                <.icon name="ri-more-2-line" class="w-3.5 h-3.5" />
+                <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Remove access
               </button>
-              <div
-                :if={@resource_access_actions_open_id == row.resource.id}
-                phx-click-away="close_resource_access_actions"
-                class="absolute right-0 top-full mt-1 w-44 rounded-md border border-[var(--border)] bg-[var(--surface-overlay)] shadow-lg z-10 py-1"
-              >
-                <button
-                  :if={is_nil(row.policy_disabled_at)}
-                  type="button"
-                  phx-click="disable_resource_access"
-                  phx-value-resource_id={row.resource.id}
-                  class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
-                >
-                  <.icon name="ri-pause-line" class="w-3.5 h-3.5 shrink-0" /> Disable
-                </button>
-                <button
-                  :if={not is_nil(row.policy_disabled_at)}
-                  type="button"
-                  phx-click="enable_resource_access"
-                  phx-value-resource_id={row.resource.id}
-                  class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
-                >
-                  <.icon name="ri-play-line" class="w-3.5 h-3.5 shrink-0" /> Enable
-                </button>
-                <button
-                  type="button"
-                  phx-click="confirm_remove_resource_access"
-                  phx-value-resource_id={row.resource.id}
-                  class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--status-error)] hover:bg-[var(--surface-raised)] transition-colors"
-                >
-                  <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Remove access
-                </button>
-              </div>
-            </div>
+            </.actions_dropdown>
           </div>
         </li>
       </ul>

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -902,28 +902,28 @@ defmodule PortalWeb.Groups.Components do
               </div>
             </.link>
             <.actions_dropdown
-              open={@resource_access_actions_open_id == resource.id}
+              open={@resource_access_actions_open_id == row.resource.id}
               close_event="close_resource_access_actions"
               button_class="flex items-center justify-center w-6 h-6 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
               icon_class="w-3.5 h-3.5"
               phx-click="toggle_resource_access_actions"
-              phx-value-resource_id={resource.id}
+              phx-value-resource_id={row.resource.id}
               title="More actions"
             >
               <button
-                :if={is_nil(resource.policy_disabled_at)}
+                :if={is_nil(row.policy_disabled_at)}
                 type="button"
                 phx-click="disable_resource_access"
-                phx-value-resource_id={resource.id}
+                phx-value-resource_id={row.resource.id}
                 class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
               >
                 <.icon name="ri-pause-line" class="w-3.5 h-3.5 shrink-0" /> Disable
               </button>
               <button
-                :if={not is_nil(resource.policy_disabled_at)}
+                :if={not is_nil(row.policy_disabled_at)}
                 type="button"
                 phx-click="enable_resource_access"
-                phx-value-resource_id={resource.id}
+                phx-value-resource_id={row.resource.id}
                 class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
               >
                 <.icon name="ri-play-line" class="w-3.5 h-3.5 shrink-0" /> Enable
@@ -931,7 +931,7 @@ defmodule PortalWeb.Groups.Components do
               <button
                 type="button"
                 phx-click="confirm_remove_resource_access"
-                phx-value-resource_id={resource.id}
+                phx-value-resource_id={row.resource.id}
                 class="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[var(--status-error)] hover:bg-[var(--surface-raised)] transition-colors"
               >
                 <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Remove access

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -80,7 +80,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
         |> assign(actors_with_tokens: actors_with_tokens)
         |> assign(selected_actor: nil)
         |> assign(form: nil, encoded_token: nil)
-        |> assign(pending_confirm: nil)
+        |> assign(pending_confirm: nil, open_actor_actions_id: nil)
 
       {:ok, socket}
     else
@@ -127,7 +127,13 @@ defmodule PortalWeb.Settings.ApiClients.Index do
 
   def handle_params(_params, _uri, socket) do
     {:noreply,
-     assign(socket, selected_actor: nil, form: nil, encoded_token: nil, pending_confirm: nil)}
+     assign(socket,
+       selected_actor: nil,
+       form: nil,
+       encoded_token: nil,
+       pending_confirm: nil,
+       open_actor_actions_id: nil
+     )}
   end
 
   def render(assigns) do
@@ -207,6 +213,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
                   actor={actor}
                   token={token}
                   pending_confirm={@pending_confirm}
+                  open_actor_actions_id={@open_actor_actions_id}
                 />
               </tbody>
             </table>
@@ -360,6 +367,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
   attr :actor, :any, required: true
   attr :token, :any, required: true
   attr :pending_confirm, :any, required: true
+  attr :open_actor_actions_id, :string, default: nil
 
   defp api_client_row(assigns) do
     pending = assigns.pending_confirm
@@ -478,52 +486,45 @@ defmodule PortalWeb.Settings.ApiClients.Index do
           </td>
           <td class="px-6 py-3 w-10">
             <div class="flex justify-end">
-              <.popover placement="bottom" trigger="click">
-                <:target>
-                  <button
-                    type="button"
-                    class="flex items-center justify-center w-7 h-7 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
-                  >
-                    <.icon name="ri-more-2-line" class="w-4 h-4" />
-                  </button>
-                </:target>
-                <:content>
-                  <div class="flex flex-col py-1 w-44">
-                    <.link
-                      patch={~p"/#{@account}/settings/api_clients/#{@actor}/edit"}
-                      class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                    >
-                      <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
-                    </.link>
-                    <div class="my-1 border-t border-[var(--border)]"></div>
-                    <button
-                      phx-click="request_confirm"
-                      phx-value-id={@actor.id}
-                      phx-value-action="toggle"
-                      class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                    >
-                      <.icon
-                        name={
-                          if is_nil(@actor.disabled_at),
-                            do: "ri-pause-line",
-                            else: "ri-play-line"
-                        }
-                        class="w-3.5 h-3.5 shrink-0"
-                      />
-                      {if is_nil(@actor.disabled_at), do: "Disable", else: "Enable"}
-                    </button>
-                    <div class="my-1 border-t border-[var(--border)]"></div>
-                    <button
-                      phx-click="request_confirm"
-                      phx-value-id={@actor.id}
-                      phx-value-action="delete"
-                      class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--status-error)]"
-                    >
-                      <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Delete
-                    </button>
-                  </div>
-                </:content>
-              </.popover>
+              <.actions_dropdown
+                open={@open_actor_actions_id == @actor.id}
+                close_event="close_actor_actions"
+                phx-click="toggle_actor_actions"
+                phx-value-id={@actor.id}
+              >
+                <.link
+                  patch={~p"/#{@account}/settings/api_clients/#{@actor}/edit"}
+                  class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                >
+                  <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
+                </.link>
+                <div class="my-1 border-t border-[var(--border)]"></div>
+                <button
+                  phx-click="request_confirm"
+                  phx-value-id={@actor.id}
+                  phx-value-action="toggle"
+                  class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                >
+                  <.icon
+                    name={
+                      if is_nil(@actor.disabled_at),
+                        do: "ri-pause-line",
+                        else: "ri-play-line"
+                    }
+                    class="w-3.5 h-3.5 shrink-0"
+                  />
+                  {if is_nil(@actor.disabled_at), do: "Disable", else: "Enable"}
+                </button>
+                <div class="my-1 border-t border-[var(--border)]"></div>
+                <button
+                  phx-click="request_confirm"
+                  phx-value-id={@actor.id}
+                  phx-value-action="delete"
+                  class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--status-error)]"
+                >
+                  <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Delete
+                </button>
+              </.actions_dropdown>
             </div>
           </td>
         <% end %>
@@ -647,7 +648,11 @@ defmodule PortalWeb.Settings.ApiClients.Index do
            Portal.Safe.scoped(changeset, socket.assigns.subject) |> Portal.Safe.update() do
       socket =
         socket
-        |> assign(actors_with_tokens: reload_actors_with_tokens(socket), pending_confirm: nil)
+        |> assign(
+          actors_with_tokens: reload_actors_with_tokens(socket),
+          pending_confirm: nil,
+          open_actor_actions_id: nil
+        )
         |> maybe_update_selected(updated)
 
       {:noreply, socket}
@@ -666,7 +671,11 @@ defmodule PortalWeb.Settings.ApiClients.Index do
            Portal.Safe.scoped(changeset, socket.assigns.subject) |> Portal.Safe.update() do
       socket =
         socket
-        |> assign(actors_with_tokens: reload_actors_with_tokens(socket), pending_confirm: nil)
+        |> assign(
+          actors_with_tokens: reload_actors_with_tokens(socket),
+          pending_confirm: nil,
+          open_actor_actions_id: nil
+        )
         |> maybe_update_selected(updated)
 
       {:noreply, socket}
@@ -674,11 +683,22 @@ defmodule PortalWeb.Settings.ApiClients.Index do
   end
 
   def handle_event("request_confirm", %{"id" => id, "action" => action}, socket) do
-    {:noreply, assign(socket, pending_confirm: %{id: id, action: action})}
+    {:noreply, assign(socket, pending_confirm: %{id: id, action: action}, open_actor_actions_id: nil)}
   end
 
   def handle_event("cancel_confirm", _params, socket) do
     {:noreply, assign(socket, pending_confirm: nil)}
+  end
+
+  def handle_event("toggle_actor_actions", %{"id" => id}, socket) do
+    current = socket.assigns.open_actor_actions_id
+    next = if current == id, do: nil, else: id
+
+    {:noreply, assign(socket, open_actor_actions_id: next)}
+  end
+
+  def handle_event("close_actor_actions", _params, socket) do
+    {:noreply, assign(socket, open_actor_actions_id: nil)}
   end
 
   def handle_event("delete", %{"id" => id}, socket) do
@@ -688,7 +708,11 @@ defmodule PortalWeb.Settings.ApiClients.Index do
            Portal.Safe.scoped(actor, socket.assigns.subject) |> Portal.Safe.delete() do
       socket =
         socket
-        |> assign(actors_with_tokens: reload_actors_with_tokens(socket), pending_confirm: nil)
+        |> assign(
+          actors_with_tokens: reload_actors_with_tokens(socket),
+          pending_confirm: nil,
+          open_actor_actions_id: nil
+        )
         |> push_patch(to: ~p"/#{socket.assigns.account}/settings/api_clients")
 
       {:noreply, socket}

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -96,7 +96,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
 
       socket =
         socket
-        |> assign(selected_actor: nil, encoded_token: nil)
+        |> assign(selected_actor: nil, encoded_token: nil, open_actor_actions_id: nil)
         |> assign(form: to_form(changeset, as: "api_token"))
 
       {:noreply, socket}
@@ -119,7 +119,7 @@ defmodule PortalWeb.Settings.ApiClients.Index do
 
     socket =
       socket
-      |> assign(selected_actor: actor, encoded_token: nil)
+      |> assign(selected_actor: actor, encoded_token: nil, open_actor_actions_id: nil)
       |> assign(form: to_form(changeset, as: "actor"))
 
     {:noreply, socket}

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -268,11 +268,23 @@ defmodule PortalWeb.Settings.Authentication do
   end
 
   def handle_event("request_confirm", %{"id" => id, "action" => action}, socket) do
-    {:noreply, assign(socket, pending_confirm: %{id: id, action: action})}
+    {:noreply,
+     assign(socket, pending_confirm: %{id: id, action: action}, open_provider_actions_id: nil)}
   end
 
   def handle_event("cancel_confirm", _params, socket) do
     {:noreply, assign(socket, pending_confirm: nil)}
+  end
+
+  def handle_event("toggle_provider_actions", %{"id" => id}, socket) do
+    current = socket.assigns.open_provider_actions_id
+    next = if current == id, do: nil, else: id
+
+    {:noreply, assign(socket, open_provider_actions_id: next)}
+  end
+
+  def handle_event("close_provider_actions", _params, socket) do
+    {:noreply, assign(socket, open_provider_actions_id: nil)}
   end
 
   def handle_event("set_default_provider", %{"id" => id}, socket) do
@@ -469,7 +481,8 @@ defmodule PortalWeb.Settings.Authentication do
     assign(socket,
       providers: providers,
       verification_error: nil,
-      pending_confirm: nil
+      pending_confirm: nil,
+      open_provider_actions_id: nil
     )
   end
 
@@ -524,6 +537,7 @@ defmodule PortalWeb.Settings.Authentication do
                 account={@account}
                 provider={provider}
                 pending_confirm={@pending_confirm}
+                open_provider_actions_id={@open_provider_actions_id}
               />
             </tbody>
           </table>
@@ -916,94 +930,87 @@ defmodule PortalWeb.Settings.Authentication do
             </td>
             <td class="px-6 py-3">
               <div class="flex justify-end">
-                <.popover placement="bottom" trigger="click">
-                  <:target>
-                    <button
-                      type="button"
-                      class="flex items-center justify-center w-7 h-7 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
-                    >
-                      <.icon name="ri-more-2-line" class="w-4 h-4" />
-                    </button>
-                  </:target>
-                  <:content>
-                    <div class="flex flex-col py-1 w-44">
-                      <button
-                        :if={@can_be_default and not @is_default}
-                        phx-click="set_default_provider"
-                        phx-value-id={@provider.id}
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                      >
-                        <.icon name="ri-star-line" class="w-3.5 h-3.5 shrink-0" /> Make default
-                      </button>
-                      <button
-                        :if={@can_be_default and @is_default}
-                        phx-click="clear_default_provider"
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                      >
-                        <.icon name="ri-star-fill" class="w-3.5 h-3.5 shrink-0" /> Remove default
-                      </button>
-                      <button
-                        :if={not @can_be_default}
-                        disabled
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left text-[var(--text-tertiary)] cursor-default"
-                      >
-                        <.icon name="ri-star-line" class="w-3.5 h-3.5 shrink-0" /> Make default
-                      </button>
-                      <div class="my-1 border-t border-[var(--border)]"></div>
-                      <.link
-                        patch={~p"/#{@account}/settings/authentication/#{@type}/#{@provider.id}/edit"}
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                      >
-                        <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
-                      </.link>
-                      <div class="my-1 border-t border-[var(--border)]"></div>
-                      <button
-                        :if={@has_sessions}
-                        phx-click="request_confirm"
-                        phx-value-id={@provider.id}
-                        phx-value-action="revoke"
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                      >
-                        <.icon name="ri-logout-box-r-line" class="w-3.5 h-3.5 shrink-0" />
-                        Revoke sessions
-                      </button>
-                      <button
-                        :if={not @has_sessions}
-                        disabled
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left text-[var(--text-tertiary)] cursor-default"
-                      >
-                        <.icon name="ri-logout-box-r-line" class="w-3.5 h-3.5 shrink-0" />
-                        Revoke sessions
-                      </button>
-                      <div class="my-1 border-t border-[var(--border)]"></div>
-                      <button
-                        phx-click="request_confirm"
-                        phx-value-id={@provider.id}
-                        phx-value-action="toggle"
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                      >
-                        <.icon
-                          name={
-                            if @provider.is_disabled,
-                              do: "ri-checkbox-circle-line",
-                              else: "ri-close-circle-line"
-                          }
-                          class="w-3.5 h-3.5 shrink-0"
-                        />
-                        {if @provider.is_disabled, do: "Enable", else: "Disable"}
-                      </button>
-                      <button
-                        :if={@can_be_deleted}
-                        phx-click="request_confirm"
-                        phx-value-id={@provider.id}
-                        phx-value-action="delete"
-                        class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--status-error)]"
-                      >
-                        <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Delete
-                      </button>
-                    </div>
-                  </:content>
-                </.popover>
+                <.actions_dropdown
+                  open={@open_provider_actions_id == @provider.id}
+                  close_event="close_provider_actions"
+                  phx-click="toggle_provider_actions"
+                  phx-value-id={@provider.id}
+                >
+                  <button
+                    :if={@can_be_default and not @is_default}
+                    phx-click="set_default_provider"
+                    phx-value-id={@provider.id}
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                  >
+                    <.icon name="ri-star-line" class="w-3.5 h-3.5 shrink-0" /> Make default
+                  </button>
+                  <button
+                    :if={@can_be_default and @is_default}
+                    phx-click="clear_default_provider"
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                  >
+                    <.icon name="ri-star-fill" class="w-3.5 h-3.5 shrink-0" /> Remove default
+                  </button>
+                  <button
+                    :if={not @can_be_default}
+                    disabled
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left text-[var(--text-tertiary)] cursor-default"
+                  >
+                    <.icon name="ri-star-line" class="w-3.5 h-3.5 shrink-0" /> Make default
+                  </button>
+                  <div class="my-1 border-t border-[var(--border)]"></div>
+                  <.link
+                    patch={~p"/#{@account}/settings/authentication/#{@type}/#{@provider.id}/edit"}
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                  >
+                    <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
+                  </.link>
+                  <div class="my-1 border-t border-[var(--border)]"></div>
+                  <button
+                    :if={@has_sessions}
+                    phx-click="request_confirm"
+                    phx-value-id={@provider.id}
+                    phx-value-action="revoke"
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                  >
+                    <.icon name="ri-logout-box-r-line" class="w-3.5 h-3.5 shrink-0" />
+                    Revoke sessions
+                  </button>
+                  <button
+                    :if={not @has_sessions}
+                    disabled
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left text-[var(--text-tertiary)] cursor-default"
+                  >
+                    <.icon name="ri-logout-box-r-line" class="w-3.5 h-3.5 shrink-0" />
+                    Revoke sessions
+                  </button>
+                  <div class="my-1 border-t border-[var(--border)]"></div>
+                  <button
+                    phx-click="request_confirm"
+                    phx-value-id={@provider.id}
+                    phx-value-action="toggle"
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+                  >
+                    <.icon
+                      name={
+                        if @provider.is_disabled,
+                          do: "ri-checkbox-circle-line",
+                          else: "ri-close-circle-line"
+                      }
+                      class="w-3.5 h-3.5 shrink-0"
+                    />
+                    {if @provider.is_disabled, do: "Enable", else: "Disable"}
+                  </button>
+                  <button
+                    :if={@can_be_deleted}
+                    phx-click="request_confirm"
+                    phx-value-id={@provider.id}
+                    phx-value-action="delete"
+                    class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--status-error)]"
+                  >
+                    <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Delete
+                  </button>
+                </.actions_dropdown>
               </div>
             </td>
           <% end %>

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -64,7 +64,7 @@ defmodule PortalWeb.Settings.Authentication do
     attrs = %{id: Ecto.UUID.generate()}
     changeset = changeset(struct, attrs, socket)
 
-    {:noreply, assign(socket, type: type, form: to_form(changeset))}
+    {:noreply, assign(socket, type: type, form: to_form(changeset), open_provider_actions_id: nil)}
   end
 
   # Edit Auth Provider
@@ -86,7 +86,8 @@ defmodule PortalWeb.Settings.Authentication do
        provider_name: provider.name,
        type: type,
        form: to_form(changeset),
-       is_legacy: is_legacy
+       is_legacy: is_legacy,
+       open_provider_actions_id: nil
      )}
   end
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -80,7 +80,8 @@ defmodule PortalWeb.Settings.DirectorySync do
        verification_error: nil,
        verifying: false,
        form: to_form(changeset),
-       public_jwk: nil
+       public_jwk: nil,
+       open_directory_actions_id: nil
      )}
   end
 
@@ -115,7 +116,8 @@ defmodule PortalWeb.Settings.DirectorySync do
        type: type,
        form: to_form(changeset),
        public_jwk: public_jwk,
-       is_legacy: is_legacy
+       is_legacy: is_legacy,
+       open_directory_actions_id: nil
      )}
   end
 

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -60,8 +60,9 @@ defmodule PortalWeb.Settings.DirectorySync do
       socket
       |> assign_new(:directories, fn -> directories end)
       |> assign_new(:verification_error, fn -> nil end)
+      |> assign_new(:open_directory_actions_id, fn -> nil end)
     else
-      assign(socket, directories: directories, verification_error: nil)
+      assign(socket, directories: directories, verification_error: nil, open_directory_actions_id: nil)
     end
   end
 
@@ -293,6 +294,17 @@ defmodule PortalWeb.Settings.DirectorySync do
     end
   end
 
+  def handle_event("toggle_directory_actions", %{"id" => id}, socket) do
+    current = socket.assigns.open_directory_actions_id
+    next = if current == id, do: nil, else: id
+
+    {:noreply, assign(socket, open_directory_actions_id: next)}
+  end
+
+  def handle_event("close_directory_actions", _params, socket) do
+    {:noreply, assign(socket, open_directory_actions_id: nil)}
+  end
+
   defp toggle_directory_changeset(directory, true) do
     changeset(directory, %{
       "is_disabled" => true,
@@ -444,6 +456,7 @@ defmodule PortalWeb.Settings.DirectorySync do
                     directory={directory}
                     subject={@subject}
                     most_recent_job={directory.most_recent_job}
+                    open_directory_actions_id={@open_directory_actions_id}
                   />
                 </tbody>
               </table>
@@ -788,6 +801,7 @@ defmodule PortalWeb.Settings.DirectorySync do
   attr :directory, :any, required: true
   attr :subject, :any, required: true
   attr :most_recent_job, :map, default: nil
+  attr :open_directory_actions_id, :string, default: nil
 
   defp directory_row(assigns) do
     is_legacy = assigns.type == "google" && assigns.directory.legacy_service_account_key != nil
@@ -864,85 +878,78 @@ defmodule PortalWeb.Settings.DirectorySync do
       </td>
       <td class="px-6 py-3 w-14">
         <div class="flex justify-end">
-          <.popover placement="bottom" trigger="click">
-            <:target>
-              <button
-                type="button"
-                class="flex items-center justify-center w-7 h-7 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-raised)] transition-colors"
-              >
-                <.icon name="ri-more-2-line" class="w-4 h-4" />
-              </button>
-            </:target>
-            <:content>
-              <div class="flex flex-col py-1 w-44">
-                <.link
-                  patch={~p"/#{@account}/settings/directory_sync/#{@type}/#{@directory.id}/edit"}
-                  class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
-                >
-                  <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
-                </.link>
-                <button
-                  type="button"
-                  phx-click="sync_directory"
-                  phx-value-id={@directory.id}
-                  phx-value-type={@type}
-                  disabled={@directory.is_disabled or @directory.has_active_job}
-                  class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)] disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <.icon name="ri-loop-left-line" class="w-3.5 h-3.5 shrink-0" /> Sync Now
-                </button>
-                <div class="my-1 border-t border-[var(--border)]"></div>
-                <.button_with_confirmation
-                  id={"toggle-directory-#{@directory.id}"}
-                  on_confirm="toggle_directory"
-                  on_confirm_id={@directory.id}
-                  class="flex justify-start items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)] border-0 bg-transparent"
-                >
-                  <.icon
-                    name={
-                      if @directory.is_disabled,
-                        do: "ri-checkbox-circle-line",
-                        else: "ri-close-circle-line"
-                    }
-                    class="w-3.5 h-3.5 shrink-0"
-                  />
-                  {if @directory.is_disabled, do: "Enable", else: "Disable"}
-                  <:dialog_title>
-                    {if @directory.is_disabled, do: "Enable", else: "Disable"} Directory
-                  </:dialog_title>
-                  <:dialog_content>
-                    <p>
-                      Are you sure you want to {if @directory.is_disabled,
-                        do: "enable",
-                        else: "disable"} <strong>{@directory.name}</strong>?
-                    </p>
-                    <%= if not @directory.is_disabled do %>
-                      <p class="mt-2">This directory will no longer sync while disabled.</p>
-                    <% end %>
-                  </:dialog_content>
-                  <:dialog_confirm_button>
-                    {if @directory.is_disabled, do: "Enable", else: "Disable"}
-                  </:dialog_confirm_button>
-                  <:dialog_cancel_button>Cancel</:dialog_cancel_button>
-                </.button_with_confirmation>
-                <div class="my-1 border-t border-[var(--border)]"></div>
-                <.button_with_confirmation
-                  id={"delete-directory-#{@directory.id}"}
-                  on_confirm="delete_directory"
-                  on_confirm_id={@directory.id}
-                  class="flex justify-start items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--status-error)] border-0 bg-transparent"
-                >
-                  <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Delete
-                  <:dialog_title>Delete Directory</:dialog_title>
-                  <:dialog_content>
-                    <.deletion_stats directory={@directory} subject={@subject} />
-                  </:dialog_content>
-                  <:dialog_confirm_button>Delete</:dialog_confirm_button>
-                  <:dialog_cancel_button>Cancel</:dialog_cancel_button>
-                </.button_with_confirmation>
-              </div>
-            </:content>
-          </.popover>
+          <.actions_dropdown
+            open={@open_directory_actions_id == @directory.id}
+            close_event="close_directory_actions"
+            phx-click="toggle_directory_actions"
+            phx-value-id={@directory.id}
+          >
+            <.link
+              patch={~p"/#{@account}/settings/directory_sync/#{@type}/#{@directory.id}/edit"}
+              class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)]"
+            >
+              <.icon name="ri-pencil-line" class="w-3.5 h-3.5 shrink-0" /> Edit
+            </.link>
+            <button
+              type="button"
+              phx-click="sync_directory"
+              phx-value-id={@directory.id}
+              phx-value-type={@type}
+              disabled={@directory.is_disabled or @directory.has_active_job}
+              class="flex items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)] disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <.icon name="ri-loop-left-line" class="w-3.5 h-3.5 shrink-0" /> Sync Now
+            </button>
+            <div class="my-1 border-t border-[var(--border)]"></div>
+            <.button_with_confirmation
+              id={"toggle-directory-#{@directory.id}"}
+              on_confirm="toggle_directory"
+              on_confirm_id={@directory.id}
+              class="flex justify-start items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--text-secondary)] border-0 bg-transparent"
+            >
+              <.icon
+                name={
+                  if @directory.is_disabled,
+                    do: "ri-checkbox-circle-line",
+                    else: "ri-close-circle-line"
+                }
+                class="w-3.5 h-3.5 shrink-0"
+              />
+              {if @directory.is_disabled, do: "Enable", else: "Disable"}
+              <:dialog_title>
+                {if @directory.is_disabled, do: "Enable", else: "Disable"} Directory
+              </:dialog_title>
+              <:dialog_content>
+                <p>
+                  Are you sure you want to {if @directory.is_disabled,
+                    do: "enable",
+                    else: "disable"} <strong>{@directory.name}</strong>?
+                </p>
+                <%= if not @directory.is_disabled do %>
+                  <p class="mt-2">This directory will no longer sync while disabled.</p>
+                <% end %>
+              </:dialog_content>
+              <:dialog_confirm_button>
+                {if @directory.is_disabled, do: "Enable", else: "Disable"}
+              </:dialog_confirm_button>
+              <:dialog_cancel_button>Cancel</:dialog_cancel_button>
+            </.button_with_confirmation>
+            <div class="my-1 border-t border-[var(--border)]"></div>
+            <.button_with_confirmation
+              id={"delete-directory-#{@directory.id}"}
+              on_confirm="delete_directory"
+              on_confirm_id={@directory.id}
+              class="flex justify-start items-center gap-2.5 w-full px-3 py-2 text-xs text-left hover:bg-[var(--surface-raised)] transition-colors text-[var(--status-error)] border-0 bg-transparent"
+            >
+              <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5 shrink-0" /> Delete
+              <:dialog_title>Delete Directory</:dialog_title>
+              <:dialog_content>
+                <.deletion_stats directory={@directory} subject={@subject} />
+              </:dialog_content>
+              <:dialog_confirm_button>Delete</:dialog_confirm_button>
+              <:dialog_cancel_button>Cancel</:dialog_cancel_button>
+            </.button_with_confirmation>
+          </.actions_dropdown>
         </div>
       </td>
     </tr>

--- a/elixir/test/portal_web/live/settings/api_clients/index_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/index_test.exs
@@ -15,6 +15,10 @@ defmodule PortalWeb.Settings.ApiClients.IndexTest do
 
   defp request_confirm(lv, action, actor_id) do
     lv
+    |> element("button[phx-click='toggle_actor_actions'][phx-value-id='#{actor_id}']")
+    |> render_click()
+
+    lv
     |> element(
       "button[phx-click='request_confirm'][phx-value-action='#{action}'][phx-value-id='#{actor_id}']"
     )

--- a/elixir/test/portal_web/live/settings/api_clients/index_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/index_test.exs
@@ -25,6 +25,21 @@ defmodule PortalWeb.Settings.ApiClients.IndexTest do
     |> render_click()
   end
 
+  defp open_actor_actions(lv, actor_id) do
+    lv
+    |> element("button[phx-click='toggle_actor_actions'][phx-value-id='#{actor_id}']")
+    |> render_click()
+  end
+
+  defp has_actor_action_button?(html, action, actor_id) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find(
+      "button[phx-click='request_confirm'][phx-value-action='#{action}'][phx-value-id='#{actor_id}']"
+    )
+    |> Enum.any?()
+  end
+
   describe "unauthorized" do
     test "redirects to sign-in when not authenticated", %{conn: conn, account: account} do
       path = ~p"/#{account}/settings/api_clients"
@@ -214,6 +229,33 @@ defmodule PortalWeb.Settings.ApiClients.IndexTest do
 
       render_keydown(lv, "handle_keydown", %{"key" => "Escape"})
       assert_patch(lv, ~p"/#{account}/settings/api_clients")
+    end
+
+    test "closes the actions menu when navigating to edit", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      api_client = api_client_fixture(account: account, name: "Edit From Menu")
+      api_token_fixture(account: account, actor: api_client)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/api_clients")
+
+      html = open_actor_actions(lv, api_client.id)
+      assert has_actor_action_button?(html, "toggle", api_client.id)
+
+      lv
+      |> element("a[href='/" <> "#{account.slug}/settings/api_clients/#{api_client.id}/edit']")
+      |> render_click()
+
+      assert_patch(lv, ~p"/#{account}/settings/api_clients/#{api_client}/edit")
+
+      html = render(lv)
+      assert html =~ "Edit API Token"
+      refute has_actor_action_button?(html, "toggle", api_client.id)
     end
 
     test "opens and cancels disable confirmation", %{conn: conn, account: account, actor: actor} do

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -1,6 +1,7 @@
 defmodule PortalWeb.Settings.AuthenticationTest do
   use PortalWeb.ConnCase, async: true
 
+  import Ecto.Query
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
@@ -26,9 +27,19 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
   defp request_confirm(lv, action, provider_id) do
     lv
+    |> element("button[phx-click='toggle_provider_actions'][phx-value-id='#{provider_id}']")
+    |> render_click()
+
+    lv
     |> element(
       "button[phx-click='request_confirm'][phx-value-action='#{action}'][phx-value-id='#{provider_id}']"
     )
+    |> render_click()
+  end
+
+  defp open_provider_actions(lv, provider_id) do
+    lv
+    |> element("button[phx-click='toggle_provider_actions'][phx-value-id='#{provider_id}']")
     |> render_click()
   end
 
@@ -102,14 +113,14 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       actor: actor,
       conn: conn
     } do
-      google_provider_fixture(account: account)
+      provider = google_provider_fixture(account: account)
 
-      {:ok, _lv, html} =
+      {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
 
-      assert html =~ "Make default"
+      assert open_provider_actions(lv, provider.id) =~ "Make default"
     end
   end
 
@@ -1235,6 +1246,9 @@ defmodule PortalWeb.Settings.AuthenticationTest do
         |> live(~p"/#{account}/settings/authentication")
 
       lv
+      |> open_provider_actions(provider.id)
+
+      lv
       |> element("button[phx-click='set_default_provider'][phx-value-id='#{provider.id}']")
       |> render_click()
 
@@ -1243,12 +1257,15 @@ defmodule PortalWeb.Settings.AuthenticationTest do
     end
 
     test "can clear default provider", %{account: account, actor: actor, conn: conn} do
-      google_provider_fixture(account: account, is_default: true)
+      provider = google_provider_fixture(account: account, is_default: true)
 
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
+
+      lv
+      |> open_provider_actions(provider.id)
 
       lv
       |> element("button[phx-click='clear_default_provider']")
@@ -1259,40 +1276,39 @@ defmodule PortalWeb.Settings.AuthenticationTest do
     end
 
     test "shows current default in select", %{account: account, actor: actor, conn: conn} do
-      google_provider_fixture(account: account, is_default: true, name: "Default Provider")
+      provider = google_provider_fixture(account: account, is_default: true, name: "Default Provider")
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
 
       assert html =~ "Default Provider"
-      assert html =~ "Remove default"
+      assert open_provider_actions(lv, provider.id) =~ "Remove default"
     end
 
     test "email_otp cannot be set as default", %{account: account, actor: actor, conn: conn} do
-      # authorize_conn creates email_otp
-      {:ok, _lv, html} =
+      {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
 
-      parsed = Floki.parse_fragment!(html)
-      buttons = Floki.find(parsed, "button[phx-click='set_default_provider']")
-      assert Enum.empty?(buttons)
+      provider = Repo.one!(from p in EmailOTP.AuthProvider, where: p.account_id == ^account.id)
+      html = open_provider_actions(lv, provider.id)
+
+      refute html =~ "phx-click=\"set_default_provider\""
     end
 
     test "userpass cannot be set as default", %{account: account, actor: actor, conn: conn} do
-      userpass_provider_fixture(account: account)
+      provider = userpass_provider_fixture(account: account)
 
-      {:ok, _lv, html} =
+      {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
 
-      parsed = Floki.parse_fragment!(html)
-      buttons = Floki.find(parsed, "button[phx-click='set_default_provider']")
-      assert Enum.empty?(buttons)
+      html = open_provider_actions(lv, provider.id)
+      refute html =~ "phx-click=\"set_default_provider\""
     end
 
     test "disabled providers appear in default provider select", %{
@@ -2123,24 +2139,21 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       parsed = Floki.parse_fragment!(html)
 
       toggles =
-        Floki.find(parsed, "button[phx-click='request_confirm'][phx-value-action='toggle']")
+        Floki.find(parsed, "button[phx-click='toggle_provider_actions']")
 
       assert length(toggles) >= 2
     end
 
     test "shows edit link for each provider", %{account: account, actor: actor, conn: conn} do
-      google_provider_fixture(account: account)
+      provider = google_provider_fixture(account: account)
 
-      {:ok, _lv, html} =
+      {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
 
-      # Should have edit links
-      parsed = Floki.parse_fragment!(html)
-      edit_links = Floki.find(parsed, "a[href*='/edit']")
-      # At least 2 edit links (email_otp + google)
-      assert length(edit_links) >= 2
+      html = open_provider_actions(lv, provider.id)
+      assert html =~ "/#{account.slug}/settings/authentication/google/#{provider.id}/edit"
     end
 
     test "shows updated timestamp", %{account: account, actor: actor, conn: conn} do
@@ -3433,6 +3446,9 @@ defmodule PortalWeb.Settings.AuthenticationTest do
         |> live(~p"/#{account}/settings/authentication")
 
       lv
+      |> open_provider_actions(provider.id)
+
+      lv
       |> element("button[phx-click='set_default_provider'][phx-value-id='#{provider.id}']")
       |> render_click()
 
@@ -3445,12 +3461,15 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       actor: actor,
       conn: conn
     } do
-      google_provider_fixture(account: account, name: "Default Google", is_default: true)
+      provider = google_provider_fixture(account: account, name: "Default Google", is_default: true)
 
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/authentication")
+
+      lv
+      |> open_provider_actions(provider.id)
 
       lv
       |> element("button[phx-click='clear_default_provider']")

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -43,6 +43,15 @@ defmodule PortalWeb.Settings.AuthenticationTest do
     |> render_click()
   end
 
+  defp has_provider_action_button?(html, action, provider_id) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find(
+      "button[phx-click='request_confirm'][phx-value-action='#{action}'][phx-value-id='#{provider_id}']"
+    )
+    |> Enum.any?()
+  end
+
   defp confirm_action(lv, event, provider_id) do
     lv
     |> element("button[phx-click='#{event}'][phx-value-id='#{provider_id}']")
@@ -872,6 +881,34 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       render_keydown(lv, "handle_keydown", %{"key" => "Escape"})
       assert_patch(lv, ~p"/#{account}/settings/authentication")
+    end
+  end
+
+  describe "provider actions menu navigation" do
+    test "closes the actions menu when navigating to edit", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      provider = google_provider_fixture(account: account, name: "Edit From Menu")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication")
+
+      html = open_provider_actions(lv, provider.id)
+      assert has_provider_action_button?(html, "toggle", provider.id)
+
+      lv
+      |> element("a[href='/" <> "#{account.slug}/settings/authentication/google/#{provider.id}/edit']")
+      |> render_click()
+
+      assert_patch(lv, ~p"/#{account}/settings/authentication/google/#{provider.id}/edit")
+
+      html = render(lv)
+      assert html =~ "Edit Edit From Menu"
+      refute has_provider_action_button?(html, "toggle", provider.id)
     end
   end
 

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -13,6 +13,19 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
     %{account: account, actor: actor}
   end
 
+  defp open_directory_actions(lv, directory_id) do
+    lv
+    |> element("button[phx-click='toggle_directory_actions'][phx-value-id='#{directory_id}']")
+    |> render_click()
+  end
+
+  defp has_directory_action_button?(html, event, directory_id) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find("button[phx-click='#{event}'][phx-value-id='#{directory_id}']")
+    |> Enum.any?()
+  end
+
   describe "unauthorized" do
     test "redirects to sign-in when not authenticated", %{conn: conn, account: account} do
       path = ~p"/#{account}/settings/directory_sync"
@@ -119,6 +132,32 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       html = render_click(lv, "delete_directory", %{"id" => directory.id})
       assert html =~ "Directory deleted successfully."
       refute html =~ "Ops Google"
+    end
+
+    test "closes the actions menu when navigating to edit", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      directory = google_directory_fixture(account: account, name: "Edit From Menu")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync")
+
+      html = open_directory_actions(lv, directory.id)
+      assert has_directory_action_button?(html, "sync_directory", directory.id)
+
+      lv
+      |> element("a[href='/" <> "#{account.slug}/settings/directory_sync/google/#{directory.id}/edit']")
+      |> render_click()
+
+      assert_patch(lv, ~p"/#{account}/settings/directory_sync/google/#{directory.id}/edit")
+
+      html = render(lv)
+      assert html =~ "Edit Edit From Menu"
+      refute has_directory_action_button?(html, "sync_directory", directory.id)
     end
   end
 


### PR DESCRIPTION
When reviewing another PR to remove Flowbite I noticed an inconsistency with how some of the action dropdown/popover menus were created.  This PR tries to unify dropdown/popover action menus.  Specifically the settings/authentication, settings/directory_sync, and settings/api_clients action drop down menus didn't have the same styling as what is used in other parts of the app.  An example showing the difference is below.

### Before
<img width="524" height="318" alt="Screenshot 2026-04-29 at 5 39 14 PM" src="https://github.com/user-attachments/assets/c6ba9c35-9168-40ac-8865-e6af59a53bda" />

### After
<img width="498" height="315" alt="Screenshot 2026-04-29 at 5 39 26 PM" src="https://github.com/user-attachments/assets/f77ca864-eb83-41da-871e-64f868bd3d7e" />