### PR TITLE
chore(elixir): update dev setup instructions

### DIFF
--- a/elixir/.tool-versions
+++ b/elixir/.tool-versions
@@ -1,5 +1,6 @@
 # These are used for the dev environment.
 # This should match the versions used in the built product.
 nodejs 22.20.0
+pnpm 10.33.0
 elixir 1.19.5-otp-28
 erlang 28.4.1

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -9,10 +9,11 @@ This is not an in depth guide for setting up all dependencies, but it should giv
 Prerequisites:
 
 - All prerequisites in the [CONTRIBUTING](../docs/CONTRIBUTING.md) guide
-- Install ASDF and all plugins/tools from `.tool-version` in the top level of the Firezone repo
-- Install [pnpm](https://pnpm.io/)
+- Install all tools from `.tool-versions` in the `elixir/` directory using
+  [Mise](https://mise.jdx.dev/) (`mise install`) or
+  [asdf](https://asdf-vm.com/) (`asdf install`)
 
-From the top level director of the Firezone repo start the Postgres container:
+From the top level directory of the Firezone repo start the Postgres container:
 
 ```
 docker compose up -d postgres

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -9,9 +9,9 @@ This is not an in depth guide for setting up all dependencies, but it should giv
 Prerequisites:
 
 - All prerequisites in the [CONTRIBUTING](../docs/CONTRIBUTING.md) guide
-- Install all tools from `.tool-versions` in the `elixir/` directory using
-  [Mise](https://mise.jdx.dev/) (`mise install`) or
-  [asdf](https://asdf-vm.com/) (`asdf install`)
+- From the `elixir/` directory, install all tools from `.tool-versions` using
+  [Mise](https://mise.jdx.dev/) (`cd elixir && mise install`) or
+  [asdf](https://asdf-vm.com/) (`cd elixir && asdf install`)
 
 From the top level directory of the Firezone repo start the Postgres container:
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@ experimental_monorepo_root = true
 
 [monorepo]
 config_roots = [
+    "elixir",
     "kotlin/android",
     "rust",
     "swift/apple",


### PR DESCRIPTION
pnpm is required by `mix assets.setup` but was missing from .tool-versions, requiring a manual install step.

Also update the README to mention `mise` alongside `asdf` and register elixir/ as a Mise monorepo config root
