### PR TITLE
fix(portal): update client sign-in redirect and tests

### DIFF
--- a/elixir/lib/portal_web/authentication.ex
+++ b/elixir/lib/portal_web/authentication.ex
@@ -27,4 +27,12 @@ defmodule PortalWeb.Authentication do
     |> Map.take(["as", "state", "nonce", "redirect_to"])
     |> Map.reject(fn {_key, value} -> value in ["", nil] end)
   end
+
+  @doc """
+  Returns true when the params represent a client sign-in flow.
+  """
+  def client_sign_in?(%{"as" => as}) when as in ["client", "gui-client", "headless-client"],
+    do: true
+
+  def client_sign_in?(_params), do: false
 end

--- a/elixir/lib/portal_web/controllers/home_controller.ex
+++ b/elixir/lib/portal_web/controllers/home_controller.ex
@@ -3,15 +3,19 @@ defmodule PortalWeb.HomeController do
   alias __MODULE__.Database
 
   @spec home(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def home(conn, _params) do
+  def home(conn, params) do
     %PortalWeb.Cookie.RecentAccounts{account_ids: recent_account_ids} =
       PortalWeb.Cookie.RecentAccounts.fetch(conn)
 
-    if recent_account_ids != [] do
-      redirect(conn, to: ~p"/sign_in")
+    sign_in_params = PortalWeb.Authentication.take_sign_in_params(params)
+
+    redirect_url = if recent_account_ids != [] || PortalWeb.Authentication.client_sign_in?(sign_in_params) do
+      ~p"/sign_in?#{sign_in_params}"
     else
-      redirect(conn, to: ~p"/getting_started")
+      ~p"/getting_started?#{sign_in_params}"
     end
+
+    redirect(conn, to: redirect_url)
   end
 
   @spec getting_started(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/elixir/lib/portal_web/controllers/home_html.ex
+++ b/elixir/lib/portal_web/controllers/home_html.ex
@@ -154,11 +154,11 @@ defmodule PortalWeb.HomeHTML do
     </div>
 
     <div class="mt-6 text-xs text-[var(--text-tertiary)] space-y-1.5 text-center">
-      <p :if={@params["as"] != "client"}>
-        Organization need a new account?
+      <p :if={!PortalWeb.Authentication.client_sign_in?(@params)}>
+        Want to setup a new Organization?
         <a href={~p"/sign_up"} class={[link_style()]}>Sign up here.</a>
       </p>
-      <p :if={@params["as"] != "client"}>
+      <p :if={!PortalWeb.Authentication.client_sign_in?(@params)}>
         Not sure where to start?
         <a href={~p"/getting_started?#{@params}"} class={[link_style()]}>Let's get started.</a>
       </p>

--- a/elixir/lib/portal_web/controllers/home_html.ex
+++ b/elixir/lib/portal_web/controllers/home_html.ex
@@ -155,7 +155,7 @@ defmodule PortalWeb.HomeHTML do
 
     <div class="mt-6 text-xs text-[var(--text-tertiary)] space-y-1.5 text-center">
       <p :if={!PortalWeb.Authentication.client_sign_in?(@params)}>
-        Want to setup a new Organization?
+        Want to set up a new Organization?
         <a href={~p"/sign_up"} class={[link_style()]}>Sign up here.</a>
       </p>
       <p :if={!PortalWeb.Authentication.client_sign_in?(@params)}>

--- a/elixir/test/portal_web/controllers/account_landing_controller_test.exs
+++ b/elixir/test/portal_web/controllers/account_landing_controller_test.exs
@@ -1,22 +1,23 @@
 defmodule PortalWeb.AccountLandingControllerTest do
   use PortalWeb.ConnCase, async: true
 
+  @client_sign_in_types ["client", "gui-client", "headless-client"]
+
   describe "redirect_to_sign_in/2" do
     test "redirects /:account/ to /:account/sign_in", %{conn: conn} do
       conn = get(conn, ~p"/some-account")
       assert redirected_to(conn) == "/some-account/sign_in"
     end
 
-    test "preserves query params on redirect", %{conn: conn} do
-      conn = get(conn, "/some-account?as=client&state=abc&nonce=xyz")
-      assert redirected_to(conn) == "/some-account/sign_in?as=client&state=abc&nonce=xyz"
-    end
+    test "redirects client sign-in with slug to /:account/sign_in and preserves all sign-in params",
+         %{conn: conn} do
+      for client <- @client_sign_in_types do
+        params = "as=#{client}&state=abc&nonce=xyz&redirect_to=%2Fsites"
 
-    test "preserves gui-client params on redirect", %{conn: conn} do
-      conn = get(conn, "/some-account?as=gui-client&state=test-state&nonce=test-nonce")
+        conn = get(conn, "/some-account?#{params}")
 
-      assert redirected_to(conn) ==
-               "/some-account/sign_in?as=gui-client&state=test-state&nonce=test-nonce"
+        assert redirected_to(conn) == "/some-account/sign_in?#{params}"
+      end
     end
   end
 end

--- a/elixir/test/portal_web/controllers/home_controller_test.exs
+++ b/elixir/test/portal_web/controllers/home_controller_test.exs
@@ -3,6 +3,8 @@ defmodule PortalWeb.HomeControllerTest do
 
   import Portal.AccountFixtures
 
+  @client_sign_in_types ["client", "gui-client", "headless-client"]
+
   describe "home/2" do
     test "redirects to /getting_started when no cookie present", %{conn: conn} do
       conn = get(conn, ~p"/")
@@ -25,6 +27,22 @@ defmodule PortalWeb.HomeControllerTest do
         |> get(~p"/")
 
       assert redirected_to(conn) == ~p"/sign_in"
+    end
+
+    test "redirects client sign-in without slug to /sign_in and preserves all sign-in params", %{
+      conn: conn
+    } do
+      for client <- @client_sign_in_types do
+        params = %{
+          "as" => client,
+          "state" => "abc",
+          "nonce" => "xyz",
+          "redirect_to" => "/sites"
+        }
+
+        conn = get(conn, ~p"/?#{params}")
+        assert redirected_to(conn) == ~p"/sign_in?#{params}"
+      end
     end
   end
 
@@ -95,19 +113,56 @@ defmodule PortalWeb.HomeControllerTest do
         assert html =~ ~p"/#{account.slug}/sign_in"
       end
     end
+
+    test "hides portal-only links for client sign-in", %{conn: conn} do
+      for client <- @client_sign_in_types do
+        conn = get(conn, ~p"/sign_in?#{%{"as" => client}}")
+        html = response(conn, 200)
+
+        refute html =~ "Want to setup a new Organization?"
+        refute html =~ "Not sure where to start?"
+      end
+    end
   end
 
   describe "redirect_to_sign_in/2" do
-    test "redirects to the sign in page via POST /sign_in", %{conn: conn} do
+    test "redirects to the account sign-in page via POST /sign_in and preserves all sign-in params",
+         %{conn: conn} do
       id = Ecto.UUID.generate()
-      conn = post(conn, ~p"/sign_in", %{"account_id_or_slug" => id, "as" => "client"})
-      assert redirected_to(conn) == ~p"/#{id}/sign_in?as=client"
+
+      for client <- @client_sign_in_types do
+        params = %{
+          "account_id_or_slug" => id,
+          "as" => client,
+          "state" => "abc",
+          "nonce" => "xyz",
+          "redirect_to" => "/sites"
+        }
+
+        conn = post(conn, ~p"/sign_in", params)
+        expected_params = Map.drop(params, ["account_id_or_slug"])
+        assert redirected_to(conn) == ~p"/#{id}/sign_in?#{expected_params}"
+      end
     end
 
-    test "redirects to the sign in page via POST /", %{conn: conn} do
+    test "redirects to the account sign-in page via POST / and preserves all sign-in params", %{
+      conn: conn
+    } do
       id = Ecto.UUID.generate()
-      conn = post(conn, ~p"/", %{"account_id_or_slug" => id, "as" => "client"})
-      assert redirected_to(conn) == ~p"/#{id}/sign_in?as=client"
+
+      for client <- @client_sign_in_types do
+        params = %{
+          "account_id_or_slug" => id,
+          "as" => client,
+          "state" => "abc",
+          "nonce" => "xyz",
+          "redirect_to" => "/sites"
+        }
+
+        conn = post(conn, ~p"/", params)
+        expected_params = Map.drop(params, ["account_id_or_slug"])
+        assert redirected_to(conn) == ~p"/#{id}/sign_in?#{expected_params}"
+      end
     end
 
     test "downcases account slug on redirect", %{conn: conn} do

--- a/elixir/test/portal_web/controllers/home_controller_test.exs
+++ b/elixir/test/portal_web/controllers/home_controller_test.exs
@@ -119,7 +119,7 @@ defmodule PortalWeb.HomeControllerTest do
         conn = get(conn, ~p"/sign_in?#{%{"as" => client}}")
         html = response(conn, 200)
 
-        refute html =~ "Want to setup a new Organization?"
+        refute html =~ "Want to set up a new Organization?"
         refute html =~ "Not sure where to start?"
       end
     end


### PR DESCRIPTION
Why:

* When signing in from a client, we need to make sure that we always land on a "sign_in" page and that we also carry over any sign-in params that were passed in.  This commit updates the HomeController to make sure we always redirect properly and the tests have been updated or added to verify all client sign-ins land on a "/sign_in" page.

Fixes #13020