### PR TITLE
fix(portal): restrict redirect_to properly

### DIFF
--- a/elixir/lib/portal_web/session/redirector.ex
+++ b/elixir/lib/portal_web/session/redirector.ex
@@ -15,15 +15,14 @@ defmodule PortalWeb.Session.Redirector do
   @doc """
   Sanitizes and validates a redirect_to parameter.
 
-  Returns the redirect_to if it's valid (starts with account ID or slug),
+  Returns the redirect_to if it's valid (the first path segment is the account ID or slug),
   otherwise returns the default portal path.
   """
   def sanitize_redirect_to(account, redirect_to, actor \\ nil)
 
   def sanitize_redirect_to(%Portal.Account{} = account, redirect_to, actor)
       when is_binary(redirect_to) do
-    if String.starts_with?(redirect_to, "/#{account.id}") or
-         String.starts_with?(redirect_to, "/#{account.slug}") do
+    if account_scoped_path?(redirect_to, account) do
       redirect_to
     else
       default_portal_path(account, actor)
@@ -32,6 +31,21 @@ defmodule PortalWeb.Session.Redirector do
 
   def sanitize_redirect_to(%Portal.Account{} = account, _redirect_to, actor) do
     default_portal_path(account, actor)
+  end
+
+  defp account_scoped_path?(redirect_to, account) do
+    case URI.parse(redirect_to) do
+      %URI{scheme: nil, host: nil, path: "/" <> rest} ->
+        first_segment =
+          rest
+          |> String.split("/", parts: 2)
+          |> hd()
+
+        first_segment in [account.id, account.slug]
+
+      _ ->
+        false
+    end
   end
 
   @doc """

--- a/elixir/test/portal_web/controllers/userpass_controller_test.exs
+++ b/elixir/test/portal_web/controllers/userpass_controller_test.exs
@@ -74,6 +74,75 @@ defmodule PortalWeb.UserpassControllerTest do
       assert redirected_to(conn) =~ "/sites"
     end
 
+    test "redirects to portal redirect_to when it is scoped to the signed-in account", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      actor =
+        create_actor_with_password(
+          %{type: :account_admin_user, account: account},
+          password_hash
+        )
+
+      redirect_to = ~p"/#{account}/resources"
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "redirect_to" => redirect_to
+        })
+
+      assert redirected_to(conn) == redirect_to
+    end
+
+    test "falls back when portal redirect_to is scoped to another account", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      other_account = account_fixture()
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_admin_user, account: account},
+          password_hash
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "redirect_to" => ~p"/#{other_account}/sites"
+        })
+
+      assert redirected_to(conn) == ~p"/#{account}/sites"
+    end
+
+    test "falls back when portal redirect_to only prefixes the signed-in account slug", %{
+      conn: conn,
+      account: account,
+      provider: provider,
+      password_hash: password_hash
+    } do
+      prefix_account = account_fixture(slug: "#{account.slug}_other")
+
+      actor =
+        create_actor_with_password(
+          %{type: :account_admin_user, account: account},
+          password_hash
+        )
+
+      conn =
+        post(conn, ~p"/#{account.id}/sign_in/userpass/#{provider.id}", %{
+          "userpass" => %{"idp_id" => actor.email, "secret" => @password},
+          "redirect_to" => ~p"/#{prefix_account}/sites"
+        })
+
+      assert redirected_to(conn) == ~p"/#{account}/sites"
+    end
+
     test "rejects account_user in portal context", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/session_redirector_test.exs
+++ b/elixir/test/portal_web/session_redirector_test.exs
@@ -1,0 +1,56 @@
+defmodule PortalWeb.Session.RedirectorTest do
+  use ExUnit.Case, async: true
+
+  alias PortalWeb.Session.Redirector
+
+  describe "sanitize_redirect_to/3" do
+    setup do
+      account = %Portal.Account{id: Ecto.UUID.generate(), slug: "acme"}
+      other_account = %Portal.Account{id: Ecto.UUID.generate(), slug: "other_acme"}
+
+      {:ok, account: account, other_account: other_account}
+    end
+
+    test "allows paths scoped to the account slug", %{account: account} do
+      assert Redirector.sanitize_redirect_to(account, "/acme/sites") == "/acme/sites"
+      assert Redirector.sanitize_redirect_to(account, "/acme?tab=sites") == "/acme?tab=sites"
+    end
+
+    test "allows paths scoped to the account id", %{account: account} do
+      redirect_to = "/#{account.id}/resources?site_id=123"
+
+      assert Redirector.sanitize_redirect_to(account, redirect_to) == redirect_to
+    end
+
+    test "rejects paths scoped to another account", %{
+      account: account,
+      other_account: other_account
+    } do
+      assert Redirector.sanitize_redirect_to(account, "/#{other_account.slug}/sites") ==
+               "/#{account.slug}/sites"
+
+      assert Redirector.sanitize_redirect_to(account, "/#{other_account.id}/sites") ==
+               "/#{account.slug}/sites"
+    end
+
+    test "rejects paths whose first segment only prefixes the account slug or id", %{
+      account: account
+    } do
+      assert Redirector.sanitize_redirect_to(account, "/acme_other/sites") ==
+               "/#{account.slug}/sites"
+
+      assert Redirector.sanitize_redirect_to(account, "/#{account.id}0/sites") ==
+               "/#{account.slug}/sites"
+    end
+
+    test "rejects external, protocol-relative, and malformed redirect targets", %{account: account} do
+      assert Redirector.sanitize_redirect_to(account, "https://example.com/#{account.slug}/sites") ==
+               "/#{account.slug}/sites"
+
+      assert Redirector.sanitize_redirect_to(account, "//#{account.slug}/sites") ==
+               "/#{account.slug}/sites"
+
+      assert Redirector.sanitize_redirect_to(account, "/") == "/#{account.slug}/sites"
+    end
+  end
+end


### PR DESCRIPTION
In the portal we validate the `redirect_to` parameter in attempt to ensure it only lands users at valid paths inside the account they've just authenticated to.

Unfortunately this logic was slightly flawed: by using `String.starts_with?/2` it could allow redirecting to other paths that only start with the slug of the original account.

In practice in our system today this should be impossible for two reasons:

1. We have no account slugs that are proper subsets of other account slugs
2. The redirect would fail to be authenticated for the other account

Still it's good to get this fixed in case one of the above no longer holds in the future.
