### PR TITLE
fix(apple): surface all disconnect errors to the user

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibError.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibError.swift
@@ -8,6 +8,21 @@ import Foundation
 
 public enum ConnlibError: Swift.Error {
   case sessionExpired(String, id: String = UUID().uuidString)
+  case disconnected(String, id: String = UUID().uuidString)
+
+  public enum Code: Int {
+    case sessionExpired = 0
+    case disconnected = 1
+  }
+
+  public var code: Code {
+    switch self {
+    case .sessionExpired:
+      return .sessionExpired
+    case .disconnected:
+      return .disconnected
+    }
+  }
 }
 
 extension ConnlibError: CustomNSError {
@@ -15,16 +30,11 @@ extension ConnlibError: CustomNSError {
     return "FirezoneKit.ConnlibError"
   }
 
-  public var errorCode: Int {
-    switch self {
-    case .sessionExpired:
-      return 0
-    }
-  }
+  public var errorCode: Int { code.rawValue }
 
   public var errorUserInfo: [String: Any] {
     switch self {
-    case .sessionExpired(let reason, let id):
+    case .sessionExpired(let reason, let id), .disconnected(let reason, let id):
       return [
         "reason": reason,
         "id": id,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -134,6 +134,11 @@ public class SessionNotification: NSObject, SessionNotificationProtocol {
         await signInHandler()
       }
     }
+
+    @MainActor
+    public func showDisconnectedAlertMacOS(_ message: String?) async {
+      await MacOSAlert.showDisconnectedAlert(message)
+    }
   #endif
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/SessionNotificationProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/SessionNotificationProtocol.swift
@@ -28,5 +28,8 @@ public protocol SessionNotificationProtocol: AnyObject {
   #if os(macOS)
     /// Shows a signed-out alert on macOS.
     func showSignedOutAlertMacOS(_ message: String?) async
+
+    /// Shows a disconnected alert on macOS.
+    func showDisconnectedAlertMacOS(_ message: String?) async
   #endif
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -267,6 +267,9 @@ public final class Store: ObservableObject {
     if newVPNStatus == .connected {
       beginUpdatingState()
       fetchAndCacheFirezoneId()
+      // Reset disconnect-alert dedup so failures during the next disconnect cycle aren't suppressed
+      shownAlertIds.removeAll()
+      userDefaults.removeObject(forKey: "shownAlertIds")
     } else {
       endUpdatingState()
     }
@@ -279,16 +282,20 @@ public final class Store: ObservableObject {
           try manager().session()?.fetchLastDisconnectError { error in
             if let nsError = error as NSError?,
               nsError.domain == ConnlibError.errorDomain,
-              nsError.code == 0,  // sessionExpired error code
+              let code = ConnlibError.Code(rawValue: nsError.code),
               let reason = nsError.userInfo["reason"] as? String,
               let id = nsError.userInfo["id"] as? String
             {
               // Only show the alert if we haven't shown this specific error before
               Task { @MainActor in
-                if !self.shownAlertIds.contains(id) {
+                guard !self.shownAlertIds.contains(id) else { return }
+                switch code {
+                case .sessionExpired:
                   await self.sessionNotification.showSignedOutAlertMacOS(reason)
-                  self.markAlertAsShown(id)
+                case .disconnected:
+                  await self.sessionNotification.showDisconnectedAlertMacOS(reason)
                 }
+                self.markAlertAsShown(id)
               }
             }
           }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
@@ -324,6 +324,17 @@
       let response = await show(alert)
       return response == .alertFirstButtonReturn
     }
+
+    /// Shows a disconnected alert explaining why Firezone disconnected.
+    public static func showDisconnectedAlert(_ message: String?) async {
+      let alert = NSAlert()
+      alert.messageText = "Firezone disconnected"
+      alert.informativeText = message ?? "Firezone has been disconnected."
+      alert.addButton(withTitle: "OK")
+      NSApp.activate(ignoringOtherApps: true)
+
+      _ = await show(alert)
+    }
   }
 
 #endif

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -438,19 +438,19 @@ actor Adapter {
 
     case .disconnected(let error):
       let errorMessage = error.message()
+      let isAuthenticationError = error.isAuthenticationError()
       Log.info("Received Disconnected event: \(errorMessage)")
 
-      if error.isAuthenticationError() {
-        #if os(iOS)
-          // iOS notifications should be shown from the tunnel process
+      // iOS shows the notification from the tunnel process because the UI
+      // process isn't guaranteed to be alive; macOS handles it from the UI.
+      #if os(iOS)
+        if isAuthenticationError {
           SessionNotification.showSignedOutNotificationiOS()
-        #endif
+        }
+      #endif
 
-        let sendableError = SendableError(errorMessage, isAuthenticationError: true)
-        providerCommandSender.send(.cancelWithError(sendableError))
-      } else {
-        providerCommandSender.send(.cancelWithError(nil))
-      }
+      let sendableError = SendableError(errorMessage, isAuthenticationError: isAuthenticationError)
+      providerCommandSender.send(.cancelWithError(sendableError))
 
     case .allGatewaysOffline(let resourceId):
       self.unreachableResources.append(

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -447,17 +447,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   fileprivate func handleProviderCommand(_ command: ProviderCommand) {
     switch command {
     case .cancelWithError(let sendableError):
-      if let sendableError {
-        let error: Error =
-          sendableError.isAuthenticationError
-          ? FirezoneKit.ConnlibError.sessionExpired(sendableError.message)
-          : NSError(
-            domain: "Firezone", code: 1,
-            userInfo: [NSLocalizedDescriptionKey: sendableError.message])
-        cancelTunnelWithError(error)
-      } else {
-        cancelTunnelWithError(nil)
-      }
+      let error: Error =
+        sendableError.isAuthenticationError
+        ? FirezoneKit.ConnlibError.sessionExpired(sendableError.message)
+        : FirezoneKit.ConnlibError.disconnected(sendableError.message)
+      cancelTunnelWithError(error)
 
     case .setReasserting(let value):
       reasserting = value

--- a/swift/apple/FirezoneNetworkExtension/ProviderCommand.swift
+++ b/swift/apple/FirezoneNetworkExtension/ProviderCommand.swift
@@ -6,8 +6,8 @@ import Foundation
 /// All cases and associated values are Sendable, enabling compiler-verified
 /// thread-safe communication without @unchecked Sendable.
 enum ProviderCommand: Sendable {
-  /// Cancel the tunnel with an optional error.
-  case cancelWithError(SendableError?)
+  /// Cancel the tunnel with an error.
+  case cancelWithError(SendableError)
 
   /// Set the reasserting state (network transition indicator).
   case setReasserting(Bool)

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,13 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull={13038}>
+          Surfaces non-authentication disconnect errors (e.g. failure to reach
+          the portal) to the user via a modal alert instead of silently
+          cancelling the tunnel.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.15" date={new Date("2026-04-27")}>
         <ChangeItem pull={12849}>
           Fixes an issue on macOS where the app could be silently terminated by


### PR DESCRIPTION
This change matches behavior already present on Linux and Windows clients.

Previously on macOS, only authentication errors (session expired) were propagated from the Network Extension to the UI. Other disconnect causes — such as failing to reach the portal — silently cancelled the tunnel with no indication to the user.

Adds a `disconnected` case to `ConnlibError` and a corresponding macOS alert, so users see a modal explaining why the tunnel went down. The `ProviderCommand.cancelWithError` payload is now non-optional since every cancellation carries a message.

Fixes #13036

