### PR TITLE
refactor(portal): update error pages

### DIFF
--- a/elixir/assets/css/main.css
+++ b/elixir/assets/css/main.css
@@ -43,6 +43,30 @@ html {
   background-size: 24px 24px;
 }
 
+.error-radial-fade {
+  background: radial-gradient(ellipse 60% 60% at 50% 50%, transparent 40%, var(--canvas) 100%);
+}
+
+@keyframes pulse-ring {
+  0% { opacity: 0.6; transform: scale(0.8); }
+  100% { opacity: 0; transform: scale(1.4); }
+}
+
+@keyframes pulse-ring-inner {
+  0% { opacity: 0.5; transform: scale(0.85); }
+  100% { opacity: 0; transform: scale(1.3); }
+}
+
+.pulse-ring {
+  animation: pulse-ring 2s ease-out infinite;
+  transform-origin: 110px 55px;
+}
+
+.pulse-ring-inner {
+  animation: pulse-ring-inner 2s ease-out 0.4s infinite;
+  transform-origin: 110px 55px;
+}
+
 :root {
   /* Surfaces */
   --canvas: #eef1f6;

--- a/elixir/assets/css/main.css
+++ b/elixir/assets/css/main.css
@@ -44,17 +44,33 @@ html {
 }
 
 .error-radial-fade {
-  background: radial-gradient(ellipse 60% 60% at 50% 50%, transparent 40%, var(--canvas) 100%);
+  background: radial-gradient(
+    ellipse 60% 60% at 50% 50%,
+    transparent 40%,
+    var(--canvas) 100%
+  );
 }
 
 @keyframes pulse-ring {
-  0% { opacity: 0.6; transform: scale(0.8); }
-  100% { opacity: 0; transform: scale(1.4); }
+  0% {
+    opacity: 0.6;
+    transform: scale(0.8);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.4);
+  }
 }
 
 @keyframes pulse-ring-inner {
-  0% { opacity: 0.5; transform: scale(0.85); }
-  100% { opacity: 0; transform: scale(1.3); }
+  0% {
+    opacity: 0.5;
+    transform: scale(0.85);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.3);
+  }
 }
 
 .pulse-ring {

--- a/elixir/assets/pnpm-lock.yaml
+++ b/elixir/assets/pnpm-lock.yaml
@@ -1,30 +1,33 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
-      '@fontsource-variable/roboto':
+      "@fontsource-variable/roboto":
         specifier: ^5.2.8
         version: 5.2.10
-      '@fontsource-variable/roboto-mono':
+      "@fontsource-variable/roboto-mono":
         specifier: ^5.2.8
         version: 5.2.8
 
 packages:
+  "@fontsource-variable/roboto-mono@5.2.8":
+    resolution:
+      {
+        integrity: sha512-6M2U3wGIUxYNKRrUoKls8BRRIPDA57T8J0agqwyDkiEHrLEEAqptsxcUl3eTm6tnRNEn6yEm4pCefvtnujebDA==,
+      }
 
-  '@fontsource-variable/roboto-mono@5.2.8':
-    resolution: {integrity: sha512-6M2U3wGIUxYNKRrUoKls8BRRIPDA57T8J0agqwyDkiEHrLEEAqptsxcUl3eTm6tnRNEn6yEm4pCefvtnujebDA==}
-
-  '@fontsource-variable/roboto@5.2.10':
-    resolution: {integrity: sha512-LJ0iLg6aHbLzN515gyHzmdTqJzd9NlI95cCg1DW0F5G7KkFqRLBBKBbqEJx4nSu4aby3IKmw3ZH6Fe928IfaSQ==}
+  "@fontsource-variable/roboto@5.2.10":
+    resolution:
+      {
+        integrity: sha512-LJ0iLg6aHbLzN515gyHzmdTqJzd9NlI95cCg1DW0F5G7KkFqRLBBKBbqEJx4nSu4aby3IKmw3ZH6Fe928IfaSQ==,
+      }
 
 snapshots:
+  "@fontsource-variable/roboto-mono@5.2.8": {}
 
-  '@fontsource-variable/roboto-mono@5.2.8': {}
-
-  '@fontsource-variable/roboto@5.2.10': {}
+  "@fontsource-variable/roboto@5.2.10": {}

--- a/elixir/lib/portal_web/controllers/error_html/404.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/404.html.heex
@@ -32,16 +32,119 @@
     >
     </script>
   </head>
-  <body class="bg-neutral-50">
-    <div class="flex items-center h-screen p-16 bg-gray-50">
-      <div class="container mx-auto flex flex-col items-center">
-        <div class="flex flex-col gap-6 max-w-md text-center">
-          <img src={~p"/images/logo.svg"} class="mr-5 h-32" alt="Firezone Logo" />
-          <h2 class="font-extrabold text-9xl text-primary-600">
-            <span class="sr-only">Error</span>404
-          </h2>
-          <p class="text-2xl md:text-3xl">Sorry, we couldn't find this page.</p>
+  <body class="bg-[var(--canvas)]">
+    <div class="relative flex items-center justify-center h-screen overflow-hidden">
+      <div class="absolute inset-0 dot-grid opacity-60 pointer-events-none"></div>
+      <div class="absolute inset-0 pointer-events-none error-radial-fade"></div>
+      <div class="relative flex flex-col items-center text-center max-w-md px-6">
+        <div class="mb-10">
+          <img src={~p"/images/logo-text.svg"} alt="Firezone" class="h-8" />
         </div>
+        <div class="relative flex items-center justify-center mb-8">
+          <span class="text-[220px] font-black leading-none tracking-tighter select-none opacity-[0.05] text-[var(--text-primary)]">
+            404
+          </span>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <svg
+              width="220"
+              height="110"
+              viewBox="0 0 220 110"
+              fill="none"
+              class="overflow-visible"
+            >
+              <line
+                x1="30"
+                y1="55"
+                x2="80"
+                y2="30"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <line
+                x1="30"
+                y1="55"
+                x2="80"
+                y2="80"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <line
+                x1="80"
+                y1="30"
+                x2="110"
+                y2="55"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <line
+                x1="80"
+                y1="80"
+                x2="110"
+                y2="55"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <line
+                x1="110"
+                y1="55"
+                x2="155"
+                y2="55"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+                stroke-dasharray="5 4"
+              />
+              <circle
+                cx="30"
+                cy="55"
+                r="8"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="30" cy="55" r="3" fill="var(--text-secondary)" />
+              <circle
+                cx="80"
+                cy="30"
+                r="8"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="80" cy="30" r="3" fill="var(--text-secondary)" />
+              <circle
+                cx="80"
+                cy="80"
+                r="8"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="80" cy="80" r="3" fill="var(--text-secondary)" />
+              <circle
+                cx="110"
+                cy="55"
+                r="10"
+                fill="var(--surface-raised)"
+                stroke="var(--brand)"
+                stroke-width="2"
+              />
+              <circle cx="110" cy="55" r="4" fill="var(--brand)" />
+              <circle
+                cx="175"
+                cy="55"
+                r="10"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+                stroke-dasharray="3 3"
+              />
+            </svg>
+          </div>
+        </div>
+        <h1 class="text-lg font-semibold text-[var(--text-primary)] mb-2">Page not found</h1>
+        <p class="text-sm text-[var(--text-secondary)] leading-relaxed mb-8">
+          This route doesn't exist or has been moved. Double-check the URL or head back somewhere familiar.
+        </p>
       </div>
     </div>
   </body>

--- a/elixir/lib/portal_web/controllers/error_html/404.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/404.html.heex
@@ -50,6 +50,8 @@
               height="110"
               viewBox="0 0 220 110"
               fill="none"
+              aria-hidden="true"
+              focusable="false"
               class="overflow-visible"
             >
               <line

--- a/elixir/lib/portal_web/controllers/error_html/500.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/500.html.heex
@@ -51,6 +51,8 @@
               viewBox="0 0 220 110"
               fill="none"
               class="overflow-visible"
+              aria-hidden="true"
+              focusable="false"
             >
               <line
                 x1="110"
@@ -167,6 +169,14 @@
         <p class="text-sm text-[var(--text-secondary)] leading-relaxed mb-8">
           An unexpected error occurred on our end. Try reloading — if the problem persists, contact support.
         </p>
+        <a
+          href="https://firezone.statuspage.io"
+          target="_blank"
+          class="mt-6 flex items-center gap-1 text-xs text-[var(--brand)] hover:underline transition-colors"
+        >
+          Check platform status
+          <span class="ri-external-link-line w-3 h-3" />
+        </a>
       </div>
     </div>
   </body>

--- a/elixir/lib/portal_web/controllers/error_html/500.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/500.html.heex
@@ -32,28 +32,141 @@
     >
     </script>
   </head>
-  <body class="bg-neutral-50">
-    <div class="flex items-center h-screen p-16 bg-gray-50">
-      <div class="container mx-auto flex flex-col items-center">
-        <div class="flex flex-col gap-6 max-w-md text-center">
-          <img src={~p"/images/logo.svg"} class="mr-5 h-32" alt="Firezone Logo" />
-          <h2 class="font-extrabold text-9xl text-primary-600">
-            <span class="sr-only">Error</span>500
-          </h2>
-
-          <p class="text-2xl md:text-3xl">
-            Something went wrong. We've already been notified and will get it fixed as soon as possible.
-          </p>
-          <p class="mt-8 text-base">
-            <a
-              target="_blank"
-              href="https://firezone.statuspage.io"
-              class="text-accent-500 hover:underline"
-            >
-              Firezone platform status
-            </a>
-          </p>
+  <body class="bg-[var(--canvas)]">
+    <div class="relative flex items-center justify-center h-screen overflow-hidden">
+      <div class="absolute inset-0 dot-grid opacity-60 pointer-events-none"></div>
+      <div class="absolute inset-0 pointer-events-none error-radial-fade"></div>
+      <div class="relative flex flex-col items-center text-center max-w-md px-6">
+        <div class="mb-10">
+          <img src={~p"/images/logo-text.svg"} alt="Firezone" class="h-8" />
         </div>
+        <div class="relative flex items-center justify-center mb-8">
+          <span class="text-[220px] font-black leading-none tracking-tighter select-none opacity-[0.05] text-[var(--text-primary)]">
+            500
+          </span>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <svg
+              width="220"
+              height="110"
+              viewBox="0 0 220 110"
+              fill="none"
+              class="overflow-visible"
+            >
+              <line
+                x1="110"
+                y1="55"
+                x2="55"
+                y2="25"
+                stroke="var(--status-error)"
+                stroke-width="1.5"
+                stroke-dasharray="4 3"
+              />
+              <line
+                x1="110"
+                y1="55"
+                x2="165"
+                y2="25"
+                stroke="var(--status-error)"
+                stroke-width="1.5"
+                stroke-dasharray="4 3"
+              />
+              <line
+                x1="110"
+                y1="55"
+                x2="55"
+                y2="85"
+                stroke="var(--status-error)"
+                stroke-width="1.5"
+                stroke-dasharray="4 3"
+              />
+              <line
+                x1="110"
+                y1="55"
+                x2="165"
+                y2="85"
+                stroke="var(--status-error)"
+                stroke-width="1.5"
+                stroke-dasharray="4 3"
+              />
+              <circle
+                cx="55"
+                cy="25"
+                r="7"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="55" cy="25" r="2.5" fill="var(--text-secondary)" />
+              <circle
+                cx="165"
+                cy="25"
+                r="7"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="165" cy="25" r="2.5" fill="var(--text-secondary)" />
+              <circle
+                cx="55"
+                cy="85"
+                r="7"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="55" cy="85" r="2.5" fill="var(--text-secondary)" />
+              <circle
+                cx="165"
+                cy="85"
+                r="7"
+                fill="var(--surface-raised)"
+                stroke="var(--text-tertiary)"
+                stroke-width="1.5"
+              />
+              <circle cx="165" cy="85" r="2.5" fill="var(--text-secondary)" />
+              <circle
+                cx="110"
+                cy="55"
+                r="28"
+                stroke="var(--status-error)"
+                stroke-width="1"
+                fill="none"
+                class="pulse-ring"
+                opacity="0"
+              />
+              <circle
+                cx="110"
+                cy="55"
+                r="20"
+                stroke="var(--status-error)"
+                stroke-width="1"
+                fill="none"
+                class="pulse-ring-inner"
+                opacity="0"
+              />
+              <circle
+                cx="110"
+                cy="55"
+                r="14"
+                fill="var(--status-error-bg)"
+                stroke="var(--status-error)"
+                stroke-width="1.5"
+              />
+              <path
+                d="M105 50l10 10M115 50l-10 10"
+                stroke="var(--status-error)"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
+            </svg>
+          </div>
+        </div>
+        <h1 class="text-lg font-semibold text-[var(--text-primary)] mb-2">
+          Something went wrong
+        </h1>
+        <p class="text-sm text-[var(--text-secondary)] leading-relaxed mb-8">
+          An unexpected error occurred on our end. Try reloading — if the problem persists, contact support.
+        </p>
       </div>
     </div>
   </body>

--- a/elixir/lib/portal_web/controllers/error_html/500.html.heex
+++ b/elixir/lib/portal_web/controllers/error_html/500.html.heex
@@ -174,8 +174,7 @@
           target="_blank"
           class="mt-6 flex items-center gap-1 text-xs text-[var(--brand)] hover:underline transition-colors"
         >
-          Check platform status
-          <span class="ri-external-link-line w-3 h-3" />
+          Check platform status <span class="ri-external-link-line w-3 h-3" />
         </a>
       </div>
     </div>

--- a/elixir/lib/portal_web/plugs/fetch_account.ex
+++ b/elixir/lib/portal_web/plugs/fetch_account.ex
@@ -1,7 +1,10 @@
 defmodule PortalWeb.Plugs.FetchAccount do
   @behaviour Plug
 
+  use PortalWeb, :verified_routes
+
   import Plug.Conn
+  import Phoenix.Controller, only: [redirect: 2]
   alias __MODULE__.Database
 
   @impl true
@@ -10,12 +13,36 @@ defmodule PortalWeb.Plugs.FetchAccount do
   @impl true
   def call(%Plug.Conn{path_info: [account_id_or_slug | _rest]} = conn, _opts) do
     case Database.get_account_by_id_or_slug(account_id_or_slug) do
-      nil -> conn
       %Portal.Account{} = account -> assign(conn, :account, account)
+      nil -> handle_missing_account(conn)
     end
   end
 
   def call(conn, _opts), do: conn
+
+  defp handle_missing_account(conn) do
+    case missing_client_sign_in_redirect(conn) do
+      {:redirect, conn} -> conn
+      :noop -> conn
+    end
+  end
+
+  defp missing_client_sign_in_redirect(
+         %{path_info: [_account_id_or_slug, "sign_in" | _rest], params: params} = conn
+       ) do
+    sign_in_params = PortalWeb.Authentication.take_sign_in_params(params)
+
+    if PortalWeb.Authentication.client_sign_in?(sign_in_params) do
+      {:redirect,
+       conn
+       |> redirect(to: ~p"/sign_in?#{sign_in_params}")
+       |> halt()}
+    else
+      :noop
+    end
+  end
+
+  defp missing_client_sign_in_redirect(_conn), do: :noop
 
   defmodule Database do
     import Ecto.Query

--- a/elixir/test/portal_web/controllers/error_html_test.exs
+++ b/elixir/test/portal_web/controllers/error_html_test.exs
@@ -7,7 +7,7 @@ defmodule PortalWeb.ErrorHTMLTest do
         get(conn, ~p"/error/404")
       end
 
-    assert body =~ "Sorry, we couldn't find this page"
+    assert body =~ "Page not found"
   end
 
   test "renders 500.html", %{conn: conn} do
@@ -17,12 +17,12 @@ defmodule PortalWeb.ErrorHTMLTest do
       end
 
     assert body =~ "Something went wrong"
-    assert body =~ "We've already been notified and will get it fixed as soon as possible"
+    assert body =~ "An unexpected error occurred on our end"
   end
 
   test "renders 404.html without csp_nonce", %{conn: conn} do
     html = Phoenix.Template.render_to_string(PortalWeb.ErrorHTML, "404", "html", conn: conn)
-    assert html =~ "Sorry, we couldn't find this page"
+    assert html =~ "Page not found"
   end
 
   test "renders 500.html without csp_nonce", %{conn: conn} do

--- a/elixir/test/portal_web/live/sign_in_test.exs
+++ b/elixir/test/portal_web/live/sign_in_test.exs
@@ -4,6 +4,8 @@ defmodule PortalWeb.SignInTest do
   import Portal.AccountFixtures
   import Portal.AuthProviderFixtures
 
+  @client_sign_in_types ["client", "gui-client", "headless-client"]
+
   setup do
     account = account_fixture()
     %{account: account}
@@ -30,6 +32,20 @@ defmodule PortalWeb.SignInTest do
       {:ok, _lv, html} = live(conn, ~p"/#{account}/sign_in")
 
       refute html =~ "Send code"
+    end
+
+    test "redirects missing client account slug to root /sign_in with params preserved", %{conn: conn} do
+      for client <- @client_sign_in_types do
+        params = %{
+          "as" => client,
+          "state" => "abc",
+          "nonce" => "xyz",
+          "redirect_to" => "/sites"
+        }
+
+        conn = get(conn, ~p"/nonexistent-account/sign_in?#{params}")
+        assert redirected_to(conn) == ~p"/sign_in?#{params}"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR updates the 404/500 error page styling to better match the new UI redesign.

It also updates a small bit of functionality.  When a client is attempting to sign in with a non-existent account slug/id they will be redirected to the root sign in page (i.e. `/sign_in`) , rather than being shown a 404 page.

Fixes: #13022

### New 404 page
<img width="783" height="904" alt="Screenshot 2026-05-01 at 1 49 51 AM" src="https://github.com/user-attachments/assets/36658cb4-effa-46a4-9ba5-7819cfa75967" />

### New 500 page
<img width="661" height="953" alt="Screenshot 2026-05-01 at 2 25 12 AM" src="https://github.com/user-attachments/assets/2f55a0f6-331e-40d0-98d8-9395330e01eb" />
