### PR TITLE
fix(portal): update client version badge logic

### DIFF
--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -149,7 +149,7 @@ defmodule PortalWeb.Clients.Components do
 
   def version(assigns) do
     assigns =
-      assign(assigns, outdated?: not is_nil(assigns.latest) and assigns.current != assigns.latest)
+      assign(assigns, outdated?: outdated_version?(assigns.current, assigns.latest))
 
     ~H"""
     <.popover>
@@ -185,6 +185,17 @@ defmodule PortalWeb.Clients.Components do
     </.popover>
     """
   end
+
+  defp outdated_version?(current, latest) when is_binary(current) and is_binary(latest) do
+    with {:ok, current_version} <- Version.parse(current),
+         {:ok, latest_version} <- Version.parse(latest) do
+      Version.compare(current_version, latest_version) == :lt
+    else
+      :error -> false
+    end
+  end
+
+  defp outdated_version?(_, _), do: false
 
   attr :account, :any, required: true
   attr :client, :any, required: true

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -182,6 +182,35 @@ defmodule PortalWeb.ClientsTest do
       assert_patch(lv, ~p"/#{account}/clients")
     end
 
+    test "marks only older client versions as outdated" do
+      older_html =
+        render_component(&PortalWeb.Clients.Components.version/1,
+          current: "0.9.0",
+          latest: "1.0.0"
+        )
+
+      assert older_html =~ "A newer version"
+      assert older_html =~ "1.0.0"
+
+      latest_html =
+        render_component(&PortalWeb.Clients.Components.version/1,
+          current: "1.0.0",
+          latest: "1.0.0"
+        )
+
+      assert latest_html =~ "This component is up to date."
+      refute latest_html =~ "A newer version"
+
+      newer_html =
+        render_component(&PortalWeb.Clients.Components.version/1,
+          current: "1.0.1",
+          latest: "1.0.0"
+        )
+
+      assert newer_html =~ "This component is up to date."
+      refute newer_html =~ "A newer version"
+    end
+
     test "shows delete confirmation, cancels it, then deletes client", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
Why:

* Previously, if a client version was recorded in the portal that was ahead of the latest published version, the portal would show the client as needing to be upgraded and show a tooltip for the badge saying the client should "upgrade" to a lower version.  This commit updates the logic for that version badge to make sure that it only shows if the version is less than the current published version.

Fixes: #12991