### PR TITLE
fix(portal): restore device pool poc

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -762,6 +762,50 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
+  # !!! TODO: REMOVE ONCE THE FULL DEVICE POOLS FEATURE HAS SHIPPED !!!
+  # Restored to keep a PoC customer working until clients migrate to the
+  # `create_flow` path for static_device_pool resources. Delete this handler
+  # and `legacy_authorize_device_access/2` below as part of that cleanup.
+  def handle_in("request_device_access", %{"ipv4" => ipv4_string}, socket) do
+    account_id = socket.assigns.client.account_id
+
+    with true <- client_to_client_enabled?(socket.assigns.subject.account),
+         {:ok, {:ipv4, ipv4_tuple} = target} <-
+           parse_target_address(%{"ipv4" => ipv4_string}),
+         :ok <- legacy_authorize_device_access(socket.assigns.cache, ipv4_tuple),
+         {:ok, target_client_id, target_meta} <-
+           find_online_client_by_address(account_id, target) do
+      send_client_device_access_authorized(target_client_id, target_meta, socket)
+      {:noreply, socket}
+    else
+      false ->
+        push(socket, "client_device_access_denied", %{
+          ipv4: ipv4_string,
+          reason: :disabled
+        })
+
+        {:noreply, socket}
+
+      {:error, :invalid_address} ->
+        Logger.warning("Invalid IPv4 address provided for device access request",
+          client_id: socket.assigns.client.id,
+          account_id: socket.assigns.client.account_id,
+          account_slug: socket.assigns.subject.account.slug,
+          ipv4: ipv4_string
+        )
+
+        {:noreply, socket}
+
+      :offline ->
+        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :offline})
+        {:noreply, socket}
+
+      {:error, :forbidden} ->
+        push(socket, "client_device_access_denied", %{ipv4: ipv4_string, reason: :forbidden})
+        {:noreply, socket}
+    end
+  end
+
   # The client pushes it's ICE candidates list and the list of gateways that need to receive it
   def handle_in(
         "broadcast_ice_candidates",
@@ -818,6 +862,14 @@ defmodule PortalAPI.Client.Channel do
   end
 
   defp client_to_client_enabled?(account), do: Database.client_to_client_enabled?(account)
+
+  # !!! TODO: REMOVE ONCE THE FULL DEVICE POOLS FEATURE HAS SHIPPED !!!
+  # Used only by the legacy `request_device_access` handler. Delete alongside it.
+  defp legacy_authorize_device_access(cache, {_, _, _, _} = ipv4_tuple) do
+    if Enum.any?(cache.device_addresses, fn {_, {v4, _v6}} -> v4 == ipv4_tuple end),
+      do: :ok,
+      else: {:error, :forbidden}
+  end
 
   defp parse_target_address(%{"ipv4" => ipv4, "ipv6" => ipv6})
        when is_binary(ipv4) and is_binary(ipv6),

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5312,6 +5312,131 @@ defmodule PortalAPI.Client.ChannelTest do
     end
   end
 
+  # !!! TODO: REMOVE ONCE THE FULL DEVICE POOLS FEATURE HAS SHIPPED !!!
+  # Covers the legacy `request_device_access` handler kept around for a PoC
+  # customer. Delete this whole describe block alongside the handler.
+  describe "handle_in/3 request_device_access (legacy)" do
+    setup %{account: account, group: group, subject: subject} do
+      enable_feature(:client_to_client)
+
+      subject = put_user_agent(subject, "Mac OS/14 apple-client/1.5.16")
+
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
+
+      target_subject =
+        subject_fixture(
+          account: account,
+          actor: target_actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      pool_resource =
+        static_device_pool_resource_fixture(account: account, clients: [target_client])
+
+      policy_fixture(account: account, group: group, resource: pool_resource)
+
+      %{
+        subject: subject,
+        target_client: target_client,
+        target_subject: target_subject
+      }
+    end
+
+    test "sends authorized to both clients when target ipv4 is found in presence", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      target_client_id = target_client.id
+      initiating_client_id = client.id
+
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_authorized", %{
+        client_id: ^target_client_id,
+        ice_role: :controlling
+      }
+
+      assert_push "client_device_access_authorized", %{
+        client_id: ^initiating_client_id,
+        ice_role: :controlled
+      }
+    end
+
+    test "sends denied with :offline when target is in pool but not online", %{
+      client: client,
+      subject: subject,
+      target_client: target_client
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :offline}
+    end
+
+    test "sends denied with :forbidden when target ipv4 is not in any pool", %{
+      account: account,
+      client: client,
+      subject: subject
+    } do
+      other_actor = actor_fixture(account: account)
+      other_client = client_fixture(account: account, actor: other_actor) |> fetch_device!()
+
+      other_subject =
+        subject_fixture(
+          account: account,
+          actor: other_actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(other_client, other_subject)
+      assert_push "init", _
+
+      other_ip = Portal.Types.INET.to_string(other_client.ipv4)
+
+      push(initiating_socket, "request_device_access", %{"ipv4" => other_ip})
+
+      assert_push "client_device_access_denied", %{ipv4: ^other_ip, reason: :forbidden}
+    end
+
+    test "sends denied with :disabled when account feature is off", %{
+      account: account,
+      client: client,
+      subject: subject,
+      target_client: target_client
+    } do
+      account = update_account(account, %{features: %{client_to_client: false}})
+      subject = %{subject | account: account}
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :disabled}
+    end
+  end
+
   describe "handle_in/3 resolve_device_pool_domain" do
     setup %{account: account, group: group, subject: subject} do
       subject = put_user_agent(subject, "Mac OS/14 apple-client/1.5.16")


### PR DESCRIPTION
In #13010 we changed the prototype API we had for device pools to remove the `request_device_access` message. This breaks the proof of concept that is live with customers since we won't have the remainder of the implementation shipped until the next client release.

To prevent breaking this for them, it's critical that we get this PR in before the next production deploy.

--- 

Fixes #13048 