### PR TITLE
fix(portal): client-client filters and authzs

### DIFF
--- a/elixir/lib/portal/cache/client.ex
+++ b/elixir/lib/portal/cache/client.ex
@@ -133,7 +133,8 @@ defmodule Portal.Cache.Client do
           Ecto.UUID.t(),
           Authentication.Subject.t()
         ) ::
-          {:ok, Cache.Cacheable.Resource.t(), Ecto.UUID.t(), Ecto.UUID.t(), non_neg_integer()}
+          {:ok, Cache.Cacheable.Resource.t(), Ecto.UUID.t() | nil, Ecto.UUID.t(),
+           DateTime.t() | nil}
           | {:error, :not_found}
           | {:error, {:forbidden, violated_properties: [atom()]}}
 
@@ -220,12 +221,6 @@ defmodule Portal.Cache.Client do
   @spec track_authorized_device_ipv4(t(), Postgrex.INET.t()) :: t()
   def track_authorized_device_ipv4(cache, %Postgrex.INET{address: ipv4_tuple}) do
     %{cache | authorized_device_ipv4s: MapSet.put(cache.authorized_device_ipv4s, ipv4_tuple)}
-  end
-
-  @spec device_ipv4_relevant?(t(), ipv4_tuple()) :: boolean()
-  def device_ipv4_relevant?(cache, {_, _, _, _} = ipv4) do
-    MapSet.member?(cache.authorized_device_ipv4s, ipv4) or
-      Enum.any?(cache.device_addresses, fn {_, {v4, _v6}} -> v4 == ipv4 end)
   end
 
   @doc """
@@ -1061,16 +1056,6 @@ defmodule Portal.Cache.Client do
 
     def preload_site(resource) do
       Safe.preload(resource, :site, :replica)
-    end
-
-    def get_site(nil, _subject), do: nil
-
-    def get_site(%Portal.Cache.Cacheable.Site{} = site, subject) do
-      id = Ecto.UUID.load!(site.id)
-
-      from(s in Portal.Site, where: s.id == ^id)
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one()
     end
 
     def get_site_by_id(site_id, subject) when is_binary(site_id) do

--- a/elixir/lib/portal/cache/client/authorizations.ex
+++ b/elixir/lib/portal/cache/client/authorizations.ex
@@ -1,32 +1,22 @@
-defmodule Portal.Cache.Gateway do
+defmodule Portal.Cache.Client.Authorizations do
   @moduledoc """
-    This cache is used in the gateway channel processes to maintain a materialized view of the gateway policy_authorization state.
-    The cache is updated via WAL messages streamed from the Portal.Changes.ReplicationConnection module.
-
-    We use basic data structures and binary representations instead of full Ecto schema structs
-    to minimize memory usage. The rough structure of the two cached data structures and some napkin math
-    on their memory usage (assuming "worst-case" usage scenarios) is described below.
+    This cache is used in the client channel processes to maintain a materialized view of inbound
+    policy_authorizations — entries where the channel's client is the `receiving_device_id` of a
+    policy_authorization. It mirrors `Portal.Cache.Gateway` for client-to-client device pool flows.
 
     Data structure:
 
-      %{{client_id:uuidv4:16, resource_id:uuidv4:16}:16 => %{policy_authorization_id:uuidv4:16 => expires_at:integer:8}:40}:(num_keys * 1.8 * 8 - large map)
+      %{{client_id:uuidv4:16, resource_id:uuidv4:16}:16 => %{policy_authorization_id:uuidv4:16 => expires_at:integer:8}:40}
 
-    For 10,000 client/resource entries, consisting of 10 policy_authorizations each:
-
-      10,000 keys, 100,000 values
-      480,000 bytes (outer map keys), 6,400,000 bytes (inner map), 144,000 bytes (outer map overhead)
-
-    = 7,024,000
-    = ~ 7 MB
+    Memory characteristics match `Portal.Cache.Gateway` since the structure is identical.
   """
 
-  alias Portal.{Cache, Device}
+  alias Portal.{Cache, Device, PolicyAuthorization}
   alias __MODULE__.Database
   import Ecto.UUID, only: [dump!: 1, load!: 1]
 
   require OpenTelemetry.Tracer
 
-  # Type definitions
   @type client_resource_key ::
           {client_id :: Cache.Cacheable.uuid_binary(),
            resource_id :: Cache.Cacheable.uuid_binary()}
@@ -40,13 +30,13 @@ defmodule Portal.Cache.Gateway do
     Fetches relevant policy_authorizations from the DB and transforms them into the cache format.
   """
   @spec hydrate(Device.t()) :: t()
-  def hydrate(gateway) do
-    OpenTelemetry.Tracer.with_span "Portal.Cache.hydrate_policy_authorizations",
+  def hydrate(client) do
+    OpenTelemetry.Tracer.with_span "Portal.Cache.Client.Authorizations.hydrate",
       attributes: %{
-        gateway_id: gateway.id,
-        account_id: gateway.account_id
+        client_id: client.id,
+        account_id: client.account_id
       } do
-      Database.all_gateway_policy_authorizations_for_cache!(gateway)
+      Database.all_client_policy_authorizations_for_cache!(client)
       |> Enum.reduce(%{}, fn {{client_id, resource_id}, {policy_authorization_id, expires_at}},
                              acc ->
         cid_bytes = dump!(client_id)
@@ -72,11 +62,9 @@ defmodule Portal.Cache.Gateway do
   def prune(cache) do
     now_unix = DateTime.utc_now() |> DateTime.to_unix(:second)
 
-    # 1. Remove individual policy_authorizations older than 14 days, then remove access entry if no
-    # policy_authorizations left
     for {tuple, policy_authorization_id_map} <- cache,
         filtered =
-          Map.reject(policy_authorization_id_map, fn {_fid_bytes, expires_at_unix} ->
+          Map.reject(policy_authorization_id_map, fn {_paid_bytes, expires_at_unix} ->
             expires_at_unix < now_unix
           end),
         map_size(filtered) > 0,
@@ -86,30 +74,11 @@ defmodule Portal.Cache.Gateway do
   end
 
   @doc """
-    Fetches the max expiration for a client-resource from the cache, or nil if not found.
-  """
-  @spec get(t(), Ecto.UUID.t(), Ecto.UUID.t()) :: non_neg_integer() | nil
-  def get(cache, client_id, resource_id) do
-    tuple = {dump!(client_id), dump!(resource_id)}
-
-    case Map.get(cache, tuple) do
-      nil ->
-        nil
-
-      policy_authorization_id_map ->
-        # Use longest expiration to minimize unnecessary access churn
-        policy_authorization_id_map
-        |> Map.values()
-        |> Enum.max()
-    end
-  end
-
-  @doc """
     Add a policy_authorization to the cache. Returns the updated cache.
   """
-  @spec put(t(), Ecto.UUID.t(), Cache.Cacheable.uuid_binary(), Ecto.UUID.t(), DateTime.t()) :: t()
-  def put(%{} = cache, client_id, rid_bytes, policy_authorization_id, %DateTime{} = expires_at) do
-    tuple = {dump!(client_id), rid_bytes}
+  @spec put(t(), Ecto.UUID.t(), Ecto.UUID.t(), Ecto.UUID.t(), DateTime.t()) :: t()
+  def put(%{} = cache, client_id, resource_id, policy_authorization_id, %DateTime{} = expires_at) do
+    tuple = {dump!(client_id), dump!(resource_id)}
 
     policy_authorization_id_map =
       Map.get(cache, tuple, %{})
@@ -119,17 +88,17 @@ defmodule Portal.Cache.Gateway do
   end
 
   @doc """
-    Delete a policy_authorization from the cache. If another policy_authorization exists for the same client/resource,
-    we return the max expiration for that resource.
-    If not, we optimistically try to reauthorize access by creating a new policy_authorization. This prevents
-    removal of access on the Gateway but not the client, which would cause connectivity issues.
-    If we can't create a new authorization, we send unauthorized so that access is removed.
+    Delete a policy_authorization from the cache. If another policy_authorization exists for the same
+    {initiating_client, resource} pair, return its max expiration. Otherwise, optimistically try to
+    create a replacement policy_authorization so a transient policy churn doesn't tear down an
+    active client-to-client tunnel. If reauthorization fails, return `:unauthorized` so the channel
+    can push `client_device_access_denied`.
   """
-  @spec reauthorize_deleted_policy_authorization(t(), Portal.PolicyAuthorization.t()) ::
+  @spec reauthorize_deleted_policy_authorization(t(), PolicyAuthorization.t()) ::
           {:ok, non_neg_integer(), t()} | {:error, :unauthorized, t()} | {:error, :not_found}
   def reauthorize_deleted_policy_authorization(
         cache,
-        %Portal.PolicyAuthorization{} = policy_authorization
+        %PolicyAuthorization{} = policy_authorization
       ) do
     key = policy_authorization_key(policy_authorization)
     policy_authorization_id = dump!(policy_authorization.id)
@@ -147,7 +116,31 @@ defmodule Portal.Cache.Gateway do
     end
   end
 
-  defp policy_authorization_key(%Portal.PolicyAuthorization{
+  @doc """
+    Check if the cache has a resource entry for the given resource_id.
+  """
+  @spec has_resource?(t(), Ecto.UUID.t()) :: boolean()
+  def has_resource?(%{} = cache, resource_id) do
+    rid_bytes = dump!(resource_id)
+
+    cache
+    |> Map.keys()
+    |> Enum.any?(fn {_, rid} -> rid == rid_bytes end)
+  end
+
+  @doc """
+    Return a list of all `{client_id, resource_id}` pairs matching the given resource ID.
+  """
+  @spec all_pairs_for_resource(t(), Ecto.UUID.t()) :: [{Ecto.UUID.t(), Ecto.UUID.t()}]
+  def all_pairs_for_resource(%{} = cache, resource_id) do
+    rid_bytes = dump!(resource_id)
+
+    cache
+    |> Enum.filter(fn {{_, rid}, _} -> rid == rid_bytes end)
+    |> Enum.map(fn {{cid, _}, _} -> {load!(cid), resource_id} end)
+  end
+
+  defp policy_authorization_key(%PolicyAuthorization{
          initiating_device_id: client_id,
          resource_id: resource_id
        }) do
@@ -192,84 +185,33 @@ defmodule Portal.Cache.Gateway do
     end
   end
 
-  @doc """
-    Check if the cache has a resource entry for the given resource_id.
-    Returns true if the resource is present, false otherwise.
-  """
-  @spec has_resource?(t(), Ecto.UUID.t()) :: boolean()
-  def has_resource?(%{} = cache, resource_id) do
-    rid_bytes = dump!(resource_id)
-
-    cache
-    |> Map.keys()
-    |> Enum.any?(fn {_, rid} ->
-      rid == rid_bytes
-    end)
-  end
-
-  @doc """
-    Return a list of all pairs matching the resource ID.
-  """
-  @spec all_pairs_for_resource(t(), Ecto.UUID.t()) :: [{Ecto.UUID.t(), Ecto.UUID.t()}]
-  def all_pairs_for_resource(%{} = cache, resource_id) do
-    rid_bytes = dump!(resource_id)
-
-    cache
-    |> Enum.filter(fn {{_, rid}, _} -> rid == rid_bytes end)
-    |> Enum.map(fn {{cid, _}, _} -> {load!(cid), resource_id} end)
-  end
-
-  # Inline functions from Portal.PolicyAuthorizations - moved to DB module
-
   defmodule Database do
     alias Portal.Cache.Reauth
     alias Portal.Safe
     import Ecto.Query
     require Logger
 
-    def all_gateway_policy_authorizations_for_cache!(%{account_id: _, id: _} = gateway) do
+    def all_client_policy_authorizations_for_cache!(%{account_id: _, id: _} = client) do
       now = DateTime.utc_now()
 
-      from(f in Portal.PolicyAuthorization, as: :policy_authorizations)
-      |> where([policy_authorizations: f], f.account_id == ^gateway.account_id)
-      |> where([policy_authorizations: f], f.receiving_device_id == ^gateway.id)
-      |> where([policy_authorizations: f], f.expires_at > ^now)
+      from(pa in Portal.PolicyAuthorization, as: :policy_authorizations)
+      |> where([policy_authorizations: pa], pa.account_id == ^client.account_id)
+      |> where([policy_authorizations: pa], pa.receiving_device_id == ^client.id)
+      |> where([policy_authorizations: pa], pa.expires_at > ^now)
       |> select(
-        [policy_authorizations: f],
-        {{f.initiating_device_id, f.resource_id}, {f.id, f.expires_at}}
+        [policy_authorizations: pa],
+        {{pa.initiating_device_id, pa.resource_id}, {pa.id, pa.expires_at}}
       )
       |> Safe.unscoped(:replica)
       |> Safe.all()
     end
 
-    def fetch_gateway_by_id(account_id, id) do
-      result =
-        from(g in Portal.Device, as: :gateways)
-        |> where([gateways: g], g.type == :gateway)
-        |> where([gateways: g], g.account_id == ^account_id and g.id == ^id)
-        |> Safe.unscoped(:replica)
-        |> Safe.one()
-
-      if result do
-        {:ok, result}
-      else
-        {:error, :not_found}
-      end
-    end
-
-    def all_policies_in_site_for_resource_id_and_actor_id!(
-          account_id,
-          site_id,
-          resource_id,
-          actor_id
-        ) do
+    def all_policies_for_resource_id_and_actor_id!(account_id, resource_id, actor_id) do
       from(p in Portal.Policy, as: :policies)
       |> where([policies: p], is_nil(p.disabled_at))
       |> where([policies: p], p.account_id == ^account_id)
       |> where([policies: p], p.resource_id == ^resource_id)
       |> join(:inner, [policies: p], ag in assoc(p, :group), as: :group)
-      |> join(:inner, [policies: p], r in assoc(p, :resource), as: :resource)
-      |> where([resource: r], r.site_id == ^site_id)
       |> join(:inner, [], actor in Portal.Actor,
         on: actor.id == ^actor_id and actor.account_id == ^account_id,
         as: :actor
@@ -283,7 +225,6 @@ defmodule Portal.Cache.Gateway do
              ag.name == "Everyone" and
              ag.account_id == a.account_id)
       )
-      |> preload(resource: :site)
       |> Safe.unscoped(:replica)
       |> Safe.all()
     end
@@ -304,17 +245,11 @@ defmodule Portal.Cache.Gateway do
                policy_authorization.account_id,
                policy_authorization.token_id
              ),
-           {:ok, gateway} <-
-             fetch_gateway_by_id(
-               policy_authorization.account_id,
-               policy_authorization.receiving_device_id
-             ),
-           # We only want to reauthorize the resource for this gateway if the resource is still connected to its
-           # site.
+           # Client-to-client flows always target static_device_pool resources, which carry
+           # no site, so we drop the gateway flow's site filter when looking for replacements.
            policies when policies != [] <-
-             all_policies_in_site_for_resource_id_and_actor_id!(
+             all_policies_for_resource_id_and_actor_id!(
                policy_authorization.account_id,
-               gateway.site_id,
                policy_authorization.resource_id,
                client.actor_id
              ),
@@ -326,7 +261,6 @@ defmodule Portal.Cache.Gateway do
                token.auth_provider_id,
                policy_authorization.expires_at
              ),
-           # Membership is optional only for "Everyone" group policies
            {:ok, membership_id} <-
              Reauth.fetch_membership_id_or_nil_for_everyone(
                policy_authorization.account_id,
@@ -349,7 +283,7 @@ defmodule Portal.Cache.Gateway do
              })
              |> Safe.unscoped()
              |> Safe.insert() do
-        Logger.info("Reauthorized policy_authorization",
+        Logger.info("Reauthorized client-to-client policy_authorization",
           old_policy_authorization: inspect(policy_authorization),
           new_policy_authorization: inspect(new_policy_authorization)
         )
@@ -357,7 +291,7 @@ defmodule Portal.Cache.Gateway do
         {:ok, new_policy_authorization}
       else
         reason ->
-          Logger.info("Failed to reauthorize policy_authorization",
+          Logger.info("Failed to reauthorize client-to-client policy_authorization",
             old_policy_authorization: inspect(policy_authorization),
             reason: inspect(reason)
           )

--- a/elixir/lib/portal/cache/reauth.ex
+++ b/elixir/lib/portal/cache/reauth.ex
@@ -1,0 +1,232 @@
+defmodule Portal.Cache.Reauth do
+  @moduledoc """
+    Shared helpers for `reauthorize_policy_authorization/1` flows in the gateway and client
+    inbound caches. Both `Portal.Cache.Gateway.Database` and
+    `Portal.Cache.Client.Authorizations.Database` go through this module instead of calling
+    one another directly so the lint rule against cross-module Database calls stays happy.
+
+    The Safe-backed queries live in the nested `Database` module here; the rest of the
+    helpers are pure logic.
+  """
+
+  alias __MODULE__.Database
+
+  @infinity ~U[9999-12-31 23:59:59.999999Z]
+
+  @doc """
+    Loads a client device by `{account_id, id}`. Returns `{:error, :not_found}` if missing.
+  """
+  defdelegate fetch_client_by_id(account_id, id), to: Database
+
+  @doc """
+    Loads the most recent client session for a given client device.
+  """
+  defdelegate fetch_latest_session_for_client(account_id, client_id), to: Database
+
+  @doc """
+    Loads a non-expired client token.
+  """
+  defdelegate fetch_client_token_by_id(account_id, id), to: Database
+
+  @doc """
+    Returns `{:ok, membership_id}` or `{:ok, nil}` for "Everyone"-group policies, or
+    `{:error, :membership_not_found}` if neither path applies.
+  """
+  defdelegate fetch_membership_id_or_nil_for_everyone(account_id, actor_id, group_id),
+    to: Database
+
+  @doc """
+    Picks the longest-conforming policy for the given client/session/auth_provider, returning
+    the policy and its computed expiry (the smaller of the policy condition and token expiry).
+  """
+  def longest_conforming_policy_for_client(
+        policies,
+        client,
+        session,
+        auth_provider_id,
+        token_expires_at
+      ) do
+    policies
+    |> Enum.reduce(%{failed: [], succeeded: []}, fn policy, acc ->
+      case ensure_client_conforms_policy_conditions(policy, client, session, auth_provider_id) do
+        {:ok, expires_at} ->
+          %{acc | succeeded: [{expires_at, policy} | acc.succeeded]}
+
+        {:error, {:forbidden, violated_properties: violated_properties}} ->
+          %{acc | failed: acc.failed ++ violated_properties}
+      end
+    end)
+    |> case do
+      %{succeeded: [], failed: failed} ->
+        {:error, {:forbidden, violated_properties: Enum.uniq(failed)}}
+
+      %{succeeded: succeeded} ->
+        {condition_expires_at, policy} =
+          succeeded |> Enum.max_by(fn {exp, _policy} -> exp || @infinity end)
+
+        {:ok, policy, min_expires_at(condition_expires_at, token_expires_at)}
+    end
+  end
+
+  defp ensure_client_conforms_policy_conditions(
+         %Portal.Policy{} = policy,
+         client,
+         %Portal.ClientSession{} = session,
+         auth_provider_id
+       ) do
+    ensure_client_conforms_policy_conditions(
+      Portal.Cache.Cacheable.to_cache(policy),
+      client,
+      session,
+      auth_provider_id
+    )
+  end
+
+  defp ensure_client_conforms_policy_conditions(
+         %Portal.Cache.Cacheable.Policy{} = policy,
+         client,
+         %Portal.ClientSession{} = session,
+         auth_provider_id
+       ) do
+    case Portal.Policies.Evaluator.ensure_conforms(
+           policy.conditions,
+           client,
+           session,
+           auth_provider_id
+         ) do
+      {:ok, expires_at} ->
+        {:ok, expires_at}
+
+      {:error, violated_properties} ->
+        {:error, {:forbidden, violated_properties: violated_properties}}
+    end
+  end
+
+  defp min_expires_at(nil, nil),
+    do: raise("Both policy_expires_at and token_expires_at cannot be nil")
+
+  defp min_expires_at(nil, token_expires_at), do: token_expires_at
+
+  defp min_expires_at(policy_expires_at, nil), do: policy_expires_at
+
+  defp min_expires_at(%DateTime{} = policy_expires_at, %DateTime{} = token_expires_at) do
+    if DateTime.compare(policy_expires_at, token_expires_at) == :lt do
+      policy_expires_at
+    else
+      token_expires_at
+    end
+  end
+
+  @doc """
+    Casts and validates the attrs into a Portal.PolicyAuthorization changeset.
+    `receiver_remote_ip` is required: a policy_authorization is only ever created after
+    delivery to the receiving device succeeds, so the receiver must be online and we
+    must know its remote IP from the latest session/presence record.
+  """
+  def create_policy_authorization_changeset(attrs) do
+    import Ecto.Changeset
+
+    fields =
+      ~w[token_id policy_id initiating_device_id receiving_device_id resource_id membership_id
+                  account_id
+                  expires_at
+                  initiator_remote_ip initiator_user_agent
+                  receiver_remote_ip]a
+
+    %Portal.PolicyAuthorization{}
+    |> cast(attrs, fields)
+    |> validate_required(fields -- [:membership_id])
+    |> Portal.PolicyAuthorization.changeset()
+  end
+
+  defmodule Database do
+    alias Portal.Safe
+    import Ecto.Query
+
+    def fetch_client_by_id(account_id, id) do
+      client =
+        from(c in Portal.Device, as: :clients)
+        |> where([clients: c], c.type == :client)
+        |> where([clients: c], c.account_id == ^account_id and c.id == ^id)
+        |> Safe.unscoped(:replica)
+        |> Safe.one()
+
+      if client do
+        {:ok, client}
+      else
+        {:error, :not_found}
+      end
+    end
+
+    def fetch_latest_session_for_client(account_id, client_id) do
+      result =
+        from(s in Portal.ClientSession,
+          where: s.account_id == ^account_id and s.device_id == ^client_id,
+          order_by: [desc: s.inserted_at],
+          limit: 1
+        )
+        |> Safe.unscoped(:replica)
+        |> Safe.one()
+
+      if result, do: {:ok, result}, else: {:error, :not_found}
+    end
+
+    def fetch_client_token_by_id(account_id, id) do
+      result =
+        from(t in Portal.ClientToken,
+          where: t.account_id == ^account_id,
+          where: t.id == ^id,
+          where: t.expires_at > ^DateTime.utc_now()
+        )
+        |> Safe.unscoped(:replica)
+        |> Safe.one()
+
+      if result do
+        {:ok, result}
+      else
+        {:error, :not_found}
+      end
+    end
+
+    def fetch_membership_id_or_nil_for_everyone(account_id, actor_id, group_id) do
+      case fetch_membership_by_actor_id_and_group_id(account_id, actor_id, group_id) do
+        {:ok, membership} ->
+          {:ok, membership.id}
+
+        {:error, :not_found} ->
+          if everyone_group?(account_id, group_id) do
+            {:ok, nil}
+          else
+            {:error, :membership_not_found}
+          end
+      end
+    end
+
+    defp fetch_membership_by_actor_id_and_group_id(account_id, actor_id, group_id) do
+      from(m in Portal.Membership,
+        where: m.account_id == ^account_id,
+        where: m.actor_id == ^actor_id,
+        where: m.group_id == ^group_id
+      )
+      |> Safe.unscoped(:replica)
+      |> Safe.one(fallback_to_primary: true)
+      |> case do
+        nil -> {:error, :not_found}
+        membership -> {:ok, membership}
+      end
+    end
+
+    defp everyone_group?(account_id, group_id) do
+      from(g in Portal.Group,
+        where:
+          g.account_id == ^account_id and
+            g.id == ^group_id and
+            g.type == :managed and
+            is_nil(g.idp_id) and
+            g.name == "Everyone"
+      )
+      |> Safe.unscoped(:replica)
+      |> Safe.exists?()
+    end
+  end
+end

--- a/elixir/lib/portal/policy_authorization.ex
+++ b/elixir/lib/portal/policy_authorization.ex
@@ -16,9 +16,9 @@ defmodule Portal.PolicyAuthorization do
           # nil for "Everyone" group policies which have no explicit membership
           membership_id: Ecto.UUID.t() | nil,
           account_id: Ecto.UUID.t(),
-          client_remote_ip: Portal.Types.IP.t(),
-          client_user_agent: String.t(),
-          gateway_remote_ip: Portal.Types.IP.t() | nil,
+          initiator_remote_ip: Portal.Types.IP.t(),
+          initiator_user_agent: String.t(),
+          receiver_remote_ip: Portal.Types.IP.t(),
           expires_at: DateTime.t(),
           inserted_at: DateTime.t()
         }
@@ -44,9 +44,9 @@ defmodule Portal.PolicyAuthorization do
     belongs_to :membership, Portal.Membership
 
     # TODO: These can be removed since we don't use them
-    field :client_remote_ip, Portal.Types.IP
-    field :client_user_agent, :string
-    field :gateway_remote_ip, Portal.Types.IP
+    field :initiator_remote_ip, Portal.Types.IP
+    field :initiator_user_agent, :string
+    field :receiver_remote_ip, Portal.Types.IP
 
     field :expires_at, :utc_datetime_usec
 

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -22,6 +22,9 @@ defmodule PortalAPI.Client.Channel do
   # connlib state will be cleaned up so it can request a new connection.
   @recompute_authorized_resources_every :timer.minutes(1)
 
+  # The interval at which the inbound policy_authorizations cache is pruned.
+  @prune_authorizations_cache_every :timer.minutes(1)
+
   ####################################
   ##### Channel lifecycle events #####
   ####################################
@@ -46,6 +49,12 @@ defmodule PortalAPI.Client.Channel do
       @recompute_authorized_resources_every
     )
 
+    Process.send_after(
+      self(),
+      :prune_authorizations_cache,
+      @prune_authorizations_cache_every
+    )
+
     schedule_session_expiry(socket.assigns.subject.expires_at)
 
     # Get initial list of authorized resources, hydrating the cache
@@ -57,6 +66,11 @@ defmodule PortalAPI.Client.Channel do
         socket.assigns.subject
       )
 
+    # Hydrate inbound policy_authorizations cache so the channel can react to filter
+    # changes and policy_authorization deletions for resources another client has been
+    # authorized to access via this one.
+    authorizations_cache = Cache.Client.Authorizations.hydrate(socket.assigns.client)
+
     # Initialize relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)
     :ok = Presence.Relays.Global.subscribe()
@@ -65,7 +79,11 @@ defmodule PortalAPI.Client.Channel do
       socket
       # Cache relay IDs and stamp secrets for tracking
       |> cache_relays(relays)
-      |> assign(cache: cache, pending_flows: %{})
+      |> assign(
+        cache: cache,
+        authorizations_cache: authorizations_cache,
+        pending_flows: %{}
+      )
       # Track client's presence and monitor tracker shard processes for crash recovery
       |> track_presence()
 
@@ -133,6 +151,20 @@ defmodule PortalAPI.Client.Channel do
     end
 
     {:noreply, assign(socket, cache: cache)}
+  end
+
+  def handle_info(:prune_authorizations_cache, socket) do
+    Process.send_after(
+      self(),
+      :prune_authorizations_cache,
+      @prune_authorizations_cache_every
+    )
+
+    {:noreply,
+     assign(
+       socket,
+       authorizations_cache: Cache.Client.Authorizations.prune(socket.assigns.authorizations_cache)
+     )}
   end
 
   ####################################
@@ -322,9 +354,29 @@ defmodule PortalAPI.Client.Channel do
   end
 
   def handle_info({:client_device_access_authorized, payload}, socket) do
+    {policy_authorization_id, payload} = Map.pop(payload, :policy_authorization_id)
+    {authorization_expires_at, payload} = Map.pop(payload, :authorization_expires_at)
+
+    authorizations_cache =
+      maybe_put_authorization(
+        socket.assigns.authorizations_cache,
+        payload[:client_id],
+        payload[:resource],
+        policy_authorization_id,
+        authorization_expires_at
+      )
+
+    payload =
+      if match?(%DateTime{}, authorization_expires_at) do
+        Map.put(payload, :expires_at, DateTime.to_unix(authorization_expires_at, :second))
+      else
+        payload
+      end
+
     push(socket, "client_device_access_authorized", payload)
     cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
-    {:noreply, assign(socket, cache: cache)}
+
+    {:noreply, assign(socket, cache: cache, authorizations_cache: authorizations_cache)}
   end
 
   def handle_info({:client_ice_candidates, client_id, candidates}, socket) do
@@ -408,8 +460,18 @@ defmodule PortalAPI.Client.Channel do
            resource_id,
            socket.assigns.subject
          ) do
-      {:ok, %Cache.Cacheable.Resource{type: :static_device_pool} = resource, _, _, _} ->
-        handle_create_pool_flow(resource_id, resource, payload, socket)
+      {:ok, %Cache.Cacheable.Resource{type: type} = resource, membership_id, policy_id,
+       expires_at}
+      when type in [:static_device_pool, :dynamic_device_pool] ->
+        handle_create_pool_flow(
+          resource_id,
+          resource,
+          membership_id,
+          policy_id,
+          expires_at,
+          payload,
+          socket
+        )
 
       {:ok, resource, membership_id, policy_id, expires_at} ->
         connected_gateway_ids = Map.get(payload, "connected_gateway_ids", [])
@@ -762,10 +824,14 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
-  # !!! TODO: REMOVE ONCE THE FULL DEVICE POOLS FEATURE HAS SHIPPED !!!
-  # Restored to keep a PoC customer working until clients migrate to the
-  # `create_flow` path for static_device_pool resources. Delete this handler
-  # and `legacy_authorize_device_access/2` below as part of that cleanup.
+  # !!! TODO: REMOVE BEFORE GA !!!
+  # PoC-only shim kept for a customer until their clients migrate to the
+  # `create_flow` path for static_device_pool resources. The handler enforces
+  # pool membership only — the target IPv4 must be a member of *some* static
+  # device pool the actor has connectable access to (via `cache.device_addresses`,
+  # which is populated only from policy-authorized pools). It does NOT create a
+  # `policy_authorization` row, so revocation/reauth/expiry are not tracked for
+  # flows authorized this way. Remove this handler before GA.
   def handle_in("request_device_access", %{"ipv4" => ipv4_string}, socket) do
     account_id = socket.assigns.client.account_id
 
@@ -775,8 +841,26 @@ defmodule PortalAPI.Client.Channel do
          :ok <- legacy_authorize_device_access(socket.assigns.cache, ipv4_tuple),
          {:ok, target_client_id, target_meta} <-
            find_online_client_by_address(account_id, target) do
-      send_client_device_access_authorized(target_client_id, target_meta, socket)
-      {:noreply, socket}
+      case send_client_device_access_authorized(
+             target_client_id,
+             target_meta,
+             nil,
+             nil,
+             nil,
+             socket
+           ) do
+        :ok ->
+          {:noreply, socket}
+
+        {:error, :not_found} ->
+          push(socket, "client_device_access_denied", %{
+            client_id: target_client_id,
+            ipv4: ipv4_string,
+            reason: :offline
+          })
+
+          {:noreply, socket}
+      end
     else
       false ->
         push(socket, "client_device_access_denied", %{
@@ -863,8 +947,12 @@ defmodule PortalAPI.Client.Channel do
 
   defp client_to_client_enabled?(account), do: Database.client_to_client_enabled?(account)
 
-  # !!! TODO: REMOVE ONCE THE FULL DEVICE POOLS FEATURE HAS SHIPPED !!!
-  # Used only by the legacy `request_device_access` handler. Delete alongside it.
+  # !!! TODO: REMOVE BEFORE GA — used only by the legacy `request_device_access` !!!
+  # The check is "the IPv4 belongs to *some* device in a connectable pool we have
+  # policy-authorized access to" — `cache.device_addresses` is only populated for
+  # static_device_pool members of pools that passed `recompute_connectable_resources`,
+  # so this is effectively a pool-membership-only authorization. Doesn't create a
+  # `policy_authorization`. Remove alongside the handler before GA.
   defp legacy_authorize_device_access(cache, {_, _, _, _} = ipv4_tuple) do
     if Enum.any?(cache.device_addresses, fn {_, {v4, _v6}} -> v4 == ipv4_tuple end),
       do: :ok,
@@ -902,8 +990,33 @@ defmodule PortalAPI.Client.Channel do
     ArgumentError -> {:error, :not_found}
   end
 
-  defp client_fqdns(%Postgrex.INET{address: {a, b, c, d}}, account_key) do
-    ["#{a}-#{b}-#{c}-#{d}.#{account_key}.fz.internal"]
+  # Dispatches the pool authorization check by resource type. Static pools have
+  # their member set pre-loaded in the cache; dynamic pools resolve the target IP
+  # to a device at request-time and verify its hostname against the pool pattern.
+  defp authorize_pool_target(
+         %Cache.Cacheable.Resource{type: :static_device_pool},
+         cache,
+         resource_id,
+         target,
+         _subject
+       ) do
+    Cache.Client.authorize_device_access(cache, resource_id, target)
+  end
+
+  defp authorize_pool_target(
+         %Cache.Cacheable.Resource{type: :dynamic_device_pool, address: pattern},
+         _cache,
+         _resource_id,
+         target,
+         subject
+       ) do
+    with {:ok, %Portal.Device{} = device} <-
+           Database.get_device_by_address(target, subject),
+         true <- Portal.Resource.matches_dns_pattern?(pattern, device.hostname) do
+      {:ok, device.id}
+    else
+      _ -> {:error, :forbidden}
+    end
   end
 
   defp find_online_client_by_address(account_id, {:ipv4, ipv4_tuple}) do
@@ -1027,17 +1140,52 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
-  defp handle_create_pool_flow(resource_id, _resource, payload, socket) do
+  defp handle_create_pool_flow(
+         resource_id,
+         resource,
+         membership_id,
+         policy_id,
+         expires_at,
+         payload,
+         socket
+       ) do
     account_id = socket.assigns.client.account_id
 
     with true <- client_to_client_enabled?(socket.assigns.subject.account),
          {:ok, target} <- parse_target_address(payload),
-         {:ok, _device_id} <-
-           Cache.Client.authorize_device_access(socket.assigns.cache, resource_id, target),
-         {:ok, target_client_id, target_meta} <-
-           find_online_client_by_address(account_id, target) do
-      send_client_device_access_authorized(target_client_id, target_meta, socket)
-      {:noreply, socket}
+         {:ok, target_device_id} <-
+           authorize_pool_target(
+             resource,
+             socket.assigns.cache,
+             resource_id,
+             target,
+             socket.assigns.subject
+           ) do
+      # Once the target IP is authorized for the pool we know the device id, so even
+      # offline-target denials can carry it back to the initiator.
+      case find_online_client_by_address(account_id, target) do
+        {:ok, target_client_id, target_meta} ->
+          handle_authorized_pool_target(
+            target_client_id,
+            target_meta,
+            resource,
+            membership_id,
+            policy_id,
+            expires_at,
+            payload,
+            socket
+          )
+
+        :offline ->
+          push(socket, "client_device_access_denied", %{
+            client_id: target_device_id,
+            ipv4: payload["ipv4"],
+            ipv6: payload["ipv6"],
+            reason: :offline
+          })
+
+          {:noreply, socket}
+      end
     else
       false ->
         push(socket, "client_device_access_denied", %{
@@ -1087,15 +1235,6 @@ defmodule PortalAPI.Client.Channel do
 
         {:noreply, socket}
 
-      :offline ->
-        push(socket, "client_device_access_denied", %{
-          ipv4: payload["ipv4"],
-          ipv6: payload["ipv6"],
-          reason: :offline
-        })
-
-        {:noreply, socket}
-
       {:error, :forbidden} ->
         push(socket, "client_device_access_denied", %{
           ipv4: payload["ipv4"],
@@ -1107,7 +1246,77 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
-  defp send_client_device_access_authorized(target_client_id, target_meta, socket) do
+  # Target was found in presence — try delivery and persist the policy_authorization
+  # only if delivery succeeds.
+  defp handle_authorized_pool_target(
+         target_client_id,
+         target_meta,
+         resource,
+         membership_id,
+         policy_id,
+         expires_at,
+         payload,
+         socket
+       ) do
+    resource_id = Ecto.UUID.load!(resource.id)
+    policy_authorization_id = Ecto.UUID.generate()
+
+    # Deliver to the target FIRST so we know the peer is still registered. Only after
+    # successful delivery do we persist the policy_authorization — otherwise a
+    # disconnect between presence lookup and PG.deliver would leave a stale row in
+    # the DB authorizing access for a peer that never received the message.
+    case send_client_device_access_authorized(
+           target_client_id,
+           target_meta,
+           resource,
+           policy_authorization_id,
+           expires_at,
+           socket
+         ) do
+      :ok ->
+        target_device = %Portal.Device{
+          id: target_client_id,
+          account_id: socket.assigns.client.account_id,
+          type: :client,
+          latest_session: %{remote_ip: target_meta.remote_ip}
+        }
+
+        async_create_policy_authorization(
+          policy_authorization_id,
+          socket.assigns.client,
+          target_device,
+          resource_id,
+          policy_id,
+          membership_id,
+          socket.assigns.subject,
+          expires_at
+        )
+
+        {:noreply, socket}
+
+      {:error, :not_found} ->
+        push(socket, "client_device_access_denied", %{
+          client_id: target_client_id,
+          ipv4: payload["ipv4"],
+          ipv6: payload["ipv6"],
+          reason: :offline
+        })
+
+        {:noreply, socket}
+    end
+  end
+
+  # Tries to deliver `client_device_access_authorized` to the target client and, on
+  # successful delivery, pushes the matching message to the initiator. Returns the
+  # PG.deliver result so callers can decide whether to persist authorization state.
+  defp send_client_device_access_authorized(
+         target_client_id,
+         target_meta,
+         resource,
+         policy_authorization_id,
+         expires_at,
+         socket
+       ) do
     client = socket.assigns.client
     client_public_key = socket.assigns.session.public_key
 
@@ -1133,40 +1342,55 @@ defmodule PortalAPI.Client.Channel do
         target_meta.public_key
       )
 
-    account_key = socket.assigns.subject.account.key
+    # Mirror the gateway's `authorize_flow` payload on the receiver side: the
+    # receiving client gets the full resource view (filters, type, name,
+    # devices) plus the subject (actor) view, in addition to peer/ICE fields.
+    # We render with the initiator's session here — for static_device_pool
+    # resources the version-dependent codepaths in the resource view aren't
+    # exercised (no site fields), so this is safe across version skew.
+    rendered_resource =
+      if resource, do: Views.Resource.render(resource, socket.assigns.session)
 
-    PG.deliver(
-      target_client_id,
-      {:client_device_access_authorized,
-       %{
-         client_id: client.id,
-         client_name: client.name,
-         client_fqdns: client_fqdns(client.ipv4, account_key),
-         client_public_key: client_public_key,
-         client_ipv4: client.ipv4,
-         client_ipv6: client.ipv6,
-         preshared_key: preshared_key,
-         local_ice_credentials: ice_credentials.receiver,
-         remote_ice_credentials: ice_credentials.initiator,
-         ice_role: :controlled
-       }}
-    )
+    rendered_subject = PortalAPI.Gateway.Views.Subject.render(socket.assigns.subject)
 
-    target_ipv4 = %Postgrex.INET{address: target_meta.ipv4}
-    target_ipv6 = %Postgrex.INET{address: target_meta.ipv6}
+    case PG.deliver(
+           target_client_id,
+           {:client_device_access_authorized,
+            %{
+              client_id: client.id,
+              client_public_key: client_public_key,
+              client_ipv4: client.ipv4,
+              client_ipv6: client.ipv6,
+              preshared_key: preshared_key,
+              local_ice_credentials: ice_credentials.receiver,
+              remote_ice_credentials: ice_credentials.initiator,
+              ice_role: :controlled,
+              resource: rendered_resource,
+              subject: rendered_subject,
+              policy_authorization_id: policy_authorization_id,
+              authorization_expires_at: expires_at
+            }}
+         ) do
+      :ok ->
+        target_ipv4 = %Postgrex.INET{address: target_meta.ipv4}
+        target_ipv6 = %Postgrex.INET{address: target_meta.ipv6}
 
-    push(socket, "client_device_access_authorized", %{
-      client_id: target_client_id,
-      client_name: target_meta.name,
-      client_fqdns: client_fqdns(target_ipv4, account_key),
-      client_public_key: target_meta.public_key,
-      client_ipv4: target_ipv4,
-      client_ipv6: target_ipv6,
-      preshared_key: preshared_key,
-      local_ice_credentials: ice_credentials.initiator,
-      remote_ice_credentials: ice_credentials.receiver,
-      ice_role: :controlling
-    })
+        push(socket, "client_device_access_authorized", %{
+          client_id: target_client_id,
+          client_public_key: target_meta.public_key,
+          client_ipv4: target_ipv4,
+          client_ipv6: target_ipv6,
+          preshared_key: preshared_key,
+          local_ice_credentials: ice_credentials.initiator,
+          remote_ice_credentials: ice_credentials.receiver,
+          ice_role: :controlling
+        })
+
+        :ok
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
   end
 
   # TODO: Re-enable after verifying compatibility with older clients
@@ -1198,6 +1422,8 @@ defmodule PortalAPI.Client.Channel do
   defp init(socket, resources, relays) do
     push(socket, "init", %{
       resources: Views.Resource.render_many(resources, socket.assigns.session),
+      authorizations:
+        Views.PolicyAuthorization.render_many(socket.assigns.authorizations_cache),
       # TODO: Re-enable after verifying compatibility with older clients
       # authorized_ipv4s: render_ipv4s(cache.authorized_device_ipv4s),
       relays:
@@ -1477,16 +1703,75 @@ defmodule PortalAPI.Client.Channel do
     |> push_resource_updates(socket)
   end
 
+  # POLICY_AUTHORIZATIONS
+
+  # When a policy_authorization is deleted where this client is the receiving device,
+  # mirror the gateway flow: try to reauthorize against another conforming policy. If
+  # we succeed, push the new expiry; if no policy still grants access, push
+  # reject_access with the {initiator, resource} pair so connlib tears down the
+  # inbound peer connection. The wire shape parallels the gateway's reject_access
+  # rather than client_device_access_denied (which is keyed on {ipv4, reason} for
+  # the controlling-side denial path) — the receiver doesn't need a reason, only
+  # the identity of the connection to drop.
+  defp handle_change(
+         %Change{
+           op: :delete,
+           old_struct:
+             %Portal.PolicyAuthorization{
+               receiving_device_id: client_id,
+               initiating_device_id: initiating_client_id,
+               resource_id: resource_id
+             } = policy_authorization
+         },
+         %{assigns: %{client: %{id: client_id}}} = socket
+       ) do
+    socket.assigns.authorizations_cache
+    |> Cache.Client.Authorizations.reauthorize_deleted_policy_authorization(policy_authorization)
+    |> case do
+      {:ok, expires_at_unix, authorizations_cache} ->
+        Logger.info("Updating client-to-client authorization expiration for deleted policy authorization",
+          deleted_policy_authorization: inspect(policy_authorization),
+          new_expires_at: DateTime.from_unix!(expires_at_unix, :second)
+        )
+
+        push(
+          socket,
+          "access_authorization_expiry_updated",
+          Views.PolicyAuthorization.render(policy_authorization, expires_at_unix)
+        )
+
+        {:noreply, assign(socket, authorizations_cache: authorizations_cache)}
+
+      {:error, :unauthorized, authorizations_cache} ->
+        Logger.info(
+          "No client-to-client authorizations remaining for deleted policy authorization, revoking access",
+          deleted_policy_authorization: inspect(policy_authorization)
+        )
+
+        push(socket, "reject_access", %{
+          client_id: initiating_client_id,
+          resource_id: resource_id
+        })
+
+        {:noreply, assign(socket, authorizations_cache: authorizations_cache)}
+
+      {:error, :not_found} ->
+        {:noreply, socket}
+    end
+  end
+
   # RESOURCES
 
   defp handle_change(
          %Change{
            op: :update,
-           old_struct: %Portal.Resource{},
-           struct: %Portal.Resource{} = resource
+           old_struct: %Portal.Resource{filters: old_filters},
+           struct: %Portal.Resource{filters: filters} = resource
          },
          socket
        ) do
+    maybe_push_resource_filters_updated(socket, resource, old_filters, filters)
+
     Cache.Client.update_resource(
       socket.assigns.cache,
       resource,
@@ -1565,6 +1850,24 @@ defmodule PortalAPI.Client.Channel do
     :ok
   end
 
+  defp maybe_put_authorization(cache, client_id, %{id: resource_id}, paid, %DateTime{} = expires_at)
+       when not is_nil(client_id) and not is_nil(paid) do
+    Cache.Client.Authorizations.put(cache, client_id, resource_id, paid, expires_at)
+  end
+
+  defp maybe_put_authorization(cache, _client_id, _resource, _paid, _expires_at), do: cache
+
+  defp maybe_push_resource_filters_updated(_socket, _resource, filters, filters), do: :ok
+
+  defp maybe_push_resource_filters_updated(socket, resource, _old_filters, _filters) do
+    if Cache.Client.Authorizations.has_resource?(socket.assigns.authorizations_cache, resource.id) do
+      cacheable = Cache.Cacheable.to_cache(resource)
+      push(socket, "resource_filters_updated", Views.Resource.render_authorization(cacheable))
+    end
+
+    :ok
+  end
+
   defp push_resource_updates({:ok, added_resources, removed_ids, cache}, socket) do
     # Currently, connlib doesn't handle resources changing sites, so we need to delete then create.
     # We handle that scenario by sending resource_deleted then resource_created_or_updated, so it's
@@ -1617,9 +1920,10 @@ defmodule PortalAPI.Client.Channel do
            actor_id: actor_id
          },
          %{
-           id: gateway_id,
-           account_id: account_id
-         } = gateway,
+           id: receiving_device_id,
+           account_id: account_id,
+           latest_session: %{remote_ip: receiver_remote_ip}
+         },
          resource_id,
          policy_id,
          membership_id,
@@ -1628,26 +1932,24 @@ defmodule PortalAPI.Client.Channel do
            actor: %{id: actor_id},
            credential: %{id: token_id},
            context: %Authentication.Context{
-             remote_ip: client_remote_ip,
-             user_agent: client_user_agent
+             remote_ip: initiator_remote_ip,
+             user_agent: initiator_user_agent
            }
          } = subject,
          expires_at
        ) do
-    gateway_remote_ip = gateway.latest_session && gateway.latest_session.remote_ip
-
     attrs = %{
       id: policy_authorization_id,
       token_id: token_id,
       policy_id: policy_id,
       initiating_device_id: client_id,
-      receiving_device_id: gateway_id,
+      receiving_device_id: receiving_device_id,
       resource_id: resource_id,
       membership_id: membership_id,
       account_id: account_id,
-      client_remote_ip: client_remote_ip,
-      client_user_agent: client_user_agent,
-      gateway_remote_ip: gateway_remote_ip,
+      initiator_remote_ip: initiator_remote_ip,
+      initiator_user_agent: initiator_user_agent,
+      receiver_remote_ip: receiver_remote_ip,
       expires_at: expires_at
     }
 
@@ -1707,12 +2009,12 @@ defmodule PortalAPI.Client.Channel do
       ~w[id token_id policy_id initiating_device_id receiving_device_id resource_id membership_id
                 account_id
                 expires_at
-                client_remote_ip client_user_agent
-                gateway_remote_ip]a
+                initiator_remote_ip initiator_user_agent
+                receiver_remote_ip]a
 
     %Portal.PolicyAuthorization{}
     |> cast(attrs, fields)
-    |> validate_required(fields -- [:membership_id, :gateway_remote_ip])
+    |> validate_required(fields -- [:membership_id])
     |> Portal.PolicyAuthorization.changeset()
   end
 
@@ -1761,7 +2063,8 @@ defmodule PortalAPI.Client.Channel do
           ipv6: socket.assigns.client.ipv6.address,
           name: socket.assigns.client.name,
           public_key: socket.assigns.session.public_key,
-          psk_base: socket.assigns.client.psk_base
+          psk_base: socket.assigns.client.psk_base,
+          remote_ip: socket.assigns.session.remote_ip
         }
 
         :ok =
@@ -1841,6 +2144,45 @@ defmodule PortalAPI.Client.Channel do
         where: d.type == :client,
         where: d.hostname == ^hostname
       )
+      |> Portal.Safe.scoped(subject, :replica)
+      |> Portal.Safe.one()
+      |> case do
+        %Portal.Device{} = device -> {:ok, device}
+        _ -> {:error, :not_found}
+      end
+    end
+
+    @doc """
+      Fetches a client device by its tunnel IPv4 or IPv6 within the subject's account.
+      Used to authorize a `create_flow` against a dynamic device pool: we resolve the
+      target IP to a device and let the caller verify the device's hostname matches
+      the pool's address pattern.
+    """
+    def get_device_by_address({:ipv4, ipv4_tuple}, subject) do
+      fetch_device_by_inet(:ipv4, %Postgrex.INET{address: ipv4_tuple}, subject)
+    end
+
+    def get_device_by_address({:ipv6, ipv6_tuple}, subject) do
+      fetch_device_by_inet(:ipv6, %Postgrex.INET{address: ipv6_tuple}, subject)
+    end
+
+    defp fetch_device_by_inet(family, %Postgrex.INET{} = inet, subject) do
+      query =
+        case family do
+          :ipv4 ->
+            from(d in Portal.Device,
+              where: d.type == :client,
+              where: fragment("host(?) = host(?)", d.ipv4, ^inet)
+            )
+
+          :ipv6 ->
+            from(d in Portal.Device,
+              where: d.type == :client,
+              where: fragment("host(?) = host(?)", d.ipv6, ^inet)
+            )
+        end
+
+      query
       |> Portal.Safe.scoped(subject, :replica)
       |> Portal.Safe.one()
       |> case do

--- a/elixir/lib/portal_api/client/views/policy_authorization.ex
+++ b/elixir/lib/portal_api/client/views/policy_authorization.ex
@@ -1,0 +1,23 @@
+defmodule PortalAPI.Client.Views.PolicyAuthorization do
+  def render(policy_authorization, expires_at_unix) do
+    %{
+      client_id: policy_authorization.initiating_device_id,
+      resource_id: policy_authorization.resource_id,
+      expires_at: expires_at_unix
+    }
+  end
+
+  def render_many(cache) do
+    cache
+    |> Enum.map(fn {{cid_bytes, rid_bytes}, policy_authorization_map} ->
+      # Use longest expiration to minimize unnecessary access churn
+      expires_at_unix = Enum.max(Map.values(policy_authorization_map))
+
+      %{
+        client_id: Ecto.UUID.load!(cid_bytes),
+        resource_id: Ecto.UUID.load!(rid_bytes),
+        expires_at: expires_at_unix
+      }
+    end)
+  end
+end

--- a/elixir/lib/portal_api/client/views/resource.ex
+++ b/elixir/lib/portal_api/client/views/resource.ex
@@ -12,6 +12,18 @@ defmodule PortalAPI.Client.Views.Resource do
     render_cacheable(resource, site_key(client_session))
   end
 
+  @doc """
+    Renders the minimal `{id, filters}` view used in `client_device_access_authorized` and
+    `resource_filters_updated` payloads, where the receiving client only needs to know
+    which resource was authorized and what its filters look like.
+  """
+  def render_authorization(%Cacheable.Resource{} = resource) do
+    %{
+      id: Ecto.UUID.load!(resource.id),
+      filters: Enum.flat_map(resource.filters, &render_filter/1)
+    }
+  end
+
   defp render_cacheable(%Cacheable.Resource{} = resource, site_key) do
     resource
     |> Map.from_struct()

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -42,15 +42,15 @@ defmodule PortalWeb.Clients.Components do
     """
   end
 
-  defp client_user_agent(client) do
-    case client.latest_session do
+  defp device_user_agent(device) do
+    case device.latest_session do
       %{user_agent: ua} -> ua
       _ -> nil
     end
   end
 
   def client_os(assigns) do
-    assigns = assign(assigns, :user_agent, client_user_agent(assigns.client))
+    assigns = assign(assigns, :user_agent, device_user_agent(assigns.client))
 
     ~H"""
     <div class="flex items-center">
@@ -61,7 +61,7 @@ defmodule PortalWeb.Clients.Components do
   end
 
   def client_os_icon(assigns) do
-    assigns = assign(assigns, :user_agent, client_user_agent(assigns.client))
+    assigns = assign(assigns, :user_agent, device_user_agent(assigns.client))
 
     ~H"""
     <.icon
@@ -73,7 +73,7 @@ defmodule PortalWeb.Clients.Components do
   end
 
   def client_os_name_and_version(assigns) do
-    assigns = assign(assigns, :user_agent, client_user_agent(assigns.client))
+    assigns = assign(assigns, :user_agent, device_user_agent(assigns.client))
 
     ~H"""
     <span>
@@ -480,8 +480,8 @@ defmodule PortalWeb.Clients.Components do
                           {if row.initiating_device, do: row.initiating_device.name, else: "—"}
                         </p>
                         <p class="text-[var(--text-tertiary)] font-mono mt-0.5">
-                          {if row.authorization.client_remote_ip,
-                            do: Portal.Types.INET.to_string(row.authorization.client_remote_ip),
+                          {if row.authorization.initiator_remote_ip,
+                            do: Portal.Types.INET.to_string(row.authorization.initiator_remote_ip),
                             else: "—"}
                         </p>
                       </div>
@@ -497,8 +497,8 @@ defmodule PortalWeb.Clients.Components do
                           {if row.receiving_device, do: row.receiving_device.name, else: "—"}
                         </p>
                         <p class="text-[var(--text-tertiary)] font-mono mt-0.5">
-                          {if row.authorization.gateway_remote_ip,
-                            do: Portal.Types.INET.to_string(row.authorization.gateway_remote_ip),
+                          {if row.authorization.receiver_remote_ip,
+                            do: Portal.Types.INET.to_string(row.authorization.receiver_remote_ip),
                             else: "—"}
                         </p>
                       </div>

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -982,8 +982,8 @@ defmodule PortalWeb.Policies.Components do
                           {if row.initiating_device, do: row.initiating_device.name, else: "—"}
                         </p>
                         <p class="text-[var(--text-tertiary)] font-mono mt-0.5">
-                          {if row.authorization.client_remote_ip,
-                            do: Portal.Types.INET.to_string(row.authorization.client_remote_ip),
+                          {if row.authorization.initiator_remote_ip,
+                            do: Portal.Types.INET.to_string(row.authorization.initiator_remote_ip),
                             else: "—"}
                         </p>
                       </div>
@@ -999,8 +999,8 @@ defmodule PortalWeb.Policies.Components do
                           {if row.receiving_device, do: row.receiving_device.name, else: "—"}
                         </p>
                         <p class="text-[var(--text-tertiary)] font-mono mt-0.5">
-                          {if row.authorization.gateway_remote_ip,
-                            do: Portal.Types.INET.to_string(row.authorization.gateway_remote_ip),
+                          {if row.authorization.receiver_remote_ip,
+                            do: Portal.Types.INET.to_string(row.authorization.receiver_remote_ip),
                             else: "—"}
                         </p>
                       </div>

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1627,8 +1627,8 @@ defmodule PortalWeb.Resources.Components do
                           {if row.initiating_device, do: row.initiating_device.name, else: "—"}
                         </p>
                         <p class="text-[var(--text-tertiary)] font-mono mt-0.5">
-                          {if row.authorization.client_remote_ip,
-                            do: Portal.Types.INET.to_string(row.authorization.client_remote_ip),
+                          {if row.authorization.initiator_remote_ip,
+                            do: Portal.Types.INET.to_string(row.authorization.initiator_remote_ip),
                             else: "—"}
                         </p>
                       </div>
@@ -1644,8 +1644,8 @@ defmodule PortalWeb.Resources.Components do
                           {if row.receiving_device, do: row.receiving_device.name, else: "—"}
                         </p>
                         <p class="text-[var(--text-tertiary)] font-mono mt-0.5">
-                          {if row.authorization.gateway_remote_ip,
-                            do: Portal.Types.INET.to_string(row.authorization.gateway_remote_ip),
+                          {if row.authorization.receiver_remote_ip,
+                            do: Portal.Types.INET.to_string(row.authorization.receiver_remote_ip),
                             else: "—"}
                         </p>
                       </div>

--- a/elixir/priv/repo/migrations/20260502192732_rename_remote_ip_columns_on_policy_authorizations.exs
+++ b/elixir/priv/repo/migrations/20260502192732_rename_remote_ip_columns_on_policy_authorizations.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.RenameRemoteIpColumnsOnPolicyAuthorizations do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:policy_authorizations), :client_remote_ip, to: :initiator_remote_ip)
+    rename(table(:policy_authorizations), :gateway_remote_ip, to: :receiver_remote_ip)
+    rename(table(:policy_authorizations), :client_user_agent, to: :initiator_user_agent)
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -41,7 +41,7 @@ defmodule Portal.Repo.Seeds do
   @ua_ubuntu "Ubuntu/22.04 connlib/1.4.1"
   @ua_macos "Mac OS/14.1.0 apple-client/1.4.1 (arm64; 23.1.0)"
 
-  @client_user_agents [@ua_ios, @ua_android, @ua_windows, @ua_ubuntu, @ua_macos]
+  @initiator_user_agents [@ua_ios, @ua_android, @ua_windows, @ua_ubuntu, @ua_macos]
 
   # {region, city, lat, lon} tuples for seeded sessions.
   @locations [
@@ -584,7 +584,7 @@ defmodule Portal.Repo.Seeds do
 
       for i <- 0..count do
         user_agent =
-          Enum.random(@client_user_agents)
+          Enum.random(@initiator_user_agents)
 
         client_name = String.split(user_agent, "/") |> List.first()
 
@@ -1505,9 +1505,9 @@ defmodule Portal.Repo.Seeds do
         membership_id: membership.id,
         account_id: unprivileged_subject.account.id,
         token_id: unprivileged_subject.credential.id,
-        client_remote_ip: {127, 0, 0, 1},
-        client_user_agent: @ua_ios,
-        gateway_remote_ip: %Postgrex.INET{address: {189, 172, 73, 153}, netmask: nil},
+        initiator_remote_ip: {127, 0, 0, 1},
+        initiator_user_agent: @ua_ios,
+        receiver_remote_ip: %Postgrex.INET{address: {189, 172, 73, 153}, netmask: nil},
         expires_at: unprivileged_subject.expires_at || DateTime.utc_now() |> DateTime.add(3600)
       }
       |> Repo.insert!()

--- a/elixir/test/portal/cache/client/authorizations_test.exs
+++ b/elixir/test/portal/cache/client/authorizations_test.exs
@@ -1,0 +1,509 @@
+defmodule Portal.Cache.Client.AuthorizationsTest do
+  use Portal.DataCase, async: true
+
+  alias Portal.Cache.Client.Authorizations
+  alias Portal.PolicyAuthorization
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.DeviceFixtures
+  import Portal.IdentityFixtures
+  import Portal.PolicyAuthorizationFixtures
+
+  import Ecto.UUID, only: [dump!: 1]
+
+  describe "hydrate/1" do
+    test "returns an empty cache when there are no policy_authorizations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      client = client_fixture(account: account, actor: actor)
+
+      assert Authorizations.hydrate(client) == %{}
+    end
+
+    test "loads matching policy_authorizations into cache keyed by {client_id, resource_id}" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: actor)
+
+      initiating_actor = actor_fixture(account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client
+        )
+
+      cache = Authorizations.hydrate(target_client)
+
+      key = {dump!(initiating_client.id), dump!(policy_authorization.resource_id)}
+      assert %{^key => paid_map} = cache
+      assert Map.fetch!(paid_map, dump!(policy_authorization.id)) ==
+               DateTime.to_unix(policy_authorization.expires_at, :second)
+    end
+
+    test "groups multiple policy_authorizations for the same {client, resource} pair" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: actor)
+
+      initiating_actor = actor_fixture(account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      pa1 =
+        policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client
+        )
+
+      preloaded = Portal.Repo.preload(pa1, [:resource, :policy])
+
+      pa2 =
+        policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client,
+          resource: preloaded.resource,
+          policy: preloaded.policy
+        )
+
+      cache = Authorizations.hydrate(target_client)
+      key = {dump!(initiating_client.id), dump!(pa1.resource_id)}
+      assert %{^key => paid_map} = cache
+      assert map_size(paid_map) == 2
+      assert Map.has_key?(paid_map, dump!(pa1.id))
+      assert Map.has_key?(paid_map, dump!(pa2.id))
+    end
+
+    test "ignores expired policy_authorizations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: actor)
+
+      initiating_actor = actor_fixture(account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      expired_policy_authorization_fixture(
+        account: account,
+        client: initiating_client,
+        gateway: target_client
+      )
+
+      assert Authorizations.hydrate(target_client) == %{}
+    end
+
+    test "ignores policy_authorizations targeting other devices" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: actor)
+
+      initiating_actor = actor_fixture(account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      # Default fixture targets a gateway, not target_client
+      policy_authorization_fixture(account: account, client: initiating_client)
+
+      assert Authorizations.hydrate(target_client) == %{}
+    end
+  end
+
+  describe "put/5" do
+    test "inserts a new policy_authorization entry" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+
+      cache = Authorizations.put(%{}, client_id, resource_id, paid, expires_at)
+
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = cache
+      assert Map.fetch!(paid_map, dump!(paid)) == DateTime.to_unix(expires_at, :second)
+    end
+
+    test "appends to an existing entry without losing prior policy_authorizations" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_a = Ecto.UUID.generate()
+      paid_b = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      exp_a = DateTime.add(now, 60, :second)
+      exp_b = DateTime.add(now, 120, :second)
+
+      cache =
+        %{}
+        |> Authorizations.put(client_id, resource_id, paid_a, exp_a)
+        |> Authorizations.put(client_id, resource_id, paid_b, exp_b)
+
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = cache
+      assert map_size(paid_map) == 2
+    end
+  end
+
+  describe "prune/1" do
+    test "drops expired entries and removes client/resource keys with no remaining authorizations" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expired = DateTime.utc_now() |> DateTime.add(-3600, :second)
+
+      cache = Authorizations.put(%{}, client_id, resource_id, paid, expired)
+
+      assert Authorizations.prune(cache) == %{}
+    end
+
+    test "keeps entries that are still valid" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+
+      cache = Authorizations.put(%{}, client_id, resource_id, paid, expires_at)
+
+      assert Authorizations.prune(cache) == cache
+    end
+
+    test "preserves valid policy_authorizations on a key with mixed expirations" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_valid = Ecto.UUID.generate()
+      paid_expired = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+
+      cache =
+        %{}
+        |> Authorizations.put(client_id, resource_id, paid_valid, DateTime.add(now, 3600, :second))
+        |> Authorizations.put(client_id, resource_id, paid_expired, DateTime.add(now, -3600, :second))
+
+      pruned = Authorizations.prune(cache)
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = pruned
+      assert map_size(paid_map) == 1
+      assert Map.has_key?(paid_map, dump!(paid_valid))
+      refute Map.has_key?(paid_map, dump!(paid_expired))
+    end
+  end
+
+  describe "reauthorize_deleted_policy_authorization/2" do
+    test "returns :not_found when the {client, resource} pair is not present" do
+      pa = %PolicyAuthorization{
+        id: Ecto.UUID.generate(),
+        initiating_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate()
+      }
+
+      assert Authorizations.reauthorize_deleted_policy_authorization(%{}, pa) ==
+               {:error, :not_found}
+    end
+
+    test "returns :not_found when the policy_authorization id is not in the entry" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+      cache = Authorizations.put(%{}, client_id, resource_id, paid, expires_at)
+
+      pa = %PolicyAuthorization{
+        id: Ecto.UUID.generate(),
+        initiating_device_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert Authorizations.reauthorize_deleted_policy_authorization(cache, pa) ==
+               {:error, :not_found}
+    end
+
+    test "returns the remaining max expiration when other cached authorizations exist" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_a = Ecto.UUID.generate()
+      paid_b = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      exp_a = DateTime.add(now, 60, :second)
+      exp_b = DateTime.add(now, 3600, :second)
+
+      cache =
+        %{}
+        |> Authorizations.put(client_id, resource_id, paid_a, exp_a)
+        |> Authorizations.put(client_id, resource_id, paid_b, exp_b)
+
+      pa = %PolicyAuthorization{
+        id: paid_a,
+        initiating_device_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert {:ok, expires_at_unix, updated} =
+               Authorizations.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert expires_at_unix == DateTime.to_unix(exp_b, :second)
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = updated
+      assert map_size(paid_map) == 1
+    end
+
+    test "drops expired siblings and returns max of fresh remaining" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_target = Ecto.UUID.generate()
+      paid_stale = Ecto.UUID.generate()
+      paid_fresh = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      exp_target = DateTime.add(now, 60, :second)
+      exp_stale = DateTime.add(now, -60, :second)
+      exp_fresh = DateTime.add(now, 3600, :second)
+
+      cache =
+        %{}
+        |> Authorizations.put(client_id, resource_id, paid_target, exp_target)
+        |> Authorizations.put(client_id, resource_id, paid_stale, exp_stale)
+        |> Authorizations.put(client_id, resource_id, paid_fresh, exp_fresh)
+
+      pa = %PolicyAuthorization{
+        id: paid_target,
+        initiating_device_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert {:ok, expires_at_unix, updated} =
+               Authorizations.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert expires_at_unix == DateTime.to_unix(exp_fresh, :second)
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = updated
+      assert map_size(paid_map) == 1
+      assert Map.has_key?(paid_map, dump!(paid_fresh))
+      refute Map.has_key?(paid_map, dump!(paid_stale))
+    end
+
+    test "treats all-expired siblings as last_policy_authorization_removed" do
+      account = account_fixture()
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+
+      initiating_actor = actor_fixture(account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      pa = %PolicyAuthorization{
+        id: Ecto.UUID.generate(),
+        account_id: account.id,
+        initiating_device_id: initiating_client.id,
+        receiving_device_id: target_client.id,
+        resource_id: Ecto.UUID.generate(),
+        token_id: Ecto.UUID.generate(),
+        expires_at: DateTime.utc_now() |> DateTime.add(60, :second)
+      }
+
+      stale_at = DateTime.utc_now() |> DateTime.add(-60, :second)
+
+      cache =
+        %{}
+        |> Authorizations.put(
+          initiating_client.id,
+          pa.resource_id,
+          pa.id,
+          DateTime.utc_now() |> DateTime.add(60, :second)
+        )
+        |> Authorizations.put(
+          initiating_client.id,
+          pa.resource_id,
+          Ecto.UUID.generate(),
+          stale_at
+        )
+
+      assert {:error, :unauthorized, updated} =
+               Authorizations.reauthorize_deleted_policy_authorization(cache, pa)
+
+      key = {dump!(initiating_client.id), dump!(pa.resource_id)}
+      refute Map.has_key?(updated, key)
+    end
+
+    test "creates a new policy_authorization when another conforming policy exists" do
+      account = account_fixture()
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+
+      initiating_actor = actor_fixture(account: account)
+      identity_fixture(actor: initiating_actor, account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      group_a = Portal.GroupFixtures.group_fixture(account: account)
+      group_b = Portal.GroupFixtures.group_fixture(account: account)
+
+      Portal.MembershipFixtures.membership_fixture(
+        account: account,
+        actor: initiating_actor,
+        group: group_a
+      )
+
+      Portal.MembershipFixtures.membership_fixture(
+        account: account,
+        actor: initiating_actor,
+        group: group_b
+      )
+
+      auth_provider = Portal.AuthProviderFixtures.email_otp_provider_fixture(account: account).auth_provider
+
+      token =
+        Portal.TokenFixtures.client_token_fixture(
+          account: account,
+          actor: initiating_actor,
+          auth_provider: auth_provider
+        )
+
+      Portal.ClientSessionFixtures.client_session_fixture(
+        account: account,
+        actor: initiating_actor,
+        client: initiating_client,
+        token: token
+      )
+
+      pool_resource =
+        Portal.ResourceFixtures.static_device_pool_resource_fixture(
+          account: account,
+          clients: [target_client]
+        )
+
+      policy_a =
+        Portal.PolicyFixtures.policy_fixture(account: account, group: group_a, resource: pool_resource)
+
+      Portal.PolicyFixtures.policy_fixture(account: account, group: group_b, resource: pool_resource)
+
+      pa =
+        policy_authorization_fixture(
+          account: account,
+          actor: initiating_actor,
+          client: initiating_client,
+          gateway: target_client,
+          resource: pool_resource,
+          group: group_a,
+          policy: policy_a,
+          token: token
+        )
+
+      cache = Authorizations.hydrate(target_client)
+
+      Portal.Repo.delete!(policy_a)
+
+      assert {:ok, expires_at_unix, updated} =
+               Authorizations.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert is_integer(expires_at_unix)
+      key = {dump!(initiating_client.id), dump!(pool_resource.id)}
+      assert %{^key => paid_map} = updated
+      assert map_size(paid_map) == 1
+    end
+
+    test "returns :unauthorized when the last authorization is removed and reauth fails" do
+      account = account_fixture()
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor)
+
+      initiating_actor = actor_fixture(account: account)
+      identity_fixture(actor: initiating_actor, account: account)
+      initiating_client = client_fixture(account: account, actor: initiating_actor)
+
+      group = Portal.GroupFixtures.group_fixture(account: account)
+
+      Portal.MembershipFixtures.membership_fixture(
+        account: account,
+        actor: initiating_actor,
+        group: group
+      )
+
+      pool_resource =
+        Portal.ResourceFixtures.static_device_pool_resource_fixture(
+          account: account,
+          clients: [target_client]
+        )
+
+      policy =
+        Portal.PolicyFixtures.policy_fixture(
+          account: account,
+          group: group,
+          resource: pool_resource
+        )
+
+      pa =
+        policy_authorization_fixture(
+          account: account,
+          actor: initiating_actor,
+          client: initiating_client,
+          gateway: target_client,
+          resource: pool_resource,
+          group: group,
+          policy: policy
+        )
+
+      cache = Authorizations.hydrate(target_client)
+
+      Portal.Repo.delete!(policy)
+
+      assert {:error, :unauthorized, updated} =
+               Authorizations.reauthorize_deleted_policy_authorization(cache, pa)
+
+      key = {dump!(initiating_client.id), dump!(pool_resource.id)}
+      refute Map.has_key?(updated, key)
+    end
+  end
+
+  describe "has_resource?/2" do
+    test "returns true when the cache holds at least one entry for the resource" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+      cache = Authorizations.put(%{}, client_id, resource_id, paid, expires_at)
+
+      assert Authorizations.has_resource?(cache, resource_id)
+    end
+
+    test "returns false when the resource is not in the cache" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+      cache = Authorizations.put(%{}, client_id, resource_id, paid, expires_at)
+
+      refute Authorizations.has_resource?(cache, Ecto.UUID.generate())
+    end
+  end
+
+  describe "all_pairs_for_resource/2" do
+    test "returns every {client, resource} pair matching the resource" do
+      resource_id = Ecto.UUID.generate()
+      other_resource_id = Ecto.UUID.generate()
+      client_a = Ecto.UUID.generate()
+      client_b = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+
+      cache =
+        %{}
+        |> Authorizations.put(client_a, resource_id, Ecto.UUID.generate(), expires_at)
+        |> Authorizations.put(client_b, resource_id, Ecto.UUID.generate(), expires_at)
+        |> Authorizations.put(client_a, other_resource_id, Ecto.UUID.generate(), expires_at)
+
+      pairs = Authorizations.all_pairs_for_resource(cache, resource_id)
+
+      assert Enum.sort(pairs) ==
+               Enum.sort([{client_a, resource_id}, {client_b, resource_id}])
+    end
+
+    test "returns an empty list when no pairs match the resource" do
+      cache =
+        Authorizations.put(
+          %{},
+          Ecto.UUID.generate(),
+          Ecto.UUID.generate(),
+          Ecto.UUID.generate(),
+          DateTime.add(DateTime.utc_now(), 3600, :second)
+        )
+
+      assert Authorizations.all_pairs_for_resource(cache, Ecto.UUID.generate()) == []
+    end
+  end
+end

--- a/elixir/test/portal/cache/client_test.exs
+++ b/elixir/test/portal/cache/client_test.exs
@@ -449,4 +449,660 @@ defmodule Portal.Cache.ClientTest do
       refute Map.has_key?(cache.pool_members, Ecto.UUID.dump!(resource.id))
     end
   end
+
+  describe "track_authorized_device_ipv4/2" do
+    test "appends the IPv4 to the cache's authorized set" do
+      cache = %Cache{authorized_device_ipv4s: MapSet.new()}
+      ipv4 = %Postgrex.INET{address: {10, 0, 0, 5}}
+
+      cache = Cache.track_authorized_device_ipv4(cache, ipv4)
+
+      assert MapSet.member?(cache.authorized_device_ipv4s, {10, 0, 0, 5})
+    end
+  end
+
+  describe "add_policy/5 no-op paths" do
+    setup do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        remote_ip_location_region: subject.context.remote_ip_location_region,
+        version: "1.5.0"
+      }
+
+      %{account: account, actor: actor, subject: subject, client: client, session: session}
+    end
+
+    test "returns the cache unchanged when the policy's group isn't in memberships", %{
+      account: account,
+      subject: subject,
+      client: client,
+      session: session
+    } do
+      {:ok, _, _, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      other_group = group_fixture(account: account)
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+      policy = policy_fixture(account: account, group: other_group, resource: resource)
+
+      assert {:ok, [], [], ^cache} =
+               Cache.add_policy(cache, policy, client, session, subject)
+    end
+  end
+
+  describe "update_policy/2 no-op when not in cache" do
+    test "leaves the cache untouched if policy.id is unknown" do
+      cache = %Cache{
+        policies: %{},
+        resources: %{},
+        memberships: %{},
+        connectable_resources: [],
+        pool_members: %{},
+        device_addresses: %{},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      policy = %Portal.Policy{
+        id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate(),
+        group_id: Ecto.UUID.generate(),
+        conditions: []
+      }
+
+      assert {:ok, [], [], ^cache} = Cache.update_policy(cache, policy)
+    end
+  end
+
+  describe "delete_policy/5 no-op when not in cache" do
+    setup do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        remote_ip_location_region: subject.context.remote_ip_location_region,
+        version: "1.5.0"
+      }
+
+      %{account: account, subject: subject, client: client, session: session}
+    end
+
+    test "returns cache unchanged for an unknown policy id", %{
+      account: account,
+      subject: subject,
+      client: client,
+      session: session
+    } do
+      {:ok, _, _, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      group = group_fixture(account: account)
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+      stranger_policy = policy_fixture(account: account, group: group, resource: resource)
+
+      assert {:ok, [], [], ^cache} =
+               Cache.delete_policy(cache, stranger_policy, client, session, subject)
+    end
+  end
+
+  describe "update_resource/5 no-op when not in cache" do
+    setup do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        remote_ip_location_region: subject.context.remote_ip_location_region,
+        version: "1.5.0"
+      }
+
+      %{account: account, subject: subject, client: client, session: session}
+    end
+
+    test "returns cache unchanged when resource isn't in the cache", %{
+      account: account,
+      subject: subject,
+      client: client,
+      session: session
+    } do
+      {:ok, _, _, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      site = site_fixture(account: account)
+      stranger = dns_resource_fixture(account: account, site: site)
+
+      assert {:ok, [], [], ^cache} =
+               Cache.update_resource(cache, stranger, client, session, subject)
+    end
+  end
+
+  describe "add_static_device_pool_member/3 no-op when not connectable" do
+    setup do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      %{account: account, subject: subject}
+    end
+
+    test "ignores members for resources outside connectable_resources", %{
+      account: account,
+      subject: subject
+    } do
+      cache = %Cache{
+        policies: %{},
+        resources: %{},
+        memberships: %{},
+        connectable_resources: [],
+        pool_members: %{},
+        device_addresses: %{},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      target = client_fixture(account: account)
+
+      member = %Portal.StaticDevicePoolMember{
+        account_id: account.id,
+        resource_id: Ecto.UUID.generate(),
+        device_id: target.id
+      }
+
+      assert {:ok, [], [], ^cache} =
+               Cache.add_static_device_pool_member(cache, member, subject)
+    end
+  end
+
+  describe "handle_member_device_update/3" do
+    test "no-op when device is not tracked" do
+      cache = %Cache{
+        policies: %{},
+        resources: %{},
+        memberships: %{},
+        connectable_resources: [],
+        pool_members: %{},
+        device_addresses: %{},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      device = %Portal.Device{
+        id: Ecto.UUID.generate(),
+        type: :client,
+        ipv4: %Postgrex.INET{address: {100, 64, 0, 5}, netmask: 32},
+        ipv6: %Postgrex.INET{address: {0, 0, 0, 0, 0, 0, 0, 1}, netmask: 128}
+      }
+
+      assert {:ok, [], [], ^cache} =
+               Cache.handle_member_device_update(cache, device, nil)
+    end
+
+    test "no-op when addresses are unchanged" do
+      did_bytes = Ecto.UUID.bingenerate()
+      device_id = Ecto.UUID.load!(did_bytes)
+      ipv4_tuple = {100, 64, 0, 5}
+      ipv6_tuple = {0, 0, 0, 0, 0, 0, 0, 1}
+
+      cache = %Cache{
+        policies: %{},
+        resources: %{},
+        memberships: %{},
+        connectable_resources: [],
+        pool_members: %{},
+        device_addresses: %{did_bytes => {ipv4_tuple, ipv6_tuple}},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      device = %Portal.Device{
+        id: device_id,
+        type: :client,
+        ipv4: %Postgrex.INET{address: ipv4_tuple, netmask: 32},
+        ipv6: %Postgrex.INET{address: ipv6_tuple, netmask: 128}
+      }
+
+      assert {:ok, [], [], ^cache} =
+               Cache.handle_member_device_update(cache, device, nil)
+    end
+  end
+
+  describe "delete_policy/5 keeps resource when another policy still references it" do
+    test "keeps the resource and only removes the deleted policy" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+
+      group_a = group_fixture(account: account)
+      group_b = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group_a)
+      membership_fixture(account: account, actor: actor, group: group_b)
+
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+
+      policy_a = policy_fixture(account: account, group: group_a, resource: resource)
+      policy_fixture(account: account, group: group_b, resource: resource)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        remote_ip_location_region: subject.context.remote_ip_location_region,
+        version: "1.5.0"
+      }
+
+      {:ok, _, _, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      assert {:ok, [], [], cache} =
+               Cache.delete_policy(cache, policy_a, client, session, subject)
+
+      assert Map.has_key?(cache.resources, Ecto.UUID.dump!(resource.id))
+    end
+  end
+
+  describe "all_member_ips/2 empty input" do
+    test "returns an empty list without hitting the DB" do
+      assert Cache.Database.all_member_ips([], nil) == []
+    end
+  end
+
+  describe "ensure_device_addresses fast path" do
+    test "add_static_device_pool_member reuses existing device addresses without re-querying" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      target = client_fixture(account: account)
+      did_bytes = Ecto.UUID.dump!(target.id)
+      ipv4_tuple = target.ipv4.address
+      ipv6_tuple = target.ipv6.address
+
+      pool =
+        static_device_pool_resource_fixture(account: account, clients: [])
+
+      rid_bytes = Ecto.UUID.dump!(pool.id)
+
+      cacheable_pool = Cacheable.to_cache(pool)
+
+      cache = %Cache{
+        policies: %{},
+        resources: %{rid_bytes => cacheable_pool},
+        memberships: %{},
+        connectable_resources: [%{cacheable_pool | devices: []}],
+        pool_members: %{},
+        device_addresses: %{did_bytes => {ipv4_tuple, ipv6_tuple}},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      member = %Portal.StaticDevicePoolMember{
+        account_id: account.id,
+        resource_id: pool.id,
+        device_id: target.id
+      }
+
+      assert {:ok, [_pool], [], updated} =
+               Cache.add_static_device_pool_member(cache, member, subject)
+
+      assert MapSet.member?(updated.pool_members[rid_bytes], did_bytes)
+    end
+  end
+
+  describe "delete_static_device_pool_member/2" do
+    test "keeps remaining members for a pool when only one is removed" do
+      account = account_fixture()
+
+      target_a = client_fixture(account: account)
+      target_b = client_fixture(account: account)
+      did_a = Ecto.UUID.dump!(target_a.id)
+      did_b = Ecto.UUID.dump!(target_b.id)
+
+      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      rid_bytes = Ecto.UUID.dump!(pool.id)
+
+      cacheable_pool = Cacheable.to_cache(pool)
+
+      cache = %Cache{
+        policies: %{},
+        resources: %{rid_bytes => cacheable_pool},
+        memberships: %{},
+        connectable_resources: [%{cacheable_pool | devices: []}],
+        pool_members: %{rid_bytes => MapSet.new([did_a, did_b])},
+        device_addresses: %{
+          did_a => {target_a.ipv4.address, target_a.ipv6.address},
+          did_b => {target_b.ipv4.address, target_b.ipv6.address}
+        },
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      member = %Portal.StaticDevicePoolMember{
+        account_id: account.id,
+        resource_id: pool.id,
+        device_id: target_a.id
+      }
+
+      assert {:ok, _denied, [_pool], [], updated} =
+               Cache.delete_static_device_pool_member(cache, member)
+
+      assert MapSet.member?(updated.pool_members[rid_bytes], did_b)
+      refute MapSet.member?(updated.pool_members[rid_bytes], did_a)
+    end
+  end
+
+  describe "authorize_resource/5 logs when membership is missing from cache" do
+    test "warns and returns :not_found when policy.group_id has no membership entry" do
+      import ExUnit.CaptureLog
+
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        remote_ip_location_region: subject.context.remote_ip_location_region,
+        version: "1.5.0"
+      }
+
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+      resource_id = resource.id
+      rid_bytes = Ecto.UUID.dump!(resource_id)
+      orphan_group_id = Ecto.UUID.bingenerate()
+
+      cacheable_resource = Cacheable.to_cache(resource)
+
+      cache = %Cache{
+        policies: %{
+          Ecto.UUID.bingenerate() => %Portal.Cache.Cacheable.Policy{
+            id: Ecto.UUID.bingenerate(),
+            resource_id: rid_bytes,
+            group_id: orphan_group_id,
+            conditions: []
+          }
+        },
+        resources: %{rid_bytes => cacheable_resource},
+        memberships: %{},
+        connectable_resources: [cacheable_resource],
+        pool_members: %{},
+        device_addresses: %{},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      log =
+        capture_log(fn ->
+          assert Cache.authorize_resource(cache, client, session, resource_id, subject) ==
+                   {:error, :not_found}
+        end)
+
+      assert log =~ "membership not found in cache"
+    end
+  end
+
+  describe "add_static_device_pool_member/3 add a second member" do
+    test "extends existing pool_members entry instead of creating a new one" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      target_a = client_fixture(account: account)
+      target_b = client_fixture(account: account)
+      did_a = Ecto.UUID.dump!(target_a.id)
+      did_b = Ecto.UUID.dump!(target_b.id)
+
+      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      rid_bytes = Ecto.UUID.dump!(pool.id)
+
+      cacheable_pool = Cacheable.to_cache(pool)
+
+      cache = %Cache{
+        policies: %{},
+        resources: %{rid_bytes => cacheable_pool},
+        memberships: %{},
+        connectable_resources: [%{cacheable_pool | devices: []}],
+        pool_members: %{rid_bytes => MapSet.new([did_a])},
+        device_addresses: %{
+          did_a => {target_a.ipv4.address, target_a.ipv6.address},
+          did_b => {target_b.ipv4.address, target_b.ipv6.address}
+        },
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      member = %Portal.StaticDevicePoolMember{
+        account_id: account.id,
+        resource_id: pool.id,
+        device_id: target_b.id
+      }
+
+      assert {:ok, [_pool], [], updated} =
+               Cache.add_static_device_pool_member(cache, member, subject)
+
+      members = updated.pool_members[rid_bytes]
+      assert MapSet.member?(members, did_a)
+      assert MapSet.member?(members, did_b)
+    end
+  end
+
+  describe "all_memberships_for_actor_id!/2 includes Everyone group" do
+    test "synthesises a membership entry when actor has access to Everyone" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      everyone_group =
+        Portal.Repo.insert!(%Portal.Group{
+          account_id: account.id,
+          name: "Everyone",
+          type: :managed,
+          idp_id: nil
+        })
+
+      memberships = Cache.Database.all_memberships_for_actor_id!(actor.id, subject)
+
+      assert Enum.any?(memberships, fn m ->
+               m.group_id == everyone_group.id and is_nil(m.id)
+             end)
+    end
+  end
+
+  describe "fetch_resource_by_id/2 not_found path" do
+    test "returns :not_found for an unknown resource id" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      assert Cache.Database.fetch_resource_by_id(Ecto.UUID.generate(), subject) ==
+               {:error, :not_found}
+    end
+  end
+
+  describe "render_pool_devices ignores orphan members without addresses" do
+    test "skips members whose addresses aren't in device_addresses on refresh" do
+      account = account_fixture()
+      target_a = client_fixture(account: account)
+      target_b = client_fixture(account: account)
+      did_a = Ecto.UUID.dump!(target_a.id)
+      did_b = Ecto.UUID.dump!(target_b.id)
+
+      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      rid_bytes = Ecto.UUID.dump!(pool.id)
+
+      cacheable_pool = Cacheable.to_cache(pool)
+
+      cache = %Cache{
+        policies: %{},
+        resources: %{rid_bytes => cacheable_pool},
+        memberships: %{},
+        connectable_resources: [%{cacheable_pool | devices: []}],
+        # Both did_a and did_b are members of the pool but only did_a has
+        # device_addresses. When we remove did_a and refresh, render_pool_devices has
+        # to skip did_b via the :error branch.
+        pool_members: %{rid_bytes => MapSet.new([did_a, did_b])},
+        device_addresses: %{did_a => {target_a.ipv4.address, target_a.ipv6.address}},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      member = %Portal.StaticDevicePoolMember{
+        account_id: account.id,
+        resource_id: pool.id,
+        device_id: target_a.id
+      }
+
+      assert {:ok, _denied, [pool_view], [], updated} =
+               Cache.delete_static_device_pool_member(cache, member)
+
+      # did_b is still in pool_members but had no device_addresses, so the rendered
+      # pool has no devices.
+      assert pool_view.devices == []
+      assert MapSet.member?(updated.pool_members[rid_bytes], did_b)
+    end
+  end
+
+  describe "load_pool_state with multi-member pool" do
+    test "tracks multiple device members in the same pool" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+
+      subject =
+        subject_fixture(
+          account: account,
+          actor: actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      client = client_fixture(account: account, actor: actor)
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+
+      target_a = client_fixture(account: account)
+      target_b = client_fixture(account: account)
+
+      pool =
+        static_device_pool_resource_fixture(
+          account: account,
+          clients: [target_a, target_b]
+        )
+
+      policy_fixture(account: account, group: group, resource: pool)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: "Mac OS/14 apple-client/1.5.16",
+        remote_ip: subject.context.remote_ip,
+        version: "1.5.16"
+      }
+
+      {:ok, _, _, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      rid_bytes = Ecto.UUID.dump!(pool.id)
+      did_a = Ecto.UUID.dump!(target_a.id)
+      did_b = Ecto.UUID.dump!(target_b.id)
+
+      assert MapSet.member?(cache.pool_members[rid_bytes], did_a)
+      assert MapSet.member?(cache.pool_members[rid_bytes], did_b)
+    end
+  end
+
+  describe "ensure_device_addresses :error branch" do
+    test "add_static_device_pool_member returns no-op when get_client_addresses can't find device" do
+      import ExUnit.CaptureLog
+
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+
+      pool = static_device_pool_resource_fixture(account: account, clients: [])
+      rid_bytes = Ecto.UUID.dump!(pool.id)
+
+      cacheable_pool = Cacheable.to_cache(pool)
+
+      cache = %Cache{
+        policies: %{},
+        resources: %{rid_bytes => cacheable_pool},
+        memberships: %{},
+        connectable_resources: [%{cacheable_pool | devices: []}],
+        pool_members: %{},
+        device_addresses: %{},
+        authorized_device_ipv4s: MapSet.new()
+      }
+
+      member = %Portal.StaticDevicePoolMember{
+        account_id: account.id,
+        resource_id: pool.id,
+        device_id: Ecto.UUID.generate()
+      }
+
+      log =
+        capture_log(fn ->
+          assert {:ok, [], [], ^cache} =
+                   Cache.add_static_device_pool_member(cache, member, subject)
+        end)
+
+      assert log =~ "Addresses not found for client"
+    end
+  end
+
+  describe "fetch_site_for_resource nil branch" do
+    test "update_resource sets site to nil when get_site_by_id returns nil" do
+      account = account_fixture()
+      actor = actor_fixture(type: :account_admin_user, account: account)
+      subject = subject_fixture(account: account, actor: actor, type: :client)
+      client = client_fixture(account: account, actor: actor)
+
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+      policy_fixture(account: account, group: group, resource: resource)
+
+      session = %Portal.ClientSession{
+        device_id: client.id,
+        account_id: client.account_id,
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip,
+        remote_ip_location_region: subject.context.remote_ip_location_region,
+        version: "1.5.0"
+      }
+
+      {:ok, _, _, cache} =
+        Cache.recompute_connectable_resources(nil, client, session, subject)
+
+      # Force the resource to point at a non-existent site, then run update_resource —
+      # site will look "changed" relative to cache, but get_site_by_id returns nil.
+      orphan_site_id = Ecto.UUID.generate()
+      changed_resource = %{resource | site: nil, site_id: orphan_site_id}
+
+      assert {:ok, _, _, updated} =
+               Cache.update_resource(cache, changed_resource, client, session, subject)
+
+      cached_resource = Map.fetch!(updated.resources, Ecto.UUID.dump!(resource.id))
+      assert is_nil(cached_resource.site)
+    end
+  end
 end

--- a/elixir/test/portal/cache/gateway_test.exs
+++ b/elixir/test/portal/cache/gateway_test.exs
@@ -1,0 +1,500 @@
+defmodule Portal.Cache.GatewayTest do
+  use Portal.DataCase, async: true
+
+  alias Portal.Cache
+  alias Portal.PolicyAuthorization
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
+  import Portal.ClientSessionFixtures
+  import Portal.DeviceFixtures
+  import Portal.GroupFixtures
+  import Portal.IdentityFixtures
+  import Portal.MembershipFixtures
+  import Portal.PolicyAuthorizationFixtures
+  import Portal.PolicyFixtures
+  import Portal.ResourceFixtures
+  import Portal.SiteFixtures
+  import Portal.TokenFixtures
+
+  import Ecto.Query, only: [from: 2]
+  import Ecto.UUID, only: [dump!: 1]
+
+  describe "hydrate/1" do
+    test "returns an empty cache when there are no policy_authorizations" do
+      account = account_fixture()
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+
+      assert Cache.Gateway.hydrate(gateway) == %{}
+    end
+
+    test "loads matching policy_authorizations into the cache" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      identity_fixture(actor: actor, account: account)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      client = client_fixture(account: account, actor: actor)
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          gateway: gateway,
+          client: client
+        )
+
+      cache = Cache.Gateway.hydrate(gateway)
+
+      key = {dump!(client.id), dump!(policy_authorization.resource_id)}
+      assert %{^key => paid_map} = cache
+      assert Map.fetch!(paid_map, dump!(policy_authorization.id)) ==
+               DateTime.to_unix(policy_authorization.expires_at, :second)
+    end
+
+    test "ignores expired policy_authorizations" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      identity_fixture(actor: actor, account: account)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      client = client_fixture(account: account, actor: actor)
+
+      expired_policy_authorization_fixture(
+        account: account,
+        actor: actor,
+        gateway: gateway,
+        client: client
+      )
+
+      assert Cache.Gateway.hydrate(gateway) == %{}
+    end
+  end
+
+  describe "get/3" do
+    test "returns nil when the {client, resource} pair is not in the cache" do
+      assert Cache.Gateway.get(%{}, Ecto.UUID.generate(), Ecto.UUID.generate()) == nil
+    end
+
+    test "returns the longest expiration for the pair" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      shorter = DateTime.add(now, 60, :second)
+      longer = DateTime.add(now, 3600, :second)
+
+      cache =
+        %{}
+        |> Cache.Gateway.put(client_id, dump!(resource_id), Ecto.UUID.generate(), shorter)
+        |> Cache.Gateway.put(client_id, dump!(resource_id), Ecto.UUID.generate(), longer)
+
+      assert Cache.Gateway.get(cache, client_id, resource_id) ==
+               DateTime.to_unix(longer, :second)
+    end
+  end
+
+  describe "put/5" do
+    test "inserts a new entry" do
+      cache = %{}
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+
+      cache = Cache.Gateway.put(cache, client_id, dump!(resource_id), paid, expires_at)
+
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = cache
+      assert Map.fetch!(paid_map, dump!(paid)) == DateTime.to_unix(expires_at, :second)
+    end
+  end
+
+  describe "prune/1" do
+    test "drops expired authorizations" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expired = DateTime.utc_now() |> DateTime.add(-3600, :second)
+
+      cache = Cache.Gateway.put(%{}, client_id, dump!(resource_id), paid, expired)
+
+      assert Cache.Gateway.prune(cache) == %{}
+    end
+  end
+
+  describe "has_resource?/2" do
+    test "returns true when the resource is present" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+      cache = Cache.Gateway.put(%{}, client_id, dump!(resource_id), paid, expires_at)
+
+      assert Cache.Gateway.has_resource?(cache, resource_id)
+    end
+
+    test "returns false when the resource is not present" do
+      refute Cache.Gateway.has_resource?(%{}, Ecto.UUID.generate())
+    end
+  end
+
+  describe "all_pairs_for_resource/2" do
+    test "returns matching {client, resource} pairs" do
+      resource_id = Ecto.UUID.generate()
+      client_a = Ecto.UUID.generate()
+      client_b = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+
+      cache =
+        %{}
+        |> Cache.Gateway.put(client_a, dump!(resource_id), Ecto.UUID.generate(), expires_at)
+        |> Cache.Gateway.put(client_b, dump!(resource_id), Ecto.UUID.generate(), expires_at)
+
+      pairs = Cache.Gateway.all_pairs_for_resource(cache, resource_id)
+      assert Enum.sort(pairs) ==
+               Enum.sort([{client_a, resource_id}, {client_b, resource_id}])
+    end
+  end
+
+  describe "reauthorize_deleted_policy_authorization/2" do
+    test "returns :not_found when the {client, resource} pair is not present" do
+      pa = %PolicyAuthorization{
+        id: Ecto.UUID.generate(),
+        initiating_device_id: Ecto.UUID.generate(),
+        resource_id: Ecto.UUID.generate()
+      }
+
+      assert Cache.Gateway.reauthorize_deleted_policy_authorization(%{}, pa) ==
+               {:error, :not_found}
+    end
+
+    test "returns :not_found when the inner policy_authorization id is missing" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+      cache = Cache.Gateway.put(%{}, client_id, dump!(resource_id), paid, expires_at)
+
+      pa = %PolicyAuthorization{
+        id: Ecto.UUID.generate(),
+        initiating_device_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa) ==
+               {:error, :not_found}
+    end
+
+    test "returns the remaining max expiration when other authorizations exist" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_a = Ecto.UUID.generate()
+      paid_b = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      exp_a = DateTime.add(now, 60, :second)
+      exp_b = DateTime.add(now, 3600, :second)
+
+      cache =
+        %{}
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_a, exp_a)
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_b, exp_b)
+
+      pa = %PolicyAuthorization{
+        id: paid_a,
+        initiating_device_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert {:ok, expires_at_unix, updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert expires_at_unix == DateTime.to_unix(exp_b, :second)
+      assert map_size(updated) == 1
+    end
+
+    test "drops expired siblings and returns max of fresh remaining" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_target = Ecto.UUID.generate()
+      paid_stale = Ecto.UUID.generate()
+      paid_fresh = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      exp_target = DateTime.add(now, 60, :second)
+      exp_stale = DateTime.add(now, -60, :second)
+      exp_fresh = DateTime.add(now, 3600, :second)
+
+      cache =
+        %{}
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_target, exp_target)
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_stale, exp_stale)
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_fresh, exp_fresh)
+
+      pa = %PolicyAuthorization{
+        id: paid_target,
+        initiating_device_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert {:ok, expires_at_unix, updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert expires_at_unix == DateTime.to_unix(exp_fresh, :second)
+      key = {dump!(client_id), dump!(resource_id)}
+      assert %{^key => paid_map} = updated
+      assert map_size(paid_map) == 1
+      assert Map.has_key?(paid_map, dump!(paid_fresh))
+      refute Map.has_key?(paid_map, dump!(paid_stale))
+    end
+
+    test "treats all-expired siblings as last_policy_authorization_removed" do
+      client_id = Ecto.UUID.generate()
+      resource_id = Ecto.UUID.generate()
+      paid_target = Ecto.UUID.generate()
+      paid_stale = Ecto.UUID.generate()
+      now = DateTime.utc_now()
+      exp_target = DateTime.add(now, 60, :second)
+      exp_stale = DateTime.add(now, -60, :second)
+
+      cache =
+        %{}
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_target, exp_target)
+        |> Cache.Gateway.put(client_id, dump!(resource_id), paid_stale, exp_stale)
+
+      pa = %PolicyAuthorization{
+        id: paid_target,
+        account_id: Ecto.UUID.generate(),
+        initiating_device_id: client_id,
+        receiving_device_id: Ecto.UUID.generate(),
+        resource_id: resource_id,
+        token_id: Ecto.UUID.generate(),
+        expires_at: DateTime.utc_now() |> DateTime.add(60, :second)
+      }
+
+      assert {:error, :unauthorized, updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+
+      key = {dump!(client_id), dump!(resource_id)}
+      refute Map.has_key?(updated, key)
+    end
+
+    test "creates a new policy_authorization when another conforming policy exists" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      identity_fixture(actor: actor, account: account)
+      group_a = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group_a)
+      group_b = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group_b)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      client = client_fixture(account: account, actor: actor)
+
+      auth_provider = email_otp_provider_fixture(account: account).auth_provider
+
+      token =
+        client_token_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: auth_provider
+        )
+
+      client_session_fixture(account: account, actor: actor, client: client, token: token)
+
+      resource = resource_fixture(account: account, site: site)
+
+      policy_a = policy_fixture(account: account, group: group_a, resource: resource)
+      policy_fixture(account: account, group: group_b, resource: resource)
+
+      pa =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          gateway: gateway,
+          client: client,
+          resource: resource,
+          group: group_a,
+          policy: policy_a,
+          token: token
+        )
+
+      cache = Cache.Gateway.hydrate(gateway)
+
+      Portal.Repo.delete!(policy_a)
+
+      assert {:ok, expires_at_unix, updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert is_integer(expires_at_unix)
+      key = {dump!(client.id), dump!(resource.id)}
+      assert %{^key => paid_map} = updated
+      assert map_size(paid_map) == 1
+    end
+
+    test "creates a new authorization for an Everyone-group policy without an explicit membership" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      identity_fixture(actor: actor, account: account)
+
+      everyone_group =
+        %Portal.Group{
+          account_id: account.id,
+          name: "Everyone",
+          type: :managed,
+          idp_id: nil
+        }
+        |> Portal.Repo.insert!()
+        |> Portal.Repo.preload(:account)
+
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      client = client_fixture(account: account, actor: actor)
+
+      auth_provider = email_otp_provider_fixture(account: account).auth_provider
+
+      token =
+        client_token_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: auth_provider
+        )
+
+      client_session_fixture(account: account, actor: actor, client: client, token: token)
+
+      resource = resource_fixture(account: account, site: site)
+
+      everyone_policy =
+        policy_fixture(account: account, group: everyone_group, resource: resource)
+
+      pa =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          gateway: gateway,
+          client: client,
+          resource: resource,
+          group: everyone_group,
+          policy: everyone_policy,
+          token: token
+        )
+
+      cache = Cache.Gateway.hydrate(gateway)
+
+      # Remove the auto-created membership so the reauth flow falls into the
+      # Everyone-group nil-membership branch.
+      Portal.Repo.delete_all(
+        from(m in Portal.Membership,
+          where: m.account_id == ^account.id and m.group_id == ^everyone_group.id
+        )
+      )
+
+      assert {:ok, expires_at_unix, updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+
+      assert is_integer(expires_at_unix)
+      key = {dump!(client.id), dump!(resource.id)}
+      assert %{^key => paid_map} = updated
+      assert map_size(paid_map) == 1
+    end
+
+    test "returns :unauthorized when the last authorization is removed and reauth fails" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      identity_fixture(actor: actor, account: account)
+      group = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      client = client_fixture(account: account, actor: actor)
+      resource = resource_fixture(account: account, site: site)
+      policy = policy_fixture(account: account, group: group, resource: resource)
+
+      pa =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          gateway: gateway,
+          client: client,
+          resource: resource,
+          group: group,
+          policy: policy
+        )
+
+      # Hydrate cache while the authorization still exists.
+      cache = Cache.Gateway.hydrate(gateway)
+
+      # Now delete the policy (cascading to delete the authorization in DB) — reauth attempt
+      # should fail because no other policy grants access.
+      Portal.Repo.delete!(policy)
+
+      assert {:error, :unauthorized, updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+
+      key = {dump!(client.id), dump!(resource.id)}
+      refute Map.has_key?(updated, key)
+    end
+
+    test "returns :unauthorized when all replacement policies have non-conforming conditions" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      identity_fixture(actor: actor, account: account)
+      group_a = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group_a)
+      group_b = group_fixture(account: account)
+      membership_fixture(account: account, actor: actor, group: group_b)
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+      client = client_fixture(account: account, actor: actor)
+
+      auth_provider = email_otp_provider_fixture(account: account).auth_provider
+
+      token =
+        client_token_fixture(
+          account: account,
+          actor: actor,
+          auth_provider: auth_provider
+        )
+
+      client_session_fixture(account: account, actor: actor, client: client, token: token)
+
+      resource = resource_fixture(account: account, site: site)
+
+      policy_a = policy_fixture(account: account, group: group_a, resource: resource)
+
+      # Replacement policy with a condition that won't match (remote_ip restricted to
+      # 0.0.0.0/32, but the client_session_fixture defaults to 100.64.0.1).
+      policy_fixture(
+        account: account,
+        group: group_b,
+        resource: resource,
+        conditions: [
+          %{
+            property: :remote_ip,
+            operator: :is_in_cidr,
+            values: ["0.0.0.0/32"]
+          }
+        ]
+        )
+
+      pa =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          gateway: gateway,
+          client: client,
+          resource: resource,
+          group: group_a,
+          policy: policy_a,
+          token: token
+        )
+
+      cache = Cache.Gateway.hydrate(gateway)
+
+      Portal.Repo.delete!(policy_a)
+
+      assert {:error, :unauthorized, _updated} =
+               Cache.Gateway.reauthorize_deleted_policy_authorization(cache, pa)
+    end
+  end
+end

--- a/elixir/test/portal/policy_authorization_test.exs
+++ b/elixir/test/portal/policy_authorization_test.exs
@@ -42,9 +42,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -55,9 +55,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -88,9 +88,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: Ecto.UUID.generate(),
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -100,9 +100,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -134,9 +134,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -146,9 +146,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -180,9 +180,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -192,9 +192,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -226,9 +226,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -238,9 +238,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -273,9 +273,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: Ecto.UUID.generate(),
             token_id: token.id,
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -285,9 +285,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -319,9 +319,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: Ecto.UUID.generate(),
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -331,9 +331,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -365,9 +365,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: nil,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -377,9 +377,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )
@@ -412,9 +412,9 @@ defmodule Portal.PolicyAuthorizationTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: membership.id,
-            client_remote_ip: @valid_ip,
-            client_user_agent: @valid_user_agent,
-            gateway_remote_ip: @valid_gateway_ip,
+            initiator_remote_ip: @valid_ip,
+            initiator_user_agent: @valid_user_agent,
+            receiver_remote_ip: @valid_gateway_ip,
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -424,9 +424,9 @@ defmodule Portal.PolicyAuthorizationTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -1,5 +1,6 @@
 defmodule PortalAPI.Client.ChannelTest do
   use PortalAPI.ChannelCase, async: true
+  import Ecto.Query, only: [from: 2]
   import ExUnit.CaptureLog
   alias Portal.Changes
   alias Portal.Presence
@@ -1748,12 +1749,11 @@ defmodule PortalAPI.Client.ChannelTest do
           ip_stack: :ipv4_only
         )
 
-      _policy =
-        policy_fixture(
-          account: account,
-          group: group,
-          resource: resource
-        )
+      policy_fixture(
+        account: account,
+        group: group,
+        resource: resource
+      )
 
       # Send membership change to trigger resource access computation
       send(socket.channel_pid, %Changes.Change{
@@ -2416,19 +2416,18 @@ defmodule PortalAPI.Client.ChannelTest do
         )
 
       # Create restrictive policy with client verification requirement
-      _restrictive_policy =
-        policy_fixture(
-          account: account,
-          group: group_1,
-          resource: resource,
-          conditions: [
-            %{
-              property: :client_verified,
-              operator: :is,
-              values: ["true"]
-            }
-          ]
-        )
+      policy_fixture(
+        account: account,
+        group: group_1,
+        resource: resource,
+        conditions: [
+          %{
+            property: :client_verified,
+            operator: :is,
+            values: ["true"]
+          }
+        ]
+      )
 
       membership_1 =
         membership_fixture(
@@ -5098,7 +5097,6 @@ defmodule PortalAPI.Client.ChannelTest do
     end
 
     test "sends authorized to both clients when target ipv4 is found in presence", %{
-      account: account,
       client: client,
       subject: subject,
       target_client: target_client,
@@ -5113,15 +5111,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
-      target_client_name = target_client.name
       initiating_client_id = client.id
-      initiating_client_name = client.name
-
-      {a, b, c, d} = target_client.ipv4.address
-      target_client_fqdns = ["#{a}-#{b}-#{c}-#{d}.#{account.key}.fz.internal"]
-
-      {a, b, c, d} = client.ipv4.address
-      initiating_client_fqdns = ["#{a}-#{b}-#{c}-#{d}.#{account.key}.fz.internal"]
 
       push(initiating_socket, "create_flow", %{
         "resource_id" => pool_resource.id,
@@ -5130,17 +5120,47 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
-        client_name: ^target_client_name,
-        client_fqdns: ^target_client_fqdns,
         ice_role: :controlling
-      }
+      } = source_payload
+
+      # The initiator already knows which resource they're flowing to; they sent
+      # the create_flow with that resource_id. They also don't need expires_at
+      # (mirrors flow_created for gateway flows) — the portal will push a denial
+      # when access is revoked.
+      refute Map.has_key?(source_payload, :resource)
+      refute Map.has_key?(source_payload, :subject)
+      refute Map.has_key?(source_payload, :expires_at)
+      refute Map.has_key?(source_payload, :client_name)
+      refute Map.has_key?(source_payload, :client_fqdns)
 
       assert_push "client_device_access_authorized", %{
         client_id: ^initiating_client_id,
-        client_name: ^initiating_client_name,
-        client_fqdns: ^initiating_client_fqdns,
-        ice_role: :controlled
-      }
+        ice_role: :controlled,
+        expires_at: target_expires_at
+      } = target_payload
+
+      # The target gets the full resource view (id/type/name/filters/...) and
+      # the initiator's subject (actor) view — mirroring what we send the gateway
+      # in authorize_flow so connlib can enforce filters and surface who's
+      # connecting.
+      pool_resource_id = pool_resource.id
+      assert %{id: ^pool_resource_id, type: :static_device_pool} = target_payload.resource
+      assert is_list(target_payload.resource.filters)
+
+      assert %{
+               actor_id: actor_id,
+               actor_email: actor_email,
+               actor_name: actor_name,
+               auth_provider_id: _
+             } = target_payload.subject
+
+      assert actor_id == subject.actor.id
+      assert actor_email == subject.actor.email
+      assert actor_name == subject.actor.name
+
+      refute Map.has_key?(target_payload, :client_name)
+      refute Map.has_key?(target_payload, :client_fqdns)
+      assert is_integer(target_expires_at)
     end
 
     test "sends authorized when target ipv6 is found in presence", %{
@@ -5180,13 +5200,18 @@ defmodule PortalAPI.Client.ChannelTest do
       assert_push "init", _
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      target_client_id = target_client.id
 
       push(initiating_socket, "create_flow", %{
         "resource_id" => pool_resource.id,
         "ipv4" => target_ip
       })
 
-      assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :offline}
+      assert_push "client_device_access_denied", %{
+        client_id: ^target_client_id,
+        ipv4: ^target_ip,
+        reason: :offline
+      }
     end
 
     test "sends denied with :forbidden when target ipv4 is not a member of the pool",
@@ -5309,6 +5334,85 @@ defmodule PortalAPI.Client.ChannelTest do
       })
 
       assert_push "client_device_access_denied", %{reason: :invalid_address}
+    end
+
+    test "sends denied with :offline when target is in presence but disconnected from PG",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           target_client: target_client,
+           target_subject: target_subject,
+           pool_resource: pool_resource
+         } do
+      # Manually track presence without joining the channel — this is the race
+      # window where presence still shows the target but PG.deliver fails.
+      session_meta = %{
+        ipv4: target_client.ipv4.address,
+        ipv6: target_client.ipv6.address,
+        name: target_client.name,
+        public_key: Portal.DeviceFixtures.generate_public_key(),
+        psk_base: target_client.psk_base
+      }
+
+      :ok =
+        Presence.Clients.connect(
+          target_client,
+          target_subject.credential.id,
+          session_meta
+        )
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      target_client_id = target_client.id
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
+
+      assert_push "client_device_access_denied", %{
+        client_id: ^target_client_id,
+        ipv4: ^target_ip,
+        reason: :offline
+      }
+
+      _ = account
+    end
+
+    test "sends denied with :invalid_address when the ipv6 string is malformed",
+         %{client: client, subject: subject, pool_resource: pool_resource} do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      push(socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv6" => "not-an-ipv6"
+      })
+
+      assert_push "client_device_access_denied", %{reason: :invalid_address}
+    end
+
+    test "sends denied with :offline when target ipv6 is in pool but not online",
+         %{client: client, subject: subject, target_client: target_client, pool_resource: pool_resource} do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ipv6 = Portal.Types.INET.to_string(target_client.ipv6)
+      target_client_id = target_client.id
+
+      push(socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv6" => target_ipv6
+      })
+
+      assert_push "client_device_access_denied", %{
+        client_id: ^target_client_id,
+        ipv6: ^target_ipv6,
+        reason: :offline
+      }
     end
   end
 
@@ -5435,6 +5539,255 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_denied", %{ipv4: ^target_ip, reason: :disabled}
     end
+
+    test "logs and ignores when ipv4 string is malformed", %{
+      client: client,
+      subject: subject
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      log =
+        capture_log(fn ->
+          push(initiating_socket, "request_device_access", %{"ipv4" => "not-an-ip"})
+          # Force the channel to drain its mailbox before we close.
+          :sys.get_state(initiating_socket.channel_pid)
+        end)
+
+      assert log =~ "Invalid IPv4 address provided for device access request"
+      refute_push "client_device_access_authorized", _
+      refute_push "client_device_access_denied", _
+    end
+
+    test "sends denied with :offline when target is in presence but disconnected from PG",
+         %{
+           client: client,
+           subject: subject,
+           target_client: target_client,
+           target_subject: target_subject
+         } do
+      session_meta = %{
+        ipv4: target_client.ipv4.address,
+        ipv6: target_client.ipv6.address,
+        name: target_client.name,
+        public_key: Portal.DeviceFixtures.generate_public_key(),
+        psk_base: target_client.psk_base
+      }
+
+      :ok =
+        Presence.Clients.connect(
+          target_client,
+          target_subject.credential.id,
+          session_meta
+        )
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      target_client_id = target_client.id
+
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_denied", %{
+        client_id: ^target_client_id,
+        ipv4: ^target_ip,
+        reason: :offline
+      }
+    end
+  end
+
+  describe "handle_in/3 create_flow for dynamic_device_pool" do
+    setup %{account: account, group: group, subject: subject} do
+      enable_feature(:client_to_client)
+
+      subject = put_user_agent(subject, "Mac OS/14 apple-client/1.5.16")
+
+      target_actor = actor_fixture(account: account)
+
+      target_client =
+        client_fixture(
+          account: account,
+          actor: target_actor,
+          hostname: "device-42.devices.example.com"
+        )
+        |> fetch_device!()
+
+      target_subject =
+        subject_fixture(
+          account: account,
+          actor: target_actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      pool_resource =
+        dynamic_device_pool_resource_fixture(
+          account: account,
+          address: "*.devices.example.com"
+        )
+
+      policy_fixture(account: account, group: group, resource: pool_resource)
+
+      %{
+        subject: subject,
+        target_client: target_client,
+        target_subject: target_subject,
+        pool_resource: pool_resource
+      }
+    end
+
+    test "authorizes when target IP belongs to a device whose hostname matches the pattern",
+         %{
+           client: client,
+           subject: subject,
+           target_client: target_client,
+           target_subject: target_subject,
+           pool_resource: pool_resource
+         } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      target_client_id = target_client.id
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
+
+      assert_push "client_device_access_authorized", %{
+        client_id: ^target_client_id,
+        ice_role: :controlling
+      }
+    end
+
+    test "denies when target IP belongs to a device whose hostname doesn't match the pattern",
+         %{
+           account: account,
+           client: client,
+           subject: subject,
+           pool_resource: pool_resource
+         } do
+      stranger_actor = actor_fixture(account: account)
+
+      stranger =
+        client_fixture(
+          account: account,
+          actor: stranger_actor,
+          hostname: "secret.private.example.com"
+        )
+        |> fetch_device!()
+
+      stranger_subject =
+        subject_fixture(
+          account: account,
+          actor: stranger_actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(stranger, stranger_subject)
+      assert_push "init", _
+
+      stranger_ip = Portal.Types.INET.to_string(stranger.ipv4)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => stranger_ip
+      })
+
+      assert_push "client_device_access_denied", %{ipv4: ^stranger_ip, reason: :forbidden}
+    end
+
+    test "authorizes when target ipv6 belongs to a device whose hostname matches the pattern",
+         %{
+           client: client,
+           subject: subject,
+           target_client: target_client,
+           target_subject: target_subject,
+           pool_resource: pool_resource
+         } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      target_ipv6 = Portal.Types.INET.to_string(target_client.ipv6)
+      target_client_id = target_client.id
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv6" => target_ipv6
+      })
+
+      assert_push "client_device_access_authorized", %{
+        client_id: ^target_client_id,
+        ice_role: :controlling
+      }
+    end
+
+    test "denies when target IP belongs to no device in the account", %{
+      client: client,
+      subject: subject,
+      pool_resource: pool_resource
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      orphan_ip = "100.64.255.99"
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => orphan_ip
+      })
+
+      assert_push "client_device_access_denied", %{ipv4: ^orphan_ip, reason: :forbidden}
+    end
+
+    test "persists a policy_authorization on success", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
+
+      assert_push "client_device_access_authorized", _
+
+      :sys.get_state(initiating_socket.channel_pid)
+      Process.sleep(50)
+
+      pa =
+        Portal.Repo.one(
+          from(p in Portal.PolicyAuthorization,
+            where: p.resource_id == ^pool_resource.id,
+            where: p.initiating_device_id == ^client.id,
+            where: p.receiving_device_id == ^target_client.id
+          )
+        )
+
+      assert %Portal.PolicyAuthorization{} = pa
+    end
   end
 
   describe "handle_in/3 resolve_device_pool_domain" do
@@ -5541,12 +5894,11 @@ defmodule PortalAPI.Client.ChannelTest do
       # `*.devices.example.com` pattern.
       stranger_actor = actor_fixture(account: account)
 
-      _stranger =
-        client_fixture(
-          account: account,
-          actor: stranger_actor,
-          hostname: "secret.private.example.com"
-        )
+      client_fixture(
+        account: account,
+        actor: stranger_actor,
+        hostname: "secret.private.example.com"
+      )
 
       socket = join_channel(client, subject)
       assert_push "init", _
@@ -5577,6 +5929,24 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "device_pool_domain_resolution_failed", %{
         resource_id: ^stranger_id,
+        reason: :not_found
+      }
+    end
+
+    test "fails with :not_found when the resource_id is not a valid UUID", %{
+      client: client,
+      subject: subject
+    } do
+      socket = join_channel(client, subject)
+      assert_push "init", _
+
+      push(socket, "resolve_device_pool_domain", %{
+        "resource_id" => "not-a-uuid",
+        "domain" => "device-42.devices.example.com"
+      })
+
+      assert_push "device_pool_domain_resolution_failed", %{
+        resource_id: "not-a-uuid",
         reason: :not_found
       }
     end
@@ -6059,9 +6429,9 @@ defmodule PortalAPI.Client.ChannelTest do
         resource_id: resource.id,
         membership_id: membership.id,
         account_id: subject.account.id,
-        client_remote_ip: {100, 64, 0, 1},
-        client_user_agent: "test-agent",
-        gateway_remote_ip: {100, 64, 0, 2},
+        initiator_remote_ip: {100, 64, 0, 1},
+        initiator_user_agent: "test-agent",
+        receiver_remote_ip: {100, 64, 0, 2},
         expires_at: DateTime.utc_now() |> DateTime.add(30, :second)
       }
 
@@ -6086,9 +6456,9 @@ defmodule PortalAPI.Client.ChannelTest do
         resource_id: resource_id,
         membership_id: nil,
         account_id: subject.account.id,
-        client_remote_ip: {100, 64, 0, 1},
-        client_user_agent: "test-agent",
-        gateway_remote_ip: {100, 64, 0, 2},
+        initiator_remote_ip: {100, 64, 0, 1},
+        initiator_user_agent: "test-agent",
+        receiver_remote_ip: {100, 64, 0, 2},
         expires_at: DateTime.utc_now() |> DateTime.add(30, :second)
       }
 
@@ -6123,9 +6493,9 @@ defmodule PortalAPI.Client.ChannelTest do
         resource_id: resource.id,
         membership_id: membership.id,
         account_id: subject.account.id,
-        client_remote_ip: {100, 64, 0, 1},
-        client_user_agent: "test-agent",
-        gateway_remote_ip: {100, 64, 0, 2},
+        initiator_remote_ip: {100, 64, 0, 1},
+        initiator_user_agent: "test-agent",
+        receiver_remote_ip: {100, 64, 0, 2},
         expires_at: DateTime.utc_now() |> DateTime.add(30, :second)
       }
 
@@ -6148,9 +6518,9 @@ defmodule PortalAPI.Client.ChannelTest do
         resource_id: Ecto.UUID.generate(),
         membership_id: nil,
         account_id: subject.account.id,
-        client_remote_ip: {100, 64, 0, 1},
-        client_user_agent: "test-agent",
-        gateway_remote_ip: {100, 64, 0, 2},
+        initiator_remote_ip: {100, 64, 0, 1},
+        initiator_user_agent: "test-agent",
+        receiver_remote_ip: {100, 64, 0, 2},
         expires_at: DateTime.utc_now() |> DateTime.add(30, :second)
       }
 
@@ -6160,6 +6530,573 @@ defmodule PortalAPI.Client.ChannelTest do
         end)
 
       assert log =~ "Failed to create policy authorization"
+    end
+  end
+
+  describe "authorizations cache (inbound client-to-client)" do
+    setup %{account: account, group: group, subject: subject} do
+      enable_feature(:client_to_client)
+
+      subject = put_user_agent(subject, "Mac OS/14 apple-client/1.5.16")
+
+      target_actor = actor_fixture(account: account)
+      target_client = client_fixture(account: account, actor: target_actor) |> fetch_device!()
+
+      target_subject =
+        subject_fixture(
+          account: account,
+          actor: target_actor,
+          type: :client,
+          user_agent: "Mac OS/14 apple-client/1.5.16"
+        )
+
+      pool_resource =
+        Portal.ResourceFixtures.static_device_pool_resource_fixture(
+          account: account,
+          clients: [target_client]
+        )
+
+      policy_fixture(account: account, group: group, resource: pool_resource)
+
+      %{
+        subject: subject,
+        target_actor: target_actor,
+        target_client: target_client,
+        target_subject: target_subject,
+        pool_resource: pool_resource
+      }
+    end
+
+    test "handle_info({:client_device_access_authorized, ...}) puts entry in cache and pushes resource view",
+         %{
+           target_client: target_client,
+           target_subject: target_subject,
+           client: initiating_client,
+           pool_resource: pool_resource
+         } do
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      policy_authorization_id = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second)
+
+      cacheable_resource = Portal.Cache.Cacheable.to_cache(pool_resource)
+      rendered_resource = PortalAPI.Client.Views.Resource.render(cacheable_resource)
+
+      rendered_subject = %{
+        auth_provider_id: Ecto.UUID.generate(),
+        actor_id: Ecto.UUID.generate(),
+        actor_email: "alice@example.com",
+        actor_name: "Alice"
+      }
+
+      send(socket.channel_pid, {
+        :client_device_access_authorized,
+        %{
+          client_id: initiating_client.id,
+          client_public_key: "pk",
+          client_ipv4: initiating_client.ipv4,
+          client_ipv6: initiating_client.ipv6,
+          preshared_key: "psk",
+          local_ice_credentials: %{username: "u", password: "p"},
+          remote_ice_credentials: %{username: "u", password: "p"},
+          ice_role: :controlled,
+          resource: rendered_resource,
+          subject: rendered_subject,
+          policy_authorization_id: policy_authorization_id,
+          authorization_expires_at: expires_at
+        }
+      })
+
+      assert_push "client_device_access_authorized", payload
+      assert payload.resource == rendered_resource
+      assert payload.subject == rendered_subject
+      assert payload.expires_at == DateTime.to_unix(expires_at, :second)
+      refute Map.has_key?(payload, :policy_authorization_id)
+      refute Map.has_key?(payload, :authorization_expires_at)
+
+      state = :sys.get_state(socket.channel_pid)
+      assert Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+    end
+
+    test "handle_info({:client_device_access_authorized, ...}) without policy_authorization fields skips cache update",
+         %{
+           target_client: target_client,
+           target_subject: target_subject,
+           client: initiating_client,
+           pool_resource: pool_resource
+         } do
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      send(socket.channel_pid, {
+        :client_device_access_authorized,
+        %{
+          client_id: initiating_client.id,
+          client_public_key: "pk",
+          client_ipv4: initiating_client.ipv4,
+          client_ipv6: initiating_client.ipv6,
+          preshared_key: "psk",
+          local_ice_credentials: %{username: "u", password: "p"},
+          remote_ice_credentials: %{username: "u", password: "p"},
+          ice_role: :controlled,
+          resource: nil,
+          policy_authorization_id: nil,
+          authorization_expires_at: nil
+        }
+      })
+
+      assert_push "client_device_access_authorized", _
+
+      state = :sys.get_state(socket.channel_pid)
+
+      refute Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+    end
+
+    test "hydrates authorizations cache on join from DB", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      client: initiating_client,
+      pool_resource: pool_resource,
+      account: account,
+      target_actor: target_actor
+    } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+        account: account,
+        client: initiating_client,
+        gateway: target_client,
+        resource: pool_resource,
+        token: target_actor_token
+      )
+
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      state = :sys.get_state(socket.channel_pid)
+      cache = state.assigns.authorizations_cache
+
+      assert Portal.Cache.Client.Authorizations.has_resource?(cache, pool_resource.id)
+
+      initiating_client_id = initiating_client.id
+      pool_resource_id = pool_resource.id
+
+      assert [{^initiating_client_id, ^pool_resource_id}] =
+               Portal.Cache.Client.Authorizations.all_pairs_for_resource(cache, pool_resource.id)
+    end
+
+    test "init payload includes inbound authorizations so reconnects rehydrate connlib", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      client: initiating_client,
+      pool_resource: pool_resource,
+      account: account,
+      target_actor: target_actor
+    } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      pa =
+        Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client,
+          resource: pool_resource,
+          token: target_actor_token
+        )
+
+      join_channel(target_client, target_subject)
+
+      initiating_client_id = initiating_client.id
+      pool_resource_id = pool_resource.id
+      expected_expires_at = DateTime.to_unix(pa.expires_at, :second)
+
+      assert_push "init", %{authorizations: [authorization]}
+
+      assert authorization == %{
+               client_id: initiating_client_id,
+               resource_id: pool_resource_id,
+               expires_at: expected_expires_at
+             }
+    end
+
+    test "prune_authorizations_cache drops expired entries", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      client: initiating_client,
+      pool_resource: pool_resource
+    } do
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      expired_at = DateTime.utc_now() |> DateTime.add(-3600, :second)
+      paid = Ecto.UUID.generate()
+
+      cacheable_resource = Portal.Cache.Cacheable.to_cache(pool_resource)
+      rendered_resource = PortalAPI.Client.Views.Resource.render(cacheable_resource)
+
+      # Seed an entry that is already expired into the in-memory cache
+      send(socket.channel_pid, {
+        :client_device_access_authorized,
+        %{
+          client_id: initiating_client.id,
+          client_public_key: "pk",
+          client_ipv4: initiating_client.ipv4,
+          client_ipv6: initiating_client.ipv6,
+          preshared_key: "psk",
+          local_ice_credentials: %{username: "u", password: "p"},
+          remote_ice_credentials: %{username: "u", password: "p"},
+          ice_role: :controlled,
+          resource: rendered_resource,
+          policy_authorization_id: paid,
+          authorization_expires_at: expired_at
+        }
+      })
+
+      assert_push "client_device_access_authorized", _
+
+      state = :sys.get_state(socket.channel_pid)
+
+      assert Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+
+      send(socket.channel_pid, :prune_authorizations_cache)
+
+      state = :sys.get_state(socket.channel_pid)
+
+      refute Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+    end
+
+    test "policy_authorization delete with no replacement policy pushes reject_access",
+         %{
+           target_client: target_client,
+           target_subject: target_subject,
+           client: initiating_client,
+           pool_resource: pool_resource,
+           account: account,
+           target_actor: target_actor,
+           group: group
+         } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      pa =
+        Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client,
+          resource: pool_resource,
+          group: group,
+          token: target_actor_token
+        )
+
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      # Wipe the policy so the reauth attempt has nothing to fall back to.
+      Portal.Repo.delete_all(
+        from(p in Portal.Policy, where: p.resource_id == ^pool_resource.id)
+      )
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :delete,
+        old_struct: pa
+      })
+
+      initiating_client_id = initiating_client.id
+      pool_resource_id = pool_resource.id
+
+      assert_push "reject_access", %{
+        client_id: ^initiating_client_id,
+        resource_id: ^pool_resource_id
+      } = revoke_payload
+
+      # Receiver-side revocation doesn't carry a reason — it just identifies the
+      # connection to drop, mirroring the gateway's reject_access shape.
+      refute Map.has_key?(revoke_payload, :reason)
+      refute Map.has_key?(revoke_payload, :ipv4)
+      refute Map.has_key?(revoke_payload, :ipv6)
+
+      state = :sys.get_state(socket.channel_pid)
+
+      refute Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+    end
+
+    test "policy_authorization delete with a replacement policy pushes access_authorization_expiry_updated",
+         %{
+           target_client: target_client,
+           target_subject: target_subject,
+           client: initiating_client,
+           pool_resource: pool_resource,
+           account: account,
+           target_actor: target_actor,
+           group: group_a,
+           actor: initiating_actor
+         } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      group_b = Portal.GroupFixtures.group_fixture(account: account)
+      Portal.MembershipFixtures.membership_fixture(account: account, actor: initiating_actor, group: group_b)
+      Portal.PolicyFixtures.policy_fixture(account: account, group: group_b, resource: pool_resource)
+
+      Portal.ClientSessionFixtures.client_session_fixture(
+        account: account,
+        actor: initiating_actor,
+        client: initiating_client
+      )
+
+      pa =
+        Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client,
+          resource: pool_resource,
+          group: group_a,
+          token: target_actor_token
+        )
+
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :delete,
+        old_struct: pa
+      })
+
+      initiating_client_id = initiating_client.id
+      pool_resource_id = pool_resource.id
+
+      assert_push "access_authorization_expiry_updated", %{
+        client_id: ^initiating_client_id,
+        resource_id: ^pool_resource_id,
+        expires_at: expires_at
+      }
+
+      assert is_integer(expires_at)
+
+      state = :sys.get_state(socket.channel_pid)
+
+      assert Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+    end
+
+    test "policy_authorization delete with remaining cached authorizations updates expiry without reauth",
+         %{
+           target_client: target_client,
+           target_subject: target_subject,
+           client: initiating_client,
+           pool_resource: pool_resource,
+           account: account,
+           target_actor: target_actor
+         } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      preexisting =
+        Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client,
+          resource: pool_resource,
+          token: target_actor_token
+        )
+
+      preloaded = Portal.Repo.preload(preexisting, [:resource, :policy])
+
+      second =
+        Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+          account: account,
+          client: initiating_client,
+          gateway: target_client,
+          resource: preloaded.resource,
+          policy: preloaded.policy,
+          token: target_actor_token
+        )
+
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :delete,
+        old_struct: second
+      })
+
+      initiating_client_id = initiating_client.id
+      pool_resource_id = pool_resource.id
+
+      assert_push "access_authorization_expiry_updated", %{
+        client_id: ^initiating_client_id,
+        resource_id: ^pool_resource_id
+      }
+
+      refute_push "reject_access", _
+
+      state = :sys.get_state(socket.channel_pid)
+
+      assert Portal.Cache.Client.Authorizations.has_resource?(
+               state.assigns.authorizations_cache,
+               pool_resource.id
+             )
+    end
+
+    test "policy_authorization delete for an unknown entry is a no-op", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      client: initiating_client,
+      pool_resource: pool_resource
+    } do
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      stub_pa = %Portal.PolicyAuthorization{
+        id: Ecto.UUID.generate(),
+        initiating_device_id: initiating_client.id,
+        receiving_device_id: target_client.id,
+        resource_id: pool_resource.id
+      }
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :delete,
+        old_struct: stub_pa
+      })
+
+      refute_push "reject_access", _
+      refute_push "access_authorization_expiry_updated", _
+
+      state = :sys.get_state(socket.channel_pid)
+      assert state.assigns.authorizations_cache == %{}
+    end
+
+    test "ignores DOWN messages from unrelated processes", %{
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      stranger = spawn(fn -> :ok end)
+
+      send(socket.channel_pid, {:DOWN, make_ref(), :process, stranger, :normal})
+
+      assert :sys.get_state(socket.channel_pid)
+    end
+
+    test "resource filter change pushes resource_filters_updated when resource is in cache", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      client: initiating_client,
+      pool_resource: pool_resource,
+      account: account,
+      target_actor: target_actor
+    } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+        account: account,
+        client: initiating_client,
+        gateway: target_client,
+        resource: pool_resource,
+        token: target_actor_token
+      )
+
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      new_filters = [
+        %Portal.Resource.Filter{protocol: :tcp, ports: ["443"]}
+      ]
+
+      updated_resource = %{pool_resource | filters: new_filters}
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :update,
+        old_struct: pool_resource,
+        struct: updated_resource
+      })
+
+      pool_resource_id = pool_resource.id
+
+      assert_push "resource_filters_updated", %{
+        id: ^pool_resource_id,
+        filters: [%{protocol: :tcp, port_range_start: 443, port_range_end: 443}]
+      }
+    end
+
+    test "resource filter change does not push when resource is not in authorizations cache", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
+    } do
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      new_filters = [%Portal.Resource.Filter{protocol: :tcp, ports: ["8080"]}]
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :update,
+        old_struct: pool_resource,
+        struct: %{pool_resource | filters: new_filters}
+      })
+
+      refute_push "resource_filters_updated", _
+    end
+
+    test "resource update with unchanged filters does not push resource_filters_updated", %{
+      target_client: target_client,
+      target_subject: target_subject,
+      client: initiating_client,
+      pool_resource: pool_resource,
+      account: account,
+      target_actor: target_actor
+    } do
+      target_actor_token =
+        Portal.TokenFixtures.client_token_fixture(account: account, actor: target_actor)
+
+      Portal.PolicyAuthorizationFixtures.policy_authorization_fixture(
+        account: account,
+        client: initiating_client,
+        gateway: target_client,
+        resource: pool_resource,
+        token: target_actor_token
+      )
+
+      socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: 100,
+        op: :update,
+        old_struct: pool_resource,
+        struct: %{pool_resource | name: "Renamed pool"}
+      })
+
+      refute_push "resource_filters_updated", _
     end
   end
 end

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -698,6 +698,70 @@ defmodule PortalAPI.Gateway.ChannelTest do
              } = :sys.get_state(socket.channel_pid)
     end
 
+    test "updates gateway state without resending init when tunnel IPs are unchanged", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
+
+      lsn = System.unique_integer([:positive, :monotonic])
+      updated_gateway = %{gateway | name: "Renamed gateway"}
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: lsn,
+        op: :update,
+        old_struct: gateway,
+        struct: updated_gateway
+      })
+
+      :sys.get_state(socket.channel_pid)
+
+      refute_push "init", _
+
+      assert %{assigns: %{gateway: %{name: "Renamed gateway"}}} =
+               :sys.get_state(socket.channel_pid)
+    end
+
+    test "ignores DOWN messages from unrelated processes", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", _init_payload
+
+      stranger = spawn(fn -> :ok end)
+
+      send(socket.channel_pid, {:DOWN, make_ref(), :process, stranger, :normal})
+
+      # Channel should keep running and remain joined.
+      assert :sys.get_state(socket.channel_pid)
+    end
+
+    test "load-balances relays with mixed nil and non-nil locations", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      # Mix of relays with and without lat/lon to exercise the nils_last comparator
+      # in both pairwise orders during sort.
+      relay_with_loc = relay_fixture(%{lat: 37.0, lon: -120.0})
+      :ok = Portal.Presence.Relays.connect(relay_with_loc)
+
+      relay_no_lat = relay_fixture(%{lat: nil, lon: -121.0})
+      :ok = Portal.Presence.Relays.connect(relay_no_lat)
+
+      relay_no_lon = relay_fixture(%{lat: 37.5, lon: nil})
+      :ok = Portal.Presence.Relays.connect(relay_no_lon)
+
+      _socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: relays}
+
+      assert is_list(relays)
+    end
+
     test "pushes disconnect event and closes when the token is deleted", %{
       account: account,
       gateway: gateway,

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -824,9 +824,9 @@ defmodule PortalWeb.ResourcesTest do
             resource_id: resource.id,
             token_id: token.id,
             membership_id: nil,
-            client_remote_ip: {100, 64, 0, 1},
-            client_user_agent: "Test/1.0",
-            gateway_remote_ip: {100, 64, 0, 2},
+            initiator_remote_ip: {100, 64, 0, 1},
+            initiator_user_agent: "Test/1.0",
+            receiver_remote_ip: {100, 64, 0, 2},
             expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
           },
           [
@@ -836,9 +836,9 @@ defmodule PortalWeb.ResourcesTest do
             :resource_id,
             :token_id,
             :membership_id,
-            :client_remote_ip,
-            :client_user_agent,
-            :gateway_remote_ip,
+            :initiator_remote_ip,
+            :initiator_user_agent,
+            :receiver_remote_ip,
             :expires_at
           ]
         )

--- a/elixir/test/support/fixtures/policy_authorization_fixtures.ex
+++ b/elixir/test/support/fixtures/policy_authorization_fixtures.ex
@@ -19,9 +19,9 @@ defmodule Portal.PolicyAuthorizationFixtures do
   def valid_policy_authorization_attrs(attrs \\ %{}) do
     Enum.into(attrs, %{
       expires_at: DateTime.add(DateTime.utc_now(), 3600, :second),
-      client_remote_ip: {100, 64, 0, 1},
-      client_user_agent: "Mozilla/5.0",
-      gateway_remote_ip: {100, 64, 0, 2}
+      initiator_remote_ip: {100, 64, 0, 1},
+      initiator_user_agent: "Mozilla/5.0",
+      receiver_remote_ip: {100, 64, 0, 2}
     })
   end
 
@@ -160,9 +160,9 @@ defmodule Portal.PolicyAuthorizationFixtures do
         :token_id,
         :membership_id,
         :expires_at,
-        :client_remote_ip,
-        :client_user_agent,
-        :gateway_remote_ip
+        :initiator_remote_ip,
+        :initiator_user_agent,
+        :receiver_remote_ip
       ])
       |> Portal.PolicyAuthorization.changeset()
       |> Portal.Repo.insert()


### PR DESCRIPTION
End-to-end client-to-client authorization tracking on the portal.

### Wire protocol changes

#### `init` (portal → client)

Now includes `authorizations`, a list of `{client_id, resource_id, expires_at}` mirroring the gateway's existing `init.authorizations`. Lets a reconnecting client rehydrate its inbound authorizations instead of starting empty.

#### `client_device_access_authorized` (portal → client)

Receiver-side push (`ice_role: :controlled`) gains:

- **`resource`** — full resource view (`%{id, type, name, filters, devices, …}`), the same shape the gateway gets in `authorize_flow`. Receiver applies filters to inbound peer traffic.
- **`subject`** — `%{auth_provider_id, actor_id, actor_email, actor_name}`, same shape as `authorize_flow.subject` on the gateway side. Lets the receiver surface who's connecting.
- **`expires_at`** — unix timestamp. Lets connlib drop the inbound peer at expiry without waiting for a portal denial.

Initiator-side push (`ice_role: :controlling`) — unchanged shape; intentionally does **not** carry `resource`, `subject`, or `expires_at`, mirroring `flow_created` in the gateway flow.

Dropped from both pushes: `client_name`, `client_fqdns` — connlib's deserializer (`rust/libs/connlib/tunnel/src/messages/client.rs:137`) doesn't read either.

#### `create_flow` (client → portal)

Now accepts both `:static_device_pool` and `:dynamic_device_pool` resources (previously only static). Static pools authorize via the cached pool member set; dynamic pools resolve the target IPv4/IPv6 to a device in the account at request time and verify its hostname matches the pool's address pattern. Both paths converge on the same `client_device_access_authorized` flow.

#### `resource_filters_updated` (portal → client) — new

Pushed when a resource currently in the receiver's authorizations cache has its filter list changed. Payload `%{id, filters}`. Lets live filter edits propagate without a reconnect. Connlib will need a deserializer for this message.

#### `access_authorization_expiry_updated` (portal → client)

Already exists on the gateway channel; now also pushed on the client channel when reauth succeeds after a `policy_authorization` is deleted. Payload `%{client_id, resource_id, expires_at}`.

#### `reject_access` (portal → client) — new on client channel

Pushed to the **receiver** when reauth fails for a deleted `policy_authorization`. Payload `%{client_id, resource_id}` — no `reason`, mirroring the gateway's existing `reject_access` shape rather than `client_device_access_denied` (which is keyed on `{ipv4, reason}` for the controlling-side denial path). The receiver uses the `{client_id, resource_id}` pair to identify and tear down the inbound peer connection. Connlib will need a deserializer for this message on the client side.

#### `client_device_access_denied` (portal → client)

Still `%{ipv4, reason}` for the **controlling-side** denial path; now also carries `client_id: target_client_id` whenever the portal knows which peer was the target — i.e. when the target was authorized for the pool but is offline (`reason: :offline`), or when delivery to the target failed because it disconnected between the presence lookup and `PG.deliver/2` (also `reason: :offline`). Pre-target-resolution denials (`:disabled`, `:invalid_address`, `:ambiguous_address`, `:missing_address`) still don't carry a `client_id` since we never resolved one. Closes #13092.

#### `request_device_access` (client → portal) — PoC, deprecated

Kept around for one customer that hasn't migrated to `create_flow`. Wire-format-compatible with prod: enforces pool membership only (the target IPv4 must be in some `static_device_pool` the actor has connectable access to via `cache.device_addresses`), and emits `:forbidden` denials for IPs outside any such pool — same behavior as `83c98fd2` on prod. Does **not** create a `policy_authorization` row, so revocation/reauth/expiry tracking introduced in this PR don't apply to flows authorized this way. TODO at the handler is updated to require removal **before GA**.

---

### Server-internal changes

- **Bug fix** in `Portal.Cache.Gateway.Database.reauthorize_policy_authorization/1` — argument-order bug in `fetch_membership_id_or_nil_for_everyone/3` and a wrong-type pass in `longest_conforming_policy_for_client/5` (token struct passed where `auth_provider_id` was expected). Gateway reauth never succeeded for non-Everyone groups before this. Also fixed a typo (`fallback_to_prmary` → `fallback_to_primary`) on the `Safe.one/2` membership lookup so reauth retries the primary on replica lag.
- **Column renames** on `policy_authorizations` (single migration): `client_remote_ip → initiator_remote_ip`, `gateway_remote_ip → receiver_remote_ip`, `client_user_agent → initiator_user_agent`. `receiver_remote_ip` tightened to required — a `policy_authorization` is only inserted after `PG.deliver/2` succeeds, so the receiver is always online.
- New shared `Portal.Cache.Reauth` module factoring out the helpers used by both gateway and client-receiver reauth flows.

---

### Flows

#### Client → Gateway

```mermaid
sequenceDiagram
    participant C as Client (initiator)
    participant Portal as Portal Channel
    participant DB as policy_authorizations
    participant G as Gateway (receiver)

    C->>Portal: create_flow {resource_id}
    Portal->>Portal: Cache.Client.authorize_resource/5<br/>(policy + condition check)
    Portal->>G: PG.deliver(:authorize_policy)
    Portal->>DB: INSERT policy_authorization<br/>(receiver_remote_ip = gateway session IP)
    G-->>Portal: flow_authorized (ref)
    Portal->>C: flow_created {gateway pubkey, ICE creds}
    Note over Portal,G: On policy delete: Cache.Gateway reauth →<br/>access_authorization_expiry_updated or reject_access
```

#### Client → Client (static or dynamic device pool)

```mermaid
sequenceDiagram
    participant A as Client A (initiator)
    participant Portal as Portal Channel
    participant DB as policy_authorizations
    participant B as Client B (receiver)

    A->>Portal: create_flow {resource_id, ipv4|ipv6}
    Portal->>Portal: Cache.Client.authorize_resource/5<br/>(policy + condition check)
    Portal->>Portal: pool auth (static: cache.pool_members lookup,<br/>dynamic: device-by-IP DB lookup +<br/>hostname pattern match)
    Portal->>B: PG.deliver(:client_device_access_authorized,<br/>resource, subject, expires_at)
    Portal->>DB: INSERT policy_authorization<br/>(receiver_remote_ip = B's session IP)<br/>only after delivery succeeds
    Portal->>A: client_device_access_authorized (:controlling)
    Portal->>B: client_device_access_authorized<br/>(:controlled, resource, subject, expires_at)
    Note over Portal,B: On policy delete: Cache.Client.Authorizations reauth →<br/>access_authorization_expiry_updated or reject_access to B
    Note over Portal,B: On filter change: resource_filters_updated to B
```

---

Related: #12435
Fixes: #13050
Fixes: #13092
Related: #13035

