### PR TITLE
refactor(connlib): tidy up static-pool routing follow-ups

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -548,7 +548,13 @@ impl Eventloop {
                             .send(UserNotification::GatewayVersionMismatch { resource_id })
                             .await;
                     }
-                    FailReason::NotFound | FailReason::Forbidden | FailReason::Unknown => {}
+                    FailReason::NotFound
+                    | FailReason::Forbidden
+                    | FailReason::Disabled
+                    | FailReason::AmbiguousAddress
+                    | FailReason::MissingAddress
+                    | FailReason::InvalidAddress
+                    | FailReason::Unknown => {}
                 }
             }
             IngressMessages::ClientDeviceAccessAuthorized(ClientDeviceAccessAuthorized {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -286,30 +286,29 @@ impl ClientState {
 
         // The protocol is irrelevant: each member device has exactly one routing-table entry
         // per address, so the lookup always resolves to that entry regardless of the dummy.
-        let entry = ipv4
+        let client_id = ipv4
             .and_then(|ip| {
                 self.client_routing_table
                     .matches(IpAddr::V4(ip), Ok(Protocol::Tcp(0)))
-                    .cloned()
+                    .map(|e| e.client_id)
             })
             .or_else(|| {
                 ipv6.and_then(|ip| {
                     self.client_routing_table
                         .matches(IpAddr::V6(ip), Ok(Protocol::Tcp(0)))
-                        .cloned()
+                        .map(|e| e.client_id)
                 })
             });
-        let Some(entry) = entry else {
+        let Some(client_id) = client_id else {
             return;
         };
 
-        self.pending_device_access.remove(&entry.client_id);
+        self.pending_device_access.remove(&client_id);
         // TODO: Update resource list with offline client.
 
-        if self.clients.peer_by_id(&entry.client_id).is_some() {
-            self.clients.remove(&entry.client_id);
+        if self.clients.remove(&client_id).is_some() {
             self.node.close_connection(
-                ClientOrGatewayId::Client(entry.client_id),
+                ClientOrGatewayId::Client(client_id),
                 p2p_control::goodbye(),
                 now,
             );
@@ -700,22 +699,28 @@ impl ClientState {
         }
 
         // Static device pool routing.
-        if let Some(entry) = self
+        if let Some((client_id, resource_id, allowed)) = self
             .client_routing_table
             .matches(dst, Ok(dst_proto))
-            .cloned()
+            .map(|e| {
+                (
+                    e.client_id,
+                    e.resource_id,
+                    e.filter.apply(Ok(dst_proto)).is_ok(),
+                )
+            })
         {
-            if entry.filter.apply(Ok(dst_proto)).is_err() {
+            if !allowed {
                 bail!(UnroutablePacket::not_allowed(&packet))
             }
 
-            if self.clients.peer_by_id(&entry.client_id).is_some() {
-                return Ok(Some((ClientOrGatewayId::Client(entry.client_id), packet)));
+            if self.clients.peer_by_id(&client_id).is_some() {
+                return Ok(Some((ClientOrGatewayId::Client(client_id), packet)));
             }
 
             self.pending_device_access.on_not_connected_device(
-                entry.client_id,
-                entry.resource_id,
+                client_id,
+                resource_id,
                 dst,
                 packet,
                 now,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -277,24 +277,28 @@ impl ClientState {
     /// 2. When access is revoked after it has been established.
     pub fn handle_client_device_access_denied(
         &mut self,
-        ipv4: Ipv4Addr,
-        ipv6: Ipv6Addr,
+        ipv4: Option<Ipv4Addr>,
+        ipv6: Option<Ipv6Addr>,
         reason: FailReason,
         now: Instant,
     ) {
-        tracing::debug!(%ipv4, %ipv6, "Device access denied: {reason:?}");
+        tracing::debug!(?ipv4, ?ipv6, "Device access denied: {reason:?}");
 
         // The protocol is irrelevant: each member device has exactly one routing-table entry
         // per address, so the lookup always resolves to that entry regardless of the dummy.
-        let entry = self
-            .client_routing_table
-            .matches(IpAddr::V4(ipv4), Ok(Protocol::Tcp(0)))
-            .cloned();
-        let entry = entry.or_else(|| {
-            self.client_routing_table
-                .matches(IpAddr::V6(ipv6), Ok(Protocol::Tcp(0)))
-                .cloned()
-        });
+        let entry = ipv4
+            .and_then(|ip| {
+                self.client_routing_table
+                    .matches(IpAddr::V4(ip), Ok(Protocol::Tcp(0)))
+                    .cloned()
+            })
+            .or_else(|| {
+                ipv6.and_then(|ip| {
+                    self.client_routing_table
+                        .matches(IpAddr::V6(ip), Ok(Protocol::Tcp(0)))
+                        .cloned()
+                })
+            });
         let Some(entry) = entry else {
             return;
         };

--- a/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
@@ -197,6 +197,10 @@ impl DeviceStubResolver {
                 FailReason::Offline
                 | FailReason::VersionMismatch
                 | FailReason::Forbidden
+                | FailReason::Disabled
+                | FailReason::AmbiguousAddress
+                | FailReason::MissingAddress
+                | FailReason::InvalidAddress
                 | FailReason::Unknown,
             ) => dns_types::Response::servfail(&pending.query),
         };

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -156,10 +156,15 @@ pub struct ClientDeviceAccessAuthorized {
     pub ice_role: IceRole,
 }
 
+/// Portal's denial of a `create_flow` toward a static device pool peer.
+///
+/// Either or both of `ipv4` / `ipv6` may be absent depending on the denial reason.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClientDeviceAccessDenied {
-    pub ipv4: Ipv4Addr,
-    pub ipv6: Ipv6Addr,
+    #[serde(default)]
+    pub ipv4: Option<Ipv4Addr>,
+    #[serde(default)]
+    pub ipv6: Option<Ipv6Addr>,
     pub reason: FailReason,
 }
 
@@ -186,6 +191,10 @@ pub enum FailReason {
     Offline,
     VersionMismatch,
     Forbidden,
+    Disabled,
+    AmbiguousAddress,
+    MissingAddress,
+    InvalidAddress,
     #[serde(other)]
     Unknown,
 }
@@ -723,6 +732,68 @@ mod tests {
             msg,
             IngressMessages::DevicePoolDomainResolutionFailed(_)
         ));
+    }
+
+    #[test]
+    fn can_deserialize_client_device_access_denied_with_only_ipv4() {
+        let json = r#"{"event":"client_device_access_denied","ref":null,"topic":"client","payload":{"ipv4":"100.65.0.1","reason":"forbidden"}}"#;
+
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        let IngressMessages::ClientDeviceAccessDenied(denied) = message else {
+            panic!("expected ClientDeviceAccessDenied");
+        };
+        assert_eq!(denied.ipv4, Some("100.65.0.1".parse::<Ipv4Addr>().unwrap()));
+        assert_eq!(denied.ipv6, None);
+        assert!(matches!(denied.reason, FailReason::Forbidden));
+    }
+
+    #[test]
+    fn can_deserialize_client_device_access_denied_with_only_ipv6() {
+        let json = r#"{"event":"client_device_access_denied","ref":null,"topic":"client","payload":{"ipv6":"fd00:2021:1111::1","reason":"offline"}}"#;
+
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        let IngressMessages::ClientDeviceAccessDenied(denied) = message else {
+            panic!("expected ClientDeviceAccessDenied");
+        };
+        assert_eq!(denied.ipv4, None);
+        assert_eq!(
+            denied.ipv6,
+            Some("fd00:2021:1111::1".parse::<Ipv6Addr>().unwrap())
+        );
+        assert!(matches!(denied.reason, FailReason::Offline));
+    }
+
+    #[test]
+    fn can_deserialize_client_device_access_denied_missing_address() {
+        let json = r#"{"event":"client_device_access_denied","ref":null,"topic":"client","payload":{"reason":"missing_address"}}"#;
+
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        let IngressMessages::ClientDeviceAccessDenied(denied) = message else {
+            panic!("expected ClientDeviceAccessDenied");
+        };
+        assert_eq!(denied.ipv4, None);
+        assert_eq!(denied.ipv6, None);
+        assert!(matches!(denied.reason, FailReason::MissingAddress));
+    }
+
+    #[test]
+    fn can_deserialize_client_device_access_denied_ambiguous_address() {
+        let json = r#"{"event":"client_device_access_denied","ref":null,"topic":"client","payload":{"ipv4":"100.65.0.1","ipv6":"fd00:2021:1111::1","reason":"ambiguous_address"}}"#;
+
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        let IngressMessages::ClientDeviceAccessDenied(denied) = message else {
+            panic!("expected ClientDeviceAccessDenied");
+        };
+        assert_eq!(denied.ipv4, Some("100.65.0.1".parse::<Ipv4Addr>().unwrap()));
+        assert_eq!(
+            denied.ipv6,
+            Some("fd00:2021:1111::1".parse::<Ipv6Addr>().unwrap())
+        );
+        assert!(matches!(denied.reason, FailReason::AmbiguousAddress));
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/tests/reference.rs
+++ b/rust/libs/connlib/tunnel/src/tests/reference.rs
@@ -1759,7 +1759,10 @@ impl ReferenceState {
                     .into_iter()
                     .filter_map(|r| match r {
                         client::Resource::StaticDevicePool(p) => Some(p),
-                        _ => None,
+                        client::Resource::Dns(_)
+                        | client::Resource::Cidr(_)
+                        | client::Resource::Internet(_)
+                        | client::Resource::DynamicDevicePool(_) => None,
                     })
                     .filter(|pool| pool_filters_allow_icmp(&pool.filters))
                     .flat_map(|pool| pool.devices)

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1133,10 +1133,7 @@ impl TunnelTest {
                         .inner()
                         .sut
                         .tunnel_ip_config()
-                        .is_some_and(|tun| match ip {
-                            std::net::IpAddr::V4(v4) => tun.v4 == v4,
-                            std::net::IpAddr::V6(v6) => tun.v6 == v6,
-                        })
+                        .is_some_and(|tun| tun.is_ip(ip))
                 });
 
                 match maybe_remote_client {


### PR DESCRIPTION
  - Drop the `ClientEntry` clone in `route_packet` and
  `handle_client_device_access_denied`. `RoutingTable::matches`
   already returns `Option<&T>`; reading the `Copy` fields out
  of the borrow with `.map(|e| (e.client_id, ...))` avoids
  cloning a `FilterEngine` (with its rangemaps) on every
  outbound packet that hits the static-pool branch, plus on
  every portal-denial event.
  - Collapse the TOCTOU `peer_by_id().is_some()` +
  `clients.remove()` in `handle_client_device_access_denied`
  into `clients.remove().is_some()` — `PeerStore::remove`
  already returns the `Option<P>` we need.
  - Replace the wildcard `_ => None` in the proptest's
  `pool_routed_other_client_tun_ips` filter_map with explicit
  `Resource` variants. Now adding a new resource variant forces
   an update at this call site instead of being silently routed
   through the `None` arm.