### PR TITLE
chore(rust): allow exporting metrics to Sentry

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -17,7 +17,7 @@ use phoenix_channel::{LoginUrl, PhoenixChannel, get_user_agent};
 use platform::RELEASE;
 use secrecy::SecretString;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
-use telemetry::{Telemetry, analytics};
+use telemetry::{Telemetry, analytics, otel};
 use tokio::sync::Mutex;
 use tracing_subscriber::{Layer, layer::SubscriberExt as _};
 
@@ -486,6 +486,8 @@ fn connect(
     let mut telemetry = Telemetry::new();
     runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN, device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
+
+    otel::install_sentry_meter_provider(platform::COMPONENT, platform::VERSION, device_id.clone());
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -16,7 +16,8 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
 use phoenix_channel::get_user_agent;
 use telemetry::{
-    MaybePushMetricsExporter, NoopPushMetricsExporter, Telemetry, feature_flags, otel,
+    MaybePushMetricsExporter, NoopPushMetricsExporter, SentryMetricExporter, Telemetry,
+    feature_flags, otel,
 };
 use tokio_util::task::AbortOnDropHandle;
 use tunnel::GatewayTunnel;
@@ -174,7 +175,14 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
 
                         NoopPushMetricsExporter
                     },
-                    should_export: feature_flags::export_metrics,
+                    should_export: feature_flags::stream_metrics,
+                })
+                .with_resource(resource)
+                .build(),
+            (MetricsExporter::Sentry, _) => SdkMeterProvider::builder()
+                .with_periodic_exporter(MaybePushMetricsExporter {
+                    inner: SentryMetricExporter,
+                    should_export: feature_flags::stream_metrics,
                 })
                 .with_resource(resource)
                 .build(),
@@ -391,6 +399,7 @@ impl fmt::Display for LogFormat {
 enum MetricsExporter {
     Stdout,
     OtelCollector,
+    Sentry,
 }
 
 impl Cli {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -31,7 +31,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use telemetry::{Telemetry, analytics};
+use telemetry::{Telemetry, analytics, otel};
 use tokio::time::Instant;
 use tracing::Instrument as _;
 use url::Url;
@@ -636,6 +636,12 @@ impl<'a> Handler<'a> {
                             self.device_id.id.clone(),
                         )
                         .await;
+
+                    otel::install_sentry_meter_provider(
+                        env!("CARGO_PKG_NAME"),
+                        env!("CARGO_PKG_VERSION"),
+                        self.device_id.id.clone(),
+                    );
 
                     if let Some(account_slug) = account_slug {
                         Telemetry::set_account_slug(account_slug.clone());

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -25,7 +25,8 @@ use std::{
     time::Duration,
 };
 use telemetry::{
-    MaybePushMetricsExporter, NoopPushMetricsExporter, Telemetry, analytics, feature_flags, otel,
+    MaybePushMetricsExporter, NoopPushMetricsExporter, SentryMetricExporter, Telemetry, analytics,
+    feature_flags, otel,
 };
 use tokio::time::Instant;
 
@@ -150,6 +151,7 @@ struct Cli {
 enum MetricsExporter {
     Stdout,
     OtelCollector,
+    Sentry,
 }
 
 impl Cli {
@@ -395,7 +397,14 @@ fn try_main() -> Result<()> {
 
                             NoopPushMetricsExporter
                         },
-                        should_export: feature_flags::export_metrics,
+                        should_export: feature_flags::stream_metrics,
+                    })
+                    .with_resource(resource)
+                    .build(),
+                (MetricsExporter::Sentry, _) => SdkMeterProvider::builder()
+                    .with_periodic_exporter(MaybePushMetricsExporter {
+                        inner: SentryMetricExporter,
+                        should_export: feature_flags::stream_metrics,
                     })
                     .with_resource(resource)
                     .build(),

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 reqwest = { workspace = true, features = ["http2"] }
-sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "logs"] }
+sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "logs", "metrics"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -52,8 +52,8 @@ pub fn icmp_error_unreachable_prohibited_create_new_flow() -> bool {
     FEATURE_FLAGS.icmp_error_unreachable_prohibited_create_new_flow()
 }
 
-pub fn export_metrics() -> bool {
-    false // Placeholder until we actually deploy an OTEL collector.
+pub fn stream_metrics() -> bool {
+    FEATURE_FLAGS.stream_metrics()
 }
 
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
@@ -170,6 +170,8 @@ struct FeatureFlagsResponse {
     stream_logs: bool,
     #[serde(default)]
     icmp_error_unreachable_prohibited_create_new_flow: bool,
+    #[serde(default)]
+    stream_metrics: bool,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
@@ -185,6 +187,7 @@ struct FeatureFlags {
     drop_llmnr_nxdomain_responses: AtomicBool,
     stream_logs: RwLock<LogFilter>,
     icmp_error_unreachable_prohibited_create_new_flow: AtomicBool,
+    stream_metrics: AtomicBool,
 }
 
 /// Accessors to the actual feature flags.
@@ -201,6 +204,7 @@ impl FeatureFlags {
             drop_llmnr_nxdomain_responses,
             stream_logs,
             icmp_error_unreachable_prohibited_create_new_flow,
+            stream_metrics,
         }: FeatureFlagsResponse,
         payloads: FeatureFlagPayloadsResponse,
     ) {
@@ -213,6 +217,7 @@ impl FeatureFlags {
                 icmp_error_unreachable_prohibited_create_new_flow,
                 Ordering::Relaxed,
             );
+        self.stream_metrics.store(stream_metrics, Ordering::Relaxed);
 
         let log_filter = if stream_logs {
             LogFilter::parse(payloads.stream_logs)
@@ -240,6 +245,10 @@ impl FeatureFlags {
         self.icmp_error_unreachable_prohibited_create_new_flow
             .load(Ordering::Relaxed)
     }
+
+    fn stream_metrics(&self) -> bool {
+        self.stream_metrics.load(Ordering::Relaxed)
+    }
 }
 
 fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
@@ -257,6 +266,7 @@ fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
             "FZFF_ICMP_ERROR_UNREACHABLE_PROHIBITED_CREATE_NEW_FLOW",
             flags.icmp_error_unreachable_prohibited_create_new_flow,
         ),
+        stream_metrics: env_or("FZFF_STREAM_METRICS", flags.stream_metrics),
     }
 }
 
@@ -275,6 +285,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
         DropLlmnrNxdomainResponses { result: bool },
         StreamLogs { result: bool },
         IcmpErrorUnreachableProhibitedCreateNewFlow { result: bool },
+        StreamMetrics { result: bool },
     }
 
     // Exhaustive destruction so we don't forget to update this when we add a flag.
@@ -283,6 +294,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
         drop_llmnr_nxdomain_responses,
         stream_logs,
         icmp_error_unreachable_prohibited_create_new_flow,
+        stream_metrics,
     } = flags;
 
     let value = serde_json::json!({
@@ -293,6 +305,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
             SentryFlag::DropLlmnrNxdomainResponses { result: drop_llmnr_nxdomain_responses },
             SentryFlag::StreamLogs { result: stream_logs },
             SentryFlag::IcmpErrorUnreachableProhibitedCreateNewFlow { result: icmp_error_unreachable_prohibited_create_new_flow },
+            SentryFlag::StreamMetrics { result: stream_metrics },
         ]
     });
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use api_url::ApiUrl;
 use sentry::{
     BeforeCallback, User,
-    protocol::{Event, Log, LogAttribute},
+    protocol::{Event, Log, LogAttribute, Metric},
     transports::ReqwestHttpTransport,
 };
 use sha2::Digest as _;
@@ -27,9 +27,11 @@ mod api_url;
 mod maybe_push_metrics_exporter;
 mod noop_push_metrics_exporter;
 mod posthog;
+mod sentry_metric_exporter;
 
 pub use maybe_push_metrics_exporter::MaybePushMetricsExporter;
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
+pub use sentry_metric_exporter::SentryMetricExporter;
 
 /// Hashes a device ID using SHA256 and returns the hex-encoded result.
 pub fn hash_device_id(id: impl AsRef<[u8]>) -> String {
@@ -220,11 +222,17 @@ impl Telemetry {
             max_breadcrumbs: 500,
             before_send: Some(event_rate_limiter(Duration::from_secs(60 * 5))),
             enable_logs: true,
+            enable_metrics: true,
             before_send_log: Some(Arc::new(|log| {
-                let log = insert_user_account_slug(log);
+                let log = insert_user_account_slug_into_log(log);
                 let log = append_tracing_fields_to_message(log);
 
                 Some(log)
+            })),
+            before_send_metric: Some(Arc::new(|metric| {
+                let metric = insert_user_account_slug_into_metric(metric);
+
+                Some(metric)
             })),
             ..Default::default()
         };
@@ -398,7 +406,7 @@ fn append_tracing_fields_to_message(mut log: Log) -> Log {
     log
 }
 
-fn insert_user_account_slug(mut log: Log) -> Log {
+fn insert_user_account_slug_into_log(mut log: Log) -> Log {
     let Some(account_slug) = Telemetry::current_account_slug() else {
         return log;
     };
@@ -409,6 +417,18 @@ fn insert_user_account_slug(mut log: Log) -> Log {
     );
 
     log
+}
+
+fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
+    let Some(account_slug) = Telemetry::current_account_slug() else {
+        return metric;
+    };
+
+    metric
+        .attributes
+        .insert("user.account_slug".into(), LogAttribute::from(account_slug));
+
+    metric
 }
 
 fn update_user(update: impl FnOnce(&mut sentry::User)) {

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -1,8 +1,11 @@
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
     Resource,
+    metrics::SdkMeterProvider,
     resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
 };
+
+use crate::{MaybePushMetricsExporter, SentryMetricExporter, feature_flags};
 
 pub mod attr {
     use ip_packet::{IpPacket, IpVersion};
@@ -187,6 +190,32 @@ pub fn default_resource_with<const N: usize>(attributes: [KeyValue; N]) -> Resou
         .with_detector(Box::new(EnvResourceDetector::new()))
         .with_attributes(attributes)
         .build()
+}
+
+/// Installs a global meter provider that streams metrics into Sentry.
+///
+/// Export is gated on the `stream_metrics` feature flag, so it is safe to call
+/// this unconditionally when starting telemetry.
+pub fn install_sentry_meter_provider(
+    service_name: &'static str,
+    service_version: &'static str,
+    service_instance_id: String,
+) {
+    let resource = default_resource_with([
+        KeyValue::new("service.name", service_name),
+        KeyValue::new("service.version", service_version),
+        crate::otel::attr::service_instance_id(service_instance_id),
+    ]);
+
+    let provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(MaybePushMetricsExporter {
+            inner: SentryMetricExporter,
+            should_export: feature_flags::stream_metrics,
+        })
+        .with_resource(resource)
+        .build();
+
+    opentelemetry::global::set_meter_provider(provider);
 }
 
 pub struct OsResourceDetector;

--- a/rust/libs/telemetry/src/sentry_metric_exporter.rs
+++ b/rust/libs/telemetry/src/sentry_metric_exporter.rs
@@ -1,0 +1,180 @@
+use std::{future::Future, time::Duration};
+
+use opentelemetry::{KeyValue, Value as OtelValue};
+use opentelemetry_sdk::{
+    error::OTelSdkResult,
+    metrics::{
+        Temporality,
+        data::{
+            AggregatedMetrics, ExponentialHistogramDataPoint, HistogramDataPoint, Metric,
+            MetricData, ResourceMetrics,
+        },
+        exporter::PushMetricExporter,
+    },
+};
+use sentry::protocol::LogAttribute;
+
+/// A [`PushMetricExporter`] that re-emits OpenTelemetry metrics as Sentry metrics
+/// via the currently-initialised Sentry client on the main hub.
+///
+/// Histograms are summarised as `<name>.count`, `<name>.sum` and (when present)
+/// `<name>.min` / `<name>.max`, since the Sentry metric protocol can only carry
+/// a single value per metric.
+pub struct SentryMetricExporter;
+
+impl PushMetricExporter for SentryMetricExporter {
+    fn export(&self, metrics: &ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
+        for scope in metrics.scope_metrics() {
+            for metric in scope.metrics() {
+                emit_metric(metric);
+            }
+        }
+
+        std::future::ready(Ok(()))
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        // Each export gives us the change since the previous export, which maps
+        // cleanly onto Sentry's increment-only counters.
+        Temporality::Delta
+    }
+}
+
+fn emit_metric(metric: &Metric) {
+    let name = metric.name();
+    let unit = metric.unit();
+
+    match metric.data() {
+        AggregatedMetrics::F64(d) => emit_data(name, unit, d, |v| v),
+        AggregatedMetrics::U64(d) => emit_data(name, unit, d, |v| v as f64),
+        AggregatedMetrics::I64(d) => emit_data(name, unit, d, |v| v as f64),
+    }
+}
+
+fn emit_data<T: Copy>(name: &str, unit: &str, data: &MetricData<T>, to_f64: impl Fn(T) -> f64) {
+    match data {
+        MetricData::Gauge(g) => {
+            for dp in g.data_points() {
+                emit_gauge(name, unit, to_f64(dp.value()), dp.attributes());
+            }
+        }
+        MetricData::Sum(s) => {
+            let monotonic = s.is_monotonic();
+
+            for dp in s.data_points() {
+                if monotonic {
+                    emit_counter(name, to_f64(dp.value()), dp.attributes());
+                } else {
+                    emit_gauge(name, unit, to_f64(dp.value()), dp.attributes());
+                }
+            }
+        }
+        MetricData::Histogram(h) => {
+            for dp in h.data_points() {
+                emit_histogram(name, unit, dp, &to_f64);
+            }
+        }
+        MetricData::ExponentialHistogram(h) => {
+            for dp in h.data_points() {
+                emit_exp_histogram(name, unit, dp, &to_f64);
+            }
+        }
+    }
+}
+
+fn emit_counter<'a>(name: &str, value: f64, attrs: impl Iterator<Item = &'a KeyValue>) {
+    let mut metric = sentry::metrics::counter(name.to_owned(), value);
+    for attr in attrs {
+        metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
+    }
+    metric.capture();
+}
+
+fn emit_gauge<'a>(name: &str, unit: &str, value: f64, attrs: impl Iterator<Item = &'a KeyValue>) {
+    let mut metric = sentry::metrics::gauge(name.to_owned(), value);
+    if !unit.is_empty() {
+        metric = metric.unit(unit.to_owned());
+    }
+    for attr in attrs {
+        metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
+    }
+    metric.capture();
+}
+
+fn emit_distribution<'a>(
+    name: &str,
+    unit: &str,
+    value: f64,
+    attrs: impl Iterator<Item = &'a KeyValue>,
+) {
+    let mut metric = sentry::metrics::distribution(name.to_owned(), value);
+    if !unit.is_empty() {
+        metric = metric.unit(unit.to_owned());
+    }
+    for attr in attrs {
+        metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
+    }
+    metric.capture();
+}
+
+fn emit_histogram<T: Copy>(
+    name: &str,
+    unit: &str,
+    dp: &HistogramDataPoint<T>,
+    to_f64: &impl Fn(T) -> f64,
+) {
+    emit_counter(&format!("{name}.count"), dp.count() as f64, dp.attributes());
+    emit_distribution(
+        &format!("{name}.sum"),
+        unit,
+        to_f64(dp.sum()),
+        dp.attributes(),
+    );
+
+    if let Some(min) = dp.min() {
+        emit_gauge(&format!("{name}.min"), unit, to_f64(min), dp.attributes());
+    }
+    if let Some(max) = dp.max() {
+        emit_gauge(&format!("{name}.max"), unit, to_f64(max), dp.attributes());
+    }
+}
+
+fn emit_exp_histogram<T: Copy>(
+    name: &str,
+    unit: &str,
+    dp: &ExponentialHistogramDataPoint<T>,
+    to_f64: &impl Fn(T) -> f64,
+) {
+    emit_counter(&format!("{name}.count"), dp.count() as f64, dp.attributes());
+    emit_distribution(
+        &format!("{name}.sum"),
+        unit,
+        to_f64(dp.sum()),
+        dp.attributes(),
+    );
+
+    if let Some(min) = dp.min() {
+        emit_gauge(&format!("{name}.min"), unit, to_f64(min), dp.attributes());
+    }
+    if let Some(max) = dp.max() {
+        emit_gauge(&format!("{name}.max"), unit, to_f64(max), dp.attributes());
+    }
+}
+
+fn to_log_attr(value: &OtelValue) -> LogAttribute {
+    match value {
+        OtelValue::Bool(b) => LogAttribute::from(*b),
+        OtelValue::I64(i) => LogAttribute::from(*i),
+        OtelValue::F64(f) => LogAttribute::from(*f),
+        OtelValue::String(s) => LogAttribute::from(s.as_str().to_owned()),
+        OtelValue::Array(_) | _ => LogAttribute::from(value.to_string()),
+    }
+}


### PR DESCRIPTION
This adds an adapter to our OTEL layer that exports metrics to Sentry if the `stream_metrics` feature flag is set to `true`. Like all feature-flags, this is `false` by default.

The metrics we are collecting in Firezone haven't been particularly tuned yet which is primarily because we hadn't had a way of looking at them at all. Now that Sentry supports metrics, we can start collecting some and see if we get any value out of them.