### PR TITLE
chore(mise): require 7-day cooldown for new tool releases

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "mise version to install"
     required: false
-    default: "2026.3.10"
+    default: "2026.5.0"
   install_args:
     description: "Arguments to pass to `mise install`"
     required: false

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,12 @@
 experimental_monorepo_root = true
 
+[settings]
+# Refuse to install tool versions released less than 7 days ago. Mitigates the
+# malicious-publish supply-chain attack window: most compromised releases are
+# detected and yanked within 24-48 hours, so a 7-day cooldown blocks the bulk
+# of them at resolution time. Requires mise >= 2026.4.25.
+minimum_release_age = "7d"
+
 [monorepo]
 config_roots = [
     "elixir",


### PR DESCRIPTION
Sets `minimum_release_age = "7d"` in the root mise.toml so the resolver refuses to bump pinned tools to releases younger than 7 days. This mirrors the `cooldown` pattern already used by Dependabot for hex/pip in this repo: most malicious upstream releases are detected and yanked within 24-48 hours, so a 7-day window catches the bulk of them before they reach our `.tool-versions` files.

The setting only landed in mise 2026.4.25 (was renamed from `install_before` in jdx/mise#9384), so the pinned mise version in setup-mise is bumped from 2026.3.10 to 2026.5.0.

Note: the filter applies at version-resolution time (`mise outdated`, `mise latest`, fuzzy specs). Exact pins like `nodejs 24.13.0` still install regardless of release date — but the realistic supply-chain threat model is "automation pulls fresh malicious version into a PR", and the resolver is exactly where that automation gets its version.