### PR TITLE
fix(portal): hide internet resource in starter plan

### DIFF
--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -635,7 +635,10 @@ defmodule PortalWeb.Policies do
       end
     else
       policy = socket.assigns.selected_policy
-      changeset = change_policy(policy, params, socket.assigns.subject)
+
+      changeset =
+        change_policy(policy, params)
+        |> validate_internet_resource_allowed(socket.assigns.subject)
 
       case Database.update_policy(changeset, socket.assigns.subject) do
         {:ok, updated} ->
@@ -839,7 +842,6 @@ defmodule PortalWeb.Policies do
     %Policy{}
     |> cast(attrs, ~w[description group_id resource_id]a)
     |> validate_required(~w[group_id resource_id]a)
-    |> validate_internet_resource_allowed(subject)
     |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
     |> Policy.changeset()
     |> put_change(:account_id, subject.account.id)
@@ -848,6 +850,7 @@ defmodule PortalWeb.Policies do
   defp create_policy(attrs, %Authentication.Subject{} = subject) do
     attrs
     |> new_policy(subject)
+    |> validate_internet_resource_allowed(subject)
     |> Database.insert_policy(subject)
   end
 
@@ -855,15 +858,6 @@ defmodule PortalWeb.Policies do
     policy
     |> cast(attrs, ~w[description group_id resource_id]a)
     |> validate_required(~w[group_id resource_id]a)
-    |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
-    |> Policy.changeset()
-  end
-
-  defp change_policy(%Policy{} = policy, attrs, %Authentication.Subject{} = subject) do
-    policy
-    |> cast(attrs, ~w[description group_id resource_id]a)
-    |> validate_required(~w[group_id resource_id]a)
-    |> validate_internet_resource_allowed(subject)
     |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
     |> Policy.changeset()
   end

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -635,7 +635,7 @@ defmodule PortalWeb.Policies do
       end
     else
       policy = socket.assigns.selected_policy
-      changeset = change_policy(policy, params)
+      changeset = change_policy(policy, params, socket.assigns.subject)
 
       case Database.update_policy(changeset, socket.assigns.subject) do
         {:ok, updated} ->
@@ -839,6 +839,7 @@ defmodule PortalWeb.Policies do
     %Policy{}
     |> cast(attrs, ~w[description group_id resource_id]a)
     |> validate_required(~w[group_id resource_id]a)
+    |> validate_internet_resource_allowed(subject)
     |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
     |> Policy.changeset()
     |> put_change(:account_id, subject.account.id)
@@ -856,6 +857,36 @@ defmodule PortalWeb.Policies do
     |> validate_required(~w[group_id resource_id]a)
     |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
     |> Policy.changeset()
+  end
+
+  defp change_policy(%Policy{} = policy, attrs, %Authentication.Subject{} = subject) do
+    policy
+    |> cast(attrs, ~w[description group_id resource_id]a)
+    |> validate_required(~w[group_id resource_id]a)
+    |> validate_internet_resource_allowed(subject)
+    |> cast_embed(:conditions, with: &Portal.Policies.Condition.changeset/3)
+    |> Policy.changeset()
+  end
+
+  defp validate_internet_resource_allowed(changeset, %Authentication.Subject{} = subject) do
+    resource_id = get_field(changeset, :resource_id)
+
+    cond do
+      Portal.Account.internet_resource_enabled?(subject.account) ->
+        changeset
+
+      is_nil(resource_id) ->
+        changeset
+
+      true ->
+        case Database.get_resource(resource_id, subject) do
+          %{type: :internet} ->
+            add_error(changeset, :resource_id, "Internet Resource is not available on your plan")
+
+          _resource ->
+            changeset
+        end
+    end
   end
 
   defp disable_policy(%Policy{} = policy, %Authentication.Subject{} = subject) do

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -401,8 +401,8 @@ defmodule PortalWeb.Policies.Components do
       label="Resource"
       placeholder="Select Resource"
       field={@panel_form[:resource_id]}
-      fetch_option_callback={&PortalWeb.Resources.Components.fetch_resource_option(&1, @subject)}
-      list_options_callback={&PortalWeb.Resources.Components.list_resource_options(&1, @subject)}
+      fetch_option_callback={&fetch_policy_resource_option(&1, @subject)}
+      list_options_callback={&list_policy_resource_options(&1, @subject)}
       on_change={&PortalWeb.Policies.on_panel_resource_change/1}
       value={@panel_form[:resource_id].value}
       required
@@ -425,6 +425,40 @@ defmodule PortalWeb.Policies.Components do
     </.live_component>
     """
   end
+
+  defp fetch_policy_resource_option(id, subject) do
+    PortalWeb.Resources.Components.fetch_resource_option(id, subject)
+  end
+
+  defp list_policy_resource_options(search_query_or_nil, subject) do
+    {:ok, grouped_options, metadata} =
+      PortalWeb.Resources.Components.list_resource_options(search_query_or_nil, subject)
+
+    grouped_options = maybe_filter_internet_resource_options(grouped_options, subject.account)
+
+    {:ok, grouped_options, metadata}
+  end
+
+  defp maybe_filter_internet_resource_options(grouped_options, account) do
+    if Portal.Account.internet_resource_enabled?(account) do
+      grouped_options
+    else
+      grouped_options
+      |> Enum.map(&filter_internet_resource_option_group/1)
+      |> Enum.reject(&empty_resource_option_group?/1)
+    end
+  end
+
+  defp filter_internet_resource_option_group({group, options}) do
+    filtered =
+      Enum.reject(options, fn {_id, _name, resource} ->
+        resource.type == :internet
+      end)
+
+    {group, filtered}
+  end
+
+  defp empty_resource_option_group?({_group, options}), do: options == []
 
   attr :panel_form, :any, default: nil
 

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -963,7 +963,11 @@ defmodule PortalWeb.Sites do
   end
 
   defp load_sites_index_data(socket) do
-    internet_resource = Database.get_internet_resource(socket.assigns.subject)
+    internet_resource =
+      if Portal.Account.internet_resource_enabled?(socket.assigns.account) do
+        Database.get_internet_resource(socket.assigns.subject)
+      end
+
     sites = Database.list_all_sites(socket.assigns.subject)
     site_ids = Enum.map(sites, & &1.id)
 

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -120,6 +120,7 @@ defmodule PortalWeb.PoliciesTest do
       account =
         starter_account_fixture(
           features: %{
+            internet_resource: false,
             policy_conditions: false,
             traffic_filters: true,
             idp_sync: true,
@@ -143,6 +144,74 @@ defmodule PortalWeb.PoliciesTest do
       assert html =~ "ri-loop-left-line"
       refute html =~ "Add condition"
       refute html =~ ~s(phx-click="remove_condition")
+    end
+
+    test "does not list Internet Resource in policy creation for starter accounts", %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      _internet_resource = internet_resource_fixture(account: account, name: "Starter Internet")
+      _resource = resource_fixture(account: account, name: "Starter DNS")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/new")
+
+      assert html =~ "Starter DNS"
+      refute html =~ "Starter Internet"
+    end
+
+    test "rejects manual Internet Resource submission for starter accounts", %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      group = group_fixture(account: account)
+      internet_resource = internet_resource_fixture(account: account, name: "Blocked Internet")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/new")
+
+      html =
+        lv
+        |> form("[phx-submit='submit_policy_form']",
+          policy: %{
+            group_id: group.id,
+            resource_id: internet_resource.id,
+            description: "Blocked by plan"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "Internet Resource is not available on your plan"
+
+      refute Repo.get_by(Policy,
+               group_id: group.id,
+               resource_id: internet_resource.id,
+               description: "Blocked by plan"
+             )
     end
   end
 
@@ -267,6 +336,33 @@ defmodule PortalWeb.PoliciesTest do
 
       refute html =~ "10.10.0.0/16"
       refute html =~ ~s(phx-click="remove_condition")
+    end
+
+    test "renders existing Internet Resource policy on edit after feature loss", %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      group = group_fixture(account: account)
+      resource = internet_resource_fixture(account: account, name: "Existing Internet Resource")
+      policy = policy_fixture(group: group, resource: resource)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      assert html =~ "Edit Policy"
+      assert html =~ "Existing Internet Resource"
     end
 
     test "updates policy description and condition state", %{

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -365,6 +365,90 @@ defmodule PortalWeb.PoliciesTest do
       assert html =~ "Existing Internet Resource"
     end
 
+    test "blocks saving an existing Internet Resource policy on starter accounts",
+         %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      group = group_fixture(account: account)
+      resource = internet_resource_fixture(account: account, name: "Existing Internet Resource")
+      policy = policy_fixture(group: group, resource: resource, description: "Original")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      html =
+        lv
+        |> form("[phx-submit='submit_policy_form']",
+          policy: %{
+            group_id: group.id,
+            resource_id: resource.id,
+            description: "Updated Description"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "Internet Resource is not available on your plan"
+
+      reloaded = Repo.get_by!(Policy, id: policy.id, account_id: account.id)
+      assert reloaded.description == "Original"
+    end
+
+    test "rejects manual Internet Resource assignment when editing for starter accounts",
+         %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account, name: "Starter DNS")
+      internet_resource = internet_resource_fixture(account: account, name: "Blocked Internet")
+      policy = policy_fixture(group: group, resource: resource, description: "Original")
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}/edit")
+
+      html =
+        lv
+        |> form("[phx-submit='submit_policy_form']",
+          policy: %{
+            group_id: group.id,
+            resource_id: internet_resource.id,
+            description: "Switched to Internet"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "Internet Resource is not available on your plan"
+
+      reloaded = Repo.get_by!(Policy, id: policy.id, account_id: account.id)
+      assert reloaded.resource_id == resource.id
+      assert reloaded.description == "Original"
+    end
+
     test "updates policy description and condition state", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -127,6 +127,32 @@ defmodule PortalWeb.ResourcesTest do
       assert has_element?(lv, "#resources-type-static_device_pool")
       assert has_element?(lv, "#resources-type-dns")
     end
+
+    test "hides Internet Resource row for starter accounts without the feature", %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      _internet_resource =
+        internet_resource_fixture(account: account, name: "Starter Hidden Internet Resource")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      refute html =~ "Starter Hidden Internet Resource"
+      refute html =~ "Network traffic outside defined resources"
+    end
   end
 
   describe ":new action" do

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -6,6 +6,7 @@ defmodule PortalWeb.SitesTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.DeviceFixtures
+  import Portal.ResourceFixtures
   import Portal.SiteFixtures
 
   setup do
@@ -108,6 +109,32 @@ defmodule PortalWeb.SitesTest do
       assert html =~ "Site Chicago POP created successfully."
       assert html =~ "Chicago POP"
       assert_patch(lv, ~p"/#{account}/sites/#{site.id}")
+    end
+
+    test "hides Internet Site on the index for starter accounts without the feature", %{conn: conn} do
+      account =
+        starter_account_fixture(
+          features: %{
+            internet_resource: false,
+            policy_conditions: true,
+            traffic_filters: true,
+            idp_sync: true,
+            rest_api: true,
+            client_to_client: false
+          }
+        )
+
+      actor = admin_actor_fixture(account: account)
+      _internet_resource =
+        internet_resource_fixture(account: account, name: "Starter Hidden Internet Resource")
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites")
+
+      refute html =~ "Internet Site"
+      refute html =~ "Starter Hidden Internet Resource"
     end
   end
 


### PR DESCRIPTION
Starter plans should not see the Internet Site or Internet Resource anywhere in the UI.