### PR TITLE
feat(client): show connected devices in tray

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -413,7 +413,7 @@ impl Session {
                 })
             }
             client_shared::Event::ResourcesUpdated(resources) => {
-                let resources: Vec<Resource> = resources.into_iter().map(Into::into).collect();
+                let resources = resources.resources.into_iter().map(Into::into).collect();
 
                 Some(Event::ResourcesUpdated { resources })
             }

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -9,7 +9,7 @@ use crate::{
     view::{GeneralSettingsForm, SessionViewModel},
 };
 use anyhow::{Context, ErrorExt as _, Result, anyhow, bail};
-use connlib_model::{ResourceId, ResourceView, Site};
+use connlib_model::{ResourceId, ResourceList, ResourceView, Site};
 use futures::{
     SinkExt, StreamExt,
     stream::{self, BoxStream},
@@ -136,7 +136,7 @@ pub enum Status {
     /// Firezone is ready to use.
     TunnelReady {
         #[debug(skip)]
-        resources: Vec<ResourceView>,
+        resources: ResourceList,
     },
     /// Firezone is signing in to the Portal.
     WaitingForPortal,
@@ -647,7 +647,11 @@ impl<I: GuiIntegration> Controller<I> {
                     )?;
                 }
 
-                tracing::debug!(len = resources.len(), "Got new Resources");
+                tracing::debug!(
+                    resources = resources.resources.len(),
+                    connected_devices = resources.connected_devices.len(),
+                    "Got new Resources"
+                );
 
                 self.status = Status::TunnelReady { resources };
 
@@ -833,7 +837,8 @@ impl<I: GuiIntegration> Controller<I> {
                         actor_name: auth_session.actor_name.clone(),
                         favorite_resources: self.general_settings.favorite_resources.clone(),
                         internet_resource_enabled: self.general_settings.internet_resource_enabled,
-                        resources: resources.clone(),
+                        resources: resources.resources.clone(),
+                        connected_devices: resources.connected_devices.clone(),
                     }),
                     SessionViewModel::SignedIn {
                         account_slug: auth_session.account_slug.clone(),
@@ -908,6 +913,7 @@ impl<I: GuiIntegration> Controller<I> {
         };
 
         let resource = resources
+            .resources
             .iter()
             .find(|r| r.id() == resource_id)
             .context("Unknown resource")?;
@@ -1366,7 +1372,10 @@ mod tests {
 
         async fn send_resources(&mut self, resources: Vec<ResourceView>) {
             self.tx
-                .send(&service::ServerMsg::OnUpdateResources(resources))
+                .send(&service::ServerMsg::OnUpdateResources(ResourceList {
+                    resources,
+                    connected_devices: Vec::new(),
+                }))
                 .await
                 .unwrap();
         }

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -8,7 +8,7 @@
 use crate::updates::Release;
 use anyhow::{Context as _, Result};
 use compositor::Image;
-use connlib_model::{ResourceId, ResourceStatus, ResourceView};
+use connlib_model::{ConnectedDeviceView, ResourceId, ResourceStatus, ResourceView};
 use std::collections::HashSet;
 use tauri::AppHandle;
 use url::Url;
@@ -45,6 +45,12 @@ const REMOVE_FAVORITE: &str = "Remove from favorites";
 const FAVORITE_RESOURCES: &str = "Favorite Resources";
 const RESOURCES: &str = "Resources";
 const OTHER_RESOURCES: &str = "Other Resources";
+const DEVICES: &str = "Devices";
+
+/// Maximum number of connected devices listed inline in the Devices submenu.
+///
+/// Anything beyond this is summarized as "And N more devices…".
+const MAX_DEVICES_INLINE: usize = 20;
 const SIGN_OUT: &str = "Sign out";
 const DISCONNECT_AND_QUIT: &str = "Disconnect and quit Firezone";
 const DISABLE: &str = "Disable this resource";
@@ -306,6 +312,7 @@ pub struct SignedIn {
     pub actor_name: String,
     pub favorite_resources: HashSet<ResourceId>,
     pub resources: Vec<ResourceView>,
+    pub connected_devices: Vec<ConnectedDeviceView>,
     pub internet_resource_enabled: Option<bool>,
 }
 
@@ -399,8 +406,8 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
         actor_name,
         favorite_resources,
         resources, // Make sure these are presented in the order we receive them
+        connected_devices,
         internet_resource_enabled,
-        ..
     } = signed_in;
 
     let has_any_favorites = resources
@@ -456,6 +463,52 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
             submenu = submenu.add_submenu(res.name(), signed_in.resource_submenu(res));
         }
         menu = menu.separator().add_submenu(OTHER_RESOURCES, submenu);
+    }
+
+    if !connected_devices.is_empty() {
+        let label = format!("{DEVICES} ({})", connected_devices.len());
+        menu = menu
+            .separator()
+            .add_submenu(label, devices_submenu(connected_devices));
+    }
+
+    menu
+}
+
+fn devices_submenu(connected_devices: &[ConnectedDeviceView]) -> Menu {
+    let mut menu = Menu::default();
+    let visible = connected_devices.len().min(MAX_DEVICES_INLINE);
+    for device in &connected_devices[..visible] {
+        menu = menu.add_submenu(device.id.to_string(), device_submenu(device));
+    }
+
+    let hidden = connected_devices.len() - visible;
+    if hidden > 0 {
+        let label = if hidden == 1 {
+            "And 1 more device…".to_string()
+        } else {
+            format!("And {hidden} more devices…")
+        };
+        menu = menu.separator().disabled(label);
+    }
+    menu
+}
+
+fn device_submenu(device: &ConnectedDeviceView) -> Menu {
+    let mut menu = Menu::default()
+        .disabled("Device")
+        .copyable(&device.id.to_string());
+
+    if !device.pools.is_empty() {
+        let label = if device.pools.len() == 1 {
+            "Pool"
+        } else {
+            "Pools"
+        };
+        menu = menu.separator().disabled(label);
+        for pool in &device.pools {
+            menu = menu.copyable(pool);
+        }
     }
 
     menu
@@ -558,6 +611,7 @@ mod tests {
                 actor_name: "Jane Doe".into(),
                 favorite_resources,
                 resources,
+                connected_devices: Vec::new(),
                 internet_resource_enabled,
             }),
             release: None,
@@ -950,5 +1004,83 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn devices_submenu_lists_connected_devices_with_pool_labels() {
+        use connlib_model::ClientId;
+        let alpha = ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111);
+        let beta = ClientId::from_u128(0x2222_2222_2222_2222_2222_2222_2222_2222);
+        let connected_devices = vec![
+            ConnectedDeviceView {
+                id: alpha,
+                pools: vec!["Engineering Pool".into()],
+            },
+            ConnectedDeviceView {
+                id: beta,
+                pools: vec!["Engineering Pool".into(), "QA Pool".into()],
+            },
+        ];
+
+        let actual = devices_submenu(&connected_devices);
+
+        let expected = Menu::default()
+            .add_submenu(
+                alpha.to_string(),
+                Menu::default()
+                    .disabled("Device")
+                    .copyable(&alpha.to_string())
+                    .separator()
+                    .disabled("Pool")
+                    .copyable("Engineering Pool"),
+            )
+            .add_submenu(
+                beta.to_string(),
+                Menu::default()
+                    .disabled("Device")
+                    .copyable(&beta.to_string())
+                    .separator()
+                    .disabled("Pools")
+                    .copyable("Engineering Pool")
+                    .copyable("QA Pool"),
+            );
+
+        assert_eq!(
+            actual,
+            expected,
+            "{}",
+            serde_json::to_string_pretty(&actual).unwrap()
+        );
+    }
+
+    #[test]
+    fn devices_submenu_truncates_beyond_inline_limit() {
+        use connlib_model::ClientId;
+        let connected_devices: Vec<ConnectedDeviceView> = (0..MAX_DEVICES_INLINE + 3)
+            .map(|i| ConnectedDeviceView {
+                id: ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111 + i as u128),
+                pools: Vec::new(),
+            })
+            .collect();
+
+        let actual = devices_submenu(&connected_devices);
+
+        let mut expected = Menu::default();
+        for device in &connected_devices[..MAX_DEVICES_INLINE] {
+            expected = expected.add_submenu(
+                device.id.to_string(),
+                Menu::default()
+                    .disabled("Device")
+                    .copyable(&device.id.to_string()),
+            );
+        }
+        expected = expected.separator().disabled("And 3 more devices…");
+
+        assert_eq!(
+            actual,
+            expected,
+            "{}",
+            serde_json::to_string_pretty(&actual).unwrap()
+        );
     }
 }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -12,7 +12,7 @@ use bin_shared::{
     platform::{UdpSocketFactory, tcp_socket_factory},
     signals,
 };
-use connlib_model::{ResourceId, ResourceView};
+use connlib_model::{ResourceId, ResourceList};
 use futures::{
     Future as _, FutureExt, SinkExt as _, Stream, StreamExt,
     future::poll_fn,
@@ -98,7 +98,7 @@ pub enum ServerMsg {
     GatewayVersionMismatch {
         resource_id: ResourceId,
     },
-    OnUpdateResources(Vec<ResourceView>),
+    OnUpdateResources(ResourceList),
     /// The Tunnel service is terminating, maybe due to a software update
     ///
     /// This is a hint that the Client should exit with a message like,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -1,6 +1,6 @@
 use crate::PHOENIX_TOPIC;
 use anyhow::{Context as _, ErrorExt as _, Result};
-use connlib_model::{ClientOrGatewayId, PublicKey, ResourceId, ResourceView};
+use connlib_model::{ClientOrGatewayId, PublicKey, ResourceId, ResourceList};
 use l4_udp_dns_client::UdpDnsClient;
 use parking_lot::Mutex;
 use phoenix_channel::{PhoenixChannel, PublicKeyParam};
@@ -50,7 +50,7 @@ pub struct Eventloop {
     tunnel: Option<ClientTunnel>,
 
     cmd_rx: mpsc::UnboundedReceiver<Command>,
-    resource_list_sender: watch::Sender<Vec<ResourceView>>,
+    resource_list_sender: watch::Sender<ResourceList>,
     tun_config_sender: watch::Sender<Option<TunConfig>>,
     user_notification_sender: mpsc::Sender<UserNotification>,
 
@@ -110,7 +110,7 @@ impl Eventloop {
         dns_servers: Vec<IpAddr>,
         portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
-        resource_list_sender: watch::Sender<Vec<ResourceView>>,
+        resource_list_sender: watch::Sender<ResourceList>,
         tun_config_sender: watch::Sender<Option<TunConfig>>,
         user_notification_sender: mpsc::Sender<UserNotification>,
     ) -> Self {

--- a/rust/libs/client-shared/src/lib.rs
+++ b/rust/libs/client-shared/src/lib.rs
@@ -8,7 +8,7 @@ use tunnel::messages::client::EgressMessages;
 pub use tunnel::messages::client::{IngressMessages, ResourceDescription};
 
 use anyhow::Result;
-use connlib_model::{ResourceId, ResourceView};
+use connlib_model::{ResourceId, ResourceList};
 use eventloop::{Command, Eventloop};
 use futures::future::Fuse;
 use futures::{FutureExt, StreamExt};
@@ -43,7 +43,7 @@ pub struct Session {
 #[derive(Debug)]
 pub struct EventStream {
     eventloop: Fuse<JoinHandle<Result<(), DisconnectError>>>,
-    resource_list_receiver: WatchStream<Vec<ResourceView>>,
+    resource_list_receiver: WatchStream<ResourceList>,
     tun_config_receiver: WatchStream<Option<TunConfig>>,
     user_notification_receiver: mpsc::Receiver<UserNotification>,
 
@@ -56,7 +56,7 @@ pub enum Event {
     /// The TUN device configuration has been updated.
     TunInterfaceUpdated(TunConfig),
     /// The resource list has been updated.
-    ResourcesUpdated(Vec<ResourceView>),
+    ResourcesUpdated(ResourceList),
     /// Establishing a tunnel for a resource failed because all Gateways are offline in the corresponding site.
     AllGatewaysOffline { resource_id: ResourceId },
     /// Establishing a tunnel for a resource failed because there are no version-compatible Gateways in the corresponding site.
@@ -197,7 +197,7 @@ impl Drop for Session {
 impl EventStream {
     fn new<E>(
         make_event_loop: impl FnOnce(
-            watch::Sender<Vec<ResourceView>>,
+            watch::Sender<ResourceList>,
             watch::Sender<Option<TunConfig>>,
             mpsc::Sender<UserNotification>,
         ) -> E,
@@ -207,7 +207,8 @@ impl EventStream {
         E: Future<Output = Result<(), DisconnectError>> + Send + 'static,
     {
         let (tun_config_sender, tun_config_receiver) = watch::channel(None);
-        let (resource_list_sender, resource_list_receiver) = watch::channel(Vec::default());
+        let (resource_list_sender, resource_list_receiver) =
+            watch::channel(ResourceList::default());
         let (user_notification_sender, user_notification_receiver) = mpsc::channel(128);
 
         let event_loop = make_event_loop(

--- a/rust/libs/connlib/model/src/lib.rs
+++ b/rust/libs/connlib/model/src/lib.rs
@@ -12,7 +12,8 @@ mod view;
 pub use boringtun::x25519::PublicKey;
 pub use boringtun::x25519::StaticSecret;
 pub use view::{
-    CidrResourceView, DnsResourceView, InternetResourceView, ResourceStatus, ResourceView,
+    CidrResourceView, ConnectedDeviceView, DnsResourceView, InternetResourceView, ResourceList,
+    ResourceStatus, ResourceView,
 };
 
 use serde::{Deserialize, Serialize};

--- a/rust/libs/connlib/model/src/view.rs
+++ b/rust/libs/connlib/model/src/view.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Debug;
 
+use crate::ClientId;
 use crate::ResourceId;
 use crate::Site;
 
@@ -120,6 +121,24 @@ pub struct CidrResourceView {
     pub sites: Vec<Site>,
 
     pub status: ResourceStatus,
+}
+
+/// A device peer that the client currently has a live snownet connection to.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ConnectedDeviceView {
+    pub id: ClientId,
+    /// Names of the device pool resources this client is a member of
+    /// (typically one, but can be multiple).
+    ///
+    /// Empty if pool membership for this client is unknown.
+    pub pools: Vec<String>,
+}
+
+/// Snapshot of resources and currently-connected device peers.
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct ResourceList {
+    pub resources: Vec<ResourceView>,
+    pub connected_devices: Vec<ConnectedDeviceView>,
 }
 
 /// Description of an Internet resource

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -37,8 +37,8 @@ use crate::{IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, TunConfig, dns, p2p_control};
 use anyhow::{Context, ErrorExt, Result, bail};
 use boringtun::x25519;
 use connlib_model::{
-    ClientId, ClientOrGatewayId, GatewayId, IceCandidate, PublicKey, RelayId, ResourceId,
-    ResourceStatus, ResourceView,
+    ClientId, ClientOrGatewayId, ConnectedDeviceView, GatewayId, IceCandidate, PublicKey, RelayId,
+    ResourceId, ResourceList, ResourceStatus, ResourceView,
 };
 use connlib_model::{Site, SiteId};
 use dns_resource_nat::DnsResourceNat;
@@ -154,7 +154,9 @@ pub struct ClientState {
     /// Configuration of the TUN device, when it is up.
     tun_config: TrackedState<TunConfig>,
     /// Cache of the resource list we emitted to the app.
-    resource_list: TrackedState<Vec<ResourceView>>,
+    resource_list: TrackedState<ResourceList>,
+    /// Client peers we currently have a live connection to.
+    connected_pool_clients: BTreeSet<ClientId>,
 
     udp_dns_client: l3_udp_dns_client::Client,
     tcp_dns_client: dns_over_tcp::Client,
@@ -206,6 +208,7 @@ impl ClientState {
             pending_device_access: Default::default(),
             dns_resource_nat: Default::default(),
             resource_list: Default::default(),
+            connected_pool_clients: Default::default(),
         }
     }
 
@@ -232,6 +235,46 @@ impl ClientState {
             })
             .sorted()
             .collect_vec()
+    }
+
+    /// Builds the list of currently-connected device peers, joined against
+    /// static-pool resource memberships so each entry knows which pool(s) it
+    /// belongs to.
+    pub(crate) fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
+        let pools = self.static_device_pools().collect_vec();
+
+        self.connected_pool_clients
+            .iter()
+            .map(|client_id| {
+                let pool_names = pools
+                    .iter()
+                    .filter(|p| p.devices.iter().any(|d| d.id == *client_id))
+                    .map(|p| p.name.clone())
+                    .sorted()
+                    .collect_vec();
+                ConnectedDeviceView {
+                    id: *client_id,
+                    pools: pool_names,
+                }
+            })
+            .collect_vec()
+    }
+
+    fn static_device_pools(&self) -> impl Iterator<Item = &StaticDevicePoolResource> + '_ {
+        self.resources_by_id.values().filter_map(|r| match r {
+            Resource::StaticDevicePool(p) => Some(p),
+            Resource::Dns(_)
+            | Resource::Cidr(_)
+            | Resource::Internet(_)
+            | Resource::DynamicDevicePool(_) => None,
+        })
+    }
+
+    fn resource_list_snapshot(&self) -> ResourceList {
+        ResourceList {
+            resources: self.resources(),
+            connected_devices: self.connected_devices(),
+        }
     }
 
     fn resource_status(&self, resource: &Resource) -> ResourceStatus {
@@ -265,7 +308,7 @@ impl ClientState {
         }
 
         self.on_resource_connection_failed(id, now);
-        self.resource_list.update(self.resources());
+        self.resource_list.update(self.resource_list_snapshot());
     }
 
     /// Handles cases where access to a device is denied.
@@ -1069,6 +1112,9 @@ impl ClientState {
     #[tracing::instrument(level = "debug", skip_all, fields(client = %disconnected_client))]
     fn cleanup_connected_client(&mut self, disconnected_client: &ClientId) {
         self.clients.remove(disconnected_client);
+        if self.connected_pool_clients.remove(disconnected_client) {
+            self.resource_list.update(self.resource_list_snapshot());
+        }
     }
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {
@@ -1418,7 +1464,7 @@ impl ClientState {
         }
 
         if any_reset {
-            self.resource_list.update(self.resources());
+            self.resource_list.update(self.resource_list_snapshot());
         }
     }
 
@@ -1726,8 +1772,10 @@ impl ClientState {
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Gateway(id)) => {
                     self.update_site_status_by_gateway(&id, ResourceStatus::Online, now);
                 }
-                snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(_)) => {
-                    // TODO: Update resource list with online client.
+                snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(id)) => {
+                    if self.connected_pool_clients.insert(id) {
+                        self.resource_list.update(self.resource_list_snapshot());
+                    }
                 }
             }
         }
@@ -1820,7 +1868,7 @@ impl ClientState {
         };
 
         self.sites_status.insert(*sid, (status, now));
-        self.resource_list.update(self.resources());
+        self.resource_list.update(self.resource_list_snapshot());
     }
 
     pub(crate) fn poll_event(&mut self) -> Option<ClientEvent> {
@@ -1831,7 +1879,11 @@ impl ClientState {
         }
 
         if let Some(resources) = self.resource_list.take_pending_update() {
-            tracing::debug!(count = %resources.len(), "Updating resource list");
+            tracing::debug!(
+                resources = resources.resources.len(),
+                connected_devices = resources.connected_devices.len(),
+                "Updating resource list"
+            );
 
             return Some(ClientEvent::ResourcesChanged { resources });
         }
@@ -1918,7 +1970,7 @@ impl ClientState {
         }
 
         self.maybe_update_tun_routes();
-        self.resource_list.update(self.resources());
+        self.resource_list.update(self.resource_list_snapshot());
     }
 
     pub fn add_resource(
@@ -1982,7 +2034,7 @@ impl ClientState {
 
         self.drain_resource_stub_resolver_events();
         self.maybe_update_tun_routes();
-        self.resource_list.update(self.resources());
+        self.resource_list.update(self.resource_list_snapshot());
         self.dns_cache.flush("Resource added");
     }
 
@@ -2079,7 +2131,7 @@ impl ClientState {
         }
 
         self.maybe_update_tun_routes();
-        self.resource_list.update(self.resources());
+        self.resource_list.update(self.resource_list_snapshot());
         self.dns_cache.flush("Resource added");
     }
 
@@ -2097,16 +2149,9 @@ impl ClientState {
     /// requires tearing down its connection: a client that's still authorised
     /// via another pool must keep its connection.
     fn is_client_in_other_static_device_pool(&self, cid: ClientId, excluded: ResourceId) -> bool {
-        self.resources_by_id.values().any(|r| match r {
-            Resource::StaticDevicePool(p) if p.id != excluded => {
-                p.devices.iter().any(|d| d.id == cid)
-            }
-            Resource::StaticDevicePool(_)
-            | Resource::Dns(_)
-            | Resource::Cidr(_)
-            | Resource::Internet(_)
-            | Resource::DynamicDevicePool(_) => false,
-        })
+        self.static_device_pools()
+            .filter(|p| p.id != excluded)
+            .any(|p| p.devices.iter().any(|d| d.id == cid))
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(?id))]
@@ -2119,7 +2164,7 @@ impl ClientState {
         self.client_routing_table.remove_by_id(id);
 
         self.maybe_update_tun_routes();
-        self.resource_list.update(self.resources());
+        self.resource_list.update(self.resource_list_snapshot());
         self.dns_cache.flush("Resource removed");
     }
 
@@ -2166,7 +2211,7 @@ impl ClientState {
                 now,
             );
             self.update_site_status_by_gateway(&gid, ResourceStatus::Unknown, now);
-            self.resource_list.update(self.resources());
+            self.resource_list.update(self.resource_list_snapshot());
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -10,7 +10,7 @@
 use crate::unroutable_packet::RoutingError;
 use anyhow::{Context as _, ErrorExt as _, Result};
 use connlib_model::{
-    ClientId, ClientOrGatewayId, GatewayId, IceCandidate, PublicKey, ResourceId, ResourceView,
+    ClientId, ClientOrGatewayId, GatewayId, IceCandidate, PublicKey, ResourceId, ResourceList,
 };
 use dns_types::DomainName;
 use eventloop_budget::Budget;
@@ -615,9 +615,10 @@ pub enum ClientEvent {
         resource_id: ResourceId,
         domain: DomainName,
     },
-    /// The list of resources has changed and UI clients may have to be updated.
+    /// The list of resources or connected device peers has changed; UI clients
+    /// may have to be updated.
     ResourcesChanged {
-        resources: Vec<ResourceView>,
+        resources: ResourceList,
     },
     DnsRecordsChanged {
         records: BTreeSet<DnsResourceRecord>,

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1240,6 +1240,7 @@ impl TunnelTest {
                 let client = self.clients.get_mut(&src).unwrap();
                 client.exec_mut(|c| {
                     c.resource_status = resources
+                        .resources
                         .into_iter()
                         .map(|r| (r.id(), r.status()))
                         .collect();

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -17,6 +17,9 @@ export default function GUI({ os }: { os: OS }) {
             WiFi.
           </ChangeItem>
         )}
+        <ChangeItem pull={13126}>
+          Shows currently connected devices in the system tray menu.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.12" date={new Date("2026-04-27")}>
         <ChangeItem pull={12684}>


### PR DESCRIPTION
Adds a "Devices" submenu to the system tray listing connected device peers per resource. Connlib tracks the peer list and surfaces it to the GUI over IPC.

Devices are listed as their ClientId, with associated pool(s).

The submenu truncates inline at 20 entries with an "And N more devices…" indicator and surfaces the total count on the submenu label itself ("Devices (22)").

Partially fixes #12566 (platforms other than Linux & Windows will come as a follow-up)