### PR TITLE
chore(client): add tauri  rapid UI iteration mode

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -60,6 +60,13 @@ fn try_main(
         dialog::error("Dialogs are working!")?;
     }
 
+    let fake_controller = matches!(
+        cli.command,
+        Some(Cmd::Debug {
+            command: DebugCommand::FakeController
+        })
+    );
+
     let config = gui::RunConfig {
         inject_faults: cli.inject_faults,
         debug_update_check: cli.debug_update_check,
@@ -70,6 +77,7 @@ fn try_main(
         no_deep_links: cli.no_deep_links,
         quit_after: cli.quit_after,
         fail_with: cli.fail_on_purpose(),
+        fake_controller,
     };
 
     let mut advanced_settings =
@@ -127,8 +135,13 @@ fn try_main(
                 return Err(error.into());
             }
         },
-        None | Some(Cmd::Elevated) => {
-            // Fall-through to running the GUI if elevation check should be bypassed.
+        None
+        | Some(Cmd::Elevated)
+        | Some(Cmd::Debug {
+            command: DebugCommand::FakeController,
+        }) => {
+            // Fall-through to running the GUI if elevation check should be bypassed,
+            // or if we're in fake-controller demo mode.
         }
 
         // All commands below _don't_ end up running the GUI because they return early.
@@ -315,6 +328,9 @@ enum Cmd {
 
 #[derive(clap::Subcommand)]
 enum DebugCommand {
+    /// Run the GUI with a hardcoded fake tunnel state, for iterating on the
+    /// system tray UI without needing the tunnel service or a live portal.
+    FakeController,
     Replicate6791,
     SetAutostart(SetAutostartArgs),
 }

--- a/rust/gui-client/src-tauri/src/fake_controller.rs
+++ b/rust/gui-client/src-tauri/src/fake_controller.rs
@@ -1,0 +1,150 @@
+//! Demo mode that replaces the real `Controller`.
+//!
+//! Spawned in place of the real `Controller` when `firezone-gui-client debug
+//! fake-controller` is run. Builds a hardcoded `AppState::SignedIn` with
+//! sample resources and connected device peers, then listens for tray events
+//! so favorite toggles re-render the menu live. Other clicks (Sign Out,
+//! Internet toggle, etc.) are no-ops in fake mode — there's no real backend.
+//! `Event::Quit` breaks the loop so the demo can be torn down by the tray
+//! menu, `--quit-after`, or `smoke-test`.
+//!
+//! Lives behind a debug subcommand (not behind `cfg(debug_assertions)`) so it
+//! can be exercised against release builds when needed.
+use std::collections::HashSet;
+
+use anyhow::Result;
+use connlib_model::{
+    CidrResourceView, ClientId, ConnectedDeviceView, DnsResourceView, InternetResourceView,
+    ResourceId, ResourceStatus, ResourceView, Site, SiteId,
+};
+use ip_network::IpNetwork;
+use tokio::sync::mpsc;
+
+use crate::controller::{ControllerRequest, GuiIntegration as _};
+use crate::gui::TauriIntegration;
+use crate::gui::system_tray::{AppState, ConnlibState, Event, SignedIn};
+
+/// Drives a hardcoded fake `AppState::SignedIn` onto the tray and re-renders
+/// in response to favorite-toggle clicks.
+pub(crate) async fn run(
+    mut integration: TauriIntegration,
+    mut ctlr_rx: mpsc::Receiver<ControllerRequest>,
+) -> Result<()> {
+    let mut favorites: HashSet<ResourceId> = HashSet::new();
+    integration.set_tray_menu(build_state(&favorites));
+
+    tracing::info!("fake-controller demo started; listening for tray events");
+    while let Some(req) = ctlr_rx.recv().await {
+        #[allow(
+            clippy::wildcard_enum_match_arm,
+            reason = "fake-controller intentionally only acts on favorite toggles and Quit; everything else is a no-op"
+        )]
+        match req {
+            ControllerRequest::SystemTrayMenu(Event::AddFavorite(id)) => {
+                favorites.insert(id);
+                tracing::info!(%id, "favorited resource");
+            }
+            ControllerRequest::SystemTrayMenu(Event::RemoveFavorite(id)) => {
+                favorites.remove(&id);
+                tracing::info!(%id, "unfavorited resource");
+            }
+            ControllerRequest::SystemTrayMenu(Event::Quit) => {
+                tracing::info!("Quit requested; shutting down fake-controller");
+                break;
+            }
+            other => {
+                tracing::debug!(%other, "fake-controller ignoring event");
+                continue;
+            }
+        }
+        integration.set_tray_menu(build_state(&favorites));
+    }
+    Ok(())
+}
+
+fn build_state(favorites: &HashSet<ResourceId>) -> AppState {
+    AppState {
+        connlib: ConnlibState::SignedIn(SignedIn {
+            actor_name: "Demo User".into(),
+            favorite_resources: favorites.clone(),
+            resources: fake_resources(),
+            connected_devices: fake_connected_devices(),
+            internet_resource_enabled: Some(true),
+        }),
+        release: None,
+        hide_admin_portal_menu_item: true,
+        support_url: None,
+    }
+}
+
+fn fake_resources() -> Vec<ResourceView> {
+    let site = Site {
+        id: SiteId::from_u128(0xDEAD_BEEF),
+        name: "Demo Site".into(),
+    };
+    vec![
+        // Internet resource sorts first in connlib (`ResourceView`'s `Ord`
+        // impl in connlib_model::view), so the fixture mirrors that order.
+        ResourceView::Internet(InternetResourceView {
+            id: ResourceId::from_u128(0x103),
+            name: "Internet Resource".into(),
+            sites: vec![site.clone()],
+            status: ResourceStatus::Online,
+        }),
+        ResourceView::Cidr(CidrResourceView {
+            id: ResourceId::from_u128(0x101),
+            address: "10.0.0.0/16"
+                .parse::<IpNetwork>()
+                .expect("hardcoded CIDR is valid"),
+            name: "Office network".into(),
+            address_description: Some("CIDR resource".into()),
+            sites: vec![site.clone()],
+            status: ResourceStatus::Online,
+        }),
+        ResourceView::Dns(DnsResourceView {
+            id: ResourceId::from_u128(0x102),
+            address: "gitlab.demo.example".into(),
+            name: "Demo GitLab".into(),
+            address_description: Some("https://gitlab.demo.example".into()),
+            sites: vec![site.clone()],
+            status: ResourceStatus::Online,
+        }),
+        ResourceView::Cidr(CidrResourceView {
+            id: ResourceId::from_u128(0x104),
+            address: "192.168.50.0/24"
+                .parse::<IpNetwork>()
+                .expect("hardcoded CIDR is valid"),
+            name: "Lab network (offline)".into(),
+            address_description: Some("Gateway offline".into()),
+            sites: vec![site.clone()],
+            status: ResourceStatus::Offline,
+        }),
+        ResourceView::Dns(DnsResourceView {
+            id: ResourceId::from_u128(0x105),
+            address: "wiki.demo.example".into(),
+            name: "Demo Wiki (unknown)".into(),
+            address_description: Some("Gateway state unknown".into()),
+            sites: vec![site],
+            status: ResourceStatus::Unknown,
+        }),
+    ]
+}
+
+fn fake_connected_devices() -> Vec<ConnectedDeviceView> {
+    const POOL_PATTERNS: &[&[&str]] = &[
+        &["Engineering Pool"],
+        &["Engineering Pool", "QA Pool"],
+        &[],
+        &["QA Pool"],
+        &["Sales Pool"],
+    ];
+    (0..22u128)
+        .map(|i| ConnectedDeviceView {
+            id: ClientId::from_u128(i + 1),
+            pools: POOL_PATTERNS[(i as usize) % POOL_PATTERNS.len()]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        })
+        .collect()
+}

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -73,7 +73,7 @@ impl Managed {
     }
 }
 
-struct TauriIntegration {
+pub(crate) struct TauriIntegration {
     app: tauri::AppHandle,
     tray: system_tray::Tray,
 }
@@ -230,6 +230,11 @@ pub struct RunConfig {
     pub no_deep_links: bool,
     pub quit_after: Option<u64>,
     pub fail_with: Option<Failure>,
+    /// When `true`, skip the auth/portal/tunnel stack and drive the tray with
+    /// hardcoded fake state. Used by the `debug fake-controller` subcommand
+    /// for UI iteration without needing the privileged tunnel service or a
+    /// live portal.
+    pub fake_controller: bool,
 }
 
 /// IPC Messages that a newly launched instance (i.e. a client) may send to an already running instance of Firezone.
@@ -354,19 +359,23 @@ pub fn run(
             tray,
         };
 
-        // Spawn the controller
-        let ctrl_task = tokio::spawn(Controller::start(
-            SocketId::Tunnel,
-            integration,
-            ctlr_tx,
-            ctlr_rx,
-            general_settings,
-            mdm_settings,
-            advanced_settings,
-            reloader,
-            updates_rx,
-            gui_ipc,
-        ));
+        let ctrl_task = if config.fake_controller {
+            tokio::spawn(crate::fake_controller::run(integration, ctlr_rx))
+        } else {
+            // Spawn the controller
+            tokio::spawn(Controller::start(
+                SocketId::Tunnel,
+                integration,
+                ctlr_tx,
+                ctlr_rx,
+                general_settings,
+                mdm_settings,
+                advanced_settings,
+                reloader,
+                updates_rx,
+                gui_ipc,
+            ))
+        };
 
         anyhow::Ok(ctrl_task)
     });

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 #![cfg_attr(test, allow(clippy::unwrap_in_result))]
 
+mod fake_controller;
 mod updates;
 mod uptime;
 mod view;

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -50,6 +50,12 @@ env = { CARGO_PROFILE_TEST_OPT_LEVEL = "1", PROPTEST_CASES = "10000", PROPTEST_M
 raw = true
 run = "cargo test tunnel_test --features proptest -- --nocapture"
 
+[tasks.tauri-fake-controller]
+description = "Run the GUI client with a hardcoded fake controller (sample resources and connected devices) for rapid UI iteration; bypasses auth, the portal, and the tunnel service"
+dir = "gui-client"
+raw = true
+run = "cargo tauri dev -- -- debug fake-controller"
+
 # =============================================================================
 # Composite tasks
 # =============================================================================


### PR DESCRIPTION
Spawns the GUI client with a hardcoded `AppState::SignedIn` (sample
resources, connected device peers, internet resource enabled) instead of
the real `Controller`. Bypasses auth, the portal, and the privileged
tunnel service so the tray rendering can be iterated on without a full
backend stack.

Run with: `cargo tauri dev -- -- debug fake-controller`
or: `mise run tauri-fake-controller`

The fake controller listens on the existing `ControllerRequest` channel
and re-renders the tray on `AddFavorite` / `RemoveFavorite`, so favorite
toggles round-trip live. Other clicks (Sign Out, Quit, Internet toggle,
etc.) are intentionally no-ops.

Lives behind a debug subcommand rather than `cfg(debug_assertions)` so
it can be exercised against release builds when needed.