### PR TITLE
fix(gui-client/windows): perms on firezone-id

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -11,7 +11,6 @@ use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, dialog, elevation, gui, logging, settings};
 use settings::AdvancedSettingsLegacy;
-use telemetry::Telemetry;
 use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
@@ -26,36 +25,19 @@ fn main() -> ExitCode {
 
     let cli = Cli::parse();
 
-    let mut telemetry = if cli.is_telemetry_allowed() {
-        Telemetry::new()
-    } else {
-        Telemetry::disabled()
-    };
-
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
-    match try_main(cli, &rt, &mut bootstrap_log_guard, &mut telemetry) {
-        Ok(()) => {
-            rt.block_on(telemetry.stop());
-
-            ExitCode::SUCCESS
-        }
+    match try_main(cli, &rt, &mut bootstrap_log_guard) {
+        Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("GUI failed: {e:#}");
-
-            rt.block_on(telemetry.stop());
 
             ExitCode::FAILURE
         }
     }
 }
 
-fn try_main(
-    cli: Cli,
-    rt: &Runtime,
-    bootstrap_log_guard: &mut Option<DefaultGuard>,
-    telemetry: &mut Telemetry,
-) -> Result<()> {
+fn try_main(cli: Cli, rt: &Runtime, bootstrap_log_guard: &mut Option<DefaultGuard>) -> Result<()> {
     if cli.test_error_dialog {
         dialog::error("Dialogs are working!")?;
     }
@@ -68,6 +50,7 @@ fn try_main(
             .as_ref()
             .is_some_and(|c| matches!(c, Cmd::SmokeTest)),
         no_deep_links: cli.no_deep_links,
+        telemetry_allowed: cli.is_telemetry_allowed(),
         quit_after: cli.quit_after,
         fail_with: cli.fail_on_purpose(),
     };
@@ -79,24 +62,9 @@ fn try_main(
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
         .unwrap_or_default();
 
-    let api_url = mdm_settings
-        .api_url
-        .as_ref()
-        .unwrap_or(&advanced_settings.api_url)
-        .to_string();
-
-    // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
-    // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
-    let id = bin_shared::device_id::get_client().context("Failed to get device ID")?;
-
-    if cli.is_telemetry_allowed() {
-        rt.block_on(telemetry.start(
-            &api_url,
-            firezone_gui_client::RELEASE,
-            telemetry::GUI_DSN,
-            id.id,
-        ));
-    }
+    // `Controller` resolves the effective API URL, including MDM overrides, and
+    // initializes GUI telemetry after it receives the Firezone ID from the
+    // Tunnel service over IPC.
 
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -32,6 +32,7 @@ pub struct Controller<I: GuiIntegration> {
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     ctrl_tx: mpsc::Sender<ControllerRequest>,
+    firezone_id: String,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -40,6 +41,8 @@ pub struct Controller<I: GuiIntegration> {
     release: Option<updates::Release>,
     ctrl_rx: ReceiverStream<ControllerRequest>,
     status: Status,
+    telemetry: Option<Telemetry>,
+    telemetry_allowed: bool,
     updates_rx: ReceiverStream<Option<updates::Notification>>,
     uptime: uptime::Tracker,
 
@@ -182,6 +185,7 @@ impl<I: GuiIntegration> Controller<I> {
         mdm_settings: MdmSettings,
         advanced_settings: AdvancedSettings,
         log_filter_reloader: FilterReloadHandle,
+        telemetry_allowed: bool,
         updates_rx: mpsc::Receiver<Option<updates::Notification>>,
         gui_ipc: ipc::Server,
     ) -> Result<()> {
@@ -192,6 +196,9 @@ impl<I: GuiIntegration> Controller<I> {
         receive_hello(&mut ipc_rx)
             .await
             .map_err(FailedToReceiveHello)?;
+        let firezone_id = receive_firezone_id(&mut ipc_rx)
+            .await
+            .context("Failed to receive Firezone ID from tunnel service")?;
 
         let controller = Controller {
             general_settings,
@@ -200,6 +207,7 @@ impl<I: GuiIntegration> Controller<I> {
             auth: auth::Auth::new()?,
             clear_logs_callback: None,
             ctrl_tx,
+            firezone_id,
             ipc_client,
             ipc_rx,
             integration,
@@ -207,6 +215,8 @@ impl<I: GuiIntegration> Controller<I> {
             release: None,
             ctrl_rx: ReceiverStream::new(ctrl_rx),
             status: Default::default(),
+            telemetry: telemetry_allowed.then(Telemetry::new),
+            telemetry_allowed,
             updates_rx: ReceiverStream::new(updates_rx),
             uptime: Default::default(),
             gui_ipc_clients: stream::unfold(gui_ipc, |mut gui_ipc| async move {
@@ -293,7 +303,9 @@ impl<I: GuiIntegration> Controller<I> {
             tracing::error!("ipc_client: {error:#}");
         }
 
-        // Don't close telemetry here, `run` will close it.
+        if let Some(telemetry) = &mut self.telemetry {
+            telemetry.stop().await;
+        }
 
         Ok(())
     }
@@ -360,11 +372,31 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     async fn update_telemetry_context(&mut self) -> Result<()> {
+        // `api_url` resolves MDM settings first, then falls back to local settings.
         let environment = self.api_url().to_string();
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
+        #[cfg(not(test))]
+        if let Some(telemetry) = &mut self.telemetry {
+            telemetry
+                .start(
+                    &environment,
+                    crate::RELEASE,
+                    telemetry::GUI_DSN,
+                    self.firezone_id.clone(),
+                )
+                .await;
+        }
+
+        #[cfg(test)]
+        let _ = &self.firezone_id;
+
         if let Some(account_slug) = account_slug.clone() {
             Telemetry::set_account_slug(account_slug);
+        }
+
+        if !self.telemetry_allowed {
+            return Ok(());
         }
 
         self.send_ipc(&service::ClientMsg::StartTelemetry {
@@ -669,7 +701,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 return Ok(ControlFlow::Break(()));
             }
-            service::ServerMsg::Hello => {}
+            service::ServerMsg::Hello | service::ServerMsg::FirezoneId { .. } => {}
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
                 let (resource, site) = self.resource_by_id(resource_id)?;
 
@@ -984,6 +1016,24 @@ async fn receive_hello(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Resu
     }
 
     Ok(())
+}
+
+async fn receive_firezone_id(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Result<String> {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let server_msg = tokio::time::timeout(TIMEOUT, ipc_rx.next())
+        .await
+        .with_context(|| {
+            format!("Timeout while waiting for Firezone ID from tunnel service for {TIMEOUT:?}")
+        })?
+        .context("No Firezone ID received from tunnel service")?
+        .context("Failed to receive Firezone ID from tunnel service")?;
+
+    let service::ServerMsg::FirezoneId { firezone_id } = server_msg else {
+        bail!("Expected `FirezoneId` from tunnel service but got `{server_msg}`")
+    };
+
+    Ok(firezone_id)
 }
 
 #[cfg(test)]
@@ -1347,6 +1397,12 @@ mod tests {
     impl MockTunnel {
         async fn send_hello(&mut self) {
             self.tx.send(&service::ServerMsg::Hello).await.unwrap();
+            self.tx
+                .send(&service::ServerMsg::FirezoneId {
+                    firezone_id: "test-firezone-id".to_owned(),
+                })
+                .await
+                .unwrap();
         }
 
         async fn rx_start_telemetry(&mut self) {
@@ -1417,6 +1473,7 @@ mod tests {
                 MdmSettings::default(),
                 AdvancedSettings::default(),
                 log_filter_reloader,
+                true,
                 updates_rx,
                 gui_ipc_server,
             ));

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -228,6 +228,7 @@ pub struct RunConfig {
     pub debug_update_check: bool,
     pub smoke_test: bool,
     pub no_deep_links: bool,
+    pub telemetry_allowed: bool,
     pub quit_after: Option<u64>,
     pub fail_with: Option<Failure>,
 }
@@ -364,6 +365,7 @@ pub fn run(
             mdm_settings,
             advanced_settings,
             reloader,
+            config.telemetry_allowed,
             updates_rx,
             gui_ipc,
         ));

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -84,6 +84,9 @@ where
 #[derive(Debug, serde::Deserialize, serde::Serialize, strum::Display)]
 pub enum ServerMsg {
     Hello,
+    FirezoneId {
+        firezone_id: String,
+    },
     /// The Tunnel service finished clearing its log dir.
     ClearedLogs(Result<(), String>),
     ConnectResult(Result<(), String>),
@@ -347,6 +350,13 @@ impl<'a> Handler<'a> {
             .send(&ServerMsg::Hello)
             .await
             .context("Failed to greet to new GUI process")?; // Greet the GUI process. If the GUI process doesn't receive this after connecting, it knows that the tunnel service isn't responding.
+
+        ipc_tx
+            .send(&ServerMsg::FirezoneId {
+                firezone_id: device_id.id.clone(),
+            })
+            .await
+            .context("Failed to send Firezone ID to GUI process")?;
 
         Ok(Self {
             device_id,

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -70,6 +70,7 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_System_Com",
     # Needed to listen for system DNS changes
     "Win32_System_Registry",

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -89,8 +89,8 @@ fn get_or_create_at(path: &Path, app_id: &str) -> Result<DeviceId> {
     let dir = path
         .parent()
         .context("Device ID path should always have a parent")?;
-    // Make sure the dir exists, and fix its permissions so the GUI can write the
-    // log filter file
+    // Make sure the dir exists, and fix its permissions before writing files
+    // into it.
     fs::create_dir_all(dir).context("Failed to create dir for firezone-id")?;
     set_dir_permissions(dir).with_context(|| {
         format!(
@@ -161,8 +161,13 @@ fn set_dir_permissions(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Does nothing on non-Linux systems
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+fn set_dir_permissions(dir: &Path) -> Result<()> {
+    set_windows_dacl(dir, "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
+}
+
+/// Does nothing on other non-Linux systems
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[expect(clippy::unnecessary_wraps)]
 fn set_dir_permissions(_: &Path) -> Result<()> {
     Ok(())
@@ -177,8 +182,112 @@ fn set_id_permissions(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Does nothing on non-Linux systems
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+fn set_id_permissions(path: &Path) -> Result<()> {
+    set_windows_dacl(path, "D:P(A;;FA;;;SY)(A;;FA;;;BA)")
+}
+
+#[cfg(target_os = "windows")]
+fn set_windows_dacl(path: &Path, sddl: &str) -> Result<()> {
+    use anyhow::ensure;
+    use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
+    use windows::{
+        Win32::{
+            Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree},
+            Security::{
+                Authorization::{
+                    ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+                    SE_FILE_OBJECT, SetNamedSecurityInfoW,
+                },
+                DACL_SECURITY_INFORMATION, GetSecurityDescriptorDacl,
+                PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+            },
+        },
+        core::{BOOL, PCWSTR},
+    };
+
+    fn wide(s: impl AsRef<OsStr>) -> Vec<u16> {
+        s.as_ref().encode_wide().chain(Some(0)).collect()
+    }
+
+    struct LocalSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+    impl Drop for LocalSecurityDescriptor {
+        fn drop(&mut self) {
+            // SAFETY: The security descriptor was allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` and must be
+            // released with `LocalFree`.
+            unsafe {
+                LocalFree(Some(HLOCAL(self.0.0)));
+            }
+        }
+    }
+
+    let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
+    let sddl = wide(sddl);
+
+    // SAFETY: The SDDL string is null-terminated and the output pointer is valid
+    // for the duration of this call.
+    unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(sddl.as_ptr()),
+            SDDL_REVISION_1,
+            &mut security_descriptor,
+            None,
+        )
+    }
+    .context("Failed to build Windows security descriptor from SDDL")?;
+
+    let security_descriptor = LocalSecurityDescriptor(security_descriptor);
+
+    let mut dacl_present = BOOL::default();
+    let mut dacl_defaulted = BOOL::default();
+    let mut dacl = ptr::null_mut();
+
+    // SAFETY: The security descriptor is valid and the output pointers are local
+    // variables that live for the duration of the call.
+    unsafe {
+        GetSecurityDescriptorDacl(
+            security_descriptor.0,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        )
+    }
+    .context("Failed to get DACL from Windows security descriptor")?;
+
+    ensure!(
+        dacl_present.as_bool(),
+        "Windows security descriptor has no DACL"
+    );
+
+    let path = wide(path.as_os_str());
+    let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
+
+    // SAFETY: The path is null-terminated, the DACL comes from a valid security
+    // descriptor, and Windows does not retain these pointers after the call.
+    let err = unsafe {
+        SetNamedSecurityInfoW(
+            PCWSTR(path.as_ptr()),
+            SE_FILE_OBJECT,
+            security_info,
+            None,
+            None,
+            Some(dacl),
+            None,
+        )
+    };
+
+    if err != ERROR_SUCCESS {
+        return Err(std::io::Error::from_raw_os_error(err.0 as i32))
+            .with_context(|| "Failed to set Windows DACL");
+    }
+
+    Ok(())
+}
+
+/// Does nothing on other non-Linux systems
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[expect(clippy::unnecessary_wraps)]
 fn set_id_permissions(_: &Path) -> Result<()> {
     Ok(())


### PR DESCRIPTION
- Updates the `firezone-id` file DACL to be Administrator/System readable only
- Adds an IPC call to fetch this from the GUI proc and only then start GUI proc telemetry afterward

---

Related: https://github.com/firezone/firezone/security/advisories/GHSA-j4v6-3fmm-hgjq
