### PR TITLE
fix(gateway): use LoadCredential for token

### DIFF
--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -18,9 +18,23 @@ FIREZONE_OTLP_GRPC_ENDPOINT=${OTLP_GRPC_ENDPOINT:-}
 FIREZONE_GOOGLE_CLOUD_PROJECT_ID=${GOOGLE_CLOUD_PROJECT_ID:-}
 FIREZONE_LOG_FORMAT=${FIREZONE_LOG_FORMAT:-}
 
+SERVICE_FILE=${SERVICE_FILE:-/etc/systemd/system/firezone-gateway.service}
+TOKEN_FILE=${TOKEN_FILE:-/etc/firezone/gateway-token}
+
+legacy_unit_environment() {
+    local name=$1
+
+    [ -r "$SERVICE_FILE" ] || return 0
+
+    sed -n "s/^Environment=\"$name=\(.*\)\"$/\1/p" "$SERVICE_FILE" | tail -n 1
+}
+
 if [ -z "$FIREZONE_TOKEN" ]; then
-    echo "FIREZONE_TOKEN is required"
-    exit 1
+    FIREZONE_TOKEN=$(legacy_unit_environment FIREZONE_TOKEN)
+fi
+
+if [ -z "$FIREZONE_ID" ]; then
+    FIREZONE_ID=$(legacy_unit_environment FIREZONE_ID)
 fi
 
 if [ -z "$FIREZONE_ID" ]; then
@@ -28,12 +42,50 @@ if [ -z "$FIREZONE_ID" ]; then
     exit 1
 fi
 
+if [ -z "$FIREZONE_TOKEN" ] && ! sudo test -s "$TOKEN_FILE"; then
+    echo "FIREZONE_TOKEN is required"
+    exit 1
+fi
+
+if ! systemd_version=$(systemctl --version | awk 'NR == 1 { print $2 }'); then
+    echo "systemctl is required"
+    exit 1
+fi
+
+case "$systemd_version" in
+"" | *[!0-9]*)
+    echo "Could not determine systemd version"
+    exit 1
+    ;;
+esac
+
+if [ "$systemd_version" -lt 247 ]; then
+    echo "systemd 247 or newer is required to pass FIREZONE_TOKEN as a credential"
+    exit 1
+fi
+
 # Setup user and group
 sudo groupadd -f firezone
 id -u firezone >/dev/null 2>&1 || sudo useradd -r -g firezone -s /sbin/nologin firezone
 
+sudo install -d -m 0755 -o root -g root /etc/firezone
+
+if [ -n "$FIREZONE_TOKEN" ]; then
+    printf '%s\n' "$FIREZONE_TOKEN" | sudo sh -c '
+        set -e
+        token_file=$1
+        token_tmp=$(mktemp "${token_file}.XXXXXX")
+        trap '\''rm -f "$token_tmp"'\'' EXIT
+        cat > "$token_tmp"
+        chown root:root "$token_tmp"
+        chmod 0400 "$token_tmp"
+        mv "$token_tmp" "$token_file"
+        trap - EXIT
+    ' sh "$TOKEN_FILE"
+fi
+
 # Create systemd unit file
-cat <<EOF | sudo tee /etc/systemd/system/firezone-gateway.service
+cat <<EOF | sudo tee "$SERVICE_FILE"
 [Unit]
 Description=Firezone Gateway
 After=network.target
@@ -49,10 +101,10 @@ Group=firezone
 PermissionsStartOnly=true
 SyslogIdentifier=firezone-gateway
 
-# Environment variables
+LoadCredential=FIREZONE_TOKEN:$TOKEN_FILE
+
 Environment="FIREZONE_NAME=$FIREZONE_NAME"
 Environment="FIREZONE_ID=$FIREZONE_ID"
-Environment="FIREZONE_TOKEN=$FIREZONE_TOKEN"
 Environment="FIREZONE_API_URL=$FIREZONE_API_URL"
 Environment="RUST_LOG=$RUST_LOG"
 Environment="RUST_LOG_STYLE=never"

--- a/scripts/tests/bats/gateway_systemd_install.bats
+++ b/scripts/tests/bats/gateway_systemd_install.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+SCRIPT="$SCRIPT_DIR/scripts/gateway-systemd-install.sh"
+
+setup() {
+    export TEST_ROOT="$BATS_TEST_TMPDIR/root"
+    export MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    export PATH="$MOCK_DIR:$PATH"
+
+    mkdir -p "$TEST_ROOT" "$MOCK_DIR"
+
+    create_sudo_mock
+    create_id_mock
+    create_systemctl_mock
+    create_chown_mock
+}
+
+create_sudo_mock() {
+    cat >"$MOCK_DIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+map_path() {
+    case "$1" in
+        /etc/* | /usr/local/*)
+            printf '%s%s' "$TEST_ROOT" "$1"
+            ;;
+        *)
+            printf '%s' "$1"
+            ;;
+    esac
+}
+
+cmd=$1
+shift
+
+case "$cmd" in
+    groupadd | useradd | systemctl)
+        exit 0
+        ;;
+    test)
+        mapped=()
+        for arg in "$@"; do
+            mapped+=("$(map_path "$arg")")
+        done
+        command test "${mapped[@]}"
+        ;;
+    install)
+        if [ "${1:-}" = "-d" ]; then
+            dest="${*: -1}"
+            mkdir -p "$(map_path "$dest")"
+        else
+            echo "unexpected install command: install $*" >&2
+            exit 1
+        fi
+        ;;
+    sh)
+        if [ "${1:-}" != "-c" ]; then
+            echo "unexpected sh command: sh $*" >&2
+            exit 1
+        fi
+
+        script=$2
+        shift 2
+
+        mapped_args=()
+        for arg in "$@"; do
+            mapped_args+=("$(map_path "$arg")")
+        done
+
+        PATH="$MOCK_DIR:$PATH" command sh -c "$script" "${mapped_args[@]}"
+        ;;
+    tee)
+        dest=$(map_path "$1")
+        mkdir -p "$(dirname "$dest")"
+        cat >"$dest"
+        ;;
+    chmod)
+        mode=$1
+        dest=$(map_path "$2")
+        chmod "$mode" "$dest"
+        ;;
+    *)
+        echo "unexpected sudo command: $cmd $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$MOCK_DIR/sudo"
+}
+
+create_id_mock() {
+    cat >"$MOCK_DIR/id" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-u" ] && [ "${2:-}" = "firezone" ]; then
+    exit 1
+fi
+
+command id "$@"
+EOF
+    chmod +x "$MOCK_DIR/id"
+}
+
+create_systemctl_mock() {
+    cat >"$MOCK_DIR/systemctl" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+    echo "systemd ${MOCK_SYSTEMD_VERSION:-255}"
+    exit 0
+fi
+
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/systemctl"
+}
+
+create_chown_mock() {
+    cat >"$MOCK_DIR/chown" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/chown"
+}
+
+service_file() {
+    echo "$TEST_ROOT/etc/systemd/system/firezone-gateway.service"
+}
+
+token_file() {
+    echo "$TEST_ROOT/etc/firezone/gateway-token"
+}
+
+file_mode() {
+    stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
+}
+
+refute_file_contains() {
+    local pattern=$1
+    local file=$2
+
+    if grep -q -- "$pattern" "$file"; then
+        echo "Expected $file not to contain $pattern" >&2
+        return 1
+    fi
+}
+
+@test "gateway-systemd-install: stores token as a systemd credential" {
+    run env \
+        FIREZONE_ID="test-gateway-id" \
+        FIREZONE_TOKEN="test-secret-token" \
+        "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ -f "$(service_file)" ]
+    [ -f "$(token_file)" ]
+
+    grep -q '^LoadCredential=FIREZONE_TOKEN:/etc/firezone/gateway-token$' "$(service_file)"
+    grep -q '^Environment="FIREZONE_ID=test-gateway-id"$' "$(service_file)"
+    refute_file_contains 'test-secret-token' "$(service_file)"
+    refute_file_contains 'FIREZONE_TOKEN=' "$(service_file)"
+    grep -q '^test-secret-token$' "$(token_file)"
+    [ "$(file_mode "$(token_file)")" = "400" ]
+}
+
+@test "gateway-systemd-install: migrates token and ID from legacy unit" {
+    export SERVICE_FILE="$BATS_TEST_TMPDIR/legacy-firezone-gateway.service"
+    export TOKEN_FILE="$BATS_TEST_TMPDIR/gateway-token"
+
+    cat >"$SERVICE_FILE" <<'EOF'
+[Service]
+Environment="FIREZONE_ID=legacy-gateway-id"
+Environment="FIREZONE_TOKEN=legacy-secret-token"
+EOF
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q "^LoadCredential=FIREZONE_TOKEN:$TOKEN_FILE$" "$SERVICE_FILE"
+    grep -q '^Environment="FIREZONE_ID=legacy-gateway-id"$' "$SERVICE_FILE"
+    refute_file_contains 'legacy-secret-token' "$SERVICE_FILE"
+    refute_file_contains 'FIREZONE_TOKEN=' "$SERVICE_FILE"
+    grep -q '^legacy-secret-token$' "$TOKEN_FILE"
+    [ "$(file_mode "$TOKEN_FILE")" = "400" ]
+}
+
+@test "gateway-systemd-install: rejects systemd versions without LoadCredential support" {
+    run env \
+        FIREZONE_ID="test-gateway-id" \
+        FIREZONE_TOKEN="test-secret-token" \
+        MOCK_SYSTEMD_VERSION="219" \
+        "$SCRIPT"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"systemd 247 or newer is required"* ]]
+    [ ! -f "$(service_file)" ]
+    [ ! -f "$(token_file)" ]
+}


### PR DESCRIPTION
- Updates gateway's systemd install script to use `LoadCredential` to find token
- Migrates existing token to there if exists in the old unit file
- Preserves FIREZONE_ID for idempotency during reinstalls
- Now requires Systemd >= 247 for LoadCredential support
