### PR TITLE
fix(portal): show client_session remote_ip

### DIFF
--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -679,8 +679,8 @@ defmodule PortalWeb.Clients.Components do
           :if={@client.latest_session && @client.latest_session.remote_ip}
           label="Remote IP"
         >
-          <span class="font-mono text-xs text-[var(--text-secondary)]">
-            {@client.latest_session.remote_ip}
+          <span class="text-xs text-[var(--text-secondary)]">
+            <.last_seen schema={@client.latest_session} />
           </span>
         </.client_detail_row>
         <.client_detail_row label="Tunnel IPv4">

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -672,15 +672,23 @@ defmodule PortalWeb.Clients.Components do
 
   def client_network_section(assigns) do
     ~H"""
-    <div :if={@client.ipv4 || @client.ipv6} class="px-5 pt-4 pb-3">
+    <div class="px-5 pt-4 pb-3">
       <.section_heading title="Network" />
       <dl class="space-y-3">
-        <.client_detail_row :if={@client.ipv4} label="Tunnel IPv4">
+        <.client_detail_row
+          :if={@client.latest_session && @client.latest_session.remote_ip}
+          label="Remote IP"
+        >
+          <span class="font-mono text-xs text-[var(--text-secondary)]">
+            {@client.latest_session.remote_ip}
+          </span>
+        </.client_detail_row>
+        <.client_detail_row label="Tunnel IPv4">
           <span class="font-mono text-xs text-[var(--text-secondary)]">
             {@client.ipv4}
           </span>
         </.client_detail_row>
-        <.client_detail_row :if={@client.ipv6} label="Tunnel IPv6">
+        <.client_detail_row label="Tunnel IPv6">
           <span class="font-mono text-xs text-[var(--text-secondary)] break-all">
             {@client.ipv6}
           </span>

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -885,8 +885,8 @@ defmodule PortalWeb.Resources.Components do
 
   defp client_details(client) do
     [
-      client.ipv4 && Portal.Types.INET.to_string(client.ipv4),
-      client.ipv6 && Portal.Types.INET.to_string(client.ipv6),
+      Portal.Types.INET.to_string(client.ipv4),
+      Portal.Types.INET.to_string(client.ipv6),
       client.device_serial,
       client.device_uuid,
       client.id

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -436,8 +436,8 @@ defmodule PortalWeb.Sites.Components do
               />
             </span>
             <span class="text-xs text-[var(--text-tertiary)]">Remote IP</span>
-            <span class="font-mono text-xs text-[var(--text-primary)]">
-              {gateway.latest_session && gateway.latest_session.remote_ip}
+            <span class="text-xs text-[var(--text-primary)]">
+              <.last_seen schema={gateway.latest_session} />
             </span>
             <span class="text-xs text-[var(--text-tertiary)]">Version</span>
             <span class="font-mono text-xs text-[var(--text-primary)]">

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -167,6 +167,7 @@ defmodule PortalWeb.ClientsTest do
           actor: owner,
           client: client,
           user_agent: "macOS/15.0 apple-client/1.4.0",
+          remote_ip: {203, 0, 113, 10},
           version: "1.4.0"
         )
 
@@ -180,6 +181,8 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "SN-123"
       assert html =~ "UUID-123"
       assert html =~ "IFV-123"
+      assert html =~ "Remote IP"
+      assert html =~ "203.0.113.10"
       assert html =~ "Tunnel IPv4"
       assert html =~ "Tunnel IPv6"
       assert html =~ "Verified"

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -168,6 +168,10 @@ defmodule PortalWeb.ClientsTest do
           client: client,
           user_agent: "macOS/15.0 apple-client/1.4.0",
           remote_ip: {203, 0, 113, 10},
+          remote_ip_location_region: "US",
+          remote_ip_location_city: "San Francisco",
+          remote_ip_location_lat: 37.7749,
+          remote_ip_location_lon: -122.4194,
           version: "1.4.0"
         )
 
@@ -183,6 +187,9 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "IFV-123"
       assert html =~ "Remote IP"
       assert html =~ "203.0.113.10"
+      assert html =~ "San Francisco"
+      assert html =~ "United States of America"
+      assert html =~ "google.com/maps/place/37.7749,-122.4194"
       assert html =~ "Tunnel IPv4"
       assert html =~ "Tunnel IPv6"
       assert html =~ "Verified"

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -240,7 +240,18 @@ defmodule PortalWeb.SitesTest do
       actor: actor
     } do
       site = site_fixture(account: account)
-      gateway = gateway_fixture(account: account, site: site, name: "edge-sfo-1")
+
+      gateway =
+        gateway_fixture(
+          account: account,
+          site: site,
+          name: "edge-sfo-1",
+          last_seen_remote_ip: {198, 51, 100, 20},
+          last_seen_remote_ip_location_region: "US",
+          last_seen_remote_ip_location_city: "San Francisco",
+          last_seen_remote_ip_location_lat: 37.7749,
+          last_seen_remote_ip_location_lon: -122.4194
+        )
 
       {:ok, lv, _html} =
         conn
@@ -251,6 +262,11 @@ defmodule PortalWeb.SitesTest do
       assert html =~ gateway.name
 
       html = render_click(lv, "toggle_gateway_expand", %{"id" => gateway.id})
+      assert html =~ "Remote IP"
+      assert html =~ "198.51.100.20"
+      assert html =~ "San Francisco"
+      assert html =~ "United States of America"
+      assert html =~ "google.com/maps/place/37.7749,-122.4194"
       assert html =~ "Tunnel IPv4"
       assert html =~ gateway.latest_session.version
 


### PR DESCRIPTION
- Removes conditional logic w.r.t client ipv4 and ipv6 - these are NOT NULL fields so always exist
- Displays `remote_ip` from the latest client_session

---

Fixes #13011 