### PR TITLE
chore(rust): move comments to the same line

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -273,19 +273,15 @@ skip = [
     "cargo_metadata",
     "chacha20", # boringtun pulls chacha20 0.9 via chacha20poly1305 0.10.1; hickory 0.26 pulls 0.10 via rand 0.10.
     "convert_case",
-    # hickory 0.26 ships system-configuration 0.7 (core-foundation 0.9); tauri/reqwest/etc. are on 0.10.
-    "core-foundation",
-    # Same root cause as `chacha20` — pulled in via chacha20 0.10 from hickory 0.26.
-    "cpufeatures",
+    "core-foundation", # hickory 0.26 ships system-configuration 0.7 (core-foundation 0.9); tauri/reqwest/etc. are on 0.10.
+    "cpufeatures", # Same root cause as `chacha20` — pulled in via chacha20 0.10 from hickory 0.26.
     "derive_more",
     "foldhash",
     "getrandom",
     "hashbrown",
     "heck",
     "indexmap",
-    # hickory 0.26 uses jni 0.22 for Android DNS; tauri/tao/wry/rustls-platform-verifier/ndk still on 0.21.
-    # not a problem as they land in different binaries (Android client vs gateway)
-    "jni",
+    "jni", # hickory 0.26 uses jni 0.22 for Android DNS; tauri/tao/wry/rustls-platform-verifier/ndk still on 0.21. not a problem as they land in different binaries (Android client vs gateway)
     "jni-sys",
     "libloading",
     "linux-raw-sys",
@@ -320,8 +316,6 @@ skip = [
     "windows_x86_64_msvc",
     "winnow",
     "winreg",
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ] # Certain crates/versions that will be skipped when doing duplicate detection.
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive


### PR DESCRIPTION
In #13046, we updated `deny.toml` with some new entries but only one of them had its comment moved onto the same line. To make alphabetic sorting and git-diffing easier, move the other comments onto the respective line too.