### PR TITLE
chore(android): speed up the local install loop

### DIFF
--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -18,6 +18,17 @@ mise run build
 This installs Java, Android SDK/NDK, Rust cross-compilation targets, and
 creates `local.properties`. See `mise-tasks/setup.sh` for details.
 
+To install on a connected device or emulator:
+
+```bash
+mise run install-phone     # connected hardware device
+mise run install-emulator  # creates/boots an emulator and launches the app
+```
+
+`install-emulator` only builds the cargo target matching your host arch (x86_64
+on Linux/Intel Mac, arm64-v8a on Apple Silicon), which is roughly 4x faster than
+the all-ABI build.
+
 ### Manual setup
 
 If you'd rather not use `mise run setup`:

--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -29,6 +29,35 @@ Both tasks build only the cargo target matching the device's ABI (detected via
 `adb` for `install-phone`, host arch for `install-emulator`), which is roughly
 4x faster than the default all-ABI build.
 
+### Wireless ADB
+
+Useful when your USB connection is flaky. Both flows give you a regular `adb`
+connection, after which `mise run install-phone` works normally.
+
+**Android 11+** (native pairing, persists across reboots):
+
+1. On the device: Settings → Developer options → Wireless debugging → enable.
+1. Tap "Pair device with pairing code" — note the IP, port, and 6-digit code.
+1. On the host:
+
+   ```bash
+   adb pair <ip>:<pair-port> <code>     # one-off pairing
+   adb connect <ip>:<connect-port>      # port shown on the main wireless screen
+   ```
+
+**Android 10 and older** (USB seed required, resets on reboot):
+
+1. Connect once over USB and confirm `adb devices` lists the phone.
+1. Switch the device's adb daemon to TCP and connect:
+
+   ```bash
+   adb tcpip 5555
+   adb connect <phone-ip>:5555    # Settings → About phone → Status for the IP
+   ```
+
+1. Disconnect USB. The connection persists until the phone reboots, after which
+   you'll need to repeat the USB seed step.
+
 ### Manual setup
 
 If you'd rather not use `mise run setup`:

--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -25,9 +25,9 @@ mise run install-phone     # connected hardware device
 mise run install-emulator  # creates/boots an emulator and launches the app
 ```
 
-`install-emulator` only builds the cargo target matching your host arch (x86_64
-on Linux/Intel Mac, arm64-v8a on Apple Silicon), which is roughly 4x faster than
-the all-ABI build.
+Both tasks build only the cargo target matching the device's ABI (detected via
+`adb` for `install-phone`, host arch for `install-emulator`), which is roughly
+4x faster than the default all-ABI build.
 
 ### Manual setup
 

--- a/kotlin/android/mise-tasks/install-emulator.sh
+++ b/kotlin/android/mise-tasks/install-emulator.sh
@@ -96,6 +96,11 @@ start_emulator() {
 start_emulator
 
 echo "==> Installing debug APK (${HOST_ABI} only)..."
+# Kill any running instance so the next launch is a clean cold start (and so
+# Android doesn't keep the old process alive across install).
+echo "==> Force-stopping any running instance of ${PACKAGE}..."
+adb shell am force-stop "$PACKAGE"
+
 # Skip cargo builds for ABIs the emulator can't use; the resulting APK contains only
 # the matching .so, which saves ~4x build time vs the default all-ABI build.
 gradle_skip_args=()

--- a/kotlin/android/mise-tasks/install-emulator.sh
+++ b/kotlin/android/mise-tasks/install-emulator.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#MISE description="Build debug APK, boot emulator if needed, install and launch the app"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+PACKAGE="dev.firezone.android"
+AVD_NAME="${AVD_NAME:-firezone}"
+DEVICE_PROFILE="${DEVICE_PROFILE:-pixel_7}"
+
+# Pick a system image and matching cargo skip-list based on host arch.
+# x86_64 hosts (Linux, Intel Mac) use the x86_64 image; arm64 hosts (Apple Silicon)
+# use arm64-v8a. Running an x86_64 image on Apple Silicon works only via slow translation.
+case "$(uname -m)" in
+x86_64 | amd64)
+    HOST_ABI="x86_64"
+    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildArm64 cargoBuildX86)
+    ;;
+arm64 | aarch64)
+    HOST_ABI="arm64-v8a"
+    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildX86 cargoBuildX86_64)
+    ;;
+*)
+    echo "Unsupported host arch: $(uname -m). Set SYSTEM_IMAGE and SKIP_CARGO_TASKS manually." >&2
+    exit 1
+    ;;
+esac
+SYSTEM_IMAGE="${SYSTEM_IMAGE:-system-images;android-36;google_apis;${HOST_ABI}}"
+
+ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}}"
+export ANDROID_HOME
+# avdmanager (cmdline-tools 7+) defaults to $XDG_CONFIG_HOME/.android, emulator still looks at $HOME/.android.
+# Pin both to the same location.
+export ANDROID_USER_HOME="${ANDROID_USER_HOME:-$HOME/.android}"
+export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+
+emulator_online() {
+    adb devices | awk 'NR>1 && /^emulator-/ && $2=="device" {found=1} END {exit !found}'
+}
+
+ensure_emulator_pkg() {
+    if [ -x "$ANDROID_HOME/emulator/emulator" ]; then
+        return
+    fi
+    echo "==> Installing emulator package..."
+    sdkmanager --sdk_root="$ANDROID_HOME" "emulator" >/dev/null
+}
+
+ensure_system_image() {
+    local image_dir
+    image_dir="$ANDROID_HOME/${SYSTEM_IMAGE//;//}"
+    if [ -d "$image_dir" ]; then
+        return
+    fi
+    echo "==> Installing system image: ${SYSTEM_IMAGE}..."
+    yes 2>/dev/null | sdkmanager --sdk_root="$ANDROID_HOME" --licenses >/dev/null || true
+    sdkmanager --sdk_root="$ANDROID_HOME" "$SYSTEM_IMAGE" >/dev/null
+}
+
+ensure_avd() {
+    if avdmanager list avd 2>/dev/null | grep -qE "^\s*Name:\s+${AVD_NAME}\s*$"; then
+        return
+    fi
+    echo "==> Creating AVD '${AVD_NAME}' (device=${DEVICE_PROFILE})..."
+    echo no | avdmanager create avd -n "$AVD_NAME" -k "$SYSTEM_IMAGE" -d "$DEVICE_PROFILE" >/dev/null
+}
+
+start_emulator() {
+    if emulator_online; then
+        echo "==> Emulator already online."
+        return
+    fi
+    ensure_emulator_pkg
+    ensure_system_image
+    ensure_avd
+
+    echo "==> Booting emulator '${AVD_NAME}'..."
+    nohup emulator -avd "$AVD_NAME" -no-snapshot-save >/tmp/firezone-emulator.log 2>&1 &
+    disown
+
+    echo "==> Waiting for device..."
+    adb wait-for-device
+
+    echo "==> Waiting for boot to finish (up to 5 min; first run can be slow)..."
+    for _ in $(seq 1 150); do
+        if [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; then
+            return
+        fi
+        sleep 2
+    done
+    echo "Emulator did not finish booting within 5 min. See /tmp/firezone-emulator.log." >&2
+    exit 1
+}
+
+start_emulator
+
+echo "==> Installing debug APK (${HOST_ABI} only)..."
+# Skip cargo builds for ABIs the emulator can't use; the resulting APK contains only
+# the matching .so, which saves ~4x build time vs the default all-ABI build.
+gradle_skip_args=()
+for task in "${SKIP_CARGO_TASKS[@]}"; do
+    gradle_skip_args+=(-x "$task")
+done
+./gradlew installDebug "${gradle_skip_args[@]}"
+
+echo "==> Launching ${PACKAGE}..."
+adb shell monkey -p "$PACKAGE" -c android.intent.category.LAUNCHER 1 >/dev/null
+
+echo "==> Done. Emulator log: /tmp/firezone-emulator.log"

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -54,4 +54,41 @@ gradle_skip_args=()
 for task in "${SKIP_CARGO_TASKS[@]}"; do
     gradle_skip_args+=(-x "$task")
 done
+
+install_log="$(mktemp)"
+trap 'rm -f "$install_log"' EXIT
+
+if ./gradlew installDebug "${gradle_skip_args[@]}" 2>&1 | tee "$install_log"; then
+    exit 0
+fi
+
+if ! grep -q "INSTALL_FAILED_UPDATE_INCOMPATIBLE" "$install_log"; then
+    exit 1
+fi
+
+echo >&2
+echo "==> Signature mismatch detected." >&2
+echo "    A version of dev.firezone.android signed with a different key" >&2
+echo "    (likely the Play Store release) is already installed." >&2
+
+if [ "${REINSTALL:-0}" = "1" ]; then
+    echo "==> REINSTALL=1; uninstalling without prompting." >&2
+elif [ -t 0 ]; then
+    read -r -p "Uninstall existing app and reinstall debug build? [y/N] " reply
+    case "$reply" in
+    [yY] | [yY][eE][sS]) ;;
+    *)
+        echo "Aborted." >&2
+        exit 1
+        ;;
+    esac
+else
+    echo "    Re-run with REINSTALL=1 to uninstall and reinstall:" >&2
+    echo "        REINSTALL=1 mise run install-phone" >&2
+    exit 1
+fi
+
+echo "==> Uninstalling dev.firezone.android..."
+adb uninstall dev.firezone.android
+echo "==> Retrying install..."
 ./gradlew installDebug "${gradle_skip_args[@]}"

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -60,7 +60,7 @@ for task in "${SKIP_CARGO_TASKS[@]}"; do
     gradle_skip_args+=(-x "$task")
 done
 
-install_log="$(mktemp)"
+install_log="$(mktemp "${TMPDIR:-/tmp}/install-phone.XXXXXX")"
 trap 'rm -f "$install_log"' EXIT
 
 if ./gradlew installDebug "${gradle_skip_args[@]}" 2>&1 | tee "$install_log"; then

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#MISE description="Build debug APK and install on connected Android device (matches device ABI)"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}}"
+export ANDROID_HOME
+export PATH="$ANDROID_HOME/platform-tools:$PATH"
+
+# Require exactly one device, unless ANDROID_SERIAL is set (then adb targets that one).
+if [ -z "${ANDROID_SERIAL:-}" ]; then
+    device_count=$(adb devices | awk 'NR>1 && $2=="device"' | wc -l | tr -d ' ')
+    case "$device_count" in
+    0)
+        echo "No Android device detected. Plug one in or run 'mise run install-emulator'." >&2
+        exit 1
+        ;;
+    1) ;;
+    *)
+        echo "Multiple devices detected. Set ANDROID_SERIAL to pick one:" >&2
+        adb devices >&2
+        exit 1
+        ;;
+    esac
+fi
+
+DEVICE_ABI="$(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
+
+# Map the device ABI to the cargo build tasks we can skip. The Gradle task names
+# come from the targets list in app/build.gradle.kts.
+case "$DEVICE_ABI" in
+arm64-v8a)
+    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildX86 cargoBuildX86_64)
+    ;;
+armeabi-v7a)
+    SKIP_CARGO_TASKS=(cargoBuildArm64 cargoBuildX86 cargoBuildX86_64)
+    ;;
+x86_64)
+    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildArm64 cargoBuildX86)
+    ;;
+x86)
+    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildArm64 cargoBuildX86_64)
+    ;;
+*)
+    echo "==> Unknown device ABI '${DEVICE_ABI}', falling back to all-ABI build."
+    SKIP_CARGO_TASKS=()
+    ;;
+esac
+
+echo "==> Installing debug APK (device ABI: ${DEVICE_ABI})..."
+gradle_skip_args=()
+for task in "${SKIP_CARGO_TASKS[@]}"; do
+    gradle_skip_args+=(-x "$task")
+done
+./gradlew installDebug "${gradle_skip_args[@]}"

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -50,6 +50,11 @@ x86)
 esac
 
 echo "==> Installing debug APK (device ABI: ${DEVICE_ABI})..."
+# Kill any running instance so the next launch is a clean cold start (and so
+# Android doesn't keep the old process alive across install).
+echo "==> Force-stopping any running instance of dev.firezone.android..."
+adb shell am force-stop dev.firezone.android
+
 gradle_skip_args=()
 for task in "${SKIP_CARGO_TASKS[@]}"; do
     gradle_skip_args+=(-x "$task")

--- a/kotlin/android/mise.toml
+++ b/kotlin/android/mise.toml
@@ -23,7 +23,3 @@ run = "./gradlew assembleDebug"
 [tasks.test]
 description = "Run unit tests"
 run = "./gradlew test"
-
-[tasks.install-phone]
-description = "Build debug APK and install on connected Android device"
-run = "./gradlew installDebug"


### PR DESCRIPTION
  - Rewrite `mise run install-phone` as a script that detects the connected device's
    ABI via `adb` and skips the `cargoBuild*` Gradle tasks for the other ABIs —
    roughly 4x faster than the default all-ABI build.
  - Force-stop the app before installing so the next launch is a clean cold start
    and Android doesn't keep the old process alive across the install.
  - Handle `INSTALL_FAILED_UPDATE_INCOMPATIBLE` (signature mismatch with a Play
    Store build) by prompting interactively, with `REINSTALL=1` as a
    non-interactive override.
  - Add `mise run install-emulator`: bootstraps the emulator package, system
    image (chosen by host arch), and AVD on first run, then boots, installs, and
    launches the app. Same single-ABI optimisation.
  - README: document both tasks and add a Wireless ADB section covering the
    Android 11+ pairing flow and the Android 10 USB-seed fallback.