### PR TITLE
fix(client-ffi): install rustls crypto provider before telemetry

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -483,6 +483,8 @@ fn connect(
         .build()
         .context("Failed to create tokio runtime")?;
 
+    install_rustls_crypto_provider();
+
     let mut telemetry = Telemetry::new();
     runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN, device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
@@ -492,7 +494,6 @@ fn connect(
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
-    install_rustls_crypto_provider();
 
     let url = LoginUrl::client(
         api_url.as_str(),


### PR DESCRIPTION
`Telemetry::start` builds Sentry's reqwest-based HTTP transport, which asks rustls for the default `CryptoProvider`. The workspace pins `reqwest = { default-features = false }` without `rustls-ring`, so reqwest takes the panic-instead-of-default branch and crashes the Android client with `InternalException: No provider set` on connect.

Move the install call to the top of `connect()`, before any reqwest-using subsystem is initialised. Mirrors the pattern already used in `firezone-gui-client.rs::main` and the gateway/relay binaries.

This is a follow-up to PR #12666 (reqwest 0.13 bump)