### PR TITLE
fix(windows): reduce named pipe bind interval from 1s to 100ms

### DIFF
--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -79,16 +79,21 @@ impl Server {
     }
 
     async fn bind_to_pipe(&self) -> Result<ServerStream> {
-        const NUM_ITERS: usize = 10;
-        // This loop is defense-in-depth. The `yield_now` in `next_client` is enough
-        // to fix #5143, but Tokio doesn't guarantee any behavior when yielding, so
-        // the loop will catch it even if yielding doesn't.
+        // Defense-in-depth around #5143: when an IPC handler panics or otherwise
+        // tears down the pipe and we immediately re-bind, Windows can briefly
+        // return `AccessDenied` because the previous instance hasn't been fully
+        // released yet. Polling on a short cadence is plenty — this typically
+        // clears in tens of milliseconds. The previous 1s sleep was long enough
+        // to make the `panic_inside_handler_doesnt_interrupt_service` unit test
+        // race the test-side reconnect window on the `windows-2025` CI runner.
+        const NUM_ITERS: usize = 100;
+        const RETRY_INTERVAL: Duration = Duration::from_millis(100);
         for i in 0..NUM_ITERS {
             match create_pipe_server(&self.pipe_path) {
                 Ok(server) => return Ok(server),
                 Err(PipeError::AccessDenied) => {
                     tracing::debug!("PipeError::AccessDenied, sleeping... (loop {i})");
-                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    tokio::time::sleep(RETRY_INTERVAL).await;
                 }
                 Err(error) => Err(error)?,
             }

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use bin_shared::{DnsControlMethod, new_dns_notifier, new_network_notifier};
-use futures::StreamExt as _;
+use futures::{StreamExt as _, future::FutureExt as _};
 use std::time::Duration;
 use tokio::time::timeout;
 
@@ -21,7 +21,7 @@ async fn notifiers() {
     let mut dns = new_dns_notifier(tokio_handle.clone(), DnsControlMethod::default())
         .await
         .unwrap();
-    let _net = new_network_notifier().await.unwrap();
+    let mut net = new_network_notifier().await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
@@ -32,10 +32,8 @@ async fn notifiers() {
         .unwrap()
         .unwrap();
 
-    // We deliberately don't assert that no further notifications fire here.
-    // On Windows, the DNS notifier watches `HKLM\SYSTEM\CurrentControlSet\Services\Tcpip[6]\Parameters\Interfaces`,
-    // which the OS itself writes to for unrelated reasons (DHCP lease renewals, adapter PnP events, VM-agent
-    // metadata updates). Likewise, the COM-based network notifier can fire spuriously while Windows re-evaluates
-    // network connectivity level early in a fresh VM's lifetime. Asserting the absence of such events made this
-    // test flaky on the `windows-2025` GitHub Actions runner.
+    // After that first DNS notification, we shouldn't get any further notifications during a normal unit test.
+    // The network notifier should never have fired, since nothing changed about the primary egress path.
+    assert!(dns.next().now_or_never().is_none());
+    assert!(net.next().now_or_never().is_none());
 }

--- a/rust/libs/bin-shared/tests/network_notifiers.rs
+++ b/rust/libs/bin-shared/tests/network_notifiers.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use bin_shared::{DnsControlMethod, new_dns_notifier, new_network_notifier};
-use futures::{StreamExt as _, future::FutureExt as _};
+use futures::StreamExt as _;
 use std::time::Duration;
 use tokio::time::timeout;
 
@@ -21,7 +21,7 @@ async fn notifiers() {
     let mut dns = new_dns_notifier(tokio_handle.clone(), DnsControlMethod::default())
         .await
         .unwrap();
-    let mut net = new_network_notifier().await.unwrap();
+    let _net = new_network_notifier().await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
@@ -32,8 +32,10 @@ async fn notifiers() {
         .unwrap()
         .unwrap();
 
-    // After that first DNS notification, we shouldn't get any further notifications during a normal unit test.
-    // The network notifier should never have fired, since nothing changed about the primary egress path.
-    assert!(dns.next().now_or_never().is_none());
-    assert!(net.next().now_or_never().is_none());
+    // We deliberately don't assert that no further notifications fire here.
+    // On Windows, the DNS notifier watches `HKLM\SYSTEM\CurrentControlSet\Services\Tcpip[6]\Parameters\Interfaces`,
+    // which the OS itself writes to for unrelated reasons (DHCP lease renewals, adapter PnP events, VM-agent
+    // metadata updates). Likewise, the COM-based network notifier can fire spuriously while Windows re-evaluates
+    // network connectivity level early in a fresh VM's lifetime. Asserting the absence of such events made this
+    // test flaky on the `windows-2025` GitHub Actions runner.
 }


### PR DESCRIPTION
Adjusts the retry behaviour when trying to bind to the named pipe. The `panic_inside_handler_doesnt_interrupt_service` test has recently been flaky and not being able to bind to the pipe is what might be causing this. The overall cap of 10s stays the same.