### PR TITLE
fix(windows): lock down access to firezone ID file

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -487,7 +487,7 @@ fn connect(
 
     let mut telemetry = Telemetry::new();
     telemetry.start(&api_url, RELEASE, platform::DSN);
-    Telemetry::set_firezone_id(device_id.clone());
+    runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
 
     otel::install_sentry_meter_provider(platform::COMPONENT, platform::VERSION, device_id.clone());

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -486,7 +486,8 @@ fn connect(
     install_rustls_crypto_provider();
 
     let mut telemetry = Telemetry::new();
-    runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN, device_id.clone()));
+    runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN));
+    Telemetry::set_firezone_id(device_id.clone());
     Telemetry::set_account_slug(account_slug.clone());
 
     otel::install_sentry_meter_provider(platform::COMPONENT, platform::VERSION, device_id.clone());

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -486,7 +486,7 @@ fn connect(
     install_rustls_crypto_provider();
 
     let mut telemetry = Telemetry::new();
-    runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN));
+    telemetry.start(&api_url, RELEASE, platform::DSN);
     Telemetry::set_firezone_id(device_id.clone());
     Telemetry::set_account_slug(account_slug.clone());
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -143,7 +143,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
 
     if cli.is_telemetry_allowed() {
         telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
-        Telemetry::set_firezone_id(firezone_id.clone());
+        Telemetry::set_firezone_id(firezone_id.clone()).await;
     }
 
     if let Some(backend) = cli.metrics {

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -142,14 +142,8 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     };
 
     if cli.is_telemetry_allowed() {
-        telemetry
-            .start(
-                cli.api_url.as_str(),
-                RELEASE,
-                telemetry::GATEWAY_DSN,
-                firezone_id.clone(),
-            )
-            .await;
+        telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
+        Telemetry::set_firezone_id(firezone_id.clone());
     }
 
     if let Some(backend) = cli.metrics {

--- a/rust/gui-client/pnpm-workspace.yaml
+++ b/rust/gui-client/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 onlyBuiltDependencies:
+  - '@parcel/watcher'
   - esbuild

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -11,7 +11,6 @@ use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, dialog, elevation, gui, logging, settings};
 use settings::AdvancedSettingsLegacy;
-use telemetry::Telemetry;
 use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
@@ -26,36 +25,19 @@ fn main() -> ExitCode {
 
     let cli = Cli::parse();
 
-    let mut telemetry = if cli.is_telemetry_allowed() {
-        Telemetry::new()
-    } else {
-        Telemetry::disabled()
-    };
-
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
-    match try_main(cli, &rt, &mut bootstrap_log_guard, &mut telemetry) {
-        Ok(()) => {
-            rt.block_on(telemetry.stop());
-
-            ExitCode::SUCCESS
-        }
+    match try_main(cli, &rt, &mut bootstrap_log_guard) {
+        Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("GUI failed: {e:#}");
-
-            rt.block_on(telemetry.stop());
 
             ExitCode::FAILURE
         }
     }
 }
 
-fn try_main(
-    cli: Cli,
-    rt: &Runtime,
-    bootstrap_log_guard: &mut Option<DefaultGuard>,
-    telemetry: &mut Telemetry,
-) -> Result<()> {
+fn try_main(cli: Cli, rt: &Runtime, bootstrap_log_guard: &mut Option<DefaultGuard>) -> Result<()> {
     if cli.test_error_dialog {
         dialog::error("Dialogs are working!")?;
     }
@@ -75,6 +57,7 @@ fn try_main(
             .as_ref()
             .is_some_and(|c| matches!(c, Cmd::SmokeTest)),
         no_deep_links: cli.no_deep_links,
+        telemetry_allowed: cli.is_telemetry_allowed(),
         quit_after: cli.quit_after,
         fail_with: cli.fail_on_purpose(),
         fake_controller,
@@ -87,24 +70,9 @@ fn try_main(
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
         .unwrap_or_default();
 
-    let api_url = mdm_settings
-        .api_url
-        .as_ref()
-        .unwrap_or(&advanced_settings.api_url)
-        .to_string();
-
-    // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
-    // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
-    let id = bin_shared::device_id::get_client().context("Failed to get device ID")?;
-
-    if cli.is_telemetry_allowed() {
-        rt.block_on(telemetry.start(
-            &api_url,
-            firezone_gui_client::RELEASE,
-            telemetry::GUI_DSN,
-            id.id,
-        ));
-    }
+    // `Controller` resolves the effective API URL, including MDM overrides, and
+    // initializes GUI telemetry after it receives the Firezone ID from the
+    // Tunnel service over IPC.
 
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -25,23 +25,23 @@ fn main() -> ExitCode {
         Some(logging::setup_bootstrap().expect("Failed to setup bootstrap logger"));
 
     let cli = Cli::parse();
-
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
-    // Start telemetry in `entrypoint` mode so that crashes during settings
-    // load, Tauri setup, IPC connect, or the Hello-wait window are captured.
-    // `try_main` will switch the env to the real api_url once it has loaded
-    // settings; on graceful exit we flush below.
     let mut telemetry = if cli.is_telemetry_allowed() {
         Telemetry::new()
     } else {
         Telemetry::disabled()
     };
-    rt.block_on(telemetry.start(
+
+    // Start telemetry in `entrypoint` mode so that crashes during settings
+    // load, Tauri setup, IPC connect, or the Hello-wait window are captured.
+    // `try_main` will switch the env to the real api_url once it has loaded
+    // settings; on graceful exit we flush below.
+    telemetry.start(
         "entrypoint",
         firezone_gui_client::RELEASE,
         telemetry::GUI_DSN,
-    ));
+    );
 
     let result = try_main(cli, &rt, &mut bootstrap_log_guard, &mut telemetry);
 
@@ -103,11 +103,7 @@ fn try_main(
         .as_ref()
         .unwrap_or(&advanced_settings.api_url)
         .to_string();
-    rt.block_on(telemetry.start(
-        &api_url,
-        firezone_gui_client::RELEASE,
-        telemetry::GUI_DSN,
-    ));
+    telemetry.start(&api_url, firezone_gui_client::RELEASE, telemetry::GUI_DSN);
 
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -70,10 +70,6 @@ fn try_main(cli: Cli, rt: &Runtime, bootstrap_log_guard: &mut Option<DefaultGuar
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
         .unwrap_or_default();
 
-    // `Controller` resolves the effective API URL, including MDM overrides, and
-    // initializes GUI telemetry after it receives the Firezone ID from the
-    // Tunnel service over IPC.
-
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {
         fix_log_filter(&mut advanced_settings)?;

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -11,6 +11,7 @@ use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, dialog, elevation, gui, logging, settings};
 use settings::AdvancedSettingsLegacy;
+use telemetry::Telemetry;
 use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
@@ -27,7 +28,26 @@ fn main() -> ExitCode {
 
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
-    match try_main(cli, &rt, &mut bootstrap_log_guard) {
+    // Start telemetry in `entrypoint` mode so that crashes during settings
+    // load, Tauri setup, IPC connect, or the Hello-wait window are captured.
+    // `try_main` will switch the env to the real api_url once it has loaded
+    // settings; on graceful exit we flush below.
+    let mut telemetry = if cli.is_telemetry_allowed() {
+        Telemetry::new()
+    } else {
+        Telemetry::disabled()
+    };
+    rt.block_on(telemetry.start(
+        "entrypoint",
+        firezone_gui_client::RELEASE,
+        telemetry::GUI_DSN,
+    ));
+
+    let result = try_main(cli, &rt, &mut bootstrap_log_guard, &mut telemetry);
+
+    rt.block_on(telemetry.stop());
+
+    match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("GUI failed: {e:#}");
@@ -37,7 +57,12 @@ fn main() -> ExitCode {
     }
 }
 
-fn try_main(cli: Cli, rt: &Runtime, bootstrap_log_guard: &mut Option<DefaultGuard>) -> Result<()> {
+fn try_main(
+    cli: Cli,
+    rt: &Runtime,
+    bootstrap_log_guard: &mut Option<DefaultGuard>,
+    telemetry: &mut Telemetry,
+) -> Result<()> {
     if cli.test_error_dialog {
         dialog::error("Dialogs are working!")?;
     }
@@ -69,6 +94,20 @@ fn try_main(cli: Cli, rt: &Runtime, bootstrap_log_guard: &mut Option<DefaultGuar
     let mdm_settings = settings::load_mdm_settings()
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
         .unwrap_or_default();
+
+    // Now that we know the real api_url, switch the Sentry session out of
+    // entrypoint mode. `Telemetry::start` notices the env change and stops
+    // the previous session before initialising a new one.
+    let api_url = mdm_settings
+        .api_url
+        .as_ref()
+        .unwrap_or(&advanced_settings.api_url)
+        .to_string();
+    rt.block_on(telemetry.start(
+        &api_url,
+        firezone_gui_client::RELEASE,
+        telemetry::GUI_DSN,
+    ));
 
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -32,6 +32,7 @@ pub struct Controller<I: GuiIntegration> {
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     ctrl_tx: mpsc::Sender<ControllerRequest>,
+    firezone_id: String,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -40,6 +41,8 @@ pub struct Controller<I: GuiIntegration> {
     release: Option<updates::Release>,
     ctrl_rx: ReceiverStream<ControllerRequest>,
     status: Status,
+    telemetry: Option<Telemetry>,
+    telemetry_allowed: bool,
     updates_rx: ReceiverStream<Option<updates::Notification>>,
     uptime: uptime::Tracker,
 
@@ -182,6 +185,7 @@ impl<I: GuiIntegration> Controller<I> {
         mdm_settings: MdmSettings,
         advanced_settings: AdvancedSettings,
         log_filter_reloader: FilterReloadHandle,
+        telemetry_allowed: bool,
         updates_rx: mpsc::Receiver<Option<updates::Notification>>,
         gui_ipc: ipc::Server,
     ) -> Result<()> {
@@ -192,6 +196,9 @@ impl<I: GuiIntegration> Controller<I> {
         receive_hello(&mut ipc_rx)
             .await
             .map_err(FailedToReceiveHello)?;
+        let firezone_id = receive_firezone_id(&mut ipc_rx)
+            .await
+            .context("Failed to receive Firezone ID from tunnel service")?;
 
         let controller = Controller {
             general_settings,
@@ -200,6 +207,7 @@ impl<I: GuiIntegration> Controller<I> {
             auth: auth::Auth::new()?,
             clear_logs_callback: None,
             ctrl_tx,
+            firezone_id,
             ipc_client,
             ipc_rx,
             integration,
@@ -207,6 +215,8 @@ impl<I: GuiIntegration> Controller<I> {
             release: None,
             ctrl_rx: ReceiverStream::new(ctrl_rx),
             status: Default::default(),
+            telemetry: telemetry_allowed.then(Telemetry::new),
+            telemetry_allowed,
             updates_rx: ReceiverStream::new(updates_rx),
             uptime: Default::default(),
             gui_ipc_clients: stream::unfold(gui_ipc, |mut gui_ipc| async move {
@@ -293,7 +303,9 @@ impl<I: GuiIntegration> Controller<I> {
             tracing::error!("ipc_client: {error:#}");
         }
 
-        // Don't close telemetry here, `run` will close it.
+        if let Some(telemetry) = &mut self.telemetry {
+            telemetry.stop().await;
+        }
 
         Ok(())
     }
@@ -360,11 +372,31 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     async fn update_telemetry_context(&mut self) -> Result<()> {
+        // `api_url` resolves MDM settings first, then falls back to local settings.
         let environment = self.api_url().to_string();
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
+        #[cfg(not(test))]
+        if let Some(telemetry) = &mut self.telemetry {
+            telemetry
+                .start(
+                    &environment,
+                    crate::RELEASE,
+                    telemetry::GUI_DSN,
+                    self.firezone_id.clone(),
+                )
+                .await;
+        }
+
+        #[cfg(test)]
+        let _ = &self.firezone_id;
+
         if let Some(account_slug) = account_slug.clone() {
             Telemetry::set_account_slug(account_slug);
+        }
+
+        if !self.telemetry_allowed {
+            return Ok(());
         }
 
         self.send_ipc(&service::ClientMsg::StartTelemetry {
@@ -669,7 +701,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 return Ok(ControlFlow::Break(()));
             }
-            service::ServerMsg::Hello => {}
+            service::ServerMsg::Hello | service::ServerMsg::FirezoneId { .. } => {}
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
                 let (resource, site) = self.resource_by_id(resource_id)?;
 
@@ -984,6 +1016,24 @@ async fn receive_hello(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Resu
     }
 
     Ok(())
+}
+
+async fn receive_firezone_id(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Result<String> {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let server_msg = tokio::time::timeout(TIMEOUT, ipc_rx.next())
+        .await
+        .with_context(|| {
+            format!("Timeout while waiting for Firezone ID from tunnel service for {TIMEOUT:?}")
+        })?
+        .context("No Firezone ID received from tunnel service")?
+        .context("Failed to receive Firezone ID from tunnel service")?;
+
+    let service::ServerMsg::FirezoneId { firezone_id } = server_msg else {
+        bail!("Expected `FirezoneId` from tunnel service but got `{server_msg}`")
+    };
+
+    Ok(firezone_id)
 }
 
 #[cfg(test)]
@@ -1347,6 +1397,12 @@ mod tests {
     impl MockTunnel {
         async fn send_hello(&mut self) {
             self.tx.send(&service::ServerMsg::Hello).await.unwrap();
+            self.tx
+                .send(&service::ServerMsg::FirezoneId {
+                    firezone_id: "test-firezone-id".to_owned(),
+                })
+                .await
+                .unwrap();
         }
 
         async fn rx_start_telemetry(&mut self) {
@@ -1417,6 +1473,7 @@ mod tests {
                 MdmSettings::default(),
                 AdvancedSettings::default(),
                 log_filter_reloader,
+                true,
                 updates_rx,
                 gui_ipc_server,
             ));

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -298,6 +298,8 @@ impl<I: GuiIntegration> Controller<I> {
             tracing::error!("ipc_client: {error:#}");
         }
 
+        // Don't close telemetry here, `run` will close it.
+
         Ok(())
     }
 
@@ -363,7 +365,6 @@ impl<I: GuiIntegration> Controller<I> {
     }
 
     async fn update_telemetry_context(&mut self) -> Result<()> {
-        // `api_url` resolves MDM settings first, then falls back to local settings.
         let environment = self.api_url().to_string();
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -32,7 +32,6 @@ pub struct Controller<I: GuiIntegration> {
     auth: auth::Auth,
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     ctrl_tx: mpsc::Sender<ControllerRequest>,
-    firezone_id: String,
     ipc_client: ipc::ClientWrite<service::ClientMsg>,
     ipc_rx: ipc::ClientRead<service::ServerMsg>,
     integration: I,
@@ -41,8 +40,7 @@ pub struct Controller<I: GuiIntegration> {
     release: Option<updates::Release>,
     ctrl_rx: ReceiverStream<ControllerRequest>,
     status: Status,
-    telemetry: Option<Telemetry>,
-    telemetry_allowed: bool,
+    telemetry: MaybeTelemetry,
     updates_rx: ReceiverStream<Option<updates::Notification>>,
     uptime: uptime::Tracker,
 
@@ -175,6 +173,64 @@ enum EventloopTick {
 #[error("Failed to receive hello: {0:#}")]
 pub struct FailedToReceiveHello(anyhow::Error);
 
+/// State of the GUI process' telemetry instance.
+enum MaybeTelemetry {
+    /// Telemetry is allowed and we have the Firezone ID needed to start it.
+    Initialized {
+        telemetry: Telemetry,
+        firezone_id: String,
+    },
+    /// Telemetry has been disabled by the user.
+    Disabled,
+}
+
+impl MaybeTelemetry {
+    fn new(telemetry_allowed: bool, firezone_id: String) -> Self {
+        if telemetry_allowed {
+            Self::Initialized {
+                telemetry: Telemetry::new(),
+                firezone_id,
+            }
+        } else {
+            Self::Disabled
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        matches!(self, Self::Initialized { .. })
+    }
+
+    /// Starts the underlying GUI telemetry instance.
+    ///
+    /// Calling this in tests is a no-op so we don't make real HTTP requests to Sentry.
+    #[cfg_attr(test, allow(clippy::unused_async))]
+    async fn start(&mut self, environment: &str, release: &str) {
+        let Self::Initialized {
+            telemetry,
+            firezone_id,
+        } = self
+        else {
+            return;
+        };
+
+        #[cfg(not(test))]
+        telemetry
+            .start(environment, release, telemetry::GUI_DSN, firezone_id.clone())
+            .await;
+
+        #[cfg(test)]
+        {
+            let _ = (environment, release, telemetry, firezone_id);
+        }
+    }
+
+    async fn stop(&mut self) {
+        if let Self::Initialized { telemetry, .. } = self {
+            telemetry.stop().await;
+        }
+    }
+}
+
 impl<I: GuiIntegration> Controller<I> {
     pub(crate) async fn start(
         socket: SocketId,
@@ -193,12 +249,9 @@ impl<I: GuiIntegration> Controller<I> {
 
         let (mut ipc_rx, ipc_client) = ipc::connect(socket, ipc::ConnectOptions::default()).await?;
 
-        receive_hello(&mut ipc_rx)
+        let firezone_id = receive_hello(&mut ipc_rx)
             .await
             .map_err(FailedToReceiveHello)?;
-        let firezone_id = receive_firezone_id(&mut ipc_rx)
-            .await
-            .context("Failed to receive Firezone ID from tunnel service")?;
 
         let controller = Controller {
             general_settings,
@@ -207,7 +260,6 @@ impl<I: GuiIntegration> Controller<I> {
             auth: auth::Auth::new()?,
             clear_logs_callback: None,
             ctrl_tx,
-            firezone_id,
             ipc_client,
             ipc_rx,
             integration,
@@ -215,8 +267,7 @@ impl<I: GuiIntegration> Controller<I> {
             release: None,
             ctrl_rx: ReceiverStream::new(ctrl_rx),
             status: Default::default(),
-            telemetry: telemetry_allowed.then(Telemetry::new),
-            telemetry_allowed,
+            telemetry: MaybeTelemetry::new(telemetry_allowed, firezone_id),
             updates_rx: ReceiverStream::new(updates_rx),
             uptime: Default::default(),
             gui_ipc_clients: stream::unfold(gui_ipc, |mut gui_ipc| async move {
@@ -303,9 +354,7 @@ impl<I: GuiIntegration> Controller<I> {
             tracing::error!("ipc_client: {error:#}");
         }
 
-        if let Some(telemetry) = &mut self.telemetry {
-            telemetry.stop().await;
-        }
+        self.telemetry.stop().await;
 
         Ok(())
     }
@@ -376,26 +425,13 @@ impl<I: GuiIntegration> Controller<I> {
         let environment = self.api_url().to_string();
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
-        #[cfg(not(test))]
-        if let Some(telemetry) = &mut self.telemetry {
-            telemetry
-                .start(
-                    &environment,
-                    crate::RELEASE,
-                    telemetry::GUI_DSN,
-                    self.firezone_id.clone(),
-                )
-                .await;
-        }
-
-        #[cfg(test)]
-        let _ = &self.firezone_id;
+        self.telemetry.start(&environment, crate::RELEASE).await;
 
         if let Some(account_slug) = account_slug.clone() {
             Telemetry::set_account_slug(account_slug);
         }
 
-        if !self.telemetry_allowed {
+        if !self.telemetry.is_enabled() {
             return Ok(());
         }
 
@@ -701,7 +737,7 @@ impl<I: GuiIntegration> Controller<I> {
 
                 return Ok(ControlFlow::Break(()));
             }
-            service::ServerMsg::Hello | service::ServerMsg::FirezoneId { .. } => {}
+            service::ServerMsg::Hello { .. } => {}
             service::ServerMsg::GatewayVersionMismatch { resource_id } => {
                 let (resource, site) = self.resource_by_id(resource_id)?;
 
@@ -1000,7 +1036,7 @@ impl<I: GuiIntegration> Controller<I> {
     }
 }
 
-async fn receive_hello(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Result<()> {
+async fn receive_hello(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Result<String> {
     const TIMEOUT: Duration = Duration::from_secs(5);
 
     let server_msg = tokio::time::timeout(TIMEOUT, ipc_rx.next())
@@ -1011,26 +1047,8 @@ async fn receive_hello(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Resu
         .context("No message received from tunnel service")?
         .context("Failed to receive message from tunnel service")?;
 
-    if !matches!(server_msg, service::ServerMsg::Hello) {
+    let service::ServerMsg::Hello { firezone_id } = server_msg else {
         bail!("Expected `Hello` from tunnel service but got `{server_msg}`")
-    }
-
-    Ok(())
-}
-
-async fn receive_firezone_id(ipc_rx: &mut ipc::ClientRead<service::ServerMsg>) -> Result<String> {
-    const TIMEOUT: Duration = Duration::from_secs(5);
-
-    let server_msg = tokio::time::timeout(TIMEOUT, ipc_rx.next())
-        .await
-        .with_context(|| {
-            format!("Timeout while waiting for Firezone ID from tunnel service for {TIMEOUT:?}")
-        })?
-        .context("No Firezone ID received from tunnel service")?
-        .context("Failed to receive Firezone ID from tunnel service")?;
-
-    let service::ServerMsg::FirezoneId { firezone_id } = server_msg else {
-        bail!("Expected `FirezoneId` from tunnel service but got `{server_msg}`")
     };
 
     Ok(firezone_id)
@@ -1396,9 +1414,8 @@ mod tests {
 
     impl MockTunnel {
         async fn send_hello(&mut self) {
-            self.tx.send(&service::ServerMsg::Hello).await.unwrap();
             self.tx
-                .send(&service::ServerMsg::FirezoneId {
+                .send(&service::ServerMsg::Hello {
                     firezone_id: "test-firezone-id".to_owned(),
                 })
                 .await

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -40,7 +40,7 @@ pub struct Controller<I: GuiIntegration> {
     release: Option<updates::Release>,
     ctrl_rx: ReceiverStream<ControllerRequest>,
     status: Status,
-    telemetry: MaybeTelemetry,
+    telemetry_allowed: bool,
     updates_rx: ReceiverStream<Option<updates::Notification>>,
     uptime: uptime::Tracker,
 
@@ -173,64 +173,6 @@ enum EventloopTick {
 #[error("Failed to receive hello: {0:#}")]
 pub struct FailedToReceiveHello(anyhow::Error);
 
-/// State of the GUI process' telemetry instance.
-enum MaybeTelemetry {
-    /// Telemetry is allowed and we have the Firezone ID needed to start it.
-    Initialized {
-        telemetry: Telemetry,
-        firezone_id: String,
-    },
-    /// Telemetry has been disabled by the user.
-    Disabled,
-}
-
-impl MaybeTelemetry {
-    fn new(telemetry_allowed: bool, firezone_id: String) -> Self {
-        if telemetry_allowed {
-            Self::Initialized {
-                telemetry: Telemetry::new(),
-                firezone_id,
-            }
-        } else {
-            Self::Disabled
-        }
-    }
-
-    fn is_enabled(&self) -> bool {
-        matches!(self, Self::Initialized { .. })
-    }
-
-    /// Starts the underlying GUI telemetry instance.
-    ///
-    /// Calling this in tests is a no-op so we don't make real HTTP requests to Sentry.
-    #[cfg_attr(test, allow(clippy::unused_async))]
-    async fn start(&mut self, environment: &str, release: &str) {
-        let Self::Initialized {
-            telemetry,
-            firezone_id,
-        } = self
-        else {
-            return;
-        };
-
-        #[cfg(not(test))]
-        telemetry
-            .start(environment, release, telemetry::GUI_DSN, firezone_id.clone())
-            .await;
-
-        #[cfg(test)]
-        {
-            let _ = (environment, release, telemetry, firezone_id);
-        }
-    }
-
-    async fn stop(&mut self) {
-        if let Self::Initialized { telemetry, .. } = self {
-            telemetry.stop().await;
-        }
-    }
-}
-
 impl<I: GuiIntegration> Controller<I> {
     pub(crate) async fn start(
         socket: SocketId,
@@ -253,6 +195,14 @@ impl<I: GuiIntegration> Controller<I> {
             .await
             .map_err(FailedToReceiveHello)?;
 
+        // Attach the Firezone ID to the running Sentry session. The session
+        // itself was started in `fn main` (entrypoint) and switched to the real
+        // env in `try_main`; we just bind the user here.
+        #[cfg(not(test))]
+        Telemetry::set_firezone_id(firezone_id);
+        #[cfg(test)]
+        let _ = firezone_id;
+
         let controller = Controller {
             general_settings,
             mdm_settings,
@@ -267,7 +217,7 @@ impl<I: GuiIntegration> Controller<I> {
             release: None,
             ctrl_rx: ReceiverStream::new(ctrl_rx),
             status: Default::default(),
-            telemetry: MaybeTelemetry::new(telemetry_allowed, firezone_id),
+            telemetry_allowed,
             updates_rx: ReceiverStream::new(updates_rx),
             uptime: Default::default(),
             gui_ipc_clients: stream::unfold(gui_ipc, |mut gui_ipc| async move {
@@ -354,8 +304,6 @@ impl<I: GuiIntegration> Controller<I> {
             tracing::error!("ipc_client: {error:#}");
         }
 
-        self.telemetry.stop().await;
-
         Ok(())
     }
 
@@ -425,13 +373,11 @@ impl<I: GuiIntegration> Controller<I> {
         let environment = self.api_url().to_string();
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
-        self.telemetry.start(&environment, crate::RELEASE).await;
-
         if let Some(account_slug) = account_slug.clone() {
             Telemetry::set_account_slug(account_slug);
         }
 
-        if !self.telemetry.is_enabled() {
+        if !self.telemetry_allowed {
             return Ok(());
         }
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -195,13 +195,7 @@ impl<I: GuiIntegration> Controller<I> {
             .await
             .map_err(FailedToReceiveHello)?;
 
-        // Attach the Firezone ID to the running Sentry session. The session
-        // itself was started in `fn main` (entrypoint) and switched to the real
-        // env in `try_main`; we just bind the user here.
-        #[cfg(not(test))]
-        Telemetry::set_firezone_id(firezone_id);
-        #[cfg(test)]
-        let _ = firezone_id;
+        Telemetry::set_firezone_id(firezone_id).await;
 
         let controller = Controller {
             general_settings,

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -228,6 +228,7 @@ pub struct RunConfig {
     pub debug_update_check: bool,
     pub smoke_test: bool,
     pub no_deep_links: bool,
+    pub telemetry_allowed: bool,
     pub quit_after: Option<u64>,
     pub fail_with: Option<Failure>,
     /// When `true`, skip the auth/portal/tunnel stack and drive the tray with
@@ -372,6 +373,7 @@ pub fn run(
                 mdm_settings,
                 advanced_settings,
                 reloader,
+                config.telemetry_allowed,
                 updates_rx,
                 gui_ipc,
             ))

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -327,7 +327,20 @@ impl<'a> Handler<'a> {
     ) -> Result<Self> {
         dns_controller.deactivate()?;
 
-        let telemetry = Telemetry::new();
+        // Start a Sentry session in `entrypoint` mode immediately so that
+        // panics during TUN bring-up, DNS notifier setup, and the IPC client
+        // handshake are captured. The session is replaced with a real one
+        // (with a known api_url) once the GUI sends `ClientMsg::StartTelemetry`.
+        #[cfg_attr(test, expect(unused_mut, reason = "tests skip the .start() call"))]
+        let mut telemetry = if std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true") {
+            Telemetry::disabled()
+        } else {
+            Telemetry::new()
+        };
+        #[cfg(not(test))]
+        telemetry
+            .start("entrypoint", env!("CARGO_PKG_VERSION"), telemetry::GUI_DSN)
+            .await;
 
         tracing::info!(
             server_pid = std::process::id(),
@@ -638,13 +651,9 @@ impl<'a> Handler<'a> {
 
                 if !no_telemetry {
                     self.telemetry
-                        .start(
-                            &environment,
-                            &release,
-                            telemetry::GUI_DSN,
-                            self.device_id.id.clone(),
-                        )
+                        .start(&environment, &release, telemetry::GUI_DSN)
                         .await;
+                    Telemetry::set_firezone_id(self.device_id.id.clone());
 
                     otel::install_sentry_meter_provider(
                         env!("CARGO_PKG_NAME"),

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -637,7 +637,7 @@ impl<'a> Handler<'a> {
                 if !no_telemetry {
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
-                    Telemetry::set_firezone_id(self.device_id.id.clone());
+                    Telemetry::set_firezone_id(self.device_id.id.clone()).await;
 
                     otel::install_sentry_meter_provider(
                         env!("CARGO_PKG_NAME"),

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -327,21 +327,6 @@ impl<'a> Handler<'a> {
     ) -> Result<Self> {
         dns_controller.deactivate()?;
 
-        // Start a Sentry session in `entrypoint` mode immediately so that
-        // panics during TUN bring-up, DNS notifier setup, and the IPC client
-        // handshake are captured. The session is replaced with a real one
-        // (with a known api_url) once the GUI sends `ClientMsg::StartTelemetry`.
-        #[cfg_attr(test, expect(unused_mut, reason = "tests skip the .start() call"))]
-        let mut telemetry = if std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true") {
-            Telemetry::disabled()
-        } else {
-            Telemetry::new()
-        };
-        #[cfg(not(test))]
-        telemetry
-            .start("entrypoint", env!("CARGO_PKG_VERSION"), telemetry::GUI_DSN)
-            .await;
-
         tracing::info!(
             server_pid = std::process::id(),
             "Listening for GUI to connect over IPC..."
@@ -377,7 +362,7 @@ impl<'a> Handler<'a> {
             ipc_tx,
             log_filter_reloader,
             session: Session::None,
-            telemetry,
+            telemetry: Telemetry::new(),
             tun_device,
             dns_notifier,
             network_notifier,
@@ -651,8 +636,7 @@ impl<'a> Handler<'a> {
 
                 if !no_telemetry {
                     self.telemetry
-                        .start(&environment, &release, telemetry::GUI_DSN)
-                        .await;
+                        .start(&environment, &release, telemetry::GUI_DSN);
                     Telemetry::set_firezone_id(self.device_id.id.clone());
 
                     otel::install_sentry_meter_provider(

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -84,6 +84,9 @@ where
 #[derive(Debug, serde::Deserialize, serde::Serialize, strum::Display)]
 pub enum ServerMsg {
     Hello,
+    FirezoneId {
+        firezone_id: String,
+    },
     /// The Tunnel service finished clearing its log dir.
     ClearedLogs(Result<(), String>),
     ConnectResult(Result<(), String>),
@@ -347,6 +350,13 @@ impl<'a> Handler<'a> {
             .send(&ServerMsg::Hello)
             .await
             .context("Failed to greet to new GUI process")?; // Greet the GUI process. If the GUI process doesn't receive this after connecting, it knows that the tunnel service isn't responding.
+
+        ipc_tx
+            .send(&ServerMsg::FirezoneId {
+                firezone_id: device_id.id.clone(),
+            })
+            .await
+            .context("Failed to send Firezone ID to GUI process")?;
 
         Ok(Self {
             device_id,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -327,6 +327,8 @@ impl<'a> Handler<'a> {
     ) -> Result<Self> {
         dns_controller.deactivate()?;
 
+        let telemetry = Telemetry::new();
+
         tracing::info!(
             server_pid = std::process::id(),
             "Listening for GUI to connect over IPC..."
@@ -362,7 +364,7 @@ impl<'a> Handler<'a> {
             ipc_tx,
             log_filter_reloader,
             session: Session::None,
-            telemetry: Telemetry::new(),
+            telemetry,
             tun_device,
             dns_notifier,
             network_notifier,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -83,8 +83,12 @@ where
 /// Messages that end up in the GUI, either forwarded from connlib or from the Tunnel service.
 #[derive(Debug, serde::Deserialize, serde::Serialize, strum::Display)]
 pub enum ServerMsg {
-    Hello,
-    FirezoneId {
+    /// First message sent on every IPC connection.
+    ///
+    /// Includes the Firezone ID so the GUI can use it for telemetry without
+    /// having to read the on-disk file (which is locked-down to System and
+    /// Administrators on Windows).
+    Hello {
         firezone_id: String,
     },
     /// The Tunnel service finished clearing its log dir.
@@ -347,16 +351,11 @@ impl<'a> Handler<'a> {
             .boxed();
 
         ipc_tx
-            .send(&ServerMsg::Hello)
-            .await
-            .context("Failed to greet to new GUI process")?; // Greet the GUI process. If the GUI process doesn't receive this after connecting, it knows that the tunnel service isn't responding.
-
-        ipc_tx
-            .send(&ServerMsg::FirezoneId {
+            .send(&ServerMsg::Hello {
                 firezone_id: device_id.id.clone(),
             })
             .await
-            .context("Failed to send Firezone ID to GUI process")?;
+            .context("Failed to greet to new GUI process")?; // Greet the GUI process. If the GUI process doesn't receive this after connecting, it knows that the tunnel service isn't responding.
 
         Ok(Self {
             device_id,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -330,7 +330,7 @@ fn try_main() -> Result<()> {
         let mut telemetry = Telemetry::new();
 
         telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
-        Telemetry::set_firezone_id(firezone_id.clone());
+        rt.block_on(Telemetry::set_firezone_id(firezone_id.clone()));
 
         analytics::identify(RELEASE.to_owned(), None);
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -329,12 +329,8 @@ fn try_main() -> Result<()> {
     let mut telemetry = if cli.is_telemetry_allowed() {
         let mut telemetry = Telemetry::new();
 
-        rt.block_on(telemetry.start(
-            cli.api_url.as_ref(),
-            RELEASE,
-            telemetry::HEADLESS_DSN,
-            firezone_id.clone(),
-        ));
+        rt.block_on(telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN));
+        Telemetry::set_firezone_id(firezone_id.clone());
 
         analytics::identify(RELEASE.to_owned(), None);
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -329,7 +329,7 @@ fn try_main() -> Result<()> {
     let mut telemetry = if cli.is_telemetry_allowed() {
         let mut telemetry = Telemetry::new();
 
-        rt.block_on(telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN));
+        telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
         Telemetry::set_firezone_id(firezone_id.clone());
 
         analytics::identify(RELEASE.to_owned(), None);

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -70,6 +70,7 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_System_Com",
     # Needed to listen for system DNS changes
     "Win32_System_Registry",

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -89,8 +89,8 @@ fn get_or_create_at(path: &Path, app_id: &str) -> Result<DeviceId> {
     let dir = path
         .parent()
         .context("Device ID path should always have a parent")?;
-    // Make sure the dir exists, and fix its permissions so the GUI can write the
-    // log filter file
+    // Make sure the dir exists, and fix its permissions before writing files
+    // into it.
     fs::create_dir_all(dir).context("Failed to create dir for firezone-id")?;
     set_dir_permissions(dir).with_context(|| {
         format!(
@@ -161,8 +161,13 @@ fn set_dir_permissions(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Does nothing on non-Linux systems
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+fn set_dir_permissions(dir: &Path) -> Result<()> {
+    set_windows_dacl(dir, "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
+}
+
+/// Does nothing on other non-Linux systems
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[expect(clippy::unnecessary_wraps)]
 fn set_dir_permissions(_: &Path) -> Result<()> {
     Ok(())
@@ -177,8 +182,112 @@ fn set_id_permissions(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Does nothing on non-Linux systems
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+fn set_id_permissions(path: &Path) -> Result<()> {
+    set_windows_dacl(path, "D:P(A;;FA;;;SY)(A;;FA;;;BA)")
+}
+
+#[cfg(target_os = "windows")]
+fn set_windows_dacl(path: &Path, sddl: &str) -> Result<()> {
+    use anyhow::ensure;
+    use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
+    use windows::{
+        Win32::{
+            Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree},
+            Security::{
+                Authorization::{
+                    ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+                    SE_FILE_OBJECT, SetNamedSecurityInfoW,
+                },
+                DACL_SECURITY_INFORMATION, GetSecurityDescriptorDacl,
+                PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+            },
+        },
+        core::{BOOL, PCWSTR},
+    };
+
+    fn wide(s: impl AsRef<OsStr>) -> Vec<u16> {
+        s.as_ref().encode_wide().chain(Some(0)).collect()
+    }
+
+    struct LocalSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+    impl Drop for LocalSecurityDescriptor {
+        fn drop(&mut self) {
+            // SAFETY: The security descriptor was allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` and must be
+            // released with `LocalFree`.
+            unsafe {
+                LocalFree(Some(HLOCAL(self.0.0)));
+            }
+        }
+    }
+
+    let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
+    let sddl = wide(sddl);
+
+    // SAFETY: The SDDL string is null-terminated and the output pointer is valid
+    // for the duration of this call.
+    unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(sddl.as_ptr()),
+            SDDL_REVISION_1,
+            &mut security_descriptor,
+            None,
+        )
+    }
+    .context("Failed to build Windows security descriptor from SDDL")?;
+
+    let security_descriptor = LocalSecurityDescriptor(security_descriptor);
+
+    let mut dacl_present = BOOL::default();
+    let mut dacl_defaulted = BOOL::default();
+    let mut dacl = ptr::null_mut();
+
+    // SAFETY: The security descriptor is valid and the output pointers are local
+    // variables that live for the duration of the call.
+    unsafe {
+        GetSecurityDescriptorDacl(
+            security_descriptor.0,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        )
+    }
+    .context("Failed to get DACL from Windows security descriptor")?;
+
+    ensure!(
+        dacl_present.as_bool(),
+        "Windows security descriptor has no DACL"
+    );
+
+    let path = wide(path.as_os_str());
+    let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
+
+    // SAFETY: The path is null-terminated, the DACL comes from a valid security
+    // descriptor, and Windows does not retain these pointers after the call.
+    let err = unsafe {
+        SetNamedSecurityInfoW(
+            PCWSTR(path.as_ptr()),
+            SE_FILE_OBJECT,
+            security_info,
+            None,
+            None,
+            Some(dacl),
+            None,
+        )
+    };
+
+    if err != ERROR_SUCCESS {
+        return Err(std::io::Error::from_raw_os_error(err.0 as i32))
+            .with_context(|| "Failed to set Windows DACL");
+    }
+
+    Ok(())
+}
+
+/// Does nothing on other non-Linux systems
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[expect(clippy::unnecessary_wraps)]
 fn set_id_permissions(_: &Path) -> Result<()> {
     Ok(())

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -163,7 +163,8 @@ fn set_dir_permissions(dir: &Path) -> Result<()> {
 
 #[cfg(target_os = "windows")]
 fn set_dir_permissions(dir: &Path) -> Result<()> {
-    set_windows_dacl(dir, "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
+    windows_security::SecurityDescriptor::from_sddl(windows_security::DIR_SDDL)?
+        .apply_to_path(dir)
 }
 
 /// Does nothing on other non-Linux systems
@@ -184,17 +185,34 @@ fn set_id_permissions(path: &Path) -> Result<()> {
 
 #[cfg(target_os = "windows")]
 fn set_id_permissions(path: &Path) -> Result<()> {
-    set_windows_dacl(path, "D:P(A;;FA;;;SY)(A;;FA;;;BA)")
+    windows_security::SecurityDescriptor::from_sddl(windows_security::FILE_SDDL)?
+        .apply_to_path(path)
+}
+
+/// Does nothing on other non-Linux systems
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+#[expect(clippy::unnecessary_wraps)]
+fn set_id_permissions(_: &Path) -> Result<()> {
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]
-fn set_windows_dacl(path: &Path, sddl: &str) -> Result<()> {
-    use anyhow::ensure;
-    use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
+mod windows_security {
+    //! Safe wrappers around the Windows security descriptor APIs we need to
+    //! lock down the on-disk Firezone ID.
+    //!
+    //! The intent is to confine all unsafe FFI to this module so that callers
+    //! get a Rust-y interface that upholds Windows' lifetime and ownership
+    //! requirements (`LocalFree` on the buffer returned by
+    //! `ConvertStringSecurityDescriptorToSecurityDescriptorW`, etc.).
+
+    use anyhow::{Context as _, Result, ensure};
+    use std::{ffi::OsStr, os::windows::ffi::OsStrExt, path::Path, ptr};
     use windows::{
         Win32::{
             Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree},
             Security::{
+                ACL,
                 Authorization::{
                     ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
                     SE_FILE_OBJECT, SetNamedSecurityInfoW,
@@ -206,91 +224,132 @@ fn set_windows_dacl(path: &Path, sddl: &str) -> Result<()> {
         core::{BOOL, PCWSTR},
     };
 
-    fn wide(s: impl AsRef<OsStr>) -> Vec<u16> {
-        s.as_ref().encode_wide().chain(Some(0)).collect()
+    /// SDDL for the Tunnel service config directory.
+    ///
+    /// `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` reads as:
+    /// - `D:P` — set a *protected* DACL (don't inherit ACEs from the parent
+    ///   directory).
+    /// - `A;OICI;FA;;;SY` — *Allow* `Full Access` to `LocalSystem`, with
+    ///   `Object` and `Container` inheritance so child files and dirs inherit
+    ///   the same access.
+    /// - `A;OICI;FA;;;BA` — *Allow* `Full Access` to `BUILTIN\Administrators`,
+    ///   with the same inheritance flags.
+    pub(super) const DIR_SDDL: &str = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)";
+
+    /// SDDL for the on-disk `firezone-id` file.
+    ///
+    /// `D:P(A;;FA;;;SY)(A;;FA;;;BA)` reads as:
+    /// - `D:P` — set a *protected* DACL.
+    /// - `A;;FA;;;SY` — *Allow* `Full Access` to `LocalSystem`. No inheritance
+    ///   flags are needed since this is a leaf file.
+    /// - `A;;FA;;;BA` — *Allow* `Full Access` to `BUILTIN\Administrators`.
+    pub(super) const FILE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)";
+
+    /// Owned wrapper around a `PSECURITY_DESCRIPTOR` that was allocated by
+    /// `ConvertStringSecurityDescriptorToSecurityDescriptorW`.
+    ///
+    /// The only constructor, [`Self::from_sddl`], guarantees that the inner
+    /// pointer was returned by that API. This upholds the safety invariant of
+    /// the [`Drop`] impl, which calls `LocalFree`.
+    pub(super) struct SecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+    impl SecurityDescriptor {
+        /// Parses an SDDL string into an owned security descriptor.
+        ///
+        /// See [SDDL for Conditional ACEs](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format).
+        pub(super) fn from_sddl(sddl: &str) -> Result<Self> {
+            let sddl = wide(sddl);
+            let mut descriptor = PSECURITY_DESCRIPTOR::default();
+
+            // SAFETY: `sddl` is null-terminated by `wide` and `&mut descriptor`
+            // is a valid out-pointer to a stack-allocated value. On success,
+            // `descriptor` is set to a buffer that we own and that will be
+            // released by our `Drop` impl.
+            unsafe {
+                ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                    PCWSTR(sddl.as_ptr()),
+                    SDDL_REVISION_1,
+                    &mut descriptor,
+                    None,
+                )
+            }
+            .context("Failed to build Windows security descriptor from SDDL")?;
+
+            Ok(Self(descriptor))
+        }
+
+        /// Applies this security descriptor's DACL to the named file or
+        /// directory, replacing any inherited ACEs.
+        pub(super) fn apply_to_path(&self, path: &Path) -> Result<()> {
+            let dacl = self.dacl()?;
+            let path_wide = wide(path.as_os_str());
+            let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
+
+            // SAFETY: `path_wide` is null-terminated, `dacl` borrows from
+            // `self`'s buffer (which lives for this call), and Windows does not
+            // retain any of these pointers after the call returns.
+            let err = unsafe {
+                SetNamedSecurityInfoW(
+                    PCWSTR(path_wide.as_ptr()),
+                    SE_FILE_OBJECT,
+                    security_info,
+                    None,
+                    None,
+                    Some(dacl),
+                    None,
+                )
+            };
+
+            if err != ERROR_SUCCESS {
+                return Err(std::io::Error::from_raw_os_error(err.0 as i32)).with_context(|| {
+                    format!("Failed to set Windows DACL on `{}`", path.display())
+                });
+            }
+
+            Ok(())
+        }
+
+        fn dacl(&self) -> Result<*const ACL> {
+            let mut dacl_present = BOOL::default();
+            let mut dacl_defaulted = BOOL::default();
+            let mut dacl: *mut ACL = ptr::null_mut();
+
+            // SAFETY: `self.0` is a valid security descriptor (only constructed
+            // via `from_sddl`). The other arguments are valid out-pointers into
+            // local variables.
+            unsafe {
+                GetSecurityDescriptorDacl(
+                    self.0,
+                    &mut dacl_present,
+                    &mut dacl,
+                    &mut dacl_defaulted,
+                )
+            }
+            .context("Failed to get DACL from Windows security descriptor")?;
+
+            ensure!(
+                dacl_present.as_bool(),
+                "Windows security descriptor has no DACL"
+            );
+
+            Ok(dacl)
+        }
     }
 
-    struct LocalSecurityDescriptor(PSECURITY_DESCRIPTOR);
-
-    impl Drop for LocalSecurityDescriptor {
+    impl Drop for SecurityDescriptor {
         fn drop(&mut self) {
-            // SAFETY: The security descriptor was allocated by
-            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` and must be
-            // released with `LocalFree`.
+            // SAFETY: `self.0` was allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` (the only
+            // constructor of `Self`) and must be released with `LocalFree`.
             unsafe {
                 LocalFree(Some(HLOCAL(self.0.0)));
             }
         }
     }
 
-    let mut security_descriptor = PSECURITY_DESCRIPTOR::default();
-    let sddl = wide(sddl);
-
-    // SAFETY: The SDDL string is null-terminated and the output pointer is valid
-    // for the duration of this call.
-    unsafe {
-        ConvertStringSecurityDescriptorToSecurityDescriptorW(
-            PCWSTR(sddl.as_ptr()),
-            SDDL_REVISION_1,
-            &mut security_descriptor,
-            None,
-        )
+    fn wide(s: impl AsRef<OsStr>) -> Vec<u16> {
+        s.as_ref().encode_wide().chain(Some(0)).collect()
     }
-    .context("Failed to build Windows security descriptor from SDDL")?;
-
-    let security_descriptor = LocalSecurityDescriptor(security_descriptor);
-
-    let mut dacl_present = BOOL::default();
-    let mut dacl_defaulted = BOOL::default();
-    let mut dacl = ptr::null_mut();
-
-    // SAFETY: The security descriptor is valid and the output pointers are local
-    // variables that live for the duration of the call.
-    unsafe {
-        GetSecurityDescriptorDacl(
-            security_descriptor.0,
-            &mut dacl_present,
-            &mut dacl,
-            &mut dacl_defaulted,
-        )
-    }
-    .context("Failed to get DACL from Windows security descriptor")?;
-
-    ensure!(
-        dacl_present.as_bool(),
-        "Windows security descriptor has no DACL"
-    );
-
-    let path = wide(path.as_os_str());
-    let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
-
-    // SAFETY: The path is null-terminated, the DACL comes from a valid security
-    // descriptor, and Windows does not retain these pointers after the call.
-    let err = unsafe {
-        SetNamedSecurityInfoW(
-            PCWSTR(path.as_ptr()),
-            SE_FILE_OBJECT,
-            security_info,
-            None,
-            None,
-            Some(dacl),
-            None,
-        )
-    };
-
-    if err != ERROR_SUCCESS {
-        return Err(std::io::Error::from_raw_os_error(err.0 as i32))
-            .with_context(|| "Failed to set Windows DACL");
-    }
-
-    Ok(())
-}
-
-/// Does nothing on other non-Linux systems
-#[cfg(not(any(target_os = "linux", target_os = "windows")))]
-#[expect(clippy::unnecessary_wraps)]
-fn set_id_permissions(_: &Path) -> Result<()> {
-    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -371,5 +430,79 @@ mod tests {
         let id = compute_from_hardware_id(CLIENT_APP_ID).unwrap();
 
         assert!(!id.id.is_empty())
+    }
+
+    #[cfg(target_os = "windows")]
+    mod windows {
+        use super::super::windows_security::{DIR_SDDL, FILE_SDDL, SecurityDescriptor};
+        use tempfile::tempdir;
+
+        /// Permissive DACL we use in tests that need to actually apply a
+        /// security descriptor. Granting Full Access to `WD` (Everyone) keeps
+        /// the temp dir/file deletable by the test process during cleanup,
+        /// regardless of whether tests run as Administrator.
+        const PERMISSIVE_SDDL: &str = "D:(A;;FA;;;WD)";
+
+        #[test]
+        fn parse_dir_sddl_does_not_crash() {
+            // Exercises `ConvertStringSecurityDescriptorToSecurityDescriptorW`
+            // and the `Drop` impl that calls `LocalFree`.
+            SecurityDescriptor::from_sddl(DIR_SDDL).unwrap();
+        }
+
+        #[test]
+        fn parse_file_sddl_does_not_crash() {
+            SecurityDescriptor::from_sddl(FILE_SDDL).unwrap();
+        }
+
+        #[test]
+        fn parse_invalid_sddl_returns_err() {
+            // We accept anything that isn't valid SDDL: arbitrary garbage or
+            // empty strings.
+            assert!(SecurityDescriptor::from_sddl("not a valid SDDL").is_err());
+            assert!(SecurityDescriptor::from_sddl("").is_err());
+        }
+
+        #[test]
+        fn apply_dacl_to_temp_dir() {
+            let dir = tempdir().unwrap();
+
+            SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
+                .unwrap()
+                .apply_to_path(dir.path())
+                .unwrap();
+        }
+
+        #[test]
+        fn apply_dacl_to_temp_file() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("firezone-id");
+            std::fs::write(&path, "{}").unwrap();
+
+            SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
+                .unwrap()
+                .apply_to_path(&path)
+                .unwrap();
+        }
+
+        #[test]
+        fn apply_dacl_to_missing_path_returns_err() {
+            let dir = tempdir().unwrap();
+            let missing = dir.path().join("does-not-exist");
+
+            let result = SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
+                .unwrap()
+                .apply_to_path(&missing);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn dropping_many_security_descriptors_does_not_crash() {
+            // Hammer `Drop` to surface any double-free or use-after-free.
+            for _ in 0..1024 {
+                let _ = SecurityDescriptor::from_sddl(DIR_SDDL).unwrap();
+                let _ = SecurityDescriptor::from_sddl(FILE_SDDL).unwrap();
+            }
+        }
     }
 }

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -451,8 +451,9 @@ mod tests {
 
         #[test]
         fn parse_invalid_sddl_returns_err() {
+            // Empty strings *do* parse successfully on Windows (they yield a
+            // descriptor with no DACL/SACL set), so we only assert on garbage.
             assert!(SecurityDescriptor::from_sddl("not a valid SDDL").is_err());
-            assert!(SecurityDescriptor::from_sddl("").is_err());
         }
 
         #[test]

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -163,8 +163,7 @@ fn set_dir_permissions(dir: &Path) -> Result<()> {
 
 #[cfg(target_os = "windows")]
 fn set_dir_permissions(dir: &Path) -> Result<()> {
-    windows_security::SecurityDescriptor::from_sddl(windows_security::DIR_SDDL)?
-        .apply_to_path(dir)
+    windows_security::SecurityDescriptor::from_sddl(windows_security::DIR_SDDL)?.apply_to_path(dir)
 }
 
 /// Does nothing on other non-Linux systems
@@ -318,12 +317,7 @@ mod windows_security {
             // via `from_sddl`). The other arguments are valid out-pointers into
             // local variables.
             unsafe {
-                GetSecurityDescriptorDacl(
-                    self.0,
-                    &mut dacl_present,
-                    &mut dacl,
-                    &mut dacl_defaulted,
-                )
+                GetSecurityDescriptorDacl(self.0, &mut dacl_present, &mut dacl, &mut dacl_defaulted)
             }
             .context("Failed to get DACL from Windows security descriptor")?;
 
@@ -457,8 +451,6 @@ mod tests {
 
         #[test]
         fn parse_invalid_sddl_returns_err() {
-            // We accept anything that isn't valid SDDL: arbitrary garbage or
-            // empty strings.
             assert!(SecurityDescriptor::from_sddl("not a valid SDDL").is_err());
             assert!(SecurityDescriptor::from_sddl("").is_err());
         }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -64,7 +64,7 @@ pub(crate) async fn evaluate_now(user_id: String, env: Env) {
     let api_key = match env {
         Env::Production => posthog::API_KEY_PROD,
         Env::Staging => posthog::API_KEY_STAGING,
-        Env::OnPrem | Env::DockerCompose | Env::Localhost => return,
+        Env::Entrypoint | Env::OnPrem | Env::DockerCompose | Env::Localhost => return,
     };
 
     let (flags, payloads) = decide(user_id, api_key.to_owned())

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -102,7 +102,7 @@ impl fmt::Display for Dsn {
 #[doc(hidden)] // Only public for testing.
 pub enum Env {
     /// Pre-`api_url` placeholder used at process boot, so we can capture
-    /// crashes before settings are loaded. Mirrors Swift's `Telemetry.start()`.
+    /// crashes before settings are loaded.
     Entrypoint,
     Production,
     Staging,
@@ -135,10 +135,6 @@ impl Env {
     }
 
     /// Parses a string as either an explicit env name or an API URL.
-    ///
-    /// Tries the env name first so callers can pass `"entrypoint"` (and tests
-    /// can pass any other variant directly). Falls back to URL-based detection,
-    /// which is total — unknown URLs land on `OnPrem`.
     pub(crate) fn parse(input: &str) -> Self {
         if let Ok(env) = input.parse::<Self>() {
             return env;
@@ -262,8 +258,6 @@ impl Telemetry {
             },
         ));
         // Configure scope on the main hub so that all threads will get the tags.
-        // The api_url tag is only meaningful once we know the real URL — skip
-        // it during the entrypoint window.
         let api_url = (environment != Env::Entrypoint).then(|| env_or_api_url.to_owned());
         sentry::Hub::main().configure_scope(move |scope| {
             if let Some(api_url) = api_url {
@@ -533,10 +527,6 @@ impl sentry::TransportFactory for TransportFactory {
 }
 
 #[cfg(test)]
-// `sentry::Hub::main()` is process-global; tests that touch it must serialise
-// on `SENTRY_HUB_LOCK`, which means the guard is intentionally held across
-// `await` points in `Telemetry::start`.
-#[allow(clippy::await_holding_lock, reason = "sentry hub is process-global")]
 mod tests {
     use std::time::SystemTime;
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -318,7 +318,7 @@ impl Telemetry {
     }
 
     /// Attaches the Firezone ID to the active Sentry session.
-    pub fn set_firezone_id(firezone_id: String) {
+    pub async fn set_firezone_id(firezone_id: String) {
         let new_user = compute_user(firezone_id);
         update_user(|user| {
             user.id = new_user.id;
@@ -327,9 +327,7 @@ impl Telemetry {
 
         // In case user and env are now available, re-eval feature-flags.
         if let (Some(id), Some(env)) = (Self::current_user(), Self::current_env()) {
-            tokio::spawn(async move {
-                feature_flags::evaluate_now(id, env).await;
-            });
+            feature_flags::evaluate_now(id, env).await;
         }
     }
 
@@ -587,7 +585,7 @@ mod tests {
         let mut telemetry = Telemetry::new();
         telemetry.start("entrypoint", "1.0.0", TESTING);
 
-        Telemetry::set_firezone_id("device-abc".to_owned());
+        Telemetry::set_firezone_id("device-abc".to_owned()).await;
 
         assert_eq!(Telemetry::current_user().as_deref(), Some("device-abc"));
     }
@@ -601,7 +599,7 @@ mod tests {
         telemetry.start("entrypoint", "1.0.0", TESTING);
 
         Telemetry::set_account_slug("acme".to_owned());
-        Telemetry::set_firezone_id("device-xyz".to_owned());
+        Telemetry::set_firezone_id("device-xyz".to_owned()).await;
 
         assert_eq!(Telemetry::current_user().as_deref(), Some("device-xyz"));
         assert_eq!(Telemetry::current_account_slug().as_deref(), Some("acme"));

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -199,21 +199,7 @@ impl Telemetry {
     }
 
     /// Starts a Sentry session.
-    ///
-    /// `env_or_api_url` is parsed by [`Env::parse`]: pass `"entrypoint"` at
-    /// process boot to capture crashes before settings load, or an api URL
-    /// once it has been resolved. A subsequent call with a different env will
-    /// stop the running session and start a new one. The Firezone ID is
-    /// attached separately via [`Telemetry::set_firezone_id`].
-    //
-    // Kept `async` so callers can keep awaiting it (and so the function lives
-    // inside a tokio runtime context for reqwest client construction); the
-    // body itself no longer awaits anything.
-    #[allow(
-        clippy::unused_async,
-        reason = "callers rely on tokio runtime context being active"
-    )]
-    pub async fn start(&mut self, env_or_api_url: &str, release: &str, dsn: Dsn) {
+    pub fn start(&mut self, env_or_api_url: &str, release: &str, dsn: Dsn) {
         let environment = Env::parse(env_or_api_url);
 
         if self
@@ -331,16 +317,7 @@ impl Telemetry {
         });
     }
 
-    /// Attaches the Firezone ID to the active Sentry session and triggers a
-    /// feature-flag evaluation.
-    ///
-    /// Mirrors Swift's `Telemetry.setUser(...)`: callers may [`start`] the
-    /// session before the ID is known and bind it later without restarting
-    /// Sentry. Safe to call before [`set_account_slug`] or after — the user
-    /// fields are merged.
-    ///
-    /// [`start`]: Self::start
-    /// [`set_account_slug`]: Self::set_account_slug
+    /// Attaches the Firezone ID to the active Sentry session.
     pub fn set_firezone_id(firezone_id: String) {
         let new_user = compute_user(firezone_id);
         update_user(|user| {
@@ -348,6 +325,7 @@ impl Telemetry {
             user.other.extend(new_user.other);
         });
 
+        // In case user and env are now available, re-eval feature-flags.
         if let (Some(id), Some(env)) = (Self::current_user(), Self::current_env()) {
             tokio::spawn(async move {
                 feature_flags::evaluate_now(id, env).await;
@@ -573,12 +551,8 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let mut telemetry = Telemetry::new();
-        telemetry
-            .start("wss://api.firez.one", "1.0.0", TESTING)
-            .await;
-        telemetry
-            .start("wss://example.com", "1.0.0", TESTING)
-            .await;
+        telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
+        telemetry.start("wss://example.com", "1.0.0", TESTING);
 
         assert!(telemetry.inner.is_none());
     }
@@ -598,12 +572,10 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let mut telemetry = Telemetry::new();
-        telemetry.start("entrypoint", "1.0.0", TESTING).await;
+        telemetry.start("entrypoint", "1.0.0", TESTING);
         assert_eq!(Telemetry::current_env(), Some(Env::Entrypoint));
 
-        telemetry
-            .start("wss://api.firez.one", "1.0.0", TESTING)
-            .await;
+        telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
         assert_eq!(Telemetry::current_env(), Some(Env::Staging));
     }
 
@@ -613,7 +585,7 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let mut telemetry = Telemetry::new();
-        telemetry.start("entrypoint", "1.0.0", TESTING).await;
+        telemetry.start("entrypoint", "1.0.0", TESTING);
 
         Telemetry::set_firezone_id("device-abc".to_owned());
 
@@ -626,7 +598,7 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let mut telemetry = Telemetry::new();
-        telemetry.start("entrypoint", "1.0.0", TESTING).await;
+        telemetry.start("entrypoint", "1.0.0", TESTING);
 
         Telemetry::set_account_slug("acme".to_owned());
         Telemetry::set_firezone_id("device-xyz".to_owned());

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -100,6 +100,9 @@ impl fmt::Display for Dsn {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum Env {
+    /// Pre-`api_url` placeholder used at process boot, so we can capture
+    /// crashes before settings are loaded. Mirrors Swift's `Telemetry.start()`.
+    Entrypoint,
     Production,
     Staging,
     DockerCompose,
@@ -121,12 +124,25 @@ impl From<ApiUrl<'_>> for Env {
 impl Env {
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
+            Env::Entrypoint => "entrypoint",
             Env::Production => "production",
             Env::Staging => "staging",
             Env::DockerCompose => "docker-compose",
             Env::Localhost => "localhost",
             Env::OnPrem => "on-prem",
         }
+    }
+
+    /// Parses a string as either an explicit env name or an API URL.
+    ///
+    /// Tries the env name first so callers can pass `"entrypoint"` (and tests
+    /// can pass any other variant directly). Falls back to URL-based detection,
+    /// which is total — unknown URLs land on `OnPrem`.
+    pub(crate) fn parse(input: &str) -> Self {
+        if let Ok(env) = input.parse::<Self>() {
+            return env;
+        }
+        Self::from(ApiUrl::new(input))
     }
 }
 
@@ -135,6 +151,7 @@ impl FromStr for Env {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "entrypoint" => Ok(Self::Entrypoint),
             "production" => Ok(Self::Production),
             "staging" => Ok(Self::Staging),
             "docker-compose" => Ok(Self::DockerCompose),
@@ -181,10 +198,23 @@ impl Telemetry {
         }
     }
 
-    pub async fn start(&mut self, api_url: &str, release: &str, dsn: Dsn, firezone_id: String) {
-        // Can't use URLs as `environment` directly, because Sentry doesn't allow slashes in environments.
-        // <https://docs.sentry.io/platforms/rust/configuration/environments/>
-        let environment = Env::from(ApiUrl::new(api_url));
+    /// Starts a Sentry session.
+    ///
+    /// `env_or_api_url` is parsed by [`Env::parse`]: pass `"entrypoint"` at
+    /// process boot to capture crashes before settings load, or an api URL
+    /// once it has been resolved. A subsequent call with a different env will
+    /// stop the running session and start a new one. The Firezone ID is
+    /// attached separately via [`Telemetry::set_firezone_id`].
+    //
+    // Kept `async` so callers can keep awaiting it (and so the function lives
+    // inside a tokio runtime context for reqwest client construction); the
+    // body itself no longer awaits anything.
+    #[allow(
+        clippy::unused_async,
+        reason = "callers rely on tokio runtime context being active"
+    )]
+    pub async fn start(&mut self, env_or_api_url: &str, release: &str, dsn: Dsn) {
+        let environment = Env::parse(env_or_api_url);
 
         if self
             .inner
@@ -206,13 +236,14 @@ impl Telemetry {
             set_current_user(None);
         }
 
-        if [Env::OnPrem, Env::Localhost, Env::DockerCompose].contains(&environment) {
-            tracing::debug!(%api_url, "Telemetry won't start in unofficial environment");
+        if matches!(
+            environment,
+            Env::OnPrem | Env::Localhost | Env::DockerCompose
+        ) {
+            tracing::debug!(%env_or_api_url, "Telemetry won't start in unofficial environment");
             return;
         }
 
-        // Important: Evaluate feature flags before checking `stream_logs` to avoid hitting the default.
-        feature_flags::evaluate_now(firezone_id.clone(), environment).await;
         tracing::info!(%environment, "Starting telemetry");
 
         let client_options = sentry::ClientOptions {
@@ -243,9 +274,14 @@ impl Telemetry {
                 ..client_options
             },
         ));
-        // Configure scope on the main hub so that all threads will get the tags
+        // Configure scope on the main hub so that all threads will get the tags.
+        // The api_url tag is only meaningful once we know the real URL — skip
+        // it during the entrypoint window.
+        let api_url = (environment != Env::Entrypoint).then(|| env_or_api_url.to_owned());
         sentry::Hub::main().configure_scope(move |scope| {
-            scope.set_tag("api_url", api_url);
+            if let Some(api_url) = api_url {
+                scope.set_tag("api_url", api_url);
+            }
             let ctx = sentry::integrations::contexts::utils::device_context();
             scope.set_context("device", ctx);
             let ctx = sentry::integrations::contexts::utils::rust_context();
@@ -254,8 +290,6 @@ impl Telemetry {
             if let Some(ctx) = sentry::integrations::contexts::utils::os_context() {
                 scope.set_context("os", ctx);
             }
-
-            scope.set_user(Some(compute_user(firezone_id)));
         });
         self.inner.replace(inner);
     }
@@ -295,6 +329,30 @@ impl Telemetry {
         update_user(|user| {
             user.other.insert("account_slug".to_owned(), slug.into());
         });
+    }
+
+    /// Attaches the Firezone ID to the active Sentry session and triggers a
+    /// feature-flag evaluation.
+    ///
+    /// Mirrors Swift's `Telemetry.setUser(...)`: callers may [`start`] the
+    /// session before the ID is known and bind it later without restarting
+    /// Sentry. Safe to call before [`set_account_slug`] or after — the user
+    /// fields are merged.
+    ///
+    /// [`start`]: Self::start
+    /// [`set_account_slug`]: Self::set_account_slug
+    pub fn set_firezone_id(firezone_id: String) {
+        let new_user = compute_user(firezone_id);
+        update_user(|user| {
+            user.id = new_user.id;
+            user.other.extend(new_user.other);
+        });
+
+        if let (Some(id), Some(env)) = (Self::current_user(), Self::current_env()) {
+            tokio::spawn(async move {
+                feature_flags::evaluate_now(id, env).await;
+            });
+        }
     }
 
     pub(crate) fn current_env() -> Option<Env> {
@@ -491,24 +549,90 @@ impl sentry::TransportFactory for TransportFactory {
 }
 
 #[cfg(test)]
+// `sentry::Hub::main()` is process-global; tests that touch it must serialise
+// on `SENTRY_HUB_LOCK`, which means the guard is intentionally held across
+// `await` points in `Telemetry::start`.
+#[allow(clippy::await_holding_lock, reason = "sentry hub is process-global")]
 mod tests {
+    use std::sync::Mutex;
     use std::time::SystemTime;
 
     use super::*;
 
+    /// `sentry::Hub::main()` is process-global; tests that initialise or
+    /// inspect it must run one at a time.
+    static SENTRY_HUB_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_sentry_hub() -> std::sync::MutexGuard<'static, ()> {
+        SENTRY_HUB_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
     #[tokio::test]
     async fn starting_session_for_unsupported_env_disables_current_one() {
+        let _guard = lock_sentry_hub();
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let mut telemetry = Telemetry::new();
         telemetry
-            .start("wss://api.firez.one", "1.0.0", TESTING, String::new())
+            .start("wss://api.firez.one", "1.0.0", TESTING)
             .await;
         telemetry
-            .start("wss://example.com", "1.0.0", TESTING, String::new())
+            .start("wss://example.com", "1.0.0", TESTING)
             .await;
 
         assert!(telemetry.inner.is_none());
+    }
+
+    #[test]
+    fn env_parse_recognises_explicit_names_and_falls_back_to_api_url() {
+        assert_eq!(Env::parse("entrypoint"), Env::Entrypoint);
+        assert_eq!(Env::parse("production"), Env::Production);
+        assert_eq!(Env::parse("wss://api.firezone.dev"), Env::Production);
+        assert_eq!(Env::parse("wss://api.firez.one"), Env::Staging);
+        assert_eq!(Env::parse("https://example.com"), Env::OnPrem);
+    }
+
+    #[tokio::test]
+    async fn entrypoint_then_real_env_swaps_running_session() {
+        let _guard = lock_sentry_hub();
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mut telemetry = Telemetry::new();
+        telemetry.start("entrypoint", "1.0.0", TESTING).await;
+        assert_eq!(Telemetry::current_env(), Some(Env::Entrypoint));
+
+        telemetry
+            .start("wss://api.firez.one", "1.0.0", TESTING)
+            .await;
+        assert_eq!(Telemetry::current_env(), Some(Env::Staging));
+    }
+
+    #[tokio::test]
+    async fn set_firezone_id_attaches_user_to_running_session() {
+        let _guard = lock_sentry_hub();
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mut telemetry = Telemetry::new();
+        telemetry.start("entrypoint", "1.0.0", TESTING).await;
+
+        Telemetry::set_firezone_id("device-abc".to_owned());
+
+        assert_eq!(Telemetry::current_user().as_deref(), Some("device-abc"));
+    }
+
+    #[tokio::test]
+    async fn set_account_slug_before_set_firezone_id_preserves_both() {
+        let _guard = lock_sentry_hub();
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mut telemetry = Telemetry::new();
+        telemetry.start("entrypoint", "1.0.0", TESTING).await;
+
+        Telemetry::set_account_slug("acme".to_owned());
+        Telemetry::set_firezone_id("device-xyz".to_owned());
+
+        assert_eq!(Telemetry::current_user().as_deref(), Some("device-xyz"));
+        assert_eq!(Telemetry::current_account_slug().as_deref(), Some("acme"));
     }
 
     #[test]

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -99,7 +99,8 @@ impl fmt::Display for Dsn {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub(crate) enum Env {
+#[doc(hidden)] // Only public for testing.
+pub enum Env {
     /// Pre-`api_url` placeholder used at process boot, so we can capture
     /// crashes before settings are loaded. Mirrors Swift's `Telemetry.start()`.
     Entrypoint,
@@ -287,6 +288,10 @@ impl Telemetry {
         }
     }
 
+    pub fn is_active(&self) -> bool {
+        self.inner.is_some()
+    }
+
     async fn end_session(&mut self) -> Result<()> {
         let Some(inner) = self.inner.take() else {
             return Ok(());
@@ -331,7 +336,8 @@ impl Telemetry {
         }
     }
 
-    pub(crate) fn current_env() -> Option<Env> {
+    #[doc(hidden)] // Only public for testing.
+    pub fn current_env() -> Option<Env> {
         let client = sentry::Hub::main().client()?;
         let env = client.options().environment.as_deref()?;
         let env = Env::from_str(env).ok()?;
@@ -339,11 +345,13 @@ impl Telemetry {
         Some(env)
     }
 
-    pub(crate) fn current_user() -> Option<String> {
+    #[doc(hidden)] // Only public for testing.
+    pub fn current_user() -> Option<String> {
         sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
     }
 
-    fn current_account_slug() -> Option<String> {
+    #[doc(hidden)] // Only public for testing.
+    pub fn current_account_slug() -> Option<String> {
         sentry::Hub::main()
             .configure_scope(|s| Some(s.user()?.other.get("account_slug")?.as_str()?.to_owned()))
     }
@@ -530,30 +538,9 @@ impl sentry::TransportFactory for TransportFactory {
 // `await` points in `Telemetry::start`.
 #[allow(clippy::await_holding_lock, reason = "sentry hub is process-global")]
 mod tests {
-    use std::sync::Mutex;
     use std::time::SystemTime;
 
     use super::*;
-
-    /// `sentry::Hub::main()` is process-global; tests that initialise or
-    /// inspect it must run one at a time.
-    static SENTRY_HUB_LOCK: Mutex<()> = Mutex::new(());
-
-    fn lock_sentry_hub() -> std::sync::MutexGuard<'static, ()> {
-        SENTRY_HUB_LOCK.lock().unwrap_or_else(|p| p.into_inner())
-    }
-
-    #[tokio::test]
-    async fn starting_session_for_unsupported_env_disables_current_one() {
-        let _guard = lock_sentry_hub();
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
-        let mut telemetry = Telemetry::new();
-        telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
-        telemetry.start("wss://example.com", "1.0.0", TESTING);
-
-        assert!(telemetry.inner.is_none());
-    }
 
     #[test]
     fn env_parse_recognises_explicit_names_and_falls_back_to_api_url() {
@@ -562,47 +549,6 @@ mod tests {
         assert_eq!(Env::parse("wss://api.firezone.dev"), Env::Production);
         assert_eq!(Env::parse("wss://api.firez.one"), Env::Staging);
         assert_eq!(Env::parse("https://example.com"), Env::OnPrem);
-    }
-
-    #[tokio::test]
-    async fn entrypoint_then_real_env_swaps_running_session() {
-        let _guard = lock_sentry_hub();
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
-        let mut telemetry = Telemetry::new();
-        telemetry.start("entrypoint", "1.0.0", TESTING);
-        assert_eq!(Telemetry::current_env(), Some(Env::Entrypoint));
-
-        telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
-        assert_eq!(Telemetry::current_env(), Some(Env::Staging));
-    }
-
-    #[tokio::test]
-    async fn set_firezone_id_attaches_user_to_running_session() {
-        let _guard = lock_sentry_hub();
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
-        let mut telemetry = Telemetry::new();
-        telemetry.start("entrypoint", "1.0.0", TESTING);
-
-        Telemetry::set_firezone_id("device-abc".to_owned()).await;
-
-        assert_eq!(Telemetry::current_user().as_deref(), Some("device-abc"));
-    }
-
-    #[tokio::test]
-    async fn set_account_slug_before_set_firezone_id_preserves_both() {
-        let _guard = lock_sentry_hub();
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
-        let mut telemetry = Telemetry::new();
-        telemetry.start("entrypoint", "1.0.0", TESTING);
-
-        Telemetry::set_account_slug("acme".to_owned());
-        Telemetry::set_firezone_id("device-xyz".to_owned()).await;
-
-        assert_eq!(Telemetry::current_user().as_deref(), Some("device-xyz"));
-        assert_eq!(Telemetry::current_account_slug().as_deref(), Some("acme"));
     }
 
     #[test]

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -17,7 +17,7 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
         Env::Production => Some(API_KEY_PROD),
         Env::Staging => Some(API_KEY_STAGING),
         Env::OnPrem => Some(API_KEY_ON_PREM),
-        Env::DockerCompose | Env::Localhost => None,
+        Env::Entrypoint | Env::DockerCompose | Env::Localhost => None,
     }
 }
 

--- a/rust/libs/telemetry/tests/README.md
+++ b/rust/libs/telemetry/tests/README.md
@@ -1,0 +1,3 @@
+# Telemetry tests
+
+Sentry's internal state is per-process, hence we test its functionality in integration tests which are spawned as separate processes by cargo.

--- a/rust/libs/telemetry/tests/attach_firezone_id.rs
+++ b/rust/libs/telemetry/tests/attach_firezone_id.rs
@@ -1,0 +1,13 @@
+use telemetry::{TESTING, Telemetry};
+
+#[tokio::test]
+async fn set_firezone_id_attaches_user_to_running_session() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut telemetry = Telemetry::new();
+    telemetry.start("entrypoint", "1.0.0", TESTING);
+
+    Telemetry::set_firezone_id("device-abc".to_owned()).await;
+
+    assert_eq!(Telemetry::current_user().as_deref(), Some("device-abc"));
+}

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -1,0 +1,15 @@
+use telemetry::{TESTING, Telemetry};
+
+#[tokio::test]
+async fn set_account_slug_before_set_firezone_id_preserves_both() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut telemetry = Telemetry::new();
+    telemetry.start("entrypoint", "1.0.0", TESTING);
+
+    Telemetry::set_account_slug("acme".to_owned());
+    Telemetry::set_firezone_id("device-xyz".to_owned()).await;
+
+    assert_eq!(Telemetry::current_user().as_deref(), Some("device-xyz"));
+    assert_eq!(Telemetry::current_account_slug().as_deref(), Some("acme"));
+}

--- a/rust/libs/telemetry/tests/swap_env.rs
+++ b/rust/libs/telemetry/tests/swap_env.rs
@@ -1,0 +1,13 @@
+use telemetry::{Env, TESTING, Telemetry};
+
+#[tokio::test]
+async fn entrypoint_then_real_env_swaps_running_session() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut telemetry = Telemetry::new();
+    telemetry.start("entrypoint", "1.0.0", TESTING);
+    assert_eq!(Telemetry::current_env(), Some(Env::Entrypoint));
+
+    telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
+    assert_eq!(Telemetry::current_env(), Some(Env::Staging));
+}

--- a/rust/libs/telemetry/tests/unsupported_disables_current.rs
+++ b/rust/libs/telemetry/tests/unsupported_disables_current.rs
@@ -1,0 +1,12 @@
+use telemetry::{TESTING, Telemetry};
+
+#[tokio::test]
+async fn starting_session_for_unsupported_env_disables_current_one() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut telemetry = Telemetry::new();
+    telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
+    telemetry.start("wss://example.com", "1.0.0", TESTING);
+
+    assert!(!telemetry.is_active());
+}

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -147,8 +147,8 @@ fn main() -> ExitCode {
             args.api_url.as_str(),
             VERSION.unwrap_or("unknown"),
             RELAY_DSN,
-            String::new(), // Relays don't have a Firezone ID.
         ));
+        // Relays don't have a Firezone ID, so no `set_firezone_id` call.
 
         telemetry
     } else {

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -141,19 +141,15 @@ fn main() -> ExitCode {
         .expect("Failed to build tokio runtime");
 
     let mut telemetry = if args.telemetry {
-        let mut telemetry = Telemetry::new();
-
-        runtime.block_on(telemetry.start(
-            args.api_url.as_str(),
-            VERSION.unwrap_or("unknown"),
-            RELAY_DSN,
-        ));
-        // Relays don't have a Firezone ID, so no `set_firezone_id` call.
-
-        telemetry
+        Telemetry::new()
     } else {
         Telemetry::disabled()
     };
+    telemetry.start(
+        args.api_url.as_str(),
+        VERSION.unwrap_or("unknown"),
+        RELAY_DSN,
+    );
 
     let code = match runtime.block_on(try_main(args)) {
         Ok(()) => ExitCode::SUCCESS,

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -20,6 +20,11 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull={13126}>
           Shows currently connected devices in the system tray menu.
         </ChangeItem>
+        {os == OS.Windows && (
+          <ChangeItem pull={13153}>
+            {"Restricts access to Firezone's configuration directory."}
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.5.12" date={new Date("2026-04-27")}>
         <ChangeItem pull={12684}>


### PR DESCRIPTION
The firezone ID file on Windows is currently unprotected and can be read by all users on the system. This was initially necessary because we also needed to read the ID from the GUI process to initialise things like telemetry.

We lock the ID file to just be readable by the system user and local administrators. This however means we need to rework how our `Telemetry` setup works.

Similarly to how we do this on macOS, we now initialize telemetry with an "entrypoint" environment when neither user ID nor environment is known. Once we learn the API URL from the settings and the user ID of IPC from the tunnel binary, we then update the telemetry context.