### PR TITLE
fix(gui-client): approve esbuild script

### DIFF
--- a/rust/gui-client/pnpm-workspace.yaml
+++ b/rust/gui-client/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
Not sure when this broke but we needed to approve the `esbuild` script to keep building the GUI client.