### PR TITLE
fix(ci): pin `pnpm` version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -27,7 +27,7 @@ runs:
         RC
     - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
-        version: latest
+        version: 10.33.0
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,4 +1,4 @@
-pnpm                             10.18.3
+pnpm                             10.33.0
 nodejs                           24.13.0
 github:cargo-bins/cargo-binstall 1.18.1
 github:DevinR528/cargo-sort      2.1.4


### PR DESCRIPTION
Unfortunately, #13157 didn't quite fix it. Turns out the problem is that we don't pin `pnpm` in CI and with version 11, what is currently a warning turns into a hard-error.