### PR TITLE
refactor(connlib): remove dedicated "connected clients"

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -155,8 +155,6 @@ pub struct ClientState {
     tun_config: TrackedState<TunConfig>,
     /// Cache of the resource list we emitted to the app.
     resource_list: TrackedState<ResourceList>,
-    /// Client peers we currently have a live connection to.
-    connected_pool_clients: BTreeSet<ClientId>,
 
     udp_dns_client: l3_udp_dns_client::Client,
     tcp_dns_client: dns_over_tcp::Client,
@@ -208,7 +206,6 @@ impl ClientState {
             pending_device_access: Default::default(),
             dns_resource_nat: Default::default(),
             resource_list: Default::default(),
-            connected_pool_clients: Default::default(),
         }
     }
 
@@ -240,20 +237,20 @@ impl ClientState {
     /// Builds the list of currently-connected device peers, joined against
     /// static-pool resource memberships so each entry knows which pool(s) it
     /// belongs to.
-    pub(crate) fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
+    fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
         let pools = self.static_device_pools().collect_vec();
 
-        self.connected_pool_clients
-            .iter()
+        self.clients
+            .ids()
             .map(|client_id| {
                 let pool_names = pools
                     .iter()
-                    .filter(|p| p.devices.iter().any(|d| d.id == *client_id))
+                    .filter(|p| p.devices.iter().any(|d| d.id == client_id))
                     .map(|p| p.name.clone())
                     .sorted()
                     .collect_vec();
                 ConnectedDeviceView {
-                    id: *client_id,
+                    id: client_id,
                     pools: pool_names,
                 }
             })
@@ -342,17 +339,16 @@ impl ClientState {
         };
 
         self.pending_device_access.remove(&entry.client_id);
-        // TODO: Update resource list with offline client.
 
-        let Some(_) = self.clients.remove(&entry.client_id) else {
-            return;
+        if self.clients.remove(&entry.client_id).is_some() {
+            self.node.close_connection(
+                ClientOrGatewayId::Client(entry.client_id),
+                p2p_control::goodbye(),
+                now,
+            );
         };
 
-        self.node.close_connection(
-            ClientOrGatewayId::Client(entry.client_id),
-            p2p_control::goodbye(),
-            now,
-        );
+        self.resource_list.update(self.resource_list_snapshot());
     }
 
     pub fn handle_device_pool_domain_resolved(
@@ -1111,10 +1107,11 @@ impl ClientState {
 
     #[tracing::instrument(level = "debug", skip_all, fields(client = %disconnected_client))]
     fn cleanup_connected_client(&mut self, disconnected_client: &ClientId) {
-        self.clients.remove(disconnected_client);
-        if self.connected_pool_clients.remove(disconnected_client) {
-            self.resource_list.update(self.resource_list_snapshot());
-        }
+        let Some(_client) = self.clients.remove(disconnected_client) else {
+            return;
+        };
+
+        self.resource_list.update(self.resource_list_snapshot());
     }
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {
@@ -1772,10 +1769,8 @@ impl ClientState {
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Gateway(id)) => {
                     self.update_site_status_by_gateway(&id, ResourceStatus::Online, now);
                 }
-                snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(id)) => {
-                    if self.connected_pool_clients.insert(id) {
-                        self.resource_list.update(self.resource_list_snapshot());
-                    }
+                snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(_)) => {
+                    self.resource_list.update(self.resource_list_snapshot());
                 }
             }
         }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -155,6 +155,8 @@ pub struct ClientState {
     tun_config: TrackedState<TunConfig>,
     /// Cache of the resource list we emitted to the app.
     resource_list: TrackedState<ResourceList>,
+    /// Client peers we currently have a live connection to.
+    connected_pool_clients: BTreeSet<ClientId>,
 
     udp_dns_client: l3_udp_dns_client::Client,
     tcp_dns_client: dns_over_tcp::Client,
@@ -206,6 +208,7 @@ impl ClientState {
             pending_device_access: Default::default(),
             dns_resource_nat: Default::default(),
             resource_list: Default::default(),
+            connected_pool_clients: Default::default(),
         }
     }
 
@@ -240,17 +243,17 @@ impl ClientState {
     fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
         let pools = self.static_device_pools().collect_vec();
 
-        self.clients
-            .ids()
+        self.connected_pool_clients
+            .iter()
             .map(|client_id| {
                 let pool_names = pools
                     .iter()
-                    .filter(|p| p.devices.iter().any(|d| d.id == client_id))
+                    .filter(|p| p.devices.iter().any(|d| d.id == *client_id))
                     .map(|p| p.name.clone())
                     .sorted()
                     .collect_vec();
                 ConnectedDeviceView {
-                    id: client_id,
+                    id: *client_id,
                     pools: pool_names,
                 }
             })
@@ -1107,11 +1110,10 @@ impl ClientState {
 
     #[tracing::instrument(level = "debug", skip_all, fields(client = %disconnected_client))]
     fn cleanup_connected_client(&mut self, disconnected_client: &ClientId) {
-        let Some(_client) = self.clients.remove(disconnected_client) else {
-            return;
-        };
-
-        self.resource_list.update(self.resource_list_snapshot());
+        self.clients.remove(disconnected_client);
+        if self.connected_pool_clients.remove(disconnected_client) {
+            self.resource_list.update(self.resource_list_snapshot());
+        }
     }
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {
@@ -1769,8 +1771,10 @@ impl ClientState {
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Gateway(id)) => {
                     self.update_site_status_by_gateway(&id, ResourceStatus::Online, now);
                 }
-                snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(_)) => {
-                    self.resource_list.update(self.resource_list_snapshot());
+                snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(id)) => {
+                    if self.connected_pool_clients.insert(id) {
+                        self.resource_list.update(self.resource_list_snapshot());
+                    }
                 }
             }
         }

--- a/rust/libs/connlib/tunnel/src/peer_store.rs
+++ b/rust/libs/connlib/tunnel/src/peer_store.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -8,7 +8,7 @@ use crate::gateway::ClientOnGateway;
 
 pub(crate) struct PeerStore<TId, P> {
     id_by_ip: HashMap<IpAddr, TId>,
-    peer_by_id: BTreeMap<TId, P>,
+    peer_by_id: HashMap<TId, P>,
 }
 
 impl<TId, P> Default for PeerStore<TId, P> {
@@ -22,13 +22,13 @@ impl<TId, P> Default for PeerStore<TId, P> {
 
 impl<TId, P> PeerStore<TId, P>
 where
-    TId: Ord + Hash + Eq + Copy + fmt::Debug + fmt::Display,
+    TId: Hash + Eq + Copy + fmt::Debug + fmt::Display,
     P: Peer,
 {
     pub(crate) fn extract_if(&mut self, f: impl Fn(&TId, &mut P) -> bool) -> Vec<(TId, P)> {
         let removed_peers = self
             .peer_by_id
-            .extract_if(.., |id, peer| f(id, peer))
+            .extract_if(|id, peer| f(id, peer))
             .collect::<Vec<_>>();
 
         self.id_by_ip
@@ -98,10 +98,6 @@ where
 
     pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut P> {
         self.peer_by_id.values_mut()
-    }
-
-    pub(crate) fn ids(&self) -> impl Iterator<Item = TId> + '_ {
-        self.peer_by_id.keys().copied()
     }
 
     pub(crate) fn clear(&mut self) {

--- a/rust/libs/connlib/tunnel/src/peer_store.rs
+++ b/rust/libs/connlib/tunnel/src/peer_store.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -8,7 +8,7 @@ use crate::gateway::ClientOnGateway;
 
 pub(crate) struct PeerStore<TId, P> {
     id_by_ip: HashMap<IpAddr, TId>,
-    peer_by_id: HashMap<TId, P>,
+    peer_by_id: BTreeMap<TId, P>,
 }
 
 impl<TId, P> Default for PeerStore<TId, P> {
@@ -22,13 +22,13 @@ impl<TId, P> Default for PeerStore<TId, P> {
 
 impl<TId, P> PeerStore<TId, P>
 where
-    TId: Hash + Eq + Copy + fmt::Debug + fmt::Display,
+    TId: Ord + Hash + Eq + Copy + fmt::Debug + fmt::Display,
     P: Peer,
 {
     pub(crate) fn extract_if(&mut self, f: impl Fn(&TId, &mut P) -> bool) -> Vec<(TId, P)> {
         let removed_peers = self
             .peer_by_id
-            .extract_if(|id, peer| f(id, peer))
+            .extract_if(.., |id, peer| f(id, peer))
             .collect::<Vec<_>>();
 
         self.id_by_ip
@@ -98,6 +98,10 @@ where
 
     pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut P> {
         self.peer_by_id.values_mut()
+    }
+
+    pub(crate) fn ids(&self) -> impl Iterator<Item = TId> + '_ {
+        self.peer_by_id.keys().copied()
     }
 
     pub(crate) fn clear(&mut self) {


### PR DESCRIPTION
Follow-up refactoring from #13126. We don't need to separately track which Clients we are connected to. The `PeerStore` already tracks that with one caveat: We insert into the `PeerStore` as soon as we set up a connection to the peer.

With the change, the peer will immediately show as online even though we are still setting up the connection. This usually doesn't take more than ~300-500ms however which is unlikely to be noticed by the user. If the connection fails, the state will reset and the device will be removed again from the resource list.