### PR TITLE
fix(portal): fix/refactor relative datetime component

### DIFF
--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -930,41 +930,53 @@ defmodule PortalWeb.CoreComponents do
   end
 
   @doc """
-  Returns a string the represents a relative time for a given Datetime
+  Returns a string that represents a relative time for a given DateTime
   from the current time or a given base time
   """
   attr :datetime, DateTime, default: nil
   attr :relative_to, DateTime, required: false
   attr :negative_class, :string, default: ""
   attr :popover, :boolean, default: true
+  attr :empty, :string, default: "Never"
 
   def relative_datetime(assigns) do
     assigns =
       assign_new(assigns, :relative_to, fn -> DateTime.utc_now() end)
 
+    assigns =
+      assigns
+      |> assign(:has_datetime?, not is_nil(assigns.datetime))
+      |> assign(:relative_datetime_text, relative_datetime_text(assigns))
+
     ~H"""
-    <.popover :if={not is_nil(@datetime) and @popover}>
+    <.popover :if={@has_datetime? and @popover}>
       <:target>
         <span class={[
           "underline underline-offset-2 decoration-1 decoration-dotted",
           DateTime.compare(@datetime, @relative_to) == :lt && @negative_class
         ]}>
-          {PortalWeb.Format.relative_datetime(@datetime, @relative_to)
-          |> String.capitalize()}
+          {@relative_datetime_text}
         </span>
       </:target>
       <:content>
         {@datetime}
       </:content>
     </.popover>
-    <span :if={not @popover}>
-      {PortalWeb.Format.relative_datetime(@datetime, @relative_to)
-      |> String.capitalize()}
+    <span :if={@has_datetime? and not @popover}>
+      {@relative_datetime_text}
     </span>
-    <span :if={is_nil(@datetime)}>
-      Never
+    <span :if={not @has_datetime?}>
+      {@empty}
     </span>
     """
+  end
+
+  defp relative_datetime_text(%{datetime: nil}), do: nil
+
+  defp relative_datetime_text(%{datetime: datetime, relative_to: relative_to}) do
+    datetime
+    |> PortalWeb.Format.relative_datetime(relative_to)
+    |> String.capitalize()
   end
 
   @doc """

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -433,6 +433,7 @@ defmodule PortalWeb.Sites.Components do
               <.relative_datetime
                 datetime={gateway.latest_session && gateway.latest_session.inserted_at}
                 popover={false}
+                empty="Unknown"
               />
             </span>
             <span class="text-xs text-[var(--text-tertiary)]">Remote IP</span>

--- a/elixir/test/portal_web/components/core_components_test.exs
+++ b/elixir/test/portal_web/components/core_components_test.exs
@@ -1,0 +1,37 @@
+defmodule PortalWeb.CoreComponentsTest do
+  use PortalWeb.ConnCase, async: true
+
+  import PortalWeb.CoreComponents
+
+  describe "relative_datetime/1" do
+    test "renders Never for a nil datetime without a popover" do
+      html = render_component(&relative_datetime/1, datetime: nil, popover: false)
+
+      assert html =~ "Never"
+    end
+
+    test "renders Never for a nil datetime with the default popover" do
+      html = render_component(&relative_datetime/1, datetime: nil)
+
+      assert html =~ "Never"
+    end
+
+    test "renders custom empty text for a nil datetime" do
+      html = render_component(&relative_datetime/1, datetime: nil, empty: "Unknown")
+
+      assert html =~ "Unknown"
+      refute html =~ "Never"
+    end
+
+    test "renders relative text for a datetime without a popover" do
+      html =
+        render_component(&relative_datetime/1,
+          datetime: ~U[2026-01-27 11:55:00Z],
+          relative_to: ~U[2026-01-27 12:00:00Z],
+          popover: false
+        )
+
+      assert html =~ "5 minutes ago"
+    end
+  end
+end


### PR DESCRIPTION
The `relative_datetime` component had a path that was not accounted for and would crash if given a `nil` for the datetime and the `popover` attr was `false`.  This PR fixes that and refactors the component slightly.  It also adds a new attr called `empty` to allow the caller to define what a `nil` datetime means for their use case.

Fixes: #13161