### PR TITLE
refactor(portal): update toast message to allow delay

### DIFF
--- a/elixir/assets/js/event_listeners.js
+++ b/elixir/assets/js/event_listeners.js
@@ -7,15 +7,61 @@ window.addEventListener("phx:copy", (event) => {
 });
 
 // Toast API helpers
-window.addEventListener("toast:show", (event) => {
-  const el = event.target;
+const delayedToastTimers = new WeakMap();
+
+function clearDelayedToastTimer(el) {
+  const timer = delayedToastTimers.get(el);
+
+  if (timer) {
+    clearTimeout(timer);
+    delayedToastTimers.delete(el);
+  }
+}
+
+function showToast(el) {
+  if (!el?.isConnected) {
+    return;
+  }
+
   if (el && !el.matches(":popover-open")) {
     el.showPopover();
   }
+}
+
+function showToastAfterDelay(el, delayMs) {
+  clearDelayedToastTimer(el);
+
+  const timer = setTimeout(() => {
+    delayedToastTimers.delete(el);
+    showToast(el);
+  }, delayMs);
+
+  delayedToastTimers.set(el, timer);
+}
+
+function getToastShowDelayMs(el) {
+  const delayMs = Number(el?.dataset.showDelayMs || "0");
+
+  return Number.isInteger(delayMs) && delayMs > 0 ? delayMs : 0;
+}
+
+window.addEventListener("toast:show", (event) => {
+  const el = event.target;
+  const delayMs = getToastShowDelayMs(el);
+
+  if (delayMs > 0) {
+    showToastAfterDelay(el, delayMs);
+    return;
+  }
+
+  showToast(el);
 });
 
 window.addEventListener("toast:hide", (event) => {
   const el = event.target;
+
+  clearDelayedToastTimer(el);
+
   if (el && el.matches(":popover-open")) {
     el.hidePopover();
   }

--- a/elixir/lib/portal_web/components/layouts/app.html.heex
+++ b/elixir/lib/portal_web/components/layouts/app.html.heex
@@ -12,10 +12,11 @@
       <.flash
         id="disconnected-toast"
         kind={:error}
-        title="We can't find the internet"
+        title="Connection lost"
         style="toast"
         phx-disconnected={JS.dispatch("toast:show", to: "#disconnected-toast")}
         phx-connected={JS.dispatch("toast:hide", to: "#disconnected-toast")}
+        data-show-delay-ms="300"
         autoshow={false}
       >
         Attempting to reconnect

--- a/elixir/test/portal_web/components/navigation_components_test.exs
+++ b/elixir/test/portal_web/components/navigation_components_test.exs
@@ -23,4 +23,19 @@ defmodule PortalWeb.NavigationComponentsTest do
       assert html =~ ~s(data-theme-option="dark")
     end
   end
+
+  describe "disconnected toast" do
+    test "renders reconnecting copy", %{conn: conn, account: account, actor: actor} do
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors")
+
+      assert html =~ ~s(id="disconnected-toast")
+      assert html =~ ~s(data-show-delay-ms="300")
+      assert html =~ "Connection lost"
+      assert html =~ "Attempting to reconnect"
+      refute html =~ "We can't find the internet"
+    end
+  end
 end


### PR DESCRIPTION
This PR updates the toast message component to allow a delay to be specified.  This is done to help reduce the noise when the websocket disconnects and reconnects when viewing the Firezone Portal.

The message for the connection being severed has also been updated to better represent what has happened.

Fixes: #13116