### PR TITLE
fix(gateway): embed checksums into systemd install

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -152,6 +152,39 @@ jobs:
         with:
           key: ${{ secrets.RELEASE_PR_BOT_GPG_KEY }}
           email: github-bot@firezone.dev
+      - name: Export gateway checksums
+        if: ${{ startsWith(inputs.release_name || github.event.release.name, 'gateway') && matrix.component == 'gateway' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
+          release_name: ${{ inputs.release_name || github.event.release.name }}
+        run: |
+          set -euo pipefail
+
+          version=${release_name#gateway-}
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+
+          gh release download "$release_name" \
+            --pattern "firezone-gateway_${version}_*.sha256sum.txt" \
+            --dir "$tmpdir"
+
+          for arch in x86_64 aarch64 armv7; do
+            checksum_file="$tmpdir/firezone-gateway_${version}_${arch}.sha256sum.txt"
+            checksum=$(awk '{ print $1 }' "$checksum_file")
+
+            if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Invalid checksum in $checksum_file: $checksum" >&2
+              exit 1
+            fi
+
+            case "$arch" in
+              x86_64) env_name=GATEWAY_X86_64_SHA256 ;;
+              aarch64) env_name=GATEWAY_AARCH64_SHA256 ;;
+              armv7) env_name=GATEWAY_ARMV7_SHA256 ;;
+            esac
+
+            echo "$env_name=$checksum" >> "$GITHUB_ENV"
+          done
       - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
         run: |
           set -x

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -53,6 +53,33 @@ function update_version_marker() {
     done
 }
 
+function update_gateway_checksum_marker() {
+    local marker="$1"
+    local checksum="$2"
+    local file="$3"
+
+    sed "${SEDARG[@]}" -e "/${marker}/{n;s/[0-9a-f]\{64\}/${checksum}/g;}" "$file"
+}
+
+function update_gateway_checksums() {
+    local version="$1"
+    local x86_64_checksum="$2"
+    local aarch64_checksum="$3"
+    local armv7_checksum="$4"
+    local installer="scripts/gateway-systemd-install.sh"
+
+    for checksum in "$x86_64_checksum" "$aarch64_checksum" "$armv7_checksum"; do
+        if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Invalid gateway checksum for $version: $checksum" >&2
+            exit 1
+        fi
+    done
+
+    update_gateway_checksum_marker "mark:gateway-x86_64-sha256" "$x86_64_checksum" "$installer"
+    update_gateway_checksum_marker "mark:gateway-aarch64-sha256" "$aarch64_checksum" "$installer"
+    update_gateway_checksum_marker "mark:gateway-armv7-sha256" "$armv7_checksum" "$installer"
+}
+
 function update_version_variables() {
     local COMPONENT="$1"
     local NEW_VERSION="$2"

--- a/scripts/create-publish-pr.sh
+++ b/scripts/create-publish-pr.sh
@@ -8,11 +8,42 @@ path_to_self=$(readlink -f "$0")
 scripts_dir=$(dirname "$path_to_self")
 path_to_bump_versions="$scripts_dir/bump-versions.sh"
 
+function gateway_checksum_env() {
+    local version="$1"
+    local name="$2"
+    local checksum="${!name:-}"
+
+    if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "$name must be set to the SHA-256 checksum for gateway $version" >&2
+        exit 1
+    fi
+
+    printf '%s' "$checksum"
+}
+
+function update_gateway_checksums() {
+    local version="$1"
+    local x86_64_checksum
+    local aarch64_checksum
+    local armv7_checksum
+
+    x86_64_checksum=$(gateway_checksum_env "$version" GATEWAY_X86_64_SHA256)
+    aarch64_checksum=$(gateway_checksum_env "$version" GATEWAY_AARCH64_SHA256)
+    armv7_checksum=$(gateway_checksum_env "$version" GATEWAY_ARMV7_SHA256)
+
+    "$path_to_bump_versions" update_gateway_checksums "$version" "$x86_64_checksum" "$aarch64_checksum" "$armv7_checksum"
+}
+
 # Create branch
 git checkout -b "chore/publish-$component-$version"
 
 # Update version variables in script
 "$path_to_bump_versions" update_version_variables "$component" "$version"
+
+if [ "$component" = "gateway" ]; then
+    update_gateway_checksums "$version"
+fi
+
 # Bump versions across the codebase
 "$path_to_bump_versions"
 

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -9,9 +9,14 @@ FIREZONE_TOKEN=${FIREZONE_TOKEN:-}
 FIREZONE_API_URL=${FIREZONE_API_URL:-wss://api.firezone.dev}
 RUST_LOG=${RUST_LOG:-info}
 
-# Can be used to download a specific version of the gateway from a custom URL
-FIREZONE_VERSION=${FIREZONE_VERSION:-latest}
-FIREZONE_ARTIFACT_URL=${FIREZONE_ARTIFACT_URL:-https://www.firezone.dev/dl/firezone-gateway}
+# mark:current-gateway-version
+GATEWAY_VERSION="1.5.2"
+# mark:gateway-x86_64-sha256
+GATEWAY_X86_64_SHA256="1f1d7e575a01e592d64aa93ea9c6025ee33e7b77dc9c507c18695600c1c41cc0"
+# mark:gateway-aarch64-sha256
+GATEWAY_AARCH64_SHA256="0772158376371a16d773ecfc1e5cffc6c7f0b92418df6623d6aed61945dda82b"
+# mark:gateway-armv7-sha256
+GATEWAY_ARMV7_SHA256="57db065b1ac89e55c2d3be436164f1674130136419e242736ad9ddbf0b2b1fb1"
 
 # Optional environment variables to configure logging and tracing
 FIREZONE_OTLP_GRPC_ENDPOINT=${OTLP_GRPC_ENDPOINT:-}
@@ -181,6 +186,33 @@ set -ue
 # Define the target directory and binary path
 TARGET_DIR="/opt/firezone/bin"
 BINARY_PATH="\$TARGET_DIR/firezone-gateway"
+ARTIFACT_BASE_URL="https://www.firezone.dev/dl/firezone-gateway"
+GATEWAY_VERSION="${GATEWAY_VERSION}"
+
+case "\$(uname -m)" in
+  x86_64)
+    arch="x86_64"
+    expected_sha256="${GATEWAY_X86_64_SHA256}"
+    ;;
+  aarch64 | arm64)
+    arch="aarch64"
+    expected_sha256="${GATEWAY_AARCH64_SHA256}"
+    ;;
+  armv7 | armv7l)
+    arch="armv7"
+    expected_sha256="${GATEWAY_ARMV7_SHA256}"
+    ;;
+  *)
+    echo "Unsupported architecture: \$(uname -m)"
+    exit 1
+    ;;
+esac
+
+download_url="\$ARTIFACT_BASE_URL/\$GATEWAY_VERSION/\$arch"
+
+sha256_for() {
+  sha256sum "\$1" | awk '{ print \$1 }'
+}
 
 # Create the directory if it doesn’t exist
 if [ ! -d "\$TARGET_DIR" ]; then
@@ -190,25 +222,47 @@ if [ ! -d "\$TARGET_DIR" ]; then
 fi
 
 
-# Download ${FIREZONE_VERSION} version of the gateway if it doesn't already exist
-if [ ! -e "\$BINARY_PATH" ]; then
+# Download the configured gateway version if it doesn't already exist
+needs_download=0
+if [ -e "\$BINARY_PATH" ]; then
+  actual_sha256=\$(sha256_for "\$BINARY_PATH")
+
+  if [ "\$actual_sha256" = "\$expected_sha256" ]; then
+    echo "\$BINARY_PATH found and checksum verified. Skipping download."
+  else
+    echo "\$BINARY_PATH found, but checksum does not match Firezone Gateway \$GATEWAY_VERSION for \$arch."
+    needs_download=1
+  fi
+else
   echo "\$BINARY_PATH not found."
-  echo "Downloading ${FIREZONE_VERSION} version from ${FIREZONE_ARTIFACT_URL}..."
-  arch=\$(uname -m)
+  needs_download=1
+fi
+
+if [ "\$needs_download" -eq 1 ]; then
+  echo "Downloading Firezone Gateway \$GATEWAY_VERSION from \$download_url..."
 
   # See https://www.firezone.dev/changelog for available binaries
-  curl -fsSL ${FIREZONE_ARTIFACT_URL}/${FIREZONE_VERSION}/\$arch -o "\$BINARY_PATH.download"
+  rm -f "\$BINARY_PATH.download"
+  curl -fsSL "\$download_url" -o "\$BINARY_PATH.download"
+
+  actual_sha256=\$(sha256_for "\$BINARY_PATH.download")
+  if [ "\$actual_sha256" != "\$expected_sha256" ]; then
+    echo "\$BINARY_PATH.download failed checksum verification!"
+    echo "Expected: \$expected_sha256"
+    echo "Actual:   \$actual_sha256"
+    rm -f "\$BINARY_PATH.download"
+    exit 1
+  fi
 
   if file "\$BINARY_PATH.download" | grep -q "ELF"; then
     mv "\$BINARY_PATH.download" "\$BINARY_PATH"
   else
     echo "\$BINARY_PATH.download is not an executable!"
-    echo "Ensure '${FIREZONE_ARTIFACT_URL}/${FIREZONE_VERSION}/\$arch' is accessible from this machine,"
+    echo "Ensure '\$download_url' is accessible from this machine,"
     echo "or download binary manually and install to \$BINARY_PATH"
+    rm -f "\$BINARY_PATH.download"
     exit 1
   fi
-else
-  echo "\$BINARY_PATH found. Skipping download."
 fi
 
 # Set proper permissions on each start

--- a/scripts/tests/bats/gateway_systemd_install.bats
+++ b/scripts/tests/bats/gateway_systemd_install.bats
@@ -131,6 +131,10 @@ token_file() {
     echo "$TEST_ROOT/etc/firezone/gateway-token"
 }
 
+init_script() {
+    echo "$TEST_ROOT/usr/local/bin/firezone-gateway-init"
+}
+
 file_mode() {
     stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
 }
@@ -161,6 +165,27 @@ refute_file_contains() {
     refute_file_contains 'FIREZONE_TOKEN=' "$(service_file)"
     grep -q '^test-secret-token$' "$(token_file)"
     [ "$(file_mode "$(token_file)")" = "400" ]
+}
+
+@test "gateway-systemd-install: generated init script uses hardcoded artifact URL and verifies checksums" {
+    run env \
+        FIREZONE_ID="test-gateway-id" \
+        FIREZONE_TOKEN="test-secret-token" \
+        "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ -f "$(init_script)" ]
+
+    grep -q '^ARTIFACT_BASE_URL="https://www.firezone.dev/dl/firezone-gateway"$' "$(init_script)"
+    grep -q '^GATEWAY_VERSION="1.5.2"$' "$(init_script)"
+    grep -q 'download_url="$ARTIFACT_BASE_URL/$GATEWAY_VERSION/$arch"' "$(init_script)"
+    [ "$(grep -Ec 'expected_sha256="[0-9a-f]{64}"' "$(init_script)")" -eq 3 ]
+    grep -q 'failed checksum verification' "$(init_script)"
+    refute_file_contains 'CURRENT_GATEWAY_VERSION' "$SCRIPT"
+    refute_file_contains 'FIREZONE_VERSION' "$SCRIPT"
+    refute_file_contains 'FIREZONE_VERSION' "$(init_script)"
+    refute_file_contains 'FIREZONE_ARTIFACT_URL' "$SCRIPT"
+    refute_file_contains 'FIREZONE_ARTIFACT_URL' "$(init_script)"
 }
 
 @test "gateway-systemd-install: migrates token and ID from legacy unit" {

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -109,6 +109,13 @@ module.exports = [
     permanent: false,
   },
   {
+    source: "/dl/firezone-gateway/latest/x86_64.sha256sum.txt",
+    destination:
+      // mark:current-gateway-version
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.5.2/firezone-gateway_1.5.2_x86_64.sha256sum.txt",
+    permanent: false,
+  },
+  {
     source: "/dl/firezone-gateway/latest/aarch64",
     destination:
       // mark:current-gateway-version
@@ -116,10 +123,24 @@ module.exports = [
     permanent: false,
   },
   {
+    source: "/dl/firezone-gateway/latest/aarch64.sha256sum.txt",
+    destination:
+      // mark:current-gateway-version
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.5.2/firezone-gateway_1.5.2_aarch64.sha256sum.txt",
+    permanent: false,
+  },
+  {
     source: "/dl/firezone-gateway/latest/armv7",
     destination:
       // mark:current-gateway-version
       "https://www.github.com/firezone/firezone/releases/download/gateway-1.5.2/firezone-gateway_1.5.2_armv7",
+    permanent: false,
+  },
+  {
+    source: "/dl/firezone-gateway/latest/armv7.sha256sum.txt",
+    destination:
+      // mark:current-gateway-version
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.5.2/firezone-gateway_1.5.2_armv7.sha256sum.txt",
     permanent: false,
   },
   /*

--- a/website/src/proxy.ts
+++ b/website/src/proxy.ts
@@ -67,14 +67,30 @@ const versionedRedirects = [
       "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_x86_64",
   },
   {
+    source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/x86_64\.sha256sum\.txt$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_x86_64.sha256sum.txt",
+  },
+  {
     source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/aarch64$/,
     destination:
       "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_aarch64",
   },
   {
+    source:
+      /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/aarch64\.sha256sum\.txt$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_aarch64.sha256sum.txt",
+  },
+  {
     source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/armv7$/,
     destination:
       "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_armv7",
+  },
+  {
+    source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/armv7\.sha256sum\.txt$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_armv7.sha256sum.txt",
   },
 ];
 


### PR DESCRIPTION
- Updates our release CI to embed shasums for the upcoming gateway versions into the systemd install script
- Removes `FIREZONE_ARTIFACT_URL` from the install script. This was added as a convenience for installing the gateway on staging, but that is not needed any longer with the QA env
