### PR TITLE
fix(gui-client): update Sentry DSN and tighten Tauri CSP

### DIFF
--- a/rust/gui-client/pnpm-workspace.yaml
+++ b/rust/gui-client/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 onlyBuiltDependencies:
-  - '@parcel/watcher'
+  - "@parcel/watcher"
   - esbuild

--- a/rust/gui-client/src-frontend/initSentry.ts
+++ b/rust/gui-client/src-frontend/initSentry.ts
@@ -17,7 +17,7 @@ export default function initSentry(apiUrl: string) {
   }
 
   const options = {
-    dsn: "https://2e17bf5ed24a78c0ac9e84a5de2bd6fc@o4507971108339712.ingest.us.sentry.io/4508008945549312",
+    dsn: "https://2e17bf5ed24a78c0ac9e84a5de2bd6fc@sentry.firezone.dev/4508008945549312",
     environment: env,
     release: `gui-client@${__APP_VERSION__}`,
   };

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
   "app": {
     "withGlobalTauri": true,
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://o4507971108339712.ingest.us.sentry.io; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'none'; manifest-src 'none'",
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://sentry.firezone.dev; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'none'; manifest-src 'none'",
       "capabilities": ["default-capability"]
     },
     "windows": [

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
   "app": {
     "withGlobalTauri": true,
     "security": {
-      "csp": null,
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://o4507971108339712.ingest.us.sentry.io; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'none'; manifest-src 'none'",
       "capabilities": ["default-capability"]
     },
     "windows": [


### PR DESCRIPTION
Updates the Sentry error tracking configuration to use a custom domain (`sentry.firezone.dev`) instead of the default Sentry-hosted endpoint, and adds a Content Security Policy (CSP) to the Tauri application.