### PR TITLE
fix(windows): lock down GUI/Tunnel pipe DACLs

### DIFF
--- a/.github/codespellrc
+++ b/.github/codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = ./elixir/_build,./elixir/lib/portal/name_generator.ex,./**/*.svg,./elixir/deps,./**/*.min.js,./kotlin/android/app/build,./kotlin/android/build,./website/.next,./website/pnpm-lock.yaml,./rust/connlib/tunnel/testcases,./rust/gui-client/dist,./rust/gui-client/pnpm-lock.yaml,./**/target,Cargo.lock,./website/docs/reference/api/*.mdx,./**/erl_crash.dump,./cover,./vendor,*.json,seeds.exs,./**/node_modules,./deps,./priv/static,./priv/plts,./**/priv/static,./.git,./_build,*.cast,./**/proptest-regressions,./elixir/assets/pnpm-lock.yaml,./elixir/test/test_helper.exs
-ignore-words-list = optin,crate,keypair,keypairs,iif,statics,wee,anull,commitish,inout,fo,superceded,ect,installin,couldn,wasn,isn,keep-alives
+ignore-words-list = optin,crate,keypair,keypairs,iif,statics,wee,anull,commitish,inout,fo,superceded,ect,installin,couldn,wasn,isn,keep-alives,bu

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "windows",
  "windows-core",
  "windows-implement",
+ "windows-security",
  "winreg 0.56.0",
  "wintun",
  "zbus",
@@ -2357,6 +2358,7 @@ dependencies = [
  "uuid",
  "windows",
  "windows-native-keyring-store",
+ "windows-security",
  "windows-service",
  "winreg 0.56.0",
  "zip",
@@ -9232,6 +9234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-security"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "tempfile",
+ "windows",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "libs/known-dirs",
     "libs/logging",
     "libs/telemetry",
+    "libs/windows-security",
     "relay/ebpf-shared",
     "relay/ebpf-turn-router",
     "relay/server",
@@ -235,6 +236,7 @@ windows = "0.61.3"
 windows-core = "0.61.1"
 windows-implement = "0.60.0"
 windows-native-keyring-store = "0.4.0"
+windows-security = { path = "libs/windows-security" }
 windows-service = "0.8.0"
 winreg = "0.56.0"
 zbus = "5.14.0"

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -88,6 +88,7 @@ tracing-journald = { workspace = true }
 admx-macro = { workspace = true }
 tauri-winrt-notification = "0.7.2"
 windows-native-keyring-store = { workspace = true }
+windows-security = { workspace = true }
 windows-service = { workspace = true }
 winreg = { workspace = true }
 
@@ -95,8 +96,11 @@ winreg = { workspace = true }
 workspace = true
 features = [
     "Win32_Foundation",
+    "Win32_Security",
+    # For `SECURITY_ATTRIBUTES` on the pipe
+    "Win32_System_Pipes",
+    # For IPC system
     "Win32_System_Threading",
-    "Win32_System_Pipes", # For IPC system
 ]
 
 [build-dependencies]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -96,10 +96,12 @@ winreg = { workspace = true }
 workspace = true
 features = [
     "Win32_Foundation",
+    # `SECURITY_ATTRIBUTES`, `IsWellKnownSid` for the pipe
     "Win32_Security",
-    # For `SECURITY_ATTRIBUTES` on the pipe
+    # `GetSecurityInfo` for the pipe-owner SID check
+    "Win32_Security_Authorization",
+    # IPC system
     "Win32_System_Pipes",
-    # For IPC system
     "Win32_System_Threading",
 ]
 

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -1,10 +1,14 @@
 use super::{NotFound, SocketId};
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Result, bail, ensure};
 use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Duration};
 use tokio::net::windows::named_pipe;
 use windows::Win32::{
-    Foundation::HANDLE,
-    Security::SECURITY_ATTRIBUTES,
+    Foundation::{HANDLE, HLOCAL, LocalFree},
+    Security::{
+        Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT},
+        IsWellKnownSid, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
+        SECURITY_ATTRIBUTES, WinLocalSystemSid,
+    },
     System::Pipes::{GetNamedPipeClientProcessId, GetNamedPipeServerProcessId},
 };
 use windows_security::SecurityDescriptor;
@@ -49,6 +53,12 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
         })
         .context("Couldn't connect to named pipe")?;
     let handle = HANDLE(stream.as_raw_handle());
+
+    if matches!(id, SocketId::Tunnel) {
+        ensure_pipe_owner_is_local_system(handle)
+            .context("Refusing to talk to non-LocalSystem Tunnel pipe server")?;
+    }
+
     let mut server_pid: u32 = 0;
     // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle
     // from Tokio, so it should be valid.
@@ -57,6 +67,62 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
 
     tracing::debug!(?server_pid, "Made IPC connection");
     Ok(stream)
+}
+
+/// Verifies that the connected named pipe was created by `LocalSystem`, the
+/// account the Tunnel service runs as.
+///
+/// `first_pipe_instance(true)` ensures nobody else can create another instance
+/// of our pipe *while the legit server is bound*, but during the brief window
+/// between teardown and re-bind (or before the service starts at all on a
+/// just-booted machine) a local user-mode process can race to be the *first*
+/// creator of the pipe name. The legit service then fails closed via
+/// `ERROR_ACCESS_DENIED`, leaving the squatter as the only server. This check
+/// catches that case before the GUI sends anything sensitive over the wire.
+///
+/// We inspect the *owner* of the kernel pipe object (set at creation time)
+/// rather than the server's current process token. The latter is racy if the
+/// server process exits and its PID is recycled between
+/// `GetNamedPipeServerProcessId` and `OpenProcess`.
+fn ensure_pipe_owner_is_local_system(handle: HANDLE) -> Result<()> {
+    let mut owner_sid = PSID::default();
+    let mut sd = PSECURITY_DESCRIPTOR::default();
+
+    // SAFETY: All pointers below are out-pointers to stack locals. On success
+    // the kernel allocates `sd` (which we release via `LocalFree`) and points
+    // `owner_sid` into that allocation.
+    let err = unsafe {
+        GetSecurityInfo(
+            handle,
+            SE_KERNEL_OBJECT,
+            OWNER_SECURITY_INFORMATION.0,
+            Some(&mut owner_sid),
+            None,
+            None,
+            None,
+            Some(&mut sd),
+        )
+    };
+    if err.0 != 0 {
+        return Err(std::io::Error::from_raw_os_error(err.0 as i32))
+            .context("GetSecurityInfo on pipe handle failed");
+    }
+
+    // SAFETY: `owner_sid` is a non-NULL pointer into `sd`'s buffer (still
+    // alive for this call) and `IsWellKnownSid` does not retain it.
+    let is_local_system = unsafe { IsWellKnownSid(owner_sid, WinLocalSystemSid) }.as_bool();
+
+    // SAFETY: `sd` was allocated by `GetSecurityInfo` and must be released
+    // with `LocalFree`. After this call no pointer derived from it is used.
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+
+    ensure!(
+        is_local_system,
+        "Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack"
+    );
+    Ok(())
 }
 
 impl Server {

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -146,13 +146,10 @@ fn create_pipe_server(pipe_path: &str) -> Result<named_pipe::NamedPipeServer, Pi
     // `CreateNamedPipeW`, so `sd` may be dropped after the call returns.
     match unsafe { server_options.create_with_security_attributes_raw(pipe_path, sa_ptr) } {
         Ok(x) => Ok(x),
-        Err(err) => {
-            if err.kind() == std::io::ErrorKind::PermissionDenied {
-                Err(PipeError::AccessDenied)
-            } else {
-                Err(anyhow::Error::from(err).into())
-            }
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            Err(PipeError::AccessDenied)
         }
+        Err(err) => Err(anyhow::Error::from(err).into()),
     }
 }
 

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -95,7 +95,7 @@ fn ensure_pipe_owner_is_local_system(handle: HANDLE) -> Result<()> {
         GetSecurityInfo(
             handle,
             SE_KERNEL_OBJECT,
-            OWNER_SECURITY_INFORMATION.0,
+            OWNER_SECURITY_INFORMATION,
             Some(&mut owner_sid),
             None,
             None,

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -54,7 +54,13 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
         .context("Couldn't connect to named pipe")?;
     let handle = HANDLE(stream.as_raw_handle());
 
-    if matches!(id, SocketId::Tunnel) {
+    // Skip the owner check in debug builds so the `gui-smoke-test`, which
+    // launches the Tunnel binary as a subprocess of the test runner (not as a
+    // Windows service running under `LocalSystem`), can drive a real GUI
+    // ↔ Tunnel handshake. Production builds are always release-mode (the
+    // `gui-smoke-test` workflow explicitly skips release mode), so the check
+    // is enforced there.
+    if !cfg!(debug_assertions) && matches!(id, SocketId::Tunnel) {
         ensure_pipe_owner_is_local_system(handle)
             .context("Refusing to talk to non-LocalSystem Tunnel pipe server")?;
     }

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -4,9 +4,25 @@ use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Durati
 use tokio::net::windows::named_pipe;
 use windows::Win32::{
     Foundation::HANDLE,
-    Security as WinSec,
+    Security::SECURITY_ATTRIBUTES,
     System::Pipes::{GetNamedPipeClientProcessId, GetNamedPipeServerProcessId},
 };
+use windows_security::SecurityDescriptor;
+
+/// SDDL applied to every Firezone named pipe.
+///
+/// The Tunnel pipe is created by the LocalSystem-privileged tunnel service and
+/// must be reachable by the user-mode GUI; the GUI pipe is created by the GUI
+/// itself but uses the same DACL for uniformity.
+///
+/// - `D:P` — protected DACL (don't inherit ACEs).
+/// - `(A;;FA;;;SY)` — Full Access for `LocalSystem` (the tunnel service).
+/// - `(A;;FA;;;BA)` — Full Access for `BUILTIN\Administrators`.
+/// - `(A;;FRFW;;;BU)` — `FILE_GENERIC_READ | FILE_GENERIC_WRITE | SYNCHRONIZE`
+///   for `BUILTIN\Users`. This is the alias the non-admin GUI runs under and
+///   excludes `NETWORK SERVICE`, `LOCAL SERVICE`, `ANONYMOUS LOGON`, IIS app
+///   pool identities, and arbitrary new service accounts (unlike `AU`).
+const PIPE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
 
 pub(crate) struct Server {
     pipe_path: String,
@@ -114,32 +130,20 @@ fn create_pipe_server(pipe_path: &str) -> Result<named_pipe::NamedPipeServer, Pi
     let mut server_options = named_pipe::ServerOptions::new();
     server_options.first_pipe_instance(true);
 
-    // This will allow non-admin clients to connect to us even though we're running with privilege
-    let mut sd = WinSec::SECURITY_DESCRIPTOR::default();
-    let psd = WinSec::PSECURITY_DESCRIPTOR(&mut sd as *mut _ as *mut c_void);
-    // SAFETY: Unsafe needed to call Win32 API. There shouldn't be any threading or lifetime problems, because we only pass pointers to our local vars to Win32, and Win32 shouldn't sae them anywhere.
-    unsafe {
-        // ChatGPT pointed me to these functions
-        WinSec::InitializeSecurityDescriptor(
-            psd,
-            windows::Win32::System::SystemServices::SECURITY_DESCRIPTOR_REVISION,
-        )
-        .context("InitializeSecurityDescriptor failed")?;
-        WinSec::SetSecurityDescriptorDacl(psd, true, None, false)
-            .context("SetSecurityDescriptorDacl failed")?;
-    }
-
-    let mut sa = WinSec::SECURITY_ATTRIBUTES {
-        nLength: 0,
-        lpSecurityDescriptor: psd.0,
+    // Build a `SECURITY_ATTRIBUTES` that grants the non-admin GUI (running as
+    // `BUILTIN\Users`) read/write access to the pipe while keeping it shut to
+    // `NETWORK SERVICE`, anonymous logons, and other unintended principals.
+    let sd = SecurityDescriptor::from_sddl(PIPE_SDDL).map_err(PipeError::Other)?;
+    let mut sa = SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: sd.as_raw().0,
         bInheritHandle: false.into(),
     };
-    sa.nLength = std::mem::size_of_val(&sa)
-        .try_into()
-        .context("Size of SECURITY_ATTRIBUTES struct is not right")?;
 
     let sa_ptr = &mut sa as *mut _ as *mut c_void;
-    // SAFETY: Unsafe needed to call Win32 API. We only pass pointers to local vars, and Win32 shouldn't store them, so there shouldn't be any threading of lifetime problems.
+    // SAFETY: `sa_ptr` is a valid pointer to a fully-initialised
+    // `SECURITY_ATTRIBUTES`. The kernel copies the security descriptor during
+    // `CreateNamedPipeW`, so `sd` may be dropped after the call returns.
     match unsafe { server_options.create_with_security_attributes_raw(pipe_path, sa_ptr) } {
         Ok(x) => Ok(x),
         Err(err) => {

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -56,6 +56,7 @@ tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 windows-core = { workspace = true }
 windows-implement = { workspace = true }
+windows-security = { workspace = true }
 winreg = { workspace = true }
 wintun = "0.5.1"
 
@@ -70,14 +71,14 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_Security",
-    "Win32_Security_Authorization",
     "Win32_System_Com",
     # Needed to listen for system DNS changes
     "Win32_System_Registry",
     "Win32_System_Threading",
     "Win32_System_SystemInformation",
     # For uptime
-    "Win32_System_GroupPolicy", # For NRPT when GPO is used
+    # For NRPT when GPO is used
+    "Win32_System_GroupPolicy",
 ]
 
 [dev-dependencies]

--- a/rust/libs/bin-shared/src/device_id.rs
+++ b/rust/libs/bin-shared/src/device_id.rs
@@ -163,8 +163,21 @@ fn set_dir_permissions(dir: &Path) -> Result<()> {
 
 #[cfg(target_os = "windows")]
 fn set_dir_permissions(dir: &Path) -> Result<()> {
-    windows_security::SecurityDescriptor::from_sddl(windows_security::DIR_SDDL)?.apply_to_path(dir)
+    windows_security::SecurityDescriptor::from_sddl(DIR_SDDL)?.apply_to_path(dir)
 }
+
+/// SDDL for the Tunnel service config directory.
+///
+/// `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` reads as:
+/// - `D:P` — set a *protected* DACL (don't inherit ACEs from the parent
+///   directory).
+/// - `A;OICI;FA;;;SY` — *Allow* `Full Access` to `LocalSystem`, with
+///   `Object` and `Container` inheritance so child files and dirs inherit
+///   the same access.
+/// - `A;OICI;FA;;;BA` — *Allow* `Full Access` to `BUILTIN\Administrators`,
+///   with the same inheritance flags.
+#[cfg(target_os = "windows")]
+const DIR_SDDL: &str = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)";
 
 /// Does nothing on other non-Linux systems
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
@@ -184,166 +197,24 @@ fn set_id_permissions(path: &Path) -> Result<()> {
 
 #[cfg(target_os = "windows")]
 fn set_id_permissions(path: &Path) -> Result<()> {
-    windows_security::SecurityDescriptor::from_sddl(windows_security::FILE_SDDL)?
-        .apply_to_path(path)
+    windows_security::SecurityDescriptor::from_sddl(FILE_SDDL)?.apply_to_path(path)
 }
+
+/// SDDL for the on-disk `firezone-id` file.
+///
+/// `D:P(A;;FA;;;SY)(A;;FA;;;BA)` reads as:
+/// - `D:P` — set a *protected* DACL.
+/// - `A;;FA;;;SY` — *Allow* `Full Access` to `LocalSystem`. No inheritance
+///   flags are needed since this is a leaf file.
+/// - `A;;FA;;;BA` — *Allow* `Full Access` to `BUILTIN\Administrators`.
+#[cfg(target_os = "windows")]
+const FILE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)";
 
 /// Does nothing on other non-Linux systems
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 #[expect(clippy::unnecessary_wraps)]
 fn set_id_permissions(_: &Path) -> Result<()> {
     Ok(())
-}
-
-#[cfg(target_os = "windows")]
-mod windows_security {
-    //! Safe wrappers around the Windows security descriptor APIs we need to
-    //! lock down the on-disk Firezone ID.
-    //!
-    //! The intent is to confine all unsafe FFI to this module so that callers
-    //! get a Rust-y interface that upholds Windows' lifetime and ownership
-    //! requirements (`LocalFree` on the buffer returned by
-    //! `ConvertStringSecurityDescriptorToSecurityDescriptorW`, etc.).
-
-    use anyhow::{Context as _, Result, ensure};
-    use std::{ffi::OsStr, os::windows::ffi::OsStrExt, path::Path, ptr};
-    use windows::{
-        Win32::{
-            Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree},
-            Security::{
-                ACL,
-                Authorization::{
-                    ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
-                    SE_FILE_OBJECT, SetNamedSecurityInfoW,
-                },
-                DACL_SECURITY_INFORMATION, GetSecurityDescriptorDacl,
-                PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
-            },
-        },
-        core::{BOOL, PCWSTR},
-    };
-
-    /// SDDL for the Tunnel service config directory.
-    ///
-    /// `D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` reads as:
-    /// - `D:P` — set a *protected* DACL (don't inherit ACEs from the parent
-    ///   directory).
-    /// - `A;OICI;FA;;;SY` — *Allow* `Full Access` to `LocalSystem`, with
-    ///   `Object` and `Container` inheritance so child files and dirs inherit
-    ///   the same access.
-    /// - `A;OICI;FA;;;BA` — *Allow* `Full Access` to `BUILTIN\Administrators`,
-    ///   with the same inheritance flags.
-    pub(super) const DIR_SDDL: &str = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)";
-
-    /// SDDL for the on-disk `firezone-id` file.
-    ///
-    /// `D:P(A;;FA;;;SY)(A;;FA;;;BA)` reads as:
-    /// - `D:P` — set a *protected* DACL.
-    /// - `A;;FA;;;SY` — *Allow* `Full Access` to `LocalSystem`. No inheritance
-    ///   flags are needed since this is a leaf file.
-    /// - `A;;FA;;;BA` — *Allow* `Full Access` to `BUILTIN\Administrators`.
-    pub(super) const FILE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)";
-
-    /// Owned wrapper around a `PSECURITY_DESCRIPTOR` that was allocated by
-    /// `ConvertStringSecurityDescriptorToSecurityDescriptorW`.
-    ///
-    /// The only constructor, [`Self::from_sddl`], guarantees that the inner
-    /// pointer was returned by that API. This upholds the safety invariant of
-    /// the [`Drop`] impl, which calls `LocalFree`.
-    pub(super) struct SecurityDescriptor(PSECURITY_DESCRIPTOR);
-
-    impl SecurityDescriptor {
-        /// Parses an SDDL string into an owned security descriptor.
-        ///
-        /// See [SDDL for Conditional ACEs](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format).
-        pub(super) fn from_sddl(sddl: &str) -> Result<Self> {
-            let sddl = wide(sddl);
-            let mut descriptor = PSECURITY_DESCRIPTOR::default();
-
-            // SAFETY: `sddl` is null-terminated by `wide` and `&mut descriptor`
-            // is a valid out-pointer to a stack-allocated value. On success,
-            // `descriptor` is set to a buffer that we own and that will be
-            // released by our `Drop` impl.
-            unsafe {
-                ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                    PCWSTR(sddl.as_ptr()),
-                    SDDL_REVISION_1,
-                    &mut descriptor,
-                    None,
-                )
-            }
-            .context("Failed to build Windows security descriptor from SDDL")?;
-
-            Ok(Self(descriptor))
-        }
-
-        /// Applies this security descriptor's DACL to the named file or
-        /// directory, replacing any inherited ACEs.
-        pub(super) fn apply_to_path(&self, path: &Path) -> Result<()> {
-            let dacl = self.dacl()?;
-            let path_wide = wide(path.as_os_str());
-            let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
-
-            // SAFETY: `path_wide` is null-terminated, `dacl` borrows from
-            // `self`'s buffer (which lives for this call), and Windows does not
-            // retain any of these pointers after the call returns.
-            let err = unsafe {
-                SetNamedSecurityInfoW(
-                    PCWSTR(path_wide.as_ptr()),
-                    SE_FILE_OBJECT,
-                    security_info,
-                    None,
-                    None,
-                    Some(dacl),
-                    None,
-                )
-            };
-
-            if err != ERROR_SUCCESS {
-                return Err(std::io::Error::from_raw_os_error(err.0 as i32)).with_context(|| {
-                    format!("Failed to set Windows DACL on `{}`", path.display())
-                });
-            }
-
-            Ok(())
-        }
-
-        fn dacl(&self) -> Result<*const ACL> {
-            let mut dacl_present = BOOL::default();
-            let mut dacl_defaulted = BOOL::default();
-            let mut dacl: *mut ACL = ptr::null_mut();
-
-            // SAFETY: `self.0` is a valid security descriptor (only constructed
-            // via `from_sddl`). The other arguments are valid out-pointers into
-            // local variables.
-            unsafe {
-                GetSecurityDescriptorDacl(self.0, &mut dacl_present, &mut dacl, &mut dacl_defaulted)
-            }
-            .context("Failed to get DACL from Windows security descriptor")?;
-
-            ensure!(
-                dacl_present.as_bool(),
-                "Windows security descriptor has no DACL"
-            );
-
-            Ok(dacl)
-        }
-    }
-
-    impl Drop for SecurityDescriptor {
-        fn drop(&mut self) {
-            // SAFETY: `self.0` was allocated by
-            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` (the only
-            // constructor of `Self`) and must be released with `LocalFree`.
-            unsafe {
-                LocalFree(Some(HLOCAL(self.0.0)));
-            }
-        }
-    }
-
-    fn wide(s: impl AsRef<OsStr>) -> Vec<u16> {
-        s.as_ref().encode_wide().chain(Some(0)).collect()
-    }
 }
 
 #[cfg(target_os = "linux")]
@@ -424,78 +295,5 @@ mod tests {
         let id = compute_from_hardware_id(CLIENT_APP_ID).unwrap();
 
         assert!(!id.id.is_empty())
-    }
-
-    #[cfg(target_os = "windows")]
-    mod windows {
-        use super::super::windows_security::{DIR_SDDL, FILE_SDDL, SecurityDescriptor};
-        use tempfile::tempdir;
-
-        /// Permissive DACL we use in tests that need to actually apply a
-        /// security descriptor. Granting Full Access to `WD` (Everyone) keeps
-        /// the temp dir/file deletable by the test process during cleanup,
-        /// regardless of whether tests run as Administrator.
-        const PERMISSIVE_SDDL: &str = "D:(A;;FA;;;WD)";
-
-        #[test]
-        fn parse_dir_sddl_does_not_crash() {
-            // Exercises `ConvertStringSecurityDescriptorToSecurityDescriptorW`
-            // and the `Drop` impl that calls `LocalFree`.
-            SecurityDescriptor::from_sddl(DIR_SDDL).unwrap();
-        }
-
-        #[test]
-        fn parse_file_sddl_does_not_crash() {
-            SecurityDescriptor::from_sddl(FILE_SDDL).unwrap();
-        }
-
-        #[test]
-        fn parse_invalid_sddl_returns_err() {
-            // Empty strings *do* parse successfully on Windows (they yield a
-            // descriptor with no DACL/SACL set), so we only assert on garbage.
-            assert!(SecurityDescriptor::from_sddl("not a valid SDDL").is_err());
-        }
-
-        #[test]
-        fn apply_dacl_to_temp_dir() {
-            let dir = tempdir().unwrap();
-
-            SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
-                .unwrap()
-                .apply_to_path(dir.path())
-                .unwrap();
-        }
-
-        #[test]
-        fn apply_dacl_to_temp_file() {
-            let dir = tempdir().unwrap();
-            let path = dir.path().join("firezone-id");
-            std::fs::write(&path, "{}").unwrap();
-
-            SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
-                .unwrap()
-                .apply_to_path(&path)
-                .unwrap();
-        }
-
-        #[test]
-        fn apply_dacl_to_missing_path_returns_err() {
-            let dir = tempdir().unwrap();
-            let missing = dir.path().join("does-not-exist");
-
-            let result = SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
-                .unwrap()
-                .apply_to_path(&missing);
-            assert!(result.is_err());
-        }
-
-        #[test]
-        fn dropping_many_security_descriptors_does_not_crash() {
-            // Hammer `Drop` to surface any double-free or use-after-free.
-            for _ in 0..1024 {
-                let _ = SecurityDescriptor::from_sddl(DIR_SDDL).unwrap();
-                let _ = SecurityDescriptor::from_sddl(FILE_SDDL).unwrap();
-            }
-        }
     }
 }

--- a/rust/libs/windows-security/Cargo.toml
+++ b/rust/libs/windows-security/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 license = { workspace = true }
 description = "Safe Rust wrappers around the Windows security descriptor APIs."
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 anyhow = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]

--- a/rust/libs/windows-security/Cargo.toml
+++ b/rust/libs/windows-security/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "windows-security"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+description = "Safe Rust wrappers around the Windows security descriptor APIs."
+
+[dependencies]
+anyhow = { workspace = true }
+
+[target.'cfg(windows)'.dependencies.windows]
+workspace = true
+features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization"]
+
+[target.'cfg(windows)'.dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/windows-security/src/lib.rs
+++ b/rust/libs/windows-security/src/lib.rs
@@ -8,6 +8,7 @@
 //! Windows-only: builds to an empty rlib on other platforms so cross-platform
 //! callers can simply gate their use sites with `cfg(windows)`.
 
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 #![cfg(windows)]
 
 use anyhow::{Context as _, Result, ensure};

--- a/rust/libs/windows-security/src/lib.rs
+++ b/rust/libs/windows-security/src/lib.rs
@@ -118,6 +118,13 @@ impl SecurityDescriptor {
             dacl_present.as_bool(),
             "Windows security descriptor has no DACL"
         );
+        // A `NULL` DACL with `dacl_present == TRUE` semantically means
+        // "unrestricted access" — distinct from "no DACL set". We never
+        // want to propagate that to `SetNamedSecurityInfoW`.
+        ensure!(
+            !dacl.is_null(),
+            "Windows security descriptor has a NULL DACL"
+        );
 
         Ok(dacl)
     }

--- a/rust/libs/windows-security/src/lib.rs
+++ b/rust/libs/windows-security/src/lib.rs
@@ -1,0 +1,231 @@
+//! Safe wrappers around the Windows security descriptor APIs.
+//!
+//! The crate confines all unsafe FFI to a small set of types so that callers
+//! get a Rust-y interface that upholds Windows' lifetime and ownership
+//! requirements (e.g. `LocalFree` on the buffer returned by
+//! `ConvertStringSecurityDescriptorToSecurityDescriptorW`).
+//!
+//! Windows-only: builds to an empty rlib on other platforms so cross-platform
+//! callers can simply gate their use sites with `cfg(windows)`.
+
+#![cfg(windows)]
+
+use anyhow::{Context as _, Result, ensure};
+use std::{ffi::OsStr, os::windows::ffi::OsStrExt, path::Path, ptr};
+use windows::{
+    Win32::{
+        Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree},
+        Security::{
+            ACL,
+            Authorization::{
+                ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+                SE_FILE_OBJECT, SetNamedSecurityInfoW,
+            },
+            DACL_SECURITY_INFORMATION, GetSecurityDescriptorDacl,
+            PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+        },
+    },
+    core::{BOOL, PCWSTR},
+};
+
+/// Owned wrapper around a `PSECURITY_DESCRIPTOR` allocated by
+/// `ConvertStringSecurityDescriptorToSecurityDescriptorW`.
+///
+/// The only constructor, [`Self::from_sddl`], guarantees that the inner
+/// pointer was returned by that API. This upholds the safety invariant of the
+/// [`Drop`] impl, which calls `LocalFree`.
+pub struct SecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+impl SecurityDescriptor {
+    /// Parses an SDDL string into an owned security descriptor.
+    ///
+    /// See [SDDL for Conditional ACEs](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format).
+    pub fn from_sddl(sddl: &str) -> Result<Self> {
+        let sddl = wide(sddl);
+        let mut descriptor = PSECURITY_DESCRIPTOR::default();
+
+        // SAFETY: `sddl` is null-terminated by `wide` and `&mut descriptor` is
+        // a valid out-pointer to a stack-allocated value. On success,
+        // `descriptor` is set to a buffer that we own and that will be released
+        // by our `Drop` impl.
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                PCWSTR(sddl.as_ptr()),
+                SDDL_REVISION_1,
+                &mut descriptor,
+                None,
+            )
+        }
+        .context("Failed to build Windows security descriptor from SDDL")?;
+
+        Ok(Self(descriptor))
+    }
+
+    /// Applies this security descriptor's DACL to the named file or directory,
+    /// replacing any inherited ACEs.
+    pub fn apply_to_path(&self, path: &Path) -> Result<()> {
+        let dacl = self.dacl()?;
+        let path_wide = wide(path.as_os_str());
+        let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
+
+        // SAFETY: `path_wide` is null-terminated, `dacl` borrows from `self`'s
+        // buffer (which lives for this call), and Windows does not retain any
+        // of these pointers after the call returns.
+        let err = unsafe {
+            SetNamedSecurityInfoW(
+                PCWSTR(path_wide.as_ptr()),
+                SE_FILE_OBJECT,
+                security_info,
+                None,
+                None,
+                Some(dacl),
+                None,
+            )
+        };
+
+        if err != ERROR_SUCCESS {
+            return Err(std::io::Error::from_raw_os_error(err.0 as i32))
+                .with_context(|| format!("Failed to set Windows DACL on `{}`", path.display()));
+        }
+
+        Ok(())
+    }
+
+    /// Returns the raw `PSECURITY_DESCRIPTOR` for use in
+    /// `SECURITY_ATTRIBUTES::lpSecurityDescriptor` when creating a kernel
+    /// object (named pipe, mutex, file, ...).
+    ///
+    /// The kernel copies the descriptor when the kernel object is created, so
+    /// `self` may be dropped after the syscall returns.
+    pub fn as_raw(&self) -> PSECURITY_DESCRIPTOR {
+        self.0
+    }
+
+    fn dacl(&self) -> Result<*const ACL> {
+        let mut dacl_present = BOOL::default();
+        let mut dacl_defaulted = BOOL::default();
+        let mut dacl: *mut ACL = ptr::null_mut();
+
+        // SAFETY: `self.0` is a valid security descriptor (only constructed
+        // via `from_sddl`). The other arguments are valid out-pointers into
+        // local variables.
+        unsafe {
+            GetSecurityDescriptorDacl(self.0, &mut dacl_present, &mut dacl, &mut dacl_defaulted)
+        }
+        .context("Failed to get DACL from Windows security descriptor")?;
+
+        ensure!(
+            dacl_present.as_bool(),
+            "Windows security descriptor has no DACL"
+        );
+
+        Ok(dacl)
+    }
+}
+
+impl Drop for SecurityDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was allocated by
+        // `ConvertStringSecurityDescriptorToSecurityDescriptorW` (the only
+        // constructor of `Self`) and must be released with `LocalFree`.
+        unsafe {
+            LocalFree(Some(HLOCAL(self.0.0)));
+        }
+    }
+}
+
+fn wide(s: impl AsRef<OsStr>) -> Vec<u16> {
+    s.as_ref().encode_wide().chain(Some(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// SDDL with both protected DACL ACEs we want round-tripped through
+    /// `from_sddl` -> `Drop`.
+    const DACL_ONLY_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)";
+
+    /// Permissive DACL we use in tests that need to actually apply a security
+    /// descriptor. Granting Full Access to `WD` (Everyone) keeps the temp
+    /// dir/file deletable by the test process during cleanup, regardless of
+    /// whether tests run as Administrator.
+    const PERMISSIVE_SDDL: &str = "D:(A;;FA;;;WD)";
+
+    #[test]
+    fn parse_dacl_only_sddl_does_not_crash() {
+        // Exercises `ConvertStringSecurityDescriptorToSecurityDescriptorW`
+        // and the `Drop` impl that calls `LocalFree`.
+        SecurityDescriptor::from_sddl(DACL_ONLY_SDDL).unwrap();
+    }
+
+    #[test]
+    fn parse_invalid_sddl_returns_err() {
+        // Empty strings *do* parse successfully on Windows (they yield a
+        // descriptor with no DACL/SACL set), so we only assert on garbage.
+        assert!(SecurityDescriptor::from_sddl("not a valid SDDL").is_err());
+    }
+
+    #[test]
+    fn apply_dacl_to_temp_dir() {
+        let dir = tempdir().unwrap();
+
+        SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
+            .unwrap()
+            .apply_to_path(dir.path())
+            .unwrap();
+    }
+
+    #[test]
+    fn apply_dacl_to_temp_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("firezone-id");
+        std::fs::write(&path, "{}").unwrap();
+
+        SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
+            .unwrap()
+            .apply_to_path(&path)
+            .unwrap();
+    }
+
+    #[test]
+    fn apply_dacl_to_missing_path_returns_err() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+
+        let result = SecurityDescriptor::from_sddl(PERMISSIVE_SDDL)
+            .unwrap()
+            .apply_to_path(&missing);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn dropping_many_security_descriptors_does_not_crash() {
+        // Hammer `Drop` to surface any double-free or use-after-free.
+        for _ in 0..1024 {
+            let _ = SecurityDescriptor::from_sddl(DACL_ONLY_SDDL).unwrap();
+        }
+    }
+
+    #[test]
+    fn as_raw_returns_descriptor_with_dacl() {
+        let sd = SecurityDescriptor::from_sddl(DACL_ONLY_SDDL).unwrap();
+
+        let raw = sd.as_raw();
+        assert!(!raw.0.is_null());
+
+        let mut dacl_present = BOOL::default();
+        let mut dacl_defaulted = BOOL::default();
+        let mut dacl: *mut ACL = ptr::null_mut();
+        // SAFETY: `raw` came from a live `SecurityDescriptor`; the out-pointers
+        // are valid and Windows does not retain them.
+        unsafe {
+            GetSecurityDescriptorDacl(raw, &mut dacl_present, &mut dacl, &mut dacl_defaulted)
+        }
+        .unwrap();
+
+        assert!(dacl_present.as_bool());
+        assert!(!dacl.is_null());
+    }
+}


### PR DESCRIPTION
Currently, the named pipes used for IPC in the Windows GUI client do not have any DACLs set. This was originally done so we can run the GUI as a regular user and still connect to the privileged tunnel service.

We can preserve this requirement and still harden access to the pipes by applying DACLs that prevent access from other service users like `NETWORK SERVICE` or `ANONYMOUS LOGON`.

To implement this, we extract the safe abstraction around security descriptors introduced in #13153 into a dedicated crate.