### PR TITLE
refactor(gateway): drop `chrono::Utc::now` from `GatewayState`

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -384,10 +384,12 @@ impl Eventloop {
                     expires_at,
                 } in authorizations
                 {
-                    if let Err(e) = tunnel
-                        .state_mut()
-                        .update_access_authorization_expiry(cid, rid, expires_at)
-                    {
+                    if let Err(e) = tunnel.state_mut().update_access_authorization_expiry(
+                        cid,
+                        rid,
+                        expires_at,
+                        Instant::now(),
+                    ) {
                         tracing::debug!(%cid, %rid, "Failed to update access authorization: {e:#}");
                     }
                 }
@@ -449,10 +451,12 @@ impl Eventloop {
                     expires_at,
                 },
             ) => {
-                if let Err(e) = tunnel
-                    .state_mut()
-                    .update_access_authorization_expiry(cid, rid, expires_at)
-                {
+                if let Err(e) = tunnel.state_mut().update_access_authorization_expiry(
+                    cid,
+                    rid,
+                    expires_at,
+                    Instant::now(),
+                ) {
                     tracing::debug!(%cid, %rid, "Failed to update expiry of access authorization: {e:#}")
                 };
             }

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -13,7 +13,6 @@ use crate::unroutable_packet::UnroutablePacket;
 use crate::{FailedToDecapsulate, GatewayEvent, IpConfig, p2p_control, packet_kind};
 use anyhow::{Context, ErrorExt, Result};
 use boringtun::x25519::{self, PublicKey};
-use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, IceCandidate, RelayId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{FzP2pControlSlice, IpPacket};
@@ -100,15 +99,6 @@ impl GatewayState {
                 .checked_sub(self.start_unix_ts - unix_ts)
                 .unwrap_or(self.start_instant)
         }
-    }
-
-    fn datetime_to_instant(&self, datetime: DateTime<Utc>) -> Instant {
-        let unix_ts = datetime
-            .signed_duration_since(DateTime::UNIX_EPOCH)
-            .to_std()
-            .unwrap_or_default();
-
-        self.instant_at(unix_ts)
     }
 
     #[cfg(all(test, feature = "proptest"))]
@@ -317,7 +307,7 @@ impl GatewayState {
         subject: Subject,
         client_ice: IceCredentials,
         gateway_ice: IceCredentials,
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Duration>,
         resource: ResourceDescription,
         now: Instant,
     ) -> Result<(), NoTurnServers> {
@@ -369,15 +359,15 @@ impl GatewayState {
         client: ClientId,
         client_tun: IpConfig,
         client_props: flow_tracker::ClientProperties,
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Duration>,
         resource: ResourceDescription,
         dns_resource_nat: Option<DnsResourceNatEntry>,
     ) -> anyhow::Result<()> {
         let gateway_tun = self.tun_ip_config.context("TUN device not configured")?;
 
-        tracing::info!(cid = %client, rid = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
+        tracing::info!(cid = %client, rid = %resource.id(), expires = ?expires_at.map(|d| d.as_secs()), "Allowing access to resource");
 
-        let expires_at = expires_at.map(|dt| self.datetime_to_instant(dt));
+        let expires_at = expires_at.map(|d| self.instant_at(d));
 
         let peer = self.peers.upsert(client, || {
             ClientOnGateway::new(client, client_tun, gateway_tun, client_props)
@@ -401,11 +391,11 @@ impl GatewayState {
         &mut self,
         client: ClientId,
         resource: ResourceId,
-        expires_at: DateTime<Utc>,
+        expires_at: Duration,
     ) -> anyhow::Result<()> {
-        let new_expiry = self.datetime_to_instant(expires_at);
+        let new_expiry = self.instant_at(expires_at);
 
-        tracing::info!(cid = %client, rid = %resource, new = %expires_at.to_rfc3339(), "Updating resource expiry");
+        tracing::info!(cid = %client, rid = %resource, new = %expires_at.as_secs(), "Updating resource expiry");
 
         self.peers
             .peer_by_id_mut(&client)

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -45,6 +45,13 @@ pub struct GatewayState {
 
     tun_ip_config: Option<IpConfig>,
 
+    /// [`Instant`] sampled at startup, paired with [`Self::start_unix_ts`].
+    ///
+    /// Together, these allow us to map a unix timestamp to an [`Instant`].
+    start_instant: Instant,
+    /// Unix timestamp at the time we sampled [`Self::start_instant`].
+    start_unix_ts: Duration,
+
     buffered_events: VecDeque<GatewayEvent>,
     buffered_transmits: VecDeque<Transmit>,
 }
@@ -76,7 +83,32 @@ impl GatewayState {
             buffered_transmits: VecDeque::default(),
             flow_tracker: FlowTracker::new(flow_logs, now),
             tun_ip_config: None,
+            start_instant: now,
+            start_unix_ts: unix_ts,
         }
+    }
+
+    /// Maps a unix timestamp (`Duration` since `UNIX_EPOCH`) to an [`Instant`].
+    ///
+    /// Computes the delta between `unix_ts` and the unix timestamp captured at startup
+    /// and applies it to the `Instant` captured at startup.
+    fn instant_at(&self, unix_ts: Duration) -> Instant {
+        if unix_ts >= self.start_unix_ts {
+            self.start_instant + (unix_ts - self.start_unix_ts)
+        } else {
+            self.start_instant
+                .checked_sub(self.start_unix_ts - unix_ts)
+                .unwrap_or(self.start_instant)
+        }
+    }
+
+    fn datetime_to_instant(&self, datetime: DateTime<Utc>) -> Instant {
+        let unix_ts = datetime
+            .signed_duration_since(DateTime::UNIX_EPOCH)
+            .to_std()
+            .unwrap_or_default();
+
+        self.instant_at(unix_ts)
     }
 
     #[cfg(all(test, feature = "proptest"))]
@@ -343,6 +375,10 @@ impl GatewayState {
     ) -> anyhow::Result<()> {
         let gateway_tun = self.tun_ip_config.context("TUN device not configured")?;
 
+        tracing::info!(cid = %client, rid = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
+
+        let expires_at = expires_at.map(|dt| self.datetime_to_instant(dt));
+
         let peer = self.peers.upsert(client, || {
             ClientOnGateway::new(client, client_tun, gateway_tun, client_props)
         });
@@ -367,10 +403,14 @@ impl GatewayState {
         resource: ResourceId,
         expires_at: DateTime<Utc>,
     ) -> anyhow::Result<()> {
+        let new_expiry = self.datetime_to_instant(expires_at);
+
+        tracing::info!(cid = %client, rid = %resource, new = %expires_at.to_rfc3339(), "Updating resource expiry");
+
         self.peers
             .peer_by_id_mut(&client)
             .context("No peer state")?
-            .update_resource_expiry(resource, expires_at);
+            .update_resource_expiry(resource, new_expiry);
 
         Ok(())
     }
@@ -425,7 +465,7 @@ impl GatewayState {
             .min_by_key(|(instant, _)| *instant)
     }
 
-    pub fn handle_timeout(&mut self, now: Instant, utc_now: DateTime<Utc>) {
+    pub fn handle_timeout(&mut self, now: Instant) {
         self.node.handle_timeout(now);
         self.drain_node_events();
         self.flow_tracker.handle_timeout(now);
@@ -433,7 +473,7 @@ impl GatewayState {
         match self.next_expiry_resources_check {
             Some(next_expiry_resources_check) if now >= next_expiry_resources_check => {
                 self.peers.iter_mut().for_each(|p| {
-                    p.expire_resources(utc_now);
+                    p.expire_resources(now);
                     p.handle_timeout(now)
                 });
                 let removed_peers = self.peers.extract_if(|_, p| p.is_empty());

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -92,18 +92,30 @@ impl GatewayState {
     /// Computes the delta between `unix_ts` and the unix timestamp captured at startup
     /// and applies it to the `Instant` captured at startup.
     ///
-    /// `unix_ts` arrives from the portal and is therefore untrusted; if it would push
-    /// the result past the representable range of [`Instant`], we clamp to
-    /// [`Self::start_instant`] which compares as already-expired against any
-    /// later "now".
-    fn instant_at(&self, unix_ts: Duration) -> Instant {
-        let result = if unix_ts >= self.start_unix_ts {
-            self.start_instant.checked_add(unix_ts - self.start_unix_ts)
-        } else {
-            self.start_instant.checked_sub(self.start_unix_ts - unix_ts)
-        };
+    /// `unix_ts` arrives from the portal and is therefore untrusted:
+    /// - if it predates `start_unix_ts`, we clamp to `start_instant` so the
+    ///   resource is already expired against any later "now";
+    /// - if it would overflow [`Instant`], we log a warning and fall back to
+    ///   a 1-day expiry so access remains time-bounded.
+    fn instant_at(&self, unix_ts: Duration, now: Instant) -> Instant {
+        if unix_ts < self.start_unix_ts {
+            tracing::warn!(
+                unix_ts_secs = unix_ts.as_secs(),
+                start_unix_ts_secs = self.start_unix_ts.as_secs(),
+                "unix timestamp predates startup; treating as already expired",
+            );
+            return self.start_instant;
+        }
 
-        result.unwrap_or(self.start_instant)
+        self.start_instant
+            .checked_add(unix_ts - self.start_unix_ts)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    unix_ts_secs = unix_ts.as_secs(),
+                    "unix timestamp out of `Instant` range; falling back to 1 day expiry",
+                );
+                now + Duration::from_secs(86400)
+            })
     }
 
     #[cfg(all(test, feature = "proptest"))]
@@ -372,7 +384,7 @@ impl GatewayState {
     ) -> anyhow::Result<()> {
         let gateway_tun = self.tun_ip_config.context("TUN device not configured")?;
 
-        let expires_at = expires_at.map(|d| self.instant_at(d));
+        let expires_at = expires_at.map(|d| self.instant_at(d, now));
         let expires_in = expires_at.map(|e| e.saturating_duration_since(now));
 
         tracing::info!(
@@ -407,7 +419,7 @@ impl GatewayState {
         expires_at: Duration,
         now: Instant,
     ) -> anyhow::Result<()> {
-        let new_expiry = self.instant_at(expires_at);
+        let new_expiry = self.instant_at(expires_at, now);
         let expires_in = new_expiry.saturating_duration_since(now);
 
         tracing::info!(

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -91,14 +91,19 @@ impl GatewayState {
     ///
     /// Computes the delta between `unix_ts` and the unix timestamp captured at startup
     /// and applies it to the `Instant` captured at startup.
+    ///
+    /// `unix_ts` arrives from the portal and is therefore untrusted; if it would push
+    /// the result past the representable range of [`Instant`], we clamp to
+    /// [`Self::start_instant`] which compares as already-expired against any
+    /// later "now".
     fn instant_at(&self, unix_ts: Duration) -> Instant {
-        if unix_ts >= self.start_unix_ts {
-            self.start_instant + (unix_ts - self.start_unix_ts)
+        let result = if unix_ts >= self.start_unix_ts {
+            self.start_instant.checked_add(unix_ts - self.start_unix_ts)
         } else {
-            self.start_instant
-                .checked_sub(self.start_unix_ts - unix_ts)
-                .unwrap_or(self.start_instant)
-        }
+            self.start_instant.checked_sub(self.start_unix_ts - unix_ts)
+        };
+
+        result.unwrap_or(self.start_instant)
     }
 
     #[cfg(all(test, feature = "proptest"))]
@@ -345,6 +350,7 @@ impl GatewayState {
             expires_at,
             resource,
             None,
+            now,
         );
         debug_assert!(
             result.is_ok(),
@@ -362,12 +368,19 @@ impl GatewayState {
         expires_at: Option<Duration>,
         resource: ResourceDescription,
         dns_resource_nat: Option<DnsResourceNatEntry>,
+        now: Instant,
     ) -> anyhow::Result<()> {
         let gateway_tun = self.tun_ip_config.context("TUN device not configured")?;
 
-        tracing::info!(cid = %client, rid = %resource.id(), expires = ?expires_at.map(|d| d.as_secs()), "Allowing access to resource");
-
         let expires_at = expires_at.map(|d| self.instant_at(d));
+        let expires_in = expires_at.map(|e| e.saturating_duration_since(now));
+
+        tracing::info!(
+            cid = %client,
+            rid = %resource.id(),
+            expires_in = expires_in.map(tracing::field::debug),
+            "Allowing access to resource",
+        );
 
         let peer = self.peers.upsert(client, || {
             ClientOnGateway::new(client, client_tun, gateway_tun, client_props)
@@ -392,10 +405,17 @@ impl GatewayState {
         client: ClientId,
         resource: ResourceId,
         expires_at: Duration,
+        now: Instant,
     ) -> anyhow::Result<()> {
         let new_expiry = self.instant_at(expires_at);
+        let expires_in = new_expiry.saturating_duration_since(now);
 
-        tracing::info!(cid = %client, rid = %resource, new = %expires_at.as_secs(), "Updating resource expiry");
+        tracing::info!(
+            cid = %client,
+            rid = %resource,
+            expires_in = ?expires_in,
+            "Updating resource expiry",
+        );
 
         self.peers
             .peer_by_id_mut(&client)

--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -3,7 +3,6 @@ use std::net::IpAddr;
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
-use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, ResourceId};
 use dns_types::DomainName;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -141,7 +140,7 @@ impl ClientOnGateway {
         self.resources.is_empty()
     }
 
-    pub(crate) fn expire_resources(&mut self, now: DateTime<Utc>) {
+    pub(crate) fn expire_resources(&mut self, now: Instant) {
         let cid = self.id;
         let mut any_expired = false;
 
@@ -171,10 +170,8 @@ impl ClientOnGateway {
     pub(crate) fn add_resource(
         &mut self,
         resource: crate::messages::gateway::ResourceDescription,
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Instant>,
     ) {
-        tracing::info!(cid = %self.id, rid = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
-
         match self.resources.entry(resource.id()) {
             btree_map::Entry::Vacant(v) => {
                 v.insert(ResourceOnGateway::new(resource, expires_at));
@@ -197,22 +194,18 @@ impl ClientOnGateway {
         self.recalculate_filters();
     }
 
-    pub(crate) fn update_resource_expiry(&mut self, rid: ResourceId, new_expiry: DateTime<Utc>) {
+    pub(crate) fn update_resource_expiry(&mut self, rid: ResourceId, new_expiry: Instant) {
         let Some(resource) = self.resources.get_mut(&rid) else {
             tracing::debug!(%rid, "Unknown resource");
 
             return;
         };
 
-        let new_expiry_rfc3339 = new_expiry.to_rfc3339();
-
-        let old_expiry = match resource {
-            ResourceOnGateway::Cidr { expires_at, .. } => expires_at.replace(new_expiry),
-            ResourceOnGateway::Dns { expires_at, .. } => expires_at.replace(new_expiry),
-            ResourceOnGateway::Internet { expires_at } => expires_at.replace(new_expiry),
-        };
-
-        tracing::info!(old = ?old_expiry.map(|e| e.to_rfc3339()), new = %new_expiry_rfc3339, "Updated resource expiry");
+        match resource {
+            ResourceOnGateway::Cidr { expires_at, .. } => *expires_at = Some(new_expiry),
+            ResourceOnGateway::Dns { expires_at, .. } => *expires_at = Some(new_expiry),
+            ResourceOnGateway::Internet { expires_at } => *expires_at = Some(new_expiry),
+        }
     }
 
     pub(crate) fn retain_authorizations(&mut self, authorization: BTreeSet<ResourceId>) {
@@ -528,22 +521,22 @@ enum ResourceOnGateway {
         name: String,
         network: IpNetwork,
         filters: Vec<Filter>,
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Instant>,
     },
     Dns {
         name: String,
         address: String,
         domains: BTreeMap<DomainName, BTreeSet<IpAddr>>,
         filters: Vec<Filter>,
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Instant>,
     },
     Internet {
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Instant>,
     },
 }
 
 impl ResourceOnGateway {
-    fn new(resource: ResourceDescription, expires_at: Option<DateTime<Utc>>) -> Self {
+    fn new(resource: ResourceDescription, expires_at: Option<Instant>) -> Self {
         match resource {
             ResourceDescription::Dns(r) => ResourceOnGateway::Dns {
                 name: r.name,
@@ -604,7 +597,7 @@ impl ResourceOnGateway {
         }
     }
 
-    fn is_allowed(&self, now: &DateTime<Utc>) -> bool {
+    fn is_allowed(&self, now: &Instant) -> bool {
         let Some(expires_at) = self.expires_at() else {
             return true;
         };
@@ -612,7 +605,7 @@ impl ResourceOnGateway {
         expires_at > now
     }
 
-    fn expires_at(&self) -> Option<&DateTime<Utc>> {
+    fn expires_at(&self) -> Option<&Instant> {
         match self {
             ResourceOnGateway::Cidr { expires_at, .. } => expires_at.as_ref(),
             ResourceOnGateway::Dns { expires_at, .. } => expires_at.as_ref(),
@@ -719,7 +712,7 @@ mod tests {
             gateway_tun(),
             flow_tracker::ClientProperties::default(),
         );
-        let now = Utc::now();
+        let now = Instant::now();
         let then = now + Duration::from_secs(10);
         let after_then = then + Duration::from_secs(10);
         peer.add_resource(

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -10,7 +10,6 @@ pub use device::{Device, TunChannelClosed};
 
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{Context as _, ErrorExt, Result};
-use chrono::{DateTime, Utc};
 use dns_types::DoHUrl;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
 use gat_lending_iterator::LendingIterator;
@@ -102,7 +101,6 @@ impl Default for Buffers {
 /// handling them one at a time, improving fairness and preventing starvation.
 pub struct Input<D, I> {
     pub now: Instant,
-    pub now_utc: DateTime<Utc>,
     pub timeout: bool,
     pub device: Option<D>,
     pub network: Option<I>,
@@ -116,7 +114,6 @@ impl<D, I> Input<D, I> {
     fn error(e: impl Into<anyhow::Error>) -> Self {
         Self {
             now: Instant::now(),
-            now_utc: Utc::now(),
             timeout: false,
             device: None,
             network: None,
@@ -405,7 +402,6 @@ impl Io {
 
         Poll::Ready(Input {
             now: Instant::now(),
-            now_utc: Utc::now(),
             timeout,
             device: poll_result_to_option(device, &mut error),
             network: poll_result_to_option(network, &mut error),

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -231,7 +231,6 @@ impl ClientTunnel {
             // Process all IO sources that are ready.
             if let Poll::Ready(io::Input {
                 now,
-                now_utc: _,
                 timeout,
                 dns_response,
                 tcp_dns_queries: _,
@@ -406,7 +405,6 @@ impl GatewayTunnel {
             // Process all IO sources that are ready.
             if let Poll::Ready(io::Input {
                 now,
-                now_utc,
                 timeout,
                 dns_response,
                 tcp_dns_queries,
@@ -448,7 +446,7 @@ impl GatewayTunnel {
                 }
 
                 if timeout {
-                    self.role_state.handle_timeout(now, now_utc);
+                    self.role_state.handle_timeout(now);
                     tick.want_continue();
                 }
 

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -1,16 +1,14 @@
 //! Gateway related messages that are needed within connlib
 
 use crate::messages::{Filter, IceCredentials, Interface, Key, Relay, RelaysPresence, SecretKey};
-use chrono::{
-    DateTime, Utc,
-    serde::{ts_seconds, ts_seconds_option},
-};
 use connlib_model::{ClientId, IceCandidate, ResourceId};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
+use serde_with::{DurationSeconds, serde_as};
 use std::{
     collections::BTreeSet,
     net::{Ipv4Addr, Ipv6Addr},
+    time::Duration,
 };
 
 /// Description of a resource that maps to a DNS record.
@@ -99,12 +97,13 @@ pub struct RemoveResource {
     pub id: ResourceId,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Clone)]
 pub struct Authorization {
     pub client_id: ClientId,
     pub resource_id: ResourceId,
-    #[serde(with = "ts_seconds")]
-    pub expires_at: DateTime<Utc>,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub expires_at: Duration,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -163,6 +162,7 @@ pub struct Subject {
     pub actor_email: Option<String>,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Clone)]
 pub struct AuthorizeFlow {
     #[serde(rename = "ref")]
@@ -175,16 +175,17 @@ pub struct AuthorizeFlow {
     pub subject: Subject,
     pub client_ice_credentials: IceCredentials,
 
-    #[serde(with = "ts_seconds_option")]
-    pub expires_at: Option<DateTime<Utc>>,
+    #[serde_as(as = "Option<DurationSeconds<u64>>")]
+    pub expires_at: Option<Duration>,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Clone)]
 pub struct AccessAuthorizationExpiryUpdated {
     pub client_id: ClientId,
     pub resource_id: ResourceId,
-    #[serde(with = "ts_seconds")]
-    pub expires_at: DateTime<Utc>,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub expires_at: Duration,
 }
 
 /// A client's ice candidate message.

--- a/rust/libs/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sim_gateway.rs
@@ -7,7 +7,6 @@ use super::{
 };
 use crate::GatewayState;
 use anyhow::{Result, bail};
-use chrono::{DateTime, Utc};
 use connlib_model::{GatewayId, RelayId};
 use dns_types::DomainName;
 use ip_packet::{IcmpEchoHeader, Icmpv4Type, Icmpv6Type, IpPacket};
@@ -76,7 +75,6 @@ impl SimGateway {
         transmit: Transmit,
         icmp_error_hosts: &IcmpErrorHosts,
         now: Instant,
-        utc_now: DateTime<Utc>,
     ) -> Option<Transmit> {
         let Some(packet) = self
             .sut
@@ -85,7 +83,7 @@ impl SimGateway {
             .ok()
             .flatten()
         else {
-            self.sut.handle_timeout(now, utc_now);
+            self.sut.handle_timeout(now);
             return None;
         };
 
@@ -171,9 +169,9 @@ impl SimGateway {
         }
     }
 
-    pub fn handle_timeout(&mut self, now: Instant, utc_now: DateTime<Utc>) {
+    pub fn handle_timeout(&mut self, now: Instant) {
         if self.sut.poll_timeout().is_some_and(|(t, _)| t <= now) {
-            self.sut.handle_timeout(now, utc_now)
+            self.sut.handle_timeout(now)
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -918,9 +918,8 @@ impl TunnelTest {
             }
 
             while let Some(transmit) = gateway.poll_inbox(now) {
-                let Some(reply) = gateway.exec_mut(|g| {
-                    g.receive(transmit, icmp_error_hosts, now)
-                }) else {
+                let Some(reply) = gateway.exec_mut(|g| g.receive(transmit, icmp_error_hosts, now))
+                else {
                     continue;
                 };
 

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -919,7 +919,7 @@ impl TunnelTest {
 
             while let Some(transmit) = gateway.poll_inbox(now) {
                 let Some(reply) = gateway.exec_mut(|g| {
-                    g.receive(transmit, icmp_error_hosts, now, self.flux_capacitor.now())
+                    g.receive(transmit, icmp_error_hosts, now)
                 }) else {
                     continue;
                 };
@@ -927,7 +927,7 @@ impl TunnelTest {
                 buffered_transmits.push_from(reply, gateway, now);
             }
 
-            gateway.exec_mut(|g| g.handle_timeout(now, self.flux_capacitor.now()));
+            gateway.exec_mut(|g| g.handle_timeout(now));
         }
 
         // Handle all relay `Transmit`s and timeouts.


### PR DESCRIPTION
`GatewayState` was using `chrono::Utc::now()` for resource-access expiry while everything else (NAT, ICE, WireGuard, snownet) ran on `Instant`. The portal sends expiry as plain unix-second integers, so the chrono detour is unnecessary — `snownet::Node` already fixes the relationship between `Instant` and unix time once at construction with a `unix_ts: Duration` parameter.

By treating the expiry also just as a unix timestamp, we can simplify some of the internals.