### PR TITLE
chore(rust): bump to sentry's `main`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6304,8 +6304,8 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -6324,8 +6324,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "backtrace",
  "regex",
@@ -6334,8 +6334,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "hostname",
  "libc",
@@ -6347,8 +6347,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -6359,8 +6359,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -6368,8 +6368,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "bitflags 2.10.0",
  "log",
@@ -6378,8 +6378,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -6387,8 +6387,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "bitflags 2.10.0",
  "sentry-backtrace",
@@ -6399,8 +6399,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.0"
-source = "git+https://github.com/firezone/sentry-rust?branch=fix%2Frustls-no-provider#d0ea483be27b375e47e41efa2c35fc89a81d95dc"
+version = "0.48.1"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
 dependencies = [
  "debugid",
  "hex",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -261,8 +261,8 @@ type_complexity = "allow" # Don't care.
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.
 
 [patch.crates-io]
-sentry = { git = "https://github.com/firezone/sentry-rust", branch = "fix/rustls-no-provider" }
-sentry-tracing = { git = "https://github.com/firezone/sentry-rust", branch = "fix/rustls-no-provider" }
+sentry = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
+sentry-tracing = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 reqwest = { workspace = true, features = ["http2"] }
-sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "logs", "metrics"] }
+sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls-no-provider", "tracing", "logs", "metrics"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
Sentry has merged the fix that removes `aws-lc-rs` from the default dependency tree so we can stop depending on our fork. The fact that `Cargo.lock` doesn't change in this PR beyond _where_ we get the code from means it is working as intended.