### PR TITLE
fix(portal): fix race condition on pagination

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1394,9 +1394,9 @@ defmodule PortalWeb.Actors do
 
       actors_by_id = Map.new(actors, &{&1.id, &1})
 
-      Enum.map(actor_ids, fn actor_id ->
-        Map.fetch!(actors_by_id, actor_id)
-      end)
+      actor_ids
+      |> Enum.map(&Map.get(actors_by_id, &1))
+      |> Enum.reject(&is_nil/1)
     end
 
     def fetch_account(subject) do

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -599,9 +599,9 @@ defmodule PortalWeb.Clients do
 
       clients_by_id = Map.new(clients, &{&1.id, &1})
 
-      Enum.map(client_ids, fn client_id ->
-        Map.fetch!(clients_by_id, client_id)
-      end)
+      client_ids
+      |> Enum.map(&Map.get(clients_by_id, &1))
+      |> Enum.reject(&is_nil/1)
     end
 
     defp maybe_preload_clients(clients, preload, _subject) do

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -1387,9 +1387,9 @@ defmodule PortalWeb.Groups do
 
       groups_by_id = Map.new(groups, &{&1.group.id, &1})
 
-      Enum.map(group_ids, fn group_id ->
-        Map.fetch!(groups_by_id, group_id)
-      end)
+      group_ids
+      |> Enum.map(&Map.get(groups_by_id, &1))
+      |> Enum.reject(&is_nil/1)
     end
 
     def count_groups_with_policies(subject, filter \\ []) do

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -931,7 +931,10 @@ defmodule PortalWeb.ServiceAccounts do
         |> Enum.map(&%{&1 | identity_count: 0})
 
       actors_by_id = Map.new(actors, &{&1.id, &1})
-      Enum.map(actor_ids, &Map.fetch!(actors_by_id, &1))
+
+      actor_ids
+      |> Enum.map(&Map.get(actors_by_id, &1))
+      |> Enum.reject(&is_nil/1)
     end
 
     def get_actor(id, subject) do


### PR DESCRIPTION
Why:

* There was a small race condition in the pagination code that would throw an error when an entity was deleted between 2 separate reads from the DB.

Fixes: #13176