### PR TITLE
fix(portal): use redirect/href across live_sessions

### DIFF
--- a/elixir/lib/portal_web/live/sign_in/email.ex
+++ b/elixir/lib/portal_web/live/sign_in/email.ex
@@ -41,7 +41,7 @@ defmodule PortalWeb.SignIn.Email do
         socket =
           socket
           |> put_flash(:error, "Account not found.")
-          |> push_navigate(to: ~p"/")
+          |> redirect(to: ~p"/")
 
         {:ok, socket}
 
@@ -49,7 +49,7 @@ defmodule PortalWeb.SignIn.Email do
         socket =
           socket
           |> put_flash(:error, "Please try to sign in again.")
-          |> push_navigate(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
+          |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
 
         {:ok, socket}
     end
@@ -116,7 +116,7 @@ defmodule PortalWeb.SignIn.Email do
 
     <div class="mt-4 grid grid-cols-2 gap-2">
       <.link
-        navigate={~p"/#{@account_id_or_slug}?#{@redirect_params}"}
+        href={~p"/#{@account_id_or_slug}?#{@redirect_params}"}
         class="relative flex items-center justify-center px-4 py-2.5 rounded-md border border-[var(--border-strong)] bg-[var(--surface)] hover:bg-[var(--surface-raised)] transition-colors text-sm font-medium text-[var(--text-primary)]"
       >
         <.icon name="ri-arrow-left-line" class="absolute left-4 w-4 h-4 text-[var(--text-secondary)]" />

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -343,7 +343,7 @@ defmodule PortalWeb.SignUp do
         <div class="flex justify-between items-baseline">
           <dt class="text-xs font-medium text-[var(--text-secondary)]">Sign In URL</dt>
           <dd class="text-sm">
-            <.link class={[link_style()]} navigate={~p"/#{@account}"}>
+            <.link class={[link_style()]} href={~p"/#{@account}"}>
               {url(~p"/#{@account}")}
             </.link>
           </dd>
@@ -781,7 +781,7 @@ defmodule PortalWeb.SignUp do
        ) do
     case Database.find_account_by_owner_email(email) do
       %Portal.Account{} = account ->
-        push_navigate(socket, to: ~p"/#{account}/sign_in")
+        redirect(socket, to: ~p"/#{account}/sign_in")
 
       nil ->
         registration = %{

--- a/elixir/test/portal_web/live/sign_in/email_test.exs
+++ b/elixir/test/portal_web/live/sign_in/email_test.exs
@@ -32,7 +32,7 @@ defmodule PortalWeb.SignIn.EmailTest do
          %{conn: conn, account: account, provider: provider} do
       path = ~p"/#{account}/sign_in/email_otp/#{provider}"
 
-      assert {:error, {:live_redirect, %{to: _}}} = live(conn, path)
+      assert {:error, {:redirect, %{to: _}}} = live(conn, path)
     end
   end
 

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -271,7 +271,7 @@ defmodule PortalWeb.SignUpTest do
           actor_name: "Test User"
         })
 
-      assert {:error, {:live_redirect, %{to: path}}} =
+      assert {:error, {:redirect, %{to: path}}} =
                live(conn, ~p"/verify_sign_up?token=#{token}")
 
       assert path == ~p"/#{account}/sign_in"


### PR DESCRIPTION
Fixes a warning that occurs whenever a `push_navigate` or `link navigate=` is used across live view sessions, such as when redirecting to other controller actions in the sign in and sign up paths.

I did double-check to verify it's not a good idea to combine these into a single live_session since they require different `on_mount` hooks.