### PR TITLE
fix(portal): consistent missing record UX in tables

### DIFF
--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -850,9 +850,9 @@ defmodule PortalWeb.FormComponents do
   def button_style("warning") do
     button_style() ++
       [
-        "text-[var(--brand)]",
-        "border border-[var(--brand)]",
-        "hover:text-white hover:bg-[var(--brand)]"
+        "text-[var(--status-warn)]",
+        "border border-[var(--status-warn)]",
+        "hover:text-white hover:bg-[var(--status-warn)]"
       ]
   end
 

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -36,49 +36,46 @@ defmodule PortalWeb.Clients do
   end
 
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :show}} = socket) do
-    tab = parse_client_tab(Map.get(params, "tab", "overview"))
-
-    page =
-      case Integer.parse(Map.get(params, "page", "1")) do
-        {n, ""} when n >= 1 -> n
-        _ -> 1
-      end
-
     socket = handle_live_tables_params(socket, params, uri)
-    client = Database.get_client_for_panel(id, socket.assigns.subject)
 
-    if client do
-      {policy_authorizations, has_next} =
-        Database.list_policy_authorizations_for_client(client, socket.assigns.subject, page)
+    case Database.get_client_for_panel(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_clients_index(socket, "Client does not exist.")
 
-      {:noreply,
-       socket
-       |> assign(selected_client: client)
-       |> assign(show_client_assigns(tab))
-       |> assign(
-         policy_authorizations: policy_authorizations,
-         policy_authorizations_page: page,
-         policy_authorizations_has_next: has_next,
-         policy_authorizations_expanded_id: nil
-       )}
-    else
-      {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/clients")}
+      client ->
+        page = parse_page(params)
+        tab = parse_client_tab(Map.get(params, "tab", "overview"))
+
+        {policy_authorizations, has_next} =
+          Database.list_policy_authorizations_for_client(client, socket.assigns.subject, page)
+
+        {:noreply,
+         socket
+         |> assign(selected_client: client)
+         |> assign(show_client_assigns(tab))
+         |> assign(
+           policy_authorizations: policy_authorizations,
+           policy_authorizations_page: page,
+           policy_authorizations_has_next: has_next,
+           policy_authorizations_expanded_id: nil
+         )}
     end
   end
 
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :edit}} = socket) do
     socket = handle_live_tables_params(socket, params, uri)
-    client = Database.get_client_for_panel(id, socket.assigns.subject)
 
-    if client do
-      changeset = Database.change_client(client)
+    case Database.get_client_for_panel(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_clients_index(socket, "Client does not exist.")
 
-      {:noreply,
-       socket
-       |> assign(selected_client: client)
-       |> assign(edit_client_assigns(to_form(changeset)))}
-    else
-      {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/clients")}
+      client ->
+        changeset = Database.change_client(client)
+
+        {:noreply,
+         socket
+         |> assign(selected_client: client)
+         |> assign(edit_client_assigns(to_form(changeset)))}
     end
   end
 
@@ -480,6 +477,20 @@ defmodule PortalWeb.Clients do
   defp parse_client_tab("authorizations"), do: :authorizations
   defp parse_client_tab("overview"), do: :overview
   defp parse_client_tab(_), do: :overview
+
+  defp parse_page(params) do
+    case Integer.parse(Map.get(params, "page", "1")) do
+      {n, ""} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp redirect_to_clients_index(socket, message) do
+    {:noreply,
+     socket
+     |> put_flash(:error, message)
+     |> push_patch(to: ~p"/#{socket.assigns.account}/clients?#{socket.assigns.query_params}")}
+  end
 
   def handle_info(
         %Phoenix.Socket.Broadcast{topic: "presences:account_clients:" <> _account_id} = event,

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -49,27 +49,14 @@ defmodule PortalWeb.Groups do
 
   # Edit Group Panel
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :edit}} = socket) do
-    group = Database.get_group_with_actors!(id, socket.assigns.subject)
     socket = handle_live_tables_params(socket, params, uri)
 
-    if editable_group?(group) do
-      changeset = changeset(group, %{})
-      resources = preserved_group_resources(socket, id)
+    case Database.get_group_with_actors(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_groups_index(socket, "Group does not exist.")
 
-      {:noreply,
-       socket
-       |> assign(selected_group: group)
-       |> assign(base_group_assigns(socket))
-       |> assign(
-         group_panel: group_panel_state(view: :edit_form),
-         group_form: group_form_state(to_form(changeset)),
-         group_resources: group_resources_state(resources: resources)
-       )}
-    else
-      {:noreply,
-       socket
-       |> put_flash(:error, "This group cannot be edited")
-       |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{id}")}
+      group ->
+        edit_group_panel(socket, group, id)
     end
   end
 
@@ -79,33 +66,15 @@ defmodule PortalWeb.Groups do
     tab = parse_group_tab(Map.get(params, "tab", "members"))
 
     if selected_group_matches?(socket, id) do
-      socket =
-        socket
-        |> assign(base_group_assigns(socket))
-        |> assign(
-          selected_group: socket.assigns.selected_group,
-          group_panel: group_panel_state(tab: tab),
-          group_resources:
-            group_resources_state(resources: socket.assigns.group_resources.resources)
-        )
-        |> load_panel_members_from_selected_group()
-
-      {:noreply, socket}
+      show_selected_group_panel(socket, tab)
     else
-      group = Database.get_group_with_actors!(id, socket.assigns.subject)
-      resources = Database.list_resources_for_group(group, socket.assigns.subject)
+      case Database.get_group_with_actors(id, socket.assigns.subject) do
+        nil ->
+          redirect_to_groups_index(socket, "Group does not exist.")
 
-      socket =
-        socket
-        |> assign(selected_group: group)
-        |> assign(base_group_assigns(socket))
-        |> assign(
-          group_panel: group_panel_state(tab: tab),
-          group_resources: group_resources_state(resources: resources)
-        )
-        |> load_panel_members()
-
-      {:noreply, socket}
+        group ->
+          show_group_panel(socket, group, tab)
+      end
     end
   end
 
@@ -743,6 +712,66 @@ defmodule PortalWeb.Groups do
   defp parse_group_tab("resources"), do: :resources
   defp parse_group_tab("members"), do: :members
   defp parse_group_tab(_), do: :members
+
+  defp redirect_to_groups_index(socket, message) do
+    {:noreply,
+     socket
+     |> put_flash(:error, message)
+     |> push_patch(to: ~p"/#{socket.assigns.account}/groups?#{socket.assigns.query_params}")}
+  end
+
+  defp edit_group_panel(socket, group, id) do
+    if editable_group?(group) do
+      changeset = changeset(group, %{})
+      resources = preserved_group_resources(socket, id)
+
+      {:noreply,
+       socket
+       |> assign(selected_group: group)
+       |> assign(base_group_assigns(socket))
+       |> assign(
+         group_panel: group_panel_state(view: :edit_form),
+         group_form: group_form_state(to_form(changeset)),
+         group_resources: group_resources_state(resources: resources)
+       )}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "This group cannot be edited")
+       |> push_patch(to: ~p"/#{socket.assigns.account}/groups/#{id}")}
+    end
+  end
+
+  defp show_selected_group_panel(socket, tab) do
+    socket =
+      socket
+      |> assign(base_group_assigns(socket))
+      |> assign(
+        selected_group: socket.assigns.selected_group,
+        group_panel: group_panel_state(tab: tab),
+        group_resources:
+          group_resources_state(resources: socket.assigns.group_resources.resources)
+      )
+      |> load_panel_members_from_selected_group()
+
+    {:noreply, socket}
+  end
+
+  defp show_group_panel(socket, group, tab) do
+    resources = Database.list_resources_for_group(group, socket.assigns.subject)
+
+    socket =
+      socket
+      |> assign(selected_group: group)
+      |> assign(base_group_assigns(socket))
+      |> assign(
+        group_panel: group_panel_state(tab: tab),
+        group_resources: group_resources_state(resources: resources)
+      )
+      |> load_panel_members()
+
+    {:noreply, socket}
+  end
 
   def handle_groups_update!(socket, list_opts) do
     filter = Keyword.get(list_opts, :filter, [])
@@ -1733,7 +1762,7 @@ defmodule PortalWeb.Groups do
       end
     end
 
-    def get_group_with_actors!(id, subject, opts \\ []) do
+    def get_group_with_actors(id, subject, opts \\ []) do
       repo = Keyword.get(opts, :repo, :replica)
 
       query =
@@ -1762,7 +1791,7 @@ defmodule PortalWeb.Groups do
           directory: {d, google_directory: gd, entra_directory: ed, okta_directory: od}
         )
 
-      query |> Safe.scoped(subject, repo) |> Safe.one!(fallback_to_primary: true)
+      query |> Safe.scoped(subject, repo) |> Safe.one(fallback_to_primary: true)
     end
 
     def preloads do

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -52,57 +52,40 @@ defmodule PortalWeb.Policies do
   end
 
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :show}} = socket) do
-    t = Map.get(params, "tab", "overview")
-    tab = if t in ~w[overview authorizations], do: String.to_existing_atom(t), else: :overview
-
-    page =
-      case Integer.parse(Map.get(params, "page", "1")) do
-        {n, ""} when n >= 1 -> n
-        _ -> 1
-      end
-
     socket = handle_live_tables_params(socket, params, uri)
-    policy = Database.get_policy(id, socket.assigns.subject)
-    providers = Database.all_active_providers(socket.assigns.account, socket.assigns.subject)
 
-    {policy_authorizations, has_next} =
-      Database.list_policy_authorizations_for_policy(policy, socket.assigns.subject, page)
+    case Database.get_policy(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_policies_index(socket, "Policy does not exist.")
 
-    filter_site =
-      with %{"policies_filter" => %{"site_id" => site_id}} <- params do
-        Database.get_site(site_id, socket.assigns.subject)
-      else
-        _ -> nil
-      end
+      policy ->
+        page = parse_page(params)
+        tab = parse_show_tab(params)
 
-    filter_resource =
-      with %{"policies_filter" => %{"resource_id" => resource_id}} <- params do
-        Database.get_resource(resource_id, socket.assigns.subject)
-      else
-        _ -> nil
-      end
+        {policy_authorizations, has_next} =
+          Database.list_policy_authorizations_for_policy(policy, socket.assigns.subject, page)
 
-    {:noreply,
-     assign(
-       socket,
-       [
-         filter_site: filter_site,
-         filter_resource: filter_resource,
-         selected_policy: policy,
-         policy_providers: providers,
-         return_to: uri_path(uri),
-         policy_authorizations: policy_authorizations,
-         policy_authorizations_page: page,
-         policy_authorizations_has_next: has_next,
-         policy_authorizations_expanded_id: nil
-       ] ++ show_policy_assigns(socket, tab)
-     )}
+        {:noreply,
+         assign(
+           socket,
+           [
+             selected_policy: policy,
+             policy_providers:
+               Database.all_active_providers(socket.assigns.account, socket.assigns.subject),
+             return_to: uri_path(uri),
+             policy_authorizations: policy_authorizations,
+             policy_authorizations_page: page,
+             policy_authorizations_has_next: has_next,
+             policy_authorizations_expanded_id: nil
+           ] ++ policy_filter_assigns(params, socket.assigns.subject) ++
+             show_policy_assigns(socket, tab)
+         )}
+    end
   end
 
   def handle_params(params, uri, %{assigns: %{live_action: :new}} = socket) do
     socket = handle_live_tables_params(socket, params, uri)
     form = new_policy(%{}, socket.assigns.subject) |> to_form()
-    providers = Database.all_active_providers(socket.assigns.account, socket.assigns.subject)
 
     {:noreply,
      assign(
@@ -111,7 +94,8 @@ defmodule PortalWeb.Policies do
          filter_site: nil,
          filter_resource: nil,
          selected_policy: nil,
-         policy_providers: providers,
+         policy_providers:
+           Database.all_active_providers(socket.assigns.account, socket.assigns.subject),
          return_to: uri_path(uri)
        ] ++ new_policy_assigns(socket, form)
      )}
@@ -119,66 +103,80 @@ defmodule PortalWeb.Policies do
 
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :edit}} = socket) do
     socket = handle_live_tables_params(socket, params, uri)
-    policy = Database.get_policy(id, socket.assigns.subject)
-    form = change_policy(policy) |> to_form()
 
-    filter_site =
-      with %{"policies_filter" => %{"site_id" => site_id}} <- params do
-        Database.get_site(site_id, socket.assigns.subject)
-      else
-        _ -> nil
-      end
+    case Database.get_policy(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_policies_index(socket, "Policy does not exist.")
 
-    filter_resource =
-      with %{"policies_filter" => %{"resource_id" => resource_id}} <- params do
-        Database.get_resource(resource_id, socket.assigns.subject)
-      else
-        _ -> nil
-      end
+      policy ->
+        form = change_policy(policy) |> to_form()
 
-    {:noreply,
-     assign(
-       socket,
-       [
-         filter_site: filter_site,
-         filter_resource: filter_resource,
-         selected_policy: policy,
-         policy_providers:
-           Database.all_active_providers(socket.assigns.account, socket.assigns.subject),
-         return_to: uri_path(uri)
-       ] ++ edit_policy_assigns(socket, policy, form)
-     )}
+        {:noreply,
+         assign(
+           socket,
+           [
+             selected_policy: policy,
+             policy_providers:
+               Database.all_active_providers(socket.assigns.account, socket.assigns.subject),
+             return_to: uri_path(uri)
+           ] ++ policy_filter_assigns(params, socket.assigns.subject) ++
+             edit_policy_assigns(socket, policy, form)
+         )}
+    end
   end
 
   def handle_params(params, uri, socket) do
     socket = handle_live_tables_params(socket, params, uri)
 
-    filter_site =
-      with %{"policies_filter" => %{"site_id" => site_id}} <- params do
-        Database.get_site(site_id, socket.assigns.subject)
-      else
-        _ -> nil
-      end
-
-    filter_resource =
-      with %{"policies_filter" => %{"resource_id" => resource_id}} <- params do
-        Database.get_resource(resource_id, socket.assigns.subject)
-      else
-        _ -> nil
-      end
-
     {:noreply,
      assign(
        socket,
        [
-         filter_site: filter_site,
-         filter_resource: filter_resource,
          selected_policy: nil,
          policy_providers: [],
          return_to: uri_path(uri)
-       ] ++ default_policy_assigns(socket)
+       ] ++ policy_filter_assigns(params, socket.assigns.subject) ++
+         default_policy_assigns(socket)
      )}
   end
+
+  defp redirect_to_policies_index(socket, message) do
+    {:noreply,
+     socket
+     |> put_flash(:error, message)
+     |> push_patch(to: ~p"/#{socket.assigns.account}/policies?#{socket.assigns.query_params}")}
+  end
+
+  defp parse_page(params) do
+    case Integer.parse(Map.get(params, "page", "1")) do
+      {n, ""} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_show_tab(params) do
+    case Map.get(params, "tab", "overview") do
+      tab when tab in ~w[overview authorizations] -> String.to_existing_atom(tab)
+      _ -> :overview
+    end
+  end
+
+  defp policy_filter_assigns(params, subject) do
+    [
+      filter_site: lookup_filter_site(params, subject),
+      filter_resource: lookup_filter_resource(params, subject)
+    ]
+  end
+
+  defp lookup_filter_site(%{"policies_filter" => %{"site_id" => site_id}}, subject),
+    do: Database.get_site(site_id, subject)
+
+  defp lookup_filter_site(_params, _subject), do: nil
+
+  defp lookup_filter_resource(%{"policies_filter" => %{"resource_id" => resource_id}}, subject),
+    do: Database.get_resource(resource_id, subject)
+
+  defp lookup_filter_resource(_params, _subject), do: nil
 
   defp uri_path(uri) do
     parsed = URI.parse(uri)
@@ -812,12 +810,12 @@ defmodule PortalWeb.Policies do
     {:noreply, merge_state(socket, :policy_conditions, auth_provider_values: updated)}
   end
 
-  def handle_info(%Change{old_struct: %Portal.Policy{}}, socket) do
-    {:noreply, assign(socket, stale: true)}
+  def handle_info(%Change{old_struct: %Portal.Policy{}} = change, socket) do
+    {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
-  def handle_info(%Change{struct: %Portal.Policy{}}, socket) do
-    {:noreply, assign(socket, stale: true)}
+  def handle_info(%Change{struct: %Portal.Policy{}} = change, socket) do
+    {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
   def handle_info({:panel_change_resource, resource}, socket) do
@@ -1028,6 +1026,12 @@ defmodule PortalWeb.Policies do
 
   defp cond_values(nil), do: []
   defp cond_values(cond), do: cond.values
+
+  defp mark_stale_if_unreflected(socket, change) do
+    if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.policies, change),
+      do: socket,
+      else: assign(socket, stale: true)
+  end
 
   defmodule Database do
     import Ecto.Query

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -15,7 +15,8 @@ defmodule PortalWeb.Resources do
       panel_shell: 1,
       resource_details_panel: 1,
       resource_form_panel: 1,
-      resource_online?: 1,
+      resource_online?: 2,
+      resource_status: 2,
       resource_type_label: 1,
       type_badge_class: 1,
       to_grant_form: 0
@@ -36,6 +37,7 @@ defmodule PortalWeb.Resources do
     socket =
       socket
       |> assign(stale: false)
+      |> assign(presence_tick: 0)
       |> assign(page_title: "Resources")
       |> assign(
         selected_resource: nil,
@@ -61,38 +63,35 @@ defmodule PortalWeb.Resources do
   end
 
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :show}} = socket) do
-    tab =
-      case Map.get(params, "tab", "groups") do
-        t when t in ~w[groups authorizations] -> String.to_existing_atom(t)
-        _ -> :groups
-      end
-
-    page =
-      case Integer.parse(Map.get(params, "page", "1")) do
-        {n, ""} when n >= 1 -> n
-        _ -> 1
-      end
-
-    resource = Database.get_resource!(id, socket.assigns.subject)
-    groups = Database.list_groups_for_resource(resource, socket.assigns.subject)
-
-    {policy_authorizations, has_next_page} =
-      Database.list_policy_authorizations_for_resource(resource, socket.assigns.subject, page)
-
     socket = handle_live_tables_params(socket, params, uri)
-    filter_site = filter_site_from_params(params, socket.assigns.subject)
 
-    {:noreply,
-     socket
-     |> assign(
-       filter_site: filter_site,
-       selected_resource: resource,
-       selected_groups: groups,
-       policy_authorizations: policy_authorizations,
-       policy_authorizations_page: page,
-       policy_authorizations_has_next: has_next_page
-     )
-     |> assign(show_resource_state_assigns(socket, tab))}
+    case Database.get_resource(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_resources_index(socket, "Resource does not exist.")
+
+      resource ->
+        page = parse_page(params)
+        tab = parse_show_tab(params)
+
+        groups = Database.list_groups_for_resource(resource, socket.assigns.subject)
+
+        {policy_authorizations, has_next_page} =
+          Database.list_policy_authorizations_for_resource(resource, socket.assigns.subject, page)
+
+        filter_site = filter_site_from_params(params, socket.assigns.subject)
+
+        {:noreply,
+         socket
+         |> assign(
+           filter_site: filter_site,
+           selected_resource: resource,
+           selected_groups: groups,
+           policy_authorizations: policy_authorizations,
+           policy_authorizations_page: page,
+           policy_authorizations_has_next: has_next_page
+         )
+         |> assign(show_resource_state_assigns(socket, tab))}
+    end
   end
 
   def handle_params(params, uri, %{assigns: %{live_action: :new}} = socket) do
@@ -107,28 +106,32 @@ defmodule PortalWeb.Resources do
   end
 
   def handle_params(%{"id" => id} = params, uri, %{assigns: %{live_action: :edit}} = socket) do
-    resource = Database.get_resource!(id, socket.assigns.subject)
+    socket = handle_live_tables_params(socket, params, uri)
 
-    if resource.type == :internet do
-      {:noreply, push_patch(socket, to: resource_show_path(socket, id))}
-    else
-      sites = Database.all_sites(socket.assigns.subject)
-      changeset = Database.change_resource(resource)
-      selected_clients = Database.list_pool_members(resource, socket.assigns.subject)
-      socket = handle_live_tables_params(socket, params, uri)
+    case Database.get_resource(id, socket.assigns.subject) do
+      nil ->
+        redirect_to_resources_index(socket, "Resource does not exist.")
 
-      {:noreply,
-       socket
-       |> assign(filter_site: nil, selected_resource: resource, selected_groups: [])
-       |> assign(
-         edit_resource_state_assigns(
-           socket,
-           to_form(changeset),
-           sites,
-           resource,
-           selected_clients
-         )
-       )}
+      %{type: :internet} ->
+        {:noreply, push_patch(socket, to: resource_show_path(socket, id))}
+
+      resource ->
+        sites = Database.all_sites(socket.assigns.subject)
+        changeset = Database.change_resource(resource)
+        selected_clients = Database.list_pool_members(resource, socket.assigns.subject)
+
+        {:noreply,
+         socket
+         |> assign(filter_site: nil, selected_resource: resource, selected_groups: [])
+         |> assign(
+           edit_resource_state_assigns(
+             socket,
+             to_form(changeset),
+             sites,
+             resource,
+             selected_clients
+           )
+         )}
     end
   end
 
@@ -272,6 +275,27 @@ defmodule PortalWeb.Resources do
     end
   end
 
+  defp parse_page(params) do
+    case Integer.parse(Map.get(params, "page", "1")) do
+      {n, ""} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_show_tab(params) do
+    case Map.get(params, "tab", "groups") do
+      tab when tab in ~w[groups authorizations] -> String.to_existing_atom(tab)
+      _ -> :groups
+    end
+  end
+
+  defp redirect_to_resources_index(socket, message) do
+    {:noreply,
+     socket
+     |> put_flash(:error, message)
+     |> push_patch(to: ~p"/#{socket.assigns.account}/resources?#{socket.assigns.query_params}")}
+  end
+
   defp resources_index_path(socket), do: ~p"/#{socket.assigns.account}/resources"
   defp new_resource_path(socket), do: ~p"/#{socket.assigns.account}/resources/new"
 
@@ -332,7 +356,7 @@ defmodule PortalWeb.Resources do
           </.button>
         </:action>
         <:filters>
-          <% online_count = Enum.count(@resources, &resource_online?/1) %>
+          <% online_count = Enum.count(@resources, &resource_online?(&1, @presence_tick)) %>
           <% offline_count = length(@resources) - online_count %>
           <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border-emphasis)] bg-[var(--surface-raised)] text-[var(--text-primary)] font-medium">
             All {@resources_metadata.count}
@@ -426,9 +450,7 @@ defmodule PortalWeb.Resources do
               </td>
               <td class="px-4 py-3 text-[var(--text-secondary)] text-xs">Internet</td>
               <td class="px-4 py-3">
-                <.status_badge status={
-                  if resource_online?(@internet_resource), do: :online, else: :offline
-                } />
+                <.status_badge status={resource_status(@internet_resource, @presence_tick)} />
               </td>
             </tr>
           </:prepend_rows>
@@ -512,7 +534,7 @@ defmodule PortalWeb.Resources do
             </span>
           </:col>
           <:col :let={resource} label="Status" class="w-32">
-            <.status_badge status={if resource_online?(resource), do: :online, else: :offline} />
+            <.status_badge status={resource_status(resource, @presence_tick)} />
           </:col>
           <:empty>
             <div class="flex flex-col items-center gap-3 py-16">
@@ -551,6 +573,7 @@ defmodule PortalWeb.Resources do
           <.resource_details_panel
             account={@account}
             resource={@selected_resource}
+            presence_tick={@presence_tick}
             groups={@selected_groups}
             policy_authorizations={@policy_authorizations}
             policy_authorizations_page={@policy_authorizations_page}
@@ -1192,17 +1215,17 @@ defmodule PortalWeb.Resources do
      )}
   end
 
-  def handle_info(%Change{old_struct: %Resource{}}, socket) do
-    {:noreply, reload_live_table!(socket, "resources")}
+  def handle_info(%Change{old_struct: %Resource{}} = change, socket) do
+    {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
-  def handle_info(%Change{struct: %Resource{}}, socket) do
-    {:noreply, reload_live_table!(socket, "resources")}
+  def handle_info(%Change{struct: %Resource{}} = change, socket) do
+    {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
   def handle_info(%Phoenix.Socket.Broadcast{event: event}, socket)
       when event in ["presence_diff", "presence_state"] do
-    {:noreply, reload_live_table!(socket, "resources")}
+    {:noreply, update(socket, :presence_tick, &(&1 + 1))}
   end
 
   def handle_info(_, socket) do
@@ -1268,6 +1291,12 @@ defmodule PortalWeb.Resources do
   end
 
   defp drop_static_device_pool(filter), do: filter
+
+  defp mark_stale_if_unreflected(socket, change) do
+    if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.resources, change),
+      do: socket,
+      else: assign(socket, stale: true)
+  end
 
   defmodule Database do
     import Ecto.Query
@@ -1411,12 +1440,12 @@ defmodule PortalWeb.Resources do
 
     def list_pool_members(_resource, _subject), do: []
 
-    def get_resource!(id, subject) do
+    def get_resource(id, subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.id == ^id)
       |> preload(:site)
       |> Safe.scoped(subject, :replica)
-      |> Safe.one!(fallback_to_primary: true)
+      |> Safe.one(fallback_to_primary: true)
     end
 
     def get_site(id, subject) do

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1015,6 +1015,7 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :resource, :any, required: true
+  attr :presence_tick, :integer, default: 0
   attr :groups, :list, default: []
   attr :policy_authorizations, :list, default: []
   attr :policy_authorizations_page, :integer, default: 1
@@ -1067,7 +1068,7 @@ defmodule PortalWeb.Resources.Components do
             <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
               Status
             </span>
-            <.status_badge status={if resource_online?(@resource), do: :online, else: :offline} />
+            <.status_badge status={resource_status(@resource, @presence_tick)} />
           </div>
           <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
           <div class="flex items-center gap-1.5">
@@ -1123,6 +1124,7 @@ defmodule PortalWeb.Resources.Components do
         <.resource_sidebar
           account={@account}
           resource={@resource}
+          presence_tick={@presence_tick}
           ui_state={@ui_state}
         />
       </div>
@@ -1744,6 +1746,7 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :resource, :any, required: true
+  attr :presence_tick, :integer, default: 0
   attr :ui_state, :map, required: true
 
   def resource_sidebar(assigns) do
@@ -1842,7 +1845,7 @@ defmodule PortalWeb.Resources.Components do
                   {@resource.site.name}
                 </.link>
                 <span
-                  :if={resource_online?(@resource)}
+                  :if={resource_online?(@resource, @presence_tick)}
                   class="relative flex items-center justify-center w-1.5 h-1.5"
                 >
                   <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-[var(--status-active)]">
@@ -1918,11 +1921,17 @@ defmodule PortalWeb.Resources.Components do
     |> to_form(as: :policy)
   end
 
-  @spec resource_online?(map()) :: boolean()
-  def resource_online?(%{site_id: nil}), do: false
+  @spec resource_online?(map(), integer()) :: boolean()
+  def resource_online?(resource, _presence_tick \\ 0)
+  def resource_online?(%{site_id: nil}, _presence_tick), do: false
 
-  def resource_online?(%{site_id: site_id}) do
+  def resource_online?(%{site_id: site_id}, _presence_tick) do
     Presence.Gateways.Site.list(site_id) |> map_size() > 0
+  end
+
+  @spec resource_status(map(), integer()) :: :online | :offline
+  def resource_status(resource, presence_tick \\ 0) do
+    if resource_online?(resource, presence_tick), do: :online, else: :offline
   end
 
   @spec resource_type_label(atom()) :: String.t()

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -50,7 +50,7 @@ defmodule PortalWeb.Sites do
     else
       case Database.get_site(id, socket.assigns.subject) do
         nil ->
-          {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites")}
+          redirect_to_sites_index(socket, "Site does not exist.")
 
         site ->
           {:noreply,
@@ -79,7 +79,7 @@ defmodule PortalWeb.Sites do
     else
       case Database.get_site(id, socket.assigns.subject) do
         nil ->
-          {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites")}
+          redirect_to_sites_index(socket, "Site does not exist.")
 
         site ->
           changeset = Database.change_site(site)
@@ -110,6 +110,13 @@ defmodule PortalWeb.Sites do
 
   def handle_params(_params, _uri, socket) do
     {:noreply, socket |> unsubscribe_deploy_site_presence() |> assign(site_state_reset_assigns())}
+  end
+
+  defp redirect_to_sites_index(socket, message) do
+    {:noreply,
+     socket
+     |> put_flash(:error, message)
+     |> push_patch(to: ~p"/#{socket.assigns.account}/sites?#{socket.assigns.query_params}")}
   end
 
   defp site_panel_assigns(site, params, socket) do

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -214,13 +214,14 @@ defmodule PortalWeb.LiveTable do
         :if={@stale}
         id={"#{@live_table_id}-reload-btn"}
         type="button"
-        style="info"
-        title="The table data has changed."
+        style="warning"
+        size="xs"
+        title="The table data has changed"
         phx-click="reload"
         phx-value-table_id={@live_table_id}
         class="shrink-0"
       >
-        <.icon name="ri-loop-left-line" class="mr-1 w-3.5 h-3.5" /> Reload
+        <.icon name="ri-loop-left-line" class="mr-1 w-3 h-3" /> Reload
       </.button>
       <span
         :for={notice <- @notice}
@@ -589,6 +590,33 @@ defmodule PortalWeb.LiveTable do
         socket
     end
   end
+
+  @doc """
+  Returns true when the rendered list already reflects the change.
+
+  For inserts and updates the rendered row must be field-equal to the
+  broadcast's `struct` — sharing an id is not enough since updates leave
+  the id intact. For deletes the rendered list must no longer contain
+  the deleted id.
+
+  Used by LVs subscribed to `Portal.Changes` to drop broadcasts that
+  fired for a mutation the LV itself just performed and reloaded for.
+  """
+  def view_reflects_change?(list, %Portal.Changes.Change{op: op, struct: struct})
+      when op in [:insert, :update] do
+    Enum.any?(list, &same_record?(&1, struct))
+  end
+
+  def view_reflects_change?(list, %Portal.Changes.Change{op: :delete, old_struct: %{id: id}}) do
+    not Enum.any?(list, &(&1.id == id))
+  end
+
+  defp same_record?(%mod{} = a, %mod{} = b) do
+    fields = mod.__schema__(:fields)
+    Map.take(a, fields) == Map.take(b, fields)
+  end
+
+  defp same_record?(_, _), do: false
 
   if Mix.env() == :test do
     defp maybe_notify_test_pid(id) do

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -339,6 +339,22 @@ defmodule PortalWeb.ClientsTest do
                "Revoke verification"
              )
     end
+
+    test "patches to clients index with flash when client does not exist", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      missing_id = Ecto.UUID.generate()
+
+      assert {:error, {:live_redirect, %{to: to, flash: flash}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(~p"/#{account}/clients/#{missing_id}")
+
+      assert to == ~p"/#{account}/clients"
+      assert flash["error"] =~ "Client does not exist"
+    end
   end
 
   describe ":edit action" do

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -395,6 +395,22 @@ defmodule PortalWeb.GroupsTest do
                    flash: %{"error" => "This group cannot be edited"}
                  }}}
     end
+
+    test "patches to groups index with flash when group does not exist", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      missing_id = Ecto.UUID.generate()
+
+      assert {:error, {:live_redirect, %{to: to, flash: flash}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(~p"/#{account}/groups/#{missing_id}")
+
+      assert to == ~p"/#{account}/groups"
+      assert flash["error"] =~ "Group does not exist"
+    end
   end
 
   describe ":edit action" do

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -280,6 +280,42 @@ defmodule PortalWeb.PoliciesTest do
       render_click(lv, "close_panel")
       assert_patch(lv, ~p"/#{account}/policies")
     end
+
+    test "patches to policies index with flash when policy does not exist", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      missing_id = Ecto.UUID.generate()
+      path = ~p"/#{account}/policies/#{missing_id}"
+
+      assert {:error, {:live_redirect, %{to: to, flash: flash}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(path)
+
+      assert to == ~p"/#{account}/policies"
+      assert flash["error"] =~ "Policy does not exist"
+    end
+
+    test "preserves filter query params when redirecting from missing policy", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      missing_id = Ecto.UUID.generate()
+
+      assert {:error, {:live_redirect, %{to: to}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(
+                 ~p"/#{account}/policies/#{missing_id}?#{[policies_filter: %{site_id: site.id}]}"
+               )
+
+      assert to =~ "policies_filter"
+      assert to =~ site.id
+    end
   end
 
   describe ":edit action" do

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -704,6 +704,22 @@ defmodule PortalWeb.ResourcesTest do
       render_click(lv, "close_panel")
       assert_patch(lv, ~p"/#{account}/resources")
     end
+
+    test "patches to resources index with flash when resource does not exist", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      missing_id = Ecto.UUID.generate()
+
+      assert {:error, {:live_redirect, %{to: to, flash: flash}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(~p"/#{account}/resources/#{missing_id}")
+
+      assert to == ~p"/#{account}/resources"
+      assert flash["error"] =~ "Resource does not exist"
+    end
   end
 
   describe ":edit action" do

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -403,6 +403,22 @@ defmodule PortalWeb.SitesTest do
       render_click(lv, "select_site", %{"id" => site_b.id})
       assert_patch(lv, ~p"/#{account}/sites/#{site_b.id}")
     end
+
+    test "patches to sites index with flash when site does not exist", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      missing_id = Ecto.UUID.generate()
+
+      assert {:error, {:live_redirect, %{to: to, flash: flash}}} =
+               conn
+               |> authorize_conn(actor)
+               |> live(~p"/#{account}/sites/#{missing_id}")
+
+      assert to == ~p"/#{account}/sites"
+      assert flash["error"] =~ "Site does not exist"
+    end
   end
 
   describe ":edit action" do


### PR DESCRIPTION
Show and edit panels for policies, clients, sites, groups, and resources crashed with `BadMapError` when the targeted record was deleted between the row being rendered and the user clicking it — a race that surfaced regularly during pagination. This PR fixes the race and aligns the resources table's live-update behavior with the policies table.

## Missing-record UX

Show and edit handlers across the five LVs now match on `nil` and redirect back to the index, preserving filter and pagination query params. The flash reads `"<entity> does not exist."` in both cases.

Bang variants `Database.get_resource!/2` and `Database.get_group_with_actors!/3` were converted to non-bang so the `nil` branch can be handled explicitly instead of raising.

## Live updates on the resources table

The resources LV used to call `reload_live_table!` on every PubSub change and gateway presence diff, re-querying the DB each time. It now matches policies:

- `%Change{}` events for `Portal.Resource` set `stale: true` and surface the Reload button.
- `presence_diff` / `presence_state` events bump a new `presence_tick` assign that is referenced by `resource_online?/2` call sites, so online/offline indicators re-render without re-fetching resources.

## Stale-flag debounce

`PortalWeb.LiveTable.view_reflects_change?/2` drops broadcasts whose post-change state is already reflected in the rendered list:

| op | drop when |
| --- | --- |
| insert | a list item is field-equal to the broadcast's struct |
| update | a list item is field-equal to the broadcast's struct |
| delete | the deleted id is not in the list |

For inserts and updates, equality is checked over `__schema__(:fields)` so preloads on the in-view copy don't break the comparison. After a self-action that calls `reload_live_table!`, the view holds the post-mutation row and the broadcast is dropped. Other users' updates to a row we're already showing don't compare equal (we still hold the pre-update fields), so the Reload button surfaces.

## Misc

- Reload button now uses the real warning color (`--status-warn`) instead of `--brand`. The "The table data has changed" copy is back to a `title=` tooltip.
- Replaced inline `if resource_online?(...), do: :online, else: :offline` ternaries with a `resource_status/2` helper.

---

<img width="352" height="155" alt="Screenshot 2026-05-09 at 9 50 41 AM" src="https://github.com/user-attachments/assets/7bb2d27d-eba7-4e10-955b-4a9bf927eb05" />
<img width="167" height="81" alt="Screenshot 2026-05-09 at 9 42 15 AM" src="https://github.com/user-attachments/assets/132e16e6-d526-4d0c-8589-cfa8700b3e2b" />
<img width="181" height="118" alt="Screenshot 2026-05-09 at 9 42 13 AM" src="https://github.com/user-attachments/assets/845e0e32-a5a7-41af-941e-f8b47ca22e41" />


---

Fixes https://github.com/firezone/firezone/issues/13182