### PR TITLE
chore(portal): relax noisy logs

### DIFF
--- a/elixir/lib/portal/client_session/buffer.ex
+++ b/elixir/lib/portal/client_session/buffer.ex
@@ -75,7 +75,7 @@ defmodule Portal.ClientSession.Buffer do
     skipped = count - inserted
 
     if skipped > 0 do
-      Logger.warning(
+      Logger.info(
         "Skipped #{skipped} client sessions due to deleted associations (tokens/accounts/devices)"
       )
     end

--- a/elixir/lib/portal/gateway_session/buffer.ex
+++ b/elixir/lib/portal/gateway_session/buffer.ex
@@ -75,7 +75,7 @@ defmodule Portal.GatewaySession.Buffer do
     skipped = count - inserted
 
     if skipped > 0 do
-      Logger.warning(
+      Logger.info(
         "Skipped #{skipped} gateway sessions due to deleted associations (tokens/accounts/devices)"
       )
     end

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -253,7 +253,7 @@ defmodule PortalAPI.Client.Socket do
             [{field, %{existing: existing_value, new: new_value}}]
           end)
 
-        Logger.warning(
+        Logger.info(
           "Hardware ID mismatch for client",
           [client_id: existing_client.id] ++ details
         )


### PR DESCRIPTION
It's still good to have these logs for troubleshooting but they don't need to be alerting us.

---

Fixes #13183
Fixes #13185
