### PR TITLE
fix(portal): gracefully handle deleted records in LVs

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1655,13 +1655,18 @@ defmodule PortalWeb.Actors do
     end
 
     @spec remove_group_member(Ecto.UUID.t(), Portal.Actor.t(), Portal.Authentication.Subject.t()) ::
-            {:ok, Portal.Membership.t()} | {:error, any()}
+            {:ok, Portal.Membership.t()} | {:error, any()} | nil
     def remove_group_member(group_id, actor, subject) do
+      with %Portal.Membership{} = membership <- fetch_membership(group_id, actor, subject) do
+        Safe.scoped(membership, subject) |> Safe.delete()
+      end
+    end
+
+    defp fetch_membership(group_id, actor, subject) do
       from(m in Portal.Membership, as: :memberships)
       |> where([memberships: m], m.group_id == ^group_id and m.actor_id == ^actor.id)
       |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(&(Safe.scoped(&1, subject) |> Safe.delete()))
+      |> Safe.one()
     end
   end
 end

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -522,45 +522,25 @@ defmodule PortalWeb.Groups do
   end
 
   def handle_event("disable_resource_access", %{"resource_id" => resource_id}, socket) do
-    case Database.disable_policy_for_resource(
-           socket.assigns.selected_group,
-           resource_id,
-           socket.assigns.subject
-         ) do
-      {:ok, _} ->
-        resources =
-          Database.list_resources_for_group(socket.assigns.selected_group, socket.assigns.subject)
+    result =
+      Database.disable_policy_for_resource(
+        socket.assigns.selected_group,
+        resource_id,
+        socket.assigns.subject
+      )
 
-        {:noreply,
-         merge_state(socket, :group_resources,
-           resources: resources,
-           resource_access_actions_open_id: nil
-         )}
-
-      {:error, _} ->
-        {:noreply, socket}
-    end
+    apply_resource_access_change(socket, result)
   end
 
   def handle_event("enable_resource_access", %{"resource_id" => resource_id}, socket) do
-    case Database.enable_policy_for_resource(
-           socket.assigns.selected_group,
-           resource_id,
-           socket.assigns.subject
-         ) do
-      {:ok, _} ->
-        resources =
-          Database.list_resources_for_group(socket.assigns.selected_group, socket.assigns.subject)
+    result =
+      Database.enable_policy_for_resource(
+        socket.assigns.selected_group,
+        resource_id,
+        socket.assigns.subject
+      )
 
-        {:noreply,
-         merge_state(socket, :group_resources,
-           resources: resources,
-           resource_access_actions_open_id: nil
-         )}
-
-      {:error, _} ->
-        {:noreply, socket}
-    end
+    apply_resource_access_change(socket, result)
   end
 
   def handle_event("confirm_remove_resource_access", %{"resource_id" => resource_id}, socket) do
@@ -576,24 +556,14 @@ defmodule PortalWeb.Groups do
   end
 
   def handle_event("remove_resource_access", %{"resource_id" => resource_id}, socket) do
-    case Database.delete_policy_for_resource(
-           socket.assigns.selected_group,
-           resource_id,
-           socket.assigns.subject
-         ) do
-      {:ok, _} ->
-        resources =
-          Database.list_resources_for_group(socket.assigns.selected_group, socket.assigns.subject)
+    result =
+      Database.delete_policy_for_resource(
+        socket.assigns.selected_group,
+        resource_id,
+        socket.assigns.subject
+      )
 
-        {:noreply,
-         merge_state(socket, :group_resources,
-           resources: resources,
-           confirm_remove_resource_access_id: nil
-         )}
-
-      {:error, _} ->
-        {:noreply, merge_state(socket, :group_resources, confirm_remove_resource_access_id: nil)}
-    end
+    apply_resource_access_removal(socket, result)
   end
 
   def handle_event("prev_member_page", _params, socket) do
@@ -1263,6 +1233,50 @@ defmodule PortalWeb.Groups do
     )
   end
 
+  defp apply_resource_access_change(socket, {:error, _}) do
+    {:noreply, put_flash(socket, :error, "Could not update resource access.")}
+  end
+
+  defp apply_resource_access_change(socket, result) do
+    socket =
+      socket
+      |> refresh_group_resources(resource_access_actions_open_id: nil)
+      |> maybe_put_stale_flash(result, "Resource access state has changed.")
+
+    {:noreply, socket}
+  end
+
+  defp apply_resource_access_removal(socket, {:error, _}) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Could not remove resource access.")
+     |> merge_state(:group_resources, confirm_remove_resource_access_id: nil)}
+  end
+
+  defp apply_resource_access_removal(socket, result) do
+    socket =
+      socket
+      |> refresh_group_resources(confirm_remove_resource_access_id: nil)
+      |> maybe_put_stale_flash(result, "Resource access no longer exists.")
+
+    {:noreply, socket}
+  end
+
+  defp refresh_group_resources(socket, ui_state) do
+    resources =
+      Database.list_resources_for_group(socket.assigns.selected_group, socket.assigns.subject)
+
+    merge_state(socket, :group_resources, Keyword.put(ui_state, :resources, resources))
+  end
+
+  defp maybe_put_stale_flash(socket, nil, message) do
+    put_flash(socket, :error, message)
+  end
+
+  defp maybe_put_stale_flash(socket, _result, _message) do
+    socket
+  end
+
   defmodule Database do
     import Ecto.Query
     import Portal.Repo.Query
@@ -1586,41 +1600,23 @@ defmodule PortalWeb.Groups do
     end
 
     def disable_policy_for_resource(group, resource_id, subject) do
-      from(p in Portal.Policy, as: :policies)
-      |> where(
-        [policies: p],
-        p.group_id == ^group.id and p.resource_id == ^resource_id and is_nil(p.disabled_at)
-      )
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(fn policy ->
-        Ecto.Changeset.change(policy, %{disabled_at: DateTime.utc_now()})
-        |> Safe.scoped(subject)
-        |> Safe.update()
-      end)
+      with %Portal.Policy{} = policy <-
+             fetch_policy_for_resource(group, resource_id, subject, state: :enabled) do
+        set_policy_disabled_at(policy, subject, DateTime.utc_now())
+      end
     end
 
     def enable_policy_for_resource(group, resource_id, subject) do
-      from(p in Portal.Policy, as: :policies)
-      |> where(
-        [policies: p],
-        p.group_id == ^group.id and p.resource_id == ^resource_id and not is_nil(p.disabled_at)
-      )
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(fn policy ->
-        Ecto.Changeset.change(policy, %{disabled_at: nil})
-        |> Safe.scoped(subject)
-        |> Safe.update()
-      end)
+      with %Portal.Policy{} = policy <-
+             fetch_policy_for_resource(group, resource_id, subject, state: :disabled) do
+        set_policy_disabled_at(policy, subject, nil)
+      end
     end
 
     def delete_policy_for_resource(group, resource_id, subject) do
-      from(p in Portal.Policy, as: :policies)
-      |> where([policies: p], p.group_id == ^group.id and p.resource_id == ^resource_id)
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(&(Safe.scoped(&1, subject) |> Safe.delete()))
+      with %Portal.Policy{} = policy <- fetch_policy_for_resource(group, resource_id, subject) do
+        Safe.scoped(policy, subject) |> Safe.delete()
+      end
     end
 
     def list_group_members(group, subject, page, page_size, filter, opts \\ []) do
@@ -1671,14 +1667,6 @@ defmodule PortalWeb.Groups do
         end
 
       {members, total}
-    end
-
-    def remove_group_member(group, actor_id, subject) do
-      from(m in Portal.Membership, as: :memberships)
-      |> where([memberships: m], m.group_id == ^group.id and m.actor_id == ^actor_id)
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(&(Safe.scoped(&1, subject) |> Safe.delete()))
     end
 
     def list_available_resources(existing_resource_ids, subject) do
@@ -1814,6 +1802,28 @@ defmodule PortalWeb.Groups do
       group
       |> Safe.scoped(subject)
       |> Safe.delete()
+    end
+
+    defp fetch_policy_for_resource(group, resource_id, subject, opts \\ []) do
+      from(p in Portal.Policy, as: :policies)
+      |> where([policies: p], p.group_id == ^group.id and p.resource_id == ^resource_id)
+      |> filter_policy_state(opts[:state])
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+    end
+
+    defp filter_policy_state(query, :enabled),
+      do: where(query, [policies: p], is_nil(p.disabled_at))
+
+    defp filter_policy_state(query, :disabled),
+      do: where(query, [policies: p], not is_nil(p.disabled_at))
+
+    defp filter_policy_state(query, _), do: query
+
+    defp set_policy_disabled_at(policy, subject, disabled_at) do
+      Ecto.Changeset.change(policy, %{disabled_at: disabled_at})
+      |> Safe.scoped(subject)
+      |> Safe.update()
     end
   end
 end

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -1082,49 +1082,25 @@ defmodule PortalWeb.Resources do
   end
 
   def handle_event("disable_policy", %{"group_id" => group_id}, socket) do
-    case Database.disable_policy_for_group(
-           socket.assigns.selected_resource,
-           group_id,
-           socket.assigns.subject
-         ) do
-      {:ok, _} ->
-        groups =
-          Database.list_groups_for_resource(
-            socket.assigns.selected_resource,
-            socket.assigns.subject
-          )
+    result =
+      Database.disable_policy_for_group(
+        socket.assigns.selected_resource,
+        group_id,
+        socket.assigns.subject
+      )
 
-        {:noreply,
-         socket
-         |> assign(selected_groups: groups)
-         |> merge_state(:resource_ui, group_actions_open_id: nil)}
-
-      {:error, _} ->
-        {:noreply, socket}
-    end
+    apply_group_state_change(socket, result)
   end
 
   def handle_event("enable_policy", %{"group_id" => group_id}, socket) do
-    case Database.enable_policy_for_group(
-           socket.assigns.selected_resource,
-           group_id,
-           socket.assigns.subject
-         ) do
-      {:ok, _} ->
-        groups =
-          Database.list_groups_for_resource(
-            socket.assigns.selected_resource,
-            socket.assigns.subject
-          )
+    result =
+      Database.enable_policy_for_group(
+        socket.assigns.selected_resource,
+        group_id,
+        socket.assigns.subject
+      )
 
-        {:noreply,
-         socket
-         |> assign(selected_groups: groups)
-         |> merge_state(:resource_ui, group_actions_open_id: nil)}
-
-      {:error, _} ->
-        {:noreply, socket}
-    end
+    apply_group_state_change(socket, result)
   end
 
   def handle_event(
@@ -1155,7 +1131,10 @@ defmodule PortalWeb.Resources do
          |> push_patch(to: ~p"/#{socket.assigns.account}/resources")}
 
       {:error, _} ->
-        {:noreply, merge_state(socket, :resource_ui, confirm_delete_resource: false)}
+        {:noreply,
+         socket
+         |> put_flash(:error, "Could not delete resource.")
+         |> merge_state(:resource_ui, confirm_delete_resource: false)}
     end
   end
 
@@ -1172,21 +1151,14 @@ defmodule PortalWeb.Resources do
   end
 
   def handle_event("remove_group_access", %{"group_id" => group_id}, socket) do
-    resource = socket.assigns.selected_resource
+    result =
+      Database.delete_policy_for_group(
+        socket.assigns.selected_resource,
+        group_id,
+        socket.assigns.subject
+      )
 
-    case Database.delete_policy_for_group(resource, group_id, socket.assigns.subject) do
-      {:ok, _} ->
-        groups = Database.list_groups_for_resource(resource, socket.assigns.subject)
-
-        {:noreply,
-         socket
-         |> assign(selected_groups: groups)
-         |> merge_state(:resource_ui, confirm_remove_group_id: nil, group_actions_open_id: nil)
-         |> reload_live_table!("resources")}
-
-      {:error, _} ->
-        {:noreply, merge_state(socket, :resource_ui, confirm_remove_group_id: nil)}
-    end
+    apply_group_removal(socket, result)
   end
 
   def handle_event("toggle_conditions_dropdown", _params, socket) do
@@ -1296,6 +1268,53 @@ defmodule PortalWeb.Resources do
     if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.resources, change),
       do: socket,
       else: assign(socket, stale: true)
+  end
+
+  defp apply_group_state_change(socket, {:error, _}) do
+    {:noreply, put_flash(socket, :error, "Could not update group access.")}
+  end
+
+  defp apply_group_state_change(socket, result) do
+    socket =
+      socket
+      |> refresh_selected_groups()
+      |> merge_state(:resource_ui, group_actions_open_id: nil)
+      |> maybe_put_stale_flash(result, "Group access state has changed.")
+
+    {:noreply, socket}
+  end
+
+  defp apply_group_removal(socket, {:error, _}) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Could not remove group access.")
+     |> merge_state(:resource_ui, confirm_remove_group_id: nil)}
+  end
+
+  defp apply_group_removal(socket, result) do
+    socket =
+      socket
+      |> refresh_selected_groups()
+      |> merge_state(:resource_ui, confirm_remove_group_id: nil, group_actions_open_id: nil)
+      |> reload_live_table!("resources")
+      |> maybe_put_stale_flash(result, "Group access no longer exists.")
+
+    {:noreply, socket}
+  end
+
+  defp refresh_selected_groups(socket) do
+    groups =
+      Database.list_groups_for_resource(socket.assigns.selected_resource, socket.assigns.subject)
+
+    assign(socket, selected_groups: groups)
+  end
+
+  defp maybe_put_stale_flash(socket, nil, message) do
+    put_flash(socket, :error, message)
+  end
+
+  defp maybe_put_stale_flash(socket, _result, _message) do
+    socket
   end
 
   defmodule Database do
@@ -1608,44 +1627,22 @@ defmodule PortalWeb.Resources do
     end
 
     def delete_policy_for_group(resource, group_id, subject) do
-      from(p in Policy, as: :policies)
-      |> where(
-        [policies: p],
-        p.resource_id == ^resource.id and p.group_id == ^group_id
-      )
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(&(Safe.scoped(&1, subject) |> Safe.delete()))
+      with %Policy{} = policy <- fetch_policy_for_group(resource, group_id, subject) do
+        Safe.scoped(policy, subject) |> Safe.delete()
+      end
     end
 
     def disable_policy_for_group(resource, group_id, subject) do
-      from(p in Policy, as: :policies)
-      |> where(
-        [policies: p],
-        p.resource_id == ^resource.id and p.group_id == ^group_id and is_nil(p.disabled_at)
-      )
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(fn policy ->
-        Ecto.Changeset.change(policy, %{disabled_at: DateTime.utc_now()})
-        |> Safe.scoped(subject)
-        |> Safe.update()
-      end)
+      with %Policy{} = policy <- fetch_policy_for_group(resource, group_id, subject, state: :enabled) do
+        set_policy_disabled_at(policy, subject, DateTime.utc_now())
+      end
     end
 
     def enable_policy_for_group(resource, group_id, subject) do
-      from(p in Policy, as: :policies)
-      |> where(
-        [policies: p],
-        p.resource_id == ^resource.id and p.group_id == ^group_id and not is_nil(p.disabled_at)
-      )
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(fn policy ->
-        Ecto.Changeset.change(policy, %{disabled_at: nil})
-        |> Safe.scoped(subject)
-        |> Safe.update()
-      end)
+      with %Policy{} = policy <-
+             fetch_policy_for_group(resource, group_id, subject, state: :disabled) do
+        set_policy_disabled_at(policy, subject, nil)
+      end
     end
 
     def list_providers(subject) do
@@ -1731,6 +1728,28 @@ defmodule PortalWeb.Resources do
 
     def filter_by_type(queryable, type) do
       {queryable, dynamic([resources: r], r.type == ^String.to_existing_atom(type))}
+    end
+
+    defp fetch_policy_for_group(resource, group_id, subject, opts \\ []) do
+      from(p in Policy, as: :policies)
+      |> where([policies: p], p.resource_id == ^resource.id and p.group_id == ^group_id)
+      |> filter_policy_state(opts[:state])
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+    end
+
+    defp filter_policy_state(query, :enabled),
+      do: where(query, [policies: p], is_nil(p.disabled_at))
+
+    defp filter_policy_state(query, :disabled),
+      do: where(query, [policies: p], not is_nil(p.disabled_at))
+
+    defp filter_policy_state(query, _), do: query
+
+    defp set_policy_disabled_at(policy, subject, disabled_at) do
+      Ecto.Changeset.change(policy, %{disabled_at: disabled_at})
+      |> Safe.scoped(subject)
+      |> Safe.update()
     end
   end
 end

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -1069,11 +1069,16 @@ defmodule PortalWeb.ServiceAccounts do
     end
 
     def remove_group_member(group_id, actor, subject) do
+      with %Portal.Membership{} = membership <- fetch_membership(group_id, actor, subject) do
+        Safe.scoped(membership, subject) |> Safe.delete()
+      end
+    end
+
+    defp fetch_membership(group_id, actor, subject) do
       from(m in Portal.Membership, as: :memberships)
       |> where([memberships: m], m.group_id == ^group_id and m.actor_id == ^actor.id)
       |> Safe.scoped(subject, :replica)
-      |> Safe.one!()
-      |> then(&(Safe.scoped(&1, subject) |> Safe.delete()))
+      |> Safe.one()
     end
   end
 end

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -856,6 +856,42 @@ defmodule PortalWeb.ActorsTest do
       refute html =~ current_group.name
     end
 
+    test "saves successfully when a pending group removal was already deleted in another tab",
+         %{conn: conn, account: account, actor: actor} do
+      other_actor = actor_fixture(account: account)
+      current_group = group_fixture(account: account, name: "Current Group")
+      membership = membership_fixture(actor: other_actor, group: current_group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}/edit")
+
+      render_click(lv, "add_pending_group_removal", %{"group_id" => current_group.id})
+
+      Portal.Repo.delete!(membership)
+
+      lv
+      |> form("form[phx-submit='save']",
+        actor: %{
+          name: other_actor.name,
+          email: other_actor.email,
+          type: "account_user",
+          allow_email_otp_sign_in: "true"
+        }
+      )
+      |> render_submit()
+
+      html = render(lv)
+      assert html =~ "Actor updated successfully."
+      refute html =~ "Failed to update some group memberships."
+
+      refute Portal.Repo.get_by(Portal.Membership,
+               actor_id: other_actor.id,
+               group_id: current_group.id
+             )
+    end
+
     test "shows error flash when adding a group membership fails", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -340,6 +340,77 @@ defmodule PortalWeb.GroupsTest do
       assert render(lv) =~ "No resource access"
     end
 
+    test "shows flash when remove_resource_access loses race", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account, name: "Internal DB")
+      policy = policy_fixture(account: account, group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{group}?tab=resources")
+
+      Repo.delete!(policy)
+
+      render_click(lv, "confirm_remove_resource_access", %{"resource_id" => resource.id})
+      html = render_click(lv, "remove_resource_access", %{"resource_id" => resource.id})
+
+      assert html =~ "Resource access no longer exists."
+    end
+
+    test "shows flash when disable_resource_access loses race", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account, name: "Internal DB")
+      policy = policy_fixture(account: account, group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{group}?tab=resources")
+
+      Repo.delete!(policy)
+
+      html = render_click(lv, "disable_resource_access", %{"resource_id" => resource.id})
+
+      assert html =~ "Resource access state has changed."
+    end
+
+    test "shows flash when enable_resource_access loses race", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account, name: "Internal DB")
+
+      policy =
+        policy_fixture(
+          account: account,
+          group: group,
+          resource: resource,
+          disabled_at: DateTime.utc_now()
+        )
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{group}?tab=resources")
+
+      Repo.delete!(policy)
+
+      html = render_click(lv, "enable_resource_access", %{"resource_id" => resource.id})
+
+      assert html =~ "Resource access state has changed."
+    end
+
     test "filters and paginates members", %{conn: conn, account: account, actor: actor} do
       group = group_fixture(account: account)
 

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -666,6 +666,78 @@ defmodule PortalWeb.ResourcesTest do
       assert is_nil(Repo.get_by(Policy, resource_id: resource.id, group_id: group.id))
     end
 
+    test "shows flash and refreshes group list when remove_group_access loses race", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account, name: "Ops Team")
+      policy = policy_fixture(account: account, resource: resource, group: group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      Repo.delete!(policy)
+
+      render_click(lv, "confirm_remove_group", %{"group_id" => group.id})
+      html = render_click(lv, "remove_group_access", %{"group_id" => group.id})
+
+      assert html =~ "Group access no longer exists."
+      assert html =~ "No groups have access yet."
+    end
+
+    test "shows flash when disable_policy loses race", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account, name: "Ops Team")
+      policy = policy_fixture(account: account, resource: resource, group: group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      Repo.delete!(policy)
+
+      html = render_click(lv, "disable_policy", %{"group_id" => group.id})
+
+      assert html =~ "Group access state has changed."
+    end
+
+    test "shows flash when enable_policy loses race", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+      group = group_fixture(account: account, name: "Ops Team")
+
+      policy =
+        policy_fixture(
+          account: account,
+          resource: resource,
+          group: group,
+          disabled_at: DateTime.utc_now()
+        )
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      Repo.delete!(policy)
+
+      html = render_click(lv, "enable_policy", %{"group_id" => group.id})
+
+      assert html =~ "Group access state has changed."
+    end
+
     test "internet resource ignores edit and delete actions", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -883,6 +883,34 @@ defmodule PortalWeb.ServiceAccountsTest do
       assert render(lv) =~ group.name
     end
 
+    test "saves successfully when a pending group removal was already deleted in another tab",
+         %{conn: conn, account: account, actor: actor} do
+      service_account = service_account_fixture(account: account)
+      group = group_fixture(account: account, name: "Current Group")
+      membership = membership_fixture(actor: service_account, group: group)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}/edit")
+
+      render_click(lv, "add_pending_group_removal", %{"group_id" => group.id})
+
+      Portal.Repo.delete!(membership)
+
+      lv
+      |> form("form[phx-submit='save']", actor: %{name: service_account.name})
+      |> render_submit()
+
+      html = render(lv)
+      refute html =~ "Failed to update some group memberships."
+
+      refute Portal.Repo.get_by(Portal.Membership,
+               actor_id: service_account.id,
+               group_id: group.id
+             )
+    end
+
     test "shows error flash when adding a group membership to a service account fails", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
- Fix `Ecto.NoResultsError` crash when a policy or membership is deleted in another tab between render and click (resource and group "remove/disable/enable access" actions, and actor/service-account group membership saves).
- Database wrappers (`delete_/disable_/enable_policy_for_group`, `delete_/disable_/enable_policy_for_resource`, `remove_group_member`) follow `Repo.one` semantics: return `nil` for missing records, `{:ok, _}` on success, `{:error, _}` on real failures. Implemented with `with %Schema{} = record <- fetch_…` so `nil` and `{:error, _}` propagate without a `case`.
- LV handlers dispatch on the result: `{:error, _}` shows a generic "Could not …" toast; `nil` shows a stale-record toast and refreshes the in-view list; `{:ok, _}` silently refreshes.
- Add error toasts to previously silent error arms: `delete_resource`, and the group/resource access actions.
- Remove dead `PortalWeb.Groups.Database.remove_group_member/3` (had no callers).
- Add regression tests covering the deleted-in-other-tab race for each action.