### PR TITLE
refactor(portal): use oban query helpers

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -123,6 +123,8 @@ jobs:
         run: mix deps.unlock --check-unused
 
       - name: Validate OpenAPI spec
+        env:
+          START_OBAN: "false"
         run: |
           mix openapi.spec.yaml --spec PortalAPI.ApiSpec
           result=$(curl --fail --show-error --silent \

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -140,7 +140,14 @@ defmodule Portal.Application do
   end
 
   defp oban do
-    [{Oban, Application.fetch_env!(:portal, Oban)}]
+    # Skip starting Oban when only the application boot is needed (e.g. CI
+    # generating the OpenAPI spec without a Postgres service). Oban 2.22+
+    # verifies migrations at supervisor start, which requires a live DB.
+    if System.get_env("START_OBAN", "true") == "false" do
+      []
+    else
+      [{Oban, Application.fetch_env!(:portal, Oban)}]
+    end
   end
 
   defp replication do

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -1994,13 +1994,13 @@ defmodule PortalWeb.Settings.DirectorySync do
       # Query for active sync jobs for all directory types
       # Note: Oban.Job doesn't have account_id - security is ensured by
       # filtering on directory_ids which are already scoped to the account
+      sync_workers = [Portal.Entra.Sync, Portal.Google.Sync, Portal.Okta.Sync]
+
       active_jobs =
-        from(j in Oban.Job,
-          where: j.worker in ["Portal.Entra.Sync", "Portal.Google.Sync", "Portal.Okta.Sync"],
-          where: j.state in ["available", "executing", "scheduled"],
-          where: fragment("?->>'directory_id'", j.args) in ^directory_ids,
-          order_by: [desc: j.inserted_at]
-        )
+        [worker: sync_workers, state: [:available, :executing, :scheduled]]
+        |> Oban.Job.query()
+        |> where([j], fragment("?->>'directory_id'", j.args) in ^directory_ids)
+        |> order_by([j], desc: j.inserted_at)
         |> Safe.unscoped(:replica)
         |> Safe.all()
         |> Enum.map(fn job -> {job.args["directory_id"], job} end)
@@ -2008,12 +2008,10 @@ defmodule PortalWeb.Settings.DirectorySync do
 
       # Query for most recent completed job per directory
       completed_jobs =
-        from(j in Oban.Job,
-          where: j.worker in ["Portal.Entra.Sync", "Portal.Google.Sync", "Portal.Okta.Sync"],
-          where: j.state in ["completed", "discarded", "cancelled", "retryable"],
-          where: fragment("?->>'directory_id'", j.args) in ^directory_ids,
-          order_by: [desc: j.completed_at]
-        )
+        [worker: sync_workers, state: [:completed, :discarded, :cancelled, :retryable]]
+        |> Oban.Job.query()
+        |> where([j], fragment("?->>'directory_id'", j.args) in ^directory_ids)
+        |> order_by([j], desc: j.completed_at)
         |> Safe.unscoped(:replica)
         |> Safe.all()
         |> Enum.uniq_by(& &1.args["directory_id"])

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -94,7 +94,7 @@ defmodule Portal.MixProject do
       {:argon2_elixir, "~> 4.0"},
 
       # Background jobs
-      {:oban, "~> 2.21"},
+      {:oban, "~> 2.22"},
       {:oban_web, "~> 2.11"},
 
       # Erlang clustering

--- a/elixir/test/support/outbound_email_helpers.ex
+++ b/elixir/test/support/outbound_email_helpers.ex
@@ -7,12 +7,10 @@ defmodule Portal.OutboundEmailTestHelpers do
   alias Portal.Repo
 
   def collect_queued_emails(account_id) do
-    from(j in Oban.Job,
-      where: j.worker == "Portal.Workers.OutboundEmail",
-      order_by: [asc: j.inserted_at]
-    )
+    [worker: Portal.Workers.OutboundEmail, args: %{account_id: account_id}]
+    |> Oban.Job.query()
+    |> order_by([j], asc: j.inserted_at)
     |> Repo.all()
-    |> Enum.filter(&(&1.args["account_id"] == account_id))
     |> Enum.map(&format_queued_email/1)
   end
 


### PR DESCRIPTION
Updates our Oban job queries to use the new queries helpers introduced in Oban 2.22 - https://github.com/oban-bg/oban/blob/main/CHANGELOG.md#-job-querying.

Unfortunately the API isn't quite expressive enough to convert _all_ of queries so a few are left behind and built manually.
