### PR TITLE
fix(portal): rebuild ACS request on retry

### DIFF
--- a/elixir/lib/portal/azure_communication_services/hmac_auth.ex
+++ b/elixir/lib/portal/azure_communication_services/hmac_auth.ex
@@ -1,0 +1,74 @@
+defmodule Portal.AzureCommunicationServices.HMACAuth do
+  @moduledoc false
+
+  @spec attach(Req.Request.t(), String.t()) :: Req.Request.t()
+  def attach(%Req.Request{} = req, access_key) when is_binary(access_key) do
+    Req.Request.append_request_steps(req,
+      refresh_acs_hmac_auth: &wrap_adapter(&1, access_key)
+    )
+  end
+
+  defp wrap_adapter(%Req.Request{adapter: original_adapter} = req, access_key) do
+    req
+    |> Req.Request.put_private(:acs_hmac_original_adapter, original_adapter)
+    |> Map.put(:adapter, &sign_and_run(&1, access_key))
+  end
+
+  defp sign_and_run(%Req.Request{} = req, access_key) do
+    timestamp = timestamp()
+    content_hash = content_hash(req.body)
+    host = host(req.url)
+
+    req =
+      req
+      |> Req.Request.put_header("x-ms-date", timestamp)
+      |> Req.Request.put_header("x-ms-content-sha256", content_hash)
+      |> Req.Request.put_header("host", host)
+      |> Req.Request.put_header(
+        "authorization",
+        authorization(req, access_key, timestamp, content_hash, host)
+      )
+
+    original_adapter =
+      Req.Request.get_private(req, :acs_hmac_original_adapter, &Req.Steps.run_finch/1)
+
+    original_adapter.(req)
+  end
+
+  defp authorization(req, access_key, timestamp, content_hash, host) do
+    signature =
+      req
+      |> string_to_sign(timestamp, content_hash, host)
+      |> sign(access_key)
+
+    "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=#{signature}"
+  end
+
+  defp string_to_sign(req, timestamp, content_hash, host),
+    do: "POST\n#{path_and_query(req.url)}\n#{timestamp};#{host};#{content_hash}"
+
+  defp sign(string_to_sign, access_key) do
+    key = Base.decode64!(access_key)
+    :crypto.mac(:hmac, :sha256, key, string_to_sign) |> Base.encode64()
+  end
+
+  defp timestamp do
+    DateTime.utc_now()
+    |> Calendar.strftime("%a, %d %b %Y %H:%M:%S GMT")
+  end
+
+  defp content_hash(body) do
+    :crypto.hash(:sha256, body) |> Base.encode64()
+  end
+
+  defp host(%URI{} = uri) do
+    if uri.port in [80, 443, nil] do
+      uri.host
+    else
+      "#{uri.host}:#{uri.port}"
+    end
+  end
+
+  defp path_and_query(%URI{path: path, query: nil}), do: path
+  defp path_and_query(%URI{path: path, query: query}), do: "#{path}?#{query}"
+end

--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -53,10 +53,39 @@ defmodule Portal.Mailer do
 
   defp deliver_with_mailer_config(email, opts, metadata) do
     if opts[:adapter] do
+      email = put_adapter_client_options(email, opts)
+      metadata = %{metadata | email: email}
+
       deliver_with_telemetry(email, opts, metadata)
     else
       Logger.info("Emails are not configured", email_subject: inspect(email.subject))
       {:ok, %{}}
+    end
+  end
+
+  defp put_adapter_client_options(%Email{} = email, opts) do
+    req_opts =
+      opts[:req_opts]
+      |> List.wrap()
+      |> Keyword.merge(email.private[:client_options] || [])
+      |> maybe_put_acs_hmac_auth_plugin(opts)
+
+    case req_opts do
+      [] -> email
+      _ -> Email.put_private(email, :client_options, req_opts)
+    end
+  end
+
+  defp maybe_put_acs_hmac_auth_plugin(req_opts, opts) do
+    with Swoosh.Adapters.AzureCommunicationServices <- Keyword.get(opts, :adapter),
+         access_key when is_binary(access_key) <- Keyword.get(opts, :access_key) do
+      plugin = fn req -> Portal.AzureCommunicationServices.HMACAuth.attach(req, access_key) end
+
+      Keyword.update(req_opts, :plugins, [plugin], fn plugins ->
+        List.wrap(plugins) ++ [plugin]
+      end)
+    else
+      _ -> req_opts
     end
   end
 

--- a/elixir/lib/portal/workers/outbound_email.ex
+++ b/elixir/lib/portal/workers/outbound_email.ex
@@ -13,21 +13,10 @@ defmodule Portal.Workers.OutboundEmail do
     email =
       request
       |> deserialize()
-      |> put_acs_client_options()
       |> put_operation_id(job_id)
 
     result = Mailer.deliver_secondary(email)
     persist_delivery_result(result, account_id, email)
-  end
-
-  defp put_acs_client_options(%Swoosh.Email{} = email) do
-    req_opts = Portal.Config.fetch_env!(:portal, Portal.Mailer.Secondary)[:req_opts] || []
-
-    if req_opts == [] do
-      email
-    else
-      Swoosh.Email.put_private(email, :client_options, req_opts)
-    end
   end
 
   defp persist_delivery_result({:ok, response}, account_id, email) do

--- a/elixir/test/portal/mailer_test.exs
+++ b/elixir/test/portal/mailer_test.exs
@@ -21,6 +21,75 @@ defmodule Portal.MailerTest do
     end
   end
 
+  describe "deliver/2" do
+    test "refreshes ACS HMAC auth headers on Req retries" do
+      test_pid = self()
+      access_key = Base.encode64("acs-secret")
+      adapter_plugin = replace_req_adapter_plugin(test_pid)
+      {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        attempt = Agent.get_and_update(attempts, fn attempt -> {attempt, attempt + 1} end)
+        send(test_pid, {:acs_attempt, attempt, acs_auth_headers(conn)})
+
+        case attempt do
+          0 ->
+            conn
+            |> Plug.Conn.put_resp_header("retry-after", "1")
+            |> Plug.Conn.put_status(429)
+            |> Req.Test.json(%{"error" => %{"message" => "rate limited"}})
+
+          _ ->
+            conn
+            |> Plug.Conn.put_status(202)
+            |> Req.Test.json(%{"id" => "acs-message-123", "status" => "Running"})
+        end
+      end)
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Test")
+        |> Swoosh.Email.text_body("body")
+        |> Swoosh.Email.put_private(:client_options,
+          retry: :transient,
+          max_retries: 1
+        )
+
+      assert {:ok, %{id: "acs-message-123", status: "Running"}} =
+               deliver(email,
+                 adapter: Swoosh.Adapters.AzureCommunicationServices,
+                 endpoint: "https://acs.example.com",
+                 access_key: access_key,
+                 req_opts: [
+                   plug: {Req.Test, Portal.AzureCommunicationServices},
+                   plugins: [adapter_plugin]
+                 ]
+               )
+
+      assert_received :replace_req_adapter_plugin_called
+      assert_received :replace_req_adapter_plugin_called
+      assert_received {:acs_attempt, 0, first_headers}
+      assert_received {:acs_attempt, 1, second_headers}
+      assert first_headers.x_ms_date != second_headers.x_ms_date
+      assert first_headers.authorization != second_headers.authorization
+    end
+  end
+
+  defp replace_req_adapter_plugin(test_pid) do
+    fn req ->
+      Req.Request.append_request_steps(req,
+        replace_test_adapter: fn req ->
+          Map.put(req, :adapter, fn req ->
+            send(test_pid, :replace_req_adapter_plugin_called)
+            Req.Steps.run_plug(req)
+          end)
+        end
+      )
+    end
+  end
+
   describe "with_account_id/2" do
     test "sets account_id in email private" do
       email = Swoosh.Email.new()
@@ -294,5 +363,20 @@ defmodule Portal.MailerTest do
 
       refute changeset.valid?
     end
+  end
+
+  defp acs_auth_headers(conn) do
+    %{
+      authorization: request_header(conn, "authorization"),
+      x_ms_date: request_header(conn, "x-ms-date")
+    }
+  end
+
+  defp request_header(conn, name) do
+    name = String.downcase(name)
+
+    Enum.find_value(conn.req_headers, fn {header_name, value} ->
+      if String.downcase(header_name) == name, do: value
+    end)
   end
 end

--- a/elixir/test/portal/workers/outbound_email_test.exs
+++ b/elixir/test/portal/workers/outbound_email_test.exs
@@ -80,6 +80,53 @@ defmodule Portal.Workers.OutboundEmailTest do
       assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
     end
 
+    test "respects ACS 429 retry-after with a fresh HMAC signature" do
+      account = account_fixture()
+
+      Portal.Config.put_env_override(:portal, Portal.Mailer.Secondary,
+        adapter: Swoosh.Adapters.AzureCommunicationServices,
+        endpoint: "https://acs.example.com",
+        access_key: Base.encode64("acs-secret"),
+        req_opts: [
+          plug: {Req.Test, Portal.AzureCommunicationServices},
+          retry: :transient,
+          max_retries: 1
+        ]
+      )
+
+      test_pid = self()
+      {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        attempt = Agent.get_and_update(attempts, fn attempt -> {attempt, attempt + 1} end)
+        send(test_pid, {:acs_attempt, attempt, acs_auth_headers(conn)})
+
+        case attempt do
+          0 ->
+            conn
+            |> Plug.Conn.put_resp_header("retry-after", "1")
+            |> Plug.Conn.put_status(429)
+            |> Req.Test.json(%{"error" => %{"message" => "rate limited"}})
+
+          _ ->
+            conn
+            |> Plug.Conn.put_status(202)
+            |> Req.Test.json(%{"id" => "acs-message-429", "status" => "Running"})
+        end
+      end)
+
+      assert :ok = perform_job(Worker, queued_args(account.id))
+      assert_received {:acs_attempt, 0, first_headers}
+      assert_received {:acs_attempt, 1, second_headers}
+      assert first_headers.x_ms_date != second_headers.x_ms_date
+      assert first_headers.authorization != second_headers.authorization
+
+      db_entry =
+        Repo.get_by!(Portal.OutboundEmail, account_id: account.id, message_id: "acs-message-429")
+
+      assert db_entry.subject == "Test Subject"
+    end
+
     test "sets deterministic Operation-Id header derived from job id" do
       account = account_fixture()
       configure_acs_secondary()
@@ -122,12 +169,30 @@ defmodule Portal.Workers.OutboundEmailTest do
     }
   end
 
-  defp configure_acs_secondary do
+  defp configure_acs_secondary(req_opts \\ [
+         plug: {Req.Test, Portal.AzureCommunicationServices},
+         retry: false
+       ]) do
     Portal.Config.put_env_override(:portal, Portal.Mailer.Secondary,
       adapter: Swoosh.Adapters.AzureCommunicationServices,
       endpoint: "https://acs.example.com",
       auth: "acs-token",
-      req_opts: [plug: {Req.Test, Portal.AzureCommunicationServices}, retry: false]
+      req_opts: req_opts
     )
+  end
+
+  defp acs_auth_headers(conn) do
+    %{
+      authorization: request_header(conn, "authorization"),
+      x_ms_date: request_header(conn, "x-ms-date")
+    }
+  end
+
+  defp request_header(conn, name) do
+    name = String.downcase(name)
+
+    Enum.find_value(conn.req_headers, fn {header_name, value} ->
+      if String.downcase(header_name) == name, do: value
+    end)
   end
 end


### PR DESCRIPTION
In the outbound email worker, requests can fail with `429` if we hit the API limit. These get automatically replayed by Req, which can fail with an HMAC validation error if more than 5 minutes have elapsed since the request was initially built.

To fix this, we need to use a Req plugin that rebuilds the HMAC when hitting the ACS API.

--- 

Fixes #13229 
Fixes #12834 
