### PR TITLE
chore(android): drop unused arm-linux-androideabi target

### DIFF
--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -72,7 +72,7 @@ If you'd rather not use `mise run setup`:
    `rust/rust-toolchain.toml`:
 
    ```
-   rustup target add aarch64-linux-android arm-linux-androideabi armv7-linux-androideabi i686-linux-android x86_64-linux-android
+   rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
    ```
 
 1. Run `./gradlew assembleDebug` to verify.

--- a/kotlin/android/mise-tasks/setup.sh
+++ b/kotlin/android/mise-tasks/setup.sh
@@ -8,7 +8,6 @@ cd "${SCRIPT_DIR}/.."
 # NDK_VERSION and ANDROID_CMD_TOOLS_VERSION come from kotlin/android/mise.toml [env].
 RUST_TARGETS=(
     aarch64-linux-android
-    arm-linux-androideabi
     armv7-linux-androideabi
     i686-linux-android
     x86_64-linux-android


### PR DESCRIPTION
The Android build only compiles four ABIs (arm64-v8a, armeabi-v7a, x86,
x86_64) -- see the cargo-ndk targets list in app/build.gradle.kts.

The extra arm-linux-androideabi target maps to the legacy `armeabi` ABI
(ARMv5TE/ARMv6), which the NDK removed in r17 (2018) and the build
never produces a libconnlib.so for. Installing it just wasted disk on
an unused stdlib copy.