### PR TITLE
chore(deps): bump keyring crates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1649,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
 dependencies = [
  "dbus-secret-service",
- "keyring-core 1.0.0",
+ "keyring-core",
 ]
 
 [[package]]
@@ -2311,7 +2311,7 @@ dependencies = [
  "humantime",
  "ip-packet",
  "ip_network",
- "keyring-core 1.0.0",
+ "keyring-core",
  "known-dirs",
  "logging",
  "native-dialog",
@@ -3947,15 +3947,6 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "keyring-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8286c3ab222af2fa9e57874fe419893d967f739c7bf1743f98a88678edbf08"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -9215,12 +9206,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-native-keyring-store"
-version = "0.4.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeb875eb87bfceb88c4f9510382ba48016ca5992980c281c1b71d82d922d22e"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
 dependencies = [
  "byteorder",
- "keyring-core 0.7.4",
+ "keyring-core",
  "regex",
  "windows-sys 0.61.2",
  "zeroize",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2311,7 +2311,7 @@ dependencies = [
  "humantime",
  "ip-packet",
  "ip_network",
- "keyring-core 0.7.4",
+ "keyring-core 1.0.0",
  "known-dirs",
  "logging",
  "native-dialog",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1644,12 +1644,12 @@ dependencies = [
 
 [[package]]
 name = "dbus-secret-service-keyring-store"
-version = "0.3.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec3a0f31addb56ee6d5c55599068d2093bc737469a448b34e426603ef61f93e"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
 dependencies = [
  "dbus-secret-service",
- "keyring-core",
+ "keyring-core 1.0.0",
 ]
 
 [[package]]
@@ -2311,7 +2311,7 @@ dependencies = [
  "humantime",
  "ip-packet",
  "ip_network",
- "keyring-core",
+ "keyring-core 0.7.4",
  "known-dirs",
  "logging",
  "native-dialog",
@@ -3954,6 +3954,15 @@ name = "keyring-core"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8286c3ab222af2fa9e57874fe419893d967f739c7bf1743f98a88678edbf08"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
 ]
@@ -9211,7 +9220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb875eb87bfceb88c4f9510382ba48016ca5992980c281c1b71d82d922d22e"
 dependencies = [
  "byteorder",
- "keyring-core",
+ "keyring-core 0.7.4",
  "regex",
  "windows-sys 0.61.2",
  "zeroize",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -117,7 +117,7 @@ ip_network_table = { version = "0.2.0", default-features = false }
 is = "0.8.0"
 itertools = "0.14.0"
 jni = "0.22.4"
-keyring-core = "0.7.3"
+keyring-core = "1.0.0"
 known-dirs = { path = "libs/known-dirs" }
 known-folders = "1.4.2"
 l3-tcp = { path = "libs/connlib/l3-tcp" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -235,7 +235,7 @@ which = "4.4.2"
 windows = "0.61.3"
 windows-core = "0.61.1"
 windows-implement = "0.60.0"
-windows-native-keyring-store = "0.4.0"
+windows-native-keyring-store = "1.0.0"
 windows-security = { path = "libs/windows-security" }
 windows-service = "0.8.0"
 winreg = "0.56.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -78,7 +78,7 @@ client-shared = { path = "libs/client-shared" }
 connlib-model = { path = "libs/connlib/model" }
 crossbeam-queue = "0.3.12"
 dashmap = "6.1.0"
-dbus-secret-service-keyring-store = { version = "0.3.0", features = ["crypto-rust"] }
+dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
 derive_more = { version = "2.1.1", default-features = false }
 difference = "2.0.0"
 dirs = "6.0.0"


### PR DESCRIPTION
These dependabot changes had to be pulled in in tandem instead of separately, as they were interdependent and otherwise triggered `cargo-deny` failures.