### PR TITLE
feat(gui-client): capture segfaults into Sentry

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
  "logging",
  "netlink-packet-core",
  "netlink-packet-route",
- "nix",
+ "nix 0.30.1",
  "resolv-conf",
  "ring",
  "rtnetlink",
@@ -1421,6 +1421,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2066907075af649bcb8bcb1b9b986329b243677e6918b2d920aa64b0aac5ace3"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,7 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2114,6 +2138,15 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "error-graph"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b920e777967421aa5f9bf34f842c0ab6ba19b3bdb4a082946093860f5858879"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "etc-hosts-dns-client"
@@ -2167,6 +2200,12 @@ version = "0.1.0"
 dependencies = [
  "opentelemetry",
 ]
+
+[[package]]
+name = "failspot"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c942e64b20ecd39933d5ff938ca4fdb6ef0d298cc3855b231179a5ef0b24948d"
 
 [[package]]
 name = "fastrand"
@@ -2234,7 +2273,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow-ext",
  "clap",
- "nix",
+ "nix 0.30.1",
  "rpassword",
  "secrecy",
  "tracing",
@@ -2263,7 +2302,7 @@ dependencies = [
  "ip_network",
  "libc",
  "logging",
- "nix",
+ "nix 0.30.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",
@@ -2315,7 +2354,7 @@ dependencies = [
  "known-dirs",
  "logging",
  "native-dialog",
- "nix",
+ "nix 0.30.1",
  "notify-rust",
  "output_vt100",
  "parking_lot",
@@ -2382,7 +2421,7 @@ dependencies = [
  "known-dirs",
  "libc",
  "logging",
- "nix",
+ "nix 0.30.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",
@@ -2954,6 +2993,17 @@ name = "goblin"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
+name = "goblin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
  "log",
  "plain",
@@ -4263,6 +4313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4335,78 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minidump-common"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e16d10087ae9e375bad7a40e8ef5504bc08e808ccc6019067ff9de42a84570f"
+dependencies = [
+ "bitflags 2.10.0",
+ "debugid",
+ "num-derive",
+ "num-traits",
+ "range-map",
+ "scroll",
+ "smart-default",
+]
+
+[[package]]
+name = "minidump-writer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1fc14d6ded915b8e850801465e7096f77ed60bf87e4e85878d463720d9dc4d"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "cfg-if",
+ "crash-context",
+ "error-graph",
+ "failspot",
+ "goblin 0.9.3",
+ "libc",
+ "log",
+ "mach2",
+ "memmap2",
+ "memoffset",
+ "minidump-common",
+ "nix 0.29.0",
+ "procfs-core",
+ "scroll",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "minidumper"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d9254e42a48098d045472a5c0cb892007a42e25342eddbf2642f6978bf381a"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "log",
+ "minidump-writer",
+ "parking_lot",
+ "polling",
+ "scroll",
+ "thiserror 2.0.18",
+ "uds",
+]
+
+[[package]]
+name = "minidumper-child"
+version = "0.2.2"
+source = "git+https://github.com/klochowicz/minidumper-child?branch=feat%2Fminidumper-0.9#e3a69336138aef16b4a25c0297c33c8f8cc42d37"
+dependencies = [
+ "crash-handler",
+ "minidumper",
+ "thiserror 2.0.18",
+ "uuid",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -4460,6 +4591,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -5025,7 +5168,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -5533,6 +5676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "proptest"
 version = "1.9.0"
 source = "git+https://github.com/proptest-rs/proptest?branch=main#9b103797a9787378c55b1c2a79c9ffed13d26891"
@@ -5721,6 +5875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "range-map"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a5a2d6c7039059af621472a4389be1215a816df61aa4d531cfe85264aee95f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5967,7 +6130,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
- "nix",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6013,7 +6176,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6386,6 +6549,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry-rust-minidump"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de99278305191a207c919dc9dd18f6a9d02d6048d07491a4ce26f7811b2ecbbb"
+dependencies = [
+ "minidumper-child",
+ "sentry",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "sentry-tracing"
 version = "0.48.1"
 source = "git+https://github.com/getsentry/sentry-rust?branch=master#a6ce8b0813bc7108b0dec6c9491ac5ce778877fd"
@@ -6698,6 +6872,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "smawk"
@@ -7577,6 +7762,7 @@ dependencies = [
  "reqwest 0.13.3",
  "rustls",
  "sentry",
+ "sentry-rust-minidump",
  "serde",
  "serde_json",
  "sha2",
@@ -8328,7 +8514,7 @@ dependencies = [
  "clap",
  "futures",
  "humantime",
- "nix",
+ "nix 0.30.1",
  "num_cpus",
  "tokio",
  "tokio-stream",
@@ -8351,6 +8537,15 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uds"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "uds_windows"
@@ -8478,7 +8673,7 @@ dependencies = [
  "cargo_metadata 0.19.2",
  "fs-err",
  "glob",
- "goblin",
+ "goblin 0.8.2",
  "heck 0.5.0",
  "indexmap 2.14.0",
  "once_cell",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -172,6 +172,7 @@ sd-notify = "0.5.0" # This is a pure Rust re-implementation, so it isn't vulnera
 secrecy = "0.10.3"
 semver = "1.0.28"
 sentry = { version = "0.48.0", default-features = false }
+sentry-rust-minidump = { version = "0.15.0", default-features = false }
 sentry-tracing = "0.48.0"
 serde = "1.0.228"
 serde_json = "1.0.149"
@@ -262,6 +263,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 sentry = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
+minidumper-child = { git = "https://github.com/klochowicz/minidumper-child", branch = "feat/minidumper-0.9" } # Bumps transitive `minidumper` 0.8 -> 0.9 and `thiserror` 1 -> 2 to unify the dep graph. Drop once upstream releases.
 sentry-tracing = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -269,6 +269,7 @@ skip = [
     "cpufeatures", # Same root cause as `chacha20` — pulled in via chacha20 0.10 from hickory 0.26.
     "foldhash",
     "getrandom",
+    "goblin", # uniffi_bindgen 0.31 pins goblin 0.8; minidump-writer 0.11 pins goblin 0.9. Both are leaf transitives in unrelated subtrees.
     "hashbrown",
     "heck",
     "indexmap",
@@ -276,6 +277,7 @@ skip = [
     "jni-sys",
     "libloading",
     "linux-raw-sys",
+    "nix", # minidump-writer 0.11 pins nix 0.29; rest of the workspace (bin-shared, os_info, firezone-cli, etc.) is on 0.30.
     "nom",
     "object",
     "png",

--- a/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
@@ -11,6 +11,9 @@ fn main() -> anyhow::Result<()> {
         .install_default()
         .map_err(|_| anyhow!("Failed to install default crypto provider"))?;
 
+    let _crash_reporter =
+        telemetry::install_crash_handler(telemetry::GUI_DSN, firezone_gui_client::RELEASE);
+
     // Docs indicate that `remove_var` should actually be marked unsafe
     // SAFETY: We haven't spawned any other threads, this code should be the first
     // thing to run after entering `main` and parsing CLI args.

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -15,7 +15,6 @@ opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls-no-provider", "tracing", "logs", "metrics"] }
-sentry-rust-minidump = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -23,6 +22,9 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+sentry-rust-minidump = { workspace = true }
 
 [dev-dependencies]
 rustls = { workspace = true, features = ["ring"] }

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -15,6 +15,7 @@ opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls-no-provider", "tracing", "logs", "metrics"] }
+sentry-rust-minidump = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/libs/telemetry/examples/segfault.rs
+++ b/rust/libs/telemetry/examples/segfault.rs
@@ -1,0 +1,39 @@
+//! Reproducer that exercises the native crash handler end-to-end.
+//!
+//! Installs the crash handler against the GUI Sentry project (env=staging in
+//! debug builds) and then deliberately segfaults the parent process. The
+//! watcher subprocess should capture a minidump and upload it to Sentry.
+//!
+//! Run with:
+//!   cargo run -p telemetry --example segfault
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,sentry=trace".into()),
+        )
+        .init();
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("install default crypto provider");
+
+    let crash_reporter = telemetry::install_crash_handler(
+        telemetry::GUI_DSN,
+        concat!("crash-test@", env!("CARGO_PKG_VERSION")),
+    );
+    tracing::info!(
+        installed = crash_reporter.is_some(),
+        "crash handler initialised"
+    );
+
+    tracing::info!(pid = std::process::id(), "sleeping 3s before segfault");
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    tracing::info!("dereferencing null pointer");
+    unsafe {
+        std::ptr::null_mut::<u8>().write(0);
+    }
+}

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -102,6 +102,7 @@ impl fmt::Display for Dsn {
 ///
 /// Drop order matters: the minidump watcher handle is dropped first so the
 /// watcher subprocess shuts down before we flush the local Sentry guard.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[must_use = "drop the crash handler guard at process exit, not earlier"]
 pub struct CrashReporter {
     _minidump_handle: sentry_rust_minidump::Handle,
@@ -122,6 +123,7 @@ pub struct CrashReporter {
 /// runtime `api_url` is not yet known; once [`Telemetry::start`] runs it
 /// re-initialises the global Sentry hub with the correct environment for
 /// non-native events.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub fn install_crash_handler(dsn: Dsn, release: &'static str) -> Option<CrashReporter> {
     let environment = if cfg!(debug_assertions) {
         Env::Staging

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -98,6 +98,57 @@ impl fmt::Display for Dsn {
     }
 }
 
+/// Guard returned by [`install_crash_handler`]. Hold until process exit.
+///
+/// Drop order matters: the minidump watcher handle is dropped first so the
+/// watcher subprocess shuts down before we flush the local Sentry guard.
+#[must_use = "drop the crash handler guard at process exit, not earlier"]
+pub struct CrashReporter {
+    _minidump_handle: sentry_rust_minidump::Handle,
+    _sentry_guard: sentry::ClientInitGuard,
+}
+
+/// Install a native-crash handler that captures SIGSEGV/SIGBUS/SIGILL/SIGABRT
+/// (and the Windows equivalents) as minidumps and uploads them to Sentry.
+///
+/// Must be called as the very first thing in `main()`, before any CLI parsing
+/// or other startup work. Internally, this re-execs the current binary as a
+/// crash-reporter watcher subprocess; in that subprocess this function blocks
+/// running the minidump server and then `std::process::exit(0)`s, so anything
+/// after this call only runs in the app process.
+///
+/// `release` should be the same string passed to [`Telemetry::start`] later.
+/// The environment is hard-coded here to a build-profile default because the
+/// runtime `api_url` is not yet known; once [`Telemetry::start`] runs it
+/// re-initialises the global Sentry hub with the correct environment for
+/// non-native events.
+pub fn install_crash_handler(dsn: Dsn, release: &'static str) -> Option<CrashReporter> {
+    let environment = if cfg!(debug_assertions) {
+        Env::Staging
+    } else {
+        Env::Production
+    };
+
+    let sentry_guard = sentry::init((
+        dsn.to_string(),
+        sentry::ClientOptions {
+            release: Some(release.into()),
+            environment: Some(Cow::Borrowed(environment.as_str())),
+            debug: cfg!(debug_assertions),
+            ..Default::default()
+        },
+    ));
+
+    let minidump_handle = sentry_rust_minidump::init(&sentry_guard)
+        .inspect_err(|e| tracing::warn!("Failed to install native crash handler: {e:#}"))
+        .ok()?;
+
+    Some(CrashReporter {
+        _minidump_handle: minidump_handle,
+        _sentry_guard: sentry_guard,
+    })
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[doc(hidden)] // Only public for testing.
 pub enum Env {


### PR DESCRIPTION
The tunnel binary runs as a privileged process on Linux and Windows.
Native crashes (SIGSEGV/SIGBUS/SIGILL/SIGABRT, and the Windows
equivalents) currently leave no trace in Sentry — only Rust panics
are captured by the panic integration, so a memory bug in a C
dependency or eg. eBPF/syscall fault is invisible to telemetry.

Add `telemetry::install_crash_handler`, which wires the
out-of-process watcher pattern from `sentry-rust-minidump`: at
startup we re-exec ourselves as a watcher subprocess that listens on
a domain socket; on a fatal signal the kernel hands the dying parent
to the watcher, which writes a minidump and uploads it to Sentry.

Wire the call into `firezone-client-tunnel` as the very first thing
in `main`, before clap parsing — the watcher subprocess re-execs
the binary with an extra `--crash-reporter-server=...` argv that
`Cli::try_parse` would otherwise reject.

Pulled in via a temporary fork of `sentry-rust-minidump` that bumps
it to the sentry 0.48 family already pinned in this workspace; drop
the patch entry once upstream publishes a 0.48-compatible release.

Includes an example that trigger the minidump pipeline on demand.