### PR TITLE
chore(gui-client): migrate pnpm approval to `allowBuilds`

### DIFF
--- a/rust/gui-client/pnpm-workspace.yaml
+++ b/rust/gui-client/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - esbuild
+allowBuilds:
+  "@parcel/watcher": true
+  esbuild: true


### PR DESCRIPTION
pnpm 10.26 introduced `allowBuilds` and pnpm 11 dropped support for the
legacy `onlyBuiltDependencies` setting, treating ignored builds as a
hard error rather than a warning.

The repo previously worked around this by pinning pnpm to 10 in CI and
`.tool-versions` (#13158); migrating the workspace config to the new
`allowBuilds` map removes the underlying incompatibility so we can eventually
bump to pnpm 11 when we're ready.

Verified that this works on both the pinned pnpm 10.33 (via mise)
and a system pnpm 11.