### PR TITLE
chore(android): optimise generateUniffiBindings

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -303,9 +303,18 @@ val generateUniffiBindings =
 
         val outDir = layout.buildDirectory.dir("generated/source/uniffi/$profile").get()
 
-        // Hardcode the x86_64 target here, it doesn't matter which one we use, they are
-        // all the same from the bindings PoV.
-        val inputFile = file("$cargoTargetDir/x86_64-linux-android/$profile/libconnlib.so")
+        // UniFFI bindings are identical across ABIs, so we only need one libconnlib.so as input.
+        // Callers (e.g. install-phone.sh) may skip building ABIs they don't need; pass
+        // -PdeviceAbi=<android-abi> to point this task at an ABI that actually gets built.
+        // Defaults to x86_64 so the all-ABI build keeps working unchanged.
+        val rustTarget =
+            when (project.findProperty("deviceAbi") as String?) {
+                "arm64-v8a" -> "aarch64-linux-android"
+                "armeabi-v7a" -> "armv7-linux-androideabi"
+                "x86" -> "i686-linux-android"
+                else -> "x86_64-linux-android"
+            }
+        val inputFile = file("$cargoTargetDir/$rustTarget/$profile/libconnlib.so")
 
         inputs.file(inputFile)
         outputs.dir(outDir)

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -313,9 +313,7 @@ val generateUniffiBindings =
                 "arm64-v8a" -> "aarch64-linux-android"
                 "armeabi-v7a" -> "armv7-linux-androideabi"
                 "x86" -> "i686-linux-android"
-                else -> throw GradleException(
-                    "Unsupported deviceAbi '$deviceAbi'. Supported: arm64-v8a, armeabi-v7a, x86, x86_64.",
-                )
+                else -> throw GradleException("Unsupported deviceAbi '$deviceAbi'. Supported: arm64-v8a, armeabi-v7a, x86, x86_64.")
             }
         val inputFile = file("$cargoTargetDir/$rustTargetTriple/$profile/libconnlib.so")
 

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -307,14 +307,17 @@ val generateUniffiBindings =
         // Callers (e.g. install-phone.sh) may skip building ABIs they don't need; pass
         // -PdeviceAbi=<android-abi> to point this task at an ABI that actually gets built.
         // Defaults to x86_64 so the all-ABI build keeps working unchanged.
-        val rustTarget =
-            when (providers.gradleProperty("deviceAbi").orNull) {
+        val rustTargetTriple =
+            when (val deviceAbi = providers.gradleProperty("deviceAbi").orNull) {
+                null, "x86_64" -> "x86_64-linux-android"
                 "arm64-v8a" -> "aarch64-linux-android"
                 "armeabi-v7a" -> "armv7-linux-androideabi"
                 "x86" -> "i686-linux-android"
-                else -> "x86_64-linux-android"
+                else -> throw GradleException(
+                    "Unsupported deviceAbi '$deviceAbi'. Supported: arm64-v8a, armeabi-v7a, x86, x86_64.",
+                )
             }
-        val inputFile = file("$cargoTargetDir/$rustTarget/$profile/libconnlib.so")
+        val inputFile = file("$cargoTargetDir/$rustTargetTriple/$profile/libconnlib.so")
 
         inputs.file(inputFile)
         outputs.dir(outDir)

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -308,7 +308,7 @@ val generateUniffiBindings =
         // -PdeviceAbi=<android-abi> to point this task at an ABI that actually gets built.
         // Defaults to x86_64 so the all-ABI build keeps working unchanged.
         val rustTarget =
-            when (project.findProperty("deviceAbi") as String?) {
+            when (providers.gradleProperty("deviceAbi").orNull) {
                 "arm64-v8a" -> "aarch64-linux-android"
                 "armeabi-v7a" -> "armv7-linux-androideabi"
                 "x86" -> "i686-linux-android"

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -63,7 +63,7 @@ done
 install_log="$(mktemp "${TMPDIR:-/tmp}/install-phone.XXXXXX")"
 trap 'rm -f "$install_log"' EXIT
 
-if ./gradlew installDebug "${gradle_skip_args[@]}" 2>&1 | tee "$install_log"; then
+if ./gradlew installDebug -PdeviceAbi="$DEVICE_ABI" "${gradle_skip_args[@]}" 2>&1 | tee "$install_log"; then
     exit 0
 fi
 
@@ -96,4 +96,4 @@ fi
 echo "==> Uninstalling dev.firezone.android..."
 adb uninstall dev.firezone.android
 echo "==> Retrying install..."
-./gradlew installDebug "${gradle_skip_args[@]}"
+./gradlew installDebug -PdeviceAbi="$DEVICE_ABI" "${gradle_skip_args[@]}"

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -46,24 +46,26 @@ x86)
 *)
     echo "==> Unknown device ABI '${DEVICE_ABI}', falling back to all-ABI build."
     SKIP_CARGO_TASKS=()
+    DEVICE_ABI=""
     ;;
 esac
 
-echo "==> Installing debug APK (device ABI: ${DEVICE_ABI})..."
+echo "==> Installing debug APK (device ABI: ${DEVICE_ABI:-unknown, building all ABIs})..."
 # Kill any running instance so the next launch is a clean cold start (and so
 # Android doesn't keep the old process alive across install).
 echo "==> Force-stopping any running instance of dev.firezone.android..."
 adb shell am force-stop dev.firezone.android
 
-gradle_skip_args=()
+gradle_args=()
+[ -n "$DEVICE_ABI" ] && gradle_args+=("-PdeviceAbi=$DEVICE_ABI")
 for task in "${SKIP_CARGO_TASKS[@]}"; do
-    gradle_skip_args+=(-x "$task")
+    gradle_args+=(-x "$task")
 done
 
 install_log="$(mktemp "${TMPDIR:-/tmp}/install-phone.XXXXXX")"
 trap 'rm -f "$install_log"' EXIT
 
-if ./gradlew installDebug -PdeviceAbi="$DEVICE_ABI" "${gradle_skip_args[@]}" 2>&1 | tee "$install_log"; then
+if ./gradlew installDebug "${gradle_args[@]}" 2>&1 | tee "$install_log"; then
     exit 0
 fi
 
@@ -96,4 +98,4 @@ fi
 echo "==> Uninstalling dev.firezone.android..."
 adb uninstall dev.firezone.android
 echo "==> Retrying install..."
-./gradlew installDebug -PdeviceAbi="$DEVICE_ABI" "${gradle_skip_args[@]}"
+./gradlew installDebug "${gradle_args[@]}"


### PR DESCRIPTION
install-phone.sh skips cargoBuild tasks for ABIs other than the device's,
but generateUniffiBindings hardcoded x86_64-linux-android/libconnlib.so as
its input. Skipping x86_64 on an arm64 device therefore failed the input
validation before the build started.

Look up the ABI from a -PdeviceAbi Gradle property and map it to the rustc
target triple; default to x86_64 so plain ./gradlew installDebug keeps
working. install-phone.sh now passes -PdeviceAbi="$DEVICE_ABI".

This is also a prerequisite to potentially speed up our Android CI, if we choose
to e.g. compile against the most common ABI at the PR time.