### PR TITLE
fix(connlib): drop malformed NOERROR DNS responses

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4015,6 +4015,7 @@ dependencies = [
  "anyhow-ext",
  "dns-types",
  "futures",
+ "hex-literal",
  "socket-factory",
  "tokio",
  "tracing",

--- a/rust/libs/connlib/dns-types/lib.rs
+++ b/rust/libs/connlib/dns-types/lib.rs
@@ -239,7 +239,12 @@ impl Response {
         self.inner.header().tc()
     }
 
-    /// Returns whether this response carries any records in the authority section.
+    /// Returns whether the response header claims any records in the authority
+    /// section.
+    ///
+    /// This is a header-only check (`nscount > 0`); the authority section is
+    /// not parsed, so a packet whose `nscount` does not match its actual
+    /// payload will still return `true`.
     pub fn has_authority(&self) -> bool {
         self.inner.header_counts().nscount() > 0
     }

--- a/rust/libs/connlib/dns-types/lib.rs
+++ b/rust/libs/connlib/dns-types/lib.rs
@@ -239,6 +239,11 @@ impl Response {
         self.inner.header().tc()
     }
 
+    /// Returns whether this response carries any records in the authority section.
+    pub fn has_authority(&self) -> bool {
+        self.inner.header_counts().nscount() > 0
+    }
+
     pub fn domain(&self) -> DomainName {
         self.question().into_qname().flatten_into()
     }
@@ -534,6 +539,36 @@ mod tests {
     use http::{Method, header};
 
     use super::*;
+
+    #[test]
+    fn malformed_noerror_response_has_no_authority_records() {
+        // NOERROR response for `api.firez.one` A with all counts (an/ns/ar) zero — the
+        // exact 31-byte shape returned by a misbehaving home router we saw in the wild.
+        // Header: id=0x1234, flags=0x8180 (qr+rd+ra), qd=1, an=0, ns=0, ar=0.
+        let bytes =
+            hex_literal::hex!("1234818000010000000000000361706905666972657a036f6e650000010001");
+
+        let response = Response::parse(&bytes).unwrap();
+
+        assert_eq!(response.response_code(), ResponseCode::NOERROR);
+        assert_eq!(response.records().count(), 0);
+        assert!(!response.has_authority());
+    }
+
+    #[test]
+    fn response_with_answer_records_still_reports_no_authority_records() {
+        let domain = DomainName::vec_from_str("example.com").unwrap();
+        let query = Query::new(domain.clone(), RecordType::A);
+        let response = ResponseBuilder::for_query(&query, ResponseCode::NOERROR)
+            .with_records([(domain, 60, records::a(Ipv4Addr::LOCALHOST))])
+            .build();
+
+        let bytes = response.into_bytes(4096);
+        let parsed = Response::parse(&bytes).unwrap();
+
+        assert_eq!(parsed.records().count(), 1);
+        assert!(!parsed.has_authority());
+    }
 
     #[test]
     fn can_truncate_response() {

--- a/rust/libs/connlib/l4-udp-dns-client/Cargo.toml
+++ b/rust/libs/connlib/l4-udp-dns-client/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
+hex-literal = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [lints]

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -79,7 +79,7 @@ impl UdpDnsClient {
                         tracing::debug!(
                             domain = %response.domain(),
                             qtype = %response.qtype(),
-                            "Dropping malformed NOERROR response with no answers and no SOA in authority section (RFC 2308 §3)"
+                            "Dropping untrustworthy NOERROR response with no answers and no SOA in authority section (RFC 2308 §5)"
                         );
                         return false;
                     }
@@ -105,26 +105,35 @@ impl UdpDnsClient {
 ///
 /// Some consumer-grade DNS forwarders reply to certain UDP queries with a
 /// `NOERROR` response that contains no answer records, no authority records,
-/// and no additional records — i.e. the bare query echoed back. This is not a
-/// valid negative answer:
+/// and no additional records — i.e. the bare query echoed back. Our upstream
+/// here is a recursive forwarder, so the strict authoritative-server
+/// requirements in RFC 2308 §3 don't directly apply, but the spec still
+/// gives us a clear basis for rejection:
 ///
 /// - [RFC 2308 §2.2](https://datatracker.ietf.org/doc/html/rfc2308#section-2.2)
-///   defines a NODATA response as `NOERROR` with no answers; the authority
-///   section must contain an SOA, or there must be no NS records there.
-/// - [RFC 2308 §3](https://datatracker.ietf.org/doc/html/rfc2308#section-3)
-///   requires authoritative servers to include the zone SOA in the authority
-///   section when reporting NXDOMAIN or NODATA.
+///   defines a NODATA response as `NOERROR` with no answers and either an SOA
+///   in the authority section or no NS records.
 /// - [RFC 2308 §5](https://datatracker.ietf.org/doc/html/rfc2308#section-5)
-///   says negative responses without an SOA SHOULD NOT be cached.
+///   says negative responses without an SOA SHOULD NOT be cached, because
+///   without an SOA there is no way to confirm the response is trustworthy.
 ///
-/// Treating such a response as an authoritative empty answer hides the
-/// upstream's misbehavior and produces an empty `addresses` list at the
-/// caller, which manifests as `phoenix_channel`'s "no IP addresses available"
-/// retries until the budget expires. Instead we drop the response and let a
-/// sibling query (e.g. AAAA when the broken one was A) or a second resolver
-/// supply the real answer.
+/// A NOERROR with empty answer, authority, and additional sections satisfies
+/// the §2.2 NODATA shape only in the most degenerate way and is explicitly
+/// untrustworthy under §5. Treating it as an authoritative empty answer
+/// hides the upstream's misbehavior and produces an empty `addresses` list at
+/// the caller, which manifests as `phoenix_channel`'s "no IP addresses
+/// available" retries until the budget expires. We instead drop the response
+/// and let a sibling query (e.g. AAAA when the broken one was A) or a second
+/// resolver supply the real answer.
+///
+/// Truncated (`TC=1`) responses are *not* classified as malformed by this
+/// function: empty sections in a truncated response are a separate failure
+/// mode (the resolver couldn't fit the answer in a UDP packet), not a buggy
+/// upstream. They still produce no IPs because we don't currently retry over
+/// TCP, but conflating them here would emit a misleading log line.
 fn is_malformed(response: &dns_types::Response) -> bool {
-    response.response_code() == dns_types::ResponseCode::NOERROR
+    !response.truncated()
+        && response.response_code() == dns_types::ResponseCode::NOERROR
         && response.records().next().is_none()
         && !response.has_authority()
 }
@@ -222,8 +231,8 @@ mod tests {
     fn is_malformed_detects_buggy_router_empty_response() {
         // 31-byte NOERROR reply for `api.firez.one A` with all section counts
         // zeroed except QD — the exact shape we saw from a misbehaving consumer
-        // router. This is not a valid NODATA per RFC 2308 §3 (no SOA in
-        // authority) and should not be treated as an authoritative empty answer.
+        // router. RFC 2308 §5 marks such SOA-less negative responses as
+        // untrustworthy, so we should refuse to treat it as an empty answer.
         let bytes =
             hex_literal::hex!("1234818000010000000000000361706905666972657a036f6e650000010001");
         let response = dns_types::Response::parse(&bytes).unwrap();

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -1,3 +1,6 @@
+//! UDP DNS client used to resolve a small set of hosts (e.g. the portal) at
+//! startup, before the tunnel is up.
+
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use std::{
@@ -71,6 +74,17 @@ impl UdpDnsClient {
                 .into_iter()
                 .flat_map(|result| result.inspect_err(|e| tracing::debug!("{e:#}")).ok())
                 .filter(|response| response.response_code() == dns_types::ResponseCode::NOERROR)
+                .filter(|response| {
+                    if is_malformed(response) {
+                        tracing::debug!(
+                            domain = %response.domain(),
+                            qtype = %response.qtype(),
+                            "Dropping malformed NOERROR response with no answers and no SOA in authority section (RFC 2308 §3)"
+                        );
+                        return false;
+                    }
+                    true
+                })
                 .flat_map(|response| {
                     response
                         .records()
@@ -84,6 +98,35 @@ impl UdpDnsClient {
             Ok(ips)
         }
     }
+}
+
+/// Whether a `NOERROR` response is structurally malformed enough that it should
+/// not be trusted as an authoritative empty answer.
+///
+/// Some consumer-grade DNS forwarders reply to certain UDP queries with a
+/// `NOERROR` response that contains no answer records, no authority records,
+/// and no additional records — i.e. the bare query echoed back. This is not a
+/// valid negative answer:
+///
+/// - [RFC 2308 §2.2](https://datatracker.ietf.org/doc/html/rfc2308#section-2.2)
+///   defines a NODATA response as `NOERROR` with no answers; the authority
+///   section must contain an SOA, or there must be no NS records there.
+/// - [RFC 2308 §3](https://datatracker.ietf.org/doc/html/rfc2308#section-3)
+///   requires authoritative servers to include the zone SOA in the authority
+///   section when reporting NXDOMAIN or NODATA.
+/// - [RFC 2308 §5](https://datatracker.ietf.org/doc/html/rfc2308#section-5)
+///   says negative responses without an SOA SHOULD NOT be cached.
+///
+/// Treating such a response as an authoritative empty answer hides the
+/// upstream's misbehavior and produces an empty `addresses` list at the
+/// caller, which manifests as `phoenix_channel`'s "no IP addresses available"
+/// retries until the budget expires. Instead we drop the response and let a
+/// sibling query (e.g. AAAA when the broken one was A) or a second resolver
+/// supply the real answer.
+fn is_malformed(response: &dns_types::Response) -> bool {
+    response.response_code() == dns_types::ResponseCode::NOERROR
+        && response.records().next().is_none()
+        && !response.has_authority()
 }
 
 async fn send_query(
@@ -173,5 +216,46 @@ mod tests {
         let ips = client.resolve("example.com").await;
 
         assert_eq!(ips.unwrap_err().to_string(), "No servers specified")
+    }
+
+    #[test]
+    fn is_malformed_detects_buggy_router_empty_response() {
+        // 31-byte NOERROR reply for `api.firez.one A` with all section counts
+        // zeroed except QD — the exact shape we saw from a misbehaving consumer
+        // router. This is not a valid NODATA per RFC 2308 §3 (no SOA in
+        // authority) and should not be treated as an authoritative empty answer.
+        let bytes =
+            hex_literal::hex!("1234818000010000000000000361706905666972657a036f6e650000010001");
+        let response = dns_types::Response::parse(&bytes).unwrap();
+
+        assert!(is_malformed(&response));
+    }
+
+    #[test]
+    fn is_malformed_returns_false_for_response_with_answer() {
+        let domain = dns_types::DomainName::vec_from_str("example.com").unwrap();
+        let query = dns_types::Query::new(domain.clone(), dns_types::RecordType::A);
+        let response =
+            dns_types::ResponseBuilder::for_query(&query, dns_types::ResponseCode::NOERROR)
+                .with_records([(domain, 60, dns_types::records::a(Ipv4Addr::LOCALHOST))])
+                .build();
+        let bytes = response.into_bytes(4096);
+        let parsed = dns_types::Response::parse(&bytes).unwrap();
+
+        assert!(!is_malformed(&parsed));
+    }
+
+    #[test]
+    fn is_malformed_returns_false_for_nxdomain_with_no_records() {
+        // NXDOMAIN response (rcode=3) with zero records in any section. The
+        // structural shape matches the malformed case but the rcode tells us
+        // the server *did* speak about the name (it doesn't exist), so this is
+        // not a malformed NOERROR we should drop.
+        let bytes =
+            hex_literal::hex!("1234818300010000000000000361706905666972657a036f6e650000010001");
+        let response = dns_types::Response::parse(&bytes).unwrap();
+
+        assert_eq!(response.response_code(), dns_types::ResponseCode::NXDOMAIN);
+        assert!(!is_malformed(&response));
     }
 }

--- a/rust/libs/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l4-udp-dns-client/lib.rs
@@ -241,6 +241,47 @@ mod tests {
     }
 
     #[test]
+    fn is_malformed_returns_false_for_truncated_response() {
+        // Same shape as the buggy-router case but with TC=1 (flags 0x8380).
+        // Truncation is a different failure mode (UDP payload didn't fit) and
+        // should not be reported via the malformed-response log line.
+        let bytes =
+            hex_literal::hex!("1234838000010000000000000361706905666972657a036f6e650000010001");
+        let response = dns_types::Response::parse(&bytes).unwrap();
+
+        assert!(response.truncated());
+        assert!(!is_malformed(&response));
+    }
+
+    #[test]
+    fn is_malformed_returns_false_for_valid_nodata_with_soa() {
+        // A well-formed NODATA: NOERROR for `api.firez.one A` with no answer
+        // records but an SOA record in the authority section. This is what a
+        // real recursive resolver returns when the name exists but has no
+        // records of the requested type, and `is_malformed` must let it pass.
+        //
+        // Wire layout (82 bytes):
+        //   header     id=0x1234, flags=0x8180 (qr+rd+ra, rcode=NOERROR),
+        //              qd=1, an=0, ns=1, ar=0
+        //   question   `api.firez.one` A IN
+        //   authority  SOA for `firez.one` (name compressed to offset 16),
+        //              ttl=3600, mname=ns1.firez.one,
+        //              rname=hostmaster.firez.one, serial=1, refresh=7200,
+        //              retry=3600, expire=604800, minimum=3600
+        let bytes = hex_literal::hex!(
+            "1234818000010000000100000361706905666972657a036f6e650000010001\
+             c0100006000100000e100027036e7331c0100a686f73746d6173746572c010\
+             0000000100001c2000000e1000093a8000000e10"
+        );
+        let response = dns_types::Response::parse(&bytes).unwrap();
+
+        assert_eq!(response.response_code(), dns_types::ResponseCode::NOERROR);
+        assert_eq!(response.records().count(), 0);
+        assert!(response.has_authority());
+        assert!(!is_malformed(&response));
+    }
+
+    #[test]
     fn is_malformed_returns_false_for_response_with_answer() {
         let domain = dns_types::DomainName::vec_from_str("example.com").unwrap();
         let query = dns_types::Query::new(domain.clone(), dns_types::RecordType::A);


### PR DESCRIPTION
Some consumer-grade DNS forwarders reply to certain UDP queries with a
`NOERROR` whose answer, authority, and additional sections are all empty
— the bare question echoed back. UdpDnsClient previously treated this as
an authoritative empty answer, which surfaced upstream as
phoenix_channel's "no IP addresses available" retry loop until the
budget expired, with no diagnostic hint that the resolver had
misbehaved.

RFC 2308 §2.2 defines a NODATA response as NOERROR with no answers
*and* an SOA in the authority section (or no NS records). §3 requires
authoritative servers to include the zone SOA when reporting NXDOMAIN
or NODATA, and §5 says negative responses without an SOA SHOULD NOT be
cached because they are not trustworthy. A NOERROR with zero records in
every section therefore is not a well-formed negative answer — it
indicates a buggy upstream rather than "this name truly has no A/AAAA".

Drop such responses from the pipeline with a DEBUG log, so a sibling
query (e.g. AAAA when the A leg was malformed) or a second resolver
can still produce an answer, and the malformed-response case is
loudly visible in logs next time it recurs.

Related to #13250 