### PR TITLE
fix(connlib): align device pool messages with the portal

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -539,7 +539,13 @@ impl Eventloop {
                             .send(UserNotification::GatewayVersionMismatch { resource_id })
                             .await;
                     }
-                    FailReason::NotFound | FailReason::Forbidden | FailReason::Unknown => {}
+                    FailReason::NotFound
+                    | FailReason::Forbidden
+                    | FailReason::Disabled
+                    | FailReason::AmbiguousAddress
+                    | FailReason::MissingAddress
+                    | FailReason::InvalidAddress
+                    | FailReason::Unknown => {}
                 }
             }
             IngressMessages::ClientDeviceAccessAuthorized(ClientDeviceAccessAuthorized {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -319,24 +319,28 @@ impl ClientState {
     /// 2. When access is revoked after it has been established.
     pub fn handle_client_device_access_denied(
         &mut self,
-        ipv4: Ipv4Addr,
-        ipv6: Ipv6Addr,
+        ipv4: Option<Ipv4Addr>,
+        ipv6: Option<Ipv6Addr>,
         reason: FailReason,
         now: Instant,
     ) {
-        tracing::debug!(%ipv4, %ipv6, "Device access denied: {reason:?}");
+        tracing::debug!(?ipv4, ?ipv6, "Device access denied: {reason:?}");
 
         // The protocol is irrelevant: each member device has exactly one routing-table entry
         // per address, so the lookup always resolves to that entry regardless of the dummy.
-        let entry = self
-            .client_routing_table
-            .matches(IpAddr::V4(ipv4), Ok(Protocol::Tcp(0)))
-            .cloned();
-        let entry = entry.or_else(|| {
-            self.client_routing_table
-                .matches(IpAddr::V6(ipv6), Ok(Protocol::Tcp(0)))
-                .cloned()
-        });
+        let entry = ipv4
+            .and_then(|ip| {
+                self.client_routing_table
+                    .matches(IpAddr::V4(ip), Ok(Protocol::Tcp(0)))
+                    .cloned()
+            })
+            .or_else(|| {
+                ipv6.and_then(|ip| {
+                    self.client_routing_table
+                        .matches(IpAddr::V6(ip), Ok(Protocol::Tcp(0)))
+                        .cloned()
+                })
+            });
         let Some(entry) = entry else {
             return;
         };

--- a/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel/src/dns/device_stub_resolver.rs
@@ -197,6 +197,10 @@ impl DeviceStubResolver {
                 FailReason::Offline
                 | FailReason::VersionMismatch
                 | FailReason::Forbidden
+                | FailReason::Disabled
+                | FailReason::AmbiguousAddress
+                | FailReason::MissingAddress
+                | FailReason::InvalidAddress
                 | FailReason::Unknown,
             ) => dns_types::Response::servfail(&pending.query),
         };

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -68,6 +68,7 @@ pub struct ResourceDescriptionStaticDevicePool {
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DevicePoolMember {
+    #[serde(rename = "client_id")]
     pub id: ClientId,
     pub ipv4: Ipv4Network,
     pub ipv6: Ipv6Network,
@@ -156,10 +157,15 @@ pub struct ClientDeviceAccessAuthorized {
     pub ice_role: IceRole,
 }
 
+/// Portal's denial of a `create_flow` toward a static device pool peer.
+///
+/// Either or both of `ipv4` / `ipv6` may be absent depending on the denial reason.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClientDeviceAccessDenied {
-    pub ipv4: Ipv4Addr,
-    pub ipv6: Ipv6Addr,
+    #[serde(default)]
+    pub ipv4: Option<Ipv4Addr>,
+    #[serde(default)]
+    pub ipv6: Option<Ipv6Addr>,
     pub reason: FailReason,
 }
 
@@ -186,6 +192,10 @@ pub enum FailReason {
     Offline,
     VersionMismatch,
     Forbidden,
+    Disabled,
+    AmbiguousAddress,
+    MissingAddress,
+    InvalidAddress,
     #[serde(other)]
     Unknown,
 }
@@ -629,7 +639,20 @@ mod tests {
             {
                 "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                 "type": "static_device_pool",
-                "name": "IoT Devices"
+                "name": "IoT Devices",
+                "devices": [
+                    {
+                        "client_id": "a3632404-4b03-4468-9fc0-4a4c82415ade",
+                        "ipv4": "100.64.1.38/32",
+                        "ipv6": "fd00:2021:1111::125/128"
+                    },
+                    {
+                        "client_id": "75fb9102-2651-49eb-9b0b-80f4eee182cb",
+                        "ipv4": "100.64.23.121/32",
+                        "ipv6": "fd00:2021:1111::1777/128"
+                    }
+                ],
+                "filters": []
             }
         ]"#;
 
@@ -645,6 +668,21 @@ mod tests {
         };
         let desc = ResourceDescriptionStaticDevicePool::deserialize(json).unwrap();
         assert_eq!(desc.name, "IoT Devices");
+        assert_eq!(
+            desc.devices,
+            vec![
+                DevicePoolMember {
+                    id: "a3632404-4b03-4468-9fc0-4a4c82415ade".parse().unwrap(),
+                    ipv4: "100.64.1.38/32".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::125/128".parse().unwrap(),
+                },
+                DevicePoolMember {
+                    id: "75fb9102-2651-49eb-9b0b-80f4eee182cb".parse().unwrap(),
+                    ipv4: "100.64.23.121/32".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::1777/128".parse().unwrap(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -68,7 +68,7 @@ pub struct ResourceDescriptionStaticDevicePool {
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DevicePoolMember {
-    #[serde(rename = "client_id")]
+    #[serde(rename = "client_id", alias = "id")]
     pub id: ClientId,
     pub ipv4: Ipv4Network,
     pub ipv6: Ipv6Network,

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1168,10 +1168,7 @@ impl TunnelTest {
                         .inner()
                         .sut
                         .tunnel_ip_config()
-                        .is_some_and(|tun| match ip {
-                            std::net::IpAddr::V4(v4) => tun.v4 == v4,
-                            std::net::IpAddr::V6(v6) => tun.v6 == v6,
-                        })
+                        .is_some_and(|tun| tun.is_ip(ip))
                 });
 
                 match maybe_remote_client {


### PR DESCRIPTION
PR #13028 renamed the Rust field on `DevicePoolMember` from `client_id`
to `id`, but the portal serialiser still emits `client_id`. Every
`StaticDevicePool` resource was being silently dropped with a
`missing field id` WARN, so no client-to-client routes were ever
installed and the tray reported `connected_devices=0`.

Make ipv4/ipv6 Option<> on ClientDeviceAccessDenied and add the missing
Disabled / AmbiguousAddress / MissingAddress / InvalidAddress FailReason
variants from firezone#13010.

Restore the wire field name via `#[serde(rename = "client_id")]`,
keeping the in-memory field as `id` so call sites in `routing_table`
and `pending_device_access` are unchanged.