### PR TITLE
feat(gui-client): display tun ipv4 for connected devices

### DIFF
--- a/rust/gui-client/src-tauri/src/fake_controller.rs
+++ b/rust/gui-client/src-tauri/src/fake_controller.rs
@@ -141,7 +141,7 @@ fn fake_connected_devices() -> Vec<ConnectedDeviceView> {
     (0..22u128)
         .map(|i| ConnectedDeviceView {
             id: ClientId::from_u128(i + 1),
-            tunneled_ipv4: Some(Ipv4Addr::new(100, 96, 0, (i as u8) + 1)),
+            tunneled_ipv4: Ipv4Addr::new(100, 96, 0, (i as u8) + 1),
             pools: POOL_PATTERNS[(i as usize) % POOL_PATTERNS.len()]
                 .iter()
                 .map(|name| (*name).to_string())

--- a/rust/gui-client/src-tauri/src/fake_controller.rs
+++ b/rust/gui-client/src-tauri/src/fake_controller.rs
@@ -11,6 +11,7 @@
 //! Lives behind a debug subcommand (not behind `cfg(debug_assertions)`) so it
 //! can be exercised against release builds when needed.
 use std::collections::HashSet;
+use std::net::Ipv4Addr;
 
 use anyhow::Result;
 use connlib_model::{
@@ -134,16 +135,16 @@ fn fake_connected_devices() -> Vec<ConnectedDeviceView> {
     const POOL_PATTERNS: &[&[&str]] = &[
         &["Engineering Pool"],
         &["Engineering Pool", "QA Pool"],
-        &[],
         &["QA Pool"],
         &["Sales Pool"],
     ];
     (0..22u128)
         .map(|i| ConnectedDeviceView {
             id: ClientId::from_u128(i + 1),
+            tunneled_ipv4: Some(Ipv4Addr::new(100, 96, 0, (i as u8) + 1)),
             pools: POOL_PATTERNS[(i as usize) % POOL_PATTERNS.len()]
                 .iter()
-                .map(|s| (*s).to_string())
+                .map(|name| (*name).to_string())
                 .collect(),
         })
         .collect()

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -475,11 +475,18 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
     menu
 }
 
+fn device_label(device: &ConnectedDeviceView) -> String {
+    device
+        .tunneled_ipv4
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| device.id.to_string())
+}
+
 fn devices_submenu(connected_devices: &[ConnectedDeviceView]) -> Menu {
     let mut menu = Menu::default();
     let visible = connected_devices.len().min(MAX_DEVICES_INLINE);
     for device in &connected_devices[..visible] {
-        menu = menu.add_submenu(device.id.to_string(), device_submenu(device));
+        menu = menu.add_submenu(device_label(device), device_submenu(device));
     }
 
     let hidden = connected_devices.len() - visible;
@@ -495,8 +502,18 @@ fn devices_submenu(connected_devices: &[ConnectedDeviceView]) -> Menu {
 }
 
 fn device_submenu(device: &ConnectedDeviceView) -> Menu {
-    let mut menu = Menu::default()
-        .disabled("Device")
+    let mut menu = Menu::default().disabled("Device");
+
+    if let Some(ip) = device.tunneled_ipv4 {
+        menu = menu
+            .separator()
+            .disabled("Tunnel IPv4")
+            .copyable(&ip.to_string());
+    }
+
+    menu = menu
+        .separator()
+        .disabled("Client ID")
         .copyable(&device.id.to_string());
 
     if !device.pools.is_empty() {
@@ -506,8 +523,8 @@ fn device_submenu(device: &ConnectedDeviceView) -> Menu {
             "Pools"
         };
         menu = menu.separator().disabled(label);
-        for pool in &device.pools {
-            menu = menu.copyable(pool);
+        for name in &device.pools {
+            menu = menu.copyable(name);
         }
     }
 
@@ -1009,15 +1026,20 @@ mod tests {
     #[test]
     fn devices_submenu_lists_connected_devices_with_pool_labels() {
         use connlib_model::ClientId;
+        use std::net::Ipv4Addr;
         let alpha = ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111);
         let beta = ClientId::from_u128(0x2222_2222_2222_2222_2222_2222_2222_2222);
+        let alpha_ip = Ipv4Addr::new(100, 64, 0, 1);
+        let beta_ip = Ipv4Addr::new(100, 64, 0, 2);
         let connected_devices = vec![
             ConnectedDeviceView {
                 id: alpha,
+                tunneled_ipv4: Some(alpha_ip),
                 pools: vec!["Engineering Pool".into()],
             },
             ConnectedDeviceView {
                 id: beta,
+                tunneled_ipv4: Some(beta_ip),
                 pools: vec!["Engineering Pool".into(), "QA Pool".into()],
             },
         ];
@@ -1026,18 +1048,28 @@ mod tests {
 
         let expected = Menu::default()
             .add_submenu(
-                alpha.to_string(),
+                alpha_ip.to_string(),
                 Menu::default()
                     .disabled("Device")
+                    .separator()
+                    .disabled("Tunnel IPv4")
+                    .copyable(&alpha_ip.to_string())
+                    .separator()
+                    .disabled("Client ID")
                     .copyable(&alpha.to_string())
                     .separator()
                     .disabled("Pool")
                     .copyable("Engineering Pool"),
             )
             .add_submenu(
-                beta.to_string(),
+                beta_ip.to_string(),
                 Menu::default()
                     .disabled("Device")
+                    .separator()
+                    .disabled("Tunnel IPv4")
+                    .copyable(&beta_ip.to_string())
+                    .separator()
+                    .disabled("Client ID")
                     .copyable(&beta.to_string())
                     .separator()
                     .disabled("Pools")
@@ -1056,10 +1088,12 @@ mod tests {
     #[test]
     fn devices_submenu_truncates_beyond_inline_limit() {
         use connlib_model::ClientId;
+        use std::net::Ipv4Addr;
         let connected_devices: Vec<ConnectedDeviceView> = (0..MAX_DEVICES_INLINE + 3)
             .map(|i| ConnectedDeviceView {
                 id: ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111 + i as u128),
-                pools: Vec::new(),
+                tunneled_ipv4: Some(Ipv4Addr::new(100, 64, 0, i as u8)),
+                pools: vec!["Engineering Pool".into()],
             })
             .collect();
 
@@ -1067,11 +1101,20 @@ mod tests {
 
         let mut expected = Menu::default();
         for device in &connected_devices[..MAX_DEVICES_INLINE] {
+            let ip = device.tunneled_ipv4.unwrap().to_string();
             expected = expected.add_submenu(
-                device.id.to_string(),
+                ip.clone(),
                 Menu::default()
                     .disabled("Device")
-                    .copyable(&device.id.to_string()),
+                    .separator()
+                    .disabled("Tunnel IPv4")
+                    .copyable(&ip)
+                    .separator()
+                    .disabled("Client ID")
+                    .copyable(&device.id.to_string())
+                    .separator()
+                    .disabled("Pool")
+                    .copyable(&device.pools[0]),
             );
         }
         expected = expected.separator().disabled("And 3 more devices…");

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -476,10 +476,7 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
 }
 
 fn device_label(device: &ConnectedDeviceView) -> String {
-    device
-        .tunneled_ipv4
-        .map(|ip| ip.to_string())
-        .unwrap_or_else(|| device.id.to_string())
+    device.tunneled_ipv4.to_string()
 }
 
 fn devices_submenu(connected_devices: &[ConnectedDeviceView]) -> Menu {
@@ -504,14 +501,10 @@ fn devices_submenu(connected_devices: &[ConnectedDeviceView]) -> Menu {
 fn device_submenu(device: &ConnectedDeviceView) -> Menu {
     let mut menu = Menu::default().disabled("Device");
 
-    if let Some(ip) = device.tunneled_ipv4 {
-        menu = menu
-            .separator()
-            .disabled("Tunnel IPv4")
-            .copyable(&ip.to_string());
-    }
-
     menu = menu
+        .separator()
+        .disabled("Tunnel IPv4")
+        .copyable(&device.tunneled_ipv4.to_string())
         .separator()
         .disabled("Client ID")
         .copyable(&device.id.to_string());
@@ -1034,12 +1027,12 @@ mod tests {
         let connected_devices = vec![
             ConnectedDeviceView {
                 id: alpha,
-                tunneled_ipv4: Some(alpha_ip),
+                tunneled_ipv4: alpha_ip,
                 pools: vec!["Engineering Pool".into()],
             },
             ConnectedDeviceView {
                 id: beta,
-                tunneled_ipv4: Some(beta_ip),
+                tunneled_ipv4: beta_ip,
                 pools: vec!["Engineering Pool".into(), "QA Pool".into()],
             },
         ];
@@ -1092,7 +1085,7 @@ mod tests {
         let connected_devices: Vec<ConnectedDeviceView> = (0..MAX_DEVICES_INLINE + 3)
             .map(|i| ConnectedDeviceView {
                 id: ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111 + i as u128),
-                tunneled_ipv4: Some(Ipv4Addr::new(100, 64, 0, i as u8)),
+                tunneled_ipv4: Ipv4Addr::new(100, 64, 0, i as u8),
                 pools: vec!["Engineering Pool".into()],
             })
             .collect();
@@ -1101,7 +1094,7 @@ mod tests {
 
         let mut expected = Menu::default();
         for device in &connected_devices[..MAX_DEVICES_INLINE] {
-            let ip = device.tunneled_ipv4.unwrap().to_string();
+            let ip = device.tunneled_ipv4.to_string();
             expected = expected.add_submenu(
                 ip.clone(),
                 Menu::default()

--- a/rust/libs/connlib/model/src/view.rs
+++ b/rust/libs/connlib/model/src/view.rs
@@ -130,10 +130,9 @@ pub struct ConnectedDeviceView {
     pub id: ClientId,
     /// Tunnel IPv4 address the device is reachable on.
     ///
-    /// A device has a single tunnel IPv4 regardless of how many pools list it.
-    /// `None` only in the transient window where the snownet connection is
-    /// still up but the device has been removed from every pool.
-    pub tunneled_ipv4: Option<Ipv4Addr>,
+    /// Sourced from the live snownet connection state, so it is always known
+    /// for a connected device regardless of pool membership.
+    pub tunneled_ipv4: Ipv4Addr,
     /// Names of the static device pools the device belongs to, sorted.
     pub pools: Vec<String>,
 }

--- a/rust/libs/connlib/model/src/view.rs
+++ b/rust/libs/connlib/model/src/view.rs
@@ -3,6 +3,7 @@ use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::net::Ipv4Addr;
 
 use crate::ClientId;
 use crate::ResourceId;
@@ -127,10 +128,13 @@ pub struct CidrResourceView {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ConnectedDeviceView {
     pub id: ClientId,
-    /// Names of the device pool resources this client is a member of
-    /// (typically one, but can be multiple).
+    /// Tunnel IPv4 address the device is reachable on.
     ///
-    /// Empty if pool membership for this client is unknown.
+    /// A device has a single tunnel IPv4 regardless of how many pools list it.
+    /// `None` only in the transient window where the snownet connection is
+    /// still up but the device has been removed from every pool.
+    pub tunneled_ipv4: Option<Ipv4Addr>,
+    /// Names of the static device pools the device belongs to, sorted.
     pub pools: Vec<String>,
 }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -29,7 +29,7 @@ use crate::messages::{
     IceCredentials, IceRole, Interface as InterfaceConfig, SecretKey,
     client::{DevicePoolMember, FailReason},
 };
-use crate::peer_store::PeerStore;
+use crate::peer_store::{Peer, PeerStore};
 use crate::routing_table::{RouteEntry, RoutingTable};
 use crate::unroutable_packet::UnroutablePacket;
 use crate::{ClientEvent, FailedToDecapsulate, packet_kind};
@@ -237,21 +237,36 @@ impl ClientState {
             .collect_vec()
     }
 
-    /// Builds the list of currently-connected device peers, joined against
-    /// static-pool resource memberships so each entry knows its tunnel IPv4
-    /// and which pool(s) it belongs to.
+    /// Builds the list of currently-connected device peers. The tunnel IPv4 is
+    /// taken from the live connection state; static-pool resources are joined in
+    /// only to label which pool(s) each device belongs to.
     pub(crate) fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
         let pools = self.static_device_pools().collect_vec();
 
         self.connected_pool_clients
             .iter()
-            .map(|client_id| {
-                let mut tunneled_ipv4 = None;
-                let mut pool_names = Vec::new();
+            .filter_map(|client_id| {
+                let Some(peer) = self.clients.peer_by_id(client_id) else {
+                    tracing::debug!(
+                        %client_id,
+                        "Connected client has no peer in the connection store"
+                    );
+                    return None;
+                };
+                let tunneled_ipv4 = peer.tun_ipv4();
 
+                let mut pool_names = Vec::new();
                 for pool in &pools {
                     if let Some(device) = pool.devices.iter().find(|d| d.id == *client_id) {
-                        tunneled_ipv4.get_or_insert(device.ipv4.network_address());
+                        if device.ipv4.network_address() != tunneled_ipv4 {
+                            tracing::debug!(
+                                %client_id,
+                                pool = %pool.name,
+                                pool_ipv4 = %device.ipv4.network_address(),
+                                %tunneled_ipv4,
+                                "Pool-provided IPv4 disagrees with the connection's tunnel IPv4"
+                            );
+                        }
                         pool_names.push(pool.name.clone());
                     }
                 }
@@ -265,11 +280,11 @@ impl ClientState {
                     );
                 }
 
-                ConnectedDeviceView {
+                Some(ConnectedDeviceView {
                     id: *client_id,
                     tunneled_ipv4,
                     pools: pool_names,
-                }
+                })
             })
             .collect_vec()
     }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -259,7 +259,7 @@ impl ClientState {
                 pool_names.sort();
 
                 if pool_names.is_empty() {
-                    tracing::error!(
+                    tracing::debug!(
                         %client_id,
                         "Connected client is not a member of any pool"
                     );

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -238,22 +238,36 @@ impl ClientState {
     }
 
     /// Builds the list of currently-connected device peers, joined against
-    /// static-pool resource memberships so each entry knows which pool(s) it
-    /// belongs to.
+    /// static-pool resource memberships so each entry knows its tunnel IPv4
+    /// and which pool(s) it belongs to.
     pub(crate) fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
         let pools = self.static_device_pools().collect_vec();
 
         self.connected_pool_clients
             .iter()
             .map(|client_id| {
-                let pool_names = pools
-                    .iter()
-                    .filter(|p| p.devices.iter().any(|d| d.id == *client_id))
-                    .map(|p| p.name.clone())
-                    .sorted()
-                    .collect_vec();
+                let mut tunneled_ipv4 = None;
+                let mut pool_names = Vec::new();
+
+                for pool in &pools {
+                    if let Some(device) = pool.devices.iter().find(|d| d.id == *client_id) {
+                        tunneled_ipv4.get_or_insert(device.ipv4.network_address());
+                        pool_names.push(pool.name.clone());
+                    }
+                }
+
+                pool_names.sort();
+
+                if pool_names.is_empty() {
+                    tracing::error!(
+                        %client_id,
+                        "Connected client is not a member of any pool"
+                    );
+                }
+
                 ConnectedDeviceView {
                     id: *client_id,
+                    tunneled_ipv4,
                     pools: pool_names,
                 }
             })


### PR DESCRIPTION
Now we can copy the IP as well as the client-id in the subsection.