### PR TITLE
fix(portal): clarify enterprise limits email

### DIFF
--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.html.eex
@@ -85,7 +85,7 @@
                   </p>
                   <ul style="margin: 0; padding-left: 24px; line-height: 24px">
                     <li>Your existing connections will continue to work</li>
-                    <li>New client sign-ins will be blocked until limits are resolved</li>
+                    <li>New client sign ins may be blocked until limits are resolved</li>
                     <li>Account administrators can still access the admin portal</li>
                   </ul>
                   <div role="separator" class="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0">&zwj;</div>

--- a/elixir/lib/portal/mailer/notifications/limits_exceeded.text.eex
+++ b/elixir/lib/portal/mailer/notifications/limits_exceeded.text.eex
@@ -6,7 +6,7 @@ Your Firezone account "<%= @account.slug %>" (<%= @account.id %>) has exceeded t
 
 What happens next?
 - Your existing connections will continue to work
-- New client sign-ins will be blocked until limits are resolved
+- New client sign ins may be blocked until limits are resolved
 - Account administrators can still access the admin portal
 
 <%= case @plan_type do %>


### PR DESCRIPTION
The copy in these is not quite accurate and would raise more alarm than needed. Better to keep it accurate to say "might be blocked" since this is a soft limit.
