### PR TITLE
feat(portal): oidc proof of email ownership

### DIFF
--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -31,6 +31,7 @@ defmodule Portal.Account do
 
     has_many :auth_providers, Portal.AuthProvider
     has_many :external_identities, Portal.ExternalIdentity
+    has_many :pending_identities, Portal.PendingIdentity
 
     has_many :policies, Portal.Policy
 

--- a/elixir/lib/portal/actor.ex
+++ b/elixir/lib/portal/actor.ex
@@ -23,6 +23,7 @@ defmodule Portal.Actor do
     field :name, :string
 
     has_many :identities, Portal.ExternalIdentity, references: :id
+    has_many :pending_identities, Portal.PendingIdentity, references: :id
 
     has_many :clients, Portal.Device,
       where: [type: :client],

--- a/elixir/lib/portal/mailer/auth_email.ex
+++ b/elixir/lib/portal/mailer/auth_email.ex
@@ -17,7 +17,7 @@ defmodule Portal.Mailer.AuthEmail do
         user_agent,
         remote_ip
       ) do
-    sign_in_form_url = url(~p"/#{account.slug}")
+    sign_in_form_url = url(~p"/#{account}")
 
     default_email()
     |> subject("Welcome to Firezone")
@@ -27,7 +27,7 @@ defmodule Portal.Mailer.AuthEmail do
       account: account,
       sign_in_form_url: sign_in_form_url,
       user_agent: user_agent,
-      remote_ip: "#{:inet.ntoa(remote_ip)}"
+      remote_ip: obfuscated_remote_ip(remote_ip)
     )
   end
 
@@ -43,7 +43,7 @@ defmodule Portal.Mailer.AuthEmail do
     params = Map.merge(params, %{secret: secret})
 
     sign_in_url =
-      url(~p"/#{actor.account.slug}/sign_in/email_otp/#{auth_provider_id}/verify?#{params}")
+      url(~p"/#{actor.account}/sign_in/email_otp/#{auth_provider_id}/verify?#{params}")
 
     token_created_at =
       PortalWeb.Format.short_datetime(token_created_at) <> " UTC"
@@ -52,14 +52,63 @@ defmodule Portal.Mailer.AuthEmail do
     |> subject("Firezone sign in token")
     |> to(actor.email)
     |> with_account_id(actor.account.id)
-    |> render_body(__MODULE__, :sign_in_link,
+    |> render_body(__MODULE__, :otp_email,
       account: actor.account,
-      client_sign_in: params["as"] == "client",
+      email_title: "Firezone Sign In Token",
+      heading: "Finish Signing In!",
+      code_instruction: "Copy and paste the following token into the Sign In form",
+      link_instruction:
+        "or click on the following link if you are on the same device where you are trying to sign in:",
+      html_link_instruction: "Or click the button below",
+      button_label: "Complete Sign In",
+      unsolicited_action: "sign in",
+      show_link?: not PortalWeb.Authentication.client_sign_in?(params),
       sign_in_token_created_at: token_created_at,
       secret: secret,
       sign_in_url: sign_in_url,
       user_agent: user_agent,
-      remote_ip: "#{:inet.ntoa(remote_ip)}"
+      remote_ip: obfuscated_remote_ip(remote_ip),
+      request_location: nil
+    )
+  end
+
+  def oidc_identity_verification_email(
+        %Portal.Actor{} = actor,
+        token_created_at,
+        auth_provider_id,
+        pending_identity_id,
+        secret,
+        %Portal.Authentication.Context{} = context,
+        params \\ %{}
+      ) do
+    params = Map.merge(params, %{"pending_identity_id" => pending_identity_id})
+
+    verify_url =
+      url(~p"/#{actor.account}/sign_in/oidc/#{auth_provider_id}/verify_identity?#{params}")
+
+    token_created_at =
+      PortalWeb.Format.short_datetime(token_created_at) <> " UTC"
+
+    default_email()
+    |> subject("Firezone email verification code")
+    |> to(actor.email)
+    |> with_account_id(actor.account.id)
+    |> render_body(__MODULE__, :otp_email,
+      account: actor.account,
+      email_title: "Firezone Email Verification Code",
+      heading: "Verify Your Email Address",
+      code_instruction: "Copy and paste the following code into the email verification form",
+      link_instruction: "Use the following link to return to the email verification form:",
+      html_link_instruction: "Click the button below to return to the verification form",
+      button_label: "Enter Verification Code",
+      unsolicited_action: "email verification",
+      show_link?: true,
+      sign_in_token_created_at: token_created_at,
+      secret: secret,
+      sign_in_url: verify_url,
+      user_agent: context.user_agent,
+      remote_ip: obfuscated_remote_ip(context.remote_ip),
+      request_location: request_location(context)
     )
   end
 
@@ -109,4 +158,28 @@ defmodule Portal.Mailer.AuthEmail do
       subject: subject
     )
   end
+
+  defp request_location(%Portal.Authentication.Context{} = context) do
+    [context.remote_ip_location_city, context.remote_ip_location_region]
+    |> Enum.reject(&blank?/1)
+    |> Enum.join(", ")
+    |> blank_to_nil()
+  end
+
+  defp obfuscated_remote_ip({a, b, _c, _d}) do
+    "#{a}.#{b}.x.x"
+  end
+
+  defp obfuscated_remote_ip({a, b, c, d, _e, _f, _g, _h}) do
+    [a, b, c, d]
+    |> Enum.map(&Integer.to_string(&1, 16))
+    |> Enum.map(&String.downcase/1)
+    |> Enum.concat(["xxxx", "xxxx", "xxxx", "xxxx"])
+    |> Enum.join(":")
+  end
+
+  defp blank?(value), do: value in [nil, ""]
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
 end

--- a/elixir/lib/portal/mailer/auth_email/otp_email.html.eex
+++ b/elixir/lib/portal/mailer/auth_email/otp_email.html.eex
@@ -19,7 +19,7 @@
     td,th,div,p,a,h1,h2,h3,h4,h5,h6 {font-family: "Segoe UI", sans-serif; mso-line-height-rule: exactly;}
   </style>
   <![endif]-->
-    <title>Firezone Sign In Token</title>
+    <title><%= @email_title %></title>
     <style>
       img {
         max-width: 100%;
@@ -53,7 +53,7 @@
     </style>
   </head>
   <body style="margin: 0; width: 100%; background-color: #f6f6f6; padding: 0; -webkit-font-smoothing: antialiased; word-break: break-word">
-    <div role="article" aria-roledescription="email" aria-label="Firezone Sign In Token" lang="en">
+    <div role="article" aria-roledescription="email" aria-label="<%= @email_title %>" lang="en">
       <div
         class="sm-px-4 email-container"
         style="background-color: #f6f6f6; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif"
@@ -94,17 +94,17 @@
                       class="sm-leading-8"
                       style="margin: 0 0 24px; font-size: 24px; font-weight: 600; color: #000000"
                     >
-                      Finish Signing In!
+                      <%= @heading %>
                     </h1>
                     <p style="margin: 0; line-height: 24px">
-                      Copy and paste the following token into the Sign In form
+                      <%= @code_instruction %>
                     </p>
                     <p style="border-radius: 4px; border: 1px solid #e7e7e7; padding: 8px; text-align: center; font-size: 30px">
                       <code><%= @secret %></code>
                     </p>
-                    <%= unless @client_sign_in do %>
+                    <%= if @show_link? do %>
                     <p style="margin: 0; line-height: 24px;">
-                      Or click the button below
+                      <%= @html_link_instruction %>
                     </p>
                     <div role="separator" style="line-height: 16px">&zwj;</div>
                     <div>
@@ -118,7 +118,7 @@
       <i style="mso-font-width: -100%; letter-spacing: 32px; mso-text-raise: 30px" hidden>&nbsp;</i>
     <![endif]-->
                         <span style="mso-text-raise: 16px">
-                          Complete Sign In &rarr;
+                          <%= @button_label %> &rarr;
                         </span>
                         <!--[if mso]>
       <i style="mso-font-width: -100%; letter-spacing: 32px;" hidden>&nbsp;</i>
@@ -183,6 +183,17 @@
                         </th>
                         <td style="padding: 4px 24px;"><%= @remote_ip %></td>
                       </tr>
+                      <%= if @request_location do %>
+                        <tr style="border-bottom-width: 1px; background-color: #ffffff;">
+                          <th
+                            scope="row"
+                            style="white-space: nowrap; padding-left: 24px; padding-right: 24px; font-weight: 500; color: #3d3d3d;"
+                          >
+                            Location
+                          </th>
+                          <td style="padding: 4px 24px;"><%= @request_location %></td>
+                        </tr>
+                      <% end %>
                       <tr style="border-bottom-width: 1px; background-color: #ffffff;">
                         <th
                           scope="row"
@@ -202,7 +213,7 @@
                       &zwj;
                     </div>
                     <p style="margin: 0;">
-                      If you didn't request this sign in, you can safely ignore this email. However, if you continue to receive multiple unsolicited emails of this nature,
+                      If you didn't request this <%= @unsolicited_action %>, you can safely ignore this email. However, if you continue to receive multiple unsolicited emails of this nature,
                       we strongly recommend contacting your system administrator to report the issue.
                       <br />
                       <br /> Thanks, <br />The Firezone Team

--- a/elixir/lib/portal/mailer/auth_email/otp_email.text.eex
+++ b/elixir/lib/portal/mailer/auth_email/otp_email.text.eex
@@ -1,16 +1,16 @@
-Finish Signing In!
+<%= @heading %>
 
-Copy and paste the following token into the Sign In form
+<%= @code_instruction %>
 
 <%= @secret %>
-<%= unless @client_sign_in do %>
-or click on the following link if you are on the same device where you are trying to sign in:
+<%= if @show_link? do %>
+<%= @link_instruction %>
 
 <%= @sign_in_url %>
 <% end %>
 This email is valid for 15 minutes.
 
-If you did not request this action and have received this email in error, you can safely ignore
+If you did not request this <%= @unsolicited_action %> and have received this email in error, you can safely ignore
 and discard this email. However, if you continue to receive multiple unsolicited emails of this nature,
 we strongly recommend contacting your system administrator to report the issue.
 
@@ -19,4 +19,4 @@ Request details:
   Account ID: <%= @account.id %>
   Time: <%= @sign_in_token_created_at %>
   IP address: <%= @remote_ip %>
-  User Agent: <%= @user_agent %>
+<%= if @request_location, do: "  Location: #{@request_location}\n" %>  User Agent: <%= @user_agent %>

--- a/elixir/lib/portal/mailer/notifications.ex
+++ b/elixir/lib/portal/mailer/notifications.ex
@@ -13,7 +13,7 @@ defmodule Portal.Mailer.Notifications do
 
   def outdated_gateway_email(account, gateways, incompatible_client_count, recipients) do
     params = %{clients_order_by: "latest_session:asc:version"}
-    outdated_clients_url = url(~p"/#{account.id}/clients?#{params}")
+    outdated_clients_url = url(~p"/#{account}/clients?#{params}")
 
     default_email()
     |> subject("Firezone Gateway Upgrade Available")
@@ -29,7 +29,7 @@ defmodule Portal.Mailer.Notifications do
   end
 
   def limits_exceeded_email(account, warning, recipients) do
-    billing_url = url(~p"/#{account.id}/settings/account")
+    billing_url = url(~p"/#{account}/settings/account")
     plan_type = Portal.Billing.plan_type(account)
 
     default_email()

--- a/elixir/lib/portal/mailer/sync_email.ex
+++ b/elixir/lib/portal/mailer/sync_email.ex
@@ -12,7 +12,7 @@ defmodule Portal.Mailer.SyncEmail do
   embed_templates "sync_email/*.text", suffix: "_text"
 
   def sync_error_email(directory, recipients) do
-    settings_url = url(~p"/#{directory.account.slug}/settings/directory_sync")
+    settings_url = url(~p"/#{directory.account}/settings/directory_sync")
 
     default_email()
     |> subject("Directory Sync Error - #{directory.name}")

--- a/elixir/lib/portal/oidc/auth_provider.ex
+++ b/elixir/lib/portal/oidc/auth_provider.ex
@@ -47,7 +47,9 @@ defmodule Portal.OIDC.AuthProvider do
     field :client_id, :string
     field :client_secret, :string, redact: true
     field :discovery_document_uri, :string
-    field :require_email_verified, :boolean, default: true
+    field :email_verification_method, Ecto.Enum,
+      values: ~w[none claim proof]a,
+      default: :claim
 
     timestamps()
   end
@@ -62,7 +64,7 @@ defmodule Portal.OIDC.AuthProvider do
       :discovery_document_uri,
       :issuer,
       :is_verified,
-      :require_email_verified
+      :email_verification_method
     ])
     |> validate_acceptance(:is_verified)
     |> validate_length(:client_id, min: 1, max: 255)
@@ -89,6 +91,7 @@ defmodule Portal.OIDC.AuthProvider do
       message: "An OIDC authentication provider with this name already exists."
     )
     |> check_constraint(:context, name: :context_must_be_valid)
+    |> check_constraint(:email_verification_method, name: :email_verification_method_must_be_valid)
   end
 
   def default_portal_session_lifetime_secs, do: @default_portal_session_lifetime_secs

--- a/elixir/lib/portal/one_time_passcode.ex
+++ b/elixir/lib/portal/one_time_passcode.ex
@@ -11,6 +11,7 @@ defmodule Portal.OneTimePasscode do
     field :id, :binary_id, primary_key: true, autogenerate: true
 
     belongs_to :actor, Portal.Actor
+    has_many :pending_identities, Portal.PendingIdentity, references: :id
 
     field :code_hash, :string, redact: true
     field :code, :string, virtual: true, redact: true

--- a/elixir/lib/portal/pending_identity.ex
+++ b/elixir/lib/portal/pending_identity.ex
@@ -1,0 +1,54 @@
+defmodule Portal.PendingIdentity do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "pending_identities" do
+    belongs_to :account, Portal.Account, primary_key: true
+    field :id, :binary_id, primary_key: true
+
+    belongs_to :actor, Portal.Actor
+    belongs_to :auth_provider, Portal.AuthProvider
+    belongs_to :one_time_passcode, Portal.OneTimePasscode
+
+    field :issuer, :string
+    field :idp_id, :string
+
+    field :email, :string
+    field :name, :string
+    field :given_name, :string
+    field :family_name, :string
+    field :middle_name, :string
+    field :nickname, :string
+    field :preferred_username, :string
+    field :profile, :string
+    field :picture, :string
+
+    belongs_to :directory, Portal.Directory
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> validate_required([
+      :id,
+      :account_id,
+      :actor_id,
+      :auth_provider_id,
+      :one_time_passcode_id,
+      :issuer,
+      :idp_id,
+      :email,
+      :name
+    ])
+    |> assoc_constraint(:account)
+    |> assoc_constraint(:actor)
+    |> assoc_constraint(:auth_provider)
+    |> assoc_constraint(:one_time_passcode)
+    |> assoc_constraint(:directory)
+  end
+end

--- a/elixir/lib/portal/timing.ex
+++ b/elixir/lib/portal/timing.ex
@@ -1,0 +1,36 @@
+defmodule Portal.Timing do
+  @moduledoc """
+  Timing helpers for security-sensitive flows.
+  """
+
+  require Logger
+
+  @spec execute_with_constant_time((-> result), non_neg_integer()) :: result when result: term()
+  def execute_with_constant_time(callback, constant_time) when is_function(callback, 0) do
+    start_time = System.monotonic_time(:millisecond)
+    result = callback.()
+    end_time = System.monotonic_time(:millisecond)
+
+    elapsed_time = end_time - start_time
+    remaining_time = max(0, constant_time - elapsed_time)
+
+    if remaining_time > 0 do
+      :timer.sleep(remaining_time)
+    else
+      log_constant_time_exceeded(constant_time, elapsed_time)
+    end
+
+    result
+  end
+
+  if Mix.env() in [:dev, :test] do
+    defp log_constant_time_exceeded(_constant_time, _elapsed_time), do: :ok
+  else
+    defp log_constant_time_exceeded(constant_time, elapsed_time) do
+      Logger.error("Execution took longer than the given constant time",
+        constant_time: constant_time,
+        elapsed_time: elapsed_time
+      )
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/oidc_auth_provider_json.ex
+++ b/elixir/lib/portal_api/controllers/oidc_auth_provider_json.ex
@@ -22,7 +22,7 @@ defmodule PortalAPI.OIDCAuthProviderJSON do
       is_default: provider.is_default,
       client_id: provider.client_id,
       discovery_document_uri: provider.discovery_document_uri,
-      require_email_verified: provider.require_email_verified,
+      email_verification_method: provider.email_verification_method,
       inserted_at: provider.inserted_at,
       updated_at: provider.updated_at
     }

--- a/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
+++ b/elixir/lib/portal_api/schemas/oidc_auth_provider_schema.ex
@@ -31,9 +31,10 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         is_default: %Schema{type: :boolean, description: "Whether provider is default"},
         client_id: %Schema{type: :string, description: "Client ID"},
         discovery_document_uri: %Schema{type: :string, description: "Discovery document URI"},
-        require_email_verified: %Schema{
-          type: :boolean,
-          description: "Whether sign-in requires email_verified=true from the identity provider"
+        email_verification_method: %Schema{
+          type: :string,
+          description: "How sign-in verifies the email claim",
+          enum: ["none", "claim", "proof"]
         },
         inserted_at: %Schema{
           type: :string,
@@ -47,7 +48,7 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "name" => "OIDC Provider",
         "client_id" => "my-client-id",
-        "require_email_verified" => true
+        "email_verification_method" => "claim"
       }
     })
   end
@@ -68,7 +69,7 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
         "data" => %{
           "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
           "name" => "OIDC Provider",
-          "require_email_verified" => true
+          "email_verification_method" => "claim"
         }
       }
     })
@@ -95,7 +96,7 @@ defmodule PortalAPI.Schemas.OIDCAuthProvider do
           %{
             "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
             "name" => "OIDC Provider",
-            "require_email_verified" => true
+            "email_verification_method" => "claim"
           }
         ]
       }

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -47,7 +47,7 @@ defmodule PortalWeb.EmailOTPController do
   @spec verify(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def verify(conn, %{"secret" => entered_code} = params) do
     result =
-      execute_with_constant_time(
+      Portal.Timing.execute_with_constant_time(
         fn -> do_verify(conn, params, String.downcase(entered_code)) end,
         @constant_execution_time
       )
@@ -111,7 +111,7 @@ defmodule PortalWeb.EmailOTPController do
 
   defp maybe_send_email_otp(conn, account, email, params, auth_provider_id) do
     {actor_id, passcode_id, error} =
-      execute_with_constant_time(
+      Portal.Timing.execute_with_constant_time(
         fn ->
           with {:ok, actor} <- Database.fetch_actor_by_email(account, email),
                {:ok, otp} <- Authentication.create_one_time_passcode(account, actor),
@@ -153,7 +153,7 @@ defmodule PortalWeb.EmailOTPController do
         put_flash(
           conn,
           :error,
-          "Too many sign-in attempts. Please wait a few minutes and try again."
+          "You're attempting to do that too quickly. Wait a few minutes and try again."
         )
 
       _ ->
@@ -360,36 +360,6 @@ defmodule PortalWeb.EmailOTPController do
   defp context_type(%{"as" => "gui-client"}), do: :gui_client
   defp context_type(%{"as" => "headless-client"}), do: :headless_client
   defp context_type(_), do: :portal
-
-  # Executes a callback in constant time to prevent timing attacks.
-  # If execution is faster than constant_time, sleeps for the remainder.
-  defp execute_with_constant_time(callback, constant_time) do
-    start_time = System.monotonic_time(:millisecond)
-    result = callback.()
-    end_time = System.monotonic_time(:millisecond)
-
-    elapsed_time = end_time - start_time
-    remaining_time = max(0, constant_time - elapsed_time)
-
-    if remaining_time > 0 do
-      :timer.sleep(remaining_time)
-    else
-      log_constant_time_exceeded(constant_time, elapsed_time)
-    end
-
-    result
-  end
-
-  if Mix.env() in [:dev, :test] do
-    defp log_constant_time_exceeded(_constant_time, _elapsed_time), do: :ok
-  else
-    defp log_constant_time_exceeded(constant_time, elapsed_time) do
-      Logger.error("Execution took longer than the given constant time",
-        constant_time: constant_time,
-        elapsed_time: elapsed_time
-      )
-    end
-  end
 
   defmodule Database do
     import Ecto.Query

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -14,6 +14,7 @@ defmodule PortalWeb.OIDCController do
   @invalid_json_error_message "Discovery document contains invalid JSON. Please verify the Discovery Document URI returns valid OpenID Connect configuration."
   @unverified_email_sign_in_error "Your identity provider did not confirm that your email address is verified. Please verify your email with the identity provider or contact your administrator."
   @unverified_email_verification_error "This provider requires verified email addresses, but the identity provider did not return email_verified=true for your account."
+  @constant_execution_time Application.compile_env(:portal, :constant_execution_time, 3000)
 
   @spec sign_in(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def sign_in(conn, %{"account_id_or_slug" => account_id_or_slug} = params) do
@@ -50,6 +51,22 @@ defmodule PortalWeb.OIDCController do
   def callback(conn, params) do
     Logger.info("OIDC callback called with invalid params", params: Map.keys(params))
 
+    handle_error(conn, {:error, :invalid_callback_params})
+  end
+
+  @spec verify_identity(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def verify_identity(conn, %{"secret" => entered_code} = params) do
+    result =
+      Portal.Timing.execute_with_constant_time(
+        fn -> do_verify_identity(conn, params, String.downcase(entered_code)) end,
+        @constant_execution_time
+      )
+
+    handle_verify_identity_result(conn, result, params)
+  end
+
+  def verify_identity(conn, params) do
+    Logger.info("Invalid OIDC pending identity verification parameters", params: params)
     handle_error(conn, {:error, :invalid_callback_params})
   end
 
@@ -102,7 +119,6 @@ defmodule PortalWeb.OIDCController do
   defp run_authentication_flow(auth_context, code) do
     %{
       conn: conn,
-      params: params,
       verifier: verifier,
       context_type: context_type,
       account: account,
@@ -114,20 +130,36 @@ defmodule PortalWeb.OIDCController do
          {:ok, tokens} <- PortalWeb.OIDC.exchange_code(provider, code, verifier),
          {:ok, claims} <- PortalWeb.OIDC.verify_token(provider, tokens["id_token"]),
          userinfo = fetch_userinfo(provider, tokens["access_token"]),
-         {:ok, identity} <- upsert_identity(account, provider, claims, userinfo),
-         :ok <- check_admin(identity, context_type),
+         {:ok, identity_result} <- resolve_identity(account, provider, claims, userinfo) do
+      finish_resolved_identity(auth_context, identity_result, tokens)
+    else
+      error -> handle_error(conn, error)
+    end
+  end
+
+  defp finish_resolved_identity(
+         %{conn: conn, context_type: context_type, account: account, provider: provider, params: params},
+         {:identity, identity},
+         tokens
+       ) do
+    with :ok <- check_admin(identity, context_type),
          {:ok, session_or_token} <-
            create_session_or_token(conn, identity, provider, params) do
-      signed_in(
-        conn,
-        context_type,
-        account,
-        identity,
-        session_or_token,
-        provider,
-        tokens,
-        params
-      )
+      signed_in(conn, context_type, account, identity, session_or_token, provider, tokens, params)
+    else
+      error -> handle_error(conn, error)
+    end
+  end
+
+  defp finish_resolved_identity(
+         %{conn: conn, context_type: context_type, account: account, provider: provider, params: params},
+         {:proof_required, actor, identity_profile},
+         _tokens
+       ) do
+    with :ok <- check_actor(actor, context_type),
+         {:ok, conn} <-
+           start_owner_verification(conn, account, provider, actor, identity_profile, params) do
+      conn
     else
       error -> handle_error(conn, error)
     end
@@ -166,7 +198,7 @@ defmodule PortalWeb.OIDCController do
 
     error = authorization_error_message(reason)
     log_sign_in_redirect_error(account.id, error)
-    path = error_path_for_context(account.slug, params, error)
+    path = error_path_for_context(account, params, error)
 
     conn
     |> put_flash(:error, error)
@@ -251,30 +283,290 @@ defmodule PortalWeb.OIDCController do
     end
   end
 
-  defp upsert_identity(account, provider, claims, userinfo) do
+  defp resolve_identity(account, provider, claims, userinfo) do
     email_claim = Map.get(provider, :email_claim)
 
     with {:ok, identity_profile} <-
-           IdentityProfile.build(claims, userinfo, account.id, email_claim: email_claim),
-         :ok <- enforce_verified_email(account, provider, identity_profile) do
-      Database.upsert_identity(
-        account.id,
-        identity_profile.email,
-        identity_profile.issuer,
-        identity_profile.idp_id,
-        identity_profile.profile_attrs
-      )
+           IdentityProfile.build(claims, userinfo, account.id, email_claim: email_claim) do
+      resolve_identity(account, provider, identity_profile)
     end
   end
 
-  defp enforce_verified_email(_account, %{require_email_verified: true}, %{email_verified: true}),
-    do: :ok
+  defp resolve_identity(account, provider, identity_profile) do
+    case email_verification_method(provider) do
+      :none -> upsert_verified_identity(account, identity_profile)
+      :claim -> resolve_claim_identity(account, identity_profile)
+      :proof -> resolve_proof_identity(account, identity_profile)
+    end
+  end
 
-  defp enforce_verified_email(_account, %{require_email_verified: true}, %{email_verified: false}) do
+  defp resolve_claim_identity(account, identity_profile) do
+    with :ok <- enforce_verified_email(identity_profile) do
+      upsert_verified_identity(account, identity_profile)
+    end
+  end
+
+  defp upsert_verified_identity(account, identity_profile) do
+    with {:ok, identity} <-
+           Database.upsert_identity(
+             account.id,
+             identity_profile.email,
+             identity_profile.issuer,
+             identity_profile.idp_id,
+             identity_profile.profile_attrs
+           ) do
+      {:ok, {:identity, identity}}
+    end
+  end
+
+  defp resolve_proof_identity(account, identity_profile) do
+    case Database.fetch_active_identity_by_idp(
+           account.id,
+           identity_profile.issuer,
+           identity_profile.idp_id
+         ) do
+      {:ok, identity} ->
+        with {:ok, identity} <- Database.update_identity_profile(identity, identity_profile.profile_attrs) do
+          {:ok, {:identity, identity}}
+        end
+
+      {:error, :not_found} ->
+        with {:ok, actor} <- Database.fetch_active_actor_by_email(account, identity_profile.email) do
+          {:ok, {:proof_required, actor, identity_profile}}
+        end
+    end
+  end
+
+  defp email_verification_method(%Portal.OIDC.AuthProvider{email_verification_method: method}),
+    do: method
+
+  defp email_verification_method(_provider), do: :none
+
+  defp enforce_verified_email(%IdentityProfile{email_verified: true}), do: :ok
+
+  defp enforce_verified_email(%IdentityProfile{email_verified: false}) do
     {:error, :email_not_verified}
   end
 
-  defp enforce_verified_email(_account, _provider, _identity_profile), do: :ok
+  defp start_owner_verification(conn, account, provider, actor, identity_profile, params) do
+    pending_identity_id = Ecto.UUID.generate()
+
+    case create_pending_identity_verification(
+           conn,
+           account,
+           provider,
+           actor,
+           pending_identity_id,
+           identity_profile,
+           params
+         ) do
+      {:ok, _pending_identity, _passcode} ->
+        cookie = %Cookie.PendingIdentity{pending_identity_id: pending_identity_id}
+
+        conn =
+          conn
+          |> Cookie.PendingIdentity.put(cookie)
+          |> redirect(
+            to:
+              ~p"/#{account}/sign_in/oidc/#{provider.id}/verify_identity?#{verification_params(pending_identity_id, params)}"
+          )
+
+        {:ok, conn}
+
+      {:error, :rate_limited} ->
+        Logger.info("OIDC identity verification email rate limited",
+          account_slug: account.slug,
+          auth_provider_id: provider.id
+        )
+
+        {:error, :rate_limited}
+
+      error ->
+        Logger.info("OIDC identity verification email not sent",
+          account_slug: account.slug,
+          auth_provider_id: provider.id,
+          error: inspect(error)
+        )
+
+        error
+    end
+  end
+
+  defp create_pending_identity_verification(
+         conn,
+         account,
+         provider,
+         actor,
+         pending_identity_id,
+         identity_profile,
+         params
+       ) do
+    with {:ok, passcode} <- Database.create_one_time_passcode(account, actor) do
+      with {:ok, pending_identity} <-
+             Database.insert_pending_identity(
+               account,
+               actor,
+               provider,
+               pending_identity_id,
+               passcode,
+               identity_profile
+             ),
+           {:ok, _email} <-
+             send_identity_verification_email(
+               conn,
+               actor,
+               provider,
+               pending_identity_id,
+               passcode.code,
+               params
+             ) do
+        {:ok, pending_identity, passcode}
+      else
+        {:error, _reason} = error ->
+          :ok = Database.delete_one_time_passcode(passcode.account_id, passcode.id)
+          error
+      end
+    end
+  end
+
+  defp send_identity_verification_email(conn, actor, provider, pending_identity_id, code, params) do
+    context = authentication_context(conn, context_type(params))
+
+    Portal.Mailer.AuthEmail.oidc_identity_verification_email(
+      actor,
+      DateTime.utc_now(),
+      provider.id,
+      pending_identity_id,
+      code,
+      context,
+      sanitize(params)
+    )
+    |> Portal.Mailer.deliver_with_rate_limit(
+      rate_limit_key: {:oidc_identity_verification, actor.email},
+      rate_limit: 3,
+      rate_limit_interval: :timer.minutes(5)
+    )
+  end
+
+  defp do_verify_identity(conn, params, entered_code) do
+    case load_pending_identity_context(conn, params) do
+      {:ok, context} ->
+        run_pending_identity_verification(context, entered_code)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp load_pending_identity_context(conn, params) do
+    case Cookie.PendingIdentity.fetch(conn, params["pending_identity_id"]) do
+      %Cookie.PendingIdentity{} = cookie ->
+        account = Database.get_account_by_id_or_slug!(params["account_id_or_slug"])
+        provider = Database.get_provider!(account.id, "oidc", params["auth_provider_id"])
+        sign_in_params = sanitize(params)
+        conn = put_pending_identity_error_context(conn, account, params)
+
+        {:ok,
+         %{
+           conn: conn,
+           pending_identity_id: cookie.pending_identity_id,
+           account: account,
+           provider: provider,
+           params: sign_in_params,
+           context_type: context_type(sign_in_params)
+         }}
+
+      nil ->
+        {:error, :pending_identity_state_not_found}
+    end
+  end
+
+  defp put_pending_identity_error_context(conn, account, params) do
+    Plug.Conn.assign(conn, :oidc_error_context, %{
+      account_id: account.id,
+      account_slug: account.slug,
+      params: sanitize(params),
+      auth_provider_id: params["auth_provider_id"]
+    })
+  end
+
+  defp run_pending_identity_verification(
+         %{
+           conn: conn,
+           pending_identity_id: pending_identity_id,
+           account: account,
+           provider: provider,
+           params: params,
+           context_type: context_type
+         },
+         entered_code
+       ) do
+    with :ok <- validate_context(provider, context_type),
+         :ok <- ensure_client_sign_in_allowed(account, context_type),
+         {:ok, identity, pending_identity_ids} <-
+           Database.verify_and_promote_pending_identity(
+             account.id,
+             pending_identity_id,
+             provider.id,
+             entered_code
+           ),
+         :ok <- check_admin(identity, context_type),
+         {:ok, session_or_token} <- create_session_or_token(conn, identity, provider, params) do
+      {:ok,
+       %{
+         conn: conn,
+         account: account,
+         identity: identity,
+         provider: provider,
+         session_or_token: session_or_token,
+         context_type: context_type,
+         params: params,
+         email: identity.email,
+         pending_identity_ids: pending_identity_ids
+       }}
+    else
+      error -> {:error, error, conn}
+    end
+  end
+
+  defp handle_verify_identity_result(_conn, {:ok, result}, _params) do
+    conn = Cookie.PendingIdentity.delete_all(result.conn, result.pending_identity_ids)
+    :ok = Portal.Mailer.RateLimiter.reset_rate_limit({:oidc_identity_verification, result.email})
+
+    signed_in(
+      conn,
+      result.context_type,
+      result.account,
+      result.identity,
+      result.session_or_token,
+      result.provider,
+      %{},
+      result.params
+    )
+  end
+
+  defp handle_verify_identity_result(_conn, {:error, {:error, :invalid_code}, conn}, params) do
+    redirect_pending_identity_error(
+      conn,
+      "The verification code is invalid or expired.",
+      params
+    )
+  end
+
+  defp handle_verify_identity_result(_conn, {:error, error, conn}, _params) do
+    handle_error(conn, error)
+  end
+
+  defp handle_verify_identity_result(conn, error, _params) do
+    handle_error(conn, error)
+  end
+
+  defp redirect_pending_identity_error(conn, error, params) do
+    path =
+      ~p"/#{params["account_id_or_slug"]}/sign_in/oidc/#{params["auth_provider_id"]}/verify_identity?#{verification_params(params)}"
+
+    redirect_for_error(conn, error, path)
+  end
 
   defp check_admin(
          %Portal.ExternalIdentity{actor: %Portal.Actor{type: :account_admin_user}},
@@ -282,11 +574,18 @@ defmodule PortalWeb.OIDCController do
        ),
        do: :ok
 
-  defp check_admin(%Portal.ExternalIdentity{actor: %Portal.Actor{type: :account_user}}, t)
+  defp check_admin(%Portal.ExternalIdentity{actor: actor}, context_type),
+    do: check_actor(actor, context_type)
+
+  defp check_admin(_identity, _context_type), do: {:error, :not_admin}
+
+  defp check_actor(%Portal.Actor{type: :account_admin_user}, _context_type), do: :ok
+
+  defp check_actor(%Portal.Actor{type: :account_user}, t)
        when t in [:gui_client, :headless_client],
        do: :ok
 
-  defp check_admin(_identity, _context_type), do: {:error, :not_admin}
+  defp check_actor(_actor, _context_type), do: {:error, :not_admin}
 
   defp validate_context(%{context: context}, t)
        when t in [:gui_client, :headless_client] and
@@ -313,11 +612,8 @@ defmodule PortalWeb.OIDCController do
   defp ensure_client_sign_in_allowed(_account, _context_type), do: :ok
 
   defp create_session_or_token(conn, identity, provider, params) do
-    user_agent = conn.assigns[:user_agent]
-    remote_ip = conn.remote_ip
     type = context_type(params)
-    headers = conn.req_headers
-    context = Portal.Authentication.Context.build(remote_ip, user_agent, headers, type)
+    context = authentication_context(conn, type)
 
     # Get the provider schema module to access default values
     schema = provider.__struct__
@@ -381,7 +677,7 @@ defmodule PortalWeb.OIDCController do
       conn,
       account,
       identity.actor.name,
-      identity.email || identity.actor.email,
+      identity.email,
       token,
       params["state"]
     )
@@ -404,9 +700,27 @@ defmodule PortalWeb.OIDCController do
   defp context_type(%{"as" => "headless-client"}), do: :headless_client
   defp context_type(_), do: :portal
 
+  defp authentication_context(conn, type) do
+    Portal.Authentication.Context.build(
+      conn.remote_ip,
+      conn.assigns[:user_agent] || "",
+      conn.req_headers,
+      type
+    )
+  end
+
   defp handle_error(conn, {:error, reason})
-       when reason in [:oidc_state_not_found, :oidc_state_session_mismatch] do
+       when reason in [
+              :oidc_state_not_found,
+              :oidc_state_session_mismatch,
+              :pending_identity_state_not_found
+            ] do
     error = "Your sign-in session has timed out. Please try again."
+    redirect_with_error_context(conn, error)
+  end
+
+  defp handle_error(conn, {:error, :rate_limited}) do
+    error = "You're attempting to do that too quickly. Wait a few minutes and try again."
     redirect_with_error_context(conn, error)
   end
 
@@ -694,13 +1008,13 @@ defmodule PortalWeb.OIDCController do
   end
 
   defp error_path("", _params), do: ~p"/sign_in"
-  defp error_path(account_slug, params), do: ~p"/#{account_slug}/sign_in?#{sanitize(params)}"
+  defp error_path(account, params), do: ~p"/#{account}/sign_in?#{sanitize(params)}"
 
-  defp error_path_for_context(account_slug, params, error) do
-    if client_context?(params) and account_slug != "" do
-      ~p"/#{account_slug}/sign_in/client_auth_error?#{client_error_params(params, error)}"
+  defp error_path_for_context(account, params, error) do
+    if client_context?(params) and account != "" do
+      ~p"/#{account}/sign_in/client_auth_error?#{client_error_params(params, error)}"
     else
-      error_path(account_slug, params)
+      error_path(account, params)
     end
   end
 
@@ -714,6 +1028,19 @@ defmodule PortalWeb.OIDCController do
     Map.take(params, ["as", "redirect_to", "state", "nonce"])
   end
 
+  defp verification_params(%{"pending_identity_id" => pending_identity_id} = params)
+       when is_binary(pending_identity_id) do
+    verification_params(pending_identity_id, params)
+  end
+
+  defp verification_params(params), do: sanitize(params)
+
+  defp verification_params(pending_identity_id, params) do
+    params
+    |> sanitize()
+    |> Map.put("pending_identity_id", pending_identity_id)
+  end
+
   defp client_context?(%{"as" => as}) when as in ["client", "gui-client", "headless-client"],
     do: true
 
@@ -721,8 +1048,26 @@ defmodule PortalWeb.OIDCController do
 
   defmodule Database do
     import Ecto.Query
-    alias Portal.{Safe, AuthProvider, ExternalIdentity}
+    import Ecto.Changeset
+    alias Portal.{Safe, AuthProvider, ExternalIdentity, PendingIdentity, OneTimePasscode}
     alias Portal.Account
+
+    @otp_expiration_seconds 15 * 60
+
+    @profile_fields ~w[
+      email
+      name
+      given_name
+      family_name
+      middle_name
+      nickname
+      preferred_username
+      profile
+      picture
+      firezone_avatar_url
+    ]a
+
+    @pending_identity_profile_fields @profile_fields -- [:firezone_avatar_url]
 
     def get_account_by_id_or_slug!(id_or_slug) do
       query =
@@ -741,6 +1086,166 @@ defmodule PortalWeb.OIDCController do
       )
       |> Safe.unscoped(:replica)
       |> Safe.one!()
+    end
+
+    def fetch_active_identity_by_idp(account_id, issuer, idp_id) do
+      from(identity in ExternalIdentity,
+        join: actor in assoc(identity, :actor),
+        where: identity.account_id == ^account_id,
+        where: identity.issuer == ^issuer,
+        where: identity.idp_id == ^idp_id,
+        where: is_nil(actor.disabled_at),
+        preload: [:account, actor: actor]
+      )
+      |> Safe.unscoped(:replica)
+      |> Safe.one()
+      |> case do
+        nil -> {:error, :not_found}
+        identity -> {:ok, identity}
+      end
+    end
+
+    def fetch_active_actor_by_email(account, email) do
+      email = trim_email(email)
+
+      from(actor in Portal.Actor,
+        where: actor.account_id == ^account.id,
+        where: actor.type in [:account_admin_user, :account_user],
+        where: is_nil(actor.disabled_at),
+        where: actor.email == ^email,
+        preload: [:account],
+        limit: 1
+      )
+      |> Safe.unscoped(:replica)
+      |> Safe.one()
+      |> case do
+        nil -> {:error, :actor_not_found}
+        actor -> {:ok, actor}
+      end
+    end
+
+    def update_identity_profile(%ExternalIdentity{} = identity, profile_attrs) do
+      identity
+      |> cast(atomize_profile_attrs(profile_attrs), @profile_fields)
+      |> ExternalIdentity.changeset()
+      |> Safe.unscoped()
+      |> Safe.update()
+      |> case do
+        {:ok, identity} -> {:ok, Safe.preload(identity, [:actor, :account], :replica)}
+        error -> error
+      end
+    end
+
+    def insert_pending_identity(account, actor, provider, pending_identity_id, passcode, identity_profile) do
+      attrs =
+        identity_profile.profile_attrs
+        |> atomize_profile_attrs()
+        |> Map.merge(%{
+          id: pending_identity_id,
+          account_id: account.id,
+          actor_id: actor.id,
+          auth_provider_id: provider.id,
+          one_time_passcode_id: passcode.id,
+          issuer: identity_profile.issuer,
+          idp_id: identity_profile.idp_id
+        })
+
+      %PendingIdentity{}
+      |> cast(
+        attrs,
+        [
+          :id,
+          :account_id,
+          :actor_id,
+          :auth_provider_id,
+          :one_time_passcode_id,
+          :issuer,
+          :idp_id,
+          :directory_id | @pending_identity_profile_fields
+        ]
+      )
+      |> PendingIdentity.changeset()
+      |> Safe.unscoped()
+      |> Safe.insert()
+    end
+
+    def create_one_time_passcode(account, actor) do
+      code = Portal.Crypto.random_token(5, encoder: :user_friendly)
+      code_hash = Portal.Crypto.hash(:argon2, code)
+      expires_at = DateTime.utc_now() |> DateTime.add(@otp_expiration_seconds, :second)
+
+      %OneTimePasscode{
+        account_id: account.id,
+        actor_id: actor.id,
+        code: code,
+        code_hash: code_hash,
+        expires_at: expires_at
+      }
+      |> Safe.unscoped()
+      |> Safe.insert()
+    end
+
+    def verify_and_promote_pending_identity(
+          account_id,
+          pending_identity_id,
+          auth_provider_id,
+          entered_code
+        ) do
+      Safe.transact(fn ->
+        with {:ok, pending_identity} <-
+               fetch_pending_identity_for_update(account_id, pending_identity_id, auth_provider_id),
+             {:ok, passcode} <- fetch_pending_passcode_for_update(pending_identity),
+             :ok <- verify_pending_identity_code(entered_code, passcode),
+             pending_identity_ids <- fetch_related_pending_identity_ids(pending_identity),
+             {:ok, identity} <- insert_external_identity_from_pending(pending_identity),
+             :ok <- delete_related_pending_identities_and_passcodes(pending_identity) do
+          {:ok, {identity, pending_identity_ids}}
+        else
+          {:error, :not_found} ->
+            dummy_verify_pending_identity_code()
+            {:error, :invalid_code}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end)
+      |> case do
+        {:ok, {%ExternalIdentity{} = identity, pending_identity_ids}} ->
+          {:ok, Safe.preload(identity, [:actor, :account], :replica), pending_identity_ids}
+
+        {:error, :not_found} ->
+          {:error, :invalid_code}
+
+        {:error, :invalid_code} ->
+          {:error, :invalid_code}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+
+    defp verify_pending_identity_code(entered_code, %OneTimePasscode{} = passcode) do
+      if Portal.Crypto.equal?(:argon2, entered_code, passcode.code_hash) do
+        :ok
+      else
+        {:error, :invalid_code}
+      end
+    end
+
+    defp dummy_verify_pending_identity_code do
+      Portal.Crypto.equal?(:argon2, nil, nil)
+      :ok
+    end
+
+    def delete_one_time_passcode(account_id, passcode_id) do
+      from(passcode in OneTimePasscode,
+        where: passcode.account_id == ^account_id,
+        where: passcode.id == ^passcode_id
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+
+      :ok
     end
 
     def upsert_identity(account_id, email, issuer, idp_id, profile_attrs) do
@@ -795,7 +1300,7 @@ defmodule PortalWeb.OIDCController do
             account_id: ^account_id_bytes,
             issuer: ^issuer,
             idp_id: ^idp_id,
-            actor_id: fragment("COALESCE(?.id, ?.actor_id)", al, ei),
+            actor_id: fragment("COALESCE(?.actor_id, ?.id)", ei, al),
             email: ^profile_attrs["email"],
             name: ^profile_attrs["name"],
             given_name: ^profile_attrs["given_name"],
@@ -835,5 +1340,133 @@ defmodule PortalWeb.OIDCController do
           {:ok, Safe.preload(identity, [:actor, :account], :replica)}
       end
     end
+
+    defp fetch_related_pending_identity_ids(%PendingIdentity{} = pending_identity) do
+      from(identity in PendingIdentity,
+        where: identity.account_id == ^pending_identity.account_id,
+        where: identity.actor_id == ^pending_identity.actor_id,
+        where: identity.issuer == ^pending_identity.issuer,
+        where: identity.idp_id == ^pending_identity.idp_id,
+        select: identity.id
+      )
+      |> Safe.unscoped()
+      |> Safe.all()
+    end
+
+    defp delete_related_pending_identities_and_passcodes(%PendingIdentity{} = pending_identity) do
+      related_passcode_ids =
+        from(identity in PendingIdentity,
+          where: identity.account_id == ^pending_identity.account_id,
+          where: identity.actor_id == ^pending_identity.actor_id,
+          where: identity.issuer == ^pending_identity.issuer,
+          where: identity.idp_id == ^pending_identity.idp_id,
+          select: identity.one_time_passcode_id
+        )
+
+      # The pending_identities rows are removed by the one_time_passcode_id
+      # foreign key's ON DELETE CASCADE.
+      from(passcode in OneTimePasscode,
+        where: passcode.account_id == ^pending_identity.account_id,
+        where: passcode.id in subquery(related_passcode_ids)
+      )
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+
+      :ok
+    end
+
+    defp fetch_pending_passcode_for_update(%PendingIdentity{} = pending_identity) do
+      from(passcode in OneTimePasscode,
+        join: actor in assoc(passcode, :actor),
+        where: passcode.account_id == ^pending_identity.account_id,
+        where: passcode.actor_id == ^pending_identity.actor_id,
+        where: passcode.id == ^pending_identity.one_time_passcode_id,
+        where: passcode.expires_at > ^DateTime.utc_now(),
+        where: is_nil(actor.disabled_at),
+        lock: "FOR UPDATE"
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> case do
+        nil -> {:error, :not_found}
+        passcode -> {:ok, passcode}
+      end
+    end
+
+    defp fetch_pending_identity_for_update(account_id, pending_identity_id, auth_provider_id) do
+      from(identity in PendingIdentity,
+        where: identity.account_id == ^account_id,
+        where: identity.id == ^pending_identity_id,
+        where: identity.auth_provider_id == ^auth_provider_id,
+        lock: "FOR UPDATE"
+      )
+      |> Safe.unscoped()
+      |> Safe.one()
+      |> case do
+        nil -> {:error, :not_found}
+        identity -> {:ok, identity}
+      end
+    end
+
+    defp insert_external_identity_from_pending(%PendingIdentity{} = pending_identity) do
+      now = DateTime.utc_now()
+
+      attrs =
+        pending_identity
+        |> Map.from_struct()
+        |> Map.take([
+          :id,
+          :account_id,
+          :actor_id,
+          :issuer,
+          :idp_id,
+          :directory_id | @pending_identity_profile_fields
+        ])
+        |> Map.put(:inserted_at, now)
+        |> Map.put(:updated_at, now)
+
+      case Safe.insert_all(
+             Safe.unscoped(),
+             ExternalIdentity,
+             [attrs],
+             on_conflict: external_identity_conflict_query(pending_identity),
+             conflict_target: [:account_id, :idp_id, :issuer],
+             returning: true
+           ) do
+        {1, [%ExternalIdentity{} = identity]} -> {:ok, identity}
+        {0, []} -> {:error, :invalid_code}
+      end
+    end
+
+    defp external_identity_conflict_query(%PendingIdentity{} = pending_identity) do
+      from(identity in ExternalIdentity,
+        where: identity.actor_id == ^pending_identity.actor_id,
+        update: [
+          set: [
+            email: fragment("EXCLUDED.email"),
+            name: fragment("EXCLUDED.name"),
+            given_name: fragment("EXCLUDED.given_name"),
+            family_name: fragment("EXCLUDED.family_name"),
+            middle_name: fragment("EXCLUDED.middle_name"),
+            nickname: fragment("EXCLUDED.nickname"),
+            preferred_username: fragment("EXCLUDED.preferred_username"),
+            profile: fragment("EXCLUDED.profile"),
+            picture: fragment("EXCLUDED.picture"),
+            updated_at: fragment("EXCLUDED.updated_at")
+          ]
+        ]
+      )
+    end
+
+    defp atomize_profile_attrs(attrs) do
+      Map.new(attrs, fn
+        {key, value} when is_binary(key) -> {String.to_existing_atom(key), value}
+        {key, value} -> {key, value}
+      end)
+    end
+
+    defp trim_email(email) when is_binary(email), do: String.trim(email)
+
+    defp trim_email(email), do: email
   end
 end

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -350,6 +350,7 @@ defmodule PortalWeb.OIDCController do
 
   defp start_owner_verification(conn, account, provider, actor, identity_profile, params) do
     pending_identity_id = Ecto.UUID.generate()
+    sign_in_params = sanitize(params)
 
     case create_pending_identity_verification(
            conn,
@@ -358,17 +359,20 @@ defmodule PortalWeb.OIDCController do
            actor,
            pending_identity_id,
            identity_profile,
-           params
+           sign_in_params
          ) do
       {:ok, _pending_identity, _passcode} ->
-        cookie = %Cookie.PendingIdentity{pending_identity_id: pending_identity_id}
+        cookie = %Cookie.PendingIdentity{
+          pending_identity_id: pending_identity_id,
+          params: sign_in_params
+        }
 
         conn =
           conn
           |> Cookie.PendingIdentity.put(cookie)
           |> redirect(
             to:
-              ~p"/#{account}/sign_in/oidc/#{provider.id}/verify_identity?#{verification_params(pending_identity_id, params)}"
+              ~p"/#{account}/sign_in/oidc/#{provider.id}/verify_identity?#{verification_params(pending_identity_id, sign_in_params)}"
           )
 
         {:ok, conn}
@@ -399,7 +403,7 @@ defmodule PortalWeb.OIDCController do
          actor,
          pending_identity_id,
          identity_profile,
-         params
+         sign_in_params
        ) do
     with {:ok, passcode} <- Database.create_one_time_passcode(account, actor) do
       with {:ok, pending_identity} <-
@@ -418,7 +422,7 @@ defmodule PortalWeb.OIDCController do
                provider,
                pending_identity_id,
                passcode.code,
-               params
+               sign_in_params
              ) do
         {:ok, pending_identity, passcode}
       else
@@ -429,8 +433,15 @@ defmodule PortalWeb.OIDCController do
     end
   end
 
-  defp send_identity_verification_email(conn, actor, provider, pending_identity_id, code, params) do
-    context = authentication_context(conn, context_type(params))
+  defp send_identity_verification_email(
+         conn,
+         actor,
+         provider,
+         pending_identity_id,
+         code,
+         sign_in_params
+       ) do
+    context = authentication_context(conn, context_type(sign_in_params))
 
     Portal.Mailer.AuthEmail.oidc_identity_verification_email(
       actor,
@@ -439,7 +450,7 @@ defmodule PortalWeb.OIDCController do
       pending_identity_id,
       code,
       context,
-      sanitize(params)
+      sign_in_params
     )
     |> Portal.Mailer.deliver_with_rate_limit(
       rate_limit_key: {:oidc_identity_verification, actor.email},
@@ -453,7 +464,7 @@ defmodule PortalWeb.OIDCController do
       {:ok, context} ->
         run_pending_identity_verification(context, entered_code)
 
-      {:error, _reason} = error ->
+      error ->
         error
     end
   end
@@ -463,8 +474,8 @@ defmodule PortalWeb.OIDCController do
       %Cookie.PendingIdentity{} = cookie ->
         account = Database.get_account_by_id_or_slug!(params["account_id_or_slug"])
         provider = Database.get_provider!(account.id, "oidc", params["auth_provider_id"])
-        sign_in_params = sanitize(params)
-        conn = put_pending_identity_error_context(conn, account, params)
+        sign_in_params = sanitize(cookie.params)
+        conn = put_pending_identity_error_context(conn, account, provider.id, sign_in_params)
 
         {:ok,
          %{
@@ -481,12 +492,12 @@ defmodule PortalWeb.OIDCController do
     end
   end
 
-  defp put_pending_identity_error_context(conn, account, params) do
+  defp put_pending_identity_error_context(conn, account, auth_provider_id, sign_in_params) do
     Plug.Conn.assign(conn, :oidc_error_context, %{
       account_id: account.id,
       account_slug: account.slug,
-      params: sanitize(params),
-      auth_provider_id: params["auth_provider_id"]
+      params: sign_in_params,
+      auth_provider_id: auth_provider_id
     })
   end
 
@@ -562,10 +573,23 @@ defmodule PortalWeb.OIDCController do
   end
 
   defp redirect_pending_identity_error(conn, error, params) do
+    context = pending_identity_error_context(conn, params)
+
     path =
-      ~p"/#{params["account_id_or_slug"]}/sign_in/oidc/#{params["auth_provider_id"]}/verify_identity?#{verification_params(params)}"
+      ~p"/#{context.account_slug}/sign_in/oidc/#{context.auth_provider_id}/verify_identity?#{verification_params(params["pending_identity_id"], context.params)}"
 
     redirect_for_error(conn, error, path)
+  end
+
+  defp pending_identity_error_context(conn, params) do
+    Map.merge(
+      %{
+        account_slug: params["account_id_or_slug"],
+        auth_provider_id: params["auth_provider_id"],
+        params: sanitize(params)
+      },
+      conn.assigns[:oidc_error_context] || %{}
+    )
   end
 
   defp check_admin(
@@ -1028,13 +1052,6 @@ defmodule PortalWeb.OIDCController do
     Map.take(params, ["as", "redirect_to", "state", "nonce"])
   end
 
-  defp verification_params(%{"pending_identity_id" => pending_identity_id} = params)
-       when is_binary(pending_identity_id) do
-    verification_params(pending_identity_id, params)
-  end
-
-  defp verification_params(params), do: sanitize(params)
-
   defp verification_params(pending_identity_id, params) do
     params
     |> sanitize()
@@ -1136,7 +1153,14 @@ defmodule PortalWeb.OIDCController do
       end
     end
 
-    def insert_pending_identity(account, actor, provider, pending_identity_id, passcode, identity_profile) do
+    def insert_pending_identity(
+          account,
+          actor,
+          provider,
+          pending_identity_id,
+          passcode,
+          identity_profile
+        ) do
       attrs =
         identity_profile.profile_attrs
         |> atomize_profile_attrs()

--- a/elixir/lib/portal_web/cookie/pending_identity.ex
+++ b/elixir/lib/portal_web/cookie/pending_identity.ex
@@ -1,0 +1,98 @@
+defmodule PortalWeb.Cookie.PendingIdentity do
+  @moduledoc """
+  Cookie for OIDC pending identity verification state.
+  """
+
+  @enforce_keys [:pending_identity_id]
+  defstruct [:pending_identity_id]
+
+  @type t :: %__MODULE__{
+          pending_identity_id: Ecto.UUID.t()
+        }
+
+  @cookie_key_prefix "pending_identity_"
+
+  def put(conn, %__MODULE__{} = cookie) do
+    Plug.Conn.put_resp_cookie(conn, cookie_key(cookie.pending_identity_id), to_binary(cookie), cookie_options())
+  end
+
+  def delete(conn, %__MODULE__{} = cookie) do
+    delete(conn, cookie.pending_identity_id)
+  end
+
+  def delete(conn, pending_identity_id) when is_binary(pending_identity_id) do
+    Plug.Conn.delete_resp_cookie(conn, cookie_key(pending_identity_id), cookie_options())
+  end
+
+  def delete_all(conn, pending_identity_ids) do
+    Enum.reduce(pending_identity_ids, conn, &delete(&2, &1))
+  end
+
+  def fetch(conn) do
+    conn = Plug.Conn.fetch_query_params(conn)
+    pending_identity_id = conn.params["pending_identity_id"] || conn.query_params["pending_identity_id"]
+
+    fetch(conn, pending_identity_id)
+  end
+
+  def fetch(conn, pending_identity_id) when is_binary(pending_identity_id) do
+    key = cookie_key(pending_identity_id)
+    conn = Plug.Conn.fetch_cookies(conn, signed: [key])
+
+    case from_binary(conn.cookies[key]) do
+      %__MODULE__{pending_identity_id: ^pending_identity_id} = cookie -> cookie
+      _ -> nil
+    end
+  end
+
+  def fetch(_conn, _pending_identity_id), do: nil
+
+  def fetch_state(conn) do
+    case fetch(conn) do
+      %__MODULE__{} = cookie ->
+        %{
+          "pending_identity_id" => cookie.pending_identity_id
+        }
+
+      nil ->
+        %{}
+    end
+  end
+
+  defp cookie_options do
+    [
+      sign: true,
+      max_age: 15 * 60,
+      same_site: "Lax",
+      secure: Portal.Config.fetch_env!(:portal, :cookie_secure),
+      http_only: true,
+      signing_salt: Portal.Config.fetch_env!(:portal, :cookie_signing_salt)
+    ]
+  end
+
+  defp cookie_key(pending_identity_id), do: @cookie_key_prefix <> pending_identity_id
+
+  defp to_binary(%__MODULE__{} = cookie) do
+    Ecto.UUID.dump!(cookie.pending_identity_id)
+    |> :erlang.term_to_binary()
+  end
+
+  defp from_binary(binary) when is_binary(binary) do
+    with pending_identity_id_bytes when is_binary(pending_identity_id_bytes) <-
+           safe_binary_to_term(binary),
+         {:ok, pending_identity_id} <- Ecto.UUID.load(pending_identity_id_bytes) do
+      %__MODULE__{pending_identity_id: pending_identity_id}
+    else
+      _ -> nil
+    end
+  end
+
+  defp from_binary(_), do: nil
+
+  # sobelow_skip ["Misc.BinToTerm"]
+  defp safe_binary_to_term(binary) do
+    :erlang.binary_to_term(binary, [:safe])
+  rescue
+    _ -> :error
+  end
+end

--- a/elixir/lib/portal_web/cookie/pending_identity.ex
+++ b/elixir/lib/portal_web/cookie/pending_identity.ex
@@ -4,10 +4,11 @@ defmodule PortalWeb.Cookie.PendingIdentity do
   """
 
   @enforce_keys [:pending_identity_id]
-  defstruct [:pending_identity_id]
+  defstruct [:pending_identity_id, params: %{}]
 
   @type t :: %__MODULE__{
-          pending_identity_id: Ecto.UUID.t()
+          pending_identity_id: Ecto.UUID.t(),
+          params: map()
         }
 
   @cookie_key_prefix "pending_identity_"
@@ -50,9 +51,7 @@ defmodule PortalWeb.Cookie.PendingIdentity do
   def fetch_state(conn) do
     case fetch(conn) do
       %__MODULE__{} = cookie ->
-        %{
-          "pending_identity_id" => cookie.pending_identity_id
-        }
+        Map.put(cookie.params, "pending_identity_id", cookie.pending_identity_id)
 
       nil ->
         %{}
@@ -73,21 +72,35 @@ defmodule PortalWeb.Cookie.PendingIdentity do
   defp cookie_key(pending_identity_id), do: @cookie_key_prefix <> pending_identity_id
 
   defp to_binary(%__MODULE__{} = cookie) do
-    Ecto.UUID.dump!(cookie.pending_identity_id)
+    {Ecto.UUID.dump!(cookie.pending_identity_id), cookie.params || %{}}
     |> :erlang.term_to_binary()
   end
 
   defp from_binary(binary) when is_binary(binary) do
-    with pending_identity_id_bytes when is_binary(pending_identity_id_bytes) <-
-           safe_binary_to_term(binary),
-         {:ok, pending_identity_id} <- Ecto.UUID.load(pending_identity_id_bytes) do
-      %__MODULE__{pending_identity_id: pending_identity_id}
-    else
-      _ -> nil
+    case safe_binary_to_term(binary) do
+      {pending_identity_id_bytes, params} when is_binary(pending_identity_id_bytes) ->
+        with {:ok, pending_identity_id} <- Ecto.UUID.load(pending_identity_id_bytes) do
+          %__MODULE__{pending_identity_id: pending_identity_id, params: normalize_params(params)}
+        else
+          _ -> nil
+        end
+
+      pending_identity_id_bytes when is_binary(pending_identity_id_bytes) ->
+        with {:ok, pending_identity_id} <- Ecto.UUID.load(pending_identity_id_bytes) do
+          %__MODULE__{pending_identity_id: pending_identity_id}
+        else
+          _ -> nil
+        end
+
+      _ ->
+        nil
     end
   end
 
   defp from_binary(_), do: nil
+
+  defp normalize_params(params) when is_map(params), do: params
+  defp normalize_params(_params), do: %{}
 
   # sobelow_skip ["Misc.BinToTerm"]
   defp safe_binary_to_term(binary) do

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -44,7 +44,7 @@ defmodule PortalWeb.Settings.Authentication do
     Okta.AuthProvider => @common_fields ++ ~w[okta_domain client_id client_secret is_verified]a,
     OIDC.AuthProvider =>
       @common_fields ++
-        ~w[discovery_document_uri client_id client_secret require_email_verified is_verified is_legacy]a
+        ~w[discovery_document_uri client_id client_secret email_verification_method is_verified is_legacy]a
   }
 
   def mount(_params, _session, socket) do
@@ -183,7 +183,8 @@ defmodule PortalWeb.Settings.Authentication do
             config: config,
             verification_ref: Ecto.UUID.generate(),
             verifier: verifier,
-            require_email_verified: type == "oidc" and get_field(changeset, :require_email_verified) == true
+            require_email_verified:
+              type == "oidc" and get_field(changeset, :email_verification_method) == :claim
           }
         )
 
@@ -533,7 +534,7 @@ defmodule PortalWeb.Settings.Authentication do
         [:client_id, :client_secret, :okta_domain]
 
       OIDC.AuthProvider ->
-        [:client_id, :client_secret, :discovery_document_uri, :require_email_verified]
+        [:client_id, :client_secret, :discovery_document_uri, :email_verification_method]
 
       _ ->
         []
@@ -1351,17 +1352,88 @@ defmodule PortalWeb.Settings.Authentication do
             </div>
           </div>
 
-          <div :if={@type == "oidc"}>
-            <.input
-              field={@form[:require_email_verified]}
-              type="checkbox"
-              label="Require verified email"
-              unchecked_value="false"
-            />
-            <p class="mt-1 ml-7 text-xs text-[var(--text-tertiary)]">
-              Enforces the email_verified claim to be true on sign in.
-            </p>
-          </div>
+          <fieldset :if={@type == "oidc"}>
+            <legend class="block text-xs font-medium text-[var(--text-secondary)] mb-3">
+              Email Verification <span class="text-[var(--status-error)]">*</span>
+            </legend>
+            <% email_verification_method = get_field(@form.source, :email_verification_method) %>
+            <div class="grid gap-3 md:grid-cols-3">
+              <label class={[
+                "flex flex-col p-3 border rounded cursor-pointer transition-all",
+                if(email_verification_method == :none,
+                  do: "border-[var(--brand)] bg-[var(--surface-raised)]",
+                  else: "border-[var(--border)] hover:border-[var(--border-emphasis)]"
+                )
+              ]}>
+                <input
+                  type="radio"
+                  name={@form[:email_verification_method].name}
+                  value="none"
+                  checked={email_verification_method == :none}
+                  class="sr-only"
+                  required
+                />
+                <span class="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                  None
+                </span>
+                <span class="text-xs text-[var(--text-secondary)]">
+                  Do not require the identity provider to confirm email ownership before linking an identity.
+                  <strong class="block mt-1">Not recommended.</strong>
+                </span>
+              </label>
+
+              <label class={[
+                "flex flex-col p-3 border rounded cursor-pointer transition-all",
+                if(email_verification_method == :claim,
+                  do: "border-[var(--brand)] bg-[var(--surface-raised)]",
+                  else: "border-[var(--border)] hover:border-[var(--border-emphasis)]"
+                )
+              ]}>
+                <input
+                  type="radio"
+                  name={@form[:email_verification_method].name}
+                  value="claim"
+                  checked={email_verification_method == :claim}
+                  class="sr-only"
+                  required
+                />
+                <span class="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                  Claim
+                </span>
+                <span class="text-xs text-[var(--text-secondary)]">
+                  Trust the email address only when the identity provider returns
+                  <code class="text-xs"><strong>email_verified=true</strong></code>.
+                  Authentication fails when the claim is missing or false.
+                  <strong class="block mt-1">Default.</strong>
+                </span>
+              </label>
+
+              <label class={[
+                "flex flex-col p-3 border rounded cursor-pointer transition-all",
+                if(email_verification_method == :proof,
+                  do: "border-[var(--brand)] bg-[var(--surface-raised)]",
+                  else: "border-[var(--border)] hover:border-[var(--border-emphasis)]"
+                )
+              ]}>
+                <input
+                  type="radio"
+                  name={@form[:email_verification_method].name}
+                  value="proof"
+                  checked={email_verification_method == :proof}
+                  class="sr-only"
+                  required
+                />
+                <span class="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                  Proof
+                </span>
+                <span class="text-xs text-[var(--text-secondary)]">
+                  Send a one-time passcode to the claimed email address before linking a new OIDC identity.
+                  Use this when the provider cannot reliably send
+                  <code class="text-xs"><strong>email_verified=true</strong></code>.
+                </span>
+              </label>
+            </div>
+          </fieldset>
 
           <%!-- Redirect URI --%>
           <div>

--- a/elixir/lib/portal_web/live/sign_in.ex
+++ b/elixir/lib/portal_web/live/sign_in.ex
@@ -146,7 +146,10 @@ defmodule PortalWeb.SignIn do
       </:item>
     </.intersperse_blocks>
 
-    <div :if={@params["as"] != "client"} class="mt-8 pt-6 border-t border-[var(--border)] text-center">
+    <div
+      :if={!PortalWeb.Authentication.client_sign_in?(@params)}
+      class="mt-8 pt-6 border-t border-[var(--border)] text-center"
+    >
       <p class="text-xs text-[var(--text-tertiary)] leading-relaxed">
         Meant to sign in from a client instead?
         <.website_link path="/kb/client-apps">Read the docs.</.website_link>

--- a/elixir/lib/portal_web/live/sign_in/email.ex
+++ b/elixir/lib/portal_web/live/sign_in/email.ex
@@ -15,11 +15,20 @@ defmodule PortalWeb.SignIn.Email do
     account = Database.get_account_by_id_or_slug(account_id_or_slug)
 
     with %Portal.Account{} = account <- account,
-         {:ok, email} <- Map.fetch(session, "email") do
+         {:ok, email} <- fetch_email(socket.assigns.live_action, account, session) do
       form = to_form(%{"secret" => nil})
+      pending_identity? = socket.assigns.live_action == :pending_identity
+      pending_identity_id = Map.get(session, "pending_identity_id")
 
-      verify_action = ~p"/#{account_id_or_slug}/sign_in/email_otp/#{provider_id}/verify"
-      resend_action = ~p"/#{account_id_or_slug}/sign_in/email_otp/#{provider_id}?resend=true"
+      verify_action =
+        verify_action(
+          socket.assigns.live_action,
+          account_id_or_slug,
+          provider_id,
+          pending_identity_id
+        )
+
+      resend_action = resend_action(socket.assigns.live_action, account_id_or_slug, provider_id)
 
       socket =
         assign(socket,
@@ -28,6 +37,7 @@ defmodule PortalWeb.SignIn.Email do
           account_id_or_slug: account_id_or_slug,
           account: account,
           provider_id: provider_id,
+          pending_identity?: pending_identity?,
           resent: params["resent"],
           redirect_params: redirect_params,
           verify_action: verify_action,
@@ -67,7 +77,10 @@ defmodule PortalWeb.SignIn.Email do
     <h1 class="text-xl font-semibold text-[var(--text-primary)] mb-2">
       Check your email
     </h1>
-    <p class="text-sm text-[var(--text-secondary)] mb-6">
+    <p :if={@pending_identity?} class="text-sm text-[var(--text-secondary)] mb-6">
+      A verification code has been sent to your email address.
+    </p>
+    <p :if={!@pending_identity?} class="text-sm text-[var(--text-secondary)] mb-6">
       If <strong class="text-[var(--text-primary)]">{@email}</strong>
       is registered, a sign-in code has been sent.
     </p>
@@ -114,7 +127,7 @@ defmodule PortalWeb.SignIn.Email do
       </button>
     </form>
 
-    <div class="mt-4 grid grid-cols-2 gap-2">
+    <div class={["mt-4 grid gap-2", if(@resend_action, do: "grid-cols-2", else: "grid-cols-1")]}>
       <.link
         href={~p"/#{@account_id_or_slug}?#{@redirect_params}"}
         class="relative flex items-center justify-center px-4 py-2.5 rounded-md border border-[var(--border-strong)] bg-[var(--surface)] hover:bg-[var(--surface-raised)] transition-colors text-sm font-medium text-[var(--text-primary)]"
@@ -123,6 +136,7 @@ defmodule PortalWeb.SignIn.Email do
         Different method
       </.link>
       <.resend
+        :if={@resend_action}
         resend_action={@resend_action}
         email={@email}
         redirect_params={@redirect_params}
@@ -132,6 +146,27 @@ defmodule PortalWeb.SignIn.Email do
     <.dev_mailbox_link />
     """
   end
+
+  defp verify_action(:pending_identity, account_id_or_slug, provider_id, pending_identity_id),
+    do:
+      ~p"/#{account_id_or_slug}/sign_in/oidc/#{provider_id}/verify_identity?pending_identity_id=#{pending_identity_id}"
+
+  defp verify_action(_live_action, account_id_or_slug, provider_id, _pending_identity_id),
+    do: ~p"/#{account_id_or_slug}/sign_in/email_otp/#{provider_id}/verify"
+
+  defp resend_action(:pending_identity, _account_id_or_slug, _provider_id), do: nil
+
+  defp resend_action(_live_action, account_id_or_slug, provider_id),
+    do: ~p"/#{account_id_or_slug}/sign_in/email_otp/#{provider_id}?resend=true"
+
+  defp fetch_email(:pending_identity, _account, session) do
+    case Map.fetch(session, "pending_identity_id") do
+      {:ok, _pending_identity_id} -> {:ok, nil}
+      :error -> :error
+    end
+  end
+
+  defp fetch_email(_live_action, _account, session), do: Map.fetch(session, "email")
 
   def handle_info(:hide_resent_flash, socket) do
     {:noreply, assign(socket, :resent, nil)}

--- a/elixir/lib/portal_web/live/sign_in/email.ex
+++ b/elixir/lib/portal_web/live/sign_in/email.ex
@@ -10,7 +10,10 @@ defmodule PortalWeb.SignIn.Email do
         session,
         socket
       ) do
-    redirect_params = PortalWeb.Authentication.take_sign_in_params(params)
+    redirect_params =
+      params
+      |> PortalWeb.Authentication.take_sign_in_params()
+      |> Map.merge(PortalWeb.Authentication.take_sign_in_params(session))
 
     account = Database.get_account_by_id_or_slug(account_id_or_slug)
 

--- a/elixir/lib/portal_web/oidc/identity_profile.ex
+++ b/elixir/lib/portal_web/oidc/identity_profile.ex
@@ -5,6 +5,8 @@ defmodule PortalWeb.OIDC.IdentityProfile do
 
   alias Portal.ExternalIdentity
 
+  defstruct [:email, :idp_id, :issuer, :profile_attrs, :email_verified]
+
   @idp_fields ~w[
     email
     issuer
@@ -19,7 +21,7 @@ defmodule PortalWeb.OIDC.IdentityProfile do
     picture
   ]a
 
-  @type t :: %{
+  @type t :: %__MODULE__{
           email: String.t() | nil,
           idp_id: String.t() | nil,
           issuer: String.t() | nil,
@@ -30,7 +32,7 @@ defmodule PortalWeb.OIDC.IdentityProfile do
   @spec build(map(), map(), Ecto.UUID.t(), keyword()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def build(claims, userinfo, account_id, opts \\ []) do
     userinfo = PortalWeb.OIDC.matching_userinfo(claims, userinfo)
-    email = resolve_email(claims, Keyword.get(opts, :email_claim))
+    email = resolve_email(claims, Keyword.get(opts, :email_claim)) |> trim_email()
     idp_id = claims["oid"] || claims["sub"]
     issuer = claims["iss"]
 
@@ -49,7 +51,7 @@ defmodule PortalWeb.OIDC.IdentityProfile do
     case validate_upsert_attrs(attrs) do
       %{valid?: true} ->
         {:ok,
-         %{
+         %__MODULE__{
            email: email,
            idp_id: idp_id,
            issuer: issuer,
@@ -81,6 +83,10 @@ defmodule PortalWeb.OIDC.IdentityProfile do
 
   defp resolve_email(claims, nil), do: claims["email"]
   defp resolve_email(claims, email_claim), do: claims[email_claim]
+
+  defp trim_email(email) when is_binary(email), do: String.trim(email)
+
+  defp trim_email(email), do: email
 
   defp extract_profile_attrs(claims, userinfo) do
     Map.merge(claims, userinfo)

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -119,6 +119,9 @@ defmodule PortalWeb.Router do
     get "/sign_in/email_otp/:auth_provider_id/verify", EmailOTPController, :verify
     post "/sign_in/email_otp/:auth_provider_id/verify", EmailOTPController, :verify
 
+    # OIDC proof-of-email-ownership verification
+    post "/sign_in/oidc/:auth_provider_id/verify_identity", OIDCController, :verify_identity
+
     # Userpass auth entry point
     post "/sign_in/userpass/:auth_provider_id", UserpassController, :sign_in
 
@@ -143,6 +146,18 @@ defmodule PortalWeb.Router do
         PortalWeb.LiveHooks.RedirectIfAuthenticated
       ] do
       live "/sign_in/email_otp/:auth_provider_id", SignIn.Email
+    end
+
+    live_session :pending_identity_verify,
+      session: {PortalWeb.Cookie.PendingIdentity, :fetch_state, []},
+      on_mount: [
+        PortalWeb.LiveHooks.PutDynamicRepo,
+        PortalWeb.LiveHooks.AllowEctoSandbox,
+        PortalWeb.LiveHooks.FetchAccount,
+        PortalWeb.LiveHooks.FetchSubject,
+        PortalWeb.LiveHooks.RedirectIfAuthenticated
+      ] do
+      live "/sign_in/oidc/:auth_provider_id/verify_identity", SignIn.Email, :pending_identity
     end
 
     # OIDC auth entry point (placed after LiveView routes to avoid conflicts)

--- a/elixir/lib/portal_web/session/redirector.ex
+++ b/elixir/lib/portal_web/session/redirector.ex
@@ -97,7 +97,7 @@ defmodule PortalWeb.Session.Redirector do
         state: state
       }
 
-      redirect_url = ~p"/#{account.slug}/sign_in/client_redirect"
+      redirect_url = ~p"/#{account}/sign_in/client_redirect"
 
       conn
       |> PortalWeb.Cookie.ClientAuth.put(client_auth_cookie)

--- a/elixir/priv/repo/migrations/20260513120000_add_pending_identities_and_oidc_email_verification_method.exs
+++ b/elixir/priv/repo/migrations/20260513120000_add_pending_identities_and_oidc_email_verification_method.exs
@@ -1,0 +1,121 @@
+defmodule Portal.Repo.Migrations.AddPendingIdentitiesAndOidcEmailVerificationMethod do
+  use Ecto.Migration
+
+  def up do
+    alter table(:external_identities) do
+      modify(:email, :citext)
+    end
+
+    alter table(:oidc_auth_providers) do
+      add(:email_verification_method, :string)
+    end
+
+    execute("""
+    UPDATE oidc_auth_providers
+    SET email_verification_method =
+      CASE
+        WHEN require_email_verified THEN 'claim'
+        ELSE 'none'
+      END
+    """)
+
+    alter table(:oidc_auth_providers) do
+      modify(:email_verification_method, :string, null: false, default: "claim")
+      remove(:require_email_verified)
+    end
+
+    create(
+      constraint(:oidc_auth_providers, :email_verification_method_must_be_valid,
+        check: "email_verification_method IN ('none', 'claim', 'proof')"
+      )
+    )
+
+    create table(:pending_identities, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      add(:id, :uuid, primary_key: true)
+
+      add(
+        :actor_id,
+        references(:actors,
+          type: :binary_id,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        ),
+        null: false
+      )
+
+      add(
+        :one_time_passcode_id,
+        references(:one_time_passcodes,
+          type: :binary_id,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        ),
+        null: false
+      )
+
+      add(
+        :auth_provider_id,
+        references(:auth_providers,
+          type: :binary_id,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        ),
+        null: false
+      )
+
+      add(:issuer, :text, null: false)
+
+      add(
+        :directory_id,
+        references(:directories,
+          type: :binary_id,
+          on_delete: :delete_all,
+          with: [account_id: :account_id]
+        )
+      )
+
+      add(:idp_id, :text, null: false)
+
+      add(:email, :citext, null: false)
+      add(:name, :text, null: false)
+      add(:given_name, :text)
+      add(:family_name, :text)
+      add(:middle_name, :text)
+      add(:nickname, :text)
+      add(:preferred_username, :text)
+      add(:profile, :text)
+      add(:picture, :text)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+  end
+
+  def down do
+    drop(table(:pending_identities))
+
+    alter table(:external_identities) do
+      modify(:email, :text)
+    end
+
+    alter table(:oidc_auth_providers) do
+      add(:require_email_verified, :boolean)
+    end
+
+    execute("""
+    UPDATE oidc_auth_providers
+    SET require_email_verified = email_verification_method != 'none'
+    """)
+
+    drop(constraint(:oidc_auth_providers, :email_verification_method_must_be_valid))
+
+    alter table(:oidc_auth_providers) do
+      modify(:require_email_verified, :boolean, null: false, default: true)
+      remove(:email_verification_method)
+    end
+  end
+end

--- a/elixir/test/portal/mailer/auth_email_test.exs
+++ b/elixir/test/portal/mailer/auth_email_test.exs
@@ -27,6 +27,8 @@ defmodule Portal.Mailer.AuthEmailTest do
         )
 
       # Check HTML body contains the new links
+      assert email.html_body =~ "http://localhost:13100/#{account.slug}"
+      refute email.html_body =~ "http://localhost:13100/#{account.id}"
       assert email.html_body =~ "Next Steps:"
       assert email.html_body =~ "Download the Firezone Client"
       assert email.html_body =~ "https://www.firezone.dev/kb/client-apps"
@@ -34,11 +36,15 @@ defmodule Portal.Mailer.AuthEmailTest do
       assert email.html_body =~ "https://www.firezone.dev/kb/quickstart"
 
       # Check text body contains the new links
+      assert email.text_body =~ "http://localhost:13100/#{account.slug}"
+      refute email.text_body =~ "http://localhost:13100/#{account.id}"
       assert email.text_body =~ "Next Steps:"
       assert email.text_body =~ "Download the Firezone Client for your platform:"
       assert email.text_body =~ "https://www.firezone.dev/kb/client-apps"
       assert email.text_body =~ "View the Quickstart Guide to get started:"
       assert email.text_body =~ "https://www.firezone.dev/kb/quickstart"
+      assert email.text_body =~ "IP address: 127.0.x.x"
+      refute email.text_body =~ "127.0.0.1"
     end
   end
 
@@ -69,8 +75,12 @@ defmodule Portal.Mailer.AuthEmailTest do
 
       # The URL should have properly encoded query params
       # NOT double-encoded (e.g., secret%3Dabc123 would be wrong)
+      assert email.text_body =~ "/#{account.slug}/sign_in/email_otp/#{provider.id}/verify"
+      refute email.text_body =~ "/#{account.id}/sign_in/email_otp/#{provider.id}/verify"
       assert email.text_body =~ "secret=abc123"
       assert email.text_body =~ "redirect_to=%2Fdashboard"
+      assert email.text_body =~ "IP address: 127.0.x.x"
+      refute email.text_body =~ "127.0.0.1"
 
       # Ensure the URL is not double-encoded
       refute email.text_body =~ "secret%3D"
@@ -100,10 +110,41 @@ defmodule Portal.Mailer.AuthEmailTest do
         )
 
       # Portal sign-in should include the clickable link
-      assert email.text_body =~ "/sign_in/email_otp/#{provider.id}/verify?secret=xyz789"
+      assert email.text_body =~
+               "/#{account.slug}/sign_in/email_otp/#{provider.id}/verify?secret=xyz789"
     end
 
-    test "omits sign-in link for client sign-in" do
+    test "omits sign-in link for client sign-in contexts" do
+      account = account_fixture()
+      provider = email_otp_provider_fixture(account: account)
+
+      actor =
+        actor_fixture(
+          account: account,
+          type: :account_admin_user,
+          allow_email_otp_sign_in: true
+        )
+        |> Portal.Repo.preload(:account)
+
+      for client_context <- ["client", "gui-client", "headless-client"] do
+        email =
+          sign_in_link_email(
+            actor,
+            DateTime.utc_now(),
+            provider.id,
+            "xyz789",
+            "Mozilla/5.0",
+            {127, 0, 0, 1},
+            %{"as" => client_context}
+          )
+
+        # Client sign-in should NOT include the clickable link (only the code)
+        assert email.text_body =~ "xyz789"
+        refute email.text_body =~ "/verify?secret="
+      end
+    end
+
+    test "obfuscates IPv6 request addresses" do
       account = account_fixture()
       provider = email_otp_provider_fixture(account: account)
 
@@ -122,14 +163,65 @@ defmodule Portal.Mailer.AuthEmailTest do
           provider.id,
           "xyz789",
           "Mozilla/5.0",
-          {127, 0, 0, 1},
-          %{"as" => "client"}
+          {0x2001, 0x0DB8, 0x85A3, 0, 0, 0, 0, 1}
         )
 
-      # Client sign-in should NOT include the clickable link (only the code)
-      # The text template has a conditional that omits the URL for client sign-in
-      assert email.text_body =~ "xyz789"
+      assert email.text_body =~ "IP address: 2001:db8:85a3:0:xxxx:xxxx:xxxx:xxxx"
+      refute email.text_body =~ "2001:db8:85a3:0:0:0:0:1"
+      refute email.text_body =~ "2001:db8:85a3::1"
+    end
+  end
+
+  describe "oidc_identity_verification_email/7" do
+    test "uses email verification copy and links back to the pending verification form" do
+      account = account_fixture()
+      provider = oidc_provider_fixture(account: account)
+      pending_identity_id = Ecto.UUID.generate()
+
+      actor =
+        actor_fixture(
+          account: account,
+          type: :account_admin_user,
+          email: "admin@example.com"
+        )
+        |> Portal.Repo.preload(:account)
+
+      context = %Portal.Authentication.Context{
+        type: :portal,
+        remote_ip: {127, 0, 0, 1},
+        remote_ip_location_region: "US-CA",
+        remote_ip_location_city: "San Francisco",
+        remote_ip_location_lat: 37.7749,
+        remote_ip_location_lon: -122.4194,
+        user_agent: "Mozilla/5.0"
+      }
+
+      email =
+        oidc_identity_verification_email(
+          actor,
+          DateTime.utc_now(),
+          provider.id,
+          pending_identity_id,
+          "abc12",
+          context,
+          %{"redirect_to" => "/dashboard"}
+        )
+
+      assert email.subject == "Firezone email verification code"
+      assert email.text_body =~ "Verify Your Email Address"
+      assert email.text_body =~ "email verification form"
+      assert email.text_body =~ "/#{account.slug}/sign_in/oidc/#{provider.id}/verify_identity"
+      refute email.text_body =~ "/#{account.id}/sign_in/oidc/#{provider.id}/verify_identity"
+      assert email.text_body =~ "pending_identity_id=#{pending_identity_id}"
+      assert email.text_body =~ "redirect_to=%2Fdashboard"
+      assert email.text_body =~ "Location: San Francisco, US-CA"
+      assert email.text_body =~ "IP address: 127.0.x.x"
+      refute email.text_body =~ "127.0.0.1"
+      refute email.text_body =~ "Coordinates"
+      assert email.text_body =~ "abc12"
+      refute email.text_body =~ "Finish Signing In"
       refute email.text_body =~ "/verify?secret="
+      refute email.text_body =~ "secret=abc12"
     end
   end
 end

--- a/elixir/test/portal/mailer/notifications_test.exs
+++ b/elixir/test/portal/mailer/notifications_test.exs
@@ -48,7 +48,7 @@ defmodule Portal.Mailer.NotificationsTest do
       assert email_body.html_body =~ gateway_2.name
 
       assert email_body.html_body =~
-               "/#{account.id}/clients?clients_order_by=latest_session%3Aasc%3Aversion\" target=\"_blank\" rel=\"noopener noreferrer\">#{incompatible_client_count} recently connected client(s)</a> are not compatible"
+               "/#{account.slug}/clients?clients_order_by=latest_session%3Aasc%3Aversion\" target=\"_blank\" rel=\"noopener noreferrer\">#{incompatible_client_count} recently connected client(s)</a> are not compatible"
 
       assert email_body.html_body =~ "See all outdated clients"
     end

--- a/elixir/test/portal/mailer/sync_error_email_test.exs
+++ b/elixir/test/portal/mailer/sync_error_email_test.exs
@@ -16,7 +16,7 @@ defmodule Portal.Mailer.SyncErrorEmailTest do
   end
 
   describe "sync_error_email/2" do
-    test "should contain sync error info", %{directory: directory} do
+    test "should contain sync error info", %{account: account, directory: directory} do
       admin_email = "admin@foo.local"
       expected_msg = "403 - Forbidden"
 
@@ -31,6 +31,8 @@ defmodule Portal.Mailer.SyncErrorEmailTest do
 
       assert email_body.text_body =~ expected_msg
       assert email_body.text_body =~ directory.name
+      assert email_body.text_body =~ "/#{account.slug}/settings/directory_sync"
+      refute email_body.text_body =~ "/#{account.id}/settings/directory_sync"
     end
 
     test "email is addressed to the admin email", %{directory: directory} do

--- a/elixir/test/portal/oidc/auth_provider_test.exs
+++ b/elixir/test/portal/oidc/auth_provider_test.exs
@@ -18,7 +18,7 @@ defmodule Portal.OIDC.AuthProviderTest do
         :discovery_document_uri,
         :issuer,
         :is_verified,
-        :require_email_verified
+        :email_verification_method
       ]
     )
     |> AuthProvider.changeset()
@@ -131,13 +131,18 @@ defmodule Portal.OIDC.AuthProviderTest do
       assert %{issuer: ["should be at most 2000 character(s)"]} = errors_on(changeset)
     end
 
-    test "defaults require_email_verified to true" do
-      assert %AuthProvider{require_email_verified: true} = %AuthProvider{}
+    test "defaults email_verification_method to claim" do
+      assert %AuthProvider{email_verification_method: :claim} = %AuthProvider{}
     end
 
-    test "allows disabling require_email_verified" do
-      provider = oidc_provider_fixture(require_email_verified: false)
-      refute provider.require_email_verified
+    test "allows proof email verification" do
+      provider = oidc_provider_fixture(email_verification_method: :proof)
+      assert provider.email_verification_method == :proof
+    end
+
+    test "allows disabling email verification" do
+      provider = oidc_provider_fixture(email_verification_method: :none)
+      assert provider.email_verification_method == :none
     end
   end
 end

--- a/elixir/test/portal/workers/delete_expired_one_time_passcodes_test.exs
+++ b/elixir/test/portal/workers/delete_expired_one_time_passcodes_test.exs
@@ -4,9 +4,11 @@ defmodule Portal.Workers.DeleteExpiredOneTimePasscodesTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.AuthProviderFixtures
 
   alias Portal.Authentication
   alias Portal.OneTimePasscode
+  alias Portal.PendingIdentity
   alias Portal.Workers.DeleteExpiredOneTimePasscodes
 
   describe "perform/1" do
@@ -60,6 +62,52 @@ defmodule Portal.Workers.DeleteExpiredOneTimePasscodesTest do
 
       refute Repo.get_by(OneTimePasscode, id: passcode1.id)
       refute Repo.get_by(OneTimePasscode, id: passcode2.id)
+    end
+
+    test "deletes pending identities through one-time passcode cascade" do
+      account = account_fixture()
+      actor = actor_fixture(account: account, type: :account_admin_user)
+      auth_provider = auth_provider_fixture(account: account, type: :oidc)
+
+      {:ok, passcode} = Authentication.create_one_time_passcode(account, actor)
+
+      pending_identity =
+        %PendingIdentity{}
+        |> Ecto.Changeset.cast(
+          %{
+            id: Ecto.UUID.generate(),
+            account_id: account.id,
+            actor_id: actor.id,
+            auth_provider_id: auth_provider.id,
+            one_time_passcode_id: passcode.id,
+            issuer: "https://idp.example.com",
+            idp_id: "user-123",
+            email: actor.email,
+            name: actor.name
+          },
+          [
+            :id,
+            :account_id,
+            :actor_id,
+            :auth_provider_id,
+            :one_time_passcode_id,
+            :issuer,
+            :idp_id,
+            :email,
+            :name
+          ]
+        )
+        |> PendingIdentity.changeset()
+        |> Repo.insert!()
+
+      passcode
+      |> Ecto.Changeset.change(expires_at: DateTime.utc_now() |> DateTime.add(-1, :minute))
+      |> Repo.update!()
+
+      assert :ok = perform_job(DeleteExpiredOneTimePasscodes, %{})
+
+      refute Repo.get_by(OneTimePasscode, id: passcode.id)
+      refute Repo.get_by(PendingIdentity, id: pending_identity.id)
     end
   end
 end

--- a/elixir/test/portal_api/controllers/oidc_auth_provider_controller_test.exs
+++ b/elixir/test/portal_api/controllers/oidc_auth_provider_controller_test.exs
@@ -13,12 +13,12 @@ defmodule PortalAPI.OIDCAuthProviderControllerTest do
   end
 
   describe "index/2" do
-    test "lists OIDC providers with require_email_verified", %{
+    test "lists OIDC providers with email_verification_method", %{
       conn: conn,
       account: account,
       actor: actor
     } do
-      provider = oidc_provider_fixture(account: account, require_email_verified: false)
+      provider = oidc_provider_fixture(account: account, email_verification_method: :none)
 
       conn =
         conn
@@ -29,14 +29,14 @@ defmodule PortalAPI.OIDCAuthProviderControllerTest do
       assert %{"data" => data} = json_response(conn, 200)
 
       assert Enum.any?(data, fn item ->
-               item["id"] == provider.id and item["require_email_verified"] == false
+               item["id"] == provider.id and item["email_verification_method"] == "none"
              end)
     end
   end
 
   describe "show/2" do
-    test "shows require_email_verified", %{conn: conn, account: account, actor: actor} do
-      provider = oidc_provider_fixture(account: account, require_email_verified: true)
+    test "shows email_verification_method", %{conn: conn, account: account, actor: actor} do
+      provider = oidc_provider_fixture(account: account, email_verification_method: :proof)
 
       conn =
         conn
@@ -46,7 +46,7 @@ defmodule PortalAPI.OIDCAuthProviderControllerTest do
 
       assert %{"data" => data} = json_response(conn, 200)
       assert data["id"] == provider.id
-      assert data["require_email_verified"] == true
+      assert data["email_verification_method"] == "proof"
     end
   end
 end

--- a/elixir/test/portal_web/controllers/home_controller_test.exs
+++ b/elixir/test/portal_web/controllers/home_controller_test.exs
@@ -97,7 +97,7 @@ defmodule PortalWeb.HomeControllerTest do
       assert html =~ "Sign in to Firezone"
       assert html =~ "Recently signed in"
       assert html =~ account.name
-      assert html =~ ~p"/#{account.slug}/sign_in"
+      assert html =~ ~p"/#{account}/sign_in"
     end
 
     test "renders multiple recent accounts", %{conn: conn} do
@@ -120,7 +120,7 @@ defmodule PortalWeb.HomeControllerTest do
 
       for account <- accounts do
         assert html =~ account.name
-        assert html =~ ~p"/#{account.slug}/sign_in"
+        assert html =~ ~p"/#{account}/sign_in"
       end
     end
 

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1155,6 +1155,7 @@ defmodule PortalWeb.OIDCControllerTest do
       pending_cookie = pending_identity_cookie_from_response(conn)
 
       assert redirect_query["pending_identity_id"] == pending_cookie.pending_identity_id
+      assert pending_cookie.params == %{"redirect_to" => "/#{ctx.account.slug}/actors"}
 
       assert %Portal.PendingIdentity{} = pending_identity =
                Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
@@ -1190,7 +1191,7 @@ defmodule PortalWeb.OIDCControllerTest do
         |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
           "secret" => code,
           "pending_identity_id" => pending_cookie.pending_identity_id,
-          "redirect_to" => "/#{ctx.account.slug}/actors"
+          "redirect_to" => "/#{ctx.account.slug}/sites"
         })
 
       assert redirected_to(conn) == "/#{ctx.account.slug}/actors"
@@ -1206,6 +1207,64 @@ defmodule PortalWeb.OIDCControllerTest do
       assert identity.actor_id == actor.id
       refute Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
       refute Repo.get_by(Portal.OneTimePasscode, id: pending_identity.one_time_passcode_id)
+    end
+
+    test "proof email verification uses original client params after valid code", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, email_verified: false, sub: "regular-user-123")
+
+      auth_state =
+        build_oidc_auth_state(ctx.account, ctx.provider,
+          params: %{
+            "as" => "gui-client",
+            "state" => "original-client-state",
+            "nonce" => "original-client-nonce"
+          }
+        )
+
+      conn = perform_callback(ctx.conn, auth_state)
+      pending_cookie = pending_identity_cookie_from_response(conn)
+
+      assert pending_cookie.params == %{
+               "as" => "gui-client",
+               "state" => "original-client-state",
+               "nonce" => "original-client-nonce"
+             }
+
+      assert_received {:email, email}
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+
+      conn =
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id,
+          "as" => "headless-client",
+          "state" => "submitted-client-state",
+          "nonce" => "submitted-client-nonce"
+        })
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "client_redirect"
+      refute conn.resp_body =~ "Copy to clipboard"
+
+      client_auth =
+        conn
+        |> recycle()
+        |> with_endpoint_key_base()
+        |> Cookie.ClientAuth.fetch()
+
+      assert client_auth.state == "original-client-state"
     end
 
     test "proof email verification treats concurrent external identity insert as success", ctx do
@@ -1363,10 +1422,10 @@ defmodule PortalWeb.OIDCControllerTest do
         |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
           "secret" => "wrong",
           "pending_identity_id" => pending_cookie.pending_identity_id,
-          "as" => "gui-client",
-          "state" => "client-state",
-          "nonce" => "client-nonce",
-          "redirect_to" => "/#{ctx.account.slug}/actors"
+          "as" => "headless-client",
+          "state" => "submitted-state",
+          "nonce" => "submitted-nonce",
+          "redirect_to" => "/#{ctx.account.slug}/sites"
         })
 
       location = redirected_to(conn)
@@ -1376,6 +1435,10 @@ defmodule PortalWeb.OIDCControllerTest do
       assert location =~ "nonce=client-nonce"
       assert location =~ "redirect_to=%2F#{ctx.account.slug}%2Factors"
       assert location =~ "pending_identity_id=#{pending_cookie.pending_identity_id}"
+      refute location =~ "headless-client"
+      refute location =~ "submitted-state"
+      refute location =~ "submitted-nonce"
+      refute location =~ "sites"
       assert flash(conn, :error) == "The verification code is invalid or expired."
     end
 

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -4,10 +4,19 @@ defmodule PortalWeb.OIDCControllerTest do
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
+  import Portal.IdentityFixtures
   import ExUnit.CaptureLog
 
   alias PortalWeb.Cookie
   alias PortalWeb.Mocks
+
+  @request_context_headers ~w[
+    user-agent
+    x-geo-location-region
+    x-geo-location-city
+    x-geo-location-coordinates
+    x-azure-geo-country
+  ]
 
   setup do
     # Set up OIDC mock for all tests
@@ -656,7 +665,7 @@ defmodule PortalWeb.OIDCControllerTest do
         |> get(~p"/auth/oidc/callback", %{"state" => "test-state", "code" => "test-code"})
 
       location = get_resp_header(conn, "location") |> List.first()
-      refute location == ~p"/#{account.slug}/sites"
+      refute location == ~p"/#{account}/sites"
     end
 
     test "authenticated user can access legacy callback without being redirected to portal", %{
@@ -668,13 +677,13 @@ defmodule PortalWeb.OIDCControllerTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/#{account.slug}/sign_in/providers/#{provider.id}/handle_callback", %{
+        |> get(~p"/#{account}/sign_in/providers/#{provider.id}/handle_callback", %{
           "state" => "test-state",
           "code" => "test-code"
         })
 
       location = get_resp_header(conn, "location") |> List.first()
-      refute location == ~p"/#{account.slug}/sites"
+      refute location == ~p"/#{account}/sites"
     end
   end
 
@@ -961,14 +970,14 @@ defmodule PortalWeb.OIDCControllerTest do
     end
 
     test "successful portal sign-in for admin user creates session and redirects", ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
       setup_successful_auth(ctx, actor)
       assert_portal_sign_in_success(ctx)
     end
 
     test "successful client sign-in for admin user creates token and renders redirect page",
          ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
       setup_successful_auth(ctx, actor)
       assert_client_sign_in_success(ctx)
     end
@@ -982,7 +991,7 @@ defmodule PortalWeb.OIDCControllerTest do
 
     test "successful headless-client sign-in for admin user creates token and renders token page",
          ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
       setup_successful_auth(ctx, actor)
       assert_headless_client_sign_in_success(ctx)
     end
@@ -996,13 +1005,13 @@ defmodule PortalWeb.OIDCControllerTest do
 
     test "successful gui-client sign-in for admin user creates token and renders redirect page",
          ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
       setup_successful_auth(ctx, actor)
       assert_gui_client_sign_in_success(ctx)
     end
 
     test "rejects sign-in with unverified email when verified email is required", ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
 
       setup_successful_auth(ctx, actor, email_verified: false)
 
@@ -1020,7 +1029,7 @@ defmodule PortalWeb.OIDCControllerTest do
     end
 
     test "rejects sign-in when verified email is required and email_verified is missing", ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
 
       id_token =
         Mocks.OIDC.sign_openid_connect_token(%{
@@ -1050,7 +1059,7 @@ defmodule PortalWeb.OIDCControllerTest do
     end
 
     test "accepts sign-in when verified email comes from matching userinfo", ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
 
       id_token = sign_id_token(ctx.provider, actor, email_verified: :omit)
       expect_token_exchange(id_token)
@@ -1066,7 +1075,7 @@ defmodule PortalWeb.OIDCControllerTest do
     end
 
     test "rejects sign-in when verified email userinfo subject differs", ctx do
-      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
 
       id_token = sign_id_token(ctx.provider, actor, email_verified: :omit)
       expect_token_exchange(id_token)
@@ -1091,7 +1100,7 @@ defmodule PortalWeb.OIDCControllerTest do
       provider =
         oidc_provider_fixture(:mock,
           account: ctx.account,
-          require_email_verified: false
+          email_verification_method: :none
         )
 
       ctx = %{ctx | provider: provider}
@@ -1106,6 +1115,465 @@ defmodule PortalWeb.OIDCControllerTest do
 
       assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
       refute log =~ "OIDC identity email not verified"
+    end
+
+    test "successful sign-in matches actor email using citext semantics", ctx do
+      actor = admin_actor_fixture(account: ctx.account, email: "Admin@Example.COM")
+
+      setup_successful_auth(ctx, actor, email: "admin@example.com")
+
+      assert_portal_sign_in_success(ctx)
+    end
+
+    test "proof email verification sends OTP and promotes pending identity after valid code", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: " Admin@Example.COM ")
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      cookie =
+        build_oidc_auth_state(ctx.account, ctx.provider,
+          params: %{"redirect_to" => "/#{ctx.account.slug}/actors"}
+        )
+      conn = perform_callback(ctx.conn, cookie)
+
+      redirect_query = redirected_to(conn) |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert redirected_to(conn) =~
+               "/#{ctx.account.slug}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+
+      refute redirected_to(conn) =~
+               "/#{ctx.account.id}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+
+      pending_cookie = pending_identity_cookie_from_response(conn)
+
+      assert redirect_query["pending_identity_id"] == pending_cookie.pending_identity_id
+
+      assert %Portal.PendingIdentity{} = pending_identity =
+               Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+
+      assert pending_identity.actor_id == actor.id
+      assert pending_identity.auth_provider_id == ctx.provider.id
+
+      refute Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer,
+               idp_id: "admin-user-123"
+             )
+
+      assert_received {:email, email}
+      assert email.to == [{"", actor.email}]
+      refute email.text_body =~ "/verify?secret="
+      assert email.text_body =~
+               "/#{ctx.account.slug}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+
+      refute email.text_body =~
+               "/#{ctx.account.id}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+
+      assert email.text_body =~ "pending_identity_id=#{pending_cookie.pending_identity_id}"
+      assert email.text_body =~ "Location: Kyiv, UA"
+      assert email.text_body =~ "IP address: 127.0.x.x"
+      refute email.text_body =~ "127.0.0.1"
+      refute email.text_body =~ "Coordinates"
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+
+      conn =
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id,
+          "redirect_to" => "/#{ctx.account.slug}/actors"
+        })
+
+      assert redirected_to(conn) == "/#{ctx.account.slug}/actors"
+      assert conn.resp_cookies["sess_#{ctx.account.id}"]
+
+      assert identity =
+               Repo.get_by(Portal.ExternalIdentity,
+                 account_id: ctx.account.id,
+                 issuer: ctx.provider.issuer,
+                 idp_id: "admin-user-123"
+               )
+
+      assert identity.actor_id == actor.id
+      refute Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+      refute Repo.get_by(Portal.OneTimePasscode, id: pending_identity.one_time_passcode_id)
+    end
+
+    test "proof email verification treats concurrent external identity insert as success", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      pending_cookie = pending_identity_cookie_from_response(conn)
+      pending_identity = Repo.get_by!(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+      assert_received {:email, email}
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+
+      existing_identity =
+        identity_fixture(
+          account: ctx.account,
+          actor: actor,
+          issuer: ctx.provider.issuer,
+          idp_id: "admin-user-123",
+          email: actor.email,
+          name: actor.name
+        )
+
+      conn =
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+      assert conn.resp_cookies["sess_#{ctx.account.id}"]
+
+      assert Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer,
+               idp_id: "admin-user-123"
+             ).id == existing_identity.id
+
+      refute Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+      refute Repo.get_by(Portal.OneTimePasscode, id: pending_identity.one_time_passcode_id)
+    end
+
+    test "proof email verification does not relink an existing identity to a stale pending actor",
+         ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor_a = admin_actor_fixture(account: ctx.account, email: unique_email())
+      actor_b = admin_actor_fixture(account: ctx.account, email: unique_email())
+      idp_id = "shared-idp-subject"
+
+      setup_successful_auth(ctx, actor_a, email_verified: false, sub: idp_id)
+      first_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      first_cookie = pending_identity_cookie_from_response(first_conn)
+      assert_received {:email, first_email}
+      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, first_email.text_body)
+
+      setup_successful_auth(ctx, actor_b, email_verified: false, sub: idp_id)
+      second_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      second_cookie = pending_identity_cookie_from_response(second_conn)
+      assert_received {:email, second_email}
+      [_, second_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, second_email.text_body)
+
+      conn =
+        build_conn()
+        |> with_endpoint_key_base()
+        |> put_pending_identity_req_cookie(first_conn, first_cookie.pending_identity_id)
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => first_code,
+          "pending_identity_id" => first_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+
+      assert identity =
+               Repo.get_by(Portal.ExternalIdentity,
+                 account_id: ctx.account.id,
+                 issuer: ctx.provider.issuer,
+                 idp_id: idp_id
+               )
+
+      assert identity.actor_id == actor_a.id
+      assert identity.email == actor_a.email
+
+      conn =
+        build_conn()
+        |> with_endpoint_key_base()
+        |> put_pending_identity_req_cookie(second_conn, second_cookie.pending_identity_id)
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => second_code,
+          "pending_identity_id" => second_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) =~
+               "/#{ctx.account.slug}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+
+      assert flash(conn, :error) == "The verification code is invalid or expired."
+
+      identity =
+        Repo.get_by!(Portal.ExternalIdentity,
+          account_id: ctx.account.id,
+          issuer: ctx.provider.issuer,
+          idp_id: idp_id
+        )
+
+      assert identity.actor_id == actor_a.id
+      assert identity.email == actor_a.email
+    end
+
+    test "proof email verification preserves sign-in params after invalid code", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      auth_state =
+        build_oidc_auth_state(ctx.account, ctx.provider,
+          params: %{
+            "as" => "gui-client",
+            "state" => "client-state",
+            "nonce" => "client-nonce",
+            "redirect_to" => "/#{ctx.account.slug}/actors"
+          }
+        )
+
+      conn = perform_callback(ctx.conn, auth_state)
+      pending_cookie = pending_identity_cookie_from_response(conn)
+
+      conn =
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => "wrong",
+          "pending_identity_id" => pending_cookie.pending_identity_id,
+          "as" => "gui-client",
+          "state" => "client-state",
+          "nonce" => "client-nonce",
+          "redirect_to" => "/#{ctx.account.slug}/actors"
+        })
+
+      location = redirected_to(conn)
+      assert location =~ "/#{ctx.account.slug}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+      assert location =~ "as=gui-client"
+      assert location =~ "state=client-state"
+      assert location =~ "nonce=client-nonce"
+      assert location =~ "redirect_to=%2F#{ctx.account.slug}%2Factors"
+      assert location =~ "pending_identity_id=#{pending_cookie.pending_identity_id}"
+      assert flash(conn, :error) == "The verification code is invalid or expired."
+    end
+
+    test "proof email verification requires the signed pending identity cookie", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      callback_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      pending_cookie = pending_identity_cookie_from_response(callback_conn)
+      assert_received {:email, email}
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+
+      conn =
+        build_conn()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) == "/sign_in"
+      assert flash(conn, :error) == "Your sign-in session has timed out. Please try again."
+    end
+
+    test "proof email verification requires the pending identity provider", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      other_provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof,
+          issuer: "https://other-idp.example.com"
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      callback_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      pending_cookie = pending_identity_cookie_from_response(callback_conn)
+      assert_received {:email, email}
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+
+      conn =
+        callback_conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{other_provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) =~
+               "/#{ctx.account.slug}/sign_in/oidc/#{other_provider.id}/verify_identity"
+
+      assert flash(conn, :error) == "The verification code is invalid or expired."
+
+      assert Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+
+      refute Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer,
+               idp_id: "admin-user-123"
+             )
+    end
+
+    test "proof email verification binds each code to the pending identity link and cookie", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+
+      setup_successful_auth(ctx, actor, email_verified: false)
+      first_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      first_cookie = pending_identity_cookie_from_response(first_conn)
+      assert_received {:email, first_email}
+      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, first_email.text_body)
+
+      setup_successful_auth(ctx, actor, email_verified: false)
+      second_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      second_cookie = pending_identity_cookie_from_response(second_conn)
+      assert_received {:email, second_email}
+      [_, _second_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, second_email.text_body)
+
+      conn =
+        build_conn()
+        |> with_endpoint_key_base()
+        |> put_pending_identity_req_cookie(first_conn, first_cookie.pending_identity_id)
+        |> put_pending_identity_req_cookie(second_conn, second_cookie.pending_identity_id)
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => first_code,
+          "pending_identity_id" => second_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) =~
+               "/#{ctx.account.slug}/sign_in/oidc/#{ctx.provider.id}/verify_identity"
+
+      assert flash(conn, :error) == "The verification code is invalid or expired."
+
+      refute Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer,
+               idp_id: "admin-user-123"
+             )
+    end
+
+    test "proof email verification keeps multiple pending links valid and clears them all after success",
+         ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+
+      setup_successful_auth(ctx, actor, email_verified: false)
+      first_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      first_cookie = pending_identity_cookie_from_response(first_conn)
+      first_pending_identity = Repo.get_by!(Portal.PendingIdentity, id: first_cookie.pending_identity_id)
+      assert_received {:email, first_email}
+      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, first_email.text_body)
+
+      setup_successful_auth(ctx, actor, email_verified: false)
+      second_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      second_cookie = pending_identity_cookie_from_response(second_conn)
+      second_pending_identity = Repo.get_by!(Portal.PendingIdentity, id: second_cookie.pending_identity_id)
+      assert_received {:email, _second_email}
+
+      conn =
+        build_conn()
+        |> with_endpoint_key_base()
+        |> put_pending_identity_req_cookie(first_conn, first_cookie.pending_identity_id)
+        |> put_pending_identity_req_cookie(second_conn, second_cookie.pending_identity_id)
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => first_code,
+          "pending_identity_id" => first_cookie.pending_identity_id
+        })
+
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+      assert conn.resp_cookies["sess_#{ctx.account.id}"]
+
+      assert conn.resp_cookies[pending_identity_cookie_key(first_cookie.pending_identity_id)].max_age == 0
+      assert conn.resp_cookies[pending_identity_cookie_key(second_cookie.pending_identity_id)].max_age == 0
+
+      refute Repo.get_by(Portal.PendingIdentity, id: first_cookie.pending_identity_id)
+      refute Repo.get_by(Portal.PendingIdentity, id: second_cookie.pending_identity_id)
+      refute Repo.get_by(Portal.OneTimePasscode, id: first_pending_identity.one_time_passcode_id)
+      refute Repo.get_by(Portal.OneTimePasscode, id: second_pending_identity.one_time_passcode_id)
+    end
+
+    test "proof email verification skips OTP when external identity already exists", ctx do
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: "admin@example.com")
+
+      identity_fixture(
+        account: ctx.account,
+        actor: actor,
+        issuer: ctx.provider.issuer,
+        idp_id: "admin-user-123",
+        email: actor.email,
+        name: actor.name
+      )
+
+      setup_successful_auth(ctx, actor, email_verified: false)
+      conn = assert_portal_sign_in_success(ctx)
+
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+      refute_received {:email, _email}
+      refute conn.resp_cookies["pending_identity"]
     end
 
     test "successful sign-in derives name from given_name and family_name", ctx do
@@ -2104,6 +2572,10 @@ defmodule PortalWeb.OIDCControllerTest do
     %{provider: provider}
   end
 
+  defp unique_email do
+    "admin-#{System.unique_integer([:positive, :monotonic])}@example.com"
+  end
+
   # Builds an OIDC auth state map for cookie-backed callbacks.
   defp build_oidc_auth_state(account, provider, opts \\ []) do
     %{
@@ -2137,7 +2609,17 @@ defmodule PortalWeb.OIDCControllerTest do
     |> with_endpoint_key_base()
     |> Cookie.AuthenticationState.put(cookie)
     |> recycle()
+    |> copy_req_headers(conn, @request_context_headers)
     |> get(~p"/auth/oidc/callback", %{"state" => state, "code" => code})
+  end
+
+  defp copy_req_headers(conn, source_conn, headers) do
+    Enum.reduce(headers, conn, fn header, conn ->
+      case Plug.Conn.get_req_header(source_conn, header) do
+        [] -> conn
+        [value | _rest] -> Plug.Conn.put_req_header(conn, header, value)
+      end
+    end)
   end
 
   # Reads the oidc cookie from a response conn by recycling it to make cookies readable.
@@ -2147,6 +2629,31 @@ defmodule PortalWeb.OIDCControllerTest do
     |> with_endpoint_key_base()
     |> Cookie.AuthenticationState.fetch()
   end
+
+  defp pending_identity_cookie_from_response(conn) do
+    pending_identity_id =
+      conn
+      |> redirected_to()
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+      |> Map.fetch!("pending_identity_id")
+
+    conn
+    |> recycle()
+    |> with_endpoint_key_base()
+    |> Cookie.PendingIdentity.fetch(pending_identity_id)
+  end
+
+  defp put_pending_identity_req_cookie(conn, response_conn, pending_identity_id) do
+    Plug.Test.put_req_cookie(
+      conn,
+      pending_identity_cookie_key(pending_identity_id),
+      response_conn.resp_cookies[pending_identity_cookie_key(pending_identity_id)].value
+    )
+  end
+
+  defp pending_identity_cookie_key(pending_identity_id), do: "pending_identity_#{pending_identity_id}"
 
   # Sets the secret_key_base from the endpoint so signed cookies can be read/written.
   defp with_endpoint_key_base(conn) do
@@ -2185,11 +2692,12 @@ defmodule PortalWeb.OIDCControllerTest do
   # Signs a JWT id_token for testing.
   defp sign_id_token(provider, actor, opts \\ []) do
     sub = Keyword.get(opts, :sub, "admin-user-123")
+    email = Keyword.get(opts, :email, actor.email)
 
     claims =
       %{
         "iss" => provider.issuer,
-        "email" => actor.email,
+        "email" => email,
         "sub" => sub,
         "aud" => provider.client_id,
         "exp" => token_exp()
@@ -2235,11 +2743,12 @@ defmodule PortalWeb.OIDCControllerTest do
   defp expect_userinfo(actor, opts) do
     sub = Keyword.get(opts, :sub, "admin-user-123")
     email_verified = Keyword.get(opts, :email_verified, true)
+    email = Keyword.get(opts, :email, actor.email)
 
     userinfo =
       %{
         "sub" => sub,
-        "email" => actor.email,
+        "email" => email,
         "email_verified" => email_verified
       }
       |> maybe_add_claim("name", opts, actor.name)
@@ -2277,6 +2786,8 @@ defmodule PortalWeb.OIDCControllerTest do
 
     assert conn.status == 200
     assert conn.resp_body =~ "client_redirect"
+    assert conn.resp_body =~ "/#{ctx.account.slug}/sign_in/client_redirect"
+    refute conn.resp_body =~ "/#{ctx.account.id}/sign_in/client_redirect"
     assert conn.resp_cookies["client_auth"]
 
     conn
@@ -2293,6 +2804,8 @@ defmodule PortalWeb.OIDCControllerTest do
 
     assert conn.status == 200
     assert conn.resp_body =~ "client_redirect"
+    assert conn.resp_body =~ "/#{ctx.account.slug}/sign_in/client_redirect"
+    refute conn.resp_body =~ "/#{ctx.account.id}/sign_in/client_redirect"
     assert conn.resp_cookies["client_auth"]
 
     conn

--- a/elixir/test/portal_web/cookie/pending_identity_test.exs
+++ b/elixir/test/portal_web/cookie/pending_identity_test.exs
@@ -16,16 +16,18 @@ defmodule PortalWeb.Cookie.PendingIdentityTest do
   end
 
   describe "put/2 and fetch/1" do
-    test "stores and retrieves only the pending identity id", %{conn: conn} do
+    test "stores and retrieves pending identity id and params", %{conn: conn} do
       pending_identity_id = Ecto.UUID.generate()
-      cookie = %PendingIdentity{pending_identity_id: pending_identity_id}
+      params = %{"as" => "gui-client", "state" => "client-state"}
+      cookie = %PendingIdentity{pending_identity_id: pending_identity_id, params: params}
 
       conn =
         conn
         |> PendingIdentity.put(cookie)
         |> recycle_conn(pending_identity_id)
 
-      assert %PendingIdentity{pending_identity_id: ^pending_identity_id} = PendingIdentity.fetch(conn)
+      assert %PendingIdentity{pending_identity_id: ^pending_identity_id, params: ^params} =
+               PendingIdentity.fetch(conn)
     end
 
     test "returns nil when the requested id does not match the cookie name", %{conn: conn} do
@@ -56,9 +58,20 @@ defmodule PortalWeb.Cookie.PendingIdentityTest do
         |> PendingIdentity.put(cookie)
         |> recycle_conn(pending_identity_id)
 
-      assert PendingIdentity.fetch_state(conn) == %{
-               "pending_identity_id" => pending_identity_id
-             }
+      assert PendingIdentity.fetch_state(conn) == %{"pending_identity_id" => pending_identity_id}
+    end
+
+    test "returns pending identity params in map format", %{conn: conn} do
+      pending_identity_id = Ecto.UUID.generate()
+      params = %{"as" => "gui-client", "state" => "client-state"}
+      cookie = %PendingIdentity{pending_identity_id: pending_identity_id, params: params}
+
+      conn =
+        conn
+        |> PendingIdentity.put(cookie)
+        |> recycle_conn(pending_identity_id)
+
+      assert PendingIdentity.fetch_state(conn) == Map.put(params, "pending_identity_id", pending_identity_id)
     end
 
     test "returns empty map when cookie is not present", %{conn: conn} do

--- a/elixir/test/portal_web/cookie/pending_identity_test.exs
+++ b/elixir/test/portal_web/cookie/pending_identity_test.exs
@@ -1,0 +1,84 @@
+defmodule PortalWeb.Cookie.PendingIdentityTest do
+  use PortalWeb.ConnCase, async: true
+
+  alias PortalWeb.Cookie.PendingIdentity
+
+  defp cookie_key(pending_identity_id), do: "pending_identity_#{pending_identity_id}"
+
+  defp recycle_conn(conn, pending_identity_id) do
+    key = cookie_key(pending_identity_id)
+    cookie_value = conn.resp_cookies[key].value
+
+    build_conn()
+    |> Map.put(:secret_key_base, PortalWeb.Endpoint.config(:secret_key_base))
+    |> Plug.Test.put_req_cookie(key, cookie_value)
+    |> Map.put(:params, %{"pending_identity_id" => pending_identity_id})
+  end
+
+  describe "put/2 and fetch/1" do
+    test "stores and retrieves only the pending identity id", %{conn: conn} do
+      pending_identity_id = Ecto.UUID.generate()
+      cookie = %PendingIdentity{pending_identity_id: pending_identity_id}
+
+      conn =
+        conn
+        |> PendingIdentity.put(cookie)
+        |> recycle_conn(pending_identity_id)
+
+      assert %PendingIdentity{pending_identity_id: ^pending_identity_id} = PendingIdentity.fetch(conn)
+    end
+
+    test "returns nil when the requested id does not match the cookie name", %{conn: conn} do
+      pending_identity_id = Ecto.UUID.generate()
+      cookie = %PendingIdentity{pending_identity_id: pending_identity_id}
+
+      conn =
+        conn
+        |> PendingIdentity.put(cookie)
+        |> recycle_conn(pending_identity_id)
+        |> Map.put(:params, %{"pending_identity_id" => Ecto.UUID.generate()})
+
+      assert PendingIdentity.fetch(conn) == nil
+    end
+
+    test "returns nil when cookie is not present", %{conn: conn} do
+      assert PendingIdentity.fetch(conn) == nil
+    end
+  end
+
+  describe "fetch_state/1" do
+    test "returns map format for live_session compatibility", %{conn: conn} do
+      pending_identity_id = Ecto.UUID.generate()
+      cookie = %PendingIdentity{pending_identity_id: pending_identity_id}
+
+      conn =
+        conn
+        |> PendingIdentity.put(cookie)
+        |> recycle_conn(pending_identity_id)
+
+      assert PendingIdentity.fetch_state(conn) == %{
+               "pending_identity_id" => pending_identity_id
+             }
+    end
+
+    test "returns empty map when cookie is not present", %{conn: conn} do
+      assert PendingIdentity.fetch_state(conn) == %{}
+    end
+  end
+
+  describe "delete/1" do
+    test "removes the cookie", %{conn: conn} do
+      cookie = %PendingIdentity{pending_identity_id: Ecto.UUID.generate()}
+
+      conn =
+        conn
+        |> PendingIdentity.put(cookie)
+        |> recycle_conn(cookie.pending_identity_id)
+
+      assert PendingIdentity.fetch(conn) != nil
+
+      conn = PendingIdentity.delete(conn, cookie.pending_identity_id)
+      assert conn.resp_cookies[cookie_key(cookie.pending_identity_id)].max_age == 0
+    end
+  end
+end

--- a/elixir/test/portal_web/live/find_account_test.exs
+++ b/elixir/test/portal_web/live/find_account_test.exs
@@ -1,6 +1,9 @@
 defmodule PortalWeb.FindAccountTest do
   use PortalWeb.ConnCase, async: true
 
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+
   describe "mount" do
     test "renders email input form", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/find_account")
@@ -35,6 +38,27 @@ defmodule PortalWeb.FindAccountTest do
 
       assert html =~ "Check your inbox"
       assert html =~ "user@example.com"
+    end
+
+    test "emails account sign-in links with account slugs", %{conn: conn} do
+      email = "user@example.com"
+      account = account_fixture()
+      actor_fixture(account: account, email: email)
+
+      {:ok, lv, _html} = live(conn, ~p"/find_account")
+
+      html =
+        lv
+        |> form("form", email_form: %{email: email})
+        |> render_submit()
+
+      assert html =~ "Check your inbox"
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "http://localhost:13100/#{account.slug}/sign_in"
+        refute email.text_body =~ "http://localhost:13100/#{account.id}/sign_in"
+        true
+      end)
     end
 
     test "invalid email stays on form with error", %{conn: conn} do

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -620,8 +620,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Discovery Document URI"
       assert html =~ "Client ID"
       assert html =~ "Client Secret"
-      assert html =~ "Require verified email"
-      assert html =~ "Enforces the email_verified claim to be true on sign in."
+      assert html =~ "Email Verification"
+      assert html =~ "Do not require the identity provider to confirm email ownership"
+      assert html =~ "email_verified=true"
+      assert html =~ "Send a one-time passcode to the claimed email address"
       assert html =~ "Redirect URI"
       assert html =~ "Verify Now"
     end
@@ -1053,8 +1055,10 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Discovery Document URI"
       assert html =~ "Client ID"
       assert html =~ "Client Secret"
-      assert html =~ "Require verified email"
-      assert html =~ "Enforces the email_verified claim to be true on sign in."
+      assert html =~ "Email Verification"
+      assert html =~ "Do not require the identity provider to confirm email ownership"
+      assert html =~ "email_verified=true"
+      assert html =~ "Send a one-time passcode to the claimed email address"
       assert html =~ "Verification"
     end
 
@@ -1084,12 +1088,12 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Verify Now"
     end
 
-    test "clears verification when require_email_verified changes", %{
+    test "clears verification when email_verification_method changes", %{
       account: account,
       actor: actor,
       conn: conn
     } do
-      provider = oidc_provider_fixture(account: account, require_email_verified: true)
+      provider = oidc_provider_fixture(account: account, email_verification_method: :claim)
 
       {:ok, lv, html} =
         conn
@@ -1101,7 +1105,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       html =
         lv
         |> form("#auth-provider-form", %{
-          auth_provider: %{require_email_verified: "false"}
+          auth_provider: %{email_verification_method: "none"}
         })
         |> render_change()
 
@@ -2491,7 +2495,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Verify Now" or html =~ "error"
     end
 
-    test "passes require_email_verified from oidc form into pending verification", %{
+    test "passes email_verification_method from oidc form into pending verification", %{
       account: account,
       actor: actor,
       conn: conn
@@ -2510,7 +2514,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
           discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
           client_id: "test-client",
           client_secret: "test-secret",
-          require_email_verified: "false"
+          email_verification_method: "none"
         }
       })
       |> render_change()
@@ -2525,7 +2529,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert is_binary(verifier)
     end
 
-    test "clears pending oidc verification when require_email_verified changes", %{
+    test "clears pending oidc verification when email_verification_method changes", %{
       account: account,
       actor: actor,
       conn: conn
@@ -2542,7 +2546,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
         discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
         client_id: "test-client",
         client_secret: "test-secret",
-        require_email_verified: "false"
+        email_verification_method: "none"
       }
 
       lv
@@ -2553,7 +2557,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       lv
       |> form("#auth-provider-form", %{
-        auth_provider: %{attrs | require_email_verified: "true"}
+        auth_provider: %{attrs | email_verification_method: "claim"}
       })
       |> render_change()
 
@@ -2562,7 +2566,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert_receive {:pending_verification, nil}
     end
 
-    test "ignores stale oidc verification completion after require_email_verified changes", %{
+    test "ignores stale oidc verification completion after email_verification_method changes", %{
       account: account,
       actor: actor,
       conn: conn
@@ -2579,7 +2583,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
         discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
         client_id: "test-client",
         client_secret: "test-secret",
-        require_email_verified: "false"
+        email_verification_method: "none"
       }
 
       lv
@@ -2596,7 +2600,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       html =
         lv
         |> form("#auth-provider-form", %{
-          auth_provider: %{attrs | require_email_verified: "true"}
+          auth_provider: %{attrs | email_verification_method: "claim"}
         })
         |> render_change()
 
@@ -2629,7 +2633,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
         discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
         client_id: "test-client",
         client_secret: "test-secret",
-        require_email_verified: "false"
+        email_verification_method: "none"
       }
 
       lv
@@ -2643,7 +2647,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert_receive {:pending_verification,
                       %{require_email_verified: false, verification_ref: stale_ref}}
 
-      updated_attrs = %{attrs | require_email_verified: "true"}
+      updated_attrs = %{attrs | email_verification_method: "claim"}
 
       lv
       |> form("#auth-provider-form", %{auth_provider: updated_attrs})

--- a/elixir/test/portal_web/live/sign_in/email_test.exs
+++ b/elixir/test/portal_web/live/sign_in/email_test.exs
@@ -27,9 +27,9 @@ defmodule PortalWeb.SignIn.EmailTest do
     |> then(fn c -> put_req_cookie(c, "email_otp", c.resp_cookies["email_otp"].value) end)
   end
 
-  defp put_pending_identity_cookie(conn) do
+  defp put_pending_identity_cookie(conn, params \\ %{}) do
     pending_identity_id = Ecto.UUID.generate()
-    cookie = %PendingIdentity{pending_identity_id: pending_identity_id}
+    cookie = %PendingIdentity{pending_identity_id: pending_identity_id, params: params}
     cookie_key = "pending_identity_#{pending_identity_id}"
 
     conn =
@@ -86,6 +86,32 @@ defmodule PortalWeb.SignIn.EmailTest do
       assert html =~ "pending_identity_id=#{pending_identity_id}"
       refute html =~ actor.email
       refute html =~ "Resend email"
+    end
+
+    test "uses pending identity cookie params for verification form context",
+         %{conn: conn, account: account} do
+      provider = oidc_provider_fixture(account: account)
+
+      {conn, pending_identity_id} =
+        put_pending_identity_cookie(conn, %{
+          "as" => "gui-client",
+          "state" => "original-state",
+          "nonce" => "original-nonce",
+          "redirect_to" => "/#{account.slug}/actors"
+        })
+
+      {:ok, _lv, html} =
+        live(
+          conn,
+          ~p"/#{account}/sign_in/oidc/#{provider}/verify_identity?pending_identity_id=#{pending_identity_id}&as=headless-client&state=submitted-state"
+        )
+
+      assert html =~ "as\" value=\"gui-client"
+      assert html =~ "state\" value=\"original-state"
+      assert html =~ "nonce\" value=\"original-nonce"
+      assert html =~ "redirect_to\" value=\"/#{account.slug}/actors"
+      refute html =~ "headless-client"
+      refute html =~ "submitted-state"
     end
   end
 end

--- a/elixir/test/portal_web/live/sign_in/email_test.exs
+++ b/elixir/test/portal_web/live/sign_in/email_test.exs
@@ -5,7 +5,7 @@ defmodule PortalWeb.SignIn.EmailTest do
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
 
-  alias PortalWeb.Cookie.EmailOTP
+  alias PortalWeb.Cookie.{EmailOTP, PendingIdentity}
 
   setup do
     account = account_fixture()
@@ -25,6 +25,19 @@ defmodule PortalWeb.SignIn.EmailTest do
     conn
     |> EmailOTP.put(cookie)
     |> then(fn c -> put_req_cookie(c, "email_otp", c.resp_cookies["email_otp"].value) end)
+  end
+
+  defp put_pending_identity_cookie(conn) do
+    pending_identity_id = Ecto.UUID.generate()
+    cookie = %PendingIdentity{pending_identity_id: pending_identity_id}
+    cookie_key = "pending_identity_#{pending_identity_id}"
+
+    conn =
+      conn
+      |> PendingIdentity.put(cookie)
+      |> then(fn c -> put_req_cookie(c, cookie_key, c.resp_cookies[cookie_key].value) end)
+
+    {conn, pending_identity_id}
   end
 
   describe "mount without auth state" do
@@ -55,6 +68,24 @@ defmodule PortalWeb.SignIn.EmailTest do
 
       assert html =~ "Resend email"
       assert html =~ "Different method"
+    end
+
+    test "renders pending identity verification form without loading email",
+         %{conn: conn, account: account, actor: actor} do
+      provider = oidc_provider_fixture(account: account)
+      {conn, pending_identity_id} = put_pending_identity_cookie(conn)
+
+      {:ok, _lv, html} =
+        live(
+          conn,
+          ~p"/#{account}/sign_in/oidc/#{provider}/verify_identity?pending_identity_id=#{pending_identity_id}"
+        )
+
+      assert html =~ "Check your email"
+      assert html =~ "A verification code has been sent to your email address."
+      assert html =~ "pending_identity_id=#{pending_identity_id}"
+      refute html =~ actor.email
+      refute html =~ "Resend email"
     end
   end
 end

--- a/elixir/test/portal_web/live/sign_up_test.exs
+++ b/elixir/test/portal_web/live/sign_up_test.exs
@@ -33,7 +33,7 @@ defmodule PortalWeb.SignUpTest do
   describe "fill_form edge cases" do
     test "already-registered email shows email sent step", %{conn: conn} do
       email = "existing@example.com"
-      account_fixture(metadata: %{stripe: %{billing_email: email}})
+      account = account_fixture(metadata: %{stripe: %{billing_email: email}})
 
       {:ok, lv, _html} = live(conn, ~p"/sign_up")
 
@@ -49,6 +49,12 @@ defmodule PortalWeb.SignUpTest do
         |> render_submit()
 
       assert html =~ "Check your email"
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "http://localhost:13100/#{account.slug}"
+        refute email.text_body =~ "http://localhost:13100/#{account.id}"
+        true
+      end)
     end
 
     test "too-short company name stays on fill_form with errors", %{conn: conn} do

--- a/elixir/test/portal_web/live_hooks/redirect_if_authenticated_test.exs
+++ b/elixir/test/portal_web/live_hooks/redirect_if_authenticated_test.exs
@@ -107,7 +107,7 @@ defmodule PortalWeb.LiveHooks.RedirectIfAuthenticatedTest do
       {:ok, _view, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account.slug}/sign_in?as=client&nonce=test-nonce&state=test-state")
+        |> live(~p"/#{account}/sign_in?as=client&nonce=test-nonce&state=test-state")
 
       # Should render the sign-in page, not redirect to /sites
       assert html =~ "Sign In"
@@ -122,7 +122,7 @@ defmodule PortalWeb.LiveHooks.RedirectIfAuthenticatedTest do
       {:ok, _view, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account.slug}/sign_in?as=headless-client&state=test-state")
+        |> live(~p"/#{account}/sign_in?as=headless-client&state=test-state")
 
       assert html =~ "Sign In"
     end
@@ -136,7 +136,7 @@ defmodule PortalWeb.LiveHooks.RedirectIfAuthenticatedTest do
       {:ok, _view, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account.slug}/sign_in?as=gui-client&nonce=test-nonce&state=test-state")
+        |> live(~p"/#{account}/sign_in?as=gui-client&nonce=test-nonce&state=test-state")
 
       assert html =~ "Sign In"
     end
@@ -152,10 +152,10 @@ defmodule PortalWeb.LiveHooks.RedirectIfAuthenticatedTest do
       {:error, {:redirect, %{to: redirect_path}}} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account.slug}/sign_in")
+        |> live(~p"/#{account}/sign_in")
 
       # Should redirect to /sites (portal)
-      assert redirect_path == ~p"/#{account.slug}/sites"
+      assert redirect_path == ~p"/#{account}/sites"
     end
   end
 end

--- a/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
+++ b/elixir/test/portal_web/plugs/auto_redirect_default_provider_test.exs
@@ -209,7 +209,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
     } do
       provider = oidc_provider_fixture(account: account, is_default: true)
 
-      conn = get(conn, ~p"/#{account.slug}/sign_in?as=client&nonce=test-nonce&state=test-state")
+      conn = get(conn, ~p"/#{account}/sign_in?as=client&nonce=test-nonce&state=test-state")
 
       location = redirected_to(conn)
       assert location =~ "/sign_in/oidc/#{provider.id}"
@@ -224,7 +224,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
     } do
       provider = oidc_provider_fixture(account: account, is_default: true)
 
-      conn = get(conn, ~p"/#{account.slug}/sign_in?as=headless-client&state=test-state")
+      conn = get(conn, ~p"/#{account}/sign_in?as=headless-client&state=test-state")
 
       location = redirected_to(conn)
       assert location =~ "/sign_in/oidc/#{provider.id}"
@@ -239,7 +239,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
       provider = oidc_provider_fixture(account: account, is_default: true)
 
       conn =
-        get(conn, ~p"/#{account.slug}/sign_in?as=gui-client&nonce=test-nonce&state=test-state")
+        get(conn, ~p"/#{account}/sign_in?as=gui-client&nonce=test-nonce&state=test-state")
 
       location = redirected_to(conn)
       assert location =~ "/sign_in/oidc/#{provider.id}"
@@ -251,7 +251,7 @@ defmodule PortalWeb.Plugs.AutoRedirectDefaultProviderTest do
     test "does not redirect when no default provider", %{conn: conn, account: account} do
       _provider = oidc_provider_fixture(account: account, is_default: false)
 
-      conn = get(conn, ~p"/#{account.slug}/sign_in?as=client&state=test-state")
+      conn = get(conn, ~p"/#{account}/sign_in?as=client&state=test-state")
 
       assert html_response(conn, 200) =~ "Sign In"
     end

--- a/elixir/test/portal_web/plugs/redirect_if_authenticated_test.exs
+++ b/elixir/test/portal_web/plugs/redirect_if_authenticated_test.exs
@@ -26,7 +26,7 @@ defmodule PortalWeb.Plugs.RedirectIfAuthenticatedTest do
         |> RedirectIfAuthenticated.call([])
 
       assert conn.halted
-      assert redirected_to(conn) == ~p"/#{account.slug}/sites"
+      assert redirected_to(conn) == ~p"/#{account}/sites"
     end
 
     test "does not redirect authenticated user when as=client param is set", %{
@@ -101,7 +101,7 @@ defmodule PortalWeb.Plugs.RedirectIfAuthenticatedTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/#{account.slug}/sign_in?as=client&nonce=test-nonce&state=test-state")
+        |> get(~p"/#{account}/sign_in?as=client&nonce=test-nonce&state=test-state")
 
       # Should render the sign-in page (200)
       assert html_response(conn, 200) =~ "Sign In"
@@ -115,7 +115,7 @@ defmodule PortalWeb.Plugs.RedirectIfAuthenticatedTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/#{account.slug}/sign_in?as=headless-client&state=test-state")
+        |> get(~p"/#{account}/sign_in?as=headless-client&state=test-state")
 
       assert html_response(conn, 200) =~ "Sign In"
     end
@@ -128,7 +128,7 @@ defmodule PortalWeb.Plugs.RedirectIfAuthenticatedTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/#{account.slug}/sign_in?as=gui-client&nonce=test-nonce&state=test-state")
+        |> get(~p"/#{account}/sign_in?as=gui-client&nonce=test-nonce&state=test-state")
 
       assert html_response(conn, 200) =~ "Sign In"
     end
@@ -143,10 +143,10 @@ defmodule PortalWeb.Plugs.RedirectIfAuthenticatedTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/#{account.slug}/sign_in")
+        |> get(~p"/#{account}/sign_in")
 
       # Should redirect to /sites (portal)
-      assert redirected_to(conn) == ~p"/#{account.slug}/sites"
+      assert redirected_to(conn) == ~p"/#{account}/sites"
     end
 
     test "integration: authenticated user with default provider and as=client auto-redirects to provider",
@@ -164,7 +164,7 @@ defmodule PortalWeb.Plugs.RedirectIfAuthenticatedTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/#{account.slug}/sign_in?as=client&nonce=test-nonce&state=test-state")
+        |> get(~p"/#{account}/sign_in?as=client&nonce=test-nonce&state=test-state")
 
       # With a default provider and as=client, should redirect to the provider-specific URL with params intact
       location = redirected_to(conn)

--- a/elixir/test/support/fixtures/auth_provider_fixtures.ex
+++ b/elixir/test/support/fixtures/auth_provider_fixtures.ex
@@ -202,7 +202,7 @@ defmodule Portal.AuthProviderFixtures do
       |> Map.put_new(:issuer, "https://accounts.google.com")
       |> Map.put_new(:is_verified, true)
       |> Map.put_new(:is_disabled, false)
-      |> Map.put_new(:require_email_verified, true)
+      |> Map.put_new(:email_verification_method, :claim)
 
     {:ok, oidc_provider} =
       %Portal.OIDC.AuthProvider{}
@@ -215,7 +215,7 @@ defmodule Portal.AuthProviderFixtures do
         :client_secret,
         :discovery_document_uri,
         :issuer,
-        :require_email_verified,
+        :email_verification_method,
         :is_verified,
         :is_default,
         :is_disabled,


### PR DESCRIPTION
Updates the new email verification for the generic OIDC auth provider flow to add a `proof` method which requires the email to be confirmed with a OTP before the identity will be linked.

Uses a 15-minute cookie and a new table `pending_identities` that are tied together for each link attempt.

<img width="626" height="509" alt="Screenshot 2026-05-13 at 9 49 36 PM" src="https://github.com/user-attachments/assets/b46179c1-f242-475c-83f1-4a59bc6f0577" />

<img width="864" height="931" alt="Screenshot 2026-05-13 at 9 00 38 PM" src="https://github.com/user-attachments/assets/e1a9e761-f538-4dc7-812b-a28b10b04ae3" />

<img width="666" height="545" alt="Screenshot 2026-05-13 at 8 59 44 PM" src="https://github.com/user-attachments/assets/6f3ebd9a-8994-44c3-baae-f64189345168" />

---

Fixes #13233 

