### PR TITLE
refactor(tunnel): extract `UnixTsClock` helper

### DIFF
--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -9,6 +9,7 @@ use crate::gateway::flow_tracker::FlowTracker;
 use crate::messages::gateway::{Client, ResourceDescription, Subject};
 use crate::messages::{IceCredentials, ResolveRequest};
 use crate::peer_store::PeerStore;
+use crate::unix_ts::UnixTsClock;
 use crate::unroutable_packet::UnroutablePacket;
 use crate::{FailedToDecapsulate, GatewayEvent, IpConfig, p2p_control, packet_kind};
 use anyhow::{Context, ErrorExt, Result};
@@ -44,12 +45,7 @@ pub struct GatewayState {
 
     tun_ip_config: Option<IpConfig>,
 
-    /// [`Instant`] sampled at startup, paired with [`Self::start_unix_ts`].
-    ///
-    /// Together, these allow us to map a unix timestamp to an [`Instant`].
-    start_instant: Instant,
-    /// Unix timestamp at the time we sampled [`Self::start_instant`].
-    start_unix_ts: Duration,
+    unix_ts_clock: UnixTsClock,
 
     buffered_events: VecDeque<GatewayEvent>,
     buffered_transmits: VecDeque<Transmit>,
@@ -82,40 +78,8 @@ impl GatewayState {
             buffered_transmits: VecDeque::default(),
             flow_tracker: FlowTracker::new(flow_logs, now),
             tun_ip_config: None,
-            start_instant: now,
-            start_unix_ts: unix_ts,
+            unix_ts_clock: UnixTsClock::new(now, unix_ts),
         }
-    }
-
-    /// Maps a unix timestamp (`Duration` since `UNIX_EPOCH`) to an [`Instant`].
-    ///
-    /// Computes the delta between `unix_ts` and the unix timestamp captured at startup
-    /// and applies it to the `Instant` captured at startup.
-    ///
-    /// `unix_ts` arrives from the portal and is therefore untrusted:
-    /// - if it predates `start_unix_ts`, we clamp to `start_instant` so the
-    ///   resource is already expired against any later "now";
-    /// - if it would overflow [`Instant`], we log a warning and fall back to
-    ///   a 1-day expiry so access remains time-bounded.
-    fn instant_at(&self, unix_ts: Duration, now: Instant) -> Instant {
-        if unix_ts < self.start_unix_ts {
-            tracing::warn!(
-                unix_ts_secs = unix_ts.as_secs(),
-                start_unix_ts_secs = self.start_unix_ts.as_secs(),
-                "unix timestamp predates startup; treating as already expired",
-            );
-            return self.start_instant;
-        }
-
-        self.start_instant
-            .checked_add(unix_ts - self.start_unix_ts)
-            .unwrap_or_else(|| {
-                tracing::warn!(
-                    unix_ts_secs = unix_ts.as_secs(),
-                    "unix timestamp out of `Instant` range; falling back to 1 day expiry",
-                );
-                now + Duration::from_secs(86400)
-            })
     }
 
     #[cfg(all(test, feature = "proptest"))]
@@ -384,7 +348,7 @@ impl GatewayState {
     ) -> anyhow::Result<()> {
         let gateway_tun = self.tun_ip_config.context("TUN device not configured")?;
 
-        let expires_at = expires_at.map(|d| self.instant_at(d, now));
+        let expires_at = expires_at.map(|d| self.unix_ts_clock.instant_at(d, now));
         let expires_in = expires_at.map(|e| e.saturating_duration_since(now));
 
         tracing::info!(
@@ -419,7 +383,7 @@ impl GatewayState {
         expires_at: Duration,
         now: Instant,
     ) -> anyhow::Result<()> {
-        let new_expiry = self.instant_at(expires_at, now);
+        let new_expiry = self.unix_ts_clock.instant_at(expires_at, now);
         let expires_in = new_expiry.saturating_duration_since(now);
 
         tracing::info!(

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -51,6 +51,7 @@ mod sockets;
 #[allow(clippy::unwrap_in_result)]
 mod tests;
 mod unique_packet_buffer;
+mod unix_ts;
 mod unroutable_packet;
 mod utils;
 

--- a/rust/libs/connlib/tunnel/src/unix_ts.rs
+++ b/rust/libs/connlib/tunnel/src/unix_ts.rs
@@ -1,0 +1,79 @@
+use std::time::{Duration, Instant};
+
+/// Maps portal-supplied unix timestamps (`Duration` since `UNIX_EPOCH`) to
+/// monotonic [`Instant`]s.
+///
+/// Captures an `Instant` and a unix timestamp at startup, then converts
+/// later portal timestamps by applying the elapsed delta to the captured
+/// baseline `Instant`.
+#[derive(Debug, Clone, Copy)]
+pub struct UnixTsClock {
+    start_instant: Instant,
+    start_unix_ts: Duration,
+}
+
+impl UnixTsClock {
+    pub fn new(now: Instant, unix_ts: Duration) -> Self {
+        Self {
+            start_instant: now,
+            start_unix_ts: unix_ts,
+        }
+    }
+
+    /// Map a unix timestamp to an [`Instant`].
+    ///
+    /// `unix_ts` arrives from the portal and is therefore untrusted:
+    /// - if it predates `start_unix_ts`, clamp to `start_instant` so the
+    ///   resource is already expired against any later `now`;
+    /// - if it would overflow `Instant`, log a warning and fall back to a
+    ///   1-day expiry so access remains time-bounded.
+    pub fn instant_at(&self, unix_ts: Duration, now: Instant) -> Instant {
+        if unix_ts < self.start_unix_ts {
+            tracing::warn!(
+                ?unix_ts,
+                start_unix_ts = ?self.start_unix_ts,
+                "unix timestamp predates startup; treating as already expired",
+            );
+            return self.start_instant;
+        }
+
+        self.start_instant
+            .checked_add(unix_ts - self.start_unix_ts)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    ?unix_ts,
+                    "unix timestamp out of `Instant` range; falling back to 1 day expiry",
+                );
+                now + Duration::from_secs(86400)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forward_offset() {
+        let now = Instant::now();
+        let baseline_unix = Duration::from_secs(1_700_000_000);
+        let clock = UnixTsClock::new(now, baseline_unix);
+        let later_unix = baseline_unix + Duration::from_secs(30);
+        assert_eq!(
+            clock.instant_at(later_unix, now),
+            now + Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn past_timestamp_clamps_to_start() {
+        let now = Instant::now();
+        let baseline_unix = Duration::from_secs(1_700_000_000);
+        let clock = UnixTsClock::new(now, baseline_unix);
+        let earlier_unix = baseline_unix - Duration::from_secs(10);
+        assert_eq!(
+            clock.instant_at(earlier_unix, now + Duration::from_secs(60)),
+            now
+        );
+    }
+}


### PR DESCRIPTION
Extract the `(Instant, Duration)` baseline + `instant_at(unix_ts, now)` conversion that lives on `GatewayState` into a small `UnixTsClock` helper.

Related: #13263
Related: #13118