### PR TITLE
ci: update macOS runners to macos-26

### DIFF
--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: analyze-${{ matrix.working-directory }}
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-14') || 'ubuntu-24.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-15') || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: analyze-${{ matrix.working-directory }}
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-15') || 'ubuntu-24.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-26') || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-24.04, macos-15, windows-2022]
+        runs-on: [ubuntu-24.04, macos-26, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -83,7 +83,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-24.04, macos-15, windows-2022]
+        runs-on: [ubuntu-24.04, macos-26, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-24.04, macos-14, windows-2022]
+        runs-on: [ubuntu-24.04, macos-15, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -83,7 +83,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-24.04, macos-14, windows-2022]
+        runs-on: [ubuntu-24.04, macos-15, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       XCODE_VERSION: "26.2"
     steps:
@@ -49,7 +49,7 @@ jobs:
           fail-on-error: false
 
   static-analysis:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       XCODE_VERSION: "26.2"
     steps:
@@ -66,7 +66,7 @@ jobs:
     # Skip builds on CD (push to main) - only needed for PR validation and releases
     if: github.event_name != 'push'
     needs: update-release-draft
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       XCODE_VERSION: "26.2"
       MISE_EXPERIMENTAL: "1"


### PR DESCRIPTION
MacOS 14 runners are being deprecated and we need to move to newer versions. MacOS 26 runners are now GA so we update to that. Unfortunately, macOS-15 runners also had problems.

Related: https://github.com/actions/runner-images/issues/13518
Related: https://github.com/actions/runner-images/issues/13739