### PR TITLE
ci: use same planner on merge_group as on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,13 @@ jobs:
             echo "Changed files:"
             cat changed_files.txt
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            git fetch origin ${{ github.event.merge_group.base_sha }} --depth=1
-            git diff --name-only ${{ github.event.merge_group.base_sha }} ${{ github.sha }} > changed_files.txt
+            base_sha="${{ github.event.merge_group.base_sha }}"
+            git fetch origin "$base_sha" --depth=1
+            if ! git cat-file -e "${base_sha}^{commit}"; then
+              echo "::error::merge_group base SHA $base_sha not available after fetch" >&2
+              exit 1
+            fi
+            git diff --name-only "$base_sha" ${{ github.sha }} > changed_files.txt
 
             echo "Changed files:"
             cat changed_files.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,17 +53,16 @@ jobs:
             exit 0;
           fi
 
-          # For merge group, run all jobs
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            echo "jobs_to_run=$jobs" >> "$GITHUB_OUTPUT"
-
-            exit 0;
-          fi
-
-          # Fetch base ref for PRs
+          # Fetch base ref for PRs and merge group
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin ${{ github.base_ref }} --depth=1
             git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} > changed_files.txt
+
+            echo "Changed files:"
+            cat changed_files.txt
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            git fetch origin ${{ github.event.merge_group.base_sha }} --depth=1
+            git diff --name-only ${{ github.event.merge_group.base_sha }} ${{ github.sha }} > changed_files.txt
 
             echo "Changed files:"
             cat changed_files.txt


### PR DESCRIPTION
Previously the planner short-circuited to "run every job" on merge_group
events, so Tauri, Kotlin, Swift, loadtest, etc. all rebuilt even when the
queued change couldn't possibly affect them.

Compute changed_files.txt the same way as for pull_request, using
github.event.merge_group.base_sha as the diff base. The existing path
rules below stay untouched.

Cross-PR semantic-conflict catching is preserved: when two PRs are queued
together the diff is computed against the combined merge-group head, so
any path either PR touched still triggers the relevant jobs.