### PR TITLE
ci: use upstream `mise` action

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -22,8 +22,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       run: echo "MISE_INSTALLS_DIR=C:\.mise-installs" >> "$GITHUB_ENV"
 
-    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      if: ${{ runner.os != 'Windows' }}
+    - uses: jdx/mise-action@93ca8a4cef410a93642d35fc79bc9e08a145a17e # main
       id: mise-1
       continue-on-error: true
       with:
@@ -32,8 +31,8 @@ runs:
         reshim: true
         cache_key_prefix: "mise-v2"
 
-    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      if: ${{ runner.os != 'Windows' && steps.mise-1.outcome == 'failure' }}
+    - uses: jdx/mise-action@93ca8a4cef410a93642d35fc79bc9e08a145a17e # main
+      if: ${{ steps.mise-1.outcome == 'failure' }}
       id: mise-2
       continue-on-error: true
       with:
@@ -42,70 +41,10 @@ runs:
         reshim: true
         cache_key_prefix: "mise-v2"
 
-    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      if: ${{ runner.os != 'Windows' && steps.mise-2.outcome == 'failure' }}
+    - uses: jdx/mise-action@93ca8a4cef410a93642d35fc79bc9e08a145a17e # main
+      if: ${{ steps.mise-2.outcome == 'failure' }}
       with:
         version: ${{ inputs.version }}
         install_args: ${{ inputs.install_args }}
         reshim: true
         cache_key_prefix: "mise-v2"
-
-    # jdx/mise-action on Windows does not bundle `mise-shim.exe`, so cargo
-    # subcommand discovery (`cargo udeps` -> `cargo-udeps.exe`) silently fails
-    # because reshim has nothing to copy into the shims directory. Install mise
-    # manually from the upstream release zip, which contains both `mise.exe`
-    # and `mise-shim.exe`.
-    # We can remove this once https://github.com/jdx/mise-action/issues/475 ships.
-    - name: Install mise (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = "Stop"
-        $version = "${{ inputs.version }}"
-        $url = "https://github.com/jdx/mise/releases/download/v$version/mise-v$version-windows-x64.zip"
-        $zip = "$env:RUNNER_TEMP\mise.zip"
-        $extracted = "$env:RUNNER_TEMP\mise-extracted"
-        $installDir = "C:\mise"
-
-        for ($attempt = 1; $attempt -le 3; $attempt++) {
-          try {
-            Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
-            break
-          } catch {
-            if ($attempt -eq 3) { throw }
-            Write-Host "Download attempt $attempt failed: $_"
-            Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
-          }
-        }
-
-        Expand-Archive -Path $zip -DestinationPath $extracted -Force
-        New-Item -ItemType Directory -Force -Path "$installDir\bin" | Out-Null
-        Copy-Item "$extracted\mise\bin\mise.exe" "$installDir\bin\mise.exe" -Force
-        Copy-Item "$extracted\mise\bin\mise-shim.exe" "$installDir\bin\mise-shim.exe" -Force
-
-        Add-Content -Path $env:GITHUB_PATH -Value "$installDir\bin"
-        Add-Content -Path $env:GITHUB_PATH -Value "$env:LOCALAPPDATA\mise\shims"
-
-    - name: mise install (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = "Stop"
-        & "C:\mise\bin\mise.exe" trust --all
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-        $installArgs = @()
-        if ("${{ inputs.install_args }}".Trim().Length -gt 0) {
-          $installArgs = "${{ inputs.install_args }}".Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries)
-        }
-
-        for ($attempt = 1; $attempt -le 3; $attempt++) {
-          & "C:\mise\bin\mise.exe" install @installArgs
-          if ($LASTEXITCODE -eq 0) { break }
-          if ($attempt -eq 3) { exit $LASTEXITCODE }
-          Write-Host "mise install attempt $attempt failed (exit $LASTEXITCODE)"
-          Start-Sleep -Seconds ([Math]::Pow(2, $attempt + 1))
-        }
-
-        & "C:\mise\bin\mise.exe" reshim
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
Upstream has fixed the bug where `mise-shim.exe` was not installed as part of the action which caused `cargo` subcommands to not be discovered. The update is not released yet but we can pin the action to a SHA on `main` to make use of it.

Related: https://github.com/jdx/mise-action/pull/476