### PR TITLE
feat(windows): pin pipe DACLs to MSIX package SID

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_variant",
+ "sha2",
  "specta",
  "specta-typescript",
  "strum",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -121,6 +121,7 @@ features = [
 
 [build-dependencies]
 anyhow = { workspace = true }
+sha2 = { workspace = true }
 tauri-build = { workspace = true, features = [] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/rust/gui-client/src-tauri/build.rs
+++ b/rust/gui-client/src-tauri/build.rs
@@ -2,11 +2,7 @@ use anyhow::Result;
 use sha2::{Digest as _, Sha256};
 
 /// `Name` half of the Package Family Name. Must match
-/// `<Identity Name="…"/>` in `win_files/AppxManifest.xml`; the
-/// install canary
-/// (`scripts/tests/tunnel-pipe-dacl-windows.ps1`) fails loudly
-/// if any of `PACKAGE_NAME`, `PUBLISHER_DN`, or the algorithms
-/// below drift from what the kernel produces.
+/// `<Identity Name="…"/>` in `win_files/AppxManifest.xml`.
 const PACKAGE_NAME: &str = "Firezone.Client.GUI";
 
 /// Publisher cert Subject DN (canonical form, post-XML-entity-decoding).

--- a/rust/gui-client/src-tauri/build.rs
+++ b/rust/gui-client/src-tauri/build.rs
@@ -1,6 +1,29 @@
-fn main() -> anyhow::Result<()> {
+use anyhow::Result;
+use sha2::{Digest as _, Sha256};
+
+/// `Name` half of the Package Family Name. Must match
+/// `<Identity Name="…"/>` in `win_files/AppxManifest.xml`; the
+/// install canary
+/// (`scripts/tests/tunnel-pipe-dacl-windows.ps1`) fails loudly
+/// if any of `PACKAGE_NAME`, `PUBLISHER_DN`, or the algorithms
+/// below drift from what the kernel produces.
+const PACKAGE_NAME: &str = "Firezone.Client.GUI";
+
+/// Publisher cert Subject DN (canonical form, post-XML-entity-decoding).
+/// Must match `<Identity Publisher="…"/>` in
+/// `win_files/AppxManifest.xml` after `&quot;` -> `"` decoding.
+const PUBLISHER_DN: &str = "CN=\"Firezone, Inc.\", \
+    O=\"Firezone, Inc.\", \
+    STREET=\"2261 Market Street, Suite 4574\", \
+    L=San Francisco, S=California, C=US, \
+    OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
+    OID.1.3.6.1.4.1.311.60.2.1.3=US, \
+    SERIALNUMBER=6383880, \
+    OID.2.5.4.15=Private Organization";
+
+fn main() -> Result<()> {
     // Skip tauri-build's default Common-Controls manifest: we embed
-    // our own SXS / fusion manifest below — only into `Firezone.exe`,
+    // our own SXS / fusion manifest below -- only into `Firezone.exe`,
     // not into the tunnel-service or register-sparse binaries (SCM-
     // launched services with an embedded `<msix>` identity claim
     // hang on startup, and the helper has no use for identity).
@@ -23,5 +46,75 @@ fn main() -> anyhow::Result<()> {
 
     println!("cargo:rerun-if-changed=../website/public/policy-templates/windows/firezone.admx");
 
+    let pfn = format!("{PACKAGE_NAME}_{}", publisher_id(PUBLISHER_DN));
+    let sid = package_sid(&pfn);
+    println!("cargo:rustc-env=FIREZONE_PACKAGE_FAMILY_NAME={pfn}");
+    println!("cargo:rustc-env=FIREZONE_PACKAGE_SID={sid}");
+
     Ok(())
+}
+
+/// SHA-256 of the input encoded as UTF-16 LE (no null terminator).
+/// Both Windows hashes we compute -- publisher ID and package SID --
+/// feed bytes in this encoding to SHA-256.
+fn sha256_utf16le(s: &str) -> [u8; 32] {
+    let bytes: Vec<u8> = s.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    Sha256::digest(&bytes).into()
+}
+
+/// Crockford base32 alphabet Windows uses for the publisher ID half
+/// of a PFN: digits + lowercase letters minus `i`, `l`, `o`, `u`
+/// (visually-confusable chars).
+const CROCKFORD: &[u8; 32] = b"0123456789abcdefghjkmnpqrstvwxyz";
+
+/// Encodes a 9-byte (72-bit) buffer as a 13-character Crockford
+/// string. The MSB of byte 0 lands in the first output char's high
+/// bits; the trailing 7 bits of byte 8 fill out the last char (the
+/// 13 * 5 = 65 output bits fit the 72 input bits with 7 to spare).
+fn crockford13(input: &[u8; 9]) -> String {
+    let mut value: u128 = 0;
+    for &b in input {
+        value = (value << 8) | u128::from(b);
+    }
+    let mut out = String::with_capacity(13);
+    for i in 0..13 {
+        let shift = (12 - i) * 5 + 7;
+        let idx = ((value >> shift) & 0x1f) as usize;
+        out.push(CROCKFORD[idx] as char);
+    }
+    out
+}
+
+/// The publisher ID is the 13-char Crockford-base32 hash of the
+/// publisher's cert Subject DN. Windows requires PFNs in the form
+/// `Name_publisherId`, so this is half of the PFN derivation.
+fn publisher_id(publisher: &str) -> String {
+    let h = sha256_utf16le(publisher);
+    let mut buf = [0u8; 9];
+    buf[..8].copy_from_slice(&h[..8]);
+    crockford13(&buf)
+}
+
+/// Reverse-engineered equivalent of
+/// `DeriveAppContainerSidFromAppContainerName`: lowercase the PFN,
+/// SHA-256 the UTF-16 LE bytes, split the first 28 bytes of the
+/// digest into 7 × u32 little-endian, and prefix with
+/// `S-1-15-2-…` (the AppPackage authority + base RID). The
+/// final 4 bytes of the 32-byte SHA-256 digest are *not* used --
+/// the kernel API truncates to 28 bytes (verified empirically
+/// against `DeriveAppContainerSidFromAppContainerName` for
+/// Firezone's PFN; the install canary catches drift).
+fn package_sid(pfn: &str) -> String {
+    let h = sha256_utf16le(&pfn.to_lowercase());
+    let dword = |i: usize| u32::from_le_bytes(h[i..i + 4].try_into().expect("4 bytes"));
+    format!(
+        "S-1-15-2-{}-{}-{}-{}-{}-{}-{}",
+        dword(0),
+        dword(4),
+        dword(8),
+        dword(12),
+        dword(16),
+        dword(20),
+        dword(24),
+    )
 }

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -31,11 +31,8 @@ use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
 ///   check in [`is_pipe_owned_by_local_system`] to reject the
 ///   legitimate pipe.
 /// - ACEs: Full Access for `LocalSystem` and `BUILTIN\Administrators`;
-///   `FILE_GENERIC_READ | FILE_GENERIC_WRITE | SYNCHRONIZE` for
-///   `BUILTIN\Users`. The `BU` alias is the one the non-admin GUI
-///   runs under and excludes `NETWORK SERVICE`, `LOCAL SERVICE`,
-///   `ANONYMOUS LOGON`, IIS app pool identities, and arbitrary new
-///   service accounts (unlike `AU`).
+///   `FILE_GENERIC_READ | FILE_GENERIC_WRITE | SYNCHRONIZE` for the
+///   Firezone MSIX package SID (baked at build time by `build.rs`).
 ///
 /// In debug builds the Tunnel pipe may also be opened without the
 /// `Owner` pin — see [`skip_tunnel_pipe_owner_check`] — so the
@@ -43,13 +40,16 @@ use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
 /// subprocess of the test runner (not as a service running under
 /// LocalSystem), doesn't fail `CreateNamedPipeW` with
 /// `ERROR_INVALID_OWNER` (1307). Smoke tests fall back to
-/// [`gui_pipe_dacl`] for that reason.
+/// [`test_pipe_dacl`] for that reason.
 fn tunnel_pipe_dacl() -> PipeDacl {
     PipeDacl::new()
         .owner(Trustee::local_system())
         .allow(FileRights::FullAccess, Trustee::local_system())
         .allow(FileRights::FullAccess, Trustee::builtin_administrators())
-        .allow(FileRights::ReadWrite, Trustee::builtin_users())
+        .allow(
+            FileRights::ReadWrite,
+            Trustee::from_sid_string(crate::PACKAGE_SID),
+        )
 }
 
 /// Security descriptor for the GUI pipe.
@@ -59,6 +59,23 @@ fn tunnel_pipe_dacl() -> PipeDacl {
 /// outside its own token. The GUI pipe's owner isn't validated by
 /// clients, so leaving it at the token default is fine.
 fn gui_pipe_dacl() -> PipeDacl {
+    PipeDacl::new()
+        .allow(FileRights::FullAccess, Trustee::local_system())
+        .allow(FileRights::FullAccess, Trustee::builtin_administrators())
+        .allow(
+            FileRights::ReadWrite,
+            Trustee::from_sid_string(crate::PACKAGE_SID),
+        )
+}
+
+/// Relaxed DACL for test contexts (gui-smoke-test, `SocketId::Test`
+/// unit tests). The production DACLs grant read/write only to
+/// processes carrying the Firezone package SID -- but a `cargo run`
+/// / `cargo test` process has no MSIX identity, so opening either
+/// pipe would fail with `ERROR_ACCESS_DENIED`. Grant `BUILTIN\Users`
+/// instead so the test process can act as both server and client.
+#[cfg(any(debug_assertions, test))]
+fn test_pipe_dacl() -> PipeDacl {
     PipeDacl::new()
         .allow(FileRights::FullAccess, Trustee::local_system())
         .allow(FileRights::FullAccess, Trustee::builtin_administrators())
@@ -137,12 +154,12 @@ impl Server {
         let dacl = match id {
             #[cfg(debug_assertions)]
             SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => {
-                gui_pipe_dacl()
+                test_pipe_dacl()
             }
             SocketId::Tunnel => tunnel_pipe_dacl(),
             SocketId::Gui => gui_pipe_dacl(),
             #[cfg(test)]
-            SocketId::Test(_) => gui_pipe_dacl(),
+            SocketId::Test(_) => test_pipe_dacl(),
         };
         Ok(Self {
             socket_id: id,
@@ -248,7 +265,6 @@ fn create_pipe_server(
     }
 }
 
-/// Named pipe for an IPC connection.
 fn ipc_path(id: SocketId) -> String {
     let name = match id {
         SocketId::Tunnel => format!("{}_tunnel.ipc", crate::BUNDLE_ID),

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -38,14 +38,20 @@ pub const RELEASE: &str = concat!("gui-client@", env!("CARGO_PKG_VERSION"));
 
 pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 
-/// `Name_publisherId` derived from `win_files/AppxManifest.xml`. The
-/// `publisherId` half is the Crockford-base32 hash of the cert
-/// Subject DN that signs the sparse MSIX, so this value only
-/// changes when the cert rotates. Used as a runtime input to
-/// `windows_security::pipe_dacl::Trustee::from_package_family_name`
-/// for the pipe DACL ACEs that pin access to the
-/// MSIX-registered Firezone binaries.
-pub const PACKAGE_FAMILY_NAME: &str = "Firezone.Client.GUI_r4567a5vks0bt";
+/// `Name_publisherId` for the sparse MSIX. Derived at build time
+/// from the manifest's `Name` + Publisher DN in `build.rs`. Used by
+/// `register-sparse.exe` to stage / provision / deprovision the
+/// package against the AppX deployment service.
+pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
+
+/// AppContainer SID for [`PACKAGE_FAMILY_NAME`], derived at build
+/// time. Baked in so the tunnel pipe DACL is deterministic. The
+/// install canary
+/// (`scripts/tests/tunnel-pipe-dacl-windows.ps1`) cross-checks
+/// this against what the kernel actually attaches to
+/// MSIX-registered processes -- any drift fails CI on the next
+/// push.
+pub const PACKAGE_SID: &str = env!("FIREZONE_PACKAGE_SID");
 
 #[cfg(target_os = "linux")]
 pub fn firezone_client_group() -> anyhow::Result<nix::unistd::Group> {

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -45,12 +45,7 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 
 /// AppContainer SID for [`PACKAGE_FAMILY_NAME`], derived at build
-/// time. Baked in so the tunnel pipe DACL is deterministic. The
-/// install canary
-/// (`scripts/tests/tunnel-pipe-dacl-windows.ps1`) cross-checks
-/// this against what the kernel actually attaches to
-/// MSIX-registered processes -- any drift fails CI on the next
-/// push.
+/// time. Baked in so the tunnel pipe DACL is deterministic.
 pub const PACKAGE_SID: &str = env!("FIREZONE_PACKAGE_SID");
 
 #[cfg(target_os = "linux")]

--- a/rust/libs/windows-security/src/pipe_dacl.rs
+++ b/rust/libs/windows-security/src/pipe_dacl.rs
@@ -85,6 +85,16 @@ impl Trustee {
         Ok(Self(Cow::Owned(sid)))
     }
 
+    /// Wraps a pre-computed SID string (typically a `pub const`
+    /// emitted from `build.rs`). The caller owns ensuring the input
+    /// is a well-formed SDDL SID like `S-1-5-32-544` or
+    /// `S-1-15-2-…`; we just hand it through to the SDDL builder
+    /// unchanged. Useful for baking AppContainer / Package SIDs at
+    /// compile time and skipping the runtime kernel-API call.
+    pub const fn from_sid_string(sid: &'static str) -> Self {
+        Self(Cow::Borrowed(sid))
+    }
+
     /// The string Windows expects for this trustee inside an SDDL
     /// ACE — `"SY"` for an alias, `"S-1-…"` for a SID.
     pub fn as_sddl_str(&self) -> &str {
@@ -260,5 +270,17 @@ mod tests {
             "expected S-1-15-2-… SID, got `{}`",
             trustee.as_sddl_str()
         );
+    }
+
+    /// `from_sid_string` is an infallible wrapper -- the input flows
+    /// straight to the SDDL builder. Test that it round-trips a
+    /// build-time-baked SID through `PipeDacl::Display` unchanged.
+    #[test]
+    fn from_sid_string_round_trips_through_dacl() {
+        const SID: &str = "S-1-15-2-1-2-3-4-5-6-7-8";
+        let dacl = PipeDacl::new()
+            .allow(FileRights::ReadWrite, Trustee::from_sid_string(SID))
+            .to_string();
+        assert_eq!(dacl, format!("D:P(A;;FRFW;;;{SID})"));
     }
 }

--- a/rust/libs/windows-security/src/pipe_dacl.rs
+++ b/rust/libs/windows-security/src/pipe_dacl.rs
@@ -42,9 +42,9 @@ impl FileRights {
 }
 
 /// A trustee — either a fixed two-letter SDDL alias (`SY`, `BA`,
-/// `BU`) or a process-derived SID string like `S-1-15-2-…`. There is
-/// no public string-based constructor; the SID variants come from
-/// Windows APIs that read kernel state.
+/// `BU`) or a SID string like `S-1-15-2-…`. SIDs come from
+/// `from_sid_string` (compile-time-baked) or
+/// `from_package_family_name` (runtime kernel lookup).
 #[derive(Debug, Clone)]
 pub struct Trustee(Cow<'static, str>);
 

--- a/scripts/tests/expect-pipe-denied-lua-windows.ps1
+++ b/scripts/tests/expect-pipe-denied-lua-windows.ps1
@@ -1,0 +1,127 @@
+# Open the given Windows named pipe under a LUA-filtered token --
+# the same restricted token UAC hands non-elevated apps -- and
+# assert that `CreateFileW` fails with `ACCESS_DENIED`. Catches DACL
+# regressions where the pipe grants access to `BUILTIN\Users` (or
+# anything else a typical non-admin caller is in), letting any
+# same-user process drive it.
+#
+# Spawning an unelevated child in CI is awkward (no interactive
+# desktop, no `runas` keychain), so we drop privileges in-process:
+# `CreateRestrictedToken(LUA_TOKEN)` builds the same filtered token
+# UAC produces (Administrators becomes deny-only, integrity drops
+# to Medium); `ImpersonateLoggedOnUser` installs it on the current
+# thread; the kernel then performs the named-pipe access check
+# against the impersonation token.
+#
+# Safe against single-client pipes like `debug single-instance`:
+# the kernel performs the DACL check *before* the server's
+# `ConnectNamedPipe` returns, so a denied open never consumes the
+# accept slot.
+
+param(
+    [Parameter(Mandatory)]
+    [string]$PipePath
+)
+
+$ErrorActionPreference = "Stop"
+
+Add-Type -MemberDefinition @"
+[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+public static extern IntPtr CreateFileW(
+    string lpFileName, uint dwDesiredAccess, uint dwShareMode,
+    IntPtr lpSecurityAttributes, uint dwCreationDisposition,
+    uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool CloseHandle(IntPtr hObject);
+
+[DllImport("advapi32.dll", SetLastError = true)]
+public static extern bool OpenProcessToken(
+    IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);
+
+[DllImport("advapi32.dll", SetLastError = true)]
+public static extern bool CreateRestrictedToken(
+    IntPtr ExistingTokenHandle, uint Flags,
+    uint DisableSidCount, IntPtr SidsToDisable,
+    uint DeletePrivilegeCount, IntPtr PrivilegesToDelete,
+    uint RestrictedSidCount, IntPtr SidsToRestrict,
+    out IntPtr NewTokenHandle);
+
+[DllImport("advapi32.dll", SetLastError = true)]
+public static extern bool ImpersonateLoggedOnUser(IntPtr hToken);
+
+[DllImport("advapi32.dll", SetLastError = true)]
+public static extern bool RevertToSelf();
+
+[DllImport("kernel32.dll")]
+public static extern IntPtr GetCurrentProcess();
+"@ -Name PipeProbe -Namespace W32
+
+$READ_CONTROL = 0x20000
+$OPEN_EXISTING = 3
+$INVALID_HANDLE = [IntPtr]::new(-1)
+$ERROR_FILE_NOT_FOUND = 2
+$ERROR_ACCESS_DENIED = 5
+$TOKEN_DUPLICATE_QUERY = 0x0A  # TOKEN_DUPLICATE (0x2) | TOKEN_QUERY (0x8)
+$LUA_TOKEN = 0x4
+
+$procToken = [IntPtr]::Zero
+if (-not [W32.PipeProbe]::OpenProcessToken(
+    [W32.PipeProbe]::GetCurrentProcess(), $TOKEN_DUPLICATE_QUERY, [ref]$procToken)) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Error "OpenProcessToken failed (err=$err)"
+    exit 1
+}
+
+$luaToken = [IntPtr]::Zero
+$ok = [W32.PipeProbe]::CreateRestrictedToken(
+    $procToken, $LUA_TOKEN, 0, [IntPtr]::Zero, 0, [IntPtr]::Zero,
+    0, [IntPtr]::Zero, [ref]$luaToken
+)
+[W32.PipeProbe]::CloseHandle($procToken) | Out-Null
+if (-not $ok) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Error "CreateRestrictedToken failed (err=$err)"
+    exit 1
+}
+
+if (-not [W32.PipeProbe]::ImpersonateLoggedOnUser($luaToken)) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    [W32.PipeProbe]::CloseHandle($luaToken) | Out-Null
+    Write-Error "ImpersonateLoggedOnUser failed (err=$err)"
+    exit 1
+}
+
+# Under the LUA-filtered token, `BUILTIN\Administrators` is
+# deny-only and we don't carry the package SID, so the only
+# possible match is the `LocalSystem` ACE (we aren't), leaving us
+# with `ERROR_ACCESS_DENIED`. The pipe server may still be coming
+# up (single-instance binds the GUI pipe after process start), so
+# retry while `CreateFileW` returns `ERROR_FILE_NOT_FOUND`. A
+# denied open does not consume the server's accept slot.
+$h = $INVALID_HANDLE
+$lastError = 0
+for ($i = 0; $i -lt 50; $i++) {
+    $h = [W32.PipeProbe]::CreateFileW(
+        $PipePath, $READ_CONTROL, 0, [IntPtr]::Zero, $OPEN_EXISTING, 0, [IntPtr]::Zero
+    )
+    $lastError = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($h -ne $INVALID_HANDLE -or $lastError -ne $ERROR_FILE_NOT_FOUND) { break }
+    Start-Sleep -Milliseconds 100
+}
+
+[W32.PipeProbe]::RevertToSelf() | Out-Null
+[W32.PipeProbe]::CloseHandle($luaToken) | Out-Null
+
+if ($h -ne $INVALID_HANDLE) {
+    [W32.PipeProbe]::CloseHandle($h) | Out-Null
+    Write-Error "${PipePath} accepted a LUA-filtered open -- DACL did not pin access"
+    exit 1
+}
+
+if ($lastError -ne $ERROR_ACCESS_DENIED) {
+    Write-Error "expected ERROR_ACCESS_DENIED ($ERROR_ACCESS_DENIED) opening ${PipePath} under LUA token; got err=$lastError"
+    exit 1
+}
+
+Write-Output "${PipePath} correctly denied non-Firezone-signed (LUA-filtered) open (err=$lastError ERROR_ACCESS_DENIED)"

--- a/scripts/tests/gui-client-install-windows-msi.ps1
+++ b/scripts/tests/gui-client-install-windows-msi.ps1
@@ -63,6 +63,14 @@ try {
     Write-Output "==> Verifying Firezone.exe has package identity attached..."
     & "$scriptDir\gui-package-identity-windows.ps1" -ProcessId $proc.Id
     Write-Output "==> Package identity attached to Firezone.exe"
+
+    Write-Output "==> Verifying tunnel pipe denies non-Firezone-signed callers..."
+    & "$scriptDir\expect-pipe-denied-lua-windows.ps1" -PipePath '\\.\pipe\dev.firezone.client_tunnel.ipc'
+    Write-Output "==> Tunnel pipe DACL pinned to package SID"
+
+    Write-Output "==> Verifying GUI pipe denies non-Firezone-signed callers..."
+    & "$scriptDir\expect-pipe-denied-lua-windows.ps1" -PipePath '\\.\pipe\dev.firezone.client_gui.ipc'
+    Write-Output "==> GUI pipe DACL pinned to package SID"
 }
 finally {
     Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -32,6 +32,13 @@ export default function GUI({ os }: { os: OS }) {
             no longer drive the tunnel.
           </ChangeItem>
         )}
+        {os == OS.Windows && (
+          <ChangeItem pull={13275}>
+            Restricts the tunnel and GUI named pipes to processes carrying the
+            Firezone MSIX package SID, so other processes running as the same
+            user can no longer drive the tunnel or hijack deep links.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.5.12" date={new Date("2026-04-27")}>
         <ChangeItem pull={12684}>


### PR DESCRIPTION
Pins the Tunnel and GUI named-pipe DACLs to the Firezone MSIX package SID instead of the previous `BUILTIN\Users` grant, so same-user but non-Firezone processes can no longer drive the tunnel or hijack the GUI deep-link pipe.

`build.rs` derives `PACKAGE_SID` at compile time using `SHA-256(lowercased PFN)` -> 8-DWORD AppContainer SID, the same algorithm `DeriveAppContainerSidFromAppContainerName` runs and emits it as a `pub const` on `firezone_gui_client`.

To verify the effectiveness of this change, the test-install script attempts to connect to both the GUI and the Tunnel pipe using a non-elevated, non-Firezone package SID token and asserts that in both cases, we receive an "Access Denied" from the Windows kernel.

Related: #13274
Related: #13375