### PR TITLE
ci: fix macOS cargo llvm-cov failure on macos-26 image

### DIFF
--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -62,3 +62,13 @@ runs:
         components: rustfmt,clippy,llvm-tools-preview
         target: ${{ inputs.targets }}
         cache: false # We explicitly configure caching somewhere else.
+
+    # Workaround for actions/runner-images#14099: the macos-26 image pre-installs
+    # rustup via Homebrew, which leaves /opt/homebrew/bin/cargo ahead of
+    # ~/.cargo/bin/cargo on PATH. The Homebrew shim is currently broken and
+    # rejects valid cargo argv (e.g. `cargo llvm-cov` -> "unexpected argument
+    # 'llvm-cov'"). Force the toolchain proxies to win PATH resolution.
+    - name: Prepend ~/.cargo/bin to PATH (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -30,45 +30,25 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Extract Rust version
-      run: |
-        RUST_TOOLCHAIN=$(grep 'channel' rust/rust-toolchain.toml | awk -F '"' '{print $2}')
-        echo "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" >> $GITHUB_ENV
-      shell: bash
-
-    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-      id: toolchain-1
-      continue-on-error: true
-      with:
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-        components: rustfmt,clippy,llvm-tools-preview
-        target: ${{ inputs.targets }}
-        cache: false # We explicitly configure caching somewhere else.
-
-    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-      if: ${{ steps.toolchain-1.outcome == 'failure' }}
-      continue-on-error: true
-      id: toolchain-2
-      with:
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-        components: rustfmt,clippy,llvm-tools-preview
-        target: ${{ inputs.targets }}
-        cache: false # We explicitly configure caching somewhere else.
-
-    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-      if: ${{ steps.toolchain-2.outcome == 'failure' }}
-      with:
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-        components: rustfmt,clippy,llvm-tools-preview
-        target: ${{ inputs.targets }}
-        cache: false # We explicitly configure caching somewhere else.
-
-    # Workaround for actions/runner-images#14099: the macos-26 image pre-installs
-    # rustup via Homebrew, which leaves /opt/homebrew/bin/cargo ahead of
-    # ~/.cargo/bin/cargo on PATH. The Homebrew shim is currently broken and
-    # rejects valid cargo argv (e.g. `cargo llvm-cov` -> "unexpected argument
-    # 'llvm-cov'"). Force the toolchain proxies to win PATH resolution.
-    - name: Prepend ~/.cargo/bin to PATH (macOS)
+    # macos-26 ships a broken Homebrew rustup formula whose proxies reject
+    # cargo argv (actions/runner-images#14099, #14097). Replace it with an
+    # official install so PATH resolution is clean.
+    - name: Replace Homebrew rustup with official install (macOS)
       if: runner.os == 'macOS'
       shell: bash
-      run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      run: |
+        brew uninstall --ignore-dependencies rustup 2>/dev/null || true
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+          | sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+    # Auto-installs the channel + components pinned in rust/rust-toolchain.toml.
+    - name: Install pinned Rust toolchain
+      shell: bash
+      working-directory: rust
+      run: rustup show
+
+    - name: Install additional targets
+      if: ${{ inputs.targets != '' }}
+      shell: bash
+      run: rustup target add ${{ inputs.targets }}

--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -55,7 +55,6 @@ runs:
         rustup toolchain install ${{ steps.rust.outputs.channel }} \
           --profile minimal \
           --component rust-src \
-          --component rust-analyzer \
           --component clippy \
           --component rustfmt \
           --component llvm-tools-preview

--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -46,9 +46,10 @@ runs:
     - name: Install pinned Rust toolchain
       shell: bash
       working-directory: rust
-      run: rustup show
+      run: rustup show active-toolchain --install
 
     - name: Install additional targets
       if: ${{ inputs.targets != '' }}
       shell: bash
+      working-directory: rust
       run: rustup target add ${{ inputs.targets }}

--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Install pinned Rust toolchain
       shell: bash
       working-directory: rust
-      run: rustup show active-toolchain --install
+      run: rustup show
 
     - name: Install additional targets
       if: ${{ inputs.targets != '' }}

--- a/.github/actions/setup-rust-stable/action.yml
+++ b/.github/actions/setup-rust-stable/action.yml
@@ -42,14 +42,26 @@ runs:
           | sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
-    # Auto-installs the channel + components pinned in rust/rust-toolchain.toml.
-    - name: Install pinned Rust toolchain
+    - name: Extract pinned Rust channel
+      id: rust
       shell: bash
-      working-directory: rust
-      run: rustup show
+      run: |
+        CHANNEL=$(awk -F'"' '/^channel/ {print $2}' rust/rust-toolchain.toml)
+        echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+
+    - name: Install Rust toolchain
+      shell: bash
+      run: |
+        rustup toolchain install ${{ steps.rust.outputs.channel }} \
+          --profile minimal \
+          --component rust-src \
+          --component rust-analyzer \
+          --component clippy \
+          --component rustfmt \
+          --component llvm-tools-preview
+        rustup default ${{ steps.rust.outputs.channel }}
 
     - name: Install additional targets
       if: ${{ inputs.targets != '' }}
       shell: bash
-      working-directory: rust
       run: rustup target add ${{ inputs.targets }}

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0" # Keep in sync with `Dockerfile`
-components = ["rust-src", "rust-analyzer", "clippy", "rustfmt", "llvm-tools-preview"]
+components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0" # Keep in sync with `Dockerfile`
-components = ["rust-src", "rust-analyzer", "clippy"]
+components = ["rust-src", "rust-analyzer", "clippy", "rustfmt", "llvm-tools-preview"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
The macos-26 runner image rebuilt on 2026-05-12 pulled in a Homebrew rustup formula update that ships a broken `cargo` shim at `/opt/homebrew/bin/cargo`. The shim rejects valid cargo argv, so `cargo llvm-cov` fails with `error: unexpected argument 'llvm-cov' found / Usage: rustup-init[EXE]`.

Drop the `actions-rust-lang/setup-rust-toolchain` dependency in favour of direct `rustup` calls against the rustup that ships pre-installed on every GitHub-hosted runner. On macOS, replace the broken Homebrew rustup with an official install from `https://sh.rustup.rs` so PATH resolution is clean rather than papered over.

Related: https://github.com/actions/runner-images/issues/14099
Related: https://github.com/actions/runner-images/issues/14097