### PR TITLE
fix(apple): store settings in providerConfiguration

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ConfigurationMigrator.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ConfigurationMigrator.swift
@@ -26,12 +26,15 @@ enum ConfigurationMigrator {
       userDefaultsDomain.flatMap { userDefaults.persistentDomain(forName: $0) } ?? [:]
 
     for entry in Configuration.providerEntries {
-      if entry.isBool, let value = userDomain[entry.key] as? Bool {
-        configuration.setProviderValue(value, forKey: entry.key)
-      } else if !entry.isBool,
-        let value = userDomain[entry.key] as? String, !value.isEmpty
-      {
-        configuration.setProviderValue(value, forKey: entry.key)
+      switch entry {
+      case .bool(let key, _):
+        if let value = userDomain[key] as? Bool {
+          configuration.setProviderValue(value, forKey: key)
+        }
+      case .string(let key, _):
+        if let value = userDomain[key] as? String, !value.isEmpty {
+          configuration.setProviderValue(value, forKey: key)
+        }
       }
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ConfigurationMigrator.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ConfigurationMigrator.swift
@@ -1,0 +1,61 @@
+//
+//  ConfigurationMigrator.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+
+@MainActor
+enum ConfigurationMigrator {
+  static func migrateUserDefaultsIfNeeded(
+    userDefaults: UserDefaults,
+    vpnConfigurationManager: VPNConfigurationManager,
+    userDefaultsDomain: String? = Bundle.main.bundleIdentifier
+  ) async throws {
+    let providerConfiguration = try vpnConfigurationManager.providerConfiguration()
+
+    guard providerConfiguration[Configuration.Keys.userDefaultsMigrated] != "true" else {
+      return
+    }
+
+    let configuration = Configuration(userDefaults: userDefaults)
+    configuration.loadProviderConfiguration(providerConfiguration)
+
+    let userDomain =
+      userDefaultsDomain.flatMap { userDefaults.persistentDomain(forName: $0) } ?? [:]
+
+    for entry in Configuration.providerEntries {
+      if entry.isBool, let value = userDomain[entry.key] as? Bool {
+        configuration.setProviderValue(value, forKey: entry.key)
+      } else if !entry.isBool,
+        let value = userDomain[entry.key] as? String, !value.isEmpty
+      {
+        configuration.setProviderValue(value, forKey: entry.key)
+      }
+    }
+
+    try await vpnConfigurationManager.save(configuration: configuration)
+    removeLegacyUserDefaults(userDefaults, userDefaultsDomain: userDefaultsDomain)
+  }
+
+  private static func removeLegacyUserDefaults(
+    _ userDefaults: UserDefaults,
+    userDefaultsDomain: String?
+  ) {
+    let keys = Configuration.providerEntries.map(\.key)
+
+    guard let userDefaultsDomain else {
+      for key in keys {
+        userDefaults.removeObject(forKey: key)
+      }
+      return
+    }
+
+    var userDomain = userDefaults.persistentDomain(forName: userDefaultsDomain) ?? [:]
+    for key in keys {
+      userDomain.removeValue(forKey: key)
+    }
+    userDefaults.setPersistentDomain(userDomain, forName: userDefaultsDomain)
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -32,30 +32,17 @@ enum IPCClient {
   private static let encoder = PropertyListEncoder()
   private static let decoder = PropertyListDecoder()
 
-  // Auto-connect
+  // Auto-connect: the GUI must save providerConfiguration before calling this so
+  // any MDM forced overrides are available to the provider.
   @MainActor
-  static func start(
-    session: NETunnelProviderSession, configuration: TunnelConfiguration
-  ) throws {
-    let configData = try encoder.encode(configuration)
-    let options: [String: NSObject] = [
-      "configuration": configData as NSObject
-    ]
-    try session.startTunnel(options: options)
+  static func start(session: NETunnelProviderSession) throws {
+    try session.startTunnel()
   }
 
   // Sign in
   @MainActor
-  static func start(
-    session: NETunnelProviderSession, token: String, configuration: TunnelConfiguration
-  ) throws {
-    let configData = try encoder.encode(configuration)
-    let options: [String: NSObject] = [
-      "token": token as NSObject,
-      "configuration": configData as NSObject,
-    ]
-
-    try session.startTunnel(options: options)
+  static func start(session: NETunnelProviderSession, token: String) throws {
+    try session.startTunnel(options: ["token": token as NSObject])
   }
 
   @MainActor
@@ -77,10 +64,11 @@ enum IPCClient {
   }
 
   @MainActor
-  static func setConfiguration(
-    session: NETunnelProviderSession, _ configuration: TunnelConfiguration
+  static func setInternetResourceEnabled(
+    session: NETunnelProviderSession,
+    _ enabled: Bool
   ) async throws {
-    let message = ProviderMessage.setConfiguration(configuration)
+    let message = ProviderMessage.setInternetResourceEnabled(enabled)
     _ = try await sendProviderMessage(session: session, message: message)
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -50,11 +50,14 @@ public final class NETunnelProviderManagerFactory: TunnelProviderManagerFactory 
 
 enum VPNConfigurationManagerError: Error {
   case managerNotInitialized
+  case savedProtocolConfigurationIsInvalid
 
   var localizedDescription: String {
     switch self {
     case .managerNotInitialized:
       return "NETunnelProviderManager is not yet initialized. Race condition?"
+    case .savedProtocolConfigurationIsInvalid:
+      return "Saved protocol configuration is invalid. Check types?"
     }
   }
 }
@@ -74,7 +77,10 @@ public final class VPNConfigurationManager {
   init(manager: any TunnelProviderManager) async throws {
     let protocolConfiguration = NETunnelProviderProtocol()
 
-    protocolConfiguration.providerConfiguration = nil
+    // Seed with defaults (and any forced overrides) but don't mark migrated;
+    // the migrator runs separately and is responsible for flipping the flag.
+    protocolConfiguration.providerConfiguration =
+      Configuration().toProviderConfiguration(markUserDefaultsMigrated: false)
     protocolConfiguration.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
     protocolConfiguration.serverAddress = "Firezone"  // can be any non-empty string
     manager.localizedDescription = VPNConfigurationManager.bundleDescription
@@ -88,22 +94,6 @@ public final class VPNConfigurationManager {
 
   init(from manager: any TunnelProviderManager) {
     self.manager = manager
-  }
-
-  // Pure function - doesn't access actor-isolated state.
-  nonisolated public static func legacyConfiguration(
-    protocolConfiguration: NETunnelProviderProtocol?
-  )
-    // swiftlint:disable:next discouraged_optional_collection - nil means no legacy config exists
-    -> [String: String]?
-  {
-    guard let protocolConfiguration = protocolConfiguration,
-      let providerConfiguration = protocolConfiguration.providerConfiguration as? [String: String]
-    else {
-      return nil
-    }
-
-    return providerConfiguration
   }
 
   static func load(using factory: TunnelProviderManagerFactory) async throws
@@ -132,58 +122,79 @@ public final class VPNConfigurationManager {
     return manager.connection as? NETunnelProviderSession
   }
 
-  // Firezone 1.4.14 and below stored some app configuration in the VPN provider configuration fields. This has since
-  // been moved to a dedicated UserDefaults-backed persistent store.
-  func maybeMigrateConfiguration() async throws {
-    guard
-      let legacyConfiguration = Self.legacyConfiguration(
-        protocolConfiguration: manager.protocolConfiguration as? NETunnelProviderProtocol
-      ),
-      let session = session()
+  func loadConfiguration(into configuration: Configuration, userDefaults: UserDefaults) async throws
+  {
+    try await ConfigurationMigrator.migrateUserDefaultsIfNeeded(
+      userDefaults: userDefaults,
+      vpnConfigurationManager: self
+    )
+
+    // Pick up stored config and refresh cached forced overrides if MDM changed
+    // since the last GUI launch. When the migrator just ran this is a no-op.
+    let stored = try providerConfiguration()
+    configuration.loadProviderConfiguration(stored)
+
+    let refreshed = configuration.toProviderConfiguration()
+    if stored != refreshed {
+      try await save(providerConfiguration: refreshed)
+    }
+  }
+
+  func save(
+    configuration: Configuration,
+    markUserDefaultsMigrated: Bool = true
+  ) async throws {
+    try await save(
+      providerConfiguration: configuration.toProviderConfiguration(
+        markUserDefaultsMigrated: markUserDefaultsMigrated
+      )
+    )
+  }
+
+  func providerConfiguration() throws -> [String: String] {
+    guard let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol
     else {
+      throw VPNConfigurationManagerError.savedProtocolConfigurationIsInvalid
+    }
+
+    guard let rawProviderConfiguration = protocolConfiguration.providerConfiguration else {
+      return [:]
+    }
+
+    guard let providerConfiguration = rawProviderConfiguration as? [String: String] else {
+      throw VPNConfigurationManagerError.savedProtocolConfigurationIsInvalid
+    }
+
+    return providerConfiguration
+  }
+
+  func save(providerConfiguration newProviderConfiguration: [String: String]) async throws {
+    guard let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol
+    else {
+      throw VPNConfigurationManagerError.savedProtocolConfigurationIsInvalid
+    }
+
+    let providerConfiguration: [String: String]
+    if let rawProviderConfiguration = protocolConfiguration.providerConfiguration {
+      guard let typedProviderConfiguration = rawProviderConfiguration as? [String: String] else {
+        throw VPNConfigurationManagerError.savedProtocolConfigurationIsInvalid
+      }
+      providerConfiguration = typedProviderConfiguration
+    } else {
+      providerConfiguration = [:]
+    }
+
+    if providerConfiguration == newProviderConfiguration
+      && protocolConfiguration.serverAddress == "Firezone"
+    {
       return
     }
 
-    let configuration = Configuration.shared
+    protocolConfiguration.providerConfiguration = newProviderConfiguration
+    protocolConfiguration.serverAddress = "Firezone"
+    manager.protocolConfiguration = protocolConfiguration
 
-    if let actorName = legacyConfiguration["actorName"] {
-      // swiftlint:disable:next no_userdefaults_standard - legacy migration, runs before DI is available
-      UserDefaults.standard.set(actorName, forKey: "actorName")
-    }
-
-    if let apiURL = legacyConfiguration["apiURL"] {
-      configuration.apiURL = apiURL
-    }
-
-    if let authURL = legacyConfiguration["authBaseURL"] {
-      configuration.authURL = authURL
-    }
-
-    if let accountSlug = legacyConfiguration["accountSlug"] {
-      configuration.accountSlug = accountSlug
-    }
-
-    if let logFilter = legacyConfiguration["logFilter"],
-      !logFilter.isEmpty
-    {
-      configuration.logFilter = logFilter
-    }
-
-    if let internetResourceEnabled = legacyConfiguration["internetResourceEnabled"],
-      ["false", "true"].contains(internetResourceEnabled)
-    {
-      configuration.internetResourceEnabled = internetResourceEnabled == "true"
-    }
-
-    try await IPCClient.setConfiguration(session: session, configuration.toTunnelConfiguration())
-
-    // Remove fields to prevent confusion if the user sees these in System Settings and wonders why they're stale.
-    if let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol {
-      protocolConfiguration.providerConfiguration = nil
-      protocolConfiguration.serverAddress = "Firezone"
-      manager.protocolConfiguration = protocolConfiguration
-      try await manager.saveToPreferences()
-      try await manager.loadFromPreferences()
-    }
+    try await manager.saveToPreferences()
+    try await manager.loadFromPreferences()
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -239,7 +239,7 @@ public class Configuration: ObservableObject {
   }
 
   private func providerBool(_ key: String, default defaultValue: Bool) -> Bool {
-    Self.bool(providerConfiguration[key], default: defaultValue)
+    Self.parseBool(providerConfiguration[key], default: defaultValue)
   }
 
   private func managedBool(_ key: String) -> Bool {
@@ -271,7 +271,7 @@ public class Configuration: ObservableObject {
     }
   }
 
-  nonisolated public static func bool(_ value: String?, default defaultValue: Bool) -> Bool {
+  nonisolated public static func parseBool(_ value: String?, default defaultValue: Bool) -> Bool {
     switch value {
     case "true": return true
     case "false": return false

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -178,9 +178,8 @@ public class Configuration: ObservableObject {
   }
 
   func loadProviderConfiguration(_ providerConfiguration: [String: String]) {
-    if self.providerConfiguration != providerConfiguration {
-      self.providerConfiguration = providerConfiguration
-    }
+    guard self.providerConfiguration != providerConfiguration else { return }
+    self.providerConfiguration = providerConfiguration
     handleConfigurationChanged()
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -3,19 +3,111 @@
 //  (c) 2024 Firezone, Inc.
 //  LICENSE: Apache-2.0
 //
-//  A thin wrapper around UserDefaults for user and admin managed app configuration.
+//  App configuration facade.
+//
+//  All user-editable settings live in the VPN provider configuration so only the
+//  host app and provider can write to them. UserDefaults is used only for MDM:
+//  read-only managed values (hideResourceList, supportURL, …) and forced
+//  overrides of tunnel keys, both deployed via .mobileconfig profiles. Forced
+//  overrides are also cached in providerConfiguration under a "forced." prefix
+//  so the network extension can apply them after restart without the GUI.
 
 import Combine
 import Foundation
 
+public enum ConfigurationDefaults {
+  #if DEBUG
+    public static let authURL = "https://app.firez.one"
+    public static let apiURL = "wss://api.firez.one"
+    public static let logFilter = "debug"
+  #else
+    public static let authURL = "https://app.firezone.dev"
+    public static let apiURL = "wss://api.firezone.dev"
+    public static let logFilter = "info"
+  #endif
+
+  public static let accountSlug = ""
+  public static let actorName = "Unknown user"
+  public static let supportURL = "https://www.firezone.dev/support"
+  public static let connectOnStart = false
+  public static let startOnLogin = false
+  public static let disableUpdateCheck = false
+  public static let internetResourceEnabled = false
+}
+
 @MainActor
 public class Configuration: ObservableObject {
   static let shared = Configuration()
-  private var cancellables = Set<AnyCancellable>()
 
-  @Published private(set) var publishedInternetResourceEnabled = false
-  @Published private(set) var publishedHideAdminPortalMenuItem = false
-  @Published private(set) var publishedHideResourceList = false
+  // Forced overrides are cached in providerConfiguration as "forced.<key>".
+  nonisolated public static let forcedPrefix = "forced."
+  nonisolated public static func forcedKey(for key: String) -> String {
+    "\(forcedPrefix)\(key)"
+  }
+
+  public enum Keys {
+    public static let authURL = "authURL"
+    public static let apiURL = "apiURL"
+    public static let logFilter = "logFilter"
+    public static let accountSlug = "accountSlug"
+    public static let actorName = "actorName"
+    public static let internetResourceEnabled = "internetResourceEnabled"
+    public static let hideAdminPortalMenuItem = "hideAdminPortalMenuItem"
+    public static let hideResourceList = "hideResourceList"
+    public static let connectOnStart = "connectOnStart"
+    public static let startOnLogin = "startOnLogin"
+    public static let disableUpdateCheck = "disableUpdateCheck"
+    public static let supportURL = "supportURL"
+    public static let userDefaultsMigrated = "userDefaultsMigrated"
+  }
+
+  // Each entry describes a key persisted to providerConfiguration. The getters
+  // additionally honor an MDM forced value (UserDefaults.objectIsForced) for the
+  // is*Forced properties below, regardless of whether the key is forwarded to
+  // the network extension.
+  struct ProviderEntry: Sendable {
+    let key: String
+    let defaultString: String
+    let isBool: Bool
+  }
+
+  nonisolated static let providerEntries: [ProviderEntry] = [
+    ProviderEntry(key: Keys.authURL, defaultString: ConfigurationDefaults.authURL, isBool: false),
+    ProviderEntry(key: Keys.apiURL, defaultString: ConfigurationDefaults.apiURL, isBool: false),
+    ProviderEntry(
+      key: Keys.logFilter, defaultString: ConfigurationDefaults.logFilter, isBool: false),
+    ProviderEntry(
+      key: Keys.accountSlug, defaultString: ConfigurationDefaults.accountSlug, isBool: false),
+    ProviderEntry(
+      key: Keys.actorName, defaultString: ConfigurationDefaults.actorName, isBool: false),
+    ProviderEntry(
+      key: Keys.connectOnStart, defaultString: string(ConfigurationDefaults.connectOnStart),
+      isBool: true),
+    ProviderEntry(
+      key: Keys.startOnLogin, defaultString: string(ConfigurationDefaults.startOnLogin),
+      isBool: true),
+    ProviderEntry(
+      key: Keys.internetResourceEnabled,
+      defaultString: string(ConfigurationDefaults.internetResourceEnabled), isBool: true),
+  ]
+
+  // Subset of provider entries whose MDM forced values are cached in
+  // providerConfiguration as "forced.<key>" so the network extension can apply
+  // them at tunnel start without having to contact the GUI.
+  nonisolated static let forwardedForcedKeys: Set<String> = [
+    Keys.apiURL, Keys.logFilter, Keys.accountSlug,
+  ]
+
+  private var cancellables = Set<AnyCancellable>()
+  private let internetResourceEnabledSubject = PassthroughSubject<Bool, Never>()
+
+  private(set) var publishedInternetResourceEnabled = false
+  private(set) var publishedHideAdminPortalMenuItem = false
+  private(set) var publishedHideResourceList = false
+
+  var internetResourceEnabledPublisher: AnyPublisher<Bool, Never> {
+    internetResourceEnabledSubject.eraseToAnyPublisher()
+  }
 
   var isAuthURLForced: Bool { defaults.objectIsForced(forKey: Keys.authURL) }
   var isApiURLForced: Bool { defaults.objectIsForced(forKey: Keys.apiURL) }
@@ -25,98 +117,55 @@ public class Configuration: ObservableObject {
   var isStartOnLoginForced: Bool { defaults.objectIsForced(forKey: Keys.startOnLogin) }
 
   var authURL: String {
-    get { defaults.string(forKey: Keys.authURL) ?? Self.defaultAuthURL }
-    set { defaults.set(newValue, forKey: Keys.authURL) }
+    get { effectiveString(Keys.authURL, default: ConfigurationDefaults.authURL) }
+    set { setProviderValue(newValue, forKey: Keys.authURL) }
   }
-
   var apiURL: String {
-    get { defaults.string(forKey: Keys.apiURL) ?? Self.defaultApiURL }
-    set { defaults.set(newValue, forKey: Keys.apiURL) }
+    get { effectiveString(Keys.apiURL, default: ConfigurationDefaults.apiURL) }
+    set { setProviderValue(newValue, forKey: Keys.apiURL) }
   }
-
   var logFilter: String {
-    get { defaults.string(forKey: Keys.logFilter) ?? Self.defaultLogFilter }
-    set { defaults.set(newValue, forKey: Keys.logFilter) }
+    get { effectiveString(Keys.logFilter, default: ConfigurationDefaults.logFilter) }
+    set { setProviderValue(newValue, forKey: Keys.logFilter) }
   }
-
   var accountSlug: String {
-    get { defaults.string(forKey: Keys.accountSlug) ?? Self.defaultAccountSlug }
-    set { defaults.set(newValue, forKey: Keys.accountSlug) }
+    get { effectiveString(Keys.accountSlug, default: ConfigurationDefaults.accountSlug) }
+    set { setProviderValue(newValue, forKey: Keys.accountSlug) }
   }
-
-  var hideAdminPortalMenuItem: Bool {
-    get { defaults.bool(forKey: Keys.hideAdminPortalMenuItem) }
-    set { defaults.set(newValue, forKey: Keys.hideAdminPortalMenuItem) }
+  var actorName: String {
+    get { providerString(Keys.actorName, default: ConfigurationDefaults.actorName) }
+    set { setProviderValue(newValue, forKey: Keys.actorName) }
   }
-
-  var hideResourceList: Bool {
-    get { defaults.bool(forKey: Keys.hideResourceList) }
-    set { defaults.set(newValue, forKey: Keys.hideResourceList) }
-  }
-
   var connectOnStart: Bool {
-    get { defaults.bool(forKey: Keys.connectOnStart) }
-    set { defaults.set(newValue, forKey: Keys.connectOnStart) }
+    get { effectiveBool(Keys.connectOnStart, default: ConfigurationDefaults.connectOnStart) }
+    set { setProviderValue(newValue, forKey: Keys.connectOnStart) }
   }
-
   var startOnLogin: Bool {
-    get { defaults.bool(forKey: Keys.startOnLogin) }
-    set { defaults.set(newValue, forKey: Keys.startOnLogin) }
+    get { effectiveBool(Keys.startOnLogin, default: ConfigurationDefaults.startOnLogin) }
+    set { setProviderValue(newValue, forKey: Keys.startOnLogin) }
   }
-
-  var disableUpdateCheck: Bool {
-    get { defaults.bool(forKey: Keys.disableUpdateCheck) }
-    set { defaults.set(newValue, forKey: Keys.disableUpdateCheck) }
-  }
-
-  var supportURL: String {
-    get { defaults.string(forKey: Keys.supportURL) ?? Self.defaultSupportURL }
-    set { defaults.set(newValue, forKey: Keys.supportURL) }
-  }
-
-  // User-configurable only
   var internetResourceEnabled: Bool {
-    get { defaults.bool(forKey: Keys.internetResourceEnabled) }
-    set { defaults.set(newValue, forKey: Keys.internetResourceEnabled) }
+    get {
+      providerBool(
+        Keys.internetResourceEnabled, default: ConfigurationDefaults.internetResourceEnabled)
+    }
+    set { setProviderValue(newValue, forKey: Keys.internetResourceEnabled) }
   }
 
-  #if DEBUG
-    static let defaultAuthURL = "https://app.firez.one"
-    static let defaultApiURL = "wss://api.firez.one"
-    static let defaultLogFilter = "debug"
-  #else
-    static let defaultAuthURL = "https://app.firezone.dev"
-    static let defaultApiURL = "wss://api.firezone.dev"
-    static let defaultLogFilter = "info"
-  #endif
-
-  static let defaultAccountSlug = ""
-  static let defaultSupportURL = "https://www.firezone.dev/support"
-
-  // Bools are always default false
-  static let defaultConnectOnStart = false
-  static let defaultStartOnLogin = false
-  static let defaultDisableUpdateCheck = false
-
-  private struct Keys {
-    static let authURL = "authURL"
-    static let apiURL = "apiURL"
-    static let logFilter = "logFilter"
-    static let accountSlug = "accountSlug"
-    static let internetResourceEnabled = "internetResourceEnabled"
-    static let hideAdminPortalMenuItem = "hideAdminPortalMenuItem"
-    static let hideResourceList = "hideResourceList"
-    static let connectOnStart = "connectOnStart"
-    static let startOnLogin = "startOnLogin"
-    static let disableUpdateCheck = "disableUpdateCheck"
-    static let supportURL = "supportURL"
+  var hideAdminPortalMenuItem: Bool { managedBool(Keys.hideAdminPortalMenuItem) }
+  var hideResourceList: Bool { managedBool(Keys.hideResourceList) }
+  var disableUpdateCheck: Bool { managedBool(Keys.disableUpdateCheck) }
+  var supportURL: String {
+    defaults.string(forKey: Keys.supportURL) ?? ConfigurationDefaults.supportURL
   }
 
   private var defaults: UserDefaults
+  private var providerConfiguration: [String: String]
 
   // swiftlint:disable:next no_userdefaults_standard - DI entry point
   init(userDefaults: UserDefaults = UserDefaults.standard) {
     defaults = userDefaults
+    providerConfiguration = [:]
 
     self.publishedInternetResourceEnabled = internetResourceEnabled
     self.publishedHideAdminPortalMenuItem = hideAdminPortalMenuItem
@@ -124,54 +173,112 @@ public class Configuration: ObservableObject {
 
     NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification, object: defaults)
       .receive(on: DispatchQueue.main)
-      .sink { [weak self] _ in
-        self?.handleUserDefaultsChanged()
-      }
+      .sink { [weak self] _ in self?.handleConfigurationChanged() }
       .store(in: &cancellables)
   }
 
-  func toTunnelConfiguration() -> TunnelConfiguration {
-    return TunnelConfiguration(
-      apiURL: apiURL,
-      accountSlug: accountSlug,
-      logFilter: logFilter,
-      internetResourceEnabled: internetResourceEnabled
-    )
+  func loadProviderConfiguration(_ providerConfiguration: [String: String]) {
+    if self.providerConfiguration != providerConfiguration {
+      self.providerConfiguration = providerConfiguration
+    }
+    handleConfigurationChanged()
   }
 
-  private func handleUserDefaultsChanged() {
-    Task { do { try await LoginItemManager.syncStartOnLogin(startOnLogin: startOnLogin) } }
+  func toProviderConfiguration(markUserDefaultsMigrated: Bool = true) -> [String: String] {
+    var result: [String: String] = [:]
 
-    // Update published properties
-    self.publishedInternetResourceEnabled = internetResourceEnabled
-    self.publishedHideAdminPortalMenuItem = hideAdminPortalMenuItem
-    self.publishedHideResourceList = hideResourceList
+    for entry in Self.providerEntries {
+      result[entry.key] = providerConfiguration[entry.key] ?? entry.defaultString
+    }
 
-    // Announce we changed
+    // Cache MDM forced overrides so the network extension can apply them without the GUI.
+    for (key, value) in forcedConfiguration() {
+      result[Self.forcedKey(for: key)] = value
+    }
+
+    if markUserDefaultsMigrated {
+      result[Keys.userDefaultsMigrated] = "true"
+    }
+
+    return result
+  }
+
+  func forcedConfiguration() -> [String: String] {
+    var result: [String: String] = [:]
+    for entry in Self.providerEntries where Self.forwardedForcedKeys.contains(entry.key) {
+      guard defaults.objectIsForced(forKey: entry.key) else { continue }
+      if entry.isBool {
+        result[entry.key] = Self.string(defaults.bool(forKey: entry.key))
+      } else if let value = defaults.string(forKey: entry.key) {
+        result[entry.key] = value
+      }
+    }
+    return result
+  }
+
+  private func effectiveString(_ key: String, default defaultValue: String) -> String {
+    if defaults.objectIsForced(forKey: key), let value = defaults.string(forKey: key) {
+      return value
+    }
+    return providerString(key, default: defaultValue)
+  }
+
+  private func providerString(_ key: String, default defaultValue: String) -> String {
+    providerConfiguration[key] ?? defaultValue
+  }
+
+  private func effectiveBool(_ key: String, default defaultValue: Bool) -> Bool {
+    if defaults.objectIsForced(forKey: key) { return defaults.bool(forKey: key) }
+    return providerBool(key, default: defaultValue)
+  }
+
+  private func providerBool(_ key: String, default defaultValue: Bool) -> Bool {
+    Self.bool(providerConfiguration[key], default: defaultValue)
+  }
+
+  private func managedBool(_ key: String) -> Bool {
+    guard defaults.object(forKey: key) != nil else { return false }
+    return defaults.bool(forKey: key)
+  }
+
+  func setProviderValue(_ value: String, forKey key: String) {
+    guard providerConfiguration[key] != value else { return }
+    providerConfiguration[key] = value
+    handleConfigurationChanged()
+  }
+
+  func setProviderValue(_ value: Bool, forKey key: String) {
+    setProviderValue(Self.string(value), forKey: key)
+  }
+
+  private func handleConfigurationChanged() {
+    let previousInternetResourceEnabled = publishedInternetResourceEnabled
+
+    publishedInternetResourceEnabled = internetResourceEnabled
+    publishedHideAdminPortalMenuItem = hideAdminPortalMenuItem
+    publishedHideResourceList = hideResourceList
+
     objectWillChange.send()
+
+    if previousInternetResourceEnabled != publishedInternetResourceEnabled {
+      internetResourceEnabledSubject.send(publishedInternetResourceEnabled)
+    }
   }
+
+  nonisolated public static func bool(_ value: String?, default defaultValue: Bool) -> Bool {
+    switch value {
+    case "true": return true
+    case "false": return false
+    default: return defaultValue
+    }
+  }
+
+  nonisolated static func string(_ value: Bool) -> String { value ? "true" : "false" }
 }
 
-// Configuration does not conform to Decodable, so introduce a simpler type here to encode for IPC
-public struct TunnelConfiguration: Codable, Sendable {
-  public let apiURL: String
-  public let accountSlug: String
-  public let logFilter: String
-  public let internetResourceEnabled: Bool
-
-  public init(apiURL: String, accountSlug: String, logFilter: String, internetResourceEnabled: Bool)
-  {
-    self.apiURL = apiURL
-    self.accountSlug = accountSlug
-    self.logFilter = logFilter
-    self.internetResourceEnabled = internetResourceEnabled
-  }
-}
-
-extension TunnelConfiguration: Equatable {
-  public static func == (lhs: TunnelConfiguration, rhs: TunnelConfiguration) -> Bool {
-    return lhs.apiURL == rhs.apiURL && lhs.accountSlug == rhs.accountSlug
-      && lhs.logFilter == rhs.logFilter
-      && lhs.internetResourceEnabled == rhs.internetResourceEnabled
+extension Dictionary where Key == String, Value == String {
+  /// Returns the forced override for `key` if present, else the plain value.
+  public func effectiveValue(forKey key: String) -> String? {
+    self[Configuration.forcedKey(for: key)] ?? self[key]
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -65,30 +65,34 @@ public class Configuration: ObservableObject {
   // additionally honor an MDM forced value (UserDefaults.objectIsForced) for the
   // is*Forced properties below, regardless of whether the key is forwarded to
   // the network extension.
-  struct ProviderEntry: Sendable {
-    let key: String
-    let defaultString: String
-    let isBool: Bool
+  enum ProviderEntry: Sendable {
+    case string(key: String, default: String)
+    case bool(key: String, default: Bool)
+
+    var key: String {
+      switch self {
+      case .string(let key, _), .bool(let key, _): return key
+      }
+    }
+
+    var defaultString: String {
+      switch self {
+      case .string(_, let value): return value
+      case .bool(_, let value): return Configuration.string(value)
+      }
+    }
   }
 
   nonisolated static let providerEntries: [ProviderEntry] = [
-    ProviderEntry(key: Keys.authURL, defaultString: ConfigurationDefaults.authURL, isBool: false),
-    ProviderEntry(key: Keys.apiURL, defaultString: ConfigurationDefaults.apiURL, isBool: false),
-    ProviderEntry(
-      key: Keys.logFilter, defaultString: ConfigurationDefaults.logFilter, isBool: false),
-    ProviderEntry(
-      key: Keys.accountSlug, defaultString: ConfigurationDefaults.accountSlug, isBool: false),
-    ProviderEntry(
-      key: Keys.actorName, defaultString: ConfigurationDefaults.actorName, isBool: false),
-    ProviderEntry(
-      key: Keys.connectOnStart, defaultString: string(ConfigurationDefaults.connectOnStart),
-      isBool: true),
-    ProviderEntry(
-      key: Keys.startOnLogin, defaultString: string(ConfigurationDefaults.startOnLogin),
-      isBool: true),
-    ProviderEntry(
-      key: Keys.internetResourceEnabled,
-      defaultString: string(ConfigurationDefaults.internetResourceEnabled), isBool: true),
+    .string(key: Keys.authURL, default: ConfigurationDefaults.authURL),
+    .string(key: Keys.apiURL, default: ConfigurationDefaults.apiURL),
+    .string(key: Keys.logFilter, default: ConfigurationDefaults.logFilter),
+    .string(key: Keys.accountSlug, default: ConfigurationDefaults.accountSlug),
+    .string(key: Keys.actorName, default: ConfigurationDefaults.actorName),
+    .bool(key: Keys.connectOnStart, default: ConfigurationDefaults.connectOnStart),
+    .bool(key: Keys.startOnLogin, default: ConfigurationDefaults.startOnLogin),
+    .bool(
+      key: Keys.internetResourceEnabled, default: ConfigurationDefaults.internetResourceEnabled),
   ]
 
   // Subset of provider entries whose MDM forced values are cached in
@@ -206,10 +210,13 @@ public class Configuration: ObservableObject {
     var result: [String: String] = [:]
     for entry in Self.providerEntries where Self.forwardedForcedKeys.contains(entry.key) {
       guard defaults.objectIsForced(forKey: entry.key) else { continue }
-      if entry.isBool {
-        result[entry.key] = Self.string(defaults.bool(forKey: entry.key))
-      } else if let value = defaults.string(forKey: entry.key) {
-        result[entry.key] = value
+      switch entry {
+      case .bool(let key, _):
+        result[key] = Self.string(defaults.bool(forKey: key))
+      case .string(let key, _):
+        if let value = defaults.string(forKey: key) {
+          result[key] = value
+        }
       }
     }
     return result

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -283,8 +283,13 @@ public class Configuration: ObservableObject {
 }
 
 extension Dictionary where Key == String, Value == String {
-  /// Returns the forced override for `key` if present, else the plain value.
-  public func effectiveValue(forKey key: String) -> String? {
+  /// Returns the MDM-forced override for `key` if cached, else the plain value.
+  ///
+  /// Only keys in `Configuration.forwardedForcedKeys` ever have a cached
+  /// override — user-controlled values like `internetResourceEnabled` must be
+  /// read directly via `self[key]`, since calling this would silently fall
+  /// through to the same lookup and obscure intent at the call site.
+  public func withMDMOverride(forKey key: String) -> String? {
     self[Configuration.forcedKey(for: key)] ?? self[key]
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public enum ProviderMessage: Codable {
   case getState(Data)
-  case setConfiguration(TunnelConfiguration)
+  case setInternetResourceEnabled(Bool)
   case signOut
   case clearLogs
   case getLogFolderSize
@@ -23,7 +23,7 @@ public enum ProviderMessage: Codable {
 
   enum MessageType: String, Codable {
     case getState
-    case setConfiguration
+    case setInternetResourceEnabled
     case signOut
     case clearLogs
     case getLogFolderSize
@@ -38,9 +38,9 @@ public enum ProviderMessage: Codable {
     case .getState:
       let value = try container.decode(Data.self, forKey: .value)
       self = .getState(value)
-    case .setConfiguration:
-      let value = try container.decode(TunnelConfiguration.self, forKey: .value)
-      self = .setConfiguration(value)
+    case .setInternetResourceEnabled:
+      let value = try container.decode(Bool.self, forKey: .value)
+      self = .setInternetResourceEnabled(value)
     case .signOut:
       self = .signOut
     case .clearLogs:
@@ -60,8 +60,8 @@ public enum ProviderMessage: Codable {
     case .getState(let value):
       try container.encode(MessageType.getState, forKey: .type)
       try container.encode(value, forKey: .value)
-    case .setConfiguration(let value):
-      try container.encode(MessageType.setConfiguration, forKey: .type)
+    case .setInternetResourceEnabled(let value):
+      try container.encode(MessageType.setInternetResourceEnabled, forKey: .type)
       try container.encode(value, forKey: .value)
     case .signOut:
       try container.encode(MessageType.signOut, forKey: .type)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -56,10 +56,16 @@ public final class Store: ObservableObject {
   private static let statePollingInterval: Duration = .seconds(1)
   private var stateUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
-  private var lastSavedConfiguration: TunnelConfiguration?
+  private var lastSyncedSnapshot: ConfigurationSnapshot?
   private var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
   private let tunnelManagerFactory: TunnelProviderManagerFactory
+
+  private struct ConfigurationSnapshot: Equatable {
+    var providerConfiguration: [String: String]
+    var internetResourceEnabled: Bool
+    var startOnLogin: Bool
+  }
 
   // Track which session expired alerts have been shown to prevent duplicates
   private var shownAlertIds: Set<String>
@@ -89,7 +95,7 @@ public final class Store: ObservableObject {
       self.tunnelManagerFactory = tunnelManagerFactory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
-      self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
+      self.actorName = self.configuration.actorName
       self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
     }
@@ -106,7 +112,7 @@ public final class Store: ObservableObject {
       self.tunnelManagerFactory = tunnelManagerFactory
       self.userDefaults = userDefaults
       self.favorites = Favorites(userDefaults: userDefaults)
-      self.actorName = userDefaults.string(forKey: "actorName") ?? "Unknown user"
+      self.actorName = self.configuration.actorName
       self.shownAlertIds = Set(userDefaults.stringArray(forKey: "shownAlertIds") ?? [])
       self.postInit()
     }
@@ -117,34 +123,15 @@ public final class Store: ObservableObject {
       do { try await WebAuthSession.signIn(store: self) } catch { Log.error(error) }
     }
 
-    // We monitor for any configuration changes and tell the tunnel service about them
+    // We monitor for configuration changes and persist them to the VPN provider configuration.
     self.configuration.objectWillChange
       .receive(on: DispatchQueue.main)
       .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)  // These happen quite frequently
       .sink(receiveValue: { [weak self] _ in
         guard let self = self else { return }
-        let current = self.configuration.toTunnelConfiguration()
-
-        if self.vpnConfigurationManager == nil {
-          // No manager yet, nothing to update
-          return
-        }
-
-        if self.lastSavedConfiguration == current {
-          // No changes
-          return
-        }
-
-        self.lastSavedConfiguration = current
-
-        Task {
-          do {
-            guard let session = try self.manager().session() else { return }
-            try await IPCClient.setConfiguration(session: session, current)
-          } catch {
-            Log.error(error)
-          }
-        }
+        self.objectWillChange.send()
+        guard self.vpnConfigurationManager != nil else { return }
+        Task { @MainActor in await self.syncConfiguration() }
       })
       .store(in: &cancellables)
 
@@ -163,8 +150,7 @@ public final class Store: ObservableObject {
     // Forward internet resource toggle changes for immediate UI feedback.
     // The debounced configuration.objectWillChange subscription above handles
     // tunnel sync but adds 0.3s latency. This provides instant menu updates.
-    self.configuration.$publishedInternetResourceEnabled
-      .dropFirst()  // Skip initial value
+    self.configuration.internetResourceEnabledPublisher
       .receive(on: DispatchQueue.main)
       .sink { [weak self] _ in
         self?.objectWillChange.send()
@@ -174,12 +160,6 @@ public final class Store: ObservableObject {
     // Load our state from the system. Based on what's loaded, we may need to ask the user for permission for things.
     // When everything loads correctly, we attempt to start the tunnel if connectOnStart is enabled.
     Task {
-      do {
-        try await LoginItemManager.syncStartOnLogin(startOnLogin: configuration.startOnLogin)
-      } catch {
-        Log.error(error)
-      }
-
       do {
         try await LaunchAgentManager.syncKeepAppRunning()
       } catch {
@@ -318,12 +298,8 @@ public final class Store: ObservableObject {
   /// extension daemon isn't ready yet). Steps that run inside the retry loop are
   /// idempotent, so retrying is safe.
   private func startupSequence() async {
-    // Configure telemetry once before retryable steps — it only depends on the
-    // API URL which is fixed, and calling setEnvironmentOrClose multiple times
-    // can close the Sentry SDK with no way to reopen it.
-    Telemetry.setEnvironmentOrClose(configuration.apiURL)
-
     let maxAttempts = 4
+    var telemetryConfigured = false
 
     for attempt in 0..<maxAttempts {
       do {
@@ -331,6 +307,10 @@ public final class Store: ObservableObject {
         try await initSystemExtension()
         Log.debug("Startup: initVPNConfiguration")
         try await initVPNConfiguration()
+        if !telemetryConfigured {
+          Telemetry.setEnvironmentOrClose(configuration.apiURL)
+          telemetryConfigured = true
+        }
         Log.debug("Startup: setupTunnelObservers")
         try await setupTunnelObservers()
         Log.debug("Startup: maybeAutoConnect")
@@ -386,7 +366,10 @@ public final class Store: ObservableObject {
   private func initVPNConfiguration() async throws {
     // Try to load existing configuration
     if let manager = try await VPNConfigurationManager.load(using: tunnelManagerFactory) {
-      try await manager.maybeMigrateConfiguration()
+      try await manager.loadConfiguration(into: configuration, userDefaults: userDefaults)
+      actorName = configuration.actorName
+      lastSyncedSnapshot = currentSnapshot()
+      await syncStartOnLogin()
       self.vpnConfigurationManager = manager
       SharedAccess.markAppRunning()
     } else {
@@ -396,11 +379,12 @@ public final class Store: ObservableObject {
 
   private func maybeAutoConnect() async throws {
     if configuration.connectOnStart {
+      try await manager().save(configuration: configuration)
       try await manager().enable()
       guard let session = try manager().session() else {
         throw VPNConfigurationManagerError.managerNotInitialized
       }
-      try IPCClient.start(session: session, configuration: configuration.toTunnelConfiguration())
+      try IPCClient.start(session: session)
     }
   }
   func installVPNConfiguration() async throws {
@@ -408,6 +392,11 @@ public final class Store: ObservableObject {
     self.vpnConfigurationManager = try await VPNConfigurationManager(
       manager: tunnelManagerFactory.createManager()
     )
+
+    try await manager().loadConfiguration(into: configuration, userDefaults: userDefaults)
+    actorName = configuration.actorName
+    lastSyncedSnapshot = currentSnapshot()
+    await syncStartOnLogin()
 
     try await setupTunnelObservers()
     SharedAccess.markAppRunning()
@@ -420,6 +409,61 @@ public final class Store: ObservableObject {
     }
 
     return vpnConfigurationManager
+  }
+
+  private func syncStartOnLogin() async {
+    do {
+      try await LoginItemManager.syncStartOnLogin(startOnLogin: configuration.startOnLogin)
+      lastSyncedSnapshot = currentSnapshot()
+    } catch {
+      Log.error(error)
+    }
+  }
+
+  private func currentSnapshot() -> ConfigurationSnapshot {
+    ConfigurationSnapshot(
+      providerConfiguration: configuration.toProviderConfiguration(),
+      internetResourceEnabled: configuration.internetResourceEnabled,
+      startOnLogin: configuration.startOnLogin
+    )
+  }
+
+  private func syncConfiguration() async {
+    let target = currentSnapshot()
+    // initVPNConfiguration / installVPNConfiguration seed lastSyncedSnapshot
+    // before the configuration sink can fire, so this is expected to be non-nil.
+    guard var synced = lastSyncedSnapshot else { return }
+    defer { lastSyncedSnapshot = synced }
+    guard synced != target else { return }
+
+    // Advance `synced` per-field only after each step's async work succeeds so a
+    // failure in one step doesn't lose the retry signal for the others.
+    do {
+      if synced.startOnLogin != target.startOnLogin {
+        try await LoginItemManager.syncStartOnLogin(startOnLogin: target.startOnLogin)
+        synced.startOnLogin = target.startOnLogin
+      }
+      if synced.providerConfiguration != target.providerConfiguration {
+        try await manager().save(providerConfiguration: target.providerConfiguration)
+        synced.providerConfiguration = target.providerConfiguration
+      }
+      if synced.internetResourceEnabled != target.internetResourceEnabled {
+        // The new value is already persisted via providerConfiguration above;
+        // push it live to a running tunnel as well. If IPC throws we exit before
+        // advancing synced so the next configuration change retries.
+        if let session = try manager().session(),
+          [.connected, .connecting, .reasserting].contains(session.status)
+        {
+          try await IPCClient.setInternetResourceEnabled(
+            session: session,
+            target.internetResourceEnabled
+          )
+        }
+        synced.internetResourceEnabled = target.internetResourceEnabled
+      }
+    } catch {
+      Log.error(error)
+    }
   }
 
   func grantNotifications() async throws {
@@ -438,12 +482,13 @@ public final class Store: ObservableObject {
     let actorName = authResponse.actorName
     let accountSlug = authResponse.accountSlug
 
-    // This is only shown in the GUI, cache it here
+    // This is only shown in the GUI.
+    configuration.actorName = actorName
     self.actorName = actorName
-    userDefaults.set(actorName, forKey: "actorName")
 
     configuration.accountSlug = accountSlug
 
+    try await manager().save(configuration: configuration)
     try await manager().enable()
 
     // Clear shown alerts when starting a new session so user can see new errors
@@ -453,14 +498,11 @@ public final class Store: ObservableObject {
     // Clear notified unreachable resources for fresh session
     unreachableResources.removeAll()
 
-    // Bring the tunnel up and send it a token and configuration to start
+    // Bring the tunnel up and send it a token to start
     guard let session = try manager().session() else {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
-    try IPCClient.start(
-      session: session, token: authResponse.token,
-      configuration: configuration.toTunnelConfiguration()
-    )
+    try IPCClient.start(session: session, token: authResponse.token)
   }
 
   func signOut() async throws {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -306,7 +306,6 @@ public final class Store: ObservableObject {
   /// idempotent, so retrying is safe.
   private func startupSequence() async {
     let maxAttempts = 4
-    var telemetryConfigured = false
 
     for attempt in 0..<maxAttempts {
       do {
@@ -314,10 +313,7 @@ public final class Store: ObservableObject {
         try await initSystemExtension()
         Log.debug("Startup: initVPNConfiguration")
         try await initVPNConfiguration()
-        if !telemetryConfigured {
-          Telemetry.setEnvironmentOrClose(configuration.apiURL)
-          telemetryConfigured = true
-        }
+        Telemetry.setEnvironmentOrClose(configuration.apiURL)
         Log.debug("Startup: setupTunnelObservers")
         try await setupTunnelObservers()
         Log.debug("Startup: maybeAutoConnect")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -57,6 +57,13 @@ public final class Store: ObservableObject {
   private var stateUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
   private var lastSyncedSnapshot: ConfigurationSnapshot?
+  // Serialization for `syncConfiguration`. The MainActor is reentrant at `await`
+  // points, so without a guard a second sink invocation could observe a stale
+  // `lastSyncedSnapshot` mid-flight. Treat `Store` as a single-method serial
+  // actor: while one sync is running, later callers just flip `pending` and the
+  // running pass loops until the latest target is durable.
+  private var syncInFlight = false
+  private var syncPending = false
   private var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
   private let tunnelManagerFactory: TunnelProviderManagerFactory
@@ -368,8 +375,7 @@ public final class Store: ObservableObject {
     if let manager = try await VPNConfigurationManager.load(using: tunnelManagerFactory) {
       try await manager.loadConfiguration(into: configuration, userDefaults: userDefaults)
       actorName = configuration.actorName
-      lastSyncedSnapshot = currentSnapshot()
-      await syncStartOnLogin()
+      await seedInitialSyncedSnapshot()
       self.vpnConfigurationManager = manager
       SharedAccess.markAppRunning()
     } else {
@@ -395,8 +401,7 @@ public final class Store: ObservableObject {
 
     try await manager().loadConfiguration(into: configuration, userDefaults: userDefaults)
     actorName = configuration.actorName
-    lastSyncedSnapshot = currentSnapshot()
-    await syncStartOnLogin()
+    await seedInitialSyncedSnapshot()
 
     try await setupTunnelObservers()
     SharedAccess.markAppRunning()
@@ -411,13 +416,21 @@ public final class Store: ObservableObject {
     return vpnConfigurationManager
   }
 
-  private func syncStartOnLogin() async {
+  /// Establishes `lastSyncedSnapshot` after the VPN configuration is loaded and
+  /// performs the one-shot reconciliation of OS-level state (LoginItem) that
+  /// isn't covered by simply mirroring `providerConfiguration` to disk.
+  ///
+  /// If the LoginItem sync fails we deliberately leave `startOnLogin` inverted
+  /// in the snapshot so the next `syncConfiguration` pass diffs and retries.
+  private func seedInitialSyncedSnapshot() async {
+    var snapshot = currentSnapshot()
     do {
       try await LoginItemManager.syncStartOnLogin(startOnLogin: configuration.startOnLogin)
-      lastSyncedSnapshot = currentSnapshot()
     } catch {
       Log.error(error)
+      snapshot.startOnLogin.toggle()
     }
+    lastSyncedSnapshot = snapshot
   }
 
   private func currentSnapshot() -> ConfigurationSnapshot {
@@ -429,6 +442,20 @@ public final class Store: ObservableObject {
   }
 
   private func syncConfiguration() async {
+    if syncInFlight {
+      syncPending = true
+      return
+    }
+    syncInFlight = true
+    defer { syncInFlight = false }
+
+    repeat {
+      syncPending = false
+      await runSyncOnce()
+    } while syncPending
+  }
+
+  private func runSyncOnce() async {
     let target = currentSnapshot()
     // initVPNConfiguration / installVPNConfiguration seed lastSyncedSnapshot
     // before the configuration sink can fire, so this is expected to be non-nil.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/ViewModels/SettingsViewModel.swift
@@ -47,6 +47,7 @@ class SettingsViewModel: ObservableObject {
       .receive(on: RunLoop.main)
       .debounce(for: .seconds(0.3), scheduler: RunLoop.main)
       .sink(receiveValue: { [weak self] _ in
+        self?.syncForcedValuesFromConfiguration()
         self?.updateDerivedState()
       })
       .store(in: &cancellables)
@@ -65,27 +66,25 @@ class SettingsViewModel: ObservableObject {
   }
 
   func reset() {
-    if !configuration.isAuthURLForced { authURL = Configuration.defaultAuthURL }
-    if !configuration.isApiURLForced { apiURL = Configuration.defaultApiURL }
-    if !configuration.isLogFilterForced { logFilter = Configuration.defaultLogFilter }
-    if !configuration.isAccountSlugForced { accountSlug = Configuration.defaultAccountSlug }
+    if !configuration.isAuthURLForced { authURL = ConfigurationDefaults.authURL }
+    if !configuration.isApiURLForced { apiURL = ConfigurationDefaults.apiURL }
+    if !configuration.isLogFilterForced { logFilter = ConfigurationDefaults.logFilter }
+    if !configuration.isAccountSlugForced { accountSlug = ConfigurationDefaults.accountSlug }
     if !configuration.isConnectOnStartForced {
-      connectOnStart = Configuration.defaultConnectOnStart
+      connectOnStart = ConfigurationDefaults.connectOnStart
     }
-    if !configuration.isStartOnLoginForced { startOnLogin = Configuration.defaultStartOnLogin }
+    if !configuration.isStartOnLoginForced { startOnLogin = ConfigurationDefaults.startOnLogin }
 
     updateDerivedState()
   }
 
   func save() async throws {
-    configuration.authURL = authURL
-    configuration.apiURL = apiURL
-    configuration.logFilter = logFilter
-    configuration.accountSlug = accountSlug
-    configuration.connectOnStart = connectOnStart
-    configuration.startOnLogin = startOnLogin
-
-    try await LoginItemManager.syncStartOnLogin(startOnLogin: startOnLogin)
+    if !configuration.isAuthURLForced { configuration.authURL = authURL }
+    if !configuration.isApiURLForced { configuration.apiURL = apiURL }
+    if !configuration.isLogFilterForced { configuration.logFilter = logFilter }
+    if !configuration.isAccountSlugForced { configuration.accountSlug = accountSlug }
+    if !configuration.isConnectOnStartForced { configuration.connectOnStart = connectOnStart }
+    if !configuration.isStartOnLoginForced { configuration.startOnLogin = startOnLogin }
 
     updateDerivedState()
   }
@@ -124,13 +123,14 @@ class SettingsViewModel: ObservableObject {
 
   func isDefault() -> Bool {
     return
-      ((configuration.isAuthURLForced || authURL == Configuration.defaultAuthURL)
-      && (configuration.isApiURLForced || apiURL == Configuration.defaultApiURL)
-      && (configuration.isLogFilterForced || logFilter == Configuration.defaultLogFilter)
-      && (configuration.isAccountSlugForced || accountSlug == Configuration.defaultAccountSlug)
+      ((configuration.isAuthURLForced || authURL == ConfigurationDefaults.authURL)
+      && (configuration.isApiURLForced || apiURL == ConfigurationDefaults.apiURL)
+      && (configuration.isLogFilterForced || logFilter == ConfigurationDefaults.logFilter)
+      && (configuration.isAccountSlugForced || accountSlug == ConfigurationDefaults.accountSlug)
       && (configuration.isConnectOnStartForced
-        || connectOnStart == Configuration.defaultConnectOnStart)
-      && (configuration.isStartOnLoginForced || startOnLogin == Configuration.defaultStartOnLogin))
+        || connectOnStart == ConfigurationDefaults.connectOnStart)
+      && (configuration.isStartOnLoginForced
+        || startOnLogin == ConfigurationDefaults.startOnLogin))
   }
 
   func isSaved() -> Bool {
@@ -145,5 +145,14 @@ class SettingsViewModel: ObservableObject {
     shouldDisableApplyButton = (isAllForced() || isSaved() || !isValid())
 
     shouldDisableResetButton = (isAllForced() || isDefault())
+  }
+
+  private func syncForcedValuesFromConfiguration() {
+    if configuration.isAuthURLForced { authURL = configuration.authURL }
+    if configuration.isApiURLForced { apiURL = configuration.apiURL }
+    if configuration.isLogFilterForced { logFilter = configuration.logFilter }
+    if configuration.isAccountSlugForced { accountSlug = configuration.accountSlug }
+    if configuration.isConnectOnStartForced { connectOnStart = configuration.connectOnStart }
+    if configuration.isStartOnLoginForced { startOnLogin = configuration.startOnLogin }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
@@ -187,7 +187,7 @@
     func openSupport() {
       guard
         let url = URL(string: store.configuration.supportURL)
-          ?? URL(string: Configuration.defaultSupportURL)
+          ?? URL(string: ConfigurationDefaults.supportURL)
       else { return }
       Task { await NSWorkspace.shared.openAsync(url) }
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -245,10 +245,11 @@ import SwiftUI
     init() {
       self.enabled = configuration.internetResourceEnabled
 
-      configuration.$publishedInternetResourceEnabled
+      configuration.objectWillChange
         .receive(on: RunLoop.main)
-        .sink(receiveValue: { [self] enabled in
-          self.enabled = enabled
+        .sink(receiveValue: { [weak self] _ in
+          guard let self else { return }
+          self.enabled = self.configuration.internetResourceEnabled
         })
         .store(in: &cancellables)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
@@ -141,10 +141,11 @@ import SwiftUI
     }
 
     private func supportButtonTapped() {
-      // defaultSupportURL is a static constant guaranteed to be valid
+      guard let defaultURL = URL(string: ConfigurationDefaults.supportURL) else { return }
+
       let url =
         URL(string: configuration.supportURL)
-        ?? URL(string: Configuration.defaultSupportURL)!  // swiftlint:disable:this force_unwrapping
+        ?? defaultURL
       openURL(url)
     }
   }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
@@ -6,29 +6,81 @@
 
 import Combine
 import Foundation
+import NetworkExtension
 import Testing
 
 @testable import FirezoneKit
+
+private final class ForcedUserDefaults: UserDefaults {
+  let domainName: String
+  private let forcedKeys: Set<String>
+  private let forcedValues: [String: Any]
+
+  init?(forcedKeys: Set<String>, forcedValues: [String: Any] = [:]) {
+    let domainName = "dev.firezone.firezone.tests.\(UUID().uuidString)"
+    self.domainName = domainName
+    self.forcedKeys = forcedKeys
+    self.forcedValues = forcedValues
+
+    super.init(suiteName: domainName)
+    removePersistentDomain(forName: domainName)
+  }
+
+  override func objectIsForced(forKey defaultName: String) -> Bool {
+    forcedKeys.contains(defaultName)
+  }
+
+  override func object(forKey defaultName: String) -> Any? {
+    forcedValues[defaultName] ?? super.object(forKey: defaultName)
+  }
+
+  override func string(forKey defaultName: String) -> String? {
+    forcedValues[defaultName] as? String ?? super.string(forKey: defaultName)
+  }
+
+  override func bool(forKey defaultName: String) -> Bool {
+    forcedValues[defaultName] as? Bool ?? super.bool(forKey: defaultName)
+  }
+}
+
+@MainActor
+private final class MockTunnelProviderManager: TunnelProviderManager {
+  var isEnabled = true
+  var localizedDescription: String?
+  var protocolConfiguration: NEVPNProtocol?
+  let connection: NEVPNConnection = NETunnelProviderManager().connection
+  var saveCount = 0
+  var loadCount = 0
+
+  func saveToPreferences() async throws {
+    saveCount += 1
+  }
+
+  func loadFromPreferences() async throws {
+    loadCount += 1
+  }
+}
 
 @Suite("Configuration Tests")
 struct ConfigurationTests {
 
   // MARK: - Default Values
 
-  @Test("Returns default values when UserDefaults is empty")
+  @Test("Returns default values when provider configuration is empty")
   @MainActor
   func defaultValues() async {
     let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
-    #expect(config.authURL == Configuration.defaultAuthURL)
-    #expect(config.apiURL == Configuration.defaultApiURL)
-    #expect(config.logFilter == Configuration.defaultLogFilter)
-    #expect(config.accountSlug == Configuration.defaultAccountSlug)
-    #expect(config.supportURL == Configuration.defaultSupportURL)
-    #expect(config.connectOnStart == Configuration.defaultConnectOnStart)
-    #expect(config.startOnLogin == Configuration.defaultStartOnLogin)
-    #expect(config.disableUpdateCheck == Configuration.defaultDisableUpdateCheck)
+    #expect(config.authURL == ConfigurationDefaults.authURL)
+    #expect(config.apiURL == ConfigurationDefaults.apiURL)
+    #expect(config.logFilter == ConfigurationDefaults.logFilter)
+    #expect(config.accountSlug == ConfigurationDefaults.accountSlug)
+    #expect(config.actorName == ConfigurationDefaults.actorName)
+    #expect(config.supportURL == ConfigurationDefaults.supportURL)
+    #expect(config.connectOnStart == ConfigurationDefaults.connectOnStart)
+    #expect(config.startOnLogin == ConfigurationDefaults.startOnLogin)
+    #expect(config.disableUpdateCheck == ConfigurationDefaults.disableUpdateCheck)
     #expect(config.internetResourceEnabled == false)
     #expect(config.hideAdminPortalMenuItem == false)
     #expect(config.hideResourceList == false)
@@ -55,7 +107,7 @@ struct ConfigurationTests {
 
   // MARK: - Read/Write Properties
 
-  @Test("String properties persist to UserDefaults")
+  @Test("String properties persist to provider configuration")
   @MainActor
   func stringPropertiesPersist() async {
     let defaults = UserDefaults.makeTestDefaults()
@@ -65,23 +117,33 @@ struct ConfigurationTests {
     config.apiURL = "wss://custom.api.url"
     config.logFilter = "trace"
     config.accountSlug = "test-slug"
-    config.supportURL = "https://custom.support.url"
+    config.actorName = "Test User"
 
     #expect(config.authURL == "https://custom.auth.url")
     #expect(config.apiURL == "wss://custom.api.url")
     #expect(config.logFilter == "trace")
     #expect(config.accountSlug == "test-slug")
-    #expect(config.supportURL == "https://custom.support.url")
+    #expect(config.actorName == "Test User")
+    #expect(config.supportURL == ConfigurationDefaults.supportURL)
 
-    // Verify values are actually in UserDefaults
-    #expect(defaults.string(forKey: "authURL") == "https://custom.auth.url")
-    #expect(defaults.string(forKey: "apiURL") == "wss://custom.api.url")
-    #expect(defaults.string(forKey: "logFilter") == "trace")
-    #expect(defaults.string(forKey: "accountSlug") == "test-slug")
-    #expect(defaults.string(forKey: "supportURL") == "https://custom.support.url")
+    let providerConfiguration = config.toProviderConfiguration()
+
+    // User-editable connection settings are no longer written to UserDefaults.
+    #expect(defaults.string(forKey: "authURL") == nil)
+    #expect(defaults.string(forKey: "apiURL") == nil)
+    #expect(defaults.string(forKey: "logFilter") == nil)
+    #expect(defaults.string(forKey: "accountSlug") == nil)
+    #expect(defaults.string(forKey: "actorName") == nil)
+    #expect(providerConfiguration["authURL"] == "https://custom.auth.url")
+    #expect(providerConfiguration["apiURL"] == "wss://custom.api.url")
+    #expect(providerConfiguration["logFilter"] == "trace")
+    #expect(providerConfiguration["accountSlug"] == "test-slug")
+    #expect(providerConfiguration["actorName"] == "Test User")
+
+    #expect(defaults.string(forKey: "supportURL") == nil)
   }
 
-  @Test("Boolean properties persist to UserDefaults")
+  @Test("Boolean properties persist to their configured stores")
   @MainActor
   func booleanPropertiesPersist() async {
     let defaults = UserDefaults.makeTestDefaults()
@@ -89,90 +151,156 @@ struct ConfigurationTests {
 
     config.connectOnStart = true
     config.startOnLogin = true
-    config.disableUpdateCheck = true
     config.internetResourceEnabled = true
-    config.hideAdminPortalMenuItem = true
-    config.hideResourceList = true
 
     #expect(config.connectOnStart == true)
     #expect(config.startOnLogin == true)
-    #expect(config.disableUpdateCheck == true)
+    #expect(config.disableUpdateCheck == false)
     #expect(config.internetResourceEnabled == true)
-    #expect(config.hideAdminPortalMenuItem == true)
-    #expect(config.hideResourceList == true)
+    #expect(config.hideAdminPortalMenuItem == false)
+    #expect(config.hideResourceList == false)
 
-    // Verify values are actually in UserDefaults
-    #expect(defaults.bool(forKey: "connectOnStart") == true)
-    #expect(defaults.bool(forKey: "startOnLogin") == true)
-    #expect(defaults.bool(forKey: "disableUpdateCheck") == true)
-    #expect(defaults.bool(forKey: "internetResourceEnabled") == true)
-    #expect(defaults.bool(forKey: "hideAdminPortalMenuItem") == true)
-    #expect(defaults.bool(forKey: "hideResourceList") == true)
+    let providerConfiguration = config.toProviderConfiguration()
+
+    #expect(defaults.object(forKey: "connectOnStart") == nil)
+    #expect(defaults.object(forKey: "startOnLogin") == nil)
+    #expect(defaults.object(forKey: "internetResourceEnabled") == nil)
+    #expect(providerConfiguration["connectOnStart"] == "true")
+    #expect(providerConfiguration["startOnLogin"] == "true")
+    #expect(providerConfiguration["internetResourceEnabled"] == "true")
+
+    #expect(defaults.object(forKey: "disableUpdateCheck") == nil)
+    #expect(defaults.object(forKey: "hideAdminPortalMenuItem") == nil)
+    #expect(defaults.object(forKey: "hideResourceList") == nil)
   }
 
-  // MARK: - TunnelConfiguration
-
-  @Test("toTunnelConfiguration returns correct values")
+  @Test("MDM-only UserDefaults values are read from UserDefaults")
   @MainActor
-  func tunnelConfiguration() async {
+  func mdmOnlyValuesReadFromUserDefaults() async {
     let defaults = UserDefaults.makeTestDefaults()
+
+    defaults.set(true, forKey: "hideAdminPortalMenuItem")
+    defaults.set(true, forKey: "hideResourceList")
+    defaults.set(true, forKey: "disableUpdateCheck")
+    defaults.set("https://custom.support.url", forKey: "supportURL")
+
     let config = Configuration(userDefaults: defaults)
 
-    config.apiURL = "wss://test.api"
-    config.accountSlug = "test-account"
-    config.logFilter = "warn"
-    config.internetResourceEnabled = true
-
-    let tunnelConfig = config.toTunnelConfiguration()
-
-    #expect(tunnelConfig.apiURL == "wss://test.api")
-    #expect(tunnelConfig.accountSlug == "test-account")
-    #expect(tunnelConfig.logFilter == "warn")
-    #expect(tunnelConfig.internetResourceEnabled == true)
+    #expect(config.hideAdminPortalMenuItem == true)
+    #expect(config.hideResourceList == true)
+    #expect(config.disableUpdateCheck == true)
+    #expect(config.supportURL == "https://custom.support.url")
   }
 
-  @Test("TunnelConfiguration equality")
-  func tunnelConfigurationEquality() {
-    let config1 = TunnelConfiguration(
-      apiURL: "wss://api",
-      accountSlug: "slug",
-      logFilter: "info",
-      internetResourceEnabled: true
+  @Test("Forced MDM values override effective configuration without changing base provider values")
+  @MainActor
+  func forcedValuesOverrideEffectiveConfigurationOnly() async throws {
+    let defaults = try #require(
+      ForcedUserDefaults(forcedKeys: [
+        Configuration.Keys.apiURL
+      ])
+    )
+    defaults.set("wss://mdm.api", forKey: Configuration.Keys.apiURL)
+
+    let config = Configuration(userDefaults: defaults)
+    config.loadProviderConfiguration([
+      Configuration.Keys.apiURL: "wss://provider.api",
+      Configuration.Keys.internetResourceEnabled: "false",
+    ])
+
+    #expect(config.apiURL == "wss://mdm.api")
+    #expect(config.internetResourceEnabled == false)
+
+    let providerConfiguration = config.toProviderConfiguration()
+    #expect(providerConfiguration[Configuration.Keys.apiURL] == "wss://provider.api")
+    #expect(providerConfiguration[Configuration.Keys.internetResourceEnabled] == "false")
+    #expect(
+      providerConfiguration[Configuration.forcedKey(for: Configuration.Keys.apiURL)]
+        == "wss://mdm.api")
+    #expect(
+      providerConfiguration[
+        Configuration.forcedKey(for: Configuration.Keys.internetResourceEnabled)] == nil)
+  }
+
+  @Test("Forced configuration contains only MDM-forced tunnel settings")
+  @MainActor
+  func forcedConfigurationContainsOnlyForcedTunnelSettings() async throws {
+    let defaults = try #require(
+      ForcedUserDefaults(forcedKeys: [
+        Configuration.Keys.apiURL,
+        Configuration.Keys.logFilter,
+        Configuration.Keys.authURL,
+        Configuration.Keys.internetResourceEnabled,
+      ])
+    )
+    defaults.set("wss://mdm.api", forKey: Configuration.Keys.apiURL)
+    defaults.set("trace", forKey: Configuration.Keys.logFilter)
+    defaults.set("https://mdm.auth", forKey: Configuration.Keys.authURL)
+    defaults.set(true, forKey: Configuration.Keys.internetResourceEnabled)
+
+    let config = Configuration(userDefaults: defaults)
+    let forcedConfiguration = config.forcedConfiguration()
+
+    #expect(forcedConfiguration[Configuration.Keys.apiURL] == "wss://mdm.api")
+    #expect(forcedConfiguration[Configuration.Keys.logFilter] == "trace")
+    #expect(forcedConfiguration[Configuration.Keys.authURL] == nil)
+    #expect(forcedConfiguration[Configuration.Keys.internetResourceEnabled] == nil)
+
+    let providerConfiguration = config.toProviderConfiguration()
+    for (key, value) in forcedConfiguration {
+      #expect(providerConfiguration[Configuration.forcedKey(for: key)] == value)
+    }
+    // Keys absent from forcedConfiguration must not appear under the forced prefix either.
+    #expect(
+      providerConfiguration[Configuration.forcedKey(for: Configuration.Keys.authURL)] == nil)
+    #expect(
+      providerConfiguration[
+        Configuration.forcedKey(
+          for: Configuration.Keys.internetResourceEnabled)] == nil)
+  }
+
+  @Test("Settings save skips forced MDM fields")
+  @MainActor
+  func settingsSaveSkipsForcedFields() async throws {
+    let defaults = try #require(
+      ForcedUserDefaults(forcedKeys: [
+        Configuration.Keys.authURL
+      ])
+    )
+    defaults.set("https://mdm.auth", forKey: Configuration.Keys.authURL)
+
+    let config = Configuration(userDefaults: defaults)
+    config.loadProviderConfiguration(
+      [
+        Configuration.Keys.authURL: "https://provider.auth",
+        Configuration.Keys.apiURL: "wss://provider.api",
+      ]
     )
 
-    let config2 = TunnelConfiguration(
-      apiURL: "wss://api",
-      accountSlug: "slug",
-      logFilter: "info",
-      internetResourceEnabled: true
-    )
+    let viewModel = SettingsViewModel(configuration: config)
+    viewModel.authURL = "https://attempted-user-change.auth"
+    viewModel.apiURL = "wss://saved-user-change.api"
 
-    let config3 = TunnelConfiguration(
-      apiURL: "wss://different",
-      accountSlug: "slug",
-      logFilter: "info",
-      internetResourceEnabled: true
-    )
+    try await viewModel.save()
 
-    #expect(config1 == config2)
-    #expect(config1 != config3)
+    let providerConfiguration = config.toProviderConfiguration()
+    #expect(providerConfiguration[Configuration.Keys.authURL] == "https://provider.auth")
+    #expect(providerConfiguration[Configuration.Keys.apiURL] == "wss://saved-user-change.api")
   }
 
   // MARK: - Published Properties Initialization
 
-  @Test("Published properties initialized from UserDefaults")
+  @Test("Published MDM-only properties initialize from UserDefaults")
   @MainActor
   func publishedPropertiesInitialized() async {
     let defaults = UserDefaults.makeTestDefaults()
 
-    // Set values before creating Configuration
-    defaults.set(true, forKey: "internetResourceEnabled")
     defaults.set(true, forKey: "hideAdminPortalMenuItem")
     defaults.set(true, forKey: "hideResourceList")
 
     let config = Configuration(userDefaults: defaults)
+    config.loadProviderConfiguration(["internetResourceEnabled": "true"])
 
-    // Published properties should be initialized from UserDefaults
     #expect(config.publishedInternetResourceEnabled == true)
     #expect(config.publishedHideAdminPortalMenuItem == true)
     #expect(config.publishedHideResourceList == true)
@@ -191,7 +319,7 @@ struct ConfigurationTests {
 
     // Wait for the published property to update to the expected value
     await confirmation { confirm in
-      let cancellable = config.$publishedInternetResourceEnabled
+      let cancellable = config.internetResourceEnabledPublisher
         .sink { value in
           if value { confirm() }  // only confirm when true
         }
@@ -205,30 +333,20 @@ struct ConfigurationTests {
     }
   }
 
-  @Test("Published properties update when UserDefaults changes externally")
+  @Test("Published MDM-only properties update from UserDefaults changes")
   @MainActor
   func publishedPropertiesUpdateFromExternalChanges() async {
     let defaults = UserDefaults.makeTestDefaults()
     let config = Configuration(userDefaults: defaults)
 
-    // Initially false
-    #expect(config.publishedInternetResourceEnabled == false)
+    #expect(config.publishedHideResourceList == false)
 
-    // Wait for the published property to update to the expected value
-    await confirmation { confirm in
-      let cancellable = config.$publishedInternetResourceEnabled
-        .sink { value in
-          if value { confirm() }  // only confirm when true
-        }
+    defaults.set(true, forKey: "hideResourceList")
 
-      // Simulate an external change (e.g., from MDM or another process)
-      defaults.set(true, forKey: "internetResourceEnabled")
+    // Give async notification time to propagate
+    try? await Task.sleep(for: .milliseconds(100))
 
-      // Give async notification time to propagate
-      try? await Task.sleep(for: .milliseconds(100))
-
-      _ = cancellable
-    }
+    #expect(config.publishedHideResourceList == true)
   }
 
   @Test("objectWillChange emits when properties change")
@@ -259,86 +377,265 @@ struct ConfigurationTests {
 
   // MARK: - Reading Pre-existing Values
 
-  @Test("Configuration reads pre-existing UserDefaults values")
+  @Test("ConfigurationMigrator migrates pre-existing UserDefaults values")
   @MainActor
-  func readsPreExistingValues() async {
-    let defaults = UserDefaults.makeTestDefaults()
+  func readsPreExistingValues() async throws {
+    let defaults = try #require(ForcedUserDefaults(forcedKeys: []))
 
     // Set values before creating Configuration
-    defaults.set("https://preset.auth", forKey: "authURL")
-    defaults.set("wss://preset.api", forKey: "apiURL")
-    defaults.set(true, forKey: "connectOnStart")
-    defaults.set(true, forKey: "internetResourceEnabled")
+    defaults.set("https://preset.auth", forKey: Configuration.Keys.authURL)
+    defaults.set("wss://preset.api", forKey: Configuration.Keys.apiURL)
+    defaults.set("Preset User", forKey: Configuration.Keys.actorName)
+    defaults.set(true, forKey: Configuration.Keys.connectOnStart)
+    defaults.set(true, forKey: Configuration.Keys.internetResourceEnabled)
 
-    let config = Configuration(userDefaults: defaults)
+    let protocolConfiguration = NETunnelProviderProtocol()
+    protocolConfiguration.providerConfiguration = [:]
+    let tunnelProviderManager = MockTunnelProviderManager()
+    tunnelProviderManager.protocolConfiguration = protocolConfiguration
+    let vpnConfigurationManager = VPNConfigurationManager(from: tunnelProviderManager)
 
-    #expect(config.authURL == "https://preset.auth")
-    #expect(config.apiURL == "wss://preset.api")
-    #expect(config.connectOnStart == true)
-    #expect(config.internetResourceEnabled == true)
+    try await ConfigurationMigrator.migrateUserDefaultsIfNeeded(
+      userDefaults: defaults,
+      vpnConfigurationManager: vpnConfigurationManager,
+      userDefaultsDomain: defaults.domainName
+    )
 
-    // Published properties should also reflect pre-existing values
-    #expect(config.publishedInternetResourceEnabled == true)
+    let providerConfiguration = protocolConfiguration.providerConfiguration as? [String: String]
+    #expect(providerConfiguration?[Configuration.Keys.authURL] == "https://preset.auth")
+    #expect(providerConfiguration?[Configuration.Keys.apiURL] == "wss://preset.api")
+    #expect(providerConfiguration?[Configuration.Keys.logFilter] == ConfigurationDefaults.logFilter)
+    #expect(
+      providerConfiguration?[Configuration.Keys.accountSlug] == ConfigurationDefaults.accountSlug)
+    #expect(providerConfiguration?[Configuration.Keys.actorName] == "Preset User")
+    #expect(providerConfiguration?[Configuration.Keys.connectOnStart] == "true")
+    #expect(providerConfiguration?[Configuration.Keys.startOnLogin] == "false")
+    #expect(providerConfiguration?[Configuration.Keys.internetResourceEnabled] == "true")
+    #expect(providerConfiguration?[Configuration.Keys.userDefaultsMigrated] == "true")
+    #expect(defaults.object(forKey: Configuration.Keys.authURL) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.apiURL) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.logFilter) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.accountSlug) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.actorName) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.connectOnStart) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.startOnLogin) == nil)
+    #expect(defaults.object(forKey: Configuration.Keys.internetResourceEnabled) == nil)
+    #expect(tunnelProviderManager.saveCount == 1)
+  }
+
+  @Test("ConfigurationMigrator migrates user-domain values without copying MDM-only values")
+  @MainActor
+  func migratorMigratesUserDomainValuesWithoutCopyingMDMOnlyValues() async throws {
+    let defaults = try #require(
+      ForcedUserDefaults(
+        forcedKeys: [
+          Configuration.Keys.authURL,
+          Configuration.Keys.apiURL,
+          Configuration.Keys.connectOnStart,
+          Configuration.Keys.hideAdminPortalMenuItem,
+          Configuration.Keys.hideResourceList,
+          Configuration.Keys.disableUpdateCheck,
+          Configuration.Keys.supportURL,
+        ],
+        forcedValues: [
+          Configuration.Keys.authURL: "https://forced.auth",
+          Configuration.Keys.apiURL: "wss://forced.api",
+          Configuration.Keys.connectOnStart: true,
+          Configuration.Keys.hideAdminPortalMenuItem: true,
+          Configuration.Keys.hideResourceList: true,
+          Configuration.Keys.disableUpdateCheck: true,
+          Configuration.Keys.supportURL: "https://forced.support",
+        ]
+      )
+    )
+
+    defaults.set("", forKey: Configuration.Keys.authURL)
+    defaults.set("wss://user.api", forKey: Configuration.Keys.apiURL)
+    defaults.set("trace", forKey: Configuration.Keys.logFilter)
+    defaults.set("user-account", forKey: Configuration.Keys.accountSlug)
+    defaults.set("Legacy User", forKey: Configuration.Keys.actorName)
+    defaults.set(false, forKey: Configuration.Keys.connectOnStart)
+    defaults.set(true, forKey: Configuration.Keys.startOnLogin)
+    defaults.set(true, forKey: Configuration.Keys.internetResourceEnabled)
+    defaults.set(true, forKey: Configuration.Keys.hideAdminPortalMenuItem)
+    defaults.set(true, forKey: Configuration.Keys.hideResourceList)
+    defaults.set(true, forKey: Configuration.Keys.disableUpdateCheck)
+    defaults.set("https://support.example", forKey: Configuration.Keys.supportURL)
+
+    let protocolConfiguration = NETunnelProviderProtocol()
+    protocolConfiguration.providerConfiguration = [:]
+    let tunnelProviderManager = MockTunnelProviderManager()
+    tunnelProviderManager.protocolConfiguration = protocolConfiguration
+    let vpnConfigurationManager = VPNConfigurationManager(from: tunnelProviderManager)
+
+    try await ConfigurationMigrator.migrateUserDefaultsIfNeeded(
+      userDefaults: defaults,
+      vpnConfigurationManager: vpnConfigurationManager,
+      userDefaultsDomain: defaults.domainName
+    )
+
+    let providerConfiguration = try #require(
+      protocolConfiguration.providerConfiguration as? [String: String]
+    )
+    #expect(providerConfiguration[Configuration.Keys.authURL] == ConfigurationDefaults.authURL)
+    #expect(providerConfiguration[Configuration.Keys.apiURL] == "wss://user.api")
+    #expect(providerConfiguration[Configuration.Keys.logFilter] == "trace")
+    #expect(providerConfiguration[Configuration.Keys.accountSlug] == "user-account")
+    #expect(providerConfiguration[Configuration.Keys.actorName] == "Legacy User")
+    #expect(providerConfiguration[Configuration.Keys.connectOnStart] == "false")
+    #expect(providerConfiguration[Configuration.Keys.startOnLogin] == "true")
+    #expect(providerConfiguration[Configuration.Keys.internetResourceEnabled] == "true")
+    #expect(providerConfiguration[Configuration.Keys.hideAdminPortalMenuItem] == nil)
+    #expect(providerConfiguration[Configuration.Keys.hideResourceList] == nil)
+    #expect(providerConfiguration[Configuration.Keys.disableUpdateCheck] == nil)
+    #expect(providerConfiguration[Configuration.Keys.supportURL] == nil)
+    #expect(providerConfiguration[Configuration.Keys.userDefaultsMigrated] == "true")
+    let userDomain = defaults.persistentDomain(forName: defaults.domainName) ?? [:]
+    #expect(userDomain[Configuration.Keys.apiURL] == nil)
+    #expect(userDomain[Configuration.Keys.logFilter] == nil)
+    #expect(userDomain[Configuration.Keys.accountSlug] == nil)
+    #expect(userDomain[Configuration.Keys.actorName] == nil)
+    #expect(userDomain[Configuration.Keys.connectOnStart] == nil)
+    #expect(userDomain[Configuration.Keys.startOnLogin] == nil)
+    #expect(userDomain[Configuration.Keys.internetResourceEnabled] == nil)
+    #expect(userDomain[Configuration.Keys.hideAdminPortalMenuItem] != nil)
+    #expect(userDomain[Configuration.Keys.hideResourceList] != nil)
+    #expect(userDomain[Configuration.Keys.disableUpdateCheck] != nil)
+    #expect(userDomain[Configuration.Keys.supportURL] != nil)
+    #expect(tunnelProviderManager.saveCount == 1)
+  }
+
+  @Test("ConfigurationMigrator does not persist forced MDM values")
+  @MainActor
+  func migratorDoesNotPersistForcedValues() async throws {
+    let defaults = try #require(
+      ForcedUserDefaults(forcedKeys: [
+        Configuration.Keys.apiURL,
+        Configuration.Keys.logFilter,
+      ])
+    )
+    defaults.set("wss://forced.api", forKey: Configuration.Keys.apiURL)
+    defaults.set("trace", forKey: Configuration.Keys.logFilter)
+
+    let protocolConfiguration = NETunnelProviderProtocol()
+    protocolConfiguration.providerConfiguration = [
+      Configuration.Keys.apiURL: "wss://provider.api",
+      Configuration.Keys.logFilter: "info",
+      Configuration.Keys.userDefaultsMigrated: "true",
+    ]
+    let tunnelProviderManager = MockTunnelProviderManager()
+    tunnelProviderManager.protocolConfiguration = protocolConfiguration
+    let vpnConfigurationManager = VPNConfigurationManager(from: tunnelProviderManager)
+
+    try await ConfigurationMigrator.migrateUserDefaultsIfNeeded(
+      userDefaults: defaults,
+      vpnConfigurationManager: vpnConfigurationManager
+    )
+
+    let providerConfiguration = try #require(
+      protocolConfiguration.providerConfiguration as? [String: String]
+    )
+    #expect(providerConfiguration[Configuration.Keys.apiURL] == "wss://provider.api")
+    #expect(providerConfiguration[Configuration.Keys.logFilter] == "info")
+    #expect(tunnelProviderManager.saveCount == 0)
+  }
+
+  @Test("VPNConfigurationManager caches forced configuration on load")
+  @MainActor
+  func vpnConfigurationManagerCachesForcedConfigurationOnLoad() async throws {
+    let defaults = try #require(
+      ForcedUserDefaults(
+        forcedKeys: [
+          Configuration.Keys.apiURL,
+          Configuration.Keys.logFilter,
+        ],
+        forcedValues: [
+          Configuration.Keys.apiURL: "wss://forced.api",
+          Configuration.Keys.logFilter: "trace",
+        ]
+      )
+    )
+    let configuration = Configuration(userDefaults: defaults)
+
+    let protocolConfiguration = NETunnelProviderProtocol()
+    protocolConfiguration.serverAddress = "Firezone"
+    protocolConfiguration.providerConfiguration = [
+      Configuration.Keys.authURL: "https://provider.auth",
+      Configuration.Keys.apiURL: "wss://provider.api",
+      Configuration.Keys.logFilter: "info",
+      Configuration.Keys.accountSlug: "provider-account",
+      Configuration.Keys.actorName: "Provider User",
+      Configuration.Keys.connectOnStart: "false",
+      Configuration.Keys.startOnLogin: "false",
+      Configuration.Keys.internetResourceEnabled: "false",
+      Configuration.Keys.userDefaultsMigrated: "true",
+    ]
+    let tunnelProviderManager = MockTunnelProviderManager()
+    tunnelProviderManager.protocolConfiguration = protocolConfiguration
+    let vpnConfigurationManager = VPNConfigurationManager(from: tunnelProviderManager)
+
+    try await vpnConfigurationManager.loadConfiguration(
+      into: configuration,
+      userDefaults: defaults
+    )
+
+    let providerConfiguration = try #require(
+      protocolConfiguration.providerConfiguration as? [String: String]
+    )
+
+    #expect(providerConfiguration[Configuration.Keys.apiURL] == "wss://provider.api")
+    #expect(providerConfiguration[Configuration.Keys.logFilter] == "info")
+    #expect(
+      providerConfiguration[Configuration.forcedKey(for: Configuration.Keys.apiURL)]
+        == "wss://forced.api")
+    #expect(
+      providerConfiguration[Configuration.forcedKey(for: Configuration.Keys.logFilter)]
+        == "trace")
+    #expect(tunnelProviderManager.saveCount == 1)
+  }
+
+  @Test("VPNConfigurationManager rejects wrong providerConfiguration value types")
+  @MainActor
+  func providerConfigurationRejectsWrongValueTypes() async throws {
+    let protocolConfiguration = NETunnelProviderProtocol()
+    protocolConfiguration.providerConfiguration = [
+      Configuration.Keys.apiURL: 42
+    ]
+    let tunnelProviderManager = MockTunnelProviderManager()
+    tunnelProviderManager.protocolConfiguration = protocolConfiguration
+    let vpnConfigurationManager = VPNConfigurationManager(from: tunnelProviderManager)
+
+    do {
+      _ = try vpnConfigurationManager.providerConfiguration()
+      Issue.record("Expected savedProtocolConfigurationIsInvalid")
+    } catch VPNConfigurationManagerError.savedProtocolConfigurationIsInvalid {
+      // Expected
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
   }
 
   // MARK: - Multiple Configuration Instances
 
-  @Test("Multiple Configuration instances share same UserDefaults")
+  @Test("Provider configuration round trips between Configuration instances")
   @MainActor
-  func sharedUserDefaults() async throws {
+  func providerConfigurationRoundTrip() async throws {
     let defaults = UserDefaults.makeTestDefaults()
     let config1 = Configuration(userDefaults: defaults)
     let config2 = Configuration(userDefaults: defaults)
 
     config1.authURL = "https://shared.url"
+    config1.apiURL = "wss://shared.api"
+    config1.actorName = "Shared User"
+    config1.internetResourceEnabled = true
+    let providerConfiguration = config1.toProviderConfiguration()
 
-    // config2 should see the same value (reading from same UserDefaults)
+    config2.loadProviderConfiguration(providerConfiguration)
+
     #expect(config2.authURL == "https://shared.url")
-  }
-}
-
-// MARK: - TunnelConfiguration Codable Tests
-
-@Suite("TunnelConfiguration Codable Tests")
-struct TunnelConfigurationCodableTests {
-
-  @Test("TunnelConfiguration encodes and decodes correctly")
-  func encodeDecode() throws {
-    let original = TunnelConfiguration(
-      apiURL: "wss://api.example.com",
-      accountSlug: "my-account",
-      logFilter: "debug",
-      internetResourceEnabled: true
-    )
-
-    let encoder = JSONEncoder()
-    let data = try encoder.encode(original)
-
-    let decoder = JSONDecoder()
-    let decoded = try decoder.decode(TunnelConfiguration.self, from: data)
-
-    #expect(decoded == original)
-  }
-
-  @Test("TunnelConfiguration decodes from JSON string")
-  func decodeFromJSON() throws {
-    let json = """
-      {
-        "apiURL": "wss://test.api",
-        "accountSlug": "test-slug",
-        "logFilter": "info",
-        "internetResourceEnabled": false
-      }
-      """
-
-    let jsonData = try #require(json.data(using: .utf8))
-    let decoder = JSONDecoder()
-    let config = try decoder.decode(TunnelConfiguration.self, from: jsonData)
-
-    #expect(config.apiURL == "wss://test.api")
-    #expect(config.accountSlug == "test-slug")
-    #expect(config.logFilter == "info")
-    #expect(config.internetResourceEnabled == false)
+    #expect(config2.apiURL == "wss://shared.api")
+    #expect(config2.actorName == "Shared User")
+    #expect(config2.internetResourceEnabled == true)
   }
 }
 
@@ -391,20 +688,14 @@ struct ProviderMessageCodableTests {
     }
   }
 
-  @Test("setConfiguration round-trips through JSON")
-  func setConfigurationRoundTrip() throws {
-    let config = TunnelConfiguration(
-      apiURL: "wss://api.example.com",
-      accountSlug: "test",
-      logFilter: "info",
-      internetResourceEnabled: true
-    )
-    let decoded = try roundTrip(.setConfiguration(config))
+  @Test("setInternetResourceEnabled round-trips through JSON")
+  func setInternetResourceEnabledRoundTrip() throws {
+    let decoded = try roundTrip(.setInternetResourceEnabled(true))
 
-    if case .setConfiguration(let decodedConfig) = decoded {
-      #expect(decodedConfig == config)
+    if case .setInternetResourceEnabled(let enabled) = decoded {
+      #expect(enabled == true)
     } else {
-      Issue.record("Expected .setConfiguration, got \(decoded)")
+      Issue.record("Expected .setInternetResourceEnabled, got \(decoded)")
     }
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -99,13 +99,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     let apiURL =
-      providerConfiguration.effectiveValue(forKey: Configuration.Keys.apiURL)
+      providerConfiguration.withMDMOverride(forKey: Configuration.Keys.apiURL)
       ?? ConfigurationDefaults.apiURL
     let logFilter =
-      providerConfiguration.effectiveValue(forKey: Configuration.Keys.logFilter)
+      providerConfiguration.withMDMOverride(forKey: Configuration.Keys.logFilter)
       ?? ConfigurationDefaults.logFilter
     let accountSlug =
-      providerConfiguration.effectiveValue(forKey: Configuration.Keys.accountSlug)
+      providerConfiguration.withMDMOverride(forKey: Configuration.Keys.accountSlug)
       ?? ConfigurationDefaults.accountSlug
     let internetResourceEnabled = Configuration.bool(
       providerConfiguration[Configuration.Keys.internetResourceEnabled],

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -10,7 +10,7 @@ import System
 import os
 
 enum PacketTunnelProviderError: Error {
-  case tunnelConfigurationIsInvalid
+  case providerConfigurationIsInvalid
   case firezoneIdIsInvalid
   case tokenNotFoundInKeychain
 }
@@ -29,7 +29,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   private var logCleanupTask: CancellableTask?
 
   private var logExportState: LogExportState = .idle
-  private var tunnelConfiguration: TunnelConfiguration?
   // swiftlint:disable:next no_userdefaults_standard - NetworkExtension DI entry point uses shared UserDefaults store
   private let defaults = UserDefaults.standard
 
@@ -50,7 +49,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       "NetworkExtension starting - Version: \(version), Build: \(build), Bundle ID: \(bundleId)")
 
     migrateFirezoneId()
-    self.tunnelConfiguration = TunnelConfiguration.tryLoad(from: defaults)
   }
 
   override func startTunnel(
@@ -70,26 +68,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
     Log.info("Starting tunnel - Version: \(version), Build: \(build)")
-
-    // Try to load configuration from options first (passed from client at startup)
-    if let configData = options?["configuration"] as? Data {
-      do {
-        let decoder = PropertyListDecoder()
-        let configFromOptions = try decoder.decode(TunnelConfiguration.self, from: configData)
-        // Save it for future fallback (e.g., system-initiated restarts)
-        configFromOptions.save(to: defaults)
-        self.tunnelConfiguration = configFromOptions
-      } catch {
-        Log.error(error)
-      }
-    }
-
-    // If the tunnel starts up before the GUI after an upgrade crossing the 1.4.15 version boundary,
-    // the old system settings-based config will still be present and the new configuration will be empty.
-    // So handle that edge case gracefully.
-    let legacyConfiguration = VPNConfigurationManager.legacyConfiguration(
-      protocolConfiguration: protocolConfiguration as? NETunnelProviderProtocol
-    )
 
     // Extract token from options before any async work
     let passedToken = options?["token"] as? String
@@ -112,20 +90,30 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
     let firezoneId = FirezoneId(uuid: rawId)
 
-    guard let apiURL = legacyConfiguration?["apiURL"] ?? tunnelConfiguration?.apiURL,
-      let logFilter = legacyConfiguration?["logFilter"] ?? tunnelConfiguration?.logFilter,
-      let accountSlug = legacyConfiguration?["accountSlug"] ?? tunnelConfiguration?.accountSlug
-    else {
-      completionHandler(PacketTunnelProviderError.tunnelConfigurationIsInvalid)
+    let providerConfiguration: [String: String]
+    do {
+      providerConfiguration = try loadProviderConfiguration()
+    } catch {
+      completionHandler(PacketTunnelProviderError.providerConfigurationIsInvalid)
       return
     }
 
+    let apiURL =
+      providerConfiguration.effectiveValue(forKey: Configuration.Keys.apiURL)
+      ?? ConfigurationDefaults.apiURL
+    let logFilter =
+      providerConfiguration.effectiveValue(forKey: Configuration.Keys.logFilter)
+      ?? ConfigurationDefaults.logFilter
+    let accountSlug =
+      providerConfiguration.effectiveValue(forKey: Configuration.Keys.accountSlug)
+      ?? ConfigurationDefaults.accountSlug
+    let internetResourceEnabled = Configuration.bool(
+      providerConfiguration[Configuration.Keys.internetResourceEnabled],
+      default: ConfigurationDefaults.internetResourceEnabled
+    )
+
     Telemetry.setEnvironmentOrClose(apiURL)
     Telemetry.setUser(firezoneId: firezoneId.encoded, accountSlug: accountSlug)
-
-    let enabled = legacyConfiguration?["internetResourceEnabled"]
-    let internetResourceEnabled =
-      enabled != nil ? enabled == "true" : (tunnelConfiguration?.internetResourceEnabled ?? false)
 
     // Create command channel for Adapter -> Provider communication
     let (commandSender, commandReceiver): (Sender<ProviderCommand>, Receiver<ProviderCommand>) =
@@ -178,6 +166,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     return Token(passedToken) ?? keychainToken
   }
 
+  private func loadProviderConfiguration() throws -> [String: String] {
+    guard let protocolConfiguration = protocolConfiguration as? NETunnelProviderProtocol
+    else { throw PacketTunnelProviderError.providerConfigurationIsInvalid }
+
+    guard let raw = protocolConfiguration.providerConfiguration else { return [:] }
+    guard let typed = raw as? [String: String] else {
+      throw PacketTunnelProviderError.providerConfigurationIsInvalid
+    }
+    return typed
+  }
+
   override func wake() {
     let adapter = self.adapter
     Task { @Sendable in
@@ -217,13 +216,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
       switch providerMessage {
 
-      case .setConfiguration(let tunnelConfiguration):
-        tunnelConfiguration.save(to: defaults)
-        self.tunnelConfiguration = tunnelConfiguration
-
+      case .setInternetResourceEnabled(let enabled):
         let adapter = self.adapter
         Task { @Sendable in
-          await adapter?.setInternetResourceEnabled(tunnelConfiguration.internetResourceEnabled)
+          await adapter?.setInternetResourceEnabled(enabled)
         }
         completionHandler?(nil)
 
@@ -504,45 +500,5 @@ private final class PacketTunnelProviderActorBridge: @unchecked Sendable {
     DispatchQueue.main.async {
       provider.handleProviderCommand(command)
     }
-  }
-}
-
-// Increase usefulness of TunnelConfiguration now that we're over the IPC barrier
-extension TunnelConfiguration {
-  func save(to userDefaults: UserDefaults) {
-    let key = "configurationCache"
-
-    let dict: [String: Any] = [
-      "apiURL": apiURL,
-      "logFilter": logFilter,
-      "accountSlug": accountSlug,
-      "internetResourceEnabled": internetResourceEnabled,
-    ]
-
-    userDefaults.set(dict, forKey: key)
-  }
-
-  static func tryLoad(from userDefaults: UserDefaults) -> TunnelConfiguration? {
-    let key = "configurationCache"
-
-    guard let dict = userDefaults.dictionary(forKey: key)
-    else {
-      return nil
-    }
-
-    guard let apiURL = dict["apiURL"] as? String,
-      let logFilter = dict["logFilter"] as? String,
-      let accountSlug = dict["accountSlug"] as? String,
-      let internetResourceEnabled = dict["internetResourceEnabled"] as? Bool
-    else {
-      return nil
-    }
-
-    return TunnelConfiguration(
-      apiURL: apiURL,
-      accountSlug: accountSlug,
-      logFilter: logFilter,
-      internetResourceEnabled: internetResourceEnabled
-    )
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -107,7 +107,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     let accountSlug =
       providerConfiguration.withMDMOverride(forKey: Configuration.Keys.accountSlug)
       ?? ConfigurationDefaults.accountSlug
-    let internetResourceEnabled = Configuration.bool(
+    let internetResourceEnabled = Configuration.parseBool(
       providerConfiguration[Configuration.Keys.internetResourceEnabled],
       default: ConfigurationDefaults.internetResourceEnabled
     )

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -30,6 +30,12 @@ export default function Apple() {
           the portal) to the user via a modal alert instead of silently
           cancelling the tunnel.
         </ChangeItem>
+        <ChangeItem pull={13282}>
+          Moves user-editable settings from UserDefaults into the VPN provider
+          configuration so they can only be modified by Firezone, not by other
+          processes running as the user. MDM-pushed values continue to override
+          these settings.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.15" date={new Date("2026-04-27")}>
         <ChangeItem pull={12849}>


### PR DESCRIPTION
Moves settings / user configuration keys back to the `providerConfiguration` which is writable only by the host app and NE provider.

---

Fixes https://github.com/firezone/firezone/security/advisories/GHSA-32fq-m6qg-hp48
