### PR TITLE
ci(rust): install mold via mise and use it as the linker

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -55,6 +55,21 @@ runs:
         reshim: true
         cache_key_prefix: "mise-v2"
 
+    # The cargo linker (`clang -fuse-ld=mold`) invokes `ld.mold` from
+    # build-script subdirs (e.g. rust/target/.../proc-macro2-*/) where mise's
+    # cwd-based config lookup does not find rust/mise.toml, so the `ld.mold`
+    # mise shim aborts with "No version is set". Exporting mold's actual
+    # install bin to GITHUB_PATH lets clang resolve ld.mold directly,
+    # bypassing the shim.
+    - name: Add mold to PATH for the cargo linker
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        bin_path=$(mise ${{ inputs.install_args }} bin-paths http:mold)
+        if [ -n "$bin_path" ]; then
+          echo "$bin_path" >> "$GITHUB_PATH"
+        fi
+
     # jdx/mise-action on Windows does not bundle `mise-shim.exe`, so cargo
     # subcommand discovery (`cargo udeps` -> `cargo-udeps.exe`) silently fails
     # because reshim has nothing to copy into the shims directory. Install mise

--- a/.github/actions/setup-rust-target-dependency-cache/action.yml
+++ b/.github/actions/setup-rust-target-dependency-cache/action.yml
@@ -23,6 +23,6 @@ runs:
         # provides no speed-up while exposing CI to cache-restore corruption
         # of the rustup-managed cargo binary.
         cache-bin: false
-        key: ${{ inputs.key }}
+        key: ${{ inputs.key }}-${{ hashFiles('rust/.cargo/config.toml') }}
         prefix-key: v2-rust-deps
         save-if: ${{ inputs.save-if }}

--- a/.github/actions/setup-rust-target-workspace-cache/action.yml
+++ b/.github/actions/setup-rust-target-workspace-cache/action.yml
@@ -22,6 +22,6 @@ runs:
         workspaces: rust
         cache-targets: true
         cache-workspace-crates: true
-        key: ${{ inputs.key }}-${{ hashFiles('rust/**/*.rs') }}
+        key: ${{ inputs.key }}-${{ hashFiles('rust/.cargo/config.toml', 'rust/**/*.rs') }}
         prefix-key: v2-rust
         save-if: ${{ inputs.save-if }}

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -70,6 +70,11 @@ jobs:
       - uses: ./.github/actions/setup-mise
         with:
           install_args: --cd kotlin/android
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: --cd rust
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build the release package
         env:
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
@@ -169,6 +174,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-android
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: --cd rust
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build debug APK
         run: |
           ./gradlew assembleDebug

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -55,6 +55,12 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: --cd rust
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies (Linux)
         if: matrix.os == 'linux'
         run: |

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -74,6 +74,11 @@ jobs:
         timeout-minutes: 15
         with:
           runtime: true
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: --cd rust
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm install
       - run: pnpm vite build
       - name: Build client
@@ -145,6 +150,11 @@ jobs:
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 15
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: --cd rust
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,8 +1,14 @@
 [target.x86_64-unknown-linux-musl]
-rustflags="-C force-frame-pointers=yes"
+linker = "clang"
+rustflags = ["-C", "force-frame-pointers=yes", "-C", "link-arg=-fuse-ld=mold"]
 
 [target.x86_64-unknown-linux-gnu]
-rustflags="-C force-frame-pointers=yes"
+linker = "clang"
+rustflags = ["-C", "force-frame-pointers=yes", "-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 # https://github.com/rust-lang/rust/issues/141626
 # (can be removed once link.exe is fixed)

--- a/rust/.tool-versions
+++ b/rust/.tool-versions
@@ -1,6 +1,5 @@
 pnpm                             10.33.0
 nodejs                           24.13.0
 github:cargo-bins/cargo-binstall 1.18.1
-github:DevinR528/cargo-sort      2.1.4
 github:EmbarkStudios/cargo-deny  0.19.4
 github:est31/cargo-udeps         0.1.61

--- a/rust/mise.lock
+++ b/rust/mise.lock
@@ -12,25 +12,21 @@ backend = "github:DevinR528/cargo-sort"
 checksum = "sha256:c10fdf954e51221d63743884aaf6ee5d576464abdc4965b395e3ec26948072ee"
 url = "https://github.com/DevinR528/cargo-sort/releases/download/v2.1.4/cargo-sort-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/DevinR528/cargo-sort/releases/assets/405268442"
-github_attestations = "unavailable"
 
 [tools."github:DevinR528/cargo-sort"."platforms.linux-x64-musl"]
 checksum = "sha256:c10fdf954e51221d63743884aaf6ee5d576464abdc4965b395e3ec26948072ee"
 url = "https://github.com/DevinR528/cargo-sort/releases/download/v2.1.4/cargo-sort-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/DevinR528/cargo-sort/releases/assets/405268442"
-github_attestations = "unavailable"
 
 [tools."github:DevinR528/cargo-sort"."platforms.macos-arm64"]
 checksum = "sha256:d2091a14be8482d8771ac379ef46a9501d678cee000a5e855490009fad3a65a3"
 url = "https://github.com/DevinR528/cargo-sort/releases/download/v2.1.4/cargo-sort-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/DevinR528/cargo-sort/releases/assets/405268421"
-github_attestations = "unavailable"
 
 [tools."github:DevinR528/cargo-sort"."platforms.windows-x64"]
 checksum = "sha256:0c59ef2433e523e060909cdfa678969eaa81a44fdc4313cb5a1a9592e8ded2b3"
 url = "https://github.com/DevinR528/cargo-sort/releases/download/v2.1.4/cargo-sort-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/DevinR528/cargo-sort/releases/assets/405268766"
-github_attestations = "unavailable"
 
 [[tools."github:EmbarkStudios/cargo-deny"]]
 version = "0.19.4"
@@ -40,43 +36,36 @@ backend = "github:EmbarkStudios/cargo-deny"
 checksum = "sha256:c32ded194b38b48e0b44a838a0d85c856120801e1253fc7febf6f2e48ccb84d8"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396997007"
-github_attestations = "unavailable"
 
 [tools."github:EmbarkStudios/cargo-deny"."platforms.linux-arm64-musl"]
 checksum = "sha256:c32ded194b38b48e0b44a838a0d85c856120801e1253fc7febf6f2e48ccb84d8"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396997007"
-github_attestations = "unavailable"
 
 [tools."github:EmbarkStudios/cargo-deny"."platforms.linux-x64"]
 checksum = "sha256:3bd58b784e83715b86ddbc9deac591890372ec77fda5741bb0826970b958506f"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396996900"
-github_attestations = "unavailable"
 
 [tools."github:EmbarkStudios/cargo-deny"."platforms.linux-x64-musl"]
 checksum = "sha256:3bd58b784e83715b86ddbc9deac591890372ec77fda5741bb0826970b958506f"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396996900"
-github_attestations = "unavailable"
 
 [tools."github:EmbarkStudios/cargo-deny"."platforms.macos-arm64"]
 checksum = "sha256:2437a51d904b29abe2d3aa9ea87e353c86cff108d519ba1e5fb495bb28e7fbaf"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396996898"
-github_attestations = "unavailable"
 
 [tools."github:EmbarkStudios/cargo-deny"."platforms.macos-x64"]
 checksum = "sha256:90fb22528daae11d0ce68cd968ea1f8e4d852b33510d0243d8c6666fc1dbea16"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396996891"
-github_attestations = "unavailable"
 
 [tools."github:EmbarkStudios/cargo-deny"."platforms.windows-x64"]
 checksum = "sha256:410b2f2bcb4d802dd8b018939156617ca290ac06554e95c35ab0a2bd07be2298"
 url = "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.19.4/cargo-deny-0.19.4-x86_64-pc-windows-msvc.tar.gz"
 url_api = "https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/assets/396997478"
-github_attestations = "unavailable"
 
 [[tools."github:aya-rs/bpf-linker"]]
 version = "0.10.3"
@@ -86,37 +75,31 @@ backend = "github:aya-rs/bpf-linker"
 checksum = "sha256:02f71967eddf61229fd0ae39736bfcaa00b27872df5af868b025f578371204d1"
 url = "https://github.com/aya-rs/bpf-linker/releases/download/v0.10.3/bpf-linker-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aya-rs/bpf-linker/releases/assets/395525950"
-github_attestations = "unavailable"
 
 [tools."github:aya-rs/bpf-linker"."platforms.linux-arm64-musl"]
 checksum = "sha256:02f71967eddf61229fd0ae39736bfcaa00b27872df5af868b025f578371204d1"
 url = "https://github.com/aya-rs/bpf-linker/releases/download/v0.10.3/bpf-linker-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aya-rs/bpf-linker/releases/assets/395525950"
-github_attestations = "unavailable"
 
 [tools."github:aya-rs/bpf-linker"."platforms.linux-x64"]
 checksum = "sha256:0fa4645d2dfbb5cafe6231b0aa9fad4f1430bd0871e3bd7319e82d827bf6262c"
 url = "https://github.com/aya-rs/bpf-linker/releases/download/v0.10.3/bpf-linker-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aya-rs/bpf-linker/releases/assets/395525972"
-github_attestations = "unavailable"
 
 [tools."github:aya-rs/bpf-linker"."platforms.linux-x64-musl"]
 checksum = "sha256:0fa4645d2dfbb5cafe6231b0aa9fad4f1430bd0871e3bd7319e82d827bf6262c"
 url = "https://github.com/aya-rs/bpf-linker/releases/download/v0.10.3/bpf-linker-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aya-rs/bpf-linker/releases/assets/395525972"
-github_attestations = "unavailable"
 
 [tools."github:aya-rs/bpf-linker"."platforms.macos-arm64"]
 checksum = "sha256:983f86e20f5353c9645e6ee314dcd897133c613315b57b00c7e75ddb507ee6a3"
 url = "https://github.com/aya-rs/bpf-linker/releases/download/v0.10.3/bpf-linker-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/aya-rs/bpf-linker/releases/assets/395525317"
-github_attestations = "unavailable"
 
 [tools."github:aya-rs/bpf-linker"."platforms.macos-x64"]
 checksum = "sha256:8dbea75f14d96e84a5fe7ce6120627e3c3511a49c406e76c14d187dc191ca528"
 url = "https://github.com/aya-rs/bpf-linker/releases/download/v0.10.3/bpf-linker-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/aya-rs/bpf-linker/releases/assets/395527257"
-github_attestations = "unavailable"
 
 [[tools."github:cargo-bins/cargo-binstall"]]
 version = "1.18.1"
@@ -126,43 +109,36 @@ backend = "github:cargo-bins/cargo-binstall"
 checksum = "sha256:f6ec6ac6e5782327863bcaa1b0acdd0ad81caee05c79b0074549829c41ffd52e"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-gnu.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392671"
-github_attestations = "unavailable"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-arm64-musl"]
 checksum = "sha256:c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392646"
-github_attestations = "unavailable"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-x64"]
 checksum = "sha256:6cfb065d6a5ee29dea185e9878d1e055357744ec1339987ca34d6f86853d537a"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-gnu.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392385"
-github_attestations = "unavailable"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.linux-x64-musl"]
 checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392355"
-github_attestations = "unavailable"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.macos-arm64"]
 checksum = "sha256:955abf167994c90f3547e233edace4c0f794465dd4aa408249b38999aa5ca3cf"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-apple-darwin.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392739"
-github_attestations = "unavailable"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.macos-x64"]
 checksum = "sha256:e06370bec7143668653bb7c09d0b8b689fc703dd4fa58ec5847c4b571d8a490d"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-apple-darwin.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392447"
-github_attestations = "unavailable"
 
 [tools."github:cargo-bins/cargo-binstall"."platforms.windows-x64"]
 checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/cargo-bins/cargo-binstall/releases/assets/395392416"
-github_attestations = "unavailable"
 
 [[tools."github:est31/cargo-udeps"]]
 version = "0.1.61"
@@ -172,43 +148,36 @@ backend = "github:est31/cargo-udeps"
 checksum = "sha256:e59b967cfd4ee60fda5bc615f96e6702fde22641282decce662a6ba4e6d4b843"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407801768"
-github_attestations = "unavailable"
 
 [tools."github:est31/cargo-udeps"."platforms.linux-arm64-musl"]
 checksum = "sha256:d257553c03b36d2ee7e8028d622c80b1244fc512fabb2de058c1e0ceeb92169b"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407801801"
-github_attestations = "unavailable"
 
 [tools."github:est31/cargo-udeps"."platforms.linux-x64"]
 checksum = "sha256:458419d47f48bc177e9b895b06abdccb08613f8a2d1b6eaf1729e968c041e03b"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407801002"
-github_attestations = "unavailable"
 
 [tools."github:est31/cargo-udeps"."platforms.linux-x64-musl"]
 checksum = "sha256:27031ca3902390a1d793901d17ec073ac85297ab3477b13faea984e4c97de479"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407802602"
-github_attestations = "unavailable"
 
 [tools."github:est31/cargo-udeps"."platforms.macos-arm64"]
 checksum = "sha256:0ca49f226c268ff3f7d65e82dd471900b962e4dcb3e75793558e5f4287be2011"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407800985"
-github_attestations = "unavailable"
 
 [tools."github:est31/cargo-udeps"."platforms.macos-x64"]
 checksum = "sha256:0840c47e3ac640db8cf1ac9136c7a133eff68f07753a8a450363b95124d0ee34"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407802892"
-github_attestations = "unavailable"
 
 [tools."github:est31/cargo-udeps"."platforms.windows-x64"]
 checksum = "sha256:6920b6f493f0c13a28e32522ccb7efffcc57c8849d887366b19c599dc2238cc0"
 url = "https://github.com/est31/cargo-udeps/releases/download/v0.1.61/cargo-udeps-v0.1.61-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/est31/cargo-udeps/releases/assets/407804338"
-github_attestations = "unavailable"
 
 [[tools."github:taiki-e/cargo-llvm-cov"]]
 version = "0.6.21"
@@ -218,43 +187,48 @@ backend = "github:taiki-e/cargo-llvm-cov"
 checksum = "sha256:8187c40fa3cbef6fe65e426bee24ddcfefee943dc68bdb0617f0293a092941af"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302796358"
-github_attestations = "unavailable"
 
 [tools."github:taiki-e/cargo-llvm-cov"."platforms.linux-arm64-musl"]
 checksum = "sha256:f7f3d23104f79dbc66831335f1e77e5fa12932f9b88d449a8170390c86e4d064"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302795822"
-github_attestations = "unavailable"
 
 [tools."github:taiki-e/cargo-llvm-cov"."platforms.linux-x64"]
 checksum = "sha256:57f491aedf7cdb261538ceb49cbb1ee9d27df7ca205a5e1a009caaf5cb911afb"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302795845"
-github_attestations = "unavailable"
 
 [tools."github:taiki-e/cargo-llvm-cov"."platforms.linux-x64-musl"]
 checksum = "sha256:0fa9ac9953583fa993786b529ce9c828a2e548ee9d183f5e908a357157d030f0"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302795801"
-github_attestations = "unavailable"
 
 [tools."github:taiki-e/cargo-llvm-cov"."platforms.macos-arm64"]
 checksum = "sha256:623bab61799ab4de8a88e0bd8c5101133cb6a4377a0f22f06be91913f40a3ba9"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302796471"
-github_attestations = "unavailable"
 
 [tools."github:taiki-e/cargo-llvm-cov"."platforms.macos-x64"]
 checksum = "sha256:0bae81daedc549de52691cab8ecc4c6bf9fb03d16eb693f6de4a871cfe1f2413"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302796569"
-github_attestations = "unavailable"
 
 [tools."github:taiki-e/cargo-llvm-cov"."platforms.windows-x64"]
 checksum = "sha256:521a638aec9f85dfdfafe705cb1fd8a34b518564ff9ff81cb79b8ffd1f0be5f1"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.21/cargo-llvm-cov-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/taiki-e/cargo-llvm-cov/releases/assets/302796221"
-github_attestations = "unavailable"
+
+[[tools."http:mold"]]
+version = "2.41.0"
+backend = "http:mold"
+
+[tools."http:mold"."platforms.linux-arm64"]
+checksum = "sha256:946de2774b06a71346bd59b55fddba610b65b8d93c3a4a1559cc84e103472710"
+url = "https://github.com/rui314/mold/releases/download/v2.41.0/mold-2.41.0-aarch64-linux.tar.gz"
+
+[tools."http:mold"."platforms.linux-x64"]
+checksum = "sha256:a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d"
+url = "https://github.com/rui314/mold/releases/download/v2.41.0/mold-2.41.0-x86_64-linux.tar.gz"
 
 [[tools.node]]
 version = "24.13.0"

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -14,7 +14,20 @@ NIGHTLY_VERSION = "nightly-2025-09-30"
 [tools]
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }
+"github:DevinR528/cargo-sort" = { version = "2.1.4", os = ["linux/x64", "macos/arm64"] }
 "github:taiki-e/cargo-llvm-cov" = "0.6.21"
+
+[tools."http:mold"]
+version = "2.41.0"
+os = ["linux"]
+
+[tools."http:mold".platforms.linux-x64]
+url = "https://github.com/rui314/mold/releases/download/v2.41.0/mold-2.41.0-x86_64-linux.tar.gz"
+bin_path = "mold-2.41.0-x86_64-linux/bin"
+
+[tools."http:mold".platforms.linux-arm64]
+url = "https://github.com/rui314/mold/releases/download/v2.41.0/mold-2.41.0-aarch64-linux.tar.gz"
+bin_path = "mold-2.41.0-aarch64-linux/bin"
 
 # =============================================================================
 # Individual checks (matching CI)


### PR DESCRIPTION
Despite recent default-linker changes for Rust on Linux, `mold` is still measurably faster — presumably because we have LTO enabled. With the increased usage of `mise`, we can install `mold` consistently across developer workstations and CI, and wire it up as the default linker via `clang -fuse-ld=mold` for x86_64 and aarch64 Linux targets.