### PR TITLE
fix(windows): use correct DACL for named pipes

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -65,7 +65,7 @@ fn try_main(
 ) -> Result<()> {
     #[cfg(debug_assertions)]
     if cli.skip_tunnel_pipe_owner_check {
-        firezone_gui_client::ipc::enable_skip_tunnel_pipe_owner_check();
+        firezone_gui_client::ipc::skip_tunnel_pipe_owner_check();
     }
 
     if cli.test_error_dialog {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -63,6 +63,11 @@ fn try_main(
     bootstrap_log_guard: &mut Option<DefaultGuard>,
     telemetry: &mut Telemetry,
 ) -> Result<()> {
+    #[cfg(debug_assertions)]
+    if cli.skip_tunnel_pipe_owner_check {
+        firezone_gui_client::ipc::enable_skip_tunnel_pipe_owner_check();
+    }
+
     if cli.test_error_dialog {
         dialog::error("Dialogs are working!")?;
     }
@@ -296,6 +301,13 @@ struct Cli {
         hide = true
     )]
     no_telemetry: bool,
+
+    /// Windows-only smoke-test escape hatch: skip the LocalSystem owner check
+    /// on the Tunnel named pipe. Only exists in debug builds, so release
+    /// binaries can't disable the check.
+    #[cfg(debug_assertions)]
+    #[arg(long, hide = true)]
+    skip_tunnel_pipe_owner_check: bool,
 }
 
 impl Cli {

--- a/rust/gui-client/src-tauri/src/ipc.rs
+++ b/rust/gui-client/src-tauri/src/ipc.rs
@@ -28,15 +28,8 @@ pub(crate) mod platform;
 #[error("Couldn't find IPC socket `{0}`")]
 pub struct NotFound(String);
 
-/// Disables the Windows Tunnel-pipe owner pinning + check used by the
-/// `gui-smoke-test`. See `ipc::windows::enable_skip_tunnel_pipe_owner_check`
-/// for details. No-op on unix where the check doesn't exist. Debug-only so
-/// production code cannot reach it.
 #[cfg(debug_assertions)]
-pub fn enable_skip_tunnel_pipe_owner_check() {
-    #[cfg(target_os = "windows")]
-    platform::enable_skip_tunnel_pipe_owner_check();
-}
+pub use platform::skip_tunnel_pipe_owner_check;
 
 /// A name that both the server and client can use to find each other
 ///
@@ -58,7 +51,7 @@ pub fn enable_skip_tunnel_pipe_owner_check() {
 ///
 /// Because the paths are so different (and Windows actually uses a `String`),
 /// we have this [`SocketId`] abstraction instead of just a `PathBuf`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SocketId {
     /// The IPC socket used by Firezone GUI Client in production to connect to the tunnel service.
     ///

--- a/rust/gui-client/src-tauri/src/ipc.rs
+++ b/rust/gui-client/src-tauri/src/ipc.rs
@@ -28,6 +28,16 @@ pub(crate) mod platform;
 #[error("Couldn't find IPC socket `{0}`")]
 pub struct NotFound(String);
 
+/// Disables the Windows Tunnel-pipe owner pinning + check used by the
+/// `gui-smoke-test`. See `ipc::windows::enable_skip_tunnel_pipe_owner_check`
+/// for details. No-op on unix where the check doesn't exist. Debug-only so
+/// production code cannot reach it.
+#[cfg(debug_assertions)]
+pub fn enable_skip_tunnel_pipe_owner_check() {
+    #[cfg(target_os = "windows")]
+    platform::enable_skip_tunnel_pipe_owner_check();
+}
+
 /// A name that both the server and client can use to find each other
 ///
 /// In the platform-specific code, this is translated to a Unix Domain Socket

--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -9,6 +9,11 @@ use anyhow::{Context as _, Result};
 use std::{io::ErrorKind, os::unix::fs::PermissionsExt, path::PathBuf};
 use tokio::net::{UnixListener, UnixStream};
 
+/// No-op twin of the Windows function. Unix IPC uses filesystem permissions
+/// instead of an owner-SID check, so there is nothing to skip.
+#[cfg(debug_assertions)]
+pub fn skip_tunnel_pipe_owner_check() {}
+
 pub struct Server {
     listener: UnixListener,
     id: SocketId,

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -28,8 +28,7 @@ use windows_security::SecurityDescriptor;
 /// The Tunnel pipe pins its owner with `O:SY`. Without that, the kernel fills
 /// in the owner from the creating token's `TokenOwner`; for the LocalSystem
 /// token that is `BUILTIN\Administrators` (S-1-5-32-544, not S-1-5-18), which
-/// would cause the client-side check in [`ensure_pipe_owner_is_local_system`]
-/// to reject the legitimate pipe.
+/// would cause the client-side check in to reject the legitimate pipe.
 ///
 /// The GUI pipe omits `O:SY` because the non-admin GUI lacks
 /// `SeRestorePrivilege` and cannot assign an owner outside its own token; its

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -28,7 +28,7 @@ use windows_security::SecurityDescriptor;
 /// The Tunnel pipe pins its owner with `O:SY`. Without that, the kernel fills
 /// in the owner from the creating token's `TokenOwner`; for the LocalSystem
 /// token that is `BUILTIN\Administrators` (S-1-5-32-544, not S-1-5-18), which
-/// would cause the client-side check in to reject the legitimate pipe.
+/// would cause the client-side check to reject the legitimate pipe.
 ///
 /// The GUI pipe omits `O:SY` because the non-admin GUI lacks
 /// `SeRestorePrivilege` and cannot assign an owner outside its own token; its

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -13,11 +13,7 @@ use windows::Win32::{
 };
 use windows_security::SecurityDescriptor;
 
-/// SDDL applied to every Firezone named pipe.
-///
-/// The Tunnel pipe is created by the LocalSystem-privileged tunnel service and
-/// must be reachable by the user-mode GUI; the GUI pipe is created by the GUI
-/// itself but uses the same DACL for uniformity.
+/// DACL shared by both Firezone named pipes.
 ///
 /// - `D:P` — protected DACL (don't inherit ACEs).
 /// - `(A;;FA;;;SY)` — Full Access for `LocalSystem` (the tunnel service).
@@ -26,10 +22,20 @@ use windows_security::SecurityDescriptor;
 ///   for `BUILTIN\Users`. This is the alias the non-admin GUI runs under and
 ///   excludes `NETWORK SERVICE`, `LOCAL SERVICE`, `ANONYMOUS LOGON`, IIS app
 ///   pool identities, and arbitrary new service accounts (unlike `AU`).
-const PIPE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
+///
+/// The Tunnel pipe additionally pins its owner with `O:SY`. Without that, the
+/// kernel falls back to the creating token's default owner; for the LocalSystem
+/// token that is `BUILTIN\Administrators` (S-1-5-32-544), which would cause the
+/// client-side check in [`ensure_pipe_owner_is_local_system`] to reject the
+/// legitimate pipe. The GUI pipe omits `O:SY` because the non-admin GUI lacks
+/// `SeRestorePrivilege` and cannot assign an owner outside its own token; its
+/// owner is not validated by clients.
+const TUNNEL_PIPE_SDDL: &str = "O:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
+const GUI_PIPE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
 
 pub struct Server {
     pipe_path: String,
+    sddl: &'static str,
 }
 
 /// Alias for the client's half of a platform-specific IPC stream
@@ -136,7 +142,17 @@ impl Server {
     #[expect(clippy::unnecessary_wraps, reason = "Linux impl is fallible")]
     pub(crate) fn new(id: SocketId) -> Result<Self> {
         let pipe_path = ipc_path(id);
-        Ok(Self { pipe_path })
+        let sddl = match id {
+            // Created by the LocalSystem tunnel service; pin owner so the
+            // client-side LocalSystem check passes.
+            SocketId::Tunnel => TUNNEL_PIPE_SDDL,
+            // Created by the non-admin GUI; cannot pin owner.
+            SocketId::Gui => GUI_PIPE_SDDL,
+            // Tests run unprivileged.
+            #[cfg(test)]
+            SocketId::Test(_) => GUI_PIPE_SDDL,
+        };
+        Ok(Self { pipe_path, sddl })
     }
 
     // `&mut self` needed to match the Linux signature
@@ -177,7 +193,7 @@ impl Server {
         const NUM_ITERS: usize = 100;
         const RETRY_INTERVAL: Duration = Duration::from_millis(100);
         for i in 0..NUM_ITERS {
-            match create_pipe_server(&self.pipe_path) {
+            match create_pipe_server(&self.pipe_path, self.sddl) {
                 Ok(server) => return Ok(server),
                 Err(PipeError::AccessDenied) => {
                     tracing::debug!("PipeError::AccessDenied, sleeping... (loop {i})");
@@ -198,14 +214,17 @@ enum PipeError {
     Other(#[from] anyhow::Error),
 }
 
-fn create_pipe_server(pipe_path: &str) -> Result<named_pipe::NamedPipeServer, PipeError> {
+fn create_pipe_server(
+    pipe_path: &str,
+    sddl: &str,
+) -> Result<named_pipe::NamedPipeServer, PipeError> {
     let mut server_options = named_pipe::ServerOptions::new();
     server_options.first_pipe_instance(true);
 
     // Build a `SECURITY_ATTRIBUTES` that grants the non-admin GUI (running as
     // `BUILTIN\Users`) read/write access to the pipe while keeping it shut to
     // `NETWORK SERVICE`, anonymous logons, and other unintended principals.
-    let sd = SecurityDescriptor::from_sddl(PIPE_SDDL).map_err(PipeError::Other)?;
+    let sd = SecurityDescriptor::from_sddl(sddl).map_err(PipeError::Other)?;
     let mut sa = SECURITY_ATTRIBUTES {
         nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
         lpSecurityDescriptor: sd.as_raw().0,
@@ -283,7 +302,7 @@ mod tests {
         let (_rx, _tx) =
             crate::ipc::connect::<(), ()>(ID, crate::ipc::ConnectOptions::default()).await?;
 
-        match super::create_pipe_server(&pipe_path) {
+        match super::create_pipe_server(&pipe_path, super::GUI_PIPE_SDDL) {
             Err(super::PipeError::AccessDenied) => {}
             Err(error) => {
                 Err(error).context("Expected `PipeError::AccessDenied` but got another error")?

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -1,6 +1,8 @@
 use super::{NotFound, SocketId};
 use anyhow::{Context as _, Result, bail, ensure};
 use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Duration};
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::net::windows::named_pipe;
 use windows::Win32::{
     Foundation::{HANDLE, HLOCAL, LocalFree},
@@ -23,15 +25,59 @@ use windows_security::SecurityDescriptor;
 ///   excludes `NETWORK SERVICE`, `LOCAL SERVICE`, `ANONYMOUS LOGON`, IIS app
 ///   pool identities, and arbitrary new service accounts (unlike `AU`).
 ///
-/// The Tunnel pipe additionally pins its owner with `O:SY`. Without that, the
-/// kernel falls back to the creating token's default owner; for the LocalSystem
-/// token that is `BUILTIN\Administrators` (S-1-5-32-544), which would cause the
-/// client-side check in [`ensure_pipe_owner_is_local_system`] to reject the
-/// legitimate pipe. The GUI pipe omits `O:SY` because the non-admin GUI lacks
+/// The Tunnel pipe pins its owner with `O:SY`. Without that, the kernel fills
+/// in the owner from the creating token's `TokenOwner`; for the LocalSystem
+/// token that is `BUILTIN\Administrators` (S-1-5-32-544, not S-1-5-18), which
+/// would cause the client-side check in [`ensure_pipe_owner_is_local_system`]
+/// to reject the legitimate pipe.
+///
+/// The GUI pipe omits `O:SY` because the non-admin GUI lacks
 /// `SeRestorePrivilege` and cannot assign an owner outside its own token; its
 /// owner is not validated by clients.
+///
+/// In debug builds the Tunnel pipe may also be opened without `O:SY` — see
+/// [`skip_tunnel_pipe_owner_check`] — so the `gui-smoke-test`, which launches
+/// the Tunnel binary as a subprocess of the test runner (not as a service
+/// running under LocalSystem), doesn't fail `CreateNamedPipeW` with
+/// `ERROR_INVALID_OWNER` (1307).
 const TUNNEL_PIPE_SDDL: &str = "O:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
 const GUI_PIPE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
+
+/// In debug builds only, lets the `gui-smoke-test` opt out of the LocalSystem
+/// owner check on the Tunnel pipe (and the matching `O:SY` server-side SDDL),
+/// because that test runs the Tunnel binary as an unprivileged subprocess
+/// instead of as a Windows service.
+///
+/// Release builds don't define this static or its setter, so production code
+/// has no way to disable the check.
+#[cfg(debug_assertions)]
+static SKIP_TUNNEL_PIPE_OWNER_CHECK: AtomicBool = AtomicBool::new(false);
+
+/// Enable [`SKIP_TUNNEL_PIPE_OWNER_CHECK`]. Call this once at process startup,
+/// before any `Server::new(SocketId::Tunnel, ...)` or `connect_to_socket`.
+///
+/// Exposed only in debug builds. The `firezone-gui-client` CLI wires this to
+/// its `--skip-tunnel-pipe-owner-check` flag (which is itself debug-only); the
+/// Tunnel binary's `run_smoke_test` entry point (already debug-only) calls
+/// this directly.
+#[cfg(debug_assertions)]
+pub fn enable_skip_tunnel_pipe_owner_check() {
+    SKIP_TUNNEL_PIPE_OWNER_CHECK.store(true, Ordering::Relaxed);
+    tracing::warn!(
+        "Tunnel pipe owner check disabled (debug build only); pipe will be created and accepted without `O:SY`"
+    );
+}
+
+fn skip_tunnel_pipe_owner_check() -> bool {
+    #[cfg(debug_assertions)]
+    {
+        SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed)
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        false
+    }
+}
 
 pub struct Server {
     pipe_path: String,
@@ -60,13 +106,12 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
         .context("Couldn't connect to named pipe")?;
     let handle = HANDLE(stream.as_raw_handle());
 
-    // Skip the owner check in debug builds so the `gui-smoke-test`, which
-    // launches the Tunnel binary as a subprocess of the test runner (not as a
-    // Windows service running under `LocalSystem`), can drive a real GUI
-    // ↔ Tunnel handshake. Production builds are always release-mode (the
-    // `gui-smoke-test` workflow explicitly skips release mode), so the check
-    // is enforced there.
-    if !cfg!(debug_assertions) && matches!(id, SocketId::Tunnel) {
+    // Skip the owner check only when [`enable_skip_tunnel_pipe_owner_check`]
+    // has been called, which is reachable only in debug builds via the
+    // `gui-smoke-test`. That test launches the Tunnel binary as a subprocess of
+    // the test runner instead of as a Windows service running under
+    // `LocalSystem`, so the legit pipe legitimately has no `LocalSystem` owner.
+    if !skip_tunnel_pipe_owner_check() && matches!(id, SocketId::Tunnel) {
         ensure_pipe_owner_is_local_system(handle)
             .context("Refusing to talk to non-LocalSystem Tunnel pipe server")?;
     }
@@ -144,8 +189,12 @@ impl Server {
         let pipe_path = ipc_path(id);
         let sddl = match id {
             // Created by the LocalSystem tunnel service; pin owner so the
-            // client-side LocalSystem check passes.
-            SocketId::Tunnel => TUNNEL_PIPE_SDDL,
+            // client-side LocalSystem check passes. The smoke test runs the
+            // Tunnel binary unprivileged and opts out of `O:SY` via
+            // [`enable_skip_tunnel_pipe_owner_check`] — otherwise
+            // `CreateNamedPipeW` would fail with `ERROR_INVALID_OWNER`.
+            SocketId::Tunnel if !skip_tunnel_pipe_owner_check() => TUNNEL_PIPE_SDDL,
+            SocketId::Tunnel => GUI_PIPE_SDDL,
             // Created by the non-admin GUI; cannot pin owner.
             SocketId::Gui => GUI_PIPE_SDDL,
             // Tests run unprivileged.

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -1,8 +1,8 @@
 use super::{NotFound, SocketId};
-use anyhow::{Context as _, Result, bail, ensure};
-use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Duration};
+use anyhow::{Context as _, Result, bail};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Duration};
 use tokio::net::windows::named_pipe;
 use windows::Win32::{
     Foundation::{HANDLE, HLOCAL, LocalFree},
@@ -43,40 +43,16 @@ use windows_security::SecurityDescriptor;
 const TUNNEL_PIPE_SDDL: &str = "O:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
 const GUI_PIPE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FRFW;;;BU)";
 
-/// In debug builds only, lets the `gui-smoke-test` opt out of the LocalSystem
-/// owner check on the Tunnel pipe (and the matching `O:SY` server-side SDDL),
-/// because that test runs the Tunnel binary as an unprivileged subprocess
-/// instead of as a Windows service.
-///
-/// Release builds don't define this static or its setter, so production code
-/// has no way to disable the check.
+/// Whether to skip the tunnel pipe owner check.
 #[cfg(debug_assertions)]
 static SKIP_TUNNEL_PIPE_OWNER_CHECK: AtomicBool = AtomicBool::new(false);
 
-/// Enable [`SKIP_TUNNEL_PIPE_OWNER_CHECK`]. Call this once at process startup,
-/// before any `Server::new(SocketId::Tunnel, ...)` or `connect_to_socket`.
+/// Set [`SKIP_TUNNEL_PIPE_OWNER_CHECK`].
 ///
-/// Exposed only in debug builds. The `firezone-gui-client` CLI wires this to
-/// its `--skip-tunnel-pipe-owner-check` flag (which is itself debug-only); the
-/// Tunnel binary's `run_smoke_test` entry point (already debug-only) calls
-/// this directly.
+/// Call once at process startup, before any `Server::new(SocketId::Tunnel)` or `connect_to_socket`.
 #[cfg(debug_assertions)]
-pub fn enable_skip_tunnel_pipe_owner_check() {
+pub fn skip_tunnel_pipe_owner_check() {
     SKIP_TUNNEL_PIPE_OWNER_CHECK.store(true, Ordering::Relaxed);
-    tracing::warn!(
-        "Tunnel pipe owner check disabled (debug build only); pipe will be created and accepted without `O:SY`"
-    );
-}
-
-fn skip_tunnel_pipe_owner_check() -> bool {
-    #[cfg(debug_assertions)]
-    {
-        SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed)
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        false
-    }
 }
 
 pub struct Server {
@@ -106,15 +82,7 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
         .context("Couldn't connect to named pipe")?;
     let handle = HANDLE(stream.as_raw_handle());
 
-    // Skip the owner check only when [`enable_skip_tunnel_pipe_owner_check`]
-    // has been called, which is reachable only in debug builds via the
-    // `gui-smoke-test`. That test launches the Tunnel binary as a subprocess of
-    // the test runner instead of as a Windows service running under
-    // `LocalSystem`, so the legit pipe legitimately has no `LocalSystem` owner.
-    if !skip_tunnel_pipe_owner_check() && matches!(id, SocketId::Tunnel) {
-        ensure_pipe_owner_is_local_system(handle)
-            .context("Refusing to talk to non-LocalSystem Tunnel pipe server")?;
-    }
+    enforce_pipe_ownership(id, handle)?;
 
     let mut server_pid: u32 = 0;
     // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle
@@ -126,7 +94,7 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
     Ok(stream)
 }
 
-/// Verifies that the connected named pipe was created by `LocalSystem`, the
+/// Checks if the connected named pipe was created by `LocalSystem`, the
 /// account the Tunnel service runs as.
 ///
 /// `first_pipe_instance(true)` ensures nobody else can create another instance
@@ -141,7 +109,7 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
 /// rather than the server's current process token. The latter is racy if the
 /// server process exits and its PID is recycled between
 /// `GetNamedPipeServerProcessId` and `OpenProcess`.
-fn ensure_pipe_owner_is_local_system(handle: HANDLE) -> Result<()> {
+fn is_pipe_owned_by_local_system(handle: HANDLE) -> Result<bool> {
     let mut owner_sid = PSID::default();
     let mut sd = PSECURITY_DESCRIPTOR::default();
 
@@ -175,10 +143,23 @@ fn ensure_pipe_owner_is_local_system(handle: HANDLE) -> Result<()> {
         let _ = LocalFree(Some(HLOCAL(sd.0)));
     }
 
-    ensure!(
-        is_local_system,
-        "Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack"
-    );
+    Ok(is_local_system)
+}
+
+fn enforce_pipe_ownership(id: SocketId, handle: HANDLE) -> Result<()> {
+    if id != SocketId::Tunnel {
+        return Ok(());
+    }
+
+    #[cfg(debug_assertions)]
+    if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
+    if !is_pipe_owned_by_local_system(handle)? {
+        bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
+    }
+
     Ok(())
 }
 
@@ -188,13 +169,11 @@ impl Server {
     pub(crate) fn new(id: SocketId) -> Result<Self> {
         let pipe_path = ipc_path(id);
         let sddl = match id {
-            // Created by the LocalSystem tunnel service; pin owner so the
-            // client-side LocalSystem check passes. The smoke test runs the
-            // Tunnel binary unprivileged and opts out of `O:SY` via
-            // [`enable_skip_tunnel_pipe_owner_check`] — otherwise
-            // `CreateNamedPipeW` would fail with `ERROR_INVALID_OWNER`.
-            SocketId::Tunnel if !skip_tunnel_pipe_owner_check() => TUNNEL_PIPE_SDDL,
-            SocketId::Tunnel => GUI_PIPE_SDDL,
+            #[cfg(debug_assertions)]
+            SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => {
+                GUI_PIPE_SDDL
+            }
+            SocketId::Tunnel => TUNNEL_PIPE_SDDL,
             // Created by the non-admin GUI; cannot pin owner.
             SocketId::Gui => GUI_PIPE_SDDL,
             // Tests run unprivileged.

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -788,6 +788,12 @@ pub fn run_smoke_test() -> Result<()> {
     use anyhow::{Context as _, bail};
     use bin_shared::{DnsController, device_id};
 
+    // The smoke test runs this binary as an unprivileged subprocess of the
+    // test runner — not as a Windows service under LocalSystem. Tell the IPC
+    // layer to skip pinning/checking LocalSystem ownership on the Tunnel pipe;
+    // otherwise `CreateNamedPipeW` fails with `ERROR_INVALID_OWNER` on Windows.
+    ipc::enable_skip_tunnel_pipe_owner_check();
+
     let log_filter_reloader = logging::setup_stdout()?;
     if !elevation_check()? {
         bail!("Tunnel service failed its elevation check, try running as admin / root");

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -792,7 +792,7 @@ pub fn run_smoke_test() -> Result<()> {
     // test runner — not as a Windows service under LocalSystem. Tell the IPC
     // layer to skip pinning/checking LocalSystem ownership on the Tunnel pipe;
     // otherwise `CreateNamedPipeW` fails with `ERROR_INVALID_OWNER` on Windows.
-    ipc::enable_skip_tunnel_pipe_owner_check();
+    ipc::skip_tunnel_pipe_owner_check();
 
     let log_filter_reloader = logging::setup_stdout()?;
     if !elevation_check()? {

--- a/rust/tests/gui-smoke-test/src/main.rs
+++ b/rust/tests/gui-smoke-test/src/main.rs
@@ -238,6 +238,12 @@ impl App {
         Ok(Exec::cmd(gui_path())
             .arg("--no-deep-links")
             .arg("--no-elevation-check")
+            // The smoke test runs the Tunnel binary as an unprivileged
+            // subprocess instead of as a `LocalSystem` Windows service, so the
+            // pipe it creates legitimately has no `LocalSystem` owner. Tell
+            // the GUI to skip that check. The flag only exists in debug
+            // builds; release builds reject it.
+            .arg("--skip-tunnel-pipe-owner-check")
             .args(args))
     }
 }


### PR DESCRIPTION
The DACL we shipped for the named pipe between the GUI and Tunnel process in #13171 was not quite correct. We need to explicitly declare it as owned by "Local System", otherwise Windows assigns a default and the check on the GUI side no longer works.