### PR TITLE
fix(android): only build target ABI from Android Studio

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -268,7 +268,9 @@ val cargoTargetDir: String by lazy {
 // ABI first) and passed explicitly by `mise-tasks/install-phone.sh`. When unset (e.g. plain
 // `assembleDebug` or CI), build all ABIs.
 val targetAndroidAbi: String? =
-    providers.gradleProperty("android.injected.build.abi").orNull
+    providers
+        .gradleProperty("android.injected.build.abi")
+        .orNull
         ?.split(",")
         ?.firstOrNull()
         ?.trim()

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -263,6 +263,35 @@ val cargoTargetDir: String by lazy {
         )
 }
 
+// Resolve the target Android ABI from the `android.injected.build.abi` Gradle property,
+// injected by Android Studio when launching on a connected device (comma-separated, preferred
+// ABI first) and passed explicitly by `mise-tasks/install-phone.sh`. When unset (e.g. plain
+// `assembleDebug` or CI), build all ABIs.
+val targetAndroidAbi: String? =
+    providers.gradleProperty("android.injected.build.abi").orNull
+        ?.split(",")
+        ?.firstOrNull()
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+fun androidAbiToCargoTarget(abi: String): String =
+    when (abi) {
+        "arm64-v8a" -> "arm64"
+        "armeabi-v7a" -> "arm"
+        "x86" -> "x86"
+        "x86_64" -> "x86_64"
+        else -> throw GradleException("Unsupported ABI '$abi'. Supported: arm64-v8a, armeabi-v7a, x86, x86_64.")
+    }
+
+fun androidAbiToRustTriple(abi: String): String =
+    when (abi) {
+        "arm64-v8a" -> "aarch64-linux-android"
+        "armeabi-v7a" -> "armv7-linux-androideabi"
+        "x86" -> "i686-linux-android"
+        "x86_64" -> "x86_64-linux-android"
+        else -> throw GradleException("Unsupported ABI '$abi'. Supported: arm64-v8a, armeabi-v7a, x86, x86_64.")
+    }
+
 cargo {
     if (gradle.startParameter.taskNames.any { it.lowercase().contains("release") }) {
         profile = "release"
@@ -275,12 +304,8 @@ cargo {
     module = "../../../rust/client-ffi"
     libname = "connlib"
     targets =
-        listOf(
-            "arm64",
-            "x86_64",
-            "x86",
-            "arm",
-        )
+        targetAndroidAbi?.let { listOf(androidAbiToCargoTarget(it)) }
+            ?: listOf("arm64", "x86_64", "x86", "arm")
     targetDirectory = cargoTargetDir
 }
 
@@ -304,17 +329,10 @@ val generateUniffiBindings =
         val outDir = layout.buildDirectory.dir("generated/source/uniffi/$profile").get()
 
         // UniFFI bindings are identical across ABIs, so we only need one libconnlib.so as input.
-        // Callers (e.g. install-phone.sh) may skip building ABIs they don't need; pass
-        // -PdeviceAbi=<android-abi> to point this task at an ABI that actually gets built.
-        // Defaults to x86_64 so the all-ABI build keeps working unchanged.
+        // Point this task at an ABI that actually gets built when callers narrow the target list
+        // via `android.injected.build.abi`. Defaults to x86_64 so the all-ABI build keeps working.
         val rustTargetTriple =
-            when (val deviceAbi = providers.gradleProperty("deviceAbi").orNull) {
-                null, "x86_64" -> "x86_64-linux-android"
-                "arm64-v8a" -> "aarch64-linux-android"
-                "armeabi-v7a" -> "armv7-linux-androideabi"
-                "x86" -> "i686-linux-android"
-                else -> throw GradleException("Unsupported deviceAbi '$deviceAbi'. Supported: arm64-v8a, armeabi-v7a, x86, x86_64.")
-            }
+            targetAndroidAbi?.let { androidAbiToRustTriple(it) } ?: "x86_64-linux-android"
         val inputFile = file("$cargoTargetDir/$rustTargetTriple/$profile/libconnlib.so")
 
         inputs.file(inputFile)

--- a/kotlin/android/mise-tasks/install-phone.sh
+++ b/kotlin/android/mise-tasks/install-phone.sh
@@ -28,39 +28,13 @@ fi
 
 DEVICE_ABI="$(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
 
-# Map the device ABI to the cargo build tasks we can skip. The Gradle task names
-# come from the targets list in app/build.gradle.kts.
-case "$DEVICE_ABI" in
-arm64-v8a)
-    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildX86 cargoBuildX86_64)
-    ;;
-armeabi-v7a)
-    SKIP_CARGO_TASKS=(cargoBuildArm64 cargoBuildX86 cargoBuildX86_64)
-    ;;
-x86_64)
-    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildArm64 cargoBuildX86)
-    ;;
-x86)
-    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildArm64 cargoBuildX86_64)
-    ;;
-*)
-    echo "==> Unknown device ABI '${DEVICE_ABI}', falling back to all-ABI build."
-    SKIP_CARGO_TASKS=()
-    DEVICE_ABI=""
-    ;;
-esac
-
-echo "==> Installing debug APK (device ABI: ${DEVICE_ABI:-unknown, building all ABIs})..."
+echo "==> Installing debug APK (device ABI: ${DEVICE_ABI})..."
 # Kill any running instance so the next launch is a clean cold start (and so
 # Android doesn't keep the old process alive across install).
 echo "==> Force-stopping any running instance of dev.firezone.android..."
 adb shell am force-stop dev.firezone.android
 
-gradle_args=()
-[ -n "$DEVICE_ABI" ] && gradle_args+=("-PdeviceAbi=$DEVICE_ABI")
-for task in "${SKIP_CARGO_TASKS[@]}"; do
-    gradle_args+=(-x "$task")
-done
+gradle_args=("-Pandroid.injected.build.abi=$DEVICE_ABI")
 
 install_log="$(mktemp "${TMPDIR:-/tmp}/install-phone.XXXXXX")"
 trap 'rm -f "$install_log"' EXIT


### PR DESCRIPTION
In #13148, we added mise tasks to only build the Rust code for the target ABI of the device we are about to install the debug build on. This is a useful speed-up that should also be accessible when using Android Studio. AS injects the device's ABI as `android.injected.build.abi` property.

We migrate functionality of only building for 1 ABI to the gradle build script and change the mise task to set that property instead.