### PR TITLE
fix(ci): extend budget for roaming integration test

### DIFF
--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -3,11 +3,11 @@
 source "./scripts/tests/lib.sh"
 
 # Download 10MB at a max rate of 1MB/s. The first two UDP socket writes will fail as checksum offload is disabled.
-# This means it will take 13 seconds + the resent STUN binding request round trip time.
+# Budget: 10s for the download + 5s pre-roam wait + ~7s reconnect overhead + buffer.
 client sh -c \
     "curl \
         --fail \
-        --max-time 16 \
+        --max-time 25 \
         --keepalive-time 1 \
         --limit-rate 1000000 \
         --output download.file \
@@ -41,6 +41,16 @@ computed_checksum=$(client sha256sum download.file | awk '{ print $1 }')
 
 if [[ "$computed_checksum" != "$known_checksum" ]]; then
     echo "Checksum of downloaded file does not match"
+    exit 1
+fi
+
+# Assert the roam itself was fast. The download budget above is generous to
+# accommodate TCP slow-start after the disconnect, but the Firezone-side
+# recovery (ICE renegotiation + TURN allocate + WireGuard handshake) should
+# stay well under a second. Catch regressions here, not via the curl timeout.
+handshake_ms=$(last_wg_handshake_ms)
+if [ "$handshake_ms" -gt 2000 ]; then
+    echo "Roam took too long: WireGuard handshake completed ${handshake_ms}ms after intent (budget: 2000ms)"
     exit 1
 fi
 

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -138,3 +138,29 @@ function get_flow_field() {
 
     echo "$flow_log" | grep -oP "${field_name}=\K[^ ]+" || echo ""
 }
+
+# Get the `duration_since_intent` (in milliseconds) of the most recent
+# "Completed wireguard handshake" client log line. Use after a roam to
+# bound how long the tunnel took to come back up, independent of any TCP
+# recovery that happens afterwards.
+function last_wg_handshake_ms() {
+    local raw
+    raw=$(docker compose logs client --since 60s 2>/dev/null |
+        grep "Completed wireguard handshake" |
+        tail -n 1 |
+        grep -oP 'duration_since_intent=\K[^ ]+')
+
+    # Rust's Duration debug-format is one of: 350.9ms, 1.5s, 350µs, 350ns.
+    # Convert whichever shows up to integer milliseconds.
+    if [[ "$raw" == *ms ]]; then
+        awk -v n="${raw%ms}" 'BEGIN { printf("%.0f\n", n) }'
+    elif [[ "$raw" == *µs ]]; then
+        awk -v n="${raw%µs}" 'BEGIN { printf("%.0f\n", n / 1000) }'
+    elif [[ "$raw" == *ns ]]; then
+        echo 0
+    elif [[ "$raw" == *s ]]; then
+        awk -v n="${raw%s}" 'BEGIN { printf("%.0f\n", n * 1000) }'
+    else
+        echo 999999 # No handshake log line found — treat as failure.
+    fi
+}


### PR DESCRIPTION
The roaming integration test has been flaky recently. We extend the budget to 25s but also add an additional assertion that ensures we complete the roam within a reasonable timeframe.

Fixes: #13284 