### PR TITLE
feat(gui-client): restrict tunnel IPC socket to GUI via AppArmor

### DIFF
--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -47,6 +47,19 @@ jobs:
             exit 1
           fi
 
+  apparmor-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate AppArmor profiles parse
+        run: |
+          # `-Q` runs the full parser/compiler but skips the kernel load,
+          # so we catch syntax bugs (like the path-based `addr=` that's
+          # rejected by AppArmor 3.x) without needing root or a running
+          # AppArmor LSM.
+          apparmor_parser -Q rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+          apparmor_parser -Q rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-gui
+
   link-check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -47,19 +47,6 @@ jobs:
             exit 1
           fi
 
-  apparmor-check:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Validate AppArmor profiles parse
-        run: |
-          # `-Q` runs the full parser/compiler but skips the kernel load,
-          # so we catch syntax bugs (like the path-based `addr=` that's
-          # rejected by AppArmor 3.x) without needing root or a running
-          # AppArmor LSM.
-          apparmor_parser -Q rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
-          apparmor_parser -Q rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-gui
-
   link-check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -48,6 +48,19 @@ jobs:
       - run: pnpm install
       - run: pnpm eslint .
 
+  apparmor-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate AppArmor profiles parse
+        run: |
+          # `-Q` runs the full parser/compiler but skips the kernel load,
+          # so we catch syntax bugs (like the path-based `addr=` that's
+          # rejected by AppArmor 3.x) without needing root or a running
+          # AppArmor LSM.
+          apparmor_parser -Q src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+          apparmor_parser -Q src-tauri/linux_package/apparmor.d/firezone-client-gui
+
   # Runs the Tauri client smoke test, built in debug mode. We can't run it in release
   # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>
   smoke-test:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -57,12 +57,12 @@ jobs:
         run: sudo apt-get install -y apparmor
       - name: Validate AppArmor profiles parse
         run: |
-          # `-Q` runs the full parser/compiler but skips the kernel load,
-          # so we catch syntax bugs (like the path-based `addr=` that's
-          # rejected by AppArmor 3.x) without needing root or a running
-          # AppArmor LSM.
-          apparmor_parser -Q src-tauri/linux_package/apparmor.d/firezone-client-tunnel
-          apparmor_parser -Q src-tauri/linux_package/apparmor.d/firezone-client-gui
+          # `-Q` runs the full parser/compiler but skips the kernel load and
+          # `-K` skips the cache (which lives under /var/cache/apparmor and
+          # would otherwise need root). Together they let us validate the
+          # profile as a normal user with no LSM running.
+          apparmor_parser -Q -K src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+          apparmor_parser -Q -K src-tauri/linux_package/apparmor.d/firezone-client-gui
 
   # Runs the Tauri client smoke test, built in debug mode. We can't run it in release
   # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -52,6 +52,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install apparmor_parser
+        # The runner image only ships libapparmor1, not the parser itself.
+        run: sudo apt-get install -y apparmor
       - name: Validate AppArmor profiles parse
         run: |
           # `-Q` runs the full parser/compiler but skips the kernel load,

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -47,11 +47,6 @@ jobs:
           lockfile-dir: ./rust/gui-client
       - run: pnpm install
       - run: pnpm eslint .
-
-  apparmor-check:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install apparmor_parser
         # The runner image only ships libapparmor1, not the parser itself.
         run: sudo apt-get install -y apparmor

--- a/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-gui
+++ b/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-gui
@@ -1,0 +1,11 @@
+# AppArmor label-only profile for the Firezone GUI client.
+#
+# Loaded so the GUI process gets the `firezone-client-gui` label that the
+# Tunnel service checks for in its UDS accept rule. The GUI is otherwise
+# unconfined: `flags=(complain)` makes the kernel allow every action this
+# profile doesn't explicitly permit (denials are logged but not enforced).
+
+abi <abi/3.0>,
+
+profile firezone-client-gui /usr/bin/firezone-client-gui flags=(complain) {
+}

--- a/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+++ b/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
@@ -1,0 +1,52 @@
+# AppArmor profile for the Firezone Tunnel service.
+#
+# This profile's only job is to enforce that connections to the Tunnel
+# service's Unix domain socket (/run/dev.firezone.client/tunnel.sock) come
+# from a process labeled `firezone-client-gui`. Everything else the tunnel
+# does is intentionally left unrestricted.
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+profile firezone-client-tunnel /usr/bin/firezone-client-tunnel
+    flags=(attach_disconnected) {
+
+  include <abstractions/base>
+
+  # Permissive on everything that isn't a unix socket; unix sockets are
+  # enumerated below so the peer-restricted rule for the IPC socket isn't
+  # shadowed by a broader allow.
+  capability,
+  network inet,
+  network inet6,
+  network netlink,
+  network unix,
+  signal,
+  ptrace,
+  dbus,
+  mount,
+  umount,
+  pivot_root,
+
+  /** mrwlkix,
+
+  # The IPC socket: bind/listen are unrestricted, accept is restricted to
+  # peers confined by the `firezone-client-gui` profile.
+  unix (bind, listen, getattr, getopt, setopt, shutdown)
+    type=stream
+    addr="/run/dev.firezone.client/tunnel.sock",
+  unix (accept, send, receive)
+    type=stream
+    addr="/run/dev.firezone.client/tunnel.sock"
+    peer=(label=firezone-client-gui),
+
+  # All other unix sockets the tunnel uses (sd_notify, dbus, internal tokio
+  # sockets, etc.) - matched by peer address or anonymous local address, so
+  # they cannot match the server-side accept on the IPC socket above.
+  unix peer=(addr="@*"),
+  unix peer=(addr="/{,var/}run/**"),
+  unix peer=(addr="/tmp/**"),
+  unix peer=(addr=none),
+  unix addr=none,
+}

--- a/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+++ b/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
@@ -14,9 +14,8 @@ profile firezone-client-tunnel /usr/bin/firezone-client-tunnel
 
   include <abstractions/base>
 
-  # Permissive on everything that isn't a unix socket; unix sockets are
-  # enumerated below so the peer-restricted rule for the IPC socket isn't
-  # shadowed by a broader allow.
+  # Permissive on everything except unix-socket operations, which are
+  # enumerated below.
   capability,
   network inet,
   network inet6,
@@ -31,22 +30,23 @@ profile firezone-client-tunnel /usr/bin/firezone-client-tunnel
 
   /** mrwlkix,
 
-  # The IPC socket: bind/listen are unrestricted, accept is restricted to
-  # peers confined by the `firezone-client-gui` profile.
-  unix (bind, listen, getattr, getopt, setopt, shutdown)
-    type=stream
-    addr="/run/dev.firezone.client/tunnel.sock",
-  unix (accept, send, receive)
-    type=stream
-    addr="/run/dev.firezone.client/tunnel.sock"
+  # The IPC socket lives at /run/dev.firezone.client/tunnel.sock. Path-based
+  # `addr=` in unix rules isn't accepted by AppArmor 3.x (Ubuntu 22.04 / 24.04
+  # ship 3.x), so the per-path restriction is handled by filesystem
+  # permissions (root:firezone-client 0660); the peer-label rule below is
+  # what the kernel actually enforces.
+  unix (bind, listen, getattr, getopt, setopt, shutdown) type=stream,
+  unix (accept, send, receive) type=stream
     peer=(label=firezone-client-gui),
 
-  # All other unix sockets the tunnel uses (sd_notify, dbus, internal tokio
-  # sockets, etc.) - matched by peer address or anonymous local address, so
-  # they cannot match the server-side accept on the IPC socket above.
-  unix peer=(addr="@*"),
-  unix peer=(addr="/{,var/}run/**"),
-  unix peer=(addr="/tmp/**"),
-  unix peer=(addr=none),
-  unix addr=none,
+  # All other unix socket use (sd_notify, dbus, internal tokio sockets, etc.).
+  # Operations are listed explicitly so `accept`, `bind` and `listen` aren't
+  # in the set - otherwise these rules would shadow the peer-restricted accept
+  # above and any peer could connect (the bypass Copilot flagged on review).
+  unix (create, connect, send, receive, shutdown, getattr, getopt, setopt)
+    peer=(addr="@*"),
+  unix (create, connect, send, receive, shutdown, getattr, getopt, setopt)
+    peer=(addr="/{,var/}run/**"),
+  unix (create, send, receive, shutdown, getattr, getopt, setopt)
+    addr=none,
 }

--- a/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+++ b/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
@@ -30,23 +30,21 @@ profile firezone-client-tunnel /usr/bin/firezone-client-tunnel
 
   /** mrwlkix,
 
-  # The IPC socket lives at /run/dev.firezone.client/tunnel.sock. Path-based
-  # `addr=` in unix rules isn't accepted by AppArmor 3.x (Ubuntu 22.04 / 24.04
-  # ship 3.x), so the per-path restriction is handled by filesystem
-  # permissions (root:firezone-client 0660); the peer-label rule below is
-  # what the kernel actually enforces.
-  unix (bind, listen, getattr, getopt, setopt, shutdown) type=stream,
+  # The IPC socket lives at /run/dev.firezone.client/tunnel.sock. AppArmor's
+  # unix rule grammar doesn't accept path-based `addr=` values, so the per-
+  # path restriction is handled by filesystem permissions on the socket
+  # (root:firezone-client 0660); the peer-label rule below is what the
+  # kernel actually enforces.
+  #
+  # Local-only operations (`bind`, `listen`, `getattr`, `getopt`, `setopt`,
+  # `shutdown`, `create`) must live in a separate rule from peer-involved
+  # ops - AppArmor 4.x rejects combining them with `peer=` conditionals.
+  unix (bind, listen) type=stream,
   unix (accept, send, receive) type=stream
     peer=(label=firezone-client-gui),
 
-  # All other unix socket use (sd_notify, dbus, internal tokio sockets, etc.).
-  # Operations are listed explicitly so `accept`, `bind` and `listen` aren't
-  # in the set - otherwise these rules would shadow the peer-restricted accept
-  # above and any peer could connect (the bypass Copilot flagged on review).
-  unix (create, connect, send, receive, shutdown, getattr, getopt, setopt)
-    peer=(addr="@*"),
-  unix (create, connect, send, receive, shutdown, getattr, getopt, setopt)
-    peer=(addr="/{,var/}run/**"),
-  unix (create, send, receive, shutdown, getattr, getopt, setopt)
-    addr=none,
+  # Outgoing client connections (sd_notify, dbus, etc.). `accept` is
+  # deliberately omitted so this can't shadow the peer-restricted accept
+  # above. Local-only ops are already provided by `abstractions/base`.
+  unix (connect, send, receive),
 }

--- a/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
+++ b/rust/gui-client/src-tauri/linux_package/apparmor.d/firezone-client-tunnel
@@ -1,9 +1,11 @@
 # AppArmor profile for the Firezone Tunnel service.
 #
-# This profile's only job is to enforce that connections to the Tunnel
-# service's Unix domain socket (/run/dev.firezone.client/tunnel.sock) come
-# from a process labeled `firezone-client-gui`. Everything else the tunnel
-# does is intentionally left unrestricted.
+# The profile's role is to attach the `firezone-client-tunnel` label so the
+# Tunnel service can authenticate IPC peers in code (see
+# `rust/gui-client/src-tauri/src/ipc/unix.rs::authorize_peer`). AppArmor's
+# unix `peer=(label=...)` mediation for path-based sockets isn't reliably
+# enforced on kernels older than 6.17, so we don't try to gate at the
+# AppArmor layer.
 
 abi <abi/3.0>,
 
@@ -14,37 +16,19 @@ profile firezone-client-tunnel /usr/bin/firezone-client-tunnel
 
   include <abstractions/base>
 
-  # Permissive on everything except unix-socket operations, which are
-  # enumerated below.
+  # The tunnel runs as root and is intentionally not confined beyond getting
+  # an AppArmor label - peer authentication on the IPC socket happens in
+  # userspace, and the rest of the tunnel's behaviour is bounded by the
+  # systemd unit (CapabilityBoundingSet, RestrictAddressFamilies, ...).
   capability,
-  network inet,
-  network inet6,
-  network netlink,
-  network unix,
+  network,
   signal,
   ptrace,
   dbus,
   mount,
   umount,
   pivot_root,
+  unix,
 
   /** mrwlkix,
-
-  # The IPC socket lives at /run/dev.firezone.client/tunnel.sock. AppArmor's
-  # unix rule grammar doesn't accept path-based `addr=` values, so the per-
-  # path restriction is handled by filesystem permissions on the socket
-  # (root:firezone-client 0660); the peer-label rule below is what the
-  # kernel actually enforces.
-  #
-  # Local-only operations (`bind`, `listen`, `getattr`, `getopt`, `setopt`,
-  # `shutdown`, `create`) must live in a separate rule from peer-involved
-  # ops - AppArmor 4.x rejects combining them with `peer=` conditionals.
-  unix (bind, listen) type=stream,
-  unix (accept, send, receive) type=stream
-    peer=(label=firezone-client-gui),
-
-  # Outgoing client connections (sd_notify, dbus, etc.). `accept` is
-  # deliberately omitted so this can't shadow the peer-restricted accept
-  # above. Local-only ops are already provided by `abstractions/base`.
-  unix (connect, send, receive),
 }

--- a/rust/gui-client/src-tauri/linux_package/firezone-client-tunnel.service
+++ b/rust/gui-client/src-tauri/linux_package/firezone-client-tunnel.service
@@ -5,6 +5,13 @@ Wants=systemd-resolved.service
 
 [Service]
 AmbientCapabilities=CAP_NET_ADMIN
+# Apply the `firezone-client-tunnel` AppArmor profile (defined in
+# /etc/apparmor.d/firezone-client-tunnel), which restricts the IPC socket
+# peer to the firezone-client-gui binary. The leading `-` makes systemd
+# silently ignore this directive when AppArmor isn't enabled or the profile
+# hasn't been loaded; without it, the unit would fail to start on those
+# systems.
+AppArmorProfile=-firezone-client-tunnel
 CapabilityBoundingSet=CAP_CHOWN CAP_NET_ADMIN
 DeviceAllow=/dev/net/tun
 LockPersonality=true

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -52,11 +52,15 @@ fi
 # Load the AppArmor profiles into the running kernel. Dropping the files into
 # /etc/apparmor.d/ is not enough on its own: apparmor.service only reads that
 # directory at boot, so without an explicit `apparmor_parser -r` the profile
-# wouldn't take effect until the next reboot. Failures (no AppArmor, parser
-# missing, kernel without AppArmor) are tolerated; the profile is a defence
-# in depth and the tunnel must still work without it.
-apparmor_parser -r -W /etc/apparmor.d/firezone-client-tunnel 2>/dev/null || true
-apparmor_parser -r -W /etc/apparmor.d/firezone-client-gui 2>/dev/null || true
+# wouldn't take effect until the next reboot. Failures (no AppArmor, kernel
+# without AppArmor, profile syntax bug) are tolerated; the profile is a
+# defence in depth and the tunnel must still work without it. Parser output
+# is intentionally not suppressed so problems are visible in install logs
+# (e.g. `/var/log/apt/term.log`).
+if command -v apparmor_parser >/dev/null 2>&1; then
+    apparmor_parser -r -W /etc/apparmor.d/firezone-client-tunnel || true
+    apparmor_parser -r -W /etc/apparmor.d/firezone-client-gui || true
+fi
 
 systemctl daemon-reload
 systemctl enable "$SERVICE_NAME"

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -49,6 +49,15 @@ if ! id -nG "$INVOKING_USER" | grep -qw "firezone-client"; then
     echo ""
 fi
 
+# Load the AppArmor profiles into the running kernel. Dropping the files into
+# /etc/apparmor.d/ is not enough on its own: apparmor.service only reads that
+# directory at boot, so without an explicit `apparmor_parser -r` the profile
+# wouldn't take effect until the next reboot. Failures (no AppArmor, parser
+# missing, kernel without AppArmor) are tolerated; the profile is a defence
+# in depth and the tunnel must still work without it.
+apparmor_parser -r -W /etc/apparmor.d/firezone-client-tunnel 2>/dev/null || true
+apparmor_parser -r -W /etc/apparmor.d/firezone-client-gui 2>/dev/null || true
+
 systemctl daemon-reload
 systemctl enable "$SERVICE_NAME"
 systemctl restart "$SERVICE_NAME"

--- a/rust/gui-client/src-tauri/linux_package/prerm_deb
+++ b/rust/gui-client/src-tauri/linux_package/prerm_deb
@@ -6,3 +6,9 @@ SERVICE_NAME="firezone-client-tunnel"
 
 sudo systemctl disable "$SERVICE_NAME"
 sudo systemctl stop "$SERVICE_NAME"
+
+# Unload the AppArmor profiles from the running kernel. Failures (no AppArmor,
+# parser missing, profiles already unloaded) are tolerated so uninstall always
+# succeeds.
+sudo apparmor_parser -R /etc/apparmor.d/firezone-client-tunnel 2>/dev/null || true
+sudo apparmor_parser -R /etc/apparmor.d/firezone-client-gui 2>/dev/null || true

--- a/rust/gui-client/src-tauri/linux_package/prerm_rpm
+++ b/rust/gui-client/src-tauri/linux_package/prerm_rpm
@@ -14,3 +14,9 @@ fi
 
 sudo systemctl disable "$SERVICE_NAME"
 sudo systemctl stop "$SERVICE_NAME"
+
+# Unload the AppArmor profiles from the running kernel. Failures (no AppArmor,
+# parser missing, profiles already unloaded) are tolerated so uninstall always
+# succeeds.
+sudo apparmor_parser -R /etc/apparmor.d/firezone-client-tunnel 2>/dev/null || true
+sudo apparmor_parser -R /etc/apparmor.d/firezone-client-gui 2>/dev/null || true

--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -131,8 +131,7 @@ fn authorize_peer(pid: i32) -> Result<()> {
         return Ok(());
     }
 
-    let peer_label =
-        read_apparmor_label(pid).context("Failed to read peer's AppArmor label")?;
+    let peer_label = read_apparmor_label(pid).context("Failed to read peer's AppArmor label")?;
     anyhow::ensure!(
         peer_label == GUI_LABEL,
         "Peer AppArmor label {peer_label:?} is not {GUI_LABEL:?}",

--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -89,14 +89,85 @@ impl Server {
     pub(crate) async fn next_client(&mut self) -> Result<ServerStream> {
         let (stream, _) = self.listener.accept().await?;
         let cred = stream.peer_cred()?;
+        let pid = cred.pid();
         tracing::info!(
             uid = cred.uid(),
             gid = cred.gid(),
-            pid = cred.pid(),
+            pid = pid,
             "Accepted an IPC connection"
         );
+        if let Some(pid) = pid {
+            authorize_peer(pid).inspect_err(|error| {
+                tracing::warn!(pid, "Rejecting IPC peer: {error:#}");
+            })?;
+        }
         Ok(stream)
     }
+}
+
+/// Authorize an IPC peer using its AppArmor label.
+///
+/// When the Tunnel service itself is confined by the `firezone-client-tunnel`
+/// AppArmor profile (the deb/rpm packaging loads one at install time), the
+/// peer's process must be confined by the matching `firezone-client-gui`
+/// profile. This is checked here in userspace rather than via an AppArmor
+/// `peer=(label=...)` rule because AppArmor unix peer mediation for
+/// path-based sockets is unreliable on upstream kernels older than 6.17
+/// (see Launchpad bug #1208988).
+///
+/// In every other case - AppArmor not active, profile failed to load, the
+/// tunnel started before the profile was installed, the label is "kernel"
+/// or "unconfined" - the peer check is skipped and POSIX permissions on the
+/// socket (`root:firezone-client 0660`) remain the only gate. This preserves
+/// behaviour on distros without AppArmor and on systems where the install
+/// hasn't completed yet.
+#[cfg(target_os = "linux")]
+fn authorize_peer(pid: i32) -> Result<()> {
+    const TUNNEL_LABEL: &str = "firezone-client-tunnel";
+    const GUI_LABEL: &str = "firezone-client-gui";
+
+    let our_label = read_apparmor_label(std::process::id() as i32);
+    if our_label.as_deref() != Some(TUNNEL_LABEL) {
+        return Ok(());
+    }
+
+    let peer_label =
+        read_apparmor_label(pid).context("Failed to read peer's AppArmor label")?;
+    anyhow::ensure!(
+        peer_label == GUI_LABEL,
+        "Peer AppArmor label {peer_label:?} is not {GUI_LABEL:?}",
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn authorize_peer(_pid: i32) -> Result<()> {
+    // macOS doesn't have AppArmor; the production macOS client uses the
+    // native Swift implementation in `swift/apple/` and this code path only
+    // runs from controller tests.
+    Ok(())
+}
+
+/// Read a process's AppArmor label from `/proc/<pid>/attr/current`.
+///
+/// Returns `None` when the file isn't readable - which happens when the
+/// kernel was built without LSM support, or the peer process exited before
+/// we could read its attribute.
+///
+/// Format of the file (newline- and sometimes null-terminated):
+///  - `unconfined\n` - no profile attached
+///  - `kernel\0` - kernel-internal label (e.g. in containers without AppArmor)
+///  - `<profile-name>\n` - profile attached in enforce mode
+///  - `<profile-name> (mode)\n` - profile attached in complain/etc. mode
+#[cfg(target_os = "linux")]
+fn read_apparmor_label(pid: i32) -> Option<String> {
+    let raw = std::fs::read_to_string(format!("/proc/{pid}/attr/current")).ok()?;
+    let cleaned = raw
+        .trim_matches(|c: char| c.is_whitespace() || c == '\0')
+        .split(' ')
+        .next()
+        .unwrap_or("");
+    Some(cleaned.to_string())
 }
 
 /// The path for our Unix Domain Socket

--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -96,6 +96,7 @@ impl Server {
             pid = pid,
             "Accepted an IPC connection"
         );
+        #[cfg(target_os = "linux")]
         if let Some(pid) = pid {
             authorize_peer(pid).inspect_err(|error| {
                 tracing::warn!(pid, "Rejecting IPC peer: {error:#}");
@@ -121,6 +122,9 @@ impl Server {
 /// socket (`root:firezone-client 0660`) remain the only gate. This preserves
 /// behaviour on distros without AppArmor and on systems where the install
 /// hasn't completed yet.
+///
+/// macOS doesn't have AppArmor; production macOS uses the native Swift
+/// implementation in `swift/apple/`, so this function only exists on Linux.
 #[cfg(target_os = "linux")]
 fn authorize_peer(pid: i32) -> Result<()> {
     const TUNNEL_LABEL: &str = "firezone-client-tunnel";
@@ -136,14 +140,6 @@ fn authorize_peer(pid: i32) -> Result<()> {
         peer_label == GUI_LABEL,
         "Peer AppArmor label {peer_label:?} is not {GUI_LABEL:?}",
     );
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn authorize_peer(_pid: i32) -> Result<()> {
-    // macOS doesn't have AppArmor; the production macOS client uses the
-    // native Swift implementation in `swift/apple/` and this code path only
-    // runs from controller tests.
     Ok(())
 }
 

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
         "files": {
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
+          "/etc/apparmor.d/firezone-client-tunnel": "./linux_package/apparmor.d/firezone-client-tunnel",
+          "/etc/apparmor.d/firezone-client-gui": "./linux_package/apparmor.d/firezone-client-gui",
           "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel"
         },
         "desktopTemplate": "./linux_package/firezone-client-gui.desktop"
@@ -25,6 +27,8 @@
         "files": {
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
+          "/etc/apparmor.d/firezone-client-tunnel": "./linux_package/apparmor.d/firezone-client-tunnel",
+          "/etc/apparmor.d/firezone-client-gui": "./linux_package/apparmor.d/firezone-client-gui",
           "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel"
         },
         "desktopTemplate": "./linux_package/firezone-client-gui.desktop"

--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -31,9 +31,10 @@ firezone-client-gui --help | grep "Usage: firezone-client-gui"
 # Make sure the Tunnel service is running
 systemctl status "$SERVICE_NAME" || debug_exit
 
-# Verify the AppArmor profiles loaded and the tunnel is actually confined.
-# The whole point of the profile is to refuse IPC connections from peers that
-# aren't labeled `firezone-client-gui`; check that property end-to-end.
+# Verify the AppArmor profiles loaded and the tunnel rejects peers that
+# aren't labeled `firezone-client-gui`. The rejection is implemented in code
+# (see `ipc/unix.rs::authorize_peer`); the AppArmor profiles only attach
+# labels so the code-side check has something to compare against.
 SOCKET=/run/dev.firezone.client/tunnel.sock
 
 sudo aa-status
@@ -41,7 +42,11 @@ sudo aa-status | grep -q firezone-client-tunnel
 sudo aa-status | grep -q firezone-client-gui
 sudo aa-status --enforced | grep -q firezone-client-tunnel
 
-# Positive: a process with the `firezone-client-gui` label is accepted.
+# The tunnel just needs to stay alive long enough to log the peer reject,
+# so we connect, attempt one read, and disconnect. We rely on the socket
+# being open being enough for the tunnel's `authorize_peer` to run.
+
+# Positive: a process labeled firezone-client-gui is accepted.
 sudo aa-exec -p firezone-client-gui -- python3 -c "
 import socket
 s = socket.socket(socket.AF_UNIX)
@@ -49,15 +54,24 @@ s.connect('$SOCKET')
 s.close()
 "
 
-# Negative: an unconfined process is refused by the tunnel's AppArmor profile
-# even though it runs as root (POSIX permissions would let it through).
+# Negative: an unconfined root process is refused. POSIX permissions would
+# let root through, so this only fails if the tunnel's code-side
+# `authorize_peer` check actually rejects on label mismatch.
+#
+# The Python here exits 0 if the tunnel sent us any bytes (= the peer was
+# accepted, which is what we DON'T want), and exits 1 if the tunnel closed
+# the stream without sending data (= the peer was rejected as expected).
 if sudo python3 -c "
-import socket
+import socket, sys
 s = socket.socket(socket.AF_UNIX)
 s.connect('$SOCKET')
-s.close()
-" 2>/dev/null
-then
-    echo "FAIL: unconfined process was allowed to connect to the IPC socket"
+s.settimeout(2)
+try:
+    data = s.recv(1)
+except Exception:
+    data = b''
+sys.exit(0 if data else 1)
+"; then
+    echo "FAIL: unconfined process was allowed to talk to the IPC socket"
     exit 1
 fi

--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -30,3 +30,34 @@ firezone-client-gui --help | grep "Usage: firezone-client-gui"
 
 # Make sure the Tunnel service is running
 systemctl status "$SERVICE_NAME" || debug_exit
+
+# Verify the AppArmor profiles loaded and the tunnel is actually confined.
+# The whole point of the profile is to refuse IPC connections from peers that
+# aren't labeled `firezone-client-gui`; check that property end-to-end.
+SOCKET=/run/dev.firezone.client/tunnel.sock
+
+sudo aa-status
+sudo aa-status | grep -q firezone-client-tunnel
+sudo aa-status | grep -q firezone-client-gui
+sudo aa-status --enforced | grep -q firezone-client-tunnel
+
+# Positive: a process with the `firezone-client-gui` label is accepted.
+sudo aa-exec -p firezone-client-gui -- python3 -c "
+import socket
+s = socket.socket(socket.AF_UNIX)
+s.connect('$SOCKET')
+s.close()
+"
+
+# Negative: an unconfined process is refused by the tunnel's AppArmor profile
+# even though it runs as root (POSIX permissions would let it through).
+if sudo python3 -c "
+import socket
+s = socket.socket(socket.AF_UNIX)
+s.connect('$SOCKET')
+s.close()
+" 2>/dev/null
+then
+    echo "FAIL: unconfined process was allowed to connect to the IPC socket"
+    exit 1
+fi


### PR DESCRIPTION
Adds AppArmor profiles to the Linux deb/rpm bundles that restrict the Tunnel service's IPC socket so only the GUI client binary may connect to it, on top of the existing `root:firezone-client 0660` filesystem permissions.

The tunnel profile gates `accept` on `/run/dev.firezone.client/tunnel.sock` to peers labeled `firezone-client-gui`; the GUI profile is a label-only complain-mode profile that exists solely to attach that label. Both are loaded by `postinst` and unloaded by `prerm`; the systemd unit also references the profile with a leading `-` so the unit still starts on systems without AppArmor.