### PR TITLE
refactor(gui-client): drop legacy advanced-settings migration

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -10,7 +10,7 @@ use anyhow::{Context as _, ErrorExt, Result, bail};
 use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, dialog, elevation, gui, logging, settings};
-use settings::AdvancedSettingsLegacy;
+use settings::AdvancedSettings;
 use telemetry::Telemetry;
 use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
@@ -88,8 +88,7 @@ fn try_main(
         fake_controller,
     };
 
-    let mut advanced_settings =
-        settings::load_advanced_settings::<AdvancedSettingsLegacy>().unwrap_or_default();
+    let mut advanced_settings = settings::load_advanced_settings().unwrap_or_default();
 
     let mdm_settings = settings::load_mdm_settings()
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
@@ -225,11 +224,11 @@ fn try_main(
 }
 
 /// Parse the log filter from settings, showing an error and fixing it if needed
-fn fix_log_filter(settings: &mut AdvancedSettingsLegacy) -> Result<()> {
+fn fix_log_filter(settings: &mut AdvancedSettings) -> Result<()> {
     if EnvFilter::try_new(&settings.log_filter).is_ok() {
         return Ok(());
     }
-    settings.log_filter = AdvancedSettingsLegacy::default().log_filter;
+    settings.log_filter = AdvancedSettings::default().log_filter;
 
     firezone_gui_client::dialog::error(
         "The custom log filter is not parsable. Using the default log filter.",

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -9,7 +9,7 @@ use crate::{
     ipc::{self, ClientRead, ClientWrite, SocketId},
     logging::FileCount,
     settings::{
-        self, AdvancedSettings, AdvancedSettingsLegacy, AdvancedSettingsViewModel, GeneralSettings,
+        self, AdvancedSettings, AdvancedSettingsViewModel, GeneralSettings,
         GeneralSettingsViewModel, MdmSettings,
     },
     updates,
@@ -257,15 +257,14 @@ pub fn run(
     rt: &Runtime,
     config: RunConfig,
     mdm_settings: MdmSettings,
-    advanced_settings: AdvancedSettingsLegacy,
+    advanced_settings: AdvancedSettings,
     reloader: logging::FilterReloadHandle,
 ) -> Result<()> {
     tauri::async_runtime::set(rt.handle().clone());
 
     let gui_ipc = rt.block_on(create_gui_ipc_server())?;
 
-    let (general_settings, advanced_settings) =
-        rt.block_on(settings::migrate_legacy_settings(advanced_settings));
+    let general_settings = settings::load_general_settings().unwrap_or_default();
 
     let (ctlr_tx, ctlr_rx) = mpsc::channel(5);
     let req_tx = ctlr_tx.clone();

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -40,6 +40,11 @@ pub struct MdmSettings {
 
 #[derive(Clone, Deserialize, Serialize, specta::Type)]
 pub struct AdvancedSettings {
+    // `auth_base_url` was the field name before #9211 (May 2025) split the
+    // settings file. The alias keeps pre-split installs deserializing
+    // successfully so their custom self-hosted portal URL isn't silently
+    // reset to the default.
+    #[serde(alias = "auth_base_url")]
     pub auth_url: Url,
     pub api_url: Url,
     pub log_filter: String,
@@ -216,4 +221,28 @@ pub fn load_general_settings() -> Result<GeneralSettings> {
     let text = std::fs::read_to_string(path)?;
     let settings = serde_json::from_str(&text)?;
     Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pre_9211_format_via_auth_base_url_alias() {
+        // Snapshot of the on-disk shape used by GUI builds before #9211
+        // (May 2025). The new `AdvancedSettings` accepts `auth_base_url`
+        // via a serde alias so pre-9211 installs preserve their custom
+        // portal URLs after this PR removes the legacy migration code.
+        let s = r#"{
+            "auth_base_url": "https://example.com/",
+            "api_url": "wss://example.com/",
+            "favorite_resources": [],
+            "internet_resource_enabled": true,
+            "log_filter": "info"
+        }"#;
+        let actual: AdvancedSettings = serde_json::from_str(s).unwrap();
+        assert_eq!(actual.auth_url.as_str(), "https://example.com/");
+        assert_eq!(actual.api_url.as_str(), "wss://example.com/");
+        assert_eq!(actual.log_filter, "info");
+    }
 }

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -40,11 +40,6 @@ pub struct MdmSettings {
 
 #[derive(Clone, Deserialize, Serialize, specta::Type)]
 pub struct AdvancedSettings {
-    // `auth_base_url` was the field name before #9211 (May 2025) split the
-    // settings file. The alias keeps pre-split installs deserializing
-    // successfully so their custom self-hosted portal URL isn't silently
-    // reset to the default.
-    #[serde(alias = "auth_base_url")]
     pub auth_url: Url,
     pub api_url: Url,
     pub log_filter: String,
@@ -221,28 +216,4 @@ pub fn load_general_settings() -> Result<GeneralSettings> {
     let text = std::fs::read_to_string(path)?;
     let settings = serde_json::from_str(&text)?;
     Ok(settings)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_pre_9211_format_via_auth_base_url_alias() {
-        // Snapshot of the on-disk shape used by GUI builds before #9211
-        // (May 2025). The new `AdvancedSettings` accepts `auth_base_url`
-        // via a serde alias so pre-9211 installs preserve their custom
-        // portal URLs after this PR removes the legacy migration code.
-        let s = r#"{
-            "auth_base_url": "https://example.com/",
-            "api_url": "wss://example.com/",
-            "favorite_resources": [],
-            "internet_resource_enabled": true,
-            "log_filter": "info"
-        }"#;
-        let actual: AdvancedSettings = serde_json::from_str(s).unwrap();
-        assert_eq!(actual.auth_url.as_str(), "https://example.com/");
-        assert_eq!(actual.api_url.as_str(), "wss://example.com/");
-        assert_eq!(actual.log_filter, "info");
-    }
 }

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -217,4 +217,3 @@ pub fn load_general_settings() -> Result<GeneralSettings> {
     let settings = serde_json::from_str(&text)?;
     Ok(settings)
 }
-

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{Context as _, Result};
 use connlib_model::ResourceId;
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, path::PathBuf};
 use url::Url;
@@ -37,18 +36,6 @@ pub struct MdmSettings {
     pub connect_on_start: Option<bool>,
     pub check_for_updates: Option<bool>,
     pub support_url: Option<Url>,
-}
-
-#[derive(Clone, Deserialize, Serialize)]
-pub struct AdvancedSettingsLegacy {
-    #[serde(alias = "auth_url")]
-    pub auth_base_url: Url,
-    pub api_url: Url,
-    #[serde(default)]
-    pub favorite_resources: HashSet<ResourceId>,
-    #[serde(default)]
-    pub internet_resource_enabled: Option<bool>,
-    pub log_filter: String,
 }
 
 #[derive(Clone, Deserialize, Serialize, specta::Type)]
@@ -141,28 +128,16 @@ impl AdvancedSettingsViewModel {
 
 #[cfg(debug_assertions)]
 mod defaults {
-    pub(crate) const AUTH_BASE_URL: &str = "https://app.firez.one";
+    pub(crate) const AUTH_URL: &str = "https://app.firez.one";
     pub(crate) const API_URL: &str = "wss://api.firez.one/";
     pub(crate) const LOG_FILTER: &str = "debug";
 }
 
 #[cfg(not(debug_assertions))]
 mod defaults {
-    pub(crate) const AUTH_BASE_URL: &str = "https://app.firezone.dev";
+    pub(crate) const AUTH_URL: &str = "https://app.firezone.dev";
     pub(crate) const API_URL: &str = "wss://api.firezone.dev/";
     pub(crate) const LOG_FILTER: &str = "info";
-}
-
-impl Default for AdvancedSettingsLegacy {
-    fn default() -> Self {
-        Self {
-            auth_base_url: Url::parse(defaults::AUTH_BASE_URL).expect("static URL is a valid URL"),
-            api_url: Url::parse(defaults::API_URL).expect("static URL is a valid URL"),
-            favorite_resources: Default::default(),
-            internet_resource_enabled: Default::default(),
-            log_filter: defaults::LOG_FILTER.to_string(),
-        }
-    }
 }
 
 impl GeneralSettings {
@@ -174,7 +149,7 @@ impl GeneralSettings {
 impl Default for AdvancedSettings {
     fn default() -> Self {
         Self {
-            auth_url: Url::parse(defaults::AUTH_BASE_URL).expect("static URL is a valid URL"),
+            auth_url: Url::parse(defaults::AUTH_URL).expect("static URL is a valid URL"),
             api_url: Url::parse(defaults::API_URL).expect("static URL is a valid URL"),
             log_filter: defaults::LOG_FILTER.to_string(),
         }
@@ -191,44 +166,6 @@ pub fn general_settings_path() -> Result<PathBuf> {
     Ok(known_dirs::settings()
         .context("`known_dirs::settings` failed")?
         .join("general_settings.json"))
-}
-
-pub async fn migrate_legacy_settings(
-    legacy: AdvancedSettingsLegacy,
-) -> (GeneralSettings, AdvancedSettings) {
-    let general_settings = load_general_settings();
-
-    let advanced = AdvancedSettings {
-        auth_url: legacy.auth_base_url,
-        api_url: legacy.api_url,
-        log_filter: legacy.log_filter,
-    };
-
-    if let Ok(general) = general_settings {
-        return (general, advanced);
-    }
-
-    let general = GeneralSettings {
-        favorite_resources: legacy.favorite_resources,
-        internet_resource_enabled: legacy.internet_resource_enabled,
-        start_minimized: true,
-        start_on_login: None,
-        connect_on_start: None,
-        account_slug: None,
-    };
-
-    if let Err(e) = save_general(&general).await {
-        tracing::error!("Failed to write new general settings: {e:#}");
-        return (general, advanced);
-    }
-    if let Err(e) = save_advanced(&advanced).await {
-        tracing::error!("Failed to write new advanced settings: {e:#}");
-        return (general, advanced);
-    }
-
-    tracing::info!("Successfully migrate settings");
-
-    (general, advanced)
 }
 
 /// Saves the advanced settings to disk
@@ -264,10 +201,7 @@ pub async fn save_general(settings: &GeneralSettings) -> Result<()> {
 /// Return advanced settings if they're stored on disk
 ///
 /// Uses std::fs, so stick it in `spawn_blocking` for async contexts
-pub fn load_advanced_settings<T>() -> Result<T>
-where
-    T: DeserializeOwned,
-{
+pub fn load_advanced_settings() -> Result<AdvancedSettings> {
     let path = advanced_settings_path()?;
     let text = std::fs::read_to_string(path)?;
     let settings = serde_json::from_str(&text)?;
@@ -284,31 +218,3 @@ pub fn load_general_settings() -> Result<GeneralSettings> {
     Ok(settings)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn load_old_formats() {
-        let s = r#"{
-            "auth_base_url": "https://example.com/",
-            "api_url": "wss://example.com/",
-            "log_filter": "info"
-        }"#;
-
-        let actual = serde_json::from_str::<AdvancedSettingsLegacy>(s).unwrap();
-        // Apparently the trailing slash here matters
-        assert_eq!(actual.auth_base_url.to_string(), "https://example.com/");
-        assert_eq!(actual.api_url.to_string(), "wss://example.com/");
-        assert_eq!(actual.log_filter, "info");
-    }
-
-    #[test]
-    fn legacy_settings_can_parse_new_config() {
-        let advanced_settings = AdvancedSettings::default();
-
-        let new_format = serde_json::to_string(&advanced_settings).unwrap();
-
-        serde_json::from_str::<AdvancedSettingsLegacy>(&new_format).unwrap();
-    }
-}


### PR DESCRIPTION
The `AdvancedSettingsLegacy` struct and `migrate_legacy_settings` exist to convert the pre-`general_settings.json` on-disk format (with `auth_base_url` instead of `auth_url` and embedded `favorite_resources`). That migration has been in tree long enough that current installs have already converted.

Removing it shrinks the settings surface area before the upcoming work to move advanced-settings ownership into the privileged Tunnel Service.