### PR TITLE
fix(flaky): download-roaming-network

### DIFF
--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -3,11 +3,11 @@
 source "./scripts/tests/lib.sh"
 
 # Download 10MB at a max rate of 1MB/s. The first two UDP socket writes will fail as checksum offload is disabled.
-# This means it will take 13 seconds + the resent STUN binding request round trip time.
+# This means it will take ~13 seconds + ICE reconnection time after roaming. Allow 30s for CI timing variability.
 client sh -c \
     "curl \
         --fail \
-        --max-time 16 \
+        --max-time 30 \
         --keepalive-time 1 \
         --limit-rate 1000000 \
         --output download.file \


### PR DESCRIPTION
Increase `curl --max-time` from 16s to 30s in the `download-roaming-network` integration test.

The test disconnects the client network for 3 seconds then sends SIGHUP to trigger ICE reconnection. The nominal transfer time is ~13s (10 MB at 1 MB/s + two failed UDP socket writes due to checksum offload being disabled), leaving only 3s for ICE reconnection within the old 16s limit. On loaded CI runners that margin is frequently exceeded, causing ~25% failure rate.

Related: #13284

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSLYXTgkDaPyKcL8sGQNse)_