### PR TITLE
chore(agent): tell Claude to not hard-wrap PR descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,5 +48,7 @@ For example, for Rust code, check `rust/AGENT.md`; for Elixir code, check `elixi
   - Do not include links to the Claude session.
   - Link relevant PRs / issues using `Related: #XXXX`
   - Take inspiration from https://cbea.ms/git-commit; the squash-merged PRs will have the PR description as a commit message on main.
+    However, do not add hard line-breaks to the PR description itself.
+    GitHub will take care of that when merging.
 - Run static analysis locally before committing.
 - If a required tool is missing, check whether `mise.toml` declares it and install it via `mise` rather than through another package manager.


### PR DESCRIPTION
Having Claude directly create PRs with a meaningful description is useful. They do often have to be edited by hand afterwards though and having hard line-breaks in there makes this difficult. GitHub already takes care of formatting them to a nice commit message when merging, hence we don't need to hard-wrap them manually in the description. PR descriptions are also much easier to read without hard-wraps.