### PR TITLE
docs: add Claude Code skills for project conventions

### DIFF
--- a/.claude/skills/firezone-data-plane-trace/SKILL.md
+++ b/.claude/skills/firezone-data-plane-trace/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: firezone-data-plane-trace
+description: Explain how a packet flows through Firezone's data plane, or locate the right component for a packet-path question. Use when answering questions about `connlib`, `Tunnel`, ICE, WireGuard integration, TUN device handling, or the thread / channel topology in `rust/libs/connlib/`. Also useful for onboarding answers and grounding architectural review comments.
+---
+
+# Firezone data plane: packet flow
+
+Source of truth: `CLAUDE.md` and `docs/AGENT.md` -> "Data plane architecture".
+
+## The three components
+
+The data-plane entry point is [`Tunnel`](../../../rust/libs/connlib/tunnel). It is a single big event loop that mediates between three components:
+
+1. A **platform-specific TUN device** - the OS interface that delivers IP packets from / to the host.
+2. A **sans-IO state component** - either the Client or the Gateway state machine. Pure logic, no I/O.
+3. A **platform-specific UDP socket** - the wire to the peer.
+
+Packets from either I/O source (TUN, UDP) feed into the state. The state produces UDP or IP packets in return. Some UDP traffic is consumed internally by ICE - that traffic is handed to [`snownet`](../../../rust/libs/connlib/snownet) inside the state and never yields a payload IP packet.
+
+```
+   TUN read  ->\                 /-> TUN write
+                >  state (sans-IO, Client or Gateway)
+   UDP read  ->/                 \-> UDP write
+                         |
+                         v
+                      snownet (ICE, internal-only UDP)
+```
+
+## Thread / task layout
+
+Three sources, one brain. Connected by bounded channels:
+
+- 1 thread reading the TUN device.
+- 1 thread writing the TUN device.
+- 1 thread for IPv4 UDP, with one task each for send and receive.
+- 1 thread for IPv6 UDP, with one task each for send and receive.
+- 1 task on the **main** thread owning the state, draining inbound channels and feeding the outbound channels.
+
+The state is single-threaded - it does not need internal locking. Everything crossing a thread boundary crosses a bounded channel. Backpressure is therefore explicit at the channel.
+
+## Using this in review
+
+When reviewing a packet-path change, ask:
+
+1. Which of the three components is changing?
+2. Does the change cross a channel boundary? If so, is the channel still bounded and does it backpressure correctly?
+3. Is per-packet code on `TRACE` only? (See `firezone-log-audit`.)
+4. Does state-component code touch I/O directly? It should not - it is sans-IO.

--- a/.claude/skills/firezone-log-audit/SKILL.md
+++ b/.claude/skills/firezone-log-audit/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: firezone-log-audit
+description: Audit `tracing` log statements in Firezone Rust code against the project's log-level and sensitive-data policy. Use when adding or reviewing any `tracing::trace!`, `debug!`, `info!`, `warn!`, `error!`, or `Span` in `rust/`, or when a log line might contain a domain name, IP address, or other customer data. This skill catches mistakes the compiler cannot.
+---
+
+# Firezone log audit
+
+Source of truth: `rust/AGENT.md` -> "Use of log levels".
+
+## Sensitive data
+
+- **Domain names, customer IP addresses, and similar identifiers MUST NOT be logged above `DEBUG`.** When in doubt, drop to `DEBUG` or omit the field.
+- Anything triggered by an individual network packet **MUST** be at `TRACE`, not `DEBUG`.
+
+These two rules are non-negotiable. They are the first thing to grep for in a review.
+
+## Level guide
+
+| Level   | When to use                                                                                                                                                       |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TRACE` | Code that follows along with execution unconditionally - every incoming packet, every channel send.                                                               |
+| `DEBUG` | A condition or minor state change. "I would want to know this triggered to understand what the system did." Early exits and deviations from the happy path.       |
+| `INFO`  | Significant, often user-impacting state changes - connection established / closed, configuration applied.                                                         |
+| `WARN`  | Unusual but recoverable. An ops person may alert on a _rate_ of these. Ask: "would I want to be paged at 3am for this?" If no, it stays `WARN`; if yes, escalate. |
+| `ERROR` | Things are broken and we cannot continue this operation. Rare.                                                                                                    |
+
+## Spans
+
+- Prefer `tracing::Span` to attach context (`connection_id`, `resource_id`, ...) over repeating fields in every event - especially in highly concurrent code where events interleave.
+- Use **identifiers**, not whole structs. `?conn_id` is good; `?connection` that debug-prints the entire connection struct is not.
+
+## Structured fields vs format strings
+
+Always prefer structured fields:
+
+```rust
+tracing::info!(?duration_since_intent, "Established new connection");
+```
+
+over interpolation:
+
+```rust
+tracing::info!("Established new connection in {duration_since_intent:?}");
+```
+
+Structured fields are searchable, filterable, and survive JSON formatting; the message is a constant string suitable for grouping.
+
+## Review checklist
+
+When reviewing a diff that touches logging:
+
+1. Any `info!` / `warn!` / `error!` carrying a domain or IP? -> downgrade or strip the field.
+2. Any log inside a per-packet hot path? -> must be `TRACE`.
+3. Any whole-struct `?value` in a span or event? -> replace with an ID.
+4. Any `format!`-style interpolation that could be a field? -> convert to a field.
+5. Any `warn!` that fires on normal operation? -> downgrade to `debug!` or remove.

--- a/.claude/skills/firezone-mise-install/SKILL.md
+++ b/.claude/skills/firezone-mise-install/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: firezone-mise-install
+description: Install a missing development tool the Firezone way - via `mise`, using the version declared in `mise.toml`, rather than reaching for `apt`, `brew`, `cargo install`, or `pipx`. Use whenever a build, lint, or test command fails with "command not found" or a version mismatch.
+---
+
+# Installing Firezone tools
+
+Source of truth: `CLAUDE.md` -> "If a required tool is missing, check whether `mise.toml` declares it and install it via `mise` rather than through another package manager."
+
+## Where tools are declared
+
+The repo uses a `mise` monorepo layout (see `mise.toml` -> `[monorepo]`). Each language area has its own config root:
+
+- `/mise.toml` - top-level tasks (lint, format) and shared settings.
+- `/rust/mise.toml` - Rust toolchain plus `bpf-linker`, `cargo-deb`, `cargo-llvm-cov`, nightly version.
+- `/elixir/mise.toml` - Erlang / Elixir versions.
+- `/kotlin/android/mise.toml`, `/swift/apple/mise.toml` - mobile toolchains.
+
+Always check the config root closest to the directory you are working in first, then the repo root.
+
+## Flow when a command is missing
+
+1. `grep -R "<tool-name>" $(find . -maxdepth 3 -name mise.toml)` - check whether mise already declares it.
+2. If declared: `mise install` (from the relevant config root) and retry.
+3. If not declared but needed: add it to the appropriate `mise.toml` under `[tools]` with a pinned version, then `mise install`. Do **not** install globally with another package manager and skip `mise.toml` - that breaks reproducibility for other contributors and CI.
+4. Do not bypass `settings.minimum_release_age = "7d"` in the root `mise.toml` - that cooldown is a supply-chain mitigation, not a quirk.
+
+## What `mise` provides
+
+Beyond language toolchains, `mise` also installs the `cargo:`, `github:`, `pipx:` plugins seen in `rust/mise.toml`. Prefer those over the ambient system equivalents so versions match CI.

--- a/.claude/skills/firezone-pr/SKILL.md
+++ b/.claude/skills/firezone-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: firezone-pr
+description: Draft a Firezone PR title and description that follow the repo's contribution rules. Use when opening, retitling, or rewriting a pull request in this repo - the title must follow Conventional Commits and stay under 64 characters (enforced by `.github/workflows/_static-analysis.yml`), and the description must be minimal high-level prose with no test plan or Claude session link.
+---
+
+# Firezone PR drafting
+
+Source of truth: `CLAUDE.md` -> "Code contributions" and `docs/AGENT.md`.
+
+## Title
+
+- Conventional Commits: `type(scope): subject`.
+- Length: 64 characters or fewer. CI fails otherwise (`_static-analysis.yml`).
+- Common types in this repo: `feat`, `fix`, `chore`, `ci`, `build`, `docs`, `refactor`, `test`.
+- Common scopes: `rust`, `portal`, `gateway`, `relay`, `gui-client`, `headless-client`, `android`, `apple`, `website`, `connlib`, `snownet`, `claude`, `deps`.
+- The squash-merge commit message on `main` will be the PR title, so write it for that audience.
+
+Check the length before submitting:
+
+```bash
+printf '%s' "feat(scope): subject" | wc -c
+```
+
+## Description
+
+- One or two short paragraphs explaining **what** is changing at a high level and **why**.
+- Do not restate the diff. If a reader can see it in the patch, do not narrate it in prose.
+- Do not include a "Test plan" section.
+- Do not include any `https://claude.ai/code/session_...` links.
+- Link related work with `Related: #1234` (one per line). Use this for both PRs and issues.
+- Take inspiration from https://cbea.ms/git-commit.
+
+## Template
+
+```
+<one or two sentences: what + why, at a high level>
+
+Related: #XXXX
+```
+
+That is the entire template. Omit `Related:` if there is nothing to link.

--- a/.claude/skills/firezone-rust-style/SKILL.md
+++ b/.claude/skills/firezone-rust-style/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: firezone-rust-style
+description: Apply Firezone's Rust coding conventions when writing or reviewing code under `rust/`. Use when generating new Rust code in this repo, refactoring existing Rust code, or reviewing a Rust diff for style consistency. Covers iterator-first style, turbofish, `let-else` early returns, test conventions, and module ordering.
+---
+
+# Firezone Rust style
+
+Source of truth: `rust/AGENT.md`.
+
+## Code style
+
+- **No excessive comments.** Only comment the _why_ when it is non-obvious. Identifiers and signatures cover the _what_.
+- **Functional over imperative.** Prefer iterator chains (`map`, `filter`, `collect`, `try_fold`, ...) over `for` loops that push into a `Vec`.
+- **Turbofish over type hints.** Write `parse::<u32>()`, not `let x: u32 = s.parse()?;` when the turbofish is clearer at the call site.
+- **Early returns; flatten the happy path.**
+  - Use `let-else` instead of `if let Some(x) = ... { ... }` when the `None` branch returns.
+  - Use `let Ok(x) = ... else { return ... };` over `match` for two-arm error guards.
+  - Goal: the happy path stays at the leftmost indentation; failure cases are short and visible at the top.
+
+## Tests
+
+- Test the **public API** of the module, not the private internals. If a test needs to reach into private state, that is a hint to either expose a real API or rethink what is being tested.
+- Follow **arrange / act / assert**, with a blank line between the three phases when it aids readability.
+
+## Module layout
+
+Order items within a module from high to low priority:
+
+1. Public API (`pub` types and functions).
+2. The functions those call, roughly in call order.
+3. Lower-level helpers last.
+
+Scrolling top to bottom should feel like drilling down through the module. A reader who only reads the first screen should understand what the module _does_.
+
+## Logging
+
+Logging is non-trivial in this codebase - see the `firezone-log-audit` skill for the full level / span / sensitive-data rules.

--- a/.claude/skills/firezone-security-review/SKILL.md
+++ b/.claude/skills/firezone-security-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: firezone-security-review
+description: Perform a focused security review on Firezone changes touching cryptography, authentication, or access control. Use when a diff modifies `rust/libs/connlib/snownet`, WireGuard / boringtun integration, key material, ICE credentials, the Elixir portal's auth modules, RBAC / policy code, or anything that decides who is allowed to reach what. The general code-review guidelines say to give this code "extra special attention" - this skill says how.
+---
+
+# Firezone security review
+
+Source of truth: `CLAUDE.md` -> "Code review guidelines" and `docs/AGENT.md`.
+
+## Scope
+
+Code worth flagging for extra scrutiny:
+
+- `rust/libs/connlib/snownet` - ICE, STUN, key exchange.
+- `rust/libs/connlib/tunnel` and `rust/libs/connlib/*` touching boringtun / WireGuard state.
+- Anything handling private keys, pre-shared keys, session keys, certificates, or ICE credentials.
+- `elixir/lib/portal*` modules that perform authentication, authorization, or policy evaluation.
+- Token issuance, validation, refresh, and revocation paths in either plane.
+- Code paths that decide whether a packet is forwarded, dropped, or routed to a specific peer.
+
+## Review checklist
+
+### Crypto
+
+- Are nonces / IVs unique per key? Counter resets after rekey?
+- Are secret comparisons constant-time (`subtle::ConstantTimeEq`, `crypto::Eq`, etc.)?
+- Is key material ever logged, `Debug`-printed, or serialized into errors? It must not be. (See also `firezone-log-audit`.)
+- Is key material zeroized on drop where reasonable (`zeroize::Zeroize`)?
+- Does any code roll its own primitive instead of using `ring`, `rustcrypto`, or `boringtun`?
+
+### Authentication
+
+- Is every entry point reachable without a token actually intended to be public?
+- Are token expiry, audience, issuer, and signature all validated - not just signature?
+- Do error paths leak whether a user exists, a token was malformed, or it was just expired?
+- Are auth decisions cached? If so, how long, and what invalidates the cache?
+
+### Authorization / access control
+
+- Are policy decisions evaluated **server-side**, not implied by the client request?
+- Are resource IDs from the request authorized for the **caller**, not just well-formed?
+- Are list endpoints filtered by tenant / account before the response is built, not after?
+- Is there a missing check on the `update` / `delete` path that exists on `read`?
+
+### Operational
+
+- Does a new failure mode produce a flood of `error!` logs (denial-of-service-by-logging)?
+- Does a panic exist on attacker-influenced input?
+- Does an unbounded queue or map exist on attacker-influenced input?
+
+## Output
+
+When reporting, separate **must fix before merge** from **worth a follow-up**. Cite file and line. For each finding, state the threat (who can do what) before the remediation.

--- a/.claude/skills/firezone-static-analysis/SKILL.md
+++ b/.claude/skills/firezone-static-analysis/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: firezone-static-analysis
+description: Run Firezone's pre-commit static analysis locally before committing. Use whenever the user is about to commit, before opening a PR, or when CI's static-analysis job fails and you need to reproduce it locally. Runs the same `pre-commit` config that CI runs, via the `mise` tasks declared in the repo root `mise.toml`.
+---
+
+# Firezone static analysis
+
+Source of truth: `mise.toml` (repo root) and `CLAUDE.md` -> "Run static analysis locally before committing."
+
+## Tasks
+
+All tasks are declared in the repo-root `mise.toml`:
+
+- `mise run lint-staged` - run pre-commit hooks on staged files only. Use this in the normal pre-commit workflow.
+- `mise run lint` - run pre-commit hooks on **all** files. Use this when investigating CI failures or after a large refactor.
+- `mise run lint-setup` - install the lint toolchain (Python `pip` deps for pre-commit hooks, pnpm deps under `.github/` and `website/`). Run this once per fresh checkout, or after Dependabot bumps any pinned lint tool.
+- `mise run format` - run `prettier --write` over `website/`. Use only when website files were touched.
+
+## Recommended flow
+
+```bash
+# First time on a fresh checkout
+mise run lint-setup
+
+# Before every commit
+git add <paths>
+mise run lint-staged
+```
+
+If `lint-staged` reports auto-fixed files, `git add` them again and re-run before committing.
+
+## When the tool itself is missing
+
+If `mise` or `pre-commit` is not installed, see the `firezone-mise-install` skill - do not reach for `apt`, `brew`, or `pipx` first.

--- a/.claude/skills/no-user-impersonation/SKILL.md
+++ b/.claude/skills/no-user-impersonation/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: no-user-impersonation
+description: Hard rule against impersonating the session user when responding to other humans via an MCP server. Use whenever you are tempted to call an MCP tool that posts, comments, replies, or messages under the user's identity in response to content authored by someone other than the session user - for example, posting a GitHub comment that replies to a reviewer's review comment, or sending a chat message that answers another teammate. The MCP credential is the user's, so anything you post appears to come from them.
+---
+
+# Never impersonate the session user
+
+## The rule
+
+**Do not reply to a message authored by another human by posting through an MCP tool that uses the session user's identity.** The recipient will read your reply as words written by the user themselves. They did not write them. That is impersonation, and it damages trust in every future message the user actually sends.
+
+This applies to every MCP-mediated channel:
+
+- GitHub: `mcp__github__add_issue_comment`, `mcp__github__add_reply_to_pull_request_comment`, `mcp__github__add_comment_to_pending_review`, `mcp__github__pull_request_review_write`, `mcp__github__issue_write`, and any other write tool that posts under the authenticated user.
+- Any future MCP server that posts to Slack, Linear, Jira, email, or another human-readable channel as the user.
+
+If the MCP tool acts as the user, treat its write surface the same way you would treat the user's own keyboard: you do not type on it without explicit instruction for that specific message.
+
+## What counts as "another human"
+
+Anyone who is not the session user. PR reviewers, issue commenters, teammates, customers, bots that escalate to humans. If you did not just receive the message in this session from the user, do not reply on their behalf.
+
+## What you should do instead
+
+- **Draft, do not post.** Write the proposed reply as plain text in your response to the user. They can copy it, edit it, or tell you to send it.
+- **Ask before posting.** Use `AskUserQuestion` (or equivalent) to confirm - including the exact text and the exact destination - before any MCP write tool that targets a human audience. A single approval covers a single message, not a category.
+- **Act on the technical content, not the social surface.** A reviewer asks for a code change? Make the code change and push it. Pushing the fix is unambiguously your work. Posting a comment that says "good catch, fixed!" is the user's voice and needs their sign-off.
+- **CI / bots are not human comments.** Fixing a failed check, rebasing, or re-running a job is fine - that work appears as code or as CI activity, not as the user's words. The line is "are these words attributed to the user when read by another human."
+
+## When the user has explicitly asked you to reply
+
+If the user says "reply to that review comment with X" or "post a comment saying X", that _is_ explicit authorization. Post exactly what they asked for, then stop. Do not extend the authorization to other comments in the same thread, other PRs, or follow-ups - each reply needs its own go-ahead.
+
+## When in doubt
+
+Stay silent on the MCP channel and reply to the user in this session instead. Silence on an MCP surface is always recoverable; an impersonating message is not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,47 +6,14 @@ Firezone is a zero-trust access platform built on top of WireGuard.
 The data plane components are built in Rust and reside in `rust/`.
 The control plane components are built in Elixir and reside in `elixir/`.
 
-## Data plane architecture
-
-At the core of the data plane resides a shared library called [`connlib`](../rust/libs/connlib).
-It combines ICE (using the `is` library) and WireGuard (using the `boringtun` library) to establish on-the-fly tunnels between Clients and Gateways.
-The entry-point for the data plane is [`Tunnel`](../rust/libs/connlib/tunnel) which acts as a big event-loop combining three components:
-
-- A platform-specific TUN device
-- A sans-IO state component representing either the Client or the Gateway
-- A platform-specific UDP socket
-
-Packets from IO sources (TUN device and UDP socket) are passed to the state component, resulting in a UDP or IP packet.
-The state component also manages ICE through the [`snownet`](../rust/libs/connlib/snownet) library, so some UDP traffic is handled internally and does not yield an IP packet.
-
-These three components are split into multiple threads and connected via bounded channels:
-
-- 1 thread for reading from the TUN device
-- 1 thread for writing to the TUN device
-- 1 thread for handling IPv4 UDP traffic with 1 task each for sending / receiving
-- 1 thread for handling IPv6 UDP traffic with 1 task each for sending / receiving
-- 1 task on the "main" thread that holds the state and reads / writes from and to the channels connecting to the IO threads
-
 ## Coding guidelines
 
 For guidelines on generating or reviewing specific parts of the codebase, check for an `AGENT.md` file in the corresponding sub-directory.
 For example, for Rust code, check `rust/AGENT.md`; for Elixir code, check `elixir/AGENT.md`, etc.
 
+Task-specific rules (data-plane architecture, log-level policy, PR conventions, `mise` tooling, security review, MCP impersonation guardrail, etc.) are encoded as invokable skills under `.claude/skills/` and surfaced on demand rather than kept always-loaded here.
+
 ## Code review guidelines
 
 - Assume that code compiles and is syntactically correct.
 - Focus on consistency and correctness.
-- Give extra special attention to any security-sensitive code, such as cryptographic operations, authentication logic, and access control mechanisms.
-
-## Code contributions
-
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for PR titles. The static analysis workflow enforces a maximum length of 64 characters (see `.github/workflows/_static-analysis.yml`).
-- Keep PR descriptions minimal.
-  - Concise prose explaining what is changing **at a high level** and why.
-  - Do not describe the code changes that can be seen in the diff again in prose.
-  - Do not add a test plan section.
-  - Do not include links to the Claude session.
-  - Link relevant PRs / issues using `Related: #XXXX`
-  - Take inspiration from https://cbea.ms/git-commit; the squash-merged PRs will have the PR description as a commit message on main.
-- Run static analysis locally before committing.
-- If a required tool is missing, check whether `mise.toml` declares it and install it via `mise` rather than through another package manager.


### PR DESCRIPTION
Codify the rules in `CLAUDE.md`, `docs/AGENT.md`, and `rust/AGENT.md` as reusable skills under `.claude/skills/`, so an agent in this repo can surface them on demand instead of re-deriving them from the top-level markdown each session.

Trims the now-duplicated rules from `CLAUDE.md`, leaving only the high-level summary, the `AGENT.md` pointer, and the two general code-review heuristics that no skill covers. `docs/AGENT.md` is left intact for non-Claude agents that have no access to the skills directory.

Also adds a guardrail skill prohibiting impersonation of the session user when replying to other humans through an MCP server (notably the GitHub MCP server, whose write tools post under the user's identity).