### PR TITLE
fix(portal): narrow unsafe repo usage exemption

### DIFF
--- a/elixir/.credo/check/warning/unsafe_repo_usage.ex
+++ b/elixir/.credo/check/warning/unsafe_repo_usage.ex
@@ -27,8 +27,9 @@ defmodule Credo.Check.Warning.UnsafeRepoUsage do
       String.ends_with?(file_path, "lib/portal/safe.ex") ->
         []
 
-      # Allow in Portal.Repo itself and its submodules (Preloader, Paginator, Filter, Query)
-      String.contains?(file_path, "lib/portal/repo") ->
+      # Allow only known Portal.Repo infrastructure files. Other helpers under
+      # lib/portal/repo still need to use Portal.Safe.
+      repo_infrastructure_file?(file_path) ->
         []
 
       # Allow in seeds.exs files
@@ -128,6 +129,19 @@ defmodule Credo.Check.Warning.UnsafeRepoUsage do
 
   defp traverse(ast, issues, _issue_meta) do
     {ast, issues}
+  end
+
+  defp repo_infrastructure_file?(file_path) do
+    Enum.any?(
+      [
+        "lib/portal/repo.ex",
+        "lib/portal/repo/list.ex",
+        "lib/portal/repo/offset_list.ex",
+        "lib/portal/repo/preloader.ex",
+        "lib/portal/repo/replica.ex"
+      ],
+      &String.ends_with?(file_path, &1)
+    )
   end
 
   defp issue_for(_ast, line_no, issue_meta) do

--- a/elixir/test/credo/check/warning/unsafe_repo_usage_test.exs
+++ b/elixir/test/credo/check/warning/unsafe_repo_usage_test.exs
@@ -1,0 +1,78 @@
+defmodule Credo.Check.Warning.UnsafeRepoUsageTest do
+  use ExUnit.Case, async: true
+
+  alias Credo.Check.Warning.UnsafeRepoUsage
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  test "reports direct Portal.Repo calls in application code" do
+    issues =
+      """
+      defmodule Portal.Example do
+        def list do
+          Portal.Repo.all(Portal.Account)
+        end
+      end
+      """
+      |> source_file("lib/portal/example.ex")
+      |> UnsafeRepoUsage.run()
+
+    assert [%{trigger: "Portal.Repo", line_no: 3}] = issues
+  end
+
+  test "reports direct Repo calls in non-infrastructure lib/portal/repo files" do
+    issues =
+      """
+      defmodule Portal.Repo.Batch do
+        alias Portal.Repo
+
+        def list do
+          Repo.all(Portal.Account)
+        end
+      end
+      """
+      |> source_file("lib/portal/repo/batch.ex")
+      |> UnsafeRepoUsage.run()
+
+    assert Enum.map(issues, & &1.line_no) == [5, 2]
+  end
+
+  test "allows direct Repo usage in Portal.Repo infrastructure files" do
+    issues =
+      """
+      defmodule Portal.Repo do
+        alias Portal.Repo
+
+        def list do
+          Repo.all(Portal.Account)
+        end
+      end
+      """
+      |> source_file("lib/portal/repo.ex")
+      |> UnsafeRepoUsage.run()
+
+    assert issues == []
+  end
+
+  test "allows Portal.Repo preload usage in preloader infrastructure" do
+    issues =
+      """
+      defmodule Portal.Repo.Preloader do
+        def preload(results, preload) do
+          Portal.Repo.preload(results, preload)
+        end
+      end
+      """
+      |> source_file("lib/portal/repo/preloader.ex")
+      |> UnsafeRepoUsage.run()
+
+    assert issues == []
+  end
+
+  defp source_file(source, filename) do
+    Credo.SourceFile.parse(source, filename)
+  end
+end


### PR DESCRIPTION
Plugs a couple linter holes we have regarding the use of `Repo` outside `Portal.Safe`.