### PR TITLE
chore(android): only build target ABI in mise tasks

### DIFF
--- a/kotlin/android/mise-tasks/build.sh
+++ b/kotlin/android/mise-tasks/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#MISE description="Build debug APK (host ABI for fast local iteration; all ABIs when CI=1 for cross-ABI compile-check coverage)"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+# On CI, build every ABI so a regression on any one of them fails the debug build.
+# Locally, build only the host ABI to keep iteration fast — Android Studio launches and
+# the install-phone/install-emulator tasks already pass `android.injected.build.abi`
+# explicitly, so this only narrows the otherwise-unscoped `mise run build`.
+if [ -n "${CI:-}" ]; then
+    exec ./gradlew assembleDebug
+fi
+
+case "$(uname -m)" in
+x86_64 | amd64) host_abi=x86_64 ;;
+arm64 | aarch64) host_abi=arm64-v8a ;;
+*)
+    echo "Unsupported host arch $(uname -m); building all ABIs." >&2
+    exec ./gradlew assembleDebug
+    ;;
+esac
+
+exec ./gradlew assembleDebug "-Pandroid.injected.build.abi=$host_abi"

--- a/kotlin/android/mise-tasks/install-emulator.sh
+++ b/kotlin/android/mise-tasks/install-emulator.sh
@@ -9,20 +9,18 @@ PACKAGE="dev.firezone.android"
 AVD_NAME="${AVD_NAME:-firezone}"
 DEVICE_PROFILE="${DEVICE_PROFILE:-pixel_7}"
 
-# Pick a system image and matching cargo skip-list based on host arch.
+# Pick a system image based on host arch.
 # x86_64 hosts (Linux, Intel Mac) use the x86_64 image; arm64 hosts (Apple Silicon)
 # use arm64-v8a. Running an x86_64 image on Apple Silicon works only via slow translation.
 case "$(uname -m)" in
 x86_64 | amd64)
     HOST_ABI="x86_64"
-    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildArm64 cargoBuildX86)
     ;;
 arm64 | aarch64)
     HOST_ABI="arm64-v8a"
-    SKIP_CARGO_TASKS=(cargoBuildArm cargoBuildX86 cargoBuildX86_64)
     ;;
 *)
-    echo "Unsupported host arch: $(uname -m). Set SYSTEM_IMAGE and SKIP_CARGO_TASKS manually." >&2
+    echo "Unsupported host arch: $(uname -m). Set SYSTEM_IMAGE manually." >&2
     exit 1
     ;;
 esac
@@ -101,13 +99,8 @@ echo "==> Installing debug APK (${HOST_ABI} only)..."
 echo "==> Force-stopping any running instance of ${PACKAGE}..."
 adb shell am force-stop "$PACKAGE"
 
-# Skip cargo builds for ABIs the emulator can't use; the resulting APK contains only
-# the matching .so, which saves ~4x build time vs the default all-ABI build.
-gradle_skip_args=()
-for task in "${SKIP_CARGO_TASKS[@]}"; do
-    gradle_skip_args+=(-x "$task")
-done
-./gradlew installDebug "${gradle_skip_args[@]}"
+# Build only the ABI the emulator uses; saves ~4x build time vs the default all-ABI build.
+./gradlew installDebug "-Pandroid.injected.build.abi=$HOST_ABI"
 
 echo "==> Launching ${PACKAGE}..."
 adb shell monkey -p "$PACKAGE" -c android.intent.category.LAUNCHER 1 >/dev/null

--- a/kotlin/android/mise.toml
+++ b/kotlin/android/mise.toml
@@ -16,10 +16,6 @@ ANDROID_CMD_TOOLS_VERSION = "11076708"
 [task_config]
 includes = ["mise-tasks"]
 
-[tasks.build]
-description = "Build debug APK"
-run = "./gradlew assembleDebug"
-
 [tasks.test]
 description = "Run unit tests"
 run = "./gradlew test"


### PR DESCRIPTION
Extends `android.injected.build.abi` adoption from `install-phone` to the remaining mise tasks so that the all-ABI fallback in `app/build.gradle.kts` only ever fires from CI release flows.

- `mise run build`: builds the host ABI by default, falls back to all ABIs when `CI` is set so the eventual move to invoke this from `_kotlin.yml` keeps cross-ABI compile-check coverage on debug PRs.
- `mise run install-emulator`: replaces the `-x cargoBuild*` skip array with `-Pandroid.injected.build.abi=$HOST_ABI`, mirroring `install-phone.sh`.

Follow-up cleanup after #13328 