### PR TITLE
ci: Only run data-plane and mobile CI when affected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,17 @@ jobs:
           jobs=""
 
           if grep -q '^rust/' changed_files.txt; then
-            jobs="${jobs},rust,kotlin,swift,control-plane,data-plane,loadtest"
+            jobs="${jobs},rust,control-plane,data-plane,loadtest"
+          fi
+
+          # Swift and Kotlin only build rust/client-ffi (the FFI shim) and its
+          # workspace dependencies, which are platform-agnostic and already
+          # covered by the `rust` job. The mobile builds exist to guard the FFI
+          # boundary, so only run them when client-ffi itself changes. For
+          # riskier changes elsewhere, trigger _swift.yml / _kotlin.yml manually
+          # via workflow_dispatch.
+          if grep -q '^rust/client-ffi/' changed_files.txt; then
+            jobs="${jobs},kotlin,swift"
           fi
           if grep -q '^rust/gui-client/' changed_files.txt; then
             jobs="${jobs},tauri"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,19 @@ jobs:
           jobs=""
 
           if grep -q '^rust/' changed_files.txt; then
-            jobs="${jobs},rust,control-plane,data-plane,loadtest"
+            jobs="${jobs},rust"
+          fi
+
+          # The data plane (client/gateway/relay/http-test-server images) and the
+          # integration/compatibility tests that exercise them are built from the
+          # headless client, gateway and relay. The platform client shims
+          # (rust/gui-client for Tauri, rust/client-ffi for the Swift/Kotlin FFI)
+          # are leaf crates that nothing in the data plane depends on, so a change
+          # confined to them only needs the workspace `rust` job above plus the
+          # tauri / kotlin / swift jobs. Run the data-plane chain only for rust
+          # changes outside those shims.
+          if grep '^rust/' changed_files.txt | grep -qEv '^rust/(gui-client|client-ffi)/'; then
+            jobs="${jobs},control-plane,data-plane,loadtest"
           fi
 
           # Swift and Kotlin only build rust/client-ffi (the FFI shim) and its


### PR DESCRIPTION
The platform client shims — `rust/gui-client` (the Tauri desktop client) and `rust/client-ffi` (the Swift/Kotlin FFI) — are leaf crates that nothing in the data plane links against. Because they live under `rust/`, today any change to them triggers the entire Rust CI matrix: the data-plane image builds, the load test, and the integration and compatibility tests.

Gate the Swift and Kotlin builds on `rust/client-ffi` changes, and run the data-plane build, load test and integration/compatibility tests only when a Rust change reaches code outside the two shims. A shim-only change still compiles and tests the whole workspace through the `rust` job and runs its own platform build, so coverage of the shim itself is unchanged.

Riskier changes elsewhere can still trigger the Swift and Kotlin builds on demand via `workflow_dispatch`.
