### PR TITLE
refactor(portal): (non)interactive terminology

### DIFF
--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -13,8 +13,10 @@ defmodule Portal.Authentication do
 
   # Client Tokens
 
-  # GUI client token - called from auth controllers
-  def create_gui_client_token(attrs) do
+  # Interactive client token - created during an interactive sign-in flow
+  # (OIDC, Email/OTP, userpass). Carries an auth_provider_id. Used by both GUI
+  # and headless client sign-ins.
+  def create_interactive_client_token(attrs) do
     changeset =
       %ClientToken{}
       |> cast(attrs, ~w[secret_nonce account_id actor_id auth_provider_id expires_at]a)
@@ -32,12 +34,15 @@ defmodule Portal.Authentication do
     |> Database.insert_token()
   end
 
-  # Headless client token - used with service accounts
-  def create_headless_client_token(
-        %Portal.Actor{type: :service_account, account_id: account_id} = actor,
+  # Non-interactive client token - issued directly by an admin (no sign-in flow,
+  # no auth_provider_id). Available for service accounts and regular users alike.
+  # api_client actors must use create_api_token/3 instead.
+  def create_non_interactive_client_token(
+        %Portal.Actor{type: type, account_id: account_id} = actor,
         attrs,
         %Subject{account: %{id: account_id}} = subject
-      ) do
+      )
+      when type in [:service_account, :account_user, :account_admin_user] do
     {secret_fragment, secret_salt, secret_hash} = generate_token_secrets()
 
     %ClientToken{

--- a/elixir/lib/portal/authentication/credential.ex
+++ b/elixir/lib/portal/authentication/credential.ex
@@ -10,9 +10,9 @@ defmodule Portal.Authentication.Credential do
 
   @type api_token :: %__MODULE__{type: :api_token, id: Ecto.UUID.t()}
 
-  @type headless_client_token :: %__MODULE__{type: :client_token, id: Ecto.UUID.t()}
+  @type non_interactive_client_token :: %__MODULE__{type: :client_token, id: Ecto.UUID.t()}
 
-  @type gui_client_token :: %__MODULE__{
+  @type interactive_client_token :: %__MODULE__{
           type: :client_token,
           id: Ecto.UUID.t(),
           auth_provider_id: Ecto.UUID.t()
@@ -24,7 +24,8 @@ defmodule Portal.Authentication.Credential do
           auth_provider_id: Ecto.UUID.t()
         }
 
-  @type t :: api_token() | headless_client_token() | gui_client_token() | portal_session()
+  @type t ::
+          api_token() | non_interactive_client_token() | interactive_client_token() | portal_session()
 
   @enforce_keys [:type, :id]
   defstruct [:type, :id, :auth_provider_id]

--- a/elixir/lib/portal/authentication/credential.ex
+++ b/elixir/lib/portal/authentication/credential.ex
@@ -2,10 +2,12 @@ defmodule Portal.Authentication.Credential do
   @moduledoc """
   Represents the authentication credential used to create a Subject.
 
-  There are three credential types:
-  - `:api_token` - API tokens for api_client actors (no auth_provider_id)
-  - `:token` - Client tokens for service accounts and users (has auth_provider_id)
-  - `:portal_session` - Portal sessions for web users (has auth_provider_id)
+  Two `type` values are used:
+  - `:api_token` - API tokens for api_client actors. `auth_provider_id` is always nil.
+  - `:client_token` - Client tokens. `auth_provider_id` is set when the token was
+    minted from an interactive sign-in flow (OIDC, Email/OTP, userpass) and nil
+    when the token was issued directly by an admin (no sign-in flow).
+  - `:portal_session` - Portal sessions for web users. `auth_provider_id` is always set.
   """
 
   @type api_token :: %__MODULE__{type: :api_token, id: Ecto.UUID.t()}

--- a/elixir/lib/portal/authentication/credential.ex
+++ b/elixir/lib/portal/authentication/credential.ex
@@ -2,7 +2,7 @@ defmodule Portal.Authentication.Credential do
   @moduledoc """
   Represents the authentication credential used to create a Subject.
 
-  Two `type` values are used:
+  The `type` field takes one of three values:
   - `:api_token` - API tokens for api_client actors. `auth_provider_id` is always nil.
   - `:client_token` - Client tokens. `auth_provider_id` is set when the token was
     minted from an interactive sign-in flow (OIDC, Email/OTP, userpass) and nil

--- a/elixir/lib/portal/dev/account_population.ex
+++ b/elixir/lib/portal/dev/account_population.ex
@@ -928,7 +928,7 @@ defmodule Portal.Dev.AccountPopulation do
 
   defp create_client_token(%Actor{type: :service_account} = actor, _provider, account) do
     {:ok, token} =
-      Authentication.create_headless_client_token(
+      Authentication.create_non_interactive_client_token(
         actor,
         %{expires_at: DateTime.add(DateTime.utc_now(), 30, :day)},
         subject_for(account)
@@ -939,7 +939,7 @@ defmodule Portal.Dev.AccountPopulation do
 
   defp create_client_token(actor, provider, _account) do
     {:ok, token} =
-      Authentication.create_gui_client_token(%{
+      Authentication.create_interactive_client_token(%{
         account_id: actor.account_id,
         actor_id: actor.id,
         auth_provider_id: provider.id,

--- a/elixir/lib/portal_web/controllers/email_otp_controller.ex
+++ b/elixir/lib/portal_web/controllers/email_otp_controller.ex
@@ -238,7 +238,7 @@ defmodule PortalWeb.EmailOTPController do
           expires_at: expires_at
         }
 
-        Authentication.create_gui_client_token(attrs)
+        Authentication.create_interactive_client_token(attrs)
 
       :headless_client ->
         attrs = %{
@@ -251,7 +251,7 @@ defmodule PortalWeb.EmailOTPController do
           expires_at: expires_at
         }
 
-        Authentication.create_gui_client_token(attrs)
+        Authentication.create_interactive_client_token(attrs)
     end
   end
 

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -356,7 +356,7 @@ defmodule PortalWeb.OIDCController do
       expires_at: expires_at
     }
 
-    Portal.Authentication.create_gui_client_token(attrs)
+    Portal.Authentication.create_interactive_client_token(attrs)
   end
 
   defp session_lifetime_secs(provider, schema, type)

--- a/elixir/lib/portal_web/controllers/sign_in_html.ex
+++ b/elixir/lib/portal_web/controllers/sign_in_html.ex
@@ -196,7 +196,7 @@ defmodule PortalWeb.SignInHTML do
     """
   end
 
-  def headless_client_token(assigns) do
+  def headless_client_signed_in(assigns) do
     ~H"""
     <!DOCTYPE html>
     <html lang="en" class="scrollbar-gutter-stable">

--- a/elixir/lib/portal_web/controllers/userpass_controller.ex
+++ b/elixir/lib/portal_web/controllers/userpass_controller.ex
@@ -117,7 +117,7 @@ defmodule PortalWeb.UserpassController do
           expires_at: expires_at
         }
 
-        Portal.Authentication.create_gui_client_token(attrs)
+        Portal.Authentication.create_interactive_client_token(attrs)
 
       :headless_client ->
         attrs = %{
@@ -130,7 +130,7 @@ defmodule PortalWeb.UserpassController do
           expires_at: expires_at
         }
 
-        Portal.Authentication.create_gui_client_token(attrs)
+        Portal.Authentication.create_interactive_client_token(attrs)
     end
   end
 

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1162,7 +1162,7 @@ defmodule PortalWeb.Actors do
         # Build the token attributes
         attrs = %{"expires_at" => expires_at}
 
-        case Authentication.create_headless_client_token(actor, attrs, subject) do
+        case Authentication.create_non_interactive_client_token(actor, attrs, subject) do
           {:ok, token} ->
             encoded_token = Authentication.encode_fragment!(token)
             {:ok, {token, encoded_token}}

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -832,7 +832,11 @@ defmodule PortalWeb.ServiceAccounts do
         {:error, :invalid_date}
 
       expires_at ->
-        case Authentication.create_headless_client_token(actor, %{"expires_at" => expires_at}, subject) do
+        case Authentication.create_non_interactive_client_token(
+               actor,
+               %{"expires_at" => expires_at},
+               subject
+             ) do
           {:ok, token} ->
             {:ok, {token, Authentication.encode_fragment!(token)}}
 

--- a/elixir/lib/portal_web/session/redirector.ex
+++ b/elixir/lib/portal_web/session/redirector.ex
@@ -141,7 +141,7 @@ defmodule PortalWeb.Session.Redirector do
       |> PortalWeb.Cookie.RecentAccounts.prepend(account.id)
       |> Phoenix.Controller.put_root_layout(false)
       |> Phoenix.Controller.put_view(PortalWeb.SignInHTML)
-      |> Phoenix.Controller.render("headless_client_token.html",
+      |> Phoenix.Controller.render("headless_client_signed_in.html",
         token: fragment,
         actor_name: actor_name,
         account: account,

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -9,7 +9,7 @@ defmodule Portal.AuthenticationTest do
   import Portal.SiteFixtures
   alias Portal.ClientToken
 
-  describe "create_headless_client_token/3" do
+  describe "create_non_interactive_client_token/3" do
     test "returns valid client token for a given service account" do
       account = account_fixture()
       service_account = actor_fixture(account: account, type: :service_account)
@@ -18,7 +18,7 @@ defmodule Portal.AuthenticationTest do
       one_day = DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.truncate(:second)
 
       assert {:ok, token} =
-               create_headless_client_token(
+               create_non_interactive_client_token(
                  service_account,
                  %{expires_at: one_day},
                  admin_subject
@@ -44,7 +44,7 @@ defmodule Portal.AuthenticationTest do
       expires_at = DateTime.add(DateTime.utc_now(), 1, :day)
 
       assert {:ok, token} =
-               create_headless_client_token(
+               create_non_interactive_client_token(
                  service_account,
                  %{expires_at: expires_at},
                  admin_subject
@@ -65,28 +65,48 @@ defmodule Portal.AuthenticationTest do
       expires_at = DateTime.add(DateTime.utc_now(), 1, :day)
 
       assert_raise FunctionClauseError, fn ->
-        create_headless_client_token(service_account, %{expires_at: expires_at}, admin_subject)
+        create_non_interactive_client_token(
+          service_account,
+          %{expires_at: expires_at},
+          admin_subject
+        )
       end
     end
 
-    test "raises an error when trying to create a token not for a service account" do
+    test "creates a token for a regular account_user" do
       account = account_fixture()
       regular_user = actor_fixture(account: account, type: :account_user)
       admin_subject = admin_subject_fixture(account: account)
+      expires_at = DateTime.add(DateTime.utc_now(), 1, :day)
 
-      assert_raise FunctionClauseError, fn ->
-        create_headless_client_token(regular_user, %{}, admin_subject)
-      end
+      assert {:ok, token} =
+               create_non_interactive_client_token(
+                 regular_user,
+                 %{expires_at: expires_at},
+                 admin_subject
+               )
+
+      assert token.actor_id == regular_user.id
+      assert token.account_id == account.id
+      assert is_nil(token.auth_provider_id)
     end
 
-    test "raises for account_admin_user actor type" do
+    test "creates a token for an account_admin_user" do
       account = account_fixture()
       admin_user = actor_fixture(account: account, type: :account_admin_user)
       admin_subject = admin_subject_fixture(account: account)
+      expires_at = DateTime.add(DateTime.utc_now(), 1, :day)
 
-      assert_raise FunctionClauseError, fn ->
-        create_headless_client_token(admin_user, %{}, admin_subject)
-      end
+      assert {:ok, token} =
+               create_non_interactive_client_token(
+                 admin_user,
+                 %{expires_at: expires_at},
+                 admin_subject
+               )
+
+      assert token.actor_id == admin_user.id
+      assert token.account_id == account.id
+      assert is_nil(token.auth_provider_id)
     end
 
     test "raises for api_client actor type" do
@@ -95,7 +115,7 @@ defmodule Portal.AuthenticationTest do
       admin_subject = admin_subject_fixture(account: account)
 
       assert_raise FunctionClauseError, fn ->
-        create_headless_client_token(api_client, %{}, admin_subject)
+        create_non_interactive_client_token(api_client, %{}, admin_subject)
       end
     end
   end
@@ -291,7 +311,7 @@ defmodule Portal.AuthenticationTest do
       expires_at = DateTime.add(DateTime.utc_now(), 1, :day)
 
       assert {:ok, token} =
-               create_headless_client_token(
+               create_non_interactive_client_token(
                  service_account,
                  %{expires_at: expires_at},
                  admin_subject
@@ -451,7 +471,7 @@ defmodule Portal.AuthenticationTest do
     end
   end
 
-  describe "create_gui_client_token/1" do
+  describe "create_interactive_client_token/1" do
     test "creates a client token with required attributes" do
       account = account_fixture()
       actor = actor_fixture(account: account)
@@ -465,7 +485,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      assert {:ok, token} = create_gui_client_token(attrs)
+      assert {:ok, token} = create_interactive_client_token(attrs)
       assert token.__struct__ == ClientToken
       assert token.account_id == account.id
       assert token.actor_id == actor.id
@@ -485,7 +505,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      assert {:error, changeset} = create_gui_client_token(attrs)
+      assert {:error, changeset} = create_interactive_client_token(attrs)
       assert "can't be blank" in errors_on(changeset).actor_id
     end
 
@@ -500,7 +520,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      assert {:error, changeset} = create_gui_client_token(attrs)
+      assert {:error, changeset} = create_interactive_client_token(attrs)
       assert "can't be blank" in errors_on(changeset).auth_provider_id
     end
 
@@ -516,7 +536,7 @@ defmodule Portal.AuthenticationTest do
         secret_nonce: "invalid.nonce"
       }
 
-      assert {:error, changeset} = create_gui_client_token(attrs)
+      assert {:error, changeset} = create_interactive_client_token(attrs)
       assert errors_on(changeset).secret_nonce != []
     end
 
@@ -532,7 +552,7 @@ defmodule Portal.AuthenticationTest do
         secret_nonce: String.duplicate("a", 129)
       }
 
-      assert {:error, changeset} = create_gui_client_token(attrs)
+      assert {:error, changeset} = create_interactive_client_token(attrs)
       assert errors_on(changeset).secret_nonce != []
     end
 
@@ -549,7 +569,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      assert {:ok, _token} = create_gui_client_token(attrs)
+      assert {:ok, _token} = create_interactive_client_token(attrs)
     end
 
     test "creates an api token for api_client actor" do
@@ -719,7 +739,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      assert {:ok, token} = create_gui_client_token(attrs)
+      assert {:ok, token} = create_interactive_client_token(attrs)
       assert token.secret_hash != nil
       assert token.secret_nonce == "my-custom-nonce"
     end
@@ -737,8 +757,8 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      {:ok, token1} = create_gui_client_token(base_attrs)
-      {:ok, token2} = create_gui_client_token(base_attrs)
+      {:ok, token1} = create_interactive_client_token(base_attrs)
+      {:ok, token2} = create_interactive_client_token(base_attrs)
 
       assert token1.secret_salt != token2.secret_salt
     end
@@ -756,8 +776,8 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      {:ok, token1} = create_gui_client_token(attrs)
-      {:ok, token2} = create_gui_client_token(attrs)
+      {:ok, token1} = create_interactive_client_token(attrs)
+      {:ok, token2} = create_interactive_client_token(attrs)
 
       # Same nonce but different salts/fragments should produce different hashes
       assert token1.secret_hash != token2.secret_hash
@@ -971,7 +991,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      {:ok, token} = create_gui_client_token(attrs)
+      {:ok, token} = create_interactive_client_token(attrs)
       encoded = encode_fragment!(token)
 
       # Fragment starts with "." - client will prepend its nonce
@@ -993,7 +1013,7 @@ defmodule Portal.AuthenticationTest do
         expires_at: DateTime.add(DateTime.utc_now(), 1, :day)
       }
 
-      {:ok, token} = create_gui_client_token(attrs)
+      {:ok, token} = create_interactive_client_token(attrs)
       encoded = encode_fragment!(token)
 
       # Client prepends the nonce to the fragment

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -154,7 +154,7 @@ defmodule PortalAPI.Client.SocketTest do
       in_one_minute = DateTime.utc_now() |> DateTime.add(60, :second)
 
       {:ok, token} =
-        Portal.Authentication.create_headless_client_token(
+        Portal.Authentication.create_non_interactive_client_token(
           actor,
           %{expires_at: in_one_minute},
           admin_subject


### PR DESCRIPTION
In the portal we were heavily conflating the term `headless` between headless clients, service accounts, and the auth context / flow that was used.

Since these areas of the codebase deal with authentication, it's important to use consistent and accurate terminology here.

In this PR we adopt the new naming pattern for all authentication and token-minting flows:

- `interactive`: used whenever an end-user is physically completing the sign in flow
- `non-interactive`: used whenever an admin is creating a token to be used non-interactively

The non-interactive tokens are typically minted only for service accounts and typically used for headless clients. But interactive tokens can also be used for headless clients as of #13093.