### PR TITLE
fix(portal): prevent actor type changes

### DIFF
--- a/elixir/lib/portal/actor.ex
+++ b/elixir/lib/portal/actor.ex
@@ -50,12 +50,39 @@ defmodule Portal.Actor do
     |> validate_required(~w[name type]a)
     |> trim_change(~w[name email]a)
     |> validate_length(:name, max: 255)
+    |> validate_type_transition()
     |> normalize_email(:email)
     |> validate_email(:email)
     |> assoc_constraint(:account)
     |> assoc_constraint(:directory, name: :actors_created_by_directory_id_fkey)
     |> unique_constraint(:email, name: :actors_account_id_email_index)
     |> check_constraint(:type, name: :type_is_valid)
+  end
+
+  defp validate_type_transition(changeset) do
+    old_type = changeset.data.type
+    new_type = get_change(changeset, :type)
+
+    cond do
+      is_nil(new_type) ->
+        changeset
+
+      is_nil(old_type) ->
+        changeset
+
+      old_type == :api_client ->
+        add_error(changeset, :type, "cannot change the type of an API client")
+
+      old_type == :service_account ->
+        add_error(changeset, :type, "cannot change the type of a service account")
+
+      old_type in [:account_user, :account_admin_user] and
+          new_type in [:api_client, :service_account] ->
+        add_error(changeset, :type, "cannot change a user to a service account or API client")
+
+      true ->
+        changeset
+    end
   end
 
   defp normalize_email(changeset, field) do

--- a/elixir/test/portal/actor_test.exs
+++ b/elixir/test/portal/actor_test.exs
@@ -37,6 +37,110 @@ defmodule Portal.ActorTest do
     end
   end
 
+  describe "changeset/1 type transitions" do
+    test "allows setting type on a new actor" do
+      changeset =
+        %Actor{}
+        |> cast(%{name: "Alice", type: :account_user}, [:name, :type])
+        |> Actor.changeset()
+
+      assert changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :type)
+    end
+
+    test "allows account_user to account_admin_user transition" do
+      changeset =
+        %Actor{type: :account_user, name: "Alice"}
+        |> cast(%{type: :account_admin_user}, [:type])
+        |> Actor.changeset()
+
+      assert changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :type)
+    end
+
+    test "allows account_admin_user to account_user transition" do
+      changeset =
+        %Actor{type: :account_admin_user, name: "Alice"}
+        |> cast(%{type: :account_user}, [:type])
+        |> Actor.changeset()
+
+      assert changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :type)
+    end
+
+    test "rejects account_user to service_account transition" do
+      changeset =
+        %Actor{type: :account_user, name: "Alice"}
+        |> cast(%{type: :service_account}, [:type])
+        |> Actor.changeset()
+
+      assert %{type: ["cannot change a user to a service account or API client"]} =
+               errors_on(changeset)
+    end
+
+    test "rejects account_user to api_client transition" do
+      changeset =
+        %Actor{type: :account_user, name: "Alice"}
+        |> cast(%{type: :api_client}, [:type])
+        |> Actor.changeset()
+
+      assert %{type: ["cannot change a user to a service account or API client"]} =
+               errors_on(changeset)
+    end
+
+    test "rejects account_admin_user to service_account transition" do
+      changeset =
+        %Actor{type: :account_admin_user, name: "Alice"}
+        |> cast(%{type: :service_account}, [:type])
+        |> Actor.changeset()
+
+      assert %{type: ["cannot change a user to a service account or API client"]} =
+               errors_on(changeset)
+    end
+
+    test "rejects account_admin_user to api_client transition" do
+      changeset =
+        %Actor{type: :account_admin_user, name: "Alice"}
+        |> cast(%{type: :api_client}, [:type])
+        |> Actor.changeset()
+
+      assert %{type: ["cannot change a user to a service account or API client"]} =
+               errors_on(changeset)
+    end
+
+    test "rejects api_client to any other type" do
+      for new_type <- [:account_user, :account_admin_user, :service_account] do
+        changeset =
+          %Actor{type: :api_client, name: "Bot"}
+          |> cast(%{type: new_type}, [:type])
+          |> Actor.changeset()
+
+        assert %{type: ["cannot change the type of an API client"]} = errors_on(changeset)
+      end
+    end
+
+    test "rejects service_account to any other type" do
+      for new_type <- [:account_user, :account_admin_user, :api_client] do
+        changeset =
+          %Actor{type: :service_account, name: "Svc"}
+          |> cast(%{type: new_type}, [:type])
+          |> Actor.changeset()
+
+        assert %{type: ["cannot change the type of a service account"]} = errors_on(changeset)
+      end
+    end
+
+    test "allows no-op when type field is set but unchanged" do
+      changeset =
+        %Actor{type: :api_client, name: "Bot"}
+        |> cast(%{type: :api_client}, [:type])
+        |> Actor.changeset()
+
+      assert changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :type)
+    end
+  end
+
   describe "changeset/1 association constraints" do
     test "enforces account association constraint" do
       {:error, changeset} =

--- a/elixir/test/portal_api/controllers/actor_controller_test.exs
+++ b/elixir/test/portal_api/controllers/actor_controller_test.exs
@@ -582,13 +582,14 @@ defmodule PortalAPI.ActorControllerTest do
       target = actor_fixture(account: account, type: :api_client)
 
       for type <- ["account_user", "account_admin_user", "service_account"] do
-        conn =
+        request_conn =
           conn
+          |> recycle()
           |> authorize_conn(api_actor)
           |> put_req_header("content-type", "application/json")
           |> put("/actors/#{target.id}", actor: %{"type" => type})
 
-        assert resp = json_response(conn, 422)
+        assert resp = json_response(request_conn, 422)
         assert resp["error"]["validation_errors"]["type"] ==
                  ["cannot change the type of an API client"]
       end
@@ -605,13 +606,14 @@ defmodule PortalAPI.ActorControllerTest do
       target = actor_fixture(account: account, type: :service_account)
 
       for type <- ["account_user", "account_admin_user", "api_client"] do
-        conn =
+        request_conn =
           conn
+          |> recycle()
           |> authorize_conn(api_actor)
           |> put_req_header("content-type", "application/json")
           |> put("/actors/#{target.id}", actor: %{"type" => type})
 
-        assert resp = json_response(conn, 422)
+        assert resp = json_response(request_conn, 422)
         assert resp["error"]["validation_errors"]["type"] ==
                  ["cannot change the type of a service account"]
       end

--- a/elixir/test/portal_api/controllers/actor_controller_test.exs
+++ b/elixir/test/portal_api/controllers/actor_controller_test.exs
@@ -479,6 +479,146 @@ defmodule PortalAPI.ActorControllerTest do
 
       assert json_response(conn, 201)
     end
+
+    test "rejects changing account_user to service_account", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_user)
+
+      attrs = %{"type" => "service_account"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert resp = json_response(conn, 422)
+      assert resp["error"]["validation_errors"]["type"] ==
+               ["cannot change a user to a service account or API client"]
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: actor.id).type ==
+               :account_user
+    end
+
+    test "rejects changing account_user to api_client", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_user)
+
+      attrs = %{"type" => "api_client"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert resp = json_response(conn, 422)
+      assert resp["error"]["validation_errors"]["type"] ==
+               ["cannot change a user to a service account or API client"]
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: actor.id).type ==
+               :account_user
+    end
+
+    test "rejects changing account_admin_user to service_account", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_admin_user)
+      _other_admin = actor_fixture(account: account, type: :account_admin_user)
+
+      attrs = %{"type" => "service_account"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert resp = json_response(conn, 422)
+      assert resp["error"]["validation_errors"]["type"] ==
+               ["cannot change a user to a service account or API client"]
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: actor.id).type ==
+               :account_admin_user
+    end
+
+    test "rejects changing account_admin_user to api_client", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      actor = actor_fixture(account: account, type: :account_admin_user)
+      _other_admin = actor_fixture(account: account, type: :account_admin_user)
+
+      attrs = %{"type" => "api_client"}
+
+      conn =
+        conn
+        |> authorize_conn(api_actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/actors/#{actor.id}", actor: attrs)
+
+      assert resp = json_response(conn, 422)
+      assert resp["error"]["validation_errors"]["type"] ==
+               ["cannot change a user to a service account or API client"]
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: actor.id).type ==
+               :account_admin_user
+    end
+
+    test "rejects changing api_client to any other type", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      target = actor_fixture(account: account, type: :api_client)
+
+      for type <- ["account_user", "account_admin_user", "service_account"] do
+        conn =
+          conn
+          |> authorize_conn(api_actor)
+          |> put_req_header("content-type", "application/json")
+          |> put("/actors/#{target.id}", actor: %{"type" => type})
+
+        assert resp = json_response(conn, 422)
+        assert resp["error"]["validation_errors"]["type"] ==
+                 ["cannot change the type of an API client"]
+      end
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: target.id).type ==
+               :api_client
+    end
+
+    test "rejects changing service_account to any other type", %{
+      conn: conn,
+      account: account,
+      actor: api_actor
+    } do
+      target = actor_fixture(account: account, type: :service_account)
+
+      for type <- ["account_user", "account_admin_user", "api_client"] do
+        conn =
+          conn
+          |> authorize_conn(api_actor)
+          |> put_req_header("content-type", "application/json")
+          |> put("/actors/#{target.id}", actor: %{"type" => type})
+
+        assert resp = json_response(conn, 422)
+        assert resp["error"]["validation_errors"]["type"] ==
+                 ["cannot change the type of a service account"]
+      end
+
+      assert Repo.get_by!(Portal.Actor, account_id: account.id, id: target.id).type ==
+               :service_account
+    end
   end
 
   describe "delete/2" do

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -753,6 +753,79 @@ defmodule PortalWeb.ActorsTest do
                :account_admin_user
     end
 
+    test "prevents changing a user to a service account via forged save event", %{
+      conn: conn,
+      account: account,
+      actor: admin
+    } do
+      target = actor_fixture(account: account, type: :account_user)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(admin)
+        |> live(~p"/#{account}/actors/#{target}/edit")
+
+      render_click(lv, "save", %{
+        "actor" => %{
+          "name" => target.name,
+          "email" => target.email,
+          "type" => "service_account",
+          "allow_email_otp_sign_in" => "true"
+        }
+      })
+
+      assert Portal.Repo.get_by!(Portal.Actor, id: target.id, account_id: account.id).type ==
+               :account_user
+    end
+
+    test "prevents changing a user to an api_client via forged save event", %{
+      conn: conn,
+      account: account,
+      actor: admin
+    } do
+      target = actor_fixture(account: account, type: :account_user)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(admin)
+        |> live(~p"/#{account}/actors/#{target}/edit")
+
+      render_click(lv, "save", %{
+        "actor" => %{
+          "name" => target.name,
+          "email" => target.email,
+          "type" => "api_client",
+          "allow_email_otp_sign_in" => "true"
+        }
+      })
+
+      assert Portal.Repo.get_by!(Portal.Actor, id: target.id, account_id: account.id).type ==
+               :account_user
+    end
+
+    test "prevents changing a service account via forged save event", %{
+      conn: conn,
+      account: account,
+      actor: admin
+    } do
+      target = actor_fixture(account: account, type: :service_account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(admin)
+        |> live(~p"/#{account}/actors/#{target}/edit")
+
+      render_click(lv, "save", %{
+        "actor" => %{
+          "name" => target.name,
+          "type" => "account_admin_user"
+        }
+      })
+
+      assert Portal.Repo.get_by!(Portal.Actor, id: target.id, account_id: account.id).type ==
+               :service_account
+    end
+
     test "saves edited actor name and group membership changes", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
Prevents invalid actor type transitions in both REST API and UI.
