### PR TITLE
feat(relay): emit XDP processing duration histogram

### DIFF
--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -260,7 +260,6 @@ impl StatsEvent {
     }
 
     /// Time the XDP program spent processing this packet.
-    #[cfg(feature = "std")]
     pub fn processing_duration(&self) -> core::time::Duration {
         core::time::Duration::from_nanos(self.processing_duration_ns)
     }

--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -243,11 +243,27 @@ impl PortAndPeerV6 {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct StatsEvent {
-    pub relayed_data: u64,
-    pub processing_duration_ns: u64,
+    relayed_data: u64,
+    processing_duration_ns: u64,
 }
 
 impl StatsEvent {
+    pub fn new(relayed_data: u64, processing_duration: core::time::Duration) -> Self {
+        Self {
+            relayed_data,
+            processing_duration_ns: duration_as_nanos_u64(processing_duration),
+        }
+    }
+
+    pub fn relayed_data(&self) -> u64 {
+        self.relayed_data
+    }
+
+    /// Time the XDP program spent processing this packet.
+    pub fn processing_duration(&self) -> core::time::Duration {
+        core::time::Duration::from_nanos(self.processing_duration_ns)
+    }
+
     #[cfg(feature = "std")]
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
         let (relayed_chunk, rest) = bytes.split_first_chunk::<8>()?;
@@ -258,10 +274,38 @@ impl StatsEvent {
             processing_duration_ns: u64::from_ne_bytes(*duration_chunk),
         })
     }
+}
 
-    /// Time the XDP program spent processing this packet.
-    pub fn processing_duration(&self) -> core::time::Duration {
-        core::time::Duration::from_nanos(self.processing_duration_ns)
+#[inline]
+fn duration_as_nanos_u64(d: core::time::Duration) -> u64 {
+    // Stays in u64; avoids `Duration::as_nanos`'s u128 path for the BPF target.
+    d.as_secs() * 1_000_000_000 + d.subsec_nanos() as u64
+}
+
+#[cfg(all(test, feature = "std"))]
+mod stats_event_tests {
+    use super::*;
+
+    #[test]
+    fn from_bytes_roundtrips_the_wire_format() {
+        let original = StatsEvent {
+            relayed_data: 4242,
+            processing_duration_ns: 9999,
+        };
+
+        // The kernel writes the struct's bytes verbatim into the perf buffer; lock in that the
+        // wire format matches the `#[repr(C)]` in-memory layout.
+        // SAFETY: `StatsEvent` is `#[repr(C)]` and contains only `u64`s, so every byte pattern
+        // of its size is a valid `[u8; 16]` and vice versa.
+        let bytes: [u8; 16] = unsafe { core::mem::transmute(original) };
+
+        let parsed = StatsEvent::from_bytes(&bytes).expect("size-matching slice parses");
+
+        assert_eq!(parsed.relayed_data, original.relayed_data);
+        assert_eq!(
+            parsed.processing_duration_ns,
+            original.processing_duration_ns
+        );
     }
 }
 

--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -244,15 +244,25 @@ impl PortAndPeerV6 {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct StatsEvent {
     pub relayed_data: u64,
+    pub processing_duration_ns: u64,
 }
 
 impl StatsEvent {
     #[cfg(feature = "std")]
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        let (chunk, _) = bytes.split_first_chunk()?;
-        let relayed_data = u64::from_ne_bytes(*chunk);
+        let (relayed_chunk, rest) = bytes.split_first_chunk::<8>()?;
+        let (duration_chunk, _) = rest.split_first_chunk::<8>()?;
 
-        Some(Self { relayed_data })
+        Some(Self {
+            relayed_data: u64::from_ne_bytes(*relayed_chunk),
+            processing_duration_ns: u64::from_ne_bytes(*duration_chunk),
+        })
+    }
+
+    /// Time the XDP program spent processing this packet.
+    #[cfg(feature = "std")]
+    pub fn processing_duration(&self) -> core::time::Duration {
+        core::time::Duration::from_nanos(self.processing_duration_ns)
     }
 }
 

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -10,6 +10,8 @@ fn main() {
 }
 
 #[cfg(any(target_arch = "bpf", target_os = "linux"))]
+mod time;
+#[cfg(any(target_arch = "bpf", target_os = "linux"))]
 mod try_handle_turn;
 
 #[cfg(any(target_arch = "bpf", target_os = "linux"))]

--- a/rust/relay/ebpf-turn-router/src/time.rs
+++ b/rust/relay/ebpf-turn-router/src/time.rs
@@ -1,0 +1,32 @@
+use core::time::Duration;
+
+/// A monotonic instant captured by the BPF `bpf_ktime_get_ns` helper.
+///
+/// Equivalent in spirit to [`std::time::Instant`], but usable from XDP/BPF
+/// programs where `std` is unavailable. Backed by `CLOCK_MONOTONIC`.
+#[derive(Copy, Clone)]
+pub struct KernelInstant(u64);
+
+impl KernelInstant {
+    #[inline]
+    pub fn now() -> Self {
+        Self(ktime_get_ns())
+    }
+
+    #[inline]
+    pub fn duration_since(self, earlier: Self) -> Duration {
+        Duration::from_nanos(self.0.saturating_sub(earlier.0))
+    }
+
+    #[inline]
+    pub fn elapsed(self) -> Duration {
+        Self::now().duration_since(self)
+    }
+}
+
+#[inline]
+fn ktime_get_ns() -> u64 {
+    // SAFETY: `bpf_ktime_get_ns` is a parameterless BPF kernel helper that
+    // cannot fault and is always safe to call from any BPF program context.
+    unsafe { aya_ebpf::helpers::bpf_ktime_get_ns() }
+}

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn.rs
@@ -55,7 +55,7 @@ pub fn try_handle_turn(ctx: &XdpContext) -> Result<(), Error> {
         Ok(EtherType::Ipv6) => try_handle_turn_ipv6(ctx)?,
         _ => return Err(Error::NotIp),
     };
-    stats::emit_packet_stats(ctx, num_bytes, start.elapsed());
+    stats::emit(ctx, num_bytes, start.elapsed());
 
     Ok(())
 }

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn.rs
@@ -30,6 +30,8 @@ use network_types::{
 };
 use ref_mut_at::ref_mut_at;
 
+use crate::time::KernelInstant;
+
 /// Lower bound for TURN UDP ports
 const LOWER_PORT: u16 = 49152;
 /// Upper bound for TURN UDP ports
@@ -43,6 +45,8 @@ const DNS_PORT: u16 = 53;
 
 #[inline(always)]
 pub fn try_handle_turn(ctx: &XdpContext) -> Result<(), Error> {
+    let start = KernelInstant::now();
+
     // SAFETY: The offset must point to the start of a valid `EthHdr`.
     let eth = unsafe { ref_mut_at::<EthHdr>(ctx, 0)? };
 
@@ -51,7 +55,7 @@ pub fn try_handle_turn(ctx: &XdpContext) -> Result<(), Error> {
         Ok(EtherType::Ipv6) => try_handle_turn_ipv6(ctx)?,
         _ => return Err(Error::NotIp),
     };
-    stats::emit_data_relayed(ctx, num_bytes);
+    stats::emit_packet_stats(ctx, num_bytes, start.elapsed());
 
     Ok(())
 }

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn/stats.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn/stats.rs
@@ -1,15 +1,23 @@
 use aya_ebpf::{macros::map, maps::PerfEventArray, programs::XdpContext};
+use core::time::Duration;
 use ebpf_shared::StatsEvent;
 
 #[map]
 static STATS: PerfEventArray<StatsEvent> = PerfEventArray::new(0);
 
-pub fn emit_data_relayed(ctx: &XdpContext, bytes: impl Into<u64>) {
+pub fn emit_packet_stats(ctx: &XdpContext, bytes: impl Into<u64>, processing_duration: Duration) {
     STATS.output(
         ctx,
         StatsEvent {
             relayed_data: bytes.into(),
+            processing_duration_ns: duration_as_nanos_u64(processing_duration),
         },
         0,
     );
+}
+
+#[inline]
+fn duration_as_nanos_u64(d: Duration) -> u64 {
+    // Stays in u64; avoids `Duration::as_nanos`'s u128 path for the BPF target.
+    d.as_secs() * 1_000_000_000 + d.subsec_nanos() as u64
 }

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn/stats.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn/stats.rs
@@ -5,7 +5,7 @@ use ebpf_shared::StatsEvent;
 #[map]
 static STATS: PerfEventArray<StatsEvent> = PerfEventArray::new(0);
 
-pub fn emit_packet_stats(ctx: &XdpContext, bytes: impl Into<u64>, processing_duration: Duration) {
+pub fn emit(ctx: &XdpContext, bytes: impl Into<u64>, processing_duration: Duration) {
     STATS.output(
         ctx,
         StatsEvent {

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn/stats.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn/stats.rs
@@ -6,18 +6,5 @@ use ebpf_shared::StatsEvent;
 static STATS: PerfEventArray<StatsEvent> = PerfEventArray::new(0);
 
 pub fn emit(ctx: &XdpContext, bytes: impl Into<u64>, processing_duration: Duration) {
-    STATS.output(
-        ctx,
-        StatsEvent {
-            relayed_data: bytes.into(),
-            processing_duration_ns: duration_as_nanos_u64(processing_duration),
-        },
-        0,
-    );
-}
-
-#[inline]
-fn duration_as_nanos_u64(d: Duration) -> u64 {
-    // Stays in u64; avoids `Duration::as_nanos`'s u128 path for the BPF target.
-    d.as_secs() * 1_000_000_000 + d.subsec_nanos() as u64
+    STATS.output(ctx, StatsEvent::new(bytes.into(), processing_duration), 0);
 }

--- a/rust/relay/server/src/ebpf/linux.rs
+++ b/rust/relay/server/src/ebpf/linux.rs
@@ -95,8 +95,8 @@ impl Program {
             .with_description("Time the eBPF XDP program spent processing one relayed packet")
             .with_unit("ns")
             .with_boundaries(vec![
-                50.0, 100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 20_000.0,
-                50_000.0, 100_000.0,
+                50.0, 100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 20_000.0, 50_000.0,
+                100_000.0,
             ])
             .build();
 
@@ -156,8 +156,7 @@ impl Program {
                             };
 
                             data_relayed.add(stats.relayed_data, &[]);
-                            processing_duration
-                                .record(stats.processing_duration().as_nanos() as u64, &[]);
+                            processing_duration.record(stats.processing_duration_ns, &[]);
                         }
                     }
                 }

--- a/rust/relay/server/src/ebpf/linux.rs
+++ b/rust/relay/server/src/ebpf/linux.rs
@@ -90,6 +90,16 @@ impl Program {
             .with_unit("b")
             .build();
 
+        let processing_duration = opentelemetry::global::meter("relay")
+            .u64_histogram("xdp_processing_duration_ns")
+            .with_description("Time the eBPF XDP program spent processing one relayed packet")
+            .with_unit("ns")
+            .with_boundaries(vec![
+                50.0, 100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 20_000.0,
+                50_000.0, 100_000.0,
+            ])
+            .build();
+
         for cpu_id in aya::util::online_cpus()
             .map_err(|(_, error)| error)
             .context("Failed to determine number of CPUs")?
@@ -103,6 +113,7 @@ impl Program {
             // process each perf buffer in a separate task
             tokio::task::spawn({
                 let data_relayed = data_relayed.clone();
+                let processing_duration = processing_duration.clone();
 
                 async move {
                     let mut buffers = (0..PAGE_COUNT)
@@ -145,6 +156,8 @@ impl Program {
                             };
 
                             data_relayed.add(stats.relayed_data, &[]);
+                            processing_duration
+                                .record(stats.processing_duration().as_nanos() as u64, &[]);
                         }
                     }
                 }

--- a/rust/relay/server/src/ebpf/linux.rs
+++ b/rust/relay/server/src/ebpf/linux.rs
@@ -155,8 +155,9 @@ impl Program {
                                 continue;
                             };
 
-                            data_relayed.add(stats.relayed_data, &[]);
-                            processing_duration.record(stats.processing_duration_ns, &[]);
+                            data_relayed.add(stats.relayed_data(), &[]);
+                            processing_duration
+                                .record(stats.processing_duration().as_nanos() as u64, &[]);
                         }
                     }
                 }


### PR DESCRIPTION
Capture the time spent inside the XDP program per relayed packet and record it into a new OTel histogram `xdp_processing_duration_ns`, alongside the existing `data_relayed_ebpf_bytes` counter. Gives us a direct, in-kernel measurement of TURN packet-processing latency.