### PR TITLE
fix(portal): enqueue session after channel register

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -105,9 +105,6 @@ defmodule PortalAPI.Client.Channel do
 
     {:noreply, socket} = register(socket)
 
-    # Must follow register/1: the queue's on_confirmed callback uses
-    # PG.deliver, which silently drops if no pid is registered for the
-    # device_id.
     PortalAPI.Client.Socket.enqueue_session(socket.assigns.session)
 
     init(socket, resources, relays)

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -105,13 +105,9 @@ defmodule PortalAPI.Client.Channel do
 
     {:noreply, socket} = register(socket)
 
-    # Must follow register/1; the queue's on-confirmed delivery via Portal.PG
-    # silently drops if the channel pid isn't registered yet.
-    Portal.Queue.enqueue(:client_session_queue, session_attrs(socket.assigns.session))
-
     init(socket, resources, relays)
 
-    {:noreply, arm_session_durability_timer(socket)}
+    {:noreply, socket}
   end
 
   ####################################
@@ -2357,7 +2353,16 @@ defmodule PortalAPI.Client.Channel do
         Process.monitor(new_pid)
         :ok = PG.register(socket.assigns.client.id)
         :ok = PG.join(socket.assigns.subject.credential.id)
-        {:noreply, assign(socket, :pg_scope_pid, new_pid)}
+        socket = assign(socket, :pg_scope_pid, new_pid)
+
+        # Only enqueue + arm on the first successful registration; re-registrations
+        # after a PG scope crash share the same channel and session row.
+        if is_nil(current_pid) do
+          Portal.Queue.enqueue(:client_session_queue, session_attrs(socket.assigns.session))
+          {:noreply, arm_session_durability_timer(socket)}
+        else
+          {:noreply, socket}
+        end
     end
   end
 

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -105,7 +105,9 @@ defmodule PortalAPI.Client.Channel do
 
     {:noreply, socket} = register(socket)
 
-    PortalAPI.Client.Socket.enqueue_session(socket.assigns.session)
+    # Must follow register/1; the queue's on-confirmed delivery via Portal.PG
+    # silently drops if the channel pid isn't registered yet.
+    Portal.Queue.enqueue(:client_session_queue, session_attrs(socket.assigns.session))
 
     init(socket, resources, relays)
 
@@ -2398,6 +2400,12 @@ defmodule PortalAPI.Client.Channel do
 
         assign(socket, presence_monitors: monitors)
     end
+  end
+
+  defp session_attrs(%Portal.ClientSession{} = session) do
+    session
+    |> Map.from_struct()
+    |> Map.drop([:__meta__, :account, :device, :client_token])
   end
 
   defmodule Database do

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -105,6 +105,11 @@ defmodule PortalAPI.Client.Channel do
 
     {:noreply, socket} = register(socket)
 
+    # Must follow register/1: the queue's on_confirmed callback uses
+    # PG.deliver, which silently drops if no pid is registered for the
+    # device_id.
+    PortalAPI.Client.Socket.enqueue_session(socket.assigns.session)
+
     init(socket, resources, relays)
 
     {:noreply, arm_session_durability_timer(socket)}

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -23,6 +23,14 @@ defmodule PortalAPI.Client.Socket do
     ]
   end
 
+  # Buffer a session for batched INSERT. Called from the channel's `:after_join`
+  # after `register/1` so the channel pid is in `Portal.PG` before the queue can
+  # flush — otherwise the `:confirm_session_durability` PG.deliver lands on no
+  # members and the durability timer fires a spurious disconnect.
+  def enqueue_session(%ClientSession{} = session) do
+    Portal.Queue.enqueue(:client_session_queue, session_attrs(session))
+  end
+
   ## Authentication
 
   @impl true
@@ -64,7 +72,6 @@ defmodule PortalAPI.Client.Socket do
       {context, version} = PortalAPI.Sockets.truncate_session_fields(subject.context, version)
       subject = %{subject | context: context}
       session = build_session(client, token_id, public_key, subject, version)
-      Portal.Queue.enqueue(:client_session_queue, session_attrs(session))
       set_connect_attributes(token_id, client, subject, version)
       {:ok, assign_connect(socket, subject, client, session, version)}
     else

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -23,10 +23,9 @@ defmodule PortalAPI.Client.Socket do
     ]
   end
 
-  # Buffer a session for batched INSERT. Called from the channel's `:after_join`
-  # after `register/1` so the channel pid is in `Portal.PG` before the queue can
-  # flush — otherwise the `:confirm_session_durability` PG.deliver lands on no
-  # members and the durability timer fires a spurious disconnect.
+  # Must run from the channel's `:after_join` after `register/1`; the queue's
+  # on-confirmed delivery via `Portal.PG` silently drops if the channel pid
+  # isn't registered yet.
   def enqueue_session(%ClientSession{} = session) do
     Portal.Queue.enqueue(:client_session_queue, session_attrs(session))
   end

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -23,13 +23,6 @@ defmodule PortalAPI.Client.Socket do
     ]
   end
 
-  # Must run from the channel's `:after_join` after `register/1`; the queue's
-  # on-confirmed delivery via `Portal.PG` silently drops if the channel pid
-  # isn't registered yet.
-  def enqueue_session(%ClientSession{} = session) do
-    Portal.Queue.enqueue(:client_session_queue, session_attrs(session))
-  end
-
   ## Authentication
 
   @impl true
@@ -105,12 +98,6 @@ defmodule PortalAPI.Client.Socket do
       remote_ip_location_lon: subject.context.remote_ip_location_lon,
       version: version
     }
-  end
-
-  defp session_attrs(%ClientSession{} = session) do
-    session
-    |> Map.from_struct()
-    |> Map.drop([:__meta__, :account, :device, :client_token])
   end
 
   defp flush_client_sessions(entries) do

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -114,6 +114,11 @@ defmodule PortalAPI.Gateway.Channel do
 
     {:noreply, socket} = register(socket)
 
+    # Must follow register/1: the queue's on_confirmed callback uses
+    # PG.deliver, which silently drops if no pid is registered for the
+    # device_id.
+    PortalAPI.Gateway.Socket.enqueue_session(socket.assigns.session)
+
     # Return all connected relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)
     :ok = Presence.Relays.Global.subscribe()

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -114,7 +114,9 @@ defmodule PortalAPI.Gateway.Channel do
 
     {:noreply, socket} = register(socket)
 
-    PortalAPI.Gateway.Socket.enqueue_session(socket.assigns.session)
+    # Must follow register/1; the queue's on-confirmed delivery via Portal.PG
+    # silently drops if the channel pid isn't registered yet.
+    Portal.Queue.enqueue(:gateway_session_queue, session_attrs(socket.assigns.session))
 
     # Return all connected relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)
@@ -1077,6 +1079,12 @@ defmodule PortalAPI.Gateway.Channel do
 
         assign(socket, presence_monitors: monitors)
     end
+  end
+
+  defp session_attrs(%Portal.GatewaySession{} = session) do
+    session
+    |> Map.from_struct()
+    |> Map.drop([:__meta__, :account, :device, :gateway_token])
   end
 
   defmodule Database do

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -114,10 +114,6 @@ defmodule PortalAPI.Gateway.Channel do
 
     {:noreply, socket} = register(socket)
 
-    # Must follow register/1; the queue's on-confirmed delivery via Portal.PG
-    # silently drops if the channel pid isn't registered yet.
-    Portal.Queue.enqueue(:gateway_session_queue, session_attrs(socket.assigns.session))
-
     # Return all connected relays and subscribe to global relay presence
     {:ok, relays} = select_relays(socket)
     :ok = Presence.Relays.Global.subscribe()
@@ -129,7 +125,7 @@ defmodule PortalAPI.Gateway.Channel do
     # Cache relay IDs and stamp secrets for tracking
     socket = cache_relays(socket, relays)
 
-    {:noreply, arm_session_durability_timer(socket)}
+    {:noreply, socket}
   end
 
   def handle_info(:prune_cache, socket) do
@@ -1039,7 +1035,16 @@ defmodule PortalAPI.Gateway.Channel do
         Process.monitor(new_pid)
         :ok = PG.register(socket.assigns.gateway.id)
         :ok = PG.join(socket.assigns.token_id)
-        {:noreply, assign(socket, :pg_scope_pid, new_pid)}
+        socket = assign(socket, :pg_scope_pid, new_pid)
+
+        # Only enqueue + arm on the first successful registration; re-registrations
+        # after a PG scope crash share the same channel and session row.
+        if is_nil(current_pid) do
+          Portal.Queue.enqueue(:gateway_session_queue, session_attrs(socket.assigns.session))
+          {:noreply, arm_session_durability_timer(socket)}
+        else
+          {:noreply, socket}
+        end
     end
   end
 

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -114,9 +114,6 @@ defmodule PortalAPI.Gateway.Channel do
 
     {:noreply, socket} = register(socket)
 
-    # Must follow register/1: the queue's on_confirmed callback uses
-    # PG.deliver, which silently drops if no pid is registered for the
-    # device_id.
     PortalAPI.Gateway.Socket.enqueue_session(socket.assigns.session)
 
     # Return all connected relays and subscribe to global relay presence

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -24,10 +24,9 @@ defmodule PortalAPI.Gateway.Socket do
     ]
   end
 
-  # Buffer a session for batched INSERT. Called from the channel's `:after_join`
-  # after `register/1` so the channel pid is in `Portal.PG` before the queue can
-  # flush — otherwise the `:confirm_session_durability` PG.deliver lands on no
-  # members and the durability timer fires a spurious disconnect.
+  # Must run from the channel's `:after_join` after `register/1`; the queue's
+  # on-confirmed delivery via `Portal.PG` silently drops if the channel pid
+  # isn't registered yet.
   def enqueue_session(%GatewaySession{} = session) do
     Portal.Queue.enqueue(:gateway_session_queue, session_attrs(session))
   end

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -24,6 +24,14 @@ defmodule PortalAPI.Gateway.Socket do
     ]
   end
 
+  # Buffer a session for batched INSERT. Called from the channel's `:after_join`
+  # after `register/1` so the channel pid is in `Portal.PG` before the queue can
+  # flush — otherwise the `:confirm_session_durability` PG.deliver lands on no
+  # members and the durability timer fires a spurious disconnect.
+  def enqueue_session(%GatewaySession{} = session) do
+    Portal.Queue.enqueue(:gateway_session_queue, session_attrs(session))
+  end
+
   ## Authentication
 
   @impl true
@@ -59,7 +67,6 @@ defmodule PortalAPI.Gateway.Socket do
       version = derive_version(context.user_agent)
       {context, version} = PortalAPI.Sockets.truncate_session_fields(context, version)
       session = build_session(gateway, gateway_token.id, public_key, context, version)
-      Portal.Queue.enqueue(:gateway_session_queue, session_attrs(session))
 
       OpenTelemetry.Tracer.set_attributes(%{
         token_id: gateway_token.id,

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -24,13 +24,6 @@ defmodule PortalAPI.Gateway.Socket do
     ]
   end
 
-  # Must run from the channel's `:after_join` after `register/1`; the queue's
-  # on-confirmed delivery via `Portal.PG` silently drops if the channel pid
-  # isn't registered yet.
-  def enqueue_session(%GatewaySession{} = session) do
-    Portal.Queue.enqueue(:gateway_session_queue, session_attrs(session))
-  end
-
   ## Authentication
 
   @impl true
@@ -136,12 +129,6 @@ defmodule PortalAPI.Gateway.Socket do
       remote_ip_location_lon: context.remote_ip_location_lon,
       version: version
     }
-  end
-
-  defp session_attrs(%GatewaySession{} = session) do
-    session
-    |> Map.from_struct()
-    |> Map.drop([:__meta__, :account, :device, :gateway_token])
   end
 
   defp flush_gateway_sessions(entries) do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -39,6 +39,7 @@ defmodule PortalAPI.Client.ChannelTest do
       id: session_id,
       device_id: client.id,
       account_id: client.account_id,
+      client_token_id: subject.credential.id,
       public_key: Portal.DeviceFixtures.generate_public_key(),
       user_agent: subject.context.user_agent,
       remote_ip: subject.context.remote_ip,
@@ -286,6 +287,41 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert %{metas: [%{online_at: online_at, phx_ref: _ref}]} = Map.fetch!(presence, client.id)
       assert is_number(online_at)
+    end
+
+    test "after_join enqueues the session and a flush persists it", %{
+      client: client,
+      subject: subject
+    } do
+      session_id = Ecto.UUID.generate()
+      socket = join_channel(client, subject, session_id: session_id)
+      assert_push "init", _init_payload
+
+      Portal.Queue.flush(:client_session_queue)
+
+      persisted = Portal.Repo.get_by!(Portal.ClientSession, id: session_id)
+      assert persisted.device_id == client.id
+      assert persisted.account_id == client.account_id
+      assert persisted.client_token_id == subject.credential.id
+      assert persisted.public_key == socket.assigns.session.public_key
+      assert persisted.user_agent == socket.assigns.session.user_agent
+      assert persisted.version == socket.assigns.session.version
+    end
+
+    test "session_durability timer is cancelled by the queue's confirm message", %{
+      client: client,
+      subject: subject
+    } do
+      session_id = Ecto.UUID.generate()
+      socket = join_channel(client, subject, session_id: session_id)
+      assert_push "init", _init_payload
+
+      assert {^session_id, _generation, _timer_ref} =
+               :sys.get_state(socket.channel_pid).assigns.session_durability
+
+      Portal.Queue.flush(:client_session_queue)
+
+      refute :sys.get_state(socket.channel_pid).assigns.session_durability
     end
 
     test "channel crash takes down the transport", %{client: client, subject: subject} do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -90,6 +90,13 @@ defmodule PortalAPI.Client.ChannelTest do
        )}
     )
 
+    start_supervised!(
+      {Portal.Queue,
+       Keyword.merge(PortalAPI.Client.Socket.client_session_queue_opts(),
+         callers: [self()]
+       )}
+    )
+
     account =
       account_fixture(
         config: %{

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -14,15 +14,14 @@ defmodule PortalAPI.Client.SocketTest do
 
   describe "connect/3" do
     setup do
-      queue =
-        start_supervised!(
-          {Portal.Queue,
-           Keyword.merge(Socket.client_session_queue_opts(),
-             callers: [self()]
-           )}
-        )
+      start_supervised!(
+        {Portal.Queue,
+         Keyword.merge(Socket.client_session_queue_opts(),
+           callers: [self()]
+         )}
+      )
 
-      %{queue: queue}
+      :ok
     end
 
     test "returns error when token is missing" do
@@ -147,6 +146,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert socket.assigns.session.public_key == attrs["public_key"]
       assert socket.assigns.client_version == "1.3.0"
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:client_session_queue)
 
       # Verify session was created with session data
@@ -188,6 +188,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert socket.assigns.session.public_key == attrs["public_key"]
       assert socket.assigns.client_version == "1.3.0"
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:client_session_queue)
 
       # Verify session was created with session data
@@ -239,6 +240,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert socket.assigns.client.id == existing_client.id
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:client_session_queue)
 
       # Verify session was created with location data
@@ -300,6 +302,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert socket.assigns.client.id == existing_client.id
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:client_session_queue)
 
       # Verify session was created with region-derived coordinates
@@ -479,6 +482,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       client = socket.assigns.client
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:client_session_queue)
 
       sessions = Repo.all(Portal.ClientSession)

--- a/elixir/test/portal_api/client/socket_test.exs
+++ b/elixir/test/portal_api/client/socket_test.exs
@@ -13,17 +13,6 @@ defmodule PortalAPI.Client.SocketTest do
   @client_remote_ip {189, 172, 73, 153}
 
   describe "connect/3" do
-    setup do
-      start_supervised!(
-        {Portal.Queue,
-         Keyword.merge(Socket.client_session_queue_opts(),
-           callers: [self()]
-         )}
-      )
-
-      :ok
-    end
-
     test "returns error when token is missing" do
       connect_info = build_connect_info()
       assert connect(Socket, %{}, connect_info: connect_info) == {:error, :missing_token}
@@ -143,18 +132,13 @@ defmodule PortalAPI.Client.SocketTest do
       assert client = Map.fetch!(socket.assigns, :client)
 
       assert client.firezone_id == attrs["external_id"]
-      assert socket.assigns.session.public_key == attrs["public_key"]
       assert socket.assigns.client_version == "1.3.0"
 
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:client_session_queue)
-
-      # Verify session was created with session data
-      [session] = Repo.all(Portal.ClientSession)
-      assert session.id == socket.assigns.session.id
+      session = socket.assigns.session
+      assert session.public_key == attrs["public_key"]
       assert session.device_id == client.id
       assert session.user_agent == connect_info.user_agent
-      assert session.remote_ip.address == @client_remote_ip
+      assert session.remote_ip == @client_remote_ip
       assert session.remote_ip_location_region == "Ukraine"
       assert session.remote_ip_location_city == "Kyiv"
       assert session.remote_ip_location_lat == 50.4333
@@ -185,17 +169,13 @@ defmodule PortalAPI.Client.SocketTest do
       assert client = Map.fetch!(socket.assigns, :client)
 
       assert client.firezone_id == attrs["external_id"]
-      assert socket.assigns.session.public_key == attrs["public_key"]
       assert socket.assigns.client_version == "1.3.0"
 
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:client_session_queue)
-
-      # Verify session was created with session data
-      [session] = Repo.all(Portal.ClientSession)
+      session = socket.assigns.session
+      assert session.public_key == attrs["public_key"]
       assert session.device_id == client.id
       assert session.user_agent == connect_info.user_agent
-      assert session.remote_ip.address == @client_remote_ip
+      assert session.remote_ip == @client_remote_ip
       assert session.remote_ip_location_region == "Ukraine"
       assert session.remote_ip_location_city == "Kyiv"
       assert session.remote_ip_location_lat == 50.4333
@@ -240,11 +220,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert socket.assigns.client.id == existing_client.id
 
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:client_session_queue)
-
-      # Verify session was created with location data
-      [session] = Repo.all(Portal.ClientSession)
+      session = socket.assigns.session
       assert session.device_id == existing_client.id
       assert session.remote_ip_location_region == "Ukraine"
       assert session.remote_ip_location_city == "Kyiv"
@@ -302,11 +278,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert socket.assigns.client.id == existing_client.id
 
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:client_session_queue)
-
-      # Verify session was created with region-derived coordinates
-      [session] = Repo.all(Portal.ClientSession)
+      session = socket.assigns.session
       assert session.remote_ip_location_region == "UA"
       assert session.remote_ip_location_city == nil
       assert session.remote_ip_location_lat == 49.0
@@ -472,7 +444,7 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, _socket} = connect(Socket, attrs, connect_info: connect_info)
     end
 
-    test "creates a client_session on successful connect" do
+    test "builds a client_session on successful connect" do
       token = client_token_fixture()
       encoded_token = encode_token(token)
 
@@ -482,17 +454,12 @@ defmodule PortalAPI.Client.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       client = socket.assigns.client
 
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:client_session_queue)
-
-      sessions = Repo.all(Portal.ClientSession)
-      assert length(sessions) == 1
-      session = hd(sessions)
+      session = socket.assigns.session
       assert session.device_id == client.id
       assert session.client_token_id == token.id
       assert session.account_id == client.account_id
       assert session.user_agent == connect_info.user_agent
-      assert session.remote_ip.address == @client_remote_ip
+      assert session.remote_ip == @client_remote_ip
       assert session.remote_ip_location_region == "Ukraine"
       assert session.remote_ip_location_city == "Kyiv"
     end

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -62,6 +62,13 @@ defmodule PortalAPI.Gateway.ChannelTest do
   end
 
   setup do
+    start_supervised!(
+      {Portal.Queue,
+       Keyword.merge(PortalAPI.Gateway.Socket.gateway_session_queue_opts(),
+         callers: [self()]
+       )}
+    )
+
     account = account_fixture()
     actor = actor_fixture(type: :account_admin_user, account: account)
     group = group_fixture(account: account)

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -129,6 +129,43 @@ defmodule PortalAPI.Gateway.ChannelTest do
       assert is_number(online_at)
     end
 
+    test "after_join enqueues the session and a flush persists it", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      session_id = Ecto.UUID.generate()
+      socket = join_channel(gateway, site, token, session_id: session_id)
+      assert_push "init", _init_payload
+
+      Portal.Queue.flush(:gateway_session_queue)
+
+      persisted = Portal.Repo.get_by!(Portal.GatewaySession, id: session_id)
+      assert persisted.device_id == gateway.id
+      assert persisted.account_id == gateway.account_id
+      assert persisted.gateway_token_id == token.id
+      assert persisted.public_key == socket.assigns.session.public_key
+      assert persisted.user_agent == socket.assigns.session.user_agent
+      assert persisted.version == socket.assigns.session.version
+    end
+
+    test "session_durability timer is cancelled by the queue's confirm message", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      session_id = Ecto.UUID.generate()
+      socket = join_channel(gateway, site, token, session_id: session_id)
+      assert_push "init", _init_payload
+
+      assert {^session_id, _generation, _timer_ref} =
+               :sys.get_state(socket.channel_pid).assigns.session_durability
+
+      Portal.Queue.flush(:gateway_session_queue)
+
+      refute :sys.get_state(socket.channel_pid).assigns.session_durability
+    end
+
     test "channel crash takes down the transport", %{gateway: gateway, site: site, token: token} do
       socket = join_channel(gateway, site, token)
       assert_push "init", _init_payload

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -11,17 +11,6 @@ defmodule PortalAPI.Gateway.SocketTest do
   @connlib_version "1.3.0"
 
   describe "connect/3" do
-    setup do
-      start_supervised!(
-        {Portal.Queue,
-         Keyword.merge(Socket.gateway_session_queue_opts(),
-           callers: [self()]
-         )}
-      )
-
-      :ok
-    end
-
     test "returns error when token is missing" do
       connect_info = build_connect_info()
       assert connect(Socket, %{}, connect_info: connect_info) == {:error, :missing_token}
@@ -107,19 +96,7 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert session.remote_ip_location_lat == 50.4333
       assert session.remote_ip_location_lon == 30.5167
       assert session.version == @connlib_version
-
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:gateway_session_queue)
-
-      [persisted_session] = Repo.all(Portal.GatewaySession)
-      assert persisted_session.id == socket.assigns.session.id
-      assert persisted_session.device_id == gateway.id
-      assert persisted_session.user_agent == connect_info.user_agent
-      assert persisted_session.remote_ip_location_region == "Ukraine"
-      assert persisted_session.remote_ip_location_city == "Kyiv"
-      assert persisted_session.remote_ip_location_lat == 50.4333
-      assert persisted_session.remote_ip_location_lon == 30.5167
-      assert persisted_session.version == @connlib_version
+      assert session.device_id == gateway.id
     end
 
     test "uses region code to put default coordinates" do
@@ -170,16 +147,9 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert socket.assigns.gateway.id == gateway.id
 
-      Socket.enqueue_session(socket.assigns.session)
-      Portal.Queue.flush(:gateway_session_queue)
-
-      import Ecto.Query
-
-      session =
-        from(gs in Portal.GatewaySession, where: gs.gateway_token_id == ^token.id)
-        |> Repo.one!()
-
+      session = socket.assigns.session
       assert session.device_id == gateway.id
+      assert session.gateway_token_id == token.id
       assert session.remote_ip_location_region == "Ukraine"
       assert session.remote_ip_location_city == "Kyiv"
       assert session.remote_ip_location_lat == 50.4333

--- a/elixir/test/portal_api/gateway/socket_test.exs
+++ b/elixir/test/portal_api/gateway/socket_test.exs
@@ -12,15 +12,14 @@ defmodule PortalAPI.Gateway.SocketTest do
 
   describe "connect/3" do
     setup do
-      queue =
-        start_supervised!(
-          {Portal.Queue,
-           Keyword.merge(Socket.gateway_session_queue_opts(),
-             callers: [self()]
-           )}
-        )
+      start_supervised!(
+        {Portal.Queue,
+         Keyword.merge(Socket.gateway_session_queue_opts(),
+           callers: [self()]
+         )}
+      )
 
-      %{queue: queue}
+      :ok
     end
 
     test "returns error when token is missing" do
@@ -109,6 +108,7 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert session.remote_ip_location_lon == 30.5167
       assert session.version == @connlib_version
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:gateway_session_queue)
 
       [persisted_session] = Repo.all(Portal.GatewaySession)
@@ -170,6 +170,7 @@ defmodule PortalAPI.Gateway.SocketTest do
       assert {:ok, socket} = connect(Socket, attrs, connect_info: connect_info)
       assert socket.assigns.gateway.id == gateway.id
 
+      Socket.enqueue_session(socket.assigns.session)
       Portal.Queue.flush(:gateway_session_queue)
 
       import Ecto.Query


### PR DESCRIPTION
**Problem:** `Socket.connect/3` buffered the session into a queue. That queue flushed every 5s and confirmed durability to the channel via `PG.deliver`. But the channel pid hadn't joined `PG` yet — that happens later, in `:after_join`. So if a flush landed in the gap, the confirm went nowhere, and 15s later the durability timer fired a spurious disconnect. See [this CI run](https://github.com/firezone/firezone/actions/runs/26166535467/job/76973007245).

The gap is one websocket round-trip — sub-millisecond locally, but ~100ms in CI thanks to the 50ms simulated latency on `portal-router`. That's about 2% of the flush cycle, enough to hit occasionally. Real prod RTTs would land in the same range.

**Fix:** Enqueue from the success arm inside `register/1`. The channel is in `PG` before the queue sees the entry, so the window is gone.

Related: #13226