### PR TITLE
fix(portal): restore :headless case

### DIFF
--- a/elixir/lib/portal/version.ex
+++ b/elixir/lib/portal/version.ex
@@ -57,6 +57,7 @@ defmodule Portal.Version do
       :apple -> Version.compare(session.version, "1.5.9") == :lt
       :android -> Version.compare(session.version, "1.5.5") == :lt
       :gui -> Version.compare(session.version, "1.5.9") == :lt
+      :headless -> Version.compare(session.version, "1.5.5") == :lt
     end
   end
 

--- a/elixir/test/portal/version_test.exs
+++ b/elixir/test/portal/version_test.exs
@@ -121,6 +121,33 @@ defmodule Portal.VersionTest do
       refute Portal.Version.resource_cannot_change_sites_on_client?(session)
     end
 
+    test "headless session below version cannot change sites" do
+      session = %Portal.ClientSession{
+        version: "1.5.3",
+        user_agent: "Fedora/42.0.0 headless-client/1.5.3 (arm64; 24.1.0)"
+      }
+
+      assert Portal.Version.resource_cannot_change_sites_on_client?(session)
+    end
+
+    test "headless session at version cannot change sites" do
+      session = %Portal.ClientSession{
+        version: "1.5.4",
+        user_agent: "Fedora/42.0.0 headless-client/1.5.4 (arm64; 24.1.0)"
+      }
+
+      assert Portal.Version.resource_cannot_change_sites_on_client?(session)
+    end
+
+    test "headless session above version can change sites" do
+      session = %Portal.ClientSession{
+        version: "1.5.5",
+        user_agent: "Fedora/42.0.0 headless-client/1.5.5 (arm64; 24.1.0)"
+      }
+
+      refute Portal.Version.resource_cannot_change_sites_on_client?(session)
+    end
+
     test "nil version returns false" do
       session = %Portal.ClientSession{version: nil}
       refute Portal.Version.resource_cannot_change_sites_on_client?(session)


### PR DESCRIPTION
In #12125 I introduced a regression which failed to match headless clients when determining whether resources could accept a site change.

This fixes that regression and adds a test to prevent it from reoccurring.

---

Fixes #13363 
