### PR TITLE
chore(rust): namespace `latest` link of file appender

### DIFF
--- a/rust/libs/logging/src/file.rs
+++ b/rust/libs/logging/src/file.rs
@@ -242,7 +242,7 @@ mod tests {
         tracing::info!("Write after delete");
         std::thread::sleep(Duration::from_millis(1000)); // Wait a bit until background thread has flushed the log.
 
-        let content = std::fs::read_to_string(dir.path().join("latest")).unwrap();
+        let content = std::fs::read_to_string(dir.path().join("connlib.latest")).unwrap();
 
         assert!(content.contains("Write after delete"))
     }

--- a/rust/libs/logging/src/file.rs
+++ b/rust/libs/logging/src/file.rs
@@ -144,7 +144,9 @@ impl Appender {
         let filename = format!("{}.{date}.{}", self.file_base_name, self.file_extension);
 
         let path = self.directory.join(&filename);
-        let latest = self.directory.join("latest");
+        let latest = self
+            .directory
+            .join(format!("{}.latest", self.file_base_name));
         let mut open_options = fs::OpenOptions::new();
         open_options.append(true).create(true);
 

--- a/swift/apple/mise-tasks/log/all-tail.sh
+++ b/swift/apple/mise-tasks/log/all-tail.sh
@@ -10,8 +10,8 @@ trap 'kill 0' INT TERM EXIT
 log stream --predicate '(process CONTAINS "Firezone" OR subsystem CONTAINS "dev.firezone" OR category == "connlib") AND process != "codebook-lsp"' &
 
 # Also tail connlib log file if accessible
-if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest" ]; then
-    tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest" &
+if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" ]; then
+    tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" &
 else
     echo "Note: connlib file logs require sudo access. Run 'mise run log:connlib-tail' with sudo for file logs."
 fi

--- a/swift/apple/mise-tasks/log/connlib-show.sh
+++ b/swift/apple/mise-tasks/log/connlib-show.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 echo "Viewing connlib log (requires sudo)..."
-if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest" ]; then
-    less "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest"
+if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" ]; then
+    less "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
 else
-    sudo less "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest"
+    sudo less "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
 fi

--- a/swift/apple/mise-tasks/log/connlib-tail.sh
+++ b/swift/apple/mise-tasks/log/connlib-tail.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 echo "Following connlib log (requires sudo)..."
-if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest" ]; then
-    exec tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest"
+if [ -r "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest" ]; then
+    exec tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
 else
-    exec sudo tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/latest"
+    exec sudo tail -f "/private/var/root/Library/Group Containers/47R2M6779T.dev.firezone.firezone/Library/Caches/logs/connlib/connlib.latest"
 fi


### PR DESCRIPTION
With the introduction of the `register-sparse` binary in #13274, we will have two file loggers logging to the same directory. In order to not clobber their `latest` symlinks, namespace with the base name of the logger.