### PR TITLE
fix(portal): handle POOL_MEMBER_FIREZONE_ID missing

### DIFF
--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -871,7 +871,7 @@ defmodule Portal.Repo.Seeds do
         @ua_macos
       )
 
-    pool_member_firezone_id = System.fetch_env!("POOL_MEMBER_FIREZONE_ID")
+    pool_member_firezone_id = System.get_env("POOL_MEMBER_FIREZONE_ID", Ecto.UUID.generate())
 
     {:ok, pool_member_device} =
       create_client(


### PR DESCRIPTION
Fixes a minor local dev regression introduced in #13257.

```
** (System.EnvError) could not fetch environment variable "POOL_MEMBER_FIREZONE_ID" because it is not set
    (elixir 1.19.5) lib/system.ex:731: System.fetch_env!/1
    priv/repo/seeds.exs:874: Portal.Repo.Seeds.seed/0
    priv/repo/seeds.exs:1601: (file)
    (elixir 1.19.5) lib/code.ex:1613: Code.require_file/2
    (mix 1.19.5) lib/mix/tasks/run.ex:167: Mix.Tasks.Run.run/5
    (mix 1.19.5) lib/mix/tasks/run.ex:106: Mix.Tasks.Run.run/1
    (mix 1.19.5) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.19.5) lib/mix/task.ex:573: Mix.Task.run_alias/6
    (mix 1.19.5) lib/mix/cli.ex:129: Mix.CLI.run_task/2
    /Users/jamil/.local/share/mise/installs/elixir/1.19.5-otp-28/bin/mix:7: (file)
```