### PR TITLE
fix(portal): drop per-test queue buffer silently on shutdown

### DIFF
--- a/elixir/lib/portal/queue.ex
+++ b/elixir/lib/portal/queue.ex
@@ -30,6 +30,9 @@ defmodule Portal.Queue do
     * `:label` — short string used in log lines
     * `:callers` — pids to copy into `$callers` so the GenServer inherits
       sandbox ownership in tests.
+    * `:flush_on_terminate` — when `true` (default), `terminate/2` attempts a
+      best-effort flush of buffered entries and logs a warning. Tests can set
+      this to `false` to drop the buffer silently on supervisor shutdown.
   """
 
   use GenServer
@@ -45,7 +48,8 @@ defmodule Portal.Queue do
       :flush_interval,
       :flush_threshold,
       :label,
-      :on_flush
+      :on_flush,
+      :flush_on_terminate
     ]
     defstruct @enforce_keys
   end
@@ -110,7 +114,8 @@ defmodule Portal.Queue do
       flush_interval: Keyword.fetch!(opts, :flush_interval),
       flush_threshold: Keyword.fetch!(opts, :flush_threshold),
       label: Keyword.get(opts, :label, inspect(name)),
-      on_flush: Keyword.fetch!(opts, :on_flush)
+      on_flush: Keyword.fetch!(opts, :on_flush),
+      flush_on_terminate: Keyword.get(opts, :flush_on_terminate, true)
     }
 
     schedule_flush(config.flush_interval)
@@ -158,14 +163,15 @@ defmodule Portal.Queue do
 
   @impl true
   def terminate(_reason, %{buffer: buffer, config: config} = state) do
-    if buffer != [] do
+    if buffer != [] and config.flush_on_terminate do
       Logger.warning(
         "Queue #{config.label} terminating with #{length(buffer)} buffered entries; " <>
           "attempting best-effort flush"
       )
+
+      _ = do_flush(state)
     end
 
-    _ = do_flush(state)
     :ok
   end
 

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -32,7 +32,7 @@ defmodule PortalAPI.Client.ChannelTest do
     # Fetch the Device row matching the client — the channel now expects Device structs
     device = fetch_device!(client)
 
-    session_id = Keyword.get(opts, :session_id)
+    session_id = Keyword.get_lazy(opts, :session_id, &Ecto.UUID.generate/0)
 
     # Build a ClientSession struct to match what Socket.connect does
     session = %Portal.ClientSession{
@@ -87,14 +87,16 @@ defmodule PortalAPI.Client.ChannelTest do
     start_supervised!(
       {Portal.Queue,
        Keyword.merge(PortalAPI.Client.Channel.policy_authorization_queue_opts(),
-         callers: [self()]
+         callers: [self()],
+         flush_on_terminate: false
        )}
     )
 
     start_supervised!(
       {Portal.Queue,
        Keyword.merge(PortalAPI.Client.Socket.client_session_queue_opts(),
-         callers: [self()]
+         callers: [self()],
+         flush_on_terminate: false
        )}
     )
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -42,7 +42,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
   defp build_gateway_session(gateway, token, opts \\ []) do
     %Portal.GatewaySession{
-      id: Keyword.get(opts, :session_id),
+      id: Keyword.get_lazy(opts, :session_id, &Ecto.UUID.generate/0),
       device_id: gateway.id,
       account_id: gateway.account_id,
       gateway_token_id: token.id,
@@ -65,7 +65,8 @@ defmodule PortalAPI.Gateway.ChannelTest do
     start_supervised!(
       {Portal.Queue,
        Keyword.merge(PortalAPI.Gateway.Socket.gateway_session_queue_opts(),
-         callers: [self()]
+         callers: [self()],
+         flush_on_terminate: false
        )}
     )
 


### PR DESCRIPTION
Fixes a minor output regression introduced in #13361.

The channel module test pids start up their on `Queue` which tries to flush on terminate. The problem is they don't have access to the sandbox, so a warning + error log is emitted.

To fix this we simply add an option to bypass flushing on terminate. Any tests that want to exercise this code path already do so explicitly.