### PR TITLE
ci(static-analysis): lint XML well-formedness via pre-commit

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -32,6 +32,9 @@ repos:
         description: Forces to replace line ending by the UNIX 'lf' character.
         exclude: "(^website/public/images/|^kotlin/android/gradlew.bat|^rust/windows-client/wintun/|^elixir/priv/static/)"
       - id: check-yaml
+      - id: check-xml
+        files: '\.(xml|manifest|wxs|svg)$'
+        types: [file]
       - id: check-merge-conflict
       - id: end-of-file-fixer
         exclude: (^website/public/images/|^elixir/priv/static/|^swift/apple/FirezoneNetworkExtension/Connlib/Generated/)


### PR DESCRIPTION
Adds `pre-commit/pre-commit-hooks:check-xml` to the global pre-commit config with a `files:` override covering `.xml`, `.manifest`, `.wxs`, and `.svg`.

The SXS application manifests, AppxManifest, and WiX fragments are all XML by content but not by extension — the default `types: [xml]` matcher misses them. Without explicit validation they break far from the edit site (kernel SXS loader, MakeAppx, light, aapt) as an opaque CI failure in a downstream packaging job.

Related: #13274