### PR TITLE
fix(windows): reject cross-user GUI pipe connections

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -104,6 +104,8 @@ features = [
     # IPC system
     "Win32_System_Pipes",
     "Win32_System_Threading",
+    # `ProcessIdToSessionId` for the GUI-pipe cross-session check.
+    "Win32_System_RemoteDesktop",
 ]
 
 [build-dependencies]

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -205,6 +205,14 @@ fn try_main(
                 return Ok(());
             }
 
+            if anyhow.any_is::<firezone_gui_client::ipc::WrongUser>() {
+                dialog::error(
+                    "Firezone is already running in another logon session. \
+                     Sign out of that session first, then try again.",
+                )?;
+                return Ok(());
+            }
+
             if anyhow.any_is::<gui::NewInstanceHandshakeFailed>() {
                 dialog::error(
                     "Firezone is already running but not responding. Please force-stop it first.",

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -276,7 +276,7 @@ impl<I: GuiIntegration> Controller<I> {
                     return Err(anyhow!("GUI IPC socket closed"));
                 }
                 EventloopTick::NewInstanceLaunched(Some(Err(e))) => {
-                    tracing::warn!("Failed to accept IPC connection from new GUI instance: {e:#}");
+                    tracing::debug!("Failed to accept IPC connection from new GUI instance: {e:#}");
                 }
                 EventloopTick::NewInstanceLaunched(Some(Ok((mut read, mut write)))) => {
                     let client_msg = read.next().await;

--- a/rust/gui-client/src-tauri/src/ipc.rs
+++ b/rust/gui-client/src-tauri/src/ipc.rs
@@ -28,13 +28,6 @@ pub(crate) mod platform;
 #[error("Couldn't find IPC socket `{0}`")]
 pub struct NotFound(String);
 
-/// The GUI pipe's server lives in a different Windows logon session
-/// than the connecting one. Surfaced as
-/// `anyhow::Error::new(WrongUser)`; the launcher catches it via
-/// `any_is::<WrongUser>()` and shows a dialog instead of silently
-/// handing off into the wrong user's signed-in session. Cross-platform
-/// so the launcher's dispatch is platform-agnostic; only the Windows
-/// IPC layer ever constructs it.
 #[derive(Debug, thiserror::Error)]
 #[error("Firezone is already running in another logon session")]
 pub struct WrongUser;

--- a/rust/gui-client/src-tauri/src/ipc.rs
+++ b/rust/gui-client/src-tauri/src/ipc.rs
@@ -28,6 +28,17 @@ pub(crate) mod platform;
 #[error("Couldn't find IPC socket `{0}`")]
 pub struct NotFound(String);
 
+/// The GUI pipe's server lives in a different Windows logon session
+/// than the connecting one. Surfaced as
+/// `anyhow::Error::new(WrongUser)`; the launcher catches it via
+/// `any_is::<WrongUser>()` and shows a dialog instead of silently
+/// handing off into the wrong user's signed-in session. Cross-platform
+/// so the launcher's dispatch is platform-agnostic; only the Windows
+/// IPC layer ever constructs it.
+#[derive(Debug, thiserror::Error)]
+#[error("Firezone is already running in another logon session")]
+pub struct WrongUser;
+
 #[cfg(debug_assertions)]
 pub use platform::skip_tunnel_pipe_owner_check;
 

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -119,10 +119,9 @@ fn enforce_pipe_ownership(id: SocketId, handle: HANDLE) -> Result<()> {
             bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
         }
         SocketId::Tunnel => Ok(()),
-        // Cross-session GUI server -- FUS/RDP. Surfaces to the launcher
-        // as `WrongUser`; the kernel snapshots `*SessionId` at pipe
-        // creation, so this is TOCTOU-safe.
-        SocketId::Gui if pipe_server_session_id(handle)? != current_session_id()? => {
+        // Cross-session GUI server -- FUS/RDP. Surfaces to the
+        // launcher as `WrongUser`.
+        SocketId::Gui if !is_pipe_server_owned_by_current_session(handle)? => {
             Err(anyhow::Error::new(WrongUser))
         }
         SocketId::Gui => Ok(()),
@@ -179,7 +178,7 @@ impl Server {
         // next iteration, so we just return an error here -- no
         // internal retry loop.
         if matches!(self.socket_id, SocketId::Gui)
-            && pipe_client_session_id(handle)? != current_session_id()?
+            && !is_pipe_client_owned_by_current_session(handle)?
         {
             bail!("Dropped IPC connection from PID {client_pid} -- different logon session");
         }
@@ -325,27 +324,27 @@ fn is_pipe_owned_by_local_system(handle: HANDLE) -> Result<bool> {
     Ok(is_local_system)
 }
 
-/// Wraps `GetNamedPipeServerSessionId`. Returns the logon-session
-/// ID of the process that *created* the pipe (set by the kernel at
-/// `CreateNamedPipeW` time).
-fn pipe_server_session_id(handle: HANDLE) -> Result<u32> {
-    let mut session = 0u32;
+/// Whether the pipe was *created* in this process's logon session.
+/// The kernel snapshots the value at `CreateNamedPipeW` time, so
+/// this is TOCTOU-safe.
+fn is_pipe_server_owned_by_current_session(handle: HANDLE) -> Result<bool> {
+    let mut server = 0u32;
     // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
-    // writes only to `&mut session` and doesn't retain the pointer.
-    unsafe { GetNamedPipeServerSessionId(handle, &mut session) }
+    // writes only to `&mut server` and doesn't retain the pointer.
+    unsafe { GetNamedPipeServerSessionId(handle, &mut server) }
         .context("GetNamedPipeServerSessionId failed")?;
-    Ok(session)
+    Ok(server == current_session_id()?)
 }
 
-/// Wraps `GetNamedPipeClientSessionId`. Returns the logon-session
-/// ID of the process that *connected* to the pipe.
-fn pipe_client_session_id(handle: HANDLE) -> Result<u32> {
-    let mut session = 0u32;
+/// Whether the pipe was *connected* by a process in this process's
+/// logon session. Snapshotted at connection time by the kernel.
+fn is_pipe_client_owned_by_current_session(handle: HANDLE) -> Result<bool> {
+    let mut client = 0u32;
     // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
-    // writes only to `&mut session` and doesn't retain the pointer.
-    unsafe { GetNamedPipeClientSessionId(handle, &mut session) }
+    // writes only to `&mut client` and doesn't retain the pointer.
+    unsafe { GetNamedPipeClientSessionId(handle, &mut client) }
         .context("GetNamedPipeClientSessionId failed")?;
-    Ok(session)
+    Ok(client == current_session_id()?)
 }
 
 /// The current process's logon-session ID, via

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -1,4 +1,4 @@
-use super::{NotFound, SocketId};
+use super::{NotFound, SocketId, WrongUser};
 use anyhow::{Context as _, Result, bail};
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,7 +11,14 @@ use windows::Win32::{
         IsWellKnownSid, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
         SECURITY_ATTRIBUTES, WinLocalSystemSid,
     },
-    System::Pipes::{GetNamedPipeClientProcessId, GetNamedPipeServerProcessId},
+    System::{
+        Pipes::{
+            GetNamedPipeClientProcessId, GetNamedPipeClientSessionId, GetNamedPipeServerProcessId,
+            GetNamedPipeServerSessionId,
+        },
+        RemoteDesktop::ProcessIdToSessionId,
+        Threading::GetCurrentProcessId,
+    },
 };
 use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
 
@@ -71,6 +78,7 @@ pub fn skip_tunnel_pipe_owner_check() {
 }
 
 pub struct Server {
+    socket_id: SocketId,
     pipe_path: String,
     dacl: PipeDacl,
 }
@@ -99,13 +107,7 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
 
     enforce_pipe_ownership(id, handle)?;
 
-    let mut server_pid: u32 = 0;
-    // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle
-    // from Tokio, so it should be valid.
-    unsafe { GetNamedPipeServerProcessId(handle, &mut server_pid) }
-        .context("Couldn't get PID of named pipe server")?;
-
-    tracing::debug!(?server_pid, "Made IPC connection");
+    tracing::debug!(server_pid = pipe_server_pid(handle)?, "Made IPC connection");
     Ok(stream)
 }
 
@@ -162,20 +164,84 @@ fn is_pipe_owned_by_local_system(handle: HANDLE) -> Result<bool> {
 }
 
 fn enforce_pipe_ownership(id: SocketId, handle: HANDLE) -> Result<()> {
-    if id != SocketId::Tunnel {
-        return Ok(());
-    }
-
-    #[cfg(debug_assertions)]
-    if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) {
-        return Ok(());
-    }
-
-    if !is_pipe_owned_by_local_system(handle)? {
-        bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
+    match id {
+        #[cfg(debug_assertions)]
+        SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => {}
+        SocketId::Tunnel => {
+            if !is_pipe_owned_by_local_system(handle)? {
+                bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
+            }
+        }
+        SocketId::Gui => {
+            // The running GUI's logon session must match ours.
+            // Cross-user collisions on a multi-user host
+            // (fast-user-switching, RDP) hit here; the launcher
+            // surfaces this to the user as a dialog instead of
+            // silently handing off the deep-link into another
+            // session. Session IDs are kernel-assigned and not
+            // spoofable, and `Get*SessionId` snapshots the value
+            // at pipe-creation time so this is TOCTOU-safe.
+            if pipe_server_session_id(handle)? != current_session_id()? {
+                return Err(anyhow::Error::new(WrongUser));
+            }
+        }
+        #[cfg(test)]
+        SocketId::Test(_) => {}
     }
 
     Ok(())
+}
+
+/// Wraps `GetNamedPipeServerSessionId`. Returns the logon-session
+/// ID of the process that *created* the pipe (set by the kernel at
+/// `CreateNamedPipeW` time).
+fn pipe_server_session_id(handle: HANDLE) -> Result<u32> {
+    let mut session = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
+    // writes only to `&mut session` and doesn't retain the pointer.
+    unsafe { GetNamedPipeServerSessionId(handle, &mut session) }
+        .context("GetNamedPipeServerSessionId failed")?;
+    Ok(session)
+}
+
+/// Wraps `GetNamedPipeClientSessionId`. Returns the logon-session
+/// ID of the process that *connected* to the pipe.
+fn pipe_client_session_id(handle: HANDLE) -> Result<u32> {
+    let mut session = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
+    // writes only to `&mut session` and doesn't retain the pointer.
+    unsafe { GetNamedPipeClientSessionId(handle, &mut session) }
+        .context("GetNamedPipeClientSessionId failed")?;
+    Ok(session)
+}
+
+/// The current process's logon-session ID, via
+/// `ProcessIdToSessionId(GetCurrentProcessId(), …)`.
+fn current_session_id() -> Result<u32> {
+    let mut session = 0u32;
+    // SAFETY: `GetCurrentProcessId` is infallible; `&mut session` is a
+    // valid out-pointer.
+    unsafe { ProcessIdToSessionId(GetCurrentProcessId(), &mut session) }
+        .context("ProcessIdToSessionId failed")?;
+    Ok(session)
+}
+
+/// Wraps `GetNamedPipeClientProcessId`. Used only for tracing.
+fn pipe_client_pid(handle: HANDLE) -> Result<u32> {
+    let mut pid = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio.
+    unsafe { GetNamedPipeClientProcessId(handle, &mut pid) }
+        .context("GetNamedPipeClientProcessId failed")?;
+    Ok(pid)
+}
+
+/// Wraps `GetNamedPipeServerProcessId`. Used only for tracing.
+fn pipe_server_pid(handle: HANDLE) -> Result<u32> {
+    let mut pid = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio.
+    unsafe { GetNamedPipeServerProcessId(handle, &mut pid) }
+        .context("GetNamedPipeServerProcessId failed")?;
+    Ok(pid)
 }
 
 impl Server {
@@ -193,34 +259,55 @@ impl Server {
             #[cfg(test)]
             SocketId::Test(_) => gui_pipe_dacl(),
         };
-        Ok(Self { pipe_path, dacl })
+        Ok(Self {
+            socket_id: id,
+            pipe_path,
+            dacl,
+        })
     }
 
     // `&mut self` needed to match the Linux signature
     pub(crate) async fn next_client(&mut self) -> Result<ServerStream> {
-        // Fixes #5143. In the Tunnel service, if we close the pipe and immediately re-open
-        // it, Tokio may not get a chance to clean up the pipe. Yielding seems to fix
-        // this in tests, but `yield_now` doesn't make any such guarantees, so
-        // we also do a loop.
-        tokio::task::yield_now().await;
+        loop {
+            // Fixes #5143. In the Tunnel service, if we close the pipe and immediately re-open
+            // it, Tokio may not get a chance to clean up the pipe. Yielding seems to fix
+            // this in tests, but `yield_now` doesn't make any such guarantees, so
+            // we also do a loop.
+            tokio::task::yield_now().await;
 
-        let server = self
-            .bind_to_pipe()
-            .await
-            .context("Couldn't bind to named pipe")?;
-        // Note that Tokio has no `poll_connect`
-        server
-            .connect()
-            .await
-            .context("Couldn't accept IPC connection from GUI")?;
-        let handle = HANDLE(server.as_raw_handle());
-        let mut client_pid: u32 = 0;
-        // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle
-        // from Tokio, so it should be valid.
-        unsafe { GetNamedPipeClientProcessId(handle, &mut client_pid) }
-            .context("Couldn't get PID of named pipe client")?;
-        tracing::debug!(?client_pid, "Accepted IPC connection");
-        Ok(server)
+            let server = self
+                .bind_to_pipe()
+                .await
+                .context("Couldn't bind to named pipe")?;
+            // Note that Tokio has no `poll_connect`
+            server
+                .connect()
+                .await
+                .context("Couldn't accept IPC connection from GUI")?;
+            let handle = HANDLE(server.as_raw_handle());
+            let client_pid = pipe_client_pid(handle)?;
+
+            // GUI pipe: refuse to talk to a client running in a
+            // different logon session (cross-user FUS/RDP), so a
+            // launcher in user B's session can't drive user A's
+            // signed-in GUI. Session IDs are kernel-assigned at pipe
+            // creation -- not spoofable, no TOCTOU. `tracing::debug!`
+            // (not `warn!`) because mismatch is an expected state on a
+            // multi-user host, not an error worth Sentry-paging on.
+            if matches!(self.socket_id, SocketId::Gui)
+                && pipe_client_session_id(handle)? != current_session_id()?
+            {
+                tracing::debug!(
+                    ?client_pid,
+                    "Dropping GUI pipe connection from different logon session",
+                );
+                drop(server);
+                continue;
+            }
+
+            tracing::debug!(?client_pid, "Accepted IPC connection");
+            return Ok(server);
+        }
     }
 
     async fn bind_to_pipe(&self) -> Result<ServerStream> {
@@ -285,7 +372,7 @@ fn create_pipe_server(
     }
 }
 
-/// Named pipe for an IPC connection
+/// Named pipe for an IPC connection.
 fn ipc_path(id: SocketId) -> String {
     let name = match id {
         SocketId::Tunnel => format!("{}_tunnel.ipc", crate::BUNDLE_ID),

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -181,9 +181,7 @@ impl Server {
         if matches!(self.socket_id, SocketId::Gui)
             && pipe_client_session_id(handle)? != current_session_id()?
         {
-            bail!(
-                "Dropped IPC connection from PID {client_pid} -- different logon session",
-            );
+            bail!("Dropped IPC connection from PID {client_pid} -- different logon session");
         }
 
         tracing::debug!(?client_pid, "Accepted IPC connection");

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -111,137 +111,24 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
     Ok(stream)
 }
 
-/// Checks if the connected named pipe was created by `LocalSystem`, the
-/// account the Tunnel service runs as.
-///
-/// `first_pipe_instance(true)` ensures nobody else can create another instance
-/// of our pipe *while the legit server is bound*, but during the brief window
-/// between teardown and re-bind (or before the service starts at all on a
-/// just-booted machine) a local user-mode process can race to be the *first*
-/// creator of the pipe name. The legit service then fails closed via
-/// `ERROR_ACCESS_DENIED`, leaving the squatter as the only server. This check
-/// catches that case before the GUI sends anything sensitive over the wire.
-///
-/// We inspect the *owner* of the kernel pipe object (set at creation time)
-/// rather than the server's current process token. The latter is racy if the
-/// server process exits and its PID is recycled between
-/// `GetNamedPipeServerProcessId` and `OpenProcess`.
-fn is_pipe_owned_by_local_system(handle: HANDLE) -> Result<bool> {
-    let mut owner_sid = PSID::default();
-    let mut sd = PSECURITY_DESCRIPTOR::default();
-
-    // SAFETY: All pointers below are out-pointers to stack locals. On success
-    // the kernel allocates `sd` (which we release via `LocalFree`) and points
-    // `owner_sid` into that allocation.
-    let err = unsafe {
-        GetSecurityInfo(
-            handle,
-            SE_KERNEL_OBJECT,
-            OWNER_SECURITY_INFORMATION,
-            Some(&mut owner_sid),
-            None,
-            None,
-            None,
-            Some(&mut sd),
-        )
-    };
-    if err.0 != 0 {
-        return Err(std::io::Error::from_raw_os_error(err.0 as i32))
-            .context("GetSecurityInfo on pipe handle failed");
-    }
-
-    // SAFETY: `owner_sid` is a non-NULL pointer into `sd`'s buffer (still
-    // alive for this call) and `IsWellKnownSid` does not retain it.
-    let is_local_system = unsafe { IsWellKnownSid(owner_sid, WinLocalSystemSid) }.as_bool();
-
-    // SAFETY: `sd` was allocated by `GetSecurityInfo` and must be released
-    // with `LocalFree`. After this call no pointer derived from it is used.
-    unsafe {
-        let _ = LocalFree(Some(HLOCAL(sd.0)));
-    }
-
-    Ok(is_local_system)
-}
-
 fn enforce_pipe_ownership(id: SocketId, handle: HANDLE) -> Result<()> {
     match id {
         #[cfg(debug_assertions)]
-        SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => {}
-        SocketId::Tunnel => {
-            if !is_pipe_owned_by_local_system(handle)? {
-                bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
-            }
+        SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => Ok(()),
+        SocketId::Tunnel if !is_pipe_owned_by_local_system(handle)? => {
+            bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
         }
-        SocketId::Gui => {
-            // The running GUI's logon session must match ours.
-            // Cross-user collisions on a multi-user host
-            // (fast-user-switching, RDP) hit here; the launcher
-            // surfaces this to the user as a dialog instead of
-            // silently handing off the deep-link into another
-            // session. Session IDs are kernel-assigned and not
-            // spoofable, and `Get*SessionId` snapshots the value
-            // at pipe-creation time so this is TOCTOU-safe.
-            if pipe_server_session_id(handle)? != current_session_id()? {
-                return Err(anyhow::Error::new(WrongUser));
-            }
+        SocketId::Tunnel => Ok(()),
+        // Cross-session GUI server -- FUS/RDP. Surfaces to the launcher
+        // as `WrongUser`; the kernel snapshots `*SessionId` at pipe
+        // creation, so this is TOCTOU-safe.
+        SocketId::Gui if pipe_server_session_id(handle)? != current_session_id()? => {
+            Err(anyhow::Error::new(WrongUser))
         }
+        SocketId::Gui => Ok(()),
         #[cfg(test)]
-        SocketId::Test(_) => {}
+        SocketId::Test(_) => Ok(()),
     }
-
-    Ok(())
-}
-
-/// Wraps `GetNamedPipeServerSessionId`. Returns the logon-session
-/// ID of the process that *created* the pipe (set by the kernel at
-/// `CreateNamedPipeW` time).
-fn pipe_server_session_id(handle: HANDLE) -> Result<u32> {
-    let mut session = 0u32;
-    // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
-    // writes only to `&mut session` and doesn't retain the pointer.
-    unsafe { GetNamedPipeServerSessionId(handle, &mut session) }
-        .context("GetNamedPipeServerSessionId failed")?;
-    Ok(session)
-}
-
-/// Wraps `GetNamedPipeClientSessionId`. Returns the logon-session
-/// ID of the process that *connected* to the pipe.
-fn pipe_client_session_id(handle: HANDLE) -> Result<u32> {
-    let mut session = 0u32;
-    // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
-    // writes only to `&mut session` and doesn't retain the pointer.
-    unsafe { GetNamedPipeClientSessionId(handle, &mut session) }
-        .context("GetNamedPipeClientSessionId failed")?;
-    Ok(session)
-}
-
-/// The current process's logon-session ID, via
-/// `ProcessIdToSessionId(GetCurrentProcessId(), …)`.
-fn current_session_id() -> Result<u32> {
-    let mut session = 0u32;
-    // SAFETY: `GetCurrentProcessId` is infallible; `&mut session` is a
-    // valid out-pointer.
-    unsafe { ProcessIdToSessionId(GetCurrentProcessId(), &mut session) }
-        .context("ProcessIdToSessionId failed")?;
-    Ok(session)
-}
-
-/// Wraps `GetNamedPipeClientProcessId`. Used only for tracing.
-fn pipe_client_pid(handle: HANDLE) -> Result<u32> {
-    let mut pid = 0u32;
-    // SAFETY: `handle` is a live pipe handle from Tokio.
-    unsafe { GetNamedPipeClientProcessId(handle, &mut pid) }
-        .context("GetNamedPipeClientProcessId failed")?;
-    Ok(pid)
-}
-
-/// Wraps `GetNamedPipeServerProcessId`. Used only for tracing.
-fn pipe_server_pid(handle: HANDLE) -> Result<u32> {
-    let mut pid = 0u32;
-    // SAFETY: `handle` is a live pipe handle from Tokio.
-    unsafe { GetNamedPipeServerProcessId(handle, &mut pid) }
-        .context("GetNamedPipeServerProcessId failed")?;
-    Ok(pid)
 }
 
 impl Server {
@@ -268,46 +155,39 @@ impl Server {
 
     // `&mut self` needed to match the Linux signature
     pub(crate) async fn next_client(&mut self) -> Result<ServerStream> {
-        loop {
-            // Fixes #5143. In the Tunnel service, if we close the pipe and immediately re-open
-            // it, Tokio may not get a chance to clean up the pipe. Yielding seems to fix
-            // this in tests, but `yield_now` doesn't make any such guarantees, so
-            // we also do a loop.
-            tokio::task::yield_now().await;
+        // Fixes #5143. In the Tunnel service, if we close the pipe and immediately re-open
+        // it, Tokio may not get a chance to clean up the pipe. Yielding seems to fix
+        // this in tests, but `yield_now` doesn't make any such guarantees, so
+        // `bind_to_pipe` also runs its own retry loop.
+        tokio::task::yield_now().await;
 
-            let server = self
-                .bind_to_pipe()
-                .await
-                .context("Couldn't bind to named pipe")?;
-            // Note that Tokio has no `poll_connect`
-            server
-                .connect()
-                .await
-                .context("Couldn't accept IPC connection from GUI")?;
-            let handle = HANDLE(server.as_raw_handle());
-            let client_pid = pipe_client_pid(handle)?;
+        let server = self
+            .bind_to_pipe()
+            .await
+            .context("Couldn't bind to named pipe")?;
+        // Note that Tokio has no `poll_connect`
+        server
+            .connect()
+            .await
+            .context("Couldn't accept IPC connection from GUI")?;
+        let handle = HANDLE(server.as_raw_handle());
+        let client_pid = pipe_client_pid(handle)?;
 
-            // GUI pipe: refuse to talk to a client running in a
-            // different logon session (cross-user FUS/RDP), so a
-            // launcher in user B's session can't drive user A's
-            // signed-in GUI. Session IDs are kernel-assigned at pipe
-            // creation -- not spoofable, no TOCTOU. `tracing::debug!`
-            // (not `warn!`) because mismatch is an expected state on a
-            // multi-user host, not an error worth Sentry-paging on.
-            if matches!(self.socket_id, SocketId::Gui)
-                && pipe_client_session_id(handle)? != current_session_id()?
-            {
-                tracing::debug!(
-                    ?client_pid,
-                    "Dropping GUI pipe connection from different logon session",
-                );
-                drop(server);
-                continue;
-            }
-
-            tracing::debug!(?client_pid, "Accepted IPC connection");
-            return Ok(server);
+        // GUI pipe: refuse a client running in a different logon
+        // session (cross-user FUS/RDP). Caller-side
+        // (`controller::eventloop`) calls `next_client` again on the
+        // next iteration, so we just return an error here -- no
+        // internal retry loop.
+        if matches!(self.socket_id, SocketId::Gui)
+            && pipe_client_session_id(handle)? != current_session_id()?
+        {
+            bail!(
+                "Dropped IPC connection from PID {client_pid} -- different logon session",
+            );
         }
+
+        tracing::debug!(?client_pid, "Accepted IPC connection");
+        Ok(server)
     }
 
     async fn bind_to_pipe(&self) -> Result<ServerStream> {
@@ -393,6 +273,110 @@ fn ipc_path(id: SocketId) -> String {
 /// will be de-duped into this code.
 pub fn named_pipe_path(id: &str) -> String {
     format!(r"\\.\pipe\{id}")
+}
+
+/// Checks if the connected named pipe was created by `LocalSystem`, the
+/// account the Tunnel service runs as.
+///
+/// `first_pipe_instance(true)` ensures nobody else can create another instance
+/// of our pipe *while the legit server is bound*, but during the brief window
+/// between teardown and re-bind (or before the service starts at all on a
+/// just-booted machine) a local user-mode process can race to be the *first*
+/// creator of the pipe name. The legit service then fails closed via
+/// `ERROR_ACCESS_DENIED`, leaving the squatter as the only server. This check
+/// catches that case before the GUI sends anything sensitive over the wire.
+///
+/// We inspect the *owner* of the kernel pipe object (set at creation time)
+/// rather than the server's current process token. The latter is racy if the
+/// server process exits and its PID is recycled between
+/// `GetNamedPipeServerProcessId` and `OpenProcess`.
+fn is_pipe_owned_by_local_system(handle: HANDLE) -> Result<bool> {
+    let mut owner_sid = PSID::default();
+    let mut sd = PSECURITY_DESCRIPTOR::default();
+
+    // SAFETY: All pointers below are out-pointers to stack locals. On success
+    // the kernel allocates `sd` (which we release via `LocalFree`) and points
+    // `owner_sid` into that allocation.
+    let err = unsafe {
+        GetSecurityInfo(
+            handle,
+            SE_KERNEL_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            Some(&mut owner_sid),
+            None,
+            None,
+            None,
+            Some(&mut sd),
+        )
+    };
+    if err.0 != 0 {
+        return Err(std::io::Error::from_raw_os_error(err.0 as i32))
+            .context("GetSecurityInfo on pipe handle failed");
+    }
+
+    // SAFETY: `owner_sid` is a non-NULL pointer into `sd`'s buffer (still
+    // alive for this call) and `IsWellKnownSid` does not retain it.
+    let is_local_system = unsafe { IsWellKnownSid(owner_sid, WinLocalSystemSid) }.as_bool();
+
+    // SAFETY: `sd` was allocated by `GetSecurityInfo` and must be released
+    // with `LocalFree`. After this call no pointer derived from it is used.
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+
+    Ok(is_local_system)
+}
+
+/// Wraps `GetNamedPipeServerSessionId`. Returns the logon-session
+/// ID of the process that *created* the pipe (set by the kernel at
+/// `CreateNamedPipeW` time).
+fn pipe_server_session_id(handle: HANDLE) -> Result<u32> {
+    let mut session = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
+    // writes only to `&mut session` and doesn't retain the pointer.
+    unsafe { GetNamedPipeServerSessionId(handle, &mut session) }
+        .context("GetNamedPipeServerSessionId failed")?;
+    Ok(session)
+}
+
+/// Wraps `GetNamedPipeClientSessionId`. Returns the logon-session
+/// ID of the process that *connected* to the pipe.
+fn pipe_client_session_id(handle: HANDLE) -> Result<u32> {
+    let mut session = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio; the kernel
+    // writes only to `&mut session` and doesn't retain the pointer.
+    unsafe { GetNamedPipeClientSessionId(handle, &mut session) }
+        .context("GetNamedPipeClientSessionId failed")?;
+    Ok(session)
+}
+
+/// The current process's logon-session ID, via
+/// `ProcessIdToSessionId(GetCurrentProcessId(), …)`.
+fn current_session_id() -> Result<u32> {
+    let mut session = 0u32;
+    // SAFETY: `GetCurrentProcessId` is infallible; `&mut session` is a
+    // valid out-pointer.
+    unsafe { ProcessIdToSessionId(GetCurrentProcessId(), &mut session) }
+        .context("ProcessIdToSessionId failed")?;
+    Ok(session)
+}
+
+/// Wraps `GetNamedPipeClientProcessId`. Used only for tracing.
+fn pipe_client_pid(handle: HANDLE) -> Result<u32> {
+    let mut pid = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio.
+    unsafe { GetNamedPipeClientProcessId(handle, &mut pid) }
+        .context("GetNamedPipeClientProcessId failed")?;
+    Ok(pid)
+}
+
+/// Wraps `GetNamedPipeServerProcessId`. Used only for tracing.
+fn pipe_server_pid(handle: HANDLE) -> Result<u32> {
+    let mut pid = 0u32;
+    // SAFETY: `handle` is a live pipe handle from Tokio.
+    unsafe { GetNamedPipeServerProcessId(handle, &mut pid) }
+        .context("GetNamedPipeServerProcessId failed")?;
+    Ok(pid)
 }
 
 #[cfg(test)]

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -113,20 +113,19 @@ pub(crate) async fn connect_to_socket(id: SocketId) -> Result<ClientStream> {
 
 fn enforce_pipe_ownership(id: SocketId, handle: HANDLE) -> Result<()> {
     match id {
+        #[cfg(test)]
+        SocketId::Test(_) => Ok(()),
         #[cfg(debug_assertions)]
         SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => Ok(()),
+        // Refuse to connect to tunnel pipes not owned by local system
         SocketId::Tunnel if !is_pipe_owned_by_local_system(handle)? => {
             bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
         }
-        SocketId::Tunnel => Ok(()),
-        // Cross-session GUI server -- FUS/RDP. Surfaces to the
-        // launcher as `WrongUser`.
+        // Refuse to connect to GUI pipes owned by a different logon session
         SocketId::Gui if !is_pipe_server_owned_by_current_session(handle)? => {
-            Err(anyhow::Error::new(WrongUser))
+            bail!(WrongUser)
         }
-        SocketId::Gui => Ok(()),
-        #[cfg(test)]
-        SocketId::Test(_) => Ok(()),
+        SocketId::Tunnel | SocketId::Gui => Ok(()),
     }
 }
 
@@ -333,6 +332,7 @@ fn is_pipe_server_owned_by_current_session(handle: HANDLE) -> Result<bool> {
     // writes only to `&mut server` and doesn't retain the pointer.
     unsafe { GetNamedPipeServerSessionId(handle, &mut server) }
         .context("GetNamedPipeServerSessionId failed")?;
+
     Ok(server == current_session_id()?)
 }
 
@@ -344,6 +344,7 @@ fn is_pipe_client_owned_by_current_session(handle: HANDLE) -> Result<bool> {
     // writes only to `&mut client` and doesn't retain the pointer.
     unsafe { GetNamedPipeClientSessionId(handle, &mut client) }
         .context("GetNamedPipeClientSessionId failed")?;
+
     Ok(client == current_session_id()?)
 }
 
@@ -355,6 +356,7 @@ fn current_session_id() -> Result<u32> {
     // valid out-pointer.
     unsafe { ProcessIdToSessionId(GetCurrentProcessId(), &mut session) }
         .context("ProcessIdToSessionId failed")?;
+
     Ok(session)
 }
 
@@ -364,6 +366,7 @@ fn pipe_client_pid(handle: HANDLE) -> Result<u32> {
     // SAFETY: `handle` is a live pipe handle from Tokio.
     unsafe { GetNamedPipeClientProcessId(handle, &mut pid) }
         .context("GetNamedPipeClientProcessId failed")?;
+
     Ok(pid)
 }
 
@@ -373,6 +376,7 @@ fn pipe_server_pid(handle: HANDLE) -> Result<u32> {
     // SAFETY: `handle` is a live pipe handle from Tokio.
     unsafe { GetNamedPipeServerProcessId(handle, &mut pid) }
         .context("GetNamedPipeServerProcessId failed")?;
+
     Ok(pid)
 }
 


### PR DESCRIPTION
The GUI pipe is the single-instance / deep-link handoff channel. With a shared `gui.ipc` namespace and a non-elevated GUI, two simultaneously logged-in users (fast-user-switching, RDP without sign-out) collide: user B's launcher hits user A's pipe, sends the `NewInstance`, and the deep-link gets activated in user A's signed-in session. Bad UX, mild security smell.

To prevent this, we add a check for the logon-session ID on both sides of the pipe, comparing it against our own logon session ID. If it doesn't match, we bail out early. The 2nd instance displays as an alert dialog, telling the user what is going on.

Related: #13275