### PR TITLE
fix(portal): scope Safe.delete_all by account

### DIFF
--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -630,7 +630,13 @@ defmodule Portal.Safe do
 
   @spec delete_all(Scoped.t(), Keyword.t()) ::
           {integer(), nil | [term()]} | {:error, :unauthorized}
-  def delete_all(%Scoped{subject: subject, queryable: queryable}, opts) do
+  def delete_all(
+        %Scoped{
+          subject: %Subject{account: %{id: account_id}} = subject,
+          queryable: queryable
+        },
+        opts
+      ) do
     schema = get_schema_module(queryable)
 
     case permit(:delete_all, schema, subject) do
@@ -639,7 +645,8 @@ defmodule Portal.Safe do
           Repo.transact(fn ->
             emit_subject_message(subject)
 
-            {:ok, Repo.delete_all(queryable, opts)}
+            filtered_query = apply_account_filter(queryable, schema, account_id)
+            {:ok, Repo.delete_all(filtered_query, opts)}
           end)
 
         result


### PR DESCRIPTION
`Safe.delete_all/2` on a `Scoped` subject built and ran the queryable as-is, without the `apply_account_filter` step the read paths (`Safe.all/1`, `Safe.one/2`, etc.) apply. A query referencing another account's rows, e.g. a `client_tokens` row matched only by `id` and `actor_id`, would delete them.

Route the queryable through `apply_account_filter` so the WHERE clause always includes `account_id` matching the subject's account.

A follow-up will use Postgres RLS to provide the same guarantee across all DML, which subsumes equivalent fixes for `update_all` and `insert_all`.

Related: #13357