### PR TITLE
feat(connlib): gate connected-device behind feature flag

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -307,9 +307,15 @@ impl ClientState {
     }
 
     fn resource_list_snapshot(&self) -> ResourceList {
+        let connected_devices = if feature_flags::connected_devices() {
+            self.connected_devices()
+        } else {
+            Vec::new()
+        };
+
         ResourceList {
             resources: self.resources(),
-            connected_devices: self.connected_devices(),
+            connected_devices,
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -307,7 +307,7 @@ impl ClientState {
     }
 
     fn resource_list_snapshot(&self) -> ResourceList {
-        let connected_devices = if feature_flags::connected_devices() {
+        let connected_devices = if feature_flags::show_connected_devices() {
             self.connected_devices()
         } else {
             Vec::new()

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -56,8 +56,8 @@ pub fn stream_metrics() -> bool {
     FEATURE_FLAGS.stream_metrics()
 }
 
-pub fn connected_devices() -> bool {
-    FEATURE_FLAGS.connected_devices()
+pub fn show_connected_devices() -> bool {
+    FEATURE_FLAGS.show_connected_devices()
 }
 
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
@@ -177,7 +177,7 @@ struct FeatureFlagsResponse {
     #[serde(default)]
     stream_metrics: bool,
     #[serde(default)]
-    connected_devices: bool,
+    show_connected_devices: bool,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
@@ -194,7 +194,7 @@ struct FeatureFlags {
     stream_logs: RwLock<LogFilter>,
     icmp_error_unreachable_prohibited_create_new_flow: AtomicBool,
     stream_metrics: AtomicBool,
-    connected_devices: AtomicBool,
+    show_connected_devices: AtomicBool,
 }
 
 /// Accessors to the actual feature flags.
@@ -212,7 +212,7 @@ impl FeatureFlags {
             stream_logs,
             icmp_error_unreachable_prohibited_create_new_flow,
             stream_metrics,
-            connected_devices,
+            show_connected_devices,
         }: FeatureFlagsResponse,
         payloads: FeatureFlagPayloadsResponse,
     ) {
@@ -226,8 +226,8 @@ impl FeatureFlags {
                 Ordering::Relaxed,
             );
         self.stream_metrics.store(stream_metrics, Ordering::Relaxed);
-        self.connected_devices
-            .store(connected_devices, Ordering::Relaxed);
+        self.show_connected_devices
+            .store(show_connected_devices, Ordering::Relaxed);
 
         let log_filter = if stream_logs {
             LogFilter::parse(payloads.stream_logs)
@@ -260,8 +260,8 @@ impl FeatureFlags {
         self.stream_metrics.load(Ordering::Relaxed)
     }
 
-    fn connected_devices(&self) -> bool {
-        self.connected_devices.load(Ordering::Relaxed)
+    fn show_connected_devices(&self) -> bool {
+        self.show_connected_devices.load(Ordering::Relaxed)
     }
 }
 
@@ -281,7 +281,10 @@ fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
             flags.icmp_error_unreachable_prohibited_create_new_flow,
         ),
         stream_metrics: env_or("FZFF_STREAM_METRICS", flags.stream_metrics),
-        connected_devices: env_or("FZFF_CONNECTED_DEVICES", flags.connected_devices),
+        show_connected_devices: env_or(
+            "FZFF_SHOW_CONNECTED_DEVICES",
+            flags.show_connected_devices,
+        ),
     }
 }
 
@@ -301,7 +304,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
         StreamLogs { result: bool },
         IcmpErrorUnreachableProhibitedCreateNewFlow { result: bool },
         StreamMetrics { result: bool },
-        ConnectedDevices { result: bool },
+        ShowConnectedDevices { result: bool },
     }
 
     // Exhaustive destruction so we don't forget to update this when we add a flag.
@@ -311,7 +314,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
         stream_logs,
         icmp_error_unreachable_prohibited_create_new_flow,
         stream_metrics,
-        connected_devices,
+        show_connected_devices,
     } = flags;
 
     let value = serde_json::json!({
@@ -323,7 +326,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
             SentryFlag::StreamLogs { result: stream_logs },
             SentryFlag::IcmpErrorUnreachableProhibitedCreateNewFlow { result: icmp_error_unreachable_prohibited_create_new_flow },
             SentryFlag::StreamMetrics { result: stream_metrics },
-            SentryFlag::ConnectedDevices { result: connected_devices },
+            SentryFlag::ShowConnectedDevices { result: show_connected_devices },
         ]
     });
 

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -281,10 +281,7 @@ fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
             flags.icmp_error_unreachable_prohibited_create_new_flow,
         ),
         stream_metrics: env_or("FZFF_STREAM_METRICS", flags.stream_metrics),
-        show_connected_devices: env_or(
-            "FZFF_SHOW_CONNECTED_DEVICES",
-            flags.show_connected_devices,
-        ),
+        show_connected_devices: env_or("FZFF_SHOW_CONNECTED_DEVICES", flags.show_connected_devices),
     }
 }
 

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -56,6 +56,10 @@ pub fn stream_metrics() -> bool {
     FEATURE_FLAGS.stream_metrics()
 }
 
+pub fn connected_devices() -> bool {
+    FEATURE_FLAGS.connected_devices()
+}
+
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
     if user_id.is_empty() {
         return;
@@ -172,6 +176,8 @@ struct FeatureFlagsResponse {
     icmp_error_unreachable_prohibited_create_new_flow: bool,
     #[serde(default)]
     stream_metrics: bool,
+    #[serde(default)]
+    connected_devices: bool,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
@@ -188,6 +194,7 @@ struct FeatureFlags {
     stream_logs: RwLock<LogFilter>,
     icmp_error_unreachable_prohibited_create_new_flow: AtomicBool,
     stream_metrics: AtomicBool,
+    connected_devices: AtomicBool,
 }
 
 /// Accessors to the actual feature flags.
@@ -205,6 +212,7 @@ impl FeatureFlags {
             stream_logs,
             icmp_error_unreachable_prohibited_create_new_flow,
             stream_metrics,
+            connected_devices,
         }: FeatureFlagsResponse,
         payloads: FeatureFlagPayloadsResponse,
     ) {
@@ -218,6 +226,8 @@ impl FeatureFlags {
                 Ordering::Relaxed,
             );
         self.stream_metrics.store(stream_metrics, Ordering::Relaxed);
+        self.connected_devices
+            .store(connected_devices, Ordering::Relaxed);
 
         let log_filter = if stream_logs {
             LogFilter::parse(payloads.stream_logs)
@@ -249,6 +259,10 @@ impl FeatureFlags {
     fn stream_metrics(&self) -> bool {
         self.stream_metrics.load(Ordering::Relaxed)
     }
+
+    fn connected_devices(&self) -> bool {
+        self.connected_devices.load(Ordering::Relaxed)
+    }
 }
 
 fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
@@ -267,6 +281,7 @@ fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
             flags.icmp_error_unreachable_prohibited_create_new_flow,
         ),
         stream_metrics: env_or("FZFF_STREAM_METRICS", flags.stream_metrics),
+        connected_devices: env_or("FZFF_CONNECTED_DEVICES", flags.connected_devices),
     }
 }
 
@@ -286,6 +301,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
         StreamLogs { result: bool },
         IcmpErrorUnreachableProhibitedCreateNewFlow { result: bool },
         StreamMetrics { result: bool },
+        ConnectedDevices { result: bool },
     }
 
     // Exhaustive destruction so we don't forget to update this when we add a flag.
@@ -295,6 +311,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
         stream_logs,
         icmp_error_unreachable_prohibited_create_new_flow,
         stream_metrics,
+        connected_devices,
     } = flags;
 
     let value = serde_json::json!({
@@ -306,6 +323,7 @@ fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context
             SentryFlag::StreamLogs { result: stream_logs },
             SentryFlag::IcmpErrorUnreachableProhibitedCreateNewFlow { result: icmp_error_unreachable_prohibited_create_new_flow },
             SentryFlag::StreamMetrics { result: stream_metrics },
+            SentryFlag::ConnectedDevices { result: connected_devices },
         ]
     });
 


### PR DESCRIPTION
Add a 'show-connected-devices' PostHog feature flag and check it where ClientState builds the ResourceList snapshot. When the flag is off (the default), connlib emits an empty connected_devices vec so every client UI naturally renders nothing without per-client work.