### PR TITLE
fix(gui/linux): don't canonicalise peer exe in allowlist check

### DIFF
--- a/rust/gui-client/src-tauri/src/ipc/unix/peer_check/linux.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix/peer_check/linux.rs
@@ -25,9 +25,10 @@ impl AllowedPeer {
     /// can connect to themselves.
     #[cfg(test)]
     pub fn for_current_exe() -> Self {
+        // Use the raw `/proc/self/exe` target (no canonicalisation) so it
+        // matches what `verify` reads for the peer.
         let exe = std::env::current_exe().expect("test binary must have an exe path");
-        let canonical = std::fs::canonicalize(&exe).unwrap_or(exe);
-        Self { exe: canonical }
+        Self { exe }
     }
 
     /// Verify the peer of `stream` and return the stream on accept, or an
@@ -42,8 +43,14 @@ impl AllowedPeer {
     ///      pidfd keeps the PID from being reused.
     ///   3. Resolve `/proc/<peer_pid>/exe` and reject if the kernel marks
     ///      it `(deleted)`.
-    ///   4. Canonicalise the exe path and compare against the allowlisted
-    ///      path.
+    ///   4. Compare the resolved path against the allowlisted path.
+    ///
+    /// `/proc/<pid>/exe` is already a kernel-resolved absolute path with no
+    /// symlink components, so we compare it directly rather than running it
+    /// through `std::fs::canonicalize`. Canonicalising would re-`stat` every
+    /// path component, which fails with `EACCES` when the daemon's systemd
+    /// sandbox (`ProtectHome=true`) hides a peer that lives under `/home`
+    /// (e.g. a developer build) — even though the path is correct.
     pub fn verify(&self, stream: UnixStream) -> Result<UnixStream> {
         let pidfd = match peer_pidfd(stream.as_raw_fd()) {
             Ok(fd) => fd,
@@ -71,13 +78,10 @@ impl AllowedPeer {
             );
         }
 
-        let canonical = std::fs::canonicalize(&target)
-            .with_context(|| format!("Couldn't canonicalise peer's exe `{}`", target.display()))?;
-
-        if canonical != self.exe {
+        if target != self.exe {
             bail!(
                 "Peer's executable `{}` does not match the expected GUI binary `{}`",
-                canonical.display(),
+                target.display(),
                 self.exe.display(),
             );
         }

--- a/rust/gui-client/src-tauri/src/ipc/unix/peer_check/linux.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix/peer_check/linux.rs
@@ -49,8 +49,7 @@ impl AllowedPeer {
     /// symlink components, so we compare it directly rather than running it
     /// through `std::fs::canonicalize`. Canonicalising would re-`stat` every
     /// path component, which fails with `EACCES` when the daemon's systemd
-    /// sandbox (`ProtectHome=true`) hides a peer that lives under `/home`
-    /// (e.g. a developer build) — even though the path is correct.
+    /// sandbox (`ProtectHome=true`) hides a peer that lives under `/home`.
     pub fn verify(&self, stream: UnixStream) -> Result<UnixStream> {
         let pidfd = match peer_pidfd(stream.as_raw_fd()) {
             Ok(fd) => fd,


### PR DESCRIPTION
`/proc/<pid>/exe` is already a kernel-resolved absolute path, so running it through `std::fs::canonicalize` in the SO_PEERPIDFD allowlist check was redundant. Worse, it re-`stat`s every path component, which fails with `EACCES` when the tunnel service's systemd sandbox (`ProtectHome=true`) hides a peer binary that lives under `/home`.

Anything from `/home` is not allowed to connect anyway as `/usr/bin/firezone-client-gui` is the only valid path. However, the error message hides this because we trip on the `std::fs::canonicalize` call before we can compare the path, masking the real problem.

Related: #13323