### PR TITLE
ci: grant security-events to kotlin build_release job

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -10,7 +10,6 @@ defaults:
 permissions:
   contents: "read"
   id-token: "write" # OIDC auth
-  security-events: "write" # trivy SARIF upload from setup-mise
 
 jobs:
   static-analysis:
@@ -47,6 +46,7 @@ jobs:
     permissions:
       contents: write # for uploading artifacts to the release
       id-token: write # OIDC auth
+      security-events: write # trivy SARIF upload from setup-mise
     name: build-release-${{ matrix.package-type }}
     needs: update-release-draft
     if: "${{ github.event_name == 'workflow_dispatch' }}"


### PR DESCRIPTION
Job-level permissions replace, rather than merge with, the workflow-level block, so the top-level security-events grant never reached build_release (the only job that runs setup-mise and uploads the trivy SARIF). Scope the permission to that job instead.