### PR TITLE
feat(portal): delete change_logs older than 90 days

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -320,6 +320,9 @@ if config_env() == :prod do
     # Delete expired portal sessions every 5 minutes
     {"*/5 * * * *", Portal.Workers.DeleteExpiredPortalSessions},
 
+    # Delete old change_logs every 5 minutes
+    {"*/5 * * * *", Portal.Workers.DeleteOldChangeLogs},
+
     # Sweep accounts due for deletion every minute
     {"* * * * *", Portal.Workers.SweepAccountDeletions}
   ]

--- a/elixir/lib/portal/workers/delete_old_change_logs.ex
+++ b/elixir/lib/portal/workers/delete_old_change_logs.ex
@@ -1,0 +1,36 @@
+defmodule Portal.Workers.DeleteOldChangeLogs do
+  @moduledoc """
+  Oban worker that deletes change_logs older than 90 days.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 1,
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
+
+  alias __MODULE__.Database
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_job) do
+    {count, _} = Database.delete_old_change_logs()
+
+    Logger.info("Deleted #{count} old change_logs")
+
+    :ok
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.ChangeLog
+    alias Portal.Safe
+
+    def delete_old_change_logs do
+      from(cl in ChangeLog, as: :change_logs)
+      |> where([change_logs: cl], cl.timestamp < ago(90, "day"))
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
+  end
+end

--- a/elixir/test/portal/workers/delete_old_change_logs_test.exs
+++ b/elixir/test/portal/workers/delete_old_change_logs_test.exs
@@ -1,0 +1,45 @@
+defmodule Portal.Workers.DeleteOldChangeLogsTest do
+  use Portal.DataCase, async: true
+  use Oban.Testing, repo: Portal.Repo
+
+  import Ecto.Query
+  import Portal.AccountFixtures
+  import Portal.ChangeLogFixtures
+
+  alias Portal.ChangeLog
+  alias Portal.Workers.DeleteOldChangeLogs
+
+  describe "perform/1" do
+    test "deletes change_logs older than 90 days" do
+      old = change_log_fixture(timestamp: DateTime.utc_now() |> DateTime.add(-91, :day))
+
+      assert :ok = perform_job(DeleteOldChangeLogs, %{})
+
+      refute Repo.one(from cl in ChangeLog, where: cl.lsn == ^old.lsn)
+    end
+
+    test "does not delete change_logs newer than 90 days" do
+      recent = change_log_fixture(timestamp: DateTime.utc_now() |> DateTime.add(-89, :day))
+
+      assert :ok = perform_job(DeleteOldChangeLogs, %{})
+
+      assert Repo.one(from cl in ChangeLog, where: cl.lsn == ^recent.lsn)
+    end
+
+    test "deletes old change_logs across accounts" do
+      account1 = account_fixture()
+      account2 = account_fixture()
+
+      hundred_days_ago = DateTime.utc_now() |> DateTime.add(-100, :day)
+      old1 = change_log_fixture(account: account1, timestamp: hundred_days_ago)
+      old2 = change_log_fixture(account: account2, timestamp: hundred_days_ago)
+      recent = change_log_fixture(account: account1)
+
+      assert :ok = perform_job(DeleteOldChangeLogs, %{})
+
+      refute Repo.one(from cl in ChangeLog, where: cl.lsn == ^old1.lsn)
+      refute Repo.one(from cl in ChangeLog, where: cl.lsn == ^old2.lsn)
+      assert Repo.one(from cl in ChangeLog, where: cl.lsn == ^recent.lsn)
+    end
+  end
+end

--- a/elixir/test/support/fixtures/change_log_fixtures.ex
+++ b/elixir/test/support/fixtures/change_log_fixtures.ex
@@ -1,0 +1,36 @@
+defmodule Portal.ChangeLogFixtures do
+  @moduledoc """
+  Test helpers for creating change_logs.
+  """
+
+  import Portal.AccountFixtures
+
+  alias Portal.ChangeLog
+  alias Portal.Repo
+  alias Portal.Types.EventId
+
+  def change_log_fixture(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+
+    account = Map.get(attrs, :account) || account_fixture()
+    lsn = Map.get(attrs, :lsn, System.unique_integer([:positive, :monotonic]))
+
+    row =
+      attrs
+      |> Map.drop([:account])
+      |> Map.put_new(:event_id, EventId.build_change_log(System.os_time(:microsecond), lsn))
+      |> Map.put_new(:account_id, account.id)
+      |> Map.put_new(:lsn, lsn)
+      |> Map.put_new(:timestamp, DateTime.utc_now())
+      |> Map.put_new(:table, "accounts")
+      |> Map.put_new(:op, :insert)
+      |> Map.put_new(:data, %{"id" => account.id})
+      |> Map.put_new(:old_data, nil)
+      |> Map.put_new(:subject, nil)
+      |> Map.put_new(:vsn, 0)
+
+    {1, [change_log]} = Repo.insert_all(ChangeLog, [row], returning: true)
+
+    change_log
+  end
+end


### PR DESCRIPTION
Adds a worker to delete change_logs older than 90 days. This is not account tier specific, for the following reasons:

- we may want to expose a 90-day history to all tiers to remain competitive
- we may want to support account upgrades with retroactive log history
- the cost to storage in the DB for these is minimal

--- 

Fixes: #10146 