### PR TITLE
feat(portal): add Portal.UUIDv7 module

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -2,7 +2,7 @@ name: "Setup Postgres"
 description: "Starts a Postgres container"
 inputs:
   version:
-    default: "17"
+    default: "18"
     description: "Postgres version"
     required: false
   port:

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -239,6 +239,10 @@ jobs:
         if: "!cancelled()"
         run: docker compose logs portal
 
+      - name: Show Postgres logs
+        if: "!cancelled()"
+        run: docker compose logs postgres
+
       - name: Ensure no eBPF checksum errors on relay-1
         if: "!cancelled() && steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure'"
         run: |

--- a/elixir/lib/portal/uuidv7.ex
+++ b/elixir/lib/portal/uuidv7.ex
@@ -1,0 +1,22 @@
+defmodule Portal.UUIDv7 do
+  @moduledoc """
+  Generates UUIDv7 values per RFC 9562.
+
+  Layout (128 bits):
+
+      48 bits unix_ts_ms
+       4 bits version (0b0111)
+      12 bits rand_a
+       2 bits variant (0b10)
+      62 bits rand_b
+  """
+
+  @spec generate(DateTime.t()) :: String.t()
+  def generate(%DateTime{} = datetime) do
+    ms = DateTime.to_unix(datetime, :millisecond)
+    <<rand_a::12, rand_b::62, _::6>> = :crypto.strong_rand_bytes(10)
+    raw = <<ms::48, 0b0111::4, rand_a::12, 0b10::2, rand_b::62>>
+    {:ok, uuid} = Ecto.UUID.load(raw)
+    uuid
+  end
+end

--- a/elixir/lib/portal/uuidv7.ex
+++ b/elixir/lib/portal/uuidv7.ex
@@ -11,9 +11,21 @@ defmodule Portal.UUIDv7 do
       62 bits rand_b
   """
 
+  @max_unix_ms Bitwise.bsl(1, 48) - 1
+
   @spec generate(DateTime.t()) :: String.t()
   def generate(%DateTime{} = datetime) do
-    ms = DateTime.to_unix(datetime, :millisecond)
+    datetime
+    |> DateTime.to_unix(:millisecond)
+    |> build(datetime)
+  end
+
+  defp build(ms, datetime) when ms < 0 or ms > @max_unix_ms do
+    raise ArgumentError,
+          "timestamp #{inspect(datetime)} is outside the 48-bit unix_ts_ms range supported by UUIDv7"
+  end
+
+  defp build(ms, _datetime) do
     <<rand_a::12, rand_b::62, _::6>> = :crypto.strong_rand_bytes(10)
     raw = <<ms::48, 0b0111::4, rand_a::12, 0b10::2, rand_b::62>>
     {:ok, uuid} = Ecto.UUID.load(raw)

--- a/elixir/test/portal/uuidv7_test.exs
+++ b/elixir/test/portal/uuidv7_test.exs
@@ -53,5 +53,20 @@ defmodule Portal.UUIDv7Test do
 
       assert earlier < later
     end
+
+    test "accepts the unix epoch (lower 48-bit bound)" do
+      uuid = UUIDv7.generate(DateTime.from_unix!(0, :millisecond))
+
+      {:ok, <<ms::48, _::80>>} = Ecto.UUID.dump(uuid)
+      assert ms == 0
+    end
+
+    test "raises ArgumentError for timestamps before the unix epoch" do
+      dt = DateTime.from_unix!(-1, :millisecond)
+
+      assert_raise ArgumentError, ~r/outside the 48-bit unix_ts_ms range/, fn ->
+        UUIDv7.generate(dt)
+      end
+    end
   end
 end

--- a/elixir/test/portal/uuidv7_test.exs
+++ b/elixir/test/portal/uuidv7_test.exs
@@ -1,0 +1,57 @@
+defmodule Portal.UUIDv7Test do
+  use ExUnit.Case, async: true
+
+  alias Portal.UUIDv7
+
+  describe "generate/1" do
+    test "returns a 36-character UUID string" do
+      uuid = UUIDv7.generate(~U[2026-05-26 12:00:00.123Z])
+
+      assert is_binary(uuid)
+      assert byte_size(uuid) == 36
+      assert uuid =~ ~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    end
+
+    test "sets the version field to 7" do
+      uuid = UUIDv7.generate(~U[2026-05-26 12:00:00.123Z])
+
+      {:ok, <<_::48, version::4, _::76>>} = Ecto.UUID.dump(uuid)
+      assert version == 7
+    end
+
+    test "sets the variant field to 0b10" do
+      uuid = UUIDv7.generate(~U[2026-05-26 12:00:00.123Z])
+
+      {:ok, <<_::64, variant::2, _::62>>} = Ecto.UUID.dump(uuid)
+      assert variant == 0b10
+    end
+
+    test "embeds the given timestamp at millisecond precision" do
+      dt = ~U[2026-05-26 12:00:00.123Z]
+      uuid = UUIDv7.generate(dt)
+
+      {:ok, <<ms::48, _::80>>} = Ecto.UUID.dump(uuid)
+      assert DateTime.from_unix!(ms, :millisecond) == dt
+    end
+
+    test "truncates sub-millisecond precision" do
+      dt = ~U[2026-05-26 12:00:00.123456Z]
+      uuid = UUIDv7.generate(dt)
+
+      {:ok, <<ms::48, _::80>>} = Ecto.UUID.dump(uuid)
+      assert DateTime.from_unix!(ms, :millisecond) == ~U[2026-05-26 12:00:00.123Z]
+    end
+
+    test "two calls with the same timestamp produce different UUIDs" do
+      dt = ~U[2026-05-26 12:00:00.123Z]
+      refute UUIDv7.generate(dt) == UUIDv7.generate(dt)
+    end
+
+    test "UUIDs from earlier timestamps sort before later ones" do
+      earlier = UUIDv7.generate(~U[2026-05-26 12:00:00.000Z])
+      later = UUIDv7.generate(~U[2026-05-26 12:00:01.000Z])
+
+      assert earlier < later
+    end
+  end
+end

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -6,7 +6,7 @@ services:
     command:
       ["postgres", "-c", "wal_level=logical", "-c", "max_connections=200"]
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/18/docker
     environment:
       POSTGRES_USER: ${DATABASE_USER:-postgres}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -2,7 +2,7 @@ services:
   # Dependencies
   postgres:
     # TODO: Enable pgaudit on dev instance. See https://github.com/pgaudit/pgaudit/issues/44#issuecomment-455090262
-    image: postgres:17
+    image: postgres:18
     command:
       ["postgres", "-c", "wal_level=logical", "-c", "max_connections=200"]
     volumes:


### PR DESCRIPTION
Adds a minimal `Portal.UUIDv7` module that generates UUIDv7 values per RFC 9562 from a given `DateTime`. The timestamp-embedded, sortable ids are needed for upcoming change_logs work where we want a public sort/cursor key derived from the WAL commit timestamp without exposing internal LSNs.

Split out from #13423 to keep that PR focused.