### PR TITLE
feat(portal): change_logs rest api

### DIFF
--- a/elixir/lib/portal/authentication/subject.ex
+++ b/elixir/lib/portal/authentication/subject.ex
@@ -18,4 +18,24 @@ defmodule Portal.Authentication.Subject do
             credential: nil,
             expires_at: nil,
             context: nil
+
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = subject) do
+    %{
+      actor_id: subject.actor.id,
+      actor_name: subject.actor.name,
+      actor_email: subject.actor.email,
+      actor_type: to_string(subject.actor.type),
+      auth_provider_id: subject.credential.auth_provider_id,
+      ip: format_ip(subject.context.remote_ip),
+      ip_region: subject.context.remote_ip_location_region,
+      ip_city: subject.context.remote_ip_location_city,
+      ip_lat: subject.context.remote_ip_location_lat,
+      ip_lon: subject.context.remote_ip_location_lon,
+      user_agent: subject.context.user_agent
+    }
+  end
+
+  defp format_ip(nil), do: nil
+  defp format_ip(ip), do: to_string(:inet.ntoa(ip))
 end

--- a/elixir/lib/portal/repo/list.ex
+++ b/elixir/lib/portal/repo/list.ex
@@ -11,7 +11,7 @@ defmodule Portal.Repo.List do
 
     with {:ok, paginator_opts} <- Paginator.init(query_module, order_by, paginator_opts),
          {:ok, queryable} <- Filter.filter(queryable, query_module, filter) do
-      count = repo.aggregate(queryable, :count, :id)
+      count = repo.aggregate(queryable, :count)
 
       {results, metadata} =
         queryable

--- a/elixir/lib/portal/repo/offset_list.ex
+++ b/elixir/lib/portal/repo/offset_list.ex
@@ -11,7 +11,7 @@ defmodule Portal.Repo.OffsetList do
 
     with {:ok, paginator_opts} <- OffsetPaginator.init(query_module, order_by, paginator_opts),
          {:ok, queryable} <- Filter.filter(queryable, query_module, filter) do
-      count = repo.aggregate(queryable, :count, :id)
+      count = repo.aggregate(queryable, :count)
 
       {results, metadata} =
         queryable

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -926,25 +926,15 @@ defmodule Portal.Safe do
   def permit(_action, Portal.Membership, :api_client), do: :ok
   def permit(:read, Portal.Membership, _), do: :ok
 
+  # ChangeLog permissions
+  def permit(:read, Portal.ChangeLog, :account_admin_user), do: :ok
+  def permit(:read, Portal.ChangeLog, :api_client), do: :ok
+
   def permit(_action, _struct, _type), do: {:error, :unauthorized}
 
   # Helper function to emit subject information to the replication stream
   defp emit_subject_message(%Subject{} = subject) do
-    subject_info = %{
-      "ip" => to_string(:inet.ntoa(subject.context.remote_ip)),
-      "ip_region" => subject.context.remote_ip_location_region,
-      "ip_city" => subject.context.remote_ip_location_city,
-      "ip_lat" => subject.context.remote_ip_location_lat,
-      "ip_lon" => subject.context.remote_ip_location_lon,
-      "user_agent" => subject.context.user_agent,
-      "actor_name" => subject.actor.name,
-      "actor_type" => to_string(subject.actor.type),
-      "actor_email" => subject.actor.email,
-      "actor_id" => subject.actor.id,
-      "auth_provider_id" => subject.credential.auth_provider_id
-    }
-
-    message = JSON.encode!(subject_info)
+    message = subject |> Subject.to_map() |> JSON.encode!()
     Repo.query!("SELECT pg_logical_emit_message(true, 'subject', $1)", [message])
   end
 end

--- a/elixir/lib/portal/types/event_id.ex
+++ b/elixir/lib/portal/types/event_id.ex
@@ -37,6 +37,29 @@ defmodule Portal.Types.EventId do
   def load(_), do: :error
 
   @doc """
+  Validate and normalize the canonical public representation: a 24-char
+  hexadecimal string. Returns the lowercased form, or `:error` for anything
+  that is not exactly 24 hex characters.
+
+  Stricter than `cast/1`, which accepts any 24-char binary without checking
+  that it is hex and also accepts the 12-byte on-disk form. Use this to
+  validate untrusted input such as path parameters.
+  """
+  def parse(<<_::binary-size(24)>> = hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, _} -> {:ok, String.downcase(hex)}
+      :error -> :error
+    end
+  end
+
+  def parse(_), do: :error
+
+  @doc """
+  Returns `true` if the value is a valid 24-char hex public representation.
+  """
+  def valid?(value), do: match?({:ok, _}, parse(value))
+
+  @doc """
   Build a change_log event_id from seq_start (52 bits) and tenant_offset (40 bits).
 
   Returns the canonical 24-char lowercase hex string. Raises FunctionClauseError

--- a/elixir/lib/portal_api/controllers/change_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/change_log_controller.ex
@@ -102,12 +102,13 @@ defmodule PortalAPI.ChangeLogController do
   operation(:show,
     summary: "Show Change Log",
     description: """
-    Fetches a single Change Log entry by its `id`.
+    Fetches a single Change Log entry by its `event_id`.
     """,
     parameters: [
-      id: [
+      event_id: [
         in: :path,
-        description: "Identifier of the Change Log entry.",
+        description:
+          "Identifier of the Change Log entry. A 24-character lowercase hexadecimal string.",
         type: :string,
         example: "c00060db0c2c8eb400000000"
       ]
@@ -118,8 +119,8 @@ defmodule PortalAPI.ChangeLogController do
   )
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, %{"id" => id}) do
-    with {:ok, event_id} <- parse_event_id(id),
+  def show(conn, %{"event_id" => event_id}) do
+    with {:ok, event_id} <- parse_event_id(event_id),
          {:ok, change_log} <- Database.fetch_change_log(event_id, conn.assigns.subject) do
       render(conn, :show, change_log: change_log)
     else
@@ -185,15 +186,15 @@ defmodule PortalAPI.ChangeLogController do
     {:error, :bad_request, reason: "`#{name}` must be a string"}
   end
 
-  defp parse_event_id(<<_::binary-size(24)>> = id) do
-    case Base.decode16(id, case: :mixed) do
-      {:ok, _} -> {:ok, String.downcase(id)}
-      :error -> {:error, :bad_request, reason: "`id` must be a 24-char hex string"}
+  defp parse_event_id(<<_::binary-size(24)>> = event_id) do
+    case Base.decode16(event_id, case: :mixed) do
+      {:ok, _} -> {:ok, String.downcase(event_id)}
+      :error -> {:error, :bad_request, reason: "`event_id` must be a 24-char hex string"}
     end
   end
 
   defp parse_event_id(_value),
-    do: {:error, :bad_request, reason: "`id` must be a 24-char hex string"}
+    do: {:error, :bad_request, reason: "`event_id` must be a 24-char hex string"}
 
   defp validate_window(begin_at, end_at) do
     if DateTime.compare(begin_at, end_at) in [:lt, :eq] do

--- a/elixir/lib/portal_api/controllers/change_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/change_log_controller.ex
@@ -3,6 +3,7 @@ defmodule PortalAPI.ChangeLogController do
   use OpenApiSpex.ControllerSpecs
   alias PortalAPI.Pagination
   alias PortalAPI.Error
+  alias Portal.Types.EventId
   alias __MODULE__.Database
 
   # Default window when `begin` is omitted from a list request.
@@ -36,7 +37,11 @@ defmodule PortalAPI.ChangeLogController do
     parameters: [
       limit: [
         in: :query,
-        description: "Maximum number of Change Logs to return.",
+        description: """
+        Maximum number of Change Logs to return per page. Defaults to 50.
+        Values greater than 100 are capped to 100, and values less than 1
+        are raised to 1.
+        """,
         type: :integer,
         example: 50
       ],
@@ -186,15 +191,12 @@ defmodule PortalAPI.ChangeLogController do
     {:error, :bad_request, reason: "`#{name}` must be a string"}
   end
 
-  defp parse_event_id(<<_::binary-size(24)>> = event_id) do
-    case Base.decode16(event_id, case: :mixed) do
-      {:ok, _} -> {:ok, String.downcase(event_id)}
+  defp parse_event_id(value) do
+    case EventId.parse(value) do
+      {:ok, event_id} -> {:ok, event_id}
       :error -> {:error, :bad_request, reason: "`event_id` must be a 24-char hex string"}
     end
   end
-
-  defp parse_event_id(_value),
-    do: {:error, :bad_request, reason: "`event_id` must be a 24-char hex string"}
 
   defp validate_window(begin_at, end_at) do
     if DateTime.compare(begin_at, end_at) in [:lt, :eq] do

--- a/elixir/lib/portal_api/controllers/change_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/change_log_controller.ex
@@ -1,0 +1,281 @@
+defmodule PortalAPI.ChangeLogController do
+  use PortalAPI, :controller
+  use OpenApiSpex.ControllerSpecs
+  alias PortalAPI.Pagination
+  alias PortalAPI.Error
+  alias __MODULE__.Database
+
+  # Default window when `begin` is omitted from a list request.
+  @default_window_days 90
+
+  tags(["Change Logs"])
+
+  operation(:index,
+    summary: "List Change Logs",
+    description: """
+    Lists audit Change Log entries for the authenticated account.
+
+    Each entry records a single insert, update, or delete event against an
+    account-scoped object. Entries are returned in `event_id` order with
+    the most recent change first.
+
+    The `begin` and `end` query parameters bound the window in which to
+    look up Change Logs by their `timestamp`. Both must be RFC 3339 (ISO
+    8601) timestamps, for example `2026-05-26T00:00:00Z`; values with a
+    non-UTC offset are accepted and converted to UTC. When omitted,
+    `begin` defaults to 90 days before the current time and `end`
+    defaults to the current time. `begin` must be less than or equal to
+    `end`.
+
+    Results can be further narrowed by `actor_id` or `actor_email`, which
+    match against the corresponding fields on the entry's `subject`.
+
+    Use the `next_page` cursor returned in `metadata` to fetch the
+    following page of results.
+    """,
+    parameters: [
+      limit: [
+        in: :query,
+        description: "Maximum number of Change Logs to return.",
+        type: :integer,
+        example: 50
+      ],
+      page_cursor: [
+        in: :query,
+        description: "Next/Prev page cursor returned by a previous request.",
+        type: :string
+      ],
+      begin: [
+        in: :query,
+        description: """
+        Inclusive lower bound on `timestamp`. RFC 3339 timestamp; non-UTC
+        offsets are accepted and converted to UTC. Defaults to 90 days
+        before the current time when omitted.
+        """,
+        type: :string,
+        example: "2026-02-25T00:00:00Z"
+      ],
+      end: [
+        in: :query,
+        description: """
+        Inclusive upper bound on `timestamp`. RFC 3339 timestamp; non-UTC
+        offsets are accepted and converted to UTC. Defaults to the current
+        time when omitted.
+        """,
+        type: :string,
+        example: "2026-05-26T00:00:00Z"
+      ],
+      actor_id: [
+        in: :query,
+        description: "Filter to entries whose `subject.actor_id` matches.",
+        type: :string,
+        example: "84e7f82f-831a-4a9d-8f17-c66c2bb6e205"
+      ],
+      actor_email: [
+        in: :query,
+        description: "Filter to entries whose `subject.actor_email` matches.",
+        type: :string,
+        example: "admin@example.com"
+      ]
+    ],
+    responses: [
+      ok: {"Change Logs Response", "application/json", PortalAPI.Schemas.ChangeLog.ListResponse}
+    ]
+  )
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, params) do
+    pagination_opts = Pagination.params_to_list_opts(params)
+
+    with {:ok, filters} <- coerce_filters(params),
+         {:ok, change_logs, metadata} <-
+           Database.list_change_logs(
+             conn.assigns.subject,
+             Keyword.put(pagination_opts, :filter, filters)
+           ) do
+      render(conn, :index, change_logs: change_logs, metadata: metadata)
+    else
+      error -> Error.handle(conn, error)
+    end
+  end
+
+  operation(:show,
+    summary: "Show Change Log",
+    description: """
+    Fetches a single Change Log entry by its `id`.
+    """,
+    parameters: [
+      id: [
+        in: :path,
+        description: "Identifier of the Change Log entry.",
+        type: :string,
+        example: "c00060db0c2c8eb400000000"
+      ]
+    ],
+    responses: [
+      ok: {"Change Log Response", "application/json", PortalAPI.Schemas.ChangeLog.Response}
+    ]
+  )
+
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def show(conn, %{"id" => id}) do
+    with {:ok, event_id} <- parse_event_id(id),
+         {:ok, change_log} <- Database.fetch_change_log(event_id, conn.assigns.subject) do
+      render(conn, :show, change_log: change_log)
+    else
+      error -> Error.handle(conn, error)
+    end
+  end
+
+  defp coerce_filters(params) do
+    now = DateTime.utc_now()
+    default_begin = DateTime.add(now, -@default_window_days * 24 * 60 * 60, :second)
+
+    with {:ok, begin_at} <- parse_timestamp(params["begin"], "begin", default_begin),
+         {:ok, end_at} <- parse_timestamp(params["end"], "end", now),
+         :ok <- validate_window(begin_at, end_at),
+         {:ok, actor_id} <- parse_uuid(params["actor_id"], "actor_id"),
+         {:ok, actor_email} <- parse_string(params["actor_email"], "actor_email") do
+      filters =
+        [begin: begin_at, end: end_at]
+        |> maybe_append(:actor_id, actor_id)
+        |> maybe_append(:actor_email, actor_email)
+
+      {:ok, filters}
+    end
+  end
+
+  defp parse_timestamp(nil, _name, default), do: {:ok, default}
+  defp parse_timestamp("", _name, default), do: {:ok, default}
+
+  defp parse_timestamp(value, name, _default) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} ->
+        {:ok, dt}
+
+      {:error, _reason} ->
+        {:error, :bad_request,
+         reason: "`#{name}` must be an RFC 3339 timestamp (e.g. `2026-05-26T00:00:00Z`)"}
+    end
+  end
+
+  defp parse_timestamp(_value, name, _default) do
+    {:error, :bad_request, reason: "`#{name}` must be a string"}
+  end
+
+  defp parse_uuid(nil, _name), do: {:ok, nil}
+  defp parse_uuid("", _name), do: {:ok, nil}
+
+  defp parse_uuid(value, name) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, :bad_request, reason: "`#{name}` must be a UUID"}
+    end
+  end
+
+  defp parse_uuid(_value, name) do
+    {:error, :bad_request, reason: "`#{name}` must be a string"}
+  end
+
+  defp parse_string(nil, _name), do: {:ok, nil}
+  defp parse_string("", _name), do: {:ok, nil}
+  defp parse_string(value, _name) when is_binary(value), do: {:ok, value}
+
+  defp parse_string(_value, name) do
+    {:error, :bad_request, reason: "`#{name}` must be a string"}
+  end
+
+  defp parse_event_id(<<_::binary-size(24)>> = id) do
+    case Base.decode16(id, case: :mixed) do
+      {:ok, _} -> {:ok, String.downcase(id)}
+      :error -> {:error, :bad_request, reason: "`id` must be a 24-char hex string"}
+    end
+  end
+
+  defp parse_event_id(_value),
+    do: {:error, :bad_request, reason: "`id` must be a 24-char hex string"}
+
+  defp validate_window(begin_at, end_at) do
+    if DateTime.compare(begin_at, end_at) in [:lt, :eq] do
+      :ok
+    else
+      {:error, :bad_request, reason: "`begin` must be less than or equal to `end`"}
+    end
+  end
+
+  defp maybe_append(filters, _name, nil), do: filters
+  defp maybe_append(filters, name, value), do: filters ++ [{name, value}]
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.ChangeLog
+    alias Portal.Safe
+
+    def list_change_logs(subject, opts \\ []) do
+      from(cl in ChangeLog, as: :change_logs)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.list(__MODULE__, opts)
+    end
+
+    def cursor_fields do
+      [{:change_logs, :desc, :event_id}]
+    end
+
+    def filters do
+      [
+        %Portal.Repo.Filter{
+          name: :begin,
+          type: :datetime,
+          fun: &filter_by_begin/2
+        },
+        %Portal.Repo.Filter{
+          name: :end,
+          type: :datetime,
+          fun: &filter_by_end/2
+        },
+        %Portal.Repo.Filter{
+          name: :actor_id,
+          type: {:string, :uuid},
+          fun: &filter_by_actor_id/2
+        },
+        %Portal.Repo.Filter{
+          name: :actor_email,
+          type: {:string, :email},
+          fun: &filter_by_actor_email/2
+        }
+      ]
+    end
+
+    def fetch_change_log(event_id, subject) do
+      result =
+        from(cl in ChangeLog, as: :change_logs)
+        |> where([change_logs: cl], cl.event_id == ^event_id)
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one()
+
+      case result do
+        nil -> {:error, :not_found}
+        {:error, :unauthorized} -> {:error, :unauthorized}
+        change_log -> {:ok, change_log}
+      end
+    end
+
+    defp filter_by_begin(queryable, %DateTime{} = begin_at) do
+      {queryable, dynamic([change_logs: cl], cl.timestamp >= ^begin_at)}
+    end
+
+    defp filter_by_end(queryable, %DateTime{} = end_at) do
+      {queryable, dynamic([change_logs: cl], cl.timestamp <= ^end_at)}
+    end
+
+    defp filter_by_actor_id(queryable, actor_id) do
+      {queryable,
+       dynamic([change_logs: cl], fragment("?->>'actor_id' = ?", cl.subject, ^actor_id))}
+    end
+
+    defp filter_by_actor_email(queryable, actor_email) do
+      {queryable,
+       dynamic([change_logs: cl], fragment("?->>'actor_email' = ?", cl.subject, ^actor_email))}
+    end
+  end
+end

--- a/elixir/lib/portal_api/controllers/change_log_json.ex
+++ b/elixir/lib/portal_api/controllers/change_log_json.ex
@@ -1,0 +1,27 @@
+defmodule PortalAPI.ChangeLogJSON do
+  alias PortalAPI.Pagination
+  alias Portal.ChangeLog
+
+  def index(%{change_logs: change_logs, metadata: metadata}) do
+    %{
+      data: Enum.map(change_logs, &data/1),
+      metadata: Pagination.metadata(metadata)
+    }
+  end
+
+  def show(%{change_log: change_log}) do
+    %{data: data(change_log)}
+  end
+
+  defp data(%ChangeLog{} = change_log) do
+    %{
+      id: change_log.event_id,
+      timestamp: change_log.timestamp,
+      kind: change_log.table,
+      op: change_log.op,
+      old_data: change_log.old_data,
+      data: change_log.data,
+      subject: change_log.subject
+    }
+  end
+end

--- a/elixir/lib/portal_api/controllers/change_log_json.ex
+++ b/elixir/lib/portal_api/controllers/change_log_json.ex
@@ -15,7 +15,7 @@ defmodule PortalAPI.ChangeLogJSON do
 
   defp data(%ChangeLog{} = change_log) do
     %{
-      id: change_log.event_id,
+      event_id: change_log.event_id,
       timestamp: change_log.timestamp,
       kind: change_log.table,
       op: change_log.op,

--- a/elixir/lib/portal_api/gateway/views/subject.ex
+++ b/elixir/lib/portal_api/gateway/views/subject.ex
@@ -2,11 +2,6 @@ defmodule PortalAPI.Gateway.Views.Subject do
   alias Portal.Authentication
 
   def render(%Authentication.Subject{} = subject) do
-    %{
-      auth_provider_id: subject.credential.auth_provider_id,
-      actor_id: subject.actor.id,
-      actor_email: subject.actor.email,
-      actor_name: subject.actor.name
-    }
+    Authentication.Subject.to_map(subject)
   end
 end

--- a/elixir/lib/portal_api/plugs/validate_uuid_params.ex
+++ b/elixir/lib/portal_api/plugs/validate_uuid_params.ex
@@ -7,7 +7,7 @@ defmodule PortalAPI.Plugs.ValidateUUIDParams do
     invalid? =
       conn.path_params
       |> Enum.filter(fn {key, _} -> key == "id" or String.ends_with?(key, "_id") end)
-      |> Enum.any?(fn {_, value} -> Ecto.UUID.cast(value) == :error end)
+      |> Enum.any?(fn {_, value} -> not valid_id?(value) end)
 
     if invalid? do
       conn
@@ -19,4 +19,19 @@ defmodule PortalAPI.Plugs.ValidateUUIDParams do
       conn
     end
   end
+
+  defp valid_id?(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, _} -> true
+      :error -> event_id?(value)
+    end
+  end
+
+  defp valid_id?(_), do: false
+
+  defp event_id?(<<_::binary-size(24)>> = value) do
+    match?({:ok, _}, Base.decode16(value, case: :mixed))
+  end
+
+  defp event_id?(_), do: false
 end

--- a/elixir/lib/portal_api/plugs/validate_uuid_params.ex
+++ b/elixir/lib/portal_api/plugs/validate_uuid_params.ex
@@ -1,6 +1,8 @@
 defmodule PortalAPI.Plugs.ValidateUUIDParams do
   import Plug.Conn
 
+  alias Portal.Types.EventId
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
@@ -23,15 +25,9 @@ defmodule PortalAPI.Plugs.ValidateUUIDParams do
   defp valid_id?(value) when is_binary(value) do
     case Ecto.UUID.cast(value) do
       {:ok, _} -> true
-      :error -> event_id?(value)
+      :error -> EventId.valid?(value)
     end
   end
 
   defp valid_id?(_), do: false
-
-  defp event_id?(<<_::binary-size(24)>> = value) do
-    match?({:ok, _}, Base.decode16(value, case: :mixed))
-  end
-
-  defp event_id?(_), do: false
 end

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -64,7 +64,7 @@ defmodule PortalAPI.Router do
     resources "/gateway_sessions", GatewaySessionController, only: [:index, :show]
 
     get "/change_logs", ChangeLogController, :index
-    get "/change_logs/:id", ChangeLogController, :show
+    get "/change_logs/:event_id", ChangeLogController, :show
 
     resources "/resources", ResourceController, except: [:new, :edit]
     resources "/policies", PolicyController, except: [:new, :edit]

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -63,6 +63,9 @@ defmodule PortalAPI.Router do
     resources "/client_sessions", ClientSessionController, only: [:index, :show]
     resources "/gateway_sessions", GatewaySessionController, only: [:index, :show]
 
+    get "/change_logs", ChangeLogController, :index
+    get "/change_logs/:id", ChangeLogController, :show
+
     resources "/resources", ResourceController, except: [:new, :edit]
     resources "/policies", PolicyController, except: [:new, :edit]
 

--- a/elixir/lib/portal_api/schemas/change_log_schema.ex
+++ b/elixir/lib/portal_api/schemas/change_log_schema.ex
@@ -1,0 +1,153 @@
+defmodule PortalAPI.Schemas.ChangeLog do
+  defmodule GetSchema do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+    alias PortalAPI.Schemas
+
+    OpenApiSpex.schema(%{
+      title: "ChangeLog",
+      description: """
+      A single entry from the account audit log.
+
+      Each entry records one create, update, or delete event against an
+      account-scoped object. Entries are returned in time-based order with
+      the most recent change first.
+      """,
+      type: :object,
+      properties: %{
+        id: %Schema{
+          type: :string,
+          description: """
+          Opaque identifier for the audit log entry. Lexicographically sortable
+          within an account and aligned with the order changes were committed.
+          """,
+          example: "c00060db0c2c8eb400000000"
+        },
+        timestamp: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "RFC 3339 timestamp identifying when the change was committed."
+        },
+        kind: %Schema{
+          type: :string,
+          description: "The kind of object that was changed.",
+          example: "actors"
+        },
+        op: %Schema{
+          type: :string,
+          enum: ["insert", "update", "delete"],
+          description: "The kind of change that was applied."
+        },
+        old_data: %Schema{
+          type: :object,
+          nullable: true,
+          description: """
+          The state of the object before the change. `null` for `insert`
+          events. Sensitive fields such as tokens, secrets, and password
+          hashes are replaced with the literal string `"[redacted]"`.
+          """,
+          additionalProperties: true
+        },
+        data: %Schema{
+          type: :object,
+          nullable: true,
+          description: """
+          The state of the object after the change. `null` for `delete`
+          events. Sensitive fields such as tokens, secrets, and password
+          hashes are replaced with the literal string `"[redacted]"`.
+          """,
+          additionalProperties: true
+        },
+        subject: Schemas.Subject
+      },
+      required: [:id, :timestamp, :kind, :op],
+      example: %{
+        "id" => "c00060db0c2c8eb400000000",
+        "timestamp" => "2026-05-26T12:34:56.789Z",
+        "kind" => "actors",
+        "op" => "update",
+        "old_data" => %{
+          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "name" => "Jane Doe",
+          "email" => "jane@example.com"
+        },
+        "data" => %{
+          "id" => "42a7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "name" => "Jane Smith",
+          "email" => "jane.smith@example.com"
+        },
+        "subject" => %{
+          "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+          "actor_name" => "Admin User",
+          "actor_email" => "admin@example.com",
+          "actor_type" => "account_admin_user",
+          "auth_provider_id" => "98776234-1234-5678-9012-345678901234",
+          "ip" => "1.2.3.4",
+          "ip_region" => "California",
+          "ip_city" => "San Francisco",
+          "ip_lat" => 37.7749,
+          "ip_lon" => -122.4194,
+          "user_agent" => "Mozilla/5.0"
+        }
+      }
+    })
+  end
+
+  defmodule Response do
+    require OpenApiSpex
+    alias PortalAPI.Schemas.ChangeLog
+
+    OpenApiSpex.schema(%{
+      title: "ChangeLogResponse",
+      description: "Response schema for a single Change Log entry.",
+      type: :object,
+      properties: %{
+        data: ChangeLog.GetSchema
+      }
+    })
+  end
+
+  defmodule ListResponse do
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+    alias PortalAPI.Schemas.ChangeLog
+
+    OpenApiSpex.schema(%{
+      title: "ChangeLogsResponse",
+      description: """
+      Response schema for a page of Change Log entries.
+
+      Entries are returned in `event_id` order with the most recent change
+      first. Use the `metadata.next_page` cursor to fetch the following page.
+      """,
+      type: :object,
+      properties: %{
+        data: %Schema{
+          description: "Change log entries for the requested window.",
+          type: :array,
+          items: ChangeLog.GetSchema
+        },
+        metadata: %Schema{description: "Pagination metadata", type: :object}
+      },
+      example: %{
+        "data" => [
+          %{
+            "id" => "c00060db0c2c8eb400000000",
+            "timestamp" => "2026-05-26T12:34:56.789Z",
+            "kind" => "actors",
+            "op" => "update",
+            "old_data" => %{"name" => "Jane Doe"},
+            "data" => %{"name" => "Jane Smith"},
+            "subject" => nil
+          }
+        ],
+        "metadata" => %{
+          "count" => 1,
+          "limit" => 50,
+          "next_page" => nil,
+          "prev_page" => nil
+        }
+      }
+    })
+  end
+end

--- a/elixir/lib/portal_api/schemas/change_log_schema.ex
+++ b/elixir/lib/portal_api/schemas/change_log_schema.ex
@@ -15,11 +15,12 @@ defmodule PortalAPI.Schemas.ChangeLog do
       """,
       type: :object,
       properties: %{
-        id: %Schema{
+        event_id: %Schema{
           type: :string,
           description: """
-          Opaque identifier for the audit log entry. Lexicographically sortable
-          within an account and aligned with the order changes were committed.
+          Opaque identifier for the audit log entry. A 24-character lowercase
+          hexadecimal string, lexicographically sortable within an account and
+          aligned with the order changes were committed.
           """,
           example: "c00060db0c2c8eb400000000"
         },
@@ -60,9 +61,9 @@ defmodule PortalAPI.Schemas.ChangeLog do
         },
         subject: Schemas.Subject
       },
-      required: [:id, :timestamp, :kind, :op],
+      required: [:event_id, :timestamp, :kind, :op],
       example: %{
-        "id" => "c00060db0c2c8eb400000000",
+        "event_id" => "c00060db0c2c8eb400000000",
         "timestamp" => "2026-05-26T12:34:56.789Z",
         "kind" => "actors",
         "op" => "update",
@@ -132,7 +133,7 @@ defmodule PortalAPI.Schemas.ChangeLog do
       example: %{
         "data" => [
           %{
-            "id" => "c00060db0c2c8eb400000000",
+            "event_id" => "c00060db0c2c8eb400000000",
             "timestamp" => "2026-05-26T12:34:56.789Z",
             "kind" => "actors",
             "op" => "update",

--- a/elixir/lib/portal_api/schemas/change_log_schema.ex
+++ b/elixir/lib/portal_api/schemas/change_log_schema.ex
@@ -119,7 +119,8 @@ defmodule PortalAPI.Schemas.ChangeLog do
       Response schema for a page of Change Log entries.
 
       Entries are returned in `event_id` order with the most recent change
-      first. Use the `metadata.next_page` cursor to fetch the following page.
+      first. Each page contains at most 100 entries (50 by default); use the
+      `metadata.next_page` cursor to fetch the following page.
       """,
       type: :object,
       properties: %{

--- a/elixir/lib/portal_api/schemas/subject_schema.ex
+++ b/elixir/lib/portal_api/schemas/subject_schema.ex
@@ -1,0 +1,87 @@
+defmodule PortalAPI.Schemas.Subject do
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "Subject",
+    description: """
+    Identifies the actor and request context that initiated an action.
+
+    Used to describe the principal behind an audit log entry, an authorized
+    flow, or any other event surfaced through the API. May be `null` when
+    the action originated outside the context of a Firezone session.
+    """,
+    type: :object,
+    nullable: true,
+    properties: %{
+      actor_id: %Schema{
+        type: :string,
+        format: :uuid,
+        description: "Identifier of the actor that initiated the action."
+      },
+      actor_name: %Schema{
+        type: :string,
+        description: "Display name of the actor."
+      },
+      actor_email: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Email address of the actor, if any."
+      },
+      actor_type: %Schema{
+        type: :string,
+        enum: ["account_user", "account_admin_user", "service_account", "api_client"],
+        description: "Type of the actor."
+      },
+      auth_provider_id: %Schema{
+        type: :string,
+        format: :uuid,
+        nullable: true,
+        description: "Identifier of the authentication provider that authenticated the actor."
+      },
+      ip: %Schema{
+        type: :string,
+        nullable: true,
+        description: "IP address the action originated from."
+      },
+      ip_region: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Geo-located region for `ip`, if known."
+      },
+      ip_city: %Schema{
+        type: :string,
+        nullable: true,
+        description: "Geo-located city for `ip`, if known."
+      },
+      ip_lat: %Schema{
+        type: :number,
+        nullable: true,
+        description: "Geo-located latitude for `ip`, if known."
+      },
+      ip_lon: %Schema{
+        type: :number,
+        nullable: true,
+        description: "Geo-located longitude for `ip`, if known."
+      },
+      user_agent: %Schema{
+        type: :string,
+        nullable: true,
+        description: "User agent of the client that initiated the action."
+      }
+    },
+    example: %{
+      "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+      "actor_name" => "Admin User",
+      "actor_email" => "admin@example.com",
+      "actor_type" => "account_admin_user",
+      "auth_provider_id" => "98776234-1234-5678-9012-345678901234",
+      "ip" => "1.2.3.4",
+      "ip_region" => "California",
+      "ip_city" => "San Francisco",
+      "ip_lat" => 37.7749,
+      "ip_lon" => -122.4194,
+      "user_agent" => "Mozilla/5.0"
+    }
+  })
+end

--- a/elixir/test/portal/types/event_id_test.exs
+++ b/elixir/test/portal/types/event_id_test.exs
@@ -148,6 +148,49 @@ defmodule Portal.Types.EventIdTest do
     end
   end
 
+  describe "parse/1" do
+    test "normalizes a valid 24-char hex string to lowercase" do
+      assert {:ok, "c00060db0c2c8eb400000000"} =
+               EventId.parse("C00060DB0C2C8EB400000000")
+    end
+
+    test "rejects a 24-char string that is not valid hex" do
+      assert :error = EventId.parse(String.duplicate("z", 24))
+    end
+
+    test "rejects the 12-byte on-disk binary form" do
+      bin = <<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+      assert :error = EventId.parse(bin)
+    end
+
+    test "rejects binaries of any other length" do
+      assert :error = EventId.parse("")
+      assert :error = EventId.parse(String.duplicate("a", 23))
+      assert :error = EventId.parse(String.duplicate("a", 25))
+    end
+
+    test "rejects nil and non-binary inputs" do
+      assert :error = EventId.parse(nil)
+      assert :error = EventId.parse(123)
+      assert :error = EventId.parse(%{})
+    end
+  end
+
+  describe "valid?/1" do
+    test "returns true for a valid 24-char hex string" do
+      assert EventId.valid?(EventId.build_change_log(1_234, 5))
+      assert EventId.valid?("C00060DB0C2C8EB400000000")
+    end
+
+    test "returns false for non-hex, wrong-length, and non-binary inputs" do
+      refute EventId.valid?(String.duplicate("z", 24))
+      refute EventId.valid?(String.duplicate("a", 23))
+      refute EventId.valid?(<<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
+      refute EventId.valid?(nil)
+      refute EventId.valid?(123)
+    end
+  end
+
   describe "round-trip" do
     test "cast → dump → load is lossless" do
       original = EventId.build_change_log(987_654_321, 17)

--- a/elixir/test/portal_api/controllers/change_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/change_log_controller_test.exs
@@ -53,7 +53,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
       assert is_nil(next_page)
       assert is_nil(prev_page)
 
-      data_ids = Enum.map(data, & &1["id"])
+      data_ids = Enum.map(data, & &1["event_id"])
       change_log_ids = Enum.map(change_logs, & &1.event_id)
       assert MapSet.equal?(MapSet.new(data_ids), MapSet.new(change_log_ids))
     end
@@ -76,7 +76,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> get(~p"/change_logs")
 
       assert %{"data" => data} = json_response(conn, 200)
-      ids = Enum.map(data, & &1["id"])
+      ids = Enum.map(data, & &1["event_id"])
 
       assert ids == [cl_newest.event_id, cl_mid.event_id, cl_older.event_id]
     end
@@ -104,8 +104,8 @@ defmodule PortalAPI.ChangeLogControllerTest do
 
       assert %{"data" => data, "metadata" => %{"count" => count}} = json_response(conn, 200)
       assert count == 1
-      assert [%{"id" => id}] = data
-      assert id == keeper.event_id
+      assert [%{"event_id" => event_id}] = data
+      assert event_id == keeper.event_id
     end
 
     test "filters by end (inclusive upper bound)", %{
@@ -129,10 +129,10 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> put_req_header("content-type", "application/json")
         |> get(~p"/change_logs", end: DateTime.to_iso8601(end_at))
 
-      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+      assert %{"data" => [%{"event_id" => event_id}], "metadata" => %{"count" => 1}} =
                json_response(conn, 200)
 
-      assert id == keeper.event_id
+      assert event_id == keeper.event_id
     end
 
     test "begin and end are inclusive on the boundary", %{
@@ -153,8 +153,8 @@ defmodule PortalAPI.ChangeLogControllerTest do
           end: DateTime.to_iso8601(ts)
         )
 
-      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
-      assert id == keeper.event_id
+      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
+      assert event_id == keeper.event_id
     end
 
     test "defaults exclude entries older than 90 days", %{
@@ -182,10 +182,10 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> put_req_header("content-type", "application/json")
         |> get(~p"/change_logs")
 
-      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+      assert %{"data" => [%{"event_id" => event_id}], "metadata" => %{"count" => 1}} =
                json_response(conn, 200)
 
-      assert id == keeper.event_id
+      assert event_id == keeper.event_id
     end
 
     test "filters by actor_id on subject", %{
@@ -216,10 +216,10 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> put_req_header("content-type", "application/json")
         |> get(~p"/change_logs", actor_id: target_actor_id)
 
-      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+      assert %{"data" => [%{"event_id" => event_id}], "metadata" => %{"count" => 1}} =
                json_response(conn, 200)
 
-      assert id == keeper.event_id
+      assert event_id == keeper.event_id
     end
 
     test "filters by actor_email on subject", %{
@@ -253,10 +253,10 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> put_req_header("content-type", "application/json")
         |> get(~p"/change_logs", actor_email: "admin@example.com")
 
-      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+      assert %{"data" => [%{"event_id" => event_id}], "metadata" => %{"count" => 1}} =
                json_response(conn, 200)
 
-      assert id == keeper.event_id
+      assert event_id == keeper.event_id
     end
 
     test "actor_id and actor_email filters combine", %{
@@ -284,10 +284,10 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> put_req_header("content-type", "application/json")
         |> get(~p"/change_logs", actor_id: actor_id, actor_email: "admin@example.com")
 
-      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+      assert %{"data" => [%{"event_id" => event_id}], "metadata" => %{"count" => 1}} =
                json_response(conn, 200)
 
-      assert id == keeper.event_id
+      assert event_id == keeper.event_id
     end
 
     test "returns 400 when begin is not a valid RFC 3339 timestamp", %{
@@ -477,7 +477,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
       assert length(page2) == 2
       refute is_nil(prev2)
 
-      seen = Enum.map(page1 ++ page2, & &1["id"])
+      seen = Enum.map(page1 ++ page2, & &1["event_id"])
 
       all_ids = Enum.map(change_logs, & &1.event_id)
       assert MapSet.subset?(MapSet.new(seen), MapSet.new(all_ids))
@@ -536,7 +536,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
       assert %{"data" => [entry]} = json_response(conn, 200)
 
       assert entry == %{
-               "id" => change_log.event_id,
+               "event_id" => change_log.event_id,
                "timestamp" => DateTime.to_iso8601(change_log.timestamp),
                "kind" => "actors",
                "op" => "update",
@@ -571,7 +571,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
         |> get(~p"/change_logs/#{change_log.event_id}")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] == change_log.event_id
+      assert data["event_id"] == change_log.event_id
       assert data["kind"] == change_log.table
       assert data["op"] == Atom.to_string(change_log.op)
       refute Map.has_key?(data, "lsn")
@@ -579,7 +579,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
       refute Map.has_key?(data, "table")
     end
 
-    test "returns 404 for non-existent id", %{conn: conn, actor: actor} do
+    test "returns 404 for non-existent event_id", %{conn: conn, actor: actor} do
       missing_id = EventId.build_change_log(1, 0)
 
       conn =
@@ -591,7 +591,7 @@ defmodule PortalAPI.ChangeLogControllerTest do
       assert json_response(conn, 404) == %{"error" => %{"reason" => "Not Found"}}
     end
 
-    test "returns 400 when id is not a valid identifier", %{conn: conn, actor: actor} do
+    test "returns 400 when event_id is not a valid identifier", %{conn: conn, actor: actor} do
       conn =
         conn
         |> authorize_conn(actor)

--- a/elixir/test/portal_api/controllers/change_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/change_log_controller_test.exs
@@ -1,0 +1,620 @@
+defmodule PortalAPI.ChangeLogControllerTest do
+  use PortalAPI.ConnCase, async: true
+
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  import Portal.ChangeLogFixtures
+
+  alias Portal.Types.EventId
+
+  setup do
+    account = account_fixture()
+    actor = api_client_fixture(account: account)
+
+    %{account: account, actor: actor}
+  end
+
+  describe "index/2" do
+    test "returns error when not authorized", %{conn: conn} do
+      conn = get(conn, ~p"/change_logs")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "lists change logs scoped to the account", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      change_logs =
+        for _ <- 1..3,
+            do: change_log_fixture(account: account)
+
+      other_account = account_fixture()
+      _other = change_log_fixture(account: other_account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs")
+
+      assert %{
+               "data" => data,
+               "metadata" => %{
+                 "count" => count,
+                 "limit" => limit,
+                 "next_page" => next_page,
+                 "prev_page" => prev_page
+               }
+             } = json_response(conn, 200)
+
+      assert count == 3
+      assert limit == 50
+      assert is_nil(next_page)
+      assert is_nil(prev_page)
+
+      data_ids = Enum.map(data, & &1["id"])
+      change_log_ids = Enum.map(change_logs, & &1.event_id)
+      assert MapSet.equal?(MapSet.new(data_ids), MapSet.new(change_log_ids))
+    end
+
+    test "orders most recent first", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      base = DateTime.utc_now()
+
+      cl_older = change_log_fixture(account: account, timestamp: DateTime.add(base, -60, :second))
+      cl_mid = change_log_fixture(account: account, timestamp: DateTime.add(base, -30, :second))
+      cl_newest = change_log_fixture(account: account, timestamp: base)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      ids = Enum.map(data, & &1["id"])
+
+      assert ids == [cl_newest.event_id, cl_mid.event_id, cl_older.event_id]
+    end
+
+    test "filters by begin (inclusive lower bound)", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      now = DateTime.utc_now()
+
+      _too_old =
+        change_log_fixture(account: account, timestamp: DateTime.add(now, -120, :second))
+
+      keeper =
+        change_log_fixture(account: account, timestamp: DateTime.add(now, -60, :second))
+
+      begin_at = DateTime.add(now, -90, :second)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", begin: DateTime.to_iso8601(begin_at))
+
+      assert %{"data" => data, "metadata" => %{"count" => count}} = json_response(conn, 200)
+      assert count == 1
+      assert [%{"id" => id}] = data
+      assert id == keeper.event_id
+    end
+
+    test "filters by end (inclusive upper bound)", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      now = DateTime.utc_now()
+
+      keeper =
+        change_log_fixture(account: account, timestamp: DateTime.add(now, -120, :second))
+
+      _too_new =
+        change_log_fixture(account: account, timestamp: DateTime.add(now, -10, :second))
+
+      end_at = DateTime.add(now, -60, :second)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", end: DateTime.to_iso8601(end_at))
+
+      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+               json_response(conn, 200)
+
+      assert id == keeper.event_id
+    end
+
+    test "begin and end are inclusive on the boundary", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      ts = ~U[2026-05-01 12:00:00.000000Z]
+
+      keeper = change_log_fixture(account: account, timestamp: ts)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs",
+          begin: DateTime.to_iso8601(ts),
+          end: DateTime.to_iso8601(ts)
+        )
+
+      assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
+      assert id == keeper.event_id
+    end
+
+    test "defaults exclude entries older than 90 days", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      now = DateTime.utc_now()
+
+      _too_old =
+        change_log_fixture(
+          account: account,
+          timestamp: DateTime.add(now, -91 * 24 * 60 * 60, :second)
+        )
+
+      keeper =
+        change_log_fixture(
+          account: account,
+          timestamp: DateTime.add(now, -3600, :second)
+        )
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs")
+
+      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+               json_response(conn, 200)
+
+      assert id == keeper.event_id
+    end
+
+    test "filters by actor_id on subject", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      target_actor_id = "84e7f82f-831a-4a9d-8f17-c66c2bb6e205"
+      other_actor_id = "00000000-0000-0000-0000-000000000001"
+
+      keeper =
+        change_log_fixture(
+          account: account,
+          subject: %{"actor_id" => target_actor_id, "actor_email" => "x@example.com"}
+        )
+
+      _miss =
+        change_log_fixture(
+          account: account,
+          subject: %{"actor_id" => other_actor_id, "actor_email" => "y@example.com"}
+        )
+
+      _no_subject = change_log_fixture(account: account, subject: nil)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_id: target_actor_id)
+
+      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+               json_response(conn, 200)
+
+      assert id == keeper.event_id
+    end
+
+    test "filters by actor_email on subject", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      keeper =
+        change_log_fixture(
+          account: account,
+          subject: %{
+            "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "actor_email" => "admin@example.com"
+          }
+        )
+
+      _miss =
+        change_log_fixture(
+          account: account,
+          subject: %{
+            "actor_id" => "00000000-0000-0000-0000-000000000001",
+            "actor_email" => "other@example.com"
+          }
+        )
+
+      _no_subject = change_log_fixture(account: account, subject: nil)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_email: "admin@example.com")
+
+      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+               json_response(conn, 200)
+
+      assert id == keeper.event_id
+    end
+
+    test "actor_id and actor_email filters combine", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      actor_id = "84e7f82f-831a-4a9d-8f17-c66c2bb6e205"
+
+      keeper =
+        change_log_fixture(
+          account: account,
+          subject: %{"actor_id" => actor_id, "actor_email" => "admin@example.com"}
+        )
+
+      _wrong_email =
+        change_log_fixture(
+          account: account,
+          subject: %{"actor_id" => actor_id, "actor_email" => "other@example.com"}
+        )
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_id: actor_id, actor_email: "admin@example.com")
+
+      assert %{"data" => [%{"id" => id}], "metadata" => %{"count" => 1}} =
+               json_response(conn, 200)
+
+      assert id == keeper.event_id
+    end
+
+    test "returns 400 when begin is not a valid RFC 3339 timestamp", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", begin: "not-a-date")
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`begin`"
+      assert reason =~ "RFC 3339"
+    end
+
+    test "returns 400 when end is not a valid RFC 3339 timestamp", %{
+      conn: conn,
+      actor: actor
+    } do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", end: "2026-13-99")
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`end`"
+    end
+
+    test "returns 400 when begin is after end", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs",
+          begin: "2026-05-26T00:00:00Z",
+          end: "2026-05-25T00:00:00Z"
+        )
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`begin`"
+      assert reason =~ "`end`"
+    end
+
+    test "returns 400 when actor_id is not a UUID", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_id: "not-a-uuid")
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`actor_id`"
+    end
+
+    test "accepts empty begin and end as defaults", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      _keeper = change_log_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", begin: "", end: "")
+
+      assert %{"metadata" => %{"count" => 1}} = json_response(conn, 200)
+    end
+
+    test "accepts empty actor_id and actor_email as no filter", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      _keeper =
+        change_log_fixture(
+          account: account,
+          subject: %{
+            "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "actor_email" => "admin@example.com"
+          }
+        )
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_id: "", actor_email: "")
+
+      assert %{"metadata" => %{"count" => 1}} = json_response(conn, 200)
+    end
+
+    test "returns 400 when begin is not a string", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", begin: %{"x" => "1"})
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`begin`"
+      assert reason =~ "must be a string"
+    end
+
+    test "returns 400 when actor_id is not a string", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_id: %{"x" => "1"})
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`actor_id`"
+      assert reason =~ "must be a string"
+    end
+
+    test "returns 400 when actor_email is not a string", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", actor_email: %{"x" => "1"})
+
+      assert %{"error" => %{"reason" => reason}} = json_response(conn, 400)
+      assert reason =~ "`actor_email`"
+      assert reason =~ "must be a string"
+    end
+
+    test "renders subject as null when the entry has no subject", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      _change_log = change_log_fixture(account: account, subject: nil)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs")
+
+      assert %{"data" => [entry]} = json_response(conn, 200)
+      assert Map.has_key?(entry, "subject")
+      assert entry["subject"] == nil
+    end
+
+    test "supports pagination with limit and cursor", %{
+      conn: conn,
+      actor: actor,
+      account: account
+    } do
+      base = DateTime.utc_now()
+
+      change_logs =
+        for offset <- 0..4 do
+          change_log_fixture(
+            account: account,
+            timestamp: DateTime.add(base, -offset, :second)
+          )
+        end
+
+      conn1 =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", limit: "2")
+
+      assert %{
+               "data" => page1,
+               "metadata" => %{"count" => 5, "limit" => 2, "next_page" => next, "prev_page" => nil}
+             } = json_response(conn1, 200)
+
+      assert length(page1) == 2
+      refute is_nil(next)
+
+      conn2 =
+        build_conn()
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs", limit: "2", page_cursor: next)
+
+      assert %{"data" => page2, "metadata" => %{"prev_page" => prev2}} = json_response(conn2, 200)
+      assert length(page2) == 2
+      refute is_nil(prev2)
+
+      seen = Enum.map(page1 ++ page2, & &1["id"])
+
+      all_ids = Enum.map(change_logs, & &1.event_id)
+      assert MapSet.subset?(MapSet.new(seen), MapSet.new(all_ids))
+
+      newest_four =
+        change_logs
+        |> Enum.sort_by(& &1.event_id, :desc)
+        |> Enum.take(4)
+        |> Enum.map(& &1.event_id)
+
+      assert hd(seen) in newest_four
+    end
+
+    test "does not expose internal fields", %{conn: conn, actor: actor, account: account} do
+      _change_log = change_log_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs")
+
+      assert %{"data" => [entry]} = json_response(conn, 200)
+      refute Map.has_key?(entry, "lsn")
+      refute Map.has_key?(entry, "vsn")
+      refute Map.has_key?(entry, "table")
+    end
+
+    test "renders all documented fields", %{conn: conn, actor: actor, account: account} do
+      timestamp = ~U[2026-05-01 12:00:00.000000Z]
+
+      change_log =
+        change_log_fixture(
+          account: account,
+          op: :update,
+          table: "actors",
+          old_data: %{"name" => "Before"},
+          data: %{"name" => "After"},
+          subject: %{
+            "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+            "actor_name" => "Admin",
+            "actor_email" => "admin@example.com",
+            "actor_type" => "account_admin_user",
+            "auth_provider_id" => "98776234-1234-5678-9012-345678901234",
+            "ip" => "1.2.3.4"
+          },
+          timestamp: timestamp
+        )
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs")
+
+      assert %{"data" => [entry]} = json_response(conn, 200)
+
+      assert entry == %{
+               "id" => change_log.event_id,
+               "timestamp" => DateTime.to_iso8601(change_log.timestamp),
+               "kind" => "actors",
+               "op" => "update",
+               "old_data" => %{"name" => "Before"},
+               "data" => %{"name" => "After"},
+               "subject" => %{
+                 "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
+                 "actor_name" => "Admin",
+                 "actor_email" => "admin@example.com",
+                 "actor_type" => "account_admin_user",
+                 "auth_provider_id" => "98776234-1234-5678-9012-345678901234",
+                 "ip" => "1.2.3.4"
+               }
+             }
+    end
+  end
+
+  describe "show/2" do
+    test "returns error when not authorized", %{conn: conn, account: account} do
+      change_log = change_log_fixture(account: account)
+      conn = get(conn, ~p"/change_logs/#{change_log.event_id}")
+      assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
+    end
+
+    test "returns a single change log", %{conn: conn, actor: actor, account: account} do
+      change_log = change_log_fixture(account: account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs/#{change_log.event_id}")
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert data["id"] == change_log.event_id
+      assert data["kind"] == change_log.table
+      assert data["op"] == Atom.to_string(change_log.op)
+      refute Map.has_key?(data, "lsn")
+      refute Map.has_key?(data, "vsn")
+      refute Map.has_key?(data, "table")
+    end
+
+    test "returns 404 for non-existent id", %{conn: conn, actor: actor} do
+      missing_id = EventId.build_change_log(1, 0)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs/#{missing_id}")
+
+      assert json_response(conn, 404) == %{"error" => %{"reason" => "Not Found"}}
+    end
+
+    test "returns 400 when id is not a valid identifier", %{conn: conn, actor: actor} do
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs/not-a-uuid")
+
+      assert json_response(conn, 400) == %{"error" => %{"reason" => "Bad Request"}}
+    end
+
+    test "returns 404 when the change log belongs to a different account", %{
+      conn: conn,
+      actor: actor
+    } do
+      other_account = account_fixture()
+      change_log = change_log_fixture(account: other_account)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get(~p"/change_logs/#{change_log.event_id}")
+
+      assert json_response(conn, 404) == %{"error" => %{"reason" => "Not Found"}}
+    end
+  end
+end

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -2772,12 +2772,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
                device_os_version: "14.0"
              }
 
-      assert payload.subject == %{
-               auth_provider_id: subject.credential.auth_provider_id,
-               actor_id: subject.actor.id,
-               actor_email: subject.actor.email,
-               actor_name: subject.actor.name
-             }
+      assert payload.subject == PortalAPI.Gateway.Views.Subject.render(subject)
 
       assert payload.client_ice_credentials == ice_credentials.initiator
       assert payload.gateway_ice_credentials == ice_credentials.receiver

--- a/elixir/test/portal_api/plugs/validate_uuid_params_test.exs
+++ b/elixir/test/portal_api/plugs/validate_uuid_params_test.exs
@@ -7,6 +7,7 @@ defmodule PortalAPI.Plugs.ValidateUUIDParamsTest do
   alias PortalAPI.Plugs.ValidateUUIDParams
 
   @valid_uuid "00000000-0000-0000-0000-000000000000"
+  @valid_event_id "c00060db0c2c8eb400000000"
   @opts ValidateUUIDParams.init([])
 
   defp build_conn(path_params) do
@@ -33,6 +34,19 @@ defmodule PortalAPI.Plugs.ValidateUUIDParamsTest do
       conn = build_conn(%{"id" => @valid_uuid})
       result = ValidateUUIDParams.call(conn, @opts)
       refute result.halted
+    end
+
+    test "passes through when id param is a valid 24-char hex event_id" do
+      conn = build_conn(%{"id" => @valid_event_id})
+      result = ValidateUUIDParams.call(conn, @opts)
+      refute result.halted
+    end
+
+    test "halts when id param is 24 chars but not hex" do
+      conn = build_conn(%{"id" => "zzzzzzzzzzzzzzzzzzzzzzzz"})
+      result = ValidateUUIDParams.call(conn, @opts)
+      assert result.halted
+      assert result.status == 400
     end
 
     test "passes through when all _id params are valid UUIDs" do


### PR DESCRIPTION
- Adds a new `/change_logs` endpoint with both `show` and `index` routes
- Accepts `begin, end, actor_id, actor_email` filter parameters
- Adds a new `Subject` schema and normalizes the existing message we send to receiving devices in the authorize_flow message to this schema