### PR TITLE
feat(apple): show connected devices in macOS and iOS clients

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -119,6 +119,8 @@ pub enum Resource {
 #[derive(uniffi::Record)]
 pub struct ConnectedDevice {
     pub id: String,
+    /// Tunnel IPv4 address the device is reachable on.
+    pub tunneled_ipv4: String,
     /// Names of the device-pool resources this peer is a member of
     /// (typically one, but can be multiple). Empty if unknown.
     pub pools: Vec<String>,
@@ -728,6 +730,7 @@ impl From<connlib_model::ConnectedDeviceView> for ConnectedDevice {
     fn from(device: connlib_model::ConnectedDeviceView) -> Self {
         ConnectedDevice {
             id: device.id.to_string(),
+            tunneled_ipv4: device.tunneled_ipv4.to_string(),
             pools: device.pools,
         }
     }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -115,6 +115,15 @@ pub enum Resource {
     Internet { resource: InternetResource },
 }
 
+/// A device peer that this client currently has a live connection to.
+#[derive(uniffi::Record)]
+pub struct ConnectedDevice {
+    pub id: String,
+    /// Names of the device-pool resources this peer is a member of
+    /// (typically one, but can be multiple). Empty if unknown.
+    pub pools: Vec<String>,
+}
+
 #[derive(uniffi::Enum)]
 pub enum Event {
     TunInterfaceUpdated {
@@ -127,6 +136,7 @@ pub enum Event {
     },
     ResourcesUpdated {
         resources: Vec<Resource>,
+        connected_devices: Vec<ConnectedDevice>,
     },
     AllGatewaysOffline {
         resource_id: String,
@@ -412,10 +422,22 @@ impl Session {
                     ipv6_routes,
                 })
             }
-            client_shared::Event::ResourcesUpdated(resources) => {
-                let resources = resources.resources.into_iter().map(Into::into).collect();
+            client_shared::Event::ResourcesUpdated(resource_list) => {
+                let resources = resource_list
+                    .resources
+                    .into_iter()
+                    .map(Into::into)
+                    .collect();
+                let connected_devices = resource_list
+                    .connected_devices
+                    .into_iter()
+                    .map(Into::into)
+                    .collect();
 
-                Some(Event::ResourcesUpdated { resources })
+                Some(Event::ResourcesUpdated {
+                    resources,
+                    connected_devices,
+                })
             }
             client_shared::Event::AllGatewaysOffline { resource_id } => {
                 Some(Event::AllGatewaysOffline {
@@ -698,6 +720,15 @@ impl From<connlib_model::InternetResourceView> for InternetResource {
             name: internet.name,
             sites: internet.sites.into_iter().map(Into::into).collect(),
             status: internet.status.into(),
+        }
+    }
+}
+
+impl From<connlib_model::ConnectedDeviceView> for ConnectedDevice {
+    fn from(device: connlib_model::ConnectedDeviceView) -> Self {
+        ConnectedDevice {
+            id: device.id.to_string(),
+            pools: device.pools,
         }
     }
 }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -121,8 +121,8 @@ pub struct ConnectedDevice {
     pub id: String,
     /// Tunnel IPv4 address the device is reachable on.
     pub tunneled_ipv4: String,
-    /// Names of the device-pool resources this peer is a member of
-    /// (typically one, but can be multiple). Empty if unknown.
+    /// Names of the device pools this peer belongs to, sorted (typically one,
+    /// but can be multiple).
     pub pools: Vec<String>,
 }
 

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -120,7 +120,7 @@ pub enum Resource {
 pub struct ConnectedDevice {
     pub id: String,
     /// Tunnel IPv4 address the device is reachable on.
-    pub tunneled_ipv4: String,
+    pub tun_ipv4: String,
     /// Names of the device pools this peer belongs to, sorted (typically one,
     /// but can be multiple).
     pub pools: Vec<String>,
@@ -730,7 +730,7 @@ impl From<connlib_model::ConnectedDeviceView> for ConnectedDevice {
     fn from(device: connlib_model::ConnectedDeviceView) -> Self {
         ConnectedDevice {
             id: device.id.to_string(),
-            tunneled_ipv4: device.tunneled_ipv4.to_string(),
+            tun_ipv4: device.tunneled_ipv4.to_string(),
             pools: device.pools,
         }
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Clipboard.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Clipboard.swift
@@ -6,12 +6,18 @@
 
 #if os(macOS)
   import AppKit
+#elseif os(iOS)
+  import UIKit
+#endif
 
-  enum Clipboard {
-    static func copy(_ string: String) {
+enum Clipboard {
+  static func copy(_ string: String) {
+    #if os(macOS)
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       pasteboard.setString(string, forType: .string)
-    }
+    #elseif os(iOS)
+      UIPasteboard.general.string = string
+    #endif
   }
-#endif
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Clipboard.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Clipboard.swift
@@ -1,0 +1,17 @@
+//
+//  Clipboard.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import AppKit
+
+  enum Clipboard {
+    static func copy(_ string: String) {
+      let pasteboard = NSPasteboard.general
+      pasteboard.clearContents()
+      pasteboard.setString(string, forType: .string)
+    }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
@@ -1,0 +1,21 @@
+//
+//  ConnectedDevice.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+// Models a peer device the client currently has a live connection to, shown in the UI.
+
+import Foundation
+
+public struct ConnectedDevice: Codable, Identifiable, Equatable, Sendable {
+  public let id: String
+  public let tunneledIPv4: String
+  public let pools: [String]
+
+  public init(id: String, tunneledIPv4: String, pools: [String]) {
+    self.id = id
+    self.tunneledIPv4 = tunneledIPv4
+    self.pools = pools
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
@@ -10,12 +10,12 @@ import Foundation
 
 public struct ConnectedDevice: Codable, Identifiable, Equatable, Sendable {
   public let id: String
-  public let tunneledIPv4: String
+  public let tunIPv4: String
   public let pools: [String]
 
-  public init(id: String, tunneledIPv4: String, pools: [String]) {
+  public init(id: String, tunIPv4: String, pools: [String]) {
     self.id = id
-    self.tunneledIPv4 = tunneledIPv4
+    self.tunIPv4 = tunIPv4
     self.pools = pools
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnlibState.swift
@@ -10,21 +10,25 @@ import Foundation
 public struct ConnlibState: Encodable, Decodable {
   // swiftlint:disable:next discouraged_optional_collection
   public let resources: [FirezoneKit.Resource]?
+  public let connectedDevices: [FirezoneKit.ConnectedDevice]
   public let unreachableResources: [UnreachableResource]
   public let isLogStreamingActive: Bool
 
   private enum CodingKeys: String, CodingKey {
     case resources
+    case connectedDevices
     case unreachableResources
     case isLogStreamingActive
   }
 
   private init(
     resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
+    connectedDevices: [FirezoneKit.ConnectedDevice],
     unreachableResources: [UnreachableResource],
     isLogStreamingActive: Bool
   ) {
     self.resources = resources
+    self.connectedDevices = connectedDevices
     self.unreachableResources = unreachableResources
     self.isLogStreamingActive = isLogStreamingActive
   }
@@ -32,6 +36,9 @@ public struct ConnlibState: Encodable, Decodable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     resources = try container.decodeIfPresent([FirezoneKit.Resource].self, forKey: .resources)
+    connectedDevices =
+      try container.decodeIfPresent([FirezoneKit.ConnectedDevice].self, forKey: .connectedDevices)
+      ?? []
     unreachableResources = try container.decode(
       [UnreachableResource].self, forKey: .unreachableResources)
     isLogStreamingActive =
@@ -54,6 +61,7 @@ public struct ConnlibState: Encodable, Decodable {
   /// Creates a ConnlibState from resources and returns encoded data only if different from currentHash
   /// - Parameters:
   ///   - resources: Optional array of resources
+  ///   - connectedDevices: Peer devices with a live connection
   ///   - unreachableResources: Set of unreachable resources
   ///   - isLogStreamingActive: Whether the NE has log streaming enabled
   ///   - currentHash: The hash to compare against
@@ -61,12 +69,14 @@ public struct ConnlibState: Encodable, Decodable {
   /// - Throws: If encoding fails
   public static func encodeIfChanged(
     resources: [FirezoneKit.Resource]?,  // swiftlint:disable:this discouraged_optional_collection
+    connectedDevices: [FirezoneKit.ConnectedDevice],
     unreachableResources: [UnreachableResource],
     isLogStreamingActive: Bool,
     comparedTo currentHash: Data
   ) throws -> Data? {
     let state = ConnlibState(
-      resources: resources, unreachableResources: unreachableResources,
+      resources: resources, connectedDevices: connectedDevices,
+      unreachableResources: unreachableResources,
       isLogStreamingActive: isLogStreamingActive)
     let encodedData = try Self.encoder.encode(state)
     let newHash = Data(SHA256.hash(data: encodedData))

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -616,6 +616,7 @@ public final class Store: ObservableObject {
     resourceList = ResourceList.loading
     connlibStateHash = Data()
     unreachableResources.removeAll()
+    connectedDevices.removeAll()
     Log.setStreamingActive(false)
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -19,6 +19,7 @@ public final class Store: ObservableObject {
   @Published private(set) var actorName: String
   @Published private(set) var favorites: Favorites
   @Published private(set) var resourceList: ResourceList = .loading
+  @Published private(set) var connectedDevices: [ConnectedDevice] = []
 
   // Encapsulate Tunnel status here to make it easier for other components to observe
   @Published public private(set) var vpnStatus: NEVPNStatus?
@@ -656,6 +657,8 @@ public final class Store: ObservableObject {
     if let resources = state.resources {
       resourceList = ResourceList.loaded(resources)
     }
+
+    connectedDevices = state.connectedDevices
 
     let newlyUnreachableResources = Set(state.unreachableResources).subtracting(
       self.unreachableResources)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
@@ -55,7 +55,7 @@
         Text("Tunnel IPv4")
           .foregroundStyle(.secondary)
         Button(device.tunneledIPv4) {
-          copyToClipboard(device.tunneledIPv4)
+          Clipboard.copy(device.tunneledIPv4)
         }
 
         Divider()
@@ -63,7 +63,7 @@
         Text("Client ID")
           .foregroundStyle(.secondary)
         Button(device.id) {
-          copyToClipboard(device.id)
+          Clipboard.copy(device.id)
         }
 
         if !device.pools.isEmpty {
@@ -73,17 +73,11 @@
             .foregroundStyle(.secondary)
           ForEach(device.pools, id: \.self) { pool in
             Button(pool) {
-              copyToClipboard(pool)
+              Clipboard.copy(pool)
             }
           }
         }
       }
-    }
-
-    func copyToClipboard(_ string: String) {
-      let pasteboard = NSPasteboard.general
-      pasteboard.clearContents()
-      pasteboard.setString(string, forType: .string)
     }
   }
 #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
@@ -1,0 +1,89 @@
+//
+//  ConnectedDevicesMenuSection.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+  import SwiftUI
+
+  /// Maximum number of connected devices listed inline before collapsing the rest
+  /// into an "And N more…" row. Mirrors the desktop client's tray (`MAX_DEVICES_INLINE`).
+  private let maxDevicesInline = 20
+
+  /// "Devices (N)" submenu listing the peer devices this client is connected to.
+  /// Renders nothing when there are no connected peers.
+  struct ConnectedDevicesSection: View {
+    @EnvironmentObject var store: Store
+
+    var body: some View {
+      if !store.connectedDevices.isEmpty {
+        Menu("Devices (\(store.connectedDevices.count))") {
+          let visible = store.connectedDevices.prefix(maxDevicesInline)
+          ForEach(visible) { device in
+            ConnectedDeviceMenuItem(device: device)
+          }
+
+          let hidden = store.connectedDevices.count - visible.count
+          if hidden > 0 {
+            Divider()
+            Text(hidden == 1 ? "And 1 more device…" : "And \(hidden) more devices…")
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+
+  /// A single connected device, labelled by its tunnel IPv4, with details in a submenu.
+  struct ConnectedDeviceMenuItem: View {
+    let device: ConnectedDevice
+
+    var body: some View {
+      Menu(device.tunneledIPv4) {
+        ConnectedDeviceDetailsSubmenu(device: device)
+      }
+    }
+  }
+
+  /// Copyable details for a connected device: tunnel IPv4, client ID, and pools.
+  struct ConnectedDeviceDetailsSubmenu: View {
+    let device: ConnectedDevice
+
+    var body: some View {
+      Group {
+        Text("Tunnel IPv4")
+          .foregroundStyle(.secondary)
+        Button(device.tunneledIPv4) {
+          copyToClipboard(device.tunneledIPv4)
+        }
+
+        Divider()
+
+        Text("Client ID")
+          .foregroundStyle(.secondary)
+        Button(device.id) {
+          copyToClipboard(device.id)
+        }
+
+        if !device.pools.isEmpty {
+          Divider()
+
+          Text(device.pools.count == 1 ? "Pool" : "Pools")
+            .foregroundStyle(.secondary)
+          ForEach(device.pools, id: \.self) { pool in
+            Button(pool) {
+              copyToClipboard(pool)
+            }
+          }
+        }
+      }
+    }
+
+    func copyToClipboard(_ string: String) {
+      let pasteboard = NSPasteboard.general
+      pasteboard.clearContents()
+      pasteboard.setString(string, forType: .string)
+    }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
@@ -11,14 +11,14 @@
   /// into an "And N more…" row. Mirrors the desktop client's tray (`MAX_DEVICES_INLINE`).
   private let maxDevicesInline = 20
 
-  /// "Devices (N)" submenu listing the peer devices this client is connected to.
+  /// "Connected Devices (N)" submenu listing the peer devices this client is connected to.
   /// Renders nothing when there are no connected peers.
   struct ConnectedDevicesSection: View {
     @EnvironmentObject var store: Store
 
     var body: some View {
       if !store.connectedDevices.isEmpty {
-        Menu("Devices (\(store.connectedDevices.count))") {
+        Menu("Connected Devices (\(store.connectedDevices.count))") {
           let visible = store.connectedDevices.prefix(maxDevicesInline)
           ForEach(visible) { device in
             ConnectedDeviceMenuItem(device: device)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
@@ -40,7 +40,7 @@
     let device: ConnectedDevice
 
     var body: some View {
-      Menu(device.tunneledIPv4) {
+      Menu(device.tunIPv4) {
         ConnectedDeviceDetailsSubmenu(device: device)
       }
     }
@@ -54,8 +54,8 @@
       Group {
         Text("Tunnel IPv4")
           .foregroundStyle(.secondary)
-        Button(device.tunneledIPv4) {
-          Clipboard.copy(device.tunneledIPv4)
+        Button(device.tunIPv4) {
+          Clipboard.copy(device.tunIPv4)
         }
 
         Divider()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
@@ -10,14 +10,14 @@
 #if os(iOS)
   import SwiftUI
 
-  /// "Devices (N)" section listing the peer devices this client is connected to.
+  /// "Connected Devices (N)" section listing the peer devices this client is connected to.
   /// Renders nothing when there are no connected peers.
   struct ConnectedDevicesSection: View {
     @EnvironmentObject var store: Store
 
     var body: some View {
       if !store.connectedDevices.isEmpty {
-        Section("Devices (\(store.connectedDevices.count))") {
+        Section("Connected Devices (\(store.connectedDevices.count))") {
           ForEach(store.connectedDevices) { device in
             NavigationLink {
               ConnectedDeviceView(device: device)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
@@ -22,7 +22,7 @@
             NavigationLink {
               ConnectedDeviceView(device: device)
             } label: {
-              Text(device.tunneledIPv4)
+              Text(device.tunIPv4)
             }
           }
         }
@@ -38,7 +38,7 @@
     var body: some View {
       List {
         Section(header: Text("Tunnel IPv4")) {
-          copyableRow(device.tunneledIPv4)
+          copyableRow(device.tunIPv4)
         }
 
         Section(header: Text("Client ID")) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
@@ -1,0 +1,74 @@
+//
+//  ConnectedDevicesSection.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+// iOS counterpart of the macOS menu's connected-devices submenu
+// (see ConnectedDevicesMenuSection.swift). Renders as a list section inside SessionView.
+
+#if os(iOS)
+  import SwiftUI
+
+  /// "Devices (N)" section listing the peer devices this client is connected to.
+  /// Renders nothing when there are no connected peers.
+  struct ConnectedDevicesSection: View {
+    @EnvironmentObject var store: Store
+
+    var body: some View {
+      if !store.connectedDevices.isEmpty {
+        Section("Devices (\(store.connectedDevices.count))") {
+          ForEach(store.connectedDevices) { device in
+            NavigationLink {
+              ConnectedDeviceView(device: device)
+            } label: {
+              Text(device.tunneledIPv4)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Detail screen for a connected device: tunnel IPv4, client ID, and pools,
+  /// each copyable via a long-press context menu.
+  struct ConnectedDeviceView: View {
+    let device: ConnectedDevice
+
+    var body: some View {
+      List {
+        Section(header: Text("Tunnel IPv4")) {
+          copyableRow(device.tunneledIPv4)
+        }
+
+        Section(header: Text("Client ID")) {
+          copyableRow(device.id)
+        }
+
+        if !device.pools.isEmpty {
+          Section(header: Text(device.pools.count == 1 ? "Pool" : "Pools")) {
+            ForEach(device.pools, id: \.self) { pool in
+              copyableRow(pool)
+            }
+          }
+        }
+      }
+      .listStyle(GroupedListStyle())
+      .navigationBarTitle("Details", displayMode: .inline)
+    }
+
+    @ViewBuilder
+    private func copyableRow(_ value: String) -> some View {
+      Text(value)
+        .contextMenu {
+          Button(
+            action: { Clipboard.copy(value) },
+            label: {
+              Text("Copy")
+              Image(systemName: "doc.on.doc")
+            }
+          )
+        }
+    }
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
@@ -24,6 +24,7 @@
       // Resources (only when connected and not hidden by admin)
       if store.vpnStatus == .connected && !store.configuration.publishedHideResourceList {
         ResourcesSection()
+        ConnectedDevicesSection()
         Divider()
       }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
@@ -57,7 +57,7 @@
               }
             } else {
               Button(displayAddress) {
-                copyToClipboard(displayAddress)
+                Clipboard.copy(displayAddress)
               }
             }
           }
@@ -68,12 +68,12 @@
             .foregroundStyle(.secondary)
 
           Button(resource.name) {
-            copyToClipboard(resource.name)
+            Clipboard.copy(resource.name)
           }
 
           if let address = resource.address {
             Button("Copy address") {
-              copyToClipboard(address)
+              Clipboard.copy(address)
             }
           }
 
@@ -90,11 +90,11 @@
             .foregroundStyle(.secondary)
 
           Button(site.name) {
-            copyToClipboard(site.name)
+            Clipboard.copy(site.name)
           }
 
           Button {
-            copyToClipboard(resource.status.toSiteStatus())
+            Clipboard.copy(resource.status.toSiteStatus())
           } label: {
             HStack {
               if let icon = resource.status.statusIcon {
@@ -122,12 +122,6 @@
       } else {
         store.favorites.add(resource.id)
       }
-    }
-
-    func copyToClipboard(_ string: String) {
-      let pasteboard = NSPasteboard.general
-      pasteboard.clearContents()
-      pasteboard.setString(string, forType: .string)
     }
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -9,11 +9,6 @@ import Combine
 import SwiftUI
 
 #if os(iOS)
-  private func copyToClipboard(_ value: String) {
-    let pasteboard = UIPasteboard.general
-    pasteboard.string = value
-  }
-
   struct ResourceView: View {
     @EnvironmentObject var store: Store
     var resource: Resource
@@ -40,7 +35,7 @@ import SwiftUI
             .contextMenu {
               Button(
                 action: {
-                  copyToClipboard(site.name)
+                  Clipboard.copy(site.name)
                 },
                 label: {
                   Text("Copy name")
@@ -62,7 +57,7 @@ import SwiftUI
             .contextMenu {
               Button(
                 action: {
-                  copyToClipboard(resource.status.toSiteStatus())
+                  Clipboard.copy(resource.status.toSiteStatus())
                 },
                 label: {
                   Text("Copy status")
@@ -120,7 +115,7 @@ import SwiftUI
         .contextMenu {
           Button(
             action: {
-              copyToClipboard(resource.name)
+              Clipboard.copy(resource.name)
             },
             label: {
               Text("Copy name")
@@ -148,7 +143,7 @@ import SwiftUI
                   .contextMenu {
                     Button(
                       action: {
-                        copyToClipboard(displayAddress)
+                        Clipboard.copy(displayAddress)
                       },
                       label: {
                         Text("Copy address")
@@ -163,7 +158,7 @@ import SwiftUI
               .contextMenu {
                 Button(
                   action: {
-                    copyToClipboard(displayAddress)
+                    Clipboard.copy(displayAddress)
                   },
                   label: {
                     Text("Copy address")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -37,6 +37,8 @@ import SwiftUI
                 } else {
                   ResourceSection(resources: resources)
                 }
+
+                ConnectedDevicesSection()
               }
               .listStyle(GroupedListStyle())
             }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -22,6 +22,7 @@ struct ConnlibStateTests {
     // Use encodeIfChanged with empty hash to get initial data
     let data = try ConnlibState.encodeIfChanged(
       resources: [resource],
+      connectedDevices: [],
       unreachableResources: [unreachable],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -42,6 +43,7 @@ struct ConnlibStateTests {
 
     let data1 = try ConnlibState.encodeIfChanged(
       resources: [resource],
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -49,6 +51,7 @@ struct ConnlibStateTests {
 
     let data2 = try ConnlibState.encodeIfChanged(
       resources: [resource],
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -69,6 +72,7 @@ struct ConnlibStateTests {
 
     let data1 = try ConnlibState.encodeIfChanged(
       resources: [resource1],
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -76,6 +80,7 @@ struct ConnlibStateTests {
 
     let data2 = try ConnlibState.encodeIfChanged(
       resources: [resource2],
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -99,6 +104,7 @@ struct ConnlibStateTests {
     // First encode to get the hash
     let data = try ConnlibState.encodeIfChanged(
       resources: [resource],
+      connectedDevices: [],
       unreachableResources: [unreachable],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -110,6 +116,7 @@ struct ConnlibStateTests {
     // Now try to encode again with the same hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource],
+      connectedDevices: [],
       unreachableResources: [unreachable],
       isLogStreamingActive: false,
       comparedTo: hash
@@ -126,6 +133,7 @@ struct ConnlibStateTests {
     // Get hash for first state
     let data1 = try ConnlibState.encodeIfChanged(
       resources: [resource1],
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -137,6 +145,7 @@ struct ConnlibStateTests {
     // Try to encode different state with first hash
     let result = try ConnlibState.encodeIfChanged(
       resources: [resource2],
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: hash1
@@ -154,6 +163,7 @@ struct ConnlibStateTests {
   func encodeIfChangedHandlesNilResources() throws {
     let result = try ConnlibState.encodeIfChanged(
       resources: nil,
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -173,6 +183,7 @@ struct ConnlibStateTests {
   func decodeRoundTripsLogStreamingActive() throws {
     let data = try ConnlibState.encodeIfChanged(
       resources: nil,
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: true,
       comparedTo: Data()
@@ -188,6 +199,7 @@ struct ConnlibStateTests {
   func encodeIfChangedDetectsLogStreamingChange() throws {
     let data = try ConnlibState.encodeIfChanged(
       resources: nil,
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: false,
       comparedTo: Data()
@@ -199,6 +211,7 @@ struct ConnlibStateTests {
     // Same resources, different streaming flag — should return data
     let result = try ConnlibState.encodeIfChanged(
       resources: nil,
+      connectedDevices: [],
       unreachableResources: [],
       isLogStreamingActive: true,
       comparedTo: hash

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -239,7 +239,7 @@ struct ConnlibStateTests {
 
     #expect(state.connectedDevices.count == 1)
     #expect(state.connectedDevices[0].id == "device-1")
-    #expect(state.connectedDevices[0].tunneledIPv4 == "100.64.0.1")
+    #expect(state.connectedDevices[0].tunIPv4 == "100.64.0.1")
     #expect(state.connectedDevices[0].pools == ["pool-a"])
   }
 
@@ -284,6 +284,6 @@ struct ConnlibStateTests {
   }
 
   private func makeTestConnectedDevice(id: String) -> FirezoneKit.ConnectedDevice {
-    FirezoneKit.ConnectedDevice(id: id, tunneledIPv4: "100.64.0.1", pools: ["pool-a"])
+    FirezoneKit.ConnectedDevice(id: id, tunIPv4: "100.64.0.1", pools: ["pool-a"])
   }
 }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -220,6 +220,54 @@ struct ConnlibStateTests {
     #expect(result != nil)
   }
 
+  // MARK: - connectedDevices Tests
+
+  @Test("decode() round-trips non-empty connectedDevices")
+  func decodeRoundTripsConnectedDevices() throws {
+    let device = makeTestConnectedDevice(id: "device-1")
+
+    let data = try ConnlibState.encodeIfChanged(
+      resources: nil,
+      connectedDevices: [device],
+      unreachableResources: [],
+      isLogStreamingActive: false,
+      comparedTo: Data()
+    )
+
+    let unwrapped = try #require(data)
+    let (state, _) = try ConnlibState.decode(from: unwrapped)
+
+    #expect(state.connectedDevices.count == 1)
+    #expect(state.connectedDevices[0].id == "device-1")
+    #expect(state.connectedDevices[0].tunneledIPv4 == "100.64.0.1")
+    #expect(state.connectedDevices[0].pools == ["pool-a"])
+  }
+
+  @Test("encodeIfChanged() detects connectedDevices change")
+  func encodeIfChangedDetectsConnectedDevicesChange() throws {
+    let data = try ConnlibState.encodeIfChanged(
+      resources: nil,
+      connectedDevices: [],
+      unreachableResources: [],
+      isLogStreamingActive: false,
+      comparedTo: Data()
+    )
+
+    let unwrapped = try #require(data)
+    let (_, hash) = try ConnlibState.decode(from: unwrapped)
+
+    // Only the device list differs from the encoded state — should return data.
+    let result = try ConnlibState.encodeIfChanged(
+      resources: nil,
+      connectedDevices: [makeTestConnectedDevice(id: "device-1")],
+      unreachableResources: [],
+      isLogStreamingActive: false,
+      comparedTo: hash
+    )
+
+    #expect(result != nil)
+  }
+
   // MARK: - Helper Functions
 
   private func makeTestResource(id: String, name: String) -> FirezoneKit.Resource {
@@ -233,5 +281,9 @@ struct ConnlibStateTests {
       sites: [site],
       type: .dns
     )
+  }
+
+  private func makeTestConnectedDevice(id: String) -> FirezoneKit.ConnectedDevice {
+    FirezoneKit.ConnectedDevice(id: id, tunneledIPv4: "100.64.0.1", pools: ["pool-a"])
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -118,6 +118,7 @@ actor Adapter {
 
   /// Keep track of resources for UI
   private var resources: [Resource]?  // swiftlint:disable:this discouraged_optional_collection
+  private var connectedDevices: [ConnectedDevice] = []
 
   /// Resources we couldn't connect to
   private var unreachableResources: [UnreachableResource]
@@ -305,6 +306,7 @@ actor Adapter {
     do {
       return try ConnlibState.encodeIfChanged(
         resources: self.resources?.map { self.convertResource($0) },
+        connectedDevices: self.connectedDevices.map { FirezoneKit.ConnectedDevice($0) },
         unreachableResources: self.unreachableResources,
         isLogStreamingActive: Log.isStreamingActive,
         comparedTo: hash
@@ -414,11 +416,12 @@ actor Adapter {
         }
       }
 
-    case .resourcesUpdated(let resourceList, _):
+    case .resourcesUpdated(let resourceList, let connectedDeviceList):
       Log.log("Received ResourcesUpdated event with \(resourceList.count) resources")
 
       // Store resource list (actor-isolated, no dispatch needed)
       resources = resourceList
+      connectedDevices = connectedDeviceList
 
       // Update DNS resource addresses to trigger network settings apply when they change
       // This flushes the DNS cache so new DNS resources are immediately resolvable
@@ -567,6 +570,12 @@ actor Adapter {
 extension FirezoneKit.Site {
   init(_ site: Site) {
     self.init(id: site.id, name: site.name)
+  }
+}
+
+extension FirezoneKit.ConnectedDevice {
+  init(_ device: ConnectedDevice) {
+    self.init(id: device.id, tunneledIPv4: device.tunneledIpv4, pools: device.pools)
   }
 }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -575,7 +575,7 @@ extension FirezoneKit.Site {
 
 extension FirezoneKit.ConnectedDevice {
   init(_ device: ConnectedDevice) {
-    self.init(id: device.id, tunneledIPv4: device.tunneledIpv4, pools: device.pools)
+    self.init(id: device.id, tunIPv4: device.tunIpv4, pools: device.pools)
   }
 }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -414,7 +414,7 @@ actor Adapter {
         }
       }
 
-    case .resourcesUpdated(let resourceList):
+    case .resourcesUpdated(let resourceList, _):
       Log.log("Received ResourcesUpdated event with \(resourceList.count) resources")
 
       // Store resource list (actor-isolated, no dispatch needed)

--- a/swift/apple/mise-tasks/uniffi-bindings.sh
+++ b/swift/apple/mise-tasks/uniffi-bindings.sh
@@ -31,6 +31,8 @@ rm -f "${GENERATED_DIR}"/*.modulemap
 
 if [ -f "${GENERATED_DIR}/connlib.swift" ]; then
     sed -i.bak '/#if canImport(connlibFFI)/,/#endif/s/^/\/\/ /' "${GENERATED_DIR}/connlib.swift"
+    # FIXME: remove this workaround when 0.31.1 gets upgraded
+    sed -i.bak 's/^\([[:space:]]*\)static let vtablePtr:/\1nonisolated(unsafe) static let vtablePtr:/' "${GENERATED_DIR}/connlib.swift"
     rm -f "${GENERATED_DIR}/connlib.swift.bak"
 fi
 


### PR DESCRIPTION
Surfaces the list of peer devices a client currently has a live connection to in the Apple clients, bringing them to parity with the desktop GUI client's system tray.

  The macOS menu bar gains a "Devices (N)" submenu and the iOS app gains a matching list section; each entry exposes the peer's tunnel IPv4, client ID, and device pools, all copyable. connlib already produced this data, so the change threads it through the client FFI and the Network Extension's encoded state into the UI.

Fixes #13430 

Visual representation:

https://github.com/user-attachments/assets/db3a9c4e-6f4d-4be0-936a-4e938885c7fc


https://github.com/user-attachments/assets/7cb06344-0498-460e-8c55-ab109e7335e1

