### PR TITLE
refactor(portal): send all emails with ACS

### DIFF
--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -16,7 +16,13 @@ defmodule Portal.Mailer do
     {rate_limit_interval, config} = Keyword.pop(config, :rate_limit_interval, :timer.minutes(2))
 
     RateLimiter.rate_limit(key, rate_limit, rate_limit_interval, fn ->
-      deliver(email, config)
+      # Tracking depends on the message id ACS returns and the ACS Event Grid
+      # delivery webhooks; revert by pointing the adapter env var elsewhere.
+      if effective_adapter(config) == Swoosh.Adapters.AzureCommunicationServices do
+        deliver_and_track(email, config)
+      else
+        deliver(email, config)
+      end
     end)
     |> case do
       {:ok, result} -> result
@@ -39,6 +45,22 @@ defmodule Portal.Mailer do
     metadata = %{email: email, config: config, mailer: __MODULE__}
 
     deliver_with_mailer_config(email, opts, metadata)
+  end
+
+  @doc """
+  Delivers an email synchronously and, on success, inserts a tracked row when
+  the adapter returns a message id (ACS). Used by the primary mailer call sites
+  so delivery report webhooks can update those messages too.
+  """
+  def deliver_and_track(email, config \\ []) do
+    case deliver(email, config) do
+      {:ok, result} = ok ->
+        maybe_insert_tracked(email, result)
+        ok
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   def deliver_secondary(email, config \\ []) do
@@ -151,7 +173,7 @@ defmodule Portal.Mailer do
   `{:ok, :suppressed}` if all recipients are suppressed.
   """
   def enqueue(%Email{} = email) do
-    account_id = require_account_id!(email)
+    account_id = email.private[:account_id]
     request = serialize(email)
 
     case drop_suppressed_recipients(request) do
@@ -174,11 +196,43 @@ defmodule Portal.Mailer do
     Database.insert_tracked(account_id, message_id, subject, recipients)
   end
 
-  defp require_account_id!(%Email{} = email) do
-    case email.private[:account_id] do
-      account_id when is_binary(account_id) -> account_id
-      _ -> raise ArgumentError, "call Portal.Mailer.with_account_id/2 before enqueue/1"
+  defp maybe_insert_tracked(%Email{} = email, result) do
+    with message_id when is_binary(message_id) <- result_message_id(result),
+         [_ | _] = recipients <- email_addresses(email) do
+      account_id = email.private[:account_id]
+
+      case Database.insert_tracked(account_id, message_id, email.subject, recipients) do
+        {:ok, _entry} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.error("Failed to persist tracked outbound email; email was already sent",
+            account_id: account_id,
+            message_id: message_id,
+            reason: inspect(reason)
+          )
+
+          :ok
+      end
+    else
+      _ -> :ok
     end
+  end
+
+  defp result_message_id(result) when is_map(result), do: result[:id] || result["id"]
+  defp result_message_id(_), do: nil
+
+  defp effective_adapter(config) do
+    Mailer.parse_config(:portal, __MODULE__, [], config)[:adapter]
+  end
+
+  defp email_addresses(%Email{} = email) do
+    (List.wrap(email.to) ++ List.wrap(email.cc) ++ List.wrap(email.bcc))
+    |> Enum.map(fn
+      {_, addr} -> addr
+      addr when is_binary(addr) -> addr
+    end)
+    |> Enum.uniq()
   end
 
   defp serialize(%Email{} = email) do

--- a/elixir/lib/portal/outbound_email.ex
+++ b/elixir/lib/portal/outbound_email.ex
@@ -2,13 +2,12 @@ defmodule Portal.OutboundEmail do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key false
+  @primary_key {:message_id, :string, autogenerate: false}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime_usec]
 
   schema "outbound_emails" do
-    belongs_to(:account, Portal.Account, primary_key: true)
-    field(:message_id, :string, primary_key: true)
+    belongs_to(:account, Portal.Account)
 
     has_many(:deliveries, Portal.OutboundEmailDelivery,
       references: :message_id,
@@ -25,6 +24,6 @@ defmodule Portal.OutboundEmail do
     changeset
     |> validate_required([:message_id, :subject, :recipients])
     |> assoc_constraint(:account)
-    |> unique_constraint([:account_id, :message_id], name: :outbound_emails_pkey)
+    |> unique_constraint(:message_id, name: :outbound_emails_pkey)
   end
 end

--- a/elixir/lib/portal/outbound_email_delivery.ex
+++ b/elixir/lib/portal/outbound_email_delivery.ex
@@ -12,9 +12,10 @@ defmodule Portal.OutboundEmailDelivery do
   @timestamps_opts [type: :utc_datetime_usec]
 
   schema "outbound_email_deliveries" do
-    belongs_to(:account, Portal.Account, primary_key: true)
     field(:message_id, :string, primary_key: true)
     field(:email, :string, primary_key: true)
+
+    belongs_to(:account, Portal.Account)
 
     belongs_to(:outbound_email, Portal.OutboundEmail,
       define_field: false,

--- a/elixir/priv/repo/migrations/20260527000000_make_outbound_email_account_id_optional.exs
+++ b/elixir/priv/repo/migrations/20260527000000_make_outbound_email_account_id_optional.exs
@@ -1,0 +1,66 @@
+defmodule Portal.Repo.Migrations.MakeOutboundEmailAccountIdOptional do
+  use Ecto.Migration
+
+  def up do
+    # Drop the composite FK from deliveries so we can change outbound_emails' PK.
+    execute("""
+    ALTER TABLE outbound_email_deliveries
+      DROP CONSTRAINT outbound_email_deliveries_message_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE outbound_emails
+      DROP CONSTRAINT outbound_emails_pkey,
+      DROP CONSTRAINT outbound_emails_account_id_fkey,
+      ADD CONSTRAINT outbound_emails_pkey PRIMARY KEY (message_id),
+      ALTER COLUMN account_id DROP NOT NULL,
+      ADD CONSTRAINT outbound_emails_account_id_fkey
+        FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE SET NULL
+    """)
+
+    execute("""
+    ALTER TABLE outbound_email_deliveries
+      DROP CONSTRAINT outbound_email_deliveries_account_id_fkey,
+      DROP CONSTRAINT outbound_email_deliveries_pkey,
+      ADD CONSTRAINT outbound_email_deliveries_pkey PRIMARY KEY (message_id, email),
+      ALTER COLUMN account_id DROP NOT NULL,
+      ADD CONSTRAINT outbound_email_deliveries_account_id_fkey
+        FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE SET NULL,
+      ADD CONSTRAINT outbound_email_deliveries_message_id_fkey
+        FOREIGN KEY (message_id) REFERENCES outbound_emails(message_id) ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    execute("DELETE FROM outbound_emails WHERE account_id IS NULL")
+    execute("DELETE FROM outbound_email_deliveries WHERE account_id IS NULL")
+
+    execute("""
+    ALTER TABLE outbound_email_deliveries
+      DROP CONSTRAINT outbound_email_deliveries_message_id_fkey,
+      DROP CONSTRAINT outbound_email_deliveries_account_id_fkey,
+      DROP CONSTRAINT outbound_email_deliveries_pkey,
+      ALTER COLUMN account_id SET NOT NULL,
+      ADD CONSTRAINT outbound_email_deliveries_pkey PRIMARY KEY (message_id, account_id, email),
+      ADD CONSTRAINT outbound_email_deliveries_account_id_fkey
+        FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+    """)
+
+    execute("""
+    ALTER TABLE outbound_emails
+      DROP CONSTRAINT outbound_emails_pkey,
+      DROP CONSTRAINT outbound_emails_account_id_fkey,
+      ALTER COLUMN account_id SET NOT NULL,
+      ADD CONSTRAINT outbound_emails_pkey PRIMARY KEY (account_id, message_id),
+      ADD CONSTRAINT outbound_emails_account_id_fkey
+        FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+    """)
+
+    execute("""
+    ALTER TABLE outbound_email_deliveries
+      ADD CONSTRAINT outbound_email_deliveries_message_id_fkey
+        FOREIGN KEY (message_id, account_id) REFERENCES outbound_emails(message_id, account_id)
+        ON DELETE CASCADE
+    """)
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -254,7 +254,7 @@ defmodule Portal.Repo.Seeds do
   def seed do
     # Seeds can be run both with MIX_ENV=prod and MIX_ENV=test, for test env we don't have
     # an adapter configured and creation of email provider will fail, so we will override it here.
-    System.put_env("OUTBOUND_EMAIL_ADAPTER", "Elixir.Swoosh.Adapters.Mailgun")
+    System.put_env("OUTBOUND_EMAIL_ADAPTER", "Elixir.Swoosh.Adapters.AzureCommunicationServices")
 
     # Ensure seeds are deterministic
     :rand.seed(:exsss, {1, 2, 3})

--- a/elixir/test/portal/mailer_test.exs
+++ b/elixir/test/portal/mailer_test.exs
@@ -102,7 +102,7 @@ defmodule Portal.MailerTest do
   end
 
   describe "enqueue/1" do
-    test "raises when account_id is missing" do
+    test "enqueues with a nil account_id when not set" do
       email =
         Swoosh.Email.new()
         |> Swoosh.Email.to({"", "recipient@example.com"})
@@ -110,9 +110,8 @@ defmodule Portal.MailerTest do
         |> Swoosh.Email.subject("Missing Account")
         |> Swoosh.Email.text_body("body")
 
-      assert_raise ArgumentError, ~r/with_account_id\/2/, fn ->
-        enqueue(email)
-      end
+      assert {:ok, job} = enqueue(email)
+      assert job.args["account_id"] == nil
     end
 
     test "enqueues an Oban job without delivering" do
@@ -321,6 +320,98 @@ defmodule Portal.MailerTest do
 
       assert {:ok, %{}} = deliver(email)
       assert_email_sent(subject: "Bypass")
+    end
+  end
+
+  describe "deliver_and_track/2" do
+    test "inserts a tracked row when ACS returns a message id, with nil account_id" do
+      adapter_plugin = replace_req_adapter_plugin(self())
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-tracked-msg", "status" => "Running"})
+      end)
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "tracked@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Sync Tracked")
+        |> Swoosh.Email.text_body("body")
+
+      assert {:ok, %{id: "acs-tracked-msg"}} =
+               deliver_and_track(email,
+                 adapter: Swoosh.Adapters.AzureCommunicationServices,
+                 endpoint: "https://acs.example.com",
+                 access_key: Base.encode64("acs-secret"),
+                 req_opts: [
+                   plug: {Req.Test, Portal.AzureCommunicationServices},
+                   plugins: [adapter_plugin]
+                 ]
+               )
+
+      entry = Repo.get!(Portal.OutboundEmail, "acs-tracked-msg")
+      assert entry.account_id == nil
+      assert entry.subject == "Sync Tracked"
+      assert entry.recipients == ["tracked@example.com"]
+
+      delivery =
+        Repo.get_by!(Portal.OutboundEmailDelivery,
+          message_id: "acs-tracked-msg",
+          email: "tracked@example.com"
+        )
+
+      assert delivery.status == :pending
+      assert delivery.account_id == nil
+    end
+
+    test "associates account_id when set via with_account_id/2" do
+      account = account_fixture()
+      adapter_plugin = replace_req_adapter_plugin(self())
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-tracked-account-msg", "status" => "Running"})
+      end)
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "tracked@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Sync Tracked Account")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, %{id: "acs-tracked-account-msg"}} =
+               deliver_and_track(email,
+                 adapter: Swoosh.Adapters.AzureCommunicationServices,
+                 endpoint: "https://acs.example.com",
+                 access_key: Base.encode64("acs-secret"),
+                 req_opts: [
+                   plug: {Req.Test, Portal.AzureCommunicationServices},
+                   plugins: [adapter_plugin]
+                 ]
+               )
+
+      entry = Repo.get!(Portal.OutboundEmail, "acs-tracked-account-msg")
+      assert entry.account_id == account.id
+    end
+
+    test "does not insert a tracked row when the adapter response has no message id" do
+      account = account_fixture()
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to({"", "recipient@example.com"})
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Untracked")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, %{}} = deliver_and_track(email)
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
     end
   end
 


### PR DESCRIPTION
Adds a new `Mailer.deliver_and_track` function that sends emails immediately and tracks them in our outbound tables so that ACS event grid webhooks can update them with delivery health data.

We need to do this so that we have better visibility into emails that are having delivery issues.

The Swoosh adapter is used to determine whether to use plain `deliver` as before, with no tracking (what current `main` uses), or if ACS is used, `deliver_and_track` with the same API shape.

## Note

This should be deployed AFTER https://github.com/firezone/infra/pull/654

--- 

Related: https://github.com/firezone/infra/pull/654
