### PR TITLE
fix(gui-client): keep file logger alive across `try_main`

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -16,13 +16,32 @@ use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
 
+/// Keeps the active log sink alive for the whole process.
+///
+/// `main` owns this across the `try_main` boundary so that a fatal
+/// error logged *after* `try_main` returns still reaches the log file.
+/// It starts as the bootstrap logger, then is swapped for the GUI file
+/// logger once that is installed.
+#[expect(
+    dead_code,
+    reason = "Variants are held only for their `Drop` side effects."
+)]
+enum LogGuard {
+    /// Pre-settings bootstrap logger: a thread-local default that must
+    /// be dropped before the global GUI logger is installed.
+    Bootstrap(DefaultGuard),
+    /// GUI file logger and log-cleanup thread.
+    Gui(logging::file::Handle, logging::CleanupHandle),
+}
+
 fn main() -> ExitCode {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Failed to install default crypto provider");
 
-    let mut bootstrap_log_guard =
-        Some(logging::setup_bootstrap().expect("Failed to setup bootstrap logger"));
+    let mut log_guard = Some(LogGuard::Bootstrap(
+        logging::setup_bootstrap().expect("Failed to setup bootstrap logger"),
+    ));
 
     let cli = Cli::parse();
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
@@ -43,7 +62,7 @@ fn main() -> ExitCode {
         telemetry::GUI_DSN,
     );
 
-    let result = try_main(cli, &rt, &mut bootstrap_log_guard, &mut telemetry);
+    let result = try_main(cli, &rt, &mut log_guard, &mut telemetry);
 
     rt.block_on(telemetry.stop());
 
@@ -60,7 +79,7 @@ fn main() -> ExitCode {
 fn try_main(
     cli: Cli,
     rt: &Runtime,
-    bootstrap_log_guard: &mut Option<DefaultGuard>,
+    log_guard: &mut Option<LogGuard>,
     telemetry: &mut Telemetry,
 ) -> Result<()> {
     #[cfg(debug_assertions)]
@@ -121,13 +140,20 @@ fn try_main(
         .or(mdm_settings.log_filter.clone())
         .unwrap_or_else(|| advanced_settings.log_filter.clone());
 
-    drop(bootstrap_log_guard.take());
+    // Drop the bootstrap logger (a thread-local default) so the GUI's
+    // global default takes effect on this thread, then hand the GUI
+    // logger's keep-alive handles up to `main`. That keeps the file
+    // logger running past `try_main`, so a fatal error logged in `main`
+    // lands in the log file instead of a torn-down appender.
+    *log_guard = None;
 
     let logging::Handles {
-        logger: _logger,
+        logger,
         reloader,
-        cleanup: _cleanup,
+        cleanup,
     } = firezone_gui_client::logging::setup_gui(&log_filter)?;
+
+    *log_guard = Some(LogGuard::Gui(logger, cleanup));
 
     match cli.command {
         None if cli.check_elevation() => match elevation::gui_check() {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -16,12 +16,6 @@ use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
 
-/// Keeps the active log sink alive for the whole process.
-///
-/// `main` owns this across the `try_main` boundary so that a fatal
-/// error logged *after* `try_main` returns still reaches the log file.
-/// It starts as the bootstrap logger, then is swapped for the GUI file
-/// logger once that is installed.
 #[expect(
     dead_code,
     reason = "Variants are held only for their `Drop` side effects."
@@ -140,11 +134,6 @@ fn try_main(
         .or(mdm_settings.log_filter.clone())
         .unwrap_or_else(|| advanced_settings.log_filter.clone());
 
-    // Drop the bootstrap logger (a thread-local default) so the GUI's
-    // global default takes effect on this thread, then hand the GUI
-    // logger's keep-alive handles up to `main`. That keeps the file
-    // logger running past `try_main`, so a fatal error logged in `main`
-    // lands in the log file instead of a torn-down appender.
     *log_guard = None;
 
     let logging::Handles {


### PR DESCRIPTION
The GUI's file logger is installed inside `try_main`, but its keep-alive handles only lived for that function's scope. They dropped — tearing down the appender — before `main`'s final `tracing::error!`, so a fatal startup error (for example, failing to open the tunnel IPC pipe) was written to a torn-down appender and never reached the log file; the on-disk log simply stopped after the startup line.

Holding the log guards in `main` so they outlive `try_main` makes the final error reach the log, which is essential for diagnosing startup failures from logs alone.