### PR TITLE
refactor(gui-client): increase coverage of fake sign-in

### DIFF
--- a/rust/gui-client/src-tauri/src/auth.rs
+++ b/rust/gui-client/src-tauri/src/auth.rs
@@ -15,6 +15,26 @@ use url::Url;
 
 const NONCE_LENGTH: usize = 32;
 
+/// Whether to skip the portal during sign-in.
+///
+/// When set, [`Auth::new`] uses an in-memory keystore and signs in with a
+/// fabricated response instead of contacting the portal, so the real controller
+/// / IPC / UI can be exercised against the mock Tunnel service without touching
+/// the real keyring or persisted session. Debug builds only.
+#[cfg(debug_assertions)]
+static SKIP_PORTAL_AUTH: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Set [`SKIP_PORTAL_AUTH`]. Call once at process startup.
+#[cfg(debug_assertions)]
+pub fn skip_portal_auth() {
+    SKIP_PORTAL_AUTH.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(debug_assertions)]
+pub(crate) fn portal_auth_skipped() -> bool {
+    SKIP_PORTAL_AUTH.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("`known_dirs` failed")]
@@ -87,6 +107,22 @@ pub(crate) struct Response {
     pub(crate) state: SecretString,
 }
 
+#[cfg(debug_assertions)]
+impl Response {
+    /// Fabricate the response the portal would send back for `state`.
+    ///
+    /// The fragment is a placeholder because the mock Tunnel service ignores the
+    /// token's value. Debug builds only.
+    pub(crate) fn fake(state: SecretString) -> Self {
+        Self {
+            account_slug: "demo-co".to_owned(),
+            actor_name: "Demo User".to_owned(),
+            fragment: SecretString::from("fake-fragment"),
+            state,
+        }
+    }
+}
+
 #[derive(Default, Clone, Deserialize, Serialize)]
 pub struct Session {
     pub(crate) account_slug: String,
@@ -103,6 +139,11 @@ impl Auth {
     ///
     /// Performs I/O except on `cfg(test)`.
     pub fn new() -> Result<Self> {
+        #[cfg(debug_assertions)]
+        if portal_auth_skipped() {
+            return Self::new_fake();
+        }
+
         #[cfg(all(target_os = "linux", not(test)))]
         let store = dbus_secret_service_keyring_store::Store::new()?;
 
@@ -122,6 +163,22 @@ impl Auth {
             store,
             known_dirs::session().context("Failed to determine `session` directory")?,
         )
+    }
+
+    /// Creates an [`Auth`] backed by an in-memory keystore and a temp session
+    /// dir, already signed in with a fabricated response.
+    #[cfg(debug_assertions)]
+    fn new_fake() -> Result<Self> {
+        let mut this = Self::new_with_key(
+            "dev.firezone.client/token",
+            keyring_core::mock::Store::new()?,
+            std::env::temp_dir().join("dev.firezone.client.skip-portal-auth"),
+        )?;
+        let request = this.start_sign_in()?;
+        let response = Response::fake(request.state.clone());
+        this.handle_response(response)?;
+
+        Ok(this)
     }
 
     /// Creates a new Auth struct with a custom keyring key for testing.
@@ -226,20 +283,6 @@ impl Auth {
         self.save_session(&session, &token)?;
         self.state = State::SignedIn(session);
         Ok(SecretString::from(token))
-    }
-
-    /// Transition straight to a signed-in state with a fake session, bypassing
-    /// the portal. The session and the returned token live in memory only —
-    /// nothing is written to the keyring or disk, so a later non-mock launch is
-    /// unaffected. The returned token is a placeholder; the mock Tunnel service
-    /// ignores its value.
-    #[cfg(debug_assertions)]
-    pub(crate) fn fake_sign_in(&mut self) -> SecretString {
-        self.state = State::SignedIn(Session {
-            account_slug: "demo-co".into(),
-            actor_name: "Demo User".into(),
-        });
-        SecretString::from("skip-portal-auth-token")
     }
 
     fn save_session(&self, session: &Session, token: &SecretString) -> Result<(), Error> {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -70,7 +70,7 @@ fn try_main(
 
     #[cfg(debug_assertions)]
     if cli.skip_portal_auth {
-        controller::skip_portal_auth();
+        firezone_gui_client::auth::skip_portal_auth();
     }
 
     #[cfg(debug_assertions)]

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -24,27 +24,6 @@ use url::Url;
 
 mod ran_before;
 
-/// Whether to skip the portal during sign-in.
-///
-/// When set, a fake session/token is created on the fly (never persisted) at
-/// sign-in time, decoupling the GUI from the portal so the real controller /
-/// IPC / UI can be exercised against the mock Tunnel service. Debug builds only.
-#[cfg(debug_assertions)]
-static SKIP_PORTAL_AUTH: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Set [`SKIP_PORTAL_AUTH`].
-///
-/// Call once at process startup.
-#[cfg(debug_assertions)]
-pub fn skip_portal_auth() {
-    SKIP_PORTAL_AUTH.store(true, std::sync::atomic::Ordering::Relaxed);
-}
-
-#[cfg(debug_assertions)]
-fn portal_auth_skipped() -> bool {
-    SKIP_PORTAL_AUTH.load(std::sync::atomic::Ordering::Relaxed)
-}
-
 pub struct Controller<I: GuiIntegration> {
     general_settings: GeneralSettings,
     mdm_settings: MdmSettings,
@@ -218,11 +197,13 @@ impl<I: GuiIntegration> Controller<I> {
 
         Telemetry::set_firezone_id(firezone_id).await;
 
+        let auth = auth::Auth::new()?;
+
         let controller = Controller {
             general_settings,
             mdm_settings,
             advanced_settings,
-            auth: auth::Auth::new()?,
+            auth,
             clear_logs_callback: None,
             ctrl_tx,
             ipc_client,
@@ -250,21 +231,7 @@ impl<I: GuiIntegration> Controller<I> {
 
     pub async fn main_loop(mut self) -> Result<()> {
         self.update_telemetry_context().await?;
-
-        // When the portal is skipped, still honor connect-on-start, but mint the
-        // token on the fly instead of reading a persisted one from disk.
-        #[cfg(debug_assertions)]
-        if portal_auth_skipped() {
-            if self.connect_on_start().is_none_or(|c| c) {
-                let token = self.auth.fake_sign_in();
-                self.start_session(token).await?;
-            }
-        } else {
-            self.resume_persisted_session().await?;
-        }
-        #[cfg(not(debug_assertions))]
-        self.resume_persisted_session().await?;
-
+        self.maybe_start_session().await?;
         self.refresh_ui_state();
 
         if !ran_before::get().await? || !self.general_settings.start_minimized {
@@ -328,9 +295,9 @@ impl<I: GuiIntegration> Controller<I> {
         Ok(())
     }
 
-    /// Resume a persisted session at startup: if a token is on disk and
-    /// connect-on-start is enabled, reconnect.
-    async fn resume_persisted_session(&mut self) -> Result<()> {
+    /// Resume a session at startup: if a token is available and connect-on-start
+    /// is enabled, reconnect.
+    async fn maybe_start_session(&mut self) -> Result<()> {
         let Some(token) = self
             .auth
             .token()
@@ -526,26 +493,28 @@ impl<I: GuiIntegration> Controller<I> {
             Fail(Failure::Error) => Err(anyhow!("Test error"))?,
             Fail(Failure::Panic) => panic!("Test panic"),
             SignIn | SystemTrayMenu(system_tray::Event::SignIn) => {
-                // Decoupled from the portal: mint a fake session/token on the fly
-                // and transition straight to signed-in, as a real deep-link
-                // callback would, instead of opening the browser.
-                #[cfg(debug_assertions)]
-                if portal_auth_skipped() {
-                    let token = self.auth.fake_sign_in();
-                    self.start_session(token).await?;
-                    return Ok(());
-                }
-
                 let auth_url = self.auth_url().clone();
                 let account_slug = self.account_slug().map(|a| a.to_owned());
 
-                let req = self
+                let url = self
                     .auth
                     .start_sign_in()
-                    .context("Couldn't start sign-in flow")?;
-
-                let url = req.to_url(&auth_url, account_slug.as_deref());
+                    .context("Couldn't start sign-in flow")?
+                    .to_url(&auth_url, account_slug.as_deref());
                 self.refresh_ui_state();
+
+                #[cfg(debug_assertions)]
+                if auth::portal_auth_skipped() {
+                    let callback_url = deep_link::fake_callback_url(&url)
+                        .context("Couldn't fabricate deep-link")?;
+
+                    // Simulate sign-in.
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+
+                    self.handle_deep_link(&callback_url).await?;
+                    return Ok(());
+                }
+
                 self.integration
                     .open_url(url.expose_secret())
                     .context("Couldn't open auth page")?;

--- a/rust/gui-client/src-tauri/src/deep_link.rs
+++ b/rust/gui-client/src-tauri/src/deep_link.rs
@@ -117,6 +117,35 @@ pub(crate) fn parse_auth_callback(url: &Url) -> Result<auth::Response> {
     })
 }
 
+/// Transforms the real auth URL (from [`auth::Request::to_url`]) into the
+/// deep-link callback the portal would send back, reusing its `state`.
+///
+/// The inverse of [`parse_auth_callback`] for a fabricated [`auth::Response`].
+/// Used by `--skip-portal-auth` to synthesize the URL we'd otherwise receive
+/// from the browser. Debug builds only.
+#[cfg(debug_assertions)]
+pub(crate) fn fake_callback_url(real_auth_url: &SecretString) -> Result<Url> {
+    use secrecy::ExposeSecret as _;
+
+    let state = Url::parse(real_auth_url.expose_secret())
+        .context("Failed to parse generated auth URL")?
+        .query_pairs()
+        .find(|(key, _)| &**key == "state")
+        .map(|(_, value)| value.into_owned())
+        .context("Generated auth URL is missing `state`")?;
+
+    let response = auth::Response::fake(SecretString::from(state));
+
+    let mut url = Url::parse("firezone-fd0020211111://handle_client_sign_in_callback/")
+        .context("Static deep-link URL should be valid")?;
+    url.query_pairs_mut()
+        .append_pair("account_slug", &response.account_slug)
+        .append_pair("actor_name", &response.actor_name)
+        .append_pair("fragment", response.fragment.expose_secret())
+        .append_pair("state", response.state.expose_secret());
+    Ok(url)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
In #13382, we extended the GUI client with a CLI switch that allows us to fake the sign-in flow by returning a fake token. This required some conditionals inside the controller that ended up making it difficult to reason about the code.

It turns out we can simplify this by intercepting things at a different level. We can introduce a dedicated `new_fake` constructor for `Auth` which always holds a signed-in state. This is equivalent to our production code. We always read the token if it is there, we just don't use it unless `connect-on-start` is set.

With this mocking in place, we can exercise the rest of the auth code paths and simply suppress the opening of the link in the browser and instead supply a fake callback URL.

All of this code is still gated behind `#[cfg(debug_assertions]` and therefore doesn't exist in a release build.