### PR TITLE
feat(portal): per-tenant ordered event_id

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -2,7 +2,7 @@ name: "Setup Postgres"
 description: "Starts a Postgres container"
 inputs:
   version:
-    default: "17"
+    default: "18"
     description: "Postgres version"
     required: false
   port:

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -239,6 +239,10 @@ jobs:
         if: "!cancelled()"
         run: docker compose logs portal
 
+      - name: Show Postgres logs
+        if: "!cancelled()"
+        run: docker compose logs postgres
+
       - name: Ensure no eBPF checksum errors on relay-1
         if: "!cancelled() && steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure'"
         run: |

--- a/elixir/lib/portal/change_log.ex
+++ b/elixir/lib/portal/change_log.ex
@@ -4,19 +4,17 @@ defmodule Portal.ChangeLog do
 
   @primary_key false
   @foreign_key_type :binary_id
-  @timestamps_opts [type: :utc_datetime_usec]
 
   schema "change_logs" do
-    belongs_to :account, Portal.Account
-
-    field :lsn, :integer, primary_key: true
+    belongs_to :account, Portal.Account, primary_key: true
+    field :event_id, Portal.Types.EventId, primary_key: true
+    field :timestamp, :utc_datetime_usec
+    field :lsn, :integer
     field :table, :string
     field :op, Ecto.Enum, values: [:insert, :update, :delete]
     field :old_data, :map
     field :data, :map
     field :subject, :map
     field :vsn, :integer
-
-    timestamps(updated_at: false)
   end
 end

--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -48,7 +48,9 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
 
   def on_logical_message(state, _message), do: state
 
-  # Handle Begin to reset transaction state
+  # Handle Begin to reset transaction state. On the first Begin of this
+  # consumer's lifetime, seed seq_start from the Postgres clock so every
+  # event_id this process emits shares a single authoritative timestamp.
   def on_begin(state, %{commit_timestamp: commit_timestamp}) do
     state
     |> Map.put_new_lazy(:seq_start, &Database.fetch_seq_start/0)

--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -1,6 +1,7 @@
 defmodule Portal.ChangeLogs.ReplicationConnection do
   use Portal.Replication.Connection
   alias __MODULE__.Database
+  alias Portal.Types.EventId
 
   # Bump this to signify a change in the audit log schema. Use with care.
   @vsn 0
@@ -42,16 +43,18 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
 
   # Handle LogicalMessage to track subject info
   def on_logical_message(state, %{prefix: "subject", content: content, transactional: true}) do
-    # Store the subject content for the current transaction
     Map.put(state, :current_subject, content)
   end
 
   def on_logical_message(state, _message), do: state
 
   # Handle Begin to reset transaction state
-  def on_begin(state, _begin_msg) do
-    # Remove the subject for the new transaction
-    Map.delete(state, :current_subject)
+  def on_begin(state, %{commit_timestamp: commit_timestamp}) do
+    state
+    |> Map.put_new(:seq_start, System.os_time(:microsecond))
+    |> Map.put_new(:tenant_offsets, %{})
+    |> Map.delete(:current_subject)
+    |> Map.put(:commit_timestamp, commit_timestamp)
   end
 
   # Handle accounts specially
@@ -111,35 +114,65 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
     %{state | flush_buffer: %{}, last_flushed_lsn: last_lsn}
   end
 
-  defp buffer(state, lsn, op, table, account_id, old_data, data) do
-    # Decode the subject JSON string if present
-    subject =
-      case Map.get(state, :current_subject) do
-        nil ->
-          nil
-
-        json_string ->
-          case JSON.decode(json_string) do
-            {:ok, decoded} -> decoded
-            {:error, _} -> nil
-          end
-      end
-
-    flush_buffer =
-      state.flush_buffer
-      |> Map.put_new(lsn, %{
-        lsn: lsn,
-        op: op,
-        table: table,
-        account_id: account_id,
-        old_data: old_data,
-        data: data,
-        subject: subject,
-        vsn: @vsn
-      })
-
-    %{state | flush_buffer: flush_buffer}
+  defp buffer(
+         %{flush_buffer: flush_buffer} = state,
+         lsn,
+         _op,
+         _table,
+         _account_id,
+         _old_data,
+         _data
+       )
+       when is_map_key(flush_buffer, lsn) do
+    state
   end
+
+  defp buffer(
+         %{
+           flush_buffer: flush_buffer,
+           commit_timestamp: commit_timestamp,
+           seq_start: seq_start,
+           tenant_offsets: tenant_offsets
+         } = state,
+         lsn,
+         op,
+         table,
+         account_id,
+         old_data,
+         data
+       ) do
+    offset = Map.get(tenant_offsets, account_id, 0)
+
+    entry = %{
+      event_id: EventId.build_change_log(seq_start, offset),
+      timestamp: commit_timestamp,
+      lsn: lsn,
+      op: op,
+      table: table,
+      account_id: account_id,
+      old_data: old_data,
+      data: data,
+      subject: decode_subject(state),
+      vsn: @vsn
+    }
+
+    %{
+      state
+      | flush_buffer: Map.put(flush_buffer, lsn, entry),
+        tenant_offsets: Map.put(tenant_offsets, account_id, offset + 1)
+    }
+  end
+
+  defp decode_subject(%{current_subject: nil}), do: nil
+
+  defp decode_subject(%{current_subject: json_string}) when is_binary(json_string) do
+    case JSON.decode(json_string) do
+      {:ok, decoded} -> decoded
+      {:error, _} -> nil
+    end
+  end
+
+  defp decode_subject(_state), do: nil
 
   # Field redactions - introspects schema to redact sensitive fields
 

--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -51,7 +51,7 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
   # Handle Begin to reset transaction state
   def on_begin(state, %{commit_timestamp: commit_timestamp}) do
     state
-    |> Map.put_new(:seq_start, System.os_time(:microsecond))
+    |> Map.put_new_lazy(:seq_start, &Database.fetch_seq_start/0)
     |> Map.put_new(:tenant_offsets, %{})
     |> Map.delete(:current_subject)
     |> Map.put(:commit_timestamp, commit_timestamp)
@@ -212,6 +212,15 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
         on_conflict: :nothing,
         conflict_target: [:lsn]
       )
+    end
+
+    # Read seq_start from Postgres so we always use a consistent clock source.
+    def fetch_seq_start do
+      {:ok, %{rows: [[seq_start]]}} =
+        Safe.unscoped()
+        |> Safe.query("SELECT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::bigint", [])
+
+      seq_start
     end
   end
 end

--- a/elixir/lib/portal/types/event_id.ex
+++ b/elixir/lib/portal/types/event_id.ex
@@ -1,0 +1,52 @@
+defmodule Portal.Types.EventId do
+  @moduledoc """
+  96-bit public event identifier for change-log-style audit streams.
+
+  Layout (MSB → LSB):
+
+      [ 4 bits log_type ][ 52 bits seq_start ][ 40 bits tenant_offset ]
+
+  - `log_type` reserves the high nibble for future event streams; change_log uses `0xC`.
+  - `seq_start` is the consumer's boot timestamp in Unix microseconds. Constant for the
+    lifetime of one consumer process; advances on every restart, giving prior events
+    a strictly-lower prefix than anything generated post-restart.
+  - `tenant_offset` is a per-tenant counter starting at 0 each consumer run.
+
+  Canonical Elixir representation is a 24-char lowercase hex string; on disk it
+  is the 12-byte `bytea` it decodes to. Lex order on the hex string matches
+  lex order on the bytea matches integer order on `(log_type, seq_start, offset)`.
+  """
+
+  use Ecto.Type
+
+  @log_type_change_log 0xC
+  @max_seq_start 2 ** 52 - 1
+  @max_tenant_offset 2 ** 40 - 1
+
+  def type, do: :binary
+
+  def cast(<<_::binary-size(24)>> = hex), do: {:ok, String.downcase(hex)}
+  def cast(<<_::binary-size(12)>> = bin), do: {:ok, Base.encode16(bin, case: :lower)}
+  def cast(_), do: :error
+
+  def dump(<<_::binary-size(24)>> = hex), do: Base.decode16(hex, case: :mixed)
+  def dump(_), do: :error
+
+  def load(<<_::binary-size(12)>> = bin), do: {:ok, Base.encode16(bin, case: :lower)}
+  def load(_), do: :error
+
+  @doc """
+  Build a change_log event_id from seq_start (52 bits) and tenant_offset (40 bits).
+
+  Returns the canonical 24-char lowercase hex string. Raises FunctionClauseError
+  if either value is out of range; binary construction would silently truncate,
+  which we never want.
+  """
+  def build_change_log(seq_start, tenant_offset)
+      when seq_start in 0..@max_seq_start and tenant_offset in 0..@max_tenant_offset do
+    Base.encode16(
+      <<@log_type_change_log::4, seq_start::52, tenant_offset::40>>,
+      case: :lower
+    )
+  end
+end

--- a/elixir/lib/portal/types/event_id.ex
+++ b/elixir/lib/portal/types/event_id.ex
@@ -7,9 +7,10 @@ defmodule Portal.Types.EventId do
       [ 4 bits log_type ][ 52 bits seq_start ][ 40 bits tenant_offset ]
 
   - `log_type` reserves the high nibble for future event streams; change_log uses `0xC`.
-  - `seq_start` is the consumer's boot timestamp in Unix microseconds. Constant for the
-    lifetime of one consumer process; advances on every restart, giving prior events
-    a strictly-lower prefix than anything generated post-restart.
+  - `seq_start` is the consumer's boot timestamp in Unix microseconds, sourced from
+    Postgres `clock_timestamp()` so all consumers share a single authoritative clock.
+    Constant for the lifetime of one consumer process; advances on every restart,
+    giving prior events a strictly-lower prefix than anything generated post-restart.
   - `tenant_offset` is a per-tenant counter starting at 0 each consumer run.
 
   Canonical Elixir representation is a 24-char lowercase hex string; on disk it

--- a/elixir/priv/repo/migrations/20260526000000_redesign_change_logs_schema.exs
+++ b/elixir/priv/repo/migrations/20260526000000_redesign_change_logs_schema.exs
@@ -1,0 +1,66 @@
+defmodule Portal.Repo.Migrations.RedesignChangeLogsSchema do
+  use Ecto.Migration
+
+  def up do
+    rename(table(:change_logs), :inserted_at, to: :timestamp)
+    rename(index(:change_logs, [:inserted_at], name: :change_logs_inserted_at_index), to: :change_logs_timestamp_index)
+
+    alter table(:change_logs) do
+      modify(:timestamp, :utc_datetime_usec, default: nil)
+      add(:event_id, :bytea)
+    end
+
+    # 96-bit event_id = [4 bits log_type=0xC][52 bits seq_start][40 bits tenant_offset].
+    # seq_start is the migration-run time in unix microseconds, shared across all
+    # backfilled rows. tenant_offset is ROW_NUMBER ordered by lsn per account.
+    # Post-migration consumer boots pick a later seq_start, so backfilled rows
+    # sort strictly before any new rows.
+    execute("""
+    UPDATE change_logs c
+    SET event_id =
+      substring(
+        int8send((12::bigint << 52) | (EXTRACT(EPOCH FROM now()) * 1000000)::bigint)
+        FROM 2 FOR 7
+      ) || substring(int8send(r.off) FROM 4 FOR 5)
+    FROM (
+      SELECT lsn, (ROW_NUMBER() OVER (PARTITION BY account_id ORDER BY lsn) - 1)::bigint AS off
+      FROM change_logs
+    ) r
+    WHERE c.lsn = r.lsn;
+    """)
+
+    alter table(:change_logs) do
+      modify(:event_id, :bytea, null: false)
+
+      modify(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        null: false
+      )
+    end
+
+    create(constraint(:change_logs, :event_id_is_12_bytes, check: "octet_length(event_id) = 12"))
+
+    execute("ALTER TABLE change_logs DROP CONSTRAINT change_logs_pkey")
+    execute("ALTER TABLE change_logs ADD PRIMARY KEY (account_id, event_id)")
+    create(unique_index(:change_logs, [:lsn]))
+  end
+
+  def down do
+    drop(unique_index(:change_logs, [:lsn]))
+    execute("ALTER TABLE change_logs DROP CONSTRAINT change_logs_pkey")
+    execute("ALTER TABLE change_logs ADD PRIMARY KEY (lsn)")
+
+    drop(constraint(:change_logs, :event_id_is_12_bytes))
+    drop(constraint(:change_logs, :change_logs_account_id_fkey))
+
+    alter table(:change_logs) do
+      remove(:event_id)
+    end
+
+    rename(table(:change_logs), :timestamp, to: :inserted_at)
+    rename(index(:change_logs, [:timestamp], name: :change_logs_timestamp_index), to: :change_logs_inserted_at_index)
+
+    alter table(:change_logs) do
+      modify(:inserted_at, :utc_datetime_usec, default: fragment("now()"))
+    end
+  end
+end

--- a/elixir/priv/repo/migrations/20260526000001_update_change_logs_indexes.exs
+++ b/elixir/priv/repo/migrations/20260526000001_update_change_logs_indexes.exs
@@ -1,0 +1,15 @@
+defmodule Portal.Repo.Migrations.UpdateChangeLogsIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  # The standalone account_id index is redundant with the new
+  # (account_id, event_id) primary-key index.
+  def up do
+    drop_if_exists(index(:change_logs, [:account_id], concurrently: true))
+  end
+
+  def down do
+    create_if_not_exists(index(:change_logs, [:account_id], concurrently: true))
+  end
+end

--- a/elixir/test/portal/change_logs/replication_connection_test.exs
+++ b/elixir/test/portal/change_logs/replication_connection_test.exs
@@ -4,6 +4,7 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
   import Ecto.Query
   import Portal.AccountFixtures
   alias Portal.ChangeLogs.ReplicationConnection
+  alias Portal.ChangeLogs.ReplicationConnection.Database
   alias Portal.ChangeLog
   alias Portal.Types.EventId
 
@@ -74,7 +75,7 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
     end
 
     test "seeds seq_start and tenant_offsets on first call" do
-      before = System.os_time(:microsecond)
+      before = Database.fetch_seq_start()
       state = %{flush_buffer: %{}}
 
       result_state =
@@ -540,8 +541,8 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
                EventId.build_change_log(old_seq_start, 5)
 
       # Post-restart: fresh empty state. on_begin seeds a brand-new seq_start
-      # from the wall clock, and per-tenant offsets start over at 0.
-      before_restart = System.os_time(:microsecond)
+      # from the Postgres clock, and per-tenant offsets start over at 0.
+      before_restart = Database.fetch_seq_start()
 
       post_restart =
         %{flush_buffer: %{}}

--- a/elixir/test/portal/change_logs/replication_connection_test.exs
+++ b/elixir/test/portal/change_logs/replication_connection_test.exs
@@ -5,6 +5,10 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
   import Portal.AccountFixtures
   alias Portal.ChangeLogs.ReplicationConnection
   alias Portal.ChangeLog
+  alias Portal.Types.EventId
+
+  @commit_timestamp ~U[2026-05-26 12:00:00.123000Z]
+  @seq_start 1_700_000_000_000_000
 
   setup do
     tables =
@@ -12,7 +16,18 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       |> Keyword.fetch!(:table_subscriptions)
 
     account = account_fixture()
-    %{account: account, tables: tables}
+
+    # In production every Write is preceded by a Begin that populates
+    # commit_timestamp, seq_start, and tenant_offsets, so seed them here
+    # for on_write/6 tests.
+    initial_state = %{
+      flush_buffer: %{},
+      commit_timestamp: @commit_timestamp,
+      seq_start: @seq_start,
+      tenant_offsets: %{}
+    }
+
+    %{account: account, tables: tables, initial_state: initial_state}
   end
 
   describe "configured tables" do
@@ -22,10 +37,71 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
     end
   end
 
-  describe "on_write/6 for inserts" do
-    test "handles account inserts", %{account: account} do
-      initial_state = %{flush_buffer: %{}}
+  describe "on_begin/2" do
+    test "captures commit_timestamp on the transaction state" do
+      commit_timestamp = ~U[2026-05-26 12:00:00.123000Z]
+      state = %{flush_buffer: %{}}
 
+      result_state =
+        ReplicationConnection.on_begin(state, %{commit_timestamp: commit_timestamp})
+
+      assert result_state.commit_timestamp == commit_timestamp
+    end
+
+    test "clears the previous transaction's subject" do
+      state = %{flush_buffer: %{}, current_subject: "stale"}
+
+      result_state =
+        ReplicationConnection.on_begin(state, %{
+          commit_timestamp: ~U[2026-05-26 12:00:00Z]
+        })
+
+      refute Map.has_key?(result_state, :current_subject)
+    end
+
+    test "overwrites a stale commit_timestamp from a prior transaction" do
+      state = %{
+        flush_buffer: %{},
+        commit_timestamp: ~U[2026-05-26 11:00:00Z]
+      }
+
+      result_state =
+        ReplicationConnection.on_begin(state, %{
+          commit_timestamp: ~U[2026-05-26 12:00:00Z]
+        })
+
+      assert result_state.commit_timestamp == ~U[2026-05-26 12:00:00Z]
+    end
+
+    test "seeds seq_start and tenant_offsets on first call" do
+      before = System.os_time(:microsecond)
+      state = %{flush_buffer: %{}}
+
+      result_state =
+        ReplicationConnection.on_begin(state, %{
+          commit_timestamp: ~U[2026-05-26 12:00:00Z]
+        })
+
+      assert is_integer(result_state.seq_start)
+      assert result_state.seq_start >= before
+      assert result_state.tenant_offsets == %{}
+    end
+
+    test "preserves seq_start and tenant_offsets on subsequent calls" do
+      state = %{flush_buffer: %{}, seq_start: @seq_start, tenant_offsets: %{"x" => 7}}
+
+      result_state =
+        ReplicationConnection.on_begin(state, %{
+          commit_timestamp: ~U[2026-05-26 12:00:00Z]
+        })
+
+      assert result_state.seq_start == @seq_start
+      assert result_state.tenant_offsets == %{"x" => 7}
+    end
+  end
+
+  describe "on_write/6 for inserts" do
+    test "handles account inserts", %{account: account, initial_state: initial_state} do
       result_state =
         ReplicationConnection.on_write(
           initial_state,
@@ -36,26 +112,26 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
           %{"id" => account.id, "name" => "test account"}
         )
 
-      assert result_state == %{
-               flush_buffer: %{
-                 12345 => %{
-                   data: %{
-                     "id" => account.id,
-                     "name" => "test account"
-                   },
-                   table: "accounts",
-                   vsn: 0,
-                   op: :insert,
-                   account_id: account.id,
-                   lsn: 12345,
-                   old_data: nil,
-                   subject: nil
-                 }
-               }
-             }
+      assert map_size(result_state.flush_buffer) == 1
+      assert result_state.commit_timestamp == @commit_timestamp
+
+      attrs = result_state.flush_buffer[12345]
+      assert attrs.lsn == 12345
+      assert attrs.table == "accounts"
+      assert attrs.op == :insert
+      assert attrs.account_id == account.id
+      assert attrs.data == %{"id" => account.id, "name" => "test account"}
+      assert attrs.old_data == nil
+      assert attrs.subject == nil
+      assert attrs.vsn == 0
+      assert attrs.timestamp == @commit_timestamp
+      assert attrs.event_id == EventId.build_change_log(@seq_start, 0)
     end
 
-    test "adds insert operation to flush buffer for non-account tables", %{account: account} do
+    test "adds insert operation to flush buffer for non-account tables", %{
+      account: account,
+      initial_state: initial_state
+    } do
       table = "resources"
 
       data = %{
@@ -65,7 +141,6 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       }
 
       lsn = 12345
-      initial_state = %{flush_buffer: %{}}
 
       result_state =
         ReplicationConnection.on_write(
@@ -88,12 +163,15 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       assert attrs.old_data == nil
       assert attrs.account_id == account.id
       assert attrs.vsn == 0
+      assert attrs.timestamp == @commit_timestamp
     end
 
-    test "preserves existing buffer items", %{account: account} do
+    test "preserves existing buffer items", %{account: account, initial_state: initial_state} do
       existing_lsn = 100
 
       existing_item = %{
+        event_id: EventId.build_change_log(@seq_start, 99),
+        timestamp: @commit_timestamp,
         lsn: existing_lsn,
         table: "other_table",
         op: :update,
@@ -104,7 +182,7 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
         subject: nil
       }
 
-      initial_state = %{flush_buffer: %{existing_lsn => existing_item}}
+      initial_state = %{initial_state | flush_buffer: %{existing_lsn => existing_item}}
 
       new_lsn = 101
 
@@ -123,7 +201,21 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       assert Map.has_key?(result_state.flush_buffer, new_lsn)
     end
 
-    test "handles complex data structures", %{account: account} do
+    test "ignores relay token inserts", %{initial_state: initial_state} do
+      result_state =
+        ReplicationConnection.on_write(
+          initial_state,
+          12345,
+          :insert,
+          "tokens",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "type" => "relay"}
+        )
+
+      assert result_state == initial_state
+    end
+
+    test "handles complex data structures", %{account: account, initial_state: initial_state} do
       complex_data = %{
         "id" => Ecto.UUID.generate(),
         "account_id" => account.id,
@@ -132,12 +224,11 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
         "boolean" => true
       }
 
-      state = %{flush_buffer: %{}}
       lsn = 200
 
       result_state =
         ReplicationConnection.on_write(
-          state,
+          initial_state,
           lsn,
           :insert,
           "resources",
@@ -151,12 +242,14 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
   end
 
   describe "on_write/6 for updates" do
-    test "adds update operation to flush buffer", %{account: account} do
+    test "adds update operation to flush buffer", %{
+      account: account,
+      initial_state: initial_state
+    } do
       table = "resources"
       old_data = %{"id" => Ecto.UUID.generate(), "account_id" => account.id, "name" => "old name"}
       data = %{"id" => old_data["id"], "account_id" => account.id, "name" => "new name"}
       lsn = 12346
-      initial_state = %{flush_buffer: %{}}
 
       result_state =
         ReplicationConnection.on_write(
@@ -180,11 +273,13 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       assert attrs.vsn == 0
     end
 
-    test "handles account updates specially", %{account: account} do
+    test "handles account updates specially", %{
+      account: account,
+      initial_state: initial_state
+    } do
       old_data = %{"id" => account.id, "name" => "old name"}
       data = %{"id" => account.id, "name" => "new name"}
       lsn = 12346
-      initial_state = %{flush_buffer: %{}}
 
       result_state =
         ReplicationConnection.on_write(
@@ -205,9 +300,7 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
   end
 
   describe "on_write/6 for deletes" do
-    test "handles account deletes", %{account: account} do
-      initial_state = %{flush_buffer: %{}}
-
+    test "handles account deletes", %{account: account, initial_state: initial_state} do
       result_state =
         ReplicationConnection.on_write(
           initial_state,
@@ -218,23 +311,25 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
           nil
         )
 
-      assert result_state == %{
-               flush_buffer: %{
-                 12345 => %{
-                   data: nil,
-                   table: "accounts",
-                   vsn: 0,
-                   op: :delete,
-                   account_id: account.id,
-                   lsn: 12345,
-                   old_data: %{"id" => account.id, "name" => "deleted account"},
-                   subject: nil
-                 }
-               }
-             }
+      assert map_size(result_state.flush_buffer) == 1
+      assert result_state.commit_timestamp == @commit_timestamp
+
+      attrs = result_state.flush_buffer[12345]
+      assert attrs.lsn == 12345
+      assert attrs.table == "accounts"
+      assert attrs.op == :delete
+      assert attrs.account_id == account.id
+      assert attrs.data == nil
+      assert attrs.old_data == %{"id" => account.id, "name" => "deleted account"}
+      assert attrs.subject == nil
+      assert attrs.vsn == 0
+      assert attrs.timestamp == @commit_timestamp
     end
 
-    test "adds delete operation to flush buffer", %{account: account} do
+    test "adds delete operation to flush buffer", %{
+      account: account,
+      initial_state: initial_state
+    } do
       table = "resources"
 
       old_data = %{
@@ -244,7 +339,6 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       }
 
       lsn = 12347
-      initial_state = %{flush_buffer: %{}}
 
       result_state =
         ReplicationConnection.on_write(
@@ -270,9 +364,10 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
   end
 
   describe "multiple operations and buffer accumulation" do
-    test "operations accumulate in flush buffer correctly", %{account: account} do
-      initial_state = %{flush_buffer: %{}}
-
+    test "operations accumulate in flush buffer correctly", %{
+      account: account,
+      initial_state: initial_state
+    } do
       state1 =
         ReplicationConnection.on_write(
           initial_state,
@@ -316,6 +411,229 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
     end
   end
 
+  describe "event_id allocation" do
+    test "every row in a transaction shares the same commit_timestamp", %{
+      account: account
+    } do
+      commit_timestamp = ~U[2026-05-26 12:00:00.001000Z]
+
+      state =
+        %{flush_buffer: %{}, seq_start: @seq_start, tenant_offsets: %{}}
+        |> ReplicationConnection.on_begin(%{commit_timestamp: commit_timestamp})
+        |> ReplicationConnection.on_write(
+          200,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+        )
+        |> ReplicationConnection.on_write(
+          201,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+        )
+
+      assert state.flush_buffer[200].timestamp == commit_timestamp
+      assert state.flush_buffer[201].timestamp == commit_timestamp
+    end
+
+    test "successive writes for the same account get sequential per-tenant offsets", %{
+      account: account,
+      initial_state: initial_state
+    } do
+      data = fn -> %{"id" => Ecto.UUID.generate(), "account_id" => account.id} end
+
+      state =
+        initial_state
+        |> ReplicationConnection.on_write(300, :insert, "resources", nil, data.())
+        |> ReplicationConnection.on_write(301, :insert, "resources", nil, data.())
+        |> ReplicationConnection.on_write(302, :insert, "resources", nil, data.())
+
+      assert state.tenant_offsets[account.id] == 3
+      assert state.flush_buffer[300].event_id == EventId.build_change_log(@seq_start, 0)
+      assert state.flush_buffer[301].event_id == EventId.build_change_log(@seq_start, 1)
+      assert state.flush_buffer[302].event_id == EventId.build_change_log(@seq_start, 2)
+    end
+
+    test "interleaved writes for three tenants each get their own dense offset progression",
+         %{initial_state: initial_state} do
+      a = account_fixture()
+      b = account_fixture()
+      c = account_fixture()
+
+      writes = [
+        {1000, a},
+        {1001, a},
+        {1002, b},
+        {1003, a},
+        {1004, c},
+        {1005, b},
+        {1006, c},
+        {1007, a},
+        {1008, b},
+        {1009, c}
+      ]
+
+      state =
+        Enum.reduce(writes, initial_state, fn {lsn, account}, acc ->
+          ReplicationConnection.on_write(
+            acc,
+            lsn,
+            :insert,
+            "resources",
+            nil,
+            %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+          )
+        end)
+
+      # Each tenant got exactly the count of writes addressed to it...
+      assert state.tenant_offsets[a.id] == 4
+      assert state.tenant_offsets[b.id] == 3
+      assert state.tenant_offsets[c.id] == 3
+
+      # ...and the per-lsn event_ids encode the tenant's own offset progression,
+      # not the global write order.
+      expected = %{
+        1000 => {a, 0},
+        1001 => {a, 1},
+        1002 => {b, 0},
+        1003 => {a, 2},
+        1004 => {c, 0},
+        1005 => {b, 1},
+        1006 => {c, 1},
+        1007 => {a, 3},
+        1008 => {b, 2},
+        1009 => {c, 2}
+      }
+
+      for {lsn, {_account, offset}} <- expected do
+        assert state.flush_buffer[lsn].event_id ==
+                 EventId.build_change_log(@seq_start, offset)
+      end
+    end
+
+    test "fresh on_begin (simulating consumer restart) seeds a new seq_start and resets offsets",
+         %{account: account} do
+      # Pre-restart "session": pre-seeded seq_start and offset counter.
+      old_seq_start = @seq_start
+
+      pre_restart =
+        %{
+          flush_buffer: %{},
+          seq_start: old_seq_start,
+          tenant_offsets: %{account.id => 5}
+        }
+        |> ReplicationConnection.on_begin(%{commit_timestamp: @commit_timestamp})
+        |> ReplicationConnection.on_write(
+          500,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+        )
+
+      assert pre_restart.seq_start == old_seq_start
+
+      assert pre_restart.flush_buffer[500].event_id ==
+               EventId.build_change_log(old_seq_start, 5)
+
+      # Post-restart: fresh empty state. on_begin seeds a brand-new seq_start
+      # from the wall clock, and per-tenant offsets start over at 0.
+      before_restart = System.os_time(:microsecond)
+
+      post_restart =
+        %{flush_buffer: %{}}
+        |> ReplicationConnection.on_begin(%{commit_timestamp: @commit_timestamp})
+        |> ReplicationConnection.on_write(
+          600,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+        )
+
+      assert post_restart.seq_start >= before_restart
+      assert post_restart.seq_start > old_seq_start
+      assert post_restart.tenant_offsets[account.id] == 1
+
+      assert post_restart.flush_buffer[600].event_id ==
+               EventId.build_change_log(post_restart.seq_start, 0)
+
+      # Crucially, the new event_id sorts strictly after the old one.
+      assert pre_restart.flush_buffer[500].event_id <
+               post_restart.flush_buffer[600].event_id
+    end
+
+    test "raises FunctionClauseError when a tenant_offset would reach 2^40", %{
+      account: account,
+      initial_state: initial_state
+    } do
+      import Bitwise
+      max_offset = bsl(1, 40)
+
+      saturated_state = %{
+        initial_state
+        | tenant_offsets: %{account.id => max_offset - 1}
+      }
+
+      # The next write at the cap is still valid (offset 2^40 - 1).
+      state =
+        ReplicationConnection.on_write(
+          saturated_state,
+          700,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+        )
+
+      assert state.tenant_offsets[account.id] == max_offset
+
+      # The write after that overflows the EventId.build_change_log guard.
+      assert_raise FunctionClauseError, fn ->
+        ReplicationConnection.on_write(
+          state,
+          701,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id}
+        )
+      end
+    end
+
+    test "persists event_id and timestamp end-to-end through on_flush", %{
+      account: account
+    } do
+      commit_timestamp = ~U[2026-05-26 12:00:00.999000Z]
+
+      state =
+        %{
+          flush_buffer: %{},
+          last_flushed_lsn: 0,
+          seq_start: @seq_start,
+          tenant_offsets: %{}
+        }
+        |> ReplicationConnection.on_begin(%{commit_timestamp: commit_timestamp})
+        |> ReplicationConnection.on_write(
+          500,
+          :insert,
+          "resources",
+          nil,
+          %{"id" => Ecto.UUID.generate(), "account_id" => account.id, "name" => "test"}
+        )
+        |> ReplicationConnection.on_flush()
+
+      assert state.flush_buffer == %{}
+
+      change_log = Repo.one(from cl in ChangeLog, where: cl.lsn == 500)
+      assert change_log.timestamp == commit_timestamp
+      assert change_log.event_id == EventId.build_change_log(@seq_start, 0)
+    end
+  end
+
   describe "on_flush/1" do
     test "handles empty flush buffer" do
       state = %{flush_buffer: %{}}
@@ -324,7 +642,11 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
     end
 
     test "successfully flushes buffer and clears it", %{account: account} do
+      committed_at = ~U[2026-05-26 12:00:00.000000Z]
+
       attrs1 = %{
+        event_id: EventId.build_change_log(@seq_start, 0),
+        timestamp: committed_at,
         lsn: 100,
         table: "resources",
         op: :insert,
@@ -336,6 +658,8 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       }
 
       attrs2 = %{
+        event_id: EventId.build_change_log(@seq_start, 1),
+        timestamp: committed_at,
         lsn: 101,
         table: "resources",
         op: :update,
@@ -362,13 +686,19 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       [log1, log2] = change_logs
       assert log1.lsn == 100
       assert log1.op == :insert
+      assert log1.timestamp == committed_at
       assert log2.lsn == 101
       assert log2.op == :update
+      assert log2.timestamp == committed_at
     end
 
     test "calculates last_flushed_lsn correctly as max LSN", %{account: account} do
+      committed_at = ~U[2026-05-26 12:00:00.000000Z]
+
       attrs_map = %{
         400 => %{
+          event_id: EventId.build_change_log(@seq_start, 0),
+          timestamp: committed_at,
           lsn: 400,
           table: "resources",
           op: :insert,
@@ -379,6 +709,8 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
           subject: nil
         },
         402 => %{
+          event_id: EventId.build_change_log(@seq_start, 1),
+          timestamp: committed_at,
           lsn: 402,
           table: "resources",
           op: :insert,
@@ -389,6 +721,8 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
           subject: nil
         },
         401 => %{
+          event_id: EventId.build_change_log(@seq_start, 2),
+          timestamp: committed_at,
           lsn: 401,
           table: "resources",
           op: :insert,
@@ -409,16 +743,14 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
   end
 
   describe "edge cases" do
-    test "logs error for writes without account_id" do
+    test "logs error for writes without account_id", %{initial_state: initial_state} do
       import ExUnit.CaptureLog
-
-      state = %{flush_buffer: %{}}
 
       log =
         capture_log(fn ->
           result =
             ReplicationConnection.on_write(
-              state,
+              initial_state,
               500,
               :insert,
               "some_table",
@@ -426,12 +758,11 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
               %{"id" => Ecto.UUID.generate(), "name" => "no account_id"}
             )
 
-          assert result == state
+          assert result == initial_state
         end)
 
       assert log =~ "Unexpected write operation!"
       assert log =~ "lsn=500"
     end
-
   end
 end

--- a/elixir/test/portal/types/event_id_test.exs
+++ b/elixir/test/portal/types/event_id_test.exs
@@ -1,0 +1,160 @@
+defmodule Portal.Types.EventIdTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Types.EventId
+
+  describe "build_change_log/2" do
+    test "produces a 24-character lowercase hex string" do
+      hex = EventId.build_change_log(1_700_000_000_000_000, 0)
+      assert byte_size(hex) == 24
+      assert hex == String.downcase(hex)
+      assert hex =~ ~r/^[0-9a-f]{24}$/
+    end
+
+    test "encodes layout as [4 bits 0xC][52 bits seq_start][40 bits tenant_offset]" do
+      seq_start = 1_700_000_000_000_000
+      offset = 42
+      hex = EventId.build_change_log(seq_start, offset)
+      bin = Base.decode16!(hex, case: :mixed)
+      assert <<0xC::4, ^seq_start::52, ^offset::40>> = bin
+    end
+
+    test "lex order matches integer order of (log_type, seq_start, offset)" do
+      a = EventId.build_change_log(1_000, 0)
+      b = EventId.build_change_log(1_000, 1)
+      c = EventId.build_change_log(1_001, 0)
+      d = EventId.build_change_log(2_000, 0)
+
+      assert a < b
+      assert b < c
+      assert c < d
+    end
+
+    test "accepts the 52-bit max seq_start and 40-bit max tenant_offset" do
+      max_seq = 2 ** 52 - 1
+      max_off = 2 ** 40 - 1
+      hex = EventId.build_change_log(max_seq, max_off)
+      bin = Base.decode16!(hex, case: :mixed)
+      assert <<0xC::4, ^max_seq::52, ^max_off::40>> = bin
+    end
+
+    test "raises FunctionClauseError when tenant_offset is 2^40" do
+      assert_raise FunctionClauseError, fn ->
+        EventId.build_change_log(0, 2 ** 40)
+      end
+    end
+
+    test "raises FunctionClauseError when seq_start is 2^52" do
+      assert_raise FunctionClauseError, fn ->
+        EventId.build_change_log(2 ** 52, 0)
+      end
+    end
+
+    test "raises FunctionClauseError on negative seq_start" do
+      assert_raise FunctionClauseError, fn ->
+        EventId.build_change_log(-1, 0)
+      end
+    end
+
+    test "raises FunctionClauseError on negative tenant_offset" do
+      assert_raise FunctionClauseError, fn ->
+        EventId.build_change_log(0, -1)
+      end
+    end
+
+    test "raises FunctionClauseError on non-integer inputs" do
+      assert_raise FunctionClauseError, fn ->
+        EventId.build_change_log("not an integer", 0)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        EventId.build_change_log(0, nil)
+      end
+    end
+  end
+
+  describe "cast/1" do
+    test "normalizes 24-char hex to lowercase" do
+      assert {:ok, "abc" <> _} = EventId.cast("ABC" <> String.duplicate("0", 21))
+    end
+
+    test "accepts a 12-byte binary and encodes as lowercase hex" do
+      bin = <<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+      assert {:ok, "c00000000000000000000000"} = EventId.cast(bin)
+    end
+
+    test "rejects integers" do
+      assert :error = EventId.cast(123)
+    end
+
+    test "rejects nil" do
+      assert :error = EventId.cast(nil)
+    end
+
+    test "rejects binaries of any other length" do
+      assert :error = EventId.cast("")
+      assert :error = EventId.cast("short")
+      assert :error = EventId.cast(String.duplicate("a", 23))
+      assert :error = EventId.cast(String.duplicate("a", 25))
+    end
+
+    test "rejects atoms and maps" do
+      assert :error = EventId.cast(:foo)
+      assert :error = EventId.cast(%{})
+    end
+  end
+
+  describe "dump/1" do
+    test "converts 24-char hex to a 12-byte binary" do
+      hex = EventId.build_change_log(1_234, 5)
+      assert {:ok, bin} = EventId.dump(hex)
+      assert byte_size(bin) == 12
+    end
+
+    test "rejects binaries that are not 24 chars" do
+      assert :error = EventId.dump("short")
+      assert :error = EventId.dump(String.duplicate("a", 23))
+      assert :error = EventId.dump(String.duplicate("a", 25))
+    end
+
+    test "rejects 24-char binaries that are not valid hex" do
+      assert :error = EventId.dump(String.duplicate("z", 24))
+    end
+
+    test "rejects nil and non-binary inputs" do
+      assert :error = EventId.dump(nil)
+      assert :error = EventId.dump(123)
+      assert :error = EventId.dump(%{})
+    end
+  end
+
+  describe "load/1" do
+    test "converts 12-byte binary to 24-char lowercase hex" do
+      bin = <<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7>>
+      assert {:ok, "c00000000000000000000007"} = EventId.load(bin)
+    end
+
+    test "rejects binaries that are not 12 bytes" do
+      assert :error = EventId.load(<<>>)
+      assert :error = EventId.load(<<0>>)
+      assert :error = EventId.load(:binary.copy(<<0>>, 11))
+      assert :error = EventId.load(:binary.copy(<<0>>, 13))
+    end
+
+    test "rejects nil and non-binary inputs" do
+      assert :error = EventId.load(nil)
+      assert :error = EventId.load(123)
+      assert :error = EventId.load(%{})
+    end
+  end
+
+  describe "round-trip" do
+    test "cast → dump → load is lossless" do
+      original = EventId.build_change_log(987_654_321, 17)
+      {:ok, cast} = EventId.cast(original)
+      {:ok, dumped} = EventId.dump(cast)
+      {:ok, loaded} = EventId.load(dumped)
+      assert loaded == original
+    end
+  end
+end

--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -2,11 +2,11 @@ services:
   # Dependencies
   postgres:
     # TODO: Enable pgaudit on dev instance. See https://github.com/pgaudit/pgaudit/issues/44#issuecomment-455090262
-    image: postgres:17
+    image: postgres:18
     command:
       ["postgres", "-c", "wal_level=logical", "-c", "max_connections=200"]
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/18/docker
     environment:
       POSTGRES_USER: ${DATABASE_USER:-postgres}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}


### PR DESCRIPTION
In forensic analysis workflows, it's helpful to guarantee that a certain series of events or logs occurred in a specific order in time.

Luckily for us, postgres' `lsn`, the Log Sequence Number, makes a great fit for this because it is guaranteed to be monotonically increasing and correct for each record emitted by the replication stream.

However, it represents a byte offset and as such, is not suitable for using directly as an ordering key in public-facing audit logs. That would expose cross-tenant database usage statistics that don't need to be made public.

Instead, we introduce a compact, new byte field and ecto type, `EventId` that is designed to meet the following requirements:

- Very fast to compute under all conditions. I.e., no reading a `SEQ` field from somewhere else in the database.
- Reasonably guaranteed to be monotonically increasing
- Prevent leaking database usage stats across tenants
- Easily displayed in user-facing interfaces (UI, API, etc)

The format of it is:

```
┌────┬────────────────────────────────────────────────┬────────────────────────────────────────┐
│ 4  │                       52                       │                   40                   │
│bits│                      bits                      │                  bits                  │
├────┼────────────────────────────────────────────────┼────────────────────────────────────────┤
│log │                  seq_start                     │             tenant_offset              │
│type│         (unix microseconds at consumer         │           (per-tenant counter,         │
│0xC │            boot, constant per run)             │           resets to 0 each run)        │
└────┴────────────────────────────────────────────────┴────────────────────────────────────────┘
  ▲                          ▲                                          ▲
  │                          │                                          │
high                  shared across all                       monotonic per account,
nibble                events from one                         independent across
of byte 0             consumer-process run                    accounts
                      (~142 yrs of µs from epoch)             (~1.1 trillion events)
```

Using this format, we:

1. initialize `seq_start` at the start of each replication consumer boot
2. Increment a `tenant_offset` counter individually for each account_id for each write message (i.e. DB operation) in the replication stream (these are guaranteed to be ordered by LSN)
3. Prefix with a 4-bit log type field - set to `0xc`. This can be used for future log types as well, i.e. `0xf` for flow logs.
4. Insert this into the batch.

In this design the only information we leak is the boot / uptime of the replication consumer process, which is not deemed to be sensitive in any way.

### Other designs considered

Our previous attempt at designing a key for this purpose was to use the `commit_timestamp`, encoded into a `UUIDv7`. However, it is not guaranteed to be monotonically increasing for each log entry and therefore cannot be used to guarantee ordering in forensic use cases.

---

Supersedes #13427 
Supersedes #13423 
