### PR TITLE
feat(gateway,headless-client): enable sentry metrics by default

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -15,10 +15,7 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
 use phoenix_channel::get_user_agent;
-use telemetry::{
-    MaybePushMetricsExporter, NoopPushMetricsExporter, SentryMetricExporter, Telemetry,
-    feature_flags, otel,
-};
+use telemetry::{MaybePushMetricsExporter, SentryMetricExporter, Telemetry, feature_flags, otel};
 use tokio_util::task::AbortOnDropHandle;
 use tunnel::GatewayTunnel;
 
@@ -162,17 +159,9 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
                 .with_periodic_exporter(tonic_otlp_exporter(endpoint)?)
                 .with_resource(resource)
                 .build(),
-            (MetricsExporter::OtelCollector, None) => SdkMeterProvider::builder()
-                .with_periodic_exporter(MaybePushMetricsExporter {
-                    inner: {
-                        // TODO: Once Firezone has a hosted OTLP exporter, it will go here.
-
-                        NoopPushMetricsExporter
-                    },
-                    should_export: feature_flags::stream_metrics,
-                })
-                .with_resource(resource)
-                .build(),
+            (MetricsExporter::OtelCollector, None) => {
+                SdkMeterProvider::builder().with_resource(resource).build()
+            }
             (MetricsExporter::Sentry, _) => SdkMeterProvider::builder()
                 .with_periodic_exporter(MaybePushMetricsExporter {
                     inner: SentryMetricExporter,
@@ -345,7 +334,7 @@ struct Cli {
     ///
     /// This configuration option is private API and has no stability guarantees.
     /// It may be removed / changed anytime.
-    #[arg(long, hide = true, env = "FIREZONE_METRICS")]
+    #[arg(long, hide = true, env = "FIREZONE_METRICS", default_value = "sentry")]
     metrics: Option<MetricsExporter>,
 
     /// Send metrics to a custom OTLP collector.

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -25,8 +25,7 @@ use std::{
     time::Duration,
 };
 use telemetry::{
-    MaybePushMetricsExporter, NoopPushMetricsExporter, SentryMetricExporter, Telemetry, analytics,
-    feature_flags, otel,
+    MaybePushMetricsExporter, SentryMetricExporter, Telemetry, analytics, feature_flags, otel,
 };
 use tokio::time::Instant;
 
@@ -122,7 +121,7 @@ struct Cli {
     ///
     /// This configuration option is private API and has no stability guarantees.
     /// It may be removed / changed anytime.
-    #[arg(long, hide = true, env = "FIREZONE_METRICS")]
+    #[arg(long, hide = true, env = "FIREZONE_METRICS", default_value = "sentry")]
     metrics: Option<MetricsExporter>,
 
     /// Send metrics to a custom OTLP collector.
@@ -386,17 +385,9 @@ fn try_main() -> Result<()> {
                     .with_periodic_exporter(tonic_otlp_exporter(endpoint)?)
                     .with_resource(resource)
                     .build(),
-                (MetricsExporter::OtelCollector, None) => SdkMeterProvider::builder()
-                    .with_periodic_exporter(MaybePushMetricsExporter {
-                        inner: {
-                            // TODO: Once Firezone has a hosted OTLP exporter, it will go here.
-
-                            NoopPushMetricsExporter
-                        },
-                        should_export: feature_flags::stream_metrics,
-                    })
-                    .with_resource(resource)
-                    .build(),
+                (MetricsExporter::OtelCollector, None) => {
+                    SdkMeterProvider::builder().with_resource(resource).build()
+                }
                 (MetricsExporter::Sentry, _) => SdkMeterProvider::builder()
                     .with_periodic_exporter(MaybePushMetricsExporter {
                         inner: SentryMetricExporter,


### PR DESCRIPTION
Right now, metrics collection via Sentry is not enabled by default for the headless-client and Gateway. Without this, enabling the "metrics" feature-flag doesn't actually do anything.

Thus, in order to be able to remotely enable metric collection, we set the default metrics exporter to "Sentry". The "no telemetry" setting still honors this. If "no telemetry" is set, Sentry doesn't even get initialised and therefore, enabling metrics via Sentry is also going to be a no-op for those cases.