### PR TITLE
fix(portal): read after write issues in liveviews

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1169,7 +1169,7 @@ defmodule PortalWeb.Actors do
         Database.remove_group_member(group_id, actor, subject)
       end)
 
-    groups = Database.get_groups_for_actor(actor.id, subject)
+    groups = Database.get_groups_for_actor(actor.id, subject, repo: :primary)
 
     errors =
       (addition_results ++ removal_results)

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -334,7 +334,7 @@ defmodule PortalWeb.Groups do
 
     case result do
       :ok ->
-        resources = Database.list_resources_for_group(group, socket.assigns.subject)
+        resources = Database.list_resources_for_group(group, socket.assigns.subject, :primary)
 
         {:noreply,
          socket
@@ -1260,7 +1260,11 @@ defmodule PortalWeb.Groups do
 
   defp refresh_group_resources(socket, ui_state) do
     resources =
-      Database.list_resources_for_group(socket.assigns.selected_group, socket.assigns.subject)
+      Database.list_resources_for_group(
+        socket.assigns.selected_group,
+        socket.assigns.subject,
+        :primary
+      )
 
     merge_state(socket, :group_resources, Keyword.put(ui_state, :resources, resources))
   end
@@ -1726,7 +1730,7 @@ defmodule PortalWeb.Groups do
       end
     end
 
-    def list_resources_for_group(group, subject) do
+    def list_resources_for_group(group, subject, repo \\ :replica) do
       from(r in Portal.Resource, as: :resources)
       |> join(:inner, [resources: r], p in Portal.Policy,
         on: p.resource_id == r.id and p.group_id == ^group.id,
@@ -1738,7 +1742,7 @@ defmodule PortalWeb.Groups do
         policy_disabled_at: p.disabled_at
       })
       |> order_by([policies: p, resources: r], desc: is_nil(p.disabled_at), asc: r.name)
-      |> Safe.scoped(subject, :replica)
+      |> Safe.scoped(subject, repo)
       |> Safe.all()
       |> case do
         {:error, _} -> []

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -1048,7 +1048,7 @@ defmodule PortalWeb.Resources do
 
     case result do
       :ok ->
-        groups = Database.list_groups_for_resource(resource, socket.assigns.subject)
+        groups = Database.list_groups_for_resource(resource, socket.assigns.subject, :primary)
 
         {:noreply,
          socket
@@ -1300,7 +1300,11 @@ defmodule PortalWeb.Resources do
 
   defp refresh_selected_groups(socket) do
     groups =
-      Database.list_groups_for_resource(socket.assigns.selected_resource, socket.assigns.subject)
+      Database.list_groups_for_resource(
+        socket.assigns.selected_resource,
+        socket.assigns.subject,
+        :primary
+      )
 
     assign(socket, selected_groups: groups)
   end
@@ -1501,7 +1505,7 @@ defmodule PortalWeb.Resources do
       end
     end
 
-    def list_groups_for_resource(resource, subject) do
+    def list_groups_for_resource(resource, subject, repo \\ :replica) do
       from(g in Group, as: :groups)
       |> join(:inner, [groups: g], p in Policy,
         on: p.group_id == g.id and p.resource_id == ^resource.id,
@@ -1518,7 +1522,7 @@ defmodule PortalWeb.Resources do
         policy_disabled_at: p.disabled_at
       })
       |> order_by([policies: p], desc: is_nil(p.disabled_at))
-      |> Safe.scoped(subject, :replica)
+      |> Safe.scoped(subject, repo)
       |> Safe.all()
       |> case do
         {:error, _} -> []

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -798,7 +798,7 @@ defmodule PortalWeb.ServiceAccounts do
         Database.remove_group_member(group_id, actor, subject)
       end)
 
-    groups = Database.get_groups_for_actor(actor.id, subject)
+    groups = Database.get_groups_for_actor(actor.id, subject, repo: :primary)
 
     errors =
       (addition_results ++ removal_results)

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -54,7 +54,8 @@ defmodule PortalWeb.Settings.DirectorySync do
 
   defp init(socket, opts \\ []) do
     new = Keyword.get(opts, :new, false)
-    directories = Database.list_all_directories(socket.assigns.subject)
+    repo = Keyword.get(opts, :repo, :replica)
+    directories = Database.list_all_directories(socket.assigns.subject, repo)
 
     if new do
       socket
@@ -1594,7 +1595,7 @@ defmodule PortalWeb.Settings.DirectorySync do
   defp handle_submit({:ok, _directory}, socket) do
     {:noreply,
      socket
-     |> init()
+     |> init(repo: :primary)
      |> put_flash(:success, "Directory saved successfully.")
      |> push_patch(to: ~p"/#{socket.assigns.account}/settings/directory_sync")}
   end
@@ -1896,11 +1897,11 @@ defmodule PortalWeb.Settings.DirectorySync do
     alias Portal.{Entra, Google, Okta, Safe}
     import Ecto.Query
 
-    def list_all_directories(subject) do
+    def list_all_directories(subject, repo \\ :replica) do
       [
-        Entra.Directory |> Safe.scoped(subject, :replica) |> Safe.all(),
-        Google.Directory |> Safe.scoped(subject, :replica) |> Safe.all(),
-        Okta.Directory |> Safe.scoped(subject, :replica) |> Safe.all()
+        Entra.Directory |> Safe.scoped(subject, repo) |> Safe.all(),
+        Google.Directory |> Safe.scoped(subject, repo) |> Safe.all(),
+        Okta.Directory |> Safe.scoped(subject, repo) |> Safe.all()
       ]
       |> List.flatten()
       |> enrich_with_job_status()

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -598,7 +598,7 @@ defmodule PortalWeb.Sites do
     with true <- Portal.Billing.can_create_sites?(account),
          changeset = Database.new_site_changeset(account, attrs),
          {:ok, site} <- Database.create_site(changeset, socket.assigns.subject) do
-      sites = Database.list_all_sites(socket.assigns.subject)
+      sites = Database.list_all_sites(socket.assigns.subject, :primary)
 
       {:noreply,
        socket
@@ -831,7 +831,7 @@ defmodule PortalWeb.Sites do
 
     case Database.update_site(changeset, socket.assigns.subject) do
       {:ok, updated_site} ->
-        sites = Database.list_all_sites(socket.assigns.subject)
+        sites = Database.list_all_sites(socket.assigns.subject, :primary)
         site_ids = Enum.map(sites, & &1.id)
         resources_counts = Database.count_resources_by_site(site_ids, socket.assigns.subject)
 
@@ -1005,11 +1005,11 @@ defmodule PortalWeb.Sites do
     alias Portal.{Safe, Site, Resource, Device}
 
     @spec list_all_sites(Portal.Authentication.Subject.t()) :: [Site.t()]
-    def list_all_sites(subject) do
+    def list_all_sites(subject, repo \\ :replica) do
       from(s in Site, as: :sites)
       |> where([sites: s], s.managed_by == :account)
       |> order_by([sites: s], asc: s.name)
-      |> Safe.scoped(subject, :replica)
+      |> Safe.scoped(subject, repo)
       |> Safe.all()
     end
 


### PR DESCRIPTION
There were a few places in the liveviews that we need to read from the DB after writing.  Because we are using replicas to read from by default the changes in some of these places was not being updated in the replica fast enough when the replica was physically far from the primary DB.  This PR forces those few places to read from the primary after doing the write operation in order to guarantee the data is up to date.

Fixes: #13368