### PR TITLE
fix(ci): grant security-events to swift job in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,6 +130,7 @@ jobs:
     permissions:
       contents: write # release draft and build artifact uploads
       id-token: write # OIDC auth
+      security-events: write # trivy SARIF upload from setup-mise
 
   coverage-finish:
     name: coverage-finish


### PR DESCRIPTION
Continuous Delivery has been failing with a `startup_failure` for every commit on `main` since #13034, which means the `notify` job never runs and staging never gets the `checks-passed` dispatch.

#13034 added a Trivy SARIF upload to the `setup-mise` action, so every job that runs `setup-mise` now needs `security-events: write`. The follow-up #13426 scoped that permission onto the individual jobs in `_swift.yml` and passed it through the swift caller in `ci.yml`, but the swift caller in `cd.yml` was missed. Because a called reusable workflow's jobs cannot request more permissions than the caller grants, CD failed to compile its workflow graph and aborted before any job ran. This grants the missing permission so CD can start again.

Related: #13034
Related: #13426