### PR TITLE
fix(ci): grant security-events to rust jobs

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -10,6 +10,7 @@ defaults:
 permissions:
   contents: "read"
   id-token: "write" # OIDC auth
+  security-events: "write" # trivy SARIF upload from setup-mise
 
 env:
   RUSTFLAGS: "--cfg tokio_unstable --deny warnings"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC auth
+      security-events: write # trivy SARIF upload from setup-mise
 
   elixir:
     uses: ./.github/workflows/_elixir.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC auth
+      security-events: write # trivy SARIF upload from setup-mise
 
   monitor-rust:
     needs: [rust]


### PR DESCRIPTION
After #13451 unblocked Continuous Delivery, every rust job started failing at the `setup-mise` step. #13034 made `setup-mise` upload a Trivy SARIF to the Security tab on every job that uses it, which requires `security-events: write`. The `_rust.yml` jobs run `setup-mise` but neither the workflow nor its callers granted that permission, so the SARIF upload failed and took the whole job down.

`_rust.yml` declares its own top-level `permissions` block, which caps what its jobs receive regardless of the caller, so the fix grants `security-events: write` there and passes it through the rust callers in both `ci.yml` and `cd.yml` (CI would otherwise hit the same startup failure swift did).

Related: #13034
Related: #13451