### PR TITLE
feat(connlib): report connections by network path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6750,6 +6750,7 @@ dependencies = [
  "itertools",
  "logging",
  "once_cell",
+ "opentelemetry",
  "rand 0.8.5",
  "ringbuffer",
  "sha2",

--- a/rust/libs/connlib/snownet/Cargo.toml
+++ b/rust/libs/connlib/snownet/Cargo.toml
@@ -19,6 +19,7 @@ is = { workspace = true }
 itertools = { workspace = true }
 logging = { workspace = true }
 once_cell = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics"] }
 rand = { workspace = true }
 ringbuffer = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -29,6 +29,7 @@ use is::stun::{StunMessage, StunPacket};
 use is::{Candidate, CandidateKind, IceConnectionState};
 use is::{IceAgent, IceAgentEvent};
 use itertools::Itertools;
+use opentelemetry::metrics::Gauge;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
@@ -102,6 +103,8 @@ pub struct Node<TId, RId> {
 
     stats: NodeStats,
     buffer_pool: BufferPool<Vec<u8>>,
+
+    connection_count: Gauge<u64>,
 
     rng: StdRng,
 
@@ -193,6 +196,7 @@ where
             connections: Default::default(),
             stats: Default::default(),
             buffer_pool: BufferPool::new(ip_packet::MAX_FZ_PAYLOAD, "snownet"),
+            connection_count: telemetry::otel::metrics::connection_count(),
             unix_now: now,
             unix_ts,
         }
@@ -605,6 +609,8 @@ where
 
         self.allocations_drain_events(now);
 
+        let mut connections_by_path = [0u64; PeerSocket::KINDS.len()];
+
         for (id, connection) in self.connections.iter_established_mut() {
             connection.handle_timeout(
                 id,
@@ -613,6 +619,18 @@ where
                 &mut self.buffered_transmits,
                 &mut self.inflight_stun_requests,
             );
+
+            if let Some(peer_socket) = connection.state.peer_socket() {
+                connections_by_path[peer_socket.kind_index()] += 1;
+            }
+        }
+
+        // Report the current number of connections per network path. Every bucket is
+        // emitted (including `0`) so that a path draining to zero is not stuck at its
+        // last non-zero value.
+        for (kind, count) in PeerSocket::KINDS.into_iter().zip(connections_by_path) {
+            self.connection_count
+                .record(count, &[telemetry::otel::attr::connection_socket(kind)]);
         }
 
         if self.connections.all_idle() {

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -225,6 +225,14 @@ impl ConnectionState {
     pub(crate) fn has_nominated_socket(&self) -> bool {
         matches!(self, Self::Connected { .. } | Self::Idle { .. })
     }
+
+    /// The currently nominated socket, if any.
+    pub(crate) fn peer_socket(&self) -> Option<PeerSocket> {
+        match self {
+            Self::Connected { peer_socket, .. } | Self::Idle { peer_socket } => Some(*peer_socket),
+            Self::Connecting { .. } | Self::Failed => None,
+        }
+    }
 }
 
 impl fmt::Display for ConnectionState {
@@ -290,12 +298,22 @@ impl PeerSocket {
         }
     }
 
-    fn kind(&self) -> &'static str {
+    /// All possible values returned by [`PeerSocket::kind`], ordered by
+    /// [`PeerSocket::kind_index`].
+    pub(crate) const KINDS: [&'static str; 4] =
+        ["PeerToPeer", "PeerToRelay", "RelayToPeer", "RelayToRelay"];
+
+    pub(crate) fn kind(&self) -> &'static str {
+        Self::KINDS[self.kind_index()]
+    }
+
+    /// Index of this socket's kind into [`PeerSocket::KINDS`].
+    pub(crate) fn kind_index(&self) -> usize {
         match self {
-            PeerSocket::PeerToPeer { .. } => "PeerToPeer",
-            PeerSocket::PeerToRelay { .. } => "PeerToRelay",
-            PeerSocket::RelayToPeer { .. } => "RelayToPeer",
-            PeerSocket::RelayToRelay { .. } => "RelayToRelay",
+            PeerSocket::PeerToPeer { .. } => 0,
+            PeerSocket::PeerToRelay { .. } => 1,
+            PeerSocket::RelayToPeer { .. } => 2,
+            PeerSocket::RelayToRelay { .. } => 3,
         }
     }
 }

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -72,6 +72,11 @@ pub mod attr {
         KeyValue::new("network.io.direction", "transmit")
     }
 
+    /// The kind of socket a connection's path uses, e.g. `PeerToPeer` or `RelayToRelay`.
+    pub fn connection_socket(socket: &'static str) -> KeyValue {
+        KeyValue::new("connection.socket", socket)
+    }
+
     pub fn io_error_code(e: &io::Error) -> KeyValue {
         KeyValue::new("error.code", e.raw_os_error().unwrap_or_default() as i64)
     }
@@ -235,6 +240,14 @@ pub mod metrics {
             .u64_counter("tunnel.error")
             .with_description("Number of errors encountered while processing a packet batch.")
             .with_unit("{error}")
+            .build()
+    }
+
+    pub fn connection_count() -> Gauge<u64> {
+        opentelemetry::global::meter("connlib")
+            .u64_gauge("tunnel.connection.count")
+            .with_description("Number of connections by the network path in use.")
+            .with_unit("{connection}")
             .build()
     }
 


### PR DESCRIPTION
Adds `tunnel.connection.count`, a gauge of currently established connections broken down by the network path in use (direct versus the relayed combinations), giving a live view of the relayed-versus-direct split.

A gauge rather than a counter because a connection's path is not fixed: ICE keeps trying to upgrade a relayed path to a direct one, so a point-in-time count reflects reality better than counting one-off establishment events. The name follows OpenTelemetry's `<area>.connection.count` naming convention.