### PR TITLE
feat(connlib): measure DNS lookup duration

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -34,7 +34,7 @@ use crate::peer_store::{Peer, PeerStore};
 use crate::routing_table::{RouteEntry, RoutingTable};
 use crate::unix_ts::UnixTsClock;
 use crate::unroutable_packet::UnroutablePacket;
-use crate::{ClientEvent, FailedToDecapsulate, packet_kind};
+use crate::{ClientEvent, FailedToDecapsulate, otel, packet_kind};
 use crate::{IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, TunConfig, dns, p2p_control};
 use anyhow::{Context, ErrorExt, Result};
 use boringtun::x25519;
@@ -167,7 +167,7 @@ pub struct ClientState {
     tcp_dns_server: dns_over_tcp::Server,
     /// Tracks the UDP/TCP stream (i.e. socket-pair) on which we received a DNS query by the ID of the recursive DNS query we issued.
     dns_streams_by_local_upstream_and_query_id:
-        HashMap<(dns::Transport, SocketAddr, SocketAddr, u16), (SocketAddr, SocketAddr)>,
+        HashMap<(dns::Transport, SocketAddr, SocketAddr, u16), (SocketAddr, SocketAddr, Instant)>,
 
     buffered_events: VecDeque<ClientEvent>,
     buffered_packets: VecDeque<IpPacket>,
@@ -175,6 +175,7 @@ pub struct ClientState {
 
     unix_ts_clock: UnixTsClock,
     buffered_dns_queries: VecDeque<dns::RecursiveQuery>,
+    dns_lookup_duration: opentelemetry::metrics::Histogram<f64>,
 }
 
 impl ClientState {
@@ -216,6 +217,7 @@ impl ClientState {
             resource_list: Default::default(),
             connected_pool_clients: Default::default(),
             unix_ts_clock: UnixTsClock::new(now, unix_ts),
+            dns_lookup_duration: otel::metrics::dns_lookup_duration(),
         }
     }
 
@@ -686,6 +688,24 @@ impl ClientState {
     }
 
     pub(crate) fn handle_dns_response(&mut self, response: dns::RecursiveResponse, now: Instant) {
+        let mut attributes = vec![
+            match response.recursion {
+                dns::Recursion::Local => otel::attr::dns_recursion_local(),
+                dns::Recursion::Tunnel => otel::attr::dns_recursion_tunnel(),
+            },
+            otel::attr::dns_question_type(response.query.qtype()),
+            otel::attr::network_transport(response.transport),
+        ];
+        match &response.message {
+            Ok(message) => attributes.push(otel::attr::dns_response_code(message.response_code())),
+            Err(e) => attributes.extend(telemetry::otel::error_layers(e)),
+        }
+        self.dns_lookup_duration.record(
+            now.saturating_duration_since(response.started_at)
+                .as_secs_f64(),
+            &attributes,
+        );
+
         let qid = response.query.id();
         let server = response.server;
         let domain = response.query.domain();
@@ -1554,7 +1574,7 @@ impl ClientState {
                 let qid = query_result.query.id();
                 let known_sockets = &mut self.dns_streams_by_local_upstream_and_query_id;
 
-                let Some((local, remote)) =
+                let Some((local, remote, started_at)) =
                     known_sockets.remove(&(dns::Transport::Udp, query_result.local, server, qid))
                 else {
                     tracing::warn!(?known_sockets, %server, %qid, "Failed to find UDP socket handle for query result");
@@ -1570,6 +1590,8 @@ impl ClientState {
                         query: query_result.query,
                         message: query_result.result,
                         transport: dns::Transport::Udp,
+                        started_at,
+                        recursion: dns::Recursion::Tunnel,
                     },
                     now,
                 );
@@ -1582,7 +1604,7 @@ impl ClientState {
                 let qid = query_result.query.id();
                 let known_sockets = &mut self.dns_streams_by_local_upstream_and_query_id;
 
-                let Some((local, remote)) =
+                let Some((local, remote, started_at)) =
                     known_sockets.remove(&(dns::Transport::Tcp, query_result.local, server, qid))
                 else {
                     tracing::warn!(?known_sockets, %server, %qid, "Failed to find TCP socket handle for query result");
@@ -1598,6 +1620,8 @@ impl ClientState {
                         query: query_result.query,
                         message: query_result.result,
                         transport: dns::Transport::Tcp,
+                        started_at,
+                        recursion: dns::Recursion::Tunnel,
                     },
                     now,
                 );
@@ -1878,11 +1902,12 @@ impl ClientState {
 
         tracing::trace!(%local_socket, %server, %local, %query_id, "Forwarded {transport} DNS query via tunnel");
 
-        let existing = self
-            .dns_streams_by_local_upstream_and_query_id
-            .insert((transport, local_socket, server, query_id), (local, remote));
+        let existing = self.dns_streams_by_local_upstream_and_query_id.insert(
+            (transport, local_socket, server, query_id),
+            (local, remote, now),
+        );
 
-        if let Some((existing_local, existing_remote)) = existing
+        if let Some((existing_local, existing_remote, _)) = existing
             && (existing_local != local || existing_remote != remote)
         {
             debug_assert!(false, "Query IDs should be unique");

--- a/rust/libs/connlib/tunnel/src/dns.rs
+++ b/rust/libs/connlib/tunnel/src/dns.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use dns_types::DoHUrl;
 use logging::err_with_src;
 use std::net::SocketAddr;
+use std::time::Instant;
 
 pub(crate) const DNS_PORT: u16 = 53;
 
@@ -56,6 +57,19 @@ pub(crate) struct RecursiveResponse {
 
     /// The transport we used.
     pub transport: Transport,
+
+    /// When we sent the query, used to measure the lookup duration on completion.
+    pub started_at: Instant,
+
+    /// Whether the query was recursed locally or through the tunnel.
+    pub recursion: Recursion,
+}
+
+/// Whether a recursive query was resolved locally or forwarded through the tunnel.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Recursion {
+    Local,
+    Tunnel,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display)]

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -82,6 +82,7 @@ struct DnsQueryMetaData {
     local: SocketAddr,
     remote: SocketAddr,
     transport: dns::Transport,
+    started_at: Instant,
 }
 
 pub(crate) struct Buffers {
@@ -355,30 +356,28 @@ impl Io {
             })
             .collect::<Vec<_>>();
 
-        let dns_response = self
-            .dns_queries
-            .poll_unpin(cx)
-            .map(|(result, meta)| match result {
-                Ok(result) => dns::RecursiveResponse {
+        let dns_response = match self.dns_queries.poll_unpin(cx) {
+            Poll::Ready((result, meta)) => {
+                let message = match result {
+                    Ok(message) => message,
+                    Err(e @ futures_bounded::Timeout { .. }) => Err(anyhow::Error::new(
+                        io::Error::new(io::ErrorKind::TimedOut, e),
+                    )),
+                };
+
+                Poll::Ready(dns::RecursiveResponse {
                     server: meta.server,
                     query: meta.query,
-                    message: result,
+                    message,
                     transport: meta.transport,
                     local: meta.local,
                     remote: meta.remote,
-                },
-                Err(e @ futures_bounded::Timeout { .. }) => dns::RecursiveResponse {
-                    server: meta.server,
-                    query: meta.query,
-                    message: Err(anyhow::Error::new(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        e,
-                    ))),
-                    transport: meta.transport,
-                    local: meta.local,
-                    remote: meta.remote,
-                },
-            });
+                    started_at: meta.started_at,
+                    recursion: dns::Recursion::Local,
+                })
+            }
+            Poll::Pending => Poll::Pending,
+        };
 
         // We need to discard DoH clients if their queries fail because the connection got closed.
         // They will get re-bootstrapped on the next requested DoH query.
@@ -524,6 +523,7 @@ impl Io {
             transport: query.transport,
             local: query.local,
             remote: query.remote,
+            started_at: Instant::now(),
         };
 
         match (query.transport, query.server) {

--- a/rust/libs/connlib/tunnel/src/otel.rs
+++ b/rust/libs/connlib/tunnel/src/otel.rs
@@ -8,6 +8,104 @@ pub mod attr {
 
         KeyValue::new(KEY, crate::packet_kind::classify(payload))
     }
+
+    /// The transport a DNS query was received / forwarded on.
+    pub fn network_transport(transport: crate::dns::Transport) -> KeyValue {
+        const KEY: &str = "network.transport";
+
+        match transport {
+            crate::dns::Transport::Udp => KeyValue::new(KEY, "udp"),
+            crate::dns::Transport::Tcp => KeyValue::new(KEY, "tcp"),
+        }
+    }
+
+    /// The DNS query type (e.g. `A`, `AAAA`).
+    ///
+    /// Only IANA-assigned record types (which `domain` renders by their mnemonic) are
+    /// emitted as-is. Unrecognised types are rendered by `domain` as `TYPE<n>` and are
+    /// collapsed into `other` so that an (untrusted) peer cannot inflate the metric's
+    /// cardinality with exotic query types.
+    pub fn dns_question_type(qtype: dns_types::RecordType) -> KeyValue {
+        const KEY: &str = "dns.question.type";
+
+        let mnemonic = qtype.to_string();
+
+        if mnemonic.starts_with("TYPE") {
+            KeyValue::new(KEY, "other")
+        } else {
+            KeyValue::new(KEY, mnemonic)
+        }
+    }
+
+    /// A DNS query that was recursed locally, i.e. forwarded directly to an upstream resolver.
+    pub fn dns_recursion_local() -> KeyValue {
+        KeyValue::new("dns.recursion", "local")
+    }
+
+    /// A DNS query that was recursed through the tunnel, i.e. forwarded to a Gateway for resolution.
+    pub fn dns_recursion_tunnel() -> KeyValue {
+        KeyValue::new("dns.recursion", "tunnel")
+    }
+
+    /// The response code of a completed DNS lookup (e.g. `NOERROR`, `NXDOMAIN`).
+    ///
+    /// `domain` renders unassigned codes as `RCODE<n>`; those are collapsed into
+    /// `other` so that an (untrusted) upstream cannot inflate the metric's cardinality.
+    pub fn dns_response_code(code: dns_types::ResponseCode) -> KeyValue {
+        const KEY: &str = "dns.response.code";
+
+        let mnemonic = code.to_string();
+
+        if mnemonic.starts_with("RCODE") {
+            KeyValue::new(KEY, "other")
+        } else {
+            KeyValue::new(KEY, mnemonic)
+        }
+    }
 }
 
-pub use telemetry::otel::metrics;
+pub mod metrics {
+    pub use telemetry::otel::metrics::*;
+
+    use opentelemetry::metrics::Histogram;
+
+    /// Measures how long connlib takes to recursively resolve a DNS query against
+    /// an upstream resolver (locally or through the tunnel).
+    pub fn dns_lookup_duration() -> Histogram<f64> {
+        opentelemetry::global::meter("connlib")
+            .f64_histogram("dns.lookup.duration")
+            .with_description("Duration of a recursive DNS lookup against an upstream resolver.")
+            .with_unit("s")
+            .with_boundaries(vec![
+                0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+            ])
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::attr::dns_question_type;
+    use dns_types::RecordType;
+    use opentelemetry::KeyValue;
+
+    #[test]
+    fn well_known_question_types_are_emitted_verbatim() {
+        assert_eq!(
+            dns_question_type(RecordType::A),
+            KeyValue::new("dns.question.type", "A")
+        );
+        assert_eq!(
+            dns_question_type(RecordType::AAAA),
+            KeyValue::new("dns.question.type", "AAAA")
+        );
+    }
+
+    #[test]
+    fn unknown_question_types_collapse_to_other() {
+        assert_eq!(
+            dns_question_type(RecordType::from_int(60000)),
+            KeyValue::new("dns.question.type", "other")
+        );
+    }
+}

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -736,6 +736,8 @@ impl TunnelTest {
                             transport,
                             local,
                             remote,
+                            started_at: now,
+                            recursion: dns::Recursion::Local,
                         },
                         now,
                     )


### PR DESCRIPTION
Adds `dns.lookup.duration`, a histogram measuring how long connlib takes to recursively resolve a DNS query against an upstream resolver.

It is dimensioned by question type, transport, and whether recursion was local or through the tunnel, plus the outcome: the response code (`NOERROR`, `NXDOMAIN`, …) on success, or the error's source chain via the `error.type.{N}` attributes (shared with event-loop error reporting) on failure — which also captures timeouts.

Like all other metrics, this is off by default and only gets enabled when we troubleshoot problems with a customer. Measuring the latency segmented by the various attributes of question type, transport etc allows us to capture many useful data points in a single metric. For example, it allows us to answer questions like "How many queries are running into a timeout and is there a pattern in the query type, IP version or transport?". A lot of components on a modern system depend on DNS functioning and it being fast, so variations in the latency is also a very good data point when troubleshooting issues.