### PR TITLE
fix(portal): don't change_log outbound emails

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -138,8 +138,6 @@ config :portal, Portal.ChangeLogs.ReplicationConnection,
     client_tokens
     one_time_passcodes
     portal_sessions
-    outbound_emails
-    outbound_email_deliveries
     api_tokens
   ],
   # Allow up to 5 minutes of processing lag before alerting. This needs to be able to survive

--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -36,8 +36,6 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
     "sites" => Portal.Site,
     "static_device_pool_members" => Portal.StaticDevicePoolMember,
     "client_tokens" => Portal.ClientToken,
-    "outbound_emails" => Portal.OutboundEmail,
-    "outbound_email_deliveries" => Portal.OutboundEmailDelivery,
     "userpass_auth_providers" => Portal.Userpass.AuthProvider
   }
 


### PR DESCRIPTION
Many times these have no associated account and are internal changes only

Fixes #13462 
