### PR TITLE
fix(portal): skip missing accounts in change_log

### DIFF
--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -99,13 +99,14 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
     to_insert = Map.values(state.flush_buffer)
     attempted_count = Enum.count(state.flush_buffer)
 
-    {successful_count, _change_logs} = Database.bulk_insert(to_insert)
+    {successful_count, _skipped_count} = Database.bulk_insert(to_insert)
 
     Logger.info("Flushed #{successful_count}/#{attempted_count} change logs")
 
-    # We always advance the LSN to the highest LSN in the flush buffer because
-    # LSN conflicts just mean the data is already inserted, and other insert_all
-    # issues like a missing account_id will raise an exception.
+    # We always advance the LSN to the highest LSN in the flush buffer. LSN
+    # conflicts just mean the data is already inserted, and entries for accounts
+    # that no longer exist are dropped during bulk_insert. Any other insert_all
+    # issue raises so we crash and replay from the durable slot.
     last_lsn =
       state.flush_buffer
       |> Map.keys()
@@ -204,14 +205,87 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
   end
 
   defmodule Database do
+    require Logger
     alias Portal.{Safe, ChangeLog}
 
     def bulk_insert(list_of_attrs) do
-      Safe.unscoped()
-      |> Safe.insert_all(ChangeLog, list_of_attrs,
-        on_conflict: :nothing,
-        conflict_target: [:lsn]
-      )
+      do_bulk_insert(list_of_attrs, 0)
+    end
+
+    # Inserts the batch, transparently dropping entries that reference an account
+    # that no longer exists and retrying with the remainder. A foreign-key
+    # violation aborts the whole statement without inserting anything, so the
+    # remaining valid entries are safe to re-attempt. We extract the offending
+    # account_id from the error detail rather than querying `accounts` to keep
+    # this hot, write-heavy path free of extra reads.
+    #
+    # Anything other than our account_id FK violation reraises so the replication
+    # connection crashes and replays from the durable slot. If the violation is
+    # ours but we cannot turn it into an account_id we can actually drop, we
+    # raise loudly instead of silently swallowing the batch, so a change in the
+    # constraint name or error format surfaces as a crash rather than data loss.
+    defp do_bulk_insert([], skipped), do: {0, skipped}
+
+    defp do_bulk_insert(list_of_attrs, skipped) do
+      case insert_all(list_of_attrs) do
+        {:ok, inserted} ->
+          {inserted, skipped}
+
+        {:missing_account, account_id} ->
+          {dropped, remaining} = Enum.split_with(list_of_attrs, &(&1.account_id == account_id))
+
+          if dropped == [] do
+            raise "change_logs account_id FK violation referenced account_id " <>
+                    "#{inspect(account_id)} that is not present in the batch"
+          end
+
+          Logger.info(
+            "Skipping #{length(dropped)} change log(s) because account no longer exists",
+            account_id: account_id
+          )
+
+          do_bulk_insert(remaining, skipped + length(dropped))
+      end
+    end
+
+    defp insert_all(list_of_attrs) do
+      {inserted, _} =
+        Safe.unscoped()
+        |> Safe.insert_all(ChangeLog, list_of_attrs,
+          on_conflict: :nothing,
+          conflict_target: [:lsn]
+        )
+
+      {:ok, inserted}
+    rescue
+      error in Postgrex.Error ->
+        case error.postgres do
+          %{code: :foreign_key_violation, constraint: "change_logs_account_id_fkey"} = pg ->
+            {:missing_account, missing_account_id!(pg)}
+
+          _ ->
+            reraise error, __STACKTRACE__
+        end
+    end
+
+    # Pull the missing account_id out of the FK violation detail line, e.g.
+    # `Key (account_id)=(c24f...) is not present in table "accounts".`. We have
+    # already confirmed this is the account_id FK violation, so failing to parse
+    # it means our assumptions about the error format broke: crash rather than
+    # guess, otherwise we risk dropping valid entries or looping forever.
+    defp missing_account_id!(%{detail: detail}) when is_binary(detail) do
+      case Regex.run(~r/\(account_id\)=\(([^)]+)\)/, detail) do
+        [_, account_id] ->
+          account_id
+
+        nil ->
+          raise "could not parse account_id from change_logs FK violation detail: " <>
+                  inspect(detail)
+      end
+    end
+
+    defp missing_account_id!(pg) do
+      raise "change_logs account_id FK violation has no usable detail: #{inspect(pg)}"
     end
 
     # Read seq_start from Postgres so we always use a consistent clock source.

--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -339,6 +339,7 @@ defmodule Portal.Mailer do
 
   defmodule Database do
     import Ecto.Query
+    require Logger
 
     alias Portal.Safe
     alias Portal.{EmailSuppression, OutboundEmail, OutboundEmailDelivery, Repo}
@@ -363,6 +364,29 @@ defmodule Portal.Mailer do
       now = DateTime.utc_now()
       recipients = normalize_recipients(recipients)
 
+      case do_insert_tracked(account_id, message_id, subject, recipients, now) do
+        {:error, %Ecto.Changeset{} = changeset} when not is_nil(account_id) ->
+          if account_does_not_exist?(changeset) do
+            # The account was deleted out from under us (e.g. a deletion-complete
+            # email racing teardown). Still persist the tracking record, just
+            # without the account_id, which the FK now allows (ON DELETE SET NULL).
+            Logger.info(
+              "Persisting tracked outbound email without account_id; account no longer exists",
+              account_id: account_id,
+              message_id: message_id
+            )
+
+            do_insert_tracked(nil, message_id, subject, recipients, now)
+          else
+            {:error, changeset}
+          end
+
+        result ->
+          result
+      end
+    end
+
+    defp do_insert_tracked(account_id, message_id, subject, recipients, now) do
       Safe.transact(
         fn ->
           with {:ok, entry} <- insert_entry(account_id, message_id, subject, recipients, now) do
@@ -378,6 +402,10 @@ defmodule Portal.Mailer do
         end,
         @db_opts
       )
+    end
+
+    defp account_does_not_exist?(%Ecto.Changeset{errors: errors}) do
+      match?({_, [{:constraint, :assoc} | _]}, Keyword.get(errors, :account))
     end
 
     defp normalize_recipients(recipients) do

--- a/elixir/test/portal/change_logs/replication_connection_test.exs
+++ b/elixir/test/portal/change_logs/replication_connection_test.exs
@@ -741,6 +741,81 @@ defmodule Portal.ChangeLogs.ReplicationConnectionTest do
       assert result_state.last_flushed_lsn == 402
       assert result_state.flush_buffer == %{}
     end
+
+    test "drops entries for a deleted account but persists valid entries in the batch", %{
+      account: account
+    } do
+      committed_at = ~U[2026-05-26 12:00:00.000000Z]
+      missing_account_id = Ecto.UUID.generate()
+
+      valid_entry = %{
+        event_id: EventId.build_change_log(@seq_start, 0),
+        timestamp: committed_at,
+        lsn: 500,
+        object: "resources",
+        operation: :insert,
+        account_id: account.id,
+        after: %{"id" => Ecto.UUID.generate(), "account_id" => account.id},
+        before: nil,
+        vsn: 0,
+        subject: nil
+      }
+
+      dead_entry = %{
+        event_id: EventId.build_change_log(@seq_start, 1),
+        timestamp: committed_at,
+        lsn: 501,
+        object: "resources",
+        operation: :insert,
+        account_id: missing_account_id,
+        after: %{"id" => Ecto.UUID.generate(), "account_id" => missing_account_id},
+        before: nil,
+        vsn: 0,
+        subject: nil
+      }
+
+      state = %{
+        flush_buffer: %{500 => valid_entry, 501 => dead_entry},
+        last_flushed_lsn: 499
+      }
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          result_state = ReplicationConnection.on_flush(state)
+
+          # LSN advances past the whole batch so we don't replay the dead entry
+          # forever, and the buffer is cleared.
+          assert result_state.last_flushed_lsn == 501
+          assert result_state.flush_buffer == %{}
+        end)
+
+      assert log =~ "Skipping 1 change log(s) because account no longer exists"
+
+      # The valid entry survived; only the dead-account entry was dropped.
+      assert [%ChangeLog{lsn: 500}] =
+               Repo.all(from cl in ChangeLog, where: cl.lsn in [500, 501])
+    end
+
+    test "reraises constraint violations that are not a missing account_id", %{account: account} do
+      committed_at = ~U[2026-05-26 12:00:00.000000Z]
+
+      # Omitting the NOT NULL vsn column triggers a different Postgrex error. It
+      # must surface as a crash rather than being silently dropped like the
+      # missing-account case.
+      entry = %{
+        event_id: EventId.build_change_log(@seq_start, 0),
+        timestamp: committed_at,
+        lsn: 600,
+        object: "resources",
+        operation: :insert,
+        account_id: account.id,
+        after: %{"id" => Ecto.UUID.generate(), "account_id" => account.id},
+        before: nil,
+        subject: nil
+      }
+
+      assert_raise Postgrex.Error, fn -> Database.bulk_insert([entry]) end
+    end
   end
 
   describe "edge cases" do

--- a/elixir/test/portal/mailer_test.exs
+++ b/elixir/test/portal/mailer_test.exs
@@ -484,6 +484,35 @@ defmodule Portal.MailerTest do
 
       refute changeset.valid?
     end
+
+    test "persists with a cleared account_id when the account no longer exists" do
+      missing_account_id = Ecto.UUID.generate()
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, entry} =
+                   Portal.Mailer.Database.insert_tracked(
+                     missing_account_id,
+                     "acs-message-orphan",
+                     "Tracked",
+                     ["recipient@example.com"]
+                   )
+
+          # The tracking row is still persisted, just without the account_id.
+          assert entry.account_id == nil
+          assert entry.message_id == "acs-message-orphan"
+        end)
+
+      assert log =~ "Persisting tracked outbound email without account_id"
+
+      delivery =
+        Repo.get_by!(Portal.OutboundEmailDelivery,
+          message_id: "acs-message-orphan",
+          email: "recipient@example.com"
+        )
+
+      assert delivery.account_id == nil
+    end
   end
 
   defp acs_auth_headers(conn) do


### PR DESCRIPTION
If an account is deleted, the operation (and others that may reference the account) make their way through the change_log consumer after the fact. This needs to be handled gracefully as a special-case because we now have a foreign key constraint on the change_logs table.

We do so by recursively re-attempting the bulk insert with the offending account's entries dropped from the buffer to insert.

Similarly, for tracking outbound emails, if the account was deleted, the account_id in the outbound email is invalid and fails the insert. What we do here instead is nilify the account_id manually but still track the outbound email so that we receive delivery reports for it.

Fixes #13464
Fixes #13463
