### PR TITLE
fix(portal): drain socket on channel crash

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -45,12 +45,37 @@ defmodule PortalAPI.Client.Channel do
 
   @impl true
   def join("client", _payload, socket) do
-    # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
-    Process.link(socket.transport_pid)
-
     send(self(), :after_join)
 
     {:ok, socket}
+  end
+
+  # On an abnormal exit we must close the whole WebSocket, not just the channel.
+  # When only the channel dies, presence tracking and the PG registration die
+  # with it, so the portal can no longer push to this client. connlib does not
+  # notice: a `phx_error` is ignored, heartbeats still answer on the surviving
+  # transport, and connlib only re-joins reactively (on its next send), leaving
+  # an unbounded state-desync window. Worse, that re-join reuses the
+  # transport-scoped session id and collides with the row already persisted.
+  #
+  # Draining the transport forces connlib through its full reconnect path, which
+  # runs `Socket.connect/3` again and mints a fresh session id. This keeps the
+  # transport:session relationship 1:1, so every session id reaching the DB is
+  # unique by construction.
+  #
+  # Graceful stops (`:normal` / `:shutdown` / `{:shutdown, _}`) already send a
+  # `phx_close` that connlib treats as a clean reconnect, so we leave those
+  # alone and only intervene on an abnormal exit. The channel does not trap
+  # exits, so `terminate/2` runs for in-process crashes; an external `:kill`
+  # skips it, but that only happens on node shutdown where the transport is
+  # going down regardless.
+  @impl true
+  def terminate(reason, socket) do
+    if abnormal_exit?(reason) do
+      send(socket.transport_pid, :socket_drain)
+    end
+
+    :ok
   end
 
   @impl true
@@ -2412,6 +2437,11 @@ defmodule PortalAPI.Client.Channel do
     |> Map.from_struct()
     |> Map.drop([:__meta__, :account, :device, :client_token])
   end
+
+  defp abnormal_exit?(:normal), do: false
+  defp abnormal_exit?(:shutdown), do: false
+  defp abnormal_exit?({:shutdown, _reason}), do: false
+  defp abnormal_exit?(_reason), do: true
 
   defmodule Database do
     import Ecto.Query, only: [from: 2]

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -50,25 +50,12 @@ defmodule PortalAPI.Client.Channel do
     {:ok, socket}
   end
 
-  # On an abnormal exit we must close the whole WebSocket, not just the channel.
-  # When only the channel dies, presence tracking and the PG registration die
-  # with it, so the portal can no longer push to this client. connlib does not
-  # notice: a `phx_error` is ignored, heartbeats still answer on the surviving
-  # transport, and connlib only re-joins reactively (on its next send), leaving
-  # an unbounded state-desync window. Worse, that re-join reuses the
-  # transport-scoped session id and collides with the row already persisted.
-  #
-  # Draining the transport forces connlib through its full reconnect path, which
-  # runs `Socket.connect/3` again and mints a fresh session id. This keeps the
-  # transport:session relationship 1:1, so every session id reaching the DB is
-  # unique by construction.
-  #
-  # Graceful stops (`:normal` / `:shutdown` / `{:shutdown, _}`) already send a
-  # `phx_close` that connlib treats as a clean reconnect, so we leave those
-  # alone and only intervene on an abnormal exit. The channel does not trap
-  # exits, so `terminate/2` runs for in-process crashes; an external `:kill`
-  # skips it, but that only happens on node shutdown where the transport is
-  # going down regardless.
+  # On an abnormal exit, drain the whole WebSocket instead of just letting the
+  # channel die. connlib ignores `phx_error` and would keep the transport alive,
+  # re-joining reactively and reusing the transport-scoped session id (which
+  # collides with the row already persisted). Draining forces a full reconnect
+  # that re-runs `Socket.connect/3` and mints a fresh id, keeping transport:session
+  # 1:1. Graceful stops already send `phx_close`, so we only intervene here.
   @impl true
   def terminate(reason, socket) do
     if abnormal_exit?(reason) do

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -80,11 +80,36 @@ defmodule PortalAPI.Gateway.Channel do
 
   @impl true
   def join("gateway", _payload, socket) do
-    # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
-    Process.link(socket.transport_pid)
-
     send(self(), :after_join)
     {:ok, socket}
+  end
+
+  # On an abnormal exit we must close the whole WebSocket, not just the channel.
+  # When only the channel dies, presence tracking and the PG registration die
+  # with it, so the portal can no longer push to this gateway. connlib does not
+  # notice: a `phx_error` is ignored, heartbeats still answer on the surviving
+  # transport, and connlib only re-joins reactively (on its next send), leaving
+  # an unbounded state-desync window. Worse, that re-join reuses the
+  # transport-scoped session id and collides with the row already persisted.
+  #
+  # Draining the transport forces connlib through its full reconnect path, which
+  # runs `Socket.connect/3` again and mints a fresh session id. This keeps the
+  # transport:session relationship 1:1, so every session id reaching the DB is
+  # unique by construction.
+  #
+  # Graceful stops (`:normal` / `:shutdown` / `{:shutdown, _}`) already send a
+  # `phx_close` that connlib treats as a clean reconnect, so we leave those
+  # alone and only intervene on an abnormal exit. The channel does not trap
+  # exits, so `terminate/2` runs for in-process crashes; an external `:kill`
+  # skips it, but that only happens on node shutdown where the transport is
+  # going down regardless.
+  @impl true
+  def terminate(reason, socket) do
+    if abnormal_exit?(reason) do
+      send(socket.transport_pid, :socket_drain)
+    end
+
+    :ok
   end
 
   ####################################
@@ -1091,6 +1116,11 @@ defmodule PortalAPI.Gateway.Channel do
     |> Map.from_struct()
     |> Map.drop([:__meta__, :account, :device, :gateway_token])
   end
+
+  defp abnormal_exit?(:normal), do: false
+  defp abnormal_exit?(:shutdown), do: false
+  defp abnormal_exit?({:shutdown, _reason}), do: false
+  defp abnormal_exit?(_reason), do: true
 
   defmodule Database do
     import Ecto.Query

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -84,25 +84,12 @@ defmodule PortalAPI.Gateway.Channel do
     {:ok, socket}
   end
 
-  # On an abnormal exit we must close the whole WebSocket, not just the channel.
-  # When only the channel dies, presence tracking and the PG registration die
-  # with it, so the portal can no longer push to this gateway. connlib does not
-  # notice: a `phx_error` is ignored, heartbeats still answer on the surviving
-  # transport, and connlib only re-joins reactively (on its next send), leaving
-  # an unbounded state-desync window. Worse, that re-join reuses the
-  # transport-scoped session id and collides with the row already persisted.
-  #
-  # Draining the transport forces connlib through its full reconnect path, which
-  # runs `Socket.connect/3` again and mints a fresh session id. This keeps the
-  # transport:session relationship 1:1, so every session id reaching the DB is
-  # unique by construction.
-  #
-  # Graceful stops (`:normal` / `:shutdown` / `{:shutdown, _}`) already send a
-  # `phx_close` that connlib treats as a clean reconnect, so we leave those
-  # alone and only intervene on an abnormal exit. The channel does not trap
-  # exits, so `terminate/2` runs for in-process crashes; an external `:kill`
-  # skips it, but that only happens on node shutdown where the transport is
-  # going down regardless.
+  # On an abnormal exit, drain the whole WebSocket instead of just letting the
+  # channel die. connlib ignores `phx_error` and would keep the transport alive,
+  # re-joining reactively and reusing the transport-scoped session id (which
+  # collides with the row already persisted). Draining forces a full reconnect
+  # that re-runs `Socket.connect/3` and mints a fresh id, keeping transport:session
+  # 1:1. Graceful stops already send `phx_close`, so we only intervene here.
   @impl true
   def terminate(reason, socket) do
     if abnormal_exit?(reason) do

--- a/elixir/lib/portal_api/relay/channel.ex
+++ b/elixir/lib/portal_api/relay/channel.ex
@@ -6,9 +6,6 @@ defmodule PortalAPI.Relay.Channel do
 
   @impl true
   def join("relay", %{"stamp_secret" => stamp_secret}, socket) do
-    # If we crash, take the transport process down with us since connlib expects the WebSocket to close on error
-    Process.link(socket.transport_pid)
-
     OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)
     OpenTelemetry.Tracer.set_current_span(socket.assigns.opentelemetry_span_ctx)
 
@@ -25,6 +22,31 @@ defmodule PortalAPI.Relay.Channel do
 
       {:ok, socket}
     end
+  end
+
+  # On an abnormal exit we must close the whole WebSocket, not just the channel.
+  # When only the channel dies, presence tracking dies with it, so the portal can
+  # no longer push to this relay. connlib does not notice: a `phx_error` is
+  # ignored, heartbeats still answer on the surviving transport, and connlib only
+  # re-joins reactively (on its next send), leaving an unbounded state-desync
+  # window.
+  #
+  # Draining the transport forces connlib through its full reconnect path, which
+  # re-runs the join and re-establishes presence.
+  #
+  # Graceful stops (`:normal` / `:shutdown` / `{:shutdown, _}`) already send a
+  # `phx_close` that connlib treats as a clean reconnect, so we leave those
+  # alone and only intervene on an abnormal exit. The channel does not trap
+  # exits, so `terminate/2` runs for in-process crashes; an external `:kill`
+  # skips it, but that only happens on node shutdown where the transport is
+  # going down regardless.
+  @impl true
+  def terminate(reason, socket) do
+    if abnormal_exit?(reason) do
+      send(socket.transport_pid, :socket_drain)
+    end
+
+    :ok
   end
 
   @impl true
@@ -54,4 +76,9 @@ defmodule PortalAPI.Relay.Channel do
 
     {:reply, {:error, %{reason: :unknown_message}}, socket}
   end
+
+  defp abnormal_exit?(:normal), do: false
+  defp abnormal_exit?(:shutdown), do: false
+  defp abnormal_exit?({:shutdown, _reason}), do: false
+  defp abnormal_exit?(_reason), do: true
 end

--- a/elixir/lib/portal_api/relay/channel.ex
+++ b/elixir/lib/portal_api/relay/channel.ex
@@ -24,22 +24,11 @@ defmodule PortalAPI.Relay.Channel do
     end
   end
 
-  # On an abnormal exit we must close the whole WebSocket, not just the channel.
-  # When only the channel dies, presence tracking dies with it, so the portal can
-  # no longer push to this relay. connlib does not notice: a `phx_error` is
-  # ignored, heartbeats still answer on the surviving transport, and connlib only
-  # re-joins reactively (on its next send), leaving an unbounded state-desync
-  # window.
-  #
-  # Draining the transport forces connlib through its full reconnect path, which
-  # re-runs the join and re-establishes presence.
-  #
-  # Graceful stops (`:normal` / `:shutdown` / `{:shutdown, _}`) already send a
-  # `phx_close` that connlib treats as a clean reconnect, so we leave those
-  # alone and only intervene on an abnormal exit. The channel does not trap
-  # exits, so `terminate/2` runs for in-process crashes; an external `:kill`
-  # skips it, but that only happens on node shutdown where the transport is
-  # going down regardless.
+  # On an abnormal exit, drain the whole WebSocket instead of just letting the
+  # channel die. connlib ignores `phx_error` and would keep the transport alive,
+  # re-joining reactively while presence stays dead. Draining forces a full
+  # reconnect that re-runs the join and re-establishes presence. Graceful stops
+  # already send `phx_close`, so we only intervene here.
   @impl true
   def terminate(reason, socket) do
     if abnormal_exit?(reason) do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -326,20 +326,48 @@ defmodule PortalAPI.Client.ChannelTest do
       refute :sys.get_state(socket.channel_pid).assigns.session_durability
     end
 
-    test "channel crash takes down the transport", %{client: client, subject: subject} do
+    test "an abnormal channel exit drains the transport so connlib reconnects", %{
+      client: client,
+      subject: subject
+    } do
       Process.flag(:trap_exit, true)
 
       socket = join_channel(client, subject)
       assert_push "init", _init_payload
 
-      # In tests, we (the test process) are the transport_pid
+      # In ChannelTest the test process is the transport_pid, so a drain message
+      # sent by terminate/2 lands in our mailbox.
       assert socket.transport_pid == self()
 
-      # Kill the channel - we receive EXIT because we're linked
-      Process.exit(socket.channel_pid, :kill)
+      # Terminate the channel with an abnormal reason. This runs terminate/2 and
+      # models an in-process crash (in production a Postgrex query raising on
+      # timeout inside a handler exits the channel the same way). The harness
+      # links the channel to us, hence the {:EXIT}.
+      capture_log(fn ->
+        GenServer.stop(socket.channel_pid, :boom)
+        assert_receive {:EXIT, _pid, :boom}
+      end)
 
-      assert_receive {:EXIT, pid, :killed}
-      assert pid == socket.channel_pid
+      # terminate/2 drained the transport, which closes the whole WebSocket and
+      # forces connlib through a full reconnect (new transport => new session).
+      assert_receive :socket_drain
+    end
+
+    test "a graceful channel stop does NOT drain the transport", %{
+      client: client,
+      subject: subject
+    } do
+      Process.flag(:trap_exit, true)
+
+      socket = join_channel(client, subject)
+      assert_push "init", _init_payload
+      assert socket.transport_pid == self()
+
+      # A :shutdown stop already sends phx_close, which connlib treats as a clean
+      # reconnect, so terminate/2 must NOT additionally drain the transport.
+      GenServer.stop(socket.channel_pid, :shutdown)
+
+      refute_receive :socket_drain
     end
 
     test "does not crash when subject expiration is too large", %{
@@ -7491,6 +7519,122 @@ defmodule PortalAPI.Client.ChannelTest do
       })
 
       refute_push "resource_filters_updated", _
+    end
+  end
+
+  describe "transport/channel teardown semantics" do
+    # These tests use a faithful transport: a separate process that traps exits
+    # like the production Bandit/Thousand Island handler, rather than the test
+    # process that `Phoenix.ChannelTest` uses by default. That lets us assert how
+    # the channel and transport bring each other down.
+
+    # Models the production transport: traps exits, and records every message it
+    # receives so tests can assert the channel drained it.
+    defp start_trapping_transport do
+      parent = self()
+
+      pid =
+        spawn(fn ->
+          Process.flag(:trap_exit, true)
+          send(parent, {:ready, self()})
+          trapping_loop(parent)
+        end)
+
+      assert_receive {:ready, ^pid}
+      on_exit(fn -> Process.exit(pid, :kill) end)
+      pid
+    end
+
+    defp trapping_loop(parent) do
+      receive do
+        msg ->
+          send(parent, {:transport_got, msg})
+          trapping_loop(parent)
+      end
+    end
+
+    # Joins the client channel with a custom transport pid instead of the test
+    # process. Mirrors `join_channel/3` otherwise.
+    defp join_channel_with_transport(client, subject, transport_pid) do
+      device = fetch_device!(client)
+      session_id = Ecto.UUID.generate()
+
+      session = %Portal.ClientSession{
+        id: session_id,
+        device_id: client.id,
+        account_id: client.account_id,
+        client_token_id: subject.credential.id,
+        public_key: Portal.DeviceFixtures.generate_public_key(),
+        user_agent: subject.context.user_agent,
+        remote_ip: subject.context.remote_ip
+      }
+
+      base =
+        PortalAPI.Client.Socket
+        |> socket("client:#{client.id}", %{
+          client: device,
+          session: session,
+          subject: subject,
+          client_version: nil
+        })
+
+      {:ok, _reply, socket} =
+        %{base | transport_pid: transport_pid}
+        |> subscribe_and_join(PortalAPI.Client.Channel, "client")
+
+      socket
+    end
+
+    test "an abnormal channel crash drains the trapping transport", %{
+      client: client,
+      subject: subject
+    } do
+      transport = start_trapping_transport()
+      socket = join_channel_with_transport(client, subject, transport)
+      channel_pid = socket.channel_pid
+
+      # The harness links the channel to the test process; drop that so the crash
+      # we trigger below doesn't also kill the test.
+      Process.unlink(channel_pid)
+      ref = Process.monitor(channel_pid)
+
+      # Terminate the channel with an abnormal reason. In production this is an
+      # in-process exception (typically a Postgrex query raising on timeout)
+      # bubbling out of a handler; that runs terminate/2 with the same kind of
+      # abnormal reason.
+      capture_log(fn ->
+        GenServer.stop(channel_pid, :boom)
+        assert_receive {:DOWN, ^ref, :process, ^channel_pid, :boom}
+      end)
+
+      # terminate/2 drained the transport, which closes the WebSocket and forces
+      # connlib through a full reconnect, minting a fresh session id. This is what
+      # keeps the transport:session relationship 1:1.
+      assert_receive {:transport_got, :socket_drain}
+    end
+
+    test "transport death takes the channel down with it (no orphan channel)", %{
+      client: client,
+      subject: subject
+    } do
+      transport = start_trapping_transport()
+      socket = join_channel_with_transport(client, subject, transport)
+      channel_pid = socket.channel_pid
+
+      Process.unlink(channel_pid)
+      ref = Process.monitor(channel_pid)
+
+      # :kill is the one signal a trapping process cannot trap, so the transport
+      # actually dies here (modeling a real WebSocket teardown).
+      capture_log(fn ->
+        Process.exit(transport, :kill)
+        assert_receive {:DOWN, ^ref, :process, ^channel_pid, _reason}
+      end)
+
+      # The channel does not outlive its transport. With the explicit link gone,
+      # this is enforced by `Phoenix.Channel.Server`, which monitors the transport
+      # pid on join and stops the channel on its :DOWN.
+      refute Process.alive?(channel_pid)
     end
   end
 end

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -335,21 +335,17 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel(client, subject)
       assert_push "init", _init_payload
 
-      # In ChannelTest the test process is the transport_pid, so a drain message
-      # sent by terminate/2 lands in our mailbox.
+      # In ChannelTest the test process is the transport_pid, so terminate/2's
+      # drain lands in our mailbox.
       assert socket.transport_pid == self()
 
-      # Terminate the channel with an abnormal reason. This runs terminate/2 and
-      # models an in-process crash (in production a Postgrex query raising on
-      # timeout inside a handler exits the channel the same way). The harness
-      # links the channel to us, hence the {:EXIT}.
+      # An abnormal stop runs terminate/2, modeling an in-process crash (e.g. a
+      # Postgrex query raising on timeout). The harness links us, hence {:EXIT}.
       capture_log(fn ->
         GenServer.stop(socket.channel_pid, :boom)
         assert_receive {:EXIT, _pid, :boom}
       end)
 
-      # terminate/2 drained the transport, which closes the whole WebSocket and
-      # forces connlib through a full reconnect (new transport => new session).
       assert_receive :socket_drain
     end
 
@@ -7593,23 +7589,18 @@ defmodule PortalAPI.Client.ChannelTest do
       socket = join_channel_with_transport(client, subject, transport)
       channel_pid = socket.channel_pid
 
-      # The harness links the channel to the test process; drop that so the crash
-      # we trigger below doesn't also kill the test.
+      # Drop the harness link so the crash below doesn't kill the test.
       Process.unlink(channel_pid)
       ref = Process.monitor(channel_pid)
 
-      # Terminate the channel with an abnormal reason. In production this is an
-      # in-process exception (typically a Postgrex query raising on timeout)
-      # bubbling out of a handler; that runs terminate/2 with the same kind of
-      # abnormal reason.
+      # An abnormal stop runs terminate/2, modeling an in-process crash (e.g. a
+      # Postgrex query raising on timeout).
       capture_log(fn ->
         GenServer.stop(channel_pid, :boom)
         assert_receive {:DOWN, ^ref, :process, ^channel_pid, :boom}
       end)
 
-      # terminate/2 drained the transport, which closes the WebSocket and forces
-      # connlib through a full reconnect, minting a fresh session id. This is what
-      # keeps the transport:session relationship 1:1.
+      # The drain reaches the real trapping transport, closing the WebSocket.
       assert_receive {:transport_got, :socket_drain}
     end
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -5,6 +5,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
   alias Portal.PG
   import Portal.Cache.Cacheable, only: [to_cache: 1]
   import Portal.SchemaHelpers, only: [struct_from_params: 2]
+  import ExUnit.CaptureLog
 
   @test_user_agent "macOS/14.0 apple-client/1.3.0"
 
@@ -38,6 +39,56 @@ defmodule PortalAPI.Gateway.ChannelTest do
       |> subscribe_and_join(PortalAPI.Gateway.Channel, "gateway")
 
     socket
+  end
+
+  # Joins the gateway channel with a custom transport pid instead of the test
+  # process, so the channel's `Process.link(transport_pid)` targets our fake
+  # trapping transport. Mirrors `join_channel/4` otherwise.
+  defp join_channel_with_transport(gateway, site, token, transport_pid) do
+    device = fetch_device!(gateway)
+    session = build_gateway_session(gateway, token)
+
+    base =
+      PortalAPI.Gateway.Socket
+      |> socket("gateway:#{gateway.id}", %{
+        token_id: token.id,
+        gateway: device,
+        site: site,
+        session: session,
+        opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+        opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test")
+      })
+
+    {:ok, _reply, socket} =
+      %{base | transport_pid: transport_pid}
+      |> subscribe_and_join(PortalAPI.Gateway.Channel, "gateway")
+
+    socket
+  end
+
+  # Models the production transport: traps exits, and records every message it
+  # receives so tests can assert the channel drained it.
+  defp start_trapping_transport do
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        Process.flag(:trap_exit, true)
+        send(parent, {:ready, self()})
+        trapping_transport_loop(parent)
+      end)
+
+    assert_receive {:ready, ^pid}
+    on_exit(fn -> Process.exit(pid, :kill) end)
+    pid
+  end
+
+  defp trapping_transport_loop(parent) do
+    receive do
+      msg ->
+        send(parent, {:transport_got, msg})
+        trapping_transport_loop(parent)
+    end
   end
 
   defp build_gateway_session(gateway, token, opts \\ []) do
@@ -167,20 +218,83 @@ defmodule PortalAPI.Gateway.ChannelTest do
       refute :sys.get_state(socket.channel_pid).assigns.session_durability
     end
 
-    test "channel crash takes down the transport", %{gateway: gateway, site: site, token: token} do
-      socket = join_channel(gateway, site, token)
-      assert_push "init", _init_payload
+    # On an abnormal channel exit, terminate/2 drains the transport so connlib
+    # fully reconnects (new transport => new session). These tests inject a
+    # separate trapping process as the transport, because `Phoenix.ChannelTest`
+    # otherwise makes the test process the transport and links the channel to it.
 
-      Process.flag(:trap_exit, true)
+    test "an abnormal channel crash drains the trapping transport", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      transport = start_trapping_transport()
+      socket = join_channel_with_transport(gateway, site, token, transport)
+      channel_pid = socket.channel_pid
 
-      # In tests, we (the test process) are the transport_pid
-      assert socket.transport_pid == self()
+      # The harness links the channel to the test process; drop that so the crash
+      # we trigger below doesn't also kill the test.
+      Process.unlink(channel_pid)
+      ref = Process.monitor(channel_pid)
 
-      # Kill the channel - we receive EXIT because we're linked
-      Process.exit(socket.channel_pid, :kill)
+      # Terminate the channel with an abnormal reason. In production this is an
+      # in-process exception (typically a Postgrex query raising on timeout)
+      # bubbling out of a handler; that runs terminate/2 with the same kind of
+      # abnormal reason.
+      capture_log(fn ->
+        GenServer.stop(channel_pid, :boom)
+        assert_receive {:DOWN, ^ref, :process, ^channel_pid, :boom}
+      end)
 
-      assert_receive {:EXIT, pid, :killed}
-      assert pid == socket.channel_pid
+      # terminate/2 drained the transport, which closes the WebSocket and forces
+      # connlib through a full reconnect, minting a fresh session id. This is what
+      # keeps the transport:session relationship 1:1.
+      assert_receive {:transport_got, :socket_drain}
+    end
+
+    test "transport death takes the channel down with it (no orphan channel)", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      transport = start_trapping_transport()
+      socket = join_channel_with_transport(gateway, site, token, transport)
+      channel_pid = socket.channel_pid
+
+      Process.unlink(channel_pid)
+      ref = Process.monitor(channel_pid)
+
+      # :kill is the one signal a trapping process cannot trap, so the transport
+      # actually dies here (modeling a real WebSocket teardown).
+      capture_log(fn ->
+        Process.exit(transport, :kill)
+        assert_receive {:DOWN, ^ref, :process, ^channel_pid, _reason}
+      end)
+
+      # The channel does not outlive its transport. With the explicit link gone,
+      # this is enforced by `Phoenix.Channel.Server`, which monitors the transport
+      # pid on join and stops the channel on its :DOWN.
+      refute Process.alive?(channel_pid)
+    end
+
+    test "a graceful channel stop does NOT drain the transport", %{
+      gateway: gateway,
+      site: site,
+      token: token
+    } do
+      transport = start_trapping_transport()
+      socket = join_channel_with_transport(gateway, site, token, transport)
+      channel_pid = socket.channel_pid
+
+      Process.unlink(channel_pid)
+      ref = Process.monitor(channel_pid)
+
+      # A :shutdown stop already sends phx_close, which connlib treats as a clean
+      # reconnect, so terminate/2 must NOT additionally drain the transport.
+      GenServer.stop(channel_pid, :shutdown)
+      assert_receive {:DOWN, ^ref, :process, ^channel_pid, :shutdown}
+
+      refute_receive {:transport_got, :socket_drain}
     end
 
     test "sends init message after join", %{

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -218,10 +218,9 @@ defmodule PortalAPI.Gateway.ChannelTest do
       refute :sys.get_state(socket.channel_pid).assigns.session_durability
     end
 
-    # On an abnormal channel exit, terminate/2 drains the transport so connlib
-    # fully reconnects (new transport => new session). These tests inject a
-    # separate trapping process as the transport, because `Phoenix.ChannelTest`
-    # otherwise makes the test process the transport and links the channel to it.
+    # These tests inject a separate trapping process as the transport, because
+    # `Phoenix.ChannelTest` otherwise makes the test process the transport and
+    # links the channel to it.
 
     test "an abnormal channel crash drains the trapping transport", %{
       gateway: gateway,
@@ -232,23 +231,18 @@ defmodule PortalAPI.Gateway.ChannelTest do
       socket = join_channel_with_transport(gateway, site, token, transport)
       channel_pid = socket.channel_pid
 
-      # The harness links the channel to the test process; drop that so the crash
-      # we trigger below doesn't also kill the test.
+      # Drop the harness link so the crash below doesn't kill the test.
       Process.unlink(channel_pid)
       ref = Process.monitor(channel_pid)
 
-      # Terminate the channel with an abnormal reason. In production this is an
-      # in-process exception (typically a Postgrex query raising on timeout)
-      # bubbling out of a handler; that runs terminate/2 with the same kind of
-      # abnormal reason.
+      # An abnormal stop runs terminate/2, modeling an in-process crash (e.g. a
+      # Postgrex query raising on timeout).
       capture_log(fn ->
         GenServer.stop(channel_pid, :boom)
         assert_receive {:DOWN, ^ref, :process, ^channel_pid, :boom}
       end)
 
-      # terminate/2 drained the transport, which closes the WebSocket and forces
-      # connlib through a full reconnect, minting a fresh session id. This is what
-      # keeps the transport:session relationship 1:1.
+      # The drain reaches the real trapping transport, closing the WebSocket.
       assert_receive {:transport_got, :socket_drain}
     end
 

--- a/elixir/test/portal_api/relay/channel_test.exs
+++ b/elixir/test/portal_api/relay/channel_test.exs
@@ -34,21 +34,17 @@ defmodule PortalAPI.Relay.ChannelTest do
     test "an abnormal channel exit drains the transport so connlib reconnects", %{socket: socket} do
       Process.flag(:trap_exit, true)
 
-      # In ChannelTest the test process is the transport_pid, so a drain message
-      # sent by terminate/2 lands in our mailbox.
+      # In ChannelTest the test process is the transport_pid, so terminate/2's
+      # drain lands in our mailbox.
       assert socket.transport_pid == self()
 
-      # Terminate the channel with an abnormal reason. This runs terminate/2 and
-      # models an in-process crash (in production a Postgrex query raising on
-      # timeout inside a handler exits the channel the same way). The harness
-      # links the channel to us, hence the {:EXIT}.
+      # An abnormal stop runs terminate/2, modeling an in-process crash (e.g. a
+      # Postgrex query raising on timeout). The harness links us, hence {:EXIT}.
       capture_log(fn ->
         GenServer.stop(socket.channel_pid, :boom)
         assert_receive {:EXIT, _pid, :boom}
       end)
 
-      # terminate/2 drained the transport, which closes the whole WebSocket and
-      # forces connlib through a full reconnect.
       assert_receive :socket_drain
     end
 

--- a/elixir/test/portal_api/relay/channel_test.exs
+++ b/elixir/test/portal_api/relay/channel_test.exs
@@ -1,6 +1,7 @@
 defmodule PortalAPI.Relay.ChannelTest do
   use PortalAPI.ChannelCase, async: true
 
+  import ExUnit.CaptureLog
   import Portal.RelayFixtures
   import Portal.TokenFixtures
 
@@ -30,17 +31,36 @@ defmodule PortalAPI.Relay.ChannelTest do
       assert %{metas: [%{ipv4: _, phx_ref: _ref}]} = Map.fetch!(presence, relay.id)
     end
 
-    test "channel crash takes down the transport", %{socket: socket} do
+    test "an abnormal channel exit drains the transport so connlib reconnects", %{socket: socket} do
       Process.flag(:trap_exit, true)
 
-      # In tests, we (the test process) are the transport_pid
+      # In ChannelTest the test process is the transport_pid, so a drain message
+      # sent by terminate/2 lands in our mailbox.
       assert socket.transport_pid == self()
 
-      # Kill the channel - we receive EXIT because we're linked
-      Process.exit(socket.channel_pid, :shutdown)
+      # Terminate the channel with an abnormal reason. This runs terminate/2 and
+      # models an in-process crash (in production a Postgrex query raising on
+      # timeout inside a handler exits the channel the same way). The harness
+      # links the channel to us, hence the {:EXIT}.
+      capture_log(fn ->
+        GenServer.stop(socket.channel_pid, :boom)
+        assert_receive {:EXIT, _pid, :boom}
+      end)
 
-      assert_receive {:EXIT, pid, :shutdown}
-      assert pid == socket.channel_pid
+      # terminate/2 drained the transport, which closes the whole WebSocket and
+      # forces connlib through a full reconnect.
+      assert_receive :socket_drain
+    end
+
+    test "a graceful channel stop does NOT drain the transport", %{socket: socket} do
+      Process.flag(:trap_exit, true)
+      assert socket.transport_pid == self()
+
+      # A :shutdown stop already sends phx_close, which connlib treats as a clean
+      # reconnect, so terminate/2 must NOT additionally drain the transport.
+      GenServer.stop(socket.channel_pid, :shutdown)
+
+      refute_receive :socket_drain
     end
 
     test "sends init message after join" do


### PR DESCRIPTION
We saw duplicate `client_sessions_pkey` errors in production. The session id was generated once when the websocket connected, so if the channel crashed but the socket stayed up, connlib re-joined on the same socket, reused that id, and the second insert hit the primary key. The channel could crash without the socket going down because the transport traps exits, so the `Process.link` in `join/1` never took the socket with it. While desynced like this we also lost presence and our push path to the client.

The simple fix would have been `on_conflict: :nothing`, but that just hides the error and leaves the client out of sync. Instead we make the channel and transport one to one: on an abnormal channel exit we drain the transport, which closes the websocket so connlib fully reconnects and gets a fresh session id. Normal stops like token expiry already close cleanly, so we only do this on abnormal exits. This also removes the old `Process.link`, and applies to the client, gateway, and relay channels.

Fixes #13496
