### PR TITLE
chore(rust): don't ignore RUSTSEC-2024-0429

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -108,8 +108,6 @@ ignore = [
     "RUSTSEC-2025-0012", # backoff, See #8386
     "RUSTSEC-2024-0436", # paste, See #8387
 
-    "RUSTSEC-2024-0429", # `glib`, need to wait for tauri to upgrade
-
     # `rand` unsoundness via re-entrant ThreadRng access from a custom logger (GHSA-cq8v-f236-94qc).
     # Not exploitable: rand's `log` feature is not enabled (verified via `cargo tree -e features`),
     # so the log!() call sites in rand's reseeding path are compiled out entirely.


### PR DESCRIPTION
The offending crate this applies to seems to have been removed. We can therefore lift the "ignore" status from this advisory.