### PR TITLE
refactor: decouple feature flags from Sentry integration

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7553,6 +7553,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -18,6 +18,7 @@ sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+smallvec = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, bail};
+use opentelemetry::KeyValue;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tracing::{Metadata, level_filters::LevelFilter};
@@ -58,6 +59,11 @@ pub fn stream_metrics() -> bool {
 
 pub fn show_connected_devices() -> bool {
     FEATURE_FLAGS.show_connected_devices()
+}
+
+/// The current state of every feature flag, as metric attributes (one per flag).
+pub(crate) fn metric_attributes() -> Vec<KeyValue> {
+    flag_attributes(FEATURE_FLAGS.snapshot())
 }
 
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
@@ -263,6 +269,18 @@ impl FeatureFlags {
     fn show_connected_devices(&self) -> bool {
         self.show_connected_devices.load(Ordering::Relaxed)
     }
+
+    fn snapshot(&self) -> FeatureFlagsResponse {
+        FeatureFlagsResponse {
+            icmp_unreachable_instead_of_nat64: self.icmp_unreachable_instead_of_nat64(),
+            drop_llmnr_nxdomain_responses: self.drop_llmnr_nxdomain_responses(),
+            stream_logs: !self.stream_logs.read().directives.is_empty(),
+            icmp_error_unreachable_prohibited_create_new_flow: self
+                .icmp_error_unreachable_prohibited_create_new_flow(),
+            stream_metrics: self.stream_metrics(),
+            show_connected_devices: self.show_connected_devices(),
+        }
+    }
 }
 
 fn update_from_env(flags: FeatureFlagsResponse) -> FeatureFlagsResponse {
@@ -290,6 +308,39 @@ fn env_or(key: &str, fallback: bool) -> bool {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(fallback)
+}
+
+fn flag_attributes(flags: FeatureFlagsResponse) -> Vec<KeyValue> {
+    // Exhaustive destruction so we don't forget to update this when we add a flag.
+    let FeatureFlagsResponse {
+        icmp_unreachable_instead_of_nat64,
+        drop_llmnr_nxdomain_responses,
+        stream_logs,
+        icmp_error_unreachable_prohibited_create_new_flow,
+        stream_metrics,
+        show_connected_devices,
+    } = flags;
+
+    vec![
+        KeyValue::new(
+            "feature_flag.icmp_unreachable_instead_of_nat64",
+            icmp_unreachable_instead_of_nat64,
+        ),
+        KeyValue::new(
+            "feature_flag.drop_llmnr_nxdomain_responses",
+            drop_llmnr_nxdomain_responses,
+        ),
+        KeyValue::new("feature_flag.stream_logs", stream_logs),
+        KeyValue::new(
+            "feature_flag.icmp_error_unreachable_prohibited_create_new_flow",
+            icmp_error_unreachable_prohibited_create_new_flow,
+        ),
+        KeyValue::new("feature_flag.stream_metrics", stream_metrics),
+        KeyValue::new(
+            "feature_flag.show_connected_devices",
+            show_connected_devices,
+        ),
+    ]
 }
 
 fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context {
@@ -387,5 +438,23 @@ mod tests {
         let filter = LogFilter::parse("\"debug,is::ice_::pair=trace\"".to_owned());
 
         assert_eq!(filter.directives, "debug,is::ice_::pair=trace");
+    }
+
+    #[test]
+    fn flag_attributes_reflect_state() {
+        let flags = FeatureFlagsResponse {
+            stream_metrics: true,
+            show_connected_devices: true,
+            ..Default::default()
+        };
+
+        let attrs = flag_attributes(flags);
+
+        assert!(attrs.contains(&KeyValue::new("feature_flag.stream_metrics", true)));
+        assert!(attrs.contains(&KeyValue::new("feature_flag.show_connected_devices", true)));
+        assert!(attrs.contains(&KeyValue::new(
+            "feature_flag.drop_llmnr_nxdomain_responses",
+            false
+        )));
     }
 }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -62,22 +62,35 @@ pub fn show_connected_devices() -> bool {
 
 /// The current value of every feature flag, by name.
 pub(crate) fn current() -> impl IntoIterator<Item = (&'static str, bool)> {
+    // Exhaustive destruction so we don't forget to update this when we add a flag.
+    let FeatureFlags {
+        icmp_unreachable_instead_of_nat64,
+        drop_llmnr_nxdomain_responses,
+        stream_logs,
+        icmp_error_unreachable_prohibited_create_new_flow,
+        stream_metrics,
+        show_connected_devices,
+    } = &*FEATURE_FLAGS;
+
     [
         (
             "icmp_unreachable_instead_of_nat64",
-            icmp_unreachable_instead_of_nat64(),
+            icmp_unreachable_instead_of_nat64.load(Ordering::Relaxed),
         ),
         (
             "drop_llmnr_nxdomain_responses",
-            drop_llmnr_nxdomain_responses(),
+            drop_llmnr_nxdomain_responses.load(Ordering::Relaxed),
         ),
-        ("stream_logs", stream_logs_active()),
+        ("stream_logs", !stream_logs.read().directives.is_empty()),
         (
             "icmp_error_unreachable_prohibited_create_new_flow",
-            icmp_error_unreachable_prohibited_create_new_flow(),
+            icmp_error_unreachable_prohibited_create_new_flow.load(Ordering::Relaxed),
         ),
-        ("stream_metrics", stream_metrics()),
-        ("show_connected_devices", show_connected_devices()),
+        ("stream_metrics", stream_metrics.load(Ordering::Relaxed)),
+        (
+            "show_connected_devices",
+            show_connected_devices.load(Ordering::Relaxed),
+        ),
     ]
 }
 

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -61,8 +61,34 @@ pub fn show_connected_devices() -> bool {
 }
 
 /// The current value of every feature flag, by name.
-pub(crate) fn current() -> [(&'static str, bool); 6] {
-    flag_pairs(FEATURE_FLAGS.snapshot())
+pub(crate) fn current() -> impl IntoIterator<Item = (&'static str, bool)> {
+    // Exhaustive destruction so we don't forget to update this when we add a flag.
+    let FeatureFlagsResponse {
+        icmp_unreachable_instead_of_nat64,
+        drop_llmnr_nxdomain_responses,
+        stream_logs,
+        icmp_error_unreachable_prohibited_create_new_flow,
+        stream_metrics,
+        show_connected_devices,
+    } = FEATURE_FLAGS.snapshot();
+
+    [
+        (
+            "icmp_unreachable_instead_of_nat64",
+            icmp_unreachable_instead_of_nat64,
+        ),
+        (
+            "drop_llmnr_nxdomain_responses",
+            drop_llmnr_nxdomain_responses,
+        ),
+        ("stream_logs", stream_logs),
+        (
+            "icmp_error_unreachable_prohibited_create_new_flow",
+            icmp_error_unreachable_prohibited_create_new_flow,
+        ),
+        ("stream_metrics", stream_metrics),
+        ("show_connected_devices", show_connected_devices),
+    ]
 }
 
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
@@ -305,36 +331,6 @@ fn env_or(key: &str, fallback: bool) -> bool {
         .unwrap_or(fallback)
 }
 
-fn flag_pairs(flags: FeatureFlagsResponse) -> [(&'static str, bool); 6] {
-    // Exhaustive destruction so we don't forget to update this when we add a flag.
-    let FeatureFlagsResponse {
-        icmp_unreachable_instead_of_nat64,
-        drop_llmnr_nxdomain_responses,
-        stream_logs,
-        icmp_error_unreachable_prohibited_create_new_flow,
-        stream_metrics,
-        show_connected_devices,
-    } = flags;
-
-    [
-        (
-            "icmp_unreachable_instead_of_nat64",
-            icmp_unreachable_instead_of_nat64,
-        ),
-        (
-            "drop_llmnr_nxdomain_responses",
-            drop_llmnr_nxdomain_responses,
-        ),
-        ("stream_logs", stream_logs),
-        (
-            "icmp_error_unreachable_prohibited_create_new_flow",
-            icmp_error_unreachable_prohibited_create_new_flow,
-        ),
-        ("stream_metrics", stream_metrics),
-        ("show_connected_devices", show_connected_devices),
-    ]
-}
-
 struct LogFilter {
     directives: String,
     targets: Targets,
@@ -392,20 +388,5 @@ mod tests {
         let filter = LogFilter::parse("\"debug,is::ice_::pair=trace\"".to_owned());
 
         assert_eq!(filter.directives, "debug,is::ice_::pair=trace");
-    }
-
-    #[test]
-    fn flag_pairs_reflect_state() {
-        let flags = FeatureFlagsResponse {
-            stream_metrics: true,
-            show_connected_devices: true,
-            ..Default::default()
-        };
-
-        let pairs = flag_pairs(flags);
-
-        assert!(pairs.contains(&("stream_metrics", true)));
-        assert!(pairs.contains(&("show_connected_devices", true)));
-        assert!(pairs.contains(&("drop_llmnr_nxdomain_responses", false)));
     }
 }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, bail};
-use opentelemetry::KeyValue;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tracing::{Metadata, level_filters::LevelFilter};
@@ -61,8 +60,8 @@ pub fn show_connected_devices() -> bool {
     FEATURE_FLAGS.show_connected_devices()
 }
 
-/// The current state of every feature flag, as metric attributes (one per flag).
-pub(crate) fn metric_attributes() -> Vec<KeyValue> {
+/// The current state of every feature flag as `(attribute key, value)` pairs (one per flag).
+pub(crate) fn metric_attributes() -> [(&'static str, bool); 6] {
     flag_attributes(FEATURE_FLAGS.snapshot())
 }
 
@@ -310,7 +309,7 @@ fn env_or(key: &str, fallback: bool) -> bool {
         .unwrap_or(fallback)
 }
 
-fn flag_attributes(flags: FeatureFlagsResponse) -> Vec<KeyValue> {
+fn flag_attributes(flags: FeatureFlagsResponse) -> [(&'static str, bool); 6] {
     // Exhaustive destruction so we don't forget to update this when we add a flag.
     let FeatureFlagsResponse {
         icmp_unreachable_instead_of_nat64,
@@ -321,22 +320,22 @@ fn flag_attributes(flags: FeatureFlagsResponse) -> Vec<KeyValue> {
         show_connected_devices,
     } = flags;
 
-    vec![
-        KeyValue::new(
+    [
+        (
             "feature_flag.icmp_unreachable_instead_of_nat64",
             icmp_unreachable_instead_of_nat64,
         ),
-        KeyValue::new(
+        (
             "feature_flag.drop_llmnr_nxdomain_responses",
             drop_llmnr_nxdomain_responses,
         ),
-        KeyValue::new("feature_flag.stream_logs", stream_logs),
-        KeyValue::new(
+        ("feature_flag.stream_logs", stream_logs),
+        (
             "feature_flag.icmp_error_unreachable_prohibited_create_new_flow",
             icmp_error_unreachable_prohibited_create_new_flow,
         ),
-        KeyValue::new("feature_flag.stream_metrics", stream_metrics),
-        KeyValue::new(
+        ("feature_flag.stream_metrics", stream_metrics),
+        (
             "feature_flag.show_connected_devices",
             show_connected_devices,
         ),
@@ -450,11 +449,8 @@ mod tests {
 
         let attrs = flag_attributes(flags);
 
-        assert!(attrs.contains(&KeyValue::new("feature_flag.stream_metrics", true)));
-        assert!(attrs.contains(&KeyValue::new("feature_flag.show_connected_devices", true)));
-        assert!(attrs.contains(&KeyValue::new(
-            "feature_flag.drop_llmnr_nxdomain_responses",
-            false
-        )));
+        assert!(attrs.contains(&("feature_flag.stream_metrics", true)));
+        assert!(attrs.contains(&("feature_flag.show_connected_devices", true)));
+        assert!(attrs.contains(&("feature_flag.drop_llmnr_nxdomain_responses", false)));
     }
 }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -60,9 +60,9 @@ pub fn show_connected_devices() -> bool {
     FEATURE_FLAGS.show_connected_devices()
 }
 
-/// The current state of every feature flag as `(attribute key, value)` pairs (one per flag).
-pub(crate) fn metric_attributes() -> [(&'static str, bool); 6] {
-    flag_attributes(FEATURE_FLAGS.snapshot())
+/// The current value of every feature flag, by name.
+pub(crate) fn current() -> [(&'static str, bool); 6] {
+    flag_pairs(FEATURE_FLAGS.snapshot())
 }
 
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
@@ -84,10 +84,6 @@ pub(crate) async fn evaluate_now(user_id: String, env: Env) {
     let flags = update_from_env(flags);
 
     FEATURE_FLAGS.update(flags, payloads);
-
-    sentry::Hub::main().configure_scope(|scope| {
-        scope.set_context("flags", sentry_flag_context(flags));
-    });
 
     tracing::debug!(%env, flags = ?FEATURE_FLAGS, "Evaluated feature-flags");
 }
@@ -309,7 +305,7 @@ fn env_or(key: &str, fallback: bool) -> bool {
         .unwrap_or(fallback)
 }
 
-fn flag_attributes(flags: FeatureFlagsResponse) -> [(&'static str, bool); 6] {
+fn flag_pairs(flags: FeatureFlagsResponse) -> [(&'static str, bool); 6] {
     // Exhaustive destruction so we don't forget to update this when we add a flag.
     let FeatureFlagsResponse {
         icmp_unreachable_instead_of_nat64,
@@ -322,62 +318,21 @@ fn flag_attributes(flags: FeatureFlagsResponse) -> [(&'static str, bool); 6] {
 
     [
         (
-            "feature_flag.icmp_unreachable_instead_of_nat64",
+            "icmp_unreachable_instead_of_nat64",
             icmp_unreachable_instead_of_nat64,
         ),
         (
-            "feature_flag.drop_llmnr_nxdomain_responses",
+            "drop_llmnr_nxdomain_responses",
             drop_llmnr_nxdomain_responses,
         ),
-        ("feature_flag.stream_logs", stream_logs),
+        ("stream_logs", stream_logs),
         (
-            "feature_flag.icmp_error_unreachable_prohibited_create_new_flow",
+            "icmp_error_unreachable_prohibited_create_new_flow",
             icmp_error_unreachable_prohibited_create_new_flow,
         ),
-        ("feature_flag.stream_metrics", stream_metrics),
-        (
-            "feature_flag.show_connected_devices",
-            show_connected_devices,
-        ),
+        ("stream_metrics", stream_metrics),
+        ("show_connected_devices", show_connected_devices),
     ]
-}
-
-fn sentry_flag_context(flags: FeatureFlagsResponse) -> sentry::protocol::Context {
-    #[derive(Debug, serde::Serialize)]
-    #[serde(tag = "flag", rename_all = "snake_case")]
-    enum SentryFlag {
-        IcmpUnreachableInsteadOfNat64 { result: bool },
-        DropLlmnrNxdomainResponses { result: bool },
-        StreamLogs { result: bool },
-        IcmpErrorUnreachableProhibitedCreateNewFlow { result: bool },
-        StreamMetrics { result: bool },
-        ShowConnectedDevices { result: bool },
-    }
-
-    // Exhaustive destruction so we don't forget to update this when we add a flag.
-    let FeatureFlagsResponse {
-        icmp_unreachable_instead_of_nat64,
-        drop_llmnr_nxdomain_responses,
-        stream_logs,
-        icmp_error_unreachable_prohibited_create_new_flow,
-        stream_metrics,
-        show_connected_devices,
-    } = flags;
-
-    let value = serde_json::json!({
-        "values": [
-            SentryFlag::IcmpUnreachableInsteadOfNat64 {
-                result: icmp_unreachable_instead_of_nat64,
-            },
-            SentryFlag::DropLlmnrNxdomainResponses { result: drop_llmnr_nxdomain_responses },
-            SentryFlag::StreamLogs { result: stream_logs },
-            SentryFlag::IcmpErrorUnreachableProhibitedCreateNewFlow { result: icmp_error_unreachable_prohibited_create_new_flow },
-            SentryFlag::StreamMetrics { result: stream_metrics },
-            SentryFlag::ShowConnectedDevices { result: show_connected_devices },
-        ]
-    });
-
-    sentry::protocol::Context::Other(serde_json::from_value(value).expect("to and from json works"))
 }
 
 struct LogFilter {
@@ -440,17 +395,17 @@ mod tests {
     }
 
     #[test]
-    fn flag_attributes_reflect_state() {
+    fn flag_pairs_reflect_state() {
         let flags = FeatureFlagsResponse {
             stream_metrics: true,
             show_connected_devices: true,
             ..Default::default()
         };
 
-        let attrs = flag_attributes(flags);
+        let pairs = flag_pairs(flags);
 
-        assert!(attrs.contains(&("feature_flag.stream_metrics", true)));
-        assert!(attrs.contains(&("feature_flag.show_connected_devices", true)));
-        assert!(attrs.contains(&("feature_flag.drop_llmnr_nxdomain_responses", false)));
+        assert!(pairs.contains(&("stream_metrics", true)));
+        assert!(pairs.contains(&("show_connected_devices", true)));
+        assert!(pairs.contains(&("drop_llmnr_nxdomain_responses", false)));
     }
 }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -62,32 +62,22 @@ pub fn show_connected_devices() -> bool {
 
 /// The current value of every feature flag, by name.
 pub(crate) fn current() -> impl IntoIterator<Item = (&'static str, bool)> {
-    // Exhaustive destruction so we don't forget to update this when we add a flag.
-    let FeatureFlagsResponse {
-        icmp_unreachable_instead_of_nat64,
-        drop_llmnr_nxdomain_responses,
-        stream_logs,
-        icmp_error_unreachable_prohibited_create_new_flow,
-        stream_metrics,
-        show_connected_devices,
-    } = FEATURE_FLAGS.snapshot();
-
     [
         (
             "icmp_unreachable_instead_of_nat64",
-            icmp_unreachable_instead_of_nat64,
+            icmp_unreachable_instead_of_nat64(),
         ),
         (
             "drop_llmnr_nxdomain_responses",
-            drop_llmnr_nxdomain_responses,
+            drop_llmnr_nxdomain_responses(),
         ),
-        ("stream_logs", stream_logs),
+        ("stream_logs", stream_logs_active()),
         (
             "icmp_error_unreachable_prohibited_create_new_flow",
-            icmp_error_unreachable_prohibited_create_new_flow,
+            icmp_error_unreachable_prohibited_create_new_flow(),
         ),
-        ("stream_metrics", stream_metrics),
-        ("show_connected_devices", show_connected_devices),
+        ("stream_metrics", stream_metrics()),
+        ("show_connected_devices", show_connected_devices()),
     ]
 }
 
@@ -289,18 +279,6 @@ impl FeatureFlags {
 
     fn show_connected_devices(&self) -> bool {
         self.show_connected_devices.load(Ordering::Relaxed)
-    }
-
-    fn snapshot(&self) -> FeatureFlagsResponse {
-        FeatureFlagsResponse {
-            icmp_unreachable_instead_of_nat64: self.icmp_unreachable_instead_of_nat64(),
-            drop_llmnr_nxdomain_responses: self.drop_llmnr_nxdomain_responses(),
-            stream_logs: !self.stream_logs.read().directives.is_empty(),
-            icmp_error_unreachable_prohibited_create_new_flow: self
-                .icmp_error_unreachable_prohibited_create_new_flow(),
-            stream_metrics: self.stream_metrics(),
-            show_connected_devices: self.show_connected_devices(),
-        }
     }
 }
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -234,7 +234,15 @@ impl Telemetry {
             // We can't get the release number ourselves because we don't know if we're embedded in a GUI Client or a Headless Client.
             release: Some(release.to_owned().into()),
             max_breadcrumbs: 500,
-            before_send: Some(event_rate_limiter(Duration::from_secs(60 * 5))),
+            before_send: Some({
+                let rate_limit = event_rate_limiter(Duration::from_secs(60 * 5));
+                Arc::new(move |event| {
+                    let event = rate_limit(event)?;
+                    let event = insert_feature_flags_into_event(event);
+
+                    Some(event)
+                })
+            }),
             enable_logs: true,
             enable_metrics: true,
             before_send_log: Some(Arc::new(|log| {
@@ -468,11 +476,34 @@ fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
     metric
 }
 
+fn insert_feature_flags_into_event(mut event: Event<'static>) -> Event<'static> {
+    // Re-emit the current flag state as Sentry's standard "flags" context shape
+    // so issue pages surface the flags that were active when the event was sent.
+    #[derive(serde::Serialize)]
+    struct SentryFlag {
+        flag: &'static str,
+        result: bool,
+    }
+
+    let values = feature_flags::current()
+        .into_iter()
+        .map(|(flag, result)| SentryFlag { flag, result })
+        .collect::<Vec<_>>();
+    let value = serde_json::json!({ "values": values });
+    let context = sentry::protocol::Context::Other(
+        serde_json::from_value(value).expect("to and from json works"),
+    );
+
+    event.contexts.insert("flags".into(), context);
+    event
+}
+
 fn insert_feature_flags_into_metric(mut metric: Metric) -> Metric {
-    for (key, value) in feature_flags::metric_attributes() {
-        metric
-            .attributes
-            .insert(key.into(), LogAttribute::from(value));
+    for (name, value) in feature_flags::current() {
+        metric.attributes.insert(
+            format!("feature_flag.{name}").into(),
+            LogAttribute::from(value),
+        );
     }
 
     metric

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -18,6 +18,7 @@ use sentry::{
     transports::ReqwestHttpTransport,
 };
 use sha2::Digest as _;
+use smallvec::SmallVec;
 
 pub mod analytics;
 pub mod feature_flags;
@@ -479,17 +480,11 @@ fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
 fn insert_feature_flags_into_event(mut event: Event<'static>) -> Event<'static> {
     // Re-emit the current flag state as Sentry's standard "flags" context shape
     // so issue pages surface the flags that were active when the event was sent.
-    #[derive(serde::Serialize)]
-    struct SentryFlag {
-        flag: &'static str,
-        result: bool,
-    }
-
-    let values = feature_flags::current()
+    let values: SmallVec<[serde_json::Value; 16]> = feature_flags::current()
         .into_iter()
-        .map(|(flag, result)| SentryFlag { flag, result })
-        .collect::<Vec<_>>();
-    let value = serde_json::json!({ "values": values });
+        .map(|(flag, result)| serde_json::json!({ "flag": flag, "result": result }))
+        .collect();
+    let value = serde_json::json!({ "values": values.as_slice() });
     let context = sentry::protocol::Context::Other(
         serde_json::from_value(value).expect("to and from json works"),
     );

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -245,6 +245,7 @@ impl Telemetry {
             })),
             before_send_metric: Some(Arc::new(|metric| {
                 let metric = insert_user_account_slug_into_metric(metric);
+                let metric = insert_feature_flags_into_metric(metric);
 
                 Some(metric)
             })),
@@ -463,6 +464,16 @@ fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
     metric
         .attributes
         .insert("user.account_slug".into(), LogAttribute::from(account_slug));
+
+    metric
+}
+
+fn insert_feature_flags_into_metric(mut metric: Metric) -> Metric {
+    for (key, value) in feature_flags::metric_attributes() {
+        metric
+            .attributes
+            .insert(key.into(), LogAttribute::from(value));
+    }
 
     metric
 }

--- a/rust/libs/telemetry/src/sentry_metric_exporter.rs
+++ b/rust/libs/telemetry/src/sentry_metric_exporter.rs
@@ -24,9 +24,12 @@ pub struct SentryMetricExporter;
 
 impl PushMetricExporter for SentryMetricExporter {
     fn export(&self, metrics: &ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
+        // Snapshot the feature flags once per export and attach them to every metric.
+        let flags = crate::feature_flags::metric_attributes();
+
         for scope in metrics.scope_metrics() {
             for metric in scope.metrics() {
-                emit_metric(metric);
+                emit_metric(metric, &flags);
             }
         }
 
@@ -48,22 +51,28 @@ impl PushMetricExporter for SentryMetricExporter {
     }
 }
 
-fn emit_metric(metric: &Metric) {
+fn emit_metric(metric: &Metric, flags: &[KeyValue]) {
     let name = metric.name();
     let unit = metric.unit();
 
     match metric.data() {
-        AggregatedMetrics::F64(d) => emit_data(name, unit, d, |v| v),
-        AggregatedMetrics::U64(d) => emit_data(name, unit, d, |v| v as f64),
-        AggregatedMetrics::I64(d) => emit_data(name, unit, d, |v| v as f64),
+        AggregatedMetrics::F64(d) => emit_data(name, unit, d, |v| v, flags),
+        AggregatedMetrics::U64(d) => emit_data(name, unit, d, |v| v as f64, flags),
+        AggregatedMetrics::I64(d) => emit_data(name, unit, d, |v| v as f64, flags),
     }
 }
 
-fn emit_data<T: Copy>(name: &str, unit: &str, data: &MetricData<T>, to_f64: impl Fn(T) -> f64) {
+fn emit_data<T: Copy>(
+    name: &str,
+    unit: &str,
+    data: &MetricData<T>,
+    to_f64: impl Fn(T) -> f64,
+    flags: &[KeyValue],
+) {
     match data {
         MetricData::Gauge(g) => {
             for dp in g.data_points() {
-                emit_gauge(name, unit, to_f64(dp.value()), dp.attributes());
+                emit_gauge(name, unit, to_f64(dp.value()), dp.attributes(), flags);
             }
         }
         MetricData::Sum(s) => {
@@ -71,39 +80,50 @@ fn emit_data<T: Copy>(name: &str, unit: &str, data: &MetricData<T>, to_f64: impl
 
             for dp in s.data_points() {
                 if monotonic {
-                    emit_counter(name, to_f64(dp.value()), dp.attributes());
+                    emit_counter(name, to_f64(dp.value()), dp.attributes(), flags);
                 } else {
-                    emit_gauge(name, unit, to_f64(dp.value()), dp.attributes());
+                    emit_gauge(name, unit, to_f64(dp.value()), dp.attributes(), flags);
                 }
             }
         }
         MetricData::Histogram(h) => {
             for dp in h.data_points() {
-                emit_histogram(name, unit, dp, &to_f64);
+                emit_histogram(name, unit, dp, &to_f64, flags);
             }
         }
         MetricData::ExponentialHistogram(h) => {
             for dp in h.data_points() {
-                emit_exp_histogram(name, unit, dp, &to_f64);
+                emit_exp_histogram(name, unit, dp, &to_f64, flags);
             }
         }
     }
 }
 
-fn emit_counter<'a>(name: &str, value: f64, attrs: impl Iterator<Item = &'a KeyValue>) {
+fn emit_counter<'a>(
+    name: &str,
+    value: f64,
+    attrs: impl Iterator<Item = &'a KeyValue>,
+    flags: &'a [KeyValue],
+) {
     let mut metric = sentry::metrics::counter(name.to_owned(), value);
-    for attr in attrs {
+    for attr in attrs.chain(flags) {
         metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
     }
     metric.capture();
 }
 
-fn emit_gauge<'a>(name: &str, unit: &str, value: f64, attrs: impl Iterator<Item = &'a KeyValue>) {
+fn emit_gauge<'a>(
+    name: &str,
+    unit: &str,
+    value: f64,
+    attrs: impl Iterator<Item = &'a KeyValue>,
+    flags: &'a [KeyValue],
+) {
     let mut metric = sentry::metrics::gauge(name.to_owned(), value);
     if !unit.is_empty() {
         metric = metric.unit(unit.to_owned());
     }
-    for attr in attrs {
+    for attr in attrs.chain(flags) {
         metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
     }
     metric.capture();
@@ -114,12 +134,13 @@ fn emit_distribution<'a>(
     unit: &str,
     value: f64,
     attrs: impl Iterator<Item = &'a KeyValue>,
+    flags: &'a [KeyValue],
 ) {
     let mut metric = sentry::metrics::distribution(name.to_owned(), value);
     if !unit.is_empty() {
         metric = metric.unit(unit.to_owned());
     }
-    for attr in attrs {
+    for attr in attrs.chain(flags) {
         metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
     }
     metric.capture();
@@ -130,20 +151,39 @@ fn emit_histogram<T: Copy>(
     unit: &str,
     dp: &HistogramDataPoint<T>,
     to_f64: &impl Fn(T) -> f64,
+    flags: &[KeyValue],
 ) {
-    emit_counter(&format!("{name}.count"), dp.count() as f64, dp.attributes());
+    emit_counter(
+        &format!("{name}.count"),
+        dp.count() as f64,
+        dp.attributes(),
+        flags,
+    );
     emit_distribution(
         &format!("{name}.sum"),
         unit,
         to_f64(dp.sum()),
         dp.attributes(),
+        flags,
     );
 
     if let Some(min) = dp.min() {
-        emit_gauge(&format!("{name}.min"), unit, to_f64(min), dp.attributes());
+        emit_gauge(
+            &format!("{name}.min"),
+            unit,
+            to_f64(min),
+            dp.attributes(),
+            flags,
+        );
     }
     if let Some(max) = dp.max() {
-        emit_gauge(&format!("{name}.max"), unit, to_f64(max), dp.attributes());
+        emit_gauge(
+            &format!("{name}.max"),
+            unit,
+            to_f64(max),
+            dp.attributes(),
+            flags,
+        );
     }
 }
 
@@ -152,20 +192,39 @@ fn emit_exp_histogram<T: Copy>(
     unit: &str,
     dp: &ExponentialHistogramDataPoint<T>,
     to_f64: &impl Fn(T) -> f64,
+    flags: &[KeyValue],
 ) {
-    emit_counter(&format!("{name}.count"), dp.count() as f64, dp.attributes());
+    emit_counter(
+        &format!("{name}.count"),
+        dp.count() as f64,
+        dp.attributes(),
+        flags,
+    );
     emit_distribution(
         &format!("{name}.sum"),
         unit,
         to_f64(dp.sum()),
         dp.attributes(),
+        flags,
     );
 
     if let Some(min) = dp.min() {
-        emit_gauge(&format!("{name}.min"), unit, to_f64(min), dp.attributes());
+        emit_gauge(
+            &format!("{name}.min"),
+            unit,
+            to_f64(min),
+            dp.attributes(),
+            flags,
+        );
     }
     if let Some(max) = dp.max() {
-        emit_gauge(&format!("{name}.max"), unit, to_f64(max), dp.attributes());
+        emit_gauge(
+            &format!("{name}.max"),
+            unit,
+            to_f64(max),
+            dp.attributes(),
+            flags,
+        );
     }
 }
 

--- a/rust/libs/telemetry/src/sentry_metric_exporter.rs
+++ b/rust/libs/telemetry/src/sentry_metric_exporter.rs
@@ -24,12 +24,9 @@ pub struct SentryMetricExporter;
 
 impl PushMetricExporter for SentryMetricExporter {
     fn export(&self, metrics: &ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
-        // Snapshot the feature flags once per export and attach them to every metric.
-        let flags = crate::feature_flags::metric_attributes();
-
         for scope in metrics.scope_metrics() {
             for metric in scope.metrics() {
-                emit_metric(metric, &flags);
+                emit_metric(metric);
             }
         }
 
@@ -51,28 +48,22 @@ impl PushMetricExporter for SentryMetricExporter {
     }
 }
 
-fn emit_metric(metric: &Metric, flags: &[KeyValue]) {
+fn emit_metric(metric: &Metric) {
     let name = metric.name();
     let unit = metric.unit();
 
     match metric.data() {
-        AggregatedMetrics::F64(d) => emit_data(name, unit, d, |v| v, flags),
-        AggregatedMetrics::U64(d) => emit_data(name, unit, d, |v| v as f64, flags),
-        AggregatedMetrics::I64(d) => emit_data(name, unit, d, |v| v as f64, flags),
+        AggregatedMetrics::F64(d) => emit_data(name, unit, d, |v| v),
+        AggregatedMetrics::U64(d) => emit_data(name, unit, d, |v| v as f64),
+        AggregatedMetrics::I64(d) => emit_data(name, unit, d, |v| v as f64),
     }
 }
 
-fn emit_data<T: Copy>(
-    name: &str,
-    unit: &str,
-    data: &MetricData<T>,
-    to_f64: impl Fn(T) -> f64,
-    flags: &[KeyValue],
-) {
+fn emit_data<T: Copy>(name: &str, unit: &str, data: &MetricData<T>, to_f64: impl Fn(T) -> f64) {
     match data {
         MetricData::Gauge(g) => {
             for dp in g.data_points() {
-                emit_gauge(name, unit, to_f64(dp.value()), dp.attributes(), flags);
+                emit_gauge(name, unit, to_f64(dp.value()), dp.attributes());
             }
         }
         MetricData::Sum(s) => {
@@ -80,50 +71,39 @@ fn emit_data<T: Copy>(
 
             for dp in s.data_points() {
                 if monotonic {
-                    emit_counter(name, to_f64(dp.value()), dp.attributes(), flags);
+                    emit_counter(name, to_f64(dp.value()), dp.attributes());
                 } else {
-                    emit_gauge(name, unit, to_f64(dp.value()), dp.attributes(), flags);
+                    emit_gauge(name, unit, to_f64(dp.value()), dp.attributes());
                 }
             }
         }
         MetricData::Histogram(h) => {
             for dp in h.data_points() {
-                emit_histogram(name, unit, dp, &to_f64, flags);
+                emit_histogram(name, unit, dp, &to_f64);
             }
         }
         MetricData::ExponentialHistogram(h) => {
             for dp in h.data_points() {
-                emit_exp_histogram(name, unit, dp, &to_f64, flags);
+                emit_exp_histogram(name, unit, dp, &to_f64);
             }
         }
     }
 }
 
-fn emit_counter<'a>(
-    name: &str,
-    value: f64,
-    attrs: impl Iterator<Item = &'a KeyValue>,
-    flags: &'a [KeyValue],
-) {
+fn emit_counter<'a>(name: &str, value: f64, attrs: impl Iterator<Item = &'a KeyValue>) {
     let mut metric = sentry::metrics::counter(name.to_owned(), value);
-    for attr in attrs.chain(flags) {
+    for attr in attrs {
         metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
     }
     metric.capture();
 }
 
-fn emit_gauge<'a>(
-    name: &str,
-    unit: &str,
-    value: f64,
-    attrs: impl Iterator<Item = &'a KeyValue>,
-    flags: &'a [KeyValue],
-) {
+fn emit_gauge<'a>(name: &str, unit: &str, value: f64, attrs: impl Iterator<Item = &'a KeyValue>) {
     let mut metric = sentry::metrics::gauge(name.to_owned(), value);
     if !unit.is_empty() {
         metric = metric.unit(unit.to_owned());
     }
-    for attr in attrs.chain(flags) {
+    for attr in attrs {
         metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
     }
     metric.capture();
@@ -134,13 +114,12 @@ fn emit_distribution<'a>(
     unit: &str,
     value: f64,
     attrs: impl Iterator<Item = &'a KeyValue>,
-    flags: &'a [KeyValue],
 ) {
     let mut metric = sentry::metrics::distribution(name.to_owned(), value);
     if !unit.is_empty() {
         metric = metric.unit(unit.to_owned());
     }
-    for attr in attrs.chain(flags) {
+    for attr in attrs {
         metric = metric.attribute(String::from(attr.key.clone()), to_log_attr(&attr.value));
     }
     metric.capture();
@@ -151,39 +130,20 @@ fn emit_histogram<T: Copy>(
     unit: &str,
     dp: &HistogramDataPoint<T>,
     to_f64: &impl Fn(T) -> f64,
-    flags: &[KeyValue],
 ) {
-    emit_counter(
-        &format!("{name}.count"),
-        dp.count() as f64,
-        dp.attributes(),
-        flags,
-    );
+    emit_counter(&format!("{name}.count"), dp.count() as f64, dp.attributes());
     emit_distribution(
         &format!("{name}.sum"),
         unit,
         to_f64(dp.sum()),
         dp.attributes(),
-        flags,
     );
 
     if let Some(min) = dp.min() {
-        emit_gauge(
-            &format!("{name}.min"),
-            unit,
-            to_f64(min),
-            dp.attributes(),
-            flags,
-        );
+        emit_gauge(&format!("{name}.min"), unit, to_f64(min), dp.attributes());
     }
     if let Some(max) = dp.max() {
-        emit_gauge(
-            &format!("{name}.max"),
-            unit,
-            to_f64(max),
-            dp.attributes(),
-            flags,
-        );
+        emit_gauge(&format!("{name}.max"), unit, to_f64(max), dp.attributes());
     }
 }
 
@@ -192,39 +152,20 @@ fn emit_exp_histogram<T: Copy>(
     unit: &str,
     dp: &ExponentialHistogramDataPoint<T>,
     to_f64: &impl Fn(T) -> f64,
-    flags: &[KeyValue],
 ) {
-    emit_counter(
-        &format!("{name}.count"),
-        dp.count() as f64,
-        dp.attributes(),
-        flags,
-    );
+    emit_counter(&format!("{name}.count"), dp.count() as f64, dp.attributes());
     emit_distribution(
         &format!("{name}.sum"),
         unit,
         to_f64(dp.sum()),
         dp.attributes(),
-        flags,
     );
 
     if let Some(min) = dp.min() {
-        emit_gauge(
-            &format!("{name}.min"),
-            unit,
-            to_f64(min),
-            dp.attributes(),
-            flags,
-        );
+        emit_gauge(&format!("{name}.min"), unit, to_f64(min), dp.attributes());
     }
     if let Some(max) = dp.max() {
-        emit_gauge(
-            &format!("{name}.max"),
-            unit,
-            to_f64(max),
-            dp.attributes(),
-            flags,
-        );
+        emit_gauge(&format!("{name}.max"), unit, to_f64(max), dp.attributes());
     }
 }
 


### PR DESCRIPTION
Refactor feature flag handling to decouple it from Sentry's scope configuration. Instead of setting flags in Sentry scope during evaluation, flags are now captured at event/metric send time through dedicated insertion functions.

This allows us to deal with feature flags in a single place inside the Sentry integration and also attach feature flags to metrics as attributes. The feature flag context we were setting before does unfortunately not apply to metrics.