### PR TITLE
fix(flaky): increase download.sh max-time from 5s to 30s

### DIFF
--- a/scripts/tests/download.sh
+++ b/scripts/tests/download.sh
@@ -2,7 +2,7 @@
 
 source "./scripts/tests/lib.sh"
 
-client sh -c "curl --fail --max-time 5 --output download.file http://download.httpbin/bytes?num=10000000" &
+client sh -c "curl --fail --max-time 30 --output download.file http://download.httpbin/bytes?num=10000000" &
 
 DOWNLOAD_PID=$!
 


### PR DESCRIPTION
The 5-second `--max-time` introduced in #13268 is too tight: it must cover DNS resolution, ICE/STUN negotiation, WireGuard handshake, and the 10 MB transfer. The `download-double-symmetric-nat` variant forces a relay-relay candidate pair which adds latency on top, making the window even narrower.

Increase to 30 s, consistent with the budget already established in `download-roaming-network.sh` (25 s).

Fixes #13351.

---
_Generated by [Claude Code](https://claude.ai/code/session_014cyZyz9X5sBtLoH4nCymcX)_