### PR TITLE
ci: free disk space in rust test and tunnel test

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,20 @@
+---
+name: "Free disk space"
+description: "Reclaim disk space by removing pre-installed toolchains we don't use"
+runs:
+  using: "composite"
+  steps:
+    - name: Free up disk space
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        # Reclaim ~25 GB from pre-installed toolchains we don't use, so the
+        # instrumented coverage builds have headroom on leaner hosted runners.
+        sudo rm -rf \
+          /usr/local/lib/android \
+          /usr/share/dotnet \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost
+        sudo docker image prune --all --force || true

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -96,6 +96,7 @@ jobs:
           install_args: --cd rust
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/free-disk-space
       - name: "cargo test"
         shell: bash
         run: cargo llvm-cov --all-features ${{ steps.setup-rust.outputs.test-packages }} --lcov --output-path lcov.info -- --include-ignored --nocapture --skip tunnel_test --skip transitions_and_state_are_deterministic
@@ -127,6 +128,7 @@ jobs:
           install_args: --cd rust
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/free-disk-space
       - name: Tunnel proptest
         id: proptest
         shell: bash


### PR DESCRIPTION
The rust test and tunnel test coverage builds intermittently exhausted disk on leaner hosted runners. This reclaims headroom by removing pre-installed toolchains we never use, extracted into a reusable composite action shared by both jobs.

Related: #13416

Co-authored-by: Mariusz Klochowicz <mariusz@klochowicz.com>