### PR TITLE
ci(dependabot): fix opentelemetry crate grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,12 +96,6 @@ updates:
         patterns:
           - rtnetlink
           - netlink-packet-*
-      # OpenTelemetry crates are pre-1.0, so Dependabot's Cargo semver rules treat
-      # every release (e.g. 0.31 -> 0.32) as a *major* update. Do NOT add an
-      # `update-types` filter here: a `minor`-only filter rejects all of these
-      # updates, and Dependabot then opens one individual PR per crate instead of
-      # grouping them. The `opentelemetry*` glob also covers `opentelemetry-stdout`
-      # and any future opentelemetry-* crate.
       otel:
         patterns:
           - "opentelemetry*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,16 +96,17 @@ updates:
         patterns:
           - rtnetlink
           - netlink-packet-*
+      # OpenTelemetry crates are pre-1.0, so Dependabot's Cargo semver rules treat
+      # every release (e.g. 0.31 -> 0.32) as a *major* update. Do NOT add an
+      # `update-types` filter here: a `minor`-only filter rejects all of these
+      # updates, and Dependabot then opens one individual PR per crate instead of
+      # grouping them. The `opentelemetry*` glob also covers `opentelemetry-stdout`
+      # and any future opentelemetry-* crate.
       otel:
         patterns:
-          - opentelemetry
-          - opentelemetry_api
-          - opentelemetry-otlp
+          - "opentelemetry*"
           - tracing-opentelemetry
           - tracing-stackdriver
-          - opentelemetry_sdk
-        update-types:
-          - minor
       windows:
         patterns:
           - windows


### PR DESCRIPTION
The `otel` Cargo group never actually grouped anything — every OpenTelemetry crate kept arriving as its own PR (even multiple in the same Dependabot run).

The group restricted itself to `update-types: [minor]`. OpenTelemetry crates are pre-1.0, and Dependabot's Cargo semver rules classify a leading-segment bump such as `0.31 -> 0.32` as a *major* update, so the `minor`-only filter rejected every release and Dependabot fell back to one PR per crate. `opentelemetry-stdout` was additionally missing from the group's patterns.

Dropping the `update-types` filter and switching to an `opentelemetry*` glob makes future OpenTelemetry releases land in a single grouped PR.

Related: #13313
Related: #13317
Related: #13320
Related: #13322
Related: #13484