### PR TITLE
chore(macos): unblock gui-client UI mock

### DIFF
--- a/rust/gui-client/src-tauri/src/deep_link/macos.rs
+++ b/rust/gui-client/src-tauri/src/deep_link/macos.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Signature must match other platforms."
+)]
 pub fn register(_path: PathBuf) -> Result<()> {
     tracing::warn!("Deep-link registration is not implemented on macOS; skipping");
 

--- a/rust/gui-client/src-tauri/src/deep_link/macos.rs
+++ b/rust/gui-client/src-tauri/src/deep_link/macos.rs
@@ -1,6 +1,8 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use std::path::PathBuf;
 
 pub fn register(_path: PathBuf) -> Result<()> {
-    bail!("not implemented")
+    tracing::warn!("Deep-link registration is not implemented on macOS; skipping");
+
+    Ok(())
 }

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -9,6 +9,10 @@ pub async fn set_autostart(_enabled: bool) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Signature must match other platforms."
+)]
 pub(crate) fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
     tracing::warn!("show_notification is not implemented on macOS; skipping");
 

--- a/rust/gui-client/src-tauri/src/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_macos.rs
@@ -1,12 +1,18 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 use crate::controller::NotificationHandle;
 
 pub async fn set_autostart(_enabled: bool) -> Result<()> {
-    bail!("Not implemented")
+    tracing::warn!("set_autostart is not implemented on macOS; skipping");
+
+    Ok(())
 }
 
 pub(crate) fn show_notification(_title: String, _body: String) -> Result<NotificationHandle> {
-    bail!("Not implemented")
+    tracing::warn!("show_notification is not implemented on macOS; skipping");
+
+    let (_tx, on_click) = futures::channel::oneshot::channel();
+
+    Ok(NotificationHandle { on_click })
 }


### PR DESCRIPTION
Allows testing & prototyping of the Tauri UI on macOS.

The mock-Tunnel work (#13382) lets the Tauri UI be driven by canned data without a real Tunnel service or portal, which is a huge win for rapid UI iteration. On macOS the flow still didn't reach the user: three dev-only stubs (`deep_link::register`, `set_autostart`, `show_notification`) returned `bail!("Not implemented")`, and because their callers propagate with `?`, each one killed a different layer of startup.

Turn the three stubs into `Ok` no-ops with `tracing::warn!`, matching the file's "stub only to do Tauri UI dev natively on a Mac" docstring. `show_notification` returns a pre-cancelled `NotificationHandle`; the existing `on_click.await.is_err()` callers already cope with a dropped sender.

Related: #13382
