### PR TITLE
feat(apple): mockable tunnel for UI iteration and iOS Simulator

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -669,7 +669,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios-sim/debug";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-ios/debug";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -680,7 +682,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -716,7 +718,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios-sim/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-ios/release";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
@@ -726,7 +730,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -764,7 +768,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*][arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios-sim/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*][arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-ios/release";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
@@ -774,7 +780,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "$(NE_PROFILE_ID)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -989,7 +995,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "macosx iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1056,7 +1062,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "macosx iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1123,7 +1129,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "macosx iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1171,7 +1177,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "$(APP_PROFILE_ID)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
@@ -1225,7 +1231,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "$(APP_PROFILE_ID)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = NO;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
@@ -1280,7 +1286,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "$(APP_PROFILE_ID)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = NO;
 				SWIFT_INSTALL_OBJC_HEADER = NO;

--- a/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/Firezone (Mock).xcscheme
+++ b/swift/apple/Firezone.xcodeproj/xcshareddata/xcschemes/Firezone (Mock).xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DCC021828D512AC007E12D2"
+               BuildableName = "Firezone.app"
+               BlueprintName = "Firezone"
+               ReferencedContainer = "container:Firezone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DCC022E28D512AE007E12D2"
+               BuildableName = "FirezoneTests.xctest"
+               BlueprintName = "FirezoneTests"
+               ReferencedContainer = "container:Firezone.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirezoneKitTests"
+               BuildableName = "FirezoneKitTests"
+               BlueprintName = "FirezoneKitTests"
+               ReferencedContainer = "container:FirezoneKit">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DCC021828D512AC007E12D2"
+            BuildableName = "Firezone.app"
+            BlueprintName = "Firezone"
+            ReferencedContainer = "container:Firezone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--mock-tunnel"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DCC021828D512AC007E12D2"
+            BuildableName = "Firezone.app"
+            BlueprintName = "Firezone"
+            ReferencedContainer = "container:Firezone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -23,7 +23,12 @@ struct FirezoneApp: App {
     // Initialize Telemetry as early as possible
     Telemetry.start()
 
-    let store = Store()
+    #if DEBUG && os(macOS)
+      // `--mock-tunnel` runs the real Store against a canned backend (see MockTunnel.swift).
+      let store = CommandLine.arguments.contains("--mock-tunnel") ? Store.mock() : Store()
+    #else
+      let store = Store()
+    #endif
     _store = StateObject(wrappedValue: store)
 
     #if os(macOS)

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -23,7 +23,7 @@ struct FirezoneApp: App {
     // Initialize Telemetry as early as possible
     Telemetry.start()
 
-    #if DEBUG && os(macOS)
+    #if DEBUG
       // `--mock-tunnel` runs the real Store against a canned backend (see MockTunnel.swift).
       let store = CommandLine.arguments.contains("--mock-tunnel") ? Store.mock() : Store()
     #else

--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -6,6 +6,8 @@ APP_GROUP_ID[sdk=macosx*] = 47R2M6779T.dev.firezone.firezone
 APP_GROUP_ID_PRE_1_4_0[sdk=macosx*] = 47R2M6779T.group.dev.firezone.firezone
 APP_GROUP_ID[sdk=iphoneos*] = group.dev.firezone.firezone
 APP_GROUP_ID_PRE_1_4_0[sdk=iphoneos*] = group.dev.firezone.firezone
+APP_GROUP_ID[sdk=iphonesimulator*] = group.dev.firezone.firezone
+APP_GROUP_ID_PRE_1_4_0[sdk=iphonesimulator*] = group.dev.firezone.firezone
 CODE_SIGN_STYLE = Automatic
 
 // Default build number - will be overridden by dynamic_build_number.xcconfig if it exists

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -35,18 +35,18 @@ enum IPCClient {
   // Auto-connect: the GUI must save providerConfiguration before calling this so
   // any MDM forced overrides are available to the provider.
   @MainActor
-  static func start(session: NETunnelProviderSession) throws {
-    try session.startTunnel()
+  static func start(session: any TunnelSessionProtocol) throws {
+    try session.startTunnel(options: nil)
   }
 
   // Sign in
   @MainActor
-  static func start(session: NETunnelProviderSession, token: String) throws {
+  static func start(session: any TunnelSessionProtocol, token: String) throws {
     try session.startTunnel(options: ["token": token as NSObject])
   }
 
   @MainActor
-  static func signOut(session: NETunnelProviderSession) async throws {
+  static func signOut(session: any TunnelSessionProtocol) async throws {
     let message = ProviderMessage.signOut
     _ = try await sendProviderMessage(session: session, message: message)
 
@@ -55,7 +55,7 @@ enum IPCClient {
 
   @MainActor
   static func fetchState(
-    session: NETunnelProviderSession, currentHash: Data
+    session: any TunnelSessionProtocol, currentHash: Data
   ) async throws -> Data? {
     let message = ProviderMessage.getState(currentHash)
 
@@ -65,7 +65,7 @@ enum IPCClient {
 
   @MainActor
   static func setInternetResourceEnabled(
-    session: NETunnelProviderSession,
+    session: any TunnelSessionProtocol,
     _ enabled: Bool
   ) async throws {
     let message = ProviderMessage.setInternetResourceEnabled(enabled)
@@ -75,13 +75,13 @@ enum IPCClient {
   // MARK: - Low-level IPC operations
 
   @MainActor
-  static func clearLogs(session: NETunnelProviderSession) async throws {
+  static func clearLogs(session: any TunnelSessionProtocol) async throws {
     let message = ProviderMessage.clearLogs
     _ = try await sendProviderMessage(session: session, message: message)
   }
 
   @MainActor
-  static func getLogFolderSize(session: NETunnelProviderSession) async throws -> Int64 {
+  static func getLogFolderSize(session: any TunnelSessionProtocol) async throws -> Int64 {
     let message = ProviderMessage.getLogFolderSize
     guard let data = try await sendProviderMessage(session: session, message: message)
     else {
@@ -94,14 +94,14 @@ enum IPCClient {
   }
 
   @MainActor
-  static func fetchEncodedFirezoneId(session: NETunnelProviderSession) async throws -> String? {
+  static func fetchEncodedFirezoneId(session: any TunnelSessionProtocol) async throws -> String? {
     guard let data = try await sendProviderMessage(session: session, message: .getEncodedFirezoneId)
     else { return nil }
     return String(data: data, encoding: .utf8)
   }
 
   @MainActor
-  static func exportLogs(session: NETunnelProviderSession, fd: FileDescriptor) async throws {
+  static func exportLogs(session: any TunnelSessionProtocol, fd: FileDescriptor) async throws {
     let isCycleStart = try await maybeCycleStart(session)
     defer {
       if isCycleStart { session.stopTunnel() }
@@ -142,7 +142,7 @@ enum IPCClient {
   /// Filters `NEVPNStatusDidChange` notifications to only those matching `session`.
   /// The caller is responsible for consuming the stream in a task they manage.
   static func vpnStatusUpdates(
-    session: NETunnelProviderSession
+    session: any TunnelSessionProtocol
   ) -> AsyncStream<NEVPNStatus> {
     AsyncStream { continuation in
       let task = Task {
@@ -165,7 +165,7 @@ enum IPCClient {
   }
 
   private static func sendProviderMessage(
-    session: NETunnelProviderSession,
+    session: any TunnelSessionProtocol,
     message: ProviderMessage,
   ) async throws -> Data? {
     let isCycleStart = try await maybeCycleStart(session)
@@ -188,7 +188,7 @@ enum IPCClient {
   /// On macOS, the tunnel needs to be in a connected, connecting, or reasserting state for the utun to be removed
   /// upon stopTunnel. We do this by ensuring the tunnel is "started" prior to any IPC call. If so, we return true
   /// so that the caller may stop the tunnel afterwards.
-  private static func maybeCycleStart(_ session: NETunnelProviderSession) async throws -> Bool {
+  private static func maybeCycleStart(_ session: any TunnelSessionProtocol) async throws -> Bool {
     if session.status == .invalid {
       throw Error.invalidStatus(session.status)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -29,7 +29,7 @@ import SystemPackage
     @MainActor
     static func export(
       to archiveURL: URL,
-      session: NETunnelProviderSession
+      session: any TunnelSessionProtocol
     ) async throws {
       guard let logFolderURL = SharedAccess.logFolderURL
       else {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -17,7 +17,9 @@ public protocol TunnelProviderManager: AnyObject {
   var isEnabled: Bool { get set }
   var localizedDescription: String? { get set }
   var protocolConfiguration: NEVPNProtocol? { get set }
-  var connection: NEVPNConnection { get }
+  /// The tunnel session backing this manager, if its connection is a provider
+  /// session. Mockable counterpart of the concrete, un-mockable `connection`.
+  var tunnelSession: (any TunnelSessionProtocol)? { get }
 
   func saveToPreferences() async throws
   func loadFromPreferences() async throws
@@ -31,7 +33,11 @@ public protocol TunnelProviderManagerFactory {
 
 // MARK: - NetworkExtension Conformances
 
-extension NETunnelProviderManager: TunnelProviderManager {}
+extension NETunnelProviderManager: TunnelProviderManager {
+  public var tunnelSession: (any TunnelSessionProtocol)? {
+    connection as? NETunnelProviderSession
+  }
+}
 
 @MainActor
 public final class NETunnelProviderManagerFactory: TunnelProviderManagerFactory {
@@ -118,8 +124,8 @@ public final class VPNConfigurationManager {
     try await manager.loadFromPreferences()
   }
 
-  func session() -> NETunnelProviderSession? {
-    return manager.connection as? NETunnelProviderSession
+  func session() -> (any TunnelSessionProtocol)? {
+    return manager.tunnelSession
   }
 
   func loadConfiguration(into configuration: Configuration, userDefaults: UserDefaults) async throws

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -38,7 +38,7 @@
   }
 
   /// Answers `getState` with the canned snapshot and reports a connected tunnel.
-  final class MockTunnelSession: TunnelSessionProtocol {
+  private final class MockTunnelSession: TunnelSessionProtocol {
     var status: NEVPNStatus { .connected }
 
     // swiftlint:disable:next discouraged_optional_collection
@@ -52,25 +52,45 @@
     func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
       guard let responseHandler else { return }
 
-      switch try? PropertyListDecoder().decode(ProviderMessage.self, from: messageData) {
+      let message: ProviderMessage
+      do {
+        message = try PropertyListDecoder().decode(ProviderMessage.self, from: messageData)
+      } catch {
+        Log.warning("MockTunnelSession: ignoring undecodable ProviderMessage: \(error)")
+        responseHandler(nil)
+        return
+      }
+
+      // Listed exhaustively (no `default`) so adding a `ProviderMessage` variant
+      // fails to compile here and forces a decision about the mock's response.
+      switch message {
       case .getState(let currentHash):
-        responseHandler(
-          try? ConnlibState.encodeIfChanged(
-            resources: MockFixtures.resources,
-            connectedDevices: MockFixtures.connectedDevices,
-            unreachableResources: [],
-            isLogStreamingActive: false,
-            comparedTo: currentHash
+        do {
+          responseHandler(
+            try ConnlibState.encodeIfChanged(
+              resources: MockFixtures.resources,
+              connectedDevices: MockFixtures.connectedDevices,
+              unreachableResources: [],
+              isLogStreamingActive: false,
+              comparedTo: currentHash
+            )
           )
-        )
-      default:
+        } catch {
+          Log.warning("MockTunnelSession: failed to encode ConnlibState: \(error)")
+          responseHandler(nil)
+        }
+      case .setInternetResourceEnabled, .signOut, .clearLogs, .getLogFolderSize, .exportLogs,
+        .getEncodedFirezoneId:
         responseHandler(nil)
       }
     }
   }
 
+  /// Both factory methods hand back the same `MockTunnelProviderManager` instance, so
+  /// session identity is stable across reloads — `Store` can subscribe to one mock
+  /// session for the lifetime of the app.
   @MainActor
-  final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
+  private final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
     private let manager = MockTunnelProviderManager()
 
     func loadAllFromPreferences() async throws -> [any TunnelProviderManager] { [manager] }
@@ -78,7 +98,7 @@
   }
 
   @MainActor
-  final class MockTunnelProviderManager: TunnelProviderManager {
+  private final class MockTunnelProviderManager: TunnelProviderManager {
     var isEnabled = true
     var localizedDescription: String? = VPNConfigurationManager.bundleDescription
     var protocolConfiguration: NEVPNProtocol?
@@ -100,7 +120,7 @@
 
   #if os(macOS)
     @MainActor
-    final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
+    private final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
       func check() async throws -> SystemExtensionStatus { .installed }
       func tryInstall() async throws -> SystemExtensionStatus { .installed }
     }
@@ -108,7 +128,7 @@
     /// Reports notifications as already authorised so the iOS app routes straight to the
     /// session UI instead of `GrantNotificationsView`.
     @MainActor
-    final class MockSessionNotification: SessionNotificationProtocol {
+    private final class MockSessionNotification: SessionNotificationProtocol {
       var signInHandler: () async -> Void = {}
 
       func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus { .authorized }
@@ -117,7 +137,6 @@
     }
   #endif
 
-  /// Canned fixtures mirroring the desktop client's `fake_controller.rs`.
   private enum MockFixtures {
     static let resources: [Resource] = {
       let site = Site(id: "demo-site", name: "Demo Site")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -5,22 +5,36 @@
 //
 
 // Backs the `--mock-tunnel` launch argument: feeds the real `Store` a connected
-// status and a canned resource + connected-device list, so the menu bar can be
-// exercised without a portal, auth, system extension, or live peers. Mirrors the
-// desktop client's `fake_controller.rs`. DEBUG-only, so it ships in no release.
+// status and a canned resource + connected-device list, so the macOS menu bar and
+// the iOS app UI can be exercised without a portal, auth, system extension, or live
+// peers. Mirrors the desktop client's `fake_controller.rs`. DEBUG-only, so it ships
+// in no release. On iOS the Simulator cannot run a Network Extension at all; the mock
+// sidesteps it entirely.
 
-#if DEBUG && os(macOS)
+#if DEBUG
   import Foundation
   @preconcurrency import NetworkExtension
+  #if os(iOS)
+    import UserNotifications
+  #endif
 
   extension Store {
     /// A `Store` wired to mock dependencies for the `--mock-tunnel` demo.
-    public static func mock() -> Store {
-      Store(
-        systemExtensionManager: MockSystemExtensionManager(),
-        tunnelManagerFactory: MockTunnelProviderManagerFactory()
-      )
-    }
+    #if os(macOS)
+      public static func mock() -> Store {
+        Store(
+          systemExtensionManager: MockSystemExtensionManager(),
+          tunnelManagerFactory: MockTunnelProviderManagerFactory()
+        )
+      }
+    #else
+      public static func mock() -> Store {
+        Store(
+          sessionNotification: MockSessionNotification(),
+          tunnelManagerFactory: MockTunnelProviderManagerFactory()
+        )
+      }
+    #endif
   }
 
   /// Answers `getState` with the canned snapshot and reports a connected tunnel.
@@ -84,11 +98,24 @@
     func loadFromPreferences() async throws {}
   }
 
-  @MainActor
-  final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
-    func check() async throws -> SystemExtensionStatus { .installed }
-    func tryInstall() async throws -> SystemExtensionStatus { .installed }
-  }
+  #if os(macOS)
+    @MainActor
+    final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
+      func check() async throws -> SystemExtensionStatus { .installed }
+      func tryInstall() async throws -> SystemExtensionStatus { .installed }
+    }
+  #else
+    /// Reports notifications as already authorised so the iOS app routes straight to the
+    /// session UI instead of `GrantNotificationsView`.
+    @MainActor
+    final class MockSessionNotification: SessionNotificationProtocol {
+      var signInHandler: () async -> Void = {}
+
+      func askUserForNotificationPermissions() async throws -> UNAuthorizationStatus { .authorized }
+      func loadAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
+      func showResourceNotification(title: String, body: String) async {}
+    }
+  #endif
 
   /// Canned fixtures mirroring the desktop client's `fake_controller.rs`.
   private enum MockFixtures {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -1,0 +1,133 @@
+//
+//  MockTunnel.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+// Backs the `--mock-tunnel` launch argument: feeds the real `Store` a connected
+// status and a canned resource + connected-device list, so the menu bar can be
+// exercised without a portal, auth, system extension, or live peers. Mirrors the
+// desktop client's `fake_controller.rs`. DEBUG-only, so it ships in no release.
+
+#if DEBUG && os(macOS)
+  import Foundation
+  @preconcurrency import NetworkExtension
+
+  extension Store {
+    /// A `Store` wired to mock dependencies for the `--mock-tunnel` demo.
+    public static func mock() -> Store {
+      Store(
+        systemExtensionManager: MockSystemExtensionManager(),
+        tunnelManagerFactory: MockTunnelProviderManagerFactory()
+      )
+    }
+  }
+
+  /// Answers `getState` with the canned snapshot and reports a connected tunnel.
+  final class MockTunnelSession: TunnelSessionProtocol {
+    var status: NEVPNStatus { .connected }
+
+    // swiftlint:disable:next discouraged_optional_collection
+    func startTunnel(options: [String: Any]?) throws {}
+    func stopTunnel() {}
+
+    func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void) {
+      completionHandler(nil)
+    }
+
+    func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
+      guard let responseHandler else { return }
+
+      switch try? PropertyListDecoder().decode(ProviderMessage.self, from: messageData) {
+      case .getState(let currentHash):
+        responseHandler(
+          try? ConnlibState.encodeIfChanged(
+            resources: MockFixtures.resources,
+            connectedDevices: MockFixtures.connectedDevices,
+            unreachableResources: [],
+            isLogStreamingActive: false,
+            comparedTo: currentHash
+          )
+        )
+      default:
+        responseHandler(nil)
+      }
+    }
+  }
+
+  @MainActor
+  final class MockTunnelProviderManagerFactory: TunnelProviderManagerFactory {
+    private let manager = MockTunnelProviderManager()
+
+    func loadAllFromPreferences() async throws -> [any TunnelProviderManager] { [manager] }
+    func createManager() -> any TunnelProviderManager { manager }
+  }
+
+  @MainActor
+  final class MockTunnelProviderManager: TunnelProviderManager {
+    var isEnabled = true
+    var localizedDescription: String? = VPNConfigurationManager.bundleDescription
+    var protocolConfiguration: NEVPNProtocol?
+    var tunnelSession: (any TunnelSessionProtocol)? { session }
+
+    private let session = MockTunnelSession()
+
+    init() {
+      let proto = NETunnelProviderProtocol()
+      proto.providerConfiguration = Configuration().toProviderConfiguration()
+      proto.providerBundleIdentifier = VPNConfigurationManager.bundleIdentifier
+      proto.serverAddress = "Firezone"
+      protocolConfiguration = proto
+    }
+
+    func saveToPreferences() async throws {}
+    func loadFromPreferences() async throws {}
+  }
+
+  @MainActor
+  final class MockSystemExtensionManager: SystemExtensionManagerProtocol {
+    func check() async throws -> SystemExtensionStatus { .installed }
+    func tryInstall() async throws -> SystemExtensionStatus { .installed }
+  }
+
+  /// Canned fixtures mirroring the desktop client's `fake_controller.rs`.
+  private enum MockFixtures {
+    static let resources: [Resource] = {
+      let site = Site(id: "demo-site", name: "Demo Site")
+      return [
+        Resource(
+          id: "internet-resource", name: "Internet Resource", address: nil,
+          addressDescription: nil, status: .online, sites: [site], type: .internet),
+        Resource(
+          id: "office-network", name: "Office network", address: "10.0.0.0/16",
+          addressDescription: "CIDR resource", status: .online, sites: [site], type: .cidr),
+        Resource(
+          id: "demo-gitlab", name: "Demo GitLab", address: "gitlab.demo.example",
+          addressDescription: "https://gitlab.demo.example", status: .online, sites: [site],
+          type: .dns),
+        Resource(
+          id: "lab-network", name: "Lab network (offline)", address: "192.168.50.0/24",
+          addressDescription: "Gateway offline", status: .offline, sites: [site], type: .cidr),
+        Resource(
+          id: "demo-wiki", name: "Demo Wiki (unknown)", address: "wiki.demo.example",
+          addressDescription: "Gateway state unknown", status: .unknown, sites: [site], type: .dns),
+      ]
+    }()
+
+    static let connectedDevices: [ConnectedDevice] = {
+      let poolPatterns: [[String]] = [
+        ["Engineering Pool"],
+        ["Engineering Pool", "QA Pool"],
+        ["QA Pool"],
+        ["Sales Pool"],
+      ]
+      return (0..<22).map { index in
+        ConnectedDevice(
+          id: "client-\(index + 1)",
+          tunIPv4: "100.96.0.\(index + 1)",
+          pools: poolPatterns[index % poolPatterns.count]
+        )
+      }
+    }()
+  }
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Protocols/TunnelSessionProtocol.swift
@@ -1,0 +1,23 @@
+//
+//  TunnelSessionProtocol.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+@preconcurrency import NetworkExtension
+
+/// Abstracts the slice of `NETunnelProviderSession` that the GUI talks to, so a
+/// mock session can drive `Store` without a real Network Extension.
+///
+/// The methods mirror Apple's API exactly, which lets `NETunnelProviderSession`
+/// conform via an empty extension — there is no "real" wrapper to keep in sync.
+public protocol TunnelSessionProtocol: AnyObject, Sendable {
+  var status: NEVPNStatus { get }
+  // swiftlint:disable:next discouraged_optional_collection
+  func startTunnel(options: [String: Any]?) throws
+  func stopTunnel()
+  func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws
+  func fetchLastDisconnectError(completionHandler: @escaping @Sendable (Error?) -> Void)
+}
+
+extension NETunnelProviderSession: TunnelSessionProtocol {}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -632,7 +632,7 @@ public final class Store: ObservableObject {
   ///
   /// - Parameter session: The tunnel provider session to communicate with
   /// - Throws: IPCClient.Error if IPC communication fails
-  private func fetchState(session: NETunnelProviderSession) async throws {
+  private func fetchState(session: any TunnelSessionProtocol) async throws {
     // Capture current hash before IPC call
     let currentHash = self.connlibStateHash
 

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConfigurationTests.swift
@@ -49,6 +49,7 @@ private final class MockTunnelProviderManager: TunnelProviderManager {
   var localizedDescription: String?
   var protocolConfiguration: NEVPNProtocol?
   let connection: NEVPNConnection = NETunnelProviderManager().connection
+  var tunnelSession: (any TunnelSessionProtocol)? { nil }
   var saveCount = 0
   var loadCount = 0
 

--- a/swift/apple/mise-tasks/build-rust.sh
+++ b/swift/apple/mise-tasks/build-rust.sh
@@ -97,14 +97,17 @@ iphoneos)
     TARGETS=("aarch64-apple-ios")
     ;;
 iphonesimulator)
-    if [[ "$NATIVE_ARCH" == "arm64" ]]; then
-        TARGETS=("aarch64-apple-ios-sim")
-    elif [[ "$NATIVE_ARCH" == "x86_64" ]]; then
-        TARGETS=("x86_64-apple-ios")
-    else
-        echo "ERROR: Unsupported native arch for $PLATFORM_NAME: $NATIVE_ARCH" >&2
-        exit 1
-    fi
+    TARGETS=()
+    for arch in $NATIVE_ARCH; do
+        case "$arch" in
+        arm64) TARGETS+=("aarch64-apple-ios-sim") ;;
+        x86_64) TARGETS+=("x86_64-apple-ios") ;;
+        *)
+            echo "ERROR: Unsupported native arch for $PLATFORM_NAME: $arch" >&2
+            exit 1
+            ;;
+        esac
+    done
     ;;
 *)
     echo "ERROR: Unknown platform: $PLATFORM_NAME" >&2


### PR DESCRIPTION
Picks up the dependency-injection thread from #12217, #12228, and #12394 by adding a `TunnelSessionProtocol` seam over `NETunnelProviderSession` - the last piece of the menu bar that still reached straight into the real Network Extension. With that in place, a `--mock-tunnel` debug flag and a "Firezone (Mock)" Xcode scheme swap a canned backend into the real `Store`, so the macOS menu bar can be exercised without a portal, auth, system extension, or live peers.

The same flag also lights up the iOS app on the Simulator; with a mocked protocol, we can inject canned data there and test UX even without NE running.

All of it is gated behind `#if DEBUG` and an explicit launch argument; the default `Firezone` scheme and CI builds are unchanged.

Related: #12217, #12228, #12394