### PR TITLE
refactor(relay): bind nonces to client sockets

### DIFF
--- a/rust/relay/server/src/auth.rs
+++ b/rust/relay/server/src/auth.rs
@@ -161,9 +161,10 @@ impl Encode for MessageEncoder {
 /// For simplicity reasons, we use a count-based strategy.
 /// Each nonce can be used for a certain number of requests before it is invalid.
 ///
-/// We remember the nonce we last handed out to each client and keep reusing it
-/// for as long as it is valid, rather than minting a fresh one on every request.
-/// This keeps the number of stored nonces bounded by the number of clients.
+/// We remember the nonce we last handed out to each client socket and keep
+/// reusing it for as long as it is valid, rather than minting a fresh one on
+/// every request. This bounds the stored nonces to one per client socket
+/// instead of one per request.
 #[derive(Default, Debug, Clone)]
 pub(crate) struct Nonces {
     inner: HashMap<ClientSocket, Nonce>,
@@ -385,7 +386,7 @@ mod tests {
 
         nonces.add_new(client, nonce);
 
-        for _ in 0..10_000 {
+        for _ in 0..Nonces::NUM_REQUESTS {
             nonces.handle_nonce_used(client, nonce).unwrap();
         }
 
@@ -452,7 +453,7 @@ mod tests {
         let mut rng = StepRng::new(0, 1);
 
         let first = nonces.issue(client, &mut rng);
-        for _ in 0..10_000 {
+        for _ in 0..Nonces::NUM_REQUESTS {
             nonces.handle_nonce_used(client, first).unwrap();
         }
 

--- a/rust/relay/server/src/auth.rs
+++ b/rust/relay/server/src/auth.rs
@@ -38,6 +38,7 @@ use base64::Engine;
 use base64::prelude::BASE64_STANDARD_NO_PAD;
 use bytecodec::Encode;
 use once_cell::sync::Lazy;
+use rand::Rng;
 use secrecy::{ExposeSecret, SecretString};
 use sha2::Sha256;
 use sha2::digest::FixedOutput;
@@ -48,7 +49,7 @@ use stun_codec::Message;
 use stun_codec::rfc5389::attributes::{MessageIntegrity, Realm, Username};
 use uuid::Uuid;
 
-use crate::Attribute;
+use crate::{Attribute, ClientSocket};
 
 // TODO: Upstream a const constructor to `stun-codec`.
 pub static FIREZONE: Lazy<Realm> =
@@ -159,35 +160,78 @@ impl Encode for MessageEncoder {
 ///
 /// For simplicity reasons, we use a count-based strategy.
 /// Each nonce can be used for a certain number of requests before it is invalid.
+///
+/// We remember the nonce we last handed out to each client and keep reusing it
+/// for as long as it is valid, rather than minting a fresh one on every request.
+/// This keeps the number of stored nonces bounded by the number of clients.
 #[derive(Default, Debug, Clone)]
 pub(crate) struct Nonces {
-    inner: HashMap<Uuid, u64>,
+    inner: HashMap<ClientSocket, Nonce>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Nonce {
+    value: Uuid,
+    remaining_requests: u64,
 }
 
 impl Nonces {
     /// How many requests a client can perform with the same nonce.
     const NUM_REQUESTS: u64 = 10_000;
 
-    pub(crate) fn add_new(&mut self, nonce: Uuid) {
-        self.inner.insert(nonce, Self::NUM_REQUESTS);
+    /// Returns a valid nonce for the given client.
+    ///
+    /// If we have already issued a nonce to this client that is still valid, the
+    /// same nonce is returned. Otherwise, a fresh one is minted using `rng`.
+    pub(crate) fn issue(&mut self, client: ClientSocket, rng: &mut impl Rng) -> Uuid {
+        if let Some(nonce) = self
+            .inner
+            .get(&client)
+            .filter(|nonce| nonce.remaining_requests > 0)
+        {
+            return nonce.value;
+        }
+
+        let value = Uuid::from_u128(rng.r#gen());
+        self.add_new(client, value);
+
+        value
+    }
+
+    pub(crate) fn add_new(&mut self, client: ClientSocket, value: Uuid) {
+        self.inner.insert(
+            client,
+            Nonce {
+                value,
+                remaining_requests: Self::NUM_REQUESTS,
+            },
+        );
     }
 
     /// Record the usage of a nonce in a request.
-    pub(crate) fn handle_nonce_used(&mut self, nonce: Uuid) -> Result<(), Error> {
-        let mut entry = match self.inner.entry(nonce) {
+    pub(crate) fn handle_nonce_used(
+        &mut self,
+        client: ClientSocket,
+        value: Uuid,
+    ) -> Result<(), Error> {
+        let mut entry = match self.inner.entry(client) {
             Entry::Vacant(_) => return Err(Error::UnknownNonce),
             Entry::Occupied(entry) => entry,
         };
 
-        let remaining_requests = entry.get_mut();
+        let nonce = entry.get_mut();
 
-        if *remaining_requests == 0 {
+        if nonce.value != value {
+            return Err(Error::UnknownNonce);
+        }
+
+        if nonce.remaining_requests == 0 {
             entry.remove();
 
             return Err(Error::NonceUsedUp);
         }
 
-        *remaining_requests -= 1;
+        nonce.remaining_requests -= 1;
 
         Ok(())
     }
@@ -245,6 +289,8 @@ pub(crate) fn systemtime_from_unix(seconds: u64) -> SystemTime {
 mod tests {
     use super::*;
     use crate::Attribute;
+    use rand::rngs::mock::StepRng;
+    use std::net::SocketAddr;
     use stun_codec::rfc5389::methods::BINDING;
     use stun_codec::{Message, MessageClass, TransactionId};
 
@@ -332,18 +378,19 @@ mod tests {
     }
 
     #[test]
-    fn nonces_are_valid_for_100_requests() {
+    fn nonces_are_valid_for_a_fixed_number_of_requests() {
         let mut nonces = Nonces::default();
+        let client = client_socket(1);
         let nonce = Uuid::new_v4();
 
-        nonces.add_new(nonce);
+        nonces.add_new(client, nonce);
 
         for _ in 0..10_000 {
-            nonces.handle_nonce_used(nonce).unwrap();
+            nonces.handle_nonce_used(client, nonce).unwrap();
         }
 
         assert!(matches!(
-            nonces.handle_nonce_used(nonce).unwrap_err(),
+            nonces.handle_nonce_used(client, nonce).unwrap_err(),
             Error::NonceUsedUp
         ));
     }
@@ -351,12 +398,67 @@ mod tests {
     #[test]
     fn unknown_nonces_are_invalid() {
         let mut nonces = Nonces::default();
+        let client = client_socket(1);
         let nonce = Uuid::new_v4();
 
         assert!(matches!(
-            nonces.handle_nonce_used(nonce).unwrap_err(),
+            nonces.handle_nonce_used(client, nonce).unwrap_err(),
             Error::UnknownNonce
         ));
+    }
+
+    #[test]
+    fn reuses_the_same_nonce_for_repeated_requests_from_one_client() {
+        let mut nonces = Nonces::default();
+        let client = client_socket(1);
+        let mut rng = StepRng::new(0, 1);
+
+        let first = nonces.issue(client, &mut rng);
+        let second = nonces.issue(client, &mut rng);
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn issues_distinct_nonces_to_distinct_clients() {
+        let mut nonces = Nonces::default();
+        let mut rng = StepRng::new(0, 1);
+
+        let alice = nonces.issue(client_socket(1), &mut rng);
+        let bob = nonces.issue(client_socket(2), &mut rng);
+
+        assert_ne!(alice, bob);
+    }
+
+    #[test]
+    fn a_nonce_issued_to_one_client_is_invalid_for_another() {
+        let mut nonces = Nonces::default();
+        let mut rng = StepRng::new(0, 1);
+
+        let nonce = nonces.issue(client_socket(1), &mut rng);
+
+        assert!(matches!(
+            nonces
+                .handle_nonce_used(client_socket(2), nonce)
+                .unwrap_err(),
+            Error::UnknownNonce
+        ));
+    }
+
+    #[test]
+    fn issues_a_fresh_nonce_once_the_previous_one_is_used_up() {
+        let mut nonces = Nonces::default();
+        let client = client_socket(1);
+        let mut rng = StepRng::new(0, 1);
+
+        let first = nonces.issue(client, &mut rng);
+        for _ in 0..10_000 {
+            nonces.handle_nonce_used(client, first).unwrap();
+        }
+
+        let second = nonces.issue(client, &mut rng);
+
+        assert_ne!(first, second);
     }
 
     fn message_integrity(
@@ -382,5 +484,9 @@ mod tests {
             BINDING,
             TransactionId::new([0u8; 12]),
         )
+    }
+
+    fn client_socket(id: u8) -> ClientSocket {
+        ClientSocket::new(SocketAddr::from(([127, 0, 0, id], 51820)))
     }
 }

--- a/rust/relay/server/src/server.rs
+++ b/rust/relay/server/src/server.rs
@@ -237,11 +237,9 @@ where
         self.listen_port
     }
 
-    /// Registers a new, valid nonce.
-    ///
-    /// Each nonce is valid for 10 requests.
-    pub fn add_nonce(&mut self, nonce: Uuid) {
-        self.nonces.add_new(nonce);
+    /// Registers a new, valid nonce for the given client.
+    pub fn add_nonce(&mut self, client: ClientSocket, nonce: Uuid) {
+        self.nonces.add_new(client, nonce);
     }
 
     pub fn num_relayed_bytes(&self) -> u64 {
@@ -342,7 +340,7 @@ where
         // In case of a 401 or 438 response, attach a realm and nonce.
         if is_auth_error {
             error_response.add_attribute((*FIREZONE).clone());
-            error_response.add_attribute(self.new_nonce_attribute());
+            error_response.add_attribute(self.new_nonce_attribute(sender));
         }
 
         let message = match message.username() {
@@ -490,7 +488,7 @@ where
         sender: ClientSocket,
         now: Instant,
     ) -> Result<(), Message<Attribute>> {
-        let username = self.verify_auth(request)?;
+        let username = self.verify_auth(sender, request)?;
 
         if let Some(allocation) = self.allocations.get(&sender) {
             let (error_response, msg) = make_error_response(AllocationMismatch, request);
@@ -617,7 +615,7 @@ where
         sender: ClientSocket,
         now: Instant,
     ) -> Result<(), Message<Attribute>> {
-        let username = self.verify_auth(request)?;
+        let username = self.verify_auth(sender, request)?;
 
         // TODO: Verify that this is the correct error code.
         let Some(allocation) = self.allocations.get_mut(&sender) else {
@@ -666,7 +664,7 @@ where
         sender: ClientSocket,
         now: Instant,
     ) -> Result<(), Message<Attribute>> {
-        let username = self.verify_auth(request)?;
+        let username = self.verify_auth(sender, request)?;
 
         let Some(allocation) = self.allocations.get_mut(&sender) else {
             let (error_response, msg) = make_error_response(AllocationMismatch, request);
@@ -775,7 +773,7 @@ where
         request: &CreatePermission,
         sender: ClientSocket,
     ) -> Result<(), Message<Attribute>> {
-        let username = self.verify_auth(request)?;
+        let username = self.verify_auth(sender, request)?;
 
         self.authenticate_and_send(
             &username,
@@ -821,6 +819,7 @@ where
 
     fn verify_auth(
         &mut self,
+        sender: ClientSocket,
         request: &(impl StunRequest + ProtectedRequest),
     ) -> Result<Username, Message<Attribute>> {
         let message_integrity = request.message_integrity().ok_or_else(|| {
@@ -852,7 +851,7 @@ where
                 error_response
             })?;
 
-        self.nonces.handle_nonce_used(nonce).map_err(|e| {
+        self.nonces.handle_nonce_used(sender, nonce).map_err(|e| {
             let (error_response, msg) = make_error_response(StaleNonce, request);
             tracing::debug!(target: "relay", "{msg}: Nonce is invalid: {e}");
 
@@ -1108,12 +1107,10 @@ where
         tracing::info!(target: "relay", channel = %chan.value(), %client, %peer, %allocation, "Channel binding is now deleted (and can be rebound)");
     }
 
-    fn new_nonce_attribute(&mut self) -> Nonce {
-        let new_nonce = Uuid::from_u128(self.rng.r#gen());
+    fn new_nonce_attribute(&mut self, sender: ClientSocket) -> Nonce {
+        let nonce = self.nonces.issue(sender, &mut self.rng);
 
-        self.add_nonce(new_nonce);
-
-        Nonce::new(new_nonce.to_string())
+        Nonce::new(nonce.to_string())
             .expect("UUIDs are valid nonces because they are less than 128 characters long")
     }
 }

--- a/rust/relay/server/tests/regression.rs
+++ b/rust/relay/server/tests/regression.rs
@@ -53,7 +53,7 @@ fn deallocate_once_time_expired(
 ) {
     let now = Instant::now();
 
-    let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
+    let mut server = TestServer::new(public_relay_addr).with_nonce(source, nonce);
     let secret = server.auth_secret();
 
     server.assert_commands(
@@ -158,7 +158,7 @@ fn when_refreshed_in_time_allocation_does_not_expire(
 ) {
     let now = Instant::now();
 
-    let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
+    let mut server = TestServer::new(public_relay_addr).with_nonce(source, nonce);
     let secret = server.auth_secret().to_owned();
     let first_wake = now + allocate_lifetime.lifetime();
 
@@ -238,7 +238,7 @@ fn when_receiving_lifetime_0_for_existing_allocation_then_delete(
 ) {
     let now = Instant::now();
 
-    let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
+    let mut server = TestServer::new(public_relay_addr).with_nonce(source, nonce);
     let secret = server.auth_secret().to_owned();
     let first_wake = now + allocate_lifetime.lifetime();
 
@@ -321,7 +321,7 @@ fn freeing_allocation_clears_all_channels(
 
     let _guard = logging::test("debug");
 
-    let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
+    let mut server = TestServer::new(public_relay_addr).with_nonce(source, nonce);
     let secret = server.auth_secret().to_owned();
 
     let _ = server.server.handle_client_message(
@@ -393,7 +393,7 @@ fn ping_pong_relay(
 
     let _guard = logging::test("debug");
 
-    let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
+    let mut server = TestServer::new(public_relay_addr).with_nonce(source, nonce);
     let secret = server.auth_secret().to_owned();
     let lifetime = Lifetime::new(Duration::from_secs(60 * 60)).unwrap(); // Lifetime longer than channel expiry
 
@@ -504,7 +504,7 @@ fn allows_rebind_channel_after_expiry(
 
     let _guard = logging::test("debug");
 
-    let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
+    let mut server = TestServer::new(public_relay_addr).with_nonce(source, nonce);
     let secret = server.auth_secret().to_owned();
     let lifetime = Lifetime::new(Duration::from_secs(60 * 60)).unwrap(); // Lifetime longer than channel expiry
 
@@ -628,7 +628,7 @@ fn ping_pong_ip6_relay(
     let _guard = logging::test("debug");
 
     let mut server =
-        TestServer::new((public_relay_ip4_addr, public_relay_ip6_addr)).with_nonce(nonce);
+        TestServer::new((public_relay_ip4_addr, public_relay_ip6_addr)).with_nonce(source, nonce);
     let secret = server.auth_secret().to_owned();
     let lifetime = Lifetime::new(Duration::from_secs(60 * 60)).unwrap(); // Lifetime longer than channel expiry
 
@@ -729,8 +729,9 @@ impl TestServer {
         }
     }
 
-    fn with_nonce(mut self, nonce: Uuid) -> Self {
-        self.server.add_nonce(nonce);
+    fn with_nonce(mut self, client: impl Into<SocketAddr>, nonce: Uuid) -> Self {
+        self.server
+            .add_nonce(ClientSocket::new(client.into()), nonce);
 
         self
     }


### PR DESCRIPTION
Associate nonces with client sockets rather than treating them as globally unique tokens. This allows the relay to reuse the same nonce for repeated requests from a single client, keeping the number of stored nonces bounded by the number of active clients rather than the number of requests.

The `Nonces` struct now tracks both the nonce value and remaining request count per client. A new `issue()` method returns an existing valid nonce for a client or mints a fresh one if needed. The `handle_nonce_used()` method now validates that the nonce belongs to the requesting client.

Updated all call sites to pass the client socket when issuing or validating nonces.