### PR TITLE
ci: only pull images once per integration test matrix

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -259,6 +259,11 @@ jobs:
             PROFILE="--release"
           else
             PROFILE=""
+            # Build the debug images with `line-tables-only` debug info: keeps
+            # backtraces but roughly halves the binaries, so the images pull
+            # faster/more reliably from ghcr and are smaller in the test-image
+            # artifact. Local `cargo build` is unaffected (keeps full debug).
+            export CARGO_PROFILE_DEV_DEBUG=line-tables-only
           fi
 
           cargo build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }} --verbose

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -3,6 +3,10 @@ run-name: Triggered from ${{ github.event_name }} by ${{ github.actor }}
 on:
   workflow_call:
     inputs:
+      id:
+        description: "Unique identifier for this invocation. Used to namespace the artifact holding the pre-pulled images so that concurrent invocations within the same run don't collide."
+        required: true
+        type: string
       portal_image:
         required: false
         type: string
@@ -56,9 +60,62 @@ env:
   COMPOSE_PARALLEL_LIMIT: 1 # Temporary fix for https://github.com/docker/compose/pull/12752 until compose v2.36.0 lands on GitHub actions runners.
 
 jobs:
+  collect-images:
+    name: collect-images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      PORTAL_IMAGE: ${{ inputs.portal_image }}
+      PORTAL_TAG: ${{ inputs.portal_tag }}
+      RELAY_IMAGE: ${{ inputs.relay_image }}
+      RELAY_TAG: ${{ inputs.relay_tag }}
+      GATEWAY_IMAGE: ${{ inputs.gateway_image }}
+      GATEWAY_TAG: ${{ inputs.gateway_tag }}
+      CLIENT_IMAGE: ${{ inputs.client_image }}
+      CLIENT_TAG: ${{ inputs.client_tag }}
+      ELIXIR_IMAGE: ${{ inputs.elixir_image }}
+      ELIXIR_TAG: ${{ inputs.elixir_tag }}
+      HTTP_TEST_SERVER_IMAGE: ${{ inputs.http_test_server_image }}
+      HTTP_TEST_SERVER_TAG: ${{ inputs.http_test_server_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/ghcr-docker-login
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-scripts
+      - name: Pull all images once
+        # Pulls every registry image in the compose project (resolving `extends`,
+        # anchors and env interpolation). Services that are only built locally
+        # (the routers) have no `image:` and are skipped.
+        run: retry docker compose pull
+      - name: Save pulled images as a single archive
+        run: |
+          set -xe
+
+          # Save exactly the images that were pulled (i.e. are present locally) so
+          # that the auto-generated names of build-only services are excluded.
+          images=$(docker compose config --images | sort -u | while read -r image; do
+            if docker image inspect "$image" > /dev/null 2>&1; then
+              echo "$image"
+            fi
+          done)
+
+          echo "Saving images:"
+          echo "$images"
+
+          docker save $images | gzip > images.tar.gz
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          overwrite: true
+          name: images-${{ inputs.id }}
+          path: images.tar.gz
+          retention-days: 1
+
   integration-tests:
     name: ${{ matrix.test.name || matrix.test.script }}
     runs-on: ubuntu-24.04
+    needs: collect-images
     permissions:
       contents: read
       id-token: write # OIDC auth
@@ -119,9 +176,13 @@ jobs:
             rust_log: debug,flow_logs=trace # Too noisy can cause flaky tests due to the amount of data
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/ghcr-docker-login
+      - uses: ./.github/actions/setup-docker
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: images-${{ inputs.id }}
+      - name: Load pre-pulled images
+        run: docker load -i images.tar.gz
+      - uses: ./.github/actions/setup-scripts
       - name: Check minimum client version
         id: client_version_check
         if: ${{ matrix.test.min_client_version }}
@@ -146,8 +207,6 @@ jobs:
           echo "MIN_VERSION=${MIN_VERSION}"
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
-      - uses: ./.github/actions/setup-docker
-      - uses: ./.github/actions/setup-scripts
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
       - name: Start docker compose in the background

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -110,7 +110,7 @@ jobs:
           echo "$images"
 
           # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images | zstd --long=31 -T0 -o images.tar.zst
+          docker save $images | zstd --long=30 -T0 -o images.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true
@@ -188,7 +188,7 @@ jobs:
         with:
           name: images-${{ inputs.id }}
       - name: Load pre-pulled images
-        run: zstd -dc --long=31 images.tar.zst | docker load
+        run: zstd -dc --long=30 images.tar.zst | docker load
       - uses: ./.github/actions/setup-scripts
       - name: Check minimum client version
         id: client_version_check

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -110,7 +110,7 @@ jobs:
           echo "$images"
 
           # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images | zstd -T0 -o images.tar.zst
+          docker save $images | zstd -19 -T0 -o images.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -87,8 +87,12 @@ jobs:
       - name: Pull all images once
         # Pulls every registry image in the compose project (resolving `extends`,
         # anchors and env interpolation). Services that are only built locally
-        # (the routers) have no `image:` and are skipped.
-        run: retry docker compose pull
+        # (the routers) have no `image:` and are skipped, so we additionally pull
+        # their base image (see `scripts/router/Dockerfile`) to let the test jobs
+        # build the routers without reaching out to Docker Hub.
+        run: |
+          retry docker compose pull
+          retry docker pull alpine:3.23
       - name: Save pulled images as a single archive
         run: |
           set -xe
@@ -100,6 +104,10 @@ jobs:
               echo "$image"
             fi
           done)
+
+          # Also archive the routers' base image so the build-only `*-router`
+          # services can be built offline in the test jobs.
+          images="$images alpine:3.23"
 
           echo "Saving images:"
           echo "$images"
@@ -188,7 +196,7 @@ jobs:
         if: ${{ matrix.test.min_client_version }}
         continue-on-error: true
         run: |
-          ACTUAL_VERSION=$(docker run --privileged ${{ inputs.client_image }}:${{ inputs.client_tag }} firezone-headless-client --version | awk '{print $2}')
+          ACTUAL_VERSION=$(docker run --pull never --privileged ${{ inputs.client_image }}:${{ inputs.client_tag }} firezone-headless-client --version | awk '{print $2}')
           MIN_VERSION="${{ matrix.test.min_client_version }}"
 
           echo "ACTUAL_VERSION=${ACTUAL_VERSION}"
@@ -200,7 +208,7 @@ jobs:
         if: ${{ matrix.test.min_gateway_version }}
         continue-on-error: true
         run: |
-          ACTUAL_VERSION=$(docker run --privileged ${{ inputs.gateway_image }}:${{ inputs.gateway_tag }} firezone-gateway --version | awk '{print $2}')
+          ACTUAL_VERSION=$(docker run --pull never --privileged ${{ inputs.gateway_image }}:${{ inputs.gateway_tag }} firezone-gateway --version | awk '{print $2}')
           MIN_VERSION="${{ matrix.test.min_gateway_version }}"
 
           echo "ACTUAL_VERSION=${ACTUAL_VERSION}"
@@ -208,7 +216,7 @@ jobs:
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
       - name: Seed database
-        run: docker compose run elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
+        run: docker compose run --pull never elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
       - name: Start docker compose in the background
         if: ${{ steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure' }} # Run if version checks succeed or are skipped
         run: |
@@ -234,16 +242,16 @@ jobs:
 
           # Start one-by-one to avoid variability in service startup order
           # Retries are used because network I/O is flaky in GitHub Actions runners
-          retry docker compose up -d dns.httpbin.search.test --no-build
-          retry docker compose up -d httpbin --no-build
-          retry docker compose up -d download.httpbin --no-build
-          retry docker compose up -d portal --no-build
-          retry docker compose up -d otel --no-build
-          retry docker compose up -d relay-1 --no-build
-          retry docker compose up -d relay-2 --no-build
-          retry docker compose up -d gateway --no-build
-          retry docker compose up -d client-1 ${{ matrix.test.extra_services }} --no-build
-          retry docker compose up -d network-config
+          retry docker compose up -d dns.httpbin.search.test --no-build --pull never
+          retry docker compose up -d httpbin --no-build --pull never
+          retry docker compose up -d download.httpbin --no-build --pull never
+          retry docker compose up -d portal --no-build --pull never
+          retry docker compose up -d otel --no-build --pull never
+          retry docker compose up -d relay-1 --no-build --pull never
+          retry docker compose up -d relay-2 --no-build --pull never
+          retry docker compose up -d gateway --no-build --pull never
+          retry docker compose up -d client-1 ${{ matrix.test.extra_services }} --no-build --pull never
+          retry docker compose up -d network-config --pull never
 
           docker compose exec -d relay-1 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'
           docker compose exec -d relay-2 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -110,13 +110,13 @@ jobs:
           echo "$images"
 
           # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images -o images.tar
+          docker save $images | zstd -T0 -o images.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true
           name: images-${{ inputs.id }}
-          path: images.tar
-          compression-level: 1
+          path: images.tar.zst
+          compression-level: 0
           retention-days: 1
 
   integration-tests:
@@ -188,7 +188,7 @@ jobs:
         with:
           name: images-${{ inputs.id }}
       - name: Load pre-pulled images
-        run: docker load -i images.tar
+        run: zstd -dc images.tar.zst | docker load
       - uses: ./.github/actions/setup-scripts
       - name: Check minimum client version
         id: client_version_check

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -112,6 +112,7 @@ jobs:
           echo "Saving images:"
           echo "$images"
 
+          # shellcheck disable=SC2086 # $images must be split into separate args
           docker save $images | gzip > images.tar.gz
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -56,9 +56,6 @@ on:
         type: string
         default: ${{ github.sha }}
 
-env:
-  COMPOSE_PARALLEL_LIMIT: 1 # Temporary fix for https://github.com/docker/compose/pull/12752 until compose v2.36.0 lands on GitHub actions runners.
-
 jobs:
   collect-images:
     name: collect-images
@@ -119,9 +116,6 @@ jobs:
           overwrite: true
           name: images-${{ inputs.id }}
           path: images.tar
-          # upload-artifact already compresses (and decompresses on download),
-          # so gzipping first was redundant. A low level stays much faster than
-          # gzip while keeping the artifact small for the many downloading jobs.
           compression-level: 1
           retention-days: 1
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -110,7 +110,7 @@ jobs:
           echo "$images"
 
           # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images | zstd -T0 -o images.tar.zst
+          docker save $images | zstd --long=31 -T0 -o images.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true
@@ -188,7 +188,7 @@ jobs:
         with:
           name: images-${{ inputs.id }}
       - name: Load pre-pulled images
-        run: zstd -dc images.tar.zst | docker load
+        run: zstd -dc --long=31 images.tar.zst | docker load
       - uses: ./.github/actions/setup-scripts
       - name: Check minimum client version
         id: client_version_check

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -113,12 +113,16 @@ jobs:
           echo "$images"
 
           # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images | gzip > images.tar.gz
+          docker save $images -o images.tar
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true
           name: images-${{ inputs.id }}
-          path: images.tar.gz
+          path: images.tar
+          # upload-artifact already compresses (and decompresses on download),
+          # so gzipping first was redundant. A low level stays much faster than
+          # gzip while keeping the artifact small for the many downloading jobs.
+          compression-level: 1
           retention-days: 1
 
   integration-tests:
@@ -190,7 +194,7 @@ jobs:
         with:
           name: images-${{ inputs.id }}
       - name: Load pre-pulled images
-        run: docker load -i images.tar.gz
+        run: docker load -i images.tar
       - uses: ./.github/actions/setup-scripts
       - name: Check minimum client version
         id: client_version_check

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -110,7 +110,7 @@ jobs:
           echo "$images"
 
           # shellcheck disable=SC2086 # $images must be split into separate args
-          docker save $images | zstd -19 -T0 -o images.tar.zst
+          docker save $images | zstd -T0 -o images.tar.zst
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,7 @@ jobs:
       id-token: write # OIDC auth
       pull-requests: write # post test result comments
     with:
+      id: integration
       gateway_image: ${{ needs.data-plane.outputs.gateway_image }}
       client_image: ${{ needs.data-plane.outputs.client_image }}
       relay_image: ${{ needs.data-plane.outputs.relay_image }}
@@ -408,6 +409,7 @@ jobs:
       id-token: write # OIDC auth
       pull-requests: write # post test result comments
     with:
+      id: compat-client-${{ matrix.client.ci-name }}-gateway-${{ matrix.gateway.ci-name }}
       gateway_image: ${{ matrix.gateway.image }}
       gateway_tag: ${{ matrix.gateway.tag }}
       client_image: ${{ matrix.client.image }}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -287,3 +287,21 @@ debug = 2
 [profile.dev.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
+
+# Shrink the integration-test images: build their binaries with
+# `line-tables-only`, which keeps file/line info for backtraces but drops the
+# bulk of the type/variable DWARF (roughly halves the binaries). This shrinks
+# the images pulled from ghcr and shipped through the test-image artifact. The
+# eBPF object (built via the relay's build script) keeps full debug info for
+# BTF, and the GUI client keeps its full debug info, via their own overrides.
+[profile.dev.package.firezone-headless-client]
+debug = "line-tables-only"
+
+[profile.dev.package.firezone-gateway]
+debug = "line-tables-only"
+
+[profile.dev.package.firezone-relay]
+debug = "line-tables-only"
+
+[profile.dev.package.http-test-server]
+debug = "line-tables-only"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -287,21 +287,3 @@ debug = 2
 [profile.dev.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
-
-# Shrink the integration-test images: build their binaries with
-# `line-tables-only`, which keeps file/line info for backtraces but drops the
-# bulk of the type/variable DWARF (roughly halves the binaries). This shrinks
-# the images pulled from ghcr and shipped through the test-image artifact. The
-# eBPF object (built via the relay's build script) keeps full debug info for
-# BTF, and the GUI client keeps its full debug info, via their own overrides.
-[profile.dev.package.firezone-headless-client]
-debug = "line-tables-only"
-
-[profile.dev.package.firezone-gateway]
-debug = "line-tables-only"
-
-[profile.dev.package.firezone-relay]
-debug = "line-tables-only"
-
-[profile.dev.package.http-test-server]
-debug = "line-tables-only"


### PR DESCRIPTION
Optimize integration test workflow by pulling Docker images once in a dedicated job and sharing them across concurrent test invocations. This prevents redundant image pulls which should hopefully reduce the number of IO errors we have been experiencing in CI.

This greatly reduced the number of container pulls by a factor of 17 (the number of integration tests) meaning we should be able to safely re-enable parallel container pulls.

By setting `--pull never` on each invocation, we make sure CI fails loudly if we ever mess up this optimisation and forget to include an image that we need in the pre-pull step.