### PR TITLE
chore(rust): upgrade rand to 0.10.1

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -49,16 +49,6 @@ jobs:
         name: cargo doc
         shell: bash
       - run: cargo fmt -- --check
-      - name: Guard RUSTSEC-2026-0097 allowlist assumption
-        run: |
-          # RUSTSEC-2026-0097 is allowlisted because rand's `log` feature is not enabled,
-          # meaning the vulnerable re-entrant ThreadRng code path is compiled out.
-          # If a dependency ever enables rand/log, the allowlist is no longer valid.
-          if cargo tree -e features 2>/dev/null | grep -q 'rand feature "log"'; then
-            echo "::error::rand's 'log' feature is now enabled — RUSTSEC-2026-0097 allowlist in deny.toml is no longer safe to keep"
-            exit 1
-          fi
-        shell: bash
       - run: cargo deny check --hide-inclusion-graph --deny unnecessary-skip
         shell: bash
       # cargo-shear does not compile the workspace; it runs `cargo metadata` and

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -695,7 +695,7 @@ dependencies = [
  "gat-lending-iterator",
  "hex",
  "hex-literal",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "ip-packet",
  "ip_network",
@@ -763,11 +763,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -777,6 +777,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -830,18 +839,20 @@ dependencies = [
 
 [[package]]
 name = "boringtun"
-version = "0.6.1"
-source = "git+https://github.com/firezone/boringtun?branch=master#bb3034dcd12b63970ccd364ab779ce90f3561653"
+version = "0.7.0"
+source = "git+https://github.com/firezone/boringtun?branch=master#f1c65a468e6b65a9c69ac4676d6331e4990c4ece"
 dependencies = [
  "aead",
  "blake2",
  "chacha20poly1305",
  "constant_time_eq",
- "hmac",
+ "hmac 0.13.0",
  "parking_lot",
- "rand 0.8.5",
+ "portable-atomic",
+ "rand 0.10.1",
  "ring",
  "tracing",
+ "typenum",
  "x25519-dalek",
 ]
 
@@ -1161,7 +1172,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -1273,6 +1284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "1a1ec0cfec728a79a5109075543131387f911cb4d07716436d7ae20533657a96"
 
 [[package]]
 name = "convert_case"
@@ -1501,6 +1518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,13 +1566,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -1777,9 +1812,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1885,7 +1931,7 @@ dependencies = [
  "ip_network",
  "l3-tcp",
  "logging",
- "rand 0.8.5",
+ "rand 0.10.1",
  "tokio",
  "tracing",
  "tun",
@@ -2192,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -2323,7 +2369,7 @@ dependencies = [
  "parking_lot",
  "phoenix-channel",
  "png 0.18.1",
- "rand 0.8.5",
+ "rand 0.10.1",
  "reqwest",
  "rustls",
  "sadness-generator",
@@ -2415,7 +2461,7 @@ dependencies = [
  "known-dirs",
  "logging",
  "phoenix-channel",
- "rand 0.8.5",
+ "rand 0.10.1",
  "reqwest",
  "secrecy",
  "serde",
@@ -2461,7 +2507,7 @@ dependencies = [
  "opentelemetry_sdk",
  "phoenix-channel",
  "proptest",
- "rand 0.8.5",
+ "rand 0.10.1",
  "rustls",
  "secrecy",
  "serde",
@@ -3227,7 +3273,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3236,7 +3282,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3343,6 +3398,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3713,7 +3777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "840878b6e30d40e5bda1a7116100f1a18b7bdb91814513b87be80bbfb5d41879"
 dependencies = [
  "crc",
- "hmac",
+ "hmac 0.12.1",
  "serde",
  "sha1",
  "str0m-proto",
@@ -3999,7 +4063,7 @@ dependencies = [
  "anyhow-ext",
  "dns-types",
  "ip-packet",
- "rand 0.8.5",
+ "rand 0.10.1",
  "tracing",
 ]
 
@@ -5197,7 +5261,7 @@ dependencies = [
  "libc",
  "logging",
  "os_info",
- "rand_core 0.6.4",
+ "rand 0.10.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -5327,9 +5391,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
@@ -5496,7 +5560,7 @@ dependencies = [
  "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -5603,22 +5667,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
@@ -5631,16 +5684,6 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6538,7 +6581,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6549,7 +6592,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6674,7 +6717,7 @@ dependencies = [
  "itertools",
  "logging",
  "opentelemetry",
- "rand 0.8.5",
+ "rand 0.10.1",
  "ringbuffer",
  "smallvec",
  "stun_codec",
@@ -6912,7 +6955,7 @@ dependencies = [
  "bytecodec",
  "byteorder",
  "crc",
- "hmac",
+ "hmac 0.12.1",
  "md5",
  "sha1",
  "trackable",
@@ -8178,7 +8221,7 @@ dependencies = [
  "opentelemetry",
  "proptest",
  "proptest-state-machine",
- "rand 0.8.5",
+ "rand 0.10.1",
  "rangemap",
  "ringbuffer",
  "rustls",
@@ -8229,9 +8272,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -8458,7 +8501,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -9722,13 +9765,13 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "f17b575e04fcdb37e5509a85a14ff08116678a1c9724befb8b571db742dbdbb0"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,7 +69,7 @@ bimap = "0.6.3"
 bin-shared = { path = "libs/bin-shared" }
 bnum = "0.14.4"
 bootstrap-dns-client = { path = "libs/connlib/bootstrap-dns-client" }
-boringtun = { version = "0.6.0", default-features = false }
+boringtun = { version = "0.7.0", default-features = false }
 bufferpool = { path = "libs/connlib/bufferpool" }
 bytecodec = "0.5.0"
 bytes = { version = "1.11.1", default-features = false }
@@ -154,8 +154,7 @@ proptest = "1.9.0"
 proptest-state-machine = "0.6.0"
 quinn-udp = { version = "0.6.0", features = ["fast-apple-datapath"] }
 quote = "1.0.45"
-rand = "0.8.5"
-rand_core = "0.6.4"
+rand = "0.10.1"
 rangemap = "1.7.1"
 reqwest = { version = "0.13.4", default-features = false }
 resolv-conf = "0.7.6"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -260,15 +260,19 @@ deny = [
 skip = [
     "base64",
     "bitflags",
+    "block-buffer", # boringtun 0.7 pulls the RC crypto stack (curve25519-dalek 5.0-rc, blake2 0.11-rc) on RustCrypto's 0.12 `block-buffer`; the rest of the tree is on 0.10.
     "cargo-platform",
     "cargo_metadata",
     "chacha20", # boringtun pulls chacha20 0.9 via chacha20poly1305 0.10.1; hickory 0.26 pulls 0.10 via rand 0.10.
     "core-foundation", # hickory 0.26 ships system-configuration 0.7 (core-foundation 0.9); tauri/reqwest/etc. are on 0.10.
     "cpufeatures", # Same root cause as `chacha20` — pulled in via chacha20 0.10 from hickory 0.26.
+    "crypto-common", # See `block-buffer`: pulled by boringtun 0.7's RC crypto crates (0.2 vs 0.1 elsewhere).
+    "digest", # See `block-buffer`: pulled by boringtun 0.7's RC crypto crates (0.11 vs 0.10 elsewhere).
     "foldhash",
     "getrandom",
     "hashbrown",
     "heck",
+    "hmac", # See `block-buffer`: pulled by boringtun 0.7's RC crypto crates (0.13 vs 0.12 elsewhere).
     "indexmap",
     "jni", # hickory 0.26 uses jni 0.22 for Android DNS; tauri/tao/wry/rustls-platform-verifier/ndk still on 0.21. not a problem as they land in different binaries (Android client vs gateway)
     "jni-sys",
@@ -281,7 +285,6 @@ skip = [
     "proc-macro-crate",
     "quick-xml",
     "rand",
-    "rand_chacha",
     "rand_core",
     "rustix",
     "serde_spanned",

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -106,12 +106,6 @@ ignore = [
 
     "RUSTSEC-2024-0436", # paste, See #8387
 
-    # `rand` unsoundness via re-entrant ThreadRng access from a custom logger (GHSA-cq8v-f236-94qc).
-    # Not exploitable: rand's `log` feature is not enabled (verified via `cargo tree -e features`),
-    # so the log!() call sites in rand's reseeding path are compiled out entirely.
-    # Upgrading to rand 0.9 is blocked by x25519-dalek requiring rand_core 0.6.
-    "RUSTSEC-2026-0097",
-
     # `rust-unic` crates are unmaintained but still pulled in via tauri.
     "RUSTSEC-2025-0075",
     "RUSTSEC-2025-0080",

--- a/rust/gui-client/src-tauri/src/auth.rs
+++ b/rust/gui-client/src-tauri/src/auth.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use keyring_core::CredentialStore;
 use logging::err_with_src;
-use rand::{RngCore, thread_rng};
+use rand::Rng;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -395,7 +395,7 @@ fn session_data_path(session_dir: &Path) -> PathBuf {
 fn generate_nonce() -> SecretString {
     let mut buf = [0u8; NONCE_LENGTH];
     // rand's thread-local RNG is said to be cryptographically secure here: https://docs.rs/rand/latest/rand/rngs/struct.ThreadRng.html
-    thread_rng().fill_bytes(&mut buf);
+    rand::rng().fill_bytes(&mut buf);
 
     // Make sure it's not somehow all still zeroes.
     assert_ne!(buf, [0u8; NONCE_LENGTH]);

--- a/rust/gui-client/src-tauri/src/updates.rs
+++ b/rust/gui-client/src-tauri/src/updates.rs
@@ -1,7 +1,7 @@
 //! Module to check the Firezone website API for new releases
 
 use anyhow::{Context, Result};
-use rand::{Rng as _, thread_rng};
+use rand::RngExt as _;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{io::Write, path::PathBuf, str::FromStr, time::Duration};
@@ -62,7 +62,7 @@ pub async fn checker_task(
             }
             Event::WaitRandom => {
                 tracing::debug!("WaitRandom");
-                let rand_time = thread_rng().gen_range(0..interval_in_seconds);
+                let rand_time = rand::rng().random_range(0..interval_in_seconds);
                 tokio::time::sleep(Duration::from_secs(rand_time)).await;
                 // Discard the first interval, which always elapses instantly
                 interval.reset();

--- a/rust/libs/connlib/dns-over-tcp/src/client.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/client.rs
@@ -11,7 +11,7 @@ use ip_packet::{IpPacket, Layer4Protocol};
 use l3_tcp::{
     InMemoryDevice, Interface, PollResult, SocketSet, create_interface, create_tcp_socket,
 };
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 /// A sans-io DNS-over-TCP client.
 ///
@@ -429,7 +429,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         }
 
         loop {
-            let port = self.rng.gen_range(range.clone());
+            let port = self.rng.random_range(range.clone());
 
             if !used_ports.contains(&port) {
                 return Ok(port);

--- a/rust/libs/connlib/l3-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l3-udp-dns-client/lib.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use ip_packet::{FailedPacket, IpPacket, Layer4Protocol};
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -264,7 +264,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         }
 
         loop {
-            let port = self.rng.gen_range(range.clone());
+            let port = self.rng.random_range(range.clone());
 
             if !self.pending_queries_by_local_port.contains_key(&port) {
                 return Ok(port);

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -16,7 +16,7 @@ itertools = { workspace = true }
 libc = { workspace = true }
 logging = { workspace = true }
 os_info = { workspace = true }
-rand_core = { workspace = true, features = ["getrandom"] }
+rand = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -20,7 +20,6 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt};
 use itertools::Itertools as _;
 use logging::err_with_src;
-use rand_core::{OsRng, RngCore};
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use socket_factory::{SocketFactory, TcpSocket, TcpStream};
@@ -1051,8 +1050,7 @@ impl<T> PhoenixMessage<T> {
 
 // This is basically the same as tungstenite does but we add some new headers (namely user-agent)
 fn make_request(url: Url, host: String, user_agent: String, token: &SecretString) -> Request {
-    let mut r = [0u8; 16];
-    OsRng.fill_bytes(&mut r);
+    let r: [u8; 16] = rand::random();
     let key = base64::engine::general_purpose::STANDARD.encode(r);
 
     let user_agent = user_agent.replace(|c: char| !c.is_ascii(), "");

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -31,7 +31,7 @@ use is::{IceAgent, IceAgentEvent};
 use itertools::Itertools;
 use opentelemetry::metrics::Gauge;
 use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use smallvec::SmallVec;
 use std::collections::BTreeSet;

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -502,7 +502,7 @@ mod tests {
         let mut connections: Connections<u32, u32> = Connections::default();
         let mut allocations: Allocations<u32> = Allocations::default();
         let now = Instant::now();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Insert a connection that is using relay id 1.
         let conn = new_connection(12345, 1, [1u8; 32]);
@@ -595,7 +595,7 @@ mod tests {
     }
 
     fn new_connection(idx: u32, relay_id: u32, key: [u8; 32]) -> Connection<u32> {
-        let private = StaticSecret::random_from_rng(rand::thread_rng());
+        let private = StaticSecret::random_from_rng(&mut rand::rng());
         let new_local = Index::new_local(idx);
 
         Connection {

--- a/rust/libs/connlib/tunnel/src/dns/resource_stub_resolver.rs
+++ b/rust/libs/connlib/tunnel/src/dns/resource_stub_resolver.rs
@@ -743,7 +743,7 @@ mod tests {
 #[allow(clippy::unwrap_used)]
 mod benches {
     use super::*;
-    use rand::{Rng, distributions::DistString, seq::IteratorRandom};
+    use rand::{RngExt, distr::SampleString, seq::IteratorRandom};
 
     #[divan::bench(
         consts = [10, 100, 1_000, 10_000, 100_000]
@@ -752,7 +752,7 @@ mod benches {
         bencher
             .with_inputs(|| {
                 let mut resolver = ResourceStubResolver::default();
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
 
                 for n in 0..NUM_RES {
                     resolver.add_resource(
@@ -777,9 +777,9 @@ mod benches {
             .bench_refs(|(resolver, needle)| resolver.match_resource_linear(needle));
     }
 
-    fn make_domain(rng: &mut impl Rng) -> String {
-        (0..rng.gen_range(2..5))
-            .map(|_| rand::distributions::Alphanumeric.sample_string(rng, 3))
+    fn make_domain(rng: &mut impl RngExt) -> String {
+        (0..rng.random_range(2..5))
+            .map(|_| rand::distr::Alphanumeric.sample_string(rng, 3))
             .join(".")
     }
 }

--- a/rust/libs/connlib/tunnel/src/messages/key.rs
+++ b/rust/libs/connlib/tunnel/src/messages/key.rs
@@ -91,8 +91,8 @@ pub type SecretKey = SecretBox<Key>;
 
 #[cfg(test)]
 mod test {
-    use boringtun::x25519::{PublicKey, StaticSecret};
     use super::Key;
+    use boringtun::x25519::{PublicKey, StaticSecret};
 
     #[test]
     fn can_deserialize_public_key() {

--- a/rust/libs/connlib/tunnel/src/messages/key.rs
+++ b/rust/libs/connlib/tunnel/src/messages/key.rs
@@ -92,8 +92,6 @@ pub type SecretKey = SecretBox<Key>;
 #[cfg(test)]
 mod test {
     use boringtun::x25519::{PublicKey, StaticSecret};
-    use rand::rngs::OsRng;
-
     use super::Key;
 
     #[test]
@@ -105,7 +103,7 @@ mod test {
 
     #[test]
     fn can_serialize_from_private_key_and_back() {
-        let private_key = StaticSecret::random_from_rng(OsRng);
+        let private_key = StaticSecret::random_from_rng(&mut rand::rng());
         let expected_public_key = PublicKey::from(private_key.to_bytes());
         let public_key = Key(expected_public_key.to_bytes());
         let public_key_string = serde_json::to_string(&public_key).unwrap();

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -22,7 +22,7 @@ use dns_types::ResponseCode;
 use dns_types::prelude::*;
 use ip_packet::Ecn;
 use rand::SeedableRng;
-use rand::distributions::DistString;
+use rand::distr::SampleString;
 use sha2::Digest;
 use snownet::{NoTurnServers, Transmit};
 use std::collections::BTreeSet;
@@ -1386,8 +1386,8 @@ fn ice_creds(domain: &str, client_key: PublicKey, gateway_key: PublicKey) -> Ice
     let mut rng = rand::rngs::StdRng::from_seed(hkdf(domain, client_key, gateway_key));
 
     IceCredentials {
-        username: rand::distributions::Alphanumeric.sample_string(&mut rng, 4),
-        password: rand::distributions::Alphanumeric.sample_string(&mut rng, 12),
+        username: rand::distr::Alphanumeric.sample_string(&mut rng, 4),
+        password: rand::distr::Alphanumeric.sample_string(&mut rng, 12),
     }
 }
 

--- a/rust/relay/server/src/auth.rs
+++ b/rust/relay/server/src/auth.rs
@@ -38,7 +38,7 @@ use base64::Engine;
 use base64::prelude::BASE64_STANDARD_NO_PAD;
 use bytecodec::Encode;
 use once_cell::sync::Lazy;
-use rand::Rng;
+use rand::RngExt;
 use secrecy::{ExposeSecret, SecretString};
 use sha2::Sha256;
 use sha2::digest::FixedOutput;
@@ -184,7 +184,7 @@ impl Nonces {
     ///
     /// If we have already issued a nonce to this client that is still valid, the
     /// same nonce is returned. Otherwise, a fresh one is minted using `rng`.
-    pub(crate) fn issue(&mut self, client: ClientSocket, rng: &mut impl Rng) -> Uuid {
+    pub(crate) fn issue(&mut self, client: ClientSocket, rng: &mut impl RngExt) -> Uuid {
         if let Some(nonce) = self
             .inner
             .get(&client)
@@ -193,7 +193,7 @@ impl Nonces {
             return nonce.value;
         }
 
-        let value = Uuid::from_u128(rng.r#gen());
+        let value = Uuid::from_u128(rng.random());
         self.add_new(client, value);
 
         value
@@ -290,10 +290,42 @@ pub(crate) fn systemtime_from_unix(seconds: u64) -> SystemTime {
 mod tests {
     use super::*;
     use crate::Attribute;
-    use rand::rngs::mock::StepRng;
     use std::net::SocketAddr;
     use stun_codec::rfc5389::methods::BINDING;
     use stun_codec::{Message, MessageClass, TransactionId};
+
+    /// Deterministic RNG yielding an arithmetic sequence. Replaces the `StepRng`
+    /// mock that was removed from `rand`'s public API in 0.10.
+    #[derive(Clone, Debug)]
+    struct StepRng(u64, u64);
+
+    impl StepRng {
+        fn new(initial: u64, increment: u64) -> Self {
+            Self(initial, increment)
+        }
+    }
+
+    impl rand::TryRng for StepRng {
+        type Error = core::convert::Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            self.try_next_u64().map(|x| x as u32)
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            let res = self.0;
+            self.0 = self.0.wrapping_add(self.1);
+            Ok(res)
+        }
+
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+            for chunk in dst.chunks_mut(8) {
+                let bytes = self.try_next_u64()?.to_le_bytes();
+                chunk.copy_from_slice(&bytes[..chunk.len()]);
+            }
+            Ok(())
+        }
+    }
 
     const RELAY_SECRET_1: &str = "4c98bf59c99b3e467ecd7cf9d6b3e5279645fca59be67bc5bb4af3cf653761ab";
     const RELAY_SECRET_2: &str = "7e35e34801e766a6a29ecb9e22810ea4e3476c2b37bf75882edf94a68b1d9607";

--- a/rust/relay/server/src/auth.rs
+++ b/rust/relay/server/src/auth.rs
@@ -290,42 +290,10 @@ pub(crate) fn systemtime_from_unix(seconds: u64) -> SystemTime {
 mod tests {
     use super::*;
     use crate::Attribute;
+    use rand::{SeedableRng as _, rngs::StdRng};
     use std::net::SocketAddr;
     use stun_codec::rfc5389::methods::BINDING;
     use stun_codec::{Message, MessageClass, TransactionId};
-
-    /// Deterministic RNG yielding an arithmetic sequence. Replaces the `StepRng`
-    /// mock that was removed from `rand`'s public API in 0.10.
-    #[derive(Clone, Debug)]
-    struct StepRng(u64, u64);
-
-    impl StepRng {
-        fn new(initial: u64, increment: u64) -> Self {
-            Self(initial, increment)
-        }
-    }
-
-    impl rand::TryRng for StepRng {
-        type Error = core::convert::Infallible;
-
-        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-            self.try_next_u64().map(|x| x as u32)
-        }
-
-        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-            let res = self.0;
-            self.0 = self.0.wrapping_add(self.1);
-            Ok(res)
-        }
-
-        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-            for chunk in dst.chunks_mut(8) {
-                let bytes = self.try_next_u64()?.to_le_bytes();
-                chunk.copy_from_slice(&bytes[..chunk.len()]);
-            }
-            Ok(())
-        }
-    }
 
     const RELAY_SECRET_1: &str = "4c98bf59c99b3e467ecd7cf9d6b3e5279645fca59be67bc5bb4af3cf653761ab";
     const RELAY_SECRET_2: &str = "7e35e34801e766a6a29ecb9e22810ea4e3476c2b37bf75882edf94a68b1d9607";
@@ -444,7 +412,7 @@ mod tests {
     fn reuses_the_same_nonce_for_repeated_requests_from_one_client() {
         let mut nonces = Nonces::default();
         let client = client_socket(1);
-        let mut rng = StepRng::new(0, 1);
+        let mut rng = StdRng::seed_from_u64(0);
 
         let first = nonces.issue(client, &mut rng);
         let second = nonces.issue(client, &mut rng);
@@ -455,7 +423,7 @@ mod tests {
     #[test]
     fn issues_distinct_nonces_to_distinct_clients() {
         let mut nonces = Nonces::default();
-        let mut rng = StepRng::new(0, 1);
+        let mut rng = StdRng::seed_from_u64(0);
 
         let alice = nonces.issue(client_socket(1), &mut rng);
         let bob = nonces.issue(client_socket(2), &mut rng);
@@ -466,7 +434,7 @@ mod tests {
     #[test]
     fn a_nonce_issued_to_one_client_is_invalid_for_another() {
         let mut nonces = Nonces::default();
-        let mut rng = StepRng::new(0, 1);
+        let mut rng = StdRng::seed_from_u64(0);
 
         let nonce = nonces.issue(client_socket(1), &mut rng);
 
@@ -482,7 +450,7 @@ mod tests {
     fn issues_a_fresh_nonce_once_the_previous_one_is_used_up() {
         let mut nonces = Nonces::default();
         let client = client_socket(1);
-        let mut rng = StepRng::new(0, 1);
+        let mut rng = StdRng::seed_from_u64(0);
 
         let first = nonces.issue(client, &mut rng);
         for _ in 0..Nonces::NUM_REQUESTS {

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -14,7 +14,7 @@ use futures::{FutureExt, future};
 use logging::{FilterReloadHandle, err_with_src, sentry_layer};
 use phoenix_channel::{Event, LoginUrl, NoParams, PhoenixChannel, get_user_agent};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use secrecy::{ExposeSecret, SecretString};
 use std::borrow::Cow;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -414,7 +414,7 @@ struct JoinMessage {
 
 fn make_rng(seed: Option<u64>) -> StdRng {
     let Some(seed) = seed else {
-        return StdRng::from_entropy();
+        return StdRng::from_seed(rand::random());
     };
 
     tracing::info!(target: "relay", "Seeding RNG from '{seed}'");
@@ -450,7 +450,7 @@ struct Eventloop<R> {
 
 impl<R> Eventloop<R>
 where
-    R: Rng,
+    R: RngExt,
 {
     fn new(
         server: Server<R>,

--- a/rust/relay/server/src/server.rs
+++ b/rust/relay/server/src/server.rs
@@ -16,7 +16,7 @@ use core::fmt;
 use logging::err_with_src;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
-use rand::Rng;
+use rand::RngExt;
 use secrecy::SecretString;
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -162,7 +162,7 @@ const CHANNEL_REBIND_TIMEOUT: Duration = Duration::from_secs(300);
 
 impl<R> Server<R>
 where
-    R: Rng,
+    R: RngExt,
 {
     /// Constructs a new [`Server`].
     ///
@@ -194,7 +194,7 @@ where
             channels_by_client_and_number: Default::default(),
             channel_numbers_by_client_and_peer: Default::default(),
             pending_commands: Default::default(),
-            auth_secret: SecretString::from(hex::encode(rng.r#gen::<[u8; 32]>())),
+            auth_secret: SecretString::from(hex::encode(rng.random::<[u8; 32]>())),
             rng,
             nonces: Default::default(),
             allocations_up_down_counter,
@@ -881,7 +881,7 @@ where
         );
 
         let port = loop {
-            let candidate = AllocationPort(self.rng.gen_range(self.ports.clone()));
+            let candidate = AllocationPort(self.rng.random_range(self.ports.clone()));
 
             if !self.clients_by_allocation.contains_key(&candidate) {
                 break candidate;

--- a/rust/relay/server/tests/regression.rs
+++ b/rust/relay/server/tests/regression.rs
@@ -6,10 +6,42 @@ use firezone_relay::{
     AddressFamily, Allocate, AllocationPort, Attribute, Binding, ChannelBind, ChannelData,
     ClientMessage, ClientSocket, Command, IpStack, PeerSocket, Refresh, SOFTWARE, Server,
 };
-use rand::rngs::mock::StepRng;
 use secrecy::SecretString;
 use std::iter;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+/// Deterministic RNG yielding an arithmetic sequence. Replaces the `StepRng`
+/// mock that was removed from `rand`'s public API in 0.10.
+#[derive(Clone, Debug)]
+struct StepRng(u64, u64);
+
+impl StepRng {
+    fn new(initial: u64, increment: u64) -> Self {
+        Self(initial, increment)
+    }
+}
+
+impl rand::TryRng for StepRng {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        self.try_next_u64().map(|x| x as u32)
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let res = self.0;
+        self.0 = self.0.wrapping_add(self.1);
+        Ok(res)
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        for chunk in dst.chunks_mut(8) {
+            let bytes = self.try_next_u64()?.to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+        Ok(())
+    }
+}
 use std::time::{Duration, Instant, SystemTime};
 use stun_codec::rfc5389::attributes::{
     ErrorCode, MessageIntegrity, Nonce, Realm, Username, XorMappedAddress,

--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -7,7 +7,7 @@
 use crate::cli::parse_bitrate;
 use crate::turn::TURN_HEADER_SIZE;
 use anyhow::{Context as _, Result, bail};
-use rand::distributions::uniform::SampleRange;
+use rand::distr::uniform::SampleRange;
 use rand::prelude::*;
 use serde::Deserialize;
 use std::net::SocketAddr;
@@ -73,8 +73,11 @@ impl<'de> serde::Deserialize<'de> for Range {
 }
 
 impl SampleRange<u64> for Range {
-    fn sample_single<R: RngCore + ?Sized>(self, rng: &mut R) -> u64 {
-        rng.gen_range(std::ops::RangeInclusive::new(self.min, self.max))
+    fn sample_single<R: Rng + ?Sized>(
+        self,
+        rng: &mut R,
+    ) -> Result<u64, rand::distr::uniform::Error> {
+        std::ops::RangeInclusive::new(self.min, self.max).sample_single(rng)
     }
 
     fn is_empty(&self) -> bool {

--- a/rust/tests/loadtest/src/http.rs
+++ b/rust/tests/loadtest/src/http.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use clap::Parser;
 use clap::ValueEnum;
-use rand::Rng;
+use rand::RngExt;
 use rand::SeedableRng as _;
 use tracing::Instrument;
 
@@ -110,7 +110,7 @@ async fn run(config: TestConfig, seed: u64) -> Result<()> {
     let client = build_client(&config)?;
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
 
-    let num_connections = rng.gen_range(1..=config.max_connections);
+    let num_connections = rng.random_range(1..=config.max_connections);
 
     tracing::info!(
         url = %config.address,

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -55,8 +55,8 @@ use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 use config::LoadTestConfig;
 use rand::rngs::StdRng;
-use rand::seq::SliceRandom;
-use rand::{Rng as _, SeedableRng as _};
+use rand::seq::IndexedRandom;
+use rand::{RngExt as _, SeedableRng as _};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -290,7 +290,7 @@ impl TestSelector {
 
     fn select(&mut self, config: &LoadTestConfig) -> AnyTestConfig {
         let types = config.enabled_types();
-        let test_type = types[self.rng.gen_range(0..types.len())];
+        let test_type = types[self.rng.random_range(0..types.len())];
 
         match test_type {
             TestType::Http => AnyTestConfig::Http(
@@ -337,16 +337,16 @@ impl TestSelector {
             .choose(&mut self.rng)
             .expect("should have at least one address");
 
-        let concurrent = self.rng.gen_range(config.concurrent) as usize;
-        let duration = Duration::from_secs(self.rng.gen_range(config.duration_secs));
-        let timeout = Duration::from_secs(self.rng.gen_range(config.timeout_secs));
+        let concurrent = self.rng.random_range(config.concurrent) as usize;
+        let duration = Duration::from_secs(self.rng.random_range(config.duration_secs));
+        let timeout = Duration::from_secs(self.rng.random_range(config.timeout_secs));
         let echo_mode = config.echo_mode;
-        let echo_payload_size = self.rng.gen_range(config.echo_payload_size) as usize;
+        let echo_payload_size = self.rng.random_range(config.echo_payload_size) as usize;
         let echo_interval = Some(Duration::from_secs(
-            self.rng.gen_range(config.echo_interval_secs),
+            self.rng.random_range(config.echo_interval_secs),
         ));
         let echo_read_timeout =
-            Duration::from_secs(self.rng.gen_range(config.echo_read_timeout_secs));
+            Duration::from_secs(self.rng.random_range(config.echo_read_timeout_secs));
 
         tcp::TestConfig {
             target: address.to_owned(),
@@ -367,8 +367,8 @@ impl TestSelector {
             .expect("should have at least one address");
         let address = Url::parse(address).expect("URL validated during config load");
 
-        let concurrent = self.rng.gen_range(config.concurrent) as usize;
-        let duration = Duration::from_secs(self.rng.gen_range(config.duration_secs));
+        let concurrent = self.rng.random_range(config.concurrent) as usize;
+        let duration = Duration::from_secs(self.rng.random_range(config.duration_secs));
 
         websocket::TestConfig {
             url: address,

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
@@ -172,7 +172,7 @@ async fn run_echo_loop(
     let hold_start = Instant::now();
 
     while hold_start.elapsed() < config.hold_duration {
-        let payload_size = rng.gen_range(0..MAX_PAYLOAD_SIZE);
+        let payload_size = rng.random_range(0..MAX_PAYLOAD_SIZE);
         let mut buffer = vec![0u8; payload_size];
         rng.fill_bytes(&mut buffer);
 
@@ -199,7 +199,7 @@ async fn run_echo_loop(
             Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
         }
 
-        let interval = rng.gen_range(Duration::ZERO..config.max_echo_interval);
+        let interval = rng.random_range(Duration::ZERO..config.max_echo_interval);
 
         tracing::trace!("Next message in {interval:?}");
 


### PR DESCRIPTION
Upgrade the `rand` crate from 0.8.5 to 0.10.1 and adapt code to the new API.

This also bumps `boringtun` 0.6 → 0.7, which brings in `x25519-dalek` 3.0 (on `rand_core` 0.10). That alignment is what lets the whole workspace converge on a single `rand`/`rand_core` version instead of straddling 0.8 and 0.10. The bump pulls in release-candidate RustCrypto crates (curve25519-dalek 5.0-rc, blake2 0.11-rc, etc.) as new transitive duplicates — hence the additions to `deny.toml`'s duplicate-skip list — so the crypto impact is worth reviewing alongside the `rand` changes.