### PR TITLE
refactor: replace unmaintained `backoff` crate with `backon`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -617,16 +617,18 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+version = "0.1.0"
 dependencies = [
- "futures-core",
- "getrandom 0.2.16",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
+ "backon",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -3608,15 +3610,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "gui-client/src-tauri",
     "headless-client",
     "libs/anyhow-ext",
+    "libs/backoff",
     "libs/bin-shared",
     "libs/client-shared",
     "libs/connlib/bootstrap-dns-client",
@@ -61,7 +62,8 @@ aya-build = { git = "https://github.com/aya-rs/aya" }
 aya-ebpf = { git = "https://github.com/aya-rs/aya" }
 aya-log = { git = "https://github.com/aya-rs/aya" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
-backoff = { version = "0.4.0", features = ["tokio"] }
+backoff = { path = "libs/backoff" }
+backon = { version = "1.6.0", default-features = false, features = ["std"] }
 base64 = { version = "0.22.1", default-features = false }
 bimap = "0.6.3"
 bin-shared = { path = "libs/bin-shared" }

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -90,7 +90,6 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2020-0095", # `difference` is unmaintained
-    "RUSTSEC-2024-0384", # `instant` is unmaintained
     "RUSTSEC-2024-0370", # `proc-macro-error` is unmaintained
 
     # `gtk-rs` crates are unmaintained
@@ -105,7 +104,6 @@ ignore = [
     "RUSTSEC-2024-0419",
     "RUSTSEC-2024-0420",
 
-    "RUSTSEC-2025-0012", # backoff, See #8386
     "RUSTSEC-2024-0436", # paste, See #8387
 
     # `rand` unsoundness via re-entrant ThreadRng access from a custom logger (GHSA-cq8v-f236-94qc).

--- a/rust/libs/backoff/Cargo.toml
+++ b/rust/libs/backoff/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "backoff"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+backon = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/backoff/src/lib.rs
+++ b/rust/libs/backoff/src/lib.rs
@@ -1,0 +1,110 @@
+//! A behaviour-preserving replacement for the unmaintained `backoff` crate, backed by [`backon`].
+//!
+//! We only ever used the upstream `backoff` crate as a stateful exponential-delay iterator: build
+//! a strategy, then call [`ExponentialBackoff::next_backoff`] to get each delay. This crate keeps
+//! that exact surface (including the public `max_elapsed_time` field, which callers surface in
+//! their reconnect events) while delegating the interval maths to [`backon::ExponentialBuilder`].
+//!
+//! Two intentional differences from the original crate:
+//! - The retry budget (`max_elapsed_time`) is mapped onto [`backon`]'s `with_total_delay`, which
+//!   bounds the *cumulative* delay rather than wall-clock time. For large reconnect budgets this
+//!   is indistinguishable in practice.
+//! - `randomization_factor` only toggles [`backon`]'s jitter on/off; the exact jitter distribution
+//!   differs. Strategies that disable jitter (`randomization_factor == 0.0`) remain fully
+//!   deterministic.
+
+use backon::{BackoffBuilder, ExponentialBuilder};
+use std::time::Duration;
+
+/// Builder for an [`ExponentialBackoff`], mirroring the upstream `backoff` crate's
+/// `ExponentialBackoffBuilder`.
+///
+/// The logical configuration is stored verbatim and only translated to [`backon`] in
+/// [`ExponentialBackoffBuilder::build`]. This lets us reproduce the *original* crate's defaults
+/// (rather than `backon`'s) for any field a caller leaves unset.
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoffBuilder {
+    initial_interval: Duration,
+    max_interval: Duration,
+    multiplier: f64,
+    randomization_factor: f64,
+    max_elapsed_time: Option<Duration>,
+}
+
+impl Default for ExponentialBackoffBuilder {
+    fn default() -> Self {
+        // These mirror the `backoff` crate's defaults so that callers who only override a subset
+        // of the configuration keep their previous behaviour.
+        Self {
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(60),
+            multiplier: 1.5,
+            randomization_factor: 0.5,
+            max_elapsed_time: Some(Duration::from_secs(15 * 60)),
+        }
+    }
+}
+
+impl ExponentialBackoffBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_initial_interval(mut self, initial_interval: Duration) -> Self {
+        self.initial_interval = initial_interval;
+        self
+    }
+
+    pub fn with_max_interval(mut self, max_interval: Duration) -> Self {
+        self.max_interval = max_interval;
+        self
+    }
+
+    pub fn with_multiplier(mut self, multiplier: f64) -> Self {
+        self.multiplier = multiplier;
+        self
+    }
+
+    pub fn with_randomization_factor(mut self, randomization_factor: f64) -> Self {
+        self.randomization_factor = randomization_factor;
+        self
+    }
+
+    pub fn with_max_elapsed_time(mut self, max_elapsed_time: Option<Duration>) -> Self {
+        self.max_elapsed_time = max_elapsed_time;
+        self
+    }
+
+    pub fn build(self) -> ExponentialBackoff {
+        let mut inner = ExponentialBuilder::default()
+            .with_min_delay(self.initial_interval)
+            .with_max_delay(self.max_interval)
+            .with_factor(self.multiplier as f32)
+            .with_total_delay(self.max_elapsed_time)
+            // `backon` defaults to retrying at most 3 times; we bound retries by the time budget.
+            .without_max_times();
+
+        if self.randomization_factor > 0.0 {
+            inner = inner.with_jitter();
+        }
+
+        ExponentialBackoff {
+            inner: inner.build(),
+            max_elapsed_time: self.max_elapsed_time,
+        }
+    }
+}
+
+/// A stateful exponential backoff, mirroring the upstream `backoff` crate's `ExponentialBackoff`.
+pub struct ExponentialBackoff {
+    inner: backon::ExponentialBackoff,
+    /// The configured retry budget; exposed so callers can surface it (e.g. in a reconnect event).
+    pub max_elapsed_time: Option<Duration>,
+}
+
+impl ExponentialBackoff {
+    /// Returns the next backoff delay, or `None` once the retry budget is exhausted.
+    pub fn next_backoff(&mut self) -> Option<Duration> {
+        self.inner.next()
+    }
+}

--- a/rust/libs/connlib/phoenix-channel/Cargo.toml
+++ b/rust/libs/connlib/phoenix-channel/Cargo.toml
@@ -16,7 +16,7 @@ itertools = { workspace = true }
 libc = { workspace = true }
 logging = { workspace = true }
 os_info = { workspace = true }
-rand_core = { workspace = true }
+rand_core = { workspace = true, features = ["getrandom"] }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -15,7 +15,6 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
 use backoff::ExponentialBackoff;
 use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
 use base64::Engine;
 use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt};


### PR DESCRIPTION
Migrate from the unmaintained `backoff` crate to `backon` for exponential backoff functionality. This addresses security advisory RUSTSEC-2025-0012 and removes one instance of the `rand 0.8.5` dependency from our dependency tree. 