### PR TITLE
chore(gui-client): fix developer UX papercuts

### DIFF
--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -101,8 +101,9 @@ PowerShell 7 terminal. Make sure mise is activated in each (`mise activate pwsh 
    mise run tunnel
    ```
 
-   This runs `firezone-client-tunnel run-debug`, which serves the Tunnel IPC pipe
-   without pinning it to `LocalSystem`, so the unprivileged GUI below can connect.
+   This runs `firezone-client-tunnel run-interactive`, which in a debug build serves
+   the Tunnel IPC pipe without pinning it to `LocalSystem`, so the unprivileged GUI
+   below can connect.
 
 2. **GUI client** — from a normal (non-elevated) terminal. Connects to the Tunnel
    service above, skipping the pipe-owner check so it accepts the non-`LocalSystem` pipe:
@@ -131,7 +132,7 @@ The app's config and logs will be stored at
 
 ### What this workflow can't test
 
-Running the GUI against a `run-debug` Tunnel deliberately bypasses the named-pipe
+Running the GUI against a debug-build `run-interactive` Tunnel deliberately bypasses the named-pipe
 ownership check, so it does **not** exercise the production pipe-ownership security
 model (GUI ⇄ `LocalSystem` Tunnel service). It also doesn't cover MSI packaging, the
 bundled Windows service, sparse-package registration, or the installed app identity.

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -12,10 +12,26 @@ To compile natively for x86_64 Linux:
 
 ## Setup (Windows)
 
-To compile natively for x86_64 Windows:
+To compile natively for x86_64 Windows, install the following (winget commands shown):
 
-1. [Install rustup](https://rustup.rs/)
-1. Install [pnpm](https://pnpm.io/installation)
+1. PowerShell 7 — `winget install Microsoft.PowerShell`
+1. Visual Studio C++ build tools (MSVC compiler + Windows SDK) —
+   `winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"`
+1. rustup — `winget install Rustlang.Rustup`
+1. mise — `winget install jdx.mise`
+1. An editor of your choice (see [Recommended IDE Setup](#recommended-ide-setup))
+
+`node` and `pnpm` are pinned in [`rust/.tool-versions`](../.tool-versions) and provided
+by mise — you don't install them separately. After installing mise, activate it in
+PowerShell 7 and install the toolchain from `rust/`:
+
+```powershell
+# Activate mise for the current session (add to $PROFILE to persist)
+mise activate pwsh | Out-String | Invoke-Expression
+
+# Install the pinned tools (node, pnpm, cargo-tauri, etc.)
+mise install
+```
 
 ### Recommended IDE Setup
 
@@ -73,24 +89,58 @@ If that doesn't work:
 - Click `New client secret`
 - Note down the secret value. This should be entered into the GitHub repository's secrets as `AZURE_CLIENT_SECRET`.
 
-## Running
+## Running (Windows)
 
-From this dir:
+A live dev session needs **two** processes running at once, each in its own
+PowerShell 7 terminal. Make sure mise is activated in each (`mise activate pwsh | Out-String | Invoke-Expression`).
 
-```powershell
-# This will start the frontend tools in watch mode and then run `tauri dev`
-pnpm dev
+1. **Tunnel service** — run from an **elevated (Administrator)** terminal. It manages
+   the system tunnel and serves the privileged IPC pipe:
 
-# You can call debug subcommands on the exe from this directory too
-# e.g. this is equivalent to `cargo run -- debug hostname`
-cargo tauri dev -- -- debug hostname
+   ```powershell
+   mise run tunnel
+   ```
 
-# The exe is up in the workspace
-stat ../target/debug/Firezone.exe
-```
+   This runs `firezone-client-tunnel run-debug`, which serves the Tunnel IPC pipe
+   without pinning it to `LocalSystem`, so the unprivileged GUI below can connect.
+
+2. **GUI client** — from a normal (non-elevated) terminal. Connects to the Tunnel
+   service above, skipping the pipe-owner check so it accepts the non-`LocalSystem` pipe:
+
+   ```powershell
+   mise run tauri-dev
+   # equivalent to: cargo tauri dev -- -- --skip-tunnel-pipe-owner-check
+
+   # You can call debug subcommands on the exe this way too, e.g.
+   cargo tauri dev -- -- debug hostname
+
+   # The exe is up in the workspace
+   stat ../target/debug/Firezone.exe
+   ```
+
+   `tauri dev` starts the Vite dev server itself (via `beforeDevCommand`) and points the
+   webview at it (`devUrl`), so you get hot-reload and client-side routing works. No
+   separate frontend build is needed for dev.
 
 The app's config and logs will be stored at
 `C:\Users\$USER\AppData\Local\dev.firezone.client`.
+
+> Note: `pnpm dev` does **not** work for this flow. `dev.bat` hard-codes `tauri dev`
+> and forwards no arguments, so it can't pass `--skip-tunnel-pipe-owner-check`, and it
+> doesn't start an elevated Tunnel service.
+
+### What this workflow can't test
+
+Running the GUI against a `run-debug` Tunnel deliberately bypasses the named-pipe
+ownership check, so it does **not** exercise the production pipe-ownership security
+model (GUI ⇄ `LocalSystem` Tunnel service). It also doesn't cover MSI packaging, the
+bundled Windows service, sparse-package registration, or the installed app identity.
+
+To test installation end-to-end you need a real signed release MSI, which **cannot** be
+produced locally: the installer is signed with AzureSignTool against HSM-backed keys
+that are only available to CI. Use the GitHub CI pipeline to build a signed release MSI
+(see [Signing the Windows MSI in GitHub CI](#signing-the-windows-msi-in-github-ci)).
+`pnpm build` can still produce an *unsigned* MSI locally to sanity-check the build itself.
 
 ## Platform support
 

--- a/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         Cmd::Install => service::install(),
         Cmd::Run => service::run(cli.log_dir, cli.dns_control),
-        Cmd::RunDebug => service::run_debug(cli.dns_control),
+        Cmd::RunInteractive => service::run_interactive(cli.dns_control),
         Cmd::RunSmokeTest => service::run_smoke_test(),
     }
 }
@@ -66,7 +66,9 @@ enum Cmd {
     Install,
     #[default]
     Run,
-    RunDebug,
+    /// Run the Tunnel service in an interactive terminal instead of as a
+    /// background service. Used for local development and debugging.
+    RunInteractive,
     RunSmokeTest,
 }
 
@@ -83,8 +85,9 @@ mod tests {
     #[test]
     fn cli() {
         let actual =
-            Cli::try_parse_from([EXE_NAME, "--log-dir", "bogus_log_dir", "run-debug"]).unwrap();
-        assert!(matches!(actual.command, Cmd::RunDebug));
+            Cli::try_parse_from([EXE_NAME, "--log-dir", "bogus_log_dir", "run-interactive"])
+                .unwrap();
+        assert!(matches!(actual.command, Cmd::RunInteractive));
         assert_eq!(actual.log_dir, Some(PathBuf::from("bogus_log_dir")));
 
         let actual = Cli::try_parse_from([EXE_NAME, "run"]).unwrap();

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -793,6 +793,7 @@ impl<'a> Handler<'a> {
     }
 }
 
+#[cfg(debug_assertions)]
 pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
     let log_filter_reloader = logging::setup_stdout()?;
     tracing::info!(
@@ -800,6 +801,11 @@ pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
         version = env!("CARGO_PKG_VERSION"),
         system_uptime_seconds = bin_shared::uptime::get().map(|dur| dur.as_secs()),
     );
+
+    // run-debug runs as the local Administrator which does not have the package
+    // identity.
+    ipc::skip_tunnel_pipe_owner_check();
+
     if !elevation_check()? {
         bail!("Tunnel service failed its elevation check, try running as admin / root");
     }
@@ -817,6 +823,11 @@ pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
         SocketId::Tunnel,
         &mut signals,
     ))
+}
+
+#[cfg(not(debug_assertions))]
+pub fn run_debug(_dns_control: DnsControlMethod) -> Result<()> {
+    anyhow::bail!("run-debug is not built for release binaries.");
 }
 
 /// Listen for exactly one connection from a GUI, then exit

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -793,8 +793,12 @@ impl<'a> Handler<'a> {
     }
 }
 
-#[cfg(debug_assertions)]
-pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
+/// Run the Tunnel service in an interactive terminal rather than as a
+/// background Windows service / systemd unit.
+///
+/// Mostly used for debugging, but also handy for running a release build
+/// interactively, hence it remains available in release builds.
+pub fn run_interactive(dns_control: DnsControlMethod) -> Result<()> {
     let log_filter_reloader = logging::setup_stdout()?;
     tracing::info!(
         arch = std::env::consts::ARCH,
@@ -802,8 +806,11 @@ pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
         system_uptime_seconds = bin_shared::uptime::get().map(|dur| dur.as_secs()),
     );
 
-    // run-debug runs as the local Administrator which does not have the package
-    // identity.
+    // Run interactively (e.g. as the local Administrator) the process has
+    // neither the `LocalSystem` nor the MSIX package identity, so the
+    // production pipe-ownership check would reject the connection. Skip it in
+    // debug builds so local GUI dev works; release builds keep the check.
+    #[cfg(debug_assertions)]
     ipc::skip_tunnel_pipe_owner_check();
 
     if !elevation_check()? {
@@ -823,11 +830,6 @@ pub fn run_debug(dns_control: DnsControlMethod) -> Result<()> {
         SocketId::Tunnel,
         &mut signals,
     ))
-}
-
-#[cfg(not(debug_assertions))]
-pub fn run_debug(_dns_control: DnsControlMethod) -> Result<()> {
-    anyhow::bail!("run-debug is not built for release binaries.");
 }
 
 /// Listen for exactly one connection from a GUI, then exit

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -1,8 +1,9 @@
 {
   "build": {
-    "beforeDevCommand": "",
+    "beforeDevCommand": "pnpm vite dev",
     "beforeBuildCommand": "",
-    "frontendDist": "../dist"
+    "frontendDist": "../dist",
+    "devUrl": "http://localhost:1420"
   },
   "bundle": {
     "active": true,

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -67,10 +67,10 @@ raw = true
 run = "cargo tauri dev -- -- --skip-tunnel-pipe-owner-check"
 
 [tasks.tunnel]
-description = "Run the Tunnel service in debug mode for local GUI dev. `run-debug` skips the LocalSystem pipe-owner check; must be run from an elevated (Administrator) shell."
+description = "Run the Tunnel service interactively for local GUI dev. In debug builds `run-interactive` skips the LocalSystem pipe-owner check; must be run from an elevated (Administrator) shell."
 dir = "gui-client"
 raw = true
-run = "cargo run -p firezone-gui-client --bin firezone-client-tunnel -- run-debug"
+run = "cargo run -p firezone-gui-client --bin firezone-client-tunnel -- run-interactive"
 
 # =============================================================================
 # Composite tasks

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -60,6 +60,18 @@ dir = "gui-client"
 raw = true
 run = "cargo tauri dev -- -- --skip-portal-auth --mock-tunnel"
 
+[tasks.tauri-dev]
+description = "Run the GUI client in dev against a dev tunnel service"
+dir = "gui-client"
+raw = true
+run = "cargo tauri dev -- -- --skip-tunnel-pipe-owner-check"
+
+[tasks.tunnel]
+description = "Run the Tunnel service in debug mode for local GUI dev. `run-debug` skips the LocalSystem pipe-owner check; must be run from an elevated (Administrator) shell."
+dir = "gui-client"
+raw = true
+run = "cargo run -p firezone-gui-client --bin firezone-client-tunnel -- run-debug"
+
 # =============================================================================
 # Composite tasks
 # =============================================================================


### PR DESCRIPTION
- Adds a `mise run tunnel` task to start the tun service in CLI `run-debug`
- Adds a flag to skip the pipe check on the GUI side for dev envs
- Fixes a `404` issue by updating the dev server pnpm script to properly start `pnpm vite dev`
- Updates the README with all of the above + more
