### PR TITLE
fix(gui-client): skip MSIX SXS manifest in debug builds

### DIFF
--- a/rust/gui-client/src-tauri/build.rs
+++ b/rust/gui-client/src-tauri/build.rs
@@ -18,16 +18,29 @@ const PUBLISHER_DN: &str = "CN=\"Firezone, Inc.\", \
     OID.2.5.4.15=Private Organization";
 
 fn main() -> Result<()> {
-    // Skip tauri-build's default Common-Controls manifest: we embed
-    // our own SXS / fusion manifest below -- only into `Firezone.exe`,
-    // not into the tunnel-service or register-sparse binaries (SCM-
-    // launched services with an embedded `<msix>` identity claim
-    // hang on startup, and the helper has no use for identity).
-    let win = tauri_build::WindowsAttributes::new_without_app_manifest();
-    let attr = tauri_build::Attributes::new().windows_attributes(win);
+    // Release builds embed our own SXS / fusion manifest below -- only
+    // into `Firezone.exe`, not into the tunnel-service or
+    // register-sparse binaries (SCM-launched services with an embedded
+    // `<msix>` identity claim hang on startup, and the helper has no
+    // use for identity).
+    //
+    // Debug builds keep tauri-build's default manifest (Common-Controls
+    // v6 only, no `<msix>` claim): a debug binary run from `target\debug`
+    // typically has no registered sparse package on the dev box, and
+    // an embedded MSIX identity claim makes the kernel fail
+    // `CreateProcess` with `APPMODEL_ERROR_NO_PACKAGE` (15700) before
+    // `main` even runs. The runtime's debug-only `test_pipe_dacl` path
+    // (gated on `SKIP_TUNNEL_PIPE_OWNER_CHECK`) covers IPC without
+    // needing identity.
+    let attr = if cfg!(debug_assertions) {
+        tauri_build::Attributes::new()
+    } else {
+        let win = tauri_build::WindowsAttributes::new_without_app_manifest();
+        tauri_build::Attributes::new().windows_attributes(win)
+    };
     tauri_build::try_build(attr)?;
 
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", not(debug_assertions)))]
     {
         embed_resource::compile_for(
             "win_files/Firezone.exe.manifest.rc",

--- a/rust/gui-client/src-tauri/build.rs
+++ b/rust/gui-client/src-tauri/build.rs
@@ -24,24 +24,34 @@ fn main() -> Result<()> {
     // `<msix>` identity claim hang on startup, and the helper has no
     // use for identity).
     //
-    // Debug builds keep tauri-build's default manifest (Common-Controls
-    // v6 only, no `<msix>` claim): a debug binary run from `target\debug`
-    // typically has no registered sparse package on the dev box, and
-    // an embedded MSIX identity claim makes the kernel fail
-    // `CreateProcess` with `APPMODEL_ERROR_NO_PACKAGE` (15700) before
-    // `main` even runs. The runtime's debug-only `test_pipe_dacl` path
-    // (gated on `SKIP_TUNNEL_PIPE_OWNER_CHECK`) covers IPC without
-    // needing identity.
-    let attr = if cfg!(debug_assertions) {
-        tauri_build::Attributes::new()
-    } else {
+    // Non-release profiles (dev, profiling, …) keep tauri-build's
+    // default manifest (Common-Controls v6 only, no `<msix>` claim):
+    // a non-release binary run from `target\<profile>` typically has
+    // no registered sparse package on the dev box, and an embedded
+    // MSIX identity claim makes the kernel fail `CreateProcess` with
+    // `APPMODEL_ERROR_NO_PACKAGE` (15700) before `main` even runs. The
+    // runtime's debug-only `test_pipe_dacl` path (gated on
+    // `SKIP_TUNNEL_PIPE_OWNER_CHECK`) covers IPC without needing
+    // identity.
+    //
+    // We gate on Cargo's `PROFILE` env var rather than
+    // `cfg!(debug_assertions)` so the `profiling` profile (inherits
+    // from `release` in `.cargo/config.toml`, but still runs
+    // un-packaged from `target\profiling`) does not embed the
+    // manifest. Only an actual `--profile release` build does.
+    println!("cargo:rerun-if-env-changed=PROFILE");
+    let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
+
+    let attr = if is_release {
         let win = tauri_build::WindowsAttributes::new_without_app_manifest();
         tauri_build::Attributes::new().windows_attributes(win)
+    } else {
+        tauri_build::Attributes::new()
     };
     tauri_build::try_build(attr)?;
 
-    #[cfg(all(target_os = "windows", not(debug_assertions)))]
-    {
+    #[cfg(target_os = "windows")]
+    if is_release {
         embed_resource::compile_for(
             "win_files/Firezone.exe.manifest.rc",
             ["firezone-gui-client"],


### PR DESCRIPTION
A debug binary run from `target\debug` typically has no registered sparse package on the dev box, so the MSIX `<msix>` identity claim in our SXS manifest makes the kernel fail `CreateProcess` with `APPMODEL_ERROR_NO_PACKAGE` (15700) before `main` runs — breaking `cargo run -- --mock-tunnel --skip-portal-auth --skip-tunnel-pipe-owner-check`.

Embed our manifest only in release builds; debug keeps tauri-build's default (Common-Controls v6 for themed widgets, no identity claim). The runtime's debug-only `test_pipe_dacl` path (gated on `SKIP_TUNNEL_PIPE_OWNER_CHECK`) already covers IPC without needing identity.

This is only relevant now once the package identity exists on a system which happens as soon as a developer installs the current pre-release client.

Related: #13433