### PR TITLE
refactor(windows): use `Owned<T>` for Windows handles

### DIFF
--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{ffi::c_void, io::ErrorKind, os::windows::io::AsRawHandle, time::Duration};
 use tokio::net::windows::named_pipe;
 use windows::Win32::{
-    Foundation::{HANDLE, HLOCAL, LocalFree},
+    Foundation::{HANDLE, HLOCAL},
     Security::{
         Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT},
         IsWellKnownSid, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
@@ -20,6 +20,7 @@ use windows::Win32::{
         Threading::GetCurrentProcessId,
     },
 };
+use windows::core::Owned;
 use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
 
 /// Security descriptor for the Tunnel pipe.
@@ -334,16 +335,14 @@ fn is_pipe_owned_by_local_system(handle: HANDLE) -> Result<bool> {
         return Err(std::io::Error::from_raw_os_error(err.0 as i32))
             .context("GetSecurityInfo on pipe handle failed");
     }
+    // SAFETY: `sd` was allocated by `GetSecurityInfo` via `LocalAlloc`;
+    // wrap the underlying pointer as `HLOCAL` so `LocalFree` runs on
+    // scope exit. `owner_sid` points into this allocation.
+    let _sd_owned = unsafe { Owned::new(HLOCAL(sd.0)) };
 
     // SAFETY: `owner_sid` is a non-NULL pointer into `sd`'s buffer (still
     // alive for this call) and `IsWellKnownSid` does not retain it.
     let is_local_system = unsafe { IsWellKnownSid(owner_sid, WinLocalSystemSid) }.as_bool();
-
-    // SAFETY: `sd` was allocated by `GetSecurityInfo` and must be released
-    // with `LocalFree`. After this call no pointer derived from it is used.
-    unsafe {
-        let _ = LocalFree(Some(HLOCAL(sd.0)));
-    }
 
     Ok(is_local_system)
 }

--- a/rust/libs/bin-shared/src/network_changes/windows.rs
+++ b/rust/libs/bin-shared/src/network_changes/windows.rs
@@ -491,13 +491,14 @@ mod async_dns {
         task::LocalSet,
     };
     use windows::Win32::{
-        Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+        Foundation::{HANDLE, INVALID_HANDLE_VALUE},
         System::Registry,
         System::Threading::{
             CreateEventA, INFINITE, RegisterWaitForSingleObject, UnregisterWaitEx,
             WT_EXECUTEINWAITTHREAD,
         },
     };
+    use windows::core::Owned;
     use winreg::RegKey;
 
     /// Opens and returns the IPv4 and IPv6 registry keys
@@ -593,8 +594,9 @@ mod async_dns {
         ///
         /// `RegNotifyChangeKeyValue` can't call a callback directly, so it signals this
         /// event, and we use `RegisterWaitForSingleObject` to adapt that signal into
-        /// a C callback.
-        event: HANDLE,
+        /// a C callback. `Owned<HANDLE>` so the event is closed on `Drop`; the
+        /// wait must be unregistered first (see `close_dont_drop`).
+        event: Owned<HANDLE>,
     }
 
     impl Listener {
@@ -602,7 +604,10 @@ mod async_dns {
             let (tx, rx) = mpsc::channel(1);
             let tx = Box::new(tx);
             let tx_ptr: *const _ = tx.deref();
-            let event = unsafe { CreateEventA(None, false, false, None) }?;
+            // SAFETY: `CreateEventA` returns a handle we must release with
+            // `CloseHandle`; `Owned<HANDLE>` does that on drop, covering the
+            // failure path of `RegisterWaitForSingleObject` below.
+            let event = unsafe { Owned::new(CreateEventA(None, false, false, None)?) };
             let mut wait_handle = HANDLE::default();
 
             // The docs say that `RegisterWaitForSingleObject` uses "a worker thread" from
@@ -625,7 +630,7 @@ mod async_dns {
             unsafe {
                 RegisterWaitForSingleObject(
                     &mut wait_handle,
-                    event,
+                    *event,
                     Some(callback),
                     Some(tx_ptr as *const _),
                     INFINITE,
@@ -695,7 +700,7 @@ mod async_dns {
                     key_handle,
                     true,
                     notify_flags,
-                    Some(inner.event),
+                    Some(*inner.event),
                     true,
                 )
             }
@@ -714,12 +719,23 @@ mod async_dns {
         /// - `close` which consumes `self` and returns a `Result` for error bubbling
         /// - `drop` which does not consume `self` and does not bubble errors, but which runs even if we forget to call `close`
         fn close_dont_drop(&mut self) -> Result<()> {
-            if let Some(inner) = self.inner.take() {
-                unsafe { UnregisterWaitEx(inner.wait_handle, Some(INVALID_HANDLE_VALUE)) }
-                    .context("Should be able to `UnregisterWaitEx` in the DNS change listener")?;
-                unsafe { CloseHandle(inner.event) }
-                    .context("Should be able to `CloseHandle` in the DNS change listener")?;
+            let Some(inner) = self.inner.take() else {
+                return Ok(());
+            };
+            let ListenerInner { wait_handle, event } = inner;
+            // `UnregisterWaitEx(INVALID_HANDLE_VALUE)` blocks until every
+            // pending callback has finished, so closing `event` is only safe
+            // after it returns successfully. On failure the threadpool wait
+            // may still be active and would signal `event`, so leak the
+            // handle in that branch rather than triggering a use-after-free
+            // via the `Owned<HANDLE>` drop.
+            if let Err(e) = unsafe { UnregisterWaitEx(wait_handle, Some(INVALID_HANDLE_VALUE)) } {
+                std::mem::forget(event);
+                return Err(e)
+                    .context("Should be able to `UnregisterWaitEx` in the DNS change listener");
             }
+            // `event` is dropped here, closing the handle now that the wait
+            // is guaranteed to be unregistered.
             Ok(())
         }
     }
@@ -788,24 +804,27 @@ mod async_dns {
                 .create_subkey_with_flags(&key_path, flags)
                 .expect("`open_subkey_with_flags` failed");
 
-            let event =
-                unsafe { CreateEventA(None, false, false, None) }.expect("`CreateEventA` failed");
+            // SAFETY: `CreateEventA` returns a handle we must release with
+            // `CloseHandle`; `Owned<HANDLE>` does that on drop.
+            let event = unsafe {
+                Owned::new(CreateEventA(None, false, false, None).expect("`CreateEventA` failed"))
+            };
 
             // Registering the notify alone does not signal the event
-            reg_notify(&key, event);
-            assert!(!event_is_signaled(event));
+            reg_notify(&key, *event);
+            assert!(!event_is_signaled(*event));
 
             // Setting the value after we've registered does
             set_reg_value(&key, 0);
-            assert!(event_is_signaled(event));
+            assert!(event_is_signaled(*event));
 
             // Do that one more time to prove it wasn't a fluke
-            reset_event(event);
-            reg_notify(&key, event);
-            assert!(!event_is_signaled(event));
+            reset_event(*event);
+            reg_notify(&key, *event);
+            assert!(!event_is_signaled(*event));
 
             set_reg_value(&key, 500);
-            assert!(event_is_signaled(event));
+            assert!(event_is_signaled(*event));
 
             // I thought there was a gap here, but there's actually not -
             // If we get the notification, then the value changes, then we re-register,
@@ -813,24 +832,23 @@ mod async_dns {
             // Maybe it's storing the state with our regkey handle instead of with the
             // wait operation. This is convenient but it's confusing since the docs don't
             // make it clear. I'll leave the workaround in the main code.
-            reset_event(event);
+            reset_event(*event);
             set_reg_value(&key, 1000);
-            assert!(!event_is_signaled(event));
-            reg_notify(&key, event);
+            assert!(!event_is_signaled(*event));
+            reg_notify(&key, *event);
             // This is the part I was wrong about
-            assert!(event_is_signaled(event));
+            assert!(event_is_signaled(*event));
 
             // Signal normally one more time
-            reset_event(event);
-            reg_notify(&key, event);
+            reset_event(*event);
+            reg_notify(&key, *event);
             set_reg_value(&key, 2000);
-            assert!(event_is_signaled(event));
+            assert!(event_is_signaled(*event));
 
             // Close the handle before the notification goes off
-            reset_event(event);
-            reg_notify(&key, event);
-            unsafe { CloseHandle(event) }.expect("`CloseHandle` failed");
-            let _ = event;
+            reset_event(*event);
+            reg_notify(&key, *event);
+            drop(event);
 
             // Setting the value shouldn't break anything or crash here.
             set_reg_value(&key, 3000);

--- a/rust/libs/logging/src/windows_event_log/implementation.rs
+++ b/rust/libs/logging/src/windows_event_log/implementation.rs
@@ -13,10 +13,10 @@ use windows::Win32::System::EventLog::{
     REPORT_EVENT_TYPE, RegisterEventSourceW, ReportEventW,
 };
 use windows::Win32::System::Registry::{
-    HKEY_LOCAL_MACHINE, KEY_WRITE, REG_DWORD, REG_EXPAND_SZ, REG_OPTION_NON_VOLATILE, RegCloseKey,
+    HKEY_LOCAL_MACHINE, KEY_WRITE, REG_DWORD, REG_EXPAND_SZ, REG_OPTION_NON_VOLATILE,
     RegCreateKeyExW, RegSetValueExW,
 };
-use windows::core::{PCWSTR, w};
+use windows::core::{Owned, PCWSTR, w};
 
 const EVENT_ID_ERROR: u32 = 1;
 const EVENT_ID_WARNING: u32 = 2;
@@ -168,6 +168,7 @@ fn try_register_source(source: &str) -> Result<()> {
     let key_path_wide = to_wide_string(&key_path);
     let mut hkey = windows::Win32::System::Registry::HKEY::default();
 
+    // SAFETY: out-param into the stack local below.
     unsafe {
         RegCreateKeyExW(
             HKEY_LOCAL_MACHINE,
@@ -180,43 +181,48 @@ fn try_register_source(source: &str) -> Result<()> {
             &mut hkey,
             None,
         )
-        .ok()
-        .context("Failed to create registry key")?;
-
-        let result = (|| {
-            RegSetValueExW(
-                hkey,
-                w!("TypesSupported"),
-                Some(0),
-                REG_DWORD,
-                Some(TYPES_SUPPORTED.to_le_bytes().as_slice()),
-            )
-            .ok()
-            .context("Failed to set registry value")?;
-
-            let message_file = "%SystemRoot%\\System32\\EventCreate.exe";
-            let message_file_wide = to_wide_string(message_file);
-            let message_file_bytes: Vec<u8> = message_file_wide
-                .iter()
-                .flat_map(|&word| word.to_le_bytes())
-                .collect();
-
-            RegSetValueExW(
-                hkey,
-                w!("EventMessageFile"),
-                Some(0),
-                REG_EXPAND_SZ,
-                Some(&message_file_bytes),
-            )
-            .ok()
-            .context("Failed to set registry value")?;
-
-            Ok(())
-        })();
-
-        let _ = RegCloseKey(hkey);
-        result
     }
+    .ok()
+    .context("Failed to create registry key")?;
+    // SAFETY: `RegCreateKeyExW` succeeded so `hkey` is a valid key handle;
+    // `Owned<HKEY>` calls `RegCloseKey` on drop so we don't leak on any of
+    // the `?`-propagated failure paths below.
+    let hkey = unsafe { Owned::new(hkey) };
+
+    // SAFETY: `*hkey` is the valid handle wrapped above.
+    unsafe {
+        RegSetValueExW(
+            *hkey,
+            w!("TypesSupported"),
+            Some(0),
+            REG_DWORD,
+            Some(TYPES_SUPPORTED.to_le_bytes().as_slice()),
+        )
+    }
+    .ok()
+    .context("Failed to set registry value")?;
+
+    let message_file = "%SystemRoot%\\System32\\EventCreate.exe";
+    let message_file_wide = to_wide_string(message_file);
+    let message_file_bytes: Vec<u8> = message_file_wide
+        .iter()
+        .flat_map(|&word| word.to_le_bytes())
+        .collect();
+
+    // SAFETY: same as above.
+    unsafe {
+        RegSetValueExW(
+            *hkey,
+            w!("EventMessageFile"),
+            Some(0),
+            REG_EXPAND_SZ,
+            Some(&message_file_bytes),
+        )
+    }
+    .ok()
+    .context("Failed to set registry value")?;
+
+    Ok(())
 }
 
 fn to_wide_string(s: &str) -> Vec<u16> {

--- a/rust/libs/windows-security/src/pipe_dacl.rs
+++ b/rust/libs/windows-security/src/pipe_dacl.rs
@@ -15,11 +15,8 @@ use crate::{SecurityDescriptor, sid_to_string};
 use anyhow::{Context as _, Result};
 use std::{borrow::Cow, fmt};
 use windows::{
-    Win32::{
-        Foundation::{HLOCAL, LocalFree},
-        Security::Isolation::DeriveAppContainerSidFromAppContainerName,
-    },
-    core::{HSTRING, PCWSTR},
+    Win32::{Foundation::HLOCAL, Security::Isolation::DeriveAppContainerSidFromAppContainerName},
+    core::{HSTRING, Owned, PCWSTR},
 };
 
 /// File-system rights expressible in a Firezone pipe ACE. Encoded
@@ -117,17 +114,12 @@ fn derive_package_sid(pfn: &str) -> Result<String> {
     // allocates a SID we must release with `LocalFree`.
     let sid = unsafe { DeriveAppContainerSidFromAppContainerName(PCWSTR(pfn_wide.as_ptr())) }
         .context("DeriveAppContainerSidFromAppContainerName failed")?;
+    // SAFETY: `sid` was allocated via `LocalAlloc` by the call above; wrap
+    // the underlying pointer as `HLOCAL` so `LocalFree` runs on scope exit
+    // even if `sid_to_string` returns an error.
+    let _sid_owned = unsafe { Owned::new(HLOCAL(sid.0)) };
 
-    let sid_string = sid_to_string(sid);
-
-    // SAFETY: `sid` came from `DeriveAppContainerSidFromAppContainerName`
-    // (LocalAlloc-allocated). Free it now; the SDDL string is on the
-    // Rust heap and survives.
-    unsafe {
-        let _ = LocalFree(Some(HLOCAL(sid.0)));
-    }
-
-    sid_string
+    sid_to_string(sid)
 }
 
 /// A security descriptor for a Firezone named pipe: an optional


### PR DESCRIPTION
Replace four hand-rolled free-on-exit patterns across the Windows code with `windows::core::Owned<T>`. The pattern was already on the dependency tree via `windows-0.61.3`; the `Free` impls cover `HANDLE`, `HKEY`, and `HLOCAL`, which is everything we needed here.