### PR TITLE
fix(portal): gracefully handle flaky replicas

### DIFF
--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -348,20 +348,19 @@ defmodule Portal.Config.Definitions do
   defconfig(:database_queue_interval, :integer, default: 1000)
 
   @doc """
-  Socket options for database connections.
+  TCP socket options for database connections, tuning how quickly dead connections are
+  detected so queries fail over instead of hanging until the checkout timeout.
 
-  These options are passed to the underlying TCP socket. The most important option is
-  `keepalive: true` which enables TCP keepalive probes to detect dead connections.
+  Accepts a JSON object with any of: `keepalive` (boolean), `tcp_keepidle`,
+  `tcp_keepintvl`, `tcp_keepcnt` (seconds/count), `tcp_user_timeout` (ms). `keepalive`
+  alone uses Linux's 2-hour idle default, so the `tcp_keep*` options are needed to detect
+  dead connections in seconds.
 
-  Without keepalive, connections can become "zombies" when the database server becomes
-  unavailable (e.g., during Azure platform maintenance), causing queries to hang until
-  the checkout timeout is reached.
-
-  Accepts a JSON object with socket options (e.g. `{"keepalive": true}`).
+  Example: `{"keepalive": true, "tcp_keepidle": 10, "tcp_keepintvl": 5, "tcp_keepcnt": 3, "tcp_user_timeout": 10000}`.
   """
   defconfig(:database_socket_options, :map,
     default: %{},
-    dump: &Dumper.keyword/1
+    dump: &Dumper.dump_socket_opts/1
   )
 
   @doc """

--- a/elixir/lib/portal/config/dumper.ex
+++ b/elixir/lib/portal/config/dumper.ex
@@ -7,13 +7,13 @@ defmodule Portal.Config.Dumper do
   ## Examples:
 
       iex> dump_ssl_opts(%{"verify" => "verify_none", "versions" => ["tlsv1.3"]})
-      [verify: :verify_none, versions: ['tlsv1.3']]
+      [verify: :verify_none, versions: [~c"tlsv1.3"]]
 
       iex> dump_ssl_opts(%{"keep_secrets" => true})
       ** (ArgumentError) unsupported key keep_secrets in ssl opts
 
       iex> dump_ssl_opts(%{"cacertfile" => "/tmp/cacerts.pem"})
-      [cacertfile: '/tmp/cacerts.pem']
+      [cacertfile: ~c"/tmp/cacerts.pem"]
   """
   # sobelow_skip ["DOS.StringToAtom"]
   def dump_ssl_opts(decoded_json) do
@@ -37,4 +37,33 @@ defmodule Portal.Config.Dumper do
       {k, v} when is_atom(k) -> {k, v}
     end)
   end
+
+  @doc ~S"""
+  Maps JSON-decoded database socket options to `:gen_tcp` terms, translating
+  friendly keys to Linux `IPPROTO_TCP` (6) options. `tcp_*` values are seconds,
+  except `tcp_user_timeout` (ms).
+
+  ## Examples:
+
+      iex> dump_socket_opts(%{"keepalive" => true})
+      [{:keepalive, true}]
+
+      iex> dump_socket_opts(%{"tcp_keepidle" => 10}) == [{:raw, 6, 4, <<10::32-native>>}]
+      true
+
+      iex> dump_socket_opts(%{"keep_secrets" => true})
+      ** (ArgumentError) unsupported key keep_secrets in socket opts
+  """
+  def dump_socket_opts(decoded_json) do
+    Enum.map(decoded_json, fn {k, v} -> socket_opt(k, v) end)
+  end
+
+  defp socket_opt("keepalive", v), do: {:keepalive, v}
+  defp socket_opt("tcp_keepidle", v), do: {:raw, 6, 4, <<v::32-native>>}
+  defp socket_opt("tcp_keepintvl", v), do: {:raw, 6, 5, <<v::32-native>>}
+  defp socket_opt("tcp_keepcnt", v), do: {:raw, 6, 6, <<v::32-native>>}
+  defp socket_opt("tcp_user_timeout", v), do: {:raw, 6, 18, <<v::32-native>>}
+
+  defp socket_opt(k, _v),
+    do: raise(ArgumentError, message: "unsupported key #{k} in socket opts")
 end

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -698,21 +698,61 @@ defmodule Portal.Safe do
   end
 
   defp fetch_one_with_primary_retry(repo, query, retry?) do
-    result = safe_repo(fn -> repo.one(query) end)
-    if is_nil(result) and retry?, do: safe_repo(fn -> Repo.one(query) end), else: result
+    case read_replica(fn -> repo.one(query) end, retry?) do
+      :fallback ->
+        safe_repo(fn -> Repo.one(query) end)
+
+      nil when retry? ->
+        safe_repo(fn -> Repo.one(query) end)
+
+      result ->
+        result
+    end
   end
 
   defp fetch_one_with_primary_retry!(repo, query, retry?) do
-    case safe_repo(fn -> repo.one(query) end) do
-      nil when retry? -> safe_repo!(fn -> Repo.one!(query) end, query)
-      nil -> raise(Ecto.NoResultsError, queryable: query)
-      result -> result
+    case read_replica(fn -> repo.one(query) end, retry?) do
+      :fallback ->
+        safe_repo!(fn -> Repo.one!(query) end, query)
+
+      nil when retry? ->
+        safe_repo!(fn -> Repo.one!(query) end, query)
+
+      nil ->
+        raise(Ecto.NoResultsError, queryable: query)
+
+      result ->
+        result
     end
   end
 
   defp exists_with_primary_retry?(repo, query, retry?) do
-    result = safe_repo(fn -> repo.exists?(query) end) || false
-    if not result and retry?, do: safe_repo(fn -> Repo.exists?(query) end) || false, else: result
+    case read_replica(fn -> repo.exists?(query) end, retry?) do
+      :fallback -> safe_repo(fn -> Repo.exists?(query) end) || false
+      true -> true
+      _ when retry? -> safe_repo(fn -> Repo.exists?(query) end) || false
+      _ -> false
+    end
+  end
+
+  # Runs a read against the (possibly replica) repo. When a fallback to the
+  # primary is requested and the replica connection fails (e.g. a non-HA Azure
+  # read replica dropping connections during a transient outage), returns
+  # `:fallback` so the caller can retry against the primary. When fallback is
+  # disabled the connection error propagates so the real failure surfaces.
+  defp read_replica(fun, retry?) do
+    safe_repo(fun)
+  rescue
+    error in DBConnection.ConnectionError ->
+      if retry? do
+        Logger.warning("Replica read failed, falling back to primary",
+          error: Exception.message(error)
+        )
+
+        :fallback
+      else
+        reraise error, __STACKTRACE__
+      end
   end
 
   defp resolve_repo(:primary), do: Repo

--- a/elixir/test/portal/config/dumper_test.exs
+++ b/elixir/test/portal/config/dumper_test.exs
@@ -1,0 +1,34 @@
+defmodule Portal.Config.DumperTest do
+  use ExUnit.Case, async: true
+  import Portal.Config.Dumper
+  doctest Portal.Config.Dumper
+
+  describe "dump_socket_opts/1" do
+    test "translates the full keepalive tuning set" do
+      opts =
+        dump_socket_opts(%{
+          "keepalive" => true,
+          "tcp_keepidle" => 10,
+          "tcp_keepintvl" => 5,
+          "tcp_keepcnt" => 3,
+          "tcp_user_timeout" => 10_000
+        })
+
+      assert {:keepalive, true} in opts
+      assert {:raw, 6, 4, <<10::32-native>>} in opts
+      assert {:raw, 6, 5, <<5::32-native>>} in opts
+      assert {:raw, 6, 6, <<3::32-native>>} in opts
+      assert {:raw, 6, 18, <<10_000::32-native>>} in opts
+    end
+
+    test "returns an empty list for an empty map" do
+      assert dump_socket_opts(%{}) == []
+    end
+
+    test "raises on unknown keys" do
+      assert_raise ArgumentError, ~r/unsupported key nope in socket opts/, fn ->
+        dump_socket_opts(%{"nope" => 1})
+      end
+    end
+  end
+end

--- a/elixir/test/portal/safe_test.exs
+++ b/elixir/test/portal/safe_test.exs
@@ -1,0 +1,58 @@
+defmodule Portal.SafeTest do
+  use Portal.DataCase, async: true
+  import Ecto.Query
+  import Portal.AccountFixtures
+  alias Portal.Safe
+  alias Portal.Account
+
+  defmodule FlakyReplica do
+    @moduledoc false
+    # Stands in for a read replica that drops its connection during a transient
+    # outage, raising the same error Postgrex surfaces in production.
+    def one(_query),
+      do: raise(DBConnection.ConnectionError, "ssl recv (idle): closed")
+
+    def exists?(_query),
+      do: raise(DBConnection.ConnectionError, "ssl recv (idle): closed")
+  end
+
+  describe "fallback_to_primary on replica connection errors" do
+    setup do
+      account = account_fixture()
+      query = from(a in Account, where: a.id == ^account.id)
+      %{account: account, query: query}
+    end
+
+    test "one/2 falls back to the primary", %{account: account, query: query} do
+      assert result =
+               query
+               |> Safe.unscoped(FlakyReplica)
+               |> Safe.one(fallback_to_primary: true)
+
+      assert result.id == account.id
+    end
+
+    test "one!/2 falls back to the primary", %{account: account, query: query} do
+      assert result =
+               query
+               |> Safe.unscoped(FlakyReplica)
+               |> Safe.one!(fallback_to_primary: true)
+
+      assert result.id == account.id
+    end
+
+    test "exists?/2 falls back to the primary", %{query: query} do
+      assert query
+             |> Safe.unscoped(FlakyReplica)
+             |> Safe.exists?(fallback_to_primary: true)
+    end
+
+    test "re-raises when fallback is disabled", %{query: query} do
+      assert_raise DBConnection.ConnectionError, fn ->
+        query
+        |> Safe.unscoped(FlakyReplica)
+        |> Safe.one()
+      end
+    end
+  end
+end


### PR DESCRIPTION
- If a query is used with `fallback_to_primary: true`, and then hits a DB connection error, it now retries on the primary as well. This should soften the blow for temporary blips in read replica availability
- Improves support for TCP socket options in the `database_socket_opts` env var so that we can better configure keepalive settings to detect severed DB connections sooner (coming in a later PR). This will reduce the detection threshold from its current 15000ms for the failed query timeout to proactively sever TCP connections after just 2-3s of missing keepalive probes.

--- 

Related: https://github.com/firezone/infra/pull/664