### PR TITLE
fix(connlib): set tcp idle timeout to rfc floor

### DIFF
--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -122,7 +122,8 @@ struct Key {
     peer_ip: IpAddr,
 }
 
-const TCP_TTL: Duration = Duration::from_secs(60 * 60 * 2);
+// RFC 5382 REQ-5 floor for an established connection: 2h4m (see `nat_table`).
+const TCP_TTL: Duration = Duration::from_secs(60 * 60 * 2 + 60 * 4);
 const UDP_TTL: Duration = Duration::from_secs(60 * 2);
 const ICMP_TTL: Duration = Duration::from_secs(60 * 2);
 

--- a/rust/libs/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/nat_table.rs
@@ -41,7 +41,10 @@ impl Outside {
     }
 }
 
-pub(crate) const TCP_TTL: Duration = Duration::from_secs(60 * 60 * 2);
+// RFC 5382 REQ-5 floor for an established connection: 2h4m. The extra 4 minutes over
+// the 2-hour TCP keep-alive interval (RFC 1122) let an in-flight keep-alive refresh
+// the mapping before it expires.
+pub(crate) const TCP_TTL: Duration = Duration::from_secs(60 * 60 * 2 + 60 * 4);
 pub(crate) const UDP_TTL: Duration = Duration::from_secs(60 * 2);
 pub(crate) const ICMP_TTL: Duration = Duration::from_secs(60 * 2);
 
@@ -379,7 +382,7 @@ mod tests {
         let translate_incoming = table.translate_incoming(&response, now).unwrap();
 
         let ttl = match src {
-            Protocol::Tcp(_) => 7200,
+            Protocol::Tcp(_) => 7200 + 240,
             Protocol::Udp(_) => 120,
             Protocol::IcmpEcho(_) => 120,
         };

--- a/rust/libs/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/nat_table.rs
@@ -42,8 +42,8 @@ impl Outside {
 }
 
 // RFC 5382 REQ-5 floor for an established connection: 2h4m. The extra 4 minutes over
-// the 2-hour TCP keep-alive interval (RFC 1122) let an in-flight keep-alive refresh
-// the mapping before it expires.
+// the 2-hour TCP keep-alive interval (RFC 1122) leave time for an in-flight keep-alive
+// to refresh the mapping before it expires.
 pub(crate) const TCP_TTL: Duration = Duration::from_secs(60 * 60 * 2 + 60 * 4);
 pub(crate) const UDP_TTL: Duration = Duration::from_secs(60 * 2);
 pub(crate) const ICMP_TTL: Duration = Duration::from_secs(60 * 2);
@@ -382,13 +382,13 @@ mod tests {
         let translate_incoming = table.translate_incoming(&response, now).unwrap();
 
         let ttl = match src {
-            Protocol::Tcp(_) => 7200 + 240,
-            Protocol::Udp(_) => 120,
-            Protocol::IcmpEcho(_) => 120,
+            Protocol::Tcp(_) => TCP_TTL,
+            Protocol::Udp(_) => UDP_TTL,
+            Protocol::IcmpEcho(_) => ICMP_TTL,
         };
 
         // Assert
-        if response_delay >= Duration::from_secs(ttl) {
+        if response_delay >= ttl {
             assert_eq!(
                 translate_incoming,
                 TranslateIncomingResult::ExpiredNatSession


### PR DESCRIPTION
RFC 5382 calls for a 2h 4m minimum before tearing down established TCP connections. This is because the keepalive probe on many modern operating systems occurs at the 2h mark.

To prevent a race window where we tear down an otherwise healthy TCP connections moments before receiving the keepalive probe from either end, we extend this to the RFC required floor of 2h 4m.

Note that modern operating systems set this much higher:

- Windows: 24h
- Linux: 5d
- macOS: 24h