### PR TITLE
fix(gui-client): dedup system DNS resolvers

### DIFF
--- a/rust/libs/bin-shared/src/dns_control.rs
+++ b/rust/libs/bin-shared/src/dns_control.rs
@@ -45,13 +45,48 @@ impl Drop for DnsController {
 
 impl DnsController {
     pub fn system_resolvers(&self) -> Vec<IpAddr> {
-        // Multiple NICs on the same network can report the same upstream
-        // resolvers, so de-duplicate while preserving order.
-        let mut seen = HashSet::new();
-        system_resolvers(self.dns_control_method)
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|ip| seen.insert(*ip))
-            .collect()
+        dedup(system_resolvers(self.dns_control_method).unwrap_or_default())
+    }
+}
+
+/// Removes duplicate resolvers while preserving order.
+///
+/// Multiple NICs on the same network can report the same upstream resolvers.
+/// We keep the first occurrence of each because the downstream sentinel mapping
+/// relies on the resolver order.
+fn dedup(resolvers: Vec<IpAddr>) -> Vec<IpAddr> {
+    let mut seen = HashSet::new();
+    resolvers
+        .into_iter()
+        .filter(|ip| seen.insert(*ip))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_removes_duplicates_and_preserves_order() {
+        let resolvers = vec![
+            ip("192.168.1.254"),
+            ip("2600:1700:3ecb:2410::1"),
+            ip("192.168.1.254"),
+            ip("2600:1700:3ecb:2410::1"),
+            ip("1.1.1.1"),
+        ];
+
+        assert_eq!(
+            dedup(resolvers),
+            vec![
+                ip("192.168.1.254"),
+                ip("2600:1700:3ecb:2410::1"),
+                ip("1.1.1.1"),
+            ]
+        );
+    }
+
+    fn ip(address: &str) -> IpAddr {
+        address.parse().unwrap()
     }
 }

--- a/rust/libs/bin-shared/src/dns_control.rs
+++ b/rust/libs/bin-shared/src/dns_control.rs
@@ -5,7 +5,7 @@
 //!
 //! On Windows, we use NRPT by default. We can also explicitly not control DNS.
 
-use std::net::IpAddr;
+use std::{collections::HashSet, net::IpAddr};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -45,6 +45,13 @@ impl Drop for DnsController {
 
 impl DnsController {
     pub fn system_resolvers(&self) -> Vec<IpAddr> {
-        system_resolvers(self.dns_control_method).unwrap_or_default()
+        // Multiple NICs on the same network can report the same upstream
+        // resolvers, so de-duplicate while preserving order.
+        let mut seen = HashSet::new();
+        system_resolvers(self.dns_control_method)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|ip| seen.insert(*ip))
+            .collect()
     }
 }


### PR DESCRIPTION
When multiple network interfaces are attached to the same network, each one reports the same upstream DNS resolvers, so the system-resolver list read by the client contains duplicates.

De-duplicate the resolvers in the shared `DnsController::system_resolvers`, which is the single point all platforms read through, preserving first-seen order since downstream sentinel mapping depends on it.

Fixes #13567