### PR TITLE
fix(gui-client): register toasts under MSIX package AUMID

### DIFF
--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -42,11 +42,12 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 
 /// Show a notification in the bottom right of the screen
 ///
-/// Notifications are registered under the GUI's package AUMID
-/// ([`crate::PACKAGE_AUMID`]), so the title and icon come from the
-/// sparse MSIX manifest's `VisualElements`. Windows silently drops a
-/// toast whose AUMID doesn't match the calling process's package, so
-/// this must stay in sync with `win_files/AppxManifest.xml`.
+/// Windows silently drops a toast whose AUMID doesn't match the calling
+/// process's identity. Packaged builds run under the sparse MSIX
+/// identity, so we register under the package AUMID ([`crate::PACKAGE_AUMID`])
+/// and the title and icon come from the manifest's `VisualElements`;
+/// this must stay in sync with `win_files/AppxManifest.xml`. Un-packaged
+/// dev builds (no package identity) fall back to [`crate::BUNDLE_ID`].
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
 ///
 /// Known issue: If the notification times out and goes into the notification center
@@ -66,7 +67,13 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
     // For some reason `on_activated` is FnMut
     let mut tx = Some(tx);
 
-    tauri_winrt_notification::Toast::new(crate::PACKAGE_AUMID)
+    let app_id = if crate::package_identity::has_package_identity() {
+        crate::PACKAGE_AUMID
+    } else {
+        crate::BUNDLE_ID
+    };
+
+    tauri_winrt_notification::Toast::new(app_id)
         .title(&title)
         .text1(&body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -44,10 +44,9 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 ///
 /// Windows silently drops a toast whose AUMID doesn't match the calling
 /// process's identity. Packaged builds run under the sparse MSIX
-/// identity, so we register under the package AUMID ([`crate::PACKAGE_AUMID`])
-/// and the title and icon come from the manifest's `VisualElements`;
-/// this must stay in sync with `win_files/AppxManifest.xml`. Un-packaged
-/// dev builds (no package identity) fall back to [`crate::BUNDLE_ID`].
+/// identity, so we register under the package AUMID and the title and
+/// icon come from the manifest's `VisualElements`. Un-packaged dev
+/// builds (no package identity) fall back to [`crate::BUNDLE_ID`].
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
 ///
 /// Known issue: If the notification times out and goes into the notification center
@@ -67,13 +66,16 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
     // For some reason `on_activated` is FnMut
     let mut tx = Some(tx);
 
+    // `Firezone` is the `<Application Id="Firezone">` from
+    // `win_files/AppxManifest.xml`; together with the package family
+    // name it forms the package AUMID Windows attributes toasts to.
     let app_id = if crate::package_identity::has_package_identity() {
-        crate::PACKAGE_AUMID
+        format!("{}!Firezone", crate::PACKAGE_FAMILY_NAME)
     } else {
-        crate::BUNDLE_ID
+        crate::BUNDLE_ID.to_owned()
     };
 
-    tauri_winrt_notification::Toast::new(app_id)
+    tauri_winrt_notification::Toast::new(&app_id)
         .title(&title)
         .text1(&body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)

--- a/rust/gui-client/src-tauri/src/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_windows.rs
@@ -42,10 +42,11 @@ pub async fn set_autostart(enabled: bool) -> Result<()> {
 
 /// Show a notification in the bottom right of the screen
 ///
-/// May say "Windows Powershell" and have the wrong icon in dev mode
-/// See <https://github.com/tauri-apps/tauri/issues/3700>
-///
-/// TODO: Warn about silent failure if the AppID is not installed:
+/// Notifications are registered under the GUI's package AUMID
+/// ([`crate::PACKAGE_AUMID`]), so the title and icon come from the
+/// sparse MSIX manifest's `VisualElements`. Windows silently drops a
+/// toast whose AUMID doesn't match the calling process's package, so
+/// this must stay in sync with `win_files/AppxManifest.xml`.
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
 ///
 /// Known issue: If the notification times out and goes into the notification center
@@ -65,7 +66,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
     // For some reason `on_activated` is FnMut
     let mut tx = Some(tx);
 
-    tauri_winrt_notification::Toast::new(crate::BUNDLE_ID)
+    tauri_winrt_notification::Toast::new(crate::PACKAGE_AUMID)
         .title(&title)
         .text1(&body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -32,8 +32,11 @@ pub mod settings;
 /// but sometimes I need to use this before Tauri has booted up, or in a place where
 /// getting the Tauri app handle would be awkward.
 ///
-/// Note: this is *not* the AppUserModelId Windows uses to label notifications. Now
-/// that the GUI runs under a sparse MSIX identity, that is [`PACKAGE_AUMID`].
+/// Note: under the sparse MSIX identity this is *not* the
+/// AppUserModelId Windows uses to label notifications; that is derived
+/// from [`PACKAGE_FAMILY_NAME`] in `gui::os::show_notification`. It is
+/// still used as the toast AUMID for un-packaged dev builds, which have
+/// no package identity.
 pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 /// The Sentry "release" we are part of.
@@ -47,19 +50,10 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `Name_publisherId` for the sparse MSIX. Derived at build time
 /// from the manifest's `Name` + Publisher DN in `build.rs`. Used by
 /// `register-sparse.exe` to stage / provision / deprovision the
-/// package against the AppX deployment service.
+/// package against the AppX deployment service, and to derive the
+/// package AUMID (`<PACKAGE_FAMILY_NAME>!Firezone`) that Windows uses to
+/// label toast notifications (see `gui::os::show_notification`).
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
-
-/// The AppUserModelId of the GUI under its sparse MSIX identity:
-/// `<PackageFamilyName>!<Application Id>`, where `Firezone` is the
-/// `<Application Id="Firezone">` from `win_files/AppxManifest.xml`.
-///
-/// Windows attributes toast notifications to the calling process's
-/// package AUMID, so this is what we register them under when the
-/// process has package identity (not [`BUNDLE_ID`], which only worked
-/// back when the GUI was a plain MSI install with a Start Menu shortcut
-/// carrying that AUMID).
-pub const PACKAGE_AUMID: &str = concat!(env!("FIREZONE_PACKAGE_FAMILY_NAME"), "!Firezone");
 
 #[cfg(target_os = "linux")]
 pub fn firezone_client_group() -> anyhow::Result<nix::unistd::Group> {

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -55,10 +55,10 @@ pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
 /// `<Application Id="Firezone">` from `win_files/AppxManifest.xml`.
 ///
 /// Windows attributes toast notifications to the calling process's
-/// package AUMID, so this is what we must register them under (not
-/// [`BUNDLE_ID`], which only worked back when the GUI was a plain MSI
-/// install with a Start Menu shortcut carrying that AUMID).
-#[cfg(target_os = "windows")]
+/// package AUMID, so this is what we register them under when the
+/// process has package identity (not [`BUNDLE_ID`], which only worked
+/// back when the GUI was a plain MSI install with a Start Menu shortcut
+/// carrying that AUMID).
 pub const PACKAGE_AUMID: &str = concat!(env!("FIREZONE_PACKAGE_FAMILY_NAME"), "!Firezone");
 
 #[cfg(target_os = "linux")]

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -32,9 +32,8 @@ pub mod settings;
 /// but sometimes I need to use this before Tauri has booted up, or in a place where
 /// getting the Tauri app handle would be awkward.
 ///
-/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
-/// so if your dev system has Firezone installed by MSI, the notifications will look right.
-/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
+/// Note: this is *not* the AppUserModelId Windows uses to label notifications. Now
+/// that the GUI runs under a sparse MSIX identity, that is [`PACKAGE_AUMID`].
 pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 /// The Sentry "release" we are part of.
@@ -50,6 +49,17 @@ pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
 /// `register-sparse.exe` to stage / provision / deprovision the
 /// package against the AppX deployment service.
 pub const PACKAGE_FAMILY_NAME: &str = env!("FIREZONE_PACKAGE_FAMILY_NAME");
+
+/// The AppUserModelId of the GUI under its sparse MSIX identity:
+/// `<PackageFamilyName>!<Application Id>`, where `Firezone` is the
+/// `<Application Id="Firezone">` from `win_files/AppxManifest.xml`.
+///
+/// Windows attributes toast notifications to the calling process's
+/// package AUMID, so this is what we must register them under (not
+/// [`BUNDLE_ID`], which only worked back when the GUI was a plain MSI
+/// install with a Start Menu shortcut carrying that AUMID).
+#[cfg(target_os = "windows")]
+pub const PACKAGE_AUMID: &str = concat!(env!("FIREZONE_PACKAGE_FAMILY_NAME"), "!Firezone");
 
 #[cfg(target_os = "linux")]
 pub fn firezone_client_group() -> anyhow::Result<nix::unistd::Group> {

--- a/rust/gui-client/src-tauri/src/package_identity.rs
+++ b/rust/gui-client/src-tauri/src/package_identity.rs
@@ -51,7 +51,7 @@ pub fn ensure_package_identity() -> Result<()> {
 /// process activated with package identity; on a non-packaged process
 /// it errors, which is our signal to register for the current user.
 #[cfg(target_os = "windows")]
-fn has_package_identity() -> bool {
+pub fn has_package_identity() -> bool {
     windows::ApplicationModel::Package::Current().is_ok()
 }
 


### PR DESCRIPTION
Windows toast notifications stopped appearing on the GUI client after it began running under a sparse MSIX identity. Windows attributes toasts to the calling process's package AUMID, but the toast path still passed `BUNDLE_ID` ("dev.firezone.client"), which no longer matches, so Windows silently dropped every notification. Registering toasts under the package AUMID fixes this and also restores the correct title and icon from the MSIX manifest.

---

Fixes #13565
Fixes #13566 