### PR TITLE
feat: record cause of portal connection hiccups as a metric

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7507,6 +7507,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -540,19 +540,7 @@ async fn phoenix_channel_event_loop(
                 }),
                 _,
             )) => {
-                let http_error_body = error
-                    .chain()
-                    .find_map(|e| e.downcast_ref::<phoenix_channel::WebSocketError>())
-                    .and_then(|e| {
-                        let phoenix_channel::WebSocketError::Http(response) = e else {
-                            return None;
-                        };
-
-                        response
-                            .body()
-                            .as_deref()
-                            .map(|body| String::from_utf8_lossy(body).into_owned())
-                    });
+                let http_error_body = phoenix_channel::http_error_body(&error);
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -518,6 +518,8 @@ async fn phoenix_channel_event_loop(
     let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
     portal.connect(ips, Duration::ZERO, public_key.clone());
 
+    let hiccups = telemetry::otel::metrics::portal_connection_hiccups();
+
     loop {
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {
             Either::Left((Ok(phoenix_channel::Event::Message { msg, .. }), _)) => {
@@ -543,6 +545,7 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
+                hiccups.add(1, &telemetry::otel::error_layers(&error));
 
                 let ips = resolve_portal_host_ips(&resolver, portal.host()).await;
                 portal.connect(ips, backoff, public_key.clone());

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -540,11 +540,10 @@ async fn phoenix_channel_event_loop(
                 }),
                 _,
             )) => {
-                let http_error_body = phoenix_channel::http_error_body(&error);
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,
-                    body = http_error_body.as_deref(),
+                    body = phoenix_channel::http_error_body(&error).map(tracing::field::display),
                     "Hiccup in portal connection: {error:#}"
                 );
                 hiccups.add(1, &telemetry::otel::error_layers(&error));

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -540,9 +540,23 @@ async fn phoenix_channel_event_loop(
                 }),
                 _,
             )) => {
+                let http_error_body = error
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<phoenix_channel::WebSocketError>())
+                    .and_then(|e| {
+                        let phoenix_channel::WebSocketError::Http(response) = e else {
+                            return None;
+                        };
+
+                        response
+                            .body()
+                            .as_deref()
+                            .map(|body| String::from_utf8_lossy(body).into_owned())
+                    });
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,
+                    body = http_error_body.as_deref(),
                     "Hiccup in portal connection: {error:#}"
                 );
                 hiccups.add(1, &telemetry::otel::error_layers(&error));

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -786,9 +786,23 @@ async fn phoenix_channel_event_loop(
                 }),
                 _,
             )) => {
+                let http_error_body = error
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<phoenix_channel::WebSocketError>())
+                    .and_then(|e| {
+                        let phoenix_channel::WebSocketError::Http(response) = e else {
+                            return None;
+                        };
+
+                        response
+                            .body()
+                            .as_deref()
+                            .map(|body| String::from_utf8_lossy(body).into_owned())
+                    });
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,
+                    body = http_error_body.as_deref(),
                     "Hiccup in portal connection: {error:#}"
                 );
                 hiccups.add(1, &telemetry::otel::error_layers(&error));

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -786,19 +786,7 @@ async fn phoenix_channel_event_loop(
                 }),
                 _,
             )) => {
-                let http_error_body = error
-                    .chain()
-                    .find_map(|e| e.downcast_ref::<phoenix_channel::WebSocketError>())
-                    .and_then(|e| {
-                        let phoenix_channel::WebSocketError::Http(response) = e else {
-                            return None;
-                        };
-
-                        response
-                            .body()
-                            .as_deref()
-                            .map(|body| String::from_utf8_lossy(body).into_owned())
-                    });
+                let http_error_body = phoenix_channel::http_error_body(&error);
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -736,6 +736,8 @@ async fn phoenix_channel_event_loop(
     let ips = resolve_portal_host_ips(&bootstrap_dns_client, portal.host()).await;
     portal.connect(ips, Duration::ZERO, public_key.clone());
 
+    let hiccups = telemetry::otel::metrics::portal_connection_hiccups();
+
     loop {
         // We process commands from the channel first (i.e. it is polled first) to update the DNS servers as quickly as possible.
         // This allows `Hiccup` events to use the updated `BootstrapDnsClient` to resolve the domain.
@@ -789,6 +791,7 @@ async fn phoenix_channel_event_loop(
                     ?max_elapsed_time,
                     "Hiccup in portal connection: {error:#}"
                 );
+                hiccups.add(1, &telemetry::otel::error_layers(&error));
 
                 let ips = resolve_portal_host_ips(&bootstrap_dns_client, portal.host()).await;
                 portal.connect(ips, backoff, public_key.clone());

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -786,11 +786,10 @@ async fn phoenix_channel_event_loop(
                 }),
                 _,
             )) => {
-                let http_error_body = phoenix_channel::http_error_body(&error);
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,
-                    body = http_error_body.as_deref(),
+                    body = phoenix_channel::http_error_body(&error).map(tracing::field::display),
                     "Hiccup in portal connection: {error:#}"
                 );
                 hiccups.add(1, &telemetry::otel::error_layers(&error));

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -305,9 +305,6 @@ impl std::error::Error for InternalError {
 }
 
 /// Recovers the body of an HTTP error response from a portal connection error.
-///
-/// The body is intentionally kept out of the error's `Display` to avoid high-cardinality
-/// telemetry attributes, so this is the way to surface it for diagnostic logging.
 pub fn http_error_body(error: &anyhow::Error) -> Option<String> {
     use anyhow::ErrorExt as _;
 

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -35,6 +35,7 @@ use url::Url;
 
 pub use get_user_agent::get_user_agent;
 pub use login_url::{DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam};
+pub use tokio_tungstenite::tungstenite::Error as WebSocketError;
 pub use tokio_tungstenite::tungstenite::http::StatusCode;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
@@ -257,16 +258,6 @@ fn parse_retry_after_value(value: &str) -> Option<Duration> {
 impl fmt::Display for InternalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            InternalError::WebSocket(tungstenite::Error::Http(http)) => {
-                let status = http.status();
-                let body = http
-                    .body()
-                    .as_deref()
-                    .map(String::from_utf8_lossy)
-                    .unwrap_or_default();
-
-                write!(f, "http error: {status} - {body}")
-            }
             InternalError::WebSocket(_) => write!(f, "websocket connection failed"),
             InternalError::Serde(_) => write!(f, "failed to deserialize message"),
             InternalError::CloseMessage => write!(f, "portal closed the websocket connection"),
@@ -300,7 +291,6 @@ impl fmt::Display for InternalError {
 impl std::error::Error for InternalError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            InternalError::WebSocket(tungstenite::Error::Http(_)) => None,
             InternalError::WebSocket(e) => Some(e),
             InternalError::Serde(e) => Some(e),
             InternalError::SocketConnection(_) => None,

--- a/rust/libs/connlib/phoenix-channel/src/lib.rs
+++ b/rust/libs/connlib/phoenix-channel/src/lib.rs
@@ -35,7 +35,6 @@ use url::Url;
 
 pub use get_user_agent::get_user_agent;
 pub use login_url::{DeviceInfo, LoginUrl, LoginUrlError, NoParams, PublicKeyParam};
-pub use tokio_tungstenite::tungstenite::Error as WebSocketError;
 pub use tokio_tungstenite::tungstenite::http::StatusCode;
 
 const MAX_BUFFERED_MESSAGES: usize = 32; // Chosen pretty arbitrarily. If we are connected, these should never build up.
@@ -303,6 +302,23 @@ impl std::error::Error for InternalError {
             InternalError::TooManyUnansweredHeartbeats => None,
         }
     }
+}
+
+/// Recovers the body of an HTTP error response from a portal connection error.
+///
+/// The body is intentionally kept out of the error's `Display` to avoid high-cardinality
+/// telemetry attributes, so this is the way to surface it for diagnostic logging.
+pub fn http_error_body(error: &anyhow::Error) -> Option<String> {
+    use anyhow::ErrorExt as _;
+
+    let tungstenite::Error::Http(response) = error.any_downcast_ref::<tungstenite::Error>()? else {
+        return None;
+    };
+
+    response
+        .body()
+        .as_deref()
+        .map(|body| String::from_utf8_lossy(body).into_owned())
 }
 
 /// A strict-monotonically increasing ID for outbound requests.
@@ -1088,6 +1104,25 @@ mod tests {
     use tokio::net::TcpListener;
 
     use super::*;
+
+    #[test]
+    fn http_error_body_recovers_response_body() {
+        let response = tungstenite::http::Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .body(Some(b"service down".to_vec()))
+            .unwrap();
+        let error = anyhow::Error::new(tungstenite::Error::Http(Box::new(response)))
+            .context("Connection hiccup");
+
+        assert_eq!(http_error_body(&error).as_deref(), Some("service down"));
+    }
+
+    #[test]
+    fn http_error_body_is_none_for_non_http_errors() {
+        let error = anyhow::Error::msg("some other failure").context("Connection hiccup");
+
+        assert_eq!(http_error_body(&error), None);
+    }
 
     #[derive(Deserialize, PartialEq, Debug)]
     #[serde(rename_all = "snake_case", tag = "event", content = "payload")] // This line makes it all work.

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
+tokio-tungstenite = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -499,6 +499,14 @@ pub mod metrics {
             .build()
     }
 
+    pub fn portal_connection_hiccups() -> Counter<u64> {
+        opentelemetry::global::meter("connlib")
+            .u64_counter("portal.connection.hiccup")
+            .with_description("Number of portal connection hiccups by cause.")
+            .with_unit("{hiccup}")
+            .build()
+    }
+
     pub fn connection_count() -> Gauge<u64> {
         opentelemetry::global::meter("connlib")
             .u64_gauge("tunnel.connection.count")

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -321,8 +321,8 @@ mod error_layer_tests {
 
         // `tungstenite`'s own `Display` is status-only ("HTTP error: 503 Service
         // Unavailable"): the body never appears and the numeric code is masked to `{num}`.
-        // The body that motivated this PR is added by `phoenix-channel`'s custom
-        // `InternalError` `Display`, not by tungstenite.
+        // `phoenix-channel` surfaces this `tungstenite` error via `source()`, so this is
+        // exactly the layer that reaches the metric for an HTTP hiccup.
         assert_eq!(
             error_layers(&error),
             vec![KeyValue::new(

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -334,6 +334,25 @@ mod error_layer_tests {
         );
     }
 
+    #[test]
+    fn error_layers_masks_http_status_code() {
+        // `StatusCode`'s `Display` renders the numeric code plus its reason phrase,
+        // e.g. "503 Service Unavailable", which is what `phoenix-channel` interpolates
+        // as `{status}`.
+        let error = anyhow::Error::msg("http error: 503 Service Unavailable");
+
+        // The numeric status code *is* masked to `{num}`; only the (bounded) reason
+        // phrase survives. So with the body removed, an HTTP hiccup label would be
+        // low-cardinality.
+        assert_eq!(
+            error_layers(&error),
+            vec![KeyValue::new(
+                "error.type.0",
+                "http error: {num} Service Unavailable"
+            )]
+        );
+    }
+
     #[derive(Debug, thiserror::Error)]
     #[error("failed to handle packet from {client_ip}")]
     struct StructError {

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -305,50 +305,29 @@ mod error_layer_tests {
     }
 
     #[test]
-    fn http_error_hiccup_layers() {
-        // Mirrors the error `phoenix-channel` emits on an HTTP hiccup:
-        // `anyhow::Error::new(InternalError::WebSocket(Http)).context("Connection hiccup")`,
-        // whose inner `Display` is `"http error: {status} - {body}"` (and `StatusCode`'s
-        // own `Display` is e.g. `"503 Service Unavailable"`).
-        let hiccup = anyhow::Error::new(HttpHiccup {
-            status: "503 Service Unavailable",
-            body: r#"{"error":"service_unavailable"}"#,
-        })
-        .context("Connection hiccup");
+    fn tungstenite_http_error_omits_body() {
+        use tokio_tungstenite::tungstenite::{
+            self,
+            http::{Response, StatusCode},
+        };
 
-        let layers = error_layers(&hiccup);
+        // The real error `phoenix-channel` gets from a failed websocket upgrade. The
+        // response deliberately carries a body to demonstrate it does not surface.
+        let response = Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .body(Some(br#"{"error":"service_unavailable"}"#.to_vec()))
+            .unwrap();
+        let error = anyhow::Error::new(tungstenite::Error::Http(Box::new(response)));
 
-        // Only the numeric status code is masked (to `{num}`); the status reason and the
-        // entire response body survive verbatim as the label value. This both leaks the
-        // body into telemetry and makes the value high-cardinality (a per-request body
-        // yields a new series), while 429 vs 503 become indistinguishable.
-        assert_eq!(
-            layers,
-            vec![
-                KeyValue::new("error.type.0", "Connection hiccup"),
-                KeyValue::new(
-                    "error.type.1",
-                    r#"http error: {num} Service Unavailable - {"error":"service_unavailable"}"#
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn error_layers_masks_http_status_code() {
-        // `StatusCode`'s `Display` renders the numeric code plus its reason phrase,
-        // e.g. "503 Service Unavailable", which is what `phoenix-channel` interpolates
-        // as `{status}`.
-        let error = anyhow::Error::msg("http error: 503 Service Unavailable");
-
-        // The numeric status code *is* masked to `{num}`; only the (bounded) reason
-        // phrase survives. So with the body removed, an HTTP hiccup label would be
-        // low-cardinality.
+        // `tungstenite`'s own `Display` is status-only ("HTTP error: 503 Service
+        // Unavailable"): the body never appears and the numeric code is masked to `{num}`.
+        // The body that motivated this PR is added by `phoenix-channel`'s custom
+        // `InternalError` `Display`, not by tungstenite.
         assert_eq!(
             error_layers(&error),
             vec![KeyValue::new(
                 "error.type.0",
-                "http error: {num} Service Unavailable"
+                "HTTP error: {num} Service Unavailable"
             )]
         );
     }
@@ -362,13 +341,6 @@ mod error_layer_tests {
     #[derive(Debug, thiserror::Error)]
     #[error("{0} is not a client IP")]
     struct TupleError(&'static str);
-
-    #[derive(Debug, thiserror::Error)]
-    #[error("http error: {status} - {body}")]
-    struct HttpHiccup {
-        status: &'static str,
-        body: &'static str,
-    }
 }
 
 #[cfg(test)]

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -304,6 +304,36 @@ mod error_layer_tests {
         assert_eq!(error_layers(&error).len(), MAX_ERROR_LAYERS);
     }
 
+    #[test]
+    fn http_error_hiccup_layers() {
+        // Mirrors the error `phoenix-channel` emits on an HTTP hiccup:
+        // `anyhow::Error::new(InternalError::WebSocket(Http)).context("Connection hiccup")`,
+        // whose inner `Display` is `"http error: {status} - {body}"` (and `StatusCode`'s
+        // own `Display` is e.g. `"503 Service Unavailable"`).
+        let hiccup = anyhow::Error::new(HttpHiccup {
+            status: "503 Service Unavailable",
+            body: r#"{"error":"service_unavailable"}"#,
+        })
+        .context("Connection hiccup");
+
+        let layers = error_layers(&hiccup);
+
+        // Only the numeric status code is masked (to `{num}`); the status reason and the
+        // entire response body survive verbatim as the label value. This both leaks the
+        // body into telemetry and makes the value high-cardinality (a per-request body
+        // yields a new series), while 429 vs 503 become indistinguishable.
+        assert_eq!(
+            layers,
+            vec![
+                KeyValue::new("error.type.0", "Connection hiccup"),
+                KeyValue::new(
+                    "error.type.1",
+                    r#"http error: {num} Service Unavailable - {"error":"service_unavailable"}"#
+                ),
+            ]
+        );
+    }
+
     #[derive(Debug, thiserror::Error)]
     #[error("failed to handle packet from {client_ip}")]
     struct StructError {
@@ -313,6 +343,13 @@ mod error_layer_tests {
     #[derive(Debug, thiserror::Error)]
     #[error("{0} is not a client IP")]
     struct TupleError(&'static str);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("http error: {status} - {body}")]
+    struct HttpHiccup {
+        status: &'static str,
+        body: &'static str,
+    }
 }
 
 #[cfg(test)]

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -780,11 +780,10 @@ async fn phoenix_channel_event_loop(
                 error,
             }) => {
                 is_connected.store(false, Ordering::Relaxed);
-                let http_error_body = phoenix_channel::http_error_body(&error);
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,
-                    body = http_error_body.as_deref(),
+                    body = phoenix_channel::http_error_body(&error).map(tracing::field::display),
                     "{error:#}"
                 );
 

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -780,7 +780,25 @@ async fn phoenix_channel_event_loop(
                 error,
             }) => {
                 is_connected.store(false, Ordering::Relaxed);
-                tracing::info!(?backoff, ?max_elapsed_time, "{error:#}");
+                let http_error_body = error
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<phoenix_channel::WebSocketError>())
+                    .and_then(|e| {
+                        let phoenix_channel::WebSocketError::Http(response) = e else {
+                            return None;
+                        };
+
+                        response
+                            .body()
+                            .as_deref()
+                            .map(|body| String::from_utf8_lossy(body).into_owned())
+                    });
+                tracing::info!(
+                    ?backoff,
+                    ?max_elapsed_time,
+                    body = http_error_body.as_deref(),
+                    "{error:#}"
+                );
 
                 let ips = resolve_portal_host_ips(portal.host()).await;
                 portal.connect(ips, backoff, NoParams);

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -780,19 +780,7 @@ async fn phoenix_channel_event_loop(
                 error,
             }) => {
                 is_connected.store(false, Ordering::Relaxed);
-                let http_error_body = error
-                    .chain()
-                    .find_map(|e| e.downcast_ref::<phoenix_channel::WebSocketError>())
-                    .and_then(|e| {
-                        let phoenix_channel::WebSocketError::Http(response) = e else {
-                            return None;
-                        };
-
-                        response
-                            .body()
-                            .as_deref()
-                            .map(|body| String::from_utf8_lossy(body).into_owned())
-                    });
+                let http_error_body = phoenix_channel::http_error_body(&error);
                 tracing::info!(
                     ?backoff,
                     ?max_elapsed_time,


### PR DESCRIPTION
We currently only log portal connection hiccups, so there is no way to tell in aggregate why a client or gateway keeps losing its connection to the portal. This adds a counter to both event loops that records each hiccup together with its cause, letting us distinguish reconnects driven by connect timeouts, websocket closes, unanswered heartbeats, and the like.