### PR TITLE
build(relay): allow skipping eBPF build via 'ebpf' feature

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,7 +95,10 @@ etherparse-ext = { path = "libs/connlib/etherparse-ext" }
 eventloop-budget = { path = "libs/eventloop-budget" }
 fd-lock = "4.0.4"
 filetime = "0.2.29"
-firezone-relay = { path = "relay/server" }
+# `default-features = false` disables the `ebpf` feature for library consumers (currently
+# only `tunnel`'s tests), so they don't need the nightly toolchain + `bpf-linker` to build it.
+# The relay binary builds from the package directly and keeps `ebpf` via its own default feature.
+firezone-relay = { path = "relay/server", default-features = false }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"
 gat-lending-iterator = "0.1.8"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,9 +95,6 @@ etherparse-ext = { path = "libs/connlib/etherparse-ext" }
 eventloop-budget = { path = "libs/eventloop-budget" }
 fd-lock = "4.0.4"
 filetime = "0.2.29"
-# `default-features = false` disables the `ebpf` feature for library consumers (currently
-# only `tunnel`'s tests), so they don't need the nightly toolchain + `bpf-linker` to build it.
-# The relay binary builds from the package directly and keeps `ebpf` via its own default feature.
 firezone-relay = { path = "relay/server", default-features = false }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 
+[features]
+default = ["ebpf"]
+# Compiles and embeds the XDP/eBPF TURN router. This requires a pinned nightly
+# toolchain and `bpf-linker`. Disable it (e.g. via `default-features = false`) to
+# skip the eBPF build when only the sans-IO `Server` is needed, such as in the
+# `tunnel` crate's tests.
+ebpf = ["dep:aya", "dep:aya-log", "dep:ebpf-shared"]
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio", "query"] }
@@ -46,9 +54,9 @@ url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aya = { workspace = true }
-aya-log = { workspace = true }
-ebpf-shared = { workspace = true, features = ["std"] }
+aya = { workspace = true, optional = true }
+aya-log = { workspace = true, optional = true }
+ebpf-shared = { workspace = true, features = ["std"], optional = true }
 
 [target.'cfg(target_os = "linux")'.build-dependencies]
 anyhow = { workspace = true }

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -6,10 +6,6 @@ license = { workspace = true }
 
 [features]
 default = ["ebpf"]
-# Compiles and embeds the XDP/eBPF TURN router. This requires a pinned nightly
-# toolchain and `bpf-linker`. Disable it (e.g. via `default-features = false`) to
-# skip the eBPF build when only the sans-IO `Server` is needed, such as in the
-# `tunnel` crate's tests.
 ebpf = ["dep:aya", "dep:aya-log", "dep:ebpf-shared"]
 
 [dependencies]

--- a/rust/relay/server/build.rs
+++ b/rust/relay/server/build.rs
@@ -3,6 +3,14 @@ fn main() -> anyhow::Result<()> {
     use anyhow::Context as _;
     use aya_build::cargo_metadata::{MetadataCommand, Package};
 
+    // Build scripts don't receive feature cfgs, only the `CARGO_FEATURE_<name>`
+    // env var for each activated feature. When the `ebpf` feature is disabled we
+    // skip compiling the eBPF program entirely, which avoids the dependency on the
+    // pinned nightly toolchain and `bpf-linker`.
+    if std::env::var_os("CARGO_FEATURE_EBPF").is_none() {
+        return Ok(());
+    }
+
     let package = MetadataCommand::new()
         .no_deps()
         .exec()

--- a/rust/relay/server/src/ebpf.rs
+++ b/rust/relay/server/src/ebpf.rs
@@ -1,7 +1,7 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
 #[path = "ebpf/linux.rs"]
 mod platform;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "ebpf")))]
 #[path = "ebpf/stub.rs"]
 mod platform;
 

--- a/rust/relay/server/src/metrics.rs
+++ b/rust/relay/server/src/metrics.rs
@@ -42,7 +42,7 @@ pub(crate) fn packet_size() -> Histogram<u64> {
 }
 
 /// Histogram of the time the eBPF XDP program spent processing one relayed packet.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
 pub(crate) fn xdp_processing_duration() -> Histogram<u64> {
     opentelemetry::global::meter("relay")
         .u64_histogram("relay.xdp.processing.duration")
@@ -61,7 +61,7 @@ pub(crate) fn datapath_userspace() -> KeyValue {
 }
 
 /// `relay.datapath = xdp`: relayed by the in-kernel XDP program.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "ebpf"))]
 pub(crate) fn datapath_xdp() -> KeyValue {
     KeyValue::new("relay.datapath", "xdp")
 }


### PR DESCRIPTION
The `tunnel` crate dev-depends on `firezone-relay` for its sans-IO `Server`, which forced every `cargo test -p tunnel` to compile the relay's XDP/eBPF TURN router — pulling in a pinned nightly toolchain and `bpf-linker` despite the tests never exercising the eBPF datapath.

This puts the eBPF program and its loader behind a default `ebpf` feature and disables it for the relay's library consumers (currently just the tunnel tests), so they build without the eBPF toolchain. The relay binary keeps eBPF enabled by default, leaving production builds unchanged.

Note that Cargo feature unification means a single invocation that also builds the relay binary (e.g. `cargo test --workspace` or `cargo clippy --all-features`) still compiles the eBPF program; the speed-up applies to targeted commands like `cargo test -p tunnel`.