### PR TITLE
refactor(portal): refactor show panel headers

### DIFF
--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -826,6 +826,7 @@ defmodule PortalWeb.CoreComponents do
   end
 
   attr :type, :string, default: "neutral"
+  attr :size, :string, default: "sm", values: ["xs", "sm", "md"]
   attr :class, :string, default: nil
   attr :rest, :global
   slot :inner_block, required: true
@@ -841,12 +842,19 @@ defmodule PortalWeb.CoreComponents do
       "neutral" => "bg-neutral-100 text-neutral-800"
     }
 
-    assigns = assign(assigns, colors: colors)
+    sizes = %{
+      "xs" => "text-[10px] px-1.5 py-px",
+      "sm" => "text-xs px-2.5 py-0.5",
+      "md" => "text-sm px-3 py-1"
+    }
+
+    assigns = assign(assigns, colors: colors, sizes: sizes)
 
     ~H"""
     <span
       class={[
-        "text-xs px-2.5 py-0.5 rounded-sm whitespace-nowrap",
+        "rounded whitespace-nowrap",
+        @sizes[@size],
         @colors[@type],
         @class
       ]}

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -1717,91 +1717,42 @@ defmodule PortalWeb.CoreComponents do
 
   ## Statuses
 
-  - `:online` / `:healthy` / `:active` — green
-  - `:degraded` — amber
-  - `:offline` — gray
-  - `:disabled` — red
+  - `:success` — green
+  - `:warning` — amber
+  - `:danger` — red
+  - `:neutral` — gray
 
   ## Examples
 
-    <.status_badge status={:online} />
-    <.status_badge status={:offline} />
-    <.status_badge status={:active} />
-    <.status_badge status={:disabled} />
-    <.status_badge status={:healthy} />
-    <.status_badge status={:degraded} />
+    <.status_badge style={:success}>Online</.status_badge>
+    <.status_badge style={:neutral}>Offline</.status_badge>
+    <.status_badge style={:warning}>Degraded</.status_badge>
+    <.status_badge style={:danger}>Disabled</.status_badge>
+    <.status_badge style={:success} dot={false}>Active</.status_badge>
   """
-  attr :status, :atom,
-    required: true,
-    values: [:online, :offline, :active, :disabled, :healthy, :degraded, :expired]
+  attr :style, :atom, required: true, values: [:success, :warning, :danger, :neutral]
+  attr :dot, :boolean, default: true
+  slot :inner_block, required: true
 
   def status_badge(assigns) do
-    assigns = assign(assigns, :cfg, status_badge_config(assigns.status))
-
     ~H"""
     <span class={[
       "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-medium",
-      @cfg.pill_class
+      badge_pill_class(@style)
     ]}>
-      <span class={["w-1.5 h-1.5 rounded-full shrink-0", @cfg.dot_class]}></span>
-      {@cfg.label}
+      <span :if={@dot} class={["w-1.5 h-1.5 rounded-full shrink-0", badge_dot_class(@style)]}></span>
+      {render_slot(@inner_block)}
     </span>
     """
   end
 
-  defp status_badge_config(:online) do
-    %{
-      label: "Online",
-      pill_class: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-      dot_class: "bg-green-500"
-    }
-  end
+  defp badge_pill_class(:success), do: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+  defp badge_pill_class(:warning), do: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+  defp badge_pill_class(:danger), do: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+  defp badge_pill_class(:neutral), do: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
 
-  defp status_badge_config(:healthy) do
-    %{
-      label: "Healthy",
-      pill_class: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-      dot_class: "bg-green-500"
-    }
-  end
-
-  defp status_badge_config(:active) do
-    %{
-      label: "Active",
-      pill_class: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-      dot_class: "bg-green-500"
-    }
-  end
-
-  defp status_badge_config(:degraded) do
-    %{
-      label: "Degraded",
-      pill_class: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-      dot_class: "bg-amber-500"
-    }
-  end
-
-  defp status_badge_config(:offline) do
-    %{
-      label: "Offline",
-      pill_class: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400",
-      dot_class: "bg-gray-400"
-    }
-  end
-
-  defp status_badge_config(:disabled) do
-    %{
-      label: "Disabled",
-      pill_class: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-      dot_class: "bg-red-500"
-    }
-  end
-
-  defp status_badge_config(:expired) do
-    %{
-      label: "Expired",
-      pill_class: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400",
-      dot_class: "bg-gray-400"
-    }
-  end
+  defp badge_dot_class(:success), do: "bg-green-500"
+  defp badge_dot_class(:warning), do: "bg-amber-500"
+  defp badge_dot_class(:danger), do: "bg-red-500"
+  defp badge_dot_class(:neutral), do: "bg-gray-400"
 end

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1047,7 +1047,7 @@ defmodule PortalWeb.Actors do
             </span>
           </:col>
           <:col :let={actor} label="status" class="w-32">
-            <.status_badge status={if is_nil(actor.disabled_at), do: :active, else: :disabled} />
+            <.actor_status_badge disabled_at={actor.disabled_at} />
           </:col>
           <:empty>
             <span class="text-sm text-[var(--text-tertiary)]">No people to display.</span>

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -110,17 +110,22 @@ defmodule PortalWeb.Actors.Components do
 
   def actor_detail_header(assigns) do
     ~H"""
-    <div class="shrink-0 px-5 pt-4 pb-3 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
-      <div class="flex items-start justify-between gap-3">
-        <div class="flex items-center gap-3 min-w-0">
+    <div class="shrink-0 px-5 py-4 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
+      <div class="flex items-center gap-4">
+        <%!-- Left: icon + name + status + email --%>
+        <div class="flex items-center gap-3 min-w-0 flex-1">
           <.actor_type_icon_circle actor={@actor} />
           <div class="min-w-0">
-            <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">{@actor.name}</h2>
-            <p :if={@actor.email} class="text-xs text-[var(--text-tertiary)] truncate">
+            <div class="flex items-center gap-2">
+              <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">{@actor.name}</h2>
+              <.actor_status_badge disabled_at={@actor.disabled_at} />
+            </div>
+            <p :if={@actor.email} class="text-xs text-[var(--text-tertiary)] truncate mt-0.5">
               {@actor.email}
             </p>
           </div>
         </div>
+        <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
           <button
             type="button"
@@ -136,32 +141,6 @@ defmodule PortalWeb.Actors.Components do
           >
             <.icon name="ri-close-line" class="w-4 h-4" />
           </button>
-        </div>
-      </div>
-      <div class="flex items-center gap-5 mt-3 pt-3 border-t border-[var(--border)]">
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            Status
-          </span>
-          <.status_badge status={if is_nil(@actor.disabled_at), do: :active, else: :disabled} />
-        </div>
-        <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            Groups
-          </span>
-          <span class="text-xs font-semibold tabular-nums text-[var(--text-primary)]">
-            {length(@groups)}
-          </span>
-        </div>
-        <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            {if @actor.type == :service_account, do: "Tokens", else: "Clients"}
-          </span>
-          <span class="text-xs font-semibold tabular-nums text-[var(--text-primary)]">
-            {length(@tokens)}
-          </span>
         </div>
       </div>
     </div>
@@ -1758,5 +1737,15 @@ defmodule PortalWeb.Actors.Components do
     if String.contains?(user_agent, "X11") and String.contains?(user_agent, "Linux") do
       "os-linux"
     end
+  end
+
+  attr :disabled_at, :any, required: true
+
+  def actor_status_badge(assigns) do
+    ~H"""
+    <.status_badge style={if is_nil(@disabled_at), do: :success, else: :danger}>
+      {if is_nil(@disabled_at), do: "Active", else: "Disabled"}
+    </.status_badge>
+    """
   end
 end

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -191,7 +191,7 @@ defmodule PortalWeb.Clients do
             </span>
           </:col>
           <:col :let={client} label="Status" class="w-28">
-            <.status_badge status={if client.online?, do: :online, else: :offline} />
+            <.client_status_badge online?={client.online?} />
           </:col>
           <:col
             :let={client}

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -558,15 +558,18 @@ defmodule PortalWeb.Clients.Components do
 
   def client_details_header(assigns) do
     ~H"""
-    <div class="shrink-0 px-5 pt-4 pb-3 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
-      <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0">
-          <div class="flex items-center gap-2 flex-wrap">
-            <h2 class="text-sm font-semibold text-[var(--text-primary)]">{@client.name}</h2>
+    <div class="shrink-0 px-5 py-4 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
+      <div class="flex items-center gap-4">
+        <%!-- Left: name + status + ID --%>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">{@client.name}</h2>
+            <.client_status_badge online?={@client.online?} />
             <.client_verified_badge client={@client} />
           </div>
-          <p class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5">{@client.id}</p>
+          <p class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5 truncate">{@client.id}</p>
         </div>
+        <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
           <button
             phx-click="open_client_edit_form"
@@ -582,31 +585,6 @@ defmodule PortalWeb.Clients.Components do
             <.icon name="ri-close-line" class="w-4 h-4" />
           </button>
         </div>
-      </div>
-      <.client_summary_bar client={@client} />
-    </div>
-    """
-  end
-
-  attr :client, :any, required: true
-
-  def client_summary_bar(assigns) do
-    ~H"""
-    <div class="flex items-center gap-5 mt-3 pt-3 border-t border-[var(--border)]">
-      <div class="flex items-center gap-1.5">
-        <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-          Status
-        </span>
-        <.status_badge status={if @client.online?, do: :online, else: :offline} />
-      </div>
-      <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
-      <div class="flex items-center gap-1.5">
-        <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-          Last Seen
-        </span>
-        <span class="text-xs text-[var(--text-secondary)]">
-          <.relative_datetime datetime={@client.latest_session && @client.latest_session.inserted_at} />
-        </span>
       </div>
     </div>
     """
@@ -745,6 +723,13 @@ defmodule PortalWeb.Clients.Components do
             current={@client.latest_session && @client.latest_session.version}
             latest={ComponentVersions.client_version(@client)}
           />
+        </.client_detail_row>
+        <.client_detail_row label="Last Seen">
+          <span class="text-xs text-[var(--text-secondary)]">
+            <.relative_datetime
+              datetime={@client.latest_session && @client.latest_session.inserted_at}
+            />
+          </span>
         </.client_detail_row>
         <.client_detail_row label="Created">
           <span class="text-xs text-[var(--text-secondary)]">
@@ -910,6 +895,16 @@ defmodule PortalWeb.Clients.Components do
       <dt class="text-[10px] text-[var(--text-tertiary)] mb-0.5">{@label}</dt>
       <dd>{render_slot(@inner_block)}</dd>
     </div>
+    """
+  end
+
+  attr :online?, :boolean, required: true
+
+  def client_status_badge(assigns) do
+    ~H"""
+    <.status_badge style={if @online?, do: :success, else: :neutral}>
+      {if @online?, do: "Online", else: "Offline"}
+    </.status_badge>
     """
   end
 

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -298,8 +298,9 @@ defmodule PortalWeb.Groups.Components do
   def group_details_header(assigns) do
     ~H"""
     <div class="shrink-0 px-5 py-4 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
-      <div class="flex items-start justify-between gap-3">
-        <div class="flex items-center gap-3 min-w-0">
+      <div class="flex items-center gap-4">
+        <%!-- Left: icon + name + directory info --%>
+        <div class="flex items-center gap-3 min-w-0 flex-1">
           <div class="flex items-center justify-center w-8 h-8 shrink-0">
             <.provider_icon type={provider_type_from_group(@group)} class="w-6 h-6" />
           </div>
@@ -320,6 +321,7 @@ defmodule PortalWeb.Groups.Components do
             </div>
           </div>
         </div>
+        <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
           <.link
             :if={editable_group?(@group) and not @confirm_delete?}

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -7,6 +7,7 @@ defmodule PortalWeb.Policies do
       map_condition_params: 2,
       maybe_drop_unsupported_conditions: 2,
       policy_panel: 1,
+      policy_status_badge: 1,
       resource_type_badge_class: 1,
       condition_short_label: 1
     ]
@@ -273,7 +274,7 @@ defmodule PortalWeb.Policies do
             </div>
           </:col>
           <:col :let={policy} label="Status" class="w-32">
-            <.status_badge status={if is_nil(policy.disabled_at), do: :active, else: :disabled} />
+            <.policy_status_badge disabled_at={policy.disabled_at} />
           </:col>
           <:col :let={policy} label="Group" class="w-36 lg:w-72">
             <%= if policy.group do %>

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -745,18 +745,23 @@ defmodule PortalWeb.Policies.Components do
 
   def policy_details_header(assigns) do
     ~H"""
-    <div class="shrink-0 px-5 pt-4 pb-3 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
-      <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0">
-          <h2 class="text-sm font-semibold text-[var(--text-primary)]">
-            <%= if @policy.group do %>
-              {@policy.group.name} — {@policy.resource.name}
-            <% else %>
-              <span class="text-amber-600">(Group deleted)</span> — {@policy.resource.name}
-            <% end %>
-          </h2>
-          <p class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5">{@policy.id}</p>
+    <div class="shrink-0 px-5 py-4 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
+      <div class="flex items-center gap-4">
+        <%!-- Left: title + status + ID --%>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">
+              <%= if @policy.group do %>
+                {@policy.group.name} — {@policy.resource.name}
+              <% else %>
+                <span class="text-amber-600">(Group deleted)</span> — {@policy.resource.name}
+              <% end %>
+            </h2>
+            <.policy_status_badge disabled_at={@policy.disabled_at} />
+          </div>
+          <p class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5 truncate">{@policy.id}</p>
         </div>
+        <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
           <button
             phx-click="open_edit_form"
@@ -771,23 +776,6 @@ defmodule PortalWeb.Policies.Components do
           >
             <.icon name="ri-close-line" class="w-4 h-4" />
           </button>
-        </div>
-      </div>
-      <div class="flex items-center gap-5 mt-3 pt-3 border-t border-[var(--border)]">
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            Status
-          </span>
-          <.status_badge status={if is_nil(@policy.disabled_at), do: :active, else: :disabled} />
-        </div>
-        <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            Conditions
-          </span>
-          <span class="text-xs font-semibold tabular-nums text-[var(--text-primary)]">
-            {length(@policy.conditions)}
-          </span>
         </div>
       </div>
     </div>
@@ -3212,5 +3200,15 @@ defmodule PortalWeb.Policies.Components do
         {:policy_authorizations, :desc, :inserted_at},
         {:policy_authorizations, :asc, :id}
       ]
+  end
+
+  attr :disabled_at, :any, required: true
+
+  def policy_status_badge(assigns) do
+    ~H"""
+    <.status_badge style={if is_nil(@disabled_at), do: :success, else: :danger}>
+      {if is_nil(@disabled_at), do: "Active", else: "Disabled"}
+    </.status_badge>
+    """
   end
 end

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -16,7 +16,7 @@ defmodule PortalWeb.Resources do
       resource_details_panel: 1,
       resource_form_panel: 1,
       resource_online?: 2,
-      resource_status: 2,
+      resource_status_badge: 1,
       resource_type_label: 1,
       type_badge_class: 1,
       to_grant_form: 0
@@ -450,7 +450,7 @@ defmodule PortalWeb.Resources do
               </td>
               <td class="px-4 py-3 text-[var(--text-secondary)] text-xs">Internet</td>
               <td class="px-4 py-3">
-                <.status_badge status={resource_status(@internet_resource, @presence_tick)} />
+                <.resource_status_badge resource={@internet_resource} presence_tick={@presence_tick} />
               </td>
             </tr>
           </:prepend_rows>
@@ -534,7 +534,7 @@ defmodule PortalWeb.Resources do
             </span>
           </:col>
           <:col :let={resource} label="Status" class="w-32">
-            <.status_badge status={resource_status(resource, @presence_tick)} />
+            <.resource_status_badge resource={resource} presence_tick={@presence_tick} />
           </:col>
           <:empty>
             <div class="flex flex-col items-center gap-3 py-16">

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1031,21 +1031,24 @@ defmodule PortalWeb.Resources.Components do
 
     ~H"""
     <div class="flex flex-col h-full overflow-hidden">
-      <div class="shrink-0 px-5 pt-4 pb-3 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
-        <div class="flex items-start justify-between gap-3">
-          <div class="min-w-0">
-            <div class="flex items-center gap-2 flex-wrap">
-              <h2 class="text-sm font-semibold text-[var(--text-primary)]">{@resource.name}</h2>
-              <span class={type_badge_class(@resource.type)}>
-                {resource_type_label(@resource.type)}
-              </span>
+      <div class="shrink-0 px-5 py-4 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
+        <div class="flex items-center gap-4">
+          <%!-- Left: name + status + address --%>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">
+                {@resource.name}
+              </h2>
+              <.resource_status_badge resource={@resource} presence_tick={@presence_tick} />
             </div>
-            <div :if={@resource.type != :internet} class="flex items-center gap-1.5 mt-1">
-              <span class="font-mono text-xs text-[var(--text-secondary)]">
-                {@resource.address}
-              </span>
-            </div>
+            <p
+              :if={@resource.type != :internet}
+              class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5 truncate"
+            >
+              {@resource.address}
+            </p>
           </div>
+          <%!-- Right: actions --%>
           <div class="flex items-center gap-1.5 shrink-0">
             <button
               :if={not @confirm_delete_resource && @resource.type != :internet}
@@ -1061,34 +1064,6 @@ defmodule PortalWeb.Resources.Components do
             >
               <.icon name="ri-close-line" class="w-4 h-4" />
             </button>
-          </div>
-        </div>
-        <div class="flex items-center gap-5 mt-3 pt-3 border-t border-[var(--border)]">
-          <div class="flex items-center gap-1.5">
-            <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-              Status
-            </span>
-            <.status_badge status={resource_status(@resource, @presence_tick)} />
-          </div>
-          <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
-          <div class="flex items-center gap-1.5">
-            <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-              Site
-            </span>
-            <span class="text-xs font-semibold tabular-nums text-[var(--text-primary)]">
-              <%= if @resource.site do %>
-                <.link
-                  navigate={~p"/#{@account}/sites/#{@resource.site}"}
-                  class="text-xs underline font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-                >
-                  {@resource.site.name}
-                </.link>
-              <% else %>
-                <span class="text-xs italic text-[var(--text-muted)]">
-                  {nil_site_label(@resource)}
-                </span>
-              <% end %>
-            </span>
           </div>
         </div>
       </div>
@@ -1826,7 +1801,7 @@ defmodule PortalWeb.Resources.Components do
               <dd class="flex items-center gap-1.5 flex-wrap">
                 <.link
                   navigate={~p"/#{@account}/sites/#{@resource.site}"}
-                  class="text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                  class="text-xs underline font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
                 >
                   {@resource.site.name}
                 </.link>
@@ -1918,6 +1893,17 @@ defmodule PortalWeb.Resources.Components do
   @spec resource_status(map(), integer()) :: :online | :offline
   def resource_status(resource, presence_tick \\ 0) do
     if resource_online?(resource, presence_tick), do: :online, else: :offline
+  end
+
+  attr :resource, :any, required: true
+  attr :presence_tick, :integer, default: 0
+
+  def resource_status_badge(assigns) do
+    ~H"""
+    <.status_badge style={if resource_online?(@resource, @presence_tick), do: :success, else: :neutral}>
+      {if resource_online?(@resource, @presence_tick), do: "Online", else: "Offline"}
+    </.status_badge>
+    """
   end
 
   @spec resource_type_label(atom()) :: String.t()

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1899,9 +1899,11 @@ defmodule PortalWeb.Resources.Components do
   attr :presence_tick, :integer, default: 0
 
   def resource_status_badge(assigns) do
+    assigns = assign(assigns, :online?, resource_online?(assigns.resource, assigns.presence_tick))
+
     ~H"""
-    <.status_badge style={if resource_online?(@resource, @presence_tick), do: :success, else: :neutral}>
-      {if resource_online?(@resource, @presence_tick), do: "Online", else: "Offline"}
+    <.status_badge style={if @online?, do: :success, else: :neutral}>
+      {if @online?, do: "Online", else: "Offline"}
     </.status_badge>
     """
   end

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -626,7 +626,7 @@ defmodule PortalWeb.ServiceAccounts do
             </div>
           </:col>
           <:col :let={actor} label="status" class="w-32">
-            <.status_badge status={if is_nil(actor.disabled_at), do: :active, else: :disabled} />
+            <.actor_status_badge disabled_at={actor.disabled_at} />
           </:col>
           <:empty>
             <div class="flex flex-col items-center gap-3 py-16">

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -358,9 +358,7 @@ defmodule PortalWeb.Sites do
                   ]}>
                     Internet
                   </div>
-                  <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-violet-200/70 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-                    system
-                  </span>
+                  <.badge type="accent" size="xs">system</.badge>
                 </div>
                 <div class="font-mono text-[10px] text-[var(--text-tertiary)] mt-0.5">
                   {@internet_site.id}

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -369,8 +369,7 @@ defmodule PortalWeb.Sites do
               <td class="px-4 py-3">
                 <% online = gateway_online_count(@internet_site.id) %>
                 <span class="text-sm text-[var(--text-secondary)] tabular-nums">
-                  {online}<span class="text-[var(--text-tertiary)]">/{@internet_site.health_threshold}</span>
-                  <span class="ml-1.5 text-[10px] text-[var(--text-tertiary)]">online</span>
+                  {online}<span class="ml-1.5 text-[10px] text-[var(--text-tertiary)]">online</span>
                 </span>
               </td>
               <td class="px-4 py-3">
@@ -379,7 +378,7 @@ defmodule PortalWeb.Sites do
                 </span>
               </td>
               <td class="px-4 py-3">
-                <.status_badge status={
+                <.site_status_badge status={
                   compute_site_status(@internet_site.id, @internet_site.health_threshold)
                 } />
               </td>
@@ -413,8 +412,7 @@ defmodule PortalWeb.Sites do
               <td class="px-4 py-3">
                 <% online = gateway_online_count(site.id) %>
                 <span class="text-sm text-[var(--text-secondary)] tabular-nums">
-                  {online}<span class="text-[var(--text-tertiary)]">/{site.health_threshold}</span>
-                  <span class="ml-1.5 text-[10px] text-[var(--text-tertiary)]">online</span>
+                  {online}<span class="ml-1.5 text-[10px] text-[var(--text-tertiary)]">online</span>
                 </span>
               </td>
               <td class="px-4 py-3">
@@ -423,7 +421,7 @@ defmodule PortalWeb.Sites do
                 </span>
               </td>
               <td class="px-4 py-3">
-                <.status_badge status={compute_site_status(site.id, site.health_threshold)} />
+                <.site_status_badge status={compute_site_status(site.id, site.health_threshold)} />
               </td>
             </tr>
           </tbody>

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -112,12 +112,10 @@ defmodule PortalWeb.Sites.Components do
     assigns =
       if assigns.site do
         assigns
-        |> assign(:online_count, Enum.count(assigns.gateways, & &1.online?))
         |> assign(:total_count, Map.get(assigns.gateway_counts, assigns.site.id, 0))
         |> assign(:status, site_status(assigns.gateways, assigns.site.health_threshold))
       else
         assigns
-        |> assign(:online_count, 0)
         |> assign(:total_count, 0)
         |> assign(:status, :offline)
       end
@@ -139,8 +137,6 @@ defmodule PortalWeb.Sites.Components do
           site={@site}
           view={@view}
           status={@status}
-          online_count={@online_count}
-          resource_count={Map.get(@resources_counts, @site.id, 0)}
         />
 
         <.site_overview_view
@@ -180,21 +176,20 @@ defmodule PortalWeb.Sites.Components do
   attr :site, :any, required: true
   attr :view, :atom, required: true
   attr :status, :atom, required: true
-  attr :online_count, :integer, required: true
-  attr :resource_count, :integer, required: true
 
   def site_panel_header(assigns) do
     ~H"""
-    <div class="shrink-0 px-5 pt-4 pb-3 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
-      <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0">
-          <div class="flex items-center gap-2 flex-wrap">
-            <h2 class="text-sm font-semibold text-[var(--text-primary)]">{@site.name}</h2>
+    <div class="shrink-0 px-5 py-4 border-b border-[var(--border)] bg-[var(--surface-overlay)]">
+      <div class="flex items-center gap-4">
+        <%!-- Left: name + status + ID --%>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">{@site.name}</h2>
+            <.site_status_badge status={@status} />
           </div>
-          <p :if={@site.managed_by == :system} class="text-xs text-[var(--text-tertiary)] mt-0.5">
-            system managed
-          </p>
+          <p class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5 truncate">{@site.id}</p>
         </div>
+        <%!-- Right: actions --%>
         <div class="flex items-center gap-1.5 shrink-0">
           <button
             :if={@view == :gateways}
@@ -210,24 +205,6 @@ defmodule PortalWeb.Sites.Components do
           >
             <.icon name="ri-close-line" class="w-4 h-4" />
           </button>
-        </div>
-      </div>
-      <div class="flex items-center gap-5 mt-3 pt-3 border-t border-[var(--border)]">
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            Status
-          </span>
-          <.status_badge status={@status} />
-        </div>
-        <div class="w-px h-3.5 bg-[var(--border-strong)]"></div>
-        <div class="flex items-center gap-1.5">
-          <span class="text-[10px] font-semibold tracking-widest uppercase text-[var(--text-tertiary)]">
-            Gateways
-          </span>
-          <span class="text-xs font-semibold tabular-nums text-[var(--text-secondary)]">
-            {@online_count}<span class="text-[var(--text-tertiary)] font-normal"> online / </span>
-            {@site.health_threshold} <span class="text-[var(--text-tertiary)] font-normal"> required</span>
-          </span>
         </div>
       </div>
     </div>
@@ -1413,6 +1390,20 @@ defmodule PortalWeb.Sites.Components do
     </div>
     """
   end
+
+  attr :status, :atom, required: true, values: [:healthy, :degraded, :offline]
+
+  def site_status_badge(assigns) do
+    ~H"""
+    <.status_badge style={site_badge_style(@status)}>
+      {Phoenix.Naming.humanize(@status)}
+    </.status_badge>
+    """
+  end
+
+  defp site_badge_style(:healthy), do: :success
+  defp site_badge_style(:degraded), do: :warning
+  defp site_badge_style(:offline), do: :neutral
 
   defp site_status(gateways, threshold) do
     online_count = Enum.count(gateways, & &1.online?)

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -185,6 +185,7 @@ defmodule PortalWeb.Sites.Components do
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
             <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">{@site.name}</h2>
+            <.badge :if={@site.managed_by == :system} type="accent" size="xs">system</.badge>
             <.site_status_badge status={@status} />
           </div>
           <p class="font-mono text-xs text-[var(--text-tertiary)] mt-0.5 truncate">{@site.id}</p>

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -436,7 +436,7 @@ defmodule PortalWeb.ResourcesTest do
         |> live(~p"/#{account}/resources/#{resource.id}")
 
       assert html =~ resource.name
-      assert count_occurrences(html, "No Site Associated") == 3
+      assert count_occurrences(html, "No Site Associated") == 2
       refute html =~ "No Site Needed"
     end
 
@@ -453,7 +453,7 @@ defmodule PortalWeb.ResourcesTest do
         |> live(~p"/#{account}/resources/#{resource.id}")
 
       assert html =~ resource.name
-      assert count_occurrences(html, "No Site Needed") == 3
+      assert count_occurrences(html, "No Site Needed") == 2
       refute html =~ "No Site Associated"
     end
 

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -377,7 +377,7 @@ defmodule PortalWeb.SitesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/sites/#{site.id}")
 
-      assert html =~ "system managed"
+      assert html =~ "system"
       refute html =~ "Delete site"
       refute html =~ "Add resource"
     end

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -372,14 +372,14 @@ defmodule PortalWeb.SitesTest do
     } do
       site = system_site_fixture(%{account: account, name: "Internet"})
 
-      {:ok, _lv, html} =
+      {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
         |> live(~p"/#{account}/sites/#{site.id}")
 
-      assert html =~ "system"
-      refute html =~ "Delete site"
-      refute html =~ "Add resource"
+      assert has_element?(lv, "span.whitespace-nowrap", "system")
+      refute has_element?(lv, "button", "Delete site")
+      refute has_element?(lv, "button", "Add resource")
     end
   end
 


### PR DESCRIPTION
We've received feedback that the 'show panel' header was sometimes making people think there were clickable tabs where there weren't any.  This PR updates all of the show panel headers to be consistent and removes the "second row" from the headers.

This PR also removes the health threshold number from the Sites index page and now only shows the number of `online` gateways, as well as an `:healthy`, `:degraded`, or `:offline` status badge.

Finally there is also a couple small refactors to the `badge` and `status_badge` components.

Fixes: #13583 #13532

## Screenshots

### Resources
#### Before
<img width="1132" height="582" alt="Screenshot 2026-06-05 at 11 58 15 AM" src="https://github.com/user-attachments/assets/a9d80353-afcf-4fbb-beb4-a948ceec7479" />

#### After
<img width="1131" height="544" alt="Screenshot 2026-06-05 at 12 00 13 PM" src="https://github.com/user-attachments/assets/91b558bc-adcd-4c94-83de-0bde07cbb2dc" />

### Policies
#### Before
<img width="1132" height="500" alt="Screenshot 2026-06-05 at 11 58 42 AM" src="https://github.com/user-attachments/assets/9490481c-5888-4077-b293-829875216c01" />

#### After
<img width="1130" height="450" alt="Screenshot 2026-06-05 at 12 00 30 PM" src="https://github.com/user-attachments/assets/89d93e34-b834-4de4-9b3f-10c13a275a1b" />

### Sites
#### Before
<img width="1130" height="396" alt="Screenshot 2026-06-05 at 11 59 03 AM" src="https://github.com/user-attachments/assets/0bfc6c20-9d43-4572-9d4b-d6cd2e03554a" />

#### After
<img width="1129" height="369" alt="Screenshot 2026-06-05 at 12 00 41 PM" src="https://github.com/user-attachments/assets/7b2f3b86-c302-42b3-8737-dc015b8e92ac" />

### Clients
### Before
<img width="1129" height="428" alt="Screenshot 2026-06-05 at 11 59 20 AM" src="https://github.com/user-attachments/assets/86e2c4ce-5bb9-480e-848b-28b218911e7a" />

#### After
<img width="1131" height="436" alt="Screenshot 2026-06-05 at 12 00 54 PM" src="https://github.com/user-attachments/assets/7844a222-c360-4694-b6dc-ab2cf3791c77" />

### Actors
#### Before
<img width="1132" height="462" alt="Screenshot 2026-06-05 at 11 59 32 AM" src="https://github.com/user-attachments/assets/5c18b640-79bc-4184-ad90-91462c1d2215" />

#### After
<img width="1129" height="424" alt="Screenshot 2026-06-05 at 12 01 08 PM" src="https://github.com/user-attachments/assets/f0708b1d-9a87-42f4-a54c-d9177bd64db4" />

### Service Accounts
#### Before
<img width="1130" height="356" alt="Screenshot 2026-06-05 at 11 59 42 AM" src="https://github.com/user-attachments/assets/59677b16-ea4b-448c-8c20-2d749f3c3f80" />

#### After
<img width="1130" height="501" alt="Screenshot 2026-06-05 at 12 01 21 PM" src="https://github.com/user-attachments/assets/27bb9234-4f06-47eb-84f9-f13ad40ecacd" />
