### PR TITLE
perf(socket-factory): spin instead of sleeping on ENOBUFS

### DIFF
--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -14,7 +14,7 @@ ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
-tokio = { workspace = true, features = ["net", "time"] }
+tokio = { workspace = true, features = ["net", "rt"] }
 tracing = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -404,13 +404,7 @@ impl PerfUdpSocket {
                 .await
             {
                 Ok(()) => {
-                    self.batch_histogram.record(
-                        (contents.len() / segment_size) as u64,
-                        &[
-                            KeyValue::new("network.transport", "udp"),
-                            KeyValue::new("network.io.direction", "transmit"),
-                        ],
-                    );
+                    self.record_send_batch_size(contents.len() / segment_size);
                     self.record_send_retries(attempt);
 
                     offset = end;
@@ -434,6 +428,17 @@ impl PerfUdpSocket {
         }
 
         Ok(())
+    }
+
+    /// Records the number of segments sent in a single batched syscall.
+    fn record_send_batch_size(&self, num_segments: usize) {
+        self.batch_histogram.record(
+            num_segments as u64,
+            &[
+                KeyValue::new("network.transport", "udp"),
+                KeyValue::new("network.io.direction", "transmit"),
+            ],
+        );
     }
 
     /// Records how many times a single batch had to be retried before it went through or was dropped.

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, ErrorExt, Result};
+use anyhow::{Context as _, Result};
 use bufferpool::{Buffer, BufferPool};
 use bytes::{Buf as _, BytesMut};
 use gat_lending_iterator::LendingIterator;
@@ -8,7 +8,6 @@ use quinn_udp::{EcnCodepoint, Transmit, UdpSockRef};
 use std::io;
 use std::io::IoSliceMut;
 use std::ops::Deref;
-use std::time::Duration;
 use std::{
     net::{IpAddr, SocketAddr},
     task::{Context, Poll},
@@ -28,8 +27,13 @@ pub const RECV_BUFFER_SIZE: usize = 128 * ONE_MB;
 const ONE_MB: usize = 1024 * 1024;
 
 /// How many times we at most try to re-send a packet if we encounter ENOBUFS on MacOS / iOS or 10055 on Windows.
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows", test))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
 const MAX_ENOBUFS_RETRIES: u32 = 24;
+
+/// Upper bound (as a power of two) for how many times we busy-spin between send retries.
+///
+/// `2^6 = 64` iterations of [`std::hint::spin_loop`] stay well below a microsecond.
+const SPIN_LIMIT: u32 = 6;
 
 /// The Windows equivalent of ENOBUFS.
 ///
@@ -176,6 +180,7 @@ pub struct PerfUdpSocket {
     buffer_pool: BufferPool<Vec<u8>>,
 
     batch_histogram: opentelemetry::metrics::Histogram<u64>,
+    send_retry_histogram: opentelemetry::metrics::Histogram<u64>,
     source_ip_resolver:
         Option<Box<dyn Fn(IpAddr) -> std::io::Result<IpAddr> + Send + Sync + 'static>>,
     port: u16,
@@ -223,6 +228,14 @@ impl UdpSocket {
                 )
                 .with_unit("{batches}")
                 .with_boundaries((1..32_u64).map(|i| i as f64).collect())
+                .build(),
+            send_retry_histogram: opentelemetry::global::meter("connlib")
+                .u64_histogram("system.network.send_retries")
+                .with_description(
+                    "How many times a UDP send was retried (spun) after a transient ENOBUFS-style error before it succeeded or was dropped.",
+                )
+                .with_unit("{retry}")
+                .with_boundaries(vec![1.0, 2.0, 4.0, 8.0, 16.0, 24.0])
                 .build(),
             source_ip_resolver: self.source_ip_resolver,
             port: self.port,
@@ -318,22 +331,7 @@ impl PerfUdpSocket {
             datagram.ecn,
         )?;
 
-        let mut attempt = 0;
-
-        loop {
-            match self.send_transmit(&transmit).await {
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    let backoff = backoff(&e, attempt).ok_or(e)?; // Attempt to get a backoff value or otherwise bail with error.
-
-                    tracing::debug!(?backoff, dst = %datagram.dst, len = %datagram.packet.len(), "Retrying packet");
-
-                    tokio::time::sleep(backoff).await;
-                }
-            }
-
-            attempt += 1;
-        }
+        self.send_transmit(&transmit).await
     }
 
     pub fn set_buffer_sizes(
@@ -361,45 +359,88 @@ impl PerfUdpSocket {
         let src = transmit.src_ip;
         let dst = transmit.destination;
 
-        let chunk_size = self.calculate_chunk_size(segment_size, dst);
-        let num_batches = transmit.contents.len() / chunk_size;
+        let total = transmit.contents.len();
 
-        for (idx, chunk) in transmit
-            .contents
-            .chunks(chunk_size)
-            .map(|contents| Transmit {
+        // Offset of the next byte that still needs to be sent. On a retryable error
+        // we resume from here instead of restarting the whole transmit, so a batch
+        // the kernel already accepted is never re-sent.
+        let mut offset = 0;
+        let mut attempt = 0;
+
+        while offset < total {
+            // Recompute every iteration: an `EIO` makes `quinn-udp` disable GSO, so
+            // the remaining data needs to be re-split into smaller batches.
+            let chunk_size = self.calculate_chunk_size(segment_size, dst);
+            let end = std::cmp::min(offset + chunk_size, total);
+            let contents = &transmit.contents[offset..end];
+
+            let chunk = Transmit {
                 destination: dst,
                 ecn: transmit.ecn,
                 contents,
                 segment_size: Some(segment_size),
                 src_ip: src,
-            })
-            .enumerate()
-        {
-            let num_bytes = chunk.contents.len();
-            let batch_num = idx + 1;
+            };
 
             #[cfg(debug_assertions)]
-            tracing::trace!(target: "wire::net::send", ?src, %dst, ecn = ?chunk.ecn, num_packets = %(num_bytes / segment_size), %segment_size);
+            tracing::trace!(target: "wire::net::send", ?src, %dst, ecn = ?chunk.ecn, num_packets = %(contents.len() / segment_size), %segment_size);
 
-            let batch_size =
-                chunk.contents.len() / chunk.segment_size.unwrap_or(chunk.contents.len());
-
-            self.batch_histogram.record(
-                batch_size as u64,
-                &[
-                    KeyValue::new("network.transport", "udp"),
-                    KeyValue::new("network.io.direction", "transmit"),
-                ],
-            );
-
-            self.inner
-                .async_io(Interest::WRITABLE, || self.state.try_send((&self.inner).into(), &chunk))
+            match self
+                .inner
+                .async_io(Interest::WRITABLE, || {
+                    self.state.try_send((&self.inner).into(), &chunk)
+                })
                 .await
-                .with_context(|| format!("Failed to send datagram-batch {batch_num}/{num_batches} with segment_size {segment_size} and total length {num_bytes} to {dst}"))?;
+            {
+                Ok(()) => {
+                    self.batch_histogram.record(
+                        (contents.len() / segment_size) as u64,
+                        &[
+                            KeyValue::new("network.transport", "udp"),
+                            KeyValue::new("network.io.direction", "transmit"),
+                        ],
+                    );
+                    self.record_send_retries(attempt);
+
+                    offset = end;
+                    attempt = 0; // Each batch gets its own retry budget.
+                }
+                Err(e) => {
+                    if !should_retry(&e, attempt) {
+                        self.record_send_retries(attempt);
+
+                        return Err(e).with_context(|| {
+                            format!(
+                                "Failed to send {} bytes at offset {offset}/{total} with segment_size {segment_size} to {dst}",
+                                contents.len()
+                            )
+                        });
+                    }
+
+                    spin_and_yield(attempt).await;
+                    attempt += 1;
+                }
+            }
         }
 
         Ok(())
+    }
+
+    /// Records how many times a single batch had to be retried before it went through or was dropped.
+    ///
+    /// Batches that succeed on the first try (the common case) are not recorded, keeping the hot path cheap.
+    fn record_send_retries(&self, attempt: u32) {
+        if attempt == 0 {
+            return;
+        }
+
+        self.send_retry_histogram.record(
+            attempt as u64,
+            &[
+                KeyValue::new("network.transport", "udp"),
+                KeyValue::new("network.io.direction", "transmit"),
+            ],
+        );
     }
 
     /// Calculate the chunk size for a given segment size.
@@ -521,41 +562,51 @@ fn is_equal_modulo_scope_for_ipv6_link_local(expected: SocketAddr, actual: Socke
     }
 }
 
-fn backoff(e: &anyhow::Error, attempts: u32) -> Option<Duration> {
-    let raw_os_error = e.any_downcast_ref::<io::Error>()?.raw_os_error()?;
+/// Whether a failed send should be retried for the given attempt.
+///
+/// `ENOBUFS` (MacOS / iOS) and its Windows equivalent (10055) are transient, local
+/// conditions that clear once the network interface drains its queue. That drain
+/// happens off this thread (driver / NIC), usually within microseconds, and is not
+/// observable via write-readiness, so we retry rather than suspend.
+///
+/// On Linux / Android, `EIO` means `quinn-udp` just disabled GSO; we retry once to
+/// re-send the data split into smaller batches.
+fn should_retry(e: &io::Error, attempt: u32) -> bool {
+    let Some(raw_os_error) = e.raw_os_error() else {
+        return false;
+    };
 
-    // On Linux and Android, we retry sending once for os error 5.
-    //
-    // quinn-udp disables GSO for those but cannot automatically re-send them because we need to split the datagram differently.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    if raw_os_error == libc::EIO && attempts < 1 {
-        return Some(Duration::ZERO);
+    if raw_os_error == libc::EIO && attempt < 1 {
+        return true;
     }
 
-    // On MacOS, the kernel may return ENOBUFS if the buffer fills up.
-    //
-    // Ideally, we would be able to suspend here but MacOS doesn't support that.
-    // Thus, we do the next best thing and retry.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    if raw_os_error == libc::ENOBUFS && attempts < MAX_ENOBUFS_RETRIES {
-        return Some(exp_delay(attempts));
+    if raw_os_error == libc::ENOBUFS && attempt < MAX_ENOBUFS_RETRIES {
+        return true;
     }
 
-    // On Windows, we may sometimes encounter error 10055.
-    //
-    // Ideally, we would be able to suspend here but it is unclear how to achieve that.
-    // Thus, we do the next best thing and retry.
     #[cfg(target_os = "windows")]
-    if raw_os_error == WINDOWS_ENOBUFS && attempts < MAX_ENOBUFS_RETRIES {
-        return Some(exp_delay(attempts));
+    if raw_os_error == WINDOWS_ENOBUFS && attempt < MAX_ENOBUFS_RETRIES {
+        return true;
     }
 
-    None
+    false
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows", test))]
-fn exp_delay(attempts: u32) -> Duration {
-    Duration::from_nanos(2_u64.pow(attempts))
+/// Briefly back off after a retryable send error before trying again.
+///
+/// We avoid `tokio::time::sleep`: its timer wheel rounds up to ~1ms (~15ms on
+/// Windows), far longer than the microseconds an `ENOBUFS` needs to clear. Instead
+/// we spin a few (escalating) times and then cooperatively yield. The yield matters:
+/// send and receive share a single-threaded runtime, so a pure spin would starve the
+/// receive task.
+async fn spin_and_yield(attempt: u32) {
+    for _ in 0..(1u32 << attempt.min(SPIN_LIMIT)) {
+        std::hint::spin_loop();
+    }
+
+    tokio::task::yield_now().await;
 }
 
 /// An iterator that segments an array of buffers into individual datagrams.
@@ -763,46 +814,34 @@ mod tests {
     }
 
     #[test]
-    fn max_enobufs_delay() {
-        assert_eq!(
-            exp_delay(MAX_ENOBUFS_RETRIES),
-            Duration::from_nanos(16_777_216) // ~16ms
-        )
+    fn does_not_retry_non_os_errors() {
+        let err = io::Error::other("not an os error");
+
+        assert!(!should_retry(&err, 0));
     }
 
     #[test]
     #[cfg(target_os = "linux")]
-    fn immediate_retry_of_os_error_5() {
-        let err = anyhow::Error::new(io::Error::from_raw_os_error(libc::EIO));
+    fn retries_os_error_5_once() {
+        let err = io::Error::from_raw_os_error(libc::EIO);
 
-        let backoff = backoff(&err, 0);
-
-        assert_eq!(backoff.unwrap(), Duration::ZERO);
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn only_one_retry_of_os_error_5() {
-        let err = anyhow::Error::new(io::Error::from_raw_os_error(libc::EIO));
-
-        let backoff = backoff(&err, 1);
-
-        assert!(backoff.is_none());
+        assert!(should_retry(&err, 0));
+        assert!(!should_retry(&err, 1));
     }
 
     #[test]
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    fn at_most_24_retries_of_enobufs() {
-        let err = anyhow::Error::new(io::Error::from_raw_os_error(libc::ENOBUFS));
+    fn retries_enobufs_at_most_24_times() {
+        let err = io::Error::from_raw_os_error(libc::ENOBUFS);
 
-        assert!(backoff(&err, 23).is_some());
-        assert!(backoff(&err, 24).is_none());
+        assert!(should_retry(&err, 23));
+        assert!(!should_retry(&err, 24));
     }
 
     #[test]
     #[cfg(target_os = "windows")]
     fn windows_10055_error() {
-        let err = anyhow::Error::new(io::Error::from_raw_os_error(WINDOWS_ENOBUFS));
+        let err = io::Error::from_raw_os_error(WINDOWS_ENOBUFS);
 
         assert_eq!(
             err.to_string(),

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -230,7 +230,7 @@ impl UdpSocket {
                 .with_boundaries((1..32_u64).map(|i| i as f64).collect())
                 .build(),
             send_retry_histogram: opentelemetry::global::meter("connlib")
-                .u64_histogram("system.network.send_retries")
+                .u64_histogram("system.network.retries")
                 .with_description(
                     "How many times a UDP send was retried (spun) after a transient ENOBUFS-style error before it succeeded or was dropped.",
                 )

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -372,15 +372,7 @@ impl PerfUdpSocket {
         while offset < total {
             // Recompute every iteration: an `EIO` makes `quinn-udp` disable GSO, so
             // the remaining data needs to be re-split into smaller batches.
-            let chunk_size = self.calculate_chunk_size(segment_size, dst);
-
-            // A `segment_size` larger than the maximum UDP payload makes `chunk_size` 0,
-            // which can't be sent and would stall this loop with zero-progress iterations.
-            if chunk_size == 0 {
-                anyhow::bail!(
-                    "Cannot send to {dst}: segment_size {segment_size} exceeds the maximum UDP payload"
-                );
-            }
+            let chunk_size = self.calculate_chunk_size(segment_size, dst)?;
 
             let end = std::cmp::min(offset + chunk_size, total);
             let contents = &transmit.contents[offset..end];
@@ -465,7 +457,9 @@ impl PerfUdpSocket {
     ///
     /// In case GSO is not supported at all by the kernel, `quinn_udp` will detect this and set `max_gso_segments` to 1.
     /// We need to honor both of these constraints when calculating the chunk size.
-    fn calculate_chunk_size(&self, segment_size: usize, dst: SocketAddr) -> usize {
+    ///
+    /// Fails if `segment_size` exceeds the maximum UDP payload, in which case not even a single segment fits.
+    fn calculate_chunk_size(&self, segment_size: usize, dst: SocketAddr) -> Result<usize> {
         let header_overhead = match dst {
             SocketAddr::V4(_) => Ipv4Header::MAX_LEN + UdpHeader::LEN,
             SocketAddr::V6(_) => Ipv6Header::LEN + UdpHeader::LEN,
@@ -476,7 +470,12 @@ impl PerfUdpSocket {
 
         let max_segments = std::cmp::min(max_segments_by_config, max_segments_by_size);
 
-        segment_size * max_segments
+        anyhow::ensure!(
+            max_segments > 0,
+            "segment_size {segment_size} exceeds the maximum UDP payload for {dst}"
+        );
+
+        Ok(segment_size * max_segments)
     }
 
     fn prepare_transmit<'a>(

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -331,7 +331,9 @@ impl PerfUdpSocket {
             datagram.ecn,
         )?;
 
-        self.send_transmit(&transmit).await
+        self.send_transmit(&transmit).await?;
+
+        Ok(())
     }
 
     pub fn set_buffer_sizes(
@@ -371,6 +373,15 @@ impl PerfUdpSocket {
             // Recompute every iteration: an `EIO` makes `quinn-udp` disable GSO, so
             // the remaining data needs to be re-split into smaller batches.
             let chunk_size = self.calculate_chunk_size(segment_size, dst);
+
+            // A `segment_size` larger than the maximum UDP payload makes `chunk_size` 0,
+            // which can't be sent and would stall this loop with zero-progress iterations.
+            if chunk_size == 0 {
+                anyhow::bail!(
+                    "Cannot send to {dst}: segment_size {segment_size} exceeds the maximum UDP payload"
+                );
+            }
+
             let end = std::cmp::min(offset + chunk_size, total);
             let contents = &transmit.contents[offset..end];
 
@@ -405,20 +416,19 @@ impl PerfUdpSocket {
                     offset = end;
                     attempt = 0; // Each batch gets its own retry budget.
                 }
-                Err(e) => {
-                    if !should_retry(&e, attempt) {
-                        self.record_send_retries(attempt);
-
-                        return Err(e).with_context(|| {
-                            format!(
-                                "Failed to send {} bytes at offset {offset}/{total} with segment_size {segment_size} to {dst}",
-                                contents.len()
-                            )
-                        });
-                    }
-
+                Err(e) if should_retry(&e, attempt) => {
                     spin_and_yield(attempt).await;
                     attempt += 1;
+                }
+                Err(e) => {
+                    self.record_send_retries(attempt);
+
+                    return Err(e).with_context(|| {
+                        format!(
+                            "Failed to send {} bytes at offset {offset}/{total} with segment_size {segment_size} to {dst}",
+                            contents.len()
+                        )
+                    });
                 }
             }
         }

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -235,7 +235,7 @@ impl UdpSocket {
                     "How many times a UDP send was retried (spun) after a transient ENOBUFS-style error before it succeeded or was dropped.",
                 )
                 .with_unit("{retry}")
-                .with_boundaries(vec![1.0, 2.0, 4.0, 8.0, 16.0, 24.0])
+                .with_boundaries((1..=24_u64).map(|i| i as f64).collect())
                 .build(),
             source_ip_resolver: self.source_ip_resolver,
             port: self.port,

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -577,29 +577,27 @@ fn is_equal_modulo_scope_for_ipv6_link_local(expected: SocketAddr, actual: Socke
 }
 
 /// Whether a failed send should be retried for the given attempt.
-///
-/// `ENOBUFS` (MacOS / iOS) and its Windows equivalent (10055) are transient, local
-/// conditions that clear once the network interface drains its queue. That drain
-/// happens off this thread (driver / NIC), usually within microseconds, and is not
-/// observable via write-readiness, so we retry rather than suspend.
-///
-/// On Linux / Android, `EIO` means `quinn-udp` just disabled GSO; we retry once to
-/// re-send the data split into smaller batches.
 fn should_retry(e: &io::Error, attempt: u32) -> bool {
     let Some(raw_os_error) = e.raw_os_error() else {
         return false;
     };
 
+    // On Linux / Android, `EIO` means `quinn-udp` just disabled GSO; we retry once to
+    // re-send the data split into smaller batches.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     if raw_os_error == libc::EIO && attempt < 1 {
         return true;
     }
 
+    // On MacOS / iOS, the kernel returns `ENOBUFS` when the interface queue fills up.
+    // It's transient and clears off this thread (driver / NIC), and isn't observable
+    // via write-readiness, so we retry rather than suspend.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     if raw_os_error == libc::ENOBUFS && attempt < MAX_ENOBUFS_RETRIES {
         return true;
     }
 
+    // On Windows, error 10055 is the equivalent of `ENOBUFS`; same transient condition.
     #[cfg(target_os = "windows")]
     if raw_os_error == WINDOWS_ENOBUFS && attempt < MAX_ENOBUFS_RETRIES {
         return true;


### PR DESCRIPTION
The UDP send path backs off with `tokio::time::sleep` after a transient `ENOBUFS` (macOS/iOS) or `WSAENOBUFS`/`10055` (Windows). Tokio's timer wheel can't represent sub-millisecond delays — and rounds up to ~15 ms on stock Windows — so a condition that clears in microseconds (the interface queue draining off-thread, which isn't observable via write-readiness) costs at least a full timer tick of latency and head-of-line blocking per retry.

We now back off with a bounded, escalating busy-spin followed by a cooperative yield instead. The yield matters because each socket drives its send and receive tasks on a shared single-threaded runtime, so a pure spin would starve the receiver.

This also fixes a latent bug: a retry used to restart the whole transmit, so an `ENOBUFS` partway through a multi-batch GSO send re-sent batches the kernel had already accepted. Retries now resume from the unsent offset.

Finally, a `system.network.retries` histogram is added so the retry budget can be tuned from real data rather than guesswork.