### PR TITLE
chore(portal): fix codespell typo in version test

### DIFF
--- a/elixir/test/portal/version_test.exs
+++ b/elixir/test/portal/version_test.exs
@@ -39,7 +39,7 @@ defmodule Portal.VersionTest do
                {:ok, "1.4.5"}
     end
 
-    test "returns error for an unparseable user agent" do
+    test "returns error for an unparsable user agent" do
       assert Portal.Version.fetch_version("not a user agent") == {:error, :invalid_user_agent}
     end
 


### PR DESCRIPTION
`codespell` runs with `--all-files` in the `global-linter` check and flags `unparseable` in `version_test.exs`, turning the check red on every branch. Correct it to `unparsable`.