### PR TITLE
fix(connlib/apple): surface ENOBUFS with connected sockets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -1800,7 +1800,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2102,7 +2102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3951,7 +3951,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4322,7 +4322,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4513,7 +4513,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.6.0"
-source = "git+https://github.com/quinn-rs/quinn?branch=main#8acb578f10b02986050bc600e629f56f40162266"
+version = "0.6.1"
+source = "git+https://github.com/firezone/quinn?branch=fix%2Fapple-sendmsg-x-partial-send#0cc05e744c8aa24bfce88e341d3f55589181971a"
 dependencies = [
  "cfg_aliases",
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5992,7 +5992,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6049,7 +6049,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6745,7 +6745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7522,7 +7522,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8154,7 +8154,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9021,7 +9021,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9565,7 +9565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -261,7 +261,7 @@ boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
-quinn-udp = { git = "https://github.com/quinn-rs/quinn", version = "0.6.0", branch = "main" } # Waiting for release.
+quinn-udp = { git = "https://github.com/firezone/quinn", version = "0.6.0", branch = "fix/apple-sendmsg-x-partial-send" } # Fork: drain full batch on partial `sendmsg_x` (Apple). Upstream PR pending.
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 rtnetlink = { git = "https://github.com/rust-netlink/rtnetlink", branch = "main" } # Waiting for release.

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -14,7 +14,7 @@ ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
-tokio = { workspace = true, features = ["net", "time"] }
+tokio = { workspace = true, features = ["net", "rt", "time"] }
 tracing = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -31,6 +31,16 @@ const ONE_MB: usize = 1024 * 1024;
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows", test))]
 const MAX_ENOBUFS_RETRIES: u32 = 24;
 
+/// How many times we yield-and-retry a *connected*-socket send that returns `ENOBUFS` before
+/// giving up on the datagram.
+///
+/// On Apple, `ENOBUFS` from a connected socket means the *interface output queue* is momentarily
+/// full (not the socket buffer). Yielding lets it drain and we retry, which paces us to the link
+/// instead of stalling on a writable edge that tracks the socket buffer. Generous on purpose: real
+/// back-pressure (the bounded outbound channel slowing the TUN reader) engages long before this, so
+/// reaching the bound means the interface is wedged.
+const MAX_ENOBUFS_YIELDS: u32 = 1000;
+
 /// The Windows equivalent of ENOBUFS.
 ///
 /// "An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full. (os error 10055)"
@@ -66,6 +76,15 @@ pub fn udp(std_addr: SocketAddr) -> io::Result<UdpSocket> {
     let addr = socket2::SockAddr::from(std_addr);
     let socket = socket2::Socket::new(addr.domain(), socket2::Type::DGRAM, None)?;
 
+    // On Apple, the recv-only data-plane listener and the connected sockets (see `udp_connected`)
+    // share a single local port via `SO_REUSEADDR`/`SO_REUSEPORT`, so the listener needs the flags
+    // too. Other UDP sockets bind ephemeral ports, where the flags are harmless.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+    }
+
     // Note: for AF_INET sockets IPV6_V6ONLY is not a valid flag
     if addr.is_ipv6() {
         socket.set_only_v6(true)?;
@@ -77,6 +96,37 @@ pub fn udp(std_addr: SocketAddr) -> io::Result<UdpSocket> {
     let socket = std::net::UdpSocket::from(socket);
     let socket = tokio::net::UdpSocket::try_from(socket)?;
     let socket = UdpSocket::new(socket)?;
+
+    Ok(socket)
+}
+
+/// Creates a UDP socket that is `bind`ed to `bind` and `connect`ed to `dst`.
+///
+/// On Apple platforms, unconnected UDP sockets cannot use the batched `sendmsg_x` datapath and
+/// don't surface `ENOBUFS` for back-pressure, so all sending happens over connected sockets.
+/// `SO_REUSEADDR`/`SO_REUSEPORT` let many such sockets (and the recv-only listener) share the
+/// same local port, which is required to keep our ICE candidates reachable.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn udp_connected(bind: SocketAddr, dst: SocketAddr) -> io::Result<UdpSocket> {
+    let bind_addr = socket2::SockAddr::from(bind);
+    let socket = socket2::Socket::new(bind_addr.domain(), socket2::Type::DGRAM, None)?;
+
+    socket.set_reuse_address(true)?;
+    socket.set_reuse_port(true)?;
+
+    // Note: for AF_INET sockets IPV6_V6ONLY is not a valid flag
+    if bind_addr.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+
+    socket.set_nonblocking(true)?;
+    socket.bind(&bind_addr)?;
+    socket.connect(&socket2::SockAddr::from(dst))?;
+
+    let socket = std::net::UdpSocket::from(socket);
+    let socket = tokio::net::UdpSocket::try_from(socket)?;
+    let mut socket = UdpSocket::new(socket)?;
+    socket.connected = Some(dst);
 
     Ok(socket)
 }
@@ -165,6 +215,11 @@ pub struct UdpSocket {
     source_ip_resolver:
         Option<Box<dyn Fn(IpAddr) -> std::io::Result<IpAddr> + Send + Sync + 'static>>,
     port: u16,
+    /// The remote this socket is `connect`ed to, if any.
+    ///
+    /// Only set for sockets created via [`udp_connected`]. A connected socket sends to (and
+    /// receives from) exactly this peer; the source address is pinned by `bind`/`connect`.
+    connected: Option<SocketAddr>,
 }
 
 /// A UDP socket with performance optimisations for fast send & receive.
@@ -179,6 +234,10 @@ pub struct PerfUdpSocket {
     source_ip_resolver:
         Option<Box<dyn Fn(IpAddr) -> std::io::Result<IpAddr> + Send + Sync + 'static>>,
     port: u16,
+    /// The remote this socket is `connect`ed to, if any (see [`udp_connected`]).
+    connected: Option<SocketAddr>,
+    /// The local address this socket is bound to.
+    local: SocketAddr,
 }
 
 impl UdpSocket {
@@ -190,12 +249,14 @@ impl UdpSocket {
             port,
             inner,
             source_ip_resolver: None,
+            connected: None,
         })
     }
 
     /// Upgrade this [`UdpSocket`] to a [`PerfUdpSocket`] for optimized IO.
     pub fn into_perf(self) -> io::Result<PerfUdpSocket> {
         let socket_addr = self.inner.local_addr()?;
+        let local = socket_addr;
 
         let quinn_ref = quinn_udp::UdpSockRef::from(&self.inner);
         let quinn_state = quinn_udp::UdpSocketState::new(quinn_ref)?;
@@ -226,6 +287,8 @@ impl UdpSocket {
                 .build(),
             source_ip_resolver: self.source_ip_resolver,
             port: self.port,
+            connected: self.connected,
+            local,
         })
     }
 
@@ -306,17 +369,37 @@ impl PerfUdpSocket {
             ],
         );
 
-        Ok(DatagramSegmentIter::new(bufs, meta, self.port, len))
+        Ok(match self.connected {
+            // A connected socket only ever receives from its peer, and may not populate the
+            // `dst_ip` control message. Use the known peer/local addresses directly.
+            Some(peer) => DatagramSegmentIter::new_connected(bufs, meta, len, self.local, peer),
+            None => DatagramSegmentIter::new(bufs, meta, self.port, len),
+        })
     }
 
     pub async fn send(&self, datagram: DatagramOut) -> Result<()> {
+        // For connected sockets the source address is pinned by `bind`/`connect`, so we don't
+        // request a per-packet source IP (which would add a redundant `IP_PKTINFO`/`IP_RECVDSTADDR`
+        // control message: the very mechanism we're moving away from on Apple).
+        let src_ip = if self.connected.is_some() {
+            None
+        } else {
+            datagram.src.map(|s| s.ip())
+        };
+
         let transmit = self.prepare_transmit(
             datagram.dst,
-            datagram.src.map(|s| s.ip()),
+            src_ip,
             datagram.packet.chunk(),
             datagram.segment_size,
             datagram.ecn,
         )?;
+
+        // Connected sockets (Apple) handle `ENOBUFS` internally via a bounded yield-retry in
+        // `send_transmit`. The exp-backoff loop below is only for unconnected sockets.
+        if self.connected.is_some() {
+            return self.send_transmit(&transmit).await;
+        }
 
         let mut attempt = 0;
 
@@ -334,6 +417,11 @@ impl PerfUdpSocket {
 
             attempt += 1;
         }
+    }
+
+    /// The local address this socket is bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local
     }
 
     pub fn set_buffer_sizes(
@@ -393,10 +481,31 @@ impl PerfUdpSocket {
                 ],
             );
 
-            self.inner
-                .async_io(Interest::WRITABLE, || self.state.try_send((&self.inner).into(), &chunk))
-                .await
-                .with_context(|| format!("Failed to send datagram-batch {batch_num}/{num_batches} with segment_size {segment_size} and total length {num_bytes} to {dst}"))?;
+            let connected = self.connected.is_some();
+            let mut enobufs_yields = 0;
+            loop {
+                match self
+                    .inner
+                    .async_io(Interest::WRITABLE, || {
+                        self.state.try_send((&self.inner).into(), &chunk)
+                    })
+                    .await
+                {
+                    Ok(()) => break,
+                    // On a connected socket, `ENOBUFS` means the *interface output queue* is full,
+                    // not the socket send buffer (which is what `WRITABLE` tracks). Waiting on
+                    // writability would stall on an edge that may never fire, so we yield and retry
+                    // instead, pacing to the interface queue draining. Back-pressure still
+                    // propagates via the bounded outbound channel to the TUN reader.
+                    Err(e) if connected && is_enobufs(&e) && enobufs_yields < MAX_ENOBUFS_YIELDS => {
+                        enobufs_yields += 1;
+                        tokio::task::yield_now().await;
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| format!("Failed to send datagram-batch {batch_num}/{num_batches} with segment_size {segment_size} and total length {num_bytes} to {dst}"));
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -521,6 +630,20 @@ fn is_equal_modulo_scope_for_ipv6_link_local(expected: SocketAddr, actual: Socke
     }
 }
 
+/// Whether the given IO error is `ENOBUFS` (kernel send buffer full).
+///
+/// On non-Apple platforms we never connect our data-plane sockets, so this is always `false`
+/// and the connected-socket back-pressure path is inert.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn is_enobufs(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(libc::ENOBUFS)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+fn is_enobufs(_: &io::Error) -> bool {
+    false
+}
+
 fn backoff(e: &anyhow::Error, attempts: u32) -> Option<Duration> {
     let raw_os_error = e.any_downcast_ref::<io::Error>()?.raw_os_error()?;
 
@@ -583,6 +706,12 @@ pub struct DatagramSegmentIter<const N: usize = { quinn_udp::BATCH_SIZE }, B = B
 
     port: u16,
 
+    /// For connected sockets: the local address to report as [`DatagramIn::local`], bypassing
+    /// `dst_ip` metadata (which a connected socket may not deliver).
+    connected_local: Option<SocketAddr>,
+    /// For connected sockets: the peer to report as [`DatagramIn::from`].
+    connected_from: Option<SocketAddr>,
+
     buf_index: usize,
     segment_index: usize,
 
@@ -609,11 +738,28 @@ impl<B, const N: usize> DatagramSegmentIter<N, B> {
             metas,
             len,
             port,
+            connected_local: None,
+            connected_from: None,
             buf_index: 0,
             segment_index: 0,
             _total_bytes: total_bytes,
             _num_packets: num_packets,
         }
+    }
+
+    /// Like [`Self::new`], but for a connected socket: report `local`/`from` directly instead of
+    /// deriving them from the (possibly absent) `dst_ip`/`addr` recv-metadata.
+    fn new_connected(
+        buffers: [B; N],
+        metas: [quinn_udp::RecvMeta; N],
+        len: usize,
+        local: SocketAddr,
+        from: SocketAddr,
+    ) -> Self {
+        let mut iter = Self::new(buffers, metas, local.port(), len);
+        iter.connected_local = Some(local);
+        iter.connected_from = Some(from);
+        iter
     }
 }
 
@@ -637,11 +783,18 @@ where
                 continue;
             }
 
-            let Some(local_ip) = meta.dst_ip else {
-                tracing::warn!("Skipping packet without local IP");
+            let local = match self.connected_local {
+                Some(local) => local,
+                None => {
+                    let Some(local_ip) = meta.dst_ip else {
+                        tracing::warn!("Skipping packet without local IP");
 
-                self.buf_index += 1;
-                continue;
+                        self.buf_index += 1;
+                        continue;
+                    };
+
+                    SocketAddr::new(local_ip, self.port)
+                }
             };
 
             match meta.stride.cmp(&meta.len) {
@@ -664,8 +817,6 @@ where
                 continue;
             }
 
-            let local = SocketAddr::new(local_ip, self.port);
-
             let segment_size = meta.stride;
 
             #[cfg(debug_assertions)]
@@ -678,7 +829,7 @@ where
 
             return Some(DatagramIn {
                 local,
-                from: meta.addr,
+                from: self.connected_from.unwrap_or(meta.addr),
                 packet: &buf[segment_start..segment_end],
                 ecn: match meta.ecn {
                     Some(EcnCodepoint::Ce) => Ecn::Ce,
@@ -742,6 +893,61 @@ mod tests {
         assert_eq!(iter.next().unwrap().packet, b"baz5");
         assert_eq!(iter.next().unwrap().packet, b"foo");
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn connected_iter_overrides_from_and_local() {
+        let peer: SocketAddr = "203.0.113.5:9999".parse().unwrap();
+        let local: SocketAddr = "192.0.2.1:52625".parse().unwrap();
+
+        let mut iter = DatagramSegmentIter::new_connected(
+            [DummyBuffer(b"hello".to_vec()), DummyBuffer(Vec::new())],
+            [
+                recv_meta(
+                    "198.51.100.7:1".parse().unwrap(),
+                    IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+                    5,
+                    5,
+                ),
+                RecvMeta::default(),
+            ],
+            2,
+            local,
+            peer,
+        );
+
+        let d = iter.next().unwrap();
+        assert_eq!(d.packet, b"hello");
+        assert_eq!(d.from, peer, "from is overridden with the connected peer");
+        assert_eq!(d.local, local, "local is overridden with the bound address");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn connected_iter_yields_packet_even_without_dst_ip() {
+        let peer: SocketAddr = "203.0.113.5:9999".parse().unwrap();
+        let local: SocketAddr = "192.0.2.1:52625".parse().unwrap();
+
+        // A connected socket may not deliver the `dst_ip` control message; the unconnected path
+        // would drop this packet, but the connected path uses the known local address.
+        let mut meta = RecvMeta::default();
+        meta.addr = "198.51.100.7:1".parse().unwrap();
+        meta.dst_ip = None;
+        meta.len = 5;
+        meta.stride = 5;
+
+        let mut iter = DatagramSegmentIter::new_connected(
+            [DummyBuffer(b"hello".to_vec())],
+            [meta],
+            1,
+            local,
+            peer,
+        );
+
+        let d = iter.next().unwrap();
+        assert_eq!(d.packet, b"hello");
+        assert_eq!(d.local, local);
+        assert_eq!(d.from, peer);
     }
 
     #[test]
@@ -818,5 +1024,195 @@ mod tests {
         meta.stride = stride;
 
         meta
+    }
+}
+
+/// Spike tests validating that the Apple fast datapath (`sendmsg_x`/`recvmsg_x`) works on
+/// **connected** UDP sockets, plus `SO_REUSEPORT` coexistence. These gate the connected-socket
+/// refactor; see the plan. Run with `cargo test -p socket-factory --  --nocapture connected_spike`.
+#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
+mod connected_spike {
+    use quinn_udp::{Transmit, UdpSockRef, UdpSocketState};
+    use socket2::{Domain, Protocol, Socket, Type};
+    use std::io::IoSliceMut;
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
+    use std::time::Duration;
+
+    fn v4(port: u16) -> SocketAddr {
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+    }
+
+    fn wildcard_v4(port: u16) -> SocketAddr {
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port))
+    }
+
+    fn socket(bind: SocketAddr, connect_to: Option<SocketAddr>) -> Socket {
+        let s = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+        s.set_reuse_address(true).unwrap();
+        s.set_reuse_port(true).unwrap();
+        s.set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
+        s.bind(&bind.into()).unwrap();
+        if let Some(dst) = connect_to {
+            s.connect(&dst.into()).unwrap();
+        }
+        s
+    }
+
+    fn apple_state(s: &Socket) -> UdpSocketState {
+        let state = UdpSocketState::new(UdpSockRef::from(s)).unwrap();
+        // SAFETY: macOS/iOS support these APIs (we already rely on this in `into_perf`).
+        unsafe {
+            state.set_apple_fast_path();
+        }
+        assert!(
+            state.is_apple_fast_path_enabled(),
+            "apple fast path must be enabled for the spike"
+        );
+        state
+    }
+
+    /// THE gating question: does `sendmsg_x` (which always sets `msg_name`) succeed on a
+    /// connected socket, or does Darwin return EISCONN?
+    #[test]
+    fn sendmsg_x_single_and_batch_on_connected_socket() {
+        let receiver = socket(v4(0), None);
+        let recv_addr = receiver.local_addr().unwrap().as_socket().unwrap();
+        let receiver = UdpSocket::from(receiver);
+
+        let sender = socket(v4(0), Some(recv_addr));
+        let state = apple_state(&sender);
+
+        // Single datagram.
+        let payload = b"hello-connected";
+        state
+            .try_send(
+                UdpSockRef::from(&sender),
+                &Transmit {
+                    destination: recv_addr,
+                    ecn: None,
+                    contents: payload,
+                    segment_size: None,
+                    src_ip: None,
+                },
+            )
+            .expect("single sendmsg_x on connected socket must succeed (no EISCONN)");
+
+        let mut buf = [0u8; 2048];
+        let n = receiver.recv(&mut buf).expect("recv single");
+        assert_eq!(&buf[..n], payload);
+
+        // GSO batch: 3 segments of 10 bytes => 3 datagrams in one sendmsg_x syscall.
+        let batch = b"0123456789ABCDEFGHIJabcdefghij"; // 30 bytes
+        state
+            .try_send(
+                UdpSockRef::from(&sender),
+                &Transmit {
+                    destination: recv_addr,
+                    ecn: None,
+                    contents: batch,
+                    segment_size: Some(10),
+                    src_ip: None,
+                },
+            )
+            .expect("batched sendmsg_x on connected socket must succeed");
+
+        for expected in [&b"0123456789"[..], b"ABCDEFGHIJ", b"abcdefghij"] {
+            let n = receiver.recv(&mut buf).expect("recv batch segment");
+            assert_eq!(&buf[..n], expected);
+        }
+    }
+
+    /// Does `recvmsg_x` deliver data on a connected socket, and what `addr`/`dst_ip` metadata
+    /// do we get? (We expect to have to override `from`/`local` from known addresses.)
+    #[test]
+    fn recvmsg_x_on_connected_socket_reports_metadata() {
+        let a = socket(v4(0), None);
+        let a_addr = a.local_addr().unwrap().as_socket().unwrap();
+        let b = socket(v4(0), None);
+        let b_addr = b.local_addr().unwrap().as_socket().unwrap();
+
+        a.connect(&b_addr.into()).unwrap();
+        b.connect(&a_addr.into()).unwrap();
+
+        let a_state = apple_state(&a);
+        let b_state = apple_state(&b);
+
+        let payload = b"a->b";
+        a_state
+            .try_send(
+                UdpSockRef::from(&a),
+                &Transmit {
+                    destination: b_addr,
+                    ecn: None,
+                    contents: payload,
+                    segment_size: None,
+                    src_ip: None,
+                },
+            )
+            .unwrap();
+
+        let mut buf = [0u8; 2048];
+        let mut bufs = [IoSliceMut::new(&mut buf)];
+        let mut metas = [quinn_udp::RecvMeta::default()];
+        // `UdpSocketState::new` puts the socket in nonblocking mode, so retry until loopback
+        // delivers (production gates this on readability via `async_io`).
+        let mut msgs = 0;
+        for _ in 0..200 {
+            match b_state.recv(UdpSockRef::from(&b), &mut bufs, &mut metas) {
+                Ok(n) => {
+                    msgs = n;
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(e) => panic!("recvmsg_x on connected socket: {e}"),
+            }
+        }
+        assert!(msgs >= 1, "no datagram received within deadline");
+        let meta = &metas[0];
+        eprintln!(
+            "connected recvmsg_x: addr={:?} dst_ip={:?} stride={} len={} (a_addr={a_addr}, b_addr={b_addr})",
+            meta.addr, meta.dst_ip, meta.stride, meta.len
+        );
+        assert_eq!(&buf[..meta.stride], payload);
+    }
+
+    /// `SO_REUSEPORT` coexistence + most-specific-match demux: a wildcard listener on `:P` and a
+    /// connected socket on `:P` bind together; the peer's packets reach the connected socket,
+    /// strangers reach the listener.
+    #[test]
+    fn reuseport_listener_and_connected_coexist_and_demux() {
+        // Listener on 0.0.0.0:P.
+        let listener = socket(wildcard_v4(0), None);
+        let port = listener.local_addr().unwrap().as_socket().unwrap().port();
+        let listener = UdpSocket::from(listener);
+
+        // The peer we will connect to.
+        let peer = socket(v4(0), None);
+        let peer_addr = peer.local_addr().unwrap().as_socket().unwrap();
+        let peer = UdpSocket::from(peer);
+
+        // Connected socket bound to the SAME port as the listener.
+        let connected = socket(v4(port), Some(peer_addr));
+        let connected_local = connected.local_addr().unwrap().as_socket().unwrap();
+        let connected = UdpSocket::from(connected);
+
+        // Peer -> our (127.0.0.1:P): should land on the CONNECTED socket (4-tuple match).
+        peer.send_to(b"from-peer", connected_local).unwrap();
+        let mut buf = [0u8; 2048];
+        let n = connected
+            .recv(&mut buf)
+            .expect("connected socket should receive peer traffic");
+        assert_eq!(&buf[..n], b"from-peer");
+
+        // Stranger -> our (127.0.0.1:P): should land on the LISTENER (no connected match).
+        let stranger = UdpSocket::bind(v4(0)).unwrap();
+        stranger.send_to(b"from-stranger", v4(port)).unwrap();
+        let n = listener
+            .recv(&mut buf)
+            .expect("listener should receive stranger traffic");
+        assert_eq!(&buf[..n], b"from-stranger");
     }
 }

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -52,7 +52,7 @@ snownet = { workspace = true }
 socket-factory = { workspace = true }
 telemetry = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }

--- a/rust/libs/connlib/tunnel/src/io/device.rs
+++ b/rust/libs/connlib/tunnel/src/io/device.rs
@@ -115,7 +115,16 @@ impl Device {
             return;
         };
 
-        // Try to send immediately if channel has capacity.
+        // Preserve ordering: if we are already buffering (a previous `try_send` hit a full
+        // channel) or a flush is in flight, this packet must queue behind those. Otherwise a
+        // `try_send` here could slip it into the channel ahead of the buffered packets once
+        // `poll_flush` drains them, reordering the stream we write to the TUN device.
+        if self.flush_future.is_some() || !self.outbound_buffer.is_empty() {
+            self.outbound_buffer.push(packet);
+            return;
+        }
+
+        // Fast path: nothing queued, send immediately if the channel has capacity.
         if let Err(packet) = tun.sender().try_send(packet).map_err(|e| e.into_inner()) {
             tracing::trace!(?packet, "Unable to send packet into channel, buffering");
             self.outbound_buffer.push(packet);

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -602,10 +602,7 @@ mod connected {
         }
 
         let bind = SocketAddr::new(key.0.unwrap_or(unspecified_ip), port);
-        // On Apple we leave both `SO_SNDBUF` and `SO_RCVBUF` at the OS defaults for connected
-        // sockets: a large send buffer lets the kernel accumulate a deep queue (upload bufferbloat),
-        // and we're testing the OS defaults for the data plane.
-        let socket = socket_factory::udp_connected(bind, datagram.dst)
+        let mut socket = socket_factory::udp_connected(bind, datagram.dst)
             .and_then(|s| s.into_perf())
             .with_context(|| {
                 format!(
@@ -613,6 +610,14 @@ mod connected {
                     datagram.dst
                 )
             })?;
+
+        // These connected sockets carry the actual data plane, so they need the same large
+        // send/receive buffers as the listener. Left at the OS defaults, a BDP-sized burst on a
+        // high-latency path overruns the small buffer and gets dropped a whole window at a time.
+        let (send_buffer_size, recv_buffer_size) = buffer_sizes();
+        if let Err(e) = socket.set_buffer_sizes(send_buffer_size, recv_buffer_size) {
+            tracing::warn!("Failed to set connected socket buffer sizes: {e}");
+        }
 
         let socket = Arc::new(socket);
         let recv_task = spawn_recv(

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -1,5 +1,5 @@
 use crate::otel;
-use anyhow::{Context as _, ErrorExt as _, Result};
+use anyhow::{Context as _, Result};
 use futures::{SinkExt, ready};
 use gat_lending_iterator::LendingIterator;
 use socket_factory::{DatagramIn, DatagramSegmentIter, SocketFactory, UdpSocket};
@@ -185,7 +185,7 @@ struct Channels {
 
 impl ThreadedUdpSocket {
     fn new(sf: Arc<dyn SocketFactory<UdpSocket>>, preferred_addr: SocketAddr) -> io::Result<Self> {
-        let (outbound_tx, mut outbound_rx) = mpsc::channel(QUEUE_SIZE);
+        let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (error_tx, error_rx) = std::sync::mpsc::sync_channel(0);
 
@@ -243,103 +243,34 @@ impl ThreadedUdpSocket {
                     .with_unit("{error}")
                     .build();
 
-                let send_buffer_size = read_end_var_usize("FIREZONE_UDP_SEND_BUFFER_SIZE")
-                    .inspect_err(|e| {
-                        tracing::debug!("Failed to read `FIREZONE_UDP_SEND_BUFFER_SIZE`: {e}")
-                    })
-                    .unwrap_or_default()
-                    .unwrap_or(socket_factory::SEND_BUFFER_SIZE);
-                let recv_buffer_size = read_end_var_usize("FIREZONE_UDP_RECV_BUFFER_SIZE")
-                    .inspect_err(|e| {
-                        tracing::debug!("Failed to read `FIREZONE_UDP_RECV_BUFFER_SIZE`: {e}")
-                    })
-                    .unwrap_or_default()
-                    .unwrap_or(socket_factory::RECV_BUFFER_SIZE);
+                let (send_buffer_size, recv_buffer_size) = buffer_sizes();
 
                 if let Err(e) = socket.set_buffer_sizes(send_buffer_size, recv_buffer_size) {
                     tracing::warn!("Failed to set socket buffer sizes: {e}");
                 };
 
-                let socket = Arc::new(socket);
-
-                let send = runtime.spawn({
-                    let io_error_counter = io_error_counter.clone();
-                    let inbound_tx = inbound_tx.clone();
-                    let socket = socket.clone();
-
-                    let mut pending_datagrams = Vec::with_capacity(UDP_SEND_BATCH_LIMIT);
-
-                    async move {
-                        loop {
-                            let num_batches = outbound_rx
-                                .recv_many(&mut pending_datagrams, UDP_SEND_BATCH_LIMIT)
-                                .await;
-
-                            if num_batches == 0 {
-                                tracing::debug!(
-                                    "Channel for outbound datagrams closed; exiting UDP send task"
-                                );
-                                return;
-                            }
-
-                            for datagram in pending_datagrams.drain(..) {
-                                if let Err(e) = socket.send(datagram).await {
-                                    if let Some(io) = e.any_downcast_ref::<io::Error>() {
-                                        io_error_counter.add(
-                                            1,
-                                            &[
-                                                otel::attr::network_io_direction_transmit(),
-                                                otel::attr::network_type_for_addr(preferred_addr),
-                                                otel::attr::io_error_type(io),
-                                                otel::attr::io_error_code(io),
-                                            ],
-                                        );
-                                    }
-
-                                    // We use the inbound_tx channel to send the error back to the main thread.
-                                    if inbound_tx.send(Err(e)).await.is_err() {
-                                        tracing::debug!(
-                                            "Channel for inbound datagrams closed; exiting UDP send task"
-                                        );
-                                        return;
-                                    }
-                                };
-                            }
-                        };
-                    }
-                });
-                let receive = runtime.spawn(async move {
-                    loop {
-                        let result = socket.recv_from().await;
-
-                        if let Some(io) = result
-                            .as_ref()
-                            .err()
-                            .and_then(|e| e.any_downcast_ref::<io::Error>())
-                        {
-                            io_error_counter.add(
-                                1,
-                                &[
-                                    otel::attr::network_io_direction_receive(),
-                                    otel::attr::network_type_for_addr(preferred_addr),
-                                    otel::attr::io_error_type(io),
-                                    otel::attr::io_error_code(io),
-                                ],
-                            );
-                        }
-
-                        if inbound_tx.send(result).await.is_err() {
-                            tracing::debug!(
-                                "Channel for inbound datagrams closed; exiting UDP recv task"
-                            );
-                            return;
-                        }
-                    }
-                });
-
                 let _ = error_tx.send(Ok(()));
 
-                runtime.block_on(futures::future::select(send, receive));
+                // The single-socket model (non-Apple) and the connected-socket pool (Apple) share
+                // the same channel contract; only the in-thread behaviour differs. On Apple, `socket`
+                // is the recv-only listener and all sending happens over a pool of connected sockets.
+                #[cfg(any(target_os = "macos", target_os = "ios"))]
+                runtime.block_on(connected::run(
+                    socket,
+                    outbound_rx,
+                    inbound_tx,
+                    preferred_addr,
+                    io_error_counter,
+                ));
+
+                #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+                runtime.block_on(run_single(
+                    socket,
+                    outbound_rx,
+                    inbound_tx,
+                    preferred_addr,
+                    io_error_counter,
+                ));
             })?;
 
         error_rx.recv().map_err(io::Error::other)??;
@@ -435,6 +366,392 @@ fn read_end_var_usize(name: &str) -> Result<Option<usize>> {
     Ok(Some(var))
 }
 
+/// The configured UDP send/receive buffer sizes, falling back to [`socket_factory`]'s defaults.
+fn buffer_sizes() -> (usize, usize) {
+    let send = read_end_var_usize("FIREZONE_UDP_SEND_BUFFER_SIZE")
+        .inspect_err(|e| tracing::debug!("Failed to read `FIREZONE_UDP_SEND_BUFFER_SIZE`: {e}"))
+        .unwrap_or_default()
+        .unwrap_or(socket_factory::SEND_BUFFER_SIZE);
+    let recv = read_end_var_usize("FIREZONE_UDP_RECV_BUFFER_SIZE")
+        .inspect_err(|e| tracing::debug!("Failed to read `FIREZONE_UDP_RECV_BUFFER_SIZE`: {e}"))
+        .unwrap_or_default()
+        .unwrap_or(socket_factory::RECV_BUFFER_SIZE);
+
+    (send, recv)
+}
+
+/// The single-socket datapath used on every platform except Apple: one task draining the outbound
+/// channel and one task feeding the inbound channel, both over a single shared (unconnected) socket.
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+async fn run_single(
+    socket: PerfUdpSocket,
+    mut outbound_rx: mpsc::Receiver<DatagramOut>,
+    inbound_tx: mpsc::Sender<Result<DatagramSegmentIter>>,
+    preferred_addr: SocketAddr,
+    io_error_counter: opentelemetry::metrics::Counter<u64>,
+) {
+    use anyhow::ErrorExt as _;
+
+    let socket = Arc::new(socket);
+
+    let send = tokio::spawn({
+        let io_error_counter = io_error_counter.clone();
+        let inbound_tx = inbound_tx.clone();
+        let socket = socket.clone();
+
+        let mut pending_datagrams = Vec::with_capacity(UDP_SEND_BATCH_LIMIT);
+
+        async move {
+            loop {
+                let num_batches = outbound_rx
+                    .recv_many(&mut pending_datagrams, UDP_SEND_BATCH_LIMIT)
+                    .await;
+
+                if num_batches == 0 {
+                    tracing::debug!("Channel for outbound datagrams closed; exiting UDP send task");
+                    return;
+                }
+
+                for datagram in pending_datagrams.drain(..) {
+                    if let Err(e) = socket.send(datagram).await {
+                        if let Some(io) = e.any_downcast_ref::<io::Error>() {
+                            io_error_counter.add(
+                                1,
+                                &[
+                                    otel::attr::network_io_direction_transmit(),
+                                    otel::attr::network_type_for_addr(preferred_addr),
+                                    otel::attr::io_error_type(io),
+                                    otel::attr::io_error_code(io),
+                                ],
+                            );
+                        }
+
+                        // We use the inbound_tx channel to send the error back to the main thread.
+                        if inbound_tx.send(Err(e)).await.is_err() {
+                            tracing::debug!(
+                                "Channel for inbound datagrams closed; exiting UDP send task"
+                            );
+                            return;
+                        }
+                    };
+                }
+            }
+        }
+    });
+    let receive = tokio::spawn(async move {
+        loop {
+            let result = socket.recv_from().await;
+
+            if let Some(io) = result
+                .as_ref()
+                .err()
+                .and_then(|e| e.any_downcast_ref::<io::Error>())
+            {
+                io_error_counter.add(
+                    1,
+                    &[
+                        otel::attr::network_io_direction_receive(),
+                        otel::attr::network_type_for_addr(preferred_addr),
+                        otel::attr::io_error_type(io),
+                        otel::attr::io_error_code(io),
+                    ],
+                );
+            }
+
+            if inbound_tx.send(result).await.is_err() {
+                tracing::debug!("Channel for inbound datagrams closed; exiting UDP recv task");
+                return;
+            }
+        }
+    });
+
+    futures::future::select(send, receive).await;
+}
+
+/// The connected-socket datapath used on Apple.
+///
+/// `listener` is a recv-only, unconnected socket bound to the wildcard address. All *sending*
+/// happens over a pool of connected sockets (one per `(src_ip, dst)`) that share the listener's
+/// port via `SO_REUSEPORT`. This is required on Apple because the batched `sendmsg_x` datapath only
+/// works on connected sockets, and only connected sockets surface `ENOBUFS` for back-pressure.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod connected {
+    use super::*;
+    use anyhow::ErrorExt as _;
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+
+    /// Connected sockets idle (no send) for this long are reaped and recreated lazily on the next
+    /// send. Comfortably above connlib's keep-alive interval; inbound during a gap is caught by the
+    /// listener, so an over-eager reap is self-healing.
+    const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+    /// How often we sweep the pool for idle sockets.
+    const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+    struct Pooled {
+        socket: Arc<PerfUdpSocket>,
+        recv_task: tokio::task::AbortHandle,
+        last_send: Instant,
+    }
+
+    impl Drop for Pooled {
+        fn drop(&mut self) {
+            self.recv_task.abort();
+        }
+    }
+
+    pub(super) async fn run(
+        listener: PerfUdpSocket,
+        mut outbound_rx: mpsc::Receiver<DatagramOut>,
+        inbound_tx: mpsc::Sender<Result<DatagramSegmentIter>>,
+        preferred_addr: SocketAddr,
+        io_error_counter: opentelemetry::metrics::Counter<u64>,
+    ) {
+        let local = listener.local_addr();
+        // All connected sockets bind to the listener's actual port so our ICE candidates (derived
+        // from this port) stay reachable; `connect` then pins the egress per peer.
+        let port = local.port();
+        let unspecified_ip = local.ip();
+
+        // The listener is recv-only: it catches inbound from peers/relays we haven't sent to yet.
+        let _listener_recv = spawn_recv(
+            Arc::new(listener),
+            inbound_tx.clone(),
+            io_error_counter.clone(),
+            preferred_addr,
+        );
+
+        let mut pool: HashMap<(Option<IpAddr>, SocketAddr), Pooled> = HashMap::new();
+        let mut pending = Vec::with_capacity(UDP_SEND_BATCH_LIMIT);
+        let mut sweep = tokio::time::interval(SWEEP_INTERVAL);
+        sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                num_batches = outbound_rx.recv_many(&mut pending, UDP_SEND_BATCH_LIMIT) => {
+                    if num_batches == 0 {
+                        tracing::debug!("Channel for outbound datagrams closed; exiting UDP connected-pool task");
+                        return;
+                    }
+
+                    for datagram in pending.drain(..) {
+                        let socket = match connected_socket(
+                            &mut pool,
+                            &datagram,
+                            port,
+                            unspecified_ip,
+                            &inbound_tx,
+                            &io_error_counter,
+                            preferred_addr,
+                        ) {
+                            Ok(socket) => socket,
+                            Err(e) => {
+                                tracing::debug!(dst = %datagram.dst, "Failed to create connected UDP socket: {e:#}");
+
+                                if inbound_tx.send(Err(e)).await.is_err() {
+                                    return;
+                                }
+                                continue;
+                            }
+                        };
+
+                        // `ENOBUFS` is mapped to `WouldBlock` inside `send`, so this `await` suspends
+                        // (back-pressuring the outbound channel) instead of busy-retrying.
+                        if let Err(e) = socket.send(datagram).await {
+                            if let Some(io) = e.any_downcast_ref::<io::Error>() {
+                                io_error_counter.add(
+                                    1,
+                                    &[
+                                        otel::attr::network_io_direction_transmit(),
+                                        otel::attr::network_type_for_addr(preferred_addr),
+                                        otel::attr::io_error_type(io),
+                                        otel::attr::io_error_code(io),
+                                    ],
+                                );
+                            }
+
+                            if inbound_tx.send(Err(e)).await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                }
+                _ = sweep.tick() => {
+                    let now = Instant::now();
+                    pool.retain(|_, pooled| now.duration_since(pooled.last_send) < IDLE_TIMEOUT);
+                }
+            }
+        }
+    }
+
+    /// Looks up (or lazily creates) the connected socket for this datagram's `(src_ip, dst)`.
+    fn connected_socket(
+        pool: &mut HashMap<(Option<IpAddr>, SocketAddr), Pooled>,
+        datagram: &DatagramOut,
+        port: u16,
+        unspecified_ip: IpAddr,
+        inbound_tx: &mpsc::Sender<Result<DatagramSegmentIter>>,
+        io_error_counter: &opentelemetry::metrics::Counter<u64>,
+        preferred_addr: SocketAddr,
+    ) -> Result<Arc<PerfUdpSocket>> {
+        let key = (datagram.src.map(|s| s.ip()), datagram.dst);
+
+        if let Some(pooled) = pool.get_mut(&key) {
+            pooled.last_send = Instant::now();
+            return Ok(pooled.socket.clone());
+        }
+
+        let bind = SocketAddr::new(key.0.unwrap_or(unspecified_ip), port);
+        // On Apple we leave both `SO_SNDBUF` and `SO_RCVBUF` at the OS defaults for connected
+        // sockets: a large send buffer lets the kernel accumulate a deep queue (upload bufferbloat),
+        // and we're testing the OS defaults for the data plane.
+        let socket = socket_factory::udp_connected(bind, datagram.dst)
+            .and_then(|s| s.into_perf())
+            .with_context(|| {
+                format!(
+                    "Failed to create connected UDP socket {bind} -> {}",
+                    datagram.dst
+                )
+            })?;
+
+        let socket = Arc::new(socket);
+        let recv_task = spawn_recv(
+            socket.clone(),
+            inbound_tx.clone(),
+            io_error_counter.clone(),
+            preferred_addr,
+        );
+
+        tracing::debug!(%bind, dst = %datagram.dst, "Created connected UDP socket");
+
+        pool.insert(
+            key,
+            Pooled {
+                socket: socket.clone(),
+                recv_task: recv_task.abort_handle(),
+                last_send: Instant::now(),
+            },
+        );
+
+        Ok(socket)
+    }
+
+    /// Spawns a task that reads from `socket` and forwards batches to the inbound channel.
+    fn spawn_recv(
+        socket: Arc<PerfUdpSocket>,
+        inbound_tx: mpsc::Sender<Result<DatagramSegmentIter>>,
+        io_error_counter: opentelemetry::metrics::Counter<u64>,
+        preferred_addr: SocketAddr,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                let result = socket.recv_from().await;
+
+                if let Some(io) = result
+                    .as_ref()
+                    .err()
+                    .and_then(|e| e.any_downcast_ref::<io::Error>())
+                {
+                    io_error_counter.add(
+                        1,
+                        &[
+                            otel::attr::network_io_direction_receive(),
+                            otel::attr::network_type_for_addr(preferred_addr),
+                            otel::attr::io_error_type(io),
+                            otel::attr::io_error_code(io),
+                        ],
+                    );
+                }
+
+                if inbound_tx.send(result).await.is_err() {
+                    tracing::debug!("Channel for inbound datagrams closed; exiting UDP recv task");
+                    return;
+                }
+            }
+        })
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 #[error("UDP socket thread stopped")]
 pub struct UdpSocketThreadStopped;
+
+#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
+mod connected_tests {
+    use super::*;
+    use bufferpool::BufferPool;
+    use bytes::BytesMut;
+    use ip_packet::Ecn;
+    use std::future::poll_fn;
+    use std::net::UdpSocket as StdUdpSocket;
+
+    fn datagram(dst: SocketAddr, payload: &[u8]) -> DatagramOut {
+        let pool = BufferPool::<BytesMut>::new(2048, "connected-test");
+        DatagramOut {
+            src: None,
+            dst,
+            packet: pool.pull_initialised(payload),
+            segment_size: payload.len(),
+            ecn: Ecn::NonEct,
+        }
+    }
+
+    async fn send(family: &mut ThreadedUdpSocket, datagram: DatagramOut) {
+        poll_fn(|cx| family.poll_send_ready(cx)).await.unwrap();
+        family.send(datagram).unwrap();
+    }
+
+    async fn recv_one(family: &mut ThreadedUdpSocket) -> (Vec<u8>, SocketAddr) {
+        let mut iter = tokio::time::timeout(
+            Duration::from_secs(5),
+            poll_fn(|cx| family.poll_recv_from(cx)),
+        )
+        .await
+        .expect("recv timed out")
+        .expect("recv failed");
+        let datagram = iter.next().expect("at least one datagram in batch");
+        (datagram.packet.to_vec(), datagram.from)
+    }
+
+    /// End-to-end test of the Apple connected-socket pool: sends route through a lazily-created
+    /// connected socket, replies arrive on it (with `from` overridden to the peer), and unsolicited
+    /// traffic from a stranger falls through to the recv-only listener.
+    #[tokio::test]
+    async fn connected_pool_routes_send_and_recv_with_listener_fallback() {
+        let peer = StdUdpSocket::bind("127.0.0.1:0").unwrap();
+        peer.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+
+        let mut family = ThreadedUdpSocket::new(
+            Arc::new(socket_factory::udp),
+            "127.0.0.1:0".parse().unwrap(),
+        )
+        .unwrap();
+
+        // Send through the connected pool; the peer learns our (connected) source address.
+        send(&mut family, datagram(peer_addr, b"ping")).await;
+        let mut buf = [0u8; 64];
+        let (n, our_addr) = peer.recv_from(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"ping");
+
+        // Reply lands on the connected socket; `from` is overridden to the peer.
+        peer.send_to(b"pong", our_addr).unwrap();
+        let (payload, from) = recv_one(&mut family).await;
+        assert_eq!(payload, b"pong");
+        assert_eq!(
+            from, peer_addr,
+            "connected socket reports the peer as `from`"
+        );
+
+        // A stranger (no connected socket) hits the same port; the listener catches it.
+        let stranger = StdUdpSocket::bind("127.0.0.1:0").unwrap();
+        let stranger_addr = stranger.local_addr().unwrap();
+        stranger.send_to(b"hello", our_addr).unwrap();
+        let (payload, from) = recv_one(&mut family).await;
+        assert_eq!(payload, b"hello");
+        assert_eq!(
+            from, stranger_addr,
+            "listener reports the stranger as `from`"
+        );
+    }
+}


### PR DESCRIPTION
After some investigation tracking down slow upload speeds on Apple, it seems as though it might be a good idea to move to a connected-sockets architecture for the Apple clients, and possibly other platforms as well (pending investigation / discussion).

### Reason 1: Fixes backpressure

On Apple platforms, after some troubleshooting it was discovered that the *unconnected* sockets we use to multiplex data plane traffic over do not reliably surface `ENOBUFS` when their interface queue is full. Instead, the kernel silently drops the batch, leaving us with no back-pressure mechanism.

Here is an LLM-assisted explanation of the issue:

> #### Root cause: flow advisory is connected-only
> 
> [bsd/netinet/udp_usrreq.c, udp_output()](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/netinet/udp_usrreq.c#L1596):
> ```
> /* Enable flow advisory only when connected */
> flowadv = (so->so_state & SS_ISCONNECTED) ? 1 : 0;
> ```
> 
> That flowadv flag decides whether the socket participates in the interface's per-flow back-pressure system at all. Here's the full cycle it controls:
> 
> 1. Tagging (connected only) — the outbound mbuf only gets enrolled in flow advisory when flowadv is set:
> ```
> m->m_pkthdr.pkt_flowid  = inp->inp_flowhash;            // stable per-5-tuple hash
> m->m_pkthdr.pkt_flags  |= (PKTF_FLOW_ID | PKTF_FLOW_LOCALSRC);
> if (flowadv)
>     m->m_pkthdr.pkt_flags |= PKTF_FLOW_ADV;             // "this flow wants advisory"
> ```
> 
> 2. Queue fills → kernel marks the socket — when the interface's AQM (fq_codel/classq) hits its limit on a PKTF_FLOW_ADV packet, it looks the socket up by inp_flowhash and calls inp_set_fc_state(inp, FADV_FLOW_CONTROLLED) (in_pcb.c), which sets INP_FLOW_CONTROLLED on the inpcb and inserts it into inp_fc_tree (keyed by the flowhash).
> 
> 3. Next send returns ENOBUFS — back in udp_output():
> ```
> if (flowadv && INP_WAIT_FOR_IF_FEEDBACK(inp)) {   // INP_FLOW_CONTROLLED | INP_FLOW_SUSPENDED
>     error = ENOBUFS;                              // <-- the signal we yield_now on
> }
> ```
> That's the reliable back-pressure: once flow-controlled, every send short-circuits to ENOBUFS until the queue drains.
> 
> 4. Queue drains → socket released — the interface feeds back, inp_fc_feedback() → inp_reset_fc_state() clears the flags (and wakes the socket), so sends resume.
> 
> #### Why unconnected silently drops
> 
> An unconnected socket has flowadv = 0, so its packets are never tagged PKTF_FLOW_ADV. When the AQM queue fills, there's no flow to advise — the datagram is just dropped at the classq with no inpcb state change and no error propagated. Those are exactly the drops that only show up in the interface queue counters (netstat -qq), invisible to the sender.
> 
> #### Why Apple gates it on SS_ISCONNECTED
> 
> The entire flow-control system is per-flow, keyed on inp_flowhash — a hash of the 5-tuple — and the inpcb is tracked in a single inp_fc_tree node. A connected socket is exactly one stable flow, so it maps cleanly to one flowhash that the AQM can throttle and later release. An unconnected socket can sendto() a different destination on every call, so there's no single flow to enroll or throttle coherently — the model doesn't fit, so the kernel simply doesn't engage it.

After some in-depth testing with both unconnected and connected BSD sockets outside of Firezone, it was discovered that _connected_ sockets *do* surface ENOBUFS reliably. By back-pressuring on that signal and (and the internal kqueue-based mechanism already handled by tokio/mio) it appears that we reliably drop *zero* packets in this approach.

### Reason 2: `sendmsg_x` batching is connected-sockets-only

sendmsg_x: batching is connected-only (hard kernel gate)

[bsd/kern/uipc_syscalls.c, sendmsg_x()](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/uipc_syscalls.c#L1897):

```
/* For an atomic datagram connected socket we can build the list of
 * mbuf packets with sosend_list() */
if (so->so_type == SOCK_DGRAM && sosendallatonce(so) &&
    (so->so_state & SS_ISCONNECTED) && sendmsg_x_mode != 1) {
    error = sendit_x(p, so, uap, &uiocnt);   // → sosend_list(): one batched mbuf-list build
    goto done;
}
/* otherwise: per-message fallback */
for (i = 0; i < uap->cnt; i++) {
    ... internalize each msghdr_x ...
    error = sendit(p, so, &user_msg, auio, ...);   // sosend() one at a time
}
```

The fast path requires all of: `SOCK_DGRAM`, `sosendallatonce()` (i.e. PR_ATOMIC — UDP has it), `SS_ISCONNECTED`, and `sendmsg_x_mode != 1` (a debug sysctl: 0 = default/batched, 1 = force the one-at-a-time loop, 2 = old
impl).

So on an unconnected socket, sendmsg_x quietly degrades to a loop of sendit()/sosend() — functionally identical to calling sendmsg() N times. The actual win (sosend_list building one mbuf chain and pushing it
through the stack once) is connected-only. That's the real, kernel-enforced reason the batched datapath needs connected sockets.

**Note:** `recvmsg_x`: not connection-gated

### Reason 3: Removes the firewall permission dialog

Using a connected socket doesn't trigger the `FirezoneNetworkExtension would like to accept incoming connections` dialog, which is shown to the end-user on each new release. It is currently unknown to what extent connectivity is affected if the user clicks `Deny` on this dialog.

Fixes #9053
Fixes #9110
Related: #13578, #13623
