### PR TITLE
chore(loadtest): merge config base with CLI overrides

### DIFF
--- a/rust/tests/loadtest/src/config.rs
+++ b/rust/tests/loadtest/src/config.rs
@@ -74,7 +74,9 @@ impl SampleRange<u64> for Range {
     }
 
     fn is_empty(&self) -> bool {
-        self.max - self.min == 0
+        // An inclusive `[min, max]` range is only empty when `min > max`; when the
+        // bounds are equal it still contains that single value.
+        self.min > self.max
     }
 }
 
@@ -421,5 +423,13 @@ mod tests {
         assert_eq!(config.enabled_types(), vec![TestType::Http]);
 
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn range_with_equal_bounds_is_not_empty() {
+        // `gen_range` panics on a range it believes is empty; an inclusive range
+        // with equal bounds still contains its single value.
+        assert!(!Range { min: 5, max: 5 }.is_empty());
+        assert!(Range { min: 6, max: 5 }.is_empty());
     }
 }

--- a/rust/tests/loadtest/src/http.rs
+++ b/rust/tests/loadtest/src/http.rs
@@ -11,19 +11,25 @@ use tracing::Instrument;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Default maximum number of concurrent connections.
+const DEFAULT_MAX_CONNECTIONS: u64 = 10;
+
+/// Default HTTP version.
+const DEFAULT_HTTP_VERSION: u8 = 1;
+
 #[derive(Parser)]
 pub struct Args {
-    /// HTTP version to use (1 or 2)
-    #[arg(long, default_value = "1", value_name = "VERSION")]
-    http_version: HttpVersion,
+    /// HTTP version to use (1 or 2). Overrides the config; default 1.
+    #[arg(long, value_name = "VERSION")]
+    http_version: Option<HttpVersion>,
 
-    /// The address to GET.
+    /// The address to GET. Overrides the config's `[http]` addresses.
     #[arg(long)]
-    address: String,
+    address: Option<String>,
 
     /// The maximum number of concurrent connections.
-    #[arg(long, default_value_t = 10)]
-    max_connections: u64,
+    #[arg(long)]
+    max_connections: Option<u64>,
 }
 
 /// HTTP protocol version to use for load testing.
@@ -35,6 +41,15 @@ enum HttpVersion {
 
     #[value(name = "2", alias = "http2")]
     Http2,
+}
+
+impl HttpVersion {
+    fn to_u8(self) -> u8 {
+        match self {
+            Self::Http1 => 1,
+            Self::Http2 => 2,
+        }
+    }
 }
 
 impl std::fmt::Display for HttpVersion {
@@ -54,20 +69,34 @@ pub struct TestConfig {
     pub http_version: u8,
 }
 
-/// Run HTTP test with manual CLI args.
-pub async fn run_with_cli_args(args: Args) -> Result<()> {
-    let config = TestConfig {
-        address: args.address,
-        max_connections: args.max_connections,
-        http_version: match args.http_version {
-            HttpVersion::Http1 => 1,
-            HttpVersion::Http2 => 2,
-        },
-    };
+/// Build a [`TestConfig`] from CLI args, filling unspecified values from `base`.
+pub fn merge(args: Args, base: Option<TestConfig>) -> Result<TestConfig> {
+    let base = base.as_ref();
 
-    run(config, 0).await?;
+    let address = args
+        .address
+        .or_else(|| base.map(|b| b.address.clone()))
+        .context("--address is required (or add [http] to the config)")?;
+    let max_connections = args
+        .max_connections
+        .or_else(|| base.map(|b| b.max_connections))
+        .unwrap_or(DEFAULT_MAX_CONNECTIONS);
+    let http_version = args
+        .http_version
+        .map(HttpVersion::to_u8)
+        .or_else(|| base.map(|b| b.http_version))
+        .unwrap_or(DEFAULT_HTTP_VERSION);
 
-    Ok(())
+    Ok(TestConfig {
+        address,
+        max_connections,
+        http_version,
+    })
+}
+
+/// Run HTTP test from CLI args merged over an optional config base.
+pub async fn run_with_args(args: Args, base: Option<TestConfig>, seed: u64) -> Result<()> {
+    run_with_config(merge(args, base)?, seed).await
 }
 
 /// Run HTTP test from resolved config.

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -49,13 +49,14 @@ mod util;
 mod websocket;
 
 use crate::config::{HttpConfig, TcpConfig, TestType, WebsocketConfig};
+use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 use config::LoadTestConfig;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng as _, SeedableRng as _};
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer as _;
@@ -124,43 +125,81 @@ async fn try_main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Resolve the config (optional in subcommand mode) and seed once, then
+    // dispatch: `random` selects from the config, while each subcommand resolves
+    // its matching section as a base that explicitly-passed CLI args override.
+    let config = load_optional_config(cli.config.as_deref())?;
+    let mut selector = TestSelector::new(cli.seed);
+    let seed = selector.seed();
+
     match cli.command {
-        None | Some(Commands::Random) => run_random(cli.config, cli.seed).await?,
-        Some(Commands::Http(args)) => http::run_with_cli_args(args).await?,
-        Some(Commands::Tcp(args)) => tcp::run_with_cli_args(args).await?,
-        Some(Commands::Websocket(args)) => websocket::run_with_cli_args(args).await?,
+        None | Some(Commands::Random) => run_random(config, &mut selector, seed).await?,
+        Some(Commands::Http(args)) => {
+            let base = config
+                .as_ref()
+                .and_then(|c| c.http.as_ref())
+                .map(|s| selector.resolve_http(s));
+            http::run_with_args(args, base, seed).await?;
+        }
+        Some(Commands::Tcp(args)) => {
+            let base = config
+                .as_ref()
+                .and_then(|c| c.tcp.as_ref())
+                .map(|s| selector.resolve_tcp(s));
+            tcp::run_with_args(args, base, seed).await?;
+        }
+        Some(Commands::Websocket(args)) => {
+            let base = config
+                .as_ref()
+                .and_then(|c| c.websocket.as_ref())
+                .map(|s| selector.resolve_websocket(s));
+            websocket::run_with_args(args, base, seed).await?;
+        }
     }
 
     Ok(())
 }
 
+/// Load the config for subcommand mode, where it is optional.
+///
+/// An explicitly-specified `--config` must exist; the default file is used only
+/// if it happens to be present.
+fn load_optional_config(explicit: Option<&Path>) -> anyhow::Result<Option<LoadTestConfig>> {
+    match explicit {
+        Some(path) => Ok(Some(LoadTestConfig::load(path)?)),
+        None => {
+            let default = Path::new(DEFAULT_CONFIG_FILE);
+
+            if default.exists() {
+                Ok(Some(LoadTestConfig::load(default)?))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
 /// Default configuration compiled from the example file.
 const DEFAULT_CONFIG: &str = include_str!("../loadtest.example.toml");
 
-/// Run a random test from the config file.
-async fn run_random(config_path: Option<PathBuf>, seed: Option<u64>) -> anyhow::Result<()> {
-    let config_path = config_path.unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_FILE));
-
-    if !config_path.exists() {
-        anyhow::bail!(
-            "Config file not found: {}\n\nCreate a loadtest.toml file or specify one with --config",
-            config_path.display()
-        );
-    }
-
-    tracing::info!(config = %config_path.display(), "Loading config");
-
-    let config = LoadTestConfig::load(&config_path)?;
+/// Run a random test selected from the config.
+///
+/// Unlike subcommand mode, a config is required here: there is nothing to select
+/// from otherwise.
+async fn run_random(
+    config: Option<LoadTestConfig>,
+    selector: &mut TestSelector,
+    seed: u64,
+) -> anyhow::Result<()> {
+    let config = config.context(
+        "No config file found; create a loadtest.toml file or specify one with --config",
+    )?;
 
     let enabled_types = config.enabled_types();
     anyhow::ensure!(
         !enabled_types.is_empty(),
-        "No test sections configured in {}; add at least one of [http], [tcp] or [websocket]",
-        config_path.display()
+        "No test sections configured; add at least one of [http], [tcp] or [websocket]"
     );
-
-    let mut selector = TestSelector::new(seed);
-    let seed = selector.seed();
 
     tracing::info!(seed, ?enabled_types, "Selecting random test");
 

--- a/rust/tests/loadtest/src/tcp.rs
+++ b/rust/tests/loadtest/src/tcp.rs
@@ -6,7 +6,7 @@
 use crate::echo_payload::{self, EchoPayload};
 use crate::util::{EchoStats, StreamingStats, saturating_usize_to_u32};
 use crate::{DEFAULT_ECHO_PAYLOAD_SIZE, WithSeed};
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use clap::Parser;
 use serde::Serialize;
 use std::sync::Arc;
@@ -16,6 +16,18 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
+
+/// Default number of concurrent connections.
+const DEFAULT_CONCURRENT: usize = 10;
+
+/// Default connection hold duration.
+const DEFAULT_HOLD_DURATION: Duration = Duration::from_secs(30);
+
+/// Default connection timeout.
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default timeout for reading echo responses.
+const DEFAULT_ECHO_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Configuration for TCP connection load testing.
 #[derive(Debug, Clone)]
@@ -98,71 +110,93 @@ pub struct Args {
     #[arg(short = 'p', long, default_value = "9000")]
     port: u16,
 
-    /// Target address (host:port) - required in client mode
+    /// Target address (host:port). Overrides the config's `[tcp]` addresses.
     #[arg(long, value_name = "ADDR")]
     target: Option<String>,
 
     /// Number of concurrent connections to establish
-    #[arg(short = 'c', long, default_value = "10")]
-    concurrent: usize,
+    #[arg(short = 'c', long)]
+    concurrent: Option<usize>,
 
     /// How long to hold each connection open (e.g., 30s, 5m)
-    #[arg(short = 'd', long, default_value = "30s", value_parser = crate::cli::parse_duration)]
-    duration: Duration,
+    #[arg(short = 'd', long, value_parser = crate::cli::parse_duration)]
+    duration: Option<Duration>,
 
     /// Connection timeout for establishing connections
-    #[arg(long, default_value = "10s", value_parser = crate::cli::parse_duration)]
-    timeout: Duration,
+    #[arg(long, value_parser = crate::cli::parse_duration)]
+    timeout: Option<Duration>,
 
     /// Enable echo mode: send timestamped payloads and verify responses
     #[arg(long)]
     echo: bool,
 
     /// Echo payload size in bytes (minimum 16 for header)
-    #[arg(long, default_value_t = DEFAULT_ECHO_PAYLOAD_SIZE, value_parser = crate::cli::parse_echo_payload_size)]
-    echo_payload_size: usize,
+    #[arg(long, value_parser = crate::cli::parse_echo_payload_size)]
+    echo_payload_size: Option<usize>,
 
     /// Interval between echo messages (e.g., 1s, 500ms)
     #[arg(long, value_parser = crate::cli::parse_duration)]
     echo_interval: Option<Duration>,
 
     /// Timeout for reading echo responses (e.g., 5s)
-    #[arg(long, default_value = "5s", value_parser = crate::cli::parse_duration)]
-    echo_read_timeout: Duration,
+    #[arg(long, value_parser = crate::cli::parse_duration)]
+    echo_read_timeout: Option<Duration>,
 }
 
-/// Run TCP test with manual CLI args.
-pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
+/// Build a [`TestConfig`] from CLI args, filling unspecified values from `base`.
+///
+/// `--echo` forces echo mode on; it cannot disable echo mode set in the config.
+pub fn merge(args: Args, base: Option<TestConfig>) -> Result<TestConfig> {
+    let base = base.as_ref();
+
+    let target = args
+        .target
+        .or_else(|| base.map(|b| b.target.clone()))
+        .context("--target is required (or add [tcp] to the config)")?;
+    let concurrent = args
+        .concurrent
+        .or_else(|| base.map(|b| b.concurrent))
+        .unwrap_or(DEFAULT_CONCURRENT);
+    let hold_duration = args
+        .duration
+        .or_else(|| base.map(|b| b.hold_duration))
+        .unwrap_or(DEFAULT_HOLD_DURATION);
+    let connect_timeout = args
+        .timeout
+        .or_else(|| base.map(|b| b.connect_timeout))
+        .unwrap_or(DEFAULT_CONNECT_TIMEOUT);
+    let echo_mode = args.echo || base.is_some_and(|b| b.echo_mode);
+    let echo_payload_size = args
+        .echo_payload_size
+        .or_else(|| base.map(|b| b.echo_payload_size))
+        .unwrap_or(DEFAULT_ECHO_PAYLOAD_SIZE);
+    let echo_interval = args
+        .echo_interval
+        .or_else(|| base.and_then(|b| b.echo_interval));
+    let echo_read_timeout = args
+        .echo_read_timeout
+        .or_else(|| base.map(|b| b.echo_read_timeout))
+        .unwrap_or(DEFAULT_ECHO_READ_TIMEOUT);
+
+    Ok(TestConfig {
+        target,
+        concurrent,
+        hold_duration,
+        connect_timeout,
+        echo_mode,
+        echo_payload_size,
+        echo_interval,
+        echo_read_timeout,
+    })
+}
+
+/// Run TCP test from CLI args merged over an optional config base.
+pub async fn run_with_args(args: Args, base: Option<TestConfig>, seed: u64) -> Result<()> {
     if args.server {
-        // Server mode
-        let config = TcpServerConfig { port: args.port };
-        run_server(config).await?;
-    } else {
-        // Client mode
-        let target = args.target.ok_or_else(|| {
-            anyhow::anyhow!("--target is required in client mode (or use --server for server mode)")
-        })?;
-
-        let config = TestConfig {
-            target,
-            concurrent: args.concurrent,
-            hold_duration: args.duration,
-            connect_timeout: args.timeout,
-            echo_mode: args.echo,
-            echo_payload_size: args.echo_payload_size,
-            echo_interval: args.echo_interval,
-            echo_read_timeout: args.echo_read_timeout,
-        };
-
-        let summary = run(config, 0).await?;
-
-        println!(
-            "{}",
-            serde_json::to_string(&summary).expect("Failed to serialize metrics")
-        );
+        return run_server(TcpServerConfig { port: args.port }).await;
     }
 
-    Ok(())
+    run_with_config(merge(args, base)?, seed).await
 }
 
 /// Run TCP test from resolved config.

--- a/rust/tests/loadtest/src/websocket.rs
+++ b/rust/tests/loadtest/src/websocket.rs
@@ -15,6 +15,12 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REPLY_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_PAYLOAD_SIZE: usize = u16::MAX as usize; // Big enough to definitely spread across multiple IP packets but also small to not consume too many resources.
 
+/// Default number of concurrent connections.
+const DEFAULT_CONCURRENT: usize = 10;
+
+/// Default connection hold duration.
+const DEFAULT_HOLD_DURATION: Duration = Duration::from_secs(30);
+
 /// Configuration for WebSocket load testing.
 #[derive(Debug, Clone)]
 pub struct TestConfig {
@@ -38,46 +44,59 @@ pub struct Args {
     #[arg(short = 'p', long, default_value = "9001")]
     port: u16,
 
-    /// WebSocket URL (ws:// or wss://) - required in client mode
+    /// WebSocket URL (ws:// or wss://). Overrides the config's `[websocket]` addresses.
     #[arg(long, value_name = "URL")]
     url: Option<Url>,
 
     /// Number of concurrent connections to establish
-    #[arg(short = 'c', long, default_value = "10")]
-    concurrent: usize,
+    #[arg(short = 'c', long)]
+    concurrent: Option<usize>,
 
     /// How long to hold each connection open (e.g., 30s, 5m)
-    #[arg(short = 'd', long, default_value = "30s", value_parser = crate::cli::parse_duration)]
-    duration: Duration,
+    #[arg(short = 'd', long, value_parser = crate::cli::parse_duration)]
+    duration: Option<Duration>,
 
     /// How long to at most wait between messages. Zero means we won't send any messages.
     #[arg(long, value_parser = crate::cli::parse_duration)]
     max_echo_interval: Option<Duration>,
 }
 
-/// Run WebSocket test with manual CLI args.
-pub async fn run_with_cli_args(args: Args) -> anyhow::Result<()> {
+/// Build a [`TestConfig`] from CLI args, filling unspecified values from `base`.
+pub fn merge(args: Args, base: Option<TestConfig>) -> Result<TestConfig> {
+    let base = base.as_ref();
+
+    let url = args
+        .url
+        .or_else(|| base.map(|b| b.url.clone()))
+        .context("--url is required (or add [websocket] to the config)")?;
+    let concurrent = args
+        .concurrent
+        .or_else(|| base.map(|b| b.concurrent))
+        .unwrap_or(DEFAULT_CONCURRENT);
+    let hold_duration = args
+        .duration
+        .or_else(|| base.map(|b| b.hold_duration))
+        .unwrap_or(DEFAULT_HOLD_DURATION);
+    let max_echo_interval = args
+        .max_echo_interval
+        .or_else(|| base.map(|b| b.max_echo_interval))
+        .unwrap_or(Duration::ZERO);
+
+    Ok(TestConfig {
+        url,
+        concurrent,
+        hold_duration,
+        max_echo_interval,
+    })
+}
+
+/// Run WebSocket test from CLI args merged over an optional config base.
+pub async fn run_with_args(args: Args, base: Option<TestConfig>, seed: u64) -> Result<()> {
     if args.server {
-        // Server mode
-        let config = WebsocketServerConfig { port: args.port };
-        run_server(config).await?;
-    } else {
-        // Client mode
-        let url = args.url.ok_or_else(|| {
-            anyhow::anyhow!("--url is required in client mode (or use --server for server mode)")
-        })?;
-
-        let config = TestConfig {
-            url,
-            concurrent: args.concurrent,
-            hold_duration: args.duration,
-            max_echo_interval: args.max_echo_interval.unwrap_or_default(),
-        };
-
-        run(config, 0).await?;
+        return run_server(WebsocketServerConfig { port: args.port }).await;
     }
 
-    Ok(())
+    run_with_config(merge(args, base)?, seed).await
 }
 
 /// Run WebSocket test from resolved config.


### PR DESCRIPTION
Subcommands previously ignored the config file entirely. They now resolve the matching config section as a base (seeded, like the random mode) and let explicitly-passed CLI flags override it; required values may come from either side.

Also fixes a latent `Range::is_empty` bug that reported equal-bounds ranges (e.g. `"10..10"`) as empty, which made `gen_range` panic when resolving such a config.