### PR TITLE
fix(loadtest): install ring crypto provider at startup

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "phoenix-channel",
  "rand 0.8.5",
  "reqwest",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",

--- a/rust/tests/loadtest/Cargo.toml
+++ b/rust/tests/loadtest/Cargo.toml
@@ -25,6 +25,7 @@ logging = { workspace = true }
 phoenix-channel = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-no-provider", "gzip", "http2"] }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -112,6 +112,12 @@ enum Commands {
 async fn main() {
     init_logging();
 
+    // `reqwest` is built with `rustls-no-provider`, so no crypto provider is
+    // installed automatically. Install `ring` explicitly before any TLS is used.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process should always succeed");
+
     match try_main().await {
         Ok(()) => {}
         Err(e) => {

--- a/rust/tests/loadtest/src/main.rs
+++ b/rust/tests/loadtest/src/main.rs
@@ -112,8 +112,6 @@ enum Commands {
 async fn main() {
     init_logging();
 
-    // `reqwest` is built with `rustls-no-provider`, so no crypto provider is
-    // installed automatically. Install `ring` explicitly before any TLS is used.
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");


### PR DESCRIPTION
The loadtest panics on startup when opening the portal's TLS connection: `reqwest` is built with `rustls-no-provider`. Install `ring` explicitly at startup, as the other Firezone binaries already do.

Related: #13630