### PR TITLE
fix(ci): allow building select SHA of data-plane

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -118,10 +118,11 @@ jobs:
     env:
       ARTIFACT_PATH: ${{ matrix.artifact }}_${{ matrix.version }}_${{ matrix.arch }}.exe
       RELEASE_NAME: ${{ matrix.release_name }}
+      RESOLVED_SHA: ${{ inputs.sha || github.sha }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ env.RESOLVED_SHA }}
           fetch-depth: 0 # Required to make `setup-rust-target-cache` effective.
       - uses: ./.github/actions/setup-rust-stable
         with:
@@ -220,6 +221,7 @@ jobs:
     env:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}_${{ matrix.name.version }}_${{ matrix.arch.shortname }}
       SENTRY_ENVIRONMENT: "production"
+      RESOLVED_SHA: ${{ inputs.sha || github.sha }}
     outputs:
       client_image: ${{ steps.image-name.outputs.client_image }}
       relay_image: ${{ steps.image-name.outputs.relay_image }}
@@ -228,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ env.RESOLVED_SHA }}
           fetch-depth: 0 # Required to make `setup-rust-target-cache` effective.
       - uses: ./.github/actions/ghcr-docker-login
         id: login
@@ -281,7 +283,7 @@ jobs:
 
           az storage blob upload \
             --container-name binaries \
-            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
+            --name "${{ matrix.name.image_name }}/${{ env.RESOLVED_SHA }}/${{ matrix.arch.shortname }}" \
             --file "${{ matrix.name.package }}" \
             --overwrite true \
             --no-progress \
@@ -289,7 +291,7 @@ jobs:
 
           az storage blob upload \
             --container-name binaries \
-            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
+            --name "${{ matrix.name.image_name }}/${{ env.RESOLVED_SHA }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
             --file "${{ matrix.name.package }}.sha256sum.txt" \
             --overwrite true \
             --no-progress \
@@ -338,7 +340,7 @@ jobs:
           # We only version client and gateway
           tags: |
             type=raw,value={{branch}}
-            type=raw,value=${{ inputs.sha || github.sha }}
+            type=raw,value=${{ env.RESOLVED_SHA }}
       - name: Sanitize github.ref_name
         run: |
           # `ref_name` contains `/`, '_' or '=' which is not a valid docker image tag
@@ -363,7 +365,7 @@ jobs:
           target: ${{ matrix.stage }}
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
           labels: |
-            org.opencontainers.image.revision=${{ inputs.sha }}
+            org.opencontainers.image.revision=${{ env.RESOLVED_SHA }}
       # main: read/write cache
       - name: Build Docker images (read/write cache)
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -383,7 +385,7 @@ jobs:
           target: ${{ matrix.stage }}
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
           labels: |
-            org.opencontainers.image.revision=${{ inputs.sha }}
+            org.opencontainers.image.revision=${{ env.RESOLVED_SHA }}
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -393,7 +395,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           overwrite: true
-          name: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
+          name: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}-${{ env.RESOLVED_SHA }}-digest-${{ matrix.arch.shortname }}
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
@@ -406,6 +408,8 @@ jobs:
     needs: data-plane-linux
     if: ${{ always() }}
     runs-on: ubuntu-24.04
+    env:
+      RESOLVED_SHA: ${{ inputs.sha || github.sha }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
@@ -429,7 +433,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ env.RESOLVED_SHA }}
       - uses: ./.github/actions/ghcr-docker-login
         id: login
         with:
@@ -437,7 +441,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.image.name }}-${{ inputs.sha }}-digest-*
+          pattern: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.image.name }}-${{ env.RESOLVED_SHA }}-digest-*
           merge-multiple: true
           path: /tmp/digests/${{ matrix.image.name }}
       - name: Display structure of downloaded artifacts
@@ -451,7 +455,7 @@ jobs:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}
           tags: |
             type=raw,value={{branch}}
-            type=raw,value=${{ inputs.sha || github.sha }}
+            type=raw,value=${{ env.RESOLVED_SHA }}
       - name: Create manifest list and push
         id: manifest
         working-directory: /tmp/digests/${{ matrix.image.name }}
@@ -465,7 +469,7 @@ jobs:
 
           # shellcheck disable=SC2086 # $tags and $sources must be split by whitespace
           docker buildx imagetools create \
-            --annotation "index:org.opencontainers.image.revision=${{ inputs.sha }}" \
+            --annotation "index:org.opencontainers.image.revision=${{ env.RESOLVED_SHA }}" \
             $tags $sources
 
           first_tag=$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -338,7 +338,7 @@ jobs:
           # We only version client and gateway
           tags: |
             type=raw,value={{branch}}
-            type=raw,value=${{ inputs.sha }}
+            type=raw,value=${{ inputs.sha || github.sha }}
       - name: Sanitize github.ref_name
         run: |
           # `ref_name` contains `/`, '_' or '=' which is not a valid docker image tag
@@ -451,7 +451,7 @@ jobs:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}
           tags: |
             type=raw,value={{branch}}
-            type=raw,value=${{ inputs.sha }}
+            type=raw,value=${{ inputs.sha || github.sha }}
       - name: Create manifest list and push
         id: manifest
         working-directory: /tmp/digests/${{ matrix.image.name }}


### PR DESCRIPTION
Hit when attempting to cut headless client releases matching the SHA of the recent gui-client release.

Related: https://github.com/firezone/firezone/actions/runs/27178001941