### PR TITLE
refactor(portal): update index summary stats

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -174,6 +174,7 @@ config :portal, Portal.Changes.ReplicationConnection,
   table_subscriptions: ~w[
     accounts
     actors
+    groups
     memberships
     devices
     external_identities

--- a/elixir/lib/portal/changes/hooks/actors.ex
+++ b/elixir/lib/portal/changes/hooks/actors.ex
@@ -1,9 +1,15 @@
 defmodule Portal.Changes.Hooks.Actors do
   @behaviour Portal.Changes.Hooks
+  alias Portal.{Changes.Change, PubSub}
   alias __MODULE__.Database
+  import Portal.SchemaHelpers
 
   @impl true
-  def on_insert(_lsn, _data), do: :ok
+  def on_insert(lsn, data) do
+    actor = struct_from_params(Portal.Actor, data)
+    change = %Change{lsn: lsn, op: :insert, struct: actor}
+    PubSub.Changes.broadcast(actor.account_id, change)
+  end
 
   @impl true
 
@@ -46,8 +52,11 @@ defmodule Portal.Changes.Hooks.Actors do
   def on_update(_lsn, _old_data, _new_data), do: :ok
 
   @impl true
-  # Side effects are handled by the cascade delete hooks
-  def on_delete(_lsn, _old_data), do: :ok
+  def on_delete(lsn, old_data) do
+    actor = struct_from_params(Portal.Actor, old_data)
+    change = %Change{lsn: lsn, op: :delete, old_struct: actor}
+    PubSub.Changes.broadcast(actor.account_id, change)
+  end
 
   defmodule Database do
     alias Portal.ClientToken

--- a/elixir/lib/portal/changes/hooks/groups.ex
+++ b/elixir/lib/portal/changes/hooks/groups.ex
@@ -1,0 +1,22 @@
+defmodule Portal.Changes.Hooks.Groups do
+  @behaviour Portal.Changes.Hooks
+  alias Portal.{Changes.Change, PubSub}
+  import Portal.SchemaHelpers
+
+  @impl true
+  def on_insert(lsn, data) do
+    group = struct_from_params(Portal.Group, data)
+    change = %Change{lsn: lsn, op: :insert, struct: group}
+    PubSub.Changes.broadcast(group.account_id, change)
+  end
+
+  @impl true
+  def on_update(_lsn, _old_data, _data), do: :ok
+
+  @impl true
+  def on_delete(lsn, old_data) do
+    group = struct_from_params(Portal.Group, old_data)
+    change = %Change{lsn: lsn, op: :delete, old_struct: group}
+    PubSub.Changes.broadcast(group.account_id, change)
+  end
+end

--- a/elixir/lib/portal/changes/replication_connection.ex
+++ b/elixir/lib/portal/changes/replication_connection.ex
@@ -5,6 +5,7 @@ defmodule Portal.Changes.ReplicationConnection do
   @tables_to_hooks %{
     "accounts" => Hooks.Accounts,
     "actors" => Hooks.Actors,
+    "groups" => Hooks.Groups,
     "memberships" => Hooks.Memberships,
     "devices" => Hooks.Devices,
     "external_identities" => Hooks.ExternalIdentities,

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -905,13 +905,13 @@ defmodule PortalWeb.CoreComponents do
     assigns = assign(assigns, colors: colors)
 
     ~H"""
-    <span class="flex inline-flex">
-      <div class={[
+    <div class="inline-flex">
+      <span class={[
         "text-xs rounded-l py-0.5 px-2",
         @colors[@type]["dark"]
       ]}>
         {render_slot(@left)}
-      </div>
+      </span>
       <span class={[
         "text-xs",
         "rounded-r",
@@ -920,7 +920,7 @@ defmodule PortalWeb.CoreComponents do
       ]}>
         {render_slot(@right)}
       </span>
-    </span>
+    </div>
     """
   end
 

--- a/elixir/lib/portal_web/components/core_components.ex
+++ b/elixir/lib/portal_web/components/core_components.ex
@@ -889,8 +889,8 @@ defmodule PortalWeb.CoreComponents do
         "light" => "bg-blue-100 text-blue-800"
       },
       "primary" => %{
-        "dark" => "bg-primary-400 text-primary-800",
-        "light" => "bg-primary-100 text-primary-800"
+        "dark" => "bg-primary-500 text-white",
+        "light" => "bg-primary-200 text-primary-700"
       },
       "accent" => %{
         "dark" => "bg-accent-100 text-accent-800",
@@ -907,7 +907,7 @@ defmodule PortalWeb.CoreComponents do
     ~H"""
     <span class="flex inline-flex">
       <div class={[
-        "text-xs rounded-l py-0.5 pl-2.5 pr-1.5",
+        "text-xs rounded-l py-0.5 px-2",
         @colors[@type]["dark"]
       ]}>
         {render_slot(@left)}
@@ -915,7 +915,7 @@ defmodule PortalWeb.CoreComponents do
       <span class={[
         "text-xs",
         "rounded-r",
-        "mr-2 py-0.5 pl-1.5 pr-2.5",
+        "py-0.5 px-2",
         @colors[@type]["light"]
       ]}>
         {render_slot(@right)}

--- a/elixir/lib/portal_web/components/page_components.ex
+++ b/elixir/lib/portal_web/components/page_components.ex
@@ -87,7 +87,7 @@ defmodule PortalWeb.PageComponents do
   slot :title, required: true, doc: "The page title"
   slot :description, required: false, doc: "Short description below the title"
   slot :action, required: false, doc: "Action button(s) shown in the top-right"
-  slot :filters, required: false, doc: "Status/type filter chips shown below the title row"
+  slot :stats, required: false, doc: "Count badges or other stats shown below the title row"
 
   def page_header(assigns) do
     ~H"""
@@ -114,8 +114,8 @@ defmodule PortalWeb.PageComponents do
               {render_slot(@action)}
             </div>
           </div>
-          <div :if={not Enum.empty?(@filters)} class="mt-3 flex items-center gap-2 flex-wrap">
-            {render_slot(@filters)}
+          <div :if={not Enum.empty?(@stats)} class="mt-2 flex items-center gap-2 flex-wrap">
+            {render_slot(@stats)}
           </div>
         </div>
       </div>

--- a/elixir/lib/portal_web/components/page_components.ex
+++ b/elixir/lib/portal_web/components/page_components.ex
@@ -70,7 +70,7 @@ defmodule PortalWeb.PageComponents do
   end
 
   @doc """
-  Renders a page header with icon, title, description, action, and filter slots.
+  Renders a page header with icon, title, description, action, and stats slots.
 
   ## Examples
 
@@ -81,6 +81,12 @@ defmodule PortalWeb.PageComponents do
         <:action>
           <.add_button navigate={~p"/resources/new"}>Add Resource</.add_button>
         </:action>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@resources_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
       </.page_header>
   """
   slot :icon, required: false, doc: "Large icon displayed beside the title"

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -1272,14 +1272,8 @@ defmodule PortalWeb.Actors do
     def count_actors(subject) do
       from(a in Actor, as: :actors)
       |> where([actors: a], a.type in [:account_user, :account_admin_user])
-      |> select([actors: a], count(a.id))
       |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        n -> n
-      end
+      |> Safe.aggregate(:count)
     end
 
     defp index_query do

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -141,26 +141,6 @@ defmodule PortalWeb.Actors do
     {:noreply, socket}
   end
 
-  def handle_info(%Change{op: :insert, struct: %Actor{type: type}}, socket)
-      when type in [:account_user, :account_admin_user] do
-    {:noreply,
-     update(socket, :actors_count, fn
-       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
-       ar -> ar
-     end)}
-  end
-
-  def handle_info(%Change{op: :delete, old_struct: %Actor{type: type}}, socket)
-      when type in [:account_user, :account_admin_user] do
-    {:noreply,
-     update(socket, :actors_count, fn
-       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
-       ar -> ar
-     end)}
-  end
-
-  def handle_info(%Change{}, socket), do: {:noreply, socket}
-
   def handle_event(event, params, socket)
       when event in ["paginate", "order_by", "filter", "table_row_click", "change_limit"],
       do: handle_live_table_event(event, params, socket)
@@ -769,6 +749,26 @@ defmodule PortalWeb.Actors do
       {:noreply, put_flash(socket, :error, "Cannot send welcome email to this actor")}
     end
   end
+
+  def handle_info(%Change{op: :insert, struct: %Actor{type: type}}, socket)
+      when type in [:account_user, :account_admin_user] do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Actor{type: type}}, socket)
+      when type in [:account_user, :account_admin_user] do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{}, socket), do: {:noreply, socket}
 
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic}, socket) do
     actor = socket.assigns.selected_actor

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -19,6 +19,7 @@ defmodule PortalWeb.Actors do
     socket =
       socket
       |> assign(page_title: "People")
+      |> assign(actors_count: Database.count_actors(socket.assigns.subject))
       |> assign(
         selected_actor: nil,
         portal_sessions_subscribed_actor_id: nil,
@@ -1011,6 +1012,12 @@ defmodule PortalWeb.Actors do
             New Person
           </.button>
         </:action>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@actors_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
       </.page_header>
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -1260,6 +1267,19 @@ defmodule PortalWeb.Actors do
             actors.id
           )
       })
+    end
+
+    def count_actors(subject) do
+      from(a in Actor, as: :actors)
+      |> where([actors: a], a.type in [:account_user, :account_admin_user])
+      |> select([actors: a], count(a.id))
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        {:error, _} -> 0
+        nil -> 0
+        n -> n
+      end
     end
 
     defp index_query do

--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -6,20 +6,29 @@ defmodule PortalWeb.Actors do
 
   alias Portal.Actor
   alias Portal.Authentication
-  alias Portal.Presence
+  alias Portal.Changes.Change
   alias Portal.ExternalIdentity
   alias Portal.PortalSession
   alias Portal.ClientToken
+  alias Portal.Presence
+  alias Portal.PubSub
+  alias Phoenix.LiveView.AsyncResult
 
   import Ecto.Changeset
 
   require Logger
 
   def mount(_params, _session, socket) do
+    subject = socket.assigns.subject
+
+    if connected?(socket) do
+      :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
+    end
+
     socket =
       socket
       |> assign(page_title: "People")
-      |> assign(actors_count: Database.count_actors(socket.assigns.subject))
+      |> assign_async(:actors_count, fn -> {:ok, %{actors_count: Database.count_actors(subject)}} end)
       |> assign(
         selected_actor: nil,
         portal_sessions_subscribed_actor_id: nil,
@@ -131,6 +140,26 @@ defmodule PortalWeb.Actors do
 
     {:noreply, socket}
   end
+
+  def handle_info(%Change{op: :insert, struct: %Actor{type: type}}, socket)
+      when type in [:account_user, :account_admin_user] do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Actor{type: type}}, socket)
+      when type in [:account_user, :account_admin_user] do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{}, socket), do: {:noreply, socket}
 
   def handle_event(event, params, socket)
       when event in ["paginate", "order_by", "filter", "table_row_click", "change_limit"],
@@ -1013,10 +1042,13 @@ defmodule PortalWeb.Actors do
           </.button>
         </:action>
         <:stats>
-          <.dual_badge type="primary">
-            <:left>{@actors_count}</:left>
-            <:right>Total</:right>
-          </.dual_badge>
+          <.async_result :let={count} assign={@actors_count}>
+            <:loading><.badge type="primary">Loading...</.badge></:loading>
+            <.dual_badge type="primary">
+              <:left>{count}</:left>
+              <:right>Total</:right>
+            </.dual_badge>
+          </.async_result>
         </:stats>
       </.page_header>
 

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -2,18 +2,25 @@ defmodule PortalWeb.Clients do
   use PortalWeb, :live_view
   import PortalWeb.Clients.Components
   alias Portal.{Presence.Clients, ComponentVersions}
+  alias Portal.Changes.Change
+  alias Portal.Device
+  alias Portal.PubSub
+  alias Phoenix.LiveView.AsyncResult
   alias __MODULE__.Database
 
   def mount(_params, _session, socket) do
+    subject = socket.assigns.subject
+
     if connected?(socket) do
-      :ok = Clients.Account.subscribe(socket.assigns.subject.account.id)
+      :ok = Clients.Account.subscribe(subject.account.id)
+      :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
     end
 
     socket =
       socket
       |> assign(page_title: "Clients")
       |> assign(selected_client: nil)
-      |> assign(clients_count: Database.count_clients(socket.assigns.subject))
+      |> assign_async(:clients_count, fn -> {:ok, %{clients_count: Database.count_clients(subject)}} end)
       |> assign(
         policy_authorizations: [],
         policy_authorizations_page: 1,
@@ -116,10 +123,13 @@ defmodule PortalWeb.Clients do
           <.docs_action path="/deploy/clients" />
         </:action>
         <:stats>
-          <.dual_badge type="primary">
-            <:left>{@clients_count}</:left>
-            <:right>Total</:right>
-          </.dual_badge>
+          <.async_result :let={count} assign={@clients_count}>
+            <:loading><.badge type="primary">Loading...</.badge></:loading>
+            <.dual_badge type="primary">
+              <:left>{count}</:left>
+              <:right>Total</:right>
+            </.dual_badge>
+          </.async_result>
         </:stats>
 
       </.page_header>
@@ -483,6 +493,26 @@ defmodule PortalWeb.Clients do
      socket
      |> put_flash(:error, message)
      |> push_patch(to: ~p"/#{socket.assigns.account}/clients?#{socket.assigns.query_params}")}
+  end
+
+  def handle_info(%Change{op: :insert, struct: %Device{type: :client}}, socket) do
+    {:noreply,
+     update(socket, :clients_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Device{type: :client}}, socket) do
+    {:noreply,
+     update(socket, :clients_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{}, socket) do
+    {:noreply, socket}
   end
 
   def handle_info(

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -13,6 +13,7 @@ defmodule PortalWeb.Clients do
       socket
       |> assign(page_title: "Clients")
       |> assign(selected_client: nil)
+      |> assign(clients_count: Database.count_clients(socket.assigns.subject))
       |> assign(
         policy_authorizations: [],
         policy_authorizations_page: 1,
@@ -114,21 +115,13 @@ defmodule PortalWeb.Clients do
         <:action>
           <.docs_action path="/deploy/clients" />
         </:action>
-        <:filters>
-          <% verified_count = Enum.count(@clients, &(not is_nil(&1.verified_at))) %>
-          <% unverified_count = length(@clients) - verified_count %>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border-emphasis)] bg-[var(--surface-raised)] text-[var(--text-primary)] font-medium">
-            All {@clients_metadata.count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-[var(--status-active)]"></span>
-            Verified {verified_count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-[var(--text-muted)]"></span>
-            Unverified {unverified_count}
-          </span>
-        </:filters>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@clients_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
+
       </.page_header>
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -519,6 +512,19 @@ defmodule PortalWeb.Clients do
     alias Portal.Resource
     alias Portal.Repo.Filter
     alias Portal.Repo.OffsetPaginator
+
+    def count_clients(subject) do
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.type == :client)
+      |> select([devices: d], count(d.id))
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        {:error, _} -> 0
+        nil -> 0
+        n -> n
+      end
+    end
 
     def list_clients(subject, opts \\ []) do
       {preload, opts} = Keyword.pop(opts, :preload, [])

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -516,14 +516,8 @@ defmodule PortalWeb.Clients do
     def count_clients(subject) do
       from(d in Device, as: :devices)
       |> where([devices: d], d.type == :client)
-      |> select([devices: d], count(d.id))
       |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        n -> n
-      end
+      |> Safe.aggregate(:count)
     end
 
     def list_clients(subject, opts \\ []) do

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -2,6 +2,10 @@ defmodule PortalWeb.Groups do
   use PortalWeb, :live_view
 
   alias __MODULE__.Database
+  alias Portal.Changes.Change
+  alias Portal.Group
+  alias Portal.PubSub
+  alias Phoenix.LiveView.AsyncResult
   import PortalWeb.Groups.Components
 
   @member_page_size 10
@@ -16,10 +20,16 @@ defmodule PortalWeb.Groups do
     ]
 
   def mount(_params, _session, socket) do
+    subject = socket.assigns.subject
+
+    if connected?(socket) do
+      :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
+    end
+
     socket =
       socket
       |> assign(page_title: "Groups", selected_group: nil)
-      |> assign(groups_count: Database.count_groups(socket.assigns.subject))
+      |> assign_async(:groups_count, fn -> {:ok, %{groups_count: Database.count_groups(subject)}} end)
       |> assign(base_group_assigns(socket))
       |> assign_live_table("groups",
         query_module: Database,
@@ -88,6 +98,32 @@ defmodule PortalWeb.Groups do
      |> assign(selected_group: nil)
      |> assign(base_group_assigns(socket))}
   end
+
+  def handle_info(
+        %Change{op: :insert, struct: %Group{type: type, idp_id: idp_id, name: name}},
+        socket
+      )
+      when type != :managed or not is_nil(idp_id) or name != "Everyone" do
+    {:noreply,
+     update(socket, :groups_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(
+        %Change{op: :delete, old_struct: %Group{type: type, idp_id: idp_id, name: name}},
+        socket
+      )
+      when type != :managed or not is_nil(idp_id) or name != "Everyone" do
+    {:noreply,
+     update(socket, :groups_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{}, socket), do: {:noreply, socket}
 
   def handle_event(event, params, socket)
       when event in [
@@ -777,10 +813,13 @@ defmodule PortalWeb.Groups do
           </.button>
         </:action>
         <:stats>
-          <.dual_badge type="primary">
-            <:left>{@groups_count}</:left>
-            <:right>Total</:right>
-          </.dual_badge>
+          <.async_result :let={count} assign={@groups_count}>
+            <:loading><.badge type="primary">Loading...</.badge></:loading>
+            <.dual_badge type="primary">
+              <:left>{count}</:left>
+              <:right>Total</:right>
+            </.dual_badge>
+          </.async_result>
         </:stats>
       </.page_header>
 
@@ -1809,4 +1848,5 @@ defmodule PortalWeb.Groups do
       |> Safe.update()
     end
   end
+
 end

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -1369,14 +1369,8 @@ defmodule PortalWeb.Groups do
         [groups: g],
         not (g.type == :managed and is_nil(g.idp_id) and g.name == "Everyone")
       )
-      |> select([groups: g], count(g.id))
       |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        n -> n
-      end
+      |> Safe.aggregate(:count)
     end
 
     def list_groups(subject, opts \\ []) do

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -18,7 +18,8 @@ defmodule PortalWeb.Groups do
   def mount(_params, _session, socket) do
     socket =
       socket
-      |> assign(page_title: "Groups", groups_with_policies_count: 0, selected_group: nil)
+      |> assign(page_title: "Groups", selected_group: nil)
+      |> assign(groups_count: Database.count_groups(socket.assigns.subject))
       |> assign(base_group_assigns(socket))
       |> assign_live_table("groups",
         query_module: Database,
@@ -745,15 +746,11 @@ defmodule PortalWeb.Groups do
   end
 
   def handle_groups_update!(socket, list_opts) do
-    filter = Keyword.get(list_opts, :filter, [])
-
     with {:ok, groups, metadata} <- Database.list_groups(socket.assigns.subject, list_opts) do
       {:ok,
        assign(socket,
          groups: groups,
-         groups_metadata: metadata,
-         groups_with_policies_count:
-           Database.count_groups_with_policies(socket.assigns.subject, filter)
+         groups_metadata: metadata
        )}
     end
   end
@@ -779,17 +776,12 @@ defmodule PortalWeb.Groups do
             New Group
           </.button>
         </:action>
-        <:filters>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border-emphasis)] bg-[var(--surface-raised)] text-[var(--text-primary)] font-medium">
-            All {@groups_metadata.count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            With policies {@groups_with_policies_count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            No policies {@groups_metadata.count - @groups_with_policies_count}
-          </span>
-        </:filters>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@groups_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
       </.page_header>
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -1371,6 +1363,22 @@ defmodule PortalWeb.Groups do
     end
 
     # Inlined from Portal.Actors.list_groups
+    def count_groups(subject) do
+      from(g in Portal.Group, as: :groups)
+      |> where(
+        [groups: g],
+        not (g.type == :managed and is_nil(g.idp_id) and g.name == "Everyone")
+      )
+      |> select([groups: g], count(g.id))
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        {:error, _} -> 0
+        nil -> 0
+        n -> n
+      end
+    end
+
     def list_groups(subject, opts \\ []) do
       {filter, opts} = Keyword.pop(opts, :filter, [])
       {order_by, opts} = Keyword.pop(opts, :order_by, [])
@@ -1438,35 +1446,6 @@ defmodule PortalWeb.Groups do
       group_ids
       |> Enum.map(&Map.get(groups_by_id, &1))
       |> Enum.reject(&is_nil/1)
-    end
-
-    def count_groups_with_policies(subject, filter \\ []) do
-      query =
-        from(g in Portal.Group, as: :groups)
-        |> join(:inner, [groups: g], p in Portal.Policy,
-          on: p.group_id == g.id and is_nil(p.disabled_at),
-          as: :policies
-        )
-        |> where(
-          [groups: g],
-          not (g.type == :managed and is_nil(g.idp_id) and g.name == "Everyone")
-        )
-        |> select([groups: g], count(g.id, :distinct))
-
-      query =
-        case Filter.filter(query, __MODULE__, filter) do
-          {:ok, filtered} -> filtered
-          _ -> query
-        end
-
-      query
-      |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        count -> count
-      end
     end
 
     def count_total_members(subject) do

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -13,6 +13,7 @@ defmodule PortalWeb.Policies do
     ]
 
   alias Portal.{Changes.Change, Policy, Authentication, PubSub}
+  alias Phoenix.LiveView.AsyncResult
   alias __MODULE__.Database
 
   @tod_pending_empty %{"on" => "", "off" => "", "days" => []}
@@ -20,6 +21,8 @@ defmodule PortalWeb.Policies do
   import Portal.Changeset
 
   def mount(_params, _session, socket) do
+    subject = socket.assigns.subject
+
     if connected?(socket) do
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
     end
@@ -28,7 +31,7 @@ defmodule PortalWeb.Policies do
       socket
       |> assign(stale: false)
       |> assign(page_title: "Policies")
-      |> assign(policies_count: Database.count_policies(socket.assigns.subject))
+      |> assign_async(:policies_count, fn -> {:ok, %{policies_count: Database.count_policies(subject)}} end)
       |> assign(selected_policy: nil, policy_providers: [])
       |> assign(
         policy_authorizations: [],
@@ -219,10 +222,13 @@ defmodule PortalWeb.Policies do
           </.button>
         </:action>
         <:stats>
-          <.dual_badge type="primary">
-            <:left>{@policies_count}</:left>
-            <:right>Total</:right>
-          </.dual_badge>
+          <.async_result :let={count} assign={@policies_count}>
+            <:loading><.badge type="primary">Loading...</.badge></:loading>
+            <.dual_badge type="primary">
+              <:left>{count}</:left>
+              <:right>Total</:right>
+            </.dual_badge>
+          </.async_result>
         </:stats>
       </.page_header>
 
@@ -811,11 +817,31 @@ defmodule PortalWeb.Policies do
     {:noreply, merge_state(socket, :policy_conditions, auth_provider_values: updated)}
   end
 
-  def handle_info(%Change{old_struct: %Portal.Policy{}} = change, socket) do
+  def handle_info(%Change{op: :insert, struct: %Policy{}} = change, socket) do
+    {:noreply,
+     socket
+     |> update(:policies_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)
+     |> mark_stale_if_unreflected(change)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Policy{}} = change, socket) do
+    {:noreply,
+     socket
+     |> update(:policies_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)
+     |> mark_stale_if_unreflected(change)}
+  end
+
+  def handle_info(%Change{old_struct: %Policy{}} = change, socket) do
     {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
-  def handle_info(%Change{struct: %Portal.Policy{}} = change, socket) do
+  def handle_info(%Change{struct: %Policy{}} = change, socket) do
     {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -28,6 +28,7 @@ defmodule PortalWeb.Policies do
       socket
       |> assign(stale: false)
       |> assign(page_title: "Policies")
+      |> assign(policies_count: Database.count_policies(socket.assigns.subject))
       |> assign(selected_policy: nil, policy_providers: [])
       |> assign(
         policy_authorizations: [],
@@ -217,18 +218,12 @@ defmodule PortalWeb.Policies do
             New Policy
           </.button>
         </:action>
-        <:filters>
-          <% conditions_count = Enum.count(@policies, fn p -> length(p.conditions) > 0 end) %>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border-emphasis)] bg-[var(--surface-raised)] text-[var(--text-primary)] font-medium">
-            All {@policies_metadata.count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            With conditions {conditions_count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            No conditions {length(@policies) - conditions_count}
-          </span>
-        </:filters>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@policies_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
       </.page_header>
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -1223,6 +1218,18 @@ defmodule PortalWeb.Policies do
         |> Safe.scoped(subject, :replica)
         |> Safe.all()
       end)
+    end
+
+    def count_policies(subject) do
+      from(p in Policy, as: :policies)
+      |> select([policies: p], count(p.id))
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        {:error, _} -> 0
+        nil -> 0
+        n -> n
+      end
     end
 
     def list_policies(subject, opts \\ []) do

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -1222,14 +1222,8 @@ defmodule PortalWeb.Policies do
 
     def count_policies(subject) do
       from(p in Policy, as: :policies)
-      |> select([policies: p], count(p.id))
       |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        n -> n
-      end
+      |> Safe.aggregate(:count)
     end
 
     def list_policies(subject, opts \\ []) do

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -15,7 +15,6 @@ defmodule PortalWeb.Resources do
       panel_shell: 1,
       resource_details_panel: 1,
       resource_form_panel: 1,
-      resource_online?: 2,
       resource_status_badge: 1,
       resource_type_label: 1,
       type_badge_class: 1,
@@ -39,6 +38,7 @@ defmodule PortalWeb.Resources do
       |> assign(stale: false)
       |> assign(presence_tick: 0)
       |> assign(page_title: "Resources")
+      |> assign(resources_count: Database.count_resources(socket.assigns.subject))
       |> assign(
         selected_resource: nil,
         selected_groups: [],
@@ -355,27 +355,12 @@ defmodule PortalWeb.Resources do
             New Resource
           </.button>
         </:action>
-        <:filters>
-          <% online_count = Enum.count(@resources, &resource_online?(&1, @presence_tick)) %>
-          <% offline_count = length(@resources) - online_count %>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border-emphasis)] bg-[var(--surface-raised)] text-[var(--text-primary)] font-medium">
-            All {@resources_metadata.count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="relative flex items-center justify-center w-1.5 h-1.5">
-              <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-[var(--status-active)]">
-              </span>
-              <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-active)]">
-              </span>
-            </span>
-            Online {online_count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-neutral)]">
-            </span>
-            Offline {offline_count}
-          </span>
-        </:filters>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@resources_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
       </.page_header>
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -1485,6 +1470,19 @@ defmodule PortalWeb.Resources do
       |> preload(:site)
       |> Safe.scoped(subject, :replica)
       |> Safe.one(fallback_to_primary: true)
+    end
+
+    def count_resources(subject) do
+      from(r in Resource, as: :resources)
+      |> where([resources: r], r.type != :internet)
+      |> select([resources: r], count(r.id))
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        {:error, _} -> 0
+        nil -> 0
+        n -> n
+      end
     end
 
     def list_resources(subject, opts \\ []) do

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -1475,14 +1475,8 @@ defmodule PortalWeb.Resources do
     def count_resources(subject) do
       from(r in Resource, as: :resources)
       |> where([resources: r], r.type != :internet)
-      |> select([resources: r], count(r.id))
       |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        n -> n
-      end
+      |> Safe.aggregate(:count)
     end
 
     def list_resources(subject, opts \\ []) do

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -25,9 +25,12 @@ defmodule PortalWeb.Resources do
   alias Portal.Presence
   alias Portal.PubSub
   alias Portal.Resource
+  alias Phoenix.LiveView.AsyncResult
   alias __MODULE__.Database
 
   def mount(_params, _session, socket) do
+    subject = socket.assigns.subject
+
     if connected?(socket) do
       :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
       :ok = Presence.Gateways.Account.subscribe(socket.assigns.account.id)
@@ -38,7 +41,7 @@ defmodule PortalWeb.Resources do
       |> assign(stale: false)
       |> assign(presence_tick: 0)
       |> assign(page_title: "Resources")
-      |> assign(resources_count: Database.count_resources(socket.assigns.subject))
+      |> assign_async(:resources_count, fn -> {:ok, %{resources_count: Database.count_resources(subject)}} end)
       |> assign(
         selected_resource: nil,
         selected_groups: [],
@@ -356,10 +359,13 @@ defmodule PortalWeb.Resources do
           </.button>
         </:action>
         <:stats>
-          <.dual_badge type="primary">
-            <:left>{@resources_count}</:left>
-            <:right>Total</:right>
-          </.dual_badge>
+          <.async_result :let={count} assign={@resources_count}>
+            <:loading><.badge type="primary">Loading...</.badge></:loading>
+            <.dual_badge type="primary">
+              <:left>{count}</:left>
+              <:right>Total</:right>
+            </.dual_badge>
+          </.async_result>
         </:stats>
       </.page_header>
 
@@ -1171,6 +1177,28 @@ defmodule PortalWeb.Resources do
      merge_state(socket, :resource_grant,
        active_conditions: List.delete(socket.assigns.resource_grant.active_conditions, type)
      )}
+  end
+
+  def handle_info(%Change{op: :insert, struct: %Resource{type: type}} = change, socket)
+      when type != :internet do
+    {:noreply,
+     socket
+     |> update(:resources_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)
+     |> mark_stale_if_unreflected(change)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Resource{type: type}} = change, socket)
+      when type != :internet do
+    {:noreply,
+     socket
+     |> update(:resources_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)
+     |> mark_stale_if_unreflected(change)}
   end
 
   def handle_info(%Change{old_struct: %Resource{}} = change, socket) do

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -6,18 +6,27 @@ defmodule PortalWeb.ServiceAccounts do
 
   alias Portal.Actor
   alias Portal.Authentication
-  alias Portal.Presence
+  alias Portal.Changes.Change
   alias Portal.ClientToken
+  alias Portal.Presence
+  alias Portal.PubSub
+  alias Phoenix.LiveView.AsyncResult
 
   import Ecto.Changeset
 
   require Logger
 
   def mount(_params, _session, socket) do
+    subject = socket.assigns.subject
+
+    if connected?(socket) do
+      :ok = PubSub.Changes.subscribe(socket.assigns.account.id)
+    end
+
     socket =
       socket
       |> assign(page_title: "Service Accounts")
-      |> assign(actors_count: Database.count_actors(socket.assigns.subject))
+      |> assign_async(:actors_count, fn -> {:ok, %{actors_count: Database.count_actors(subject)}} end)
       |> assign(
         selected_actor: nil,
         portal_sessions_subscribed_actor_id: nil,
@@ -120,6 +129,24 @@ defmodule PortalWeb.ServiceAccounts do
 
     {:noreply, socket}
   end
+
+  def handle_info(%Change{op: :insert, struct: %Actor{type: :service_account}}, socket) do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Actor{type: :service_account}}, socket) do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{}, socket), do: {:noreply, socket}
 
   def handle_event(event, params, socket)
       when event in ["paginate", "order_by", "filter", "table_row_click", "change_limit"],
@@ -595,10 +622,13 @@ defmodule PortalWeb.ServiceAccounts do
           </.button>
         </:action>
         <:stats>
-          <.dual_badge type="primary">
-            <:left>{@actors_count}</:left>
-            <:right>Total</:right>
-          </.dual_badge>
+          <.async_result :let={count} assign={@actors_count}>
+            <:loading><.badge type="primary">Loading...</.badge></:loading>
+            <.dual_badge type="primary">
+              <:left>{count}</:left>
+              <:right>Total</:right>
+            </.dual_badge>
+          </.async_result>
         </:stats>
       </.page_header>
 

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -130,24 +130,6 @@ defmodule PortalWeb.ServiceAccounts do
     {:noreply, socket}
   end
 
-  def handle_info(%Change{op: :insert, struct: %Actor{type: :service_account}}, socket) do
-    {:noreply,
-     update(socket, :actors_count, fn
-       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
-       ar -> ar
-     end)}
-  end
-
-  def handle_info(%Change{op: :delete, old_struct: %Actor{type: :service_account}}, socket) do
-    {:noreply,
-     update(socket, :actors_count, fn
-       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
-       ar -> ar
-     end)}
-  end
-
-  def handle_info(%Change{}, socket), do: {:noreply, socket}
-
   def handle_event(event, params, socket)
       when event in ["paginate", "order_by", "filter", "table_row_click", "change_limit"],
       do: handle_live_table_event(event, params, socket)
@@ -579,6 +561,24 @@ defmodule PortalWeb.ServiceAccounts do
       {:noreply, put_flash(socket, :error, "Token not found")}
     end
   end
+
+  def handle_info(%Change{op: :insert, struct: %Actor{type: :service_account}}, socket) do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{op: :delete, old_struct: %Actor{type: :service_account}}, socket) do
+    {:noreply,
+     update(socket, :actors_count, fn
+       %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
+       ar -> ar
+     end)}
+  end
+
+  def handle_info(%Change{}, socket), do: {:noreply, socket}
 
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: topic}, socket) do
     actor = socket.assigns.selected_actor

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -17,6 +17,7 @@ defmodule PortalWeb.ServiceAccounts do
     socket =
       socket
       |> assign(page_title: "Service Accounts")
+      |> assign(actors_count: Database.count_actors(socket.assigns.subject))
       |> assign(
         selected_actor: nil,
         portal_sessions_subscribed_actor_id: nil,
@@ -593,6 +594,12 @@ defmodule PortalWeb.ServiceAccounts do
             New Service Account
           </.button>
         </:action>
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{@actors_count}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
       </.page_header>
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -856,6 +863,19 @@ defmodule PortalWeb.ServiceAccounts do
     alias Portal.Safe
     alias Portal.Repo.Filter
     alias Portal.Repo.OffsetPaginator
+
+    def count_actors(subject) do
+      from(a in Actor, as: :actors)
+      |> where([actors: a], a.type == :service_account)
+      |> select([actors: a], count(a.id))
+      |> Safe.scoped(subject, :replica)
+      |> Safe.one()
+      |> case do
+        {:error, _} -> 0
+        nil -> 0
+        n -> n
+      end
+    end
 
     defp index_query do
       from(actors in Actor, as: :actors)

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -867,14 +867,8 @@ defmodule PortalWeb.ServiceAccounts do
     def count_actors(subject) do
       from(a in Actor, as: :actors)
       |> where([actors: a], a.type == :service_account)
-      |> select([actors: a], count(a.id))
       |> Safe.scoped(subject, :replica)
-      |> Safe.one()
-      |> case do
-        {:error, _} -> 0
-        nil -> 0
-        n -> n
-      end
+      |> Safe.aggregate(:count)
     end
 
     defp index_query do

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -186,7 +186,7 @@ defmodule PortalWeb.Sites do
             New Site
           </.button>
         </:action>
-        <:stats>
+        <:stats :if={not @sites_loading?}>
           <.dual_badge type="primary">
             <:left>{length(@sites) + if @internet_site, do: 1, else: 0}</:left>
             <:right>Total</:right>

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -186,40 +186,13 @@ defmodule PortalWeb.Sites do
             New Site
           </.button>
         </:action>
-        <:filters>
-          <% all_sites = @sites ++ if(@internet_site, do: [@internet_site], else: [])
+        <:stats>
+          <.dual_badge type="primary">
+            <:left>{length(@sites) + if @internet_site, do: 1, else: 0}</:left>
+            <:right>Total</:right>
+          </.dual_badge>
+        </:stats>
 
-          healthy_count =
-            Enum.count(all_sites, &(compute_site_status(&1.id, &1.health_threshold) == :healthy))
-
-          degraded_count =
-            Enum.count(all_sites, &(compute_site_status(&1.id, &1.health_threshold) == :degraded))
-
-          offline_count =
-            Enum.count(all_sites, &(compute_site_status(&1.id, &1.health_threshold) == :offline)) %>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border-emphasis)] bg-[var(--surface-raised)] text-[var(--text-primary)] font-medium">
-            All {length(all_sites)}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="relative flex items-center justify-center w-1.5 h-1.5">
-              <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-[var(--status-active)]">
-              </span>
-              <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-active)]">
-              </span>
-            </span>
-            Healthy {healthy_count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-warn)]">
-            </span>
-            Degraded {degraded_count}
-          </span>
-          <span class="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full border border-[var(--border)] text-[var(--text-secondary)]">
-            <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-[var(--status-neutral)]">
-            </span>
-            Offline {offline_count}
-          </span>
-        </:filters>
       </.page_header>
 
       <div class="flex-1 overflow-auto overflow-x-auto">

--- a/elixir/test/portal/changes/hooks/actors_test.exs
+++ b/elixir/test/portal/changes/hooks/actors_test.exs
@@ -1,0 +1,59 @@
+defmodule Portal.Changes.Hooks.ActorsTest do
+  use Portal.DataCase, async: true
+  import Portal.Changes.Hooks.Actors
+  import Portal.AccountFixtures
+  import Portal.ActorFixtures
+  alias Portal.Changes.Change
+  alias Portal.Actor
+  alias Portal.PubSub
+
+  describe "on_insert/2" do
+    test "broadcasts created actor" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id)
+
+      data = %{
+        "id" => actor.id,
+        "account_id" => account.id,
+        "name" => actor.name,
+        "type" => actor.type,
+        "disabled_at" => nil
+      }
+
+      assert :ok == on_insert(0, data)
+
+      assert_receive %Change{op: :insert, struct: %Actor{} = created_actor, lsn: 0}
+
+      assert created_actor.id == actor.id
+      assert created_actor.account_id == actor.account_id
+      assert created_actor.name == actor.name
+      assert created_actor.type == actor.type
+    end
+  end
+
+  describe "on_delete/2" do
+    test "broadcasts deleted actor" do
+      account = account_fixture()
+      actor = actor_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id)
+
+      old_data = %{
+        "id" => actor.id,
+        "account_id" => account.id,
+        "name" => actor.name,
+        "type" => actor.type,
+        "disabled_at" => nil
+      }
+
+      assert :ok == on_delete(0, old_data)
+
+      assert_receive %Change{op: :delete, old_struct: %Actor{} = deleted_actor, lsn: 0}
+
+      assert deleted_actor.id == actor.id
+      assert deleted_actor.account_id == actor.account_id
+      assert deleted_actor.name == actor.name
+      assert deleted_actor.type == actor.type
+    end
+  end
+end

--- a/elixir/test/portal/changes/hooks/groups_test.exs
+++ b/elixir/test/portal/changes/hooks/groups_test.exs
@@ -1,0 +1,57 @@
+defmodule Portal.Changes.Hooks.GroupsTest do
+  use Portal.DataCase, async: true
+  import Portal.Changes.Hooks.Groups
+  import Portal.AccountFixtures
+  import Portal.GroupFixtures
+  alias Portal.Changes.Change
+  alias Portal.Group
+  alias Portal.PubSub
+
+  describe "on_insert/2" do
+    test "broadcasts created group" do
+      account = account_fixture()
+      group = group_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id)
+
+      data = %{
+        "id" => group.id,
+        "account_id" => account.id,
+        "name" => group.name,
+        "type" => group.type
+      }
+
+      assert :ok == on_insert(0, data)
+
+      assert_receive %Change{op: :insert, struct: %Group{} = created_group, lsn: 0}
+
+      assert created_group.id == group.id
+      assert created_group.account_id == group.account_id
+      assert created_group.name == group.name
+      assert created_group.type == group.type
+    end
+  end
+
+  describe "on_delete/2" do
+    test "broadcasts deleted group" do
+      account = account_fixture()
+      group = group_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id)
+
+      old_data = %{
+        "id" => group.id,
+        "account_id" => account.id,
+        "name" => group.name,
+        "type" => group.type
+      }
+
+      assert :ok == on_delete(0, old_data)
+
+      assert_receive %Change{op: :delete, old_struct: %Group{} = deleted_group, lsn: 0}
+
+      assert deleted_group.id == group.id
+      assert deleted_group.account_id == group.account_id
+      assert deleted_group.name == group.name
+      assert deleted_group.type == group.type
+    end
+  end
+end

--- a/elixir/test/portal/crypto_test.exs
+++ b/elixir/test/portal/crypto_test.exs
@@ -241,11 +241,11 @@ defmodule Portal.CryptoTest do
 
     test "raises an error when secret is not a binary" do
       assert_raise FunctionClauseError, fn ->
-        hash(:argon2, 1)
+        apply(Portal.Crypto, :hash, [:argon2, 1])
       end
 
       assert_raise FunctionClauseError, fn ->
-        hash(:sha256, 1)
+        apply(Portal.Crypto, :hash, [:sha256, 1])
       end
     end
 

--- a/elixir/test/portal/crypto_test.exs
+++ b/elixir/test/portal/crypto_test.exs
@@ -239,16 +239,6 @@ defmodule Portal.CryptoTest do
       end
     end
 
-    test "raises an error when secret is not a binary" do
-      assert_raise FunctionClauseError, fn ->
-        apply(Portal.Crypto, :hash, [:argon2, 1])
-      end
-
-      assert_raise FunctionClauseError, fn ->
-        apply(Portal.Crypto, :hash, [:sha256, 1])
-      end
-    end
-
     test "argon2 hash returns valid argon2 hash string" do
       hash = hash(:argon2, "password123")
       assert String.starts_with?(hash, "$argon2")

--- a/elixir/test/portal/types/event_id_test.exs
+++ b/elixir/test/portal/types/event_id_test.exs
@@ -64,11 +64,11 @@ defmodule Portal.Types.EventIdTest do
 
     test "raises FunctionClauseError on non-integer inputs" do
       assert_raise FunctionClauseError, fn ->
-        EventId.build_change_log("not an integer", 0)
+        apply(Portal.Types.EventId, :build_change_log, ["not an integer", 0])
       end
 
       assert_raise FunctionClauseError, fn ->
-        EventId.build_change_log(0, nil)
+        apply(Portal.Types.EventId, :build_change_log, [0, nil])
       end
     end
   end

--- a/elixir/test/portal/types/event_id_test.exs
+++ b/elixir/test/portal/types/event_id_test.exs
@@ -61,16 +61,6 @@ defmodule Portal.Types.EventIdTest do
         EventId.build_change_log(0, -1)
       end
     end
-
-    test "raises FunctionClauseError on non-integer inputs" do
-      assert_raise FunctionClauseError, fn ->
-        apply(Portal.Types.EventId, :build_change_log, ["not an integer", 0])
-      end
-
-      assert_raise FunctionClauseError, fn ->
-        apply(Portal.Types.EventId, :build_change_log, [0, nil])
-      end
-    end
   end
 
   describe "cast/1" do

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -1,6 +1,9 @@
 defmodule PortalWeb.ActorsTest do
   use PortalWeb.ConnCase, async: true
 
+  alias Portal.Actor
+  alias Portal.Changes.Change
+
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.AuthProviderFixtures
@@ -1349,6 +1352,76 @@ defmodule PortalWeb.ActorsTest do
 
       assert is_nil(Portal.Repo.get_by(Portal.Actor, account_id: account.id, id: other_actor.id))
       assert is_nil(Portal.Repo.get_by(Portal.Device, account_id: account.id, id: client.id))
+    end
+  end
+
+  describe "count badge" do
+    test "shows total actor count after async load", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors")
+
+      assert html =~ "Loading..."
+
+      html = render_async(lv)
+
+      assert html =~ "1"
+      assert html =~ "Total"
+      refute html =~ "Loading..."
+    end
+
+    test "increments count on actor insert change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Actor{type: :account_user}})
+
+      html = render(lv)
+      assert html =~ "2"
+      assert html =~ "Total"
+    end
+
+    test "decrements count on actor delete change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :delete, old_struct: %Actor{type: :account_user}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
+    end
+
+    test "ignores service account changes", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Actor{type: :service_account}})
+
+      html = render(lv)
+      assert html =~ "1"
+      assert html =~ "Total"
     end
   end
 end

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -2,6 +2,7 @@ defmodule PortalWeb.ClientsTest do
   use PortalWeb.ConnCase, async: true
 
   alias Portal.{Device, Repo}
+  alias Portal.Changes.Change
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -539,6 +540,80 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Regression Laptop"
       assert html =~ "Tunnel IPv4"
       assert html =~ "Tunnel IPv6"
+    end
+  end
+
+  describe "count badge" do
+    test "shows total client count after async load", %{conn: conn, account: account, actor: actor} do
+      _client = client_fixture(account: account, actor: actor)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      assert html =~ "Loading..."
+
+      html = render_async(lv)
+
+      assert html =~ "1"
+      assert html =~ "Total"
+      refute html =~ "Loading..."
+    end
+
+    test "increments count on client insert change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Device{type: :client}})
+
+      html = render(lv)
+      assert html =~ "1"
+      assert html =~ "Total"
+    end
+
+    test "decrements count on client delete change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _client = client_fixture(account: account, actor: actor)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :delete, old_struct: %Device{type: :client}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
+    end
+
+    test "ignores non-client device changes", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Device{type: :gateway}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
     end
   end
 end

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -100,8 +100,6 @@ defmodule PortalWeb.ClientsTest do
         |> live(~p"/#{account}/clients")
 
       html = render(lv)
-      assert html =~ "Verified 1"
-      assert html =~ "Unverified 1"
       assert html =~ verified_client.name
       assert html =~ unverified_client.name
       assert has_element?(lv, "#client-#{verified_client.id}", "Verified")

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -2,6 +2,7 @@ defmodule PortalWeb.GroupsTest do
   use PortalWeb.ConnCase, async: true
 
   alias Portal.{Group, Membership, Policy, Repo}
+  alias Portal.Changes.Change
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -623,6 +624,80 @@ defmodule PortalWeb.GroupsTest do
 
       html = render(lv)
       refute html =~ group.name
+    end
+  end
+
+  describe "count badge" do
+    test "shows total group count after async load", %{conn: conn, account: account, actor: actor} do
+      _group = group_fixture(account: account)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups")
+
+      assert html =~ "Loading..."
+
+      html = render_async(lv)
+
+      assert html =~ "1"
+      assert html =~ "Total"
+      refute html =~ "Loading..."
+    end
+
+    test "increments count on group insert change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Group{type: :static}})
+
+      html = render(lv)
+      assert html =~ "1"
+      assert html =~ "Total"
+    end
+
+    test "decrements count on group delete change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _group = group_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :delete, old_struct: %Group{type: :static}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
+    end
+
+    test "ignores managed Everyone group changes", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Group{type: :managed, idp_id: nil, name: "Everyone"}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
     end
   end
 end

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -2,6 +2,7 @@ defmodule PortalWeb.PoliciesTest do
   use PortalWeb.ConnCase, async: true
 
   alias Portal.{Policy, Repo}
+  alias Portal.Changes.Change
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -1152,6 +1153,69 @@ defmodule PortalWeb.PoliciesTest do
 
       render_click(lv, "delete_policy")
       assert_patch(lv, ~p"/#{account}/policies")
+    end
+  end
+
+  describe "count badge" do
+    test "shows total policy count after async load", %{conn: conn, account: account, actor: actor} do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      _policy = policy_fixture(account: account, group: group, resource: resource)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies")
+
+      assert html =~ "Loading..."
+
+      html = render_async(lv)
+
+      assert html =~ "1"
+      assert html =~ "Total"
+      refute html =~ "Loading..."
+    end
+
+    test "increments count on policy insert change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Policy{}})
+
+      html = render(lv)
+      assert html =~ "1"
+      assert html =~ "Total"
+    end
+
+    test "decrements count on policy delete change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      _policy = policy_fixture(account: account, group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :delete, old_struct: %Policy{}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
     end
   end
 end

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -2,6 +2,8 @@ defmodule PortalWeb.ResourcesTest do
   use PortalWeb.ConnCase, async: true
 
   alias Portal.{Policy, Repo}
+  alias Portal.Changes.Change
+  alias Portal.Resource
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
@@ -1026,6 +1028,84 @@ defmodule PortalWeb.ResourcesTest do
 
       html = render_click(lv, "open_grant_form")
       assert html =~ "Grant access"
+    end
+  end
+
+  describe "count badge" do
+    test "shows total resource count after async load", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _resource = resource_fixture(account: account)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      assert html =~ "Loading..."
+
+      html = render_async(lv)
+
+      assert html =~ "1"
+      assert html =~ "Total"
+      refute html =~ "Loading..."
+    end
+
+    test "increments count on resource insert change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Resource{type: :dns}})
+
+      html = render(lv)
+      assert html =~ "1"
+      assert html =~ "Total"
+    end
+
+    test "decrements count on resource delete change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _resource = resource_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :delete, old_struct: %Resource{type: :dns}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
+    end
+
+    test "ignores internet resource changes", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Resource{type: :internet}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
     end
   end
 

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -1,6 +1,9 @@
 defmodule PortalWeb.ServiceAccountsTest do
   use PortalWeb.ConnCase, async: true
 
+  alias Portal.Actor
+  alias Portal.Changes.Change
+
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.GroupFixtures
@@ -937,6 +940,84 @@ defmodule PortalWeb.ServiceAccountsTest do
       |> render_submit()
 
       assert render(lv) =~ "Failed to update some group memberships."
+    end
+  end
+
+  describe "count badge" do
+    test "shows total service account count after async load", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _service_account = service_account_fixture(account: account)
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts")
+
+      assert html =~ "Loading..."
+
+      html = render_async(lv)
+
+      assert html =~ "1"
+      assert html =~ "Total"
+      refute html =~ "Loading..."
+    end
+
+    test "increments count on service account insert change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Actor{type: :service_account}})
+
+      html = render(lv)
+      assert html =~ "1"
+      assert html =~ "Total"
+    end
+
+    test "decrements count on service account delete change", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      _service_account = service_account_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :delete, old_struct: %Actor{type: :service_account}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
+    end
+
+    test "ignores regular actor changes", %{conn: conn, account: account, actor: actor} do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts")
+
+      render_async(lv)
+
+      send(lv.pid, %Change{op: :insert, struct: %Actor{type: :account_user}})
+
+      html = render(lv)
+      assert html =~ "0"
+      assert html =~ "Total"
     end
   end
 end


### PR DESCRIPTION
The summary stats in each of the index views had a couple of issues:

* The counts were intentionally showing the current page counts, not the entire collection counts.  However, this was unexpected to some customers.
* The elements displaying the counts were being thought to be buttons/filters when they were not.

This PR removes most of the summary stats as they were not providing a lot of benefit and replaces them with a "Total" count of the given entity being shown.  This will allow users to get a quick understanding of how many of a given entity are being filtered out when using the filters.

Fixes: #13531
Fixes: #13113 

### Screenshots

#### Before
<img width="586" height="129" alt="Screenshot 2026-06-09 at 11 34 29 AM" src="https://github.com/user-attachments/assets/846826cb-8c40-49e6-860e-37190209b042" />

#### After
<img width="641" height="121" alt="Screenshot 2026-06-09 at 11 34 08 AM" src="https://github.com/user-attachments/assets/3eeb0f2f-62d3-44ba-beac-4f62159b6cc2" />

