### PR TITLE
fix(socket-factory): apply UDP socket buffer sizes on Apple

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -575,10 +575,10 @@ impl UdpSocket {
     }
 }
 
-/// Applies the requested buffer size to a socket, retrying with smaller sizes on failure.
+/// Applies the requested buffer size to a socket, halving it until the kernel accepts it.
 ///
-/// Apple platforms reject buffer sizes above `kern.ipc.maxsockbuf` with `ENOBUFS` instead of clamping them like Linux does.
-/// We therefore clamp the requested size ourselves and - in case that still fails - halve it until the kernel accepts it.
+/// Apple platforms reject buffer sizes above `kern.ipc.maxsockbuf` with `ENOBUFS` instead of
+/// clamping them like Linux does.
 fn apply_buffer_size(
     requested: usize,
     mut set: impl FnMut(usize) -> io::Result<()>,
@@ -586,7 +586,7 @@ fn apply_buffer_size(
     /// Buffer sizes below this are not worth trading for an error message; all platforms accept it.
     const FLOOR: usize = 64 * 1024;
 
-    let mut size = clamp_to_max_sockbuf(requested);
+    let mut size = requested;
 
     loop {
         match set(size) {
@@ -595,50 +595,6 @@ fn apply_buffer_size(
             Err(e) => return Err(e),
         }
     }
-}
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-fn clamp_to_max_sockbuf(requested: usize) -> usize {
-    // `sbreserve` only allows `kern.ipc.maxsockbuf * MCLBYTES / (MSIZE + MCLBYTES)` bytes of actual data,
-    // i.e. 8/9th of `maxsockbuf` with MSIZE = 256 and MCLBYTES = 2048.
-    match max_sockbuf() {
-        Some(max) => std::cmp::min(requested, max * 8 / 9),
-        None => requested,
-    }
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-fn clamp_to_max_sockbuf(requested: usize) -> usize {
-    requested
-}
-
-/// Reads `kern.ipc.maxsockbuf`, the upper limit for socket buffer sizes on Apple platforms.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-fn max_sockbuf() -> Option<usize> {
-    let mut value: libc::c_int = 0;
-    let mut len = std::mem::size_of::<libc::c_int>();
-
-    // SAFETY: The value and length pointers are valid for the duration of the call and match in size.
-    let ret = unsafe {
-        libc::sysctlbyname(
-            c"kern.ipc.maxsockbuf".as_ptr(),
-            std::ptr::from_mut(&mut value).cast(),
-            &mut len,
-            std::ptr::null_mut(),
-            0,
-        )
-    };
-
-    if ret != 0 {
-        tracing::debug!(
-            "Failed to read `kern.ipc.maxsockbuf`: {}",
-            io::Error::last_os_error()
-        );
-
-        return None;
-    }
-
-    usize::try_from(value).ok()
 }
 
 /// Compares the two [`SocketAddr`]s for equality, ignored IPv6 scopes for link-local addresses.

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -359,7 +359,7 @@ impl PerfUdpSocket {
         let send_buffer_size = socket.send_buffer_size().unwrap_or_default();
         let recv_buffer_size = socket.recv_buffer_size().unwrap_or_default();
 
-        tracing::debug!(%requested_send_buffer_size, %send_buffer_size, %requested_recv_buffer_size, %recv_buffer_size, port = %self.port, "Set UDP socket buffer sizes");
+        tracing::debug!(%requested_send_buffer_size, %send_buffer_size, %requested_recv_buffer_size, %recv_buffer_size, port = %self.port, "UDP socket buffer sizes");
     }
 
     async fn send_transmit(&self, transmit: &Transmit<'_>) -> Result<()> {

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -22,7 +22,15 @@ pub trait SocketFactory<S>: Send + Sync + 'static {
     fn reset(&self);
 }
 
-pub const SEND_BUFFER_SIZE: usize = 16 * ONE_MB;
+/// On Apple platforms, UDP sockets never buffer data in the send buffer: datagrams are
+/// handed straight to the interface and `SO_SNDBUF` only acts as a cap on the maximum
+/// datagram size. A large send buffer is therefore pointless (and cannot cause
+/// bufferbloat either); 64 KiB comfortably covers the largest datagram we ever send.
+pub const SEND_BUFFER_SIZE: usize = if cfg!(any(target_os = "macos", target_os = "ios")) {
+    64 * 1024
+} else {
+    16 * ONE_MB
+};
 pub const RECV_BUFFER_SIZE: usize = 128 * ONE_MB;
 const ONE_MB: usize = 1024 * 1024;
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -26,11 +26,10 @@ pub trait SocketFactory<S>: Send + Sync + 'static {
 /// handed straight to the interface and `SO_SNDBUF` only acts as a cap on the maximum
 /// datagram size. A large send buffer is therefore pointless (and cannot cause
 /// bufferbloat either); 64 KiB comfortably covers the largest datagram we ever send.
-pub const SEND_BUFFER_SIZE: usize = if cfg!(any(target_os = "macos", target_os = "ios")) {
-    64 * 1024
-} else {
-    16 * ONE_MB
-};
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub const SEND_BUFFER_SIZE: usize = 64 * 1024;
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+pub const SEND_BUFFER_SIZE: usize = 16 * ONE_MB;
 pub const RECV_BUFFER_SIZE: usize = 128 * ONE_MB;
 const ONE_MB: usize = 1024 * 1024;
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -340,18 +340,26 @@ impl PerfUdpSocket {
         &mut self,
         requested_send_buffer_size: usize,
         requested_recv_buffer_size: usize,
-    ) -> io::Result<()> {
+    ) {
         let socket = socket2::SockRef::from(&self.inner);
 
-        socket.set_send_buffer_size(requested_send_buffer_size)?;
-        socket.set_recv_buffer_size(requested_recv_buffer_size)?;
+        // Apply each direction independently: failing to set one buffer size must not prevent the other from being applied.
+        if let Err(e) = apply_buffer_size(requested_send_buffer_size, |size| {
+            socket.set_send_buffer_size(size)
+        }) {
+            tracing::warn!(%requested_send_buffer_size, "Failed to set send buffer size: {e}");
+        }
 
-        let send_buffer_size = socket.send_buffer_size()?;
-        let recv_buffer_size = socket.recv_buffer_size()?;
+        if let Err(e) = apply_buffer_size(requested_recv_buffer_size, |size| {
+            socket.set_recv_buffer_size(size)
+        }) {
+            tracing::warn!(%requested_recv_buffer_size, "Failed to set recv buffer size: {e}");
+        }
+
+        let send_buffer_size = socket.send_buffer_size().unwrap_or_default();
+        let recv_buffer_size = socket.recv_buffer_size().unwrap_or_default();
 
         tracing::debug!(%requested_send_buffer_size, %send_buffer_size, %requested_recv_buffer_size, %recv_buffer_size, port = %self.port, "Set UDP socket buffer sizes");
-
-        Ok(())
     }
 
     async fn send_transmit(&self, transmit: &Transmit<'_>) -> Result<()> {
@@ -558,6 +566,72 @@ impl UdpSocket {
 
         Ok(buffer)
     }
+}
+
+/// Applies the requested buffer size to a socket, retrying with smaller sizes on failure.
+///
+/// Apple platforms reject buffer sizes above `kern.ipc.maxsockbuf` with `ENOBUFS` instead of clamping them like Linux does.
+/// We therefore clamp the requested size ourselves and - in case that still fails - halve it until the kernel accepts it.
+fn apply_buffer_size(
+    requested: usize,
+    mut set: impl FnMut(usize) -> io::Result<()>,
+) -> io::Result<()> {
+    /// Buffer sizes below this are not worth trading for an error message; all platforms accept it.
+    const FLOOR: usize = 64 * 1024;
+
+    let mut size = clamp_to_max_sockbuf(requested);
+
+    loop {
+        match set(size) {
+            Ok(()) => return Ok(()),
+            Err(_) if size > FLOOR => size /= 2,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn clamp_to_max_sockbuf(requested: usize) -> usize {
+    // `sbreserve` only allows `kern.ipc.maxsockbuf * MCLBYTES / (MSIZE + MCLBYTES)` bytes of actual data,
+    // i.e. 8/9th of `maxsockbuf` with MSIZE = 256 and MCLBYTES = 2048.
+    match max_sockbuf() {
+        Some(max) => std::cmp::min(requested, max * 8 / 9),
+        None => requested,
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+fn clamp_to_max_sockbuf(requested: usize) -> usize {
+    requested
+}
+
+/// Reads `kern.ipc.maxsockbuf`, the upper limit for socket buffer sizes on Apple platforms.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn max_sockbuf() -> Option<usize> {
+    let mut value: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>();
+
+    // SAFETY: The value and length pointers are valid for the duration of the call and match in size.
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c"kern.ipc.maxsockbuf".as_ptr(),
+            std::ptr::from_mut(&mut value).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+
+    if ret != 0 {
+        tracing::debug!(
+            "Failed to read `kern.ipc.maxsockbuf`: {}",
+            io::Error::last_os_error()
+        );
+
+        return None;
+    }
+
+    usize::try_from(value).ok()
 }
 
 /// Compares the two [`SocketAddr`]s for equality, ignored IPv6 scopes for link-local addresses.
@@ -823,6 +897,31 @@ mod tests {
         ));
 
         assert!(is_equal_modulo_scope_for_ipv6_link_local(left, right))
+    }
+
+    #[test]
+    fn apply_buffer_size_halves_until_accepted() {
+        let mut attempts = Vec::new();
+
+        let result = apply_buffer_size(1024 * 1024, |size| {
+            attempts.push(size);
+
+            if size > 256 * 1024 {
+                return Err(io::Error::other("too big"));
+            }
+
+            Ok(())
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(attempts, vec![1024 * 1024, 512 * 1024, 256 * 1024]);
+    }
+
+    #[test]
+    fn apply_buffer_size_gives_up_at_floor() {
+        let result = apply_buffer_size(256 * 1024, |_| Err(io::Error::other("nope")));
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -256,9 +256,7 @@ impl ThreadedUdpSocket {
                     .unwrap_or_default()
                     .unwrap_or(socket_factory::RECV_BUFFER_SIZE);
 
-                if let Err(e) = socket.set_buffer_sizes(send_buffer_size, recv_buffer_size) {
-                    tracing::warn!("Failed to set socket buffer sizes: {e}");
-                };
+                socket.set_buffer_sizes(send_buffer_size, recv_buffer_size);
 
                 let socket = Arc::new(socket);
 

--- a/rust/tests/loadtest/src/turn.rs
+++ b/rust/tests/loadtest/src/turn.rs
@@ -1112,12 +1112,10 @@ async fn send_datagram(
 fn bind_socket(addr: SocketAddr) -> Result<PerfUdpSocket> {
     let mut socket = socket_factory::udp(addr)?.into_perf()?;
 
-    if let Err(e) = socket.set_buffer_sizes(
+    socket.set_buffer_sizes(
         socket_factory::SEND_BUFFER_SIZE,
         socket_factory::RECV_BUFFER_SIZE,
-    ) {
-        tracing::warn!(error = %e, "Failed to enlarge socket buffers; continuing with defaults");
-    }
+    );
 
     Ok(socket)
 }


### PR DESCRIPTION
Setting the UDP socket buffer sizes can fail entirely on macOS and iOS: Darwin rejects `SO_SNDBUF` / `SO_RCVBUF` values above `kern.ipc.maxsockbuf` (default 8 MiB) with `ENOBUFS` instead of clamping them like Linux does. Our requested 16 MiB send buffer then errors out, and since both directions were applied in one fallible call, the receive buffer was never attempted either, leaving the affected client on the kernel default of roughly 786 KiB of receive buffer — a fraction of the intended size and the most drop-prone queue in the receive path. Sentry shows this happening regularly for the 18 users we have evidence from.

Apply each direction independently so one failure cannot mask the other, and halve the requested size until the kernel accepts it, landing at 4 MiB on a default macOS system. On Apple, request only a 64 KiB send buffer: Darwin UDP sockets never buffer data in `so_snd` — `SO_SNDBUF` only acts as a cap on the maximum datagram size, so a large value buys nothing.