### PR TITLE
fix(apple): skip symlinks when zipping logs for export

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -92,27 +92,13 @@ import SystemPackage
     }
 
     static func export(to archiveURL: URL) async throws {
-      guard let logFolderURL = SharedAccess.logFolderURL,
-        let connlibLogFolderURL = SharedAccess.connlibLogFolderURL,
-        let cacheFolderURL = SharedAccess.cacheFolderURL
-
+      guard let logFolderURL = SharedAccess.logFolderURL
       else {
         throw ExportError.invalidSourceDirectory
       }
 
       // Remove existing archive if it exists
       try? fileManager.removeItem(at: archiveURL)
-
-      let latestSymlink = connlibLogFolderURL.appendingPathComponent("latest")
-      let tempSymlink = cacheFolderURL.appendingPathComponent(
-        "latest")
-
-      // Move the `latest` symlink out of the way before creating the archive.
-      // Apple's implementation of zip appears to not be able to handle symlinks well
-      _ = try? FileManager.default.moveItem(at: latestSymlink, to: tempSymlink)
-      defer {
-        _ = try? FileManager.default.moveItem(at: tempSymlink, to: latestSymlink)
-      }
 
       // Write final log archive
       try ZipService.createZip(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ZipService.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ZipService.swift
@@ -31,16 +31,29 @@ public final class ZipService {
       throw CreateZipError.urlNotADirectory(directoryURL)
     }
 
+    // Stage a copy of the directory and zip that instead: the source may contain
+    // symlinks (the Rust file appender maintains `*.latest` links), which Apple's
+    // zip-for-upload implementation chokes on when they dangle, and live log files
+    // can be rotated or deleted mid-archive.
+    let fileManager = FileManager.default
+    let stagingRootURL = fileManager
+      .temporaryDirectory
+      .appendingPathComponent("zip-staging-\(UUID().uuidString)")
+    let stagingURL = stagingRootURL.appendingPathComponent(directoryURL.lastPathComponent)
+    defer { try? fileManager.removeItem(at: stagingRootURL) }
+
+    try copyRegularFiles(from: directoryURL, to: stagingURL)
+
     var fileManagerError: Swift.Error?
     var coordinatorError: NSError?
 
     NSFileCoordinator().coordinate(
-      readingItemAt: directoryURL,
+      readingItemAt: stagingURL,
       options: .forUploading,
       error: &coordinatorError
     ) { zipAccessURL in
       do {
-        try FileManager.default.moveItem(at: zipAccessURL, to: zipFinalURL)
+        try fileManager.moveItem(at: zipAccessURL, to: zipFinalURL)
       } catch {
         fileManagerError = error
       }
@@ -52,6 +65,47 @@ public final class ZipService {
 
     if let error = fileManagerError {
       throw CreateZipError.failedToMoveZIP(error)
+    }
+  }
+
+  // Recursively copies directories and regular files, skipping symlinks and
+  // tolerating files that vanish while we're copying.
+  private static func copyRegularFiles(from sourceURL: URL, to destinationURL: URL) throws {
+    let fileManager = FileManager.default
+    try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+
+    let resourceKeys: Set<URLResourceKey> = [
+      .isSymbolicLinkKey,
+      .isDirectoryKey,
+      .isRegularFileKey,
+    ]
+    guard
+      let enumerator = fileManager.enumerator(
+        at: sourceURL,
+        includingPropertiesForKeys: Array(resourceKeys)
+      )
+    else {
+      return
+    }
+
+    let sourcePath = sourceURL.standardizedFileURL.path
+    for case let itemURL as URL in enumerator {
+      guard let resourceValues = try? itemURL.resourceValues(forKeys: resourceKeys),
+        resourceValues.isSymbolicLink != true
+      else {
+        continue
+      }
+
+      let itemPath = itemURL.standardizedFileURL.path
+      guard itemPath.hasPrefix(sourcePath + "/") else { continue }
+      let relativePath = String(itemPath.dropFirst(sourcePath.count + 1))
+      let targetURL = destinationURL.appendingPathComponent(relativePath)
+
+      if resourceValues.isDirectory == true {
+        try? fileManager.createDirectory(at: targetURL, withIntermediateDirectories: true)
+      } else if resourceValues.isRegularFile == true {
+        try? fileManager.copyItem(at: itemURL, to: targetURL)
+      }
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ZipService.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/ZipService.swift
@@ -14,6 +14,7 @@ extension URL {
 
 enum CreateZipError: Swift.Error {
   case urlNotADirectory(URL)
+  case failedToEnumerateSource(URL)
   case failedToCreateZIP(Swift.Error)
   case failedToMoveZIP(Swift.Error)
 }
@@ -85,7 +86,7 @@ public final class ZipService {
         includingPropertiesForKeys: Array(resourceKeys)
       )
     else {
-      return
+      throw CreateZipError.failedToEnumerateSource(sourceURL)
     }
 
     let sourcePath = sourceURL.standardizedFileURL.path
@@ -101,11 +102,31 @@ public final class ZipService {
       let relativePath = String(itemPath.dropFirst(sourcePath.count + 1))
       let targetURL = destinationURL.appendingPathComponent(relativePath)
 
-      if resourceValues.isDirectory == true {
-        try? fileManager.createDirectory(at: targetURL, withIntermediateDirectories: true)
-      } else if resourceValues.isRegularFile == true {
-        try? fileManager.copyItem(at: itemURL, to: targetURL)
+      do {
+        if resourceValues.isDirectory == true {
+          try fileManager.createDirectory(at: targetURL, withIntermediateDirectories: true)
+        } else if resourceValues.isRegularFile == true {
+          try fileManager.copyItem(at: itemURL, to: targetURL)
+        }
+      } catch {
+        if !isFileVanishedError(error) {
+          throw error
+        }
       }
     }
+  }
+
+  // A file disappearing between enumeration and copy is expected: log rotation
+  // and the log size cleanup both delete files while an export may be running.
+  private static func isFileVanishedError(_ error: Swift.Error) -> Bool {
+    let nsError = error as NSError
+
+    if nsError.domain == NSCocoaErrorDomain,
+      nsError.code == NSFileReadNoSuchFileError || nsError.code == NSFileNoSuchFileError
+    {
+      return true
+    }
+
+    return nsError.domain == NSPOSIXErrorDomain && nsError.code == Int(ENOENT)
   }
 }

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ZipServiceTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ZipServiceTests.swift
@@ -1,0 +1,59 @@
+//
+//  ZipServiceTests.swift
+//  (c) 2026 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import Testing
+
+@testable import FirezoneKit
+
+@Suite("ZipService tests")
+struct ZipServiceTests {
+  @Test("createZip succeeds when the source contains a dangling symlink")
+  func zipWithDanglingSymlink() throws {
+    let fileManager = FileManager.default
+    let sourceURL = fileManager
+      .temporaryDirectory
+      .appendingPathComponent("logs-\(UUID().uuidString)")
+    let nestedURL = sourceURL.appendingPathComponent("connlib")
+    try fileManager.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: sourceURL) }
+
+    try Data("log contents".utf8)
+      .write(to: nestedURL.appendingPathComponent("connlib.2026-06-10.log"))
+    try fileManager.createSymbolicLink(
+      at: nestedURL.appendingPathComponent("connlib.latest"),
+      withDestinationURL: nestedURL.appendingPathComponent("deleted.log")
+    )
+
+    let zipURL = fileManager
+      .temporaryDirectory
+      .appendingPathComponent("logs-\(UUID().uuidString).zip")
+    defer { try? fileManager.removeItem(at: zipURL) }
+
+    try ZipService.createZip(source: sourceURL, to: zipURL)
+
+    let attributes = try fileManager.attributesOfItem(atPath: zipURL.path)
+    #expect((attributes[.size] as? Int ?? 0) > 0)
+  }
+
+  @Test("createZip throws when the source is not a directory")
+  func zipWithNonDirectorySource() throws {
+    let fileManager = FileManager.default
+    let sourceURL = fileManager
+      .temporaryDirectory
+      .appendingPathComponent("file-\(UUID().uuidString)")
+    try Data("not a directory".utf8).write(to: sourceURL)
+    defer { try? fileManager.removeItem(at: sourceURL) }
+
+    let zipURL = fileManager
+      .temporaryDirectory
+      .appendingPathComponent("logs-\(UUID().uuidString).zip")
+
+    #expect(throws: CreateZipError.self) {
+      try ZipService.createZip(source: sourceURL, to: zipURL)
+    }
+  }
+}

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -315,9 +315,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       sendChunk(tunnelLogArchive)
 
     case .idle:
-      guard let logFolderURL = SharedAccess.logFolderURL,
-        let cacheFolderURL = SharedAccess.cacheFolderURL,
-        let connlibLogFolderURL = SharedAccess.connlibLogFolderURL
+      guard let logFolderURL = SharedAccess.logFolderURL
       else {
         completionHandler(nil)
 
@@ -326,18 +324,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
       let tunnelLogArchive = TunnelLogArchive(source: logFolderURL)
 
-      let latestSymlink = connlibLogFolderURL.appendingPathComponent("latest")
-      let tempSymlink = cacheFolderURL.appendingPathComponent(
-        "latest")
-
       do {
-        // Move the `latest` symlink out of the way before creating the archive.
-        // Apple's implementation of zip appears to not be able to handle symlinks well
-        _ = try? FileManager.default.moveItem(at: latestSymlink, to: tempSymlink)
-        defer {
-          _ = try? FileManager.default.moveItem(at: tempSymlink, to: latestSymlink)
-        }
-
         try tunnelLogArchive.archive()
       } catch {
         Log.error(error)


### PR DESCRIPTION
Log export is broken on macOS and iOS. #13369 renamed the file appender's symlink from `latest` to `connlib.latest` but the Swift export code still moves a file named `latest` out of the way before zipping, so the rename turned that workaround into a silent no-op and the symlink now stays in the log tree during export. Once the log size cleanup deletes the `.log` file it points to, the symlink dangles and Apple's zip-for-upload fails with NSCocoaErrorDomain 260. On macOS this surfaces as a misleading `noIPCData` alert because the tunnel returns nil over IPC.

Instead of chasing symlink names, `ZipService.createZip` now stages a copy of the source directory containing only directories and regular files and zips the staged copy. This tolerates any current or future `*.latest` links (e.g. the upcoming `register-sparse.latest`) as well as log rotation or cleanup racing the export, and lets us drop the move-the-symlink-aside dance on both platforms.

Related: #13369