### PR TITLE
chore(ci): ignore compose plugin bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -156,6 +156,8 @@ updates:
       # Depends on JDK version which is bundled with Android Studio (JDK 17)
       - dependency-name: org.jetbrains.kotlin:kotlin-gradle-plugin
       - dependency-name: org.jetbrains.kotlin.android
+      # Must match the Kotlin version bundled with AGP's built-in Kotlin support
+      - dependency-name: org.jetbrains.kotlin.plugin.compose
     groups:
       security-all:
         applies-to: security-updates


### PR DESCRIPTION
The org.jetbrains.kotlin.plugin.compose version must stay in lockstep with the Kotlin compiler version, which is provided by AGP's built-in Kotlin support since the AGP 9 migration. Bumping it independently (e.g. to 2.4.0) pulls a newer Kotlin onto the build classpath and produces classes with a metadata version that Dagger's bundled kotlin-metadata-jvm rejects, failing hiltJavaCompileDebug. Ignore it in Dependabot like the other Kotlin plugins that are pinned to the toolchain.
