### PR TITLE
feat(portal): normalize timestamp columns to timestamptz

### DIFF
--- a/elixir/priv/repo/migrations/20260608000000_normalize_accounts_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000000_normalize_accounts_timestamps.exs
@@ -1,0 +1,40 @@
+defmodule Portal.Repo.Migrations.NormalizeAccountsTimestamps do
+  use Ecto.Migration
+
+  @moduledoc """
+  Converts this table's `timestamp without time zone` columns to timestamptz,
+  one migration per table so each ACCESS EXCLUSIVE lock is acquired and
+  released in its own transaction (a lock stall affects one table for at most
+  lock_timeout, already-converted tables stay committed, and schema_migrations
+  is the resume cursor on failure).
+
+  All stored values are UTC instants (Elixir writes UTC through binary
+  params, and the DB-side `now()` defaults ran under a UTC server timezone),
+  so the conversion is a semantic no-op reinterpretation. SET LOCAL
+  timezone = UTC inside the migration transaction is load-bearing twice
+  over: it makes the timestamp -> timestamptz cast the identity (a non-UTC
+  session would reinterpret every stored value as local time), and on
+  Postgres >= 12 it lets ALTER TYPE skip the table rewrite entirely, making
+  the ALTER a metadata-only change. The transaction guarantees every
+  statement runs on the one connection the SET LOCAL applies to, regardless
+  of connection pooling.
+
+  Excluded from the series: oban_jobs / oban_peers (Oban manages its own
+  schema) and schema_migrations (Ecto-managed).
+  """
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "accounts" ALTER COLUMN "disabled_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "lock_enabled_at" TYPE #{target_type}, ALTER COLUMN "scheduled_deletion_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}, ALTER COLUMN "warning_last_sent_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000001_normalize_actors_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000001_normalize_actors_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeActorsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "actors" ALTER COLUMN "disabled_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000002_normalize_api_tokens_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000002_normalize_api_tokens_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeApiTokensTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "api_tokens" ALTER COLUMN "expires_at" TYPE #{target_type}, ALTER COLUMN "last_seen_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000003_normalize_change_logs_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000003_normalize_change_logs_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeChangeLogsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "change_logs" ALTER COLUMN "timestamp" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000004_normalize_client_tokens_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000004_normalize_client_tokens_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeClientTokensTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "client_tokens" ALTER COLUMN "expires_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000005_normalize_devices_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000005_normalize_devices_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeDevicesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "devices" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}, ALTER COLUMN "verified_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000006_normalize_email_suppressions_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000006_normalize_email_suppressions_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeEmailSuppressionsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "email_suppressions" ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000007_normalize_entra_directories_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000007_normalize_entra_directories_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeEntraDirectoriesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "entra_directories" ALTER COLUMN "errored_at" TYPE #{target_type}, ALTER COLUMN "synced_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000008_normalize_external_identities_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000008_normalize_external_identities_timestamps.exs
@@ -1,0 +1,25 @@
+defmodule Portal.Repo.Migrations.NormalizeExternalIdentitiesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "external_identities" ALTER COLUMN "inserted_at" DROP DEFAULT|)
+    execute(~s|ALTER TABLE "external_identities" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+    # Re-created so the catalog holds a native default for the new type
+    # instead of one rewritten through a cast.
+    execute(~s|ALTER TABLE "external_identities" ALTER COLUMN "inserted_at" SET DEFAULT now()|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000009_normalize_external_identity_sync_states_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000009_normalize_external_identity_sync_states_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeExternalIdentitySyncStatesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "external_identity_sync_states" ALTER COLUMN "synced_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000010_normalize_flow_logs_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000010_normalize_flow_logs_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeFlowLogsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "flow_logs" ALTER COLUMN "flow_end" TYPE #{target_type}, ALTER COLUMN "flow_start" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000011_normalize_gateway_tokens_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000011_normalize_gateway_tokens_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeGatewayTokensTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "gateway_tokens" ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000012_normalize_google_directories_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000012_normalize_google_directories_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeGoogleDirectoriesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "google_directories" ALTER COLUMN "errored_at" TYPE #{target_type}, ALTER COLUMN "synced_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000013_normalize_group_sync_states_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000013_normalize_group_sync_states_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeGroupSyncStatesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "group_sync_states" ALTER COLUMN "synced_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000014_normalize_groups_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000014_normalize_groups_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeGroupsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "groups" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000015_normalize_membership_sync_states_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000015_normalize_membership_sync_states_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeMembershipSyncStatesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "membership_sync_states" ALTER COLUMN "synced_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000016_normalize_okta_directories_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000016_normalize_okta_directories_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeOktaDirectoriesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "okta_directories" ALTER COLUMN "errored_at" TYPE #{target_type}, ALTER COLUMN "synced_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000017_normalize_one_time_passcodes_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000017_normalize_one_time_passcodes_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeOneTimePasscodesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "one_time_passcodes" ALTER COLUMN "expires_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000018_normalize_outbound_email_deliveries_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000018_normalize_outbound_email_deliveries_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeOutboundEmailDeliveriesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "outbound_email_deliveries" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000019_normalize_outbound_emails_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000019_normalize_outbound_emails_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeOutboundEmailsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "outbound_emails" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000020_normalize_pending_identities_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000020_normalize_pending_identities_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizePendingIdentitiesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "pending_identities" ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000021_normalize_policies_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000021_normalize_policies_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizePoliciesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "policies" ALTER COLUMN "disabled_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000022_normalize_policy_authorizations_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000022_normalize_policy_authorizations_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizePolicyAuthorizationsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "policy_authorizations" ALTER COLUMN "expires_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000023_normalize_portal_sessions_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000023_normalize_portal_sessions_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizePortalSessionsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "portal_sessions" ALTER COLUMN "expires_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000024_normalize_processed_stripe_events_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000024_normalize_processed_stripe_events_timestamps.exs
@@ -1,0 +1,25 @@
+defmodule Portal.Repo.Migrations.NormalizeProcessedStripeEventsTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "processed_stripe_events" ALTER COLUMN "processed_at" DROP DEFAULT|)
+    execute(~s|ALTER TABLE "processed_stripe_events" ALTER COLUMN "event_created_at" TYPE #{target_type}, ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "processed_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+    # Re-created so the catalog holds a native default for the new type
+    # instead of one rewritten through a cast.
+    execute(~s|ALTER TABLE "processed_stripe_events" ALTER COLUMN "processed_at" SET DEFAULT now()|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000025_normalize_relay_tokens_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000025_normalize_relay_tokens_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeRelayTokensTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "relay_tokens" ALTER COLUMN "inserted_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000026_normalize_resources_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000026_normalize_resources_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeResourcesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "resources" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/priv/repo/migrations/20260608000027_normalize_sites_timestamps.exs
+++ b/elixir/priv/repo/migrations/20260608000027_normalize_sites_timestamps.exs
@@ -1,0 +1,21 @@
+defmodule Portal.Repo.Migrations.NormalizeSitesTimestamps do
+  use Ecto.Migration
+
+  # Part of the timestamp -> timestamptz normalization. See
+  # 20260608000000_normalize_accounts_timestamps for the full rationale.
+
+  def up do
+    convert("timestamptz")
+  end
+
+  def down do
+    convert("timestamp")
+  end
+
+  defp convert(target_type) do
+    execute("SET LOCAL timezone TO 'UTC'")
+    execute("SET LOCAL lock_timeout TO '5s'")
+
+    execute(~s|ALTER TABLE "sites" ALTER COLUMN "inserted_at" TYPE #{target_type}, ALTER COLUMN "updated_at" TYPE #{target_type}|)
+  end
+end

--- a/elixir/test/portal/repo/timestamp_types_test.exs
+++ b/elixir/test/portal/repo/timestamp_types_test.exs
@@ -1,0 +1,29 @@
+defmodule Portal.Repo.TimestampTypesTest do
+  use Portal.DataCase, async: true
+
+  # Oban manages its own schema; schema_migrations is Ecto-managed.
+  @excluded_tables ~w[oban_jobs oban_peers schema_migrations]
+
+  test "all app-owned datetime columns are timestamptz" do
+    # Plain `timestamp` columns only stay correct as long as every SQL-level
+    # interaction (defaults, casts, now() comparisons, range expressions) is
+    # manually pinned to UTC; one missed pin silently corrupts instants on a
+    # non-UTC server. New columns must be timestamptz, matching the
+    # migration_timestamps repo default.
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT table_name || '.' || column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND data_type = 'timestamp without time zone'
+          AND table_name != ALL($1)
+        ORDER BY 1
+        """,
+        [@excluded_tables]
+      )
+
+    assert rows == [],
+           "expected no plain timestamp columns, found: #{inspect(List.flatten(rows))}"
+  end
+end


### PR DESCRIPTION
The schema mixed plain timestamp and timestamptz columns. Plain timestamp was only correct when every SQL-level interaction with it (defaults, casts, range expressions) was manually pinned to UTC, and a missed pin silently corrupted values on any non-UTC server.

All app-owned columns are now timestamptz. Stored values were already UTC instants, so the conversion is metadata-only: no table rewrite, values unchanged.

The conversion runs as one migration per table, so locks stay brief, a failure affects a single table, and re-running resumes where it left off. Oban tables are excluded, and a regression test keeps new columns timestamptz going forward.