### PR TITLE
fix(connlib): correlate recursive DNS queries via opaque token

### DIFF
--- a/rust/libs/connlib/dns-over-tcp/src/client.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/client.rs
@@ -47,12 +47,15 @@ pub struct Client<const MIN_PORT: u16 = 49152, const MAX_PORT: u16 = 65535> {
 #[derive(Debug)]
 struct PendingQuery {
     query: dns_types::Query,
+    token: u64,
     deadline: Instant,
 }
 
 #[derive(Debug)]
 pub struct QueryResult {
     pub query: dns_types::Query,
+    /// The token passed to [`Client::send_query`], identifying this query.
+    pub token: u64,
     pub local: SocketAddr,
     pub server: SocketAddr,
     pub result: Result<dns_types::Response>,
@@ -91,11 +94,15 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
 
     /// Send the given DNS query to the target server.
     ///
+    /// The `token` is opaque to the client and echoed back in the corresponding [`QueryResult`],
+    /// allowing callers to correlate results with queries.
+    ///
     /// This only queues the message. You need to call [`Client::handle_timeout`] to actually send them.
     pub fn send_query(
         &mut self,
         server: SocketAddr,
         message: dns_types::Query,
+        token: u64,
     ) -> Result<SocketAddr> {
         let (ipv4_source, ipv6_source) = self
             .source_ips
@@ -121,6 +128,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
 
             pending_queries.push_back(PendingQuery {
                 query: message,
+                token,
                 deadline,
             });
 
@@ -135,6 +143,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             .or_default()
             .push_back(PendingQuery {
                 query: message,
+                token,
                 deadline,
             });
 
@@ -363,6 +372,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             while let Some(queued) = queries.pop_front_if(|pq| pq.deadline <= now) {
                 let res = QueryResult {
                     query: queued.query,
+                    token: queued.token,
                     server: *server,
                     local: *local,
                     result: Err(anyhow!(
@@ -382,6 +392,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
                         .extract_if(.., |_, pq| pq.deadline <= now)
                         .map(|(_, queued)| QueryResult {
                             query: queued.query,
+                            token: queued.token,
                             server: *server,
                             local: *local,
                             result: Err(anyhow!(
@@ -487,6 +498,7 @@ fn send_pending_queries(
                 ));
                 query_results.push_back(QueryResult {
                     query: pending.query,
+                    token: pending.token,
                     server,
                     local,
                     result: Err(e),
@@ -519,6 +531,7 @@ fn recv_responses(
 
             Ok(vec![QueryResult {
                 query: queued.query,
+                token: queued.token,
                 server,
                 local,
                 result: Ok(response),
@@ -555,6 +568,7 @@ fn into_failed_results(
 ) -> impl Iterator<Item = QueryResult> {
     iter.into_iter().map(move |queued| QueryResult {
         query: queued.query,
+        token: queued.token,
         server,
         local,
         result: Err(make_error()),
@@ -586,7 +600,7 @@ mod tests {
         let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53);
         let query = create_test_query();
 
-        let local = client.send_query(server, query.clone()).unwrap();
+        let local = client.send_query(server, query.clone(), 1).unwrap();
         client.handle_timeout(now);
         client.handle_timeout(now);
 
@@ -599,6 +613,7 @@ mod tests {
 
         assert_eq!(query_result.query.id(), query.id());
         assert_eq!(query_result.query.domain(), query.domain());
+        assert_eq!(query_result.token, 1);
         assert_eq!(query_result.local, local);
         assert_eq!(query_result.server, server);
         assert_eq!(
@@ -616,7 +631,7 @@ mod tests {
         let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53);
         let query = create_test_query();
 
-        let local = client.send_query(server, query.clone()).unwrap();
+        let local = client.send_query(server, query.clone(), 1).unwrap();
 
         // Advance time past the query deadline without ever delivering a TCP reply.
         client.handle_timeout(now + Duration::from_secs(10) + Duration::from_millis(1));
@@ -624,6 +639,7 @@ mod tests {
         let query_result = client.poll_query_result().unwrap();
 
         assert_eq!(query_result.query.id(), query.id());
+        assert_eq!(query_result.token, 1);
         assert_eq!(query_result.local, local);
         assert_eq!(query_result.server, server);
         assert_eq!(

--- a/rust/libs/connlib/dns-over-tcp/tests/client_and_server.rs
+++ b/rust/libs/connlib/dns-over-tcp/tests/client_and_server.rs
@@ -33,6 +33,7 @@ fn smoke() {
             .send_query(
                 resolver_addr,
                 Query::new("example.com".parse().unwrap(), RecordType::A).with_id(id),
+                u64::from(id),
             )
             .unwrap();
     }
@@ -73,12 +74,14 @@ fn no_panic_after_set_listen_address() {
         .send_query(
             resolver_addr1,
             Query::new("foo.example.com".parse().unwrap(), RecordType::A),
+            1,
         )
         .unwrap();
     dns_client
         .send_query(
             resolver_addr2,
             Query::new("bar.example.com".parse().unwrap(), RecordType::A),
+            2,
         )
         .unwrap();
 

--- a/rust/libs/connlib/l3-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l3-udp-dns-client/lib.rs
@@ -29,6 +29,7 @@ pub struct Client<const MIN_PORT: u16 = 49152, const MAX_PORT: u16 = 65535> {
 
 struct PendingQuery {
     message: dns_types::Query,
+    token: u64,
     expires_at: Instant,
     server: SocketAddr,
     local: SocketAddr,
@@ -37,6 +38,8 @@ struct PendingQuery {
 #[derive(Debug)]
 pub struct QueryResult {
     pub query: dns_types::Query,
+    /// The token passed to [`Client::send_query`], identifying this query.
+    pub token: u64,
     pub local: SocketAddr,
     pub server: SocketAddr,
     pub result: Result<dns_types::Response>,
@@ -64,12 +67,16 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
 
     /// Send the given DNS query to the target server.
     ///
+    /// The `token` is opaque to the client and echoed back in the corresponding [`QueryResult`],
+    /// allowing callers to correlate results with queries.
+    ///
     /// This only queues the message. You need to call [`Client::poll_outbound`] to retrieve
     /// the resulting IP packet and send it to the server.
     pub fn send_query(
         &mut self,
         server: SocketAddr,
         message: dns_types::Query,
+        token: u64,
         now: Instant,
     ) -> Result<SocketAddr> {
         let local_port = self.sample_new_unique_port()?;
@@ -88,6 +95,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             local_port,
             PendingQuery {
                 message: message.clone(),
+                token,
                 expires_at: now + TIMEOUT,
                 server,
                 local: local_socket,
@@ -150,6 +158,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
 
             self.query_results.push_back(QueryResult {
                 query: pending_query.message,
+                token: pending_query.token,
                 local: pending_query.local,
                 server: pending_query.server,
                 result: Err(anyhow!("Received ICMP error for DNS query: {icmp_error}")),
@@ -179,6 +188,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
 
         let Some(PendingQuery {
             message,
+            token,
             server,
             local,
             ..
@@ -191,6 +201,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
 
         self.query_results.push_back(QueryResult {
             query: message,
+            token,
             local,
             server,
             result,
@@ -212,6 +223,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             _,
             PendingQuery {
                 message,
+                token,
                 server,
                 local,
                 ..
@@ -222,6 +234,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         {
             self.query_results.push_back(QueryResult {
                 query: message,
+                token,
                 local,
                 server,
                 result: Err(anyhow!("Timeout")),
@@ -248,6 +261,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
                 .drain()
                 .map(|(_, pending_query)| QueryResult {
                     query: pending_query.message,
+                    token: pending_query.token,
                     local: pending_query.local,
                     server: pending_query.server,
                     result: Err(anyhow!("Timeout")),
@@ -306,17 +320,17 @@ mod tests {
 
         // Send two queries at the same time
         client
-            .send_query(server1, create_test_query(), now)
+            .send_query(server1, create_test_query(), 1, now)
             .unwrap();
         client
-            .send_query(server2, create_test_query(), now)
+            .send_query(server2, create_test_query(), 2, now)
             .unwrap();
         assert_eq!(client.poll_timeout(), Some(now + TIMEOUT));
 
         // Send third query 10 seconds later
         let later = now + Duration::from_secs(10);
         client
-            .send_query(server1, create_test_query(), later)
+            .send_query(server1, create_test_query(), 3, later)
             .unwrap();
 
         // poll_timeout should return the earliest timeout
@@ -349,8 +363,8 @@ mod tests {
         let query2 = create_test_query();
 
         // Send multiple queries
-        client.send_query(server1, query1, now).unwrap();
-        client.send_query(server2, query2, now).unwrap();
+        client.send_query(server1, query1, 1, now).unwrap();
+        client.send_query(server2, query2, 2, now).unwrap();
 
         // Reset should abort all pending queries
         client.reset();
@@ -376,7 +390,7 @@ mod tests {
         let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53);
         let query = create_test_query();
 
-        let local = client.send_query(server, query.clone(), now).unwrap();
+        let local = client.send_query(server, query.clone(), 1, now).unwrap();
 
         let packet = client.poll_outbound().unwrap();
         let icmp_error_response = ip_packet::make::icmp_dest_unreachable_network(&packet).unwrap();
@@ -387,6 +401,7 @@ mod tests {
 
         assert_eq!(query_result.query.id(), query.id());
         assert_eq!(query_result.query.domain(), query.domain());
+        assert_eq!(query_result.token, 1);
         assert_eq!(query_result.local, local);
         assert_eq!(query_result.server, server);
         assert_eq!(

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -165,9 +165,10 @@ pub struct ClientState {
     udp_dns_client: l3_udp_dns_client::Client,
     tcp_dns_client: dns_over_tcp::Client,
     tcp_dns_server: dns_over_tcp::Server,
-    /// Tracks the UDP/TCP stream (i.e. socket-pair) on which we received a DNS query by the ID of the recursive DNS query we issued.
-    dns_streams_by_local_upstream_and_query_id:
-        HashMap<(dns::Transport, SocketAddr, SocketAddr, u16), (SocketAddr, SocketAddr, Instant)>,
+    /// Tracks the UDP/TCP stream (i.e. socket-pair) on which we received a DNS query by the token of the recursive DNS query we issued.
+    dns_streams_by_query_token: HashMap<u64, (SocketAddr, SocketAddr, Instant)>,
+    /// Monotonic counter for issuing unique tokens to recursive DNS queries.
+    next_dns_query_token: u64,
 
     buffered_events: VecDeque<ClientEvent>,
     buffered_packets: VecDeque<IpPacket>,
@@ -210,7 +211,8 @@ impl ClientState {
             udp_dns_client: l3_udp_dns_client::Client::new(seed),
             tcp_dns_client: dns_over_tcp::Client::new(now, Duration::from_secs(10), seed),
             tcp_dns_server: dns_over_tcp::Server::new(now),
-            dns_streams_by_local_upstream_and_query_id: Default::default(),
+            dns_streams_by_query_token: Default::default(),
+            next_dns_query_token: 0,
             pending_flows: Default::default(),
             pending_device_access: Default::default(),
             dns_resource_nat: Default::default(),
@@ -1572,12 +1574,11 @@ impl ClientState {
             if let Some(query_result) = self.udp_dns_client.poll_query_result() {
                 let server = query_result.server;
                 let qid = query_result.query.id();
-                let known_sockets = &mut self.dns_streams_by_local_upstream_and_query_id;
 
                 let Some((local, remote, started_at)) =
-                    known_sockets.remove(&(dns::Transport::Udp, query_result.local, server, qid))
+                    self.dns_streams_by_query_token.remove(&query_result.token)
                 else {
-                    tracing::warn!(?known_sockets, %server, %qid, "Failed to find UDP socket handle for query result");
+                    tracing::warn!(%server, %qid, token = %query_result.token, "Failed to find UDP socket handle for query result");
 
                     continue;
                 };
@@ -1602,12 +1603,11 @@ impl ClientState {
             if let Some(query_result) = self.tcp_dns_client.poll_query_result() {
                 let server = query_result.server;
                 let qid = query_result.query.id();
-                let known_sockets = &mut self.dns_streams_by_local_upstream_and_query_id;
 
                 let Some((local, remote, started_at)) =
-                    known_sockets.remove(&(dns::Transport::Tcp, query_result.local, server, qid))
+                    self.dns_streams_by_query_token.remove(&query_result.token)
                 else {
-                    tracing::warn!(?known_sockets, %server, %qid, "Failed to find TCP socket handle for query result");
+                    tracing::warn!(%server, %qid, token = %query_result.token, "Failed to find TCP socket handle for query result");
 
                     continue;
                 };
@@ -1863,10 +1863,15 @@ impl ClientState {
         now: Instant,
     ) {
         let query_id = query.id();
+        let token = self.next_dns_query_token;
+        self.next_dns_query_token = self.next_dns_query_token.wrapping_add(1);
 
         let result = match transport {
-            dns::Transport::Udp => self.udp_dns_client.send_query(server, query.clone(), now),
-            dns::Transport::Tcp => self.tcp_dns_client.send_query(server, query.clone()),
+            dns::Transport::Udp => {
+                self.udp_dns_client
+                    .send_query(server, query.clone(), token, now)
+            }
+            dns::Transport::Tcp => self.tcp_dns_client.send_query(server, query.clone(), token),
         };
 
         let local_socket = match result {
@@ -1900,18 +1905,13 @@ impl ClientState {
             }
         };
 
-        tracing::trace!(%local_socket, %server, %local, %query_id, "Forwarded {transport} DNS query via tunnel");
+        tracing::trace!(%local_socket, %server, %local, %query_id, %token, "Forwarded {transport} DNS query via tunnel");
 
-        let existing = self.dns_streams_by_local_upstream_and_query_id.insert(
-            (transport, local_socket, server, query_id),
-            (local, remote, now),
-        );
+        let existing = self
+            .dns_streams_by_query_token
+            .insert(token, (local, remote, now));
 
-        if let Some((existing_local, existing_remote, _)) = existing
-            && (existing_local != local || existing_remote != remote)
-        {
-            debug_assert!(false, "Query IDs should be unique");
-        }
+        debug_assert!(existing.is_none(), "Query tokens should be unique");
     }
 
     fn maybe_update_tun_routes(&mut self) {

--- a/rust/libs/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sim_client.rs
@@ -194,7 +194,7 @@ impl SimClient {
             }
             DnsTransport::Tcp => {
                 self.tcp_dns_client
-                    .send_query(SocketAddr::new(sentinel, 53), query)
+                    .send_query(SocketAddr::new(sentinel, 53), query, u64::from(query_id))
                     .unwrap();
                 self.sent_tcp_dns_queries.insert((upstream, query_id));
 


### PR DESCRIPTION
The socket-pair on which we received a DNS query is tracked so that the recursive query's response can be routed back to the right device socket. The map key was (transport, local socket, upstream, query ID) — a composite that can collide and silently lose entries in release builds, surfacing as "Failed to find UDP/TCP socket handle for query result" warnings.

Issue a unique, opaque token per recursive DNS query instead. The UDP and TCP DNS clients echo the token back in their query results, making the handle lookup exact and collision-free. The warning no longer dumps the entire bookkeeping map into the log.

Related: #10911

Fixes APPLE-CLIENT-F7

---
_Generated by [Claude Code](https://claude.ai/code/session_013PMm47vVdTcwYPy9mHmDCV)_