### PR TITLE
fix(connlib): retry TUN writes on ENOSPC and track drops

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8178,6 +8178,8 @@ dependencies = [
  "anyhow-ext",
  "ip-packet",
  "libc",
+ "opentelemetry",
+ "otel-instruments",
  "tokio",
  "tracing",
 ]

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -40,12 +40,14 @@ pub fn network_errors() -> Counter<u64> {
         .build()
 }
 
-/// How many times a UDP send was retried after a transient ENOBUFS-style error.
+/// How many times a network write was retried after a transient queue-full error.
+///
+/// Shared across IO paths (UDP sockets, the TUN device); distinguish them via attributes.
 pub fn network_retries() -> Histogram<u64> {
     meter()
         .u64_histogram("system.network.retries")
         .with_description(
-            "How many times a UDP send was retried (spun) after a transient ENOBUFS-style error before it succeeded or was dropped.",
+            "How many times a network write was retried (spun) after a transient queue-full error before it succeeded or was dropped.",
         )
         .with_unit("{retry}")
         .with_boundaries((1..=24_u64).map(|i| i as f64).collect())

--- a/rust/libs/connlib/tun/Cargo.toml
+++ b/rust/libs/connlib/tun/Cargo.toml
@@ -12,6 +12,8 @@ tokio = { workspace = true, features = ["net", "rt", "sync"] }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics"] }
+otel-instruments = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/rust/libs/connlib/tun/src/unix.rs
+++ b/rust/libs/connlib/tun/src/unix.rs
@@ -1,9 +1,19 @@
 use anyhow::{Context as _, ErrorExt, Result, bail};
 use ip_packet::{IpPacket, IpPacketBuf};
+use opentelemetry::KeyValue;
 use std::io;
 use std::os::fd::AsRawFd;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
+
+/// How many times we at most try to re-write a packet if the TUN queue is full (`ENOSPC` on MacOS / iOS).
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+const MAX_ENOSPC_RETRIES: u32 = 24;
+
+/// Upper bound (as a power of two) for how many times we busy-spin between write retries.
+///
+/// `2^6 = 64` iterations of [`std::hint::spin_loop`] stay well below a microsecond.
+const SPIN_LIMIT: u32 = 6;
 
 pub fn tun_send<T>(
     fd: T,
@@ -13,6 +23,9 @@ pub fn tun_send<T>(
 where
     T: AsRawFd + Clone,
 {
+    let write_retry_histogram = otel_instruments::network_retries();
+    let dropped_packets_counter = otel_instruments::network_packet_dropped();
+
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -24,13 +37,39 @@ where
                 #[cfg(debug_assertions)]
                 tracing::trace!(target: "wire::dev::send", ?packet);
 
-                if let Err(e) = fd
-                    .async_io(tokio::io::Interest::WRITABLE, |fd| {
-                        write(fd.as_raw_fd(), &packet)
-                    })
-                    .await
-                {
-                    tracing::warn!("Failed to write to TUN FD: {e}");
+                let mut attempt = 0;
+
+                loop {
+                    match fd
+                        .async_io(tokio::io::Interest::WRITABLE, |fd| {
+                            write(fd.as_raw_fd(), &packet)
+                        })
+                        .await
+                    {
+                        Ok(_) => {
+                            record_write_retries(&write_retry_histogram, attempt);
+
+                            break;
+                        }
+                        Err(e) if should_retry(&e, attempt) => {
+                            spin_and_yield(attempt).await;
+
+                            attempt += 1;
+                        }
+                        Err(e) => {
+                            record_write_retries(&write_retry_histogram, attempt);
+                            dropped_packets_counter.add(1, &drop_attributes(&e));
+
+                            if is_queue_full(&e) {
+                                // The TUN queue is still full after all retries; dropping is by design, like for any congested network device.
+                                tracing::debug!("Failed to write to TUN FD: {e}");
+                            } else {
+                                tracing::warn!("Failed to write to TUN FD: {e}");
+                            }
+
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -38,6 +77,75 @@ where
         })?;
 
     anyhow::Ok(())
+}
+
+/// Whether a failed TUN write should be retried for the given attempt.
+fn should_retry(e: &io::Error, attempt: u32) -> bool {
+    // On MacOS / iOS, the kernel returns `ENOSPC` when the TUN queue fills up.
+    // It's transient and clears off this thread, and isn't observable
+    // via write-readiness, so we retry rather than suspend.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    if is_queue_full(e) && attempt < MAX_ENOSPC_RETRIES {
+        return true;
+    }
+
+    let _ = (e, attempt);
+
+    false
+}
+
+/// Whether the write failed because the TUN queue is full (`ENOSPC` on MacOS / iOS).
+///
+/// Dropping in this case is expected back-pressure; any other error is a genuine failure.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn is_queue_full(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(libc::ENOSPC)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+fn is_queue_full(_e: &io::Error) -> bool {
+    false
+}
+
+/// Briefly back off after a retryable write error before trying again.
+///
+/// We avoid `tokio::time::sleep`: its timer wheel rounds up to ~1ms, far longer
+/// than the microseconds an `ENOSPC` needs to clear. Instead we spin a few
+/// (escalating) times and then cooperatively yield to not starve other tasks.
+async fn spin_and_yield(attempt: u32) {
+    for _ in 0..(1u32 << attempt.min(SPIN_LIMIT)) {
+        std::hint::spin_loop();
+    }
+
+    tokio::task::yield_now().await;
+}
+
+/// Records how many times a single packet write had to be retried before it went through or was dropped.
+///
+/// Writes that succeed on the first try (the common case) are not recorded, keeping the hot path cheap.
+fn record_write_retries(histogram: &opentelemetry::metrics::Histogram<u64>, attempt: u32) {
+    if attempt == 0 {
+        return;
+    }
+
+    histogram.record(attempt as u64, &metric_attributes());
+}
+
+fn metric_attributes() -> [KeyValue; 2] {
+    [
+        KeyValue::new("system.device", "tun"),
+        KeyValue::new("network.io.direction", "transmit"),
+    ]
+}
+
+/// Attributes for a dropped packet, including the OS error code so queue-full
+/// (`ENOSPC`) drops can be told apart from other write failures.
+fn drop_attributes(e: &io::Error) -> [KeyValue; 3] {
+    [
+        KeyValue::new("system.device", "tun"),
+        KeyValue::new("network.io.direction", "transmit"),
+        KeyValue::new("error.code", e.raw_os_error().unwrap_or_default() as i64),
+    ]
 }
 
 pub fn tun_recv<T>(


### PR DESCRIPTION
On MacOS / iOS, writing to the TUN device fails with `ENOSPC` ("No space left on device") when the utun queue is full, and we drop the packet after logging a warning. This is the TUN-device twin of the `ENOBUFS` condition we already handle on UDP sockets: transient, clears off-thread, and not observable via write-readiness.

Apply the same spin-and-yield retry pattern to TUN writes before giving up. Retries and dropped packets are recorded as metrics so we can track how often the queue fills up. A drop after exhausted retries is logged on debug — like any congested network device, dropping at that point is by design.