### PR TITLE
perf(client-ffi): enlarge utun read buffer and pending queue

### DIFF
--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -9,6 +9,31 @@ use tokio::sync::mpsc;
 
 const QUEUE_SIZE: usize = 10_000;
 
+/// Receive buffer we request for the utun control socket via `SO_RCVBUF`.
+///
+/// The kernel default (`ctl_recvsize`) is 512 KiB, only a few hundred MTU-sized
+/// packets, after which inbound packets are backpressured. A larger buffer lets the kernel
+/// queue more while we drain it. 8 MiB matches the default `kern.ipc.maxsockbuf`
+/// ceiling — the most the kernel grants without raising that system-wide limit.
+const RECV_BUFFER_SIZE: libc::c_int = if cfg!(target_os = "ios") {
+    2 * 1024 * 1024
+} else {
+    8 * 1024 * 1024
+};
+
+/// How many packets the kernel may park in the socket receive buffer before it pauses
+/// the interface's output queue until we read them.
+///
+/// XNU defaults this to 1, so every packet costs a full read + flow-control roundtrip
+/// before the kernel hands us the next one. We size it to [`RECV_BUFFER_SIZE`] at the
+/// TUN MTU ([`ip_packet::MAX_IP_SIZE`]), rounded up to a power of two, leaving the byte
+/// buffer as the limit that actually governs how much is queued.
+const MAX_PENDING_PACKETS: u32 =
+    (RECV_BUFFER_SIZE as u32 / ip_packet::MAX_IP_SIZE as u32).next_power_of_two();
+
+/// From XNU's `bsd/net/if_utun.h`.
+const UTUN_OPT_MAX_PENDING_PACKETS: libc::c_int = 16;
+
 pub struct Tun {
     name: String,
     outbound_tx: mpsc::Sender<IpPacket>,
@@ -36,6 +61,9 @@ impl Tun {
 
     fn from_fd_inner(fd: RawFd, runtime: &tokio::runtime::Handle) -> io::Result<Self> {
         let name = name(fd)?;
+
+        raise_recv_buffer(fd);
+        raise_max_pending_packets(fd);
 
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
@@ -108,6 +136,97 @@ fn set_non_blocking(fd: RawFd) -> io::Result<()> {
             _ => Ok(()),
         },
     }
+}
+
+/// Raises the limit of packets the kernel buffers on the utun socket, allowing it to run ahead of our reads instead of in lock-step.
+fn raise_max_pending_packets(fd: RawFd) {
+    let current = match get_sockopt::<u32>(fd, libc::SYSPROTO_CONTROL, UTUN_OPT_MAX_PENDING_PACKETS)
+    {
+        Ok(current) => current,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to get `UTUN_OPT_MAX_PENDING_PACKETS`");
+            return;
+        }
+    };
+
+    tracing::debug!(current, "Queried `UTUN_OPT_MAX_PENDING_PACKETS`");
+
+    if current >= MAX_PENDING_PACKETS {
+        return;
+    }
+
+    if let Err(e) = set_sockopt(
+        fd,
+        libc::SYSPROTO_CONTROL,
+        UTUN_OPT_MAX_PENDING_PACKETS,
+        &MAX_PENDING_PACKETS,
+    ) {
+        tracing::warn!(error = %e, "Failed to set `UTUN_OPT_MAX_PENDING_PACKETS`");
+        return;
+    }
+
+    tracing::debug!(
+        previous = current,
+        new = MAX_PENDING_PACKETS,
+        "Raised `UTUN_OPT_MAX_PENDING_PACKETS`"
+    );
+}
+
+/// Raises the utun socket's receive buffer so the kernel can queue more inbound
+/// packets between our reads.
+fn raise_recv_buffer(fd: RawFd) {
+    if let Err(e) = set_sockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUF, &RECV_BUFFER_SIZE) {
+        tracing::warn!(error = %e, "Failed to set TUN socket receive buffer");
+        return;
+    }
+
+    // The kernel clamps to `kern.ipc.maxsockbuf`; read back what it actually applied.
+    match get_sockopt::<libc::c_int>(fd, libc::SOL_SOCKET, libc::SO_RCVBUF) {
+        Ok(actual) => {
+            tracing::debug!(
+                requested = RECV_BUFFER_SIZE,
+                actual,
+                "Set TUN socket receive buffer"
+            )
+        }
+        Err(e) => tracing::warn!(error = %e, "Failed to read back TUN socket receive buffer"),
+    }
+}
+
+/// Sets an integer-valued socket option.
+fn set_sockopt<T>(fd: RawFd, level: libc::c_int, name: libc::c_int, value: &T) -> io::Result<()> {
+    // Safety: `value` points to a `T`, matching the `size_of::<T>()` length we pass.
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            name,
+            (value as *const T).cast(),
+            size_of::<T>() as libc::socklen_t,
+        )
+    };
+
+    if ret < 0 {
+        return Err(get_last_error());
+    }
+
+    Ok(())
+}
+
+/// Reads an integer-valued socket option.
+fn get_sockopt<T>(fd: RawFd, level: libc::c_int, name: libc::c_int) -> io::Result<T> {
+    let mut value = std::mem::MaybeUninit::<T>::uninit();
+    let mut len = size_of::<T>() as libc::socklen_t;
+
+    // Safety: `value` has room for the `size_of::<T>()` length we pass.
+    let ret = unsafe { libc::getsockopt(fd, level, name, value.as_mut_ptr().cast(), &mut len) };
+
+    if ret < 0 {
+        return Err(get_last_error());
+    }
+
+    // Safety: `getsockopt` succeeded; these integer options return a fully-initialized `T`.
+    Ok(unsafe { value.assume_init() })
 }
 
 fn read(fd: RawFd, dst: &mut IpPacketBuf) -> io::Result<usize> {


### PR DESCRIPTION
The utun control socket limits how much the kernel buffers on the read side — the packets local apps send, which we read from the device, encrypt and forward (the upload path). Two tiny defaults bound it: the kernel parks at most `utun_max_pending_packets` packets (XNU default 1) in the socket receive buffer before pausing the interface, and the buffer is itself byte-bounded by the kctl `ctl_recvsize` (512 KiB). Together they force a flow-control roundtrip per packet.

Raise the receive buffer via `SO_RCVBUF` to 2 MiB on iOS and 8 MiB on macOS (8 MiB is the default `kern.ipc.maxsockbuf` ceiling), and raise `UTUN_OPT_MAX_PENDING_PACKETS` to match — the buffer's capacity at a 1280-byte MTU, rounded up to a power of two — so the byte buffer governs how much the kernel queues while we read. Both applied values are logged on DEBUG.