### PR TITLE
chore(ci): notify firezone/website on publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -238,10 +238,14 @@ jobs:
 
           version=${release_name#${{ matrix.tag_prefix }}-}
 
-          gh api repos/firezone/website/dispatches \
-            -f event_type=publish \
-            -F "client_payload[component]=${{ matrix.component }}" \
-            -F "client_payload[version]=$version"
+          gh api \
+            --method POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/firezone/website/dispatches \
+            --raw-field "event_type=publish" \
+            --field "client_payload[component]=${{ matrix.component }}" \
+            --field "client_payload[version]=$version"
 
   create-sentry-release:
     name: create_${{ matrix.component }}_sentry_release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -206,6 +206,43 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
           RELEASE_PR_BOT_GPG_KEY: "${{ secrets.RELEASE_PR_BOT_GPG_KEY }}"
 
+  # The website half of the version bump (changelog entry + displayed version
+  # markers) lives in firezone/website. Notify it of the publish; its
+  # open-version-bump-pr workflow runs that repo's scripts/bump-versions.sh
+  # and opens the PR there.
+  notify-website:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.
+          - tag_prefix: gateway
+            component: gateway
+          - tag_prefix: gui-client
+            component: gui-client
+          - tag_prefix: headless-client
+            component: headless-client
+          - tag_prefix: macos-client
+            component: apple-client
+          - tag_prefix: android-client
+            component: android-client
+    steps:
+      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
+        env:
+          # repository_dispatch on firezone/website requires this token to
+          # have Contents: write there.
+          GH_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
+          release_name: ${{ inputs.release_name || github.event.release.name }}
+        run: |
+          set -xeuo pipefail
+
+          version=${release_name#${{ matrix.tag_prefix }}-}
+
+          gh api repos/firezone/website/dispatches \
+            -f event_type=publish \
+            -F "client_payload[component]=${{ matrix.component }}" \
+            -F "client_payload[version]=$version"
+
   create-sentry-release:
     name: create_${{ matrix.component }}_sentry_release
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The website half of the release version bump (changelog entry and displayed version markers) moved to the firezone/website repo in #13635. This adds a `notify-website` job to `publish-release.yml` that sends a `repository_dispatch` event of type `publish` to firezone/website with the released component and version, using the same `tag_prefix` → `component` mapping as `open-version-bump-pr`.

On the website side, a new `open-version-bump-pr` workflow (firezone/website `feat/publish` branch) receives the event, runs that repo's `scripts/bump-versions.sh <component> <version>`, and opens the changelog/version PR there as firezone-bot.

Setup required before this works end-to-end:

- [x] `RELEASE_PR_BOT_GITHUB_TOKEN` (firezone-bot's token) needs Contents: write and Pull requests: write on firezone/website — `repository_dispatch` requires Contents: write on the target repo.
- [x] Add `RELEASE_PR_BOT_GITHUB_TOKEN` and `RELEASE_PR_BOT_GPG_KEY` secrets to firezone/website (same values as here).
- [x] Merge the website-side workflow in firezone/website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)