### PR TITLE
fix(android): wire up rustls-platform-verifier

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -257,6 +257,11 @@ dependencies {
     // UniFFI
     implementation("net.java.dev.jna:jna:5.19.0@aar")
 
+    // Kotlin side of rustls-platform-verifier, called from libconnlib.so via JNI
+    // (see FirezoneApp.initRustlsPlatformVerifier). Resolved from the Maven repo
+    // bundled in the crate source (see settings.gradle.kts).
+    implementation(cargo.rustls.platform.verifier)
+
     // Sentry
     implementation("io.sentry:sentry-android:8.43.1")
 

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -1,9 +1,6 @@
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
-import groovy.json.JsonSlurper
-import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Properties
 import javax.inject.Inject
@@ -288,33 +285,10 @@ dependencies {
 
 val rustDir = layout.projectDirectory.dir("../../../rust")
 
-// Gradle 9 removed `Project.exec`; run external processes through the injected `ExecOperations`.
-val execOperations = serviceOf<ExecOperations>()
-
-// Resolve the cargo target directory from cargo metadata so we don't hardcode a path that may
-// be overridden by the user's ~/.cargo/config.toml (e.g. `target-dir`).
-val cargoTargetDir: String by lazy {
-    val metadataOutput = ByteArrayOutputStream()
-    execOperations.exec {
-        workingDir = rustDir.asFile
-        commandLine("cargo", "metadata", "--format-version", "1")
-        standardOutput = metadataOutput
-    }
-    val metadataJson = metadataOutput.toString(Charsets.UTF_8.name())
-    val metadata =
-        try {
-            JsonSlurper().parseText(metadataJson) as Map<*, *>
-        } catch (e: Exception) {
-            throw GradleException(
-                "Failed to parse cargo metadata JSON. Ensure 'cargo' is installed and accessible. Error: ${e.message}",
-                e,
-            )
-        }
-    metadata["target_directory"] as? String
-        ?: throw GradleException(
-            "cargo metadata did not contain 'target_directory' field. Output was: ${metadataJson.take(500)}",
-        )
-}
+// Cargo's target directory, not hardcoded because the user's ~/.cargo/config.toml may override
+// it (e.g. `target-dir`). Resolved from the single `cargo metadata` call in settings.gradle.kts
+// and shared via gradle extras.
+val cargoTargetDir = (gradle as ExtensionAware).extra["cargoTargetDir"] as String
 
 // Resolve the target Android ABI from the `android.injected.build.abi` Gradle property,
 // injected by Android Studio when launching on a connected device (comma-separated, preferred

--- a/kotlin/android/app/proguard-rules.pro
+++ b/kotlin/android/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# rustls-platform-verifier's Kotlin component is only reached via JNI from
+# libconnlib.so, so R8 sees no references to it and would strip it.
+-keep, includedescriptorclasses class org.rustls.platformverifier.** { *; }

--- a/kotlin/android/app/proguard-rules.pro
+++ b/kotlin/android/app/proguard-rules.pro
@@ -22,4 +22,4 @@
 
 # rustls-platform-verifier's Kotlin component is only reached via JNI from
 # libconnlib.so, so R8 sees no references to it and would strip it.
--keep, includedescriptorclasses class org.rustls.platformverifier.** { *; }
+-keep,includedescriptorclasses class org.rustls.platformverifier.** { *; }

--- a/kotlin/android/mise-tasks/setup-ndk.sh
+++ b/kotlin/android/mise-tasks/setup-ndk.sh
@@ -3,4 +3,12 @@
 set -euo pipefail
 
 : "${ANDROID_HOME:?ANDROID_HOME must point to your Android SDK root}"
-sdkmanager --sdk_root="$ANDROID_HOME" "ndk;${NDK_VERSION}"
+
+# Prefer the cmdline-tools sdkmanager; the legacy `tools/bin/sdkmanager` that may
+# shadow it on PATH requires Java <= 10 and crashes on modern JDKs.
+sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+if [[ ! -x "$sdkmanager" ]]; then
+    sdkmanager="sdkmanager"
+fi
+
+"$sdkmanager" --sdk_root="$ANDROID_HOME" "ndk;${NDK_VERSION}"

--- a/kotlin/android/settings.gradle.kts
+++ b/kotlin/android/settings.gradle.kts
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 pluginManagement {
     repositories {
         google()
@@ -6,11 +8,55 @@ pluginManagement {
     }
 }
 
+// rustls-platform-verifier delegates connlib's TLS certificate verification to a small
+// Kotlin component (org.rustls.platformverifier.CertificateVerifier) that must be bundled
+// into the APK. The crate ships it as a local Maven repo inside its source; resolve its
+// path and version via cargo metadata so they always match the Rust dependency.
+fun rustlsPlatformVerifierAndroidPackage(): Map<*, *> {
+    val metadataText =
+        providers
+            .exec {
+                workingDir = File(rootDir, "../../rust")
+                commandLine(
+                    "cargo",
+                    "metadata",
+                    "--format-version",
+                    "1",
+                    "--filter-platform",
+                    "aarch64-linux-android",
+                )
+            }.standardOutput
+            .asText
+            .get()
+
+    val metadata = JsonSlurper().parseText(metadataText) as Map<*, *>
+    val packages = (metadata["packages"] as List<*>).filterIsInstance<Map<*, *>>()
+    return packages.firstOrNull { it["name"] == "rustls-platform-verifier-android" }
+        ?: throw GradleException("rustls-platform-verifier-android not found in cargo metadata")
+}
+
+val rustlsAndroidPackage = rustlsPlatformVerifierAndroidPackage()
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
+        maven {
+            url =
+                File(rustlsAndroidPackage["manifest_path"] as String)
+                    .parentFile
+                    .resolve("maven")
+                    .toURI()
+            metadataSources { mavenPom() }
+            content { includeGroup("rustls") }
+        }
+    }
+    versionCatalogs {
+        create("cargo") {
+            library("rustls-platform-verifier", "rustls", "rustls-platform-verifier")
+                .version(rustlsAndroidPackage["version"] as String)
+        }
     }
 }
 

--- a/kotlin/android/settings.gradle.kts
+++ b/kotlin/android/settings.gradle.kts
@@ -12,8 +12,8 @@ pluginManagement {
 // Kotlin component (org.rustls.platformverifier.CertificateVerifier) that must be bundled
 // into the APK. The crate ships it as a local Maven repo inside its source; resolve its
 // path and version via cargo metadata so they always match the Rust dependency.
-fun rustlsPlatformVerifierAndroidPackage(): Map<*, *> {
-    val metadataText =
+val cargoMetadata: Map<*, *> =
+    JsonSlurper().parseText(
         providers
             .exec {
                 workingDir = File(rootDir, "../../rust")
@@ -27,15 +27,18 @@ fun rustlsPlatformVerifierAndroidPackage(): Map<*, *> {
                 )
             }.standardOutput
             .asText
-            .get()
+            .get(),
+    ) as Map<*, *>
 
-    val metadata = JsonSlurper().parseText(metadataText) as Map<*, *>
-    val packages = (metadata["packages"] as List<*>).filterIsInstance<Map<*, *>>()
-    return packages.firstOrNull { it["name"] == "rustls-platform-verifier-android" }
+// Share the cargo target directory with app/build.gradle.kts via gradle extras so project
+// scripts don't have to shell out to `cargo metadata` again at configuration time.
+(gradle as ExtensionAware).extra["cargoTargetDir"] = cargoMetadata["target_directory"] as String
+
+val rustlsAndroidPackage =
+    (cargoMetadata["packages"] as List<*>)
+        .filterIsInstance<Map<*, *>>()
+        .firstOrNull { it["name"] == "rustls-platform-verifier-android" }
         ?: throw GradleException("rustls-platform-verifier-android not found in cargo metadata")
-}
-
-val rustlsAndroidPackage = rustlsPlatformVerifierAndroidPackage()
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
Fixes a regression introduced in #13150 where the rustls platform verified was not fully wired up for Android according to the [README's instructions](https://github.com/rustls/rustls-platform-verifier#android) resulting in PostHog and Sentry coms failing with:

```
2026-06-11T03:55:32.137Z ERROR rustls_platform_verifier::verification::android: failed to verify TLS certificate: unexpected error: failed to call native verifier: Error
```

---

Related: #13150