### PR TITLE
fix(android): don't lose input focus

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -417,6 +417,13 @@ abstract class CargoBuildTask
                 execOperations.exec {
                     workingDir = clientFfiDir.get().asFile
                     environment("CARGO_TARGET_DIR", cargoTarget)
+                    if (release.get()) {
+                        // Compile the whole dependency graph with line tables so
+                        // Crashlytics gets file/line info in native stack traces.
+                        // AGP strips them from the packaged lib; Crashlytics uploads
+                        // the unstripped one (see unstrippedNativeLibsDir).
+                        environment("CARGO_PROFILE_RELEASE_DEBUG", "line-tables-only")
+                    }
                     // Linker for the Rust target plus the C/C++ toolchain for `cc`-built
                     // dependencies such as ring.
                     environment("CARGO_TARGET_${envTriple}_LINKER", clang.absolutePath)

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -95,12 +95,13 @@ android {
             // Enables code shrinking, obfuscation, and optimization for only
             // your project's release build type. Make sure to use a build
             // variant with `isDebuggable=false`.
-            // Not compatible with Rust
-            isMinifyEnabled = false
+            // R8 only processes JVM bytecode; classes reached from libconnlib.so
+            // via JNI/JNA are preserved through proguard-rules.pro.
+            isMinifyEnabled = true
 
             // Enables resource shrinking, which is performed by the
             // Android Gradle plugin.
-            isShrinkResources = false
+            isShrinkResources = true
 
             // Includes the default ProGuard rules files that are packaged with
             // the Android Gradle plugin. To learn more, go to the section about

--- a/kotlin/android/app/proguard-rules.pro
+++ b/kotlin/android/app/proguard-rules.pro
@@ -12,14 +12,28 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Preserve file and line number information so Crashlytics and Play Console
+# can show readable, deobfuscated stack traces.
+-keepattributes SourceFile,LineNumberTable
 
 # rustls-platform-verifier's Kotlin component is only reached via JNI from
 # libconnlib.so, so R8 sees no references to it and would strip it.
 -keep,includedescriptorclasses class org.rustls.platformverifier.** { *; }
+
+# The UniFFI-generated bindings are loaded through JNA, which resolves classes,
+# fields and native methods reflectively by name at runtime.
+-keep,includedescriptorclasses class uniffi.connlib.** { *; }
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }
+-dontwarn java.awt.*
+
+# Tunnel models are deserialized reflectively by Moshi's KotlinJsonAdapterFactory,
+# which reads Kotlin metadata through kotlin-reflect.
+-keep class dev.firezone.android.tunnel.model.** { *; }
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}
+
+# Persisted to SharedPreferences via Gson by constant name; renaming the
+# constants would corrupt existing installs on update.
+-keep class dev.firezone.android.core.data.ResourceState { *; }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -44,7 +44,7 @@ internal class SettingsActivity : AppCompatActivity() {
             // FOCUS_BEFORE_DESCENDANTS, so the relayout caused by the soft keyboard
             // appearing steals focus from a just-tapped EditText. Keep it out of
             // touch-mode focus so inputs retain focus on the first tap.
-            viewPager.getChildAt(0).isFocusableInTouchMode = false
+            viewPager.getChildAt(0)?.isFocusableInTouchMode = false
 
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 when (position) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -40,6 +40,12 @@ internal class SettingsActivity : AppCompatActivity() {
         with(binding) {
             viewPager.adapter = adapter
 
+            // ViewPager2's inner RecyclerView is focusable-in-touch-mode with
+            // FOCUS_BEFORE_DESCENDANTS, so the relayout caused by the soft keyboard
+            // appearing steals focus from a just-tapped EditText. Keep it out of
+            // touch-mode focus so inputs retain focus on the first tap.
+            viewPager.getChildAt(0).isFocusableInTouchMode = false
+
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 when (position) {
                     0 -> {


### PR DESCRIPTION
- Fixes a minor issue that caused the settings inputs to lose focus immediately upon first tap causing an annoying issue where entering text didn't work until you re-tapped the input
- Reduces size of the artifact using proguard / R8 and ensures crashlytics has proper line numbers to match up with traces

---

Fixes #3901 
