### PR TITLE
fix(portal): use server_wal_start as lsn

### DIFF
--- a/elixir/lib/portal/change_logs/replication_connection.ex
+++ b/elixir/lib/portal/change_logs/replication_connection.ex
@@ -103,10 +103,11 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
 
     Logger.info("Flushed #{successful_count}/#{attempted_count} change logs")
 
-    # We always advance the LSN to the highest LSN in the flush buffer. LSN
-    # conflicts just mean the data is already inserted, and entries for accounts
-    # that no longer exist are dropped during bulk_insert. Any other insert_all
-    # issue raises so we crash and replay from the durable slot.
+    # We always advance the LSN to the highest LSN in the flush buffer. Entries
+    # for accounts that no longer exist are dropped during bulk_insert. LSN
+    # conflicts are silently ignored for idempotency: after a crash/disconnect,
+    # the replication slot replays records before the slot's confirmed_flush_lsn
+    # is advanced, so we may insert the same LSN again on recovery.
     last_lsn =
       state.flush_buffer
       |> Map.keys()
@@ -249,6 +250,10 @@ defmodule Portal.ChangeLogs.ReplicationConnection do
     end
 
     defp insert_all(list_of_attrs) do
+      # Use on_conflict: :nothing to make the insert idempotent. With a durable
+      # replication slot, it's normal for WAL records to be replayed on reconnect
+      # if we crash between inserting rows and advancing the slot's
+      # confirmed_flush_lsn. Silently skipping re-inserted LSNs allows recovery.
       {inserted, _} =
         Safe.unscoped()
         |> Safe.insert_all(ChangeLog, list_of_attrs,

--- a/elixir/lib/portal/replication/connection.ex
+++ b/elixir/lib/portal/replication/connection.ex
@@ -444,11 +444,14 @@ defmodule Portal.Replication.Connection do
 
       def handle_data(data, state) when is_write(data) do
         OpenTelemetry.Tracer.with_span "#{__MODULE__}.handle_data/2" do
-          %Write{server_wal_end: server_wal_end, message: message} = parse(data)
+          # server_wal_start is the LSN of the WAL record contained in this
+          # message, unique per record. server_wal_end is just the server's
+          # current end of WAL and can repeat across messages.
+          %Write{server_wal_start: lsn, message: message} = parse(data)
 
           message
           |> decode_message()
-          |> handle_write(server_wal_end, %{state | counter: state.counter + 1})
+          |> handle_write(lsn, %{state | counter: state.counter + 1})
         end
       end
 
@@ -483,7 +486,7 @@ defmodule Portal.Replication.Connection do
                name: name,
                columns: columns
              },
-             server_wal_end,
+             _lsn,
              state
            ) do
         relation = %{
@@ -495,27 +498,27 @@ defmodule Portal.Replication.Connection do
         {:noreply, [], %{state | relations: Map.put(state.relations, id, relation)}}
       end
 
-      defp handle_write(%Decoder.Messages.Insert{} = msg, server_wal_end, state) do
-        process_write(msg, server_wal_end, state)
+      defp handle_write(%Decoder.Messages.Insert{} = msg, lsn, state) do
+        process_write(msg, lsn, state)
       end
 
-      defp handle_write(%Decoder.Messages.Update{} = msg, server_wal_end, state) do
-        process_write(msg, server_wal_end, state)
+      defp handle_write(%Decoder.Messages.Update{} = msg, lsn, state) do
+        process_write(msg, lsn, state)
       end
 
-      defp handle_write(%Decoder.Messages.Delete{} = msg, server_wal_end, state) do
-        process_write(msg, server_wal_end, state)
+      defp handle_write(%Decoder.Messages.Delete{} = msg, lsn, state) do
+        process_write(msg, lsn, state)
       end
 
-      defp process_write(_msg, _server_wal_end, %{error_threshold_exceeded?: true} = state) do
+      defp process_write(_msg, _lsn, %{error_threshold_exceeded?: true} = state) do
         {:noreply, [], state}
       end
 
-      defp process_write(msg, server_wal_end, state) do
+      defp process_write(msg, lsn, state) do
         {op, table, old_data, data} = transform(msg, state.relations)
 
         state
-        |> on_write(server_wal_end, op, table, old_data, data)
+        |> on_write(lsn, op, table, old_data, data)
         |> maybe_flush()
         |> then(&{:noreply, [], &1})
       end
@@ -534,7 +537,7 @@ defmodule Portal.Replication.Connection do
     quote do
       defp handle_write(
              %Decoder.Messages.Begin{commit_timestamp: commit_timestamp} = msg,
-             server_wal_end,
+             _lsn,
              state
            ) do
         # We can use the commit timestamp to check how far we are lagging behind
@@ -552,28 +555,28 @@ defmodule Portal.Replication.Connection do
     quote do
       # These messages are not relevant for our use case, so we ignore them.
 
-      defp handle_write(%Decoder.Messages.Commit{}, _server_wal_end, state) do
+      defp handle_write(%Decoder.Messages.Commit{}, _lsn, state) do
         {:noreply, [], state}
       end
 
-      defp handle_write(%Decoder.Messages.Origin{}, _server_wal_end, state) do
+      defp handle_write(%Decoder.Messages.Origin{}, _lsn, state) do
         {:noreply, [], state}
       end
 
-      defp handle_write(%Decoder.Messages.Truncate{}, _server_wal_end, state) do
+      defp handle_write(%Decoder.Messages.Truncate{}, _lsn, state) do
         {:noreply, [], state}
       end
 
-      defp handle_write(%Decoder.Messages.Type{}, _server_wal_end, state) do
+      defp handle_write(%Decoder.Messages.Type{}, _lsn, state) do
         {:noreply, [], state}
       end
 
-      defp handle_write(%Decoder.Messages.LogicalMessage{} = msg, _server_wal_end, state) do
+      defp handle_write(%Decoder.Messages.LogicalMessage{} = msg, _lsn, state) do
         state = on_logical_message(state, msg)
         {:noreply, [], state}
       end
 
-      defp handle_write(%Decoder.Messages.Unsupported{data: data}, _server_wal_end, state) do
+      defp handle_write(%Decoder.Messages.Unsupported{data: data}, _lsn, state) do
         Logger.warning("#{__MODULE__}: Unsupported message received",
           data: inspect(data),
           counter: state.counter

--- a/elixir/test/portal/replication/connection_test.exs
+++ b/elixir/test/portal/replication/connection_test.exs
@@ -32,8 +32,8 @@ defmodule Portal.Replication.ConnectionTest do
     end
 
     # Helper function to expose the private handle_write function for testing
-    def test_handle_write(msg, server_wal_end, state) do
-      handle_write(msg, server_wal_end, state)
+    def test_handle_write(msg, lsn, state) do
+      handle_write(msg, lsn, state)
     end
   end
 
@@ -670,6 +670,31 @@ defmodule Portal.Replication.ConnectionTest do
       assert new_state.last_sent_lsn == 1
       assert [<<?r, wal_end::64, wal_end::64, wal_end::64, _timestamp::64, 0>>] = reply_data
       assert wal_end == 1
+    end
+
+    test "uses server_wal_start as lsn for decoded write messages" do
+      state =
+        %TestReplicationConnection{step: :streaming}
+        |> Map.put(:operations, [])
+        |> Map.put(:relations, %{42 => %{name: "test_table", columns: []}})
+
+      # Create a write message where server_wal_start != server_wal_end
+      # to verify we use server_wal_start, not server_wal_end
+      server_wal_start = 100
+      server_wal_end = 500
+
+      # Decode a simple Insert message: I (insert), relation_id=42, N (new), 0 columns
+      insert_message = <<"I", 42::integer-32, "N", 0::integer-16>>
+
+      write_data = <<?w, server_wal_start::integer-64, server_wal_end::integer-64,
+                      0::integer-64, insert_message::binary>>
+
+      {:noreply, _reply, new_state} = TestReplicationConnection.handle_data(write_data, state)
+
+      # Verify on_write was called with server_wal_start, not server_wal_end
+      operations = Map.get(new_state, :operations, [])
+      assert length(operations) == 1
+      assert [%{lsn: ^server_wal_start} | _] = operations
     end
   end
 


### PR DESCRIPTION
The server_wal_start is the actual lsn of the record being decoded whereas the server_wal_end is the server's current position on disk and may in fact be duplicated across messages.

In practice this is not likely or possible since pgoutput smooths this over but it would be good to be correct here.

We also remove the `on_conflict` clause so that we crash if we unexpectedly get this wrong.


Reference:


https://raw.githubusercontent.com/postgres/postgres/master/src/backend/replication/walsender.c

> Authoritatively confirmed: WalSndPrepareWrite sets both dataStart (server_wal_start) and walEnd (server_wal_end) to the same lsn. Let me confirm the one remaining load-bearing claim — that a multi-insert (COPY) record assigns the same LSN to every tuple's change — by checking the decoder.