### PR TITLE
ci: push QA binaries to dedicated QA storage via OIDC

### DIFF
--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -100,9 +100,6 @@ jobs:
             rust/${{ matrix.binary }}
             rust/${{ matrix.binary }}.sha256sum.txt
 
-      # Authenticate to the dedicated QA artifacts storage via GitHub OIDC. The
-      # loadtest binaries are QA-only and live in their own account, separate
-      # from the production `firezoneartifacts` (firezone/infra#687).
       - name: Azure login (OIDC)
         if: github.ref == 'refs/heads/main'
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/.github/workflows/_loadtest.yml
+++ b/.github/workflows/_loadtest.yml
@@ -100,23 +100,39 @@ jobs:
             rust/${{ matrix.binary }}
             rust/${{ matrix.binary }}.sha256sum.txt
 
-      - name: Upload to Azure Storage
+      # Authenticate to the dedicated QA artifacts storage via GitHub OIDC. The
+      # loadtest binaries are QA-only and live in their own account, separate
+      # from the production `firezoneartifacts` (firezone/infra#687).
+      - name: Azure login (OIDC)
+        if: github.ref == 'refs/heads/main'
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_QA_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_QA_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_QA_SUBSCRIPTION_ID }}
+          # The QA principal only holds a data-plane role on the storage account,
+          # not subscription-wide Reader, so don't fail on subscription enumeration.
+          allow-no-subscriptions: true
+
+      - name: Upload to QA artifacts storage
         if: github.ref == 'refs/heads/main'
         shell: bash
         run: |
           set -e
           az storage blob upload \
+            --account-name firezoneqaartifacts \
+            --auth-mode login \
             --container-name binaries \
             --name "loadtest/${{ matrix.os }}/${{ inputs.sha }}/${{ matrix.artifact_name }}" \
             --file "${{ matrix.binary }}" \
             --overwrite true \
-            --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --no-progress
 
           az storage blob upload \
+            --account-name firezoneqaartifacts \
+            --auth-mode login \
             --container-name binaries \
             --name "loadtest/${{ matrix.os }}/${{ inputs.sha }}/${{ matrix.artifact_name }}.sha256sum.txt" \
             --file "${{ matrix.binary }}.sha256sum.txt" \
             --overwrite true \
-            --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --no-progress

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -259,9 +259,6 @@ jobs:
             --no-progress \
             --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
-      # The preview MSI is consumed only by the QA clients, so it goes to the
-      # dedicated QA artifacts storage account (firezone/infra#687),
-      # authenticated via GitHub OIDC.
       - name: Azure login (OIDC) for QA artifacts
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -259,20 +259,9 @@ jobs:
             --no-progress \
             --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
-      - name: Upload to preview repository
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
-        shell: bash
-        run: |
-          az storage blob upload \
-            --container-name binaries \
-            --name "windows-gui-client/preview/${{ matrix.arch }}" \
-            --file "${{ env.BINARY_DEST_PATH }}.msi" \
-            --overwrite true \
-            --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
-
-      # The QA clients consume the preview MSI too, but from their own storage
-      # account (firezone/infra#687). Push a copy there via GitHub OIDC.
+      # The preview MSI is consumed only by the QA clients, so it goes to the
+      # dedicated QA artifacts storage account (firezone/infra#687),
+      # authenticated via GitHub OIDC.
       - name: Azure login (OIDC) for QA artifacts
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -271,6 +271,32 @@ jobs:
             --no-progress \
             --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
+      # The QA clients consume the preview MSI too, but from their own storage
+      # account (firezone/infra#687). Push a copy there via GitHub OIDC.
+      - name: Azure login (OIDC) for QA artifacts
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_QA_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_QA_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_QA_SUBSCRIPTION_ID }}
+          # The QA principal only holds a data-plane role on the storage account,
+          # not subscription-wide Reader, so don't fail on subscription enumeration.
+          allow-no-subscriptions: true
+
+      - name: Upload preview MSI to QA artifacts storage
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
+        shell: bash
+        run: |
+          az storage blob upload \
+            --account-name firezoneqaartifacts \
+            --auth-mode login \
+            --container-name binaries \
+            --name "windows-gui-client/preview/${{ matrix.arch }}" \
+            --file "${{ env.BINARY_DEST_PATH }}.msi" \
+            --overwrite true \
+            --no-progress
+
   regenerate-apt-index:
     needs: build-gui
     if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}


### PR DESCRIPTION
The QA-only loadtest binaries and the preview MSI consumed by the QA clients now go to a dedicated QA artifacts storage account, authenticated with GitHub OIDC.