### PR TITLE
fix(rust): aggregate metrics before sending to Sentry

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7505,6 +7505,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",
+ "rand 0.10.1",
  "reqwest",
  "rustls",
  "sentry",

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -12,6 +12,7 @@ moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls-no-provider", "tracing", "logs", "metrics"] }
 serde = { workspace = true }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -18,6 +18,18 @@ use crate::{Env, posthog};
 
 pub(crate) const RE_EVAL_DURATION: Duration = Duration::from_secs(5 * 60);
 
+/// Number of raw samples retained per distribution series per flush interval when
+/// the `stream_metrics` payload does not specify one.
+///
+/// Percentile accuracy depends on this count, not on how many measurements were
+/// recorded, so volume stays bounded regardless of load. Larger values tighten the
+/// p99 estimate at a proportional increase in volume.
+const DEFAULT_METRICS_RESERVOIR_SIZE: usize = 64;
+
+/// Upper bound on the configurable reservoir size, guarding against a misconfigured
+/// payload requesting an allocation large enough to exhaust memory.
+const MAX_METRICS_RESERVOIR_SIZE: usize = 8192;
+
 // Process-wide storage of enabled feature flags.
 //
 // Defaults to everything off unless the env variables say otherwise.
@@ -56,6 +68,12 @@ pub fn stream_metrics() -> bool {
     FEATURE_FLAGS.stream_metrics()
 }
 
+/// Number of raw samples retained per distribution series per flush interval,
+/// configured via the `stream_metrics` feature-flag payload.
+pub fn metrics_reservoir_size() -> usize {
+    FEATURE_FLAGS.metrics_reservoir_size()
+}
+
 pub fn show_connected_devices() -> bool {
     FEATURE_FLAGS.show_connected_devices()
 }
@@ -86,7 +104,7 @@ pub(crate) fn current() -> impl IntoIterator<Item = (&'static str, bool)> {
             "icmp_error_unreachable_prohibited_create_new_flow",
             icmp_error_unreachable_prohibited_create_new_flow.load(Ordering::Relaxed),
         ),
-        ("stream_metrics", stream_metrics.load(Ordering::Relaxed)),
+        ("stream_metrics", stream_metrics.read().enabled),
         (
             "show_connected_devices",
             show_connected_devices.load(Ordering::Relaxed),
@@ -215,6 +233,8 @@ struct FeatureFlagsResponse {
 struct FeatureFlagPayloadsResponse {
     #[serde(default)]
     stream_logs: String,
+    #[serde(default)]
+    stream_metrics: String,
 }
 
 #[derive(Debug, Default)]
@@ -223,7 +243,7 @@ struct FeatureFlags {
     drop_llmnr_nxdomain_responses: AtomicBool,
     stream_logs: RwLock<LogFilter>,
     icmp_error_unreachable_prohibited_create_new_flow: AtomicBool,
-    stream_metrics: AtomicBool,
+    stream_metrics: RwLock<StreamMetrics>,
     show_connected_devices: AtomicBool,
 }
 
@@ -255,9 +275,13 @@ impl FeatureFlags {
                 icmp_error_unreachable_prohibited_create_new_flow,
                 Ordering::Relaxed,
             );
-        self.stream_metrics.store(stream_metrics, Ordering::Relaxed);
         self.show_connected_devices
             .store(show_connected_devices, Ordering::Relaxed);
+
+        *self.stream_metrics.write() = StreamMetrics {
+            enabled: stream_metrics,
+            reservoir_size: MetricsConfig::parse(&payloads.stream_metrics).reservoir_size(),
+        };
 
         let log_filter = if stream_logs {
             LogFilter::parse(payloads.stream_logs)
@@ -287,7 +311,11 @@ impl FeatureFlags {
     }
 
     fn stream_metrics(&self) -> bool {
-        self.stream_metrics.load(Ordering::Relaxed)
+        self.stream_metrics.read().enabled
+    }
+
+    fn metrics_reservoir_size(&self) -> usize {
+        self.stream_metrics.read().reservoir_size
     }
 
     fn show_connected_devices(&self) -> bool {
@@ -320,6 +348,60 @@ fn env_or(key: &str, fallback: bool) -> bool {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(fallback)
+}
+
+/// Runtime configuration carried by the `stream_metrics` feature-flag payload.
+///
+/// Fields are optional so new ones can be added without breaking clients that
+/// predate them; unknown fields are ignored.
+#[derive(Debug, Deserialize, Default)]
+struct MetricsConfig {
+    #[serde(default)]
+    reservoir_size: Option<usize>,
+}
+
+impl MetricsConfig {
+    /// Parses the config from the payload, which PostHog delivers as a JSON string.
+    /// A malformed payload yields the default config.
+    fn parse(payload: &str) -> Self {
+        serde_json::from_str(payload).unwrap_or_default()
+    }
+
+    fn reservoir_size(&self) -> usize {
+        let size = self
+            .reservoir_size
+            .filter(|&size| size > 0)
+            .unwrap_or(DEFAULT_METRICS_RESERVOIR_SIZE);
+
+        if size > MAX_METRICS_RESERVOIR_SIZE {
+            tracing::warn!(
+                requested = size,
+                max = MAX_METRICS_RESERVOIR_SIZE,
+                "Clamping metrics reservoir size"
+            );
+        }
+
+        size.min(MAX_METRICS_RESERVOIR_SIZE)
+    }
+}
+
+/// Resolved runtime state for metric streaming, kept in [`FeatureFlags`].
+///
+/// `enabled` is driven by the boolean `stream_metrics` flag, while `reservoir_size`
+/// comes from its payload; the two are independent.
+#[derive(Debug)]
+struct StreamMetrics {
+    enabled: bool,
+    reservoir_size: usize,
+}
+
+impl Default for StreamMetrics {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            reservoir_size: DEFAULT_METRICS_RESERVOIR_SIZE,
+        }
+    }
 }
 
 struct LogFilter {
@@ -379,5 +461,67 @@ mod tests {
         let filter = LogFilter::parse("\"debug,is::ice_::pair=trace\"".to_owned());
 
         assert_eq!(filter.directives, "debug,is::ice_::pair=trace");
+    }
+
+    #[test]
+    fn parses_metrics_config_from_payload() {
+        assert_eq!(
+            MetricsConfig::parse(r#"{"reservoir_size":128}"#).reservoir_size(),
+            128
+        );
+        // Unknown fields are ignored so new keys don't break older clients.
+        assert_eq!(
+            MetricsConfig::parse(r#"{"reservoir_size":64,"future_knob":true}"#).reservoir_size(),
+            64
+        );
+        // Missing, zero, or invalid payloads fall back to the default.
+        assert_eq!(
+            MetricsConfig::parse("{}").reservoir_size(),
+            DEFAULT_METRICS_RESERVOIR_SIZE
+        );
+        assert_eq!(
+            MetricsConfig::parse(r#"{"reservoir_size":0}"#).reservoir_size(),
+            DEFAULT_METRICS_RESERVOIR_SIZE
+        );
+        assert_eq!(
+            MetricsConfig::parse("not json").reservoir_size(),
+            DEFAULT_METRICS_RESERVOIR_SIZE
+        );
+        // Oversized values are clamped to the maximum.
+        assert_eq!(
+            MetricsConfig::parse(r#"{"reservoir_size":1000000}"#).reservoir_size(),
+            MAX_METRICS_RESERVOIR_SIZE
+        );
+    }
+
+    #[test]
+    fn enabled_state_is_driven_by_the_flag_not_the_size() {
+        let flags = FeatureFlags::default();
+
+        flags.update(
+            FeatureFlagsResponse {
+                stream_metrics: true,
+                ..Default::default()
+            },
+            FeatureFlagPayloadsResponse::default(),
+        );
+        assert!(flags.stream_metrics());
+        assert_eq!(
+            flags.metrics_reservoir_size(),
+            DEFAULT_METRICS_RESERVOIR_SIZE
+        );
+
+        // Disabling the flag wins even when the payload still carries a size.
+        flags.update(
+            FeatureFlagsResponse {
+                stream_metrics: false,
+                ..Default::default()
+            },
+            FeatureFlagPayloadsResponse {
+                stream_metrics: r#"{"reservoir_size":128}"#.to_owned(),
+                ..Default::default()
+            },
+        );
+        assert!(!flags.stream_metrics());
     }
 }

--- a/rust/libs/telemetry/src/sentry_instrument_provider.rs
+++ b/rust/libs/telemetry/src/sentry_instrument_provider.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use opentelemetry::{
     InstrumentationScope, KeyValue, Value as OtelValue,
@@ -8,28 +13,56 @@ use opentelemetry::{
     },
 };
 use parking_lot::Mutex;
+use rand::RngExt;
 use sentry::protocol::{LogAttribute, Unit};
 
-/// A [`MeterProvider`] that intercepts every metric recording and forwards it
-/// directly to Sentry, bypassing the SDK's aggregation pipeline.
+/// How often the aggregated metrics are flushed to Sentry.
+const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// A [`MeterProvider`] that aggregates metrics locally and periodically flushes
+/// them to Sentry.
 ///
-/// This gives Sentry exact raw values instead of bucket-midpoint approximations.
-/// Export is gated on the `stream_metrics` feature flag.
-#[derive(Default)]
+/// Counters and gauges are aggregated exactly. Distributions keep a fair random
+/// sample (plus the observed maximum) of their raw values, so Sentry can still
+/// compute meaningful percentiles without us shipping every measurement.
+///
+/// Ideally this would be an OpenTelemetry `PushMetricExporter` fed by the SDK's
+/// aggregation pipeline, reading raw distribution samples from histogram
+/// exemplars. Exemplar collection is unimplemented upstream, so we intercept at
+/// the instrument level and keep our own reservoir and flush thread instead.
+/// See <https://github.com/open-telemetry/opentelemetry-rust/issues/3369> and the
+/// migration tracking issue <https://github.com/firezone/firezone/issues/13713>.
+///
+/// Recording is gated on the `stream_metrics` feature flag.
 pub struct SentryMeterProvider {
-    up_down_totals: Arc<Mutex<HashMap<UpDownKey, f64>>>,
+    registry: Arc<Registry>,
+}
+
+impl Default for SentryMeterProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SentryMeterProvider {
+    pub fn new() -> Self {
+        let registry = Arc::new(Registry::default());
+        spawn_flush_thread(Arc::downgrade(&registry));
+
+        Self { registry }
+    }
 }
 
 impl MeterProvider for SentryMeterProvider {
     fn meter_with_scope(&self, _scope: InstrumentationScope) -> Meter {
         Meter::new(Arc::new(SentryInstrumentProvider {
-            up_down_totals: self.up_down_totals.clone(),
+            registry: self.registry.clone(),
         }))
     }
 }
 
 struct SentryInstrumentProvider {
-    up_down_totals: Arc<Mutex<HashMap<UpDownKey, f64>>>,
+    registry: Arc<Registry>,
 }
 
 impl SentryInstrumentProvider {
@@ -37,71 +70,63 @@ impl SentryInstrumentProvider {
         &self,
         name: Cow<'static, str>,
         unit: Option<Cow<'static, str>>,
-        kind: SentryMetricKind,
+        kind: MetricKind,
     ) -> Arc<SentryMetricInstrument> {
         Arc::new(SentryMetricInstrument {
             name,
             unit: Unit::from(unit.unwrap_or(Cow::Borrowed(""))),
             kind,
-            up_down_totals: self.up_down_totals.clone(),
+            registry: self.registry.clone(),
         })
     }
 }
 
 impl InstrumentProvider for SentryInstrumentProvider {
     fn u64_counter(&self, builder: InstrumentBuilder<'_, Counter<u64>>) -> Counter<u64> {
-        Counter::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Counter))
+        Counter::new(self.instrument(builder.name, builder.unit, MetricKind::Counter))
     }
 
     fn f64_counter(&self, builder: InstrumentBuilder<'_, Counter<f64>>) -> Counter<f64> {
-        Counter::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Counter))
+        Counter::new(self.instrument(builder.name, builder.unit, MetricKind::Counter))
     }
 
     fn u64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<u64>>) -> Gauge<u64> {
-        Gauge::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Gauge))
+        Gauge::new(self.instrument(builder.name, builder.unit, MetricKind::Gauge))
     }
 
     fn f64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<f64>>) -> Gauge<f64> {
-        Gauge::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Gauge))
+        Gauge::new(self.instrument(builder.name, builder.unit, MetricKind::Gauge))
     }
 
     fn i64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<i64>>) -> Gauge<i64> {
-        Gauge::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Gauge))
+        Gauge::new(self.instrument(builder.name, builder.unit, MetricKind::Gauge))
     }
 
     fn i64_up_down_counter(
         &self,
         builder: InstrumentBuilder<'_, UpDownCounter<i64>>,
     ) -> UpDownCounter<i64> {
-        UpDownCounter::new(self.instrument(
-            builder.name,
-            builder.unit,
-            SentryMetricKind::UpDownCounter,
-        ))
+        UpDownCounter::new(self.instrument(builder.name, builder.unit, MetricKind::UpDownCounter))
     }
 
     fn f64_up_down_counter(
         &self,
         builder: InstrumentBuilder<'_, UpDownCounter<f64>>,
     ) -> UpDownCounter<f64> {
-        UpDownCounter::new(self.instrument(
-            builder.name,
-            builder.unit,
-            SentryMetricKind::UpDownCounter,
-        ))
+        UpDownCounter::new(self.instrument(builder.name, builder.unit, MetricKind::UpDownCounter))
     }
 
     fn f64_histogram(&self, builder: HistogramBuilder<'_, Histogram<f64>>) -> Histogram<f64> {
-        Histogram::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Distribution))
+        Histogram::new(self.instrument(builder.name, builder.unit, MetricKind::Distribution))
     }
 
     fn u64_histogram(&self, builder: HistogramBuilder<'_, Histogram<u64>>) -> Histogram<u64> {
-        Histogram::new(self.instrument(builder.name, builder.unit, SentryMetricKind::Distribution))
+        Histogram::new(self.instrument(builder.name, builder.unit, MetricKind::Distribution))
     }
 }
 
 #[derive(Clone, Copy)]
-enum SentryMetricKind {
+enum MetricKind {
     Counter,
     Gauge,
     UpDownCounter,
@@ -111,8 +136,8 @@ enum SentryMetricKind {
 struct SentryMetricInstrument {
     name: Cow<'static, str>,
     unit: Unit,
-    kind: SentryMetricKind,
-    up_down_totals: Arc<Mutex<HashMap<UpDownKey, f64>>>,
+    kind: MetricKind,
+    registry: Arc<Registry>,
 }
 
 impl<T: ToF64> SyncInstrument<T> for SentryMetricInstrument {
@@ -121,77 +146,300 @@ impl<T: ToF64> SyncInstrument<T> for SentryMetricInstrument {
             return;
         }
 
-        let value = measurement.to_f64();
+        let key = SeriesKey::new(self.name.clone(), attrs);
 
-        match self.kind {
-            SentryMetricKind::Counter => {
-                let mut metric = sentry::metrics::counter(self.name.clone(), value);
-                for kv in attrs {
-                    metric = metric.attribute(kv.key.as_str().to_owned(), to_log_attr(&kv.value));
-                }
-                metric.capture();
-            }
-            SentryMetricKind::Gauge => {
-                let mut metric =
-                    sentry::metrics::gauge(self.name.clone(), value).unit(self.unit.clone());
-                for kv in attrs {
-                    metric = metric.attribute(kv.key.as_str().to_owned(), to_log_attr(&kv.value));
-                }
-                metric.capture();
-            }
-            SentryMetricKind::UpDownCounter => {
-                // `add()` reports a delta; accumulate it into the running total so the
-                // Sentry gauge reflects the current count rather than the ±1 change.
-                let total = accumulate(&self.up_down_totals, self.name.clone(), attrs, value);
+        self.registry
+            .lock()
+            .entry(key)
+            .or_insert_with(|| Series::new(self.unit.clone(), self.kind))
+            .record(measurement.to_f64());
+    }
+}
 
-                let mut metric =
-                    sentry::metrics::gauge(self.name.clone(), total).unit(self.unit.clone());
-                for kv in attrs {
-                    metric = metric.attribute(kv.key.as_str().to_owned(), to_log_attr(&kv.value));
-                }
-                metric.capture();
+/// In-memory aggregation state, keyed by metric name and attributes.
+///
+/// The set of series is bounded by the instruments defined in the binary and
+/// their attribute combinations, so this map does not grow unboundedly.
+type Registry = Mutex<HashMap<SeriesKey, Series>>;
+
+/// Identifies a single time series by metric name and attributes.
+#[derive(PartialEq, Eq, Hash)]
+struct SeriesKey {
+    name: Cow<'static, str>,
+    attributes: Box<[KeyValue]>,
+}
+
+impl SeriesKey {
+    fn new(name: Cow<'static, str>, attrs: &[KeyValue]) -> Self {
+        let mut attributes = attrs.to_vec();
+        // Sort so the same attribute set always maps to one series, regardless of
+        // the order in which the call site happened to list the attributes.
+        attributes.sort_by(|a, b| a.key.as_str().cmp(b.key.as_str()));
+
+        Self {
+            name,
+            attributes: attributes.into_boxed_slice(),
+        }
+    }
+}
+
+struct Series {
+    unit: Unit,
+    data: SeriesData,
+}
+
+enum SeriesData {
+    /// Monotonic counter: accumulates the per-interval delta, reset on flush.
+    Counter { delta: f64 },
+    /// Gauge: most recent value, emitted only in intervals where it was recorded.
+    Gauge { value: f64, recorded: bool },
+    /// Up/down counter: running total, emitted as a gauge only when it changed in the interval.
+    UpDown { total: f64, recorded: bool },
+    /// Distribution: a fair random sample of the raw values plus the observed maximum.
+    Distribution { reservoir: Reservoir, max: f64 },
+}
+
+impl Series {
+    fn new(unit: Unit, kind: MetricKind) -> Self {
+        let data = match kind {
+            MetricKind::Counter => SeriesData::Counter { delta: 0.0 },
+            MetricKind::Gauge => SeriesData::Gauge {
+                value: 0.0,
+                recorded: false,
+            },
+            MetricKind::UpDownCounter => SeriesData::UpDown {
+                total: 0.0,
+                recorded: false,
+            },
+            MetricKind::Distribution => SeriesData::Distribution {
+                reservoir: Reservoir::new(crate::feature_flags::metrics_reservoir_size()),
+                max: f64::NEG_INFINITY,
+            },
+        };
+
+        Self { unit, data }
+    }
+
+    fn record(&mut self, value: f64) {
+        match &mut self.data {
+            SeriesData::Counter { delta } => *delta += value,
+            SeriesData::Gauge {
+                value: latest,
+                recorded,
+            } => {
+                *latest = value;
+                *recorded = true;
             }
-            SentryMetricKind::Distribution => {
-                let mut metric =
-                    sentry::metrics::distribution(self.name.clone(), value).unit(self.unit.clone());
-                for kv in attrs {
-                    metric = metric.attribute(kv.key.as_str().to_owned(), to_log_attr(&kv.value));
-                }
-                metric.capture();
+            SeriesData::UpDown { total, recorded } => {
+                *total += value;
+                *recorded = true;
+            }
+            SeriesData::Distribution { reservoir, max } => {
+                reservoir.observe(value);
+                *max = max.max(value);
             }
         }
     }
 }
 
-/// Identifies an up-down counter time series by metric name and attributes, so
-/// we can keep a running total per series.
-#[derive(PartialEq, Eq, Hash)]
-struct UpDownKey {
-    name: Cow<'static, str>,
-    attributes: Box<[KeyValue]>,
+/// A bounded uniform random sample of a stream of values (Vitter's Algorithm R).
+///
+/// Every observed value is equally likely to be retained, so percentiles computed
+/// over the sample are unbiased estimates of the full population's percentiles.
+struct Reservoir {
+    samples: Vec<f64>,
+    capacity: usize,
+    seen: u64,
 }
 
-/// Adds `delta` to the running total of the up-down counter series identified by
-/// `name` + `attrs` and returns the new total.
+impl Reservoir {
+    fn new(capacity: usize) -> Self {
+        Self {
+            samples: Vec::with_capacity(capacity),
+            capacity,
+            seen: 0,
+        }
+    }
+
+    fn observe(&mut self, value: f64) {
+        self.seen += 1;
+
+        if self.samples.len() < self.capacity {
+            self.samples.push(value);
+            return;
+        }
+
+        // Replace a uniformly chosen sample with probability `capacity / seen`,
+        // which keeps every observed value equally likely to be retained.
+        let index = rand::rng().random_range(0..self.seen);
+        if let Some(slot) = self.samples.get_mut(index as usize) {
+            *slot = value;
+        }
+    }
+
+    /// Returns the retained samples and resets the reservoir for the next interval.
+    fn take(&mut self) -> Vec<f64> {
+        self.seen = 0;
+
+        std::mem::replace(&mut self.samples, Vec::with_capacity(self.capacity))
+    }
+
+    /// Re-arms the reservoir with `capacity` for the next interval, so a runtime
+    /// change to the configured size takes effect.
+    fn set_capacity(&mut self, capacity: usize) {
+        self.capacity = capacity;
+    }
+}
+
+fn spawn_flush_thread(registry: Weak<Registry>) {
+    let result = std::thread::Builder::new()
+        .name("sentry-metrics-flush".to_owned())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(FLUSH_INTERVAL);
+
+                let Some(registry) = registry.upgrade() else {
+                    return; // The provider has been dropped; nothing left to flush.
+                };
+
+                let pending = drain(&registry);
+
+                // Drain every interval to reset per-interval state, but only send
+                // while streaming is enabled so disabling the flag stops emission.
+                if !crate::feature_flags::stream_metrics() {
+                    continue;
+                }
+
+                tracing::debug!(count = pending.len(), "Flushing metrics to Sentry");
+
+                for metric in pending {
+                    metric.capture();
+                }
+            }
+        });
+
+    if let Err(e) = result {
+        tracing::warn!("Failed to spawn Sentry metrics flush thread: {e}");
+    }
+}
+
+/// Snapshots the registry into a list of metrics to send, resetting per-interval
+/// state. Sentry is not touched while the lock is held.
 ///
-/// The set of series is bounded by the metrics defined in the binary, so this
-/// map does not grow unboundedly.
-fn accumulate(
-    totals: &Mutex<HashMap<UpDownKey, f64>>,
+/// Series are drained and re-inserted rather than iterated in place, because the
+/// codebase forbids non-deterministic `HashMap` iteration. Re-inserting preserves
+/// the running state of gauges and up/down counters across intervals.
+fn drain(registry: &Registry) -> Vec<Emit> {
+    let mut registry = registry.lock();
+    let mut pending = Vec::new();
+    let mut retained = Vec::new();
+
+    for (key, mut series) in registry.drain() {
+        match &mut series.data {
+            SeriesData::Counter { delta } => {
+                if *delta != 0.0 {
+                    pending.push(Emit {
+                        kind: MetricKind::Counter,
+                        name: key.name.clone(),
+                        unit: series.unit.clone(),
+                        attributes: key.attributes.clone(),
+                        value: *delta,
+                    });
+                    *delta = 0.0;
+                }
+            }
+            SeriesData::Gauge { value, recorded } => {
+                if *recorded {
+                    pending.push(Emit {
+                        kind: MetricKind::Gauge,
+                        name: key.name.clone(),
+                        unit: series.unit.clone(),
+                        attributes: key.attributes.clone(),
+                        value: *value,
+                    });
+                    *recorded = false;
+                }
+            }
+            SeriesData::UpDown { total, recorded } => {
+                if *recorded {
+                    pending.push(Emit {
+                        kind: MetricKind::UpDownCounter,
+                        name: key.name.clone(),
+                        unit: series.unit.clone(),
+                        attributes: key.attributes.clone(),
+                        value: *total,
+                    });
+                    *recorded = false;
+                }
+            }
+            SeriesData::Distribution { reservoir, max } => {
+                let samples = reservoir.take();
+                reservoir.set_capacity(crate::feature_flags::metrics_reservoir_size());
+                // Append the observed maximum so sampling never drops the worst case,
+                // unless it was already retained (which would double-count it).
+                let observed_max = std::mem::replace(max, f64::NEG_INFINITY);
+                let extra_max = (observed_max.is_finite() && !samples.contains(&observed_max))
+                    .then_some(observed_max);
+
+                pending.extend(samples.into_iter().chain(extra_max).map(|value| Emit {
+                    kind: MetricKind::Distribution,
+                    name: key.name.clone(),
+                    unit: series.unit.clone(),
+                    attributes: key.attributes.clone(),
+                    value,
+                }));
+            }
+        }
+
+        retained.push((key, series));
+    }
+
+    registry.extend(retained);
+
+    pending
+}
+
+/// A single data point captured to Sentry once the registry lock is released.
+struct Emit {
+    kind: MetricKind,
     name: Cow<'static, str>,
-    attrs: &[KeyValue],
-    delta: f64,
-) -> f64 {
-    let key = UpDownKey {
-        name,
-        attributes: Box::from(attrs),
-    };
+    unit: Unit,
+    attributes: Box<[KeyValue]>,
+    value: f64,
+}
 
-    let mut totals = totals.lock();
-    let total = totals.entry(key).or_insert(0.0);
-    *total += delta;
+impl Emit {
+    fn capture(self) {
+        let Self {
+            kind,
+            name,
+            unit,
+            attributes,
+            value,
+        } = self;
 
-    *total
+        // `counter`, `gauge` and `distribution` are distinct builder types with no
+        // shared trait, so a local macro applies the attributes and sends each.
+        macro_rules! send {
+            ($builder:expr) => {{
+                let mut metric = $builder;
+                for kv in attributes.iter() {
+                    metric = metric.attribute(kv.key.as_str().to_owned(), to_log_attr(&kv.value));
+                }
+                metric.capture();
+            }};
+        }
+
+        match kind {
+            MetricKind::Counter => send!(sentry::metrics::counter(name, value)),
+            MetricKind::Gauge | MetricKind::UpDownCounter => {
+                send!(sentry::metrics::gauge(name, value).unit(unit))
+            }
+            MetricKind::Distribution => {
+                send!(sentry::metrics::distribution(name, value).unit(unit))
+            }
+        }
+    }
 }
 
 fn to_log_attr(value: &OtelValue) -> LogAttribute {
@@ -231,19 +479,117 @@ mod tests {
     use super::*;
 
     #[test]
-    fn up_down_counter_accumulates_running_total_per_series() {
-        let totals = Mutex::new(HashMap::new());
-        let name = Cow::Borrowed("system.buffer.count");
-        let pool_a = [KeyValue::new("system.buffer.pool.name", "a")];
-        let pool_b = [KeyValue::new("system.buffer.pool.name", "b")];
+    fn counter_accumulates_delta_and_resets_on_drain() {
+        let registry = Registry::default();
+        let key = SeriesKey::new(Cow::Borrowed("requests"), &[]);
 
-        assert_eq!(accumulate(&totals, name.clone(), &pool_a, 1.0), 1.0);
-        assert_eq!(accumulate(&totals, name.clone(), &pool_a, 1.0), 2.0);
-        assert_eq!(accumulate(&totals, name.clone(), &pool_a, -1.0), 1.0);
+        record(&registry, &key, MetricKind::Counter, &[1.0, 1.0, 1.0]);
 
-        // A different attribute set is tracked independently.
-        assert_eq!(accumulate(&totals, name.clone(), &pool_b, 1.0), 1.0);
+        assert_eq!(counter_values(drain(&registry)), vec![3.0]);
+        // A second drain without new measurements emits nothing.
+        assert!(drain(&registry).is_empty());
+    }
 
-        assert_eq!(accumulate(&totals, name.clone(), &pool_a, -1.0), 0.0);
+    #[test]
+    fn gauge_reports_last_value_only_when_recorded() {
+        let registry = Registry::default();
+        let key = SeriesKey::new(Cow::Borrowed("queue.length"), &[]);
+
+        record(&registry, &key, MetricKind::Gauge, &[5.0, 2.0]);
+
+        assert_eq!(gauge_values(drain(&registry)), vec![2.0]);
+        // An idle interval emits nothing rather than replaying the stale value.
+        assert!(gauge_values(drain(&registry)).is_empty());
+    }
+
+    #[test]
+    fn up_down_counter_reports_running_total() {
+        let registry = Registry::default();
+        let key = SeriesKey::new(Cow::Borrowed("buffers"), &[]);
+
+        record(
+            &registry,
+            &key,
+            MetricKind::UpDownCounter,
+            &[1.0, 1.0, -1.0],
+        );
+
+        assert_eq!(gauge_values(drain(&registry)), vec![1.0]);
+    }
+
+    #[test]
+    fn distribution_below_capacity_keeps_every_value() {
+        let mut reservoir = Reservoir::new(4);
+
+        for value in [10.0, 30.0, 20.0] {
+            reservoir.observe(value);
+        }
+
+        let mut samples = reservoir.take();
+        samples.sort_by(|a, b| a.total_cmp(b));
+
+        assert_eq!(samples, vec![10.0, 20.0, 30.0]);
+    }
+
+    #[test]
+    fn distribution_caps_at_capacity_and_resets() {
+        let mut reservoir = Reservoir::new(8);
+
+        for value in 0..1_000 {
+            reservoir.observe(value as f64);
+        }
+
+        let samples = reservoir.take();
+        assert_eq!(samples.len(), 8);
+        assert!(samples.iter().all(|s| (0.0..1_000.0).contains(s)));
+
+        // Taking resets the reservoir.
+        assert!(reservoir.take().is_empty());
+    }
+
+    #[test]
+    fn distribution_keeps_each_value_once_when_all_are_retained() {
+        let registry = Registry::default();
+        let key = SeriesKey::new(Cow::Borrowed("dns.lookup.duration"), &[]);
+
+        record(&registry, &key, MetricKind::Distribution, &[1.0, 9.0, 3.0]);
+
+        let mut values = distribution_values(drain(&registry));
+        values.sort_by(|a, b| a.total_cmp(b));
+
+        // The max (9.0) is already in the sample, so it must not be appended again.
+        assert_eq!(values, vec![1.0, 3.0, 9.0]);
+    }
+
+    fn record(registry: &Registry, key: &SeriesKey, kind: MetricKind, values: &[f64]) {
+        for value in values {
+            registry
+                .lock()
+                .entry(SeriesKey::new(key.name.clone(), &key.attributes))
+                .or_insert_with(|| Series::new(Unit::from(Cow::Borrowed("")), kind))
+                .record(*value);
+        }
+    }
+
+    fn counter_values(pending: Vec<Emit>) -> Vec<f64> {
+        values_of(pending, |kind| matches!(kind, MetricKind::Counter))
+    }
+
+    fn gauge_values(pending: Vec<Emit>) -> Vec<f64> {
+        values_of(pending, |kind| {
+            matches!(kind, MetricKind::Gauge | MetricKind::UpDownCounter)
+        })
+    }
+
+    fn distribution_values(pending: Vec<Emit>) -> Vec<f64> {
+        values_of(pending, |kind| matches!(kind, MetricKind::Distribution))
+    }
+
+    fn values_of(pending: Vec<Emit>, want: impl Fn(MetricKind) -> bool) -> Vec<f64> {
+        pending
+            .into_iter()
+            .filter(|e| want(e.kind))
+            .map(|e| e.value)
+            .collect()
     }
 }


### PR DESCRIPTION
The `SentryMeterProvider` submitted one Sentry metric per measurement, bypassing all aggregation. Because data-plane instruments such as `system.network.packets` and `eventloop.poll.duration` are recorded per packet and per event-loop poll, a handful of gateways emitted gigabytes of metrics per hour once `stream_metrics` was enabled.

This aggregates metrics in-memory and flushes them periodically instead. Counters and gauges fold to a single value per series. Distributions keep a fair, bounded random sample (reservoir sampling) plus the observed maximum, so Sentry's server-side percentiles stay accurate while the data volume is bounded by the reservoir size rather than the packet rate.

Aggregating through the OpenTelemetry exporter was tried before and reverted because summarising histograms there destroyed percentile fidelity; sampling the raw values keeps p99 meaningful while still bounding volume. Once `opentelemetry` includes exemplars for histograms, we can retire our manual sampling approach and use that instead.

Related: #13713
Related: #13557