### PR TITLE
docs(rust): document the code, not the change

### DIFF
--- a/rust/AGENT.md
+++ b/rust/AGENT.md
@@ -3,6 +3,13 @@
 ## Code style
 
 - Do not generate excessive comments
+- Document the code, not the change that introduced it. A comment should read the
+  same a year later to someone who never saw the diff: describe what the code does
+  and why it must work that way, not how it differs from what it replaced. Avoid
+  change-relative wording like "instead of", "now", "no longer", or "previously".
+  The reason a change is made belongs in the commit message — and, at a high level,
+  in the PR description, which becomes the squash-merge commit message — not in a
+  code comment.
 - Prefer a functional style (i.e. Iterators) over imperative code
 - Prefer turbofish over explicit type-hints
 - Prefer early-returns in functions to keep the indentation of the happy-path minimal, i.e. use `let-else` instead of `if let`


### PR DESCRIPTION
Comments should describe the code as it is, not the change that produced it — phrasing like "instead of …" or "now …" is meaningless to a reader who never saw the diff. The rationale for a change belongs in the commit message and PR description instead.

Related: #13712