### PR TITLE
ci: push release artifacts via OIDC not connection string

### DIFF
--- a/.github/workflows/_apt.yml
+++ b/.github/workflows/_apt.yml
@@ -8,6 +8,10 @@ concurrency:
   group: "create-apt-repository" # Unique group name to force only a single job at a time.
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  id-token: write # OIDC auth for Azure Storage
+
 jobs:
   create-apt-repository-metadata:
     runs-on: ubuntu-24.04
@@ -18,6 +22,14 @@ jobs:
 
       - uses: ./.github/actions/setup-azure-cli
 
+      - name: Azure login (OIDC)
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_ARTIFACTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_ARTIFACTS_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
+
       - uses: ./.github/actions/setup-gpg
         id: setup-gpg
         with:
@@ -26,5 +38,5 @@ jobs:
 
       - run: scripts/sync-apt.sh
         env:
-          AZURERM_ARTIFACTS_CONNECTION_STRING: ${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}
+          AZURE_STORAGE_ACCOUNT: firezoneartifacts
           GPG_KEY_ID: ${{ steps.setup-gpg.outputs.key_id }}

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -283,6 +283,16 @@ jobs:
 
           # Used for release artifact
           cp ${{ matrix.name.package }} "$BINARY_DEST_PATH"
+      - name: Azure login (OIDC)
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' }}
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_ARTIFACTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_ARTIFACTS_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
+          # The artifacts principal holds only a data-plane role on the storage
+          # account, not subscription-wide Reader.
+          allow-no-subscriptions: true
       - name: Copy binary to Azure Blob Storage
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && (matrix.name.artifact == 'firezone-relay' || matrix.name.artifact == 'firezone-gateway') }}
         run: |
@@ -294,7 +304,8 @@ jobs:
             --file "${{ matrix.name.package }}" \
             --overwrite true \
             --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --auth-mode login \
+            --account-name firezoneartifacts
 
           az storage blob upload \
             --container-name binaries \
@@ -302,7 +313,8 @@ jobs:
             --file "${{ matrix.name.package }}.sha256sum.txt" \
             --overwrite true \
             --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --auth-mode login \
+            --account-name firezoneartifacts
 
       - name: Create Firezone Gateway .deb package
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-gateway' }}
@@ -328,7 +340,8 @@ jobs:
             --destination-path import-preview \
             --overwrite \
             --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --auth-mode login \
+            --account-name firezoneartifacts
       - name: Upload `.deb` artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -246,6 +246,15 @@ jobs:
         shell: bash
         run: ${{ env.UPLOAD_SCRIPT }}
 
+      - name: Azure login (OIDC)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Linux' }}
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_ARTIFACTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_ARTIFACTS_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
+
       - name: Upload to preview repository
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Linux' }}
         shell: bash
@@ -257,7 +266,8 @@ jobs:
             --destination-path import-preview \
             --overwrite \
             --no-progress \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --auth-mode login \
+            --account-name firezoneartifacts
 
       - name: Azure login (OIDC) for QA artifacts
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -277,6 +277,9 @@ jobs:
 
   promote-deb-packages:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # OIDC auth for Azure Storage
     strategy:
       matrix:
         include:
@@ -290,6 +293,14 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-azure-cli
+
+      - name: Azure login (OIDC)
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_ARTIFACTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_ARTIFACTS_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Copy preview archive to import-stable
         if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
@@ -306,9 +317,13 @@ jobs:
             --source-container apt \
             --pattern "pool-preview/${{ matrix.deb_name }}_$version*" \
             --destination-path import-stable \
-            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+            --auth-mode login \
+            --account-name firezoneartifacts
 
   regenerate-apt-index:
     needs: promote-deb-packages
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/_apt.yml
     secrets: inherit

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -14,8 +14,8 @@ COMPONENT="main"
 WORK_DIR="$(mktemp -d)"
 DISTS_DIR="${WORK_DIR}/dists"
 
-if [ -z "${AZURERM_ARTIFACTS_CONNECTION_STRING:-}" ]; then
-    echo "Error: AZURERM_ARTIFACTS_CONNECTION_STRING not set"
+if [ -z "${AZURE_STORAGE_ACCOUNT:-}" ]; then
+    echo "Error: AZURE_STORAGE_ACCOUNT not set"
     exit 1
 fi
 
@@ -43,7 +43,8 @@ for DISTRIBUTION in "stable" "preview"; do
         --destination "${WORK_DIR}" \
         --source apt \
         --pattern "pool-${DISTRIBUTION}/*.deb" \
-        --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
         2>&1 | grep -v "WARNING" || true
 
     echo "Downloading import packages for distribution $DISTRIBUTION..."
@@ -52,7 +53,8 @@ for DISTRIBUTION in "stable" "preview"; do
         --destination "${WORK_DIR}" \
         --source apt \
         --pattern "import-${DISTRIBUTION}/*.deb" \
-        --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
         2>&1 | grep -v "WARNING" || true
 
     if [ "$(ls -A "${IMPORT_DIR}")" ]; then
@@ -136,7 +138,8 @@ EOF
         --destination apt \
         --destination-path "pool-${DISTRIBUTION}" \
         --source "${POOL_DIR}" \
-        --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
         --overwrite \
         --output table
 done
@@ -146,7 +149,8 @@ az storage blob upload-batch \
     --destination apt \
     --source "${DISTS_DIR}" \
     --destination-path dists \
-    --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
+    --auth-mode login \
+    --account-name "${AZURE_STORAGE_ACCOUNT}" \
     --overwrite \
     --output table
 
@@ -154,5 +158,6 @@ az storage blob upload-batch \
 az storage blob delete-batch \
     --source apt \
     --pattern "import-*/*.deb" \
-    --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
+    --auth-mode login \
+    --account-name "${AZURE_STORAGE_ACCOUNT}" \
     --output table


### PR DESCRIPTION
Authenticate the `firezoneartifacts` uploads (data-plane gateway/relay binaries, apt preview + index regeneration, release promotion) with the dedicated `github-actions-artifacts` OIDC identity via `azure/login` + `--auth-mode login`, replacing the shared account-key connection string.

Related: firezone/infra#687