### PR TITLE
chore(rust): remove access_authorization_expiry_updated

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -19,8 +19,8 @@ use std::{io, mem};
 use tokio::sync::mpsc;
 use tunnel::messages::RelaysPresence;
 use tunnel::messages::gateway::{
-    AccessAuthorizationExpiryUpdated, Authorization, ClientIceCandidates, ClientsIceCandidates,
-    EgressMessages, IngressMessages, InitGateway, RejectAccess,
+    Authorization, ClientIceCandidates, ClientsIceCandidates, EgressMessages, IngressMessages,
+    InitGateway, RejectAccess,
 };
 use tunnel::{
     GatewayEvent, GatewayTunnel, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest, TunnelError,
@@ -453,22 +453,6 @@ impl Eventloop {
             }
             IngressMessages::ResourceUpdated(resource_description) => {
                 tunnel.state_mut().update_resource(resource_description);
-            }
-            IngressMessages::AccessAuthorizationExpiryUpdated(
-                AccessAuthorizationExpiryUpdated {
-                    client_id: cid,
-                    resource_id: rid,
-                    expires_at,
-                },
-            ) => {
-                if let Err(e) = tunnel.state_mut().update_access_authorization_expiry(
-                    cid,
-                    rid,
-                    expires_at,
-                    Instant::now(),
-                ) {
-                    tracing::debug!(%cid, %rid, "Failed to update expiry of access authorization: {e:#}")
-                };
             }
         }
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -454,6 +454,8 @@ impl Eventloop {
             IngressMessages::ResourceUpdated(resource_description) => {
                 tunnel.state_mut().update_resource(resource_description);
             }
+            // OBSOLETE - safe to remove this when https://github.com/firezone/firezone/pull/13714 is deployed to production.
+            IngressMessages::AccessAuthorizationExpiryUpdated(_) => {}
         }
 
         Ok(())

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -618,6 +618,8 @@ impl Eventloop {
                     .state_mut()
                     .handle_reject_client_device_access(client_id, resource_id);
             }
+            // OBSOLETE - safe to remove this when https://github.com/firezone/firezone/pull/13714 is deployed to production.
+            IngressMessages::AccessAuthorizationExpiryUpdated(_) => {}
             IngressMessages::ClientDeviceAccessDenied(ClientDeviceAccessDenied {
                 ipv4,
                 ipv6,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -20,11 +20,10 @@ use tokio::sync::{mpsc, watch};
 use tun::Tun;
 use tunnel::messages::RelaysPresence;
 use tunnel::messages::client::{
-    ClientAccessAuthorizationExpiryUpdated, ClientDeviceAccessAuthorized, ClientDeviceAccessDenied,
-    ClientIceCandidates, ClientRejectAccess, DevicePoolDomainResolutionFailed,
-    DevicePoolDomainResolved, EgressMessages, FailReason, FlowCreated, FlowCreationFailed,
-    GatewayIceCandidates, IngressMessages, InitClient, ResourceAuthorization,
-    ResourceFiltersUpdated,
+    ClientDeviceAccessAuthorized, ClientDeviceAccessDenied, ClientIceCandidates,
+    ClientRejectAccess, DevicePoolDomainResolutionFailed, DevicePoolDomainResolved, EgressMessages,
+    FailReason, FlowCreated, FlowCreationFailed, GatewayIceCandidates, IngressMessages, InitClient,
+    ResourceAuthorization, ResourceFiltersUpdated,
 };
 use tunnel::{ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig, TunnelError};
 
@@ -618,22 +617,6 @@ impl Eventloop {
                 tunnel
                     .state_mut()
                     .handle_reject_client_device_access(client_id, resource_id);
-            }
-            IngressMessages::AccessAuthorizationExpiryUpdated(
-                ClientAccessAuthorizationExpiryUpdated {
-                    client_id,
-                    resource_id,
-                    expires_at,
-                },
-            ) => {
-                tunnel
-                    .state_mut()
-                    .handle_client_device_access_authorization_expiry_updated(
-                        client_id,
-                        resource_id,
-                        expires_at,
-                        Instant::now(),
-                    );
             }
             IngressMessages::ClientDeviceAccessDenied(ClientDeviceAccessDenied {
                 ipv4,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1110,22 +1110,6 @@ impl ClientState {
         peer.remove_resource(&resource_id);
     }
 
-    /// Update the recorded expiry for an active authorization.
-    pub fn handle_client_device_access_authorization_expiry_updated(
-        &mut self,
-        cid: ClientId,
-        resource_id: ResourceId,
-        expires_at: Duration,
-        now: Instant,
-    ) {
-        let new_expiry = self.unix_ts_clock.instant_at(expires_at, now);
-        let Some(peer) = self.clients.peer_by_id_mut(&cid) else {
-            tracing::debug!(%cid, "Unknown peer for expiry update");
-            return;
-        };
-        peer.update_resource_expiry(resource_id, new_expiry, now);
-    }
-
     /// For DNS queries to IPs that are a CIDR resources we want to mangle and forward to the gateway that handles that resource.
     ///
     /// We only want to do this if the upstream DNS server is set by the portal, otherwise, the server might be a local IP.

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -101,21 +101,6 @@ impl ClientOnClient {
         self.recompute_inbound_filter();
     }
 
-    /// Update the recorded expiry for an active resource.
-    pub(crate) fn update_resource_expiry(
-        &mut self,
-        resource_id: ResourceId,
-        new_expiry: Instant,
-        now: Instant,
-    ) {
-        let expires_in = new_expiry.saturating_duration_since(now);
-        if !self.resources.update_expiry(&resource_id, now, expires_in) {
-            tracing::debug!(%resource_id, "Unknown resource");
-            return;
-        }
-        tracing::info!(%resource_id, ?expires_in, "Updated peer authorization expiry");
-    }
-
     /// Drop a previously-active resource.
     pub(crate) fn remove_resource(&mut self, resource_id: &ResourceId) {
         let Some(_entry) = self.resources.remove(resource_id) else {

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -218,6 +218,16 @@ pub struct ClientRejectAccess {
     pub resource_id: ResourceId,
 }
 
+/// OBSOLETE - safe to remove this when <https://github.com/firezone/firezone/pull/13714> is deployed to production.
+#[serde_as]
+#[derive(Debug, Deserialize, Clone)]
+pub struct ClientAccessAuthorizationExpiryUpdated {
+    pub client_id: ClientId,
+    pub resource_id: ResourceId,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub expires_at: Duration,
+}
+
 /// Portal's denial of a `create_flow` toward a static device pool peer.
 ///
 /// Either or both of `ipv4` / `ipv6` may be absent depending on the denial reason.
@@ -314,6 +324,9 @@ pub enum IngressMessages {
 
     /// A previously-authorized peer-to-peer access has been revoked.
     RejectAccess(ClientRejectAccess),
+
+    /// OBSOLETE - safe to remove this when <https://github.com/firezone/firezone/pull/13714> is deployed to production.
+    AccessAuthorizationExpiryUpdated(ClientAccessAuthorizationExpiryUpdated),
 }
 
 #[serde_with::serde_as]

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -218,16 +218,6 @@ pub struct ClientRejectAccess {
     pub resource_id: ResourceId,
 }
 
-/// Sent by the portal when an authorization's expiry time changes.
-#[serde_as]
-#[derive(Debug, Deserialize, Clone)]
-pub struct ClientAccessAuthorizationExpiryUpdated {
-    pub client_id: ClientId,
-    pub resource_id: ResourceId,
-    #[serde_as(as = "DurationSeconds<u64>")]
-    pub expires_at: Duration,
-}
-
 /// Portal's denial of a `create_flow` toward a static device pool peer.
 ///
 /// Either or both of `ipv4` / `ipv6` may be absent depending on the denial reason.
@@ -324,9 +314,6 @@ pub enum IngressMessages {
 
     /// A previously-authorized peer-to-peer access has been revoked.
     RejectAccess(ClientRejectAccess),
-
-    /// An authorization's expiry time has changed.
-    AccessAuthorizationExpiryUpdated(ClientAccessAuthorizationExpiryUpdated),
 }
 
 #[serde_with::serde_as]

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -124,7 +124,6 @@ pub enum IngressMessages {
     RelaysPresence(RelaysPresence),
     ResourceUpdated(ResourceDescription),
     AuthorizeFlow(AuthorizeFlow),
-    AccessAuthorizationExpiryUpdated(AccessAuthorizationExpiryUpdated),
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -177,15 +176,6 @@ pub struct AuthorizeFlow {
 
     #[serde_as(as = "Option<DurationSeconds<u64>>")]
     pub expires_at: Option<Duration>,
-}
-
-#[serde_as]
-#[derive(Debug, Deserialize, Clone)]
-pub struct AccessAuthorizationExpiryUpdated {
-    pub client_id: ClientId,
-    pub resource_id: ResourceId,
-    #[serde_as(as = "DurationSeconds<u64>")]
-    pub expires_at: Duration,
 }
 
 /// A client's ice candidate message.

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -124,6 +124,8 @@ pub enum IngressMessages {
     RelaysPresence(RelaysPresence),
     ResourceUpdated(ResourceDescription),
     AuthorizeFlow(AuthorizeFlow),
+    /// OBSOLETE - safe to remove this when <https://github.com/firezone/firezone/pull/13714> is deployed to production.
+    AccessAuthorizationExpiryUpdated(AccessAuthorizationExpiryUpdated),
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -176,6 +178,16 @@ pub struct AuthorizeFlow {
 
     #[serde_as(as = "Option<DurationSeconds<u64>>")]
     pub expires_at: Option<Duration>,
+}
+
+/// OBSOLETE - safe to remove this when <https://github.com/firezone/firezone/pull/13714> is deployed to production.
+#[serde_as]
+#[derive(Debug, Deserialize, Clone)]
+pub struct AccessAuthorizationExpiryUpdated {
+    pub client_id: ClientId,
+    pub resource_id: ResourceId,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub expires_at: Duration,
 }
 
 /// A client's ice candidate message.


### PR DESCRIPTION
With the changes coming in #13714 we will operate under the premise that gateways will send ICMP prohibited and clients will re-request access to the resource upon receiving that.

Since this message was added in order to handle the re-authorization path that is now being deleted, it can be removed entirely in favor of the above semantics.


### NOTE

It might be best to wait to merge this until #13714 is deployed to minimize the chance for an unknown message issue.

---

Related: #13714 