### PR TITLE
fix(connlib): size perf UDP recv buffers to GRO batch

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -218,11 +218,18 @@ impl UdpSocket {
             quinn_state.set_apple_fast_path();
         }
 
+        // A single `recv` may receive several datagrams coalesced into one buffer via
+        // generic receive offload (GRO). The kernel coalesces up to `gro_segments`
+        // datagrams of at most `MAX_FZ_PAYLOAD` bytes each, so the buffer must be large
+        // enough to hold that entire batch. On platforms without GRO `gro_segments` is 1,
+        // sizing the buffer to a single datagram.
+        let recv_buf_size = ip_packet::MAX_FZ_PAYLOAD * quinn_state.gro_segments();
+
         Ok(PerfUdpSocket {
             inner: self.inner,
             state: quinn_state,
             buffer_pool: BufferPool::new(
-                u16::MAX as usize,
+                recv_buf_size,
                 match socket_addr.ip() {
                     IpAddr::V4(_) => "udp-socket-v4",
                     IpAddr::V6(_) => "udp-socket-v6",


### PR DESCRIPTION
The perf UDP socket pooled fixed 64 KiB (`u16::MAX`) receive buffers. On Linux/Android/Windows the kernel coalesces up to 64 datagrams via generic receive offload into a single buffer; a worst-case batch of full-size Firezone datagrams (64 * 1316 = 84224 bytes) exceeds 64 KiB and would be truncated, dropping segments. On Apple, which has no GRO, each buffer only ever holds one datagram, so 64 KiB wasted ~50x.

Size buffers as `MAX_FZ_PAYLOAD * gro_segments()` instead, matching quinn's own receive-buffer invariant.