### PR TITLE
chore(bufferpool): warn when returned capacity deviates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "opentelemetry_sdk",
  "otel-instruments",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/libs/connlib/bufferpool/Cargo.toml
+++ b/rust/libs/connlib/bufferpool/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { workspace = true }
 crossbeam-queue = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 opentelemetry_sdk = { workspace = true, features = ["testing", "metrics"] }

--- a/rust/libs/connlib/bufferpool/lib.rs
+++ b/rust/libs/connlib/bufferpool/lib.rs
@@ -43,11 +43,9 @@ where
             new_buffer_fn: Arc::new(move || {
                 BufferStorage::new(
                     B::with_capacity(capacity),
+                    capacity,
+                    tag,
                     buffer_counter.clone(),
-                    [
-                        KeyValue::new("system.buffer.pool.name", tag),
-                        KeyValue::new("system.buffer.pool.buffer_size", capacity as i64),
-                    ],
                 )
             }),
         }
@@ -187,14 +185,30 @@ impl<B> Drop for Buffer<B> {
     fn drop(&mut self) {
         let buffer_storage = self.inner.take().expect("should have storage in `Drop`");
 
+        let actual = (buffer_storage.capacity_of)(&buffer_storage.inner);
+        if let Some(actual) = deviating_capacity(buffer_storage.capacity, actual) {
+            tracing::warn!(
+                pool = %buffer_storage.tag,
+                expected_capacity = %buffer_storage.capacity,
+                actual_capacity = %actual,
+                "Buffer returned to pool with a different capacity than it was allocated with"
+            );
+        }
+
         self.pool.push(buffer_storage);
     }
+}
+
+/// Returns the `actual` capacity if it deviates from the `expected` one a pool allocates its buffers with.
+fn deviating_capacity(expected: usize, actual: usize) -> Option<usize> {
+    (expected != actual).then_some(actual)
 }
 
 pub trait Buf: Sized {
     fn with_capacity(capacity: usize) -> Self;
     fn clone(&self, dst: &mut Self);
     fn resize_to(&mut self, len: usize);
+    fn capacity(&self) -> usize;
 }
 
 impl Buf for Vec<u8> {
@@ -209,6 +223,10 @@ impl Buf for Vec<u8> {
 
     fn resize_to(&mut self, len: usize) {
         self.resize(len, 0);
+    }
+
+    fn capacity(&self) -> usize {
+        Vec::capacity(self)
     }
 }
 
@@ -225,11 +243,28 @@ impl Buf for BytesMut {
     fn resize_to(&mut self, len: usize) {
         self.resize(len, 0);
     }
+
+    fn capacity(&self) -> usize {
+        BytesMut::capacity(self)
+    }
 }
 
 /// A wrapper around a buffer `B` that keeps track of how many buffers there are in a counter.
 struct BufferStorage<B> {
     inner: B,
+
+    /// The size every buffer in the pool is allocated with.
+    ///
+    /// A returned buffer whose capacity deviates from this no longer fits the pool's
+    /// "all buffers are equal in size" invariant and indicates an accidental reallocation.
+    capacity: usize,
+    /// The pool's name, used to attribute a capacity deviation to a specific pool.
+    tag: &'static str,
+    /// Reads the current capacity of `inner`.
+    ///
+    /// Captured as a function pointer so the capacity can be inspected in `Buffer`'s
+    /// `Drop`, which cannot itself require the [`Buf`] bound.
+    capacity_of: fn(&B) -> usize,
 
     attributes: [KeyValue; 2],
     counter: UpDownCounter<i64>,
@@ -242,11 +277,22 @@ impl<B> Drop for BufferStorage<B> {
 }
 
 impl<B> BufferStorage<B> {
-    fn new(inner: B, counter: UpDownCounter<i64>, attributes: [KeyValue; 2]) -> Self {
+    fn new(inner: B, capacity: usize, tag: &'static str, counter: UpDownCounter<i64>) -> Self
+    where
+        B: Buf,
+    {
+        let attributes = [
+            KeyValue::new("system.buffer.pool.name", tag),
+            KeyValue::new("system.buffer.pool.buffer_size", capacity as i64),
+        ];
+
         counter.add(1, &attributes);
 
         Self {
             inner,
+            capacity,
+            tag,
+            capacity_of: B::capacity,
             counter,
             attributes,
         }
@@ -310,6 +356,23 @@ mod tests {
         let buffer = pool.pull_initialised(b"hello world");
 
         assert_eq!(buffer.len(), 11);
+    }
+
+    #[test]
+    fn deviating_capacity_flags_only_changed_sizes() {
+        assert_eq!(deviating_capacity(1024, 1024), None);
+        assert_eq!(deviating_capacity(1024, 2048), Some(2048));
+        assert_eq!(deviating_capacity(1024, 512), Some(512));
+    }
+
+    #[test]
+    fn returning_a_reallocated_buffer_does_not_panic() {
+        let pool = BufferPool::<Vec<u8>>::new(8, "test");
+
+        let mut buffer = pool.pull();
+        buffer.resize_to(8 * 1024); // Force a reallocation beyond the pool's capacity.
+
+        drop(buffer); // Exercises the capacity-deviation check on return to the pool.
     }
 
     #[test]


### PR DESCRIPTION
The pool relies on all buffers being equal in size. Operations that reallocate a buffer (e.g. growing it past its capacity) silently break this invariant and grow memory. Log a warning when a buffer is returned to the pool with a capacity other than the one it was allocated with.

We allow changing the capacity but the warning itself tells us we should investigate it.