### PR TITLE
fix(apple): run SMAppService calls off the main thread

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LaunchAgentManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LaunchAgentManager.swift
@@ -9,18 +9,12 @@ enum LaunchAgentManager {
     #if os(macOS)
       // `SMAppService.status` and `register()` block on a synchronous XPC round-trip
       // to `smd`. With approachable concurrency, `nonisolated async` functions run on
-      // the caller's executor (the MainActor), so hop onto a detached task to keep the
-      // blocking work off the main thread and avoid freezing the UI.
-      let isRegistered = await Task.detached(priority: .userInitiated) {
-        keepAppRunningService().status.isRegistered
-      }.value
-
-      if isRegistered {
-        return
-      }
-
+      // the caller's executor (the MainActor), so run the check-and-register on a
+      // single detached task to keep the blocking work off the main thread.
       try await Task.detached(priority: .userInitiated) {
-        try keepAppRunningService().register()
+        let service = keepAppRunningService()
+        guard !service.status.isRegistered else { return }
+        try service.register()
       }.value
     #endif
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LaunchAgentManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LaunchAgentManager.swift
@@ -1,28 +1,33 @@
 import Foundation
 
 #if os(macOS)
-  import Sentry
   import ServiceManagement
 #endif
 
 enum LaunchAgentManager {
   static func syncKeepAppRunning() async throws {
     #if os(macOS)
-      // Getting these statuses appears to be blocking sometimes.
-      SentrySDK.pauseAppHangTracking()
-      defer { SentrySDK.resumeAppHangTracking() }
+      // `SMAppService.status` and `register()` block on a synchronous XPC round-trip
+      // to `smd`. With approachable concurrency, `nonisolated async` functions run on
+      // the caller's executor (the MainActor), so hop onto a detached task to keep the
+      // blocking work off the main thread and avoid freezing the UI.
+      let isRegistered = await Task.detached(priority: .userInitiated) {
+        keepAppRunningService().status.isRegistered
+      }.value
 
-      if keepAppRunningService.status.isRegistered {
+      if isRegistered {
         return
       }
 
-      try keepAppRunningService.register()
+      try await Task.detached(priority: .userInitiated) {
+        try keepAppRunningService().register()
+      }.value
     #endif
   }
 }
 
 #if os(macOS)
-  private var keepAppRunningService: SMAppService {
+  private func keepAppRunningService() -> SMAppService {
     let bundleIdentifier = Bundle.main.bundleIdentifier ?? "dev.firezone.firezone"
     return SMAppService.agent(plistName: "\(bundleIdentifier).keep-app-running.plist")
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LoginItemManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LoginItemManager.swift
@@ -1,16 +1,21 @@
 import Foundation
 
 #if os(macOS)
-  import Sentry
   import ServiceManagement
 #endif
 
 enum LoginItemManager {
   static func syncStartOnLogin(startOnLogin: Bool) async throws {
     #if os(macOS)
-      SentrySDK.pauseAppHangTracking()
-      defer { SentrySDK.resumeAppHangTracking() }
-      let status = SMAppService.mainApp.status
+      // `SMAppService.status` and `register()` perform a synchronous XPC round-trip
+      // to `smd` that can block the calling thread for seconds. With approachable
+      // concurrency, `nonisolated async` functions run on the caller's executor —
+      // here the MainActor — so we hop onto a detached task to keep the blocking
+      // work off the main thread. Otherwise the UI freezes and Sentry records an
+      // App Hang. `unregister()` is already async and does not block the caller.
+      let status = await Task.detached(priority: .userInitiated) {
+        SMAppService.mainApp.status
+      }.value
 
       if !startOnLogin, status == .enabled {
         try await SMAppService.mainApp.unregister()
@@ -18,7 +23,9 @@ enum LoginItemManager {
       }
 
       if startOnLogin, status != .enabled {
-        try SMAppService.mainApp.register()
+        try await Task.detached(priority: .userInitiated) {
+          try SMAppService.mainApp.register()
+        }.value
       }
     #endif
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LoginItemManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/LoginItemManager.swift
@@ -8,25 +8,21 @@ enum LoginItemManager {
   static func syncStartOnLogin(startOnLogin: Bool) async throws {
     #if os(macOS)
       // `SMAppService.status` and `register()` perform a synchronous XPC round-trip
-      // to `smd` that can block the calling thread for seconds. With approachable
-      // concurrency, `nonisolated async` functions run on the caller's executor —
-      // here the MainActor — so we hop onto a detached task to keep the blocking
-      // work off the main thread. Otherwise the UI freezes and Sentry records an
-      // App Hang. `unregister()` is already async and does not block the caller.
-      let status = await Task.detached(priority: .userInitiated) {
-        SMAppService.mainApp.status
+      // to `smd` that can block the caller for seconds. With approachable concurrency,
+      // `nonisolated async` functions run on the caller's executor — here the
+      // MainActor — so run the whole check-and-update on a single detached task to
+      // keep the blocking work off the main thread. Otherwise the UI freezes and
+      // Sentry records an App Hang.
+      try await Task.detached(priority: .userInitiated) {
+        let service = SMAppService.mainApp
+        let isRegistered = service.status.isRegistered
+
+        if !startOnLogin, isRegistered {
+          try await service.unregister()
+        } else if startOnLogin, !isRegistered {
+          try service.register()
+        }
       }.value
-
-      if !startOnLogin, status == .enabled {
-        try await SMAppService.mainApp.unregister()
-        return
-      }
-
-      if startOnLogin, status != .enabled {
-        try await Task.detached(priority: .userInitiated) {
-          try SMAppService.mainApp.register()
-        }.value
-      }
     #endif
   }
 }


### PR DESCRIPTION
`SMAppService.status` and `register()` make a synchronous XPC round-trip to `smd` that can block the caller for seconds. Because approachable concurrency runs `nonisolated async` functions on the caller's executor, these calls ran on the MainActor (the callers in `Store` are `@MainActor`) and froze the UI.

This moves the blocking calls onto a detached task so they run off the main thread, and drops the `pauseAppHangTracking` workaround that only hid the reports without preventing the freeze.