### PR TITLE
refactor: implement socket pool for Darwin UDP fast path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6756,6 +6756,7 @@ dependencies = [
  "libc",
  "opentelemetry",
  "otel-instruments",
+ "parking_lot",
  "quinn-udp",
  "socket2",
  "tokio",

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -29,5 +29,9 @@ libc = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
+bufferpool = { workspace = true }
+bytes = { workspace = true }
 derive_more = { workspace = true, features = ["deref"] }
+gat-lending-iterator = { workspace = true }
+ip-packet = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -14,12 +14,9 @@ ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
 quinn-udp = { workspace = true }
-socket2 = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt"] }
+socket2 = { workspace = true, features = ["all"] }
+tokio = { workspace = true, features = ["net", "rt", "time"] }
 tracing = { workspace = true }
-
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-libc = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = { workspace = true }
@@ -27,5 +24,10 @@ libc = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }
 
+[target.'cfg(target_vendor = "apple")'.dependencies]
+libc = { workspace = true }
+parking_lot = { workspace = true }
+
 [dev-dependencies]
 derive_more = { workspace = true, features = ["deref"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }

--- a/rust/libs/connlib/socket-factory/build.rs
+++ b/rust/libs/connlib/socket-factory/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    // Define a convenience `apple` cfg for all Darwin targets (macOS, iOS, ...), so the source
+    // can use `#[cfg(apple)]` instead of repeating `target_vendor = "apple"` everywhere.
+    //
+    // Note: `Cargo.toml`'s `[target.'cfg(...)']` cannot use this - Cargo evaluates those before
+    // build scripts run - so dependency gating there stays on `target_vendor = "apple"`.
+    println!("cargo::rustc-check-cfg=cfg(apple)");
+
+    if std::env::var("CARGO_CFG_TARGET_VENDOR").as_deref() == Ok("apple") {
+        println!("cargo::rustc-cfg=apple");
+    }
+}

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -444,16 +444,6 @@ impl PerfUdpSocket {
                     offset = end;
                     attempt = 0; // Each batch gets its own retry budget.
                 }
-                #[cfg(apple)]
-                Err(e) if socket.connected && is_icmp_unreachable(&e) => {
-                    self.record_send_retries(attempt);
-
-                    // The kernel received an ICMP error for this path; the error is one-shot.
-                    // Drop the packet: either the path recovers or connlib migrates / times out.
-                    tracing::debug!(%dst, "Dropping packet for unreachable destination: {e}");
-
-                    return Ok(());
-                }
                 // Connected sockets get a write-readiness wakeup from the kernel's flow advisory
                 // once the interface queue drains, so we park until then.
                 #[cfg(apple)]
@@ -466,6 +456,16 @@ impl PerfUdpSocket {
                 Err(e) if should_retry(&e, attempt) => {
                     spin_and_yield(attempt).await;
                     attempt += 1;
+                }
+                #[cfg(apple)]
+                Err(e) if socket.connected && is_icmp_unreachable(&e) => {
+                    self.record_send_retries(attempt);
+
+                    // The kernel received an ICMP error for this path; the error is one-shot.
+                    // Drop the packet: either the path recovers or connlib migrates / times out.
+                    tracing::debug!(%dst, "Dropping packet for unreachable destination: {e}");
+
+                    return Ok(());
                 }
                 Err(e) => {
                     self.record_send_retries(attempt);

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -664,26 +664,6 @@ fn is_equal_modulo_scope_for_ipv6_link_local(expected: SocketAddr, actual: Socke
     }
 }
 
-/// Parks until the kernel signals send capacity on the given (connected) socket, bounded by a timeout.
-///
-/// After a flow-advisory `ENOBUFS`, the kernel marks the socket not-writable and fires
-/// `EVFILT_WRITE` once the interface queue drains. tokio's cached write-readiness is stale
-/// at that point (UDP sends never return `EWOULDBLOCK` on Darwin, so it is never cleared),
-/// which is why we clear it explicitly before parking.
-///
-/// The timeout is a liveness backstop: `ENOBUFS` without a flow advisory (e.g. from mbuf
-/// exhaustion) never produces a wakeup. An early timeout merely costs one failed send
-/// before we park again.
-#[cfg(apple)]
-async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
-    let _ = socket.try_io(Interest::WRITABLE, || {
-        Err::<(), io::Error>(io::ErrorKind::WouldBlock.into())
-    });
-
-    let timeout = std::time::Duration::from_millis(10);
-    let _ = tokio::time::timeout(timeout, socket.writable()).await;
-}
-
 /// Whether the error originates from an ICMP message for a connected socket's path.
 #[cfg(apple)]
 fn is_icmp_unreachable(e: &io::Error) -> bool {
@@ -700,9 +680,6 @@ fn is_icmp_unreachable(e: &io::Error) -> bool {
 }
 
 /// Whether a failed send should be retried for the given attempt.
-///
-/// This only classifies the error and bounds the number of attempts; how we wait between
-/// attempts (park vs spin) is decided per socket in [`backoff_send`].
 fn should_retry(e: &io::Error, attempt: u32) -> bool {
     let Some(raw_os_error) = e.raw_os_error() else {
         return false;
@@ -716,8 +693,6 @@ fn should_retry(e: &io::Error, attempt: u32) -> bool {
     }
 
     // On MacOS / iOS, the kernel returns `ENOBUFS` when the interface queue fills up.
-    // It's transient: for connected sockets the kernel signals recovery via write-readiness
-    // (see [`backoff_send`]); for the unconnected catch-all it just clears off-thread.
     #[cfg(apple)]
     if raw_os_error == libc::ENOBUFS && attempt < MAX_ENOBUFS_RETRIES {
         return true;
@@ -745,6 +720,26 @@ async fn spin_and_yield(attempt: u32) {
     }
 
     tokio::task::yield_now().await;
+}
+
+/// Parks until the kernel signals send capacity on the given (connected) socket, bounded by a timeout.
+///
+/// After a flow-advisory `ENOBUFS`, the kernel marks the socket not-writable and fires
+/// `EVFILT_WRITE` once the interface queue drains. tokio's cached write-readiness is stale
+/// at that point (UDP sends never return `EWOULDBLOCK` on Darwin, so it is never cleared),
+/// which is why we clear it explicitly before parking.
+///
+/// The timeout is a liveness backstop: `ENOBUFS` without a flow advisory (e.g. from mbuf
+/// exhaustion) never produces a wakeup. An early timeout merely costs one failed send
+/// before we park again.
+#[cfg(apple)]
+async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
+    let _ = socket.try_io(Interest::WRITABLE, || {
+        Err::<(), io::Error>(io::ErrorKind::WouldBlock.into())
+    });
+
+    let timeout = std::time::Duration::from_millis(10);
+    let _ = tokio::time::timeout(timeout, socket.writable()).await;
 }
 
 /// An iterator that segments an array of buffers into individual datagrams.

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -900,43 +900,6 @@ mod tests {
 
     use super::*;
 
-    /// Reproduces the constraint the Apple flow sockets rely on: two UDP sockets can only share a
-    /// local port if *both* opt into `SO_REUSEPORT` before binding. If the first (the catch-all)
-    /// does not, a second socket trying to bind the same port - as a connected flow socket does -
-    /// is rejected with `AddrInUse`, which would latch the fast path off.
-    #[test]
-    fn sharing_a_port_requires_reuseport_on_the_first_socket_too() {
-        use socket2::{Domain, Socket, Type};
-
-        let wildcard = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
-
-        let bind_pair = |reuse_first: bool| -> io::Result<()> {
-            let first = Socket::new(Domain::IPV4, Type::DGRAM, None).unwrap();
-            if reuse_first {
-                first.set_reuse_address(true).unwrap();
-                first.set_reuse_port(true).unwrap();
-            }
-            first.bind(&wildcard.into()).unwrap();
-            let port: SocketAddr = first.local_addr().unwrap().as_socket().unwrap();
-
-            // A connected flow socket binds the catch-all's exact port, opting into reuse itself.
-            let flow = Socket::new(Domain::IPV4, Type::DGRAM, None).unwrap();
-            flow.set_reuse_address(true).unwrap();
-            flow.set_reuse_port(true).unwrap();
-            flow.bind(&port.into())
-        };
-
-        // Catch-all bound without `SO_REUSEPORT` (today's `udp()`): the flow socket can't share it.
-        assert_eq!(
-            bind_pair(false).unwrap_err().kind(),
-            io::ErrorKind::AddrInUse,
-            "flow socket should be rejected when the catch-all lacks SO_REUSEPORT"
-        );
-
-        // Catch-all bound with `SO_REUSEPORT` (the fix): the flow socket can share the port.
-        bind_pair(true).expect("flow socket should bind once the catch-all opts into SO_REUSEPORT");
-    }
-
     #[derive(derive_more::Deref)]
     struct DummyBuffer(Vec<u8>);
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -374,6 +374,15 @@ impl PerfUdpSocket {
         self.send_transmit(pooled.as_socket(), &transmit).await
     }
 
+    /// The number of connected per-destination "flow" sockets currently cached.
+    ///
+    /// Exposed for integration tests. Always `0` on non-Apple platforms, where all
+    /// traffic uses the single catch-all socket.
+    #[doc(hidden)]
+    pub fn flow_socket_count(&self) -> usize {
+        self.pool.flow_socket_count()
+    }
+
     pub fn set_buffer_sizes(
         &mut self,
         requested_send_buffer_size: usize,
@@ -961,51 +970,6 @@ mod tests {
         ));
 
         assert!(is_equal_modulo_scope_for_ipv6_link_local(left, right))
-    }
-
-    /// A datagram sent to a fresh destination must connect a flow socket,
-    /// and the reply must arrive through it.
-    #[tokio::test]
-    #[cfg(apple)]
-    async fn sends_and_receives_via_flow_socket() {
-        let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let peer_addr = peer.local_addr().unwrap();
-
-        let socket = udp("127.0.0.1:0".parse().unwrap())
-            .unwrap()
-            .into_perf()
-            .unwrap();
-
-        let pool = BufferPool::<BytesMut>::new(2048, "test");
-
-        socket
-            .send(DatagramOut {
-                src: None,
-                dst: peer_addr,
-                packet: pool.pull_initialised(b"hello"),
-                segment_size: 5,
-                ecn: Ecn::NonEct,
-            })
-            .await
-            .unwrap();
-
-        // The send must actually go out over a connected flow socket - not silently fall back to
-        // the catch-all. A count of 0 means `connect()` failed (e.g. the catch-all lacked
-        // `SO_REUSEPORT`) and the fast path latched off.
-        assert_eq!(socket.pool.flow_socket_count(), 1);
-
-        let mut buf = [0u8; 16];
-        let (len, from) = peer.recv_from(&mut buf).await.unwrap();
-        assert_eq!(&buf[..len], b"hello");
-
-        // The reply matches the connected socket's 4-tuple exactly and must be delivered via it.
-        peer.send_to(b"world", from).await.unwrap();
-
-        let mut iter = socket.recv_from().await.unwrap();
-        let datagram = iter.next().unwrap();
-
-        assert_eq!(datagram.packet, b"world");
-        assert_eq!(datagram.from, peer_addr);
     }
 
     #[test]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -17,6 +17,10 @@ use std::any::Any;
 use std::pin::Pin;
 use tokio::io::Interest;
 
+mod pool;
+
+use pool::{OwnedSocket, Socket, SocketPool};
+
 pub trait SocketFactory<S>: Send + Sync + 'static {
     fn bind(&self, local: SocketAddr) -> io::Result<S>;
     fn reset(&self);
@@ -26,15 +30,15 @@ pub trait SocketFactory<S>: Send + Sync + 'static {
 /// handed straight to the interface and `SO_SNDBUF` only acts as a cap on the maximum
 /// datagram size. A large send buffer is therefore pointless (and cannot cause
 /// bufferbloat either); 64 KiB comfortably covers the largest datagram we ever send.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(apple)]
 pub const SEND_BUFFER_SIZE: usize = 64 * 1024;
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(apple))]
 pub const SEND_BUFFER_SIZE: usize = 16 * ONE_MB;
 pub const RECV_BUFFER_SIZE: usize = 128 * ONE_MB;
 const ONE_MB: usize = 1024 * 1024;
 
 /// How many times we at most try to re-send a packet if we encounter ENOBUFS on MacOS / iOS or 10055 on Windows.
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
+#[cfg(any(apple, target_os = "windows"))]
 const MAX_ENOBUFS_RETRIES: u32 = 24;
 
 /// Upper bound (as a power of two) for how many times we busy-spin between send retries.
@@ -180,8 +184,8 @@ pub struct UdpSocket {
 
 /// A UDP socket with performance optimisations for fast send & receive.
 pub struct PerfUdpSocket {
-    inner: tokio::net::UdpSocket,
-    state: quinn_udp::UdpSocketState,
+    /// The socket(s) we send and receive on; see [`SocketPool`].
+    pool: SocketPool,
 
     /// A buffer pool for batches of incoming UDP packets.
     buffer_pool: BufferPool<Vec<u8>>,
@@ -212,7 +216,7 @@ impl UdpSocket {
         let quinn_ref = quinn_udp::UdpSockRef::from(&self.inner);
         let quinn_state = quinn_udp::UdpSocketState::new(quinn_ref)?;
 
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(apple)]
         // SAFETY: All versions of MacOS / iOS that we tested support these APIs.
         unsafe {
             quinn_state.set_apple_fast_path();
@@ -225,9 +229,10 @@ impl UdpSocket {
         // sizing the buffer to a single datagram.
         let recv_buf_size = ip_packet::MAX_FZ_PAYLOAD * quinn_state.gro_segments();
 
+        let wildcard = OwnedSocket::new(self.inner, quinn_state, false);
+
         Ok(PerfUdpSocket {
-            inner: self.inner,
-            state: quinn_state,
+            pool: SocketPool::new(wildcard),
             buffer_pool: BufferPool::new(
                 recv_buf_size,
                 match socket_addr.ip() {
@@ -290,26 +295,45 @@ pub struct DatagramOut {
 }
 
 impl PerfUdpSocket {
+    /// Receives a batch of datagrams from whichever of our sockets becomes ready first.
     pub async fn recv_from(&self) -> Result<DatagramSegmentIter> {
+        std::future::poll_fn(|cx| {
+            self.pool
+                .poll_recv(cx, |socket| self.try_recv_batch(socket))
+        })
+        .await
+    }
+
+    /// Attempts to receive a batch of datagrams from the given socket without blocking.
+    ///
+    /// Returns `WouldBlock` if the socket is not readable, clearing tokio's cached
+    /// readiness in the process so that waiting for readiness actually suspends.
+    fn try_recv_batch(&self, socket: Socket<'_>) -> io::Result<DatagramSegmentIter> {
         // Stack-allocate arrays for buffers and meta. The size is implied from the const-generic default on `DatagramSegmentIter`.
         let mut bufs = std::array::from_fn(|_| self.buffer_pool.pull());
         let mut meta = std::array::from_fn(|_| quinn_udp::RecvMeta::default());
 
-        let recv = || {
-            // Fancy std-functions ahead: `each_mut` transforms our array into an array of references to our items and `map` allows us to create an `IoSliceMut` out of each element.
-            // `state.recv` requires us to pass `IoSliceMut` but later on, we need the original buffer again because `DatagramSegmentIter` needs to own them.
-            // That is why we cannot just create an `IoSliceMut` to begin with.
-            let mut bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
+        let len = socket.inner.try_io(Interest::READABLE, || {
+            // The loop only re-iterates on Apple, where connected sockets surface (one-shot)
+            // ICMP errors on receive that we skip past; hence the `never_loop` allow elsewhere.
+            #[cfg_attr(not(apple), allow(clippy::never_loop))]
+            loop {
+                // Fancy std-functions ahead: `each_mut` transforms our array into an array of references to our items and `map` allows us to create an `IoSliceMut` out of each element.
+                // `state.recv` requires us to pass `IoSliceMut` but later on, we need the original buffer again because `DatagramSegmentIter` needs to own them.
+                // That is why we cannot just create an `IoSliceMut` to begin with.
+                let mut io_bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
 
-            self.state
-                .recv(UdpSockRef::from(&self.inner), &mut bufs, &mut meta)
-        };
-
-        let len = self
-            .inner
-            .async_io(Interest::READABLE, recv)
-            .await
-            .context("Failed to read from socket")?;
+                match socket.recv(&mut io_bufs, &mut meta) {
+                    // Connected sockets surface (one-shot) ICMP errors on receive; they are not fatal.
+                    #[cfg(apple)]
+                    Err(e) if socket.connected && is_icmp_unreachable(&e) => {
+                        tracing::trace!("Ignoring ICMP error on connected UDP socket: {e}");
+                        continue;
+                    }
+                    result => break result,
+                }
+            }
+        })?;
 
         self.batch_histogram.record(
             len as u64,
@@ -331,9 +355,11 @@ impl PerfUdpSocket {
             datagram.ecn,
         )?;
 
-        self.send_transmit(&transmit).await?;
+        let pooled = self
+            .pool
+            .get_send_socket(transmit.src_ip, datagram.dst, &self.buffer_pool);
 
-        Ok(())
+        self.send_transmit(pooled.as_socket(), &transmit).await
     }
 
     pub fn set_buffer_sizes(
@@ -341,32 +367,29 @@ impl PerfUdpSocket {
         requested_send_buffer_size: usize,
         requested_recv_buffer_size: usize,
     ) {
-        let socket = socket2::SockRef::from(&self.inner);
-
-        // Apply each direction independently: failing to set one buffer size must not prevent the other from being applied.
-        if let Err(e) = apply_buffer_size(requested_send_buffer_size, |size| {
-            socket.set_send_buffer_size(size)
-        }) {
-            tracing::warn!(%requested_send_buffer_size, "Failed to set send buffer size: {e}");
-        }
-
-        if let Err(e) = apply_buffer_size(requested_recv_buffer_size, |size| {
-            socket.set_recv_buffer_size(size)
-        }) {
-            tracing::warn!(%requested_recv_buffer_size, "Failed to set recv buffer size: {e}");
-        }
-
-        let send_buffer_size = socket.send_buffer_size().unwrap_or_default();
-        let recv_buffer_size = socket.recv_buffer_size().unwrap_or_default();
-
-        tracing::debug!(%requested_send_buffer_size, %send_buffer_size, %requested_recv_buffer_size, %recv_buffer_size, port = %self.port, "UDP socket buffer sizes");
+        self.pool.set_buffer_sizes(
+            requested_send_buffer_size,
+            requested_recv_buffer_size,
+            self.port,
+        );
     }
 
-    async fn send_transmit(&self, transmit: &Transmit<'_>) -> Result<()> {
+    /// Sends a [`Transmit`] over the given socket, chunked to honor GSO limits.
+    ///
+    /// Connected sockets participate in Darwin's flow advisories: under congestion the kernel
+    /// drops the datagram, returns `ENOBUFS` and fails all further sends instantly until the
+    /// interface queue drains, which it signals via write-readiness. For those, we park until
+    /// that signal instead of spinning.
+    async fn send_transmit(&self, socket: Socket<'_>, transmit: &Transmit<'_>) -> Result<()> {
         let segment_size = transmit
             .segment_size
             .expect("`segment_size` must always be set");
-        let src = transmit.src_ip;
+        // On a connected socket the source is pinned by the binding, so we drop the cmsg.
+        let src = if socket.connected {
+            None
+        } else {
+            transmit.src_ip
+        };
         let dst = transmit.destination;
 
         let total = transmit.contents.len();
@@ -380,7 +403,7 @@ impl PerfUdpSocket {
         while offset < total {
             // Recompute every iteration: an `EIO` makes `quinn-udp` disable GSO, so
             // the remaining data needs to be re-split into smaller batches.
-            let chunk_size = self.calculate_chunk_size(segment_size, dst)?;
+            let chunk_size = self.calculate_chunk_size(socket.state, segment_size, dst)?;
 
             let end = std::cmp::min(offset + chunk_size, total);
             let contents = &transmit.contents[offset..end];
@@ -394,15 +417,26 @@ impl PerfUdpSocket {
             };
 
             #[cfg(debug_assertions)]
-            tracing::trace!(target: "wire::net::send", ?src, %dst, ecn = ?chunk.ecn, num_packets = %(contents.len() / segment_size), %segment_size);
+            tracing::trace!(target: "wire::net::send", ?src, %dst, ecn = ?chunk.ecn, num_packets = %(contents.len() / segment_size), %segment_size, connected = %socket.connected);
 
-            match self
-                .inner
-                .async_io(Interest::WRITABLE, || {
-                    self.state.try_send((&self.inner).into(), &chunk)
-                })
-                .await
-            {
+            let result = if socket.connected {
+                // Connected sockets never return `EWOULDBLOCK` on Darwin; issue the syscall
+                // directly instead of going through tokio's (always-set) write-readiness.
+                socket
+                    .state
+                    .try_send(UdpSockRef::from(socket.inner), &chunk)
+            } else {
+                socket
+                    .inner
+                    .async_io(Interest::WRITABLE, || {
+                        socket
+                            .state
+                            .try_send(UdpSockRef::from(socket.inner), &chunk)
+                    })
+                    .await
+            };
+
+            match result {
                 Ok(()) => {
                     self.record_send_batch_size(contents.len() / segment_size);
                     self.record_send_retries(attempt);
@@ -410,6 +444,25 @@ impl PerfUdpSocket {
                     offset = end;
                     attempt = 0; // Each batch gets its own retry budget.
                 }
+                #[cfg(apple)]
+                Err(e) if socket.connected && is_icmp_unreachable(&e) => {
+                    self.record_send_retries(attempt);
+
+                    // The kernel received an ICMP error for this path; the error is one-shot.
+                    // Drop the packet: either the path recovers or connlib migrates / times out.
+                    tracing::debug!(%dst, "Dropping packet for unreachable destination: {e}");
+
+                    return Ok(());
+                }
+                // Connected sockets get a write-readiness wakeup from the kernel's flow advisory
+                // once the interface queue drains, so we park until then.
+                #[cfg(apple)]
+                Err(e) if socket.connected && should_retry(&e, attempt) => {
+                    wait_for_send_capacity(socket.inner).await;
+                    attempt += 1;
+                }
+                // The unconnected catch-all gets no such signal; spin, since the `ENOBUFS`
+                // clears off-thread (driver / NIC) within microseconds.
                 Err(e) if should_retry(&e, attempt) => {
                     spin_and_yield(attempt).await;
                     attempt += 1;
@@ -467,13 +520,18 @@ impl PerfUdpSocket {
     /// We need to honor both of these constraints when calculating the chunk size.
     ///
     /// Fails if `segment_size` exceeds the maximum UDP payload, in which case not even a single segment fits.
-    fn calculate_chunk_size(&self, segment_size: usize, dst: SocketAddr) -> Result<usize> {
+    fn calculate_chunk_size(
+        &self,
+        state: &quinn_udp::UdpSocketState,
+        segment_size: usize,
+        dst: SocketAddr,
+    ) -> Result<usize> {
         let header_overhead = match dst {
             SocketAddr::V4(_) => Ipv4Header::MAX_LEN + UdpHeader::LEN,
             SocketAddr::V6(_) => Ipv6Header::LEN + UdpHeader::LEN,
         };
 
-        let max_segments_by_config = self.state.max_gso_segments();
+        let max_segments_by_config = state.max_gso_segments();
         let max_segments_by_size = (u16::MAX as usize - header_overhead) / segment_size;
 
         let max_segments = std::cmp::min(max_segments_by_config, max_segments_by_size);
@@ -572,7 +630,7 @@ impl UdpSocket {
 ///
 /// Apple platforms reject buffer sizes above `kern.ipc.maxsockbuf` with `ENOBUFS` instead of
 /// clamping them like Linux does.
-fn apply_buffer_size(
+pub(crate) fn apply_buffer_size(
     requested: usize,
     mut set: impl FnMut(usize) -> io::Result<()>,
 ) -> io::Result<()> {
@@ -606,7 +664,45 @@ fn is_equal_modulo_scope_for_ipv6_link_local(expected: SocketAddr, actual: Socke
     }
 }
 
+/// Parks until the kernel signals send capacity on the given (connected) socket, bounded by a timeout.
+///
+/// After a flow-advisory `ENOBUFS`, the kernel marks the socket not-writable and fires
+/// `EVFILT_WRITE` once the interface queue drains. tokio's cached write-readiness is stale
+/// at that point (UDP sends never return `EWOULDBLOCK` on Darwin, so it is never cleared),
+/// which is why we clear it explicitly before parking.
+///
+/// The timeout is a liveness backstop: `ENOBUFS` without a flow advisory (e.g. from mbuf
+/// exhaustion) never produces a wakeup. An early timeout merely costs one failed send
+/// before we park again.
+#[cfg(apple)]
+async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
+    let _ = socket.try_io(Interest::WRITABLE, || {
+        Err::<(), io::Error>(io::ErrorKind::WouldBlock.into())
+    });
+
+    let timeout = std::time::Duration::from_millis(10);
+    let _ = tokio::time::timeout(timeout, socket.writable()).await;
+}
+
+/// Whether the error originates from an ICMP message for a connected socket's path.
+#[cfg(apple)]
+fn is_icmp_unreachable(e: &io::Error) -> bool {
+    matches!(
+        e.raw_os_error(),
+        Some(
+            libc::ECONNREFUSED
+                | libc::EHOSTUNREACH
+                | libc::ENETUNREACH
+                | libc::EHOSTDOWN
+                | libc::ENETDOWN
+        )
+    )
+}
+
 /// Whether a failed send should be retried for the given attempt.
+///
+/// This only classifies the error and bounds the number of attempts; how we wait between
+/// attempts (park vs spin) is decided per socket in [`backoff_send`].
 fn should_retry(e: &io::Error, attempt: u32) -> bool {
     let Some(raw_os_error) = e.raw_os_error() else {
         return false;
@@ -620,9 +716,9 @@ fn should_retry(e: &io::Error, attempt: u32) -> bool {
     }
 
     // On MacOS / iOS, the kernel returns `ENOBUFS` when the interface queue fills up.
-    // It's transient and clears off this thread (driver / NIC), and isn't observable
-    // via write-readiness, so we retry rather than suspend.
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    // It's transient: for connected sockets the kernel signals recovery via write-readiness
+    // (see [`backoff_send`]); for the unconnected catch-all it just clears off-thread.
+    #[cfg(apple)]
     if raw_os_error == libc::ENOBUFS && attempt < MAX_ENOBUFS_RETRIES {
         return true;
     }
@@ -684,7 +780,12 @@ pub struct DatagramSegmentIter<const N: usize = { quinn_udp::BATCH_SIZE }, B = B
 }
 
 impl<B, const N: usize> DatagramSegmentIter<N, B> {
-    fn new(buffers: [B; N], metas: [quinn_udp::RecvMeta; N], port: u16, len: usize) -> Self {
+    pub(crate) fn new(
+        buffers: [B; N],
+        metas: [quinn_udp::RecvMeta; N],
+        port: u16,
+        len: usize,
+    ) -> Self {
         let total_bytes = metas.iter().map(|m| m.len).sum::<usize>();
         let num_packets = metas
             .iter()
@@ -855,6 +956,46 @@ mod tests {
         assert!(is_equal_modulo_scope_for_ipv6_link_local(left, right))
     }
 
+    /// A datagram sent to a fresh destination must connect a flow socket,
+    /// and the reply must arrive through it.
+    #[tokio::test]
+    #[cfg(apple)]
+    async fn sends_and_receives_via_flow_socket() {
+        let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let peer_addr = peer.local_addr().unwrap();
+
+        let socket = udp("127.0.0.1:0".parse().unwrap())
+            .unwrap()
+            .into_perf()
+            .unwrap();
+
+        let pool = BufferPool::<BytesMut>::new(2048, "test");
+
+        socket
+            .send(DatagramOut {
+                src: None,
+                dst: peer_addr,
+                packet: pool.pull_initialised(b"hello"),
+                segment_size: 5,
+                ecn: Ecn::NonEct,
+            })
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 16];
+        let (len, from) = peer.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..len], b"hello");
+
+        // The reply matches the connected socket's 4-tuple exactly and must be delivered via it.
+        peer.send_to(b"world", from).await.unwrap();
+
+        let mut iter = socket.recv_from().await.unwrap();
+        let datagram = iter.next().unwrap();
+
+        assert_eq!(datagram.packet, b"world");
+        assert_eq!(datagram.from, peer_addr);
+    }
+
     #[test]
     fn apply_buffer_size_halves_until_accepted() {
         let mut attempts = Vec::new();
@@ -899,7 +1040,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(apple)]
     fn retries_enobufs_at_most_24_times() {
         let err = io::Error::from_raw_os_error(libc::ENOBUFS);
 

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -87,6 +87,18 @@ pub fn udp(std_addr: SocketAddr) -> io::Result<UdpSocket> {
     }
 
     socket.set_nonblocking(true)?;
+
+    // On Apple, connected flow sockets share the catch-all socket's local port (see `pool::apple`).
+    // Darwin only lets sockets share a port if every one of them - including the one bound first -
+    // opts into `SO_REUSEPORT`, so set it (and `SO_REUSEADDR`, to match the flow sockets) before
+    // binding. Without this the first flow `bind()` fails with `EADDRINUSE` and the fast path
+    // latches off.
+    #[cfg(apple)]
+    {
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+    }
+
     socket.bind(&addr)?;
 
     let socket = std::net::UdpSocket::from(socket);
@@ -888,6 +900,43 @@ mod tests {
 
     use super::*;
 
+    /// Reproduces the constraint the Apple flow sockets rely on: two UDP sockets can only share a
+    /// local port if *both* opt into `SO_REUSEPORT` before binding. If the first (the catch-all)
+    /// does not, a second socket trying to bind the same port - as a connected flow socket does -
+    /// is rejected with `AddrInUse`, which would latch the fast path off.
+    #[test]
+    fn sharing_a_port_requires_reuseport_on_the_first_socket_too() {
+        use socket2::{Domain, Socket, Type};
+
+        let wildcard = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+
+        let bind_pair = |reuse_first: bool| -> io::Result<()> {
+            let first = Socket::new(Domain::IPV4, Type::DGRAM, None).unwrap();
+            if reuse_first {
+                first.set_reuse_address(true).unwrap();
+                first.set_reuse_port(true).unwrap();
+            }
+            first.bind(&wildcard.into()).unwrap();
+            let port: SocketAddr = first.local_addr().unwrap().as_socket().unwrap();
+
+            // A connected flow socket binds the catch-all's exact port, opting into reuse itself.
+            let flow = Socket::new(Domain::IPV4, Type::DGRAM, None).unwrap();
+            flow.set_reuse_address(true).unwrap();
+            flow.set_reuse_port(true).unwrap();
+            flow.bind(&port.into())
+        };
+
+        // Catch-all bound without `SO_REUSEPORT` (today's `udp()`): the flow socket can't share it.
+        assert_eq!(
+            bind_pair(false).unwrap_err().kind(),
+            io::ErrorKind::AddrInUse,
+            "flow socket should be rejected when the catch-all lacks SO_REUSEPORT"
+        );
+
+        // Catch-all bound with `SO_REUSEPORT` (the fix): the flow socket can share the port.
+        bind_pair(true).expect("flow socket should bind once the catch-all opts into SO_REUSEPORT");
+    }
+
     #[derive(derive_more::Deref)]
     struct DummyBuffer(Vec<u8>);
 
@@ -976,6 +1025,11 @@ mod tests {
             })
             .await
             .unwrap();
+
+        // The send must actually go out over a connected flow socket - not silently fall back to
+        // the catch-all. A count of 0 means `connect()` failed (e.g. the catch-all lacked
+        // `SO_REUSEPORT`) and the fast path latched off.
+        assert_eq!(socket.pool.flow_socket_count(), 1);
 
         let mut buf = [0u8; 16];
         let (len, from) = peer.recv_from(&mut buf).await.unwrap();

--- a/rust/libs/connlib/socket-factory/src/pool.rs
+++ b/rust/libs/connlib/socket-factory/src/pool.rs
@@ -1,0 +1,130 @@
+//! The [`SocketPool`]: the set of UDP sockets [`PerfUdpSocket`](crate::PerfUdpSocket) sends and
+//! receives on, plus the small vocabulary the send and receive paths share.
+//!
+//! There are two implementations behind a single platform-selected `SocketPool` alias:
+//!
+//! - `apple`: an unconnected catch-all socket plus a cache of connected per-destination "flow"
+//!   sockets, which unlock Darwin's UDP fast path and flow advisories.
+//! - `fallback`: just the catch-all socket, for every other platform.
+
+#[cfg(apple)]
+mod apple;
+#[cfg(not(apple))]
+mod fallback;
+
+#[cfg(apple)]
+pub(crate) use apple::SocketPool;
+#[cfg(not(apple))]
+pub(crate) use fallback::SocketPool;
+
+use std::{
+    io::{self, IoSliceMut},
+    task::{Context, Poll},
+};
+
+use anyhow::{Context as _, Result};
+use quinn_udp::UdpSockRef;
+
+use crate::{DatagramSegmentIter, apply_buffer_size};
+
+/// A borrowed handle to a UDP socket and its quinn state - the currency the send and receive
+/// paths operate on, regardless of which [`SocketPool`] member it came from.
+#[derive(Clone, Copy)]
+pub(crate) struct Socket<'a> {
+    pub(crate) inner: &'a tokio::net::UdpSocket,
+    pub(crate) state: &'a quinn_udp::UdpSocketState,
+    /// Whether the socket is `connect`ed to a fixed peer and thus takes Darwin's fast path.
+    pub(crate) connected: bool,
+}
+
+impl Socket<'_> {
+    /// Receives a batch of datagrams into `bufs`, without blocking.
+    pub(crate) fn recv(
+        &self,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [quinn_udp::RecvMeta],
+    ) -> io::Result<usize> {
+        self.state.recv(UdpSockRef::from(self.inner), bufs, meta)
+    }
+}
+
+/// A UDP socket and its quinn state, owned. The unit a [`SocketPool`] is made of.
+pub(crate) struct OwnedSocket {
+    socket: tokio::net::UdpSocket,
+    state: quinn_udp::UdpSocketState,
+    connected: bool,
+}
+
+impl OwnedSocket {
+    pub(crate) fn new(
+        socket: tokio::net::UdpSocket,
+        state: quinn_udp::UdpSocketState,
+        connected: bool,
+    ) -> Self {
+        Self {
+            socket,
+            state,
+            connected,
+        }
+    }
+
+    pub(crate) fn as_socket(&self) -> Socket<'_> {
+        Socket {
+            inner: &self.socket,
+            state: &self.state,
+            connected: self.connected,
+        }
+    }
+
+    #[cfg(apple)]
+    pub(crate) fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.socket.local_addr()
+    }
+
+    /// Applies the requested send and recv buffer sizes, best-effort.
+    pub(crate) fn apply_buffer_sizes(&self, send: usize, recv: usize, port: u16) {
+        let socket = socket2::SockRef::from(&self.socket);
+
+        // Apply each direction independently: failing to set one buffer size must not prevent the other from being applied.
+        if let Err(e) = apply_buffer_size(send, |size| socket.set_send_buffer_size(size)) {
+            tracing::warn!(requested_send_buffer_size = %send, "Failed to set send buffer size: {e}");
+        }
+
+        if let Err(e) = apply_buffer_size(recv, |size| socket.set_recv_buffer_size(size)) {
+            tracing::warn!(requested_recv_buffer_size = %recv, "Failed to set recv buffer size: {e}");
+        }
+
+        let send_buffer_size = socket.send_buffer_size().unwrap_or_default();
+        let recv_buffer_size = socket.recv_buffer_size().unwrap_or_default();
+
+        tracing::debug!(requested_send_buffer_size = %send, %send_buffer_size, requested_recv_buffer_size = %recv, %recv_buffer_size, %port, "UDP socket buffer sizes");
+    }
+}
+
+/// Polls a single socket for readiness and, when ready, tries to receive a batch.
+///
+/// Shared by every [`SocketPool`] implementation.
+pub(crate) fn poll_recv_ready<F>(
+    cx: &mut Context<'_>,
+    socket: Socket<'_>,
+    try_recv: &mut F,
+) -> Poll<Result<DatagramSegmentIter>>
+where
+    F: FnMut(Socket<'_>) -> io::Result<DatagramSegmentIter>,
+{
+    loop {
+        match socket.inner.poll_recv_ready(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => {
+                return Poll::Ready(Err(e).context("Failed to wait for socket to become readable"));
+            }
+            Poll::Ready(Ok(())) => {}
+        }
+
+        match try_recv(socket) {
+            // The readiness was stale; `try_io` cleared it, so the next poll above suspends.
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            result => return Poll::Ready(result.context("Failed to read from socket")),
+        }
+    }
+}

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -156,8 +156,8 @@ impl SocketPool {
         for (socket, flow) in inner.rotated_recv_order(self.wildcard.as_socket(), position) {
             if let Poll::Ready(result) = poll_recv_ready(cx, socket, &mut try_recv) {
                 // Only flow sockets track a last-received time (for eviction); the wildcard is `None`.
-                if result.is_ok()
-                    && let Some(flow) = flow
+                if let Some(flow) = flow
+                    && result.is_ok()
                 {
                     flow.record_received(Instant::now());
                 }
@@ -251,7 +251,8 @@ impl Inner {
         wildcard: Socket<'a>,
         position: usize,
     ) -> impl Iterator<Item = (Socket<'a>, Option<&'a Flow>)> {
-        std::iter::once((wildcard, None))
+        std::iter::empty()
+            .chain((wildcard, None))
             .chain(
                 self.flows
                     .values()

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -252,7 +252,7 @@ impl Inner {
         position: usize,
     ) -> impl Iterator<Item = (Socket<'a>, Option<&'a Flow>)> {
         std::iter::empty()
-            .chain((wildcard, None))
+            .chain(Some((wildcard, None)))
             .chain(
                 self.flows
                     .values()

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -1,0 +1,418 @@
+//! The Apple [`SocketPool`]: an unconnected catch-all socket plus a cache of connected "flow"
+//! sockets.
+//!
+//! Darwin gates its UDP fast path on connected sockets:
+//!
+//! - `sendmsg_x` only batches datagrams under a single socket lock and NECP evaluation
+//!   for connected sockets (`sosend_list`); unconnected sockets degrade to an in-kernel
+//!   loop with per-datagram cost.
+//! - Only connected sockets participate in flow advisories: congestion surfaces as an
+//!   immediate `ENOBUFS` and its clearing is signalled via write-readiness.
+//!   Unconnected sockets suffer silent head-drops in the AQM instead.
+//! - The route (and thus `so_pktheadroom`) is cached at connect time.
+//!
+//! We therefore connect a socket per `(source, destination)` pair on first send, all bound
+//! to the same local port as the unconnected catch-all socket. The kernel delivers inbound
+//! datagrams with an exact 4-tuple match to the connected socket in preference to the
+//! wildcard one. The catch-all remains as the wildcard receiver (ICE peer-reflexive
+//! traffic, NAT rebinds) and as the fallback when connecting fails.
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    io::{self, IoSliceMut},
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    task::{Context, Poll, Waker},
+    time::Instant,
+};
+
+use anyhow::Result;
+use bufferpool::BufferPool;
+use parking_lot::{Mutex, MutexGuard};
+use quinn_udp::UdpSockRef;
+
+use crate::DatagramSegmentIter;
+
+use super::{OwnedSocket, Socket, poll_recv_ready};
+
+/// How many flow sockets we maintain at most, per address family.
+///
+/// Apple devices only ever run Clients, so the steady-state working set is tiny:
+/// the connected gateway(s) and possibly a relay. The cap mainly bounds the burst
+/// of short-lived sockets during ICE connectivity checks.
+const MAX_FLOW_SOCKETS: usize = if cfg!(target_os = "ios") { 8 } else { 16 };
+
+type Key = (Option<IpAddr>, SocketAddr);
+
+/// The unconnected catch-all socket plus a cache of connected flow sockets, keyed by
+/// `(source IP, destination)`.
+pub(crate) struct SocketPool {
+    /// Unconnected socket bound to the wildcard address; receives from any peer and is the
+    /// fallback for sends when connecting fails.
+    wildcard: Arc<OwnedSocket>,
+    /// The local address flow sockets bind to; they share the wildcard socket's port.
+    local: SocketAddr,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    flows: BTreeMap<Key, Flow>,
+    /// Latched off the first time connecting a flow socket fails.
+    ///
+    /// A failure means the environment (e.g. the iOS Network Extension sandbox) doesn't permit
+    /// the `SO_REUSEPORT`-bind + `connect` we rely on. That is a property of the environment, not
+    /// the destination, so we stop trying entirely - all traffic uses the catch-all socket - and
+    /// avoid re-running the failing syscalls on the send path. A `reset()` rebuilds the pool and
+    /// gives it another chance.
+    flow_sockets_supported: bool,
+    buffer_sizes: Option<(usize, usize)>,
+    /// Datagrams rescued from an evicted socket's receive buffer just before closing it.
+    drained: VecDeque<DatagramSegmentIter>,
+    /// Waker of the receive task; woken when new sockets or drained datagrams appear.
+    recv_waker: Option<Waker>,
+    /// Counter to rotate the polling order of sockets, ensuring receive fairness.
+    round_robin: usize,
+}
+
+/// A connected flow socket plus the metadata the cache needs to evict it.
+struct Flow {
+    socket: Arc<OwnedSocket>,
+    created_at: Instant,
+    /// When we last read a datagram off this socket.
+    ///
+    /// Inbound on the exact 4-tuple is the only signal that a path actually works:
+    /// sends are self-generated and keep flowing to dead destinations too.
+    ///
+    /// Interior-mutable so the receive path can update it while iterating the cache.
+    last_received: Mutex<Option<Instant>>,
+}
+
+impl SocketPool {
+    pub(crate) fn new(wildcard: OwnedSocket) -> Self {
+        let local = wildcard
+            .local_addr()
+            .expect("a bound socket to have a local address");
+
+        Self {
+            wildcard: Arc::new(wildcard),
+            local,
+            inner: Mutex::new(Inner {
+                flows: BTreeMap::new(),
+                flow_sockets_supported: true,
+                buffer_sizes: None,
+                drained: VecDeque::new(),
+                recv_waker: None,
+                round_robin: 0,
+            }),
+        }
+    }
+
+    /// Picks the socket to send a datagram for `(src, dst)` on.
+    ///
+    /// Connects (or reuses) a flow socket; on failure it falls back to the catch-all socket.
+    pub(crate) fn get_send_socket(
+        &self,
+        src: Option<IpAddr>,
+        dst: SocketAddr,
+        buffer_pool: &BufferPool<Vec<u8>>,
+    ) -> Arc<OwnedSocket> {
+        self.get_or_connect(src, dst, buffer_pool)
+            .unwrap_or_else(|| self.wildcard.clone())
+    }
+
+    /// Polls the catch-all socket and all flow sockets for an incoming batch, applying
+    /// `try_recv` to whichever is ready first.
+    ///
+    /// This readiness multiplexing is the one place where async-await does not suffice: the
+    /// number of sockets is variable and we must suspend on all of them at once. Everything
+    /// substantial happens in `try_recv`.
+    pub(crate) fn poll_recv<F>(
+        &self,
+        cx: &mut Context<'_>,
+        mut try_recv: F,
+    ) -> Poll<Result<DatagramSegmentIter>>
+    where
+        F: FnMut(Socket<'_>) -> io::Result<DatagramSegmentIter>,
+    {
+        let mut inner = self.lock();
+
+        // Register the waker first: a flow socket connected after we inspect the
+        // set below must still be able to wake us.
+        match &mut inner.recv_waker {
+            Some(existing) if existing.will_wake(cx.waker()) => {}
+            slot => *slot = Some(cx.waker().clone()),
+        }
+
+        // Datagrams rescued from an evicted flow socket are the oldest; yield them first.
+        if let Some(iter) = inner.drained.pop_front() {
+            return Poll::Ready(Ok(iter));
+        }
+
+        // Rotate the polling order by one slot per call - with the catch-all socket occupying
+        // a virtual slot - so that no socket can starve the others under sustained traffic.
+        let position = inner.round_robin % (inner.flows.len() + 1);
+        inner.round_robin = inner.round_robin.wrapping_add(1);
+
+        let catch_all_first = position == 0;
+        let wildcard = self.wildcard.as_socket();
+
+        if catch_all_first && let Poll::Ready(result) = poll_recv_ready(cx, wildcard, &mut try_recv)
+        {
+            return Poll::Ready(result);
+        }
+
+        for flow in inner.rotated_flows(position) {
+            if let Poll::Ready(result) = poll_recv_ready(cx, flow.socket.as_socket(), &mut try_recv)
+            {
+                if result.is_ok() {
+                    flow.record_received(Instant::now());
+                }
+
+                return Poll::Ready(result);
+            }
+        }
+
+        if !catch_all_first
+            && let Poll::Ready(result) = poll_recv_ready(cx, wildcard, &mut try_recv)
+        {
+            return Poll::Ready(result);
+        }
+
+        Poll::Pending
+    }
+
+    pub(crate) fn set_buffer_sizes(&self, send: usize, recv: usize, port: u16) {
+        self.wildcard.apply_buffer_sizes(send, recv, port);
+
+        let mut inner = self.lock();
+        inner.buffer_sizes = Some((send, recv));
+
+        for flow in inner.flows.values() {
+            flow.socket.apply_buffer_sizes(send, recv, port);
+        }
+    }
+
+    /// Returns the flow socket for the given `(src, dst)` pair, connecting a new one if needed.
+    ///
+    /// Returns `None` if connecting fails (or has failed before); see `Inner::flow_sockets_supported`.
+    fn get_or_connect(
+        &self,
+        src: Option<IpAddr>,
+        dst: SocketAddr,
+        pool: &BufferPool<Vec<u8>>,
+    ) -> Option<Arc<OwnedSocket>> {
+        let key = (src, dst);
+        let mut inner = self.lock();
+
+        if let Some(flow) = inner.flows.get(&key) {
+            return Some(flow.socket.clone());
+        }
+
+        if !inner.flow_sockets_supported {
+            return None;
+        }
+
+        if inner.flows.len() >= MAX_FLOW_SOCKETS {
+            evict_one(&mut inner, self.local.port(), pool);
+        }
+
+        match connect(self.local, src, dst, inner.buffer_sizes) {
+            Ok(socket) => {
+                tracing::debug!(?src, %dst, "Connected new flow socket");
+
+                let socket = Arc::new(socket);
+                inner.flows.insert(
+                    key,
+                    Flow {
+                        socket: socket.clone(),
+                        created_at: Instant::now(),
+                        last_received: Mutex::new(None),
+                    },
+                );
+
+                // The receive task only learns about the new socket on its next poll.
+                if let Some(waker) = inner.recv_waker.take() {
+                    waker.wake();
+                }
+
+                Some(socket)
+            }
+            Err(e) => {
+                tracing::debug!(?src, %dst, "Disabling flow sockets; connecting failed: {e}");
+
+                inner.flow_sockets_supported = false;
+
+                None
+            }
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        self.inner.lock()
+    }
+}
+
+impl Inner {
+    /// The flow sockets, rotated so that `position` (a virtual slot that includes the
+    /// catch-all socket at index 0) starts the round.
+    fn rotated_flows(&self, position: usize) -> impl Iterator<Item = &Flow> {
+        let num_flows = self.flows.len();
+        let offset = position.saturating_sub(1);
+
+        self.flows.values().cycle().skip(offset).take(num_flows)
+    }
+}
+
+impl Flow {
+    fn record_received(&self, now: Instant) {
+        *self.last_received.lock() = Some(now);
+    }
+}
+
+/// Evicts the flow socket that is least likely to still be useful.
+fn evict_one(inner: &mut Inner, port: u16, pool: &BufferPool<Vec<u8>>) {
+    let Some(key) = inner
+        .flows
+        .iter()
+        .min_by_key(|(_, flow)| {
+            let last_received = *flow.last_received.lock();
+
+            eviction_rank(last_received, flow.created_at)
+        })
+        .map(|(key, _)| *key)
+    else {
+        return;
+    };
+
+    let Some(victim) = inner.flows.remove(&key) else {
+        return;
+    };
+
+    drain(&victim, port, pool, &mut inner.drained);
+
+    if !inner.drained.is_empty()
+        && let Some(waker) = inner.recv_waker.take()
+    {
+        waker.wake();
+    }
+
+    tracing::debug!(src = ?key.0, dst = %key.1, "Evicted flow socket");
+}
+
+/// Eviction order: sockets that never received anything first (oldest first),
+/// then by least-recently received.
+///
+/// Sockets that did receive are ranked strictly above those that never did,
+/// regardless of age: a quiet-but-live established socket must survive a burst
+/// of fresh, unproven sockets created during ICE connectivity checks.
+fn eviction_rank(last_received: Option<Instant>, created_at: Instant) -> (bool, Instant) {
+    match last_received {
+        None => (false, created_at),
+        Some(last_received) => (true, last_received),
+    }
+}
+
+/// Reads an evicted socket dry before it is closed.
+///
+/// A connected socket captures inbound for its 4-tuple; whatever is already queued would be
+/// discarded by the kernel on close. Packets arriving after the close are delivered to the
+/// catch-all socket instead.
+fn drain(
+    victim: &Flow,
+    port: u16,
+    pool: &BufferPool<Vec<u8>>,
+    out: &mut VecDeque<DatagramSegmentIter>,
+) {
+    let socket = victim.socket.as_socket();
+
+    loop {
+        let mut bufs = std::array::from_fn(|_| pool.pull());
+        let mut metas = std::array::from_fn(|_| quinn_udp::RecvMeta::default());
+
+        let len = {
+            let mut io_bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
+
+            match socket.recv(&mut io_bufs, &mut metas) {
+                Ok(len) => len,
+                Err(_) => break, // Typically `WouldBlock`: the socket is dry.
+            }
+        };
+
+        out.push_back(DatagramSegmentIter::new(bufs, metas, port, len));
+    }
+}
+
+fn connect(
+    local: SocketAddr,
+    src: Option<IpAddr>,
+    dst: SocketAddr,
+    buffer_sizes: Option<(usize, usize)>,
+) -> io::Result<OwnedSocket> {
+    let bind_addr = socket2::SockAddr::from(SocketAddr::new(
+        src.unwrap_or_else(|| local.ip()),
+        local.port(),
+    ));
+    let dst_addr = socket2::SockAddr::from(dst);
+
+    let socket = socket2::Socket::new(dst_addr.domain(), socket2::Type::DGRAM, None)?;
+
+    if dst.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+
+    // Share the local port with the (unconnected) catch-all socket.
+    socket.set_reuse_address(true)?;
+    socket.set_reuse_port(true)?;
+
+    socket.set_nonblocking(true)?;
+    socket.bind(&bind_addr)?;
+    socket.connect(&dst_addr)?;
+
+    let socket = tokio::net::UdpSocket::try_from(std::net::UdpSocket::from(socket))?;
+
+    let state = quinn_udp::UdpSocketState::new(UdpSockRef::from(&socket))?;
+    // SAFETY: All versions of MacOS / iOS that we tested support these APIs.
+    unsafe {
+        state.set_apple_fast_path();
+    }
+
+    let socket = OwnedSocket::new(socket, state, true);
+
+    if let Some((send, recv)) = buffer_sizes {
+        socket.apply_buffer_sizes(send, recv, local.port());
+    }
+
+    Ok(socket)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn never_received_sockets_are_evicted_before_received_ones() {
+        let earlier = Instant::now();
+        let later = earlier + Duration::from_secs(60);
+
+        // A fresh, unproven socket ranks below one that received long ago.
+        assert!(eviction_rank(None, later) < eviction_rank(Some(earlier), earlier));
+    }
+
+    #[test]
+    fn oldest_never_received_socket_is_evicted_first() {
+        let earlier = Instant::now();
+        let later = earlier + Duration::from_secs(60);
+
+        assert!(eviction_rank(None, earlier) < eviction_rank(None, later));
+    }
+
+    #[test]
+    fn least_recently_received_socket_is_evicted_first() {
+        let earlier = Instant::now();
+        let later = earlier + Duration::from_secs(60);
+
+        assert!(eviction_rank(Some(earlier), earlier) < eviction_rank(Some(later), earlier));
+    }
+}

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -241,7 +241,6 @@ impl SocketPool {
         self.inner.lock()
     }
 
-    #[cfg(test)]
     pub(crate) fn flow_socket_count(&self) -> usize {
         self.lock().flows.len()
     }

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -148,34 +148,22 @@ impl SocketPool {
             return Poll::Ready(Ok(iter));
         }
 
-        // Rotate the polling order by one slot per call - with the catch-all socket occupying
-        // a virtual slot - so that no socket can starve the others under sustained traffic.
+        // Rotate the polling order by one slot per call so no socket can starve the others
+        // under sustained traffic. The catch-all socket takes part as one slot among the flows.
         let position = inner.round_robin % (inner.flows.len() + 1);
         inner.round_robin = inner.round_robin.wrapping_add(1);
 
-        let catch_all_first = position == 0;
-        let wildcard = self.wildcard.as_socket();
-
-        if catch_all_first && let Poll::Ready(result) = poll_recv_ready(cx, wildcard, &mut try_recv)
-        {
-            return Poll::Ready(result);
-        }
-
-        for flow in inner.rotated_flows(position) {
-            if let Poll::Ready(result) = poll_recv_ready(cx, flow.socket.as_socket(), &mut try_recv)
-            {
-                if result.is_ok() {
+        for (socket, flow) in inner.rotated_recv_order(self.wildcard.as_socket(), position) {
+            if let Poll::Ready(result) = poll_recv_ready(cx, socket, &mut try_recv) {
+                // Only flow sockets track a last-received time (for eviction); the wildcard is `None`.
+                if result.is_ok()
+                    && let Some(flow) = flow
+                {
                     flow.record_received(Instant::now());
                 }
 
                 return Poll::Ready(result);
             }
-        }
-
-        if !catch_all_first
-            && let Poll::Ready(result) = poll_recv_ready(cx, wildcard, &mut try_recv)
-        {
-            return Poll::Ready(result);
         }
 
         Poll::Pending
@@ -253,13 +241,25 @@ impl SocketPool {
 }
 
 impl Inner {
-    /// The flow sockets, rotated so that `position` (a virtual slot that includes the
-    /// catch-all socket at index 0) starts the round.
-    fn rotated_flows(&self, position: usize) -> impl Iterator<Item = &Flow> {
-        let num_flows = self.flows.len();
-        let offset = position.saturating_sub(1);
-
-        self.flows.values().cycle().skip(offset).take(num_flows)
+    /// All receive sockets - the catch-all `wildcard` plus the flow sockets - rotated so that
+    /// `position` starts the round.
+    ///
+    /// Each flow socket carries its [`Flow`] so the receive path can refresh its last-received
+    /// timestamp; the wildcard carries `None`.
+    fn rotated_recv_order<'a>(
+        &'a self,
+        wildcard: Socket<'a>,
+        position: usize,
+    ) -> impl Iterator<Item = (Socket<'a>, Option<&'a Flow>)> {
+        std::iter::once((wildcard, None))
+            .chain(
+                self.flows
+                    .values()
+                    .map(|flow| (flow.socket.as_socket(), Some(flow))),
+            )
+            .cycle()
+            .skip(position)
+            .take(self.flows.len() + 1)
     }
 }
 

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -240,6 +240,11 @@ impl SocketPool {
     fn lock(&self) -> MutexGuard<'_, Inner> {
         self.inner.lock()
     }
+
+    #[cfg(test)]
+    pub(crate) fn flow_socket_count(&self) -> usize {
+        self.lock().flows.len()
+    }
 }
 
 impl Inner {

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -35,7 +35,8 @@ use crate::DatagramSegmentIter;
 
 use super::{OwnedSocket, Socket, poll_recv_ready};
 
-/// How many flow sockets we maintain at most, per address family.
+/// How many flow sockets a pool keeps at most. connlib runs one pool per address family,
+/// so this is effectively the per-family cap.
 ///
 /// Apple devices only ever run Clients, so the steady-state working set is tiny:
 /// the connected gateway(s) and possibly a relay. The cap mainly bounds the burst
@@ -61,9 +62,10 @@ struct Inner {
     ///
     /// A failure means the environment (e.g. the iOS Network Extension sandbox) doesn't permit
     /// the `SO_REUSEPORT`-bind + `connect` we rely on. That is a property of the environment, not
-    /// the destination, so we stop trying entirely - all traffic uses the catch-all socket - and
-    /// avoid re-running the failing syscalls on the send path. A `reset()` rebuilds the pool and
-    /// gives it another chance.
+    /// the destination, so we stop connecting *new* flow sockets - new destinations fall back to
+    /// the catch-all socket - and avoid re-running the failing syscalls on the send path. Any flow
+    /// sockets already connected keep working. Re-binding the sockets on a network change builds a
+    /// fresh [`SocketPool`], giving connecting another chance.
     flow_sockets_supported: bool,
     buffer_sizes: Option<(usize, usize)>,
     /// Datagrams rescued from an evicted socket's receive buffer just before closing it.

--- a/rust/libs/connlib/socket-factory/src/pool/fallback.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/fallback.rs
@@ -1,0 +1,54 @@
+//! The [`SocketPool`] for every non-Apple platform: just the catch-all socket.
+//!
+//! Connected per-destination sockets only buy us anything on Darwin (see the `apple` module),
+//! so everywhere else all traffic uses a single unconnected socket.
+
+use std::{
+    io,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use anyhow::Result;
+use bufferpool::BufferPool;
+
+use crate::DatagramSegmentIter;
+
+use super::{OwnedSocket, Socket, poll_recv_ready};
+
+pub(crate) struct SocketPool {
+    wildcard: Arc<OwnedSocket>,
+}
+
+impl SocketPool {
+    pub(crate) fn new(wildcard: OwnedSocket) -> Self {
+        Self {
+            wildcard: Arc::new(wildcard),
+        }
+    }
+
+    pub(crate) fn get_send_socket(
+        &self,
+        _src: Option<IpAddr>,
+        _dst: SocketAddr,
+        _buffer_pool: &BufferPool<Vec<u8>>,
+    ) -> Arc<OwnedSocket> {
+        self.wildcard.clone()
+    }
+
+    pub(crate) fn poll_recv<F>(
+        &self,
+        cx: &mut Context<'_>,
+        mut try_recv: F,
+    ) -> Poll<Result<DatagramSegmentIter>>
+    where
+        F: FnMut(Socket<'_>) -> io::Result<DatagramSegmentIter>,
+    {
+        poll_recv_ready(cx, self.wildcard.as_socket(), &mut try_recv)
+    }
+
+    pub(crate) fn set_buffer_sizes(&self, send: usize, recv: usize, port: u16) {
+        self.wildcard.apply_buffer_sizes(send, recv, port);
+    }
+}

--- a/rust/libs/connlib/socket-factory/src/pool/fallback.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/fallback.rs
@@ -51,4 +51,9 @@ impl SocketPool {
     pub(crate) fn set_buffer_sizes(&self, send: usize, recv: usize, port: u16) {
         self.wildcard.apply_buffer_sizes(send, recv, port);
     }
+
+    /// There are no flow sockets on non-Apple platforms; all traffic uses the catch-all.
+    pub(crate) fn flow_socket_count(&self) -> usize {
+        0
+    }
 }

--- a/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
+++ b/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
@@ -1,0 +1,55 @@
+//! Integration tests for [`socket_factory::PerfUdpSocket`], exercising it through its public API.
+
+use bufferpool::BufferPool;
+use bytes::BytesMut;
+use gat_lending_iterator::LendingIterator as _;
+use ip_packet::Ecn;
+use socket_factory::{DatagramOut, udp};
+
+/// A datagram sent to a fresh peer round-trips: the peer receives it and the reply is
+/// delivered back through the same [`PerfUdpSocket`](socket_factory::PerfUdpSocket).
+///
+/// On Apple this goes out over a connected per-destination flow socket (see the assertion
+/// below); on every other platform it uses the single catch-all socket.
+#[tokio::test]
+async fn sends_and_receives_a_datagram() {
+    let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let peer_addr = peer.local_addr().unwrap();
+
+    let socket = udp("127.0.0.1:0".parse().unwrap())
+        .unwrap()
+        .into_perf()
+        .unwrap();
+
+    let pool = BufferPool::<BytesMut>::new(2048, "test");
+
+    socket
+        .send(DatagramOut {
+            src: None,
+            dst: peer_addr,
+            packet: pool.pull_initialised(b"hello"),
+            segment_size: 5,
+            ecn: Ecn::NonEct,
+        })
+        .await
+        .unwrap();
+
+    // On Apple, the send must go out over a connected flow socket - not silently fall back to
+    // the catch-all. A count of 0 would mean `connect()` failed (e.g. the catch-all lacked
+    // `SO_REUSEPORT`) and the fast path latched off.
+    #[cfg(apple)]
+    assert_eq!(socket.flow_socket_count(), 1);
+
+    let mut buf = [0u8; 16];
+    let (len, from) = peer.recv_from(&mut buf).await.unwrap();
+    assert_eq!(&buf[..len], b"hello");
+
+    // The reply matches the (connected) socket's 4-tuple exactly and must be delivered via it.
+    peer.send_to(b"world", from).await.unwrap();
+
+    let mut iter = socket.recv_from().await.unwrap();
+    let datagram = iter.next().unwrap();
+
+    assert_eq!(datagram.packet, b"world");
+    assert_eq!(datagram.from, peer_addr);
+}


### PR DESCRIPTION
Refactor UDP socket handling to use a socket pool architecture that unlocks Darwin's UDP fast path and flow advisories. On Apple platforms, connected sockets enable `sendmsg_x` batching, flow advisory congestion signals, and cached route information. We now maintain an unconnected catch-all socket plus a cache of connected per-destination "flow" sockets, with an eviction policy based on receive activity.

The socket pool is abstracted behind a platform-specific interface: Apple uses the full flow-socket implementation while other platforms use a simple fallback with just the catch-all socket.

Related: #13594
Resolves: #13578