### PR TITLE
build: enable page hashing for executable signing

### DIFF
--- a/scripts/build/sign.sh
+++ b/scripts/build/sign.sh
@@ -15,5 +15,6 @@ do
         --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
         --azure-key-vault-certificate "$AZURE_CERT_NAME" \
         --timestamp-rfc3161 "http://timestamp.digicert.com" \
+        --page-hashing \
         --verbose "$exe"
 done


### PR DESCRIPTION
Enable the `--page-hashing` flag when signing executables with DigiCert's SignTool. This improves the integrity verification of signed binaries by hashing individual pages rather than the entire file.

https://claude.ai/code/session_01AWX3vo6meLeV8e2eoqg2mm