### PR TITLE
fix(portal): UI and validation fixes across portal

### DIFF
--- a/elixir/lib/portal/accounts/config.ex
+++ b/elixir/lib/portal/accounts/config.ex
@@ -89,6 +89,7 @@ defmodule Portal.Accounts.Config do
       sort_param: :addresses_sort,
       drop_param: :addresses_drop
     )
+    |> validate_length(:addresses, max: 8, message: "cannot exceed 8 resolvers")
     |> validate_doh_provider_for_secure()
     |> validate_addresses_for_type()
     |> validate_custom_has_addresses()

--- a/elixir/lib/portal/resource.ex
+++ b/elixir/lib/portal/resource.ex
@@ -340,6 +340,68 @@ defmodule Portal.Resource do
     struct
     |> cast(attrs, [:protocol, :ports])
     |> validate_required([:protocol])
+    |> validate_ports(attrs)
+  end
+
+  # Validates the raw port tokens rather than the cast value, since the cast
+  # parser silently strips a leading "-" (turning "-1" into "1").
+  defp validate_ports(changeset, attrs) do
+    if Keyword.has_key?(changeset.errors, :ports) do
+      changeset
+    else
+      apply_port_validation(changeset, parse_port_ranges(port_tokens(attrs)))
+    end
+  end
+
+  defp apply_port_validation(changeset, :error) do
+    add_error(changeset, :ports, "must be between 1 and 65535")
+  end
+
+  defp apply_port_validation(changeset, {:ok, ranges}) do
+    cond do
+      Enum.any?(ranges, fn {lower, upper} -> lower < 1 or upper > 65_535 end) ->
+        add_error(changeset, :ports, "must be between 1 and 65535")
+
+      port_ranges_overlap?(ranges) ->
+        add_error(changeset, :ports, "port ranges must not overlap")
+
+      true ->
+        changeset
+    end
+  end
+
+  defp port_tokens(attrs) do
+    case Map.fetch(attrs, :ports) do
+      {:ok, ports} -> ports
+      :error -> Map.get(attrs, "ports", [])
+    end
+    |> List.wrap()
+    |> Enum.map(&to_string/1)
+  end
+
+  defp parse_port_ranges(tokens) do
+    tokens
+    |> Enum.reduce_while({:ok, []}, fn token, {:ok, acc} ->
+      case Regex.run(~r/^\s*(\d+)\s*(?:-\s*(\d+))?\s*$/, token) do
+        [_, lower] -> {:cont, {:ok, [port_range(lower, lower) | acc]}}
+        [_, lower, ""] -> {:cont, {:ok, [port_range(lower, lower) | acc]}}
+        [_, lower, upper] -> {:cont, {:ok, [port_range(lower, upper) | acc]}}
+        nil -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, ranges} -> {:ok, Enum.reverse(ranges)}
+      :error -> :error
+    end
+  end
+
+  defp port_range(lower, upper), do: {String.to_integer(lower), String.to_integer(upper)}
+
+  defp port_ranges_overlap?(ranges) do
+    ranges
+    |> Enum.sort_by(fn {lower, _upper} -> lower end)
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.any?(fn [{_lower1, upper1}, {lower2, _upper2}] -> lower2 <= upper1 end)
   end
 
   # Utility functions moved from Portal.Resources

--- a/elixir/lib/portal_web/components/form_components.ex
+++ b/elixir/lib/portal_web/components/form_components.ex
@@ -186,7 +186,7 @@ defmodule PortalWeb.FormComponents do
         id={@id}
         name={@name}
         class={[
-          "text-xs py-1 pl-2.5 pr-6 rounded",
+          "text-sm py-2 pl-3 pr-8 rounded",
           "bg-[var(--surface-raised)] text-[var(--text-secondary)]",
           "border border-[var(--border)]",
           "outline-none transition-colors cursor-pointer",
@@ -233,7 +233,7 @@ defmodule PortalWeb.FormComponents do
         id={@id}
         name={@name}
         class={[
-          "text-xs py-1 pl-2.5 pr-6 rounded",
+          "text-sm py-2 pl-3 pr-8 rounded",
           "bg-[var(--surface-raised)] text-[var(--text-secondary)]",
           "border border-[var(--border)]",
           "outline-none transition-colors cursor-pointer",

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -935,9 +935,9 @@ defmodule PortalWeb.Actors.Components do
           :if={not @confirm_delete_actor}
           type="button"
           phx-click="confirm_delete_actor"
-          class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+          class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
         >
-          Delete actor
+          <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete actor
         </button>
         <div
           :if={@confirm_delete_actor}

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -809,9 +809,9 @@ defmodule PortalWeb.Clients.Components do
         :if={not @confirm_delete_client}
         type="button"
         phx-click="confirm_delete_client"
-        class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+        class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
       >
-        Delete client
+        <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete client
       </button>
       <div
         :if={@confirm_delete_client}

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -1001,9 +1001,9 @@ defmodule PortalWeb.Groups.Components do
           :if={not @confirm_delete?}
           type="button"
           phx-click="confirm_delete_group"
-          class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+          class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
         >
-          Delete group
+          <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete group
         </button>
         <div
           :if={@confirm_delete?}

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -1213,9 +1213,9 @@ defmodule PortalWeb.Policies.Components do
         :if={not @confirm_delete_policy}
         type="button"
         phx-click="confirm_delete_policy"
-        class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+        class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
       >
-        Delete policy
+        <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete policy
       </button>
       <div
         :if={@confirm_delete_policy}

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -45,6 +45,7 @@ defmodule PortalWeb.Resources do
       |> assign(
         selected_resource: nil,
         selected_resource_pool_member_ids: [],
+        online_client_ids: MapSet.new(),
         selected_groups: [],
         policy_authorizations: [],
         policy_authorizations_page: 1,
@@ -346,6 +347,7 @@ defmodule PortalWeb.Resources do
          internet_resource: internet_resource,
          resource_policy_counts: resource_policy_counts,
          device_pool_members: device_pool_members,
+         online_client_ids: online_client_ids(socket.assigns.account.id),
          resources_metadata: metadata
        )}
     end
@@ -539,6 +541,7 @@ defmodule PortalWeb.Resources do
               resource={resource}
               presence_tick={@presence_tick}
               pool_member_ids={Map.get(@device_pool_members, resource.id, [])}
+              online_client_ids={@online_client_ids}
             />
           </:col>
           <:empty>
@@ -579,6 +582,7 @@ defmodule PortalWeb.Resources do
             account={@account}
             resource={@selected_resource}
             pool_member_ids={@selected_resource_pool_member_ids}
+            online_client_ids={@online_client_ids}
             presence_tick={@presence_tick}
             groups={@selected_groups}
             policy_authorizations={@policy_authorizations}
@@ -1226,11 +1230,20 @@ defmodule PortalWeb.Resources do
 
   def handle_info(%Phoenix.Socket.Broadcast{event: event}, socket)
       when event in ["presence_diff", "presence_state"] do
-    {:noreply, update(socket, :presence_tick, &(&1 + 1))}
+    {:noreply,
+     socket
+     |> update(:presence_tick, &(&1 + 1))
+     |> assign(online_client_ids: online_client_ids(socket.assigns.account.id))}
   end
 
   def handle_info(_, socket) do
     {:noreply, socket}
+  end
+
+  defp online_client_ids(account_id) do
+    account_id
+    |> Presence.Clients.online_client_ids()
+    |> MapSet.new()
   end
 
   defp resource_filter_ports(nil), do: %{}

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -44,6 +44,7 @@ defmodule PortalWeb.Resources do
       |> assign_async(:resources_count, fn -> {:ok, %{resources_count: Database.count_resources(subject)}} end)
       |> assign(
         selected_resource: nil,
+        selected_resource_pool_member_ids: [],
         selected_groups: [],
         policy_authorizations: [],
         policy_authorizations_page: 1,
@@ -83,11 +84,16 @@ defmodule PortalWeb.Resources do
 
         filter_site = filter_site_from_params(params, socket.assigns.subject)
 
+        pool_member_ids =
+          Database.pool_member_ids_for_resources([resource], socket.assigns.subject)
+          |> Map.get(resource.id, [])
+
         {:noreply,
          socket
          |> assign(
            filter_site: filter_site,
            selected_resource: resource,
+           selected_resource_pool_member_ids: pool_member_ids,
            selected_groups: groups,
            policy_authorizations: policy_authorizations,
            policy_authorizations_page: page,
@@ -331,11 +337,15 @@ defmodule PortalWeb.Resources do
       resource_policy_counts =
         Database.count_policies_for_resources(all_resources, socket.assigns.subject)
 
+      device_pool_members =
+        Database.pool_member_ids_for_resources(all_resources, socket.assigns.subject)
+
       {:ok,
        assign(socket,
          resources: resources,
          internet_resource: internet_resource,
          resource_policy_counts: resource_policy_counts,
+         device_pool_members: device_pool_members,
          resources_metadata: metadata
        )}
     end
@@ -525,7 +535,11 @@ defmodule PortalWeb.Resources do
             </span>
           </:col>
           <:col :let={resource} label="Status" class="w-32">
-            <.resource_status_badge resource={resource} presence_tick={@presence_tick} />
+            <.resource_status_badge
+              resource={resource}
+              presence_tick={@presence_tick}
+              pool_member_ids={Map.get(@device_pool_members, resource.id, [])}
+            />
           </:col>
           <:empty>
             <div class="flex flex-col items-center gap-3 py-16">
@@ -564,6 +578,7 @@ defmodule PortalWeb.Resources do
           <.resource_details_panel
             account={@account}
             resource={@selected_resource}
+            pool_member_ids={@selected_resource_pool_member_ids}
             presence_tick={@presence_tick}
             groups={@selected_groups}
             policy_authorizations={@policy_authorizations}
@@ -1230,6 +1245,26 @@ defmodule PortalWeb.Resources do
 
   defp resource_filter_ports(_), do: %{}
 
+  defp resource_filter_errors(nil), do: %{}
+
+  defp resource_filter_errors(%Phoenix.HTML.Form{source: nil}), do: %{}
+
+  defp resource_filter_errors(%Phoenix.HTML.Form{source: %Ecto.Changeset{} = source}) do
+    source
+    |> Ecto.Changeset.get_change(:filters, [])
+    |> Enum.flat_map(fn filter ->
+      protocol = Ecto.Changeset.get_field(filter, :protocol)
+
+      case Keyword.get(filter.errors, :ports) do
+        {msg, _opts} -> [{protocol, msg}]
+        nil -> []
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp resource_filter_errors(_), do: %{}
+
   defp resource_form_panel_state(assigns) do
     %{
       resource_form: assigns.resource_form.form,
@@ -1240,7 +1275,8 @@ defmodule PortalWeb.Resources do
       resource_form_client_search: assigns.resource_form.client_search,
       resource_form_client_search_results: assigns.resource_form.client_search_results,
       client_to_client_enabled: assigns.resource_panel.client_to_client_enabled?,
-      filter_ports: resource_filter_ports(assigns.resource_form.form)
+      filter_ports: resource_filter_ports(assigns.resource_form.form),
+      filter_errors: resource_filter_errors(assigns.resource_form.form)
     }
   end
 
@@ -1527,6 +1563,30 @@ defmodule PortalWeb.Resources do
       |> case do
         {:error, _} -> %{}
         counts -> Map.new(counts)
+      end
+    end
+
+    def pool_member_ids_for_resources(resources, subject) do
+      ids =
+        resources
+        |> Enum.filter(&(&1.type == :static_device_pool))
+        |> Enum.map(& &1.id)
+        |> Enum.uniq()
+
+      from(m in StaticDevicePoolMember, as: :members)
+      |> where([members: m], m.resource_id in ^ids)
+      |> select([members: m], {m.resource_id, m.device_id})
+      |> Safe.scoped(subject, :replica)
+      |> Safe.all()
+      |> case do
+        {:error, _} ->
+          %{}
+
+        rows ->
+          Enum.group_by(rows, fn {resource_id, _device_id} -> resource_id end, fn {_resource_id,
+                                                                                   device_id} ->
+            device_id
+          end)
       end
     end
 

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1030,6 +1030,7 @@ defmodule PortalWeb.Resources.Components do
   attr :account, :any, required: true
   attr :resource, :any, required: true
   attr :pool_member_ids, :list, default: []
+  attr :online_client_ids, :any, default: %MapSet{}
   attr :presence_tick, :integer, default: 0
   attr :groups, :list, default: []
   attr :policy_authorizations, :list, default: []
@@ -1058,6 +1059,7 @@ defmodule PortalWeb.Resources.Components do
                 resource={@resource}
                 presence_tick={@presence_tick}
                 pool_member_ids={@pool_member_ids}
+                online_client_ids={@online_client_ids}
               />
             </div>
             <p
@@ -1916,14 +1918,10 @@ defmodule PortalWeb.Resources.Components do
   attr :resource, :any, required: true
   attr :presence_tick, :integer, default: 0
   attr :pool_member_ids, :list, default: []
+  attr :online_client_ids, :any, default: %MapSet{}
 
   def resource_status_badge(%{resource: %{type: :static_device_pool}} = assigns) do
-    online_ids =
-      assigns.resource.account_id
-      |> Presence.Clients.online_client_ids()
-      |> MapSet.new()
-
-    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(online_ids, &1))
+    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(assigns.online_client_ids, &1))
     assigns = assign(assigns, online: online, total: length(assigns.pool_member_ids))
 
     ~H"""

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -639,6 +639,7 @@ defmodule PortalWeb.Resources.Components do
   attr :active_protocols, :list, default: []
   attr :filters_dropdown_open, :boolean, default: false
   attr :filter_ports, :map, default: %{}
+  attr :filter_errors, :map, default: %{}
 
   def resource_traffic_restrictions_section(assigns) do
     assigns =
@@ -746,8 +747,20 @@ defmodule PortalWeb.Resources.Components do
                 name={"resource[filters][#{protocol}][ports]"}
                 value={Map.get(@filter_ports, protocol, "")}
                 placeholder="All ports"
-                class="w-full px-3 py-2 text-sm rounded-md border font-mono bg-[var(--control-bg)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none transition-colors border-[var(--control-border)] focus:border-[var(--control-focus)] focus:ring-1 focus:ring-[var(--control-focus)]/30"
+                class={[
+                  "w-full px-3 py-2 text-sm rounded-md border font-mono bg-[var(--control-bg)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none transition-colors focus:ring-1 focus:ring-[var(--control-focus)]/30",
+                  if(Map.has_key?(@filter_errors, protocol),
+                    do: "border-[var(--status-error)] focus:border-[var(--status-error)]",
+                    else: "border-[var(--control-border)] focus:border-[var(--control-focus)]"
+                  )
+                ]}
               />
+              <p
+                :if={Map.has_key?(@filter_errors, protocol)}
+                class="mt-1 text-xs text-[var(--status-error)]"
+              >
+                {Map.get(@filter_errors, protocol)}
+              </p>
             </div>
             <span
               :if={protocol == :icmp}
@@ -988,6 +1001,7 @@ defmodule PortalWeb.Resources.Components do
             active_protocols={@resource_form_active_protocols}
             filters_dropdown_open={@resource_form_filters_dropdown_open}
             filter_ports={@filter_ports}
+            filter_errors={@filter_errors}
           />
 
           <.resource_site_selector form={@resource_form} sites={@resource_form_sites} />
@@ -1015,6 +1029,7 @@ defmodule PortalWeb.Resources.Components do
 
   attr :account, :any, required: true
   attr :resource, :any, required: true
+  attr :pool_member_ids, :list, default: []
   attr :presence_tick, :integer, default: 0
   attr :groups, :list, default: []
   attr :policy_authorizations, :list, default: []
@@ -1039,7 +1054,11 @@ defmodule PortalWeb.Resources.Components do
               <h2 class="text-sm font-semibold text-[var(--text-primary)] truncate">
                 {@resource.name}
               </h2>
-              <.resource_status_badge resource={@resource} presence_tick={@presence_tick} />
+              <.resource_status_badge
+                resource={@resource}
+                presence_tick={@presence_tick}
+                pool_member_ids={@pool_member_ids}
+              />
             </div>
             <p
               :if={@resource.type != :internet}
@@ -1829,9 +1848,9 @@ defmodule PortalWeb.Resources.Components do
           :if={not @confirm_delete_resource}
           type="button"
           phx-click="confirm_delete_resource"
-          class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+          class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
         >
-          Delete resource
+          <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete resource
         </button>
         <div
           :if={@confirm_delete_resource}
@@ -1896,6 +1915,23 @@ defmodule PortalWeb.Resources.Components do
 
   attr :resource, :any, required: true
   attr :presence_tick, :integer, default: 0
+  attr :pool_member_ids, :list, default: []
+
+  def resource_status_badge(%{resource: %{type: :static_device_pool}} = assigns) do
+    online_ids =
+      assigns.resource.account_id
+      |> Presence.Clients.online_client_ids()
+      |> MapSet.new()
+
+    online = Enum.count(assigns.pool_member_ids, &MapSet.member?(online_ids, &1))
+    assigns = assign(assigns, online: online, total: length(assigns.pool_member_ids))
+
+    ~H"""
+    <.status_badge style={if @online > 0, do: :success, else: :neutral}>
+      {@online} / {@total} online
+    </.status_badge>
+    """
+  end
 
   def resource_status_badge(assigns) do
     assigns = assign(assigns, :online?, resource_online?(assigns.resource, assigns.presence_tick))

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -174,9 +174,9 @@ defmodule PortalWeb.Settings.Account do
               :if={not @confirm_delete_account}
               type="button"
               phx-click="confirm_delete_account"
-              class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+              class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
             >
-              Delete account
+              <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete account
             </button>
 
             <div

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -1226,6 +1226,9 @@ defmodule PortalWeb.Settings.Authentication do
                 placeholder="28800"
                 phx-debounce="300"
               />
+              <p class="mt-2 text-xs text-[var(--text-tertiary)]">
+                Portal default: 8 hours
+              </p>
             </div>
             <div>
               <label
@@ -1240,11 +1243,11 @@ defmodule PortalWeb.Settings.Authentication do
                 placeholder="604800"
                 phx-debounce="300"
               />
+              <p class="mt-2 text-xs text-[var(--text-tertiary)]">
+                Client default: 7 days
+              </p>
             </div>
           </div>
-          <p class="mt-2 text-xs text-[var(--text-tertiary)]">
-            Portal default: 8 hours · Client default: 7 days
-          </p>
         </div>
 
         <%!-- Entra-specific config --%>

--- a/elixir/lib/portal_web/live/settings/dns.ex
+++ b/elixir/lib/portal_web/live/settings/dns.ex
@@ -237,7 +237,7 @@ defmodule PortalWeb.Settings.DNS do
                   <label
                     for="dns-type--system"
                     class={[
-                      "flex flex-col p-3 border rounded cursor-pointer transition-all",
+                      "flex flex-col h-full p-3 border rounded cursor-pointer transition-all",
                       "peer-checked:border-[var(--brand)] peer-checked:bg-[var(--surface-raised)]",
                       "border-[var(--border)] hover:border-[var(--border-emphasis)]"
                     ]}
@@ -245,7 +245,7 @@ defmodule PortalWeb.Settings.DNS do
                     <span class="text-sm font-semibold text-[var(--text-primary)] mb-1 flex items-center gap-1.5">
                       <.icon name="ri-computer-line" class="w-4 h-4 shrink-0" /> System
                     </span>
-                    <span class="text-xs text-[var(--text-secondary)]">
+                    <span class="text-xs text-[var(--text-secondary)] my-auto">
                       Use the device's default DNS resolvers.
                     </span>
                   </label>
@@ -263,7 +263,7 @@ defmodule PortalWeb.Settings.DNS do
                   <label
                     for="dns-type--secure"
                     class={[
-                      "flex flex-col p-3 border rounded cursor-pointer transition-all",
+                      "flex flex-col h-full p-3 border rounded cursor-pointer transition-all",
                       "peer-checked:border-[var(--brand)] peer-checked:bg-[var(--surface-raised)]",
                       "border-[var(--border)] hover:border-[var(--border-emphasis)]"
                     ]}
@@ -271,7 +271,7 @@ defmodule PortalWeb.Settings.DNS do
                     <span class="text-sm font-semibold text-[var(--text-primary)] mb-1 flex items-center gap-1.5">
                       <.icon name="ri-lock-line" class="w-4 h-4 shrink-0" /> Secure
                     </span>
-                    <span class="text-xs text-[var(--text-secondary)]">
+                    <span class="text-xs text-[var(--text-secondary)] my-auto">
                       Use DNS-over-HTTPS from trusted providers.
                     </span>
                   </label>
@@ -289,7 +289,7 @@ defmodule PortalWeb.Settings.DNS do
                   <label
                     for="dns-type--custom"
                     class={[
-                      "flex flex-col p-3 border rounded cursor-pointer transition-all",
+                      "flex flex-col h-full p-3 border rounded cursor-pointer transition-all",
                       "peer-checked:border-[var(--brand)] peer-checked:bg-[var(--surface-raised)]",
                       "border-[var(--border)] hover:border-[var(--border-emphasis)]"
                     ]}
@@ -297,7 +297,7 @@ defmodule PortalWeb.Settings.DNS do
                     <span class="text-sm font-semibold text-[var(--text-primary)] mb-1 flex items-center gap-1.5">
                       <.icon name="ri-settings-3-line" class="w-4 h-4 shrink-0" /> Custom
                     </span>
-                    <span class="text-xs text-[var(--text-secondary)]">
+                    <span class="text-xs text-[var(--text-secondary)] my-auto">
                       Configure your own DNS server addresses.
                     </span>
                   </label>
@@ -388,6 +388,7 @@ defmodule PortalWeb.Settings.DNS do
                 />
 
                 <button
+                  :if={length(dns_form[:addresses].value || []) < 8}
                   type="button"
                   name="account[config][clients_upstream_dns][addresses_sort][]"
                   value="new"
@@ -396,6 +397,12 @@ defmodule PortalWeb.Settings.DNS do
                 >
                   <.icon name="ri-add-line" class="w-3.5 h-3.5" /> Add Resolver
                 </button>
+                <p
+                  :if={length(dns_form[:addresses].value || []) >= 8}
+                  class="text-xs text-[var(--text-tertiary)]"
+                >
+                  Maximum of 8 upstream resolvers reached.
+                </p>
 
                 <p class="text-xs text-[var(--text-tertiary)]">
                   <strong>Note:</strong>

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -562,9 +562,9 @@ defmodule PortalWeb.Sites.Components do
         :if={not @confirm_delete_site}
         type="button"
         phx-click="confirm_delete_site"
-        class="w-full text-left px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
+        class="w-full flex items-center gap-2 px-3 py-2 rounded border border-[var(--status-error)]/20 text-xs text-[var(--status-error)] hover:bg-[var(--status-error-bg)] transition-colors"
       >
-        Delete site
+        <.icon name="ri-delete-bin-line" class="w-4 h-4 shrink-0" /> Delete site
       </button>
       <div
         :if={@confirm_delete_site}

--- a/elixir/test/portal/accounts/config_test.exs
+++ b/elixir/test/portal/accounts/config_test.exs
@@ -1,0 +1,38 @@
+defmodule Portal.Accounts.ConfigTest do
+  use Portal.DataCase, async: true
+
+  alias Portal.Accounts.Config
+
+  defp custom_dns_changeset(count) do
+    addresses =
+      for i <- 0..(count - 1), into: %{} do
+        {Integer.to_string(i), %{"address" => "10.0.0.#{i}"}}
+      end
+
+    sort = Enum.map(0..(count - 1), &Integer.to_string/1)
+
+    Config.changeset(%Config{}, %{
+      "clients_upstream_dns" => %{
+        "type" => "custom",
+        "addresses" => addresses,
+        "addresses_sort" => sort,
+        "addresses_drop" => [""]
+      }
+    })
+  end
+
+  describe "changeset/2 upstream resolver limit" do
+    test "accepts up to 8 resolvers" do
+      assert custom_dns_changeset(8).valid?
+    end
+
+    test "rejects more than 8 resolvers" do
+      changeset = custom_dns_changeset(9)
+
+      refute changeset.valid?
+
+      assert %{clients_upstream_dns: %{addresses: ["cannot exceed 8 resolvers"]}} =
+               errors_on(changeset)
+    end
+  end
+end

--- a/elixir/test/portal/resource_test.exs
+++ b/elixir/test/portal/resource_test.exs
@@ -168,6 +168,46 @@ defmodule Portal.ResourceTest do
       assert %{filters: [%{protocol: ["can't be blank"]}]} = errors_on(changeset)
     end
 
+    test "accepts ports at the boundaries of the valid range" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["1", "65535", "80-443"]}]})
+      refute Map.has_key?(errors_on(changeset), :filters)
+    end
+
+    test "rejects a port below the valid range" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["0"]}]})
+      assert %{filters: [%{ports: ["must be between 1 and 65535"]}]} = errors_on(changeset)
+    end
+
+    test "rejects a port above the valid range" do
+      changeset = build_changeset(%{filters: [%{protocol: :udp, ports: ["65536"]}]})
+      assert %{filters: [%{ports: ["must be between 1 and 65535"]}]} = errors_on(changeset)
+    end
+
+    test "rejects a range whose upper bound exceeds the valid range" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["1-70000"]}]})
+      assert %{filters: [%{ports: ["must be between 1 and 65535"]}]} = errors_on(changeset)
+    end
+
+    test "rejects a negative port instead of coercing it to a positive value" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["-1"]}]})
+      assert %{filters: [%{ports: ["must be between 1 and 65535"]}]} = errors_on(changeset)
+    end
+
+    test "rejects overlapping port ranges" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["80-100", "90-110"]}]})
+      assert %{filters: [%{ports: ["port ranges must not overlap"]}]} = errors_on(changeset)
+    end
+
+    test "rejects duplicate single ports as overlapping" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["443", "443"]}]})
+      assert %{filters: [%{ports: ["port ranges must not overlap"]}]} = errors_on(changeset)
+    end
+
+    test "accepts adjacent non-overlapping port ranges" do
+      changeset = build_changeset(%{filters: [%{protocol: :tcp, ports: ["80-90", "91-100"]}]})
+      refute Map.has_key?(errors_on(changeset), :filters)
+    end
+
     test "trims whitespace from name, address, and address_description" do
       changeset =
         build_changeset(%{

--- a/elixir/test/portal_api/client/views/interface_test.exs
+++ b/elixir/test/portal_api/client/views/interface_test.exs
@@ -70,5 +70,26 @@ defmodule PortalAPI.Client.Views.InterfaceTest do
       assert result.upstream_do53 == []
       assert result.upstream_dns == []
     end
+
+    test "preserves the order of custom resolvers as entered" do
+      addresses = ["9.9.9.9", "1.1.1.1", "8.8.8.8", "2606:4700:4700::1111"]
+
+      account =
+        account_fixture(
+          config: %{
+            clients_upstream_dns: %{
+              type: :custom,
+              addresses: Enum.map(addresses, &%{address: &1})
+            }
+          }
+        )
+
+      client = client_fixture(account: account)
+      device = fetch_device!(client) |> Repo.preload(:account)
+
+      result = Interface.render(device)
+
+      assert Enum.map(result.upstream_do53, & &1.ip) == addresses
+    end
   end
 end

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -105,6 +105,25 @@ defmodule PortalWeb.ResourcesTest do
       refute html =~ "No Site Associated"
     end
 
+    test "shows online member count instead of offline for device pools", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client_one = client_fixture(account: account, actor: actor)
+      client_two = client_fixture(account: account, actor: actor)
+
+      _resource =
+        static_device_pool_resource_fixture(account: account, clients: [client_one, client_two])
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources")
+
+      assert html =~ "0 / 2 online"
+    end
+
     test "hides device pool option from the type filter when client_to_client is disabled",
          %{conn: conn, account: account, actor: actor} do
       {:ok, lv, _html} =

--- a/elixir/test/portal_web/live/sign_in_test.exs
+++ b/elixir/test/portal_web/live/sign_in_test.exs
@@ -34,6 +34,20 @@ defmodule PortalWeb.SignInTest do
       refute html =~ "Send code"
     end
 
+    test "shows the client sign-in hint for browser sign-in", %{conn: conn, account: account} do
+      {:ok, _lv, html} = live(conn, ~p"/#{account}/sign_in")
+
+      assert html =~ "Meant to sign in from a client instead?"
+    end
+
+    test "hides the client sign-in hint during client sign-in", %{conn: conn, account: account} do
+      for client <- @client_sign_in_types do
+        {:ok, _lv, html} = live(conn, ~p"/#{account}/sign_in?as=#{client}")
+
+        refute html =~ "Meant to sign in from a client instead?"
+      end
+    end
+
     test "redirects missing client account slug to root /sign_in with params preserved", %{conn: conn} do
       for client <- @client_sign_in_types do
         params = %{


### PR DESCRIPTION
A batch of portal UI polish and validation correctness fixes.

Danger-zone delete buttons now carry a trash icon, select inputs match the height of text inputs, the authentication provider session-lifetime helptext is split so each note sits under its own field, and the DNS resolver type cards share a consistent height.

Device pool resources previously showed a meaningless online/offline badge. They now show the number of online member devices out of the total, hydrated from Presence.

Traffic restriction ports are validated to fall within 1 to 65535 and must not overlap. Previously a negative value was silently coerced to a positive one and overlapping ranges were accepted.

Custom upstream resolvers are capped at 8 and are sent to connlib in the order they were entered. The client sign-in hint is hidden when signing in from a client (as=client, gui-client, or headless-client).

Fixes #13682
Fixes #13254
Fixes #13053
Fixes #12988
Fixes #10878
Fixes #8438