### PR TITLE
fix(windows): sign Tauri-patched GUI binary

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -155,19 +155,9 @@ jobs:
       - name: Build release exe and MSI / deb
         env:
           CARGO_PROFILE_RELEASE_LTO: thin # Fat LTO is getting too slow / RAM-hungry on Tauri builds
-        # Signs the exe before bundling it into the MSI
         run: pnpm build
       - name: Ensure unmodified Git workspace
         run: git diff --exit-code
-      # We need to sign the exe inside the MSI. Currently
-      # we do this in a "beforeBundleCommand" hook in tauri.windows.conf.json.
-      # But this will soon be natively supported in Tauri.
-      # TODO: Use Tauri's native MSI signing with support for EV certs
-      # See https://github.com/tauri-apps/tauri/pull/8718
-      - name: Sign the MSI
-        if: ${{ runner.os == 'Windows' }}
-        shell: bash
-        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}

--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -2,6 +2,14 @@
   "build": {
     "beforeBundleCommand": "bash ../../scripts/build/tauri-pre-bundle-windows.sh"
   },
+  "bundle": {
+    "windows": {
+      "signCommand": {
+        "cmd": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "args": ["-NoProfile", "-File", "../../../scripts/build/sign.ps1", "%1"]
+      }
+    }
+  },
   "mainBinaryName": "Firezone",
   "productName": "Firezone"
 }

--- a/scripts/build/build-msix-windows.sh
+++ b/scripts/build/build-msix-windows.sh
@@ -8,7 +8,7 @@
 # Requires:
 #
 # - MakeAppx.exe in PATH (or under `WIX_PATH`/`WindowsSdkPath`)
-# - AzureSignTool configured via `scripts/build/sign.sh`'s env vars.
+# - AzureSignTool configured via `scripts/build/sign.ps1`'s env vars.
 
 set -euxo pipefail
 
@@ -16,7 +16,7 @@ set -euxo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SRC_TAURI_DIR="$WORKSPACE_ROOT/rust/gui-client/src-tauri"
-SIGN_SCRIPT="$SCRIPT_DIR/sign.sh"
+SIGN_SCRIPT="$SCRIPT_DIR/sign.ps1"
 TARGET_DIR="$WORKSPACE_ROOT/rust/target/release"
 OUTPUT_MSIX="$TARGET_DIR/firezone.msix"
 MANIFEST="$SRC_TAURI_DIR/win_files/AppxManifest.xml"
@@ -86,8 +86,8 @@ done
     //nv \
     //o
 
-if [ -x "$SIGN_SCRIPT" ]; then
-    "$SIGN_SCRIPT" "$OUTPUT_MSIX"
+if [ -f "$SIGN_SCRIPT" ]; then
+    powershell.exe -NoProfile -File "$SIGN_SCRIPT" "$OUTPUT_MSIX"
 fi
 
 echo "Built $OUTPUT_MSIX"

--- a/scripts/build/sign.ps1
+++ b/scripts/build/sign.ps1
@@ -1,0 +1,30 @@
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command AzureSignTool -ErrorAction SilentlyContinue)) {
+    Write-Output "AzureSignTool not installed. Signing will be skipped."
+    exit 0
+}
+
+foreach ($file in $args) {
+    $ErrorActionPreference = "Continue"
+    $output = & AzureSignTool sign `
+        --azure-key-vault-url $env:AZURE_KEY_VAULT_URI `
+        --azure-key-vault-client-id $env:AZURE_CLIENT_ID `
+        --azure-key-vault-tenant-id $env:AZURE_TENANT_ID `
+        --azure-key-vault-client-secret $env:AZURE_CLIENT_SECRET `
+        --azure-key-vault-certificate $env:AZURE_CERT_NAME `
+        --timestamp-rfc3161 "http://timestamp.digicert.com" `
+        --verbose $file 2>&1
+    $code = $LASTEXITCODE
+    $ErrorActionPreference = "Stop"
+    Write-Output ($output | Out-String)
+    if ($code -ne 0) {
+        throw "AzureSignTool failed for $file (exit code $code)"
+    }
+    $signature = Get-AuthenticodeSignature -FilePath $file
+    if ($signature.Status -ne "Valid") {
+        throw "Authenticode verification failed for ${file}: $($signature.Status) - $($signature.StatusMessage)"
+    }
+}
+
+exit 0

--- a/scripts/build/tauri-pre-bundle-windows.sh
+++ b/scripts/build/tauri-pre-bundle-windows.sh
@@ -13,7 +13,7 @@
 # Sequence:
 #   1. Diagnostic: print cwd + contents of `target/release/` so any
 #      missing-binary case is obvious in the CI log.
-#   2. Sign the three EXEs that ship in the MSI bundle.
+#   2. Sign the side EXEs that ship in the MSI bundle.
 #   3. Build (and sign) the sparse MSIX that WiX picks up.
 set -euxo pipefail
 
@@ -25,8 +25,7 @@ echo "tauri-pre-bundle-windows.sh: PWD=$(pwd)"
 echo "tauri-pre-bundle-windows.sh: TARGET_DIR=$TARGET_DIR"
 ls -la "$TARGET_DIR" 2>&1 | head -n 60 || true
 
-"$SCRIPT_DIR/sign.sh" \
-    "$TARGET_DIR/Firezone.exe" \
+powershell.exe -NoProfile -File "$SCRIPT_DIR/sign.ps1" \
     "$TARGET_DIR/firezone-client-tunnel.exe" \
     "$TARGET_DIR/register-sparse.exe"
 


### PR DESCRIPTION
## Summary

- configure Tauri Windows `signCommand` so the bundler signs the final patched GUI EXE
- use a PowerShell Tauri signing wrapper for Windows-native `D:\...` paths, while keeping the existing Bash signer for MSIX packaging
- run the MSIX builder directly from `beforeBundleCommand` and remove the redundant pre-bundle shim
- remove the redundant post-build MSI signing step because Tauri now signs it through the same hook
- verify `Firezone.exe` Authenticode status before trusting an already-attached sparse package identity
- add Windows signing diagnostics: an early signCommand smoke test using a Windows-style path and a failure log dump for hidden Tauri/AzureSignTool output

## Why

Tauri patches the main Windows binary during bundling by replacing its bundle-type marker with `MSI`. Signing `Firezone.exe` in `beforeBundleCommand` signs the pre-patch bytes, so the later patch invalidates Authenticode and produces `HashMismatch` in diagnostics.

The diagnostic output also showed that sparse package identity can still attach when the outer EXE has `HashMismatch`, so the launch-time guard now verifies the EXE before accepting package identity.

Tauri passes real bundle targets as Windows paths such as `D:\a\...\firezone-client-tunnel.exe`. The PowerShell wrapper avoids MSYS/Git Bash argument conversion issues for those paths and logs the resolved script/target before invoking AzureSignTool.

## Validation

- `jq empty rust/gui-client/src-tauri/tauri.windows.conf.json`
- `bash -n scripts/build/sign.sh scripts/build/build-msix-windows.sh`
- `pwsh -NoProfile -File scripts/build/tauri-sign-windows.ps1 /tmp/firezone-sign-smoke.exe`
- local Node smoke test from `rust/gui-client` invoking the configured `signCommand`
- `git diff --check --cached`
- `cargo check -p firezone-gui-client`