### PR TITLE
chore(gui-client): add AppStream metadata

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/dev.firezone.client.metainfo.xml
+++ b/rust/gui-client/src-tauri/linux_package/dev.firezone.client.metainfo.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>dev.firezone.client</id>
+
+  <name>Firezone</name>
+  <summary>Zero-trust access to your network</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+
+  <developer id="dev.firezone">
+    <name>Firezone, Inc.</name>
+  </developer>
+
+  <launchable type="desktop-id">firezone-client-gui.desktop</launchable>
+
+  <description>
+    <p>
+      Firezone is an open-source, zero-trust access platform built on WireGuard®.
+      This is the GUI client used to securely connect your device to resources
+      protected by your organization's Firezone deployment.
+    </p>
+  </description>
+
+  <categories>
+    <category>Network</category>
+    <category>Security</category>
+  </categories>
+
+  <keywords>
+    <keyword>VPN</keyword>
+    <keyword>WireGuard</keyword>
+    <keyword>zero-trust</keyword>
+  </keywords>
+
+  <url type="homepage">https://www.firezone.dev</url>
+  <url type="bugtracker">https://github.com/firezone/firezone/issues</url>
+  <url type="help">https://www.firezone.dev/kb</url>
+  <url type="vcs-browser">https://github.com/firezone/firezone</url>
+
+  <content_rating type="oars-1.1" />
+</component>

--- a/rust/gui-client/src-tauri/linux_package/dev.firezone.client.metainfo.xml
+++ b/rust/gui-client/src-tauri/linux_package/dev.firezone.client.metainfo.xml
@@ -3,7 +3,7 @@
   <id>dev.firezone.client</id>
 
   <name>Firezone</name>
-  <summary>Zero-trust access to your network</summary>
+  <summary>Zero-trust access to your organization's resources</summary>
 
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>

--- a/rust/gui-client/src-tauri/linux_package/firezone-client-gui.desktop
+++ b/rust/gui-client/src-tauri/linux_package/firezone-client-gui.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Categories=Network;Security;
-Comment=Zero-trust access to your network
+Comment=Zero-trust access to your organization's resources
 Exec={{exec}}
 Icon={{icon}}
 Keywords=VPN;WireGuard;zero-trust;tunnel;

--- a/rust/gui-client/src-tauri/linux_package/firezone-client-gui.desktop
+++ b/rust/gui-client/src-tauri/linux_package/firezone-client-gui.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
-Categories=
-Comment=Firezone
+Categories=Network;Security;
+Comment=Zero-trust access to your network
 Exec={{exec}}
 Icon={{icon}}
+Keywords=VPN;WireGuard;zero-trust;tunnel;
 Name=Firezone
 Terminal=false
 Type=Application

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "files": {
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
-          "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel"
+          "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel",
+          "/usr/share/metainfo/dev.firezone.client.metainfo.xml": "./linux_package/dev.firezone.client.metainfo.xml"
         },
         "desktopTemplate": "./linux_package/firezone-client-gui.desktop"
       },
@@ -26,7 +27,8 @@
         "files": {
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
-          "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel"
+          "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel",
+          "/usr/share/metainfo/dev.firezone.client.metainfo.xml": "./linux_package/dev.firezone.client.metainfo.xml"
         },
         "desktopTemplate": "./linux_package/firezone-client-gui.desktop"
       }


### PR DESCRIPTION
Including AppStream metadata makes the page inside Gnome Software look nicer when people search for it. Unfortunately, it doesn't change the appearance when double-clicking the package on installing.