### PR TITLE
test(bufferpool): isolate metrics test from global meter

### DIFF
--- a/rust/libs/connlib/bufferpool/lib.rs
+++ b/rust/libs/connlib/bufferpool/lib.rs
@@ -7,7 +7,10 @@ use std::{
 
 use bytes::BytesMut;
 use crossbeam_queue::SegQueue;
-use opentelemetry::{KeyValue, metrics::UpDownCounter};
+use opentelemetry::{
+    KeyValue,
+    metrics::{Meter, UpDownCounter},
+};
 
 /// A lock-free pool of buffers that are all equal in size.
 ///
@@ -33,8 +36,19 @@ where
     B: Buf,
 {
     pub fn new(capacity: usize, tag: &'static str) -> Self {
-        let buffer_counter = otel_instruments::buffer_count();
+        Self::with_counter(capacity, tag, otel_instruments::buffer_count())
+    }
 
+    /// Like [`BufferPool::new`], but records the buffer count through the given `meter`.
+    pub fn with_meter(capacity: usize, tag: &'static str, meter: &Meter) -> Self {
+        Self::with_counter(capacity, tag, otel_instruments::buffer_count_with(meter))
+    }
+
+    fn with_counter(
+        capacity: usize,
+        tag: &'static str,
+        buffer_counter: UpDownCounter<i64>,
+    ) -> Self {
         Self {
             inner: Arc::new(SegQueue::new()),
 
@@ -317,7 +331,7 @@ impl<B> DerefMut for BufferStorage<B> {
 mod tests {
     use std::time::Duration;
 
-    use opentelemetry::global;
+    use opentelemetry::metrics::MeterProvider;
     use opentelemetry_sdk::metrics::{
         InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
         data::{AggregatedMetrics, MetricData},
@@ -401,9 +415,10 @@ mod tests {
 
     #[tokio::test]
     async fn buffer_pool_metrics() {
-        let (_provider, exporter) = init_meter_provider();
+        let (provider, exporter) = init_meter_provider();
+        let meter = provider.meter("connlib");
 
-        let pool = BufferPool::<Vec<u8>>::new(1024, "test");
+        let pool = BufferPool::<Vec<u8>>::with_meter(1024, "test", &meter);
 
         let buffer1 = pool.pull_initialised(b"hello world");
         let buffer2 = pool.pull_initialised(b"hello world");
@@ -449,7 +464,6 @@ mod tests {
                     .build(),
             )
             .build();
-        global::set_meter_provider(provider.clone());
 
         (provider, exporter)
     }

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -113,7 +113,12 @@ pub fn queue_length() -> Gauge<u64> {
 
 /// The number of buffers allocated in a buffer pool.
 pub fn buffer_count() -> UpDownCounter<i64> {
-    meter()
+    buffer_count_with(&meter())
+}
+
+/// [`buffer_count`] recorded through the given `meter` rather than the global provider.
+pub fn buffer_count_with(meter: &Meter) -> UpDownCounter<i64> {
+    meter
         .i64_up_down_counter("system.buffer.count")
         .with_description("The number of buffers allocated in the pool.")
         .with_unit("{buffers}")

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -116,7 +116,7 @@ pub fn buffer_count() -> UpDownCounter<i64> {
     buffer_count_with(&meter())
 }
 
-/// [`buffer_count`] recorded through the given `meter` rather than the global provider.
+/// [`buffer_count`] recorded through the given `meter` rather than the global meter.
 pub fn buffer_count_with(meter: &Meter) -> UpDownCounter<i64> {
     meter
         .i64_up_down_counter("system.buffer.count")


### PR DESCRIPTION
`buffer_pool_metrics` asserted on the process-global OpenTelemetry counter. Since `cargo test` runs a binary's tests concurrently in a single process, sibling tests' buffer pools recorded into that same counter under shared attributes, making the observed value non-deterministic and the test flaky.

The test now records into its own meter provider through a new `BufferPool::with_meter` constructor, leaving `new` — and therefore all existing call-sites — on the global meter.