### PR TITLE
ci: upload Linux client deb/rpm to QA storage

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -270,7 +270,7 @@ jobs:
             --account-name firezoneartifacts
 
       - name: Azure login (OIDC) for QA artifacts
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Windows' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_QA_CLIENT_ID }}
@@ -290,6 +290,32 @@ jobs:
             --container-name binaries \
             --name "windows-gui-client/preview/${{ matrix.arch }}" \
             --file "${{ env.BINARY_DEST_PATH }}.msi" \
+            --overwrite true \
+            --no-progress
+
+      - name: Upload preview deb to QA artifacts storage
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          az storage blob upload \
+            --account-name firezoneqaartifacts \
+            --auth-mode login \
+            --container-name binaries \
+            --name "linux-gui-client/preview/${{ matrix.arch }}.deb" \
+            --file "${{ env.BINARY_DEST_PATH }}.deb" \
+            --overwrite true \
+            --no-progress
+
+      - name: Upload preview rpm to QA artifacts storage
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          az storage blob upload \
+            --account-name firezoneqaartifacts \
+            --auth-mode login \
+            --container-name binaries \
+            --name "linux-gui-client/preview/${{ matrix.arch }}.rpm" \
+            --file "${{ env.BINARY_DEST_PATH }}.rpm" \
             --overwrite true \
             --no-progress
 


### PR DESCRIPTION
Upload the Linux client `.deb` and `.rpm` to the QA artifacts storage account as `linux-gui-client/preview/<arch>.deb` and `linux-gui-client/preview/<arch>.rpm` (e.g. `linux-gui-client/preview/x86_64.deb`), mirroring the existing Windows MSI upload at `windows-gui-client/preview/<arch>`, so the upcoming Linux QA VMs can pull preview builds the same way the Windows clients do.

Runs on the existing manual `workflow_dispatch` on `main` and reuses the `AZURE_QA_*` federated identity already used for the Windows upload — its federated credentials need to also trust this workflow on Linux runners.

Related: firezone/infra#707