### PR TITLE
feat(tun): batch Apple TUN I/O via recvmsg_x/sendmsg_x

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -94,6 +94,8 @@ jobs:
           # <https://github.com/rust-lang/cargo/issues/5999>
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
+          # Needed to create utun devices in the Apple TUN integration tests
+          CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER: "sudo --preserve-env"
           # Minimise DWARF debuginfo for the coverage build: source-based
           # coverage data lives in __llvm_covmap, independent of debug info, so
           # lcov.info / Coveralls are unaffected while target/ shrinks ~60%.

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -1,9 +1,6 @@
-use ip_packet::{IpPacket, IpPacketBuf, IpVersion};
-use libc::{AF_INET, AF_INET6, F_GETFL, F_SETFL, O_NONBLOCK, fcntl, iovec, msghdr, recvmsg};
-use std::{
-    io,
-    os::fd::{AsRawFd as _, RawFd},
-};
+use ip_packet::IpPacket;
+use libc::{F_GETFL, F_SETFL, O_NONBLOCK, fcntl};
+use std::{io, os::fd::RawFd};
 use telemetry::otel;
 use tokio::sync::mpsc;
 
@@ -83,11 +80,13 @@ impl Tun {
             ],
         ));
 
+        // `tun::apple` picks batched vs. per-packet I/O internally based on syscall
+        // availability, so we just spawn the send / receive loops here.
         std::thread::Builder::new()
             .name("TUN send".to_owned())
             .spawn(move || {
                 logging::unwrap_or_warn!(
-                    tun::unix::tun_send(fd, outbound_rx, write),
+                    tun::apple::send(fd, outbound_rx),
                     "Failed to send to TUN device: {}"
                 )
             })
@@ -96,7 +95,7 @@ impl Tun {
             .name("TUN recv".to_owned())
             .spawn(move || {
                 logging::unwrap_or_warn!(
-                    tun::unix::tun_recv(fd, inbound_tx, read),
+                    tun::apple::recv(fd, inbound_tx),
                     "Failed to recv from TUN device: {}"
                 )
             })
@@ -138,7 +137,8 @@ fn set_non_blocking(fd: RawFd) -> io::Result<()> {
     }
 }
 
-/// Raises the limit of packets the kernel buffers on the utun socket, allowing it to run ahead of our reads instead of in lock-step.
+/// Raises the limit of packets the kernel buffers on the utun socket so it can run
+/// ahead of our reads instead of in lock-step.
 fn raise_max_pending_packets(fd: RawFd) {
     let current = match get_sockopt::<u32>(fd, libc::SYSPROTO_CONTROL, UTUN_OPT_MAX_PENDING_PACKETS)
     {
@@ -227,75 +227,6 @@ fn get_sockopt<T>(fd: RawFd, level: libc::c_int, name: libc::c_int) -> io::Resul
 
     // Safety: `getsockopt` succeeded; these integer options return a fully-initialized `T`.
     Ok(unsafe { value.assume_init() })
-}
-
-fn read(fd: RawFd, dst: &mut IpPacketBuf) -> io::Result<usize> {
-    let dst = dst.buf();
-
-    let mut hdr = [0u8; 4];
-
-    let mut iov = [
-        iovec {
-            iov_base: hdr.as_mut_ptr() as _,
-            iov_len: hdr.len(),
-        },
-        iovec {
-            iov_base: dst.as_mut_ptr() as _,
-            iov_len: dst.len(),
-        },
-    ];
-
-    let mut msg_hdr = msghdr {
-        msg_name: std::ptr::null_mut(),
-        msg_namelen: 0,
-        msg_iov: &mut iov[0],
-        msg_iovlen: iov.len() as _,
-        msg_control: std::ptr::null_mut(),
-        msg_controllen: 0,
-        msg_flags: 0,
-    };
-
-    // Safety: Within this module, the file descriptor is always valid.
-    match unsafe { recvmsg(fd, &mut msg_hdr, 0) } {
-        -1 => Err(io::Error::last_os_error()),
-        0..=4 => Ok(0),
-        n => Ok((n - 4) as usize),
-    }
-}
-
-fn write(fd: RawFd, src: &IpPacket) -> io::Result<usize> {
-    let af = match src.version() {
-        IpVersion::V4 => AF_INET,
-        IpVersion::V6 => AF_INET6,
-    };
-    let src = src.packet();
-
-    let mut hdr = [0, 0, 0, af];
-    let mut iov = [
-        iovec {
-            iov_base: hdr.as_mut_ptr() as _,
-            iov_len: hdr.len(),
-        },
-        iovec {
-            iov_base: src.as_ptr() as _,
-            iov_len: src.len(),
-        },
-    ];
-
-    let msg_hdr = msghdr {
-        msg_name: std::ptr::null_mut(),
-        msg_namelen: 0,
-        msg_iov: &mut iov[0],
-        msg_iovlen: iov.len() as _,
-        msg_control: std::ptr::null_mut(),
-        msg_controllen: 0,
-        msg_flags: 0,
-    };
-
-    match unsafe { libc::sendmsg(fd.as_raw_fd(), &msg_hdr, 0) } {
-        -1 => Err(io::Error::last_os_error()),
-        n => Ok(n as usize),
-    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -80,8 +80,6 @@ impl Tun {
             ],
         ));
 
-        // `tun::apple` picks batched vs. per-packet I/O internally based on syscall
-        // availability, so we just spawn the send / receive loops here.
         std::thread::Builder::new()
             .name("TUN send".to_owned())
             .spawn(move || {

--- a/rust/libs/connlib/tun/src/apple.rs
+++ b/rust/libs/connlib/tun/src/apple.rs
@@ -1,0 +1,37 @@
+//! Apple-specific TUN I/O on the `utun` file descriptor handed to us by the
+//! NetworkExtension.
+//!
+//! [`send`] / [`recv`] are the entry points the caller spawns on their own threads.
+//! They use Apple's batched `recvmsg_x` / `sendmsg_x` syscalls (see [`sys`] / [`bulk`])
+//! when available and fall back to per-packet I/O ([`per_packet`]) otherwise.
+//!
+//! This lives here (next to [`crate::unix`]) so it can also back a future macOS
+//! `TunDeviceManager` and be exercised by integration tests.
+
+mod bulk;
+mod per_packet;
+mod sys;
+
+#[cfg(test)]
+mod tests;
+
+use anyhow::Result;
+use ip_packet::IpPacket;
+use std::os::fd::RawFd;
+use tokio::sync::mpsc;
+
+/// Sends packets from `outbound_rx` to the TUN `fd` until the channel closes.
+pub fn send(fd: RawFd, outbound_rx: mpsc::Receiver<IpPacket>) -> Result<()> {
+    match sys::batch_syscalls() {
+        Some(syscalls) => bulk::send(fd, syscalls, outbound_rx),
+        None => crate::unix::tun_send(fd, outbound_rx, per_packet::write),
+    }
+}
+
+/// Receives packets from the TUN `fd` into `inbound_tx` until the fd closes.
+pub fn recv(fd: RawFd, inbound_tx: mpsc::Sender<IpPacket>) -> Result<()> {
+    match sys::batch_syscalls() {
+        Some(syscalls) => bulk::recv(fd, syscalls, inbound_tx),
+        None => crate::unix::tun_recv(fd, inbound_tx, per_packet::read),
+    }
+}

--- a/rust/libs/connlib/tun/src/apple/bulk.rs
+++ b/rust/libs/connlib/tun/src/apple/bulk.rs
@@ -1,0 +1,296 @@
+//! Bulk TUN I/O using Apple's `recvmsg_x` / `sendmsg_x` (see [`super::sys`]).
+//!
+//! These mirror [`crate::unix::tun_send`] / [`crate::unix::tun_recv`] but exchange a
+//! whole batch of packets with the `utun` socket per syscall. The read side is the
+//! bigger win: the kernel dequeues the batch under a single lock and only runs its
+//! flow-control hand-off once per batch instead of once per packet.
+
+use anyhow::{Context as _, ErrorExt as _, Result, bail};
+use ip_packet::{IpPacket, IpPacketBuf, IpVersion};
+use libc::{AF_INET, AF_INET6, iovec};
+use opentelemetry::KeyValue;
+use std::ffi::c_void;
+use std::io;
+use std::os::fd::{AsRawFd as _, RawFd};
+use tokio::io::{Interest, unix::AsyncFd};
+use tokio::sync::mpsc;
+
+use super::sys;
+
+/// How many packets we exchange with the kernel per syscall.
+///
+/// Mirrors the rationale of `MAX_INBOUND_PACKET_BATCH` in the `tunnel` crate: mobile
+/// is memory-constrained, so we keep the batch (and the buffers we pull for it) small
+/// there. The desktop value stays below the kernel's `kern.ipc.somaxrecvmsgx` clamp.
+const BATCH_SIZE: usize = if cfg!(target_os = "ios") { 25 } else { 100 };
+
+const EMPTY_IOVEC: iovec = iovec {
+    iov_base: std::ptr::null_mut(),
+    iov_len: 0,
+};
+
+/// Sends batches of packets from `outbound_rx` to the TUN device.
+pub fn send(
+    fd: RawFd,
+    syscalls: &'static sys::BatchSyscalls,
+    mut outbound_rx: mpsc::Receiver<IpPacket>,
+) -> Result<()> {
+    let batch_count = otel_instruments::network_packets_batch_count();
+    let dropped_packets = otel_instruments::network_packet_dropped();
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to create runtime")?
+        .block_on(async move {
+            let fd = AsyncFd::with_interest(fd, Interest::WRITABLE)?;
+            let mut batch = Vec::with_capacity(BATCH_SIZE);
+
+            loop {
+                if outbound_rx.recv_many(&mut batch, BATCH_SIZE).await == 0 {
+                    break; // Channel closed.
+                }
+
+                let mut offset = 0;
+                while offset < batch.len() {
+                    let result = fd
+                        .async_io(Interest::WRITABLE, |fd| {
+                            // Safety: The file descriptor is valid within this module.
+                            unsafe { send_batch(syscalls, fd.as_raw_fd(), &batch[offset..]) }
+                        })
+                        .await;
+
+                    match result {
+                        // A genuine "can't send now" arrives as `Err(WouldBlock)` (the syscall
+                        // returns -1/EWOULDBLOCK), which `async_io` parks on. `Ok(0)` means "sent
+                        // nothing without erroring", which shouldn't happen; break rather than spin
+                        // on `offset += 0`.
+                        Ok(0) => break,
+                        Ok(n) => {
+                            batch_count.record(
+                                n as u64,
+                                &[
+                                    KeyValue::new("system.device", "tun"),
+                                    KeyValue::new("network.io.direction", "transmit"),
+                                ],
+                            );
+                            offset += n;
+                        }
+                        Err(e) => {
+                            // `sendmsg_x` does not report how many datagrams it sent before
+                            // failing, so we cannot resubmit the tail without risking a
+                            // re-injection of an already-sent prefix. Drop the rest of the batch.
+                            let dropped = batch.len() - offset;
+                            dropped_packets.add(dropped as u64, &drop_attributes(&e));
+
+                            if e.raw_os_error() == Some(libc::ENOSPC) {
+                                // The TUN queue is full; like any congested device, dropping is by design.
+                                tracing::debug!(dropped, "TUN queue full while writing: {e}");
+                            } else {
+                                tracing::warn!(dropped, "Failed to write to TUN FD: {e}");
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
+                batch.clear();
+            }
+
+            anyhow::Ok(())
+        })?;
+
+    anyhow::Ok(())
+}
+
+/// Receives batches of packets from the TUN device into `inbound_tx`.
+pub fn recv(
+    fd: RawFd,
+    syscalls: &'static sys::BatchSyscalls,
+    inbound_tx: mpsc::Sender<IpPacket>,
+) -> Result<()> {
+    let batch_count = otel_instruments::network_packets_batch_count();
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to create runtime")?
+        .block_on(async move {
+            let fd = AsyncFd::with_interest(fd, Interest::READABLE)?;
+
+            loop {
+                let mut bufs: Vec<IpPacketBuf> =
+                    (0..BATCH_SIZE).map(|_| IpPacketBuf::new()).collect();
+                let mut lens = [0usize; BATCH_SIZE];
+
+                let n = fd
+                    .async_io(Interest::READABLE, |fd| {
+                        // Safety: The file descriptor is valid within this module.
+                        unsafe { recv_batch(syscalls, fd.as_raw_fd(), &mut bufs, &mut lens) }
+                    })
+                    .await
+                    .context("Failed to read from TUN FD")?;
+
+                // `recvmsg_x` reports "nothing to read" as `-1`/`EWOULDBLOCK` (which `async_io`
+                // parks on); `0` datagrams means EOF — the fd has been closed.
+                if n == 0 {
+                    bail!("TUN file descriptor is closed");
+                }
+
+                batch_count.record(
+                    n as u64,
+                    &[
+                        KeyValue::new("system.device", "tun"),
+                        KeyValue::new("network.io.direction", "receive"),
+                    ],
+                );
+
+                let Ok(mut permits) = inbound_tx.reserve_many(n).await else {
+                    tracing::debug!("Inbound packet receiver gone, shutting down task");
+                    break;
+                };
+
+                for (buf, len) in bufs.into_iter().zip(lens).take(n) {
+                    if len == 0 {
+                        continue; // Empty or truncated datagram.
+                    }
+
+                    match IpPacket::new(buf, len).context("Failed to parse IP packet") {
+                        Ok(packet) => {
+                            #[cfg(debug_assertions)]
+                            tracing::trace!(target: "wire::dev::recv", ?packet);
+
+                            // We reserved `n` permits and send at most `n`, so this is always `Some`.
+                            let Some(permit) = permits.next() else { break };
+                            permit.send(packet);
+                        }
+                        Err(e) if e.any_is::<ip_packet::Fragmented>() => tracing::debug!("{e:#}"),
+                        Err(e) => tracing::warn!("{e:#}"),
+                    }
+                }
+            }
+
+            anyhow::Ok(())
+        })?;
+
+    anyhow::Ok(())
+}
+
+/// Writes `batch` to `fd` in one `sendmsg_x`, returning the number of packets sent.
+///
+/// # Safety
+///
+/// `fd` must be a valid, open `utun` file descriptor.
+unsafe fn send_batch(
+    syscalls: &sys::BatchSyscalls,
+    fd: RawFd,
+    batch: &[IpPacket],
+) -> io::Result<usize> {
+    let count = batch.len().min(BATCH_SIZE);
+
+    // The first 4 bytes of each datagram carry the address family in network byte order.
+    let mut afs = [[0u8; 4]; BATCH_SIZE];
+    let mut iovs = [[EMPTY_IOVEC; 2]; BATCH_SIZE];
+    let mut msgs = [sys::msghdr_x::ZEROED; BATCH_SIZE];
+
+    for i in 0..count {
+        #[cfg(debug_assertions)]
+        tracing::trace!(target: "wire::dev::send", packet = ?batch[i]);
+
+        let af = match batch[i].version() {
+            IpVersion::V4 => AF_INET,
+            IpVersion::V6 => AF_INET6,
+        };
+        afs[i] = (af as u32).to_be_bytes();
+
+        let payload = batch[i].packet();
+        iovs[i] = [
+            iovec {
+                iov_base: afs[i].as_ptr() as *mut c_void,
+                iov_len: afs[i].len(),
+            },
+            iovec {
+                iov_base: payload.as_ptr() as *mut c_void,
+                iov_len: payload.len(),
+            },
+        ];
+        msgs[i] = sys::msghdr_x {
+            msg_iov: iovs[i].as_mut_ptr(),
+            msg_iovlen: 2,
+            ..sys::msghdr_x::ZEROED
+        };
+    }
+
+    // Safety: `msgs[..count]` point at `iovs` / `afs` / packet payloads, all of which
+    // outlive this call.
+    unsafe { syscalls.sendmsg_x(fd, &msgs[..count]) }
+}
+
+/// Reads up to `bufs.len()` packets from `fd` in one `recvmsg_x`.
+///
+/// Writes each packet's length (with the 4-byte address-family header stripped) into
+/// `lens` and returns the number of packets read. A length of `0` marks a slot that
+/// should be skipped.
+///
+/// # Safety
+///
+/// `fd` must be a valid, open `utun` file descriptor.
+unsafe fn recv_batch(
+    syscalls: &sys::BatchSyscalls,
+    fd: RawFd,
+    bufs: &mut [IpPacketBuf],
+    lens: &mut [usize],
+) -> io::Result<usize> {
+    let count = bufs.len().min(BATCH_SIZE);
+
+    let mut afs = [[0u8; 4]; BATCH_SIZE];
+    let mut iovs = [[EMPTY_IOVEC; 2]; BATCH_SIZE];
+    let mut msgs = [sys::msghdr_x::ZEROED; BATCH_SIZE];
+
+    for i in 0..count {
+        let dst = bufs[i].buf();
+        iovs[i] = [
+            iovec {
+                iov_base: afs[i].as_mut_ptr() as *mut c_void,
+                iov_len: afs[i].len(),
+            },
+            iovec {
+                iov_base: dst.as_mut_ptr() as *mut c_void,
+                iov_len: dst.len(),
+            },
+        ];
+        msgs[i] = sys::msghdr_x {
+            msg_iov: iovs[i].as_mut_ptr(),
+            msg_iovlen: 2,
+            ..sys::msghdr_x::ZEROED
+        };
+    }
+
+    // Safety: `msgs[..count]` point at `iovs` / `afs` / the buffers in `bufs`, all of
+    // which outlive this call.
+    let n = unsafe { syscalls.recvmsg_x(fd, &mut msgs[..count])? };
+
+    for i in 0..n {
+        // A truncated datagram cannot happen at our MTU (each buffer holds 4 + `MAX_IP_SIZE`
+        // bytes), but guard against it anyway by skipping the slot.
+        lens[i] = if msgs[i].msg_flags & libc::MSG_TRUNC != 0 {
+            0
+        } else {
+            // `msg_datalen` includes the 4-byte address-family header.
+            msgs[i].msg_datalen.saturating_sub(4)
+        };
+    }
+
+    Ok(n)
+}
+
+/// Attributes for a dropped packet, mirroring `tun::unix`'s so the metric is uniform
+/// across platforms.
+fn drop_attributes(e: &io::Error) -> [opentelemetry::KeyValue; 3] {
+    [
+        KeyValue::new("system.device", "tun"),
+        KeyValue::new("network.io.direction", "transmit"),
+        KeyValue::new("error.code", e.raw_os_error().unwrap_or_default() as i64),
+    ]
+}

--- a/rust/libs/connlib/tun/src/apple/per_packet.rs
+++ b/rust/libs/connlib/tun/src/apple/per_packet.rs
@@ -1,0 +1,81 @@
+//! Per-packet fallback I/O for the `utun` socket.
+//!
+//! Used when Apple's batched syscalls (`recvmsg_x` / `sendmsg_x`, see [`super::sys`])
+//! are unavailable. Each datagram on the `utun` socket is prefixed with a 4-byte
+//! address-family header; these plug into [`crate::unix::tun_send`] /
+//! [`crate::unix::tun_recv`] as the per-packet `read` / `write` closures.
+
+use ip_packet::{IpPacket, IpPacketBuf, IpVersion};
+use libc::{AF_INET, AF_INET6, iovec, msghdr, recvmsg, sendmsg};
+use std::io;
+use std::os::fd::RawFd;
+
+pub fn read(fd: RawFd, dst: &mut IpPacketBuf) -> io::Result<usize> {
+    let dst = dst.buf();
+
+    let mut hdr = [0u8; 4];
+
+    let mut iov = [
+        iovec {
+            iov_base: hdr.as_mut_ptr() as _,
+            iov_len: hdr.len(),
+        },
+        iovec {
+            iov_base: dst.as_mut_ptr() as _,
+            iov_len: dst.len(),
+        },
+    ];
+
+    let mut msg_hdr = msghdr {
+        msg_name: std::ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: &mut iov[0],
+        msg_iovlen: iov.len() as _,
+        msg_control: std::ptr::null_mut(),
+        msg_controllen: 0,
+        msg_flags: 0,
+    };
+
+    // Safety: Within this module, the file descriptor is always valid.
+    match unsafe { recvmsg(fd, &mut msg_hdr, 0) } {
+        -1 => Err(io::Error::last_os_error()),
+        0..=4 => Ok(0),
+        n => Ok((n - 4) as usize),
+    }
+}
+
+pub fn write(fd: RawFd, src: &IpPacket) -> io::Result<usize> {
+    let af = match src.version() {
+        IpVersion::V4 => AF_INET,
+        IpVersion::V6 => AF_INET6,
+    };
+    let src = src.packet();
+
+    let mut hdr = [0, 0, 0, af];
+    let mut iov = [
+        iovec {
+            iov_base: hdr.as_mut_ptr() as _,
+            iov_len: hdr.len(),
+        },
+        iovec {
+            iov_base: src.as_ptr() as _,
+            iov_len: src.len(),
+        },
+    ];
+
+    let msg_hdr = msghdr {
+        msg_name: std::ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: &mut iov[0],
+        msg_iovlen: iov.len() as _,
+        msg_control: std::ptr::null_mut(),
+        msg_controllen: 0,
+        msg_flags: 0,
+    };
+
+    // Safety: Within this module, the file descriptor is always valid.
+    match unsafe { sendmsg(fd, &msg_hdr, 0) } {
+        -1 => Err(io::Error::last_os_error()),
+        n => Ok(n as usize),
+    }
+}

--- a/rust/libs/connlib/tun/src/apple/per_packet.rs
+++ b/rust/libs/connlib/tun/src/apple/per_packet.rs
@@ -51,10 +51,13 @@ pub fn write(fd: RawFd, src: &IpPacket) -> io::Result<usize> {
     };
     let src = src.packet();
 
-    let mut hdr = [0, 0, 0, af];
+    // The legacy (non-netif) utun path reads the address family straight from
+    // this 4-byte header, so it must be the family in network byte order. (A
+    // plain `[0, 0, 0, af]` infers to `[i32; 4]` and sends only zeros.)
+    let hdr = (af as u32).to_be_bytes();
     let mut iov = [
         iovec {
-            iov_base: hdr.as_mut_ptr() as _,
+            iov_base: hdr.as_ptr() as _,
             iov_len: hdr.len(),
         },
         iovec {

--- a/rust/libs/connlib/tun/src/apple/sys.rs
+++ b/rust/libs/connlib/tun/src/apple/sys.rs
@@ -1,0 +1,144 @@
+//! Bindings for Apple's private, batched socket syscalls `recvmsg_x` / `sendmsg_x`.
+//!
+//! These let us exchange multiple datagrams with the `utun` control socket in a
+//! single syscall instead of one `recvmsg`/`sendmsg` per packet. They are not part
+//! of the public SDK, so we resolve them at runtime via `dlsym` rather than link
+//! against them. On all OS versions we support (macOS 13+, iOS 16+) they are
+//! present, so resolution is expected to succeed; the `Option` return lets the
+//! caller fall back to the per-packet path if it ever does not.
+
+use std::ffi::{c_int, c_uint, c_void};
+use std::io;
+use std::os::fd::RawFd;
+use std::sync::OnceLock;
+
+/// Mirror of `struct msghdr_x` from XNU's `bsd/sys/socket_private.h`.
+///
+/// The layout matches the C definition on LP64 (the only ABI we build for on Apple).
+/// Most fields are written by us and only ever read by the kernel through the
+/// pointer we pass, so `dead_code` would flag them.
+#[repr(C)]
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub struct msghdr_x {
+    /// Optional address; must be null for `sendmsg_x`.
+    pub msg_name: *mut c_void,
+    /// Size of the address.
+    pub msg_namelen: libc::socklen_t,
+    /// Scatter/gather array.
+    pub msg_iov: *mut libc::iovec,
+    /// Number of elements in `msg_iov`.
+    pub msg_iovlen: c_int,
+    /// Ancillary data; must be null for `sendmsg_x`.
+    pub msg_control: *mut c_void,
+    /// Ancillary data buffer length.
+    pub msg_controllen: libc::socklen_t,
+    /// Flags on the received message; must be zero on input.
+    pub msg_flags: c_int,
+    /// Byte length of the datagram; must be zero on input, set on output by `recvmsg_x`.
+    pub msg_datalen: usize,
+}
+
+impl msghdr_x {
+    pub const ZEROED: Self = msghdr_x {
+        msg_name: std::ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: std::ptr::null_mut(),
+        msg_iovlen: 0,
+        msg_control: std::ptr::null_mut(),
+        msg_controllen: 0,
+        msg_flags: 0,
+        msg_datalen: 0,
+    };
+}
+
+// `socket_private.h`: `ssize_t recvmsg_x(int, const struct msghdr_x *, u_int, int)`
+// and `ssize_t sendmsg_x(int, const struct msghdr_x *, u_int, int)`. `recvmsg_x`
+// writes the per-message out-fields (`msg_datalen`, `msg_flags`), hence `*mut`.
+type RecvmsgX = unsafe extern "C" fn(RawFd, *mut msghdr_x, c_uint, c_int) -> isize;
+type SendmsgX = unsafe extern "C" fn(RawFd, *const msghdr_x, c_uint, c_int) -> isize;
+
+/// The resolved batched syscalls.
+///
+/// Both fields are plain function pointers into `libsystem`, so this is `Send + Sync`.
+pub struct BatchSyscalls {
+    recvmsg_x: RecvmsgX,
+    sendmsg_x: SendmsgX,
+}
+
+/// Resolves `recvmsg_x` / `sendmsg_x` once, returning `None` if either is unavailable.
+///
+/// Memoised, so the path-selection log below fires exactly once regardless of how many
+/// times the send / receive threads call this.
+pub fn batch_syscalls() -> Option<&'static BatchSyscalls> {
+    static SYSCALLS: OnceLock<Option<BatchSyscalls>> = OnceLock::new();
+
+    SYSCALLS
+        .get_or_init(|| {
+            // Safety: `RTLD_DEFAULT` is a valid handle and the names are valid C strings.
+            let recvmsg_x = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"recvmsg_x".as_ptr()) };
+            let sendmsg_x = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"sendmsg_x".as_ptr()) };
+
+            if recvmsg_x.is_null() || sendmsg_x.is_null() {
+                tracing::info!("Batched TUN I/O unavailable; using per-packet I/O");
+                return None;
+            }
+
+            tracing::info!("Using batched TUN I/O (recvmsg_x/sendmsg_x)");
+
+            Some(BatchSyscalls {
+                // Safety: The symbols resolve to functions with the ABI declared above.
+                recvmsg_x: unsafe { std::mem::transmute::<*mut c_void, RecvmsgX>(recvmsg_x) },
+                sendmsg_x: unsafe { std::mem::transmute::<*mut c_void, SendmsgX>(sendmsg_x) },
+            })
+        })
+        .as_ref()
+}
+
+impl BatchSyscalls {
+    /// Receives up to `msgs.len()` datagrams, returning how many were received.
+    ///
+    /// # Safety
+    ///
+    /// `fd` must be valid and each `msghdr_x` must point to valid `iovec`s / buffers
+    /// that live for the duration of the call.
+    pub unsafe fn recvmsg_x(&self, fd: RawFd, msgs: &mut [msghdr_x]) -> io::Result<usize> {
+        let n = unsafe { (self.recvmsg_x)(fd, msgs.as_mut_ptr(), msgs.len() as c_uint, 0) };
+
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(n as usize)
+    }
+
+    /// Sends up to `msgs.len()` datagrams, returning how many were sent.
+    ///
+    /// # Safety
+    ///
+    /// `fd` must be valid and each `msghdr_x` must point to valid `iovec`s / buffers
+    /// that live for the duration of the call.
+    pub unsafe fn sendmsg_x(&self, fd: RawFd, msgs: &[msghdr_x]) -> io::Result<usize> {
+        let n = unsafe { (self.sendmsg_x)(fd, msgs.as_ptr(), msgs.len() as c_uint, 0) };
+
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(n as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locks in the `msghdr_x` layout against the C definition (LP64).
+    #[test]
+    fn msghdr_x_layout() {
+        assert_eq!(size_of::<msghdr_x>(), 56);
+        assert_eq!(std::mem::offset_of!(msghdr_x, msg_iov), 16);
+        assert_eq!(std::mem::offset_of!(msghdr_x, msg_flags), 44);
+        assert_eq!(std::mem::offset_of!(msghdr_x, msg_datalen), 48);
+    }
+}

--- a/rust/libs/connlib/tun/src/apple/tests.rs
+++ b/rust/libs/connlib/tun/src/apple/tests.rs
@@ -1,0 +1,175 @@
+//! Integration tests for the batched TUN I/O against a real `utun` device.
+//!
+//! Creating a `utun` requires root, so these are `#[ignore]`d and run under `sudo`
+//! in CI (the `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER` in `_rust.yml`).
+
+use std::ffi::c_void;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+use std::os::fd::RawFd;
+use std::time::{Duration, Instant};
+
+use ip_packet::IpPacket;
+
+/// From XNU's `bsd/net/if_utun.h`.
+const UTUN_OPT_MAX_PENDING_PACKETS: libc::c_int = 16;
+
+const LOCAL: Ipv4Addr = Ipv4Addr::new(169, 254, 33, 1);
+const PEER: Ipv4Addr = Ipv4Addr::new(169, 254, 33, 2);
+
+/// Datagrams sent to [`PEER`] route out the utun and must come back through `recv`.
+#[test]
+#[ignore = "Needs root to create a utun device"]
+fn recv_reads_packets_routed_through_the_interface() {
+    let syscalls = super::sys::batch_syscalls().expect("recvmsg_x/sendmsg_x to resolve on macOS");
+
+    let (fd, name) = create_utun();
+    set_nonblocking(fd);
+    raise_max_pending_packets(fd, 64);
+    configure(&name);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<IpPacket>(1024);
+    std::thread::Builder::new()
+        .name("test TUN recv".to_owned())
+        .spawn(move || {
+            let _ = super::bulk::recv(fd, syscalls, tx);
+        })
+        .expect("spawn recv thread");
+
+    // The kernel routes datagrams addressed to the point-to-point peer out the utun,
+    // where they queue (we raised the pending limit) for `recv` to read as a batch.
+    const COUNT: usize = 8;
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).expect("bind UDP socket");
+    for i in 0..COUNT {
+        socket
+            .send_to(&[i as u8; 64], (PEER, 9999))
+            .expect("send datagram");
+    }
+
+    // Count only our datagrams; a freshly-created interface also emits other traffic
+    // (e.g. IPv6 link-local setup) that we must ignore.
+    let mut matched = 0;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while matched < COUNT && Instant::now() < deadline {
+        match rx.try_recv() {
+            Ok(packet) => {
+                if packet.destination() == IpAddr::V4(PEER) && packet.as_udp().is_some() {
+                    matched += 1;
+                }
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    assert_eq!(
+        matched, COUNT,
+        "expected to read back every datagram routed through the utun"
+    );
+}
+
+/// Creates a `utun` interface and returns its fd and name (e.g. `utun7`). Requires root.
+fn create_utun() -> (RawFd, String) {
+    const CTL_NAME: &[u8] = b"com.apple.net.utun_control";
+
+    // Safety: a standard `SYSPROTO_CONTROL` utun creation; all pointers are valid and
+    // sized, and we assert on every syscall's result.
+    unsafe {
+        let fd = libc::socket(libc::PF_SYSTEM, libc::SOCK_DGRAM, libc::SYSPROTO_CONTROL);
+        assert!(fd >= 0, "socket(PF_SYSTEM): {}", io::Error::last_os_error());
+
+        let mut info = libc::ctl_info {
+            ctl_id: 0,
+            ctl_name: [0; 96],
+        };
+        for (dst, &src) in info.ctl_name.iter_mut().zip(CTL_NAME) {
+            *dst = src as libc::c_char;
+        }
+        assert_eq!(
+            libc::ioctl(fd, libc::CTLIOCGINFO, &mut info),
+            0,
+            "CTLIOCGINFO: {}",
+            io::Error::last_os_error()
+        );
+
+        let addr = libc::sockaddr_ctl {
+            sc_len: size_of::<libc::sockaddr_ctl>() as u8,
+            sc_family: libc::AF_SYSTEM as u8,
+            ss_sysaddr: libc::AF_SYS_CONTROL as u16,
+            sc_id: info.ctl_id,
+            sc_unit: 0, // 0 => the kernel picks the next free utun unit
+            sc_reserved: [0; 5],
+        };
+        assert_eq!(
+            libc::connect(
+                fd,
+                &addr as *const libc::sockaddr_ctl as *const libc::sockaddr,
+                size_of::<libc::sockaddr_ctl>() as libc::socklen_t,
+            ),
+            0,
+            "connect(utun_control): {}",
+            io::Error::last_os_error()
+        );
+
+        let mut name = [0u8; libc::IF_NAMESIZE];
+        let mut len = name.len() as libc::socklen_t;
+        assert_eq!(
+            libc::getsockopt(
+                fd,
+                libc::SYSPROTO_CONTROL,
+                libc::UTUN_OPT_IFNAME,
+                name.as_mut_ptr() as *mut c_void,
+                &mut len,
+            ),
+            0,
+            "getsockopt(UTUN_OPT_IFNAME): {}",
+            io::Error::last_os_error()
+        );
+        let name = String::from_utf8_lossy(&name[..len as usize - 1]).into_owned();
+
+        (fd, name)
+    }
+}
+
+fn set_nonblocking(fd: RawFd) {
+    // Safety: `fd` is a valid, open socket.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        assert_eq!(
+            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK),
+            0,
+            "fcntl(O_NONBLOCK): {}",
+            io::Error::last_os_error()
+        );
+    }
+}
+
+fn raise_max_pending_packets(fd: RawFd, packets: u32) {
+    // Safety: `fd` is valid; the option's value is a `u32`.
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SYSPROTO_CONTROL,
+            UTUN_OPT_MAX_PENDING_PACKETS,
+            &packets as *const u32 as *const c_void,
+            size_of::<u32>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(
+        ret,
+        0,
+        "setsockopt(UTUN_OPT_MAX_PENDING_PACKETS): {}",
+        io::Error::last_os_error()
+    );
+}
+
+/// Brings the interface up with a point-to-point address so traffic to [`PEER`] routes out it.
+fn configure(name: &str) {
+    let status = std::process::Command::new("ifconfig")
+        .args([name, &LOCAL.to_string(), &PEER.to_string(), "up"])
+        .status()
+        .expect("run ifconfig");
+    assert!(status.success(), "`ifconfig {name}` failed");
+}

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -5,6 +5,9 @@ pub mod ioctl;
 #[cfg(target_family = "unix")]
 pub mod unix;
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub mod apple;
+
 pub trait Tun: Send + Sync + 'static {
     /// Get a reference to the sender for outbound packets.
     fn sender(&self) -> &tokio::sync::mpsc::Sender<IpPacket>;


### PR DESCRIPTION
On macOS and iOS we exchanged packets with the `utun` device one syscall per packet. This adds batched `recvmsg_x` / `sendmsg_x` I/O in the `tun` crate (`tun::apple`) — moving a whole batch of datagrams per syscall — and uses it from the NetworkExtension client, falling back to the per-packet path when the private syscalls are unavailable.

The read path is where it matters: rather than a syscall plus a kernel flow-control round-trip per packet, the kernel dequeues a batch under a single socket lock and runs that hand-off once per batch. It builds on the larger receive buffer and pending-packet limit from #13667. Writes are batched too, though there the only saving is the syscall count, since the kernel still injects each packet individually.

A batched write cannot retry the kernel's `ENOSPC` back-pressure — `sendmsg_x` does not report how many datagrams it already sent, so a retry could re-inject an already-sent prefix — so it drops the rest of the batch instead. The per-packet path keeps the retry from #13666.

Related: #13666
Related: #13667