### PR TITLE
perf(client-ffi): raise utun socket receive buffer

### DIFF
--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -9,6 +9,18 @@ use tokio::sync::mpsc;
 
 const QUEUE_SIZE: usize = 10_000;
 
+/// Receive buffer we request for the utun control socket via `SO_RCVBUF`.
+///
+/// The kernel default (`ctl_recvsize`) is 512 KiB, only a few hundred MTU-sized
+/// packets, after which inbound packets are dropped. A larger buffer lets the kernel
+/// queue more while we drain it. 8 MiB matches the default `kern.ipc.maxsockbuf`
+/// ceiling — the most the kernel grants without raising that system-wide limit.
+const RECV_BUFFER_SIZE: libc::c_int = if cfg!(target_os = "ios") {
+    2 * 1024 * 1024
+} else {
+    8 * 1024 * 1024
+};
+
 pub struct Tun {
     name: String,
     outbound_tx: mpsc::Sender<IpPacket>,
@@ -36,6 +48,8 @@ impl Tun {
 
     fn from_fd_inner(fd: RawFd, runtime: &tokio::runtime::Handle) -> io::Result<Self> {
         let name = name(fd)?;
+
+        raise_recv_buffer(fd);
 
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
@@ -108,6 +122,48 @@ fn set_non_blocking(fd: RawFd) -> io::Result<()> {
             _ => Ok(()),
         },
     }
+}
+
+/// Raises the utun socket's receive buffer so the kernel can queue more inbound
+/// packets between our reads.
+fn raise_recv_buffer(fd: RawFd) {
+    // Safety: Within this module, the file descriptor is always valid.
+    if unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            &RECV_BUFFER_SIZE as *const libc::c_int as _,
+            size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    } < 0
+    {
+        tracing::warn!(error = %get_last_error(), "Failed to set TUN socket receive buffer");
+        return;
+    }
+
+    // The kernel clamps to `kern.ipc.maxsockbuf`; read back what it actually applied.
+    let mut actual: libc::c_int = 0;
+    let mut len = size_of::<libc::c_int>() as libc::socklen_t;
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            &mut actual as *mut libc::c_int as _,
+            &mut len,
+        )
+    } < 0
+    {
+        tracing::warn!(error = %get_last_error(), "Failed to read back TUN socket receive buffer");
+        return;
+    }
+
+    tracing::debug!(
+        requested = RECV_BUFFER_SIZE,
+        actual,
+        "Set TUN socket receive buffer"
+    );
 }
 
 fn read(fd: RawFd, dst: &mut IpPacketBuf) -> io::Result<usize> {


### PR DESCRIPTION
The utun control socket's receive buffer defaults to 512 KiB (the kctl `ctl_recvsize`) — only a few hundred MTU-sized inbound packets before the kernel starts dropping them. Raise it via `SO_RCVBUF` to 2 MiB on iOS and 8 MiB on macOS so the kernel can queue more while we drain it.

8 MiB is the default `kern.ipc.maxsockbuf` ceiling; the kernel clamps anything larger, so the applied value is logged on DEBUG.

Related: #13667

---
_Generated by [Claude Code](https://claude.ai/code/session_01NemEzmch2ChceA7rcQcNZE)_