### PR TITLE
refactor(connlib): namespace metrics under connlib.*

### DIFF
--- a/rust/client-ffi/src/platform/android/tun.rs
+++ b/rust/client-ffi/src/platform/android/tun.rs
@@ -41,14 +41,14 @@ impl Tun {
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
 
-        runtime.spawn(otel_instruments::periodic_system_queue_length(
+        runtime.spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
-        runtime.spawn(otel_instruments::periodic_system_queue_length(
+        runtime.spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -40,14 +40,14 @@ impl Tun {
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
 
-        runtime.spawn(otel_instruments::periodic_system_queue_length(
+        runtime.spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
-        runtime.spawn(otel_instruments::periodic_system_queue_length(
+        runtime.spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -691,14 +691,14 @@ impl Tun {
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
 
-        tokio::spawn(otel_instruments::periodic_system_queue_length(
+        tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
-        tokio::spawn(otel_instruments::periodic_system_queue_length(
+        tokio::spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -306,14 +306,14 @@ impl Tun {
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE); // We want to be able to batch-receive from this.
 
-        tokio::spawn(otel_instruments::periodic_system_queue_length(
+        tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
-        tokio::spawn(otel_instruments::periodic_system_queue_length(
+        tokio::spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -19,6 +19,7 @@ pub fn network_packets() -> Counter<u64> {
     meter()
         .u64_counter("connlib.network.packets")
         .with_description("The number of packets processed.")
+        .with_unit("{packet}")
         .build()
 }
 
@@ -148,7 +149,7 @@ pub fn eventloop_poll_duration() -> Histogram<f64> {
 }
 
 /// Periodically records the length of a queue to the [`queue_length`] gauge until the queue is gone.
-pub async fn periodic_system_queue_length<const N: usize>(
+pub async fn periodic_queue_length<const N: usize>(
     queue: impl QueueLength,
     attributes: [KeyValue; N],
 ) {

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -17,7 +17,7 @@ fn meter() -> Meter {
 /// How many packets we have processed.
 pub fn network_packets() -> Counter<u64> {
     meter()
-        .u64_counter("system.network.packets")
+        .u64_counter("connlib.network.packets")
         .with_description("The number of packets processed.")
         .build()
 }
@@ -25,7 +25,7 @@ pub fn network_packets() -> Counter<u64> {
 /// How many packets were dropped or discarded.
 pub fn network_packet_dropped() -> Counter<u64> {
     meter()
-        .u64_counter("network.packet.dropped")
+        .u64_counter("connlib.network.dropped")
         .with_description("Count of packets that are dropped or discarded")
         .with_unit("{packet}")
         .build()
@@ -34,7 +34,7 @@ pub fn network_packet_dropped() -> Counter<u64> {
 /// How many IO errors we have encountered.
 pub fn network_errors() -> Counter<u64> {
     meter()
-        .u64_counter("system.network.errors")
+        .u64_counter("connlib.network.errors")
         .with_description("Number of IO errors encountered")
         .with_unit("{error}")
         .build()
@@ -45,7 +45,7 @@ pub fn network_errors() -> Counter<u64> {
 /// Shared across IO paths (UDP sockets, the TUN device); distinguish them via attributes.
 pub fn network_retries() -> Histogram<u64> {
     meter()
-        .u64_histogram("system.network.retries")
+        .u64_histogram("connlib.network.retries")
         .with_description(
             "How many times a network write was retried (spun) after a transient queue-full error before it succeeded or was dropped.",
         )
@@ -57,7 +57,7 @@ pub fn network_retries() -> Histogram<u64> {
 /// How many batches of packets we have processed in a single syscall.
 pub fn network_packets_batch_count() -> Histogram<u64> {
     meter()
-        .u64_histogram("system.network.packets.batch_count")
+        .u64_histogram("connlib.network.packets.batch_count")
         .with_description("How many batches of packets we have processed in a single syscall.")
         .with_unit("{batches}")
         .with_boundaries((1..32_u64).map(|i| i as f64).collect())
@@ -106,7 +106,7 @@ pub fn dns_lookup_duration() -> Histogram<f64> {
 /// The length of a queue.
 pub fn queue_length() -> Gauge<u64> {
     meter()
-        .u64_gauge("system.queue.length")
+        .u64_gauge("connlib.queue.length")
         .with_description("The length of a queue.")
         .build()
 }
@@ -119,7 +119,7 @@ pub fn buffer_count() -> UpDownCounter<i64> {
 /// [`buffer_count`] recorded through the given `meter` rather than the global meter.
 pub fn buffer_count_with(meter: &Meter) -> UpDownCounter<i64> {
     meter
-        .i64_up_down_counter("system.buffer.count")
+        .i64_up_down_counter("connlib.buffer.count")
         .with_description("The number of buffers allocated in the pool.")
         .with_unit("{buffers}")
         .build()

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -189,14 +189,14 @@ impl ThreadedUdpSocket {
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (error_tx, error_rx) = std::sync::mpsc::sync_channel(0);
 
-        tokio::spawn(otel_instruments::periodic_system_queue_length(
+        tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
                 otel::attr::queue_item_gso_batch(),
                 otel::attr::network_type_for_addr(preferred_addr),
             ],
         ));
-        tokio::spawn(otel_instruments::periodic_system_queue_length(
+        tokio::spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
                 otel::attr::queue_item_gro_batch(),


### PR DESCRIPTION
connlib's OpenTelemetry instruments lived under the `system.*` namespace, which OpenTelemetry semantic conventions reserve for metrics reported by the operating system. They actually measure connlib's own packet processing, so this moves them under a `connlib.*` namespace.

Beyond fixing the semantic mismatch, it frees the `system.network.*` names so a follow-up can report genuine OS-level, per-interface counters under them.