### PR TITLE
fix(windows): sign Firezone.exe after Tauri patches it

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -155,19 +155,11 @@ jobs:
       - name: Build release exe and MSI / deb
         env:
           CARGO_PROFILE_RELEASE_LTO: thin # Fat LTO is getting too slow / RAM-hungry on Tauri builds
-        # Signs the exe before bundling it into the MSI
+        # `tauri build` signs Firezone.exe (after Tauri patches it) and the
+        # MSI via `bundle.windows.signCommand`.
         run: pnpm build
       - name: Ensure unmodified Git workspace
         run: git diff --exit-code
-      # We need to sign the exe inside the MSI. Currently
-      # we do this in a "beforeBundleCommand" hook in tauri.windows.conf.json.
-      # But this will soon be natively supported in Tauri.
-      # TODO: Use Tauri's native MSI signing with support for EV certs
-      # See https://github.com/tauri-apps/tauri/pull/8718
-      - name: Sign the MSI
-        if: ${{ runner.os == 'Windows' }}
-        shell: bash
-        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,11 @@ jobs:
           if grep -q '^rust/tests/gui-smoke-test/' changed_files.txt; then
             jobs="${jobs},tauri"
           fi
+          # The install canary (scripts/tests/gui-client-install-*) runs inside
+          # the tauri build, so re-run that build when the canary changes.
+          if grep -q '^scripts/tests/gui-client-install' changed_files.txt; then
+            jobs="${jobs},tauri"
+          fi
           if grep -q '^elixir/' changed_files.txt; then
             jobs="${jobs},elixir,codeql,control-plane,data-plane"
           fi

--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -2,6 +2,14 @@
   "build": {
     "beforeBundleCommand": "bash ../../scripts/build/tauri-pre-bundle-windows.sh"
   },
+  "bundle": {
+    "windows": {
+      "signCommand": {
+        "cmd": "C:\\Program Files\\Git\\bin\\bash.exe",
+        "args": ["../../../scripts/build/sign.sh", "%1"]
+      }
+    }
+  },
   "mainBinaryName": "Firezone",
   "productName": "Firezone"
 }

--- a/scripts/build/tauri-pre-bundle-windows.sh
+++ b/scripts/build/tauri-pre-bundle-windows.sh
@@ -13,7 +13,7 @@
 # Sequence:
 #   1. Diagnostic: print cwd + contents of `target/release/` so any
 #      missing-binary case is obvious in the CI log.
-#   2. Sign the three EXEs that ship in the MSI bundle.
+#   2. Sign the side EXEs that ship in the MSI bundle.
 #   3. Build (and sign) the sparse MSIX that WiX picks up.
 set -euxo pipefail
 
@@ -26,8 +26,9 @@ echo "tauri-pre-bundle-windows.sh: TARGET_DIR=$TARGET_DIR"
 ls -la "$TARGET_DIR" 2>&1 | head -n 60 || true
 
 "$SCRIPT_DIR/sign.sh" \
-    "$TARGET_DIR/Firezone.exe" \
     "$TARGET_DIR/firezone-client-tunnel.exe" \
     "$TARGET_DIR/register-sparse.exe"
+# Do not enable this, Tauri already signs it for us after patching the binary.
+#    "$TARGET_DIR/Firezone.exe"
 
 bash "$SCRIPT_DIR/build-msix-windows.sh"

--- a/scripts/tests/gui-client-install-windows-msi.ps1
+++ b/scripts/tests/gui-client-install-windows-msi.ps1
@@ -11,6 +11,20 @@
 
 $ErrorActionPreference = "Stop"
 
+function Assert-ValidSignature {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Error "Expected signed file not found: $Path"
+        exit 1
+    }
+    $sig = Get-AuthenticodeSignature -LiteralPath $Path
+    Write-Output ("    {0}: {1}" -f (Split-Path -Leaf $Path), $sig.Status)
+    if ($sig.Status -ne "Valid") {
+        Write-Error "Authenticode verification failed for ${Path}: $($sig.Status) - $($sig.StatusMessage)"
+        exit 1
+    }
+}
+
 if (-not $env:BINARY_DEST_PATH) {
     Write-Error "BINARY_DEST_PATH not set"
     exit 1
@@ -18,6 +32,9 @@ if (-not $env:BINARY_DEST_PATH) {
 
 $msi = "$($env:BINARY_DEST_PATH).msi"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+Write-Output "==> Verifying the MSI's Authenticode signature..."
+Assert-ValidSignature $msi
 
 Write-Output "==> Installing $msi..."
 $msiproc = Start-Process -FilePath "msiexec.exe" `
@@ -27,6 +44,12 @@ if ($msiproc.ExitCode -ne 0) {
     Write-Error "msiexec exited with $($msiproc.ExitCode)"
     exit 1
 }
+
+Write-Output "==> Verifying Authenticode signatures on the installed binaries..."
+$installDir = "C:\Program Files\Firezone"
+Assert-ValidSignature "$installDir\Firezone.exe"
+Assert-ValidSignature "$installDir\firezone-client-tunnel.exe"
+Assert-ValidSignature "$installDir\register-sparse.exe"
 
 Write-Output "==> Checking the tunnel service is running..."
 $null = sc.exe query FirezoneClientTunnelService | Select-String "RUNNING"


### PR DESCRIPTION
Windows release binaries were shipping with an invalid Authenticode signature (hash mismatch). The `beforeBundleCommand` hook signed `Firezone.exe` before Tauri's bundler ran, but Tauri rewrites the main binary in place afterward — `patch_binary` stamps the installer type into the PE — and only re-signs it when native signing is configured, which it wasn't. The patch invalidated the hook's signature, so the exe inside the MSI failed verification.

This configures `bundle.windows.signCommand` so Tauri signs `Firezone.exe` after patching it, and signs the MSI natively (dropping the separate CI signing step). The pre-bundle hook now signs only the side EXEs and the sparse MSIX, which Tauri never patches. Signing still uses AzureSignTool — the tool was never the cause; the signing order was.

The Windows install canary now also verifies the Authenticode signature of the MSI and of the installed binaries (`Firezone.exe`, `firezone-client-tunnel.exe`, `register-sparse.exe`) is `Valid`, so a future hash mismatch fails CI instead of shipping silently.