### PR TITLE
feat(connlib): per-phase packet latency in both directions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "nix 0.31.3",
  "opentelemetry",
  "otel-instruments",
+ "packet-timing",
  "resolv-conf",
  "ring",
  "rtnetlink",
@@ -897,6 +898,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "otel-instruments",
+ "packet-timing",
  "tokio",
  "tracing",
 ]
@@ -5133,6 +5135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "packet-timing"
+version = "0.1.0"
+dependencies = [
+ "dashmap",
+ "opentelemetry",
+ "smallvec",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6757,6 +6768,7 @@ dependencies = [
  "libc",
  "opentelemetry",
  "otel-instruments",
+ "packet-timing",
  "parking_lot",
  "quinn-udp",
  "socket2",
@@ -7507,6 +7519,7 @@ dependencies = [
  "moka",
  "opentelemetry",
  "opentelemetry_sdk",
+ "packet-timing",
  "parking_lot",
  "rand 0.10.1",
  "reqwest",
@@ -8184,6 +8197,7 @@ dependencies = [
  "libc",
  "opentelemetry",
  "otel-instruments",
+ "packet-timing",
  "tokio",
  "tracing",
 ]
@@ -8243,6 +8257,7 @@ dependencies = [
  "lru",
  "opentelemetry",
  "otel-instruments",
+ "packet-timing",
  "proptest",
  "proptest-state-machine",
  "rand 0.10.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "libs/connlib/l4-udp-dns-server",
     "libs/connlib/model",
     "libs/connlib/otel-instruments",
+    "libs/connlib/packet-timing",
     "libs/connlib/phoenix-channel",
     "libs/connlib/snownet",
     "libs/connlib/socket-factory",
@@ -148,6 +149,7 @@ opentelemetry_sdk = "0.32.0"
 os_info = { version = "3.15.0", default-features = false }
 otel-instruments = { path = "libs/connlib/otel-instruments" }
 output_vt100 = "0.1.3"
+packet-timing = { path = "libs/connlib/packet-timing" }
 parking_lot = "0.12.5"
 phoenix-channel = { path = "libs/connlib/phoenix-channel" }
 png = "0.18.1"

--- a/rust/libs/bin-shared/Cargo.toml
+++ b/rust/libs/bin-shared/Cargo.toml
@@ -23,6 +23,7 @@ ip_network = { workspace = true, features = ["serde"] }
 known-dirs = { workspace = true }
 logging = { workspace = true }
 otel-instruments = { workspace = true }
+packet-timing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -423,6 +423,7 @@ fn start_send_thread(
                         session.send_packet(pkt);
 
                         record_write_retries(&write_retry_histogram, attempt);
+                        packet_timing::receive::written_to_tun(packet.buffer_id());
 
                         continue 'next_packet;
                     }
@@ -559,6 +560,8 @@ fn start_recv_thread(
                         continue;
                     }
                 };
+
+                packet_timing::transmit::tun_read(pkt.buffer_id());
 
                 #[cfg(debug_assertions)]
                 tracing::trace!(target: "wire::dev::recv", ?pkt);

--- a/rust/libs/connlib/bufferpool/Cargo.toml
+++ b/rust/libs/connlib/bufferpool/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { workspace = true }
 crossbeam-queue = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
+packet-timing = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/rust/libs/connlib/bufferpool/lib.rs
+++ b/rust/libs/connlib/bufferpool/lib.rs
@@ -2,7 +2,10 @@
 
 use std::{
     ops::{Deref, DerefMut},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use bytes::BytesMut;
@@ -11,6 +14,9 @@ use opentelemetry::{
     KeyValue,
     metrics::{Meter, UpDownCounter},
 };
+
+/// Source of process-unique identifiers for physical buffers.
+static NEXT_BUFFER_ID: AtomicU64 = AtomicU64::new(0);
 
 /// A lock-free pool of buffers that are all equal in size.
 ///
@@ -116,6 +122,15 @@ impl Buffer<Vec<u8>> {
 }
 
 impl<B> Buffer<B> {
+    /// A process-unique identifier for the underlying physical buffer.
+    ///
+    /// The identifier is assigned when the buffer is first allocated and stays with the
+    /// physical buffer as it is returned to and pulled from the pool again. While a buffer
+    /// is checked out of the pool, its identifier is therefore a stable correlation key.
+    pub fn id(&self) -> u64 {
+        self.storage().id
+    }
+
     fn storage(&self) -> &BufferStorage<B> {
         self.inner
             .as_ref()
@@ -199,6 +214,10 @@ impl<B> Drop for Buffer<B> {
     fn drop(&mut self) {
         let buffer_storage = self.inner.take().expect("should have storage in `Drop`");
 
+        // Discard any packet-timing tracking keyed by this buffer before it returns to
+        // the pool, so an abandoned timeline cannot leak or bleed into the buffer's reuse.
+        packet_timing::forget(buffer_storage.id);
+
         let actual = (buffer_storage.capacity_of)(&buffer_storage.inner);
         if let Some(actual) = deviating_capacity(buffer_storage.capacity, actual) {
             tracing::warn!(
@@ -267,6 +286,9 @@ impl Buf for BytesMut {
 struct BufferStorage<B> {
     inner: B,
 
+    /// Process-unique identifier of this physical buffer, stable across pool cycling.
+    id: u64,
+
     /// The size every buffer in the pool is allocated with.
     ///
     /// A returned buffer whose capacity deviates from this no longer fits the pool's
@@ -304,6 +326,7 @@ impl<B> BufferStorage<B> {
 
         Self {
             inner,
+            id: NEXT_BUFFER_ID.fetch_add(1, Ordering::Relaxed),
             capacity,
             tag,
             capacity_of: B::capacity,
@@ -387,6 +410,25 @@ mod tests {
         buffer.resize_to(8 * 1024); // Force a reallocation beyond the pool's capacity.
 
         drop(buffer); // Exercises the capacity-deviation check on return to the pool.
+    }
+
+    #[test]
+    fn buffer_id_is_unique_and_stable_across_recycling() {
+        let pool = BufferPool::<Vec<u8>>::new(1024, "test");
+
+        let buffer1 = pool.pull();
+        let id1 = buffer1.id();
+
+        let buffer2 = pool.pull();
+        let id2 = buffer2.id();
+
+        assert_ne!(id1, id2, "distinct buffers have distinct ids");
+
+        // Returning a buffer and pulling again reuses the physical buffer and its id.
+        drop(buffer2);
+        let buffer3 = pool.pull();
+
+        assert_eq!(buffer3.id(), id2, "recycled buffer keeps its id");
     }
 
     #[test]

--- a/rust/libs/connlib/ip-packet/src/lib.rs
+++ b/rust/libs/connlib/ip-packet/src/lib.rs
@@ -276,6 +276,12 @@ impl IpPacket {
         self.version
     }
 
+    /// The identifier of the underlying pool buffer, used to correlate the packet
+    /// across processing stages for latency tracking.
+    pub fn buffer_id(&self) -> u64 {
+        self.buf.id()
+    }
+
     pub fn source(&self) -> IpAddr {
         match self.version {
             IpVersion::V4 => self.as_ipv4_unchecked().header().source_addr().into(),

--- a/rust/libs/connlib/packet-timing/Cargo.toml
+++ b/rust/libs/connlib/packet-timing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "packet-timing"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+dashmap = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics"] }
+smallvec = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/connlib/packet-timing/src/lib.rs
+++ b/rust/libs/connlib/packet-timing/src/lib.rs
@@ -1,0 +1,387 @@
+//! Tracks how long a packet spends in each stage of connlib's data path, in both
+//! directions.
+//!
+//! As a packet travels through connlib it is carried by a series of pool buffers. On the
+//! outbound path: the buffer read from the TUN device, the buffer it is encrypted into,
+//! and finally the GSO batch buffer it is coalesced into before being sent. On the
+//! inbound path the decrypted packet's buffer carries it from decryption to the TUN
+//! device. Every buffer has a stable identifier, which lets us correlate timestamps
+//! captured at the different stages without threading them through the hot path.
+//!
+//! A packet's timeline is re-keyed as it moves from one buffer to the next, and recorded
+//! once it leaves connlib (flushed to the socket, or written to the TUN device). When a
+//! buffer is dropped before reaching that terminal stage, [`forget`] discards its
+//! timeline so nothing lingers. The per-phase durations are reported to a histogram,
+//! differentiated by a `network.io.direction` and a `packet.phase` attribute.
+//!
+//! Everything is gated on the `stream_metrics` feature-flag via [`set_enabled`]. While
+//! disabled, every function returns after a single relaxed atomic load and [`Instant`]
+//! captures nothing.
+
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+use dashmap::DashMap;
+use opentelemetry::{
+    KeyValue,
+    metrics::{Histogram, Meter},
+};
+use smallvec::SmallVec;
+
+/// Whether packet-timing is currently recording.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enables or disables packet-timing, driven by the `stream_metrics` feature-flag.
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// A timestamp that is only actually captured while packet-timing is enabled.
+///
+/// [`Instant::now`] is a no-op that captures nothing while disabled, so callers on the
+/// hot path can record timestamps unconditionally without branching themselves.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct Instant(Option<std::time::Instant>);
+
+impl Instant {
+    /// Captures the current time, or nothing if packet-timing is disabled.
+    pub fn now() -> Self {
+        Self(enabled().then(std::time::Instant::now))
+    }
+
+    /// The duration from `earlier` to `self`, or `None` if either end was not captured.
+    fn duration_since(self, earlier: Self) -> Option<std::time::Duration> {
+        Some(self.0?.saturating_duration_since(earlier.0?))
+    }
+}
+
+/// Discards any in-flight timeline keyed by the buffer `id`.
+///
+/// Called when a pool buffer is dropped, so the timeline of a packet that never reached
+/// its terminal stage (a dropped or filtered packet, or a cleared send-queue batch) is
+/// cleaned up rather than lingering until the buffer's id is reused.
+pub fn forget(id: u64) {
+    if !enabled() {
+        return;
+    }
+
+    pending().remove(&id);
+    batches().remove(&id);
+}
+
+/// Timing of the outbound path: TUN device -> encryption -> UDP socket.
+pub mod transmit {
+    use super::*;
+
+    /// A packet was read from the TUN device into the buffer `id`.
+    pub fn tun_read(id: u64) {
+        if !enabled() {
+            return;
+        }
+
+        pending().insert(id, Timeline::started(Direction::Transmit));
+    }
+
+    /// The packet, still held in buffer `id`, arrived at the processing thread, about to
+    /// be handed to the sans-IO state.
+    pub fn arrived(id: u64) {
+        set(id, |t| t.arrived = Instant::now());
+    }
+
+    /// The sans-IO state finished processing the packet, moving its timeline from the
+    /// source buffer `from` onto the buffer `into` that now holds the encrypted payload.
+    pub fn encrypted(from: u64, into: u64) {
+        if !enabled() {
+            return;
+        }
+
+        let Some((_, mut timeline)) = pending().remove(&from) else {
+            return;
+        };
+
+        timeline.processed = Instant::now();
+        pending().insert(into, timeline);
+    }
+
+    /// The encrypted `payload` buffer was coalesced into the GSO `batch` buffer, moving
+    /// its timeline onto the batch.
+    pub fn enqueued(payload: u64, batch: u64) {
+        if !enabled() {
+            return;
+        }
+
+        let Some((_, timeline)) = pending().remove(&payload) else {
+            return;
+        };
+
+        batches().entry(batch).or_default().push(timeline);
+    }
+
+    /// The GSO `batch` buffer was flushed to the socket, finalising every packet
+    /// coalesced into it.
+    ///
+    /// Called from the socket layer right after the send syscall, while the buffer is
+    /// still owned by the send, so a recycled buffer reusing this `id` cannot race it.
+    pub fn flushed(batch: u64) {
+        if !enabled() {
+            return;
+        }
+
+        let now = Instant::now();
+
+        let Some((_, timelines)) = batches().remove(&batch) else {
+            return;
+        };
+
+        for timeline in timelines {
+            timeline.record(now);
+        }
+    }
+}
+
+/// Timing of the inbound path: UDP socket -> decryption -> TUN device.
+pub mod receive {
+    use super::*;
+
+    /// The sans-IO state finished decrypting an inbound packet into the buffer `id`.
+    ///
+    /// Unlike the outbound path, an inbound datagram has no stable per-packet buffer
+    /// until it is decrypted (it starts as a slice into a coalesced GRO buffer), so the
+    /// earlier timestamps are passed in: `received_at` is when the datagram was read off
+    /// the socket and `arrived` is when the event-loop handed it to the sans-IO state.
+    pub fn decrypted(id: u64, received_at: Instant, arrived: Instant) {
+        if !enabled() {
+            return;
+        }
+
+        pending().insert(
+            id,
+            Timeline {
+                direction: Direction::Receive,
+                io_in: received_at,
+                arrived,
+                processed: Instant::now(),
+            },
+        );
+    }
+
+    /// The decrypted packet in buffer `id` was written to the TUN device, finalising it.
+    pub fn written_to_tun(id: u64) {
+        if !enabled() {
+            return;
+        }
+
+        let now = Instant::now();
+
+        let Some((_, timeline)) = pending().remove(&id) else {
+            return;
+        };
+
+        timeline.record(now);
+    }
+}
+
+fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Updates the in-flight timeline keyed by `id`, if one exists and tracking is enabled.
+fn set(id: u64, update: impl FnOnce(&mut Timeline)) {
+    if !enabled() {
+        return;
+    }
+
+    if let Some(mut timeline) = pending().get_mut(&id) {
+        update(&mut timeline);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Transmit,
+    Receive,
+}
+
+/// The timestamps captured for a single packet as it moves through connlib.
+///
+/// `arrived` is when the event-loop handed the packet to the sans-IO state and
+/// `processed` is when that call returned, so the span between them (the `processing`
+/// phase) covers routing and the (en|de)cryption that dominates it. Timestamps not yet
+/// reached are empty and simply omit their phase when recording.
+struct Timeline {
+    direction: Direction,
+    io_in: Instant,
+    arrived: Instant,
+    processed: Instant,
+}
+
+impl Timeline {
+    fn started(direction: Direction) -> Self {
+        Self {
+            direction,
+            io_in: Instant::now(),
+            arrived: Instant::default(),
+            processed: Instant::default(),
+        }
+    }
+
+    fn record(self, io_out: Instant) {
+        let direction = direction(self.direction);
+
+        if let Some(duration) = self.arrived.duration_since(self.io_in) {
+            histogram().record(
+                duration.as_secs_f64(),
+                &[direction.clone(), phase("io_to_processing")],
+            );
+        }
+        if let Some(duration) = self.processed.duration_since(self.arrived) {
+            histogram().record(
+                duration.as_secs_f64(),
+                &[direction.clone(), phase("processing")],
+            );
+        }
+        if let Some(duration) = io_out.duration_since(self.processed) {
+            histogram().record(
+                duration.as_secs_f64(),
+                &[direction.clone(), phase("processing_to_io")],
+            );
+        }
+        if let Some(duration) = io_out.duration_since(self.io_in) {
+            histogram().record(duration.as_secs_f64(), &[direction, phase("total")]);
+        }
+    }
+}
+
+fn phase(phase: &'static str) -> KeyValue {
+    KeyValue::new("packet.phase", phase)
+}
+
+fn direction(direction: Direction) -> KeyValue {
+    KeyValue::new(
+        "network.io.direction",
+        match direction {
+            Direction::Transmit => "transmit",
+            Direction::Receive => "receive",
+        },
+    )
+}
+
+fn pending() -> &'static DashMap<u64, Timeline> {
+    static PENDING: LazyLock<DashMap<u64, Timeline>> = LazyLock::new(DashMap::new);
+
+    &PENDING
+}
+
+fn batches() -> &'static DashMap<u64, SmallVec<[Timeline; 8]>> {
+    static BATCHES: LazyLock<DashMap<u64, SmallVec<[Timeline; 8]>>> = LazyLock::new(DashMap::new);
+
+    &BATCHES
+}
+
+fn histogram() -> &'static Histogram<f64> {
+    static HISTOGRAM: LazyLock<Histogram<f64>> = LazyLock::new(packet_processing_duration);
+
+    &HISTOGRAM
+}
+
+/// Time a packet spends in each phase of connlib's data path.
+///
+/// Individual phases are differentiated through the `network.io.direction` and
+/// `packet.phase` attributes.
+fn packet_processing_duration() -> Histogram<f64> {
+    meter()
+        .f64_histogram("connlib.packet.processing.duration")
+        .with_description("Time a packet spends in each phase of connlib's data path.")
+        .with_unit("s")
+        .with_boundaries(vec![
+            0.000_001, // 1µs
+            0.000_005, // 5µs
+            0.000_010, // 10µs
+            0.000_025, // 25µs
+            0.000_050, // 50µs
+            0.000_100, // 100µs
+            0.000_250, // 250µs
+            0.000_500, // 500µs
+            0.001_000, // 1ms
+            0.002_500, // 2.5ms
+            0.005_000, // 5ms
+            0.010_000, // 10ms
+            0.025_000, // 25ms
+            0.050_000, // 50ms
+            0.100_000, // 100ms
+        ])
+        .build()
+}
+
+fn meter() -> Meter {
+    opentelemetry::global::meter("connlib")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The module relies on process-global state, so the chains and the disabled case are
+    // exercised within a single test to keep it deterministic.
+    #[test]
+    fn rekeys_timelines_along_buffer_chain_and_is_a_noop_while_disabled() {
+        const TUN: u64 = 1001;
+        const PAYLOAD: u64 = 1002;
+        const BATCH: u64 = 1003;
+        const DECRYPTED: u64 = 1004;
+        const DROPPED: u64 = 1005;
+        const DISABLED: u64 = 1006;
+
+        set_enabled(true);
+
+        // Outbound: the timeline moves TUN buffer -> payload buffer -> GSO batch.
+        transmit::tun_read(TUN);
+        assert!(pending().contains_key(&TUN));
+
+        transmit::arrived(TUN);
+        transmit::encrypted(TUN, PAYLOAD);
+        assert!(
+            !pending().contains_key(&TUN),
+            "timeline moves off the TUN buffer"
+        );
+        assert!(pending().contains_key(&PAYLOAD));
+
+        transmit::enqueued(PAYLOAD, BATCH);
+        assert!(
+            !pending().contains_key(&PAYLOAD),
+            "timeline moves onto the batch"
+        );
+        assert_eq!(batches().get(&BATCH).map(|b| b.len()), Some(1));
+
+        transmit::flushed(BATCH);
+        assert!(
+            !batches().contains_key(&BATCH),
+            "flushing finalises the batch"
+        );
+
+        // Inbound: the timeline lives on the decrypted buffer until written to the TUN.
+        receive::decrypted(DECRYPTED, Instant::now(), Instant::now());
+        assert!(pending().contains_key(&DECRYPTED));
+
+        receive::written_to_tun(DECRYPTED);
+        assert!(
+            !pending().contains_key(&DECRYPTED),
+            "writing to TUN finalises it"
+        );
+
+        // A buffer dropped before its terminal stage has its timeline forgotten.
+        transmit::tun_read(DROPPED);
+        assert!(pending().contains_key(&DROPPED));
+        forget(DROPPED);
+        assert!(
+            !pending().contains_key(&DROPPED),
+            "forget cleans up an abandoned timeline"
+        );
+
+        set_enabled(false);
+        transmit::tun_read(DISABLED);
+        assert!(!pending().contains_key(&DISABLED), "no-op while disabled");
+    }
+}

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -13,6 +13,7 @@ gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
+packet-timing = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 tokio = { workspace = true, features = ["net", "rt", "time"] }

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -295,6 +295,8 @@ pub struct DatagramIn<'a> {
     pub from: SocketAddr,
     pub packet: &'a [u8],
     pub ecn: Ecn,
+    /// When the containing batch was read off the socket (for packet-timing).
+    pub received_at: packet_timing::Instant,
 }
 
 /// An outbound UDP datagram.
@@ -355,7 +357,15 @@ impl PerfUdpSocket {
             ],
         );
 
-        Ok(DatagramSegmentIter::new(bufs, meta, self.port, len))
+        let received_at = packet_timing::Instant::now();
+
+        Ok(DatagramSegmentIter::new(
+            bufs,
+            meta,
+            self.port,
+            len,
+            received_at,
+        ))
     }
 
     pub async fn send(&self, datagram: DatagramOut) -> Result<()> {
@@ -371,7 +381,13 @@ impl PerfUdpSocket {
             .pool
             .get_send_socket(transmit.src_ip, datagram.dst, &self.buffer_pool);
 
-        self.send_transmit(pooled.as_socket(), &transmit).await
+        let result = self.send_transmit(pooled.as_socket(), &transmit).await;
+
+        // Record the flush after the syscall, while the datagram still owns the GSO
+        // buffer: a buffer recycled into a new batch cannot then reuse this id and race.
+        packet_timing::transmit::flushed(datagram.packet.id());
+
+        result
     }
 
     /// The number of connected per-destination "flow" sockets currently cached.
@@ -787,6 +803,7 @@ pub struct DatagramSegmentIter<const N: usize = { quinn_udp::BATCH_SIZE }, B = B
     len: usize,
 
     port: u16,
+    received_at: packet_timing::Instant,
 
     buf_index: usize,
     segment_index: usize,
@@ -801,6 +818,7 @@ impl<B, const N: usize> DatagramSegmentIter<N, B> {
         metas: [quinn_udp::RecvMeta; N],
         port: u16,
         len: usize,
+        received_at: packet_timing::Instant,
     ) -> Self {
         let total_bytes = metas.iter().map(|m| m.len).sum::<usize>();
         let num_packets = metas
@@ -819,6 +837,7 @@ impl<B, const N: usize> DatagramSegmentIter<N, B> {
             metas,
             len,
             port,
+            received_at,
             buf_index: 0,
             segment_index: 0,
             _total_bytes: total_bytes,
@@ -896,6 +915,7 @@ where
                     Some(EcnCodepoint::Ect1) => Ecn::Ect1,
                     None => Ecn::NonEct,
                 },
+                received_at: self.received_at,
             });
         }
     }
@@ -937,6 +957,7 @@ mod tests {
             ],
             0,
             3,
+            packet_timing::Instant::default(),
         );
 
         assert_eq!(iter.next().unwrap().packet, b"foobar1");

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -345,7 +345,15 @@ fn drain(
             }
         };
 
-        out.push_back(DatagramSegmentIter::new(bufs, metas, port, len));
+        let received_at = packet_timing::Instant::now();
+
+        out.push_back(DatagramSegmentIter::new(
+            bufs,
+            metas,
+            port,
+            len,
+            received_at,
+        ));
     }
 }
 

--- a/rust/libs/connlib/tun/Cargo.toml
+++ b/rust/libs/connlib/tun/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { workspace = true, features = ["net", "rt", "sync"] }
 libc = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
+packet-timing = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/rust/libs/connlib/tun/src/unix.rs
+++ b/rust/libs/connlib/tun/src/unix.rs
@@ -48,6 +48,7 @@ where
                     {
                         Ok(_) => {
                             record_write_retries(&write_retry_histogram, attempt);
+                            packet_timing::receive::written_to_tun(packet.buffer_id());
 
                             break;
                         }
@@ -185,6 +186,8 @@ where
                 match next_inbound_packet.context("Failed to read from TUN FD") {
                     Ok(None) => bail!("TUN file descriptor is closed"),
                     Ok(Some(packet)) => {
+                        packet_timing::transmit::tun_read(packet.buffer_id());
+
                         #[cfg(debug_assertions)]
                         tracing::trace!(target: "wire::dev::recv", ?packet);
 

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -40,6 +40,7 @@ logging = { workspace = true }
 lru = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
+packet-timing = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 rangemap = { workspace = true }

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -11,6 +11,7 @@ pub use device::{Device, TunChannelClosed};
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{Context as _, ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
+use bufferpool::Buffer;
 use dns_types::DoHUrl;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
 use gat_lending_iterator::LendingIterator;
@@ -498,7 +499,7 @@ impl Io {
         &mut self,
         src: Option<SocketAddr>,
         dst: SocketAddr,
-        payload: &[u8],
+        payload: &Buffer<Vec<u8>>,
         ecn: Ecn,
     ) {
         self.gso_queue.enqueue(src, dst, payload, ecn);
@@ -506,7 +507,7 @@ impl Io {
         self.packet_counter.add(
             1,
             &[
-                otel::attr::network_protocol_name(payload),
+                otel::attr::network_protocol_name(payload.as_slice()),
                 otel::attr::network_transport_udp(),
                 otel::attr::network_io_direction_transmit(),
             ],

--- a/rust/libs/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/libs/connlib/tunnel/src/io/gso_queue.rs
@@ -30,8 +30,15 @@ impl GsoQueue {
         }
     }
 
-    pub fn enqueue(&mut self, src: Option<SocketAddr>, dst: SocketAddr, payload: &[u8], ecn: Ecn) {
-        let payload_len = payload.len();
+    pub fn enqueue(
+        &mut self,
+        src: Option<SocketAddr>,
+        dst: SocketAddr,
+        payload: &Buffer<Vec<u8>>,
+        ecn: Ecn,
+    ) {
+        let bytes = payload.as_slice();
+        let payload_len = bytes.len();
 
         debug_assert!(
             payload_len <= MAX_SEGMENT_SIZE,
@@ -41,7 +48,9 @@ impl GsoQueue {
         let batches = self.inner.entry(Connection { src, dst, ecn }).or_default();
 
         let Some((batch_size, buffer)) = batches.back_mut() else {
-            batches.push_back((payload_len, self.buffer_pool.pull_initialised(payload)));
+            let buffer = self.buffer_pool.pull_initialised(bytes);
+            packet_timing::transmit::enqueued(payload.id(), buffer.id());
+            batches.push_back((payload_len, buffer));
 
             return;
         };
@@ -51,11 +60,14 @@ impl GsoQueue {
         let batch_is_ongoing = buffer.len() % batch_size == 0;
 
         if batch_is_ongoing && payload_len <= batch_size {
-            buffer.extend_from_slice(payload);
+            buffer.extend_from_slice(bytes);
+            packet_timing::transmit::enqueued(payload.id(), buffer.id());
             return;
         }
 
-        batches.push_back((payload_len, self.buffer_pool.pull_initialised(payload)));
+        let buffer = self.buffer_pool.pull_initialised(bytes);
+        packet_timing::transmit::enqueued(payload.id(), buffer.id());
+        batches.push_back((payload_len, buffer));
     }
 
     pub fn datagrams(&mut self) -> impl Iterator<Item = DatagramOut> + '_ {
@@ -110,11 +122,15 @@ mod tests {
 
     use super::*;
 
+    fn payload(bytes: &[u8]) -> Buffer<Vec<u8>> {
+        BufferPool::<Vec<u8>>::new(MAX_SEGMENT_SIZE, "test").pull_initialised(bytes)
+    }
+
     #[test]
     fn dropping_datagram_iterator_does_not_drop_items() {
         let mut send_queue = GsoQueue::new();
 
-        send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobar"), Ecn::NonEct);
 
         let datagrams = send_queue.datagrams();
         drop(datagrams);
@@ -130,10 +146,10 @@ mod tests {
     fn appends_items_of_same_batch() {
         let mut send_queue = GsoQueue::new();
 
-        send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"foobaz", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"foo", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobar"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"barbaz"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobaz"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foo"), Ecn::NonEct);
 
         let datagrams = send_queue.datagrams().collect::<Vec<_>>();
 
@@ -146,11 +162,11 @@ mod tests {
     fn starts_new_batch_for_new_dst() {
         let mut send_queue = GsoQueue::new();
 
-        send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobar"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"barbaz"), Ecn::NonEct);
 
-        send_queue.enqueue(None, DST_2, b"barbarba", Ecn::NonEct);
-        send_queue.enqueue(None, DST_2, b"foofoo", Ecn::NonEct);
+        send_queue.enqueue(None, DST_2, &payload(b"barbarba"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_2, &payload(b"foofoo"), Ecn::NonEct);
 
         let datagrams = send_queue.datagrams().collect::<Vec<_>>();
 
@@ -167,14 +183,14 @@ mod tests {
     fn continues_batch_for_old_dst() {
         let mut send_queue = GsoQueue::new();
 
-        send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobar"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"barbaz"), Ecn::NonEct);
 
-        send_queue.enqueue(None, DST_2, b"barbarba", Ecn::NonEct);
-        send_queue.enqueue(None, DST_2, b"foofoo", Ecn::NonEct);
+        send_queue.enqueue(None, DST_2, &payload(b"barbarba"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_2, &payload(b"foofoo"), Ecn::NonEct);
 
-        send_queue.enqueue(None, DST_1, b"foobaz", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"bazfoo", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobaz"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"bazfoo"), Ecn::NonEct);
 
         let datagrams = send_queue.datagrams().collect::<Vec<_>>();
 
@@ -191,11 +207,11 @@ mod tests {
     fn starts_new_batch_after_single_item_less_than_segment_length() {
         let mut send_queue = GsoQueue::new();
 
-        send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
-        send_queue.enqueue(None, DST_1, b"bar", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"foobar"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"barbaz"), Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"bar"), Ecn::NonEct);
 
-        send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
+        send_queue.enqueue(None, DST_1, &payload(b"barbaz"), Ecn::NonEct);
 
         let datagrams = send_queue.datagrams().collect::<Vec<_>>();
 

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -253,12 +253,16 @@ impl ClientTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
+                        let id = packet.buffer_id();
+                        packet_timing::transmit::arrived(id);
+
                         match self
                             .role_state
                             .handle_tun_input(packet, now)
                             .context("Failed to handle packet from TUN device")
                         {
                             Ok(Some(transmit)) => {
+                                packet_timing::transmit::encrypted(id, transmit.payload.id());
                                 self.io.send_network(
                                     transmit.src,
                                     transmit.dst,
@@ -290,6 +294,9 @@ impl ClientTunnel {
                             ],
                         );
 
+                        let received_at = received.received_at;
+                        let arrived = packet_timing::Instant::now();
+
                         match self
                             .role_state
                             .handle_network_input(
@@ -302,9 +309,15 @@ impl ClientTunnel {
                                 local: received.local,
                                 from: received.from,
                             }) {
-                            Ok(Some(packet)) => self
-                                .io
-                                .send_tun(packet.with_ecn_from_transport(received.ecn)),
+                            Ok(Some(packet)) => {
+                                let packet = packet.with_ecn_from_transport(received.ecn);
+                                packet_timing::receive::decrypted(
+                                    packet.buffer_id(),
+                                    received_at,
+                                    arrived,
+                                );
+                                self.io.send_tun(packet);
+                            }
                             Ok(None) => self.io.schedule_timeout(now),
                             Err(e) => error.push(e),
                         };
@@ -448,12 +461,16 @@ impl GatewayTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
+                        let id = packet.buffer_id();
+                        packet_timing::transmit::arrived(id);
+
                         match self
                             .role_state
                             .handle_tun_input(packet, now)
                             .context("Failed to handle packet from TUN device")
                         {
                             Ok(Some(transmit)) => {
+                                packet_timing::transmit::encrypted(id, transmit.payload.id());
                                 self.io.send_network(
                                     transmit.src,
                                     transmit.dst,
@@ -498,6 +515,9 @@ impl GatewayTunnel {
                             ],
                         );
 
+                        let received_at = received.received_at;
+                        let arrived = packet_timing::Instant::now();
+
                         match self
                             .role_state
                             .handle_network_input(
@@ -510,9 +530,15 @@ impl GatewayTunnel {
                                 local: received.local,
                                 from: received.from,
                             }) {
-                            Ok(Some(packet)) => self
-                                .io
-                                .send_tun(packet.with_ecn_from_transport(received.ecn)),
+                            Ok(Some(packet)) => {
+                                let packet = packet.with_ecn_from_transport(received.ecn);
+                                packet_timing::receive::decrypted(
+                                    packet.buffer_id(),
+                                    received_at,
+                                    arrived,
+                                );
+                                self.io.send_tun(packet);
+                            }
                             Ok(None) => self.io.schedule_timeout(now),
                             Err(e) => error.push(e),
                         };

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -11,6 +11,7 @@ ip-packet = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
+packet-timing = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["http2"] }

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -282,6 +282,7 @@ impl FeatureFlags {
             enabled: stream_metrics,
             reservoir_size: MetricsConfig::parse(&payloads.stream_metrics).reservoir_size(),
         };
+        packet_timing::set_enabled(stream_metrics);
 
         let log_filter = if stream_logs {
             LogFilter::parse(payloads.stream_logs)


### PR DESCRIPTION
Adds an opt-in, per-phase latency histogram for the data path in both directions, so we can see where a packet spends its time between the TUN device and the UDP socket (and back): waiting on the inter-thread channels, inside the sans-IO state, and in the egress queue.

Correlation relies on the stable identifiers of the pool buffers a packet flows through, rather than threading timestamps through the hot path. Recording is gated on the `stream_metrics` feature-flag and is a no-op while disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqVxjuTPTt9q3jjxCVJte2)_