### PR TITLE
refactor: de-duplicate client-1 and client-2 compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,16 +120,12 @@ services:
 
   # Run with DOCKER_BUILD_TARGET=dev to build Rust inside Docker
   client-1:
-    healthcheck:
-      test: ["CMD-SHELL", "ip link | grep tun-firezone"]
-      <<: *health-check
+    extends:
+      file: scripts/compose/client.yml
+      service: client
     environment:
-      FIREZONE_DNS_CONTROL: "${FIREZONE_DNS_CONTROL:-etc-resolv-conf}"
       FIREZONE_TOKEN: "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAR_ywiZQBYgABUYA.PLNlzyqMSgZlbQb1QX5EzZgYNuY9oeOddP0qDkTwtGg"
-      RUST_LOG: ${RUST_LOG:-wire=trace,debug}
-      FIREZONE_API_URL: ws://portal:8081
       FIREZONE_ID: 2606a54a327020a1285cc141aeceb5737a91625e5e1a85c234682266f45820bf
-      FZFF_ICMP_ERROR_UNREACHABLE_PROHIBITED_CREATE_NEW_FLOW: true
     command:
       - sh
       - -c
@@ -147,34 +143,13 @@ services:
         ip link set dev eth0 txqueuelen 100000
 
         exec firezone-headless-client
-    init: true
-    build:
-      target: ${DOCKER_BUILD_TARGET:-debug}
-      context: rust
-      dockerfile: Dockerfile
-      args:
-        PACKAGE: firezone-headless-client
-    image: ${CLIENT_IMAGE:-ghcr.io/firezone/debug/client}:${CLIENT_TAG:-main}
-    privileged: true # Needed to tune `sysctl` inside container.
-    cap_add:
-      - NET_ADMIN
-    sysctls:
-      - net.ipv6.conf.all.disable_ipv6=0
-      - net.ipv6.conf.default.disable_ipv6=0
-    devices:
-      - "/dev/net/tun:/dev/net/tun"
     depends_on:
       client-1-router:
-        condition: "service_healthy"
-      portal:
         condition: "service_healthy"
     networks:
       client-1-internal:
         ipv4_address: 172.30.0.100
         ipv6_address: 172:30:0::100
-    extra_hosts:
-      - "portal:203.0.113.10"
-      - "portal:203:0:113::10"
 
   client-1-router:
     extends:
@@ -192,16 +167,12 @@ services:
         interface_name: internet
 
   client-2:
-    healthcheck:
-      test: ["CMD-SHELL", "ip link | grep tun-firezone"]
-      <<: *health-check
+    extends:
+      file: scripts/compose/client.yml
+      service: client
     environment:
-      FIREZONE_DNS_CONTROL: "${FIREZONE_DNS_CONTROL:-etc-resolv-conf}"
       FIREZONE_TOKEN: "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkZmUyYmYyMmQtMDk4Ni00MzNhLTg1ZWQtYThmMzdjOTBhMzRibQAAADg5SE00QTZSRE03UUxEVjhOMUMwRFFEMThKVEpOVUpJQ0Y0QThWUklKODM0SkhDTjA5NFIwPT09PW4GACphrxmeAWIAAVGA.LHufO50MaDTncVMV1CBGr3pnpemR-__n8RSbh9xwB3Y"
-      RUST_LOG: ${RUST_LOG:-wire=trace,debug}
-      FIREZONE_API_URL: ws://portal:8081
       FIREZONE_ID: *pool-member-firezone-id
-      FZFF_ICMP_ERROR_UNREACHABLE_PROHIBITED_CREATE_NEW_FLOW: true
     command:
       - sh
       - -c
@@ -219,34 +190,13 @@ services:
         ip link set dev eth0 txqueuelen 100000
 
         exec firezone-headless-client
-    init: true
-    build:
-      target: ${DOCKER_BUILD_TARGET:-debug}
-      context: rust
-      dockerfile: Dockerfile
-      args:
-        PACKAGE: firezone-headless-client
-    image: ${CLIENT_IMAGE:-ghcr.io/firezone/debug/client}:${CLIENT_TAG:-main}
-    privileged: true # Needed to tune `sysctl` inside container.
-    cap_add:
-      - NET_ADMIN
-    sysctls:
-      - net.ipv6.conf.all.disable_ipv6=0
-      - net.ipv6.conf.default.disable_ipv6=0
-    devices:
-      - "/dev/net/tun:/dev/net/tun"
     depends_on:
       client-2-router:
-        condition: "service_healthy"
-      portal:
         condition: "service_healthy"
     networks:
       client-2-internal:
         ipv4_address: 172.32.0.100
         ipv6_address: 172:32:0::100
-    extra_hosts:
-      - "portal:203.0.113.10"
-      - "portal:203:0:113::10"
 
   client-2-router:
     extends:

--- a/scripts/compose/client.yml
+++ b/scripts/compose/client.yml
@@ -1,0 +1,34 @@
+services:
+  client:
+    environment:
+      FIREZONE_DNS_CONTROL: "${FIREZONE_DNS_CONTROL:-etc-resolv-conf}"
+      RUST_LOG: ${RUST_LOG:-wire=trace,debug}
+      FIREZONE_API_URL: ws://portal:8081
+      FZFF_ICMP_ERROR_UNREACHABLE_PROHIBITED_CREATE_NEW_FLOW: true
+    init: true
+    build:
+      target: ${DOCKER_BUILD_TARGET:-debug}
+      context: ../../rust
+      dockerfile: Dockerfile
+      args:
+        PACKAGE: firezone-headless-client
+    image: ${CLIENT_IMAGE:-ghcr.io/firezone/debug/client}:${CLIENT_TAG:-main}
+    privileged: true # Needed to tune `sysctl` inside container.
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+      - net.ipv6.conf.default.disable_ipv6=0
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    healthcheck:
+      test: ["CMD-SHELL", "ip link | grep tun-firezone"]
+      interval: 1s
+      retries: 15
+      timeout: 1s
+    depends_on:
+      portal:
+        condition: "service_healthy"
+    extra_hosts:
+      - "portal:203.0.113.10"
+      - "portal:203:0:113::10"


### PR DESCRIPTION
Extract the configuration shared by `client-1` and `client-2` into a common service in `scripts/compose/client.yml` and reference it via `extends`, mirroring the existing relay setup. Each client is left to override only what is genuinely instance-specific.