### PR TITLE
refactor(connlib): encrypt packets directly into the GSO queue

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -964,6 +964,11 @@ impl Allocation {
         self.active_socket.is_some()
     }
 
+    /// The relay socket we are currently sending to, if one has been selected.
+    pub fn active_socket(&self) -> Option<SocketAddr> {
+        Some(self.active_socket.as_ref()?.addr)
+    }
+
     pub fn has_credentials(&self) -> bool {
         self.credentials.is_some()
     }

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -916,6 +916,8 @@ impl Allocation {
         let channel_number = match connected_channel_to_peer.or(inflight_channel_to_peer) {
             Some(cn) => cn,
             None => {
+                tracing::debug!(%peer, "Dropping packet; no channel bound to peer yet");
+
                 self.bind_channel(peer, now);
 
                 return None;

--- a/rust/libs/connlib/snownet/src/buffer.rs
+++ b/rust/libs/connlib/snownet/src/buffer.rs
@@ -1,0 +1,116 @@
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+
+use bufferpool::BufferPool;
+use ip_packet::Ecn;
+
+use crate::node::Transmit;
+
+/// Provides destination buffers for [`Node::encapsulate`](crate::Node::encapsulate).
+///
+/// Implementers hand out a writable slice into which the encrypted packet is written directly,
+/// avoiding an intermediate copy.
+pub trait BufferProvider {
+    /// Reserve `len` writable bytes for a datagram from `src` to `dst` with the given `ecn`.
+    fn reserve(
+        &mut self,
+        src: Option<SocketAddr>,
+        dst: SocketAddr,
+        ecn: Ecn,
+        len: usize,
+    ) -> &mut [u8];
+
+    /// Undo the most recent [`BufferProvider::reserve`] for `(src, dst, ecn)`.
+    ///
+    /// Called when we end up not writing a valid datagram into the reserved slice.
+    fn rollback(&mut self, src: Option<SocketAddr>, dst: SocketAddr, ecn: Ecn, len: usize);
+
+    /// Collect an already-formed [`Transmit`].
+    ///
+    /// Used for datagrams that were produced elsewhere as a standalone [`Transmit`] (e.g. a
+    /// handshake that cannot be encrypted in place because there is no session yet). The default
+    /// implementation copies the payload via [`BufferProvider::reserve`]; implementers that can take
+    /// ownership of the buffer should override it.
+    fn push(&mut self, transmit: Transmit) {
+        self.reserve(
+            transmit.src,
+            transmit.dst,
+            transmit.ecn,
+            transmit.payload.len(),
+        )
+        .copy_from_slice(&transmit.payload);
+    }
+}
+
+/// Collects datagrams as standalone [`Transmit`]s.
+///
+/// Datagrams are either encapsulated in place via the [`BufferProvider`] impl or pushed in
+/// fully-formed via [`BufferProvider::push`]. Used wherever packets must be surfaced as individual
+/// transmits rather than written into a shared destination buffer (e.g. control traffic, handshakes
+/// or the test harness).
+pub struct TransmitBuffer {
+    buffer_pool: BufferPool<Vec<u8>>,
+    transmits: VecDeque<Transmit>,
+}
+
+impl TransmitBuffer {
+    pub fn new() -> Self {
+        Self {
+            buffer_pool: BufferPool::new(ip_packet::MAX_FZ_PAYLOAD, "transmit-buffer"),
+            transmits: VecDeque::default(),
+        }
+    }
+
+    /// Returns the next collected [`Transmit`], if any.
+    pub fn poll_transmit(&mut self) -> Option<Transmit> {
+        self.transmits.pop_front()
+    }
+
+    pub fn clear(&mut self) {
+        self.transmits.clear();
+    }
+}
+
+impl Extend<Transmit> for TransmitBuffer {
+    fn extend<T: IntoIterator<Item = Transmit>>(&mut self, iter: T) {
+        self.transmits.extend(iter);
+    }
+}
+
+impl Default for TransmitBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferProvider for TransmitBuffer {
+    fn reserve(
+        &mut self,
+        src: Option<SocketAddr>,
+        dst: SocketAddr,
+        ecn: Ecn,
+        len: usize,
+    ) -> &mut [u8] {
+        let mut payload = self.buffer_pool.pull();
+        payload.resize(len, 0);
+
+        self.transmits.push_back(Transmit {
+            src,
+            dst,
+            payload,
+            ecn,
+        });
+
+        let last = self.transmits.back_mut().expect("just pushed an element");
+
+        &mut last.payload[..]
+    }
+
+    fn rollback(&mut self, _: Option<SocketAddr>, _: SocketAddr, _: Ecn, _: usize) {
+        self.transmits.pop_back();
+    }
+
+    fn push(&mut self, transmit: Transmit) {
+        self.transmits.push_back(transmit);
+    }
+}

--- a/rust/libs/connlib/snownet/src/buffer.rs
+++ b/rust/libs/connlib/snownet/src/buffer.rs
@@ -152,3 +152,41 @@ impl Drop for TransmitReservation<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use super::*;
+
+    const DST: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1111));
+
+    #[test]
+    fn committing_a_reservation_yields_the_transmit() {
+        let mut transmits = TransmitBuffer::new();
+
+        {
+            let mut reservation = transmits.reserve(None, DST, Ecn::NonEct, 6);
+            reservation.buffer().copy_from_slice(b"foobar");
+            reservation.commit();
+        }
+
+        let transmit = transmits.poll_transmit().expect("a committed transmit");
+        assert_eq!(transmit.dst, DST);
+        assert_eq!(&transmit.payload[..], b"foobar");
+        assert!(transmits.poll_transmit().is_none());
+    }
+
+    #[test]
+    fn dropping_a_reservation_without_committing_yields_nothing() {
+        let mut transmits = TransmitBuffer::new();
+
+        {
+            let mut reservation = transmits.reserve(None, DST, Ecn::NonEct, 6);
+            reservation.buffer().copy_from_slice(b"foobar");
+            // Dropped without committing.
+        }
+
+        assert!(transmits.poll_transmit().is_none());
+    }
+}

--- a/rust/libs/connlib/snownet/src/buffer.rs
+++ b/rust/libs/connlib/snownet/src/buffer.rs
@@ -11,43 +11,53 @@ use crate::node::Transmit;
 /// Implementers hand out a writable slice into which the encrypted packet is written directly,
 /// avoiding an intermediate copy.
 pub trait BufferProvider {
+    type Reservation<'a>: Reservation
+    where
+        Self: 'a;
+
     /// Reserve `len` writable bytes for a datagram from `src` to `dst` with the given `ecn`.
+    ///
+    /// The returned [`Reservation`] is rolled back when dropped unless it is
+    /// [committed](Reservation::commit).
     fn reserve(
         &mut self,
         src: Option<SocketAddr>,
         dst: SocketAddr,
         ecn: Ecn,
         len: usize,
-    ) -> &mut [u8];
-
-    /// Undo the most recent [`BufferProvider::reserve`] for `(src, dst, ecn)`.
-    ///
-    /// Called when we end up not writing a valid datagram into the reserved slice.
-    fn rollback(&mut self, src: Option<SocketAddr>, dst: SocketAddr, ecn: Ecn, len: usize);
+    ) -> Self::Reservation<'_>;
 
     /// Collect an already-formed [`Transmit`].
     ///
     /// Used for datagrams that were produced elsewhere as a standalone [`Transmit`] (e.g. a
     /// handshake that cannot be encrypted in place because there is no session yet). The default
-    /// implementation copies the payload via [`BufferProvider::reserve`]; implementers that can take
+    /// implementation copies the payload into a fresh reservation; implementers that can take
     /// ownership of the buffer should override it.
     fn push(&mut self, transmit: Transmit) {
-        self.reserve(
+        let mut reservation = self.reserve(
             transmit.src,
             transmit.dst,
             transmit.ecn,
             transmit.payload.len(),
-        )
-        .copy_from_slice(&transmit.payload);
+        );
+        reservation.buffer().copy_from_slice(&transmit.payload);
+        reservation.commit();
     }
 }
 
-/// Collects datagrams as standalone [`Transmit`]s.
+/// A reserved region within a [`BufferProvider`].
 ///
-/// Datagrams are either encapsulated in place via the [`BufferProvider`] impl or pushed in
-/// fully-formed via [`BufferProvider::push`]. Used wherever packets must be surfaced as individual
-/// transmits rather than written into a shared destination buffer (e.g. control traffic, handshakes
-/// or the test harness).
+/// Dropping the reservation without [committing](Self::commit) it rolls the reservation back.
+pub trait Reservation {
+    /// The writable bytes reserved for the datagram.
+    fn buffer(&mut self) -> &mut [u8];
+
+    /// Keep the bytes written into [`buffer`](Self::buffer); without this the reservation is rolled
+    /// back on drop.
+    fn commit(self);
+}
+
+/// Collects datagrams as standalone [`Transmit`]s.
 pub struct TransmitBuffer {
     buffer_pool: BufferPool<Vec<u8>>,
     transmits: VecDeque<Transmit>,
@@ -84,13 +94,15 @@ impl Default for TransmitBuffer {
 }
 
 impl BufferProvider for TransmitBuffer {
+    type Reservation<'a> = TransmitReservation<'a>;
+
     fn reserve(
         &mut self,
         src: Option<SocketAddr>,
         dst: SocketAddr,
         ecn: Ecn,
         len: usize,
-    ) -> &mut [u8] {
+    ) -> TransmitReservation<'_> {
         let mut payload = self.buffer_pool.pull();
         payload.resize(len, 0);
 
@@ -101,16 +113,42 @@ impl BufferProvider for TransmitBuffer {
             ecn,
         });
 
-        let last = self.transmits.back_mut().expect("just pushed an element");
-
-        &mut last.payload[..]
-    }
-
-    fn rollback(&mut self, _: Option<SocketAddr>, _: SocketAddr, _: Ecn, _: usize) {
-        self.transmits.pop_back();
+        TransmitReservation {
+            inner: self,
+            committed: false,
+        }
     }
 
     fn push(&mut self, transmit: Transmit) {
         self.transmits.push_back(transmit);
+    }
+}
+
+/// A [`Reservation`] into a [`TransmitBuffer`], backed by a freshly pushed [`Transmit`].
+pub struct TransmitReservation<'a> {
+    inner: &'a mut TransmitBuffer,
+    committed: bool,
+}
+
+impl Reservation for TransmitReservation<'_> {
+    fn buffer(&mut self) -> &mut [u8] {
+        &mut self
+            .inner
+            .transmits
+            .back_mut()
+            .expect("a transmit to have been reserved")
+            .payload[..]
+    }
+
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for TransmitReservation<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.inner.transmits.pop_back();
+        }
     }
 }

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -13,7 +13,7 @@ mod stats;
 mod utils;
 
 pub use allocation::RelaySocket;
-pub use buffer::{BufferProvider, TransmitBuffer};
+pub use buffer::{BufferProvider, Reservation, TransmitBuffer};
 pub use node::{
     Credentials, EncapsulateInfo, Event, IceConfig, IceRole, NoTurnServers, Node, StillConnecting,
     Transmit, UnknownConnection,

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod allocation;
 mod backoff;
+mod buffer;
 mod channel_data;
 mod index;
 mod node;
@@ -12,9 +13,10 @@ mod stats;
 mod utils;
 
 pub use allocation::RelaySocket;
+pub use buffer::{BufferProvider, TransmitBuffer};
 pub use node::{
-    Credentials, Event, IceConfig, IceRole, NoTurnServers, Node, StillConnecting, Transmit,
-    UnknownConnection,
+    Credentials, EncapsulateInfo, Event, IceConfig, IceRole, NoTurnServers, Node, StillConnecting,
+    Transmit, UnknownConnection,
 };
 pub use stats::{ConnectionStats, NodeStats};
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1673,14 +1673,11 @@ where
         debug_assert_eq!(packet_start + len, reserve_len);
 
         if let Some((peer, allocation)) = relay {
-            // Prepend the channel-data header into the reserved space.
-            if allocation
+            // Prepend the channel-data header into the reserved space. If no channel is bound to the
+            // peer yet, report the dropped packet; dropping the reservation rolls it back.
+            allocation
                 .encode_channel_data_header(peer, reservation.buffer(), now)
-                .is_none()
-            {
-                // No channel bound to the peer yet; dropping the reservation rolls it back.
-                return Ok(None);
-            }
+                .with_context(|| format!("No channel for peer {peer} on relay {relay_id}"))?;
         }
 
         reservation.commit();

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1670,11 +1670,14 @@ where
         debug_assert_eq!(packet_start + len, reserve_len);
 
         if let Some((peer, allocation)) = relay {
-            // Prepend the channel-data header into the reserved space. If no channel is bound to the
-            // peer yet, report the dropped packet; dropping the reservation rolls it back.
-            allocation
+            // A missing channel is an expected part of channel setup (`encode_channel_data_header`
+            // logs it and queues a binding), so drop the packet instead of surfacing an error.
+            if allocation
                 .encode_channel_data_header(peer, reservation.buffer(), now)
-                .with_context(|| format!("No channel for peer {peer} on relay {relay_id}"))?;
+                .is_none()
+            {
+                return Ok(None);
+            }
         }
 
         reservation.commit();

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1635,15 +1635,15 @@ where
             .on_outgoing(cid, &mut self.agent, self.default_ice_config, packet, now);
 
         let relay_id = self.relay.id;
-        let src = socket.packet_src();
         let ecn = packet.ecn();
 
-        // Resolve the relay's allocation once for relayed sockets: it provides the destination
-        // socket and, after encryption, the channel-data header. Direct sockets have no allocation
-        // and write at offset 0; relayed sockets reserve room for the channel-data header.
-        let (dst, packet_start, relay) = match socket {
-            PeerSocket::PeerToPeer { dest, .. } | PeerSocket::PeerToRelay { dest, .. } => {
-                (dest, 0, None)
+        // Resolve everything that depends on the socket kind in one place. Direct sockets carry
+        // their own source and destination and write at offset 0. Relayed sockets are sent from any
+        // interface (`src` is `None`); their destination and channel come from the relay's
+        // allocation (looked up once), and they reserve room for the channel-data header.
+        let (src, dst, packet_start, relay) = match socket {
+            PeerSocket::PeerToPeer { source, dest } | PeerSocket::PeerToRelay { source, dest } => {
+                (Some(source), dest, 0, None)
             }
             PeerSocket::RelayToPeer { dest: peer } | PeerSocket::RelayToRelay { dest: peer } => {
                 let allocation = allocations
@@ -1654,6 +1654,7 @@ where
                     .with_context(|| format!("No active socket for relay {relay_id}"))?;
 
                 (
+                    None,
                     dst,
                     ip_packet::DATA_CHANNEL_OVERHEAD,
                     Some((peer, allocation)),

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1634,6 +1634,7 @@ where
         self.state
             .on_outgoing(cid, &mut self.agent, self.default_ice_config, packet, now);
 
+        let relay_id = self.relay.id;
         let packet_start = if socket.send_from_relay() {
             ip_packet::DATA_CHANNEL_OVERHEAD
         } else {
@@ -1642,14 +1643,22 @@ where
         let src = socket.packet_src();
         let ecn = packet.ecn();
 
-        // The destination of the resulting UDP datagram. For relayed sockets this is the relay's
-        // active socket; the actual peer is encoded into the channel-data header below.
-        let dst = match socket {
-            PeerSocket::PeerToPeer { dest, .. } | PeerSocket::PeerToRelay { dest, .. } => dest,
-            PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => allocations
-                .get_by_id(&self.relay.id)
-                .and_then(|allocation| allocation.active_socket())
-                .with_context(|| format!("No allocation for relay {}", self.relay.id))?,
+        // Resolve the relay's allocation once for relayed sockets: it provides the destination
+        // socket and, after encryption, the channel-data header. Direct sockets have no allocation.
+        let (dst, relay) = match socket {
+            PeerSocket::PeerToPeer { dest, .. } | PeerSocket::PeerToRelay { dest, .. } => {
+                (dest, None)
+            }
+            PeerSocket::RelayToPeer { dest: peer } | PeerSocket::RelayToRelay { dest: peer } => {
+                let allocation = allocations
+                    .get_mut_by_id(&relay_id)
+                    .with_context(|| format!("No allocation for relay {relay_id}"))?;
+                let dst = allocation
+                    .active_socket()
+                    .with_context(|| format!("No active socket for relay {relay_id}"))?;
+
+                (dst, Some((peer, allocation)))
+            }
         };
 
         let reserve_len = packet_start + packet.packet().len() + ip_packet::WG_OVERHEAD;
@@ -1663,21 +1672,15 @@ where
         )?;
         debug_assert_eq!(packet_start + len, reserve_len);
 
-        match socket {
-            PeerSocket::RelayToPeer { dest: peer } | PeerSocket::RelayToRelay { dest: peer } => {
-                // Prepend the channel-data header into the reserved space.
-                if allocations
-                    .get_mut_by_id(&self.relay.id)
-                    .and_then(|allocation| {
-                        allocation.encode_channel_data_header(peer, reservation.buffer(), now)
-                    })
-                    .is_none()
-                {
-                    // No channel bound to the peer yet; dropping the reservation rolls it back.
-                    return Ok(None);
-                }
+        if let Some((peer, allocation)) = relay {
+            // Prepend the channel-data header into the reserved space.
+            if allocation
+                .encode_channel_data_header(peer, reservation.buffer(), now)
+                .is_none()
+            {
+                // No channel bound to the peer yet; dropping the reservation rolls it back.
+                return Ok(None);
             }
-            PeerSocket::PeerToPeer { .. } | PeerSocket::PeerToRelay { .. } => {}
         }
 
         reservation.commit();

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -7,6 +7,7 @@ mod timeout_cache;
 pub use connections::UnknownConnection;
 
 use crate::allocation::{self, Allocation, RelaySocket, Socket};
+use crate::buffer::{BufferProvider, TransmitBuffer};
 use crate::index::IndexLfsr;
 use crate::node::allocations::Allocations;
 use crate::node::connection_state::{ConnectionState, PeerSocket};
@@ -90,7 +91,7 @@ pub struct Node<TId, RId> {
     index: IndexLfsr,
     rate_limiter: Arc<RateLimiter>,
 
-    buffered_transmits: VecDeque<Transmit>,
+    buffered_transmits: TransmitBuffer,
 
     next_rate_limiter_reset: Option<Instant>,
 
@@ -197,7 +198,7 @@ where
             public_key: *public_key,
             index,
             rate_limiter: Arc::new(RateLimiter::new_at(public_key, HANDSHAKE_RATE_LIMIT, now)),
-            buffered_transmits: VecDeque::default(),
+            buffered_transmits: TransmitBuffer::default(),
             next_rate_limiter_reset: None,
             pending_events: VecDeque::default(),
             allocations,
@@ -409,11 +410,16 @@ where
 
         self.pending_events.push_back(Event::ConnectionClosed(cid));
 
-        match connection.encapsulate(cid, peer_socket, &goodbye, now, &mut self.allocations) {
-            Ok(Some(transmit)) => {
+        match connection.encapsulate(
+            cid,
+            peer_socket,
+            &goodbye,
+            now,
+            &mut self.allocations,
+            &mut self.buffered_transmits,
+        ) {
+            Ok(Some(_)) => {
                 tracing::info!("Connection closed proactively (sent goodbye)");
-
-                self.buffered_transmits.push_back(transmit);
             }
             Ok(None) => {
                 tracing::info!("Connection closed proactively (failed to send goodbye)");
@@ -524,35 +530,36 @@ where
         Ok(Some((id, packet)))
     }
 
-    /// Encapsulate an outgoing IP packet.
+    /// Encapsulate an outgoing IP packet, writing it directly into `provider` to avoid a copy.
     ///
     /// Wireguard is an IP tunnel, so we "enforce" that only IP packets are sent through it.
-    /// We say "enforce" an [`IpPacket`] can be created from an (almost) arbitrary byte buffer at virtually no cost.
-    /// Nevertheless, using [`IpPacket`] in our API has good documentation value.
+    /// We say "enforce" because an [`IpPacket`] can be created from an (almost) arbitrary byte
+    /// buffer at virtually no cost; using [`IpPacket`] in our API has good documentation value.
+    ///
+    /// Returns where the datagram was written (for observability), or `Ok(None)` if the relay path
+    /// is not ready yet (the reservation is rolled back in that case). Returns [`StillConnecting`]
+    /// while ICE is still in progress; buffering the packet and retrying once
+    /// [`Event::ConnectionEstablished`] is emitted is the caller's responsibility.
     pub fn encapsulate(
         &mut self,
         cid: TId,
         packet: &IpPacket,
         now: Instant,
-    ) -> Result<Option<Transmit>> {
+        provider: &mut impl BufferProvider,
+    ) -> Result<Option<EncapsulateInfo>> {
         let conn = self.connections.get_mut(&cid, now)?;
 
         let socket = match &conn.state {
-            ConnectionState::Connecting { .. } => {
-                return Err(StillConnecting.into());
-            }
-            ConnectionState::Connected { peer_socket, .. } => *peer_socket,
-            ConnectionState::Idle { peer_socket } => *peer_socket,
+            ConnectionState::Connecting { .. } => return Err(StillConnecting.into()),
+            ConnectionState::Connected { peer_socket, .. }
+            | ConnectionState::Idle { peer_socket } => *peer_socket,
             ConnectionState::Failed => {
                 return Err(anyhow!("Connection {cid} failed"));
             }
         };
 
-        let maybe_transmit = conn
-            .encapsulate(cid, socket, packet, now, &mut self.allocations)
-            .with_context(|| format!("cid={cid}"))?;
-
-        Ok(maybe_transmit)
+        conn.encapsulate(cid, socket, packet, now, &mut self.allocations, provider)
+            .with_context(|| format!("cid={cid}"))
     }
 
     /// Returns a pending [`Event`] from the pool.
@@ -664,7 +671,7 @@ where
             return Some(transmit);
         }
 
-        let transmit = self.buffered_transmits.pop_front()?;
+        let transmit = self.buffered_transmits.poll_transmit()?;
 
         tracing::trace!(?transmit);
 
@@ -1251,6 +1258,13 @@ impl fmt::Debug for Transmit {
     }
 }
 
+/// Describes where an encapsulated datagram was sent; returned by [`Node::encapsulate`].
+#[derive(Debug, Clone, Copy)]
+pub struct EncapsulateInfo {
+    pub src: Option<SocketAddr>,
+    pub dst: SocketAddr,
+}
+
 #[derive(derive_more::Debug)]
 struct Connection<RId> {
     agent: IceAgent,
@@ -1334,7 +1348,7 @@ where
         cid: TId,
         now: Instant,
         allocations: &mut Allocations<RId>,
-        transmits: &mut VecDeque<Transmit>,
+        transmits: &mut TransmitBuffer,
         pending_events: &mut VecDeque<Event<TId>>,
         inflight_stun_requests: &mut InflightStunRequests<TId>,
     ) where
@@ -1531,7 +1545,7 @@ where
                 self.stats.stun_bytes_to_peer_direct += stun_packet_bytes.len();
 
                 // `source` did not match any of our allocated sockets, must be a local one then!
-                transmits.push_back(Transmit {
+                transmits.push(Transmit {
                     src: Some(source),
                     dst,
                     payload: self.buffer_pool.pull_initialised(&stun_packet_bytes),
@@ -1553,7 +1567,7 @@ where
 
             self.stats.stun_bytes_to_peer_relayed += data_channel_packet.len();
 
-            transmits.push_back(Transmit {
+            transmits.push(Transmit {
                 src: None,
                 dst: encode_ok.socket,
                 payload: self.buffer_pool.pull_initialised(&data_channel_packet),
@@ -1566,7 +1580,7 @@ where
         &mut self,
         now: Instant,
         allocations: &mut Allocations<RId>,
-        transmits: &mut VecDeque<Transmit>,
+        transmits: &mut TransmitBuffer,
     ) {
         // Don't update wireguard timers until we are connected.
         let Some(peer_socket) = self.socket() else {
@@ -1605,6 +1619,14 @@ where
         };
     }
 
+    /// Encapsulate `packet` directly into the buffer handed out by `provider`, avoiding a copy.
+    ///
+    /// This is the throughput-critical path for the TUN -> network direction. When a usable
+    /// WireGuard session exists, the encrypted packet is written in place into `provider` and the
+    /// resulting [`EncapsulateInfo`] is returned. When no session is usable, the reservation is
+    /// rolled back and the [`WireGuardError`] is propagated for the caller to handle. `Ok(None)`
+    /// means nothing was written because the relay path is not ready yet (no allocation or no bound
+    /// channel).
     fn encapsulate<TId>(
         &mut self,
         cid: TId,
@@ -1612,58 +1634,73 @@ where
         packet: &IpPacket,
         now: Instant,
         allocations: &mut Allocations<RId>,
-    ) -> Result<Option<Transmit>>
+        provider: &mut impl BufferProvider,
+    ) -> Result<Option<EncapsulateInfo>, WireGuardError>
     where
         TId: fmt::Display,
     {
         self.state
             .on_outgoing(cid, &mut self.agent, self.default_ice_config, packet, now);
 
-        let packet_start = if socket.send_from_relay() { 4 } else { 0 };
+        let packet_start = if socket.send_from_relay() {
+            ip_packet::DATA_CHANNEL_OVERHEAD
+        } else {
+            0
+        };
+        let src = socket.packet_src();
+        let ecn = packet.ecn();
 
-        let mut buffer = self.buffer_pool.pull();
-        buffer.resize(ip_packet::MAX_FZ_PAYLOAD, 0);
-
-        let len =
-            self.tunnel
-                .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)?;
-
-        let packet_end = packet_start + len;
-        buffer.truncate(packet_end);
-
-        match socket {
-            PeerSocket::PeerToPeer {
-                source,
-                dest: remote,
-            }
-            | PeerSocket::PeerToRelay {
-                source,
-                dest: remote,
-            } => Ok(Some(Transmit {
-                src: Some(source),
-                dst: remote,
-                payload: buffer,
-                ecn: packet.ecn(),
-            })),
-            PeerSocket::RelayToPeer { dest: peer } | PeerSocket::RelayToRelay { dest: peer } => {
-                let Some(allocation) = allocations.get_mut_by_id(&self.relay.id) else {
+        // The destination of the resulting UDP datagram. For relayed sockets this is the relay's
+        // active socket; the actual peer is encoded into the channel-data header below.
+        let dst = match socket {
+            PeerSocket::PeerToPeer { dest, .. } | PeerSocket::PeerToRelay { dest, .. } => dest,
+            PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => {
+                let Some(dst) = allocations
+                    .get_by_id(&self.relay.id)
+                    .and_then(|allocation| allocation.active_socket())
+                else {
                     tracing::warn!(relay = %self.relay.id, "No allocation");
                     return Ok(None);
                 };
-                let Some(encode_ok) =
-                    allocation.encode_channel_data_header(peer, &mut buffer[..packet_end], now)
-                else {
-                    return Ok(None);
-                };
 
-                buffer.truncate(packet_end);
+                dst
+            }
+        };
 
-                Ok(Some(Transmit {
-                    src: None,
-                    dst: encode_ok.socket,
-                    payload: buffer,
-                    ecn: packet.ecn(),
-                }))
+        let reserve_len = packet_start + packet.packet().len() + ip_packet::WG_OVERHEAD;
+        let buffer = provider.reserve(src, dst, ecn, reserve_len);
+
+        match self
+            .tunnel
+            .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)
+        {
+            Ok(len) => {
+                debug_assert_eq!(packet_start + len, reserve_len);
+
+                match socket {
+                    PeerSocket::RelayToPeer { dest: peer }
+                    | PeerSocket::RelayToRelay { dest: peer } => {
+                        // Prepend the channel-data header into the reserved space.
+                        if allocations
+                            .get_mut_by_id(&self.relay.id)
+                            .and_then(|allocation| {
+                                allocation.encode_channel_data_header(peer, buffer, now)
+                            })
+                            .is_none()
+                        {
+                            // No channel bound to the peer yet; undo the reservation and drop.
+                            provider.rollback(src, dst, ecn, reserve_len);
+                            return Ok(None);
+                        }
+                    }
+                    PeerSocket::PeerToPeer { .. } | PeerSocket::PeerToRelay { .. } => {}
+                }
+
+                Ok(Some(EncapsulateInfo { src, dst }))
+            }
+            Err(e) => {
+                provider.rollback(src, dst, ecn, reserve_len);
+                Err(e)
             }
         }
     }
@@ -1674,7 +1711,7 @@ where
         src: IpAddr,
         packet: &[u8],
         allocations: &mut Allocations<RId>,
-        transmits: &mut VecDeque<Transmit>,
+        transmits: &mut TransmitBuffer,
         now: Instant,
     ) -> ControlFlow<Result<()>, IpPacket>
     where
@@ -1782,7 +1819,7 @@ where
     fn initiate_wg_session(
         &mut self,
         allocations: &mut Allocations<RId>,
-        transmits: &mut VecDeque<Transmit>,
+        provider: &mut impl BufferProvider,
         now: Instant,
     ) where
         RId: Copy,
@@ -1823,14 +1860,16 @@ where
 
         self.last_proactive_handshake_sent_at = Some(now);
 
-        transmits.extend(make_owned_transmit(
+        if let Some(transmit) = make_owned_transmit(
             self.relay.id,
             socket,
             bytes,
             &self.buffer_pool,
             allocations,
             now,
-        ));
+        ) {
+            provider.push(transmit);
+        }
     }
 
     fn add_local_candidate<TId>(

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1635,19 +1635,15 @@ where
             .on_outgoing(cid, &mut self.agent, self.default_ice_config, packet, now);
 
         let relay_id = self.relay.id;
-        let packet_start = if socket.send_from_relay() {
-            ip_packet::DATA_CHANNEL_OVERHEAD
-        } else {
-            0
-        };
         let src = socket.packet_src();
         let ecn = packet.ecn();
 
         // Resolve the relay's allocation once for relayed sockets: it provides the destination
-        // socket and, after encryption, the channel-data header. Direct sockets have no allocation.
-        let (dst, relay) = match socket {
+        // socket and, after encryption, the channel-data header. Direct sockets have no allocation
+        // and write at offset 0; relayed sockets reserve room for the channel-data header.
+        let (dst, packet_start, relay) = match socket {
             PeerSocket::PeerToPeer { dest, .. } | PeerSocket::PeerToRelay { dest, .. } => {
-                (dest, None)
+                (dest, 0, None)
             }
             PeerSocket::RelayToPeer { dest: peer } | PeerSocket::RelayToRelay { dest: peer } => {
                 let allocation = allocations
@@ -1657,7 +1653,11 @@ where
                     .active_socket()
                     .with_context(|| format!("No active socket for relay {relay_id}"))?;
 
-                (dst, Some((peer, allocation)))
+                (
+                    dst,
+                    ip_packet::DATA_CHANNEL_OVERHEAD,
+                    Some((peer, allocation)),
+                )
             }
         };
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -7,7 +7,7 @@ mod timeout_cache;
 pub use connections::UnknownConnection;
 
 use crate::allocation::{self, Allocation, RelaySocket, Socket};
-use crate::buffer::{BufferProvider, TransmitBuffer};
+use crate::buffer::{BufferProvider, Reservation, TransmitBuffer};
 use crate::index::IndexLfsr;
 use crate::node::allocations::Allocations;
 use crate::node::connection_state::{ConnectionState, PeerSocket};
@@ -533,13 +533,8 @@ where
     /// Encapsulate an outgoing IP packet, writing it directly into `provider` to avoid a copy.
     ///
     /// Wireguard is an IP tunnel, so we "enforce" that only IP packets are sent through it.
-    /// We say "enforce" because an [`IpPacket`] can be created from an (almost) arbitrary byte
-    /// buffer at virtually no cost; using [`IpPacket`] in our API has good documentation value.
-    ///
-    /// Returns where the datagram was written (for observability), or `Ok(None)` if the relay path
-    /// is not ready yet (the reservation is rolled back in that case). Returns [`StillConnecting`]
-    /// while ICE is still in progress; buffering the packet and retrying once
-    /// [`Event::ConnectionEstablished`] is emitted is the caller's responsibility.
+    /// We say "enforce" an [`IpPacket`] can be created from an (almost) arbitrary byte buffer at virtually no cost.
+    /// Nevertheless, using [`IpPacket`] in our API has good documentation value.
     pub fn encapsulate(
         &mut self,
         cid: TId,
@@ -550,16 +545,21 @@ where
         let conn = self.connections.get_mut(&cid, now)?;
 
         let socket = match &conn.state {
-            ConnectionState::Connecting { .. } => return Err(StillConnecting.into()),
-            ConnectionState::Connected { peer_socket, .. }
-            | ConnectionState::Idle { peer_socket } => *peer_socket,
+            ConnectionState::Connecting { .. } => {
+                return Err(StillConnecting.into());
+            }
+            ConnectionState::Connected { peer_socket, .. } => *peer_socket,
+            ConnectionState::Idle { peer_socket } => *peer_socket,
             ConnectionState::Failed => {
                 return Err(anyhow!("Connection {cid} failed"));
             }
         };
 
-        conn.encapsulate(cid, socket, packet, now, &mut self.allocations, provider)
-            .with_context(|| format!("cid={cid}"))
+        let info = conn
+            .encapsulate(cid, socket, packet, now, &mut self.allocations, provider)
+            .with_context(|| format!("cid={cid}"))?;
+
+        Ok(info)
     }
 
     /// Returns a pending [`Event`] from the pool.
@@ -1258,7 +1258,6 @@ impl fmt::Debug for Transmit {
     }
 }
 
-/// Describes where an encapsulated datagram was sent; returned by [`Node::encapsulate`].
 #[derive(Debug, Clone, Copy)]
 pub struct EncapsulateInfo {
     pub src: Option<SocketAddr>,
@@ -1620,13 +1619,6 @@ where
     }
 
     /// Encapsulate `packet` directly into the buffer handed out by `provider`, avoiding a copy.
-    ///
-    /// This is the throughput-critical path for the TUN -> network direction. When a usable
-    /// WireGuard session exists, the encrypted packet is written in place into `provider` and the
-    /// resulting [`EncapsulateInfo`] is returned. When no session is usable, the reservation is
-    /// rolled back and the [`WireGuardError`] is propagated for the caller to handle. `Ok(None)`
-    /// means nothing was written because the relay path is not ready yet (no allocation or no bound
-    /// channel).
     fn encapsulate<TId>(
         &mut self,
         cid: TId,
@@ -1668,41 +1660,36 @@ where
         };
 
         let reserve_len = packet_start + packet.packet().len() + ip_packet::WG_OVERHEAD;
-        let buffer = provider.reserve(src, dst, ecn, reserve_len);
+        let mut reservation = provider.reserve(src, dst, ecn, reserve_len);
 
-        match self
-            .tunnel
-            .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)
-        {
-            Ok(len) => {
-                debug_assert_eq!(packet_start + len, reserve_len);
+        // On `Err`, `reservation` is dropped without committing and rolls back automatically.
+        let len = self.tunnel.encapsulate_data_at(
+            packet.packet(),
+            &mut reservation.buffer()[packet_start..],
+            now,
+        )?;
+        debug_assert_eq!(packet_start + len, reserve_len);
 
-                match socket {
-                    PeerSocket::RelayToPeer { dest: peer }
-                    | PeerSocket::RelayToRelay { dest: peer } => {
-                        // Prepend the channel-data header into the reserved space.
-                        if allocations
-                            .get_mut_by_id(&self.relay.id)
-                            .and_then(|allocation| {
-                                allocation.encode_channel_data_header(peer, buffer, now)
-                            })
-                            .is_none()
-                        {
-                            // No channel bound to the peer yet; undo the reservation and drop.
-                            provider.rollback(src, dst, ecn, reserve_len);
-                            return Ok(None);
-                        }
-                    }
-                    PeerSocket::PeerToPeer { .. } | PeerSocket::PeerToRelay { .. } => {}
+        match socket {
+            PeerSocket::RelayToPeer { dest: peer } | PeerSocket::RelayToRelay { dest: peer } => {
+                // Prepend the channel-data header into the reserved space.
+                if allocations
+                    .get_mut_by_id(&self.relay.id)
+                    .and_then(|allocation| {
+                        allocation.encode_channel_data_header(peer, reservation.buffer(), now)
+                    })
+                    .is_none()
+                {
+                    // No channel bound to the peer yet; dropping the reservation rolls it back.
+                    return Ok(None);
                 }
-
-                Ok(Some(EncapsulateInfo { src, dst }))
             }
-            Err(e) => {
-                provider.rollback(src, dst, ecn, reserve_len);
-                Err(e)
-            }
+            PeerSocket::PeerToPeer { .. } | PeerSocket::PeerToRelay { .. } => {}
         }
+
+        reservation.commit();
+
+        Ok(Some(EncapsulateInfo { src, dst }))
     }
 
     fn decapsulate<TId>(

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1637,10 +1637,6 @@ where
         let relay_id = self.relay.id;
         let ecn = packet.ecn();
 
-        // Resolve everything that depends on the socket kind in one place. Direct sockets carry
-        // their own source and destination and write at offset 0. Relayed sockets are sent from any
-        // interface (`src` is `None`); their destination and channel come from the relay's
-        // allocation (looked up once), and they reserve room for the channel-data header.
         let (src, dst, packet_start, relay) = match socket {
             PeerSocket::PeerToPeer { source, dest } | PeerSocket::PeerToRelay { source, dest } => {
                 (Some(source), dest, 0, None)

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1627,7 +1627,7 @@ where
         now: Instant,
         allocations: &mut Allocations<RId>,
         provider: &mut impl BufferProvider,
-    ) -> Result<Option<EncapsulateInfo>, WireGuardError>
+    ) -> Result<Option<EncapsulateInfo>>
     where
         TId: fmt::Display,
     {
@@ -1646,17 +1646,10 @@ where
         // active socket; the actual peer is encoded into the channel-data header below.
         let dst = match socket {
             PeerSocket::PeerToPeer { dest, .. } | PeerSocket::PeerToRelay { dest, .. } => dest,
-            PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => {
-                let Some(dst) = allocations
-                    .get_by_id(&self.relay.id)
-                    .and_then(|allocation| allocation.active_socket())
-                else {
-                    tracing::warn!(relay = %self.relay.id, "No allocation");
-                    return Ok(None);
-                };
-
-                dst
-            }
+            PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => allocations
+                .get_by_id(&self.relay.id)
+                .and_then(|allocation| allocation.active_socket())
+                .with_context(|| format!("No allocation for relay {}", self.relay.id))?,
         };
 
         let reserve_len = packet_start + packet.packet().len() + ip_packet::WG_OVERHEAD;

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -269,10 +269,6 @@ pub(crate) enum PeerSocket {
 }
 
 impl PeerSocket {
-    pub(crate) fn send_from_relay(&self) -> bool {
-        matches!(self, Self::RelayToPeer { .. } | Self::RelayToRelay { .. })
-    }
-
     /// The local source address the resulting UDP datagram should be sent from, if any.
     ///
     /// This is `None` for relayed sockets because those are sent from whichever interface can

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -273,6 +273,19 @@ impl PeerSocket {
         matches!(self, Self::RelayToPeer { .. } | Self::RelayToRelay { .. })
     }
 
+    /// The local source address the resulting UDP datagram should be sent from, if any.
+    ///
+    /// This is `None` for relayed sockets because those are sent from whichever interface can
+    /// reach the relay.
+    pub(crate) fn packet_src(&self) -> Option<SocketAddr> {
+        match self {
+            PeerSocket::PeerToPeer { source, .. } | PeerSocket::PeerToRelay { source, .. } => {
+                Some(*source)
+            }
+            PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => None,
+        }
+    }
+
     pub(crate) fn fmt<RId>(&self, relay: RId) -> String
     where
         RId: fmt::Display,

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -269,19 +269,6 @@ pub(crate) enum PeerSocket {
 }
 
 impl PeerSocket {
-    /// The local source address the resulting UDP datagram should be sent from, if any.
-    ///
-    /// This is `None` for relayed sockets because those are sent from whichever interface can
-    /// reach the relay.
-    pub(crate) fn packet_src(&self) -> Option<SocketAddr> {
-        match self {
-            PeerSocket::PeerToPeer { source, .. } | PeerSocket::PeerToRelay { source, .. } => {
-                Some(*source)
-            }
-            PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => None,
-        }
-    }
-
     pub(crate) fn fmt<RId>(&self, relay: RId) -> String
     where
         RId: fmt::Display,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -568,7 +568,18 @@ impl ClientState {
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,
         };
 
-        self.encapsulate(non_dns_packet, now, provider)
+        let Some((pid, packet)) = self.prepare_outbound(non_dns_packet, now)? else {
+            return Ok(());
+        };
+
+        encapsulate_or_buffer(
+            packet,
+            pid,
+            now,
+            &mut self.node,
+            provider,
+            &mut self.pending_packets,
+        )
     }
 
     /// Handles UDP packets received on the network interface.
@@ -793,26 +804,6 @@ impl ClientState {
                 &mut self.pending_packets,
             );
         }
-    }
-
-    fn encapsulate(
-        &mut self,
-        packet: IpPacket,
-        now: Instant,
-        provider: &mut impl snownet::BufferProvider,
-    ) -> Result<()> {
-        let Some((pid, packet)) = self.prepare_outbound(packet, now)? else {
-            return Ok(());
-        };
-
-        encapsulate_or_buffer(
-            packet,
-            pid,
-            now,
-            &mut self.node,
-            provider,
-            &mut self.pending_packets,
-        )
     }
 
     /// Route an outbound IP packet and apply any DNS resource NAT, yielding the

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -579,7 +579,9 @@ impl ClientState {
             &mut self.node,
             provider,
             &mut self.pending_packets,
-        )
+        )?;
+
+        Ok(())
     }
 
     /// Handles UDP packets received on the network interface.

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -52,7 +52,7 @@ use itertools::Itertools;
 use logging::{unwrap_or_debug, unwrap_or_warn};
 use ringbuffer::RingBuffer;
 use secrecy::ExposeSecret as _;
-use snownet::{NoTurnServers, Node, RelaySocket, Transmit};
+use snownet::{NoTurnServers, Node, RelaySocket};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque, hash_map};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -175,7 +175,7 @@ pub struct ClientState {
 
     buffered_events: VecDeque<ClientEvent>,
     buffered_packets: VecDeque<IpPacket>,
-    buffered_transmits: VecDeque<Transmit>,
+    buffered_transmits: snownet::TransmitBuffer,
 
     unix_ts_clock: UnixTsClock,
     buffered_dns_queries: VecDeque<dns::RecursiveQuery>,
@@ -539,13 +539,14 @@ impl ClientState {
         &mut self,
         packet: IpPacket,
         now: Instant,
-    ) -> Result<Option<snownet::Transmit>> {
+        provider: &mut impl snownet::BufferProvider,
+    ) -> Result<()> {
         if packet.is_fz_p2p_control() {
             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
         }
 
         if packet.destination().is_multicast() {
-            return Ok(None);
+            return Ok(());
         }
 
         let tun_config = self
@@ -563,11 +564,11 @@ impl ClientState {
         );
 
         let non_dns_packet = match self.try_handle_dns(packet, now) {
-            ControlFlow::Break(()) => return Ok(None),
+            ControlFlow::Break(()) => return Ok(()),
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,
         };
 
-        self.encapsulate(non_dns_packet, now)
+        self.encapsulate(non_dns_packet, now, provider)
     }
 
     /// Handles UDP packets received on the network interface.
@@ -794,7 +795,39 @@ impl ClientState {
         }
     }
 
-    fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> Result<Option<snownet::Transmit>> {
+    fn encapsulate(
+        &mut self,
+        packet: IpPacket,
+        now: Instant,
+        provider: &mut impl snownet::BufferProvider,
+    ) -> Result<()> {
+        let Some((pid, packet)) = self.prepare_outbound(packet, now)? else {
+            return Ok(());
+        };
+
+        encapsulate_or_buffer(
+            packet,
+            pid,
+            now,
+            &mut self.node,
+            provider,
+            &mut self.pending_packets,
+        )
+    }
+
+    /// Route an outbound IP packet and apply any DNS resource NAT, yielding the
+    /// connection it should be encapsulated through.
+    ///
+    /// ## Returns
+    ///
+    /// - `Ok(Some(...))` if the packet is ready to be encapsulated
+    /// - `Ok(None)` if the packet was consumed (buffered for flow setup, replied to, etc.)
+    /// - `Err(...)` if the packet is unroutable
+    fn prepare_outbound(
+        &mut self,
+        packet: IpPacket,
+        now: Instant,
+    ) -> Result<Option<(ClientOrGatewayId, IpPacket)>> {
         let dst = packet.destination();
         let dst_proto = packet.destination_protocol()?;
 
@@ -823,10 +856,7 @@ impl ClientState {
             }
         }
 
-        let transmit =
-            encapsulate_or_buffer(packet, pid, now, &mut self.node, &mut self.pending_packets)?;
-
-        Ok(transmit)
+        Ok(Some((pid, packet)))
     }
 
     /// Decide which connection a packet should be encapsulated through.
@@ -1577,16 +1607,25 @@ impl ClientState {
                 .or_else(|| self.udp_dns_client.poll_outbound())
             {
                 // All packets from the DNS clients _should_ go through the tunnel.
-                let transmit = match self.encapsulate(packet, now) {
-                    Ok(Some(transmit)) => transmit,
-                    Ok(None) => continue,
+                let maybe_outbound = match self.prepare_outbound(packet, now) {
+                    Ok(maybe_outbound) => maybe_outbound,
                     Err(e) => {
                         tracing::debug!("{e:#}");
                         continue;
                     }
                 };
+                let Some((pid, packet)) = maybe_outbound else {
+                    continue;
+                };
 
-                self.buffered_transmits.push_back(transmit);
+                encapsulate_and_queue(
+                    packet,
+                    pid,
+                    now,
+                    &mut self.node,
+                    &mut self.buffered_transmits,
+                    &mut self.pending_packets,
+                );
                 continue;
             }
 
@@ -2157,7 +2196,7 @@ impl ClientState {
 
     pub(crate) fn poll_transmit(&mut self) -> Option<snownet::Transmit> {
         self.buffered_transmits
-            .pop_front()
+            .poll_transmit()
             .or_else(|| self.node.poll_transmit())
     }
 
@@ -2617,23 +2656,25 @@ fn filter_allows(filter: &FilterEngine, protocol: Protocol) -> bool {
     false
 }
 
-/// Encapsulate `packet` for `pid`, or buffer it if the connection is still being established.
+/// Encapsulate `packet` for `pid` directly into `provider`, or buffer it if the connection is
+/// still being established.
 fn encapsulate_or_buffer(
     packet: IpPacket,
     pid: ClientOrGatewayId,
     now: Instant,
     node: &mut Node<ClientOrGatewayId, RelayId>,
+    provider: &mut impl snownet::BufferProvider,
     pending_packets: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
-) -> Result<Option<Transmit>> {
+) -> Result<()> {
     const CONNECTION_BUFFER_CAPACITY_POW_2: usize = 7; // 2^7 = 128
 
     if let Some(buffer) = pending_packets.get_mut(&pid) {
         buffer.push(packet);
-        return Ok(None);
+        return Ok(());
     }
 
-    match node.encapsulate(pid, &packet, now) {
-        Ok(maybe_transmit) => Ok(maybe_transmit),
+    match node.encapsulate(pid, &packet, now, provider) {
+        Ok(_) => Ok(()),
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
             pending_packets
                 .entry(pid)
@@ -2644,7 +2685,7 @@ fn encapsulate_or_buffer(
                     )
                 })
                 .push(packet);
-            Ok(None)
+            Ok(())
         }
         Err(e) if e.any_is::<snownet::UnknownConnection>() => {
             Err(e.context(UnroutablePacket::not_connected(&packet)))
@@ -2653,19 +2694,20 @@ fn encapsulate_or_buffer(
     }
 }
 
-/// Like [`encapsulate_or_buffer`], but queues the resulting transmit into `buffered_transmits` and
-/// drops (with a log) any error instead of returning it.
+/// Like [`encapsulate_or_buffer`], but encapsulates into `buffered_transmits` and drops (with a
+/// log) any error instead of returning it.
 fn encapsulate_and_queue(
     packet: IpPacket,
     pid: ClientOrGatewayId,
     now: Instant,
     node: &mut Node<ClientOrGatewayId, RelayId>,
-    buffered_transmits: &mut VecDeque<Transmit>,
+    buffered_transmits: &mut snownet::TransmitBuffer,
     pending_packets: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 ) {
-    match encapsulate_or_buffer(packet, pid, now, node, pending_packets) {
-        Ok(maybe_transmit) => buffered_transmits.extend(maybe_transmit),
-        Err(e) => tracing::debug!(%pid, "Failed to encapsulate: {e:#}"),
+    if let Err(e) =
+        encapsulate_or_buffer(packet, pid, now, node, buffered_transmits, pending_packets)
+    {
+        tracing::debug!(%pid, "Failed to encapsulate: {e:#}");
     }
 }
 
@@ -2771,7 +2813,7 @@ mod tests {
 
         assert_eq!(
             state
-                .handle_tun_input(packet, Instant::now())
+                .handle_tun_input(packet, Instant::now(), &mut snownet::TransmitBuffer::new())
                 .unwrap_err()
                 .to_string(),
             "Unroutable packet: Packet destination IP is TUN device"
@@ -2789,7 +2831,7 @@ mod tests {
 
         assert_eq!(
             state
-                .handle_tun_input(packet, Instant::now())
+                .handle_tun_input(packet, Instant::now(), &mut snownet::TransmitBuffer::new())
                 .unwrap_err()
                 .to_string(),
             "Unroutable packet: Packet destination IP is TUN device"

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -18,7 +18,7 @@ use connlib_model::{ClientId, IceCandidate, RelayId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::ExposeSecret as _;
-use snownet::{IceConfig, IceRole, NoTurnServers, Node, RelaySocket, Transmit};
+use snownet::{IceConfig, IceRole, NoTurnServers, Node, RelaySocket};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
 use std::net::{IpAddr, SocketAddr};
@@ -49,7 +49,7 @@ pub struct GatewayState {
     next_periodic_tick: Option<Instant>,
 
     buffered_events: VecDeque<GatewayEvent>,
-    buffered_transmits: VecDeque<Transmit>,
+    buffered_transmits: snownet::TransmitBuffer,
 }
 
 #[derive(Debug)]
@@ -75,7 +75,7 @@ impl GatewayState {
             peers: Default::default(),
             node: Node::new(seed, now, unix_ts),
             buffered_events: VecDeque::default(),
-            buffered_transmits: VecDeque::default(),
+            buffered_transmits: snownet::TransmitBuffer::default(),
             flow_tracker: FlowTracker::new(flow_logs, now, unix_ts),
             tun_ip_config: None,
             unix_ts_clock: UnixTsClock::new(now, unix_ts),
@@ -104,7 +104,8 @@ impl GatewayState {
         &mut self,
         packet: IpPacket,
         now: Instant,
-    ) -> Result<Option<snownet::Transmit>> {
+        provider: &mut impl snownet::BufferProvider,
+    ) -> Result<()> {
         let _guard = self.flow_tracker.new_inbound_tun(&packet, now);
 
         if packet.is_fz_p2p_control() {
@@ -126,16 +127,23 @@ impl GatewayState {
             .translate_inbound(packet, now)
             .context("Failed to translate inbound packet")?;
 
-        let Some(encrypted_packet) = encrypt_packet(packet, cid, &mut self.node, now)? else {
-            return Ok(None);
+        let info = match self.node.encapsulate(cid, &packet, now, provider) {
+            Ok(Some(info)) => info,
+            Ok(None) => return Ok(()),
+            // The Gateway does not buffer: it only sends in response to Client traffic.
+            Err(e) if e.any_is::<snownet::StillConnecting>() => {
+                tracing::debug!(%cid, "Connection is still establishing; dropping packet");
+                return Ok(());
+            }
+            Err(e) if e.any_is::<snownet::UnknownConnection>() => {
+                return Err(e.context(UnroutablePacket::not_connected(&packet)));
+            }
+            Err(e) => return Err(e),
         };
 
-        flow_tracker::inbound_tun::record_wireguard_packet(
-            encrypted_packet.src,
-            encrypted_packet.dst,
-        );
+        flow_tracker::inbound_tun::record_wireguard_packet(info.src, info.dst);
 
-        Ok(Some(encrypted_packet))
+        Ok(())
     }
 
     /// Handles UDP packets received on the network interface.
@@ -196,12 +204,13 @@ impl GatewayState {
                 return Ok(None);
             };
 
-            let Some(transmit) = encrypt_packet(immediate_response, cid, &mut self.node, now)?
-            else {
-                return Ok(None);
-            };
-
-            self.buffered_transmits.push_back(transmit);
+            encrypt_packet(
+                immediate_response,
+                cid,
+                &mut self.node,
+                &mut self.buffered_transmits,
+                now,
+            )?;
 
             return Ok(None);
         }
@@ -219,11 +228,13 @@ impl GatewayState {
             | TranslateOutboundResult::Filtered(reply) => {
                 flow_tracker::inbound_wg::record_icmp_error(&reply);
 
-                let Some(transmit) = encrypt_packet(reply, cid, &mut self.node, now)? else {
-                    return Ok(None);
-                };
-
-                self.buffered_transmits.push_back(transmit);
+                encrypt_packet(
+                    reply,
+                    cid,
+                    &mut self.node,
+                    &mut self.buffered_transmits,
+                    now,
+                )?;
 
                 Ok(None)
             }
@@ -427,11 +438,13 @@ impl GatewayState {
 
         let packet = dns_resource_nat::domain_status(req.resource, req.domain, nat_status)?;
 
-        let Some(transmit) = encrypt_packet(packet, req.client, &mut self.node, now)? else {
-            return Ok(());
-        };
-
-        self.buffered_transmits.push_back(transmit);
+        encrypt_packet(
+            packet,
+            req.client,
+            &mut self.node,
+            &mut self.buffered_transmits,
+            now,
+        )?;
 
         Ok(())
     }
@@ -610,7 +623,7 @@ impl GatewayState {
 
     pub(crate) fn poll_transmit(&mut self) -> Option<snownet::Transmit> {
         self.buffered_transmits
-            .pop_front()
+            .poll_transmit()
             .or_else(|| self.node.poll_transmit())
     }
 
@@ -699,14 +712,15 @@ fn encrypt_packet(
     packet: IpPacket,
     cid: ClientId,
     node: &mut Node<ClientId, RelayId>,
+    buffered_transmits: &mut snownet::TransmitBuffer,
     now: Instant,
-) -> Result<Option<Transmit>> {
-    match node.encapsulate(cid, &packet, now) {
-        Ok(transmit) => Ok(transmit),
+) -> Result<()> {
+    match node.encapsulate(cid, &packet, now, buffered_transmits) {
+        Ok(_) => Ok(()),
         // The Gateway does not buffer: it only sends in response to Client traffic.
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
             tracing::debug!(%cid, "Connection is still establishing; dropping packet");
-            Ok(None)
+            Ok(())
         }
         Err(e) if e.any_is::<snownet::UnknownConnection>() => {
             Err(e.context(UnroutablePacket::not_connected(&packet)))

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -127,18 +127,8 @@ impl GatewayState {
             .translate_inbound(packet, now)
             .context("Failed to translate inbound packet")?;
 
-        let info = match self.node.encapsulate(cid, &packet, now, provider) {
-            Ok(Some(info)) => info,
-            Ok(None) => return Ok(()),
-            // The Gateway does not buffer: it only sends in response to Client traffic.
-            Err(e) if e.any_is::<snownet::StillConnecting>() => {
-                tracing::debug!(%cid, "Connection is still establishing; dropping packet");
-                return Ok(());
-            }
-            Err(e) if e.any_is::<snownet::UnknownConnection>() => {
-                return Err(e.context(UnroutablePacket::not_connected(&packet)));
-            }
-            Err(e) => return Err(e),
+        let Some(info) = encrypt_packet(packet, cid, &mut self.node, provider, now)? else {
+            return Ok(());
         };
 
         flow_tracker::inbound_tun::record_wireguard_packet(info.src, info.dst);
@@ -712,15 +702,15 @@ fn encrypt_packet(
     packet: IpPacket,
     cid: ClientId,
     node: &mut Node<ClientId, RelayId>,
-    buffered_transmits: &mut snownet::TransmitBuffer,
+    provider: &mut impl snownet::BufferProvider,
     now: Instant,
-) -> Result<()> {
-    match node.encapsulate(cid, &packet, now, buffered_transmits) {
-        Ok(_) => Ok(()),
+) -> Result<Option<snownet::EncapsulateInfo>> {
+    match node.encapsulate(cid, &packet, now, provider) {
+        Ok(info) => Ok(info),
         // The Gateway does not buffer: it only sends in response to Client traffic.
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
             tracing::debug!(%cid, "Connection is still establishing; dropping packet");
-            Ok(())
+            Ok(None)
         }
         Err(e) if e.any_is::<snownet::UnknownConnection>() => {
             Err(e.context(UnroutablePacket::not_connected(&packet)))

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -442,6 +442,17 @@ impl Io {
                 break;
             };
 
+            for segment in datagram.packet.chunks(datagram.segment_size) {
+                self.packet_counter.add(
+                    1,
+                    &[
+                        otel::attr::network_protocol_name(segment),
+                        otel::attr::network_transport_udp(),
+                        otel::attr::network_io_direction_transmit(),
+                    ],
+                );
+            }
+
             self.sockets.send(datagram)?;
         }
 
@@ -508,15 +519,6 @@ impl Io {
         ecn: Ecn,
     ) {
         self.gso_queue.enqueue(src, dst, payload, ecn);
-
-        self.packet_counter.add(
-            1,
-            &[
-                otel::attr::network_protocol_name(payload),
-                otel::attr::network_transport_udp(),
-                otel::attr::network_io_direction_transmit(),
-            ],
-        );
     }
 
     pub fn send_dns_query(&mut self, query: dns::RecursiveQuery) {

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -7,6 +7,7 @@ mod timeout;
 mod udp_dns;
 
 pub use device::{Device, TunChannelClosed};
+pub(crate) use gso_queue::GsoQueue;
 
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{ErrorExt, Result};
@@ -14,7 +15,6 @@ use bootstrap_dns_client::BootstrapDnsClient;
 use dns_types::DoHUrl;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
 use gat_lending_iterator::LendingIterator;
-use gso_queue::GsoQueue;
 use http_client::HttpClient;
 use ip_packet::{Ecn, IpPacket, MAX_FZ_PAYLOAD};
 use nameserver_set::NameserverSet;
@@ -493,6 +493,11 @@ impl Io {
     /// Schedules a wakeup in case one isn't registered yet.
     pub fn schedule_timeout(&mut self, now: Instant) {
         self.timeout.schedule(now + Duration::from_secs(1));
+    }
+
+    /// The GSO queue used as the destination buffer when encapsulating packets in place.
+    pub fn gso_queue_mut(&mut self) -> &mut GsoQueue {
+        &mut self.gso_queue
     }
 
     pub fn send_network(

--- a/rust/libs/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/libs/connlib/tunnel/src/io/gso_queue.rs
@@ -6,7 +6,7 @@ use std::{
 use bufferpool::{Buffer, BufferPool};
 use bytes::BytesMut;
 use ip_packet::Ecn;
-use snownet::BufferProvider;
+use snownet::{BufferProvider, Reservation};
 use socket_factory::DatagramOut;
 
 use super::MAX_INBOUND_PACKET_BATCH;
@@ -37,8 +37,31 @@ impl GsoQueue {
     /// messages and handshakes. The throughput-critical TUN -> network direction encrypts packets
     /// directly into the queue via the [`BufferProvider`] implementation.
     pub fn enqueue(&mut self, src: Option<SocketAddr>, dst: SocketAddr, payload: &[u8], ecn: Ecn) {
-        self.reserve(src, dst, ecn, payload.len())
-            .copy_from_slice(payload);
+        let mut reservation = self.reserve(src, dst, ecn, payload.len());
+        reservation.buffer().copy_from_slice(payload);
+        reservation.commit();
+    }
+
+    /// Undo the most recent reservation for `connection`.
+    fn rollback(&mut self, connection: Connection, len: usize) {
+        let Some(batches) = self.inner.get_mut(&connection) else {
+            return;
+        };
+        let Some((_, buffer)) = batches.back_mut() else {
+            return;
+        };
+
+        let new_len = buffer.len().saturating_sub(len);
+        buffer.truncate(new_len);
+
+        // Drop any batch (and connection) that became empty as a result.
+        if buffer.is_empty() {
+            batches.pop_back();
+
+            if batches.is_empty() {
+                self.inner.remove(&connection);
+            }
+        }
     }
 
     pub fn datagrams(&mut self) -> impl Iterator<Item = DatagramOut> + '_ {
@@ -51,16 +74,19 @@ impl GsoQueue {
 }
 
 impl BufferProvider for GsoQueue {
+    type Reservation<'a> = GsoReservation<'a>;
+
     fn reserve(
         &mut self,
         src: Option<SocketAddr>,
         dst: SocketAddr,
         ecn: Ecn,
         len: usize,
-    ) -> &mut [u8] {
+    ) -> GsoReservation<'_> {
         debug_assert!(len <= MAX_SEGMENT_SIZE, "MAX_SEGMENT_SIZE is miscalculated");
 
-        let batches = self.inner.entry(Connection { src, dst, ecn }).or_default();
+        let connection = Connection { src, dst, ecn };
+        let batches = self.inner.entry(connection).or_default();
 
         // Decide whether the datagram can extend the current batch or has to start a new one.
         let needs_new_batch = match batches.back() {
@@ -80,32 +106,50 @@ impl BufferProvider for GsoQueue {
         }
 
         let (_, buffer) = batches.back_mut().expect("we ensured a batch exists");
-        let offset = buffer.len();
-        buffer.resize(offset + len, 0);
+        let new_len = buffer.len() + len;
+        buffer.resize(new_len, 0);
+
+        GsoReservation {
+            queue: self,
+            connection,
+            len,
+            committed: false,
+        }
+    }
+}
+
+/// A [`Reservation`] into a [`GsoQueue`], pointing at the tail of the current batch.
+pub struct GsoReservation<'a> {
+    queue: &'a mut GsoQueue,
+    connection: Connection,
+    len: usize,
+    committed: bool,
+}
+
+impl Reservation for GsoReservation<'_> {
+    fn buffer(&mut self) -> &mut [u8] {
+        let (_, buffer) = self
+            .queue
+            .inner
+            .get_mut(&self.connection)
+            .expect("reserved connection to exist")
+            .back_mut()
+            .expect("reserved batch to exist");
+
+        let offset = buffer.len() - self.len;
 
         &mut buffer[offset..]
     }
 
-    fn rollback(&mut self, src: Option<SocketAddr>, dst: SocketAddr, ecn: Ecn, len: usize) {
-        let connection = Connection { src, dst, ecn };
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
 
-        let Some(batches) = self.inner.get_mut(&connection) else {
-            return;
-        };
-        let Some((_, buffer)) = batches.back_mut() else {
-            return;
-        };
-
-        let new_len = buffer.len().saturating_sub(len);
-        buffer.truncate(new_len);
-
-        // Drop any batch (and connection) that became empty as a result.
-        if buffer.is_empty() {
-            batches.pop_back();
-
-            if batches.is_empty() {
-                self.inner.remove(&connection);
-            }
+impl Drop for GsoReservation<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.queue.rollback(self.connection, self.len);
         }
     }
 }

--- a/rust/libs/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/libs/connlib/tunnel/src/io/gso_queue.rs
@@ -6,6 +6,7 @@ use std::{
 use bufferpool::{Buffer, BufferPool};
 use bytes::BytesMut;
 use ip_packet::Ecn;
+use snownet::BufferProvider;
 use socket_factory::DatagramOut;
 
 use super::MAX_INBOUND_PACKET_BATCH;
@@ -30,32 +31,14 @@ impl GsoQueue {
         }
     }
 
+    /// Copy an already-formed datagram into the queue.
+    ///
+    /// This is used for datagrams we cannot (or need not) encrypt in place, e.g. STUN/TURN control
+    /// messages and handshakes. The throughput-critical TUN -> network direction encrypts packets
+    /// directly into the queue via the [`BufferProvider`] implementation.
     pub fn enqueue(&mut self, src: Option<SocketAddr>, dst: SocketAddr, payload: &[u8], ecn: Ecn) {
-        let payload_len = payload.len();
-
-        debug_assert!(
-            payload_len <= MAX_SEGMENT_SIZE,
-            "MAX_SEGMENT_SIZE is miscalculated"
-        );
-
-        let batches = self.inner.entry(Connection { src, dst, ecn }).or_default();
-
-        let Some((batch_size, buffer)) = batches.back_mut() else {
-            batches.push_back((payload_len, self.buffer_pool.pull_initialised(payload)));
-
-            return;
-        };
-        let batch_size = *batch_size;
-
-        // A batch is considered "ongoing" if so far we have only pushed packets of the same length.
-        let batch_is_ongoing = buffer.len() % batch_size == 0;
-
-        if batch_is_ongoing && payload_len <= batch_size {
-            buffer.extend_from_slice(payload);
-            return;
-        }
-
-        batches.push_back((payload_len, self.buffer_pool.pull_initialised(payload)));
+        self.reserve(src, dst, ecn, payload.len())
+            .copy_from_slice(payload);
     }
 
     pub fn datagrams(&mut self) -> impl Iterator<Item = DatagramOut> + '_ {
@@ -64,6 +47,66 @@ impl GsoQueue {
 
     pub fn clear(&mut self) {
         self.inner.clear()
+    }
+}
+
+impl BufferProvider for GsoQueue {
+    fn reserve(
+        &mut self,
+        src: Option<SocketAddr>,
+        dst: SocketAddr,
+        ecn: Ecn,
+        len: usize,
+    ) -> &mut [u8] {
+        debug_assert!(len <= MAX_SEGMENT_SIZE, "MAX_SEGMENT_SIZE is miscalculated");
+
+        let batches = self.inner.entry(Connection { src, dst, ecn }).or_default();
+
+        // Decide whether the datagram can extend the current batch or has to start a new one.
+        let needs_new_batch = match batches.back() {
+            None => true,
+            Some((batch_size, buffer)) => {
+                // A batch is "ongoing" as long as every segment so far has been full-size.
+                let batch_is_ongoing = buffer.len() % batch_size == 0;
+
+                !(batch_is_ongoing && len <= *batch_size)
+            }
+        };
+
+        if needs_new_batch {
+            let mut buffer = self.buffer_pool.pull();
+            buffer.clear();
+            batches.push_back((len, buffer));
+        }
+
+        let (_, buffer) = batches.back_mut().expect("we ensured a batch exists");
+        let offset = buffer.len();
+        buffer.resize(offset + len, 0);
+
+        &mut buffer[offset..]
+    }
+
+    fn rollback(&mut self, src: Option<SocketAddr>, dst: SocketAddr, ecn: Ecn, len: usize) {
+        let connection = Connection { src, dst, ecn };
+
+        let Some(batches) = self.inner.get_mut(&connection) else {
+            return;
+        };
+        let Some((_, buffer)) = batches.back_mut() else {
+            return;
+        };
+
+        let new_len = buffer.len().saturating_sub(len);
+        buffer.truncate(new_len);
+
+        // Drop any batch (and connection) that became empty as a result.
+        if buffer.is_empty() {
+            batches.pop_back();
+
+            if batches.is_empty() {
+                self.inner.remove(&connection);
+            }
+        }
     }
 }
 

--- a/rust/libs/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/libs/connlib/tunnel/src/io/gso_queue.rs
@@ -295,6 +295,55 @@ mod tests {
         assert_eq!(datagrams[1].dst, DST_1);
     }
 
+    #[test]
+    fn committing_a_reservation_keeps_the_datagram() {
+        let mut send_queue = GsoQueue::new();
+
+        {
+            let mut reservation = send_queue.reserve(None, DST_1, Ecn::NonEct, 6);
+            reservation.buffer().copy_from_slice(b"foobar");
+            reservation.commit();
+        }
+
+        let datagrams = send_queue.datagrams().collect::<Vec<_>>();
+
+        assert_eq!(datagrams.len(), 1);
+        assert_eq!(datagrams[0].packet.as_ref(), b"foobar");
+    }
+
+    #[test]
+    fn dropping_a_reservation_without_committing_rolls_it_back() {
+        let mut send_queue = GsoQueue::new();
+
+        send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
+
+        // Reserve a second segment in the same batch but drop it without committing.
+        {
+            let mut reservation = send_queue.reserve(None, DST_1, Ecn::NonEct, 6);
+            reservation.buffer().copy_from_slice(b"barbaz");
+        }
+
+        // Only the committed datagram remains; the reserved bytes were rolled back.
+        let datagrams = send_queue.datagrams().collect::<Vec<_>>();
+
+        assert_eq!(datagrams.len(), 1);
+        assert_eq!(datagrams[0].packet.as_ref(), b"foobar");
+        assert_eq!(datagrams[0].segment_size, 6);
+    }
+
+    #[test]
+    fn dropping_the_only_reservation_leaves_the_queue_empty() {
+        let mut send_queue = GsoQueue::new();
+
+        {
+            let mut reservation = send_queue.reserve(None, DST_1, Ecn::NonEct, 6);
+            reservation.buffer().copy_from_slice(b"barbaz");
+        }
+
+        // Rolling back the last segment drops the empty batch and connection.
+        assert_eq!(send_queue.datagrams().count(), 0);
+    }
+
     const DST_1: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1111));
     const DST_2: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2222));
 }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -255,21 +255,15 @@ impl ClientTunnel {
                     for packet in packets {
                         match self
                             .role_state
-                            .handle_tun_input(packet, now)
+                            .handle_tun_input(packet, now, self.io.gso_queue_mut())
                             .context("Failed to handle packet from TUN device")
                         {
-                            Ok(Some(transmit)) => {
-                                self.io.send_network(
-                                    transmit.src,
-                                    transmit.dst,
-                                    &transmit.payload,
-                                    transmit.ecn,
-                                );
-                            }
-                            Ok(None) => self.io.schedule_timeout(now),
+                            Ok(()) => {}
                             Err(e) => error.push(e),
                         }
                     }
+
+                    self.io.schedule_timeout(now);
 
                     // Eagerly flush GSO queue.
                     if let Poll::Ready(Err(e)) = self.io.flush_gso_queue(cx) {
@@ -450,18 +444,10 @@ impl GatewayTunnel {
                     for packet in packets {
                         match self
                             .role_state
-                            .handle_tun_input(packet, now)
+                            .handle_tun_input(packet, now, self.io.gso_queue_mut())
                             .context("Failed to handle packet from TUN device")
                         {
-                            Ok(Some(transmit)) => {
-                                self.io.send_network(
-                                    transmit.src,
-                                    transmit.dst,
-                                    &transmit.payload,
-                                    transmit.ecn,
-                                );
-                            }
-                            Ok(None) => self.io.schedule_timeout(now),
+                            Ok(()) => {}
                             Err(e) => {
                                 let routing_error = e
                                     .any_downcast_ref::<UnroutablePacket>()
@@ -478,6 +464,8 @@ impl GatewayTunnel {
                             }
                         }
                     }
+
+                    self.io.schedule_timeout(now);
 
                     // Eagerly flush GSO queue.
                     if let Poll::Ready(Err(e)) = self.io.flush_gso_queue(cx) {

--- a/rust/libs/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sim_client.rs
@@ -75,6 +75,9 @@ pub(crate) struct SimClient {
     /// TCP connections to resources.
     pub(crate) tcp_client: crate::tests::tcp::Client,
     pub(crate) failed_tcp_packets: BTreeMap<(SPort, DPort), IcmpError>,
+
+    /// Collects datagrams encapsulated via [`crate::ClientState::handle_tun_input`].
+    transmit_buffer: snownet::TransmitBuffer,
 }
 
 impl SimClient {
@@ -107,6 +110,7 @@ impl SimClient {
             tcp_client: crate::tests::tcp::Client::new(now),
             failed_tcp_packets: Default::default(),
             dns_resource_record_cache: Default::default(),
+            transmit_buffer: snownet::TransmitBuffer::new(),
         }
     }
 
@@ -219,7 +223,7 @@ impl SimClient {
     ) -> Option<snownet::Transmit> {
         self.update_sent_requests(&packet, now);
 
-        match self.sut.handle_tun_input(packet, now) {
+        match self.handle_tun_input(packet, now) {
             Ok(Some(transmit)) => Some(transmit),
             Ok(None) => {
                 self.sut.handle_timeout(now); // If we handled the packet internally, make sure to advance state.
@@ -232,6 +236,21 @@ impl SimClient {
                 None
             }
         }
+    }
+
+    /// Drive the SUT's TUN -> network path, collecting the encapsulated datagram (if any).
+    ///
+    /// Routes encapsulation through the [`snownet::TransmitBuffer`] field so the rest of the
+    /// simulation can keep working with a single [`snownet::Transmit`] per packet.
+    fn handle_tun_input(
+        &mut self,
+        packet: IpPacket,
+        now: Instant,
+    ) -> anyhow::Result<Option<snownet::Transmit>> {
+        self.sut
+            .handle_tun_input(packet, now, &mut self.transmit_buffer)?;
+
+        Ok(self.transmit_buffer.poll_transmit())
     }
 
     pub fn poll_outbound(&mut self) -> Option<IpPacket> {
@@ -369,7 +388,7 @@ impl SimClient {
                 .insert(packet_id, (now, packet.clone()));
 
             let reply = echo_reply(packet)?;
-            return self.sut.handle_tun_input(reply, now).ok().flatten();
+            return self.handle_tun_input(reply, now).ok().flatten();
         }
 
         if self.tcp_dns_client.accepts(&packet) {
@@ -488,7 +507,7 @@ impl SimClient {
         )
         .expect("src and dst are taken from incoming packet");
 
-        let transmit = self.sut.handle_tun_input(reply, now).unwrap()?;
+        let transmit = self.handle_tun_input(reply, now).unwrap()?;
 
         Some(transmit)
     }

--- a/rust/libs/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sim_gateway.rs
@@ -38,6 +38,9 @@ pub(crate) struct SimGateway {
     tcp_dns_server_resources: BTreeMap<SocketAddr, TcpDnsServerResource>,
 
     tcp_resources: BTreeMap<SocketAddr, crate::tests::tcp::Server>,
+
+    /// Collects datagrams encapsulated via [`GatewayState::handle_tun_input`].
+    transmit_buffer: snownet::TransmitBuffer,
 }
 
 impl SimGateway {
@@ -68,6 +71,7 @@ impl SimGateway {
                     (address, server)
                 })
                 .collect(),
+            transmit_buffer: snownet::TransmitBuffer::new(),
         }
     }
 
@@ -131,11 +135,40 @@ impl SimGateway {
             std::iter::from_fn(|| server.poll_outbound())
         });
 
-        udp_server_packets
+        // Collect first to end the mutable borrows of the resource maps before encapsulating.
+        let packets = udp_server_packets
             .chain(tcp_server_packets)
             .chain(tcp_resource_packets)
-            .filter_map(|packet| self.sut.handle_tun_input(packet, now).unwrap())
+            .collect::<Vec<_>>();
+
+        packets
+            .into_iter()
+            .filter_map(|packet| match self.handle_tun_input(packet, now) {
+                Ok(maybe_transmit) => maybe_transmit,
+                // The gateway could not encrypt the packet (e.g. no session during a re-key). In
+                // production this error bubbles up to the event loop and the packet is dropped;
+                // model that as a drop here rather than panicking.
+                Err(e) => {
+                    tracing::debug!("Gateway failed to encapsulate resource packet: {e:#}");
+                    None
+                }
+            })
             .collect()
+    }
+
+    /// Drive the SUT's TUN -> network path, collecting the encapsulated datagram (if any).
+    ///
+    /// Routes encapsulation through the [`snownet::TransmitBuffer`] field so the rest of the
+    /// simulation can keep working with a single [`snownet::Transmit`] per packet.
+    fn handle_tun_input(
+        &mut self,
+        packet: IpPacket,
+        now: Instant,
+    ) -> anyhow::Result<Option<snownet::Transmit>> {
+        self.sut
+            .handle_tun_input(packet, now, &mut self.transmit_buffer)?;
+
+        Ok(self.transmit_buffer.poll_transmit())
     }
 
     pub(crate) fn deploy_new_dns_servers(
@@ -242,7 +275,7 @@ impl SimGateway {
 
         if let Some(reply) = icmp_error.or_else(|| echo_reply(packet.clone())) {
             self.request_received(&packet, now);
-            let transmit = self.sut.handle_tun_input(reply, now).unwrap()?;
+            let transmit = self.handle_tun_input(reply, now).unwrap()?;
 
             return Some(transmit);
         }
@@ -298,7 +331,7 @@ impl SimGateway {
             .expect("src and dst are taken from incoming packet")
         });
 
-        let transmit = self.sut.handle_tun_input(reply, now).unwrap()?;
+        let transmit = self.handle_tun_input(reply, now).unwrap()?;
 
         Some(transmit)
     }


### PR DESCRIPTION
Encapsulating an outgoing packet used to copy it twice: once when boringtun encrypted it into a pooled buffer, and again when the event loop appended that payload to the correct GSO batch. On the data-plane hot path that is one `memcpy` per packet that we can avoid.

We now hand boringtun a slice that already points into the destination GSO batch and encrypt in place, removing the copy. When no usable session exists yet, connlib buffers the packet itself and replays it in place once the handshake completes, instead of relying on boringtun's internal queue.

In order to measure this, we ran `iperf3` for 20s in both directions on both main and this branch and looked at the _ratio_ of time spent in crypto syscalls vs memcpy syscalls. Both the removed copy and ChaCha20-Poly1305 (`seal`) process one ~MTU payload per packet, so normalising memcpy self-time to `seal` within each run cancels packet rate, throughput and run length:

| | memcpy | seal | memcpy / seal |
| --- | --- | --- | --- |
| client, main | 8.4% | 13.3% | 0.63 |
| client, this PR | 7.1% | 12.8% | 0.55 |
| gateway, main | 10.6% | 12.4% | 0.86 |
| gateway, this PR | 8.6% | 12.1% | 0.71 |

The ratio drops by 0.08 (client) and 0.15 (gateway). Removing one copy removes an absolute, per-packet amount of work, so it shows up as this additive shift, and its size equals memcpy's per-byte cost divided by the cipher's. Copying is roughly 7–15× cheaper per byte than AEAD encryption (~0.15–0.3 vs ~1.5–2 cycles/byte), so one eliminated ~MTU copy is expected to cost ≈0.10–0.15 of the crypto — matching the observed shift. The measurement is therefore consistent with eliminating one copy per packet, which is exactly what this change does. Crypto self-time is otherwise unchanged, and the copies in the TUN-read and UDP-write IO threads are untouched.

Resolves: #10110
