### PR TITLE
fix(portal): sync client-client authz msgs

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -367,18 +367,41 @@ defmodule PortalAPI.Client.Channel do
     end
   end
 
-  def handle_info({:flow_creation_timeout, resource_id}, socket) do
-    case Map.pop(socket.assigns.pending_flows, resource_id) do
+  def handle_info({:flow_creation_timeout, key}, socket) do
+    case Map.pop(socket.assigns.pending_flows, key) do
       {nil, _} ->
         {:noreply, socket}
 
+      # Client-to-client: the target's channel never acked that it pushed the
+      # authorization to its data plane (e.g. it disconnected in the window).
+      {%{deny_payload: deny_payload}, remaining} ->
+        push(socket, "client_device_access_denied", deny_payload)
+        {:noreply, assign(socket, :pending_flows, remaining)}
+
       {_timer_ref, remaining} ->
-        push(socket, "flow_creation_failed", %{resource_id: resource_id, reason: :offline})
+        push(socket, "flow_creation_failed", %{resource_id: key, reason: :offline})
         {:noreply, assign(socket, :pending_flows, remaining)}
     end
   end
 
-  def handle_info({:client_device_access_authorized, payload}, socket) do
+  # Client-to-client: the target's channel confirmed it pushed the
+  # authorization onto the target's websocket. Only now is it safe to release
+  # the initiator, because the target's data plane is guaranteed to receive
+  # (and process) the authorization before any relayed ICE candidate, which
+  # travels the same socket behind it. See `deliver_pool_target_authorized/8`.
+  def handle_info({:device_access_acked, ref}, socket) do
+    case Map.pop(socket.assigns.pending_flows, ref) do
+      {nil, _} ->
+        {:noreply, socket}
+
+      {%{timer_ref: timer_ref, initiator_payload: initiator_payload}, remaining} ->
+        Process.cancel_timer(timer_ref)
+        push(socket, "client_device_access_authorized", initiator_payload)
+        {:noreply, assign(socket, :pending_flows, remaining)}
+    end
+  end
+
+  def handle_info({:client_device_access_authorized, {ack_to, ref}, payload}, socket) do
     {policy_authorization_id, payload} = Map.pop(payload, :policy_authorization_id)
     {authorization_expires_at, payload} = Map.pop(payload, :authorization_expires_at)
     {policy_authorization, payload} = Map.pop(payload, :policy_authorization)
@@ -400,6 +423,13 @@ defmodule PortalAPI.Client.Channel do
       end
 
     push(socket, "client_device_access_authorized", payload)
+
+    # Ack back to the initiator's channel that the authorization is on this
+    # target's websocket. The initiator is released only after this, so the
+    # initiator's ICE candidates (which traverse the same socket) can never
+    # overtake the authorization at the target's data plane.
+    send(ack_to, {:device_access_acked, ref})
+
     cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
 
     socket =
@@ -1023,8 +1053,11 @@ defmodule PortalAPI.Client.Channel do
            find_online_client_by_address(account_id, target),
          :ok <- check_peer_compatibility(target_meta, socket) do
       # PoC shim: bypass the Queue entirely because we don't persist a
-      # `policy_authorization` row here. Deliver to the target first; only
-      # push the initiator-side confirmation if the target was reachable.
+      # `policy_authorization` row here. Deliver to the target first; the
+      # initiator is released only once the target's channel acks (same
+      # ordering guarantee as the `create_flow` pool path).
+      ref = make_ref()
+
       {receiver_message, initiator_payload} =
         build_client_device_access_authorized_messages(
           target_client_id,
@@ -1032,13 +1065,23 @@ defmodule PortalAPI.Client.Channel do
           nil,
           nil,
           nil,
+          ref,
           socket
         )
 
       case PG.deliver(target_client_id, receiver_message) do
         :ok ->
-          push(socket, "client_device_access_authorized", initiator_payload)
-          {:noreply, socket}
+          timer_ref =
+            Process.send_after(self(), {:flow_creation_timeout, ref}, flow_creation_timeout())
+
+          pending =
+            Map.put(socket.assigns.pending_flows, ref, %{
+              timer_ref: timer_ref,
+              initiator_payload: initiator_payload,
+              deny_payload: %{client_id: target_client_id, ipv4: ipv4_string, reason: :offline}
+            })
+
+          {:noreply, assign(socket, :pending_flows, pending)}
 
         {:error, :not_found} ->
           push(socket, "client_device_access_denied", %{
@@ -1544,9 +1587,17 @@ defmodule PortalAPI.Client.Channel do
     # the Queue dispatch callback. This keeps the dispatch callback minimal
     # (just `PG.deliver/2`) so it can't raise mid-execution: any crash in
     # crypto/render code happens up front, before any allow-equivalent message
-    # is on the wire, and before the queue buffers an entry. The initiator-side
-    # push happens AFTER `Queue.enqueue/3` returns `:ok`, so we never end up in
-    # a state where the receiver got allow but the queue didn't buffer.
+    # is on the wire, and before the queue buffers an entry.
+    #
+    # `ref` correlates the target channel's ack back to this request. The
+    # initiator is NOT released on `Queue.enqueue/3` returning `:ok` — it is
+    # released only once the target's channel acks that it has pushed the
+    # authorization onto the target's websocket (`{:device_access_acked, ref}`).
+    # Until then the initiator must not start ICE, because its candidates
+    # travel the same socket as the authorization and would otherwise race
+    # ahead of it at the target's data plane.
+    ref = make_ref()
+
     {receiver_message, initiator_payload} =
       build_client_device_access_authorized_messages(
         target_client_id,
@@ -1554,6 +1605,7 @@ defmodule PortalAPI.Client.Channel do
         resource,
         policy_authorization_id,
         expires_at,
+        ref,
         socket
       )
 
@@ -1568,8 +1620,22 @@ defmodule PortalAPI.Client.Channel do
            end
          ) do
       :ok ->
-        push(socket, "client_device_access_authorized", initiator_payload)
-        {:noreply, socket}
+        timer_ref =
+          Process.send_after(self(), {:flow_creation_timeout, ref}, flow_creation_timeout())
+
+        pending =
+          Map.put(socket.assigns.pending_flows, ref, %{
+            timer_ref: timer_ref,
+            initiator_payload: initiator_payload,
+            deny_payload: %{
+              client_id: target_client_id,
+              ipv4: payload["ipv4"],
+              ipv6: payload["ipv6"],
+              reason: :offline
+            }
+          })
+
+        {:noreply, assign(socket, :pending_flows, pending)}
 
       {:error, _} ->
         push(socket, "client_device_access_denied", %{
@@ -1585,16 +1651,17 @@ defmodule PortalAPI.Client.Channel do
 
   # Returns `{receiver_message, initiator_payload}`. The receiver_message goes
   # to the target client via PG (delivered inside the Queue's dispatch
-  # callback so it shares a sender pid with any later `:reject_access`). The
-  # initiator_payload is pushed back to the originating client's socket only
-  # after Queue.enqueue returns `:ok`, so the initiator never gets a
-  # confirmation that the queue didn't durably accept.
+  # callback so it shares a sender pid with any later `:reject_access`). It
+  # carries `{ack_to, ref}` so the target's channel can ack back once it has
+  # pushed the authorization onto the target's websocket; the initiator_payload
+  # is released to the originating client only after that ack arrives.
   defp build_client_device_access_authorized_messages(
          target_client_id,
          target_meta,
          resource,
          policy_authorization_id,
          expires_at,
+         ref,
          socket
        ) do
     client = socket.assigns.client
@@ -1634,7 +1701,7 @@ defmodule PortalAPI.Client.Channel do
     rendered_subject = PortalAPI.Gateway.Views.Subject.render(socket.assigns.subject)
 
     receiver_message =
-      {:client_device_access_authorized,
+      {:client_device_access_authorized, {self(), ref},
        %{
          client_id: client.id,
          client_public_key: client_public_key,
@@ -2324,18 +2391,12 @@ defmodule PortalAPI.Client.Channel do
   #      reject, authz durability timer fire), reuse the struct for
   #      `reauthorize_deleted_policy_authorization`.
   #
-  # Accepts the two message shapes used by the gateway/peer-bound paths:
-  # `{tag, {channel_pid, socket_ref}, payload}` (used by :allow_access,
-  # :authorize_policy, :request_connection) and `{tag, payload}` (used by
-  # :client_device_access_authorized in the c2c flow).
-  defp attach_policy_authorization(message, %Portal.PolicyAuthorization{} = pa) do
-    case message do
-      {tag, ref_tuple, payload} when is_tuple(ref_tuple) ->
-        {tag, ref_tuple, Map.put(payload, :policy_authorization, pa)}
-
-      {tag, payload} when is_map(payload) ->
-        {tag, Map.put(payload, :policy_authorization, pa)}
-    end
+  # All peer-bound messages carry a `{channel_pid, ref}` reply tuple:
+  # `{tag, {channel_pid, ref}, payload}` (used by :allow_access,
+  # :authorize_policy, :request_connection, and :client_device_access_authorized).
+  defp attach_policy_authorization({tag, ref_tuple, payload}, %Portal.PolicyAuthorization{} = pa)
+       when is_tuple(ref_tuple) do
+    {tag, ref_tuple, Map.put(payload, :policy_authorization, pa)}
   end
 
   defp flow_creation_timeout do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -6153,7 +6153,7 @@ defmodule PortalAPI.Client.ChannelTest do
         "ipv4" => target_ip
       })
 
-      assert_receive {:client_device_access_authorized, _allow_payload}, 500
+      assert_receive {:client_device_access_authorized, {_ack_to, _ref}, _allow_payload}, 500
 
       # Force the queued insert to fail by deleting the policy that grants this
       # authorization. After flush, on_failed must fire reject_access for the
@@ -6172,6 +6172,100 @@ defmodule PortalAPI.Client.ChannelTest do
       assert_receive {:reject_access, %Portal.PolicyAuthorization{} = pa}, 500
       assert pa.initiating_device_id == client_id
       assert pa.resource_id == pool_resource_id
+    end
+
+    test "does not release the initiator until the target channel acks", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
+    } do
+      target_client_id = target_client.id
+
+      session_meta = %{
+        ipv4: target_client.ipv4.address,
+        ipv6: target_client.ipv6.address,
+        name: target_client.name,
+        public_key: Portal.DeviceFixtures.generate_public_key(),
+        psk_base: target_client.psk_base,
+        remote_ip: %Postgrex.INET{address: {100, 64, 0, 99}},
+        version: "1.5.16",
+        user_agent: "Mac OS/14 apple-client/1.5.16"
+      }
+
+      :ok = Presence.Clients.connect(target_client, target_subject.credential.id, session_meta)
+      # Test pid stands in for the target's channel so we can capture (and
+      # withhold) the ack.
+      :ok = PG.register(target_client_id)
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
+
+      assert_receive {:client_device_access_authorized, {ack_to, ref}, _payload}, 500
+
+      # The initiator must not be released before the target acks.
+      refute_push "client_device_access_authorized", _, 200
+
+      send(ack_to, {:device_access_acked, ref})
+
+      assert_push "client_device_access_authorized", %{
+        client_id: ^target_client_id,
+        ice_role: :controlling
+      }
+    end
+
+    test "denies the initiator with :offline when the target never acks", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject,
+      pool_resource: pool_resource
+    } do
+      target_client_id = target_client.id
+
+      session_meta = %{
+        ipv4: target_client.ipv4.address,
+        ipv6: target_client.ipv6.address,
+        name: target_client.name,
+        public_key: Portal.DeviceFixtures.generate_public_key(),
+        psk_base: target_client.psk_base,
+        remote_ip: %Postgrex.INET{address: {100, 64, 0, 99}},
+        version: "1.5.16",
+        user_agent: "Mac OS/14 apple-client/1.5.16"
+      }
+
+      :ok = Presence.Clients.connect(target_client, target_subject.credential.id, session_meta)
+      :ok = PG.register(target_client_id)
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+
+      push(initiating_socket, "create_flow", %{
+        "resource_id" => pool_resource.id,
+        "ipv4" => target_ip
+      })
+
+      assert_receive {:client_device_access_authorized, {_ack_to, ref}, _payload}, 500
+
+      # Simulate the ack-wait timeout firing before any ack arrives.
+      send(initiating_socket.channel_pid, {:flow_creation_timeout, ref})
+
+      assert_push "client_device_access_denied", %{
+        client_id: ^target_client_id,
+        reason: :offline
+      }
+
+      refute_push "client_device_access_authorized", _, 100
     end
   end
 
@@ -7010,6 +7104,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(socket.channel_pid, {
         :client_device_access_authorized,
+        {self(), make_ref()},
         %{
           client_id: initiating_client.id,
           client_public_key: "pk",
@@ -7052,6 +7147,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       send(socket.channel_pid, {
         :client_device_access_authorized,
+        {self(), make_ref()},
         %{
           client_id: initiating_client.id,
           client_public_key: "pk",
@@ -7164,6 +7260,7 @@ defmodule PortalAPI.Client.ChannelTest do
       # Seed an entry that is already expired into the in-memory cache
       send(socket.channel_pid, {
         :client_device_access_authorized,
+        {self(), make_ref()},
         %{
           client_id: initiating_client.id,
           client_public_key: "pk",


### PR DESCRIPTION
Previously the portal notified the initiating and target clients of a client-to-client flow at the same time. The two notifications travel through different processes with no ordering guarantee, so the initiator could start ICE and relay candidates before the target's data plane had set up its connection. snownet drops candidates for a connection it does not yet know about and never retransmits them, so affected connections were degraded or failed to establish.

The portal now releases the initiator only after the target's channel confirms it has pushed the authorization down to the target, guaranteeing the target is ready to receive candidates first. This mirrors the acknowledgement the gateway flow already relies on.