### PR TITLE
fix(connlib): evaluate traffic filters on the client

### DIFF
--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -845,6 +845,11 @@ impl ClientState {
             .matches(dst, Ok(dst_proto))
             .cloned()
         {
+            if !filter_allows(&entry.filter, dst_proto) {
+                self.reply_with_icmp_prohibited(packet);
+                return Ok(None);
+            }
+
             // Whether we are already authorized to send packets to this peer.
             let already_authorised = self
                 .authorized_resources
@@ -872,14 +877,8 @@ impl ClientState {
             .get_resource_by_destination(dst, dst_proto)
             .with_context(|| UnroutablePacket::unknown_resource(&packet))?;
 
-        // Evaluate the resource's traffic filters locally. A packet whose
-        // protocol the resource doesn't permit gets an ICMP "administratively
-        // prohibited" error generated right here and written back to the TUN
-        // device, exactly as the Gateway would. Filtering on the Client avoids a
-        // feedback loop where the Gateway's ICMP error would otherwise make us
-        // request a brand-new flow for traffic that can never be allowed.
         if !self.resource_filter_allows(resource, dst_proto) {
-            self.buffer_icmp_prohibited(&packet);
+            self.reply_with_icmp_prohibited(packet);
             return Ok(None);
         }
 
@@ -2474,34 +2473,18 @@ impl ClientState {
     }
 
     /// Whether the resource's traffic filters permit a packet with the given protocol.
-    ///
-    /// In tests, a malicious client can be configured to ignore its own filters,
-    /// keeping the Gateway's filtering path exercised.
     fn resource_filter_allows(&self, resource: ResourceId, protocol: Protocol) -> bool {
         let Some(resource) = self.resources_by_id.get(&resource) else {
             return false;
         };
 
-        if FilterEngine::new(resource.filters())
-            .apply(Ok(protocol))
-            .is_ok()
-        {
-            return true;
-        }
-
-        #[cfg(test)]
-        if crate::malicious_behaviour::ignore_resource_filter() {
-            tracing::debug!("Malicious client: ignoring resource filter");
-            return true;
-        }
-
-        false
+        filter_allows(&FilterEngine::new(resource.filters()), protocol)
     }
 
     /// Generate an ICMP "administratively prohibited" error for `packet` and
     /// buffer it for delivery back to the TUN device.
-    fn buffer_icmp_prohibited(&mut self, packet: &IpPacket) {
-        match ip_packet::make::icmp_dest_unreachable_prohibited(packet) {
+    fn reply_with_icmp_prohibited(&mut self, packet: IpPacket) {
+        match ip_packet::make::icmp_dest_unreachable_prohibited(&packet) {
             Ok(reply) => self.buffered_packets.push_back(reply),
             Err(e) => tracing::debug!("Failed to create ICMP prohibited error: {e:#}"),
         }
@@ -2598,6 +2581,24 @@ fn is_llmnr(dst: IpAddr) -> bool {
         IpAddr::V4(ip) => ip == LLMNR_IPV4,
         IpAddr::V6(ip) => ip == LLMNR_IPV6,
     }
+}
+
+/// Whether `filter` permits a packet with the given protocol.
+///
+/// In tests, a malicious client can be configured to ignore its own filters,
+/// keeping the remote peer's filtering path (Gateway or target Client) exercised.
+fn filter_allows(filter: &FilterEngine, protocol: Protocol) -> bool {
+    if filter.apply(Ok(protocol)).is_ok() {
+        return true;
+    }
+
+    #[cfg(test)]
+    if crate::malicious_behaviour::ignore_resource_filter() {
+        tracing::debug!("Malicious client: ignoring resource filter");
+        return true;
+    }
+
+    false
 }
 
 fn encapsulate_and_buffer(

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -872,6 +872,17 @@ impl ClientState {
             .get_resource_by_destination(dst, dst_proto)
             .with_context(|| UnroutablePacket::unknown_resource(&packet))?;
 
+        // Evaluate the resource's traffic filters locally. A packet whose
+        // protocol the resource doesn't permit gets an ICMP "administratively
+        // prohibited" error generated right here and written back to the TUN
+        // device, exactly as the Gateway would. Filtering on the Client avoids a
+        // feedback loop where the Gateway's ICMP error would otherwise make us
+        // request a brand-new flow for traffic that can never be allowed.
+        if !self.resource_filter_allows(resource, dst_proto) {
+            self.buffer_icmp_prohibited(&packet);
+            return Ok(None);
+        }
+
         if let Some(gid) = self
             .authorized_resources
             .get(&resource)
@@ -2460,6 +2471,40 @@ impl ClientState {
     ) {
         self.pending_flows
             .on_not_connected_resource(resource, trigger, &self.resources_by_id, now);
+    }
+
+    /// Whether the resource's traffic filters permit a packet with the given protocol.
+    ///
+    /// In tests, a malicious client can be configured to ignore its own filters,
+    /// keeping the Gateway's filtering path exercised.
+    fn resource_filter_allows(&self, resource: ResourceId, protocol: Protocol) -> bool {
+        let Some(resource) = self.resources_by_id.get(&resource) else {
+            return false;
+        };
+
+        if FilterEngine::new(resource.filters())
+            .apply(Ok(protocol))
+            .is_ok()
+        {
+            return true;
+        }
+
+        #[cfg(test)]
+        if crate::malicious_behaviour::ignore_resource_filter() {
+            tracing::debug!("Malicious client: ignoring resource filter");
+            return true;
+        }
+
+        false
+    }
+
+    /// Generate an ICMP "administratively prohibited" error for `packet` and
+    /// buffer it for delivery back to the TUN device.
+    fn buffer_icmp_prohibited(&mut self, packet: &IpPacket) {
+        match ip_packet::make::icmp_dest_unreachable_prohibited(packet) {
+            Ok(reply) => self.buffered_packets.push_back(reply),
+            Err(e) => tracing::debug!("Failed to create ICMP prohibited error: {e:#}"),
+        }
     }
 }
 

--- a/rust/libs/connlib/tunnel/src/tests/ref_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/ref_client.rs
@@ -512,9 +512,6 @@ impl RefClient {
 
             tracing::Span::current().record("resource", tracing::field::display(resource));
 
-            // The Client evaluates resource filters on every outbound packet and
-            // replies with an ICMP error locally rather than forwarding traffic
-            // the resource doesn't permit.
             if !self.resource_filter_allows(resource, proto) {
                 tracing::debug!("Resource filter does not allow protocol, dropping");
                 return;

--- a/rust/libs/connlib/tunnel/src/tests/ref_client.rs
+++ b/rust/libs/connlib/tunnel/src/tests/ref_client.rs
@@ -512,9 +512,10 @@ impl RefClient {
 
             tracing::Span::current().record("resource", tracing::field::display(resource));
 
-            if !self.connected_resources().contains(&resource)
-                && !self.resource_filter_allows(resource, proto)
-            {
+            // The Client evaluates resource filters on every outbound packet and
+            // replies with an ICMP error locally rather than forwarding traffic
+            // the resource doesn't permit.
+            if !self.resource_filter_allows(resource, proto) {
                 tracing::debug!("Resource filter does not allow protocol, dropping");
                 return;
             }
@@ -655,9 +656,7 @@ impl RefClient {
                 DnsTransport::Tcp => Protocol::Tcp(53),
             };
 
-            if !self.connected_resources().contains(&resource)
-                && !self.resource_filter_allows(resource, proto)
-            {
+            if !self.resource_filter_allows(resource, proto) {
                 tracing::debug!("Resource filter does not allow protocol, dropping");
                 return;
             }


### PR DESCRIPTION
The Client previously forwarded every packet for a connected resource straight to the Gateway, even when the resource's traffic filters did not permit that protocol or port. The Gateway filtered the packet and replied with an ICMP "administratively prohibited" error, which the Client treated as a signal to request a brand new flow. For traffic that can never be allowed, this produced a feedback loop of repeated `create_flow` requests.

The Client now evaluates a resource's traffic filters on the outbound path. A packet whose protocol the resource does not permit gets an ICMP "administratively prohibited" error generated locally and written back to the TUN device, mirroring what the Gateway does, and is never forwarded. Genuinely revoked access still relies on the Gateway's ICMP error to drive a new flow, so the policy-crossover signal the flow-log design depends on is preserved.

The Gateway keeps filtering as before so a misbehaving Client cannot bypass it; the proptest suite exercises that path via the malicious-behaviour flag.

---

Fixes: #13735