### PR TITLE
fix(portal): add resource filter API endpoints

### DIFF
--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -201,6 +201,7 @@ defmodule PortalAPI.ResourceController do
     changeset
     |> Ecto.Changeset.validate_required(required)
     |> Database.validate_static_device_pool_feature_enabled(subject.account)
+    |> Database.validate_traffic_filters_feature_enabled(subject.account)
   end
 
   defmodule Database do
@@ -246,6 +247,23 @@ defmodule PortalAPI.ResourceController do
       Safe.unscoped(query, :replica) |> Safe.exists?() and account_feature_enabled?
     end
 
+    def validate_traffic_filters_feature_enabled(changeset, account) do
+      adding_filters? =
+        changeset
+        |> Ecto.Changeset.get_change(:filters, [])
+        |> Enum.any?(fn filter -> filter.action in [:insert, :update] end)
+
+      if adding_filters? and not Portal.Account.traffic_filters_enabled?(account) do
+        Ecto.Changeset.add_error(
+          changeset,
+          :filters,
+          "traffic filters are not enabled for this account"
+        )
+      else
+        changeset
+      end
+    end
+
     def update_resource(resource, attrs, subject) do
       resource
       |> changeset(attrs, subject)
@@ -282,6 +300,7 @@ defmodule PortalAPI.ResourceController do
       changeset
       |> Ecto.Changeset.validate_required(required_fields)
       |> validate_static_device_pool_feature_enabled(subject.account)
+      |> validate_traffic_filters_feature_enabled(subject.account)
     end
 
     def cursor_fields do

--- a/elixir/lib/portal_api/controllers/resource_json.ex
+++ b/elixir/lib/portal_api/controllers/resource_json.ex
@@ -25,9 +25,17 @@ defmodule PortalAPI.ResourceJSON do
       name: resource.name,
       address: resource.address,
       address_description: resource.address_description,
-      type: resource.type
+      type: resource.type,
+      filters: Enum.map(resource.filters, &filter/1)
     }
     |> maybe_put_ip_stack(resource)
+  end
+
+  defp filter(%Resource.Filter{} = filter) do
+    %{
+      protocol: filter.protocol,
+      ports: filter.ports
+    }
   end
 
   defp maybe_put_ip_stack(attrs, %{ip_stack: nil}) do

--- a/elixir/lib/portal_api/schemas/resource_schema.ex
+++ b/elixir/lib/portal_api/schemas/resource_schema.ex
@@ -30,6 +30,12 @@ defmodule PortalAPI.Schemas.Resource do
             "Site to connect the Resource to. Required for all types except `static_device_pool`.",
           type: :string,
           format: :uuid
+        },
+        filters: %Schema{
+          type: :array,
+          description:
+            "Traffic filters restricting the protocols and ports the Resource exposes",
+          items: PortalAPI.Schemas.Resource.Filter
         }
       },
       required: [:name, :type],
@@ -38,7 +44,10 @@ defmodule PortalAPI.Schemas.Resource do
         "name" => "Prod DB",
         "address" => "10.0.0.10",
         "address_description" => "Production Database",
-        "type" => "ip"
+        "type" => "ip",
+        "filters" => [
+          %{"protocol" => "tcp", "ports" => ["5432"]}
+        ]
       }
     })
   end

--- a/elixir/test/portal_api/controllers/resource_controller_test.exs
+++ b/elixir/test/portal_api/controllers/resource_controller_test.exs
@@ -124,9 +124,28 @@ defmodule PortalAPI.ResourceControllerTest do
                  "id" => resource.id,
                  "name" => resource.name,
                  "type" => Atom.to_string(resource.type),
-                 "ip_stack" => "ipv4_only"
+                 "ip_stack" => "ipv4_only",
+                 "filters" => []
                }
              }
+    end
+
+    test "returns filters in the response", %{conn: conn, account: account, actor: actor} do
+      resource =
+        resource_with_filters_fixture(%{account: account, type: :ip, address: "10.0.0.9"})
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> get("/resources/#{resource.id}")
+
+      assert %{"data" => %{"filters" => filters}} = json_response(conn, 200)
+
+      assert filters == [
+               %{"protocol" => "tcp", "ports" => ["80", "443"]},
+               %{"protocol" => "udp", "ports" => ["53"]}
+             ]
     end
 
     test "returns not found when resource does not exist", %{conn: conn, actor: actor} do
@@ -228,6 +247,62 @@ defmodule PortalAPI.ResourceControllerTest do
       assert resp["data"]["name"] == attrs["name"]
       assert resp["data"]["type"] == attrs["type"]
       assert resp["data"]["address"] == nil
+    end
+
+    test "creates a resource with filters when feature enabled", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+
+      attrs = %{
+        "address" => "10.0.0.10",
+        "name" => "Prod DB",
+        "type" => "ip",
+        "site_id" => site.id,
+        "filters" => [%{"protocol" => "tcp", "ports" => ["5432"]}]
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", resource: attrs)
+
+      assert resp = json_response(conn, 201)
+      assert resp["data"]["filters"] == [%{"protocol" => "tcp", "ports" => ["5432"]}]
+    end
+
+    test "returns 422 when creating with filters and feature disabled", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      update_account(account, features: %{traffic_filters: false})
+      site = site_fixture(account: account)
+
+      attrs = %{
+        "address" => "10.0.0.10",
+        "name" => "Prod DB",
+        "type" => "ip",
+        "site_id" => site.id,
+        "filters" => [%{"protocol" => "tcp", "ports" => ["5432"]}]
+      }
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> post("/resources", resource: attrs)
+
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => %{
+                 "filters" => ["traffic filters are not enabled for this account"]
+               }
+             } = json_response(conn, 422)
     end
 
     test "returns 422 when creating static_device_pool with feature disabled", %{
@@ -345,10 +420,40 @@ defmodule PortalAPI.ResourceControllerTest do
           resource: %{"filters" => [%{"protocol" => "tcp", "ports" => ["8080"]}]}
         )
 
-      assert json_response(conn, 200)
+      assert %{"data" => %{"filters" => [%{"protocol" => "tcp", "ports" => ["8080"]}]}} =
+               json_response(conn, 200)
 
       reloaded = Portal.Repo.get_by!(Resource, id: resource.id, account_id: account.id)
       assert [%{protocol: :tcp}] = reloaded.filters
+    end
+
+    test "returns 422 when providing filters with feature disabled", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      update_account(account, features: %{traffic_filters: false})
+      site = site_fixture(account: account)
+      resource = dns_resource_fixture(account: account, site: site)
+
+      conn =
+        conn
+        |> authorize_conn(actor)
+        |> put_req_header("content-type", "application/json")
+        |> put("/resources/#{resource.id}",
+          resource: %{"filters" => [%{"protocol" => "tcp", "ports" => ["8080"]}]}
+        )
+
+      assert %{
+               "type" => "about:blank",
+               "status" => 422,
+               "validation_errors" => %{
+                 "filters" => ["traffic filters are not enabled for this account"]
+               }
+             } = json_response(conn, 422)
+
+      reloaded = Portal.Repo.get_by!(Resource, id: resource.id, account_id: account.id)
+      assert reloaded.filters == []
     end
 
     test "clears filters when an empty list is provided", %{
@@ -477,7 +582,8 @@ defmodule PortalAPI.ResourceControllerTest do
                  "id" => resource.id,
                  "name" => resource.name,
                  "type" => Atom.to_string(resource.type),
-                 "ip_stack" => Atom.to_string(resource.ip_stack)
+                 "ip_stack" => Atom.to_string(resource.ip_stack),
+                 "filters" => []
                }
              }
 


### PR DESCRIPTION
- Fixes an issue where traffic filters weren't respecting the account's enabled feature flags over the API
- Fixes an issue where rendered resource json didn't include filters
- Fixes an issue where the Resource schema didn't include filters


---

Related: https://github.com/firezone/firezone/issues/13673#issuecomment-4743236278