### PR TITLE
fix(ci): use current tags for nix

### DIFF
--- a/scripts/nix/lib.nix
+++ b/scripts/nix/lib.nix
@@ -33,7 +33,20 @@ rec {
   # delete because its per-target rustflags conflict with buildRustPackage).
   rustflags = "--cfg system_certs -C force-frame-pointers=yes";
 
-  crateVersion = crateDir: (lib.importTOML (src + "/${crateDir}/Cargo.toml")).package.version;
+  # Current released version of each component we package. Read from the
+  # sentinel comments here (kept in sync by scripts/bump-versions.sh) rather
+  # than from Cargo.toml, whose `version` tracks the next, in-development
+  # release.
+  versions = {
+    # mark:current-gateway-version
+    gateway = "1.5.2";
+
+    # mark:current-headless-version
+    headless = "1.5.9";
+
+    # mark:current-gui-version
+    gui = "1.5.14";
+  };
 
   meta = {
     homepage = "https://www.firezone.dev";

--- a/scripts/nix/packages/firezone-gateway.nix
+++ b/scripts/nix/packages/firezone-gateway.nix
@@ -2,7 +2,7 @@
 
 fzLib.rustPlatform.buildRustPackage {
   pname = "firezone-gateway";
-  version = fzLib.crateVersion "gateway";
+  version = fzLib.versions.gateway;
 
   inherit (fzLib) src cargoLock;
 

--- a/scripts/nix/packages/firezone-gui-client/frontend.nix
+++ b/scripts/nix/packages/firezone-gui-client/frontend.nix
@@ -9,7 +9,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "firezone-gui-client-frontend";
-  version = fzLib.crateVersion "gui-client/src-tauri";
+  version = fzLib.versions.gui;
 
   inherit (fzLib) src;
   sourceRoot = "rust/gui-client";

--- a/scripts/nix/packages/firezone-gui-client/package.nix
+++ b/scripts/nix/packages/firezone-gui-client/package.nix
@@ -23,7 +23,7 @@
 
 fzLib.rustPlatform.buildRustPackage {
   pname = "firezone-gui-client";
-  version = fzLib.crateVersion "gui-client/src-tauri";
+  version = fzLib.versions.gui;
 
   inherit (fzLib) src cargoLock;
 

--- a/scripts/nix/packages/firezone-headless-client.nix
+++ b/scripts/nix/packages/firezone-headless-client.nix
@@ -2,7 +2,7 @@
 
 fzLib.rustPlatform.buildRustPackage {
   pname = "firezone-headless-client";
-  version = fzLib.crateVersion "headless-client";
+  version = fzLib.versions.headless;
 
   inherit (fzLib) src cargoLock;
 


### PR DESCRIPTION
Fixes an issue where the nix cache was using the version from `Cargo.toml` which is ahead by one.