### PR TITLE
fix(portal): prevent telemetry handler crash on sync errors

### DIFF
--- a/elixir/lib/portal/entra/error_handler.ex
+++ b/elixir/lib/portal/entra/error_handler.ex
@@ -56,6 +56,7 @@ defmodule Portal.Entra.ErrorHandler do
   defp classify({_tag, _msg, _body}), do: :transient
   defp classify(nil), do: :transient
   defp classify(msg) when is_binary(msg), do: :transient
+  defp classify(_unrecognized), do: :transient
 
   # Formatting
 
@@ -120,6 +121,7 @@ defmodule Portal.Entra.ErrorHandler do
   defp format({_tag, msg}) when is_binary(msg), do: msg
   defp format(nil), do: "Unknown error occurred"
   defp format(msg) when is_binary(msg), do: msg
+  defp format(other), do: format_generic(other)
 
   # Action
 

--- a/elixir/lib/portal/google/error_handler.ex
+++ b/elixir/lib/portal/google/error_handler.ex
@@ -44,6 +44,7 @@ defmodule Portal.Google.ErrorHandler do
   defp classify({_tag, _msg, _body}), do: :transient
   defp classify(nil), do: :transient
   defp classify(msg) when is_binary(msg), do: :transient
+  defp classify(_unrecognized), do: :transient
 
   # Formatting
 
@@ -81,6 +82,7 @@ defmodule Portal.Google.ErrorHandler do
   defp format({_tag, msg}) when is_binary(msg), do: msg
   defp format(nil), do: "Unknown error occurred"
   defp format(msg) when is_binary(msg), do: msg
+  defp format(other), do: format_generic(other)
 
   # Action
 

--- a/elixir/lib/portal/okta/error_handler.ex
+++ b/elixir/lib/portal/okta/error_handler.ex
@@ -44,6 +44,7 @@ defmodule Portal.Okta.ErrorHandler do
   defp classify({_tag, _msg, _body}), do: :transient
   defp classify(nil), do: :transient
   defp classify(msg) when is_binary(msg), do: :transient
+  defp classify(_unrecognized), do: :transient
 
   # Formatting
 
@@ -65,6 +66,7 @@ defmodule Portal.Okta.ErrorHandler do
   defp format({_tag, msg}) when is_binary(msg), do: msg
   defp format(nil), do: "Unknown error occurred"
   defp format(msg) when is_binary(msg), do: msg
+  defp format(other), do: format_generic(other)
 
   # Action
 

--- a/elixir/lib/portal/telemetry/reporter/oban.ex
+++ b/elixir/lib/portal/telemetry/reporter/oban.ex
@@ -11,6 +11,8 @@ defmodule Portal.Telemetry.Reporter.Oban do
   - Returning Sentry context specific to their domain
   """
 
+  require Logger
+
   @directory_sync_workers [
     "Portal.Entra.Sync",
     "Portal.Google.Sync",
@@ -22,9 +24,20 @@ defmodule Portal.Telemetry.Reporter.Oban do
   end
 
   def handle_event([:oban, :job, :exception], _measure, meta, _config) do
-    sentry_context = handle_error(meta)
+    sentry_context = safe_handle_error(meta)
 
     Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: sentry_context)
+  end
+
+  defp safe_handle_error(meta) do
+    handle_error(meta)
+  rescue
+    exception ->
+      Logger.error("Oban error handler crashed while building Sentry context",
+        error: Exception.format(:error, exception, __STACKTRACE__)
+      )
+
+      build_sentry_context(meta.job)
   end
 
   # Route errors to domain-specific handlers based on worker type.

--- a/elixir/test/portal/directory_sync/error_handler_test.exs
+++ b/elixir/test/portal/directory_sync/error_handler_test.exs
@@ -377,6 +377,26 @@ defmodule Portal.DirectorySync.ErrorHandlerTest do
       assert updated_directory.error_message == "plain okta failure"
     end
 
+    test "classifies unknown HTTP client errors as transient without crashing", %{
+      directory: directory
+    } do
+      job = sync_job("Portal.Okta.Sync", directory.id)
+
+      error = %Portal.Okta.SyncError{
+        error: %Req.HTTPError{protocol: :http2, reason: :pool_not_available},
+        directory_id: directory.id,
+        step: :get_access_token
+      }
+
+      ErrorHandler.handle_error(%{reason: error, job: job})
+
+      updated_directory = Portal.Repo.get!(Portal.Okta.Directory, directory.id)
+      assert updated_directory.is_disabled == false
+      assert updated_directory.errored_at != nil
+      assert is_binary(updated_directory.error_message)
+      assert updated_directory.error_message != ""
+    end
+
     test "handles generic exceptions and missing directories" do
       directory_id = Ecto.UUID.generate()
 
@@ -651,6 +671,26 @@ defmodule Portal.DirectorySync.ErrorHandlerTest do
       updated_directory = Portal.Repo.get!(Portal.Entra.Directory, directory.id)
       assert updated_directory.is_disabled == false
       assert updated_directory.error_message == "Connection timed out."
+    end
+
+    test "classifies unknown HTTP client errors as transient without crashing", %{
+      directory: directory
+    } do
+      job = sync_job("Portal.Entra.Sync", directory.id)
+
+      error = %Portal.Entra.SyncError{
+        error: %Req.HTTPError{protocol: :http2, reason: :pool_not_available},
+        directory_id: directory.id,
+        step: :get_access_token
+      }
+
+      ErrorHandler.handle_error(%{reason: error, job: job})
+
+      updated_directory = Portal.Repo.get!(Portal.Entra.Directory, directory.id)
+      assert updated_directory.is_disabled == false
+      assert updated_directory.errored_at != nil
+      assert is_binary(updated_directory.error_message)
+      assert updated_directory.error_message != ""
     end
 
     test "formats HTTP 403 forbidden code responses", %{directory: directory} do
@@ -990,6 +1030,26 @@ defmodule Portal.DirectorySync.ErrorHandlerTest do
       assert updated_directory.is_disabled == false
       assert updated_directory.errored_at != nil
       assert updated_directory.error_message == "Connection timed out."
+    end
+
+    test "classifies unknown HTTP client errors as transient without crashing", %{
+      directory: directory
+    } do
+      job = sync_job("Portal.Google.Sync", directory.id)
+
+      error = %Portal.Google.SyncError{
+        error: %Req.HTTPError{protocol: :http2, reason: :pool_not_available},
+        directory_id: directory.id,
+        step: :get_access_token
+      }
+
+      ErrorHandler.handle_error(%{reason: error, job: job})
+
+      updated_directory = Portal.Repo.get!(Portal.Google.Directory, directory.id)
+      assert updated_directory.is_disabled == false
+      assert updated_directory.errored_at != nil
+      assert is_binary(updated_directory.error_message)
+      assert updated_directory.error_message != ""
     end
 
     test "classifies tuple validation errors as client_error", %{directory: directory} do

--- a/elixir/test/portal/telemetry/reporter/oban_test.exs
+++ b/elixir/test/portal/telemetry/reporter/oban_test.exs
@@ -1,0 +1,41 @@
+defmodule Portal.Telemetry.Reporter.ObanTest do
+  use Portal.DataCase, async: true
+
+  alias Portal.Telemetry.Reporter.Oban, as: Reporter
+
+  import Portal.AccountFixtures
+  import Portal.EntraDirectoryFixtures
+
+  describe "handle_event/4" do
+    setup do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+
+      %{directory: directory}
+    end
+
+    test "captures directory sync exceptions without raising the telemetry handler",
+         %{directory: directory} do
+      job = %Oban.Job{
+        id: 1,
+        worker: "Portal.Entra.Sync",
+        queue: "directory_sync",
+        meta: %{},
+        args: %{"directory_id" => directory.id}
+      }
+
+      reason = %Portal.Entra.SyncError{
+        error: %Req.HTTPError{protocol: :http2, reason: :pool_not_available},
+        directory_id: directory.id,
+        step: :get_access_token
+      }
+
+      meta = %{reason: reason, job: job, stacktrace: []}
+
+      Reporter.handle_event([:oban, :job, :exception], %{}, meta, [])
+
+      updated_directory = Portal.Repo.get!(Portal.Entra.Directory, directory.id)
+      assert updated_directory.errored_at != nil
+    end
+  end
+end


### PR DESCRIPTION
- Req surfaces pool exhaustion as a `%Req.HTTPError{}`, a shape sync error classification did not handle, raising `:function_clause` in the Oban exception telemetry handler.
- Telemetry permanently detaches a raising handler, so this silently halted all Oban exception reporting to Sentry until the next deploy.
- Unknown error shapes are now classified as transient, and the reporter guards domain handling so it can never detach.

Fixes #13763