### PR TITLE
fix(portal): increase HTTP pool size for directory sync

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -228,13 +228,13 @@ config :portal, Portal.Entra.APIClient,
   endpoint: "https://graph.microsoft.com",
   token_base_url: "https://login.microsoftonline.com",
   # 15 minutes in milliseconds
-  req_opts: [receive_timeout: 900_000]
+  req_opts: [receive_timeout: 900_000, finch: Portal.Finch]
 
 config :portal, Portal.Google.APIClient,
   endpoint: "https://admin.googleapis.com",
   service_account_key: System.get_env("GOOGLE_SERVICE_ACCOUNT_KEY"),
   token_endpoint: "https://oauth2.googleapis.com/token",
-  req_opts: [receive_timeout: 60_000]
+  req_opts: [receive_timeout: 60_000, finch: Portal.Finch]
 
 config :portal, Portal.Google.AuthProvider,
   # Should match an external OAuth2 client in Google Cloud Console
@@ -250,7 +250,8 @@ config :portal, Portal.Okta.AuthProvider,
   scope: "openid email profile"
 
 # 15 minutes in milliseconds
-config :portal, Portal.Okta.APIClient, req_opts: [receive_timeout: 900_000]
+config :portal, Portal.Okta.APIClient,
+  req_opts: [receive_timeout: 900_000, finch: Portal.Finch]
 
 config :portal, Portal.Entra.AuthProvider,
   # Should match an external OAuth2 client in Azure

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -53,7 +53,13 @@ defmodule Portal.Application do
       # Application services
       Portal.Presence,
       Portal.Mailer.RateLimiter,
-      Portal.ComponentVersions
+      Portal.ComponentVersions,
+
+      # Shared HTTP pool for directory sync / IdP API clients. Finch keys pools
+      # per host, so each provider still gets an isolated pool; this just sizes
+      # them 10x larger than Req's default (50) to survive the long-lived
+      # paginated sync streams that were exhausting the pool.
+      {Finch, name: Portal.Finch, pools: %{default: [size: 500]}}
     ]
 
     endpoint_children = [

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -151,6 +151,7 @@ defmodule Portal.MixProject do
       {:hackney, "~> 1.19"},
       {:logger_json, "~> 7.0"},
       {:req, "~> 0.5.15"},
+      {:finch, "~> 0.22"},
 
       # Asset pipeline
       {:esbuild, "~> 0.7", runtime: Mix.env() == :dev},


### PR DESCRIPTION
Long-lived paginated directory sync streams hold connections for up to 15 minutes, which exhausts Req's default Finch pool (50 connections per host) and surfaces as connection pool errors during syncs. The IdP API clients now share a Finch pool sized 10x larger.

Related: #13763 