### PR TITLE
fix(portal): handle device changes in clients liveview

### DIFF
--- a/elixir/lib/portal/changes/hooks/devices.ex
+++ b/elixir/lib/portal/changes/hooks/devices.ex
@@ -5,7 +5,12 @@ defmodule Portal.Changes.Hooks.Devices do
   import Portal.SchemaHelpers
 
   @impl true
-  def on_insert(_lsn, _data), do: :ok
+  def on_insert(lsn, data) do
+    device = struct_from_params(Portal.Device, data)
+    change = %Change{lsn: lsn, op: :insert, struct: device}
+
+    PubSub.Changes.broadcast(device.account_id, :devices, change)
+  end
 
   @impl true
   def on_update(lsn, old_data, data) do

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -20,6 +20,7 @@ defmodule PortalWeb.Clients do
       socket
       |> assign(page_title: "Clients")
       |> assign(selected_client: nil)
+      |> assign(stale: false)
       |> assign_async(:clients_count, fn -> {:ok, %{clients_count: Database.count_clients(subject)}} end)
       |> assign(
         policy_authorizations: [],
@@ -136,6 +137,7 @@ defmodule PortalWeb.Clients do
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
         <.live_table
+          stale={@stale}
           id="clients"
           rows={@clients}
           row_id={&"client-#{&1.id}"}
@@ -302,7 +304,7 @@ defmodule PortalWeb.Clients do
   end
 
   def handle_event(event, params, socket)
-      when event in ["paginate", "order_by", "filter", "table_row_click", "change_limit"],
+      when event in ["paginate", "order_by", "filter", "reload", "table_row_click", "change_limit"],
       do: handle_live_table_event(event, params, socket)
 
   def handle_event("close_panel", _params, socket) do
@@ -495,28 +497,28 @@ defmodule PortalWeb.Clients do
      |> push_patch(to: ~p"/#{socket.assigns.account}/clients?#{socket.assigns.query_params}")}
   end
 
-  def handle_info(%Change{op: :insert, struct: %Device{type: :client}}, socket) do
+  def handle_info(%Change{op: :insert, struct: %Device{type: :client}} = change, socket) do
     {:noreply,
-     update(socket, :clients_count, fn
+     socket
+     |> update(:clients_count, fn
        %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, ar.result + 1)
        ar -> ar
-     end)}
+     end)
+     |> mark_stale_if_unreflected(change)}
   end
 
-  def handle_info(%Change{op: :delete, old_struct: %Device{type: :client}}, socket) do
+  def handle_info(%Change{op: :delete, old_struct: %Device{type: :client}} = change, socket) do
     {:noreply,
-     update(socket, :clients_count, fn
+     socket
+     |> update(:clients_count, fn
        %AsyncResult{ok?: true} = ar -> AsyncResult.ok(ar, max(ar.result - 1, 0))
        ar -> ar
-     end)}
+     end)
+     |> mark_stale_if_unreflected(change)}
   end
 
-  def handle_info(%Change{op: :update, struct: %Device{type: :client, id: id}}, socket) do
-    if Enum.any?(socket.assigns.clients, &(&1.id == id)) do
-      {:noreply, reload_live_table!(socket, "clients")}
-    else
-      {:noreply, socket}
-    end
+  def handle_info(%Change{struct: %Device{type: :client}} = change, socket) do
+    {:noreply, mark_stale_if_unreflected(socket, change)}
   end
 
   def handle_info(%Change{struct: %Device{type: :gateway}}, socket), do: {:noreply, socket}
@@ -537,6 +539,14 @@ defmodule PortalWeb.Clients do
   end
 
   def handle_info(message, socket), do: PortalWeb.Live.Helpers.handle_info_fallback(message, socket)
+
+  defp mark_stale_if_unreflected(socket, change) do
+    if PortalWeb.LiveTable.view_reflects_change?(socket.assigns.clients, change) do
+      socket
+    else
+      assign(socket, stale: true)
+    end
+  end
 
   defmodule Database do
     import Ecto.Changeset

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -511,6 +511,17 @@ defmodule PortalWeb.Clients do
      end)}
   end
 
+  def handle_info(%Change{op: :update, struct: %Device{type: :client, id: id}}, socket) do
+    if Enum.any?(socket.assigns.clients, &(&1.id == id)) do
+      {:noreply, reload_live_table!(socket, "clients")}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(%Change{struct: %Device{type: :gateway}}, socket), do: {:noreply, socket}
+  def handle_info(%Change{old_struct: %Device{type: :gateway}}, socket), do: {:noreply, socket}
+
   def handle_info(
         %Phoenix.Socket.Broadcast{topic: "presences:account_clients:" <> _account_id} = event,
         socket

--- a/elixir/test/portal/changes/hooks/clients_test.exs
+++ b/elixir/test/portal/changes/hooks/clients_test.exs
@@ -9,8 +9,16 @@ defmodule Portal.Changes.Hooks.ClientsTest do
   alias Portal.PubSub
 
   describe "insert/1" do
-    test "returns :ok" do
-      assert :ok == on_insert(0, %{})
+    test "broadcasts inserted client" do
+      account = account_fixture()
+      client = client_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(client.account_id, :devices)
+
+      data = %{"id" => client.id, "type" => "client", "account_id" => client.account_id}
+
+      assert :ok == on_insert(0, data)
+      assert_receive %Change{op: :insert, struct: %Device{} = inserted_client, lsn: 0}
+      assert inserted_client.id == client.id
     end
   end
 

--- a/elixir/test/portal/changes/hooks/gateways_test.exs
+++ b/elixir/test/portal/changes/hooks/gateways_test.exs
@@ -8,8 +8,16 @@ defmodule Portal.Changes.Hooks.GatewaysTest do
   alias Portal.PubSub
 
   describe "insert/1" do
-    test "returns :ok" do
-      assert :ok == on_insert(0, %{})
+    test "broadcasts inserted gateway" do
+      account = account_fixture()
+      gateway = gateway_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id, :devices)
+
+      data = %{"id" => gateway.id, "type" => "gateway", "account_id" => account.id}
+
+      assert :ok == on_insert(0, data)
+      assert_receive %Change{op: :insert, struct: %Device{} = inserted_gateway, lsn: 0}
+      assert inserted_gateway.id == gateway.id
     end
   end
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -601,6 +601,31 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Total"
     end
 
+    test "reflects client update change in the table", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients")
+
+      render_async(lv)
+      assert render(lv) =~ client.name
+
+      {:ok, _updated} =
+        client
+        |> Ecto.Changeset.change(name: "Renamed Client")
+        |> Repo.update()
+
+      send(lv.pid, %Change{op: :update, struct: %Device{type: :client, id: client.id}})
+
+      assert render(lv) =~ "Renamed Client"
+    end
+
     test "ignores non-client device changes", %{conn: conn, account: account, actor: actor} do
       {:ok, lv, _html} =
         conn

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -601,7 +601,7 @@ defmodule PortalWeb.ClientsTest do
       assert html =~ "Total"
     end
 
-    test "reflects client update change in the table", %{
+    test "marks the table stale on client update change", %{
       conn: conn,
       account: account,
       actor: actor
@@ -614,7 +614,7 @@ defmodule PortalWeb.ClientsTest do
         |> live(~p"/#{account}/clients")
 
       render_async(lv)
-      assert render(lv) =~ client.name
+      refute has_element?(lv, "#clients-reload-btn")
 
       {:ok, _updated} =
         client
@@ -623,6 +623,9 @@ defmodule PortalWeb.ClientsTest do
 
       send(lv.pid, %Change{op: :update, struct: %Device{type: :client, id: client.id}})
 
+      assert has_element?(lv, "#clients-reload-btn")
+
+      render_click(lv, "reload", %{"table_id" => "clients"})
       assert render(lv) =~ "Renamed Client"
     end
 


### PR DESCRIPTION
The Clients LiveView crashed-logged on unhandled `handle_info` messages for device change broadcasts it didn't match.

- `Devices.on_insert` now broadcasts a change so the clients count increments live.
- Device changes that aren't already reflected mark the table stale, surfacing the "data has changed" reload affordance instead of forcing a reload.
- Gateway device changes are matched and ignored in this view.


---

Fixes https://github.com/firezone/firezone/issues/13762