### PR TITLE
fix(ci): only --no-deep-links gui bin

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -291,7 +291,10 @@ struct Cli {
     /// If true, show a fake error dialog on startup
     #[arg(long, hide = true)]
     test_error_dialog: bool,
-    /// For headless CI, disable deep links.
+    /// Disable runtime deep-link self-registration. Used by headless CI, and
+    /// by packaged builds (e.g. Nix) that register the deep-link handler
+    /// themselves and don't want it overridden at runtime with a per-user
+    /// entry pointing at the unwrapped exe.
     #[arg(long, hide = true)]
     no_deep_links: bool,
     /// For headless CI, log errors instead of showing a blocking

--- a/scripts/nix/packages/firezone-gui-client/package.nix
+++ b/scripts/nix/packages/firezone-gui-client/package.nix
@@ -78,6 +78,13 @@ fzLib.rustPlatform.buildRustPackage {
   # The workspace pulls Apple-specific crates into the test graph.
   doCheck = false;
 
+  # wrapGAppsHook3 wraps every executable in $out/bin, which would stamp the
+  # GUI-only --add-flags (notably --no-deep-links) onto the bundled
+  # firezone-client-tunnel daemon, crashing it on startup with an
+  # "unexpected argument '--no-deep-links'" error. Disable the blanket
+  # wrapping and wrap only the GUI binary ourselves in postFixup.
+  dontWrapGApps = true;
+
   postInstall = ''
     # register-sparse only does anything on Windows.
     rm -f $out/bin/register-sparse
@@ -94,6 +101,12 @@ fzLib.rustPlatform.buildRustPackage {
       $out/share/icons/hicolor/128x128/apps/firezone-client-gui.png
     install -Dm644 "gui-client/src-tauri/icons/128x128@2x.png" \
       $out/share/icons/hicolor/256x256/apps/firezone-client-gui.png
+  '';
+
+  # dontWrapGApps disables the automatic wrapping, so wrap only the GUI
+  # binary here. gappsWrapperArgs is populated in preFixup below.
+  postFixup = ''
+    wrapProgram $out/bin/firezone-client-gui "''${gappsWrapperArgs[@]}"
   '';
 
   desktopItems = [


### PR DESCRIPTION
Fixes an issue where nix would wrap every binary with the `--no-deep-links` flag causing startup failure.
