### PR TITLE
fix(connlib): skip GSO for single-segment datagrams

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -429,11 +429,20 @@ impl PerfUdpSocket {
             let end = std::cmp::min(offset + chunk_size, total);
             let contents = &transmit.contents[offset..end];
 
+            // A chunk holding a single segment must not request GSO: some kernels reject the
+            // `UDP_SEGMENT` cmsg with `EINVAL` when there is nothing to segment, particularly
+            // on IPv6. Sending it as a plain datagram avoids the spurious failure.
+            let chunk_segment_size = if contents.len() <= segment_size {
+                None
+            } else {
+                Some(segment_size)
+            };
+
             let chunk = Transmit {
                 destination: dst,
                 ecn: transmit.ecn,
                 contents,
-                segment_size: Some(segment_size),
+                segment_size: chunk_segment_size,
                 src_ip: src,
             };
 


### PR DESCRIPTION
Some kernels (Linux 7+) reject the UDP_SEGMENT cmsg with `EINVAL` when a datagram holds a single segment, particularly on the IPv6 path. Sending such a chunk as a plain datagram avoids the spurious failure.

**Note:** This fixes many but not all of the `os error 22` - it doesn't affect #13770.


Fixes #13767 
Related: #13770 
