### PR TITLE
revert(#13765)

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -228,13 +228,13 @@ config :portal, Portal.Entra.APIClient,
   endpoint: "https://graph.microsoft.com",
   token_base_url: "https://login.microsoftonline.com",
   # 15 minutes in milliseconds
-  req_opts: [receive_timeout: 900_000, finch: Portal.Finch]
+  req_opts: [receive_timeout: 900_000]
 
 config :portal, Portal.Google.APIClient,
   endpoint: "https://admin.googleapis.com",
   service_account_key: System.get_env("GOOGLE_SERVICE_ACCOUNT_KEY"),
   token_endpoint: "https://oauth2.googleapis.com/token",
-  req_opts: [receive_timeout: 60_000, finch: Portal.Finch]
+  req_opts: [receive_timeout: 60_000]
 
 config :portal, Portal.Google.AuthProvider,
   # Should match an external OAuth2 client in Google Cloud Console
@@ -250,8 +250,7 @@ config :portal, Portal.Okta.AuthProvider,
   scope: "openid email profile"
 
 # 15 minutes in milliseconds
-config :portal, Portal.Okta.APIClient,
-  req_opts: [receive_timeout: 900_000, finch: Portal.Finch]
+config :portal, Portal.Okta.APIClient, req_opts: [receive_timeout: 900_000]
 
 config :portal, Portal.Entra.AuthProvider,
   # Should match an external OAuth2 client in Azure

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -53,13 +53,7 @@ defmodule Portal.Application do
       # Application services
       Portal.Presence,
       Portal.Mailer.RateLimiter,
-      Portal.ComponentVersions,
-
-      # Shared HTTP pool for directory sync / IdP API clients. Finch keys pools
-      # per host, so each provider still gets an isolated pool; this just sizes
-      # them 10x larger than Req's default (50) to survive the long-lived
-      # paginated sync streams that were exhausting the pool.
-      {Finch, name: Portal.Finch, pools: %{default: [size: 500]}}
+      Portal.ComponentVersions
     ]
 
     endpoint_children = [

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -151,7 +151,6 @@ defmodule Portal.MixProject do
       {:hackney, "~> 1.19"},
       {:logger_json, "~> 7.0"},
       {:req, "~> 0.5.15"},
-      {:finch, "~> 0.22"},
 
       # Asset pipeline
       {:esbuild, "~> 0.7", runtime: Mix.env() == :dev},


### PR DESCRIPTION
Turns out these transient errors are tolerable and the real issue was simply the error handler detaching.

The pool size is not in play here.

Reverts firezone/firezone#13765