### PR TITLE
fix(portal): warm connection pool on boot

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -222,6 +222,9 @@ config :portal, Portal.Health,
   # TODO: Remove draining_file_path after Azure migration is complete
   draining_file_path: "/var/run/firezone/draining"
 
+# Disabled outside of prod to avoid outbound requests at boot; enabled in runtime.exs.
+config :portal, Portal.ConnectionWarmer, enabled: false
+
 config :portal, Portal.Entra.APIClient,
   client_id: System.get_env("ENTRA_SYNC_CLIENT_ID"),
   client_secret: System.get_env("ENTRA_SYNC_CLIENT_SECRET"),

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -207,6 +207,8 @@ if config_env() == :prod do
 
   config :portal, Portal.Billing.Stripe.APIClient, endpoint: "https://api.stripe.com"
 
+  config :portal, Portal.ConnectionWarmer, enabled: true
+
   config :portal,
          Portal.Billing,
          [

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -70,11 +70,22 @@ defmodule Portal.Application do
     # 3) Endpoints drain and terminate channels while Presence/PubSub/Repo are alive.
     # 4) Portal{API,Web}.RateLimit stops after endpoint traffic has ceased.
     base_children ++
+      connection_warmer() ++
       client_session_queue() ++
       gateway_session_queue() ++
       policy_authorization_queue() ++
       rate_limit() ++
       telemetry() ++ oban() ++ endpoint_children ++ replication() ++ [Portal.Cluster]
+  end
+
+  defp connection_warmer do
+    config = Application.get_env(:portal, Portal.ConnectionWarmer, [])
+
+    if Keyword.get(config, :enabled, false) do
+      [Portal.ConnectionWarmer]
+    else
+      []
+    end
   end
 
   defp configure_logger do

--- a/elixir/lib/portal/connection_warmer.ex
+++ b/elixir/lib/portal/connection_warmer.ex
@@ -1,0 +1,61 @@
+defmodule Portal.ConnectionWarmer do
+  @moduledoc """
+  Pre-creates Finch connection pools for known production hosts at startup.
+
+  Finch creates a pool per host lazily, on the first request to that host. When
+  several requests to a cold host arrive concurrently (for example parallel
+  directory sync jobs right after a deploy), the requests that lose the
+  pool-construction race fail with `%Finch.Error{reason: :pool_not_available}`.
+
+  Issuing one request per host at boot creates and registers each pool up front,
+  so later requests never race construction. The pool is created during request
+  setup, before the connection is established, so it is warmed even when the
+  warmup request itself fails. Pools persist for the lifetime of the node
+  (`pool_max_idle_time` defaults to `:infinity`), so a single pass is enough.
+  """
+
+  require Logger
+
+  @hosts [
+    "https://graph.microsoft.com",
+    "https://login.microsoftonline.com",
+    "https://admin.googleapis.com",
+    "https://www.googleapis.com",
+    "https://oauth2.googleapis.com",
+    "https://accounts.google.com",
+    "https://api.stripe.com"
+  ]
+
+  @request_timeout :timer.seconds(5)
+
+  def child_spec(_opts) do
+    %{
+      id: __MODULE__,
+      start: {Task, :start_link, [&run/0]},
+      restart: :temporary
+    }
+  end
+
+  def run do
+    @hosts
+    |> Task.async_stream(&warm/1,
+      max_concurrency: length(@hosts),
+      timeout: @request_timeout + :timer.seconds(2),
+      on_timeout: :kill_task
+    )
+    |> Stream.run()
+  end
+
+  defp warm(url) do
+    case Req.head(url, retry: false, receive_timeout: @request_timeout) do
+      {:ok, response} ->
+        Logger.debug("Warmed connection pool", url: url, status: response.status)
+
+      {:error, reason} ->
+        Logger.debug("Connection pool warmup failed", url: url, reason: inspect(reason))
+    end
+  rescue
+    error ->
+      Logger.debug("Connection pool warmup raised", url: url, error: inspect(error))
+  end
+end


### PR DESCRIPTION
When finch (used by Req) hits an endpoint for the first time, it boots a connection pool for it that lives indefinitely.

If many requests happen at "precisely" the same instant to a cold pool, there's a race window between the time which the finch pool pid is registered, and when it's actually alive ready to handle requests.

This manifests as `pool_not_available` and is retried, but it would be better to avoid the error condition altogether if we can avoid it.

Related: #13763 