### PR TITLE
fix(connlib): prefer public IPv6 source addresses on Linux

### DIFF
--- a/rust/libs/bin-shared/src/linux.rs
+++ b/rust/libs/bin-shared/src/linux.rs
@@ -1,3 +1,4 @@
+use std::os::fd::{AsFd, AsRawFd};
 use std::{io, net::SocketAddr};
 
 use crate::FIREZONE_MARK;
@@ -7,6 +8,7 @@ use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(socket_addr)?;
     setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
+    prefer_public_ipv6_source(&socket, socket_addr);
     Ok(socket)
 }
 
@@ -17,8 +19,46 @@ impl SocketFactory<UdpSocket> for UdpSocketFactory {
     fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
         let socket = socket_factory::udp(local)?;
         setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
+        prefer_public_ipv6_source(&socket, local);
         Ok(socket)
     }
 
     fn reset(&self) {}
+}
+
+/// Pins source-address selection to stable, public IPv6 addresses (RFC 5014).
+///
+/// We stamp a per-packet source IP onto the wildcard socket (via `IPV6_PKTINFO`) to honour the
+/// address we advertised as our ICE host candidate. SLAAC privacy extensions rotate temporary
+/// addresses out from under that pin, after which `sendmsg` rejects the now-unassigned source
+/// with `EINVAL`. Preferring public addresses keeps the kernel's chosen source stable for the
+/// lifetime of the candidate, so the pin stays valid.
+fn prefer_public_ipv6_source(socket: &impl AsFd, local: SocketAddr) {
+    if !local.is_ipv6() {
+        return;
+    }
+
+    // Not exposed by `libc` or `nix`; see `include/uapi/linux/in6.h`.
+    const IPV6_ADDR_PREFERENCES: libc::c_int = 72;
+    const IPV6_PREFER_SRC_PUBLIC: libc::c_int = 0x0002;
+
+    let preference = IPV6_PREFER_SRC_PUBLIC;
+
+    // SAFETY: `preference` outlives the call and its size matches the `c_int` option value.
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_fd().as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            IPV6_ADDR_PREFERENCES,
+            std::ptr::from_ref(&preference).cast(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+
+    if ret != 0 {
+        tracing::debug!(
+            "Failed to prefer public IPv6 source address: {}",
+            io::Error::last_os_error()
+        );
+    }
 }


### PR DESCRIPTION
connlib stamps a per-packet source IP onto its wildcard UDP socket to honour the address it advertises as its ICE host candidate. On Linux with SLAAC privacy extensions (Ubuntu 26.04 default), the kernel selects a temporary IPv6 address as that source. Once that address is deprecated and removed, the pinned source no longer exists and sends from it fail with `EINVAL` (os error 22), breaking the path until ICE re-nominates.

On my home network this happens every 10 - 60 minutes.

The UDP and TCP sockets now request public source addresses (RFC 5014 `IPV6_PREFER_SRC_PUBLIC`), so the kernel selects a stable address that survives privacy-extension rotation and the advertised host candidate stays reachable for its lifetime.

--- 

Related: #13770 