### PR TITLE
fix(connlib): drop sends from an unassigned source address

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -488,6 +488,17 @@ impl PerfUdpSocket {
 
                     return Ok(());
                 }
+                // A pinned source IP that is no longer assigned to any interface (e.g. an IPv6
+                // privacy address that rotated away) makes `sendmsg` fail with `EINVAL`. Drop the
+                // packet rather than erroring: ICE connectivity checks share the same dead source,
+                // so the path fails its liveness checks and traffic re-nominates onto another pair.
+                Err(e) if src.is_some() && is_unassigned_source(&e) => {
+                    self.record_send_retries(attempt);
+
+                    tracing::debug!(?src, %dst, "Dropping packet: source address unavailable: {e}");
+
+                    return Ok(());
+                }
                 Err(e) => {
                     self.record_send_retries(attempt);
 
@@ -725,6 +736,18 @@ fn should_retry(e: &io::Error, attempt: u32) -> bool {
         return true;
     }
 
+    false
+}
+
+/// Whether a send failed because the socket's pinned source address is no longer assigned to any
+/// interface, e.g. an IPv6 privacy address that the kernel rotated away.
+#[cfg(unix)]
+fn is_unassigned_source(e: &io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EINVAL)
+}
+
+#[cfg(not(unix))]
+fn is_unassigned_source(_: &io::Error) -> bool {
     false
 }
 


### PR DESCRIPTION
A pinned source IP can stop being assigned to any interface while a flow is still active, most often when an IPv6 privacy address is deprecated and removed. Such sends fail with `EINVAL`, which the send path treated as a fatal error after spending its single GSO-disable retry on the same dead source.

The send path now recognises `EINVAL` on a send with a pinned source as an unavailable source and drops the packet. ICE connectivity checks travel over the same source, so the path fails its liveness checks and traffic re-nominates onto another candidate pair (host, server-reflexive, or relay), at which point the next keep-alive binding re-learns the current source.

Related: #13773