### PR TITLE
feat(portal): negotiate snownet `iceless` capability

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -107,7 +107,8 @@ defmodule PortalAPI.Client.Channel do
       |> assign(
         cache: cache,
         authorizations_cache: authorizations_cache,
-        pending_flows: %{}
+        pending_flows: %{},
+        iceless: false
       )
       # Track client's presence and monitor tracker shard processes for crash recovery
       |> track_presence()
@@ -334,9 +335,23 @@ defmodule PortalAPI.Client.Channel do
     {:noreply, socket}
   end
 
+  # Backwards-compat: tolerate the pre-snownet-capabilities tuple from older
+  # gateway nodes during a rolling deploy. Default the iceless capability to `false`.
+  def handle_info(
+        {:connect, socket_ref, rid_bytes, site_id, gateway_id, gateway_public_key, gateway_ipv4,
+         gateway_ipv6, preshared_key, ice_credentials},
+        socket
+      ) do
+    handle_info(
+      {:connect, socket_ref, rid_bytes, site_id, gateway_id, gateway_public_key, gateway_ipv4,
+       gateway_ipv6, preshared_key, ice_credentials, false},
+      socket
+    )
+  end
+
   def handle_info(
         {:connect, _socket_ref, rid_bytes, site_id, gateway_id, gateway_public_key, gateway_ipv4,
-         gateway_ipv6, preshared_key, ice_credentials},
+         gateway_ipv6, preshared_key, ice_credentials, iceless},
         socket
       ) do
     resource_id = Ecto.UUID.load!(rid_bytes)
@@ -358,7 +373,8 @@ defmodule PortalAPI.Client.Channel do
             gateway_public_key: gateway_public_key,
             gateway_ipv4: gateway_ipv4,
             gateway_ipv6: gateway_ipv6,
-            gateway_ice_credentials: ice_credentials.receiver
+            gateway_ice_credentials: ice_credentials.receiver,
+            snownet_capabilities: %{iceless: iceless}
           }
           |> put_site_id(site_id, socket.assigns.session)
 
@@ -389,13 +405,26 @@ defmodule PortalAPI.Client.Channel do
   # the initiator, because the target's data plane is guaranteed to receive
   # (and process) the authorization before any relayed ICE candidate, which
   # travels the same socket behind it. See `deliver_pool_target_authorized/8`.
+  # Backwards-compat: tolerate the pre-snownet-capabilities ack from older
+  # initiator targets during a rolling deploy. Default the iceless capability
+  # to `false`.
   def handle_info({:device_access_acked, ref}, socket) do
+    handle_info({:device_access_acked, ref, false}, socket)
+  end
+
+  def handle_info({:device_access_acked, ref, target_iceless}, socket) do
     case Map.pop(socket.assigns.pending_flows, ref) do
       {nil, _} ->
         {:noreply, socket}
 
       {%{timer_ref: timer_ref, initiator_payload: initiator_payload}, remaining} ->
         Process.cancel_timer(timer_ref)
+
+        iceless = socket.assigns.iceless == true and target_iceless == true
+
+        initiator_payload =
+          Map.put(initiator_payload, :snownet_capabilities, %{iceless: iceless})
+
         push(socket, "client_device_access_authorized", initiator_payload)
         {:noreply, assign(socket, :pending_flows, remaining)}
     end
@@ -405,6 +434,10 @@ defmodule PortalAPI.Client.Channel do
     {policy_authorization_id, payload} = Map.pop(payload, :policy_authorization_id)
     {authorization_expires_at, payload} = Map.pop(payload, :authorization_expires_at)
     {policy_authorization, payload} = Map.pop(payload, :policy_authorization)
+    {initiator_iceless, payload} = Map.pop(payload, :initiator_iceless, false)
+
+    iceless = socket.assigns.iceless == true and initiator_iceless == true
+    payload = Map.put(payload, :snownet_capabilities, %{iceless: iceless})
 
     authorizations_cache =
       maybe_put_authorization(
@@ -427,8 +460,9 @@ defmodule PortalAPI.Client.Channel do
     # Ack back to the initiator's channel that the authorization is on this
     # target's websocket. The initiator is released only after this, so the
     # initiator's ICE candidates (which traverse the same socket) can never
-    # overtake the authorization at the target's data plane.
-    send(ack_to, {:device_access_acked, ref})
+    # overtake the authorization at the target's data plane. We report our own
+    # capabilities so the initiator can negotiate the same set on its side.
+    send(ack_to, {:device_access_acked, ref, socket.assigns.iceless})
 
     cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
 
@@ -1160,6 +1194,10 @@ defmodule PortalAPI.Client.Channel do
     {:noreply, socket}
   end
 
+  def handle_in("set_snownet_capabilities", payload, socket) when is_map(payload) do
+    {:noreply, assign(socket, iceless: payload["iceless"] == true)}
+  end
+
   def handle_in("no_relays", _payload, socket) do
     {:ok, relays} = select_relays(socket)
     socket = cache_relays(socket, relays)
@@ -1347,7 +1385,8 @@ defmodule PortalAPI.Client.Channel do
              policy_authorization_id: policy_authorization_id,
              authorization_expires_at: expires_at,
              ice_credentials: ice_credentials,
-             preshared_key: preshared_key
+             preshared_key: preshared_key,
+             client_iceless: socket.assigns.iceless
            }}
 
         attrs =
@@ -1714,7 +1753,8 @@ defmodule PortalAPI.Client.Channel do
          resource: rendered_resource,
          subject: rendered_subject,
          policy_authorization_id: policy_authorization_id,
-         authorization_expires_at: expires_at
+         authorization_expires_at: expires_at,
+         initiator_iceless: socket.assigns.iceless
        }}
 
     initiator_payload = %{

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -106,7 +106,11 @@ defmodule PortalAPI.Gateway.Channel do
   @impl true
   def handle_info(:after_join, socket) do
     # Initialize the cache
-    socket = assign(socket, cache: Cache.Gateway.hydrate(socket.assigns.gateway))
+    socket =
+      assign(socket,
+        cache: Cache.Gateway.hydrate(socket.assigns.gateway),
+        iceless: false
+      )
     Process.send_after(self(), :prune_cache, @prune_cache_every)
 
     # Track gateway's presence
@@ -299,7 +303,11 @@ defmodule PortalAPI.Gateway.Channel do
       preshared_key: preshared_key
     } = payload
 
+    client_iceless = Map.get(payload, :client_iceless, false)
+
     rid_bytes = Ecto.UUID.dump!(resource.id)
+
+    iceless = socket.assigns.iceless == true and client_iceless == true
 
     ref =
       encode_ref(socket, {
@@ -307,7 +315,8 @@ defmodule PortalAPI.Gateway.Channel do
         socket_ref,
         rid_bytes,
         preshared_key,
-        ice_credentials
+        ice_credentials,
+        iceless
       })
 
     push(socket, "authorize_flow", %{
@@ -317,7 +326,8 @@ defmodule PortalAPI.Gateway.Channel do
       client: client,
       client_ice_credentials: ice_credentials.initiator,
       expires_at: DateTime.to_unix(authorization_expires_at, :second),
-      subject: subject
+      subject: subject,
+      snownet_capabilities: %{iceless: iceless}
     })
 
     cache =
@@ -557,14 +567,19 @@ defmodule PortalAPI.Gateway.Channel do
   @impl true
   def handle_in("flow_authorized", %{"ref" => signed_ref}, socket) do
     case decode_ref(socket, signed_ref) do
-      {:ok,
-       {
-         channel_pid,
-         socket_ref,
-         resource_id,
-         preshared_key,
-         ice_credentials
-       }} ->
+      {:ok, ref_tuple} when tuple_size(ref_tuple) in [5, 6] ->
+        # 5-tuple is the legacy shape from before snownet capabilities;
+        # 6-tuple is the current one. Default the new field to `false` so
+        # in-flight refs across a rolling deploy don't fail to decode.
+        {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials, iceless} =
+          case ref_tuple do
+            {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials} ->
+              {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials, false}
+
+            {_, _, _, _, _, _} = full ->
+              full
+          end
+
         send(
           channel_pid,
           {
@@ -577,7 +592,8 @@ defmodule PortalAPI.Gateway.Channel do
             socket.assigns.gateway.ipv4,
             socket.assigns.gateway.ipv6,
             preshared_key,
-            ice_credentials
+            ice_credentials,
+            iceless
           }
         )
 
@@ -646,6 +662,10 @@ defmodule PortalAPI.Gateway.Channel do
     end)
 
     {:noreply, socket}
+  end
+
+  def handle_in("set_snownet_capabilities", payload, socket) when is_map(payload) do
+    {:noreply, assign(socket, iceless: payload["iceless"] == true)}
   end
 
   def handle_in("no_relays", _payload, socket) do

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5754,6 +5754,87 @@ defmodule PortalAPI.Client.ChannelTest do
       }
     end
 
+    test "intersects iceless snownet_capabilities across both clients", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      # Both clients advertise iceless capability before the flow.
+      push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
+      push(target_socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlling,
+        snownet_capabilities: %{iceless: true}
+      }
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlled,
+        snownet_capabilities: %{iceless: true}
+      }
+    end
+
+    test "client_device_access_authorized intersects to false when target lacks iceless", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      # Initiating client advertises iceless; target does not.
+      push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
+      push(target_socket, "set_snownet_capabilities", %{"iceless" => false})
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlling,
+        snownet_capabilities: %{iceless: false}
+      }
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlled,
+        snownet_capabilities: %{iceless: false}
+      }
+    end
+
+    test "client_device_access_authorized defaults snownet_capabilities to false when unset", %{
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      # Neither side calls `set_snownet_capabilities`.
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_authorized", %{
+        snownet_capabilities: %{iceless: false}
+      }
+    end
+
     test "sends denied with :offline when target is in pool but not online", %{
       client: client,
       subject: subject,

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -3108,7 +3108,209 @@ defmodule PortalAPI.Gateway.ChannelTest do
         ^gateway_ipv4,
         ^gateway_ipv6,
         ^preshared_key,
-        ^ice_credentials
+        ^ice_credentials,
+        _iceless
+      }
+    end
+
+    test "authorize_policy intersects gateway and client snownet capabilities", %{
+      client: client,
+      account: account,
+      actor: actor,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token,
+      subject: subject,
+      group: group
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      # Gateway advertises iceless capability via the dedicated channel message.
+      push(socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          group: group
+        )
+
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      public_key = Portal.DeviceFixtures.generate_public_key()
+
+      ice_credentials = %{
+        initiator: %{username: "A", password: "B"},
+        receiver: %{username: "C", password: "D"}
+      }
+
+      # Both sides advertise iceless → negotiated set is iceless: true.
+      send(
+        socket.channel_pid,
+        {:authorize_policy, {channel_pid, socket_ref},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               public_key,
+               preshared_key,
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key,
+           client_iceless: true
+         }}
+      )
+
+      assert_push "authorize_flow", %{
+        ref: ref,
+        snownet_capabilities: %{iceless: true}
+      }
+
+      push_ref = push(socket, "flow_authorized", %{"ref" => ref})
+      assert_reply push_ref, :ok
+
+      assert_receive {:connect, ^socket_ref, _, _, _, _, _, _, _, _, iceless}
+      assert iceless == true
+    end
+
+    test "authorize_policy with mismatched iceless flag intersects to false", %{
+      client: client,
+      account: account,
+      actor: actor,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token,
+      subject: subject,
+      group: group
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      # Gateway is iceless-capable; client isn't.
+      push(socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          group: group
+        )
+
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      public_key = Portal.DeviceFixtures.generate_public_key()
+
+      ice_credentials = %{
+        initiator: %{username: "A", password: "B"},
+        receiver: %{username: "C", password: "D"}
+      }
+
+      send(
+        socket.channel_pid,
+        {:authorize_policy, {channel_pid, socket_ref},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               public_key,
+               preshared_key,
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key,
+           client_iceless: false
+         }}
+      )
+
+      assert_push "authorize_flow", %{
+        ref: _,
+        snownet_capabilities: %{iceless: false}
+      }
+    end
+
+    test "authorize_policy without client_iceless defaults to false", %{
+      client: client,
+      account: account,
+      actor: actor,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token,
+      subject: subject,
+      group: group
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      # Even with iceless-capable gateway, missing client caps → false.
+      push(socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          group: group
+        )
+
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      public_key = Portal.DeviceFixtures.generate_public_key()
+
+      ice_credentials = %{
+        initiator: %{username: "A", password: "B"},
+        receiver: %{username: "C", password: "D"}
+      }
+
+      send(
+        socket.channel_pid,
+        {:authorize_policy, {channel_pid, socket_ref},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               public_key,
+               preshared_key,
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key
+         }}
+      )
+
+      assert_push "authorize_flow", %{
+        ref: _,
+        snownet_capabilities: %{iceless: false}
       }
     end
 


### PR DESCRIPTION
The portal control plane now tracks an `iceless` snownet capability for each client and gateway channel and intersects it across both ends of a flow, reporting the negotiated set in the authorization payloads. Channels without the capability tuple are tolerated during rolling deploys by defaulting the capability to `false`.

Related: #13088