### PR TITLE
chore(connlib): init client-ffi logger earlier

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -511,6 +511,8 @@ fn connect(
 
     install_rustls_crypto_provider();
 
+    init_logging(&PathBuf::from(log_dir), log_filter)?;
+
     let mut telemetry = Telemetry::new();
     telemetry.start(&api_url, RELEASE, platform::DSN);
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
@@ -519,8 +521,6 @@ fn connect(
     opentelemetry::global::set_meter_provider(telemetry::SentryMeterProvider::default());
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
-
-    init_logging(&PathBuf::from(log_dir), log_filter)?;
 
     let url = LoginUrl::client(
         api_url.as_str(),


### PR DESCRIPTION
Debug logs for feature flag evaluations weren't being emitted on FFI client startup due to the logger init coming after the telemetry init.

To fix this we can move the logger init up above so that we can see feature flag debug logs in the diagnostic log export.