### PR TITLE
fix(telemetry): re-resolve PostHog ingest host on each eval

### DIFF
--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -171,8 +171,12 @@ async fn decide(
 ) -> Result<(FeatureFlagsResponse, FeatureFlagPayloadsResponse)> {
     let distinct_id = crate::maybe_hash_device_id(maybe_legacy_id);
 
-    let response = posthog::CLIENT
-        .as_ref()?
+    let client = tokio::task::spawn_blocking(posthog::build_client)
+        .await
+        .context("Failed to join PostHog client build task")?
+        .context("Failed to build PostHog client")?;
+
+    let response = client
         .post(format!("https://{}/decide?v=3", posthog::INGEST_HOST))
         .json(&DecideRequest {
             api_key,

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -8,7 +8,7 @@ pub(crate) const API_KEY_STAGING: &str = "phc_tHOVtq183RpfKmzadJb4bxNpLM5jzeeb1G
 pub(crate) const API_KEY_ON_PREM: &str = "phc_4R9Ii6q4SEofVkH7LvajwuJ3nsGFhCj0ZlfysS2FNc";
 
 pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
-pub(crate) static CLIENT: LazyLock<reqwest::Result<reqwest::Client>> = LazyLock::new(init_client);
+pub(crate) static CLIENT: LazyLock<reqwest::Result<reqwest::Client>> = LazyLock::new(build_client);
 
 pub(crate) const INGEST_HOST: &str = "posthog.firezone.dev";
 
@@ -36,8 +36,9 @@ fn init_runtime() -> Runtime {
     runtime
 }
 
-/// Initialize the client to use for evaluating feature flags.
-fn init_client() -> reqwest::Result<reqwest::Client> {
+/// Builds an HTTP client for the PostHog ingest host, resolving its addresses
+/// fresh so DNS record changes are picked up between evaluations.
+pub(crate) fn build_client() -> reqwest::Result<reqwest::Client> {
     let ingest_host_addresses = (INGEST_HOST, 443u16)
         .to_socket_addrs()
         .inspect_err(|e| {
@@ -45,6 +46,8 @@ fn init_client() -> reqwest::Result<reqwest::Client> {
         })
         .unwrap_or_default()
         .collect::<Vec<_>>();
+
+    tracing::debug!(host = %INGEST_HOST, addresses = ?ingest_host_addresses, "Resolved PostHog ingest host");
 
     let mut builder = reqwest::ClientBuilder::new()
         .connection_verbose(true)
@@ -54,15 +57,8 @@ fn init_client() -> reqwest::Result<reqwest::Client> {
         .http2_keep_alive_timeout(Duration::from_secs(1))
         .http2_keep_alive_interval(Duration::from_secs(5)); // Use keep-alive to detect broken connections.
 
-    // Only pin the pre-resolved addresses if we actually got any. Passing an
-    // empty set to `resolve_to_addrs` overrides DNS with nothing, permanently
-    // breaking every request for the lifetime of the client. When resolution
-    // fails (e.g. no system DNS yet at start-up), fall back to the default
-    // resolver instead so later requests can still succeed.
-    if ingest_host_addresses.is_empty() {
-        tracing::debug!(host = %INGEST_HOST, "No addresses were pre-resolved for ingest host; falling back to the system resolver");
-    } else {
-        tracing::debug!(host = %INGEST_HOST, addresses = ?ingest_host_addresses, "Resolved PostHog ingest host addresses");
+    // An empty set would override DNS with nothing; fall back to the default resolver.
+    if !ingest_host_addresses.is_empty() {
         builder = builder.resolve_to_addrs(INGEST_HOST, &ingest_host_addresses);
     }
 

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -46,15 +46,25 @@ fn init_client() -> reqwest::Result<reqwest::Client> {
         .unwrap_or_default()
         .collect::<Vec<_>>();
 
-    tracing::debug!(host = %INGEST_HOST, addresses = ?ingest_host_addresses, "Resolved PostHog ingest host addresses");
-
-    reqwest::ClientBuilder::new()
+    let mut builder = reqwest::ClientBuilder::new()
         .connection_verbose(true)
         .pool_idle_timeout(None) // Never remove idle connections.
         .pool_max_idle_per_host(1)
         .http2_prior_knowledge() // We know PostHog supports HTTP/2.
         .http2_keep_alive_timeout(Duration::from_secs(1))
-        .http2_keep_alive_interval(Duration::from_secs(5)) // Use keep-alive to detect broken connections.
-        .resolve_to_addrs(INGEST_HOST, &ingest_host_addresses)
-        .build()
+        .http2_keep_alive_interval(Duration::from_secs(5)); // Use keep-alive to detect broken connections.
+
+    // Only pin the pre-resolved addresses if we actually got any. Passing an
+    // empty set to `resolve_to_addrs` overrides DNS with nothing, permanently
+    // breaking every request for the lifetime of the client. When resolution
+    // fails (e.g. no system DNS yet at start-up), fall back to the default
+    // resolver instead so later requests can still succeed.
+    if ingest_host_addresses.is_empty() {
+        tracing::debug!(host = %INGEST_HOST, "No addresses were pre-resolved for ingest host; falling back to the system resolver");
+    } else {
+        tracing::debug!(host = %INGEST_HOST, addresses = ?ingest_host_addresses, "Resolved PostHog ingest host addresses");
+        builder = builder.resolve_to_addrs(INGEST_HOST, &ingest_host_addresses);
+    }
+
+    builder.build()
 }


### PR DESCRIPTION
When the macOS / iOS client start, it's possible DNS has not settled and we get no IPs for `posthog.telemetry.dev`. This would cause feature flag evaluation to fail for the duration of the session.

To prevent this:

1. If no IPs are returned, we don't pin the empty set and instead use the system resolvers to resolve
2. We re-resolve `posthog.firezone.dev` on each evaluation so that we pick up IP changes here which can / will happen whenever our Azure proxy configuration is tainted