### PR TITLE
fix(snownet): update iceless capability

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -537,7 +537,23 @@ async fn phoenix_channel_event_loop(
 
     let hiccups = otel_instruments::portal_connection_hiccups();
 
+    // Last capabilities we successfully advertised. `None` forces a (re-)send,
+    // e.g. on first connect or after the feature flag flips mid-session.
+    let mut advertised_capabilities: Option<SnownetCapabilities> = None;
+
     loop {
+        let local_capabilities = SnownetCapabilities::local();
+        if advertised_capabilities != Some(local_capabilities)
+            && portal
+                .send(
+                    PHOENIX_TOPIC,
+                    EgressMessages::SetSnownetCapabilities(local_capabilities),
+                )
+                .is_ok()
+        {
+            advertised_capabilities = Some(local_capabilities);
+        }
+
         match select(poll_fn(|cx| portal.poll(cx)), pin!(cmd_rx.recv())).await {
             Either::Left((Ok(phoenix_channel::Event::Message { msg, .. }), _)) => {
                 if event_tx.send(Ok(msg)).await.is_err() {
@@ -569,12 +585,9 @@ async fn phoenix_channel_event_loop(
                 portal.connect(ips, backoff, public_key.clone());
             }
             Either::Left((Ok(phoenix_channel::Event::Connected), _)) => {
-                if let Err(phoenix_channel::NotConnected(msg)) = portal.send(
-                    PHOENIX_TOPIC,
-                    EgressMessages::SetSnownetCapabilities(SnownetCapabilities::LOCAL),
-                ) {
-                    tracing::debug!(?msg, "Failed to send snownet capabilities: Not connected");
-                }
+                // The reconnected channel has lost our capabilities; re-advertise
+                // on the next loop iteration.
+                advertised_capabilities = None;
             }
             Either::Left((Err(e), _)) => {
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -742,7 +742,23 @@ async fn phoenix_channel_event_loop(
 
     let hiccups = otel_instruments::portal_connection_hiccups();
 
+    // Last capabilities we successfully advertised. `None` forces a (re-)send,
+    // e.g. on first connect or after the feature flag flips mid-session.
+    let mut advertised_capabilities: Option<SnownetCapabilities> = None;
+
     loop {
+        let local_capabilities = SnownetCapabilities::local();
+        if advertised_capabilities != Some(local_capabilities)
+            && portal
+                .send(
+                    PHOENIX_TOPIC,
+                    EgressMessages::SetSnownetCapabilities(local_capabilities),
+                )
+                .is_ok()
+        {
+            advertised_capabilities = Some(local_capabilities);
+        }
+
         // We process commands from the channel first (i.e. it is polled first) to update the DNS servers as quickly as possible.
         // This allows `Hiccup` events to use the updated `BootstrapDnsClient` to resolve the domain.
         match select(pin!(cmd_rx.recv()), poll_fn(|cx| portal.poll(cx))).await {
@@ -802,12 +818,9 @@ async fn phoenix_channel_event_loop(
                 portal.connect(ips, backoff, public_key.clone());
             }
             Either::Right((Ok(phoenix_channel::Event::Connected), _)) => {
-                if let Err(phoenix_channel::NotConnected(msg)) = portal.send(
-                    PHOENIX_TOPIC,
-                    EgressMessages::SetSnownetCapabilities(SnownetCapabilities::LOCAL),
-                ) {
-                    tracing::debug!(?msg, "Failed to send snownet capabilities: Not connected");
-                }
+                // The reconnected channel has lost our capabilities; re-advertise
+                // on the next loop iteration.
+                advertised_capabilities = None;
             }
             Either::Right((Err(e), _)) => {
                 let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -275,10 +275,10 @@ where
     /// If we already have a connection with the same parameters, this does nothing.
     /// Otherwise, the existing connection is discarded and a new one will be created.
     ///
-    /// `capabilities` carries the negotiated capability flags from the
-    /// portal. When `capabilities.iceless` is set *and* the local PostHog
-    /// `iceless` flag is on, the new connection dispatches via the `Path`
-    /// variant of `Agent` instead of the classic ICE agent variant.
+    /// `capabilities` carries the capability flags the portal already
+    /// intersected across both peers. When `capabilities.iceless` is set,
+    /// the new connection dispatches via the `Path` variant of `Agent`
+    /// instead of the classic ICE agent variant.
     #[tracing::instrument(level = "info", skip_all, fields(%cid))]
     #[allow(clippy::too_many_arguments)]
     pub fn upsert_connection(
@@ -296,13 +296,13 @@ where
     ) -> Result<(), NoTurnServers> {
         let local_creds = local_creds.into();
         let remote_creds = remote_creds.into();
-        let want_iceless = capabilities.iceless && telemetry::feature_flags::iceless();
+        let want_iceless = capabilities.iceless;
 
         // Check if we already have a connection with the exact same parameters.
         // In order for the connection to be same, we need to compare:
         // - The agent's negotiation parameters (ICE creds + role for Ice mode;
         //   for iceless mode, only the mode itself — it always rebuilds creds)
-        // - Desired agent mode (ICE vs iceless), so a flag flip forces replace
+        // - Desired agent mode (ICE vs iceless), so a capability change forces replace
         // - Remote public key
         // - Preshared key
         //

--- a/rust/libs/connlib/tunnel/src/messages.rs
+++ b/rust/libs/connlib/tunnel/src/messages.rs
@@ -105,8 +105,14 @@ pub struct SnownetCapabilities {
 }
 
 impl SnownetCapabilities {
-    /// Capabilities of the local snownet implementation, hard-coded at compile time.
-    pub const LOCAL: Self = Self { iceless: true };
+    /// Local snownet capabilities, from the per-account feature flag. The
+    /// portal AND-intersects both peers' reports, so a one-sided rollout
+    /// converges on ICE rather than mismatching modes.
+    pub fn local() -> Self {
+        Self {
+            iceless: telemetry::feature_flags::iceless(),
+        }
+    }
 }
 
 impl From<SnownetCapabilities> for snownet::Capabilities {
@@ -298,10 +304,6 @@ mod tests {
             SnownetCapabilities { iceless: false }
         );
     }
-
-    // Compile-time guard so future edits to `LOCAL` don't accidentally turn
-    // off iceless support without us noticing.
-    const _: () = assert!(SnownetCapabilities::LOCAL.iceless);
 
     #[test]
     fn snownet_capabilities_deserialize_empty_object_is_default() {

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -739,7 +739,7 @@ mod tests {
 
     #[test]
     fn serialize_set_snownet_capabilities_message() {
-        let message = EgressMessages::SetSnownetCapabilities(SnownetCapabilities::LOCAL);
+        let message = EgressMessages::SetSnownetCapabilities(SnownetCapabilities { iceless: true });
         let expected_json = r#"{"event":"set_snownet_capabilities","payload":{"iceless":true}}"#;
         let actual_json = serde_json::to_string(&message).unwrap();
 

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn serialize_set_snownet_capabilities_message() {
-        let message = EgressMessages::SetSnownetCapabilities(SnownetCapabilities::LOCAL);
+        let message = EgressMessages::SetSnownetCapabilities(SnownetCapabilities { iceless: true });
         let expected_json = r#"{"event":"set_snownet_capabilities","payload":{"iceless":true}}"#;
         let actual_json = serde_json::to_string(&message).unwrap();
 

--- a/rust/libs/connlib/tunnel/src/tests/reference.rs
+++ b/rust/libs/connlib/tunnel/src/tests/reference.rs
@@ -22,7 +22,6 @@ use std::{
     fmt, iter,
     net::{IpAddr, SocketAddr},
 };
-use telemetry::feature_flags;
 
 /// The reference state machine of the tunnel.
 ///
@@ -1327,10 +1326,6 @@ impl ReferenceState {
     /// would soft-reset (no `ConnectionClosed`, no site-status drop)
     /// instead of hard-resetting.
     fn all_iceless(&self, client_id: &ClientId) -> bool {
-        if !feature_flags::iceless() {
-            return false;
-        }
-
         let Some(client) = self.clients.get(client_id) else {
             return false;
         };


### PR DESCRIPTION
Updates the portal's `iceless` flag whenever feature flags are re-evaluated on a client or gateway so that the connection will fallback to `ICE` if either side doesn't have the flag enabled.