### PR TITLE
fix(portal): retry transient sync requests

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -227,14 +227,25 @@ config :portal, Portal.Entra.APIClient,
   client_secret: System.get_env("ENTRA_SYNC_CLIENT_SECRET"),
   endpoint: "https://graph.microsoft.com",
   token_base_url: "https://login.microsoftonline.com",
-  # 15 minutes in milliseconds
-  req_opts: [receive_timeout: 900_000]
+  req_opts: [
+    # 15 minutes
+    receive_timeout: 900_000,
+    # Fixes `pool_not_available` errors on a cold Finch pool right after a deploy,
+    # since some requests are POSTs and the default `:safe_transient` retry strategy only retries HEADS and GETs.
+    retry: :transient
+  ]
 
 config :portal, Portal.Google.APIClient,
   endpoint: "https://admin.googleapis.com",
   service_account_key: System.get_env("GOOGLE_SERVICE_ACCOUNT_KEY"),
   token_endpoint: "https://oauth2.googleapis.com/token",
-  req_opts: [receive_timeout: 60_000]
+  req_opts: [
+    # 1 minute
+    receive_timeout: 60_000,
+    # Fixes `pool_not_available` errors on a cold Finch pool right after a deploy,
+    # since some requests are POSTs and the default `:safe_transient` retry strategy only retries HEADS and GETs.
+    retry: :transient
+  ]
 
 config :portal, Portal.Google.AuthProvider,
   # Should match an external OAuth2 client in Google Cloud Console

--- a/elixir/lib/portal/okta/api_client.ex
+++ b/elixir/lib/portal/okta/api_client.ex
@@ -489,6 +489,12 @@ defmodule Portal.Okta.ReqDPoP do
     end
   end
 
+  # Finch has a race which can cause cold pool checkout to fail on first request with :pool_not_available
+  defp retry(_req, %Req.HTTPError{reason: reason})
+       when reason in [:pool_not_available, :unprocessed] do
+    true
+  end
+
   # Handle all other response errors as non-retry-able
   # Example: %Req.TransportError{}, %Req.HTTPError{}, etc...
   defp retry(_req, _), do: false


### PR DESCRIPTION
On a cold start, Finch has a small race condition that can cause `:pool_not_available`. This condition heals after the pools are warmed.

However, Req's default `safe_transient` retry behavior did not apply to many of these requests because they are `POST` (to get an access token or submit a batch request).

To fix this, we update all three sync engines to `transient` retry behavior which will retry all requests in the sync operations. These are safe to retry.

---

Fixes #13801 
Supersedes #13772 
