### PR TITLE
fix(snownet): cookie DoS prevention in iceless handshakes

### DIFF
--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -507,12 +507,17 @@ impl PathAgent {
                 }
 
                 let mut outbound = Vec::<Vec<u8>>::new();
-                if validator
-                    .validate(bytes, now, &mut |b| outbound.push(b))
-                    .is_err()
-                {
-                    tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeInit rejected by validator");
-                    return ControlFlow::Break(());
+                match validator.validate(bytes, now, &mut |b| outbound.push(b)) {
+                    Err(crate::Rejected) => {
+                        tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeInit rejected by validator");
+                        return ControlFlow::Break(());
+                    }
+                    Ok(crate::Accepted::Cookie) => {
+                        tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeInit answered with cookie reply under load");
+                        self.send_on_path(outbound, path);
+                        return ControlFlow::Break(());
+                    }
+                    Ok(crate::Accepted::Session) => {}
                 }
 
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeInit accepted");
@@ -542,12 +547,17 @@ impl PathAgent {
                 }
 
                 let mut outbound = Vec::<Vec<u8>>::new();
-                if validator
-                    .validate(bytes, now, &mut |b| outbound.push(b))
-                    .is_err()
-                {
-                    tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse rejected by validator");
-                    return ControlFlow::Break(());
+                match validator.validate(bytes, now, &mut |b| outbound.push(b)) {
+                    Err(crate::Rejected) => {
+                        tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse rejected by validator");
+                        return ControlFlow::Break(());
+                    }
+                    Ok(crate::Accepted::Cookie) => {
+                        tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse answered with cookie reply under load");
+                        self.send_on_path(outbound, path);
+                        return ControlFlow::Break(());
+                    }
+                    Ok(crate::Accepted::Session) => {}
                 }
 
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse accepted");
@@ -568,6 +578,19 @@ impl PathAgent {
                 ControlFlow::Break(())
             }
             Packet::PacketCookieReply(_) | Packet::PacketData(_) => ControlFlow::Continue(bytes),
+        }
+    }
+
+    /// Queue `packets` to go out on `path`'s send side. Used for cookie
+    /// replies, which must reach the sender on the receive path without
+    /// adopting that path or touching any session state.
+    fn send_on_path(&mut self, packets: Vec<Vec<u8>>, path: (SocketAddr, SocketAddr)) {
+        for bytes in packets {
+            self.pending_transmits.push_back(Transmit {
+                local: path.0,
+                remote: path.1,
+                payload: Payload::Ciphertext(bytes),
+            });
         }
     }
 

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -12,4 +12,4 @@ pub use agent::{EVALUATION_WINDOW, PROBE_INTERVAL, PROBE_INTERVAL_LIVE, PROBE_TI
 pub use candidate::{Candidate, CandidateKind};
 pub use event::{Event, Payload, Transmit};
 pub use icmpv6::{PROBE_DST, PROBE_SRC};
-pub use validator::{HandshakeValidator, Rejected};
+pub use validator::{Accepted, HandshakeValidator, Rejected};

--- a/rust/libs/connlib/path-agent/src/validator.rs
+++ b/rust/libs/connlib/path-agent/src/validator.rs
@@ -17,17 +17,34 @@ use std::time::Instant;
 #[derive(Debug)]
 pub struct Rejected;
 
+/// Outcome of a validator call that did not reject the bytes.
+#[derive(Debug)]
+pub enum Accepted {
+    /// The noise session advanced. Any bytes reported via `on_outbound`
+    /// are the `HandshakeResponse` and/or data packets the implementation
+    /// had buffered while handshake-pending; `PathAgent` commits its
+    /// session / path state and routes them.
+    Session,
+    /// The bytes only passed a MAC1 check and the implementation answered
+    /// with a cookie reply because it is under load. The sender's address
+    /// is unauthenticated, so `PathAgent` commits no state; it returns the
+    /// cookie reported via `on_outbound` to the sender on the receive path
+    /// so a legitimate peer can retry with a valid MAC2.
+    Cookie,
+}
+
 /// Validates inbound WG handshake bytes. Outbound packets the
 /// implementation produces during validation (typically the
-/// `HandshakeResponse` when accepting an `Init`, or any data packets
-/// the responder buffered while handshake-pending) are reported via
-/// `on_outbound`. Returns `Err(Rejected)` to abort the call without
-/// any path-agent state mutation.
+/// `HandshakeResponse` when accepting an `Init`, any data packets the
+/// responder buffered while handshake-pending, or a cookie reply under
+/// load) are reported via `on_outbound`. Returns `Err(Rejected)` to abort
+/// the call without any path-agent state mutation; see [`Accepted`] for
+/// how the success variants are routed.
 pub trait HandshakeValidator {
     fn validate(
         &mut self,
         bytes: &[u8],
         now: Instant,
         on_outbound: &mut dyn FnMut(Vec<u8>),
-    ) -> Result<(), Rejected>;
+    ) -> Result<Accepted, Rejected>;
 }

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -19,8 +19,10 @@ struct StubValidator {
     outbound: std::collections::VecDeque<Vec<u8>>,
     /// `true` makes every call reject.
     reject: bool,
-    /// Bytes passed to each accepted call, in order — mirrors what
-    /// the previous architecture's `Event::ForwardHandshake` did.
+    /// `true` makes every accepted call report a cookie reply instead of
+    /// advancing a session.
+    cookie: bool,
+    /// Bytes passed to each accepted call, in order.
     seen: Vec<Vec<u8>>,
 }
 
@@ -30,7 +32,7 @@ impl HandshakeValidator for StubValidator {
         bytes: &[u8],
         _now: Instant,
         on_outbound: &mut dyn FnMut(Vec<u8>),
-    ) -> Result<(), path_agent::Rejected> {
+    ) -> Result<path_agent::Accepted, path_agent::Rejected> {
         if self.reject {
             return Err(path_agent::Rejected);
         }
@@ -38,7 +40,10 @@ impl HandshakeValidator for StubValidator {
         if let Some(b) = self.outbound.pop_front() {
             on_outbound(b);
         }
-        Ok(())
+        if self.cookie {
+            return Ok(path_agent::Accepted::Cookie);
+        }
+        Ok(path_agent::Accepted::Session)
     }
 }
 
@@ -296,6 +301,51 @@ fn inbound_handshake_response_validates_then_adopts_primary() {
         }
         other => panic!("expected PrimaryChanged, got {other:?}"),
     }
+}
+
+#[test]
+fn cookie_reply_returns_on_recv_path_without_adopting_primary() {
+    // Under load, boringtun answers a MAC1-only-verified handshake with a
+    // cookie reply. The sender's address is unauthenticated, so it must
+    // not become the primary path; the cookie still goes back so a real
+    // peer can retry with a MAC2.
+    let mut a = agent_with_relay_pairs();
+    let mut v = StubValidator {
+        cookie: true,
+        outbound: std::collections::VecDeque::from([cookie_reply_bytes()]),
+        ..Default::default()
+    };
+    let now = Instant::now();
+
+    assert!(
+        a.handle_inbound_network(&mut v, &handshake_init_bytes(), (addr(2), addr(4)), now)
+            .is_break()
+    );
+
+    assert!(
+        a.primary().is_none(),
+        "a cookie reply must not adopt a path"
+    );
+    assert!(a.poll_event().is_none());
+
+    match a.poll_transmit() {
+        Some(Transmit {
+            local,
+            remote,
+            payload: Payload::Ciphertext(bytes),
+        }) => {
+            assert_eq!((local, remote), (addr(2), addr(4)));
+            assert_eq!(bytes, cookie_reply_bytes());
+        }
+        other => panic!("expected cookie reply transmit, got {other:?}"),
+    }
+    assert!(a.poll_transmit().is_none());
+
+    // The cookie left no dedup residue, so a subsequent legitimate init
+    // with the same bytes is still validated.
+    let mut v2 = accept_all();
+    let _ = a.handle_inbound_network(&mut v2, &handshake_init_bytes(), (addr(2), addr(4)), now);
+    assert_eq!(v2.seen, vec![handshake_init_bytes()]);
 }
 
 #[test]
@@ -1852,6 +1902,12 @@ fn handshake_response_bytes() -> Vec<u8> {
 fn data_packet_bytes() -> Vec<u8> {
     let mut bytes = vec![0u8; 32];
     bytes[0] = 4;
+    bytes
+}
+
+fn cookie_reply_bytes() -> Vec<u8> {
+    let mut bytes = vec![0u8; 64];
+    bytes[0] = 3;
     bytes
 }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1900,6 +1900,7 @@ where
         let mut validator = BoringtunValidator {
             tunnel: &mut self.tunnel,
             buf: self.buffer.as_mut(),
+            src_ip: from.ip(),
         };
         let packet = match self.agent.handle_inbound_network(
             &mut validator,
@@ -2340,6 +2341,10 @@ fn new_agent(role: IceRole) -> IceAgent {
 struct BoringtunValidator<'a> {
     tunnel: &'a mut Tunn,
     buf: &'a mut [u8],
+    /// Source IP of the datagram under validation. boringtun's
+    /// rate-limiter binds an under-load cookie to it, so a legitimate
+    /// peer can prove address ownership by echoing the cookie in a MAC2.
+    src_ip: IpAddr,
 }
 
 impl path_agent::HandshakeValidator for BoringtunValidator<'_> {
@@ -2348,17 +2353,32 @@ impl path_agent::HandshakeValidator for BoringtunValidator<'_> {
         bytes: &[u8],
         now: Instant,
         on_outbound: &mut dyn FnMut(Vec<u8>),
-    ) -> Result<(), path_agent::Rejected> {
-        match self.tunnel.decapsulate_at(None, bytes, self.buf, now) {
-            TunnResult::Done => Ok(()),
+    ) -> Result<path_agent::Accepted, path_agent::Rejected> {
+        match self
+            .tunnel
+            .decapsulate_at(Some(self.src_ip), bytes, self.buf, now)
+        {
+            TunnResult::Done => Ok(path_agent::Accepted::Session),
             TunnResult::WriteToNetwork(first) => {
+                // When the node is under load, boringtun answers a
+                // handshake whose only verified field is MAC1 with a
+                // cookie reply rather than processing it. MAC1 is keyed
+                // by our (public) static key, so the sender's address is
+                // unauthenticated and must not be adopted as a path.
+                // Return the cookie so a legitimate peer can retry with a
+                // MAC2, but report it as such.
+                if let Ok(Packet::PacketCookieReply(_)) = Tunn::parse_incoming_packet(first) {
+                    on_outbound(first.to_vec());
+                    return Ok(path_agent::Accepted::Cookie);
+                }
+
                 on_outbound(first.to_vec());
                 while let TunnResult::WriteToNetwork(more) =
                     self.tunnel.decapsulate_at(None, &[], self.buf, now)
                 {
                     on_outbound(more.to_vec());
                 }
-                Ok(())
+                Ok(path_agent::Accepted::Session)
             }
             TunnResult::Err(e) => {
                 tracing::debug!(error = ?e, "Handshake rejected by boringtun");


### PR DESCRIPTION
Iceless handshake validation disabled WireGuard's under-load cookie mechanism. Because MAC1 is keyed only by a peer's public key, a flood of MAC1-valid inits could push the rate limiter under load, after which every legitimate iceless handshake was rejected with no cookie to recover from, stalling connection setup node-wide.

The validator now passes the source IP so cookies work, and treats a cookie reply as non-acceptance so the unauthenticated sender's address is never adopted as a path.