### PR TITLE
fix(connlib): track post-NAT source port in flow logs

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -163,7 +163,7 @@ jobs:
             script: systemd/dns-systemd-resolved
           - script: tcp-dns
           - script: download-concurrent
-            min_gateway_version: 1.4.18
+            min_gateway_version: 1.5.3
           - name: download-double-symmetric-nat
             script: download
             # Setting both client and gateway to random masquerade will force relay-relay candidate pair

--- a/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
@@ -891,6 +891,7 @@ pub mod inbound_wg {
             };
 
             inner.dst_ip = packet.destination();
+            inner.src_proto = packet.source_protocol();
         });
     }
 

--- a/scripts/compose/resources.yml
+++ b/scripts/compose/resources.yml
@@ -23,6 +23,9 @@ services:
     networks:
       dns_resources:
         ipv4_address: 172.21.0.101
+        aliases:
+          - alias.httpbin
+          - alias2.httpbin
 
   dns.httpbin.search.test:
     image: kennethreitz/httpbin

--- a/scripts/tests/download-concurrent.sh
+++ b/scripts/tests/download-concurrent.sh
@@ -2,41 +2,49 @@
 
 source "./scripts/tests/lib.sh"
 
-client sh -c "curl --fail --max-time 10 --output /tmp/download1.file http://download.httpbin/bytes?num=5000000" &
-PID1=$!
+domains=(download.httpbin alias.httpbin alias2.httpbin)
+sizes=(5000000 7000000 9000000)
 
-client sh -c "curl --fail --max-time 10 --output /tmp/download2.file http://download.httpbin/bytes?num=5000000" &
-PID2=$!
+client sh -c 'echo "5555 5555" > /proc/sys/net/ipv4/ip_local_port_range'
 
-client sh -c "curl --fail --max-time 10 --output /tmp/download3.file http://download.httpbin/bytes?num=5000000" &
-PID3=$!
+pids=()
+for i in "${!domains[@]}"; do
+    client sh -c "curl --fail --max-time 15 --output /tmp/download$i.file http://${domains[$i]}/bytes?num=${sizes[$i]}" &
+    pids+=($!)
+done
 
-wait $PID1 || {
-    echo "Download 1 failed"
-    exit 1
-}
-
-wait $PID2 || {
-    echo "Download 2 failed"
-    exit 1
-}
-
-wait $PID3 || {
-    echo "Download 3 failed"
-    exit 1
-}
+for i in "${!pids[@]}"; do
+    wait "${pids[$i]}" || {
+        echo "Download via ${domains[$i]} failed"
+        exit 1
+    }
+done
 
 sleep 3
 readarray -t flows < <(get_flow_logs "tcp")
 
-assert_gteq "${#flows[@]}" 3
+assert_eq "${#flows[@]}" 3
 
-rx_bytes=0
+for i in "${!domains[@]}"; do
+    domain="${domains[$i]}"
+    size="${sizes[$i]}"
 
-for flow in "${flows[@]}"; do
-    assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
-    assert_eq "$(get_flow_field "$flow" "inner_domain")" "download.httpbin"
-    rx_bytes+="$(get_flow_field "$flow" "rx_bytes")"
+    found=""
+    for flow in "${flows[@]}"; do
+        if [ "$(get_flow_field "$flow" "inner_domain")" == "$domain" ]; then
+            found="$flow"
+            break
+        fi
+    done
+
+    if [ -z "$found" ]; then
+        echo "No flow log found for $domain"
+        exit 1
+    fi
+
+    rx_bytes="$(get_flow_field "$found" "rx_bytes")"
+
+    assert_eq "$(get_flow_field "$found" "inner_dst_ip")" "172.21.0.101"
+    assert_gteq "$rx_bytes" "$size"
+    assert_lteq "$rx_bytes" "$((size + 1000000))"
 done
-
-assert_gteq "$rx_bytes" $((3 * 5000000))

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -84,6 +84,16 @@ function assert_gteq() {
     fi
 }
 
+function assert_lteq() {
+    local actual="$1"
+    local expected="$2"
+
+    if [ "$actual" -gt "$expected" ]; then
+        echo "Expected $actual to be less than or equal to $expected"
+        exit 1
+    fi
+}
+
 function process_state() {
     local container="$1"
 


### PR DESCRIPTION
On the Gateway, `record_translated_packet` picked up the translated destination IP but not the translated source port. When several proxy IPs map to one real IP (name-based virtual hosting), the NAT rewrites the source port to keep outbound flows distinct, so the outbound flow key and the return path disagreed:

| field | outbound key | return path |
|---|---|---|
| dst_ip | real ✓ | real ✓ |
| dst_port | 443 ✓ | 443 ✓ |
| src_port | pre-NAT (54321) | post-NAT (54322) |

Because the keys no longer matched, affected flows recorded no inbound traffic (`rx` stayed at zero), missed the TCP FIN/FIN close, and terminated only on the idle timeout.

The flow key now uses the post-NAT source port, matching what the return path observes.