### PR TITLE
feat(telemetry): self-healing PostHog & Sentry ingest client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7514,7 +7514,6 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "rand 0.10.1",
- "reqwest",
  "rustls",
  "sentry",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2388,6 +2388,7 @@ dependencies = [
  "serde_json",
  "serde_variant",
  "sha2",
+ "socket-factory",
  "specta",
  "specta-typescript",
  "strum",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7502,7 +7502,11 @@ name = "telemetry"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
+ "bootstrap-dns-client",
+ "bytes",
  "hex",
+ "http",
+ "http-client",
  "ip-packet",
  "moka",
  "opentelemetry",
@@ -7516,6 +7520,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
+ "socket-factory",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -514,6 +514,7 @@ fn connect(
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
     let mut telemetry = Telemetry::new();
+    telemetry::init_ingest_addresses();
     telemetry.start(&api_url, RELEASE, platform::DSN);
     telemetry::configure_ingest(tcp_socket_factory.clone(), udp_socket_factory.clone());
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -515,6 +515,7 @@ fn connect(
 
     let mut telemetry = Telemetry::new();
     telemetry.start(&api_url, RELEASE, platform::DSN);
+    telemetry::configure_ingest(tcp_socket_factory.clone(), udp_socket_factory.clone());
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
 

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -513,9 +513,8 @@ fn connect(
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(tcp_socket_factory.clone(), udp_socket_factory.clone());
     telemetry.start(&api_url, RELEASE, platform::DSN);
-    telemetry::configure_ingest(tcp_socket_factory.clone(), udp_socket_factory.clone());
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
 

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -514,7 +514,6 @@ fn connect(
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
     let mut telemetry = Telemetry::new();
-    telemetry::init_ingest_addresses();
     telemetry.start(&api_url, RELEASE, platform::DSN);
     telemetry::configure_ingest(tcp_socket_factory.clone(), udp_socket_factory.clone());
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -140,7 +140,6 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     };
 
     if cli.is_telemetry_allowed() {
-        telemetry::init_ingest_addresses();
         telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
         telemetry::configure_ingest(
             Arc::new(tcp_socket_factory),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -141,6 +141,10 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
 
     if cli.is_telemetry_allowed() {
         telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
+        telemetry::configure_ingest(
+            Arc::new(tcp_socket_factory),
+            Arc::new(UdpSocketFactory::default()),
+        );
         Telemetry::set_firezone_id(firezone_id.clone()).await;
     }
 
@@ -189,6 +193,8 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         .into_iter()
         .map(|ip| ip.into())
         .collect::<BTreeSet<_>>();
+
+    telemetry::update_system_resolvers(nameservers.iter().copied().collect());
 
     let mut tunnel = GatewayTunnel::new(
         Arc::new(tcp_socket_factory),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -51,7 +51,10 @@ fn main() -> ExitCode {
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(
+        Arc::new(tcp_socket_factory),
+        Arc::new(UdpSocketFactory::default()),
+    );
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -141,10 +144,6 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
 
     if cli.is_telemetry_allowed() {
         telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
-        telemetry::configure_ingest(
-            Arc::new(tcp_socket_factory),
-            Arc::new(UdpSocketFactory::default()),
-        );
         Telemetry::set_firezone_id(firezone_id.clone()).await;
     }
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -140,6 +140,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     };
 
     if cli.is_telemetry_allowed() {
+        telemetry::init_ingest_addresses();
         telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
         telemetry::configure_ingest(
             Arc::new(tcp_socket_factory),

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_variant = { workspace = true }
+socket-factory = { workspace = true }
 specta = { workspace = true, features = ["url"] }
 specta-typescript = { workspace = true }
 strum = { workspace = true }

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -39,7 +39,6 @@ fn main() -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
     let mut telemetry = if cli.is_telemetry_allowed() {
-        telemetry::init_ingest_addresses();
         Telemetry::new()
     } else {
         Telemetry::disabled()

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -39,10 +39,7 @@ fn main() -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
     let mut telemetry = if cli.is_telemetry_allowed() {
-        Telemetry::new(
-            Arc::new(socket_factory::tcp),
-            Arc::new(socket_factory::udp),
-        )
+        Telemetry::new(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp))
     } else {
         Telemetry::disabled()
     };

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -39,6 +39,7 @@ fn main() -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
     let mut telemetry = if cli.is_telemetry_allowed() {
+        telemetry::init_ingest_addresses();
         Telemetry::new()
     } else {
         Telemetry::disabled()

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -39,7 +39,10 @@ fn main() -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
     let mut telemetry = if cli.is_telemetry_allowed() {
-        Telemetry::new()
+        Telemetry::new(
+            Arc::new(socket_factory::tcp),
+            Arc::new(socket_factory::udp),
+        )
     } else {
         Telemetry::disabled()
     };

--- a/rust/gui-client/src-tauri/src/bin/register-sparse.rs
+++ b/rust/gui-client/src-tauri/src/bin/register-sparse.rs
@@ -39,7 +39,10 @@ async fn main() -> ExitCode {
         .install_default()
         .expect("Failed to install default crypto provider");
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
     telemetry.start(
         "entrypoint",
         firezone_gui_client::RELEASE,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -667,6 +667,7 @@ impl<'a> Handler<'a> {
                     std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true");
 
                 if !no_telemetry {
+                    telemetry::init_ingest_addresses();
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
                     telemetry::configure_ingest(

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -332,7 +332,10 @@ impl<'a> Handler<'a> {
     ) -> Result<Self> {
         dns_controller.deactivate()?;
 
-        let telemetry = Telemetry::new();
+        let telemetry = Telemetry::new(
+            Arc::new(tcp_socket_factory),
+            Arc::new(UdpSocketFactory::default()),
+        );
 
         tracing::info!(
             server_pid = std::process::id(),
@@ -669,10 +672,6 @@ impl<'a> Handler<'a> {
                 if !no_telemetry {
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
-                    telemetry::configure_ingest(
-                        Arc::new(tcp_socket_factory),
-                        Arc::new(UdpSocketFactory::default()),
-                    );
                     Telemetry::set_firezone_id(self.device_id.id.clone()).await;
 
                     opentelemetry::global::set_meter_provider(

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -669,6 +669,10 @@ impl<'a> Handler<'a> {
                 if !no_telemetry {
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
+                    telemetry::configure_ingest(
+                        Arc::new(tcp_socket_factory),
+                        Arc::new(UdpSocketFactory::default()),
+                    );
                     Telemetry::set_firezone_id(self.device_id.id.clone()).await;
 
                     opentelemetry::global::set_meter_provider(

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -667,7 +667,6 @@ impl<'a> Handler<'a> {
                     std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true");
 
                 if !no_telemetry {
-                    telemetry::init_ingest_addresses();
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
                     telemetry::configure_ingest(

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -324,8 +324,6 @@ fn try_main() -> Result<()> {
     };
 
     let mut telemetry = if cli.is_telemetry_allowed() {
-        telemetry::init_ingest_addresses();
-
         let mut telemetry = Telemetry::new();
 
         telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -327,6 +327,10 @@ fn try_main() -> Result<()> {
         let mut telemetry = Telemetry::new();
 
         telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
+        telemetry::configure_ingest(
+            Arc::new(tcp_socket_factory),
+            Arc::new(UdpSocketFactory::default()),
+        );
         rt.block_on(Telemetry::set_firezone_id(firezone_id.clone()));
 
         analytics::identify(RELEASE.to_owned(), None);

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -324,6 +324,8 @@ fn try_main() -> Result<()> {
     };
 
     let mut telemetry = if cli.is_telemetry_allowed() {
+        telemetry::init_ingest_addresses();
+
         let mut telemetry = Telemetry::new();
 
         telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -324,13 +324,12 @@ fn try_main() -> Result<()> {
     };
 
     let mut telemetry = if cli.is_telemetry_allowed() {
-        let mut telemetry = Telemetry::new();
-
-        telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
-        telemetry::configure_ingest(
+        let mut telemetry = Telemetry::new(
             Arc::new(tcp_socket_factory),
             Arc::new(UdpSocketFactory::default()),
         );
+
+        telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
         rt.block_on(Telemetry::set_firezone_id(firezone_id.clone()));
 
         analytics::identify(RELEASE.to_owned(), None);

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -128,6 +128,7 @@ impl Eventloop {
             is_internet_resource_active,
         );
         tunnel.update_system_resolvers(dns_servers.clone());
+        telemetry::update_system_resolvers(dns_servers.clone());
 
         tokio::spawn(phoenix_channel_event_loop(
             portal,
@@ -217,6 +218,7 @@ impl Eventloop {
                 };
 
                 let dns = tunnel.update_system_resolvers(dns);
+                telemetry::update_system_resolvers(dns.clone());
 
                 self.portal_cmd_tx
                     .send(PortalCommand::UpdateDnsServers(dns))
@@ -245,6 +247,7 @@ impl Eventloop {
                 };
 
                 tunnel.reset(&reason);
+                telemetry::reset_ingest();
                 self.portal_cmd_tx
                     .send(PortalCommand::Connect(PublicKeyParam(
                         tunnel.public_key().to_bytes(),

--- a/rust/libs/http-client/lib.rs
+++ b/rust/libs/http-client/lib.rs
@@ -78,6 +78,13 @@ impl HttpClient {
         })
     }
 
+    /// Whether the underlying connection has been closed.
+    ///
+    /// A closed client is permanently unusable and should be discarded.
+    pub fn is_closed(&self) -> bool {
+        self.client.is_closed()
+    }
+
     pub fn send_request(
         &self,
         request: http::Request<Bytes>,

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -31,6 +31,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 rustls = { workspace = true, features = ["ring"] }
+socket-factory = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tokio-tungstenite = { workspace = true }

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -17,7 +17,6 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 rand = { workspace = true }
-reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls-no-provider", "tracing", "logs", "metrics"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -6,7 +6,11 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bootstrap-dns-client = { workspace = true }
+bytes = { workspace = true }
 hex = { workspace = true }
+http = { workspace = true }
+http-client = { workspace = true }
 ip-packet = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
@@ -19,7 +23,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+socket-factory = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true }

--- a/rust/libs/telemetry/src/analytics.rs
+++ b/rust/libs/telemetry/src/analytics.rs
@@ -106,23 +106,22 @@ where
         return Ok(());
     };
 
-    let response = posthog::CLIENT
-        .as_ref()?
-        .post(format!("https://{}/i/v0/e/", posthog::INGEST_HOST))
-        .json(&CaptureRequest {
+    let response = posthog::post_json(
+        "/i/v0/e/",
+        &CaptureRequest {
             api_key: api_key.to_string(),
             distinct_id,
             event: event.clone(),
             properties,
-        })
-        .send()
-        .await
-        .context("Failed to send POST request")?;
+        },
+    )
+    .await
+    .context("Failed to send POST request")?;
 
     let status = response.status();
 
     if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
+        let body = String::from_utf8_lossy(response.body());
 
         bail!("Failed to capture event; status={status}, body={body}")
     }

--- a/rust/libs/telemetry/src/analytics.rs
+++ b/rust/libs/telemetry/src/analytics.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, bail};
 use serde::Serialize;
 
-use crate::{ApiUrl, Env, Telemetry, posthog};
+use crate::{ApiUrl, Env, Telemetry, ingest, posthog};
 
 /// Records a `new_session` event for a particular user and API url.
 ///
@@ -9,7 +9,7 @@ use crate::{ApiUrl, Env, Telemetry, posthog};
 pub fn new_session(maybe_legacy_id: String, api_url: String) {
     let distinct_id = crate::maybe_hash_device_id(maybe_legacy_id);
 
-    posthog::RUNTIME.spawn(async move {
+    ingest::RUNTIME.spawn(async move {
         if let Err(e) = capture(
             "new_session",
             distinct_id,
@@ -36,7 +36,7 @@ pub fn identify(release: String, account_slug: Option<String>) {
         return;
     };
 
-    posthog::RUNTIME.spawn({
+    ingest::RUNTIME.spawn({
         async move {
             if let Err(e) = capture(
                 "$identify",
@@ -69,7 +69,7 @@ pub fn feature_flag_called(name: impl Into<String>) {
     };
     let feature_flag = name.into();
 
-    posthog::RUNTIME.spawn({
+    ingest::RUNTIME.spawn({
         async move {
             if let Err(e) = capture(
                 "$feature_flag_called",

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Metadata, level_filters::LevelFilter};
 use tracing_subscriber::filter::Targets;
 
-use crate::{Env, posthog};
+use crate::{Env, ingest, posthog};
 
 pub(crate) const RE_EVAL_DURATION: Duration = Duration::from_secs(5 * 60);
 
@@ -140,7 +140,7 @@ pub(crate) fn reevaluate(user_id: String, env: &str) {
         return;
     };
 
-    posthog::RUNTIME.spawn(evaluate_now(user_id, env));
+    ingest::RUNTIME.spawn(evaluate_now(user_id, env));
 }
 
 /// Re-evaluates feature flags using the current telemetry user and environment.

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -143,25 +143,33 @@ pub(crate) fn reevaluate(user_id: String, env: &str) {
     posthog::RUNTIME.spawn(evaluate_now(user_id, env));
 }
 
+/// Re-evaluates feature flags using the current telemetry user and environment.
+///
+/// Does nothing until both are known. Lets us refresh flags promptly when the
+/// network situation changes instead of waiting for the next periodic re-evaluation.
+pub(crate) fn reevaluate_current() {
+    let Some(client) = sentry::Hub::main().client() else {
+        return;
+    };
+
+    let Some(env) = client.options().environment.as_ref() else {
+        return; // Nothing to do if we don't have an environment set.
+    };
+
+    let Some(user_id) =
+        sentry::Hub::main().configure_scope(|scope| scope.user().and_then(|u| u.id.clone()))
+    else {
+        return; // Nothing to do if we don't have a user-id set.
+    };
+
+    reevaluate(user_id, env);
+}
+
 pub(crate) async fn reeval_timer() {
     loop {
         tokio::time::sleep(RE_EVAL_DURATION).await;
 
-        let Some(client) = sentry::Hub::main().client() else {
-            continue;
-        };
-
-        let Some(env) = client.options().environment.as_ref() else {
-            continue; // Nothing to do if we don't have an environment set.
-        };
-
-        let Some(user_id) =
-            sentry::Hub::main().configure_scope(|scope| scope.user().and_then(|u| u.id.clone()))
-        else {
-            continue; // Nothing to do if we don't have a user-id set.
-        };
-
-        reevaluate(user_id, env);
+        reevaluate_current();
     }
 }
 

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -171,26 +171,28 @@ async fn decide(
 ) -> Result<(FeatureFlagsResponse, FeatureFlagPayloadsResponse)> {
     let distinct_id = crate::maybe_hash_device_id(maybe_legacy_id);
 
-    let response = posthog::CLIENT
-        .as_ref()?
-        .post(format!("https://{}/decide?v=3", posthog::INGEST_HOST))
-        .json(&DecideRequest {
+    let response = posthog::post_json(
+        "/decide?v=3",
+        &DecideRequest {
             api_key,
             distinct_id,
-        })
-        .send()
-        .await
-        .context("Failed to send POST request")?;
+        },
+    )
+    .await
+    .context("Failed to send POST request")?;
 
     let status = response.status();
-    let body = response.text().await.unwrap_or_default();
+    let body = response.into_body();
 
     if !status.is_success() {
-        bail!("Failed to get feature flags; status={status}, body={body}")
+        bail!(
+            "Failed to get feature flags; status={status}, body={}",
+            String::from_utf8_lossy(&body)
+        )
     }
 
-    let decide_response =
-        serde_json::from_str::<DecideResponse>(&body).context("Failed to deserialize response")?;
+    let decide_response = serde_json::from_slice::<DecideResponse>(&body)
+        .context("Failed to deserialize response")?;
 
     Ok((
         decide_response.feature_flags,

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -1,0 +1,208 @@
+use std::{
+    net::{IpAddr, ToSocketAddrs as _},
+    sync::{Arc, LazyLock},
+};
+
+use anyhow::{Context as _, ErrorExt as _, Result};
+use bootstrap_dns_client::BootstrapDnsClient;
+use bytes::Bytes;
+use http::{Request, Response};
+use http_client::HttpClient;
+use parking_lot::Mutex;
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
+use tokio::runtime::Runtime;
+
+type SocketFactories = (
+    Arc<dyn SocketFactory<TcpSocket>>,
+    Arc<dyn SocketFactory<UdpSocket>>,
+);
+
+/// Runtime hosting all ingest connections and the feature-flag re-eval timer.
+pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
+
+/// Socket factories and upstream resolvers shared by all ingest hosts.
+///
+/// connlib processes configure tunnel-bypassing factories so telemetry never
+/// loops back through connlib; the resolvers are the system's upstream DNS
+/// servers (never the system resolver itself, which may be connlib).
+static SOCKETS: LazyLock<Mutex<Option<SocketFactories>>> = LazyLock::new(|| Mutex::new(None));
+static SERVERS: LazyLock<Mutex<Vec<IpAddr>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Configures the socket factories used to reach all ingest hosts.
+pub(crate) fn configure(
+    tcp: Arc<dyn SocketFactory<TcpSocket>>,
+    udp: Arc<dyn SocketFactory<UdpSocket>>,
+) {
+    *SOCKETS.lock() = Some((tcp, udp));
+}
+
+/// Updates the upstream resolvers used to look up all ingest hosts.
+pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
+    *SERVERS.lock() = servers;
+}
+
+/// Resets the shared socket factories so the next connection rebinds.
+pub(crate) fn reset_sockets() {
+    let sockets = SOCKETS.lock().clone();
+    if let Some((tcp, udp)) = sockets {
+        tcp.reset();
+        udp.reset();
+    }
+}
+
+/// A self-healing HTTP/2 client for a single ingest host.
+///
+/// The host is resolved via [`BootstrapDnsClient`] against the configured
+/// upstreams and connected through the shared, tunnel-bypassing socket factories,
+/// falling back to addresses seeded from the system resolver at startup. The
+/// connection is re-established on demand when it is closed.
+pub(crate) struct Client {
+    host: &'static str,
+    seed_addresses: Mutex<Vec<IpAddr>>,
+    connection: Mutex<Option<HttpClient>>,
+    /// Serialises bootstrapping so concurrent senders share a single connection.
+    bootstrap: tokio::sync::Mutex<()>,
+}
+
+impl Client {
+    pub(crate) fn new(host: &'static str) -> Self {
+        Self {
+            host,
+            seed_addresses: Mutex::new(Vec::new()),
+            connection: Mutex::new(None),
+            bootstrap: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// Seeds the host addresses using the system resolver.
+    ///
+    /// Must run at startup, before connlib reconfigures the system resolver, so the
+    /// lookup reaches the real upstream and not connlib itself. Used as a fallback
+    /// until the bootstrap resolver has upstreams configured.
+    pub(crate) fn init_addresses(&self) {
+        let addresses = (self.host, 443u16)
+            .to_socket_addrs()
+            .inspect_err(|e| {
+                tracing::debug!(host = %self.host, "Failed to seed ingest host addresses: {e:#}")
+            })
+            .map(|addresses| addresses.map(|addr| addr.ip()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        tracing::debug!(host = %self.host, ?addresses, "Seeded ingest host addresses from system resolver");
+
+        *self.seed_addresses.lock() = addresses;
+    }
+
+    /// Drops the current connection so the next request reconnects.
+    pub(crate) fn reset(&self) {
+        *self.connection.lock() = None;
+    }
+
+    /// Sends an HTTP request over a (re-)established connection to the host.
+    pub(crate) async fn send_request(&self, request: Request<Bytes>) -> Result<Response<Bytes>> {
+        let connection = self.connection().await?;
+
+        let response = match connection.send_request(request) {
+            Ok(response) => response.await,
+            Err(e) => Err(e),
+        };
+
+        // A closed connection means the path is broken; discard it so the next
+        // request re-resolves and reconnects.
+        if response
+            .as_ref()
+            .is_err_and(|e| e.any_is::<http_client::Closed>())
+        {
+            *self.connection.lock() = None;
+        }
+
+        response
+    }
+
+    async fn connection(&self) -> Result<HttpClient> {
+        if let Some(connection) = self.live_connection() {
+            return Ok(connection);
+        }
+
+        let _guard = self.bootstrap.lock().await;
+
+        if let Some(connection) = self.live_connection() {
+            return Ok(connection);
+        }
+
+        let connection = self.bootstrap().await?;
+        *self.connection.lock() = Some(connection.clone());
+
+        Ok(connection)
+    }
+
+    fn live_connection(&self) -> Option<HttpClient> {
+        self.connection
+            .lock()
+            .as_ref()
+            .filter(|connection| !connection.is_closed())
+            .cloned()
+    }
+
+    async fn bootstrap(&self) -> Result<HttpClient> {
+        let host = self.host;
+        let (tcp, udp) = SOCKETS
+            .lock()
+            .clone()
+            .context("Ingest client has no socket factories configured")?;
+        let servers = SERVERS.lock().clone();
+        let seed_addresses = self.seed_addresses.lock().clone();
+
+        // Anchor the connection task on our own runtime so it outlives the caller,
+        // which may be a short-lived `block_on` on another runtime.
+        RUNTIME
+            .spawn(async move {
+                // Resolve via the bootstrap resolver, which never uses the system
+                // resolver (i.e. connlib), and add the addresses seeded at startup as
+                // extra fallback candidates. `HttpClient` tries them in order and
+                // connects to the first that works.
+                //
+                // Skip the resolver while we have no upstreams yet (e.g. before
+                // connlib reports the system DNS servers); the seed covers that.
+                let mut addresses = if servers.is_empty() {
+                    Vec::new()
+                } else {
+                    BootstrapDnsClient::new(udp, tcp.clone(), servers)
+                        .resolve(host)
+                        .await
+                        .inspect_err(
+                            |e| tracing::debug!(%host, "Failed to resolve ingest host: {e:#}"),
+                        )
+                        .unwrap_or_default()
+                };
+
+                for address in seed_addresses {
+                    if !addresses.contains(&address) {
+                        addresses.push(address);
+                    }
+                }
+
+                anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
+
+                HttpClient::new(host.to_owned(), addresses, tcp)
+                    .await
+                    .context("Failed to connect to ingest host")
+            })
+            .await
+            .context("Bootstrap task failed")?
+    }
+}
+
+fn init_runtime() -> Runtime {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1) // We only need 1 worker thread.
+        .thread_name("ingest-worker")
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("to be able to build runtime");
+
+    runtime.spawn(crate::feature_flags::reeval_timer());
+
+    runtime
+}

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -120,8 +120,10 @@ impl Client {
     }
 
     async fn connection(&self) -> Result<HttpClient> {
-        // Always serialise here: telemetry is low-volume, so this lock is
-        // effectively uncontended and a double-checked fast path isn't worth it.
+        if let Some(connection) = self.live_connection() {
+            return Ok(connection);
+        }
+
         let _guard = self.bootstrap.lock().await;
 
         if let Some(connection) = self.live_connection() {

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -120,10 +120,8 @@ impl Client {
     }
 
     async fn connection(&self) -> Result<HttpClient> {
-        if let Some(connection) = self.live_connection() {
-            return Ok(connection);
-        }
-
+        // Always serialise here: telemetry is low-volume, so this lock is
+        // effectively uncontended and a double-checked fast path isn't worth it.
         let _guard = self.bootstrap.lock().await;
 
         if let Some(connection) = self.live_connection() {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,16 +1,13 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::{
-    borrow::Cow, collections::BTreeMap, fmt, mem, net::IpAddr, str::FromStr, sync::Arc,
-    time::Duration,
-};
+use std::{collections::BTreeMap, fmt, mem, net::IpAddr, str::FromStr, sync::Arc, time::Duration};
 
-use ::sentry::{
+use anyhow::{Context, Result, anyhow, bail};
+use api_url::ApiUrl;
+use sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, Metric},
 };
-use anyhow::{Context, Result, anyhow, bail};
-use api_url::ApiUrl;
 use sha2::Digest as _;
 use smallvec::SmallVec;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
@@ -183,7 +180,7 @@ impl fmt::Display for Env {
 }
 
 pub struct Telemetry {
-    inner: Option<::sentry::ClientInitGuard>,
+    inner: Option<sentry::ClientInitGuard>,
 }
 
 impl Telemetry {
@@ -241,55 +238,19 @@ impl Telemetry {
 
         tracing::info!(%environment, "Starting telemetry");
 
-        let client_options = ::sentry::ClientOptions {
-            environment: Some(Cow::Borrowed(environment.as_str())),
-            // We can't get the release number ourselves because we don't know if we're embedded in a GUI Client or a Headless Client.
-            release: Some(release.to_owned().into()),
-            max_breadcrumbs: 500,
-            before_send: Some({
-                let rate_limit = event_rate_limiter(Duration::from_secs(60 * 5));
-                Arc::new(move |event| {
-                    let event = rate_limit(event)?;
-                    let event = insert_feature_flags_into_event(event);
-
-                    Some(event)
-                })
-            }),
-            enable_logs: true,
-            enable_metrics: true,
-            before_send_log: Some(Arc::new(|log| {
-                let log = insert_user_account_slug_into_log(log);
-                let log = append_tracing_fields_to_message(log);
-
-                Some(log)
-            })),
-            before_send_metric: Some(Arc::new(|metric| {
-                let metric = insert_user_account_slug_into_metric(metric);
-                let metric = insert_feature_flags_into_metric(metric);
-
-                Some(metric)
-            })),
-            ..Default::default()
-        };
-        let inner = ::sentry::init((
-            dsn.to_string(),
-            ::sentry::ClientOptions {
-                transport: Some(Arc::new(sentry::Factory)),
-                ..client_options
-            },
-        ));
+        let inner = sentry::init_sdk_client(dsn.to_string(), environment.as_str(), release);
         // Configure scope on the main hub so that all threads will get the tags.
         let api_url = (environment != Env::Entrypoint).then(|| env_or_api_url.to_owned());
-        ::sentry::Hub::main().configure_scope(move |scope| {
+        sentry::Hub::main().configure_scope(move |scope| {
             if let Some(api_url) = api_url {
                 scope.set_tag("api_url", api_url);
             }
-            let ctx = ::sentry::integrations::contexts::utils::device_context();
+            let ctx = sentry::integrations::contexts::utils::device_context();
             scope.set_context("device", ctx);
-            let ctx = ::sentry::integrations::contexts::utils::rust_context();
+            let ctx = sentry::integrations::contexts::utils::rust_context();
             scope.set_context("rust", ctx);
 
-            if let Some(ctx) = ::sentry::integrations::contexts::utils::os_context() {
+            if let Some(ctx) = sentry::integrations::contexts::utils::os_context() {
                 scope.set_context("os", ctx);
             }
         });
@@ -353,7 +314,7 @@ impl Telemetry {
 
     #[doc(hidden)] // Only public for testing.
     pub fn current_env() -> Option<Env> {
-        let client = ::sentry::Hub::main().client()?;
+        let client = sentry::Hub::main().client()?;
         let env = client.options().environment.as_deref()?;
         let env = Env::from_str(env).ok()?;
 
@@ -362,12 +323,12 @@ impl Telemetry {
 
     #[doc(hidden)] // Only public for testing.
     pub fn current_user() -> Option<String> {
-        ::sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
+        sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
     }
 
     #[doc(hidden)] // Only public for testing.
     pub fn current_account_slug() -> Option<String> {
-        ::sentry::Hub::main()
+        sentry::Hub::main()
             .configure_scope(|s| Some(s.user()?.other.get("account_slug")?.as_str()?.to_owned()))
     }
 }
@@ -496,7 +457,7 @@ fn insert_feature_flags_into_event(mut event: Event<'static>) -> Event<'static> 
         .map(|(flag, result)| serde_json::json!({ "flag": flag, "result": result }))
         .collect();
     let value = serde_json::json!({ "values": values.as_slice() });
-    let context = ::sentry::protocol::Context::Other(
+    let context = sentry::protocol::Context::Other(
         serde_json::from_value(value).expect("to and from json works"),
     );
 
@@ -515,8 +476,8 @@ fn insert_feature_flags_into_metric(mut metric: Metric) -> Metric {
     metric
 }
 
-fn update_user(update: impl FnOnce(&mut ::sentry::User)) {
-    ::sentry::Hub::main().configure_scope(|scope| {
+fn update_user(update: impl FnOnce(&mut sentry::User)) {
+    sentry::Hub::main().configure_scope(|scope| {
         let mut user = scope.user().cloned().unwrap_or_default();
         update(&mut user);
 
@@ -524,8 +485,8 @@ fn update_user(update: impl FnOnce(&mut ::sentry::User)) {
     });
 }
 
-fn set_current_user(user: Option<::sentry::User>) {
-    ::sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
+fn set_current_user(user: Option<sentry::User>) {
+    sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
 }
 
 #[cfg(test)]
@@ -628,7 +589,7 @@ mod tests {
 
     fn log(msg: &str, attrs: &[(&str, &str)]) -> Log {
         Log {
-            level: ::sentry::protocol::LogLevel::Info,
+            level: sentry::protocol::LogLevel::Info,
             body: msg.to_owned(),
             trace_id: None,
             timestamp: SystemTime::now(),

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -47,18 +47,6 @@ pub fn maybe_hash_device_id(id: String) -> String {
     }
 }
 
-/// Configures the socket factories used to reach our telemetry ingest hosts.
-///
-/// These must be the same tunnel-bypassing factories that connlib uses, so that
-/// telemetry resolves and connects outside the tunnel and never loops back
-/// through connlib itself.
-pub fn configure_ingest(
-    tcp: Arc<dyn SocketFactory<TcpSocket>>,
-    udp: Arc<dyn SocketFactory<UdpSocket>>,
-) {
-    posthog::configure(tcp, udp);
-}
-
 /// Updates the upstream DNS resolvers used to look up our telemetry ingest hosts.
 ///
 /// Call this wherever connlib's system resolvers are updated. Triggers a
@@ -201,18 +189,17 @@ pub struct Telemetry {
     transport: TransportFactory,
 }
 
-impl Default for Telemetry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Telemetry {
-    pub fn new() -> Self {
-        // Seed the PostHog ingest addresses via the system resolver, mirroring how
-        // the Sentry transport resolves its host below. Both run here, at telemetry
-        // construction, so the lookup happens before connlib reconfigures the system
-        // resolver and would otherwise route it through connlib itself.
+    pub fn new(
+        tcp: Arc<dyn SocketFactory<TcpSocket>>,
+        udp: Arc<dyn SocketFactory<UdpSocket>>,
+    ) -> Self {
+        // Configure and seed the PostHog ingest client. Resolving here, at telemetry
+        // construction, ensures the lookup happens before connlib reconfigures the
+        // system resolver (which would otherwise route it through connlib itself),
+        // mirroring how the Sentry transport resolves its host below. The socket
+        // factories must bypass the tunnel so telemetry never loops through connlib.
+        posthog::configure(tcp, udp);
         posthog::init_addresses();
 
         Self {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -56,8 +56,8 @@ pub fn update_system_resolvers(servers: Vec<IpAddr>) {
 /// feature-flag re-evaluation so flags are refreshed over the new connection.
 pub fn reset_ingest() {
     ingest::reset_sockets();
-    posthog::reset();
-    sentry::reset();
+    posthog::reset_client();
+    sentry::reset_client();
     feature_flags::reevaluate_current();
 }
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -47,16 +47,6 @@ pub fn maybe_hash_device_id(id: String) -> String {
     }
 }
 
-/// Seeds the telemetry ingest-host addresses using the system resolver.
-///
-/// Call this as the very first thing during startup, before connlib reconfigures
-/// the system resolver, so the lookup reaches the real upstream and not connlib
-/// itself. The result is used as a fallback until the bootstrap resolver is
-/// configured (see [`update_system_resolvers`]).
-pub fn init_ingest_addresses() {
-    posthog::init_addresses();
-}
-
 /// Configures the socket factories used to reach our telemetry ingest hosts.
 ///
 /// These must be the same tunnel-bypassing factories that connlib uses, so that
@@ -219,6 +209,12 @@ impl Default for Telemetry {
 
 impl Telemetry {
     pub fn new() -> Self {
+        // Seed the PostHog ingest addresses via the system resolver, mirroring how
+        // the Sentry transport resolves its host below. Both run here, at telemetry
+        // construction, so the lookup happens before connlib reconfigures the system
+        // resolver and would otherwise route it through connlib itself.
+        posthog::init_addresses();
+
         Self {
             inner: Default::default(),
             transport: TransportFactory::resolve_ingest_host().unwrap_or_else(|e| {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -74,8 +74,6 @@ pub struct Dsn {
 // > DSNs are safe to keep public because they only allow submission of new events and related event data; they do not allow read access to any information.
 // <https://docs.sentry.io/concepts/key-terms/dsn-explainer/#dsn-utilization>
 
-pub(crate) const INGEST_HOST: &str = "sentry.firezone.dev";
-
 pub const ANDROID_DSN: Dsn = Dsn {
     public_key: "928a6ee1f6af9734100b8bc89b2dc87d",
     project_id: 4508175126233088,
@@ -109,8 +107,10 @@ impl fmt::Display for Dsn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "https://{}@{INGEST_HOST}/{}",
-            self.public_key, self.project_id
+            "https://{}@{}/{}",
+            self.public_key,
+            sentry_transport::INGEST_HOST,
+            self.project_id
         )
     }
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -47,6 +47,16 @@ pub fn maybe_hash_device_id(id: String) -> String {
     }
 }
 
+/// Seeds the telemetry ingest-host addresses using the system resolver.
+///
+/// Call this as the very first thing during startup, before connlib reconfigures
+/// the system resolver, so the lookup reaches the real upstream and not connlib
+/// itself. The result is used as a fallback until the bootstrap resolver is
+/// configured (see [`update_system_resolvers`]).
+pub fn init_ingest_addresses() {
+    posthog::init_addresses();
+}
+
 /// Configures the socket factories used to reach our telemetry ingest hosts.
 ///
 /// These must be the same tunnel-bypassing factories that connlib uses, so that
@@ -61,16 +71,21 @@ pub fn configure_ingest(
 
 /// Updates the upstream DNS resolvers used to look up our telemetry ingest hosts.
 ///
-/// Call this wherever connlib's system resolvers are updated.
+/// Call this wherever connlib's system resolvers are updated. Triggers a
+/// feature-flag re-evaluation, since a prior attempt may have failed for lack of
+/// (working) resolvers.
 pub fn update_system_resolvers(servers: Vec<IpAddr>) {
     posthog::update_system_resolvers(servers);
+    feature_flags::reevaluate_current();
 }
 
 /// Drops the current telemetry ingest connection so it is re-established lazily.
 ///
-/// Call this on network changes, alongside resetting connlib.
+/// Call this on network changes, alongside resetting connlib. Triggers a
+/// feature-flag re-evaluation so flags are refreshed over the new connection.
 pub fn reset_ingest() {
     posthog::reset();
+    feature_flags::reevaluate_current();
 }
 
 pub struct Dsn {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     fmt, mem,
-    net::{SocketAddr, ToSocketAddrs as _},
+    net::{IpAddr, SocketAddr, ToSocketAddrs as _},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -19,6 +19,7 @@ use sentry::{
 };
 use sha2::Digest as _;
 use smallvec::SmallVec;
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 
 pub mod analytics;
 pub mod feature_flags;
@@ -44,6 +45,32 @@ pub fn maybe_hash_device_id(id: String) -> String {
     } else {
         id
     }
+}
+
+/// Configures the socket factories used to reach our telemetry ingest hosts.
+///
+/// These must be the same tunnel-bypassing factories that connlib uses, so that
+/// telemetry resolves and connects outside the tunnel and never loops back
+/// through connlib itself.
+pub fn configure_ingest(
+    tcp: Arc<dyn SocketFactory<TcpSocket>>,
+    udp: Arc<dyn SocketFactory<UdpSocket>>,
+) {
+    posthog::configure(tcp, udp);
+}
+
+/// Updates the upstream DNS resolvers used to look up our telemetry ingest hosts.
+///
+/// Call this wherever connlib's system resolvers are updated.
+pub fn update_system_resolvers(servers: Vec<IpAddr>) {
+    posthog::update_system_resolvers(servers);
+}
+
+/// Drops the current telemetry ingest connection so it is re-established lazily.
+///
+/// Call this on network changes, alongside resetting connlib.
+pub fn reset_ingest() {
+    posthog::reset();
 }
 
 pub struct Dsn {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,12 +1,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    fmt, mem,
-    net::{IpAddr, SocketAddr, ToSocketAddrs as _},
-    str::FromStr,
-    sync::Arc,
+    borrow::Cow, collections::BTreeMap, fmt, mem, net::IpAddr, str::FromStr, sync::Arc,
     time::Duration,
 };
 
@@ -15,7 +10,6 @@ use api_url::ApiUrl;
 use sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, Metric},
-    transports::ReqwestHttpTransport,
 };
 use sha2::Digest as _;
 use smallvec::SmallVec;
@@ -26,9 +20,11 @@ pub mod feature_flags;
 pub mod otel;
 
 mod api_url;
+mod ingest;
 mod noop_push_metrics_exporter;
 mod posthog;
 mod sentry_instrument_provider;
+mod sentry_transport;
 
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
 pub use sentry_instrument_provider::SentryMeterProvider;
@@ -53,16 +49,18 @@ pub fn maybe_hash_device_id(id: String) -> String {
 /// feature-flag re-evaluation, since a prior attempt may have failed for lack of
 /// (working) resolvers.
 pub fn update_system_resolvers(servers: Vec<IpAddr>) {
-    posthog::update_system_resolvers(servers);
+    ingest::update_system_resolvers(servers);
     feature_flags::reevaluate_current();
 }
 
-/// Drops the current telemetry ingest connection so it is re-established lazily.
+/// Drops the current telemetry ingest connections so they are re-established lazily.
 ///
 /// Call this on network changes, alongside resetting connlib. Triggers a
 /// feature-flag re-evaluation so flags are refreshed over the new connection.
 pub fn reset_ingest() {
+    ingest::reset_sockets();
     posthog::reset();
+    sentry_transport::reset();
     feature_flags::reevaluate_current();
 }
 
@@ -76,7 +74,7 @@ pub struct Dsn {
 // > DSNs are safe to keep public because they only allow submission of new events and related event data; they do not allow read access to any information.
 // <https://docs.sentry.io/concepts/key-terms/dsn-explainer/#dsn-utilization>
 
-const INGEST_HOST: &str = "sentry.firezone.dev";
+pub(crate) const INGEST_HOST: &str = "sentry.firezone.dev";
 
 pub const ANDROID_DSN: Dsn = Dsn {
     public_key: "928a6ee1f6af9734100b8bc89b2dc87d",
@@ -186,7 +184,6 @@ impl fmt::Display for Env {
 
 pub struct Telemetry {
     inner: Option<sentry::ClientInitGuard>,
-    transport: TransportFactory,
 }
 
 impl Telemetry {
@@ -194,29 +191,20 @@ impl Telemetry {
         tcp: Arc<dyn SocketFactory<TcpSocket>>,
         udp: Arc<dyn SocketFactory<UdpSocket>>,
     ) -> Self {
-        // Configure and seed the PostHog ingest client. Resolving here, at telemetry
-        // construction, ensures the lookup happens before connlib reconfigures the
-        // system resolver (which would otherwise route it through connlib itself),
-        // mirroring how the Sentry transport resolves its host below. The socket
+        // Configure the shared ingest socket factories and seed each ingest host's
+        // addresses via the system resolver. Seeding here, at telemetry construction,
+        // ensures the lookup happens before connlib reconfigures the system resolver
+        // (which would otherwise route it through connlib itself). The socket
         // factories must bypass the tunnel so telemetry never loops through connlib.
-        posthog::configure(tcp, udp);
+        ingest::configure(tcp, udp);
         posthog::init_addresses();
+        sentry_transport::init_addresses();
 
-        Self {
-            inner: Default::default(),
-            transport: TransportFactory::resolve_ingest_host().unwrap_or_else(|e| {
-                tracing::debug!("Failed to create telemetry transport factory: {e:#}");
-
-                TransportFactory::without_addresses()
-            }),
-        }
+        Self { inner: None }
     }
 
     pub fn disabled() -> Self {
-        Self {
-            inner: None,
-            transport: TransportFactory::without_addresses(),
-        }
+        Self { inner: None }
     }
 
     /// Starts a Sentry session.
@@ -286,7 +274,7 @@ impl Telemetry {
         let inner = sentry::init((
             dsn.to_string(),
             sentry::ClientOptions {
-                transport: Some(Arc::new(self.transport.clone())),
+                transport: Some(Arc::new(sentry_transport::Factory)),
                 ..client_options
             },
         ));
@@ -538,52 +526,6 @@ fn update_user(update: impl FnOnce(&mut sentry::User)) {
 
 fn set_current_user(user: Option<sentry::User>) {
     sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
-}
-
-#[derive(Debug, Clone)]
-pub struct TransportFactory {
-    ingest_domain_addresses: Vec<SocketAddr>,
-}
-
-impl TransportFactory {
-    pub fn resolve_ingest_host() -> Result<Self> {
-        let resolved_addresses = (INGEST_HOST, 443u16)
-            .to_socket_addrs()
-            .with_context(|| format!("Failed to resolve {INGEST_HOST}"))?
-            .collect();
-
-        tracing::debug!(host = %INGEST_HOST, addresses = ?resolved_addresses, "Resolved ingest host IPs");
-
-        Ok(Self {
-            ingest_domain_addresses: resolved_addresses,
-        })
-    }
-
-    fn without_addresses() -> Self {
-        Self {
-            ingest_domain_addresses: Default::default(),
-        }
-    }
-}
-
-impl sentry::TransportFactory for TransportFactory {
-    fn create_transport(&self, options: &sentry::ClientOptions) -> Arc<dyn sentry::Transport> {
-        let mut builder = reqwest::ClientBuilder::new()
-            .http2_prior_knowledge()
-            .http2_keep_alive_while_idle(true)
-            .http2_keep_alive_timeout(Duration::from_secs(1))
-            .http2_keep_alive_interval(Duration::from_secs(5)); // Ensure we detect broken connections, i.e. when enabling / disabling the Internet Resource.
-
-        if !self.ingest_domain_addresses.is_empty() {
-            builder = builder.resolve_to_addrs(INGEST_HOST, &self.ingest_domain_addresses);
-        } else {
-            tracing::debug!(host = %INGEST_HOST, "No addresses were pre-resolved for ingest host");
-        }
-
-        let client = builder.build().expect("Failed to build HTTP client");
-
-        Arc::new(ReqwestHttpTransport::with_client(options, client))
-    }
 }
 
 #[cfg(test)]

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -5,12 +5,12 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result, anyhow, bail};
-use api_url::ApiUrl;
-use sentry::{
+use ::sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, Metric},
 };
+use anyhow::{Context, Result, anyhow, bail};
+use api_url::ApiUrl;
 use sha2::Digest as _;
 use smallvec::SmallVec;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
@@ -23,8 +23,8 @@ mod api_url;
 mod ingest;
 mod noop_push_metrics_exporter;
 mod posthog;
+mod sentry;
 mod sentry_instrument_provider;
-mod sentry_transport;
 
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
 pub use sentry_instrument_provider::SentryMeterProvider;
@@ -60,7 +60,7 @@ pub fn update_system_resolvers(servers: Vec<IpAddr>) {
 pub fn reset_ingest() {
     ingest::reset_sockets();
     posthog::reset();
-    sentry_transport::reset();
+    sentry::reset();
     feature_flags::reevaluate_current();
 }
 
@@ -109,7 +109,7 @@ impl fmt::Display for Dsn {
             f,
             "https://{}@{}/{}",
             self.public_key,
-            sentry_transport::INGEST_HOST,
+            sentry::INGEST_HOST,
             self.project_id
         )
     }
@@ -183,7 +183,7 @@ impl fmt::Display for Env {
 }
 
 pub struct Telemetry {
-    inner: Option<sentry::ClientInitGuard>,
+    inner: Option<::sentry::ClientInitGuard>,
 }
 
 impl Telemetry {
@@ -198,7 +198,7 @@ impl Telemetry {
         // factories must bypass the tunnel so telemetry never loops through connlib.
         ingest::configure(tcp, udp);
         posthog::init_addresses();
-        sentry_transport::init_addresses();
+        sentry::init_addresses();
 
         Self { inner: None }
     }
@@ -241,7 +241,7 @@ impl Telemetry {
 
         tracing::info!(%environment, "Starting telemetry");
 
-        let client_options = sentry::ClientOptions {
+        let client_options = ::sentry::ClientOptions {
             environment: Some(Cow::Borrowed(environment.as_str())),
             // We can't get the release number ourselves because we don't know if we're embedded in a GUI Client or a Headless Client.
             release: Some(release.to_owned().into()),
@@ -271,25 +271,25 @@ impl Telemetry {
             })),
             ..Default::default()
         };
-        let inner = sentry::init((
+        let inner = ::sentry::init((
             dsn.to_string(),
-            sentry::ClientOptions {
-                transport: Some(Arc::new(sentry_transport::Factory)),
+            ::sentry::ClientOptions {
+                transport: Some(Arc::new(sentry::Factory)),
                 ..client_options
             },
         ));
         // Configure scope on the main hub so that all threads will get the tags.
         let api_url = (environment != Env::Entrypoint).then(|| env_or_api_url.to_owned());
-        sentry::Hub::main().configure_scope(move |scope| {
+        ::sentry::Hub::main().configure_scope(move |scope| {
             if let Some(api_url) = api_url {
                 scope.set_tag("api_url", api_url);
             }
-            let ctx = sentry::integrations::contexts::utils::device_context();
+            let ctx = ::sentry::integrations::contexts::utils::device_context();
             scope.set_context("device", ctx);
-            let ctx = sentry::integrations::contexts::utils::rust_context();
+            let ctx = ::sentry::integrations::contexts::utils::rust_context();
             scope.set_context("rust", ctx);
 
-            if let Some(ctx) = sentry::integrations::contexts::utils::os_context() {
+            if let Some(ctx) = ::sentry::integrations::contexts::utils::os_context() {
                 scope.set_context("os", ctx);
             }
         });
@@ -353,7 +353,7 @@ impl Telemetry {
 
     #[doc(hidden)] // Only public for testing.
     pub fn current_env() -> Option<Env> {
-        let client = sentry::Hub::main().client()?;
+        let client = ::sentry::Hub::main().client()?;
         let env = client.options().environment.as_deref()?;
         let env = Env::from_str(env).ok()?;
 
@@ -362,12 +362,12 @@ impl Telemetry {
 
     #[doc(hidden)] // Only public for testing.
     pub fn current_user() -> Option<String> {
-        sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
+        ::sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
     }
 
     #[doc(hidden)] // Only public for testing.
     pub fn current_account_slug() -> Option<String> {
-        sentry::Hub::main()
+        ::sentry::Hub::main()
             .configure_scope(|s| Some(s.user()?.other.get("account_slug")?.as_str()?.to_owned()))
     }
 }
@@ -496,7 +496,7 @@ fn insert_feature_flags_into_event(mut event: Event<'static>) -> Event<'static> 
         .map(|(flag, result)| serde_json::json!({ "flag": flag, "result": result }))
         .collect();
     let value = serde_json::json!({ "values": values.as_slice() });
-    let context = sentry::protocol::Context::Other(
+    let context = ::sentry::protocol::Context::Other(
         serde_json::from_value(value).expect("to and from json works"),
     );
 
@@ -515,8 +515,8 @@ fn insert_feature_flags_into_metric(mut metric: Metric) -> Metric {
     metric
 }
 
-fn update_user(update: impl FnOnce(&mut sentry::User)) {
-    sentry::Hub::main().configure_scope(|scope| {
+fn update_user(update: impl FnOnce(&mut ::sentry::User)) {
+    ::sentry::Hub::main().configure_scope(|scope| {
         let mut user = scope.user().cloned().unwrap_or_default();
         update(&mut user);
 
@@ -524,8 +524,8 @@ fn update_user(update: impl FnOnce(&mut sentry::User)) {
     });
 }
 
-fn set_current_user(user: Option<sentry::User>) {
-    sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
+fn set_current_user(user: Option<::sentry::User>) {
+    ::sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
 }
 
 #[cfg(test)]
@@ -628,7 +628,7 @@ mod tests {
 
     fn log(msg: &str, attrs: &[(&str, &str)]) -> Log {
         Log {
-            level: sentry::protocol::LogLevel::Info,
+            level: ::sentry::protocol::LogLevel::Info,
             body: msg.to_owned(),
             trace_id: None,
             timestamp: SystemTime::now(),

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -179,17 +179,22 @@ async fn bootstrap() -> Result<HttpClient> {
     // which may be a short-lived `block_on` on another runtime.
     RUNTIME
         .spawn(async move {
-            // Prefer the bootstrap resolver, which never uses the system resolver
-            // (i.e. connlib). Fall back to the addresses seeded at startup so we can
-            // still connect before any resolvers are configured.
+            // Resolve via the bootstrap resolver, which never uses the system
+            // resolver (i.e. connlib), and add the addresses seeded at startup as
+            // extra fallback candidates. `HttpClient` tries them in order and
+            // connects to the first that works, so freshly resolved addresses are
+            // preferred while the seed still lets us connect before any resolvers
+            // are configured or when the resolver returns unreachable addresses.
             let mut addresses = BootstrapDnsClient::new(udp, tcp.clone(), servers)
                 .resolve(INGEST_HOST)
                 .await
                 .inspect_err(|e| tracing::debug!("Failed to resolve ingest host: {e:#}"))
                 .unwrap_or_default();
 
-            if addresses.is_empty() {
-                addresses = seed_addresses;
+            for address in seed_addresses {
+                if !addresses.contains(&address) {
+                    addresses.push(address);
+                }
             }
 
             anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host");

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -74,7 +74,8 @@ pub(crate) fn init_addresses() {
 
 /// Drops the current connection so the next request re-resolves and reconnects.
 pub(crate) fn reset() {
-    if let Some((tcp, udp)) = INGEST.sockets.lock().as_ref() {
+    let sockets = INGEST.sockets.lock().clone();
+    if let Some((tcp, udp)) = sockets {
         tcp.reset();
         udp.reset();
     }

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -185,11 +185,19 @@ async fn bootstrap() -> Result<HttpClient> {
             // connects to the first that works, so freshly resolved addresses are
             // preferred while the seed still lets us connect before any resolvers
             // are configured or when the resolver returns unreachable addresses.
-            let mut addresses = BootstrapDnsClient::new(udp, tcp.clone(), servers)
-                .resolve(INGEST_HOST)
-                .await
-                .inspect_err(|e| tracing::debug!("Failed to resolve ingest host: {e:#}"))
-                .unwrap_or_default();
+            //
+            // Skip the resolver while we have no upstreams yet (e.g. before connlib
+            // reports the system DNS servers); it would only fail and the seed
+            // already covers that case.
+            let mut addresses = if servers.is_empty() {
+                Vec::new()
+            } else {
+                BootstrapDnsClient::new(udp, tcp.clone(), servers)
+                    .resolve(INGEST_HOST)
+                    .await
+                    .inspect_err(|e| tracing::debug!("Failed to resolve ingest host: {e:#}"))
+                    .unwrap_or_default()
+            };
 
             for address in seed_addresses {
                 if !addresses.contains(&address) {

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -37,9 +37,8 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
 
 /// Configures the socket factories used to reach the ingest host.
 ///
-/// The factories must bypass the tunnel so that telemetry traffic never loops
-/// back through connlib. Processes that do not run connlib themselves can skip
-/// this and fall back to [`default_socket_factories`].
+/// In connlib processes these must bypass the tunnel so that telemetry traffic
+/// never loops back through connlib; other processes pass plain socket factories.
 pub(crate) fn configure(
     tcp: Arc<dyn SocketFactory<TcpSocket>>,
     udp: Arc<dyn SocketFactory<UdpSocket>>,
@@ -172,7 +171,7 @@ async fn bootstrap() -> Result<HttpClient> {
         .sockets
         .lock()
         .clone()
-        .unwrap_or_else(default_socket_factories);
+        .context("Ingest client has no socket factories configured")?;
     let servers = INGEST.servers.lock().clone();
     let seed_addresses = INGEST.seed_addresses.lock().clone();
 
@@ -201,15 +200,6 @@ async fn bootstrap() -> Result<HttpClient> {
         })
         .await
         .context("Bootstrap task failed")?
-}
-
-/// Plain socket factories used when none have been configured via [`configure`],
-/// e.g. in the GUI process which does not run connlib itself.
-fn default_socket_factories() -> (
-    Arc<dyn SocketFactory<TcpSocket>>,
-    Arc<dyn SocketFactory<UdpSocket>>,
-) {
-    (Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp))
 }
 
 /// Initialize the runtime to use for evaluating feature flags.

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::IpAddr,
+    net::{IpAddr, ToSocketAddrs as _},
     sync::{Arc, LazyLock},
 };
 
@@ -38,7 +38,8 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
 /// Configures the socket factories used to reach the ingest host.
 ///
 /// The factories must bypass the tunnel so that telemetry traffic never loops
-/// back through connlib.
+/// back through connlib. Processes that do not run connlib themselves can skip
+/// this and fall back to [`default_socket_factories`].
 pub(crate) fn configure(
     tcp: Arc<dyn SocketFactory<TcpSocket>>,
     udp: Arc<dyn SocketFactory<UdpSocket>>,
@@ -49,6 +50,27 @@ pub(crate) fn configure(
 /// Updates the upstream resolvers used to look up the ingest host.
 pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
     *INGEST.servers.lock() = servers;
+}
+
+/// Seeds the ingest-host addresses using the system resolver.
+///
+/// Resolves the ingest host via the operating system and keeps the result as a
+/// fallback for when the bootstrap resolver has no servers or cannot resolve the
+/// host. Must run at startup, before connlib reconfigures the system resolver, so
+/// the lookup reaches the real upstream and not connlib itself.
+pub(crate) fn init_addresses() {
+    let addresses = (INGEST_HOST, 443u16)
+        .to_socket_addrs()
+        .inspect_err(|e| tracing::debug!("Failed to seed ingest host addresses: {e:#}"))
+        .map(|addresses| addresses.map(|addr| addr.ip()).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    tracing::debug!(
+        ?addresses,
+        "Seeded ingest host addresses from system resolver"
+    );
+
+    *INGEST.seed_addresses.lock() = addresses;
 }
 
 /// Drops the current connection so the next request re-resolves and reconnects.
@@ -99,7 +121,8 @@ where
 /// The connection is resolved via [`BootstrapDnsClient`] against the configured
 /// upstream resolvers and established through a tunnel-bypassing [`SocketFactory`].
 /// Resolving lazily on every (re-)connect — rather than once at startup — lets us
-/// recover from having no resolvers yet and from the network path breaking.
+/// recover from having no resolvers yet and from the network path breaking. When
+/// the bootstrap resolver yields nothing, we fall back to `seed_addresses`.
 #[derive(Default)]
 struct Ingest {
     sockets: Mutex<
@@ -109,6 +132,9 @@ struct Ingest {
         )>,
     >,
     servers: Mutex<Vec<IpAddr>>,
+    /// Addresses resolved via the system resolver at startup, before connlib took
+    /// over DNS. Used as a fallback when the bootstrap resolver yields nothing.
+    seed_addresses: Mutex<Vec<IpAddr>>,
     client: Mutex<Option<HttpClient>>,
     /// Serialises bootstrapping so concurrent senders share a single connection.
     bootstrap: tokio::sync::Mutex<()>,
@@ -146,17 +172,26 @@ async fn bootstrap() -> Result<HttpClient> {
         .sockets
         .lock()
         .clone()
-        .context("Ingest client is not configured with socket factories")?;
+        .unwrap_or_else(default_socket_factories);
     let servers = INGEST.servers.lock().clone();
+    let seed_addresses = INGEST.seed_addresses.lock().clone();
 
     // Anchor the connection task on our own runtime so it outlives the caller,
     // which may be a short-lived `block_on` on another runtime.
     RUNTIME
         .spawn(async move {
-            let addresses = BootstrapDnsClient::new(udp, tcp.clone(), servers)
+            // Prefer the bootstrap resolver, which never uses the system resolver
+            // (i.e. connlib). Fall back to the addresses seeded at startup so we can
+            // still connect before any resolvers are configured.
+            let mut addresses = BootstrapDnsClient::new(udp, tcp.clone(), servers)
                 .resolve(INGEST_HOST)
                 .await
-                .context("Failed to resolve ingest host")?;
+                .inspect_err(|e| tracing::debug!("Failed to resolve ingest host: {e:#}"))
+                .unwrap_or_default();
+
+            if addresses.is_empty() {
+                addresses = seed_addresses;
+            }
 
             anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host");
 
@@ -166,6 +201,15 @@ async fn bootstrap() -> Result<HttpClient> {
         })
         .await
         .context("Bootstrap task failed")?
+}
+
+/// Plain socket factories used when none have been configured via [`configure`],
+/// e.g. in the GUI process which does not run connlib itself.
+fn default_socket_factories() -> (
+    Arc<dyn SocketFactory<TcpSocket>>,
+    Arc<dyn SocketFactory<UdpSocket>>,
+) {
+    (Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp))
 }
 
 /// Initialize the runtime to use for evaluating feature flags.

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -30,7 +30,7 @@ pub(crate) fn init_addresses() {
 }
 
 /// Drops the current connection so the next request reconnects.
-pub(crate) fn reset() {
+pub(crate) fn reset_client() {
     CLIENT.reset();
 }
 

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -1,19 +1,11 @@
-use std::{
-    net::{IpAddr, ToSocketAddrs as _},
-    sync::{Arc, LazyLock},
-};
+use std::sync::LazyLock;
 
-use anyhow::{Context as _, ErrorExt as _, Result};
-use bootstrap_dns_client::BootstrapDnsClient;
+use anyhow::{Context as _, Result};
 use bytes::Bytes;
 use http::{Method, Request, Response, header};
-use http_client::HttpClient;
-use parking_lot::Mutex;
 use serde::Serialize;
-use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
-use tokio::runtime::Runtime;
 
-use crate::Env;
+use crate::{Env, ingest};
 
 pub(crate) const API_KEY_PROD: &str = "phc_uXXl56plyvIBHj81WwXBLtdPElIRbm7keRTdUCmk8ll";
 pub(crate) const API_KEY_STAGING: &str = "phc_tHOVtq183RpfKmzadJb4bxNpLM5jzeeb1Gu8YSH3nsK";
@@ -21,10 +13,7 @@ pub(crate) const API_KEY_ON_PREM: &str = "phc_4R9Ii6q4SEofVkH7LvajwuJ3nsGFhCj0Zl
 
 const INGEST_HOST: &str = "posthog.firezone.dev";
 
-pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
-
-/// Process-wide HTTP client for PostHog's ingest host.
-static INGEST: LazyLock<Ingest> = LazyLock::new(Ingest::default);
+static CLIENT: LazyLock<ingest::Client> = LazyLock::new(|| ingest::Client::new(INGEST_HOST));
 
 pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     match env {
@@ -35,61 +24,21 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     }
 }
 
-/// Configures the socket factories used to reach the ingest host.
-///
-/// In connlib processes these must bypass the tunnel so that telemetry traffic
-/// never loops back through connlib; other processes pass plain socket factories.
-pub(crate) fn configure(
-    tcp: Arc<dyn SocketFactory<TcpSocket>>,
-    udp: Arc<dyn SocketFactory<UdpSocket>>,
-) {
-    *INGEST.sockets.lock() = Some((tcp, udp));
-}
-
-/// Updates the upstream resolvers used to look up the ingest host.
-pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
-    *INGEST.servers.lock() = servers;
-}
-
-/// Seeds the ingest-host addresses using the system resolver.
-///
-/// Resolves the ingest host via the operating system and keeps the result as a
-/// fallback for when the bootstrap resolver has no servers or cannot resolve the
-/// host. Must run at startup, before connlib reconfigures the system resolver, so
-/// the lookup reaches the real upstream and not connlib itself.
+/// Seeds the PostHog ingest-host addresses via the system resolver.
 pub(crate) fn init_addresses() {
-    let addresses = (INGEST_HOST, 443u16)
-        .to_socket_addrs()
-        .inspect_err(|e| tracing::debug!("Failed to seed ingest host addresses: {e:#}"))
-        .map(|addresses| addresses.map(|addr| addr.ip()).collect::<Vec<_>>())
-        .unwrap_or_default();
-
-    tracing::debug!(
-        ?addresses,
-        "Seeded ingest host addresses from system resolver"
-    );
-
-    *INGEST.seed_addresses.lock() = addresses;
+    CLIENT.init_addresses();
 }
 
-/// Drops the current connection so the next request re-resolves and reconnects.
+/// Drops the current connection so the next request reconnects.
 pub(crate) fn reset() {
-    let sockets = INGEST.sockets.lock().clone();
-    if let Some((tcp, udp)) = sockets {
-        tcp.reset();
-        udp.reset();
-    }
-
-    *INGEST.client.lock() = None;
+    CLIENT.reset();
 }
 
-/// Sends a JSON `POST` to `path` on the ingest host and returns the response.
+/// Sends a JSON `POST` to `path` on the PostHog ingest host and returns the response.
 pub(crate) async fn post_json<B>(path: &str, body: &B) -> Result<Response<Bytes>>
 where
     B: Serialize,
 {
-    let client = ingest_client().await?;
-
     let request = Request::builder()
         .method(Method::POST)
         .uri(format!("https://{INGEST_HOST}{path}"))
@@ -99,134 +48,5 @@ where
         ))
         .context("Failed to build HTTP request")?;
 
-    let response = match client.send_request(request) {
-        Ok(response) => response.await,
-        Err(e) => Err(e),
-    };
-
-    // A closed connection means the path is broken; discard the client so the
-    // next request re-resolves and reconnects.
-    if response
-        .as_ref()
-        .is_err_and(|e| e.any_is::<http_client::Closed>())
-    {
-        *INGEST.client.lock() = None;
-    }
-
-    response
-}
-
-/// Holds the state needed to (re-)establish a connection to the ingest host.
-///
-/// The connection is resolved via [`BootstrapDnsClient`] against the configured
-/// upstream resolvers and established through a tunnel-bypassing [`SocketFactory`].
-/// Resolving lazily on every (re-)connect — rather than once at startup — lets us
-/// recover from having no resolvers yet and from the network path breaking. When
-/// the bootstrap resolver yields nothing, we fall back to `seed_addresses`.
-#[derive(Default)]
-struct Ingest {
-    sockets: Mutex<
-        Option<(
-            Arc<dyn SocketFactory<TcpSocket>>,
-            Arc<dyn SocketFactory<UdpSocket>>,
-        )>,
-    >,
-    servers: Mutex<Vec<IpAddr>>,
-    /// Addresses resolved via the system resolver at startup, before connlib took
-    /// over DNS. Used as a fallback when the bootstrap resolver yields nothing.
-    seed_addresses: Mutex<Vec<IpAddr>>,
-    client: Mutex<Option<HttpClient>>,
-    /// Serialises bootstrapping so concurrent senders share a single connection.
-    bootstrap: tokio::sync::Mutex<()>,
-}
-
-/// Returns a live client, bootstrapping a new connection if there is none.
-async fn ingest_client() -> Result<HttpClient> {
-    if let Some(client) = live_client() {
-        return Ok(client);
-    }
-
-    let _guard = INGEST.bootstrap.lock().await;
-
-    if let Some(client) = live_client() {
-        return Ok(client);
-    }
-
-    let client = bootstrap().await?;
-    *INGEST.client.lock() = Some(client.clone());
-
-    Ok(client)
-}
-
-fn live_client() -> Option<HttpClient> {
-    INGEST
-        .client
-        .lock()
-        .as_ref()
-        .filter(|client| !client.is_closed())
-        .cloned()
-}
-
-async fn bootstrap() -> Result<HttpClient> {
-    let (tcp, udp) = INGEST
-        .sockets
-        .lock()
-        .clone()
-        .context("Ingest client has no socket factories configured")?;
-    let servers = INGEST.servers.lock().clone();
-    let seed_addresses = INGEST.seed_addresses.lock().clone();
-
-    // Anchor the connection task on our own runtime so it outlives the caller,
-    // which may be a short-lived `block_on` on another runtime.
-    RUNTIME
-        .spawn(async move {
-            // Resolve via the bootstrap resolver, which never uses the system
-            // resolver (i.e. connlib), and add the addresses seeded at startup as
-            // extra fallback candidates. `HttpClient` tries them in order and
-            // connects to the first that works, so freshly resolved addresses are
-            // preferred while the seed still lets us connect before any resolvers
-            // are configured or when the resolver returns unreachable addresses.
-            //
-            // Skip the resolver while we have no upstreams yet (e.g. before connlib
-            // reports the system DNS servers); it would only fail and the seed
-            // already covers that case.
-            let mut addresses = if servers.is_empty() {
-                Vec::new()
-            } else {
-                BootstrapDnsClient::new(udp, tcp.clone(), servers)
-                    .resolve(INGEST_HOST)
-                    .await
-                    .inspect_err(|e| tracing::debug!("Failed to resolve ingest host: {e:#}"))
-                    .unwrap_or_default()
-            };
-
-            for address in seed_addresses {
-                if !addresses.contains(&address) {
-                    addresses.push(address);
-                }
-            }
-
-            anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host");
-
-            HttpClient::new(INGEST_HOST.to_owned(), addresses, tcp)
-                .await
-                .context("Failed to connect to ingest host")
-        })
-        .await
-        .context("Bootstrap task failed")?
-}
-
-/// Initialize the runtime to use for evaluating feature flags.
-fn init_runtime() -> Runtime {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1) // We only need 1 worker thread.
-        .thread_name("posthog-worker")
-        .enable_io()
-        .enable_time()
-        .build()
-        .expect("to be able to build runtime");
-
-    runtime.spawn(crate::feature_flags::reeval_timer());
-
-    runtime
+    CLIENT.send_request(request).await
 }

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -1,4 +1,16 @@
-use std::{net::ToSocketAddrs as _, sync::LazyLock, time::Duration};
+use std::{
+    net::IpAddr,
+    sync::{Arc, LazyLock},
+};
+
+use anyhow::{Context as _, ErrorExt as _, Result};
+use bootstrap_dns_client::BootstrapDnsClient;
+use bytes::Bytes;
+use http::{Method, Request, Response, header};
+use http_client::HttpClient;
+use parking_lot::Mutex;
+use serde::Serialize;
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use tokio::runtime::Runtime;
 
 use crate::Env;
@@ -7,10 +19,12 @@ pub(crate) const API_KEY_PROD: &str = "phc_uXXl56plyvIBHj81WwXBLtdPElIRbm7keRTdU
 pub(crate) const API_KEY_STAGING: &str = "phc_tHOVtq183RpfKmzadJb4bxNpLM5jzeeb1Gu8YSH3nsK";
 pub(crate) const API_KEY_ON_PREM: &str = "phc_4R9Ii6q4SEofVkH7LvajwuJ3nsGFhCj0ZlfysS2FNc";
 
-pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
-pub(crate) static CLIENT: LazyLock<reqwest::Result<reqwest::Client>> = LazyLock::new(init_client);
+const INGEST_HOST: &str = "posthog.firezone.dev";
 
-pub(crate) const INGEST_HOST: &str = "posthog.firezone.dev";
+pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
+
+/// Process-wide HTTP client for PostHog's ingest host.
+static INGEST: LazyLock<Ingest> = LazyLock::new(Ingest::default);
 
 pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     match env {
@@ -19,6 +33,139 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
         Env::OnPrem => Some(API_KEY_ON_PREM),
         Env::Entrypoint | Env::DockerCompose | Env::Localhost => None,
     }
+}
+
+/// Configures the socket factories used to reach the ingest host.
+///
+/// The factories must bypass the tunnel so that telemetry traffic never loops
+/// back through connlib.
+pub(crate) fn configure(
+    tcp: Arc<dyn SocketFactory<TcpSocket>>,
+    udp: Arc<dyn SocketFactory<UdpSocket>>,
+) {
+    *INGEST.sockets.lock() = Some((tcp, udp));
+}
+
+/// Updates the upstream resolvers used to look up the ingest host.
+pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
+    *INGEST.servers.lock() = servers;
+}
+
+/// Drops the current connection so the next request re-resolves and reconnects.
+pub(crate) fn reset() {
+    if let Some((tcp, udp)) = INGEST.sockets.lock().as_ref() {
+        tcp.reset();
+        udp.reset();
+    }
+
+    *INGEST.client.lock() = None;
+}
+
+/// Sends a JSON `POST` to `path` on the ingest host and returns the response.
+pub(crate) async fn post_json<B>(path: &str, body: &B) -> Result<Response<Bytes>>
+where
+    B: Serialize,
+{
+    let client = ingest_client().await?;
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(format!("https://{INGEST_HOST}{path}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Bytes::from(
+            serde_json::to_vec(body).context("Failed to serialize request body")?,
+        ))
+        .context("Failed to build HTTP request")?;
+
+    let response = match client.send_request(request) {
+        Ok(response) => response.await,
+        Err(e) => Err(e),
+    };
+
+    // A closed connection means the path is broken; discard the client so the
+    // next request re-resolves and reconnects.
+    if response
+        .as_ref()
+        .is_err_and(|e| e.any_is::<http_client::Closed>())
+    {
+        *INGEST.client.lock() = None;
+    }
+
+    response
+}
+
+/// Holds the state needed to (re-)establish a connection to the ingest host.
+///
+/// The connection is resolved via [`BootstrapDnsClient`] against the configured
+/// upstream resolvers and established through a tunnel-bypassing [`SocketFactory`].
+/// Resolving lazily on every (re-)connect — rather than once at startup — lets us
+/// recover from having no resolvers yet and from the network path breaking.
+#[derive(Default)]
+struct Ingest {
+    sockets: Mutex<
+        Option<(
+            Arc<dyn SocketFactory<TcpSocket>>,
+            Arc<dyn SocketFactory<UdpSocket>>,
+        )>,
+    >,
+    servers: Mutex<Vec<IpAddr>>,
+    client: Mutex<Option<HttpClient>>,
+    /// Serialises bootstrapping so concurrent senders share a single connection.
+    bootstrap: tokio::sync::Mutex<()>,
+}
+
+/// Returns a live client, bootstrapping a new connection if there is none.
+async fn ingest_client() -> Result<HttpClient> {
+    if let Some(client) = live_client() {
+        return Ok(client);
+    }
+
+    let _guard = INGEST.bootstrap.lock().await;
+
+    if let Some(client) = live_client() {
+        return Ok(client);
+    }
+
+    let client = bootstrap().await?;
+    *INGEST.client.lock() = Some(client.clone());
+
+    Ok(client)
+}
+
+fn live_client() -> Option<HttpClient> {
+    INGEST
+        .client
+        .lock()
+        .as_ref()
+        .filter(|client| !client.is_closed())
+        .cloned()
+}
+
+async fn bootstrap() -> Result<HttpClient> {
+    let (tcp, udp) = INGEST
+        .sockets
+        .lock()
+        .clone()
+        .context("Ingest client is not configured with socket factories")?;
+    let servers = INGEST.servers.lock().clone();
+
+    // Anchor the connection task on our own runtime so it outlives the caller,
+    // which may be a short-lived `block_on` on another runtime.
+    RUNTIME
+        .spawn(async move {
+            let addresses = BootstrapDnsClient::new(udp, tcp.clone(), servers)
+                .resolve(INGEST_HOST)
+                .await
+                .context("Failed to resolve ingest host")?;
+
+            anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host");
+
+            HttpClient::new(INGEST_HOST.to_owned(), addresses, tcp)
+                .await
+                .context("Failed to connect to ingest host")
+        })
+        .await
+        .context("Bootstrap task failed")?
 }
 
 /// Initialize the runtime to use for evaluating feature flags.
@@ -34,27 +181,4 @@ fn init_runtime() -> Runtime {
     runtime.spawn(crate::feature_flags::reeval_timer());
 
     runtime
-}
-
-/// Initialize the client to use for evaluating feature flags.
-fn init_client() -> reqwest::Result<reqwest::Client> {
-    let ingest_host_addresses = (INGEST_HOST, 443u16)
-        .to_socket_addrs()
-        .inspect_err(|e| {
-            tracing::error!("Failed to resolve ingest host (`{INGEST_HOST}`) IPs: {e:#}")
-        })
-        .unwrap_or_default()
-        .collect::<Vec<_>>();
-
-    tracing::debug!(host = %INGEST_HOST, addresses = ?ingest_host_addresses, "Resolved PostHog ingest host addresses");
-
-    reqwest::ClientBuilder::new()
-        .connection_verbose(true)
-        .pool_idle_timeout(None) // Never remove idle connections.
-        .pool_max_idle_per_host(1)
-        .http2_prior_knowledge() // We know PostHog supports HTTP/2.
-        .http2_keep_alive_timeout(Duration::from_secs(1))
-        .http2_keep_alive_interval(Duration::from_secs(5)) // Use keep-alive to detect broken connections.
-        .resolve_to_addrs(INGEST_HOST, &ingest_host_addresses)
-        .build()
 }

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -3,12 +3,12 @@ use std::{
     time::Duration,
 };
 
-use bytes::Bytes;
-use http::{Method, Request, Response, StatusCode, header};
-use sentry::{
+use ::sentry::{
     ClientOptions, Envelope, Transport,
     transports::{RateLimiter, TokioTransportThread},
 };
+use bytes::Bytes;
+use http::{Method, Request, Response, StatusCode, header};
 
 use crate::ingest;
 
@@ -30,7 +30,7 @@ pub(crate) fn reset() {
 #[derive(Clone)]
 pub(crate) struct Factory;
 
-impl sentry::TransportFactory for Factory {
+impl ::sentry::TransportFactory for Factory {
     fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
         Arc::new(SentryTransport::new(options))
     }

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -23,7 +23,7 @@ pub(crate) fn init_addresses() {
 }
 
 /// Drops the current connection so the next request reconnects.
-pub(crate) fn reset() {
+pub(crate) fn reset_client() {
     CLIENT.reset();
 }
 

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -1,16 +1,17 @@
 use std::{
+    borrow::Cow,
     sync::{Arc, LazyLock},
     time::Duration,
 };
 
-use ::sentry::{
-    ClientOptions, Envelope, Transport,
-    transports::{RateLimiter, TokioTransportThread},
-};
+use ::sentry::transports::{RateLimiter, TokioTransportThread};
 use bytes::Bytes;
 use http::{Method, Request, Response, StatusCode, header};
 
 use crate::ingest;
+
+// Re-export the Sentry SDK so the rest of the crate can reach it through this module.
+pub(crate) use ::sentry::*;
 
 pub(crate) const INGEST_HOST: &str = "sentry.firezone.dev";
 
@@ -26,11 +27,53 @@ pub(crate) fn reset() {
     CLIENT.reset();
 }
 
+/// Builds the Sentry [`ClientOptions`] with our [`Factory`] transport and starts the SDK.
+pub(crate) fn init_sdk_client(
+    dsn: String,
+    environment: &'static str,
+    release: &str,
+) -> ClientInitGuard {
+    init((
+        dsn,
+        ClientOptions {
+            environment: Some(Cow::Borrowed(environment)),
+            // We can't get the release number ourselves because we don't know if we're embedded in a GUI Client or a Headless Client.
+            release: Some(release.to_owned().into()),
+            max_breadcrumbs: 500,
+            before_send: Some({
+                let rate_limit = crate::event_rate_limiter(Duration::from_secs(60 * 5));
+                Arc::new(move |event| {
+                    let event = rate_limit(event)?;
+                    let event = crate::insert_feature_flags_into_event(event);
+
+                    Some(event)
+                })
+            }),
+            enable_logs: true,
+            enable_metrics: true,
+            before_send_log: Some(Arc::new(|log| {
+                let log = crate::insert_user_account_slug_into_log(log);
+                let log = crate::append_tracing_fields_to_message(log);
+
+                Some(log)
+            })),
+            before_send_metric: Some(Arc::new(|metric| {
+                let metric = crate::insert_user_account_slug_into_metric(metric);
+                let metric = crate::insert_feature_flags_into_metric(metric);
+
+                Some(metric)
+            })),
+            transport: Some(Arc::new(Factory)),
+            ..Default::default()
+        },
+    ))
+}
+
 /// Creates [`SentryTransport`]s for the Sentry SDK.
 #[derive(Clone)]
-pub(crate) struct Factory;
+struct Factory;
 
-impl ::sentry::TransportFactory for Factory {
+impl TransportFactory for Factory {
     fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
         Arc::new(SentryTransport::new(options))
     }

--- a/rust/libs/telemetry/src/sentry_transport.rs
+++ b/rust/libs/telemetry/src/sentry_transport.rs
@@ -10,7 +10,9 @@ use sentry::{
     transports::{RateLimiter, TokioTransportThread},
 };
 
-use crate::{INGEST_HOST, ingest};
+use crate::ingest;
+
+pub(crate) const INGEST_HOST: &str = "sentry.firezone.dev";
 
 static CLIENT: LazyLock<ingest::Client> = LazyLock::new(|| ingest::Client::new(INGEST_HOST));
 

--- a/rust/libs/telemetry/src/sentry_transport.rs
+++ b/rust/libs/telemetry/src/sentry_transport.rs
@@ -1,0 +1,121 @@
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http::{Method, Request, Response, StatusCode, header};
+use sentry::{
+    ClientOptions, Envelope, Transport,
+    transports::{RateLimiter, TokioTransportThread},
+};
+
+use crate::{INGEST_HOST, ingest};
+
+static CLIENT: LazyLock<ingest::Client> = LazyLock::new(|| ingest::Client::new(INGEST_HOST));
+
+/// Seeds the Sentry ingest-host addresses via the system resolver.
+pub(crate) fn init_addresses() {
+    CLIENT.init_addresses();
+}
+
+/// Drops the current connection so the next request reconnects.
+pub(crate) fn reset() {
+    CLIENT.reset();
+}
+
+/// Creates [`SentryTransport`]s for the Sentry SDK.
+#[derive(Clone)]
+pub(crate) struct Factory;
+
+impl sentry::TransportFactory for Factory {
+    fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
+        Arc::new(SentryTransport::new(options))
+    }
+}
+
+/// A Sentry [`Transport`] that sends envelopes through our [`ingest::Client`].
+///
+/// Sending and rate-limiting are driven by sentry's own [`TokioTransportThread`],
+/// so the queueing, back-pressure and rate-limit handling are identical to the
+/// reqwest-based transport; only the HTTP send is swapped for our loop-free,
+/// self-healing [`ingest::Client`].
+struct SentryTransport {
+    thread: TokioTransportThread,
+}
+
+impl SentryTransport {
+    fn new(options: &ClientOptions) -> Self {
+        let dsn = options
+            .dsn
+            .as_ref()
+            .expect("Sentry DSN to be set when starting telemetry");
+        let auth = dsn.to_auth(Some(&options.user_agent)).to_string();
+        let url = dsn.envelope_api_url().to_string();
+
+        let thread = TokioTransportThread::new(move |envelope, mut rate_limiter| {
+            // The request is built outside the async block so that `url` and `auth`
+            // can be borrowed from the reused closure.
+            let request = build_request(&url, &auth, &envelope);
+
+            async move {
+                match request {
+                    Ok(request) => match CLIENT.send_request(request).await {
+                        Ok(response) => update_rate_limits(&mut rate_limiter, &response),
+                        Err(e) => tracing::debug!("Failed to send envelope to Sentry: {e:#}"),
+                    },
+                    Err(e) => tracing::debug!("Failed to build Sentry request: {e:#}"),
+                }
+
+                rate_limiter
+            }
+        });
+
+        Self { thread }
+    }
+}
+
+impl Transport for SentryTransport {
+    fn send_envelope(&self, envelope: Envelope) {
+        self.thread.send(envelope);
+    }
+
+    fn flush(&self, timeout: Duration) -> bool {
+        self.thread.flush(timeout)
+    }
+
+    fn shutdown(&self, timeout: Duration) -> bool {
+        self.flush(timeout)
+    }
+}
+
+fn build_request(url: &str, auth: &str, envelope: &Envelope) -> anyhow::Result<Request<Bytes>> {
+    let mut body = Vec::new();
+    envelope.to_writer(&mut body)?;
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(url)
+        .header("X-Sentry-Auth", auth)
+        .body(Bytes::from(body))?;
+
+    Ok(request)
+}
+
+fn update_rate_limits(rate_limiter: &mut RateLimiter, response: &Response<Bytes>) {
+    let headers = response.headers();
+
+    if let Some(value) = headers
+        .get("x-sentry-rate-limits")
+        .and_then(|value| value.to_str().ok())
+    {
+        rate_limiter.update_from_sentry_header(value);
+    } else if let Some(value) = headers
+        .get(header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+    {
+        rate_limiter.update_from_retry_after(value);
+    } else if response.status() == StatusCode::TOO_MANY_REQUESTS {
+        rate_limiter.update_from_429();
+    }
+}

--- a/rust/libs/telemetry/tests/attach_firezone_id.rs
+++ b/rust/libs/telemetry/tests/attach_firezone_id.rs
@@ -4,7 +4,10 @@ use telemetry::{TESTING, Telemetry};
 async fn set_firezone_id_attaches_user_to_running_session() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
     telemetry.start("entrypoint", "1.0.0", TESTING);
 
     Telemetry::set_firezone_id("device-abc".to_owned()).await;

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -4,7 +4,10 @@ use telemetry::{TESTING, Telemetry};
 async fn set_account_slug_before_set_firezone_id_preserves_both() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
     telemetry.start("entrypoint", "1.0.0", TESTING);
 
     Telemetry::set_account_slug("acme".to_owned());

--- a/rust/libs/telemetry/tests/swap_env.rs
+++ b/rust/libs/telemetry/tests/swap_env.rs
@@ -4,7 +4,10 @@ use telemetry::{Env, TESTING, Telemetry};
 async fn entrypoint_then_real_env_swaps_running_session() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
     telemetry.start("entrypoint", "1.0.0", TESTING);
     assert_eq!(Telemetry::current_env(), Some(Env::Entrypoint));
 

--- a/rust/libs/telemetry/tests/unsupported_disables_current.rs
+++ b/rust/libs/telemetry/tests/unsupported_disables_current.rs
@@ -4,7 +4,10 @@ use telemetry::{TESTING, Telemetry};
 async fn starting_session_for_unsupported_env_disables_current_one() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new();
+    let mut telemetry = Telemetry::new(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
     telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
     telemetry.start("wss://example.com", "1.0.0", TESTING);
 

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -141,7 +141,10 @@ fn main() -> ExitCode {
         .expect("Failed to build tokio runtime");
 
     let mut telemetry = if args.telemetry {
-        Telemetry::new()
+        Telemetry::new(
+            std::sync::Arc::new(socket_factory::tcp),
+            std::sync::Arc::new(socket_factory::udp),
+        )
     } else {
         Telemetry::disabled()
     };


### PR DESCRIPTION
The telemetry ingest clients (PostHog and Sentry) resolved their hosts once at startup via the system resolver and pinned the result for the lifetime of the process. On a Client the system resolver can be connlib itself (risking a packet loop), and the pinned connections recovered neither from starting without DNS nor from the network path breaking.

Telemetry now reaches `posthog.firezone.dev` and `sentry.firezone.dev` through a shared, per-host ingest client that resolves lazily via the bootstrap DNS client against the configured upstream resolvers and connects over the same tunnel-bypassing socket factory connlib uses, seeded once from the system resolver at startup. Connections re-establish on demand, keeping telemetry off the system resolver and letting it recover from transiently having no resolvers, from DNS server changes, and from the network connection breaking.

Sentry keeps its existing rate-limiting, queueing and back-pressure: sending is still driven by sentry's own transport thread and rate limiter, so only the HTTP send is swapped for the shared ingest client.

Resolves: #10272