### PR TITLE
docs(portal): use consistent created

### DIFF
--- a/elixir/lib/portal_api/controllers/actor_controller.ex
+++ b/elixir/lib/portal_api/controllers/actor_controller.ex
@@ -67,7 +67,7 @@ defmodule PortalAPI.ActorController do
       {"Actor attributes", "application/json", PortalAPI.Schemas.Actor.CreateRequest,
        required: true},
     responses:
-      [ok: {"ActorResponse", "application/json", PortalAPI.Schemas.Actor.Response}] ++
+      [created: {"ActorResponse", "application/json", PortalAPI.Schemas.Actor.Response}] ++
         ProblemDetails.responses([
           :bad_request,
           :unauthorized,

--- a/elixir/lib/portal_api/controllers/gateway_token_controller.ex
+++ b/elixir/lib/portal_api/controllers/gateway_token_controller.ex
@@ -21,7 +21,7 @@ defmodule PortalAPI.GatewayTokenController do
     ],
     responses:
       [
-        ok: {"New Token Response", "application/json", PortalAPI.Schemas.GatewayToken.Response}
+        created: {"New Token Response", "application/json", PortalAPI.Schemas.GatewayToken.Response}
       ] ++
         ProblemDetails.responses([
           :bad_request,

--- a/elixir/lib/portal_api/controllers/group_controller.ex
+++ b/elixir/lib/portal_api/controllers/group_controller.ex
@@ -68,7 +68,7 @@ defmodule PortalAPI.GroupController do
       {"Group Attributes", "application/json", PortalAPI.Schemas.Group.CreateRequest,
        required: true},
     responses:
-      [ok: {"Group Response", "application/json", PortalAPI.Schemas.Group.Response}] ++
+      [created: {"Group Response", "application/json", PortalAPI.Schemas.Group.Response}] ++
         ProblemDetails.responses([
           :bad_request,
           :unauthorized,

--- a/elixir/lib/portal_api/controllers/policy_controller.ex
+++ b/elixir/lib/portal_api/controllers/policy_controller.ex
@@ -66,7 +66,7 @@ defmodule PortalAPI.PolicyController do
       {"Policy Attributes", "application/json", PortalAPI.Schemas.Policy.CreateRequest,
        required: true},
     responses:
-      [ok: {"Policy Response", "application/json", PortalAPI.Schemas.Policy.Response}] ++
+      [created: {"Policy Response", "application/json", PortalAPI.Schemas.Policy.Response}] ++
         ProblemDetails.responses([
           :bad_request,
           :unauthorized,

--- a/elixir/lib/portal_api/controllers/resource_controller.ex
+++ b/elixir/lib/portal_api/controllers/resource_controller.ex
@@ -67,7 +67,7 @@ defmodule PortalAPI.ResourceController do
       {"Resource Attributes", "application/json", PortalAPI.Schemas.Resource.CreateRequest,
        required: true},
     responses:
-      [ok: {"Resource Response", "application/json", PortalAPI.Schemas.Resource.Response}] ++
+      [created: {"Resource Response", "application/json", PortalAPI.Schemas.Resource.Response}] ++
         ProblemDetails.responses([
           :bad_request,
           :unauthorized,

--- a/elixir/lib/portal_api/controllers/site_controller.ex
+++ b/elixir/lib/portal_api/controllers/site_controller.ex
@@ -70,7 +70,7 @@ defmodule PortalAPI.SiteController do
     request_body:
       {"Site Attributes", "application/json", PortalAPI.Schemas.Site.CreateRequest, required: true},
     responses:
-      [ok: {"Site Response", "application/json", PortalAPI.Schemas.Site.Response}] ++
+      [created: {"Site Response", "application/json", PortalAPI.Schemas.Site.Response}] ++
         ProblemDetails.responses([
           :bad_request,
           :unauthorized,


### PR DESCRIPTION
Aligns the documented response codes in the API with their actual ones.

---

Fixes: https://github.com/firezone/firezone/issues/13809
Credit: @Intuinewin 