### PR TITLE
fix(portal): extend OTP from 5 to 6 chars

### DIFF
--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -125,7 +125,7 @@ defmodule Portal.Authentication do
   @otp_expiration_seconds 15 * 60
 
   def create_one_time_passcode(%Portal.Account{} = account, %Portal.Actor{} = actor) do
-    code = Portal.Crypto.random_token(5, encoder: :user_friendly)
+    code = Portal.Crypto.random_token(6, encoder: :user_friendly)
     code_hash = Portal.Crypto.hash(:argon2, code)
     expires_at = DateTime.utc_now() |> DateTime.add(@otp_expiration_seconds, :second)
 

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1198,7 +1198,7 @@ defmodule PortalWeb.OIDCController do
     end
 
     def create_one_time_passcode(account, actor) do
-      code = Portal.Crypto.random_token(5, encoder: :user_friendly)
+      code = Portal.Crypto.random_token(6, encoder: :user_friendly)
       code_hash = Portal.Crypto.hash(:argon2, code)
       expires_at = DateTime.utc_now() |> DateTime.add(@otp_expiration_seconds, :second)
 

--- a/elixir/lib/portal_web/live/sign_in/email.ex
+++ b/elixir/lib/portal_web/live/sign_in/email.ex
@@ -111,7 +111,7 @@ defmodule PortalWeb.SignIn.Email do
         class="flex gap-3 justify-center mb-6"
       >
         <input
-          :for={i <- 0..4}
+          :for={i <- 0..5}
           data-pin-index={i}
           type="text"
           maxlength="1"

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -632,7 +632,7 @@ defmodule Portal.AuthenticationTest do
       assert passcode.account_id == account.id
       assert passcode.actor_id == actor.id
       assert passcode.code != nil
-      assert String.length(passcode.code) == 5
+      assert String.length(passcode.code) == 6
       assert passcode.code_hash != nil
       assert passcode.expires_at != nil
     end

--- a/elixir/test/portal_web/controllers/email_otp_controller_test.exs
+++ b/elixir/test/portal_web/controllers/email_otp_controller_test.exs
@@ -1017,8 +1017,8 @@ defmodule PortalWeb.EmailOTPControllerTest do
   # Helper to extract the OTP code from the email
   defp extract_code_from_email(email) do
     # The code is on its own line after "Copy and paste..."
-    # It's 5 characters, URL-friendly (lowercase alphanumeric)
-    case Regex.run(~r/\n([a-z0-9]{5})\n/, email.text_body) do
+    # It's 6 characters, URL-friendly (lowercase alphanumeric)
+    case Regex.run(~r/\n([a-z0-9]{6})\n/, email.text_body) do
       [_, code] -> code
       _ -> raise "Could not extract code from email: #{email.text_body}"
     end

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1183,7 +1183,7 @@ defmodule PortalWeb.OIDCControllerTest do
       assert email.text_body =~ "IP address: 127.0.x.x"
       refute email.text_body =~ "127.0.0.1"
       refute email.text_body =~ "Coordinates"
-      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
 
       conn =
         conn
@@ -1241,7 +1241,7 @@ defmodule PortalWeb.OIDCControllerTest do
              }
 
       assert_received {:email, email}
-      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
 
       conn =
         conn
@@ -1284,7 +1284,7 @@ defmodule PortalWeb.OIDCControllerTest do
       pending_cookie = pending_identity_cookie_from_response(conn)
       pending_identity = Repo.get_by!(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
       assert_received {:email, email}
-      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
 
       existing_identity =
         identity_fixture(
@@ -1336,13 +1336,13 @@ defmodule PortalWeb.OIDCControllerTest do
       first_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
       first_cookie = pending_identity_cookie_from_response(first_conn)
       assert_received {:email, first_email}
-      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, first_email.text_body)
+      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, first_email.text_body)
 
       setup_successful_auth(ctx, actor_b, email_verified: false, sub: idp_id)
       second_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
       second_cookie = pending_identity_cookie_from_response(second_conn)
       assert_received {:email, second_email}
-      [_, second_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, second_email.text_body)
+      [_, second_code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, second_email.text_body)
 
       conn =
         build_conn()
@@ -1458,7 +1458,7 @@ defmodule PortalWeb.OIDCControllerTest do
       callback_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
       pending_cookie = pending_identity_cookie_from_response(callback_conn)
       assert_received {:email, email}
-      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
 
       conn =
         build_conn()
@@ -1494,7 +1494,7 @@ defmodule PortalWeb.OIDCControllerTest do
       callback_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
       pending_cookie = pending_identity_cookie_from_response(callback_conn)
       assert_received {:email, email}
-      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
 
       conn =
         callback_conn
@@ -1534,13 +1534,13 @@ defmodule PortalWeb.OIDCControllerTest do
       first_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
       first_cookie = pending_identity_cookie_from_response(first_conn)
       assert_received {:email, first_email}
-      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, first_email.text_body)
+      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, first_email.text_body)
 
       setup_successful_auth(ctx, actor, email_verified: false)
       second_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
       second_cookie = pending_identity_cookie_from_response(second_conn)
       assert_received {:email, second_email}
-      [_, _second_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, second_email.text_body)
+      [_, _second_code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, second_email.text_body)
 
       conn =
         build_conn()
@@ -1582,7 +1582,7 @@ defmodule PortalWeb.OIDCControllerTest do
       first_cookie = pending_identity_cookie_from_response(first_conn)
       first_pending_identity = Repo.get_by!(Portal.PendingIdentity, id: first_cookie.pending_identity_id)
       assert_received {:email, first_email}
-      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, first_email.text_body)
+      [_, first_code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, first_email.text_body)
 
       setup_successful_auth(ctx, actor, email_verified: false)
       second_conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))


### PR DESCRIPTION
Increases the keyspace of possible codes from 34 ^ 5 = ~45.4m possible codes to 34 ^ 6 = 1.5b.

---

Credit: @5ud0er
Related: https://github.com/firezone/firezone/security/advisories/GHSA-6wm4-2f45-mq3f
