### PR TITLE
fix(portal): explicitly limit otp attempts

### DIFF
--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -143,12 +143,13 @@ defmodule Portal.Authentication do
   end
 
   def verify_one_time_passcode(account_id, actor_id, passcode_id, entered_code) do
-    case Database.fetch_one_time_passcode(account_id, actor_id, passcode_id) do
+    case Database.consume_one_time_passcode_attempt(account_id, actor_id, passcode_id) do
       {:ok, passcode} ->
         if Portal.Crypto.equal?(:argon2, entered_code, passcode.code_hash) do
           :ok = Database.delete_one_time_passcode(passcode)
           {:ok, passcode}
         else
+          :ok = Database.delete_exhausted_one_time_passcode(passcode)
           {:error, :invalid_code}
         end
 
@@ -582,22 +583,24 @@ defmodule Portal.Authentication do
       |> Safe.insert()
     end
 
-    def fetch_one_time_passcode(account_id, actor_id, id) do
+    def consume_one_time_passcode_attempt(account_id, actor_id, id) do
       from(otp in OneTimePasscode,
         join: a in assoc(otp, :actor),
         where: otp.account_id == ^account_id,
         where: otp.actor_id == ^actor_id,
         where: otp.id == ^id,
         where: otp.expires_at > ^DateTime.utc_now(),
+        where: otp.attempts < ^OneTimePasscode.max_attempts(),
         where: is_nil(a.disabled_at),
         where: a.allow_email_otp_sign_in == true,
-        preload: [actor: a]
+        update: [inc: [attempts: 1]],
+        select: otp
       )
-      |> Safe.unscoped(:replica)
-      |> Safe.one()
+      |> Safe.unscoped()
+      |> Safe.update_all([])
       |> case do
-        nil -> {:error, :not_found}
-        otp -> {:ok, otp}
+        {1, [passcode]} -> {:ok, Safe.preload(passcode, :actor)}
+        {0, _} -> {:error, :not_found}
       end
     end
 
@@ -610,6 +613,14 @@ defmodule Portal.Authentication do
       |> Safe.delete_all()
 
       :ok
+    end
+
+    def delete_exhausted_one_time_passcode(%OneTimePasscode{} = passcode) do
+      if passcode.attempts >= OneTimePasscode.max_attempts() do
+        delete_one_time_passcode(passcode)
+      else
+        :ok
+      end
     end
 
     def delete_one_time_passcode(passcode) do

--- a/elixir/lib/portal/one_time_passcode.ex
+++ b/elixir/lib/portal/one_time_passcode.ex
@@ -6,6 +6,8 @@ defmodule Portal.OneTimePasscode do
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime_usec]
 
+  @max_attempts 3
+
   schema "one_time_passcodes" do
     belongs_to :account, Portal.Account, primary_key: true
     field :id, :binary_id, primary_key: true, autogenerate: true
@@ -17,9 +19,12 @@ defmodule Portal.OneTimePasscode do
     field :code, :string, virtual: true, redact: true
 
     field :expires_at, :utc_datetime_usec
+    field :attempts, :integer, default: 0
 
     timestamps()
   end
+
+  def max_attempts, do: @max_attempts
 
   def changeset(%Ecto.Changeset{} = changeset) do
     changeset

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -137,7 +137,13 @@ defmodule PortalWeb.OIDCController do
   end
 
   defp finish_resolved_identity(
-         %{conn: conn, context_type: context_type, account: account, provider: provider, params: params},
+         %{
+           conn: conn,
+           context_type: context_type,
+           account: account,
+           provider: provider,
+           params: params
+         },
          {:identity, identity},
          tokens
        ) do
@@ -151,7 +157,13 @@ defmodule PortalWeb.OIDCController do
   end
 
   defp finish_resolved_identity(
-         %{conn: conn, context_type: context_type, account: account, provider: provider, params: params},
+         %{
+           conn: conn,
+           context_type: context_type,
+           account: account,
+           provider: provider,
+           params: params
+         },
          {:proof_required, actor, identity_profile},
          _tokens
        ) do
@@ -325,7 +337,8 @@ defmodule PortalWeb.OIDCController do
            identity_profile.idp_id
          ) do
       {:ok, identity} ->
-        with {:ok, identity} <- Database.update_identity_profile(identity, identity_profile.profile_attrs) do
+        with {:ok, identity} <-
+               Database.update_identity_profile(identity, identity_profile.profile_attrs) do
           {:ok, {:identity, identity}}
         end
 
@@ -349,8 +362,12 @@ defmodule PortalWeb.OIDCController do
   defp email_verification_method(_provider), do: :none
 
   defp enforce_verified_email(%IdentityProfile{email_verified: :verified}), do: :ok
-  defp enforce_verified_email(%IdentityProfile{email_verified: :unverified}), do: {:error, :email_not_verified}
-  defp enforce_verified_email(%IdentityProfile{email_verified: :missing}), do: {:error, :email_verified_missing}
+
+  defp enforce_verified_email(%IdentityProfile{email_verified: :unverified}),
+    do: {:error, :email_not_verified}
+
+  defp enforce_verified_email(%IdentityProfile{email_verified: :missing}),
+    do: {:error, :email_verified_missing}
 
   defp start_owner_verification(conn, account, provider, actor, identity_profile, params) do
     pending_identity_id = Ecto.UUID.generate()
@@ -863,7 +880,11 @@ defmodule PortalWeb.OIDCController do
     redirect(conn, to: ~p"/verification/oidc?result=#{token}")
   end
 
-  defp verify_oidc_callback({:ok, %{config: config, verifier: verifier} = pending}, code, lv_pid_string) do
+  defp verify_oidc_callback(
+         {:ok, %{config: config, verifier: verifier} = pending},
+         code,
+         lv_pid_string
+       ) do
     with {:ok, claims, userinfo_result} <- PortalWeb.OIDC.verify_callback(config, code, verifier),
          :ok <- verify_email_verified_claim(pending, claims, userinfo_result) do
       %{
@@ -1221,30 +1242,27 @@ defmodule PortalWeb.OIDCController do
         ) do
       Safe.transact(fn ->
         with {:ok, pending_identity} <-
-               fetch_pending_identity_for_update(account_id, pending_identity_id, auth_provider_id),
-             {:ok, passcode} <- fetch_pending_passcode_for_update(pending_identity),
-             :ok <- verify_pending_identity_code(entered_code, passcode),
-             pending_identity_ids <- fetch_related_pending_identity_ids(pending_identity),
-             {:ok, identity} <- insert_external_identity_from_pending(pending_identity),
-             :ok <- delete_related_pending_identities_and_passcodes(pending_identity) do
-          {:ok, {identity, pending_identity_ids}}
+               fetch_pending_identity_for_update(
+                 account_id,
+                 pending_identity_id,
+                 auth_provider_id
+               ),
+             {:ok, passcode} <- fetch_pending_passcode_for_update(pending_identity) do
+          verify_and_promote(pending_identity, passcode, entered_code)
         else
           {:error, :not_found} ->
             dummy_verify_pending_identity_code()
-            {:error, :invalid_code}
-
-          {:error, reason} ->
-            {:error, reason}
+            {:ok, :not_found}
         end
       end)
       |> case do
-        {:ok, {%ExternalIdentity{} = identity, pending_identity_ids}} ->
+        {:ok, {:verified, %ExternalIdentity{} = identity, pending_identity_ids}} ->
           {:ok, Safe.preload(identity, [:actor, :account], :replica), pending_identity_ids}
 
-        {:error, :not_found} ->
+        {:ok, :invalid_code} ->
           {:error, :invalid_code}
 
-        {:error, :invalid_code} ->
+        {:ok, :not_found} ->
           {:error, :invalid_code}
 
         {:error, reason} ->
@@ -1252,11 +1270,43 @@ defmodule PortalWeb.OIDCController do
       end
     end
 
-    defp verify_pending_identity_code(entered_code, %OneTimePasscode{} = passcode) do
+    defp verify_and_promote(
+           %PendingIdentity{} = pending_identity,
+           %OneTimePasscode{} = passcode,
+           entered_code
+         ) do
       if Portal.Crypto.equal?(:argon2, entered_code, passcode.code_hash) do
-        :ok
+        pending_identity_ids = fetch_related_pending_identity_ids(pending_identity)
+
+        with {:ok, identity} <- insert_external_identity_from_pending(pending_identity),
+             :ok <- delete_related_pending_identities_and_passcodes(pending_identity) do
+          {:ok, {:verified, identity, pending_identity_ids}}
+        end
       else
-        {:error, :invalid_code}
+        :ok = record_failed_one_time_passcode_attempt(passcode)
+        {:ok, :invalid_code}
+      end
+    end
+
+    defp record_failed_one_time_passcode_attempt(%OneTimePasscode{} = passcode) do
+      from(otp in OneTimePasscode,
+        where: otp.account_id == ^passcode.account_id,
+        where: otp.id == ^passcode.id,
+        update: [inc: [attempts: 1]],
+        select: otp.attempts
+      )
+      |> Safe.unscoped()
+      |> Safe.update_all([])
+      |> case do
+        {1, [attempts]} ->
+          if attempts >= OneTimePasscode.max_attempts() do
+            delete_one_time_passcode(passcode.account_id, passcode.id)
+          else
+            :ok
+          end
+
+        _ ->
+          :ok
       end
     end
 
@@ -1410,6 +1460,7 @@ defmodule PortalWeb.OIDCController do
         where: passcode.actor_id == ^pending_identity.actor_id,
         where: passcode.id == ^pending_identity.one_time_passcode_id,
         where: passcode.expires_at > ^DateTime.utc_now(),
+        where: passcode.attempts < ^OneTimePasscode.max_attempts(),
         where: is_nil(actor.disabled_at),
         lock: "FOR UPDATE"
       )

--- a/elixir/priv/repo/migrations/20260622000000_add_attempts_to_one_time_passcodes.exs
+++ b/elixir/priv/repo/migrations/20260622000000_add_attempts_to_one_time_passcodes.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.AddAttemptsToOneTimePasscodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:one_time_passcodes) do
+      add(:attempts, :integer, null: false, default: 0)
+    end
+  end
+end

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -710,6 +710,39 @@ defmodule Portal.AuthenticationTest do
                verify_one_time_passcode(account.id, actor.id, passcode.id, passcode.code)
     end
 
+    test "tracks failed attempts without deleting before the limit" do
+      account = account_fixture()
+      actor = actor_fixture(account: account, allow_email_otp_sign_in: true)
+
+      {:ok, passcode} = create_one_time_passcode(account, actor)
+
+      for _ <- 1..(Portal.OneTimePasscode.max_attempts() - 1) do
+        assert {:error, :invalid_code} =
+                 verify_one_time_passcode(account.id, actor.id, passcode.id, "wrong")
+      end
+
+      assert {:ok, _} =
+               verify_one_time_passcode(account.id, actor.id, passcode.id, passcode.code)
+    end
+
+    test "deletes the passcode after the maximum number of failed attempts" do
+      account = account_fixture()
+      actor = actor_fixture(account: account, allow_email_otp_sign_in: true)
+
+      {:ok, passcode} = create_one_time_passcode(account, actor)
+
+      for _ <- 1..Portal.OneTimePasscode.max_attempts() do
+        assert {:error, :invalid_code} =
+                 verify_one_time_passcode(account.id, actor.id, passcode.id, "wrong")
+      end
+
+      # The passcode is deleted, so even the correct code no longer verifies
+      assert {:error, :invalid_code} =
+               verify_one_time_passcode(account.id, actor.id, passcode.id, passcode.code)
+
+      refute Repo.get_by(Portal.OneTimePasscode, id: passcode.id)
+    end
+
     test "creating a new passcode deletes existing passcodes for the actor" do
       account = account_fixture()
       actor = actor_fixture(account: account, allow_email_otp_sign_in: true)

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1442,6 +1442,55 @@ defmodule PortalWeb.OIDCControllerTest do
       assert flash(conn, :error) == "The verification code is invalid or expired."
     end
 
+    test "proof email verification deletes the passcode after too many invalid codes", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      pending_cookie = pending_identity_cookie_from_response(conn)
+      pending_identity = Repo.get_by!(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+      assert_received {:email, email}
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+
+      for _ <- 1..Portal.OneTimePasscode.max_attempts() do
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => "wrong",
+          "pending_identity_id" => pending_cookie.pending_identity_id
+        })
+      end
+
+      # Budget exhausted: the passcode and its pending identity are deleted, so even
+      # the correct code is now rejected and no identity is created.
+      conn =
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id
+        })
+
+      assert flash(conn, :error) == "The verification code is invalid or expired."
+
+      refute Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer
+             )
+
+      refute Repo.get_by(Portal.OneTimePasscode, id: pending_identity.one_time_passcode_id)
+      refute Repo.get_by(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
+    end
+
     test "proof email verification requires the signed pending identity cookie", ctx do
       Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
 


### PR DESCRIPTION
Adds an `attempts` column to limit OTP attempts to a set maximum (currently 3) after which the code is deleted.

---

Credit: @5ud0er
Related: https://github.com/firezone/firezone/security/advisories/GHSA-6wm4-2f45-mq3f