### PR TITLE
fix(apple): migrate iOS navigation to NavigationStack

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct ConnectedDevice: Codable, Identifiable, Equatable, Sendable {
+public struct ConnectedDevice: Codable, Identifiable, Hashable, Sendable {
   public let id: String
   public let tunIPv4: String
   public let pools: [String]

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -31,7 +31,7 @@ public enum ResourceList: Sendable {
   }
 }
 
-public struct Resource: Codable, Identifiable, Equatable, Sendable {
+public struct Resource: Codable, Identifiable, Hashable, Sendable {
   public let id: String
   public var name: String
   public var address: String?

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Site: Codable, Identifiable, Equatable, Sendable {
+public struct Site: Codable, Identifiable, Hashable, Sendable {
   public let id: String
   public var name: String
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
@@ -19,9 +19,7 @@
       if !store.connectedDevices.isEmpty {
         Section("Connected Devices (\(store.connectedDevices.count))") {
           ForEach(store.connectedDevices) { device in
-            NavigationLink {
-              ConnectedDeviceView(device: device)
-            } label: {
+            NavigationLink(value: device) {
               Text(device.tunIPv4)
             }
           }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -14,8 +14,16 @@ import SwiftUI
     var resource: Resource
     @Environment(\.openURL) var openURL
 
+    // Resolve the latest version from the store so the detail reflects live
+    // updates; fall back to the pushed value if the resource is no longer listed.
+    private var liveResource: Resource {
+      store.resourceList.asArray().first { $0.id == resource.id } ?? resource
+    }
+
     var body: some View {
-      List {
+      let resource = liveResource
+
+      return List {
         if resource.isInternetResource() {
           InternetResourceHeader(resource: resource)
         } else {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -15,6 +15,19 @@ import SwiftUI
     @EnvironmentObject var store: Store
 
     var body: some View {
+      // Register destinations at a stable level so a pushed detail survives
+      // store updates that mutate the resource/device lists underneath it.
+      content
+        .navigationDestination(for: Resource.self) { resource in
+          ResourceView(resource: resource)
+        }
+        .navigationDestination(for: ConnectedDevice.self) { device in
+          ConnectedDeviceView(device: device)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
       switch store.vpnStatus {
       case .connected:
         if store.configuration.publishedHideResourceList {
@@ -106,9 +119,7 @@ import SwiftUI
     var body: some View {
       ForEach(resources) { resource in
         HStack {
-          NavigationLink {
-            ResourceView(resource: resource)
-          } label: {
+          NavigationLink(value: resource) {
             Text(resourceTitle(resource: resource))
           }
         }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
@@ -24,7 +24,7 @@ import SwiftUI
     }
 
     var body: some View {
-      NavigationView {
+      NavigationStack {
         content
           .navigationBarTitleDisplayMode(.inline)
           .navigationBarItems(leading: authMenu, trailing: settingsButton)
@@ -44,7 +44,6 @@ import SwiftUI
       .sheet(isPresented: $isSettingsPresented) {
         SettingsView(store: store)
       }
-      .navigationViewStyle(StackNavigationViewStyle())
     }
 
     private var settingsButton: some View {


### PR DESCRIPTION
Fixes a regression introduced in #13439 where the ConnectedDevice view could be referenced after the resource list changed, causing a use-after-free bug.

Opening a resource's detail screen and then having the resource list refresh underneath it (often after a long time in the background) could crash the app. The old NavigationView tied the open detail to its list row, so when the row went away the detail was torn down with it, leaving a dangling reference.

NavigationStack keeps the open detail alive on its own, so list refreshes no longer crash it.

---

Related: #13439
Fixes #13753 