### PR TITLE
fix(portal): correct OTP code length in attempts test

### DIFF
--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1459,7 +1459,7 @@ defmodule PortalWeb.OIDCControllerTest do
       pending_cookie = pending_identity_cookie_from_response(conn)
       pending_identity = Repo.get_by!(Portal.PendingIdentity, id: pending_cookie.pending_identity_id)
       assert_received {:email, email}
-      [_, code] = Regex.run(~r/\n\n([a-z0-9]{5})\n/, email.text_body)
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
 
       for _ <- 1..Portal.OneTimePasscode.max_attempts() do
         conn


### PR DESCRIPTION
The passcode attempts test asserts the proof-email code against a five-character regex, but the code is generated with six characters. `Regex.run` returns nil and the assertion raises a MatchError, so the test fails as written.

Related: #13813

🤖 Generated with [Claude Code](https://claude.com/claude-code)