### PR TITLE
feat(snownet): warn on candidate for unknown connection

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -441,7 +441,7 @@ where
         tracing::debug!(?candidate, "Received candidate from remote");
 
         let Ok(c) = self.connections.get_mut(&cid, now) else {
-            tracing::debug!(ignored_candidate = %candidate, "Unknown connection");
+            tracing::warn!(kind = ?candidate.kind(), "Received candidate for unknown connection");
             return;
         };
 


### PR DESCRIPTION
With #13756 ensuring a peer's data plane sets up its connection before ICE candidates are relayed, receiving a candidate for an unknown connection should no longer happen. Surface it as a warning rather than silently dropping it at debug level, so the situation is visible if that ordering invariant is ever violated.