### PR TITLE
feat(headless-client): self-elevate via sudo when unprivileged

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "anyhow-ext",
  "backoff",
  "bin-shared",
+ "caps",
  "clap",
  "client-shared",
  "futures",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+caps = { workspace = true }
 nix = { workspace = true, features = ["fs", "user", "socket"] }
 sd-notify = { workspace = true }
 

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -16,6 +16,10 @@ const ROOT_USER: u32 = 0;
 /// the TUN device or controlling DNS. Only compiled into debug builds; in
 /// production we run as root under `systemd`.
 #[cfg(debug_assertions)]
+#[expect(
+    clippy::print_stderr,
+    reason = "No tracing subscriber is configured this early in startup"
+)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     use anyhow::Context as _;
     use std::os::unix::process::CommandExt as _;
@@ -34,12 +38,15 @@ pub(crate) fn elevate_if_needed() -> Result<()> {
     let exe = std::env::current_exe().context("Failed to find current executable")?;
     let args = std::env::args_os().skip(1).collect::<Vec<_>>();
 
-    tracing::info!("Not running as root, re-executing via `sudo`");
+    // No tracing subscriber is configured this early, so print to stderr directly.
+    eprintln!("Not running as root, re-executing via `sudo` to elevate privileges");
 
     // `-E` preserves the environment (e.g. `FIREZONE_TOKEN`, `RUST_LOG`); `--`
-    // ends `sudo`'s own flags. The guard is set via `.env` so it only affects the
-    // child and we avoid `unsafe` `set_var`. `exec` replaces the current process,
-    // so `sudo`'s prompt uses our terminal and the exit code propagates.
+    // ends `sudo`'s own flags. Setting the guard via `.env` configures only the
+    // child's environment rather than mutating our own process env (`unsafe` in
+    // this edition, and unsound once other threads exist). `exec` replaces the
+    // current process, so `sudo`'s prompt uses our terminal and the exit code
+    // propagates.
     let err = std::process::Command::new("sudo")
         .arg("-E")
         .arg("--")

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -31,16 +31,14 @@ pub(crate) fn elevate_if_needed() -> Result<()> {
 
     // `-E` preserves the environment (e.g. `FIREZONE_TOKEN`, `RUST_LOG`); `--`
     // ends `sudo`'s own flags. Setting the guard via `.env` configures only the
-    // child's environment rather than mutating our own process env (`unsafe` in
-    // this edition, and unsound once other threads exist). `exec` replaces the
-    // current process, so `sudo`'s prompt uses our terminal and the exit code
-    // propagates.
+    // child's environment.
     let err = std::process::Command::new("sudo")
         .arg("-E")
         .arg("--")
         .arg(&exe)
         .args(&args)
         .env(REEXEC_GUARD, "1")
+        // `exec` replaces the current process image via `execve(2)`.
         .exec();
 
     Err(err).context("Failed to re-execute via `sudo`; is it installed?")

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -11,15 +11,7 @@ const ROOT_GROUP: u32 = 0;
 const ROOT_USER: u32 = 0;
 
 /// Re-exec via `sudo` if we are not already root.
-///
-/// Lets `cargo run` prompt for elevation instead of failing later when opening
-/// the TUN device or controlling DNS. Only compiled into debug builds; in
-/// production we run as root under `systemd`.
 #[cfg(debug_assertions)]
-#[expect(
-    clippy::print_stderr,
-    reason = "No tracing subscriber is configured this early in startup"
-)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     use anyhow::Context as _;
     use std::os::unix::process::CommandExt as _;
@@ -38,9 +30,6 @@ pub(crate) fn elevate_if_needed() -> Result<()> {
     let exe = std::env::current_exe().context("Failed to find current executable")?;
     let args = std::env::args_os().skip(1).collect::<Vec<_>>();
 
-    // No tracing subscriber is configured this early, so print to stderr directly.
-    eprintln!("Not running as root, re-executing via `sudo` to elevate privileges");
-
     // `-E` preserves the environment (e.g. `FIREZONE_TOKEN`, `RUST_LOG`); `--`
     // ends `sudo`'s own flags. Setting the guard via `.env` configures only the
     // child's environment rather than mutating our own process env (`unsafe` in
@@ -56,15 +45,6 @@ pub(crate) fn elevate_if_needed() -> Result<()> {
         .exec();
 
     Err(err).context("Failed to re-execute via `sudo`; is it installed?")
-}
-
-#[cfg(not(debug_assertions))]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "A real implementation exists for debug builds"
-)]
-pub(crate) fn elevate_if_needed() -> Result<()> {
-    Ok(())
 }
 
 pub(crate) fn check_token_permissions(path: &Path) -> Result<()> {

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -11,7 +11,6 @@ const ROOT_GROUP: u32 = 0;
 const ROOT_USER: u32 = 0;
 
 /// Re-exec via `sudo` if we are not already root.
-#[cfg(debug_assertions)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     use anyhow::Context as _;
     use std::os::unix::process::CommandExt as _;

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -10,6 +10,56 @@ use std::path::Path;
 const ROOT_GROUP: u32 = 0;
 const ROOT_USER: u32 = 0;
 
+/// Re-exec via `sudo` if we are not already root.
+///
+/// Lets `cargo run` prompt for elevation instead of failing later when opening
+/// the TUN device or controlling DNS. Only compiled into debug builds; in
+/// production we run as root under `systemd`.
+#[cfg(debug_assertions)]
+pub(crate) fn elevate_if_needed() -> Result<()> {
+    use anyhow::Context as _;
+    use std::os::unix::process::CommandExt as _;
+
+    // Set on the re-exec'd child so we can detect and break a re-exec loop if
+    // `sudo` ever returns without actually elevating us.
+    const REEXEC_GUARD: &str = "FIREZONE_REEXEC_ELEVATED";
+
+    if nix::unistd::Uid::effective().is_root() {
+        return Ok(());
+    }
+    if std::env::var_os(REEXEC_GUARD).is_some() {
+        bail!("Re-executed via `sudo` but still not root");
+    }
+
+    let exe = std::env::current_exe().context("Failed to find current executable")?;
+    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+
+    tracing::info!("Not running as root, re-executing via `sudo`");
+
+    // `-E` preserves the environment (e.g. `FIREZONE_TOKEN`, `RUST_LOG`); `--`
+    // ends `sudo`'s own flags. The guard is set via `.env` so it only affects the
+    // child and we avoid `unsafe` `set_var`. `exec` replaces the current process,
+    // so `sudo`'s prompt uses our terminal and the exit code propagates.
+    let err = std::process::Command::new("sudo")
+        .arg("-E")
+        .arg("--")
+        .arg(&exe)
+        .args(&args)
+        .env(REEXEC_GUARD, "1")
+        .exec();
+
+    Err(err).context("Failed to re-execute via `sudo`; is it installed?")
+}
+
+#[cfg(not(debug_assertions))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "A real implementation exists for debug builds"
+)]
+pub(crate) fn elevate_if_needed() -> Result<()> {
+    Ok(())
+}
+
 pub(crate) fn check_token_permissions(path: &Path) -> Result<()> {
     let Ok(stat) = nix::sys::stat::fstatat(AT_FDCWD, path, nix::fcntl::AtFlags::empty()) else {
         // File doesn't exist or can't be read

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -10,20 +10,20 @@ use std::path::Path;
 const ROOT_GROUP: u32 = 0;
 const ROOT_USER: u32 = 0;
 
-/// Re-exec via `sudo` if we are not already root.
+/// Re-exec via `sudo` unless we already have root or `CAP_NET_ADMIN`.
 pub(crate) fn elevate_if_needed() -> Result<()> {
     use anyhow::Context as _;
     use std::os::unix::process::CommandExt as _;
 
     // Set on the re-exec'd child so we can detect and break a re-exec loop if
-    // `sudo` ever returns without actually elevating us.
+    // `sudo` ever returns without granting the permissions we need.
     const REEXEC_GUARD: &str = "FIREZONE_REEXEC_ELEVATED";
 
-    if nix::unistd::Uid::effective().is_root() {
+    if has_necessary_permissions() {
         return Ok(());
     }
     if std::env::var_os(REEXEC_GUARD).is_some() {
-        bail!("Re-executed via `sudo` but still not root");
+        bail!("Re-executed via `sudo` but still lack root / `CAP_NET_ADMIN`");
     }
 
     let exe = std::env::current_exe().context("Failed to find current executable")?;
@@ -42,6 +42,21 @@ pub(crate) fn elevate_if_needed() -> Result<()> {
         .exec();
 
     Err(err).context("Failed to re-execute via `sudo`; is it installed?")
+}
+
+/// `CAP_NET_ADMIN` is enough for the TUN device and routing; only DNS control
+/// requires full root.
+#[must_use]
+fn has_necessary_permissions() -> bool {
+    let is_root = nix::unistd::Uid::effective().is_root();
+    let has_net_admin = caps::has_cap(
+        None,
+        caps::CapSet::Effective,
+        caps::Capability::CAP_NET_ADMIN,
+    )
+    .is_ok_and(|b| b);
+
+    is_root || has_net_admin
 }
 
 pub(crate) fn check_token_permissions(path: &Path) -> Result<()> {

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use std::path::Path;
 
 // Re-exec via `sudo` is only implemented on Linux for now.
-#[cfg(debug_assertions)]
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     Ok(())

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::path::Path;
 
 // Re-exec via `sudo` is only implemented on Linux for now.
+#[cfg(debug_assertions)]
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     Ok(())

--- a/rust/headless-client/src/macos.rs
+++ b/rust/headless-client/src/macos.rs
@@ -1,6 +1,12 @@
 use anyhow::Result;
 use std::path::Path;
 
+// Re-exec via `sudo` is only implemented on Linux for now.
+#[expect(clippy::unnecessary_wraps)]
+pub(crate) fn elevate_if_needed() -> Result<()> {
+    Ok(())
+}
+
 // The return value is useful on Linux
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -209,13 +209,14 @@ fn main() {
 }
 
 fn try_main() -> Result<()> {
+    let cli = Cli::parse();
+
+    #[cfg(debug_assertions)]
+    platform::elevate_if_needed()?;
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .map_err(|_| anyhow!("Failed to install default crypto provider"))?;
-
-    let cli = Cli::parse();
-
-    platform::elevate_if_needed()?;
 
     match &cli._command {
         Some(Cmd::SignIn {

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -215,6 +215,8 @@ fn try_main() -> Result<()> {
 
     let cli = Cli::parse();
 
+    platform::elevate_if_needed()?;
+
     match &cli._command {
         Some(Cmd::SignIn {
             auth_base_url,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -211,7 +211,6 @@ fn main() {
 fn try_main() -> Result<()> {
     let cli = Cli::parse();
 
-    #[cfg(debug_assertions)]
     platform::elevate_if_needed()?;
 
     rustls::crypto::ring::default_provider()

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -7,6 +7,12 @@
 use anyhow::{Context as _, Result};
 use std::path::Path;
 
+// Re-exec via `sudo` is only implemented on Linux for now.
+#[expect(clippy::unnecessary_wraps)]
+pub(crate) fn elevate_if_needed() -> Result<()> {
+    Ok(())
+}
+
 // The return value is useful on Linux
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -8,6 +8,7 @@ use anyhow::{Context as _, Result};
 use std::path::Path;
 
 // Re-exec via `sudo` is only implemented on Linux for now.
+#[cfg(debug_assertions)]
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     Ok(())

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -8,7 +8,6 @@ use anyhow::{Context as _, Result};
 use std::path::Path;
 
 // Re-exec via `sudo` is only implemented on Linux for now.
-#[cfg(debug_assertions)]
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn elevate_if_needed() -> Result<()> {
     Ok(())


### PR DESCRIPTION
The headless client needs `CAP_NET_ADMIN` for the TUN device and routing (and root for DNS control), so running it without either — e.g. a plain `cargo run -p firezone-headless-client` — fails with an opaque permission error.

When it has neither root nor `CAP_NET_ADMIN`, it now re-execs itself via `sudo`, preserving the environment, to prompt for elevation up front. Setups that already grant `CAP_NET_ADMIN` (e.g. via `setcap`) or run as root are left untouched. Linux-only; macOS and Windows are no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)