### PR TITLE
feat(telemetry): loop-free, self-healing Sentry transport

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7514,7 +7514,6 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "rand 0.10.1",
- "reqwest",
  "rustls",
  "sentry",
  "serde",

--- a/rust/libs/telemetry/Cargo.toml
+++ b/rust/libs/telemetry/Cargo.toml
@@ -17,7 +17,6 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 rand = { workspace = true }
-reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls-no-provider", "tracing", "logs", "metrics"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/libs/telemetry/src/analytics.rs
+++ b/rust/libs/telemetry/src/analytics.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, bail};
 use serde::Serialize;
 
-use crate::{ApiUrl, Env, Telemetry, posthog};
+use crate::{ApiUrl, Env, Telemetry, ingest, posthog};
 
 /// Records a `new_session` event for a particular user and API url.
 ///
@@ -9,7 +9,7 @@ use crate::{ApiUrl, Env, Telemetry, posthog};
 pub fn new_session(maybe_legacy_id: String, api_url: String) {
     let distinct_id = crate::maybe_hash_device_id(maybe_legacy_id);
 
-    posthog::RUNTIME.spawn(async move {
+    ingest::RUNTIME.spawn(async move {
         if let Err(e) = capture(
             "new_session",
             distinct_id,
@@ -36,7 +36,7 @@ pub fn identify(release: String, account_slug: Option<String>) {
         return;
     };
 
-    posthog::RUNTIME.spawn({
+    ingest::RUNTIME.spawn({
         async move {
             if let Err(e) = capture(
                 "$identify",
@@ -69,7 +69,7 @@ pub fn feature_flag_called(name: impl Into<String>) {
     };
     let feature_flag = name.into();
 
-    posthog::RUNTIME.spawn({
+    ingest::RUNTIME.spawn({
         async move {
             if let Err(e) = capture(
                 "$feature_flag_called",

--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Metadata, level_filters::LevelFilter};
 use tracing_subscriber::filter::Targets;
 
-use crate::{Env, posthog};
+use crate::{Env, ingest, posthog};
 
 pub(crate) const RE_EVAL_DURATION: Duration = Duration::from_secs(5 * 60);
 
@@ -140,7 +140,7 @@ pub(crate) fn reevaluate(user_id: String, env: &str) {
         return;
     };
 
-    posthog::RUNTIME.spawn(evaluate_now(user_id, env));
+    ingest::RUNTIME.spawn(evaluate_now(user_id, env));
 }
 
 /// Re-evaluates feature flags using the current telemetry user and environment.

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -1,0 +1,208 @@
+use std::{
+    net::{IpAddr, ToSocketAddrs as _},
+    sync::{Arc, LazyLock},
+};
+
+use anyhow::{Context as _, ErrorExt as _, Result};
+use bootstrap_dns_client::BootstrapDnsClient;
+use bytes::Bytes;
+use http::{Request, Response};
+use http_client::HttpClient;
+use parking_lot::Mutex;
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
+use tokio::runtime::Runtime;
+
+type SocketFactories = (
+    Arc<dyn SocketFactory<TcpSocket>>,
+    Arc<dyn SocketFactory<UdpSocket>>,
+);
+
+/// Runtime hosting all ingest connections and the feature-flag re-eval timer.
+pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
+
+/// Socket factories and upstream resolvers shared by all ingest hosts.
+///
+/// connlib processes configure tunnel-bypassing factories so telemetry never
+/// loops back through connlib; the resolvers are the system's upstream DNS
+/// servers (never the system resolver itself, which may be connlib).
+static SOCKETS: LazyLock<Mutex<Option<SocketFactories>>> = LazyLock::new(|| Mutex::new(None));
+static SERVERS: LazyLock<Mutex<Vec<IpAddr>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Configures the socket factories used to reach all ingest hosts.
+pub(crate) fn configure(
+    tcp: Arc<dyn SocketFactory<TcpSocket>>,
+    udp: Arc<dyn SocketFactory<UdpSocket>>,
+) {
+    *SOCKETS.lock() = Some((tcp, udp));
+}
+
+/// Updates the upstream resolvers used to look up all ingest hosts.
+pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
+    *SERVERS.lock() = servers;
+}
+
+/// Resets the shared socket factories so the next connection rebinds.
+pub(crate) fn reset_sockets() {
+    let sockets = SOCKETS.lock().clone();
+    if let Some((tcp, udp)) = sockets {
+        tcp.reset();
+        udp.reset();
+    }
+}
+
+/// A self-healing HTTP/2 client for a single ingest host.
+///
+/// The host is resolved via [`BootstrapDnsClient`] against the configured
+/// upstreams and connected through the shared, tunnel-bypassing socket factories,
+/// falling back to addresses seeded from the system resolver at startup. The
+/// connection is re-established on demand when it is closed.
+pub(crate) struct Client {
+    host: &'static str,
+    seed_addresses: Mutex<Vec<IpAddr>>,
+    connection: Mutex<Option<HttpClient>>,
+    /// Serialises bootstrapping so concurrent senders share a single connection.
+    bootstrap: tokio::sync::Mutex<()>,
+}
+
+impl Client {
+    pub(crate) fn new(host: &'static str) -> Self {
+        Self {
+            host,
+            seed_addresses: Mutex::new(Vec::new()),
+            connection: Mutex::new(None),
+            bootstrap: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// Seeds the host addresses using the system resolver.
+    ///
+    /// Must run at startup, before connlib reconfigures the system resolver, so the
+    /// lookup reaches the real upstream and not connlib itself. Used as a fallback
+    /// until the bootstrap resolver has upstreams configured.
+    pub(crate) fn init_addresses(&self) {
+        let addresses = (self.host, 443u16)
+            .to_socket_addrs()
+            .inspect_err(|e| {
+                tracing::debug!(host = %self.host, "Failed to seed ingest host addresses: {e:#}")
+            })
+            .map(|addresses| addresses.map(|addr| addr.ip()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        tracing::debug!(host = %self.host, ?addresses, "Seeded ingest host addresses from system resolver");
+
+        *self.seed_addresses.lock() = addresses;
+    }
+
+    /// Drops the current connection so the next request reconnects.
+    pub(crate) fn reset(&self) {
+        *self.connection.lock() = None;
+    }
+
+    /// Sends an HTTP request over a (re-)established connection to the host.
+    pub(crate) async fn send_request(&self, request: Request<Bytes>) -> Result<Response<Bytes>> {
+        let connection = self.connection().await?;
+
+        let response = match connection.send_request(request) {
+            Ok(response) => response.await,
+            Err(e) => Err(e),
+        };
+
+        // A closed connection means the path is broken; discard it so the next
+        // request re-resolves and reconnects.
+        if response
+            .as_ref()
+            .is_err_and(|e| e.any_is::<http_client::Closed>())
+        {
+            *self.connection.lock() = None;
+        }
+
+        response
+    }
+
+    async fn connection(&self) -> Result<HttpClient> {
+        if let Some(connection) = self.live_connection() {
+            return Ok(connection);
+        }
+
+        let _guard = self.bootstrap.lock().await;
+
+        if let Some(connection) = self.live_connection() {
+            return Ok(connection);
+        }
+
+        let connection = self.bootstrap().await?;
+        *self.connection.lock() = Some(connection.clone());
+
+        Ok(connection)
+    }
+
+    fn live_connection(&self) -> Option<HttpClient> {
+        self.connection
+            .lock()
+            .as_ref()
+            .filter(|connection| !connection.is_closed())
+            .cloned()
+    }
+
+    async fn bootstrap(&self) -> Result<HttpClient> {
+        let host = self.host;
+        let (tcp, udp) = SOCKETS
+            .lock()
+            .clone()
+            .context("Ingest client has no socket factories configured")?;
+        let servers = SERVERS.lock().clone();
+        let seed_addresses = self.seed_addresses.lock().clone();
+
+        // Anchor the connection task on our own runtime so it outlives the caller,
+        // which may be a short-lived `block_on` on another runtime.
+        RUNTIME
+            .spawn(async move {
+                // Resolve via the bootstrap resolver, which never uses the system
+                // resolver (i.e. connlib), and add the addresses seeded at startup as
+                // extra fallback candidates. `HttpClient` tries them in order and
+                // connects to the first that works.
+                //
+                // Skip the resolver while we have no upstreams yet (e.g. before
+                // connlib reports the system DNS servers); the seed covers that.
+                let mut addresses = if servers.is_empty() {
+                    Vec::new()
+                } else {
+                    BootstrapDnsClient::new(udp, tcp.clone(), servers)
+                        .resolve(host)
+                        .await
+                        .inspect_err(
+                            |e| tracing::debug!(%host, "Failed to resolve ingest host: {e:#}"),
+                        )
+                        .unwrap_or_default()
+                };
+
+                for address in seed_addresses {
+                    if !addresses.contains(&address) {
+                        addresses.push(address);
+                    }
+                }
+
+                anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
+
+                HttpClient::new(host.to_owned(), addresses, tcp)
+                    .await
+                    .context("Failed to connect to ingest host")
+            })
+            .await
+            .context("Bootstrap task failed")?
+    }
+}
+
+fn init_runtime() -> Runtime {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1) // We only need 1 worker thread.
+        .thread_name("ingest-worker")
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("to be able to build runtime");
+
+    runtime.spawn(crate::feature_flags::reeval_timer());
+
+    runtime
+}

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,12 +1,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    fmt, mem,
-    net::{IpAddr, SocketAddr, ToSocketAddrs as _},
-    str::FromStr,
-    sync::Arc,
+    borrow::Cow, collections::BTreeMap, fmt, mem, net::IpAddr, str::FromStr, sync::Arc,
     time::Duration,
 };
 
@@ -15,7 +10,6 @@ use api_url::ApiUrl;
 use sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, Metric},
-    transports::ReqwestHttpTransport,
 };
 use sha2::Digest as _;
 use smallvec::SmallVec;
@@ -26,9 +20,11 @@ pub mod feature_flags;
 pub mod otel;
 
 mod api_url;
+mod ingest;
 mod noop_push_metrics_exporter;
 mod posthog;
 mod sentry_instrument_provider;
+mod sentry_transport;
 
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
 pub use sentry_instrument_provider::SentryMeterProvider;
@@ -53,16 +49,18 @@ pub fn maybe_hash_device_id(id: String) -> String {
 /// feature-flag re-evaluation, since a prior attempt may have failed for lack of
 /// (working) resolvers.
 pub fn update_system_resolvers(servers: Vec<IpAddr>) {
-    posthog::update_system_resolvers(servers);
+    ingest::update_system_resolvers(servers);
     feature_flags::reevaluate_current();
 }
 
-/// Drops the current telemetry ingest connection so it is re-established lazily.
+/// Drops the current telemetry ingest connections so they are re-established lazily.
 ///
 /// Call this on network changes, alongside resetting connlib. Triggers a
 /// feature-flag re-evaluation so flags are refreshed over the new connection.
 pub fn reset_ingest() {
+    ingest::reset_sockets();
     posthog::reset();
+    sentry_transport::reset();
     feature_flags::reevaluate_current();
 }
 
@@ -76,7 +74,7 @@ pub struct Dsn {
 // > DSNs are safe to keep public because they only allow submission of new events and related event data; they do not allow read access to any information.
 // <https://docs.sentry.io/concepts/key-terms/dsn-explainer/#dsn-utilization>
 
-const INGEST_HOST: &str = "sentry.firezone.dev";
+pub(crate) const INGEST_HOST: &str = "sentry.firezone.dev";
 
 pub const ANDROID_DSN: Dsn = Dsn {
     public_key: "928a6ee1f6af9734100b8bc89b2dc87d",
@@ -186,7 +184,6 @@ impl fmt::Display for Env {
 
 pub struct Telemetry {
     inner: Option<sentry::ClientInitGuard>,
-    transport: TransportFactory,
 }
 
 impl Telemetry {
@@ -194,29 +191,20 @@ impl Telemetry {
         tcp: Arc<dyn SocketFactory<TcpSocket>>,
         udp: Arc<dyn SocketFactory<UdpSocket>>,
     ) -> Self {
-        // Configure and seed the PostHog ingest client. Resolving here, at telemetry
-        // construction, ensures the lookup happens before connlib reconfigures the
-        // system resolver (which would otherwise route it through connlib itself),
-        // mirroring how the Sentry transport resolves its host below. The socket
+        // Configure the shared ingest socket factories and seed each ingest host's
+        // addresses via the system resolver. Seeding here, at telemetry construction,
+        // ensures the lookup happens before connlib reconfigures the system resolver
+        // (which would otherwise route it through connlib itself). The socket
         // factories must bypass the tunnel so telemetry never loops through connlib.
-        posthog::configure(tcp, udp);
+        ingest::configure(tcp, udp);
         posthog::init_addresses();
+        sentry_transport::init_addresses();
 
-        Self {
-            inner: Default::default(),
-            transport: TransportFactory::resolve_ingest_host().unwrap_or_else(|e| {
-                tracing::debug!("Failed to create telemetry transport factory: {e:#}");
-
-                TransportFactory::without_addresses()
-            }),
-        }
+        Self { inner: None }
     }
 
     pub fn disabled() -> Self {
-        Self {
-            inner: None,
-            transport: TransportFactory::without_addresses(),
-        }
+        Self { inner: None }
     }
 
     /// Starts a Sentry session.
@@ -286,7 +274,7 @@ impl Telemetry {
         let inner = sentry::init((
             dsn.to_string(),
             sentry::ClientOptions {
-                transport: Some(Arc::new(self.transport.clone())),
+                transport: Some(Arc::new(sentry_transport::Factory)),
                 ..client_options
             },
         ));
@@ -538,52 +526,6 @@ fn update_user(update: impl FnOnce(&mut sentry::User)) {
 
 fn set_current_user(user: Option<sentry::User>) {
     sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
-}
-
-#[derive(Debug, Clone)]
-pub struct TransportFactory {
-    ingest_domain_addresses: Vec<SocketAddr>,
-}
-
-impl TransportFactory {
-    pub fn resolve_ingest_host() -> Result<Self> {
-        let resolved_addresses = (INGEST_HOST, 443u16)
-            .to_socket_addrs()
-            .with_context(|| format!("Failed to resolve {INGEST_HOST}"))?
-            .collect();
-
-        tracing::debug!(host = %INGEST_HOST, addresses = ?resolved_addresses, "Resolved ingest host IPs");
-
-        Ok(Self {
-            ingest_domain_addresses: resolved_addresses,
-        })
-    }
-
-    fn without_addresses() -> Self {
-        Self {
-            ingest_domain_addresses: Default::default(),
-        }
-    }
-}
-
-impl sentry::TransportFactory for TransportFactory {
-    fn create_transport(&self, options: &sentry::ClientOptions) -> Arc<dyn sentry::Transport> {
-        let mut builder = reqwest::ClientBuilder::new()
-            .http2_prior_knowledge()
-            .http2_keep_alive_while_idle(true)
-            .http2_keep_alive_timeout(Duration::from_secs(1))
-            .http2_keep_alive_interval(Duration::from_secs(5)); // Ensure we detect broken connections, i.e. when enabling / disabling the Internet Resource.
-
-        if !self.ingest_domain_addresses.is_empty() {
-            builder = builder.resolve_to_addrs(INGEST_HOST, &self.ingest_domain_addresses);
-        } else {
-            tracing::debug!(host = %INGEST_HOST, "No addresses were pre-resolved for ingest host");
-        }
-
-        let client = builder.build().expect("Failed to build HTTP client");
-
-        Arc::new(ReqwestHttpTransport::with_client(options, client))
-    }
 }
 
 #[cfg(test)]

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -1,19 +1,11 @@
-use std::{
-    net::{IpAddr, ToSocketAddrs as _},
-    sync::{Arc, LazyLock},
-};
+use std::sync::LazyLock;
 
-use anyhow::{Context as _, ErrorExt as _, Result};
-use bootstrap_dns_client::BootstrapDnsClient;
+use anyhow::{Context as _, Result};
 use bytes::Bytes;
 use http::{Method, Request, Response, header};
-use http_client::HttpClient;
-use parking_lot::Mutex;
 use serde::Serialize;
-use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
-use tokio::runtime::Runtime;
 
-use crate::Env;
+use crate::{Env, ingest};
 
 pub(crate) const API_KEY_PROD: &str = "phc_uXXl56plyvIBHj81WwXBLtdPElIRbm7keRTdUCmk8ll";
 pub(crate) const API_KEY_STAGING: &str = "phc_tHOVtq183RpfKmzadJb4bxNpLM5jzeeb1Gu8YSH3nsK";
@@ -21,10 +13,7 @@ pub(crate) const API_KEY_ON_PREM: &str = "phc_4R9Ii6q4SEofVkH7LvajwuJ3nsGFhCj0Zl
 
 const INGEST_HOST: &str = "posthog.firezone.dev";
 
-pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
-
-/// Process-wide HTTP client for PostHog's ingest host.
-static INGEST: LazyLock<Ingest> = LazyLock::new(Ingest::default);
+static CLIENT: LazyLock<ingest::Client> = LazyLock::new(|| ingest::Client::new(INGEST_HOST));
 
 pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     match env {
@@ -35,61 +24,21 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     }
 }
 
-/// Configures the socket factories used to reach the ingest host.
-///
-/// In connlib processes these must bypass the tunnel so that telemetry traffic
-/// never loops back through connlib; other processes pass plain socket factories.
-pub(crate) fn configure(
-    tcp: Arc<dyn SocketFactory<TcpSocket>>,
-    udp: Arc<dyn SocketFactory<UdpSocket>>,
-) {
-    *INGEST.sockets.lock() = Some((tcp, udp));
-}
-
-/// Updates the upstream resolvers used to look up the ingest host.
-pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
-    *INGEST.servers.lock() = servers;
-}
-
-/// Seeds the ingest-host addresses using the system resolver.
-///
-/// Resolves the ingest host via the operating system and keeps the result as a
-/// fallback for when the bootstrap resolver has no servers or cannot resolve the
-/// host. Must run at startup, before connlib reconfigures the system resolver, so
-/// the lookup reaches the real upstream and not connlib itself.
+/// Seeds the PostHog ingest-host addresses via the system resolver.
 pub(crate) fn init_addresses() {
-    let addresses = (INGEST_HOST, 443u16)
-        .to_socket_addrs()
-        .inspect_err(|e| tracing::debug!("Failed to seed ingest host addresses: {e:#}"))
-        .map(|addresses| addresses.map(|addr| addr.ip()).collect::<Vec<_>>())
-        .unwrap_or_default();
-
-    tracing::debug!(
-        ?addresses,
-        "Seeded ingest host addresses from system resolver"
-    );
-
-    *INGEST.seed_addresses.lock() = addresses;
+    CLIENT.init_addresses();
 }
 
-/// Drops the current connection so the next request re-resolves and reconnects.
+/// Drops the current connection so the next request reconnects.
 pub(crate) fn reset() {
-    let sockets = INGEST.sockets.lock().clone();
-    if let Some((tcp, udp)) = sockets {
-        tcp.reset();
-        udp.reset();
-    }
-
-    *INGEST.client.lock() = None;
+    CLIENT.reset();
 }
 
-/// Sends a JSON `POST` to `path` on the ingest host and returns the response.
+/// Sends a JSON `POST` to `path` on the PostHog ingest host and returns the response.
 pub(crate) async fn post_json<B>(path: &str, body: &B) -> Result<Response<Bytes>>
 where
     B: Serialize,
 {
-    let client = ingest_client().await?;
-
     let request = Request::builder()
         .method(Method::POST)
         .uri(format!("https://{INGEST_HOST}{path}"))
@@ -99,134 +48,5 @@ where
         ))
         .context("Failed to build HTTP request")?;
 
-    let response = match client.send_request(request) {
-        Ok(response) => response.await,
-        Err(e) => Err(e),
-    };
-
-    // A closed connection means the path is broken; discard the client so the
-    // next request re-resolves and reconnects.
-    if response
-        .as_ref()
-        .is_err_and(|e| e.any_is::<http_client::Closed>())
-    {
-        *INGEST.client.lock() = None;
-    }
-
-    response
-}
-
-/// Holds the state needed to (re-)establish a connection to the ingest host.
-///
-/// The connection is resolved via [`BootstrapDnsClient`] against the configured
-/// upstream resolvers and established through a tunnel-bypassing [`SocketFactory`].
-/// Resolving lazily on every (re-)connect — rather than once at startup — lets us
-/// recover from having no resolvers yet and from the network path breaking. When
-/// the bootstrap resolver yields nothing, we fall back to `seed_addresses`.
-#[derive(Default)]
-struct Ingest {
-    sockets: Mutex<
-        Option<(
-            Arc<dyn SocketFactory<TcpSocket>>,
-            Arc<dyn SocketFactory<UdpSocket>>,
-        )>,
-    >,
-    servers: Mutex<Vec<IpAddr>>,
-    /// Addresses resolved via the system resolver at startup, before connlib took
-    /// over DNS. Used as a fallback when the bootstrap resolver yields nothing.
-    seed_addresses: Mutex<Vec<IpAddr>>,
-    client: Mutex<Option<HttpClient>>,
-    /// Serialises bootstrapping so concurrent senders share a single connection.
-    bootstrap: tokio::sync::Mutex<()>,
-}
-
-/// Returns a live client, bootstrapping a new connection if there is none.
-async fn ingest_client() -> Result<HttpClient> {
-    if let Some(client) = live_client() {
-        return Ok(client);
-    }
-
-    let _guard = INGEST.bootstrap.lock().await;
-
-    if let Some(client) = live_client() {
-        return Ok(client);
-    }
-
-    let client = bootstrap().await?;
-    *INGEST.client.lock() = Some(client.clone());
-
-    Ok(client)
-}
-
-fn live_client() -> Option<HttpClient> {
-    INGEST
-        .client
-        .lock()
-        .as_ref()
-        .filter(|client| !client.is_closed())
-        .cloned()
-}
-
-async fn bootstrap() -> Result<HttpClient> {
-    let (tcp, udp) = INGEST
-        .sockets
-        .lock()
-        .clone()
-        .context("Ingest client has no socket factories configured")?;
-    let servers = INGEST.servers.lock().clone();
-    let seed_addresses = INGEST.seed_addresses.lock().clone();
-
-    // Anchor the connection task on our own runtime so it outlives the caller,
-    // which may be a short-lived `block_on` on another runtime.
-    RUNTIME
-        .spawn(async move {
-            // Resolve via the bootstrap resolver, which never uses the system
-            // resolver (i.e. connlib), and add the addresses seeded at startup as
-            // extra fallback candidates. `HttpClient` tries them in order and
-            // connects to the first that works, so freshly resolved addresses are
-            // preferred while the seed still lets us connect before any resolvers
-            // are configured or when the resolver returns unreachable addresses.
-            //
-            // Skip the resolver while we have no upstreams yet (e.g. before connlib
-            // reports the system DNS servers); it would only fail and the seed
-            // already covers that case.
-            let mut addresses = if servers.is_empty() {
-                Vec::new()
-            } else {
-                BootstrapDnsClient::new(udp, tcp.clone(), servers)
-                    .resolve(INGEST_HOST)
-                    .await
-                    .inspect_err(|e| tracing::debug!("Failed to resolve ingest host: {e:#}"))
-                    .unwrap_or_default()
-            };
-
-            for address in seed_addresses {
-                if !addresses.contains(&address) {
-                    addresses.push(address);
-                }
-            }
-
-            anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host");
-
-            HttpClient::new(INGEST_HOST.to_owned(), addresses, tcp)
-                .await
-                .context("Failed to connect to ingest host")
-        })
-        .await
-        .context("Bootstrap task failed")?
-}
-
-/// Initialize the runtime to use for evaluating feature flags.
-fn init_runtime() -> Runtime {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1) // We only need 1 worker thread.
-        .thread_name("posthog-worker")
-        .enable_io()
-        .enable_time()
-        .build()
-        .expect("to be able to build runtime");
-
-    runtime.spawn(crate::feature_flags::reeval_timer());
-
-    runtime
+    CLIENT.send_request(request).await
 }

--- a/rust/libs/telemetry/src/sentry_transport.rs
+++ b/rust/libs/telemetry/src/sentry_transport.rs
@@ -55,7 +55,7 @@ impl SentryTransport {
 
         let thread = TokioTransportThread::new(move |envelope, mut rate_limiter| {
             // The request is built outside the async block so that `url` and `auth`
-            // can be borrowed from the re-used closure.
+            // can be borrowed from the reused closure.
             let request = build_request(&url, &auth, &envelope);
 
             async move {

--- a/rust/libs/telemetry/src/sentry_transport.rs
+++ b/rust/libs/telemetry/src/sentry_transport.rs
@@ -1,0 +1,121 @@
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http::{Method, Request, Response, StatusCode, header};
+use sentry::{
+    ClientOptions, Envelope, Transport,
+    transports::{RateLimiter, TokioTransportThread},
+};
+
+use crate::{INGEST_HOST, ingest};
+
+static CLIENT: LazyLock<ingest::Client> = LazyLock::new(|| ingest::Client::new(INGEST_HOST));
+
+/// Seeds the Sentry ingest-host addresses via the system resolver.
+pub(crate) fn init_addresses() {
+    CLIENT.init_addresses();
+}
+
+/// Drops the current connection so the next request reconnects.
+pub(crate) fn reset() {
+    CLIENT.reset();
+}
+
+/// Creates [`SentryTransport`]s for the Sentry SDK.
+#[derive(Clone)]
+pub(crate) struct Factory;
+
+impl sentry::TransportFactory for Factory {
+    fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
+        Arc::new(SentryTransport::new(options))
+    }
+}
+
+/// A Sentry [`Transport`] that sends envelopes through our [`ingest::Client`].
+///
+/// Sending and rate-limiting are driven by sentry's own [`TokioTransportThread`],
+/// so the queueing, back-pressure and rate-limit handling are identical to the
+/// reqwest-based transport; only the HTTP send is swapped for our loop-free,
+/// self-healing [`ingest::Client`].
+struct SentryTransport {
+    thread: TokioTransportThread,
+}
+
+impl SentryTransport {
+    fn new(options: &ClientOptions) -> Self {
+        let dsn = options
+            .dsn
+            .as_ref()
+            .expect("Sentry DSN to be set when starting telemetry");
+        let auth = dsn.to_auth(Some(&options.user_agent)).to_string();
+        let url = dsn.envelope_api_url().to_string();
+
+        let thread = TokioTransportThread::new(move |envelope, mut rate_limiter| {
+            // The request is built outside the async block so that `url` and `auth`
+            // can be borrowed from the re-used closure.
+            let request = build_request(&url, &auth, &envelope);
+
+            async move {
+                match request {
+                    Ok(request) => match CLIENT.send_request(request).await {
+                        Ok(response) => update_rate_limits(&mut rate_limiter, &response),
+                        Err(e) => tracing::debug!("Failed to send envelope to Sentry: {e:#}"),
+                    },
+                    Err(e) => tracing::debug!("Failed to build Sentry request: {e:#}"),
+                }
+
+                rate_limiter
+            }
+        });
+
+        Self { thread }
+    }
+}
+
+impl Transport for SentryTransport {
+    fn send_envelope(&self, envelope: Envelope) {
+        self.thread.send(envelope);
+    }
+
+    fn flush(&self, timeout: Duration) -> bool {
+        self.thread.flush(timeout)
+    }
+
+    fn shutdown(&self, timeout: Duration) -> bool {
+        self.flush(timeout)
+    }
+}
+
+fn build_request(url: &str, auth: &str, envelope: &Envelope) -> anyhow::Result<Request<Bytes>> {
+    let mut body = Vec::new();
+    envelope.to_writer(&mut body)?;
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(url)
+        .header("X-Sentry-Auth", auth)
+        .body(Bytes::from(body))?;
+
+    Ok(request)
+}
+
+fn update_rate_limits(rate_limiter: &mut RateLimiter, response: &Response<Bytes>) {
+    let headers = response.headers();
+
+    if let Some(value) = headers
+        .get("x-sentry-rate-limits")
+        .and_then(|value| value.to_str().ok())
+    {
+        rate_limiter.update_from_sentry_header(value);
+    } else if let Some(value) = headers
+        .get(header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+    {
+        rate_limiter.update_from_retry_after(value);
+    } else if response.status() == StatusCode::TOO_MANY_REQUESTS {
+        rate_limiter.update_from_429();
+    }
+}


### PR DESCRIPTION
Applies the same loop-free, self-healing ingest mechanism from #13808 to the Sentry transport: `sentry.firezone.dev` is resolved via the bootstrap DNS client and reached through the tunnel-bypassing socket factories (with a system-resolver seed), so Sentry traffic never depends on the system resolver (which may be connlib itself) and recovers from missing DNS and broken network paths — instead of a startup-pinned `reqwest` client.

Rate-limiting, queueing and back-pressure are preserved by reusing sentry's own `TokioTransportThread` and `RateLimiter`; only the HTTP send is swapped for our ingest client. The ingest client is generalised to be per-host and shared by both PostHog and Sentry.

Stacked on #13808 (base branch `claude/festive-goodall-xrrfnj`); review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Vkq32L5R5aN4DhTUfeGfE)_