### PR TITLE
fix(apple): detect installed vpn configuration

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -65,7 +65,7 @@ public final class Store: ObservableObject {
   // running pass loops until the latest target is durable.
   private var syncInFlight = false
   private var syncPending = false
-  private var vpnConfigurationManager: VPNConfigurationManager?
+  @Published private(set) var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
   private let tunnelManagerFactory: TunnelProviderManagerFactory
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -97,7 +97,7 @@ public struct AppView: View {
       switch (store.vpnStatus, store.decision) {
       case (nil, _), (_, nil):
         ProgressView()
-      case (.invalid, _):
+      case (.invalid, _) where store.vpnConfigurationManager == nil:
         GrantVPNView()
       case (_, .notDetermined):
         GrantNotificationsView()
@@ -117,7 +117,9 @@ public struct AppView: View {
           ProgressView()
           Text("Getting things ready... this should only take a few seconds.")
         }
-      case (.needsInstall, _), (_, .invalid):
+      case (.needsInstall, _):
+        GrantVPNView()
+      case (_, .invalid) where store.vpnConfigurationManager == nil:
         GrantVPNView()
       default:
         FirstTimeView()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantNotificationsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantNotificationsView.swift
@@ -52,6 +52,8 @@ struct GrantNotificationsView: View {
 
   func grantNotifications() {
     Task {
+      errorHandler.clear()
+
       do {
         try await store.grantNotifications()
       } catch {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -186,6 +186,8 @@ struct GrantVPNView: View {
   #if os(iOS)
     func installVPNConfiguration() {
       Task {
+        errorHandler.clear()
+
         do {
           try await store.installVPNConfiguration()
         } catch {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBarView.swift
@@ -54,10 +54,14 @@
         Text("Loading VPN configurations from system settings…")
           .foregroundStyle(.secondary)
 
-      case .invalid:
+      case .invalid where store.vpnConfigurationManager == nil:
         Button("Allow the VPN permission to sign in…") {
           grantPermission()
         }
+
+      case .invalid:
+        Text("Loading VPN configurations from system settings…")
+          .foregroundStyle(.secondary)
 
       case .disconnected:
         Button("Sign In") {


### PR DESCRIPTION
- Fixes a minor regression introduced in #13282 where the VPN configuration might not be detected after first install requiring the user to install/grant again (which is idempotent).
- Fixes an issue where any previous errors in the errorHandler were shown after successfully completing vpn configuration installation and notification permission.

---

Fixes #13777 