### PR TITLE
refactor(portal): gate iceless behind account feature flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,9 @@ services:
       # otherwise seeds will generate invalid tokens
       MIX_ENV: "prod"
       POOL_MEMBER_FIREZONE_ID: *pool-member-firezone-id
+      # Toggles the account-wide ICE-less feature flag in `mix ecto.seed`, so
+      # integration tests can run with or without ICE-less. Defaults to off.
+      FEATURE_ICELESS_ENABLED: ${FEATURE_ICELESS_ENABLED:-false}
     depends_on:
       postgres:
         condition: "service_healthy"

--- a/elixir/lib/portal/account.ex
+++ b/elixir/lib/portal/account.ex
@@ -127,11 +127,20 @@ defmodule Portal.Account do
   def locked?(%__MODULE__{}), do: true
 
   # sobelow_skip ["DOS.BinToAtom"]
-  for feature <- Portal.Accounts.Features.__schema__(:fields) do
+  for feature <- Portal.Accounts.Features.__schema__(:fields), feature != :iceless do
     def unquote(:"#{feature}_enabled?")(account) do
       Config.global_feature_enabled?(unquote(feature)) and
         account_feature_enabled?(account, unquote(feature))
     end
+  end
+
+  # Unlike the other features, ICE-less is gated per-account only and has no
+  # global `enabled_features` flag, so it can be rolled out to individual
+  # accounts without a release. Keeping the toggle in the portal (rather than a
+  # device-local flag) makes it the single source of truth, so client and
+  # gateway can never disagree on whether to use it.
+  def iceless_enabled?(account) do
+    account_feature_enabled?(account, :iceless)
   end
 
   defp account_feature_enabled?(account, feature) do

--- a/elixir/lib/portal/accounts/features.ex
+++ b/elixir/lib/portal/accounts/features.ex
@@ -10,6 +10,7 @@ defmodule Portal.Accounts.Features do
     field :rest_api, :boolean
     field :internet_resource, :boolean
     field :client_to_client, :boolean
+    field :iceless, :boolean
   end
 
   def changeset(features \\ %__MODULE__{}, attrs) do
@@ -20,6 +21,7 @@ defmodule Portal.Accounts.Features do
       rest_api
       internet_resource
       client_to_client
+      iceless
     ]a
 
     features

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -431,7 +431,7 @@ defmodule PortalAPI.Client.Channel do
 
     use_iceless =
       socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
-        Database.iceless_enabled?(socket.assigns.client.account_id)
+        Portal.Account.iceless_enabled?(socket.assigns.subject.account)
 
     payload = Map.put(payload, :use_iceless, use_iceless)
 
@@ -1383,7 +1383,7 @@ defmodule PortalAPI.Client.Channel do
              authorization_expires_at: expires_at,
              ice_credentials: ice_credentials,
              preshared_key: preshared_key,
-             client_iceless_capable: socket.assigns.iceless_capable
+             initiator_iceless_capable: socket.assigns.iceless_capable
            }}
 
         attrs =
@@ -2538,13 +2538,6 @@ defmodule PortalAPI.Client.Channel do
       account_feature_enabled? = account.features.client_to_client == true
 
       Portal.Safe.unscoped(query, :replica) |> Portal.Safe.exists?() and account_feature_enabled?
-    end
-
-    def iceless_enabled?(account_id) do
-      from(a in Portal.Account, where: a.id == ^account_id)
-      |> Portal.Safe.unscoped(:replica)
-      |> Portal.Safe.one!()
-      |> Portal.Account.iceless_enabled?()
     end
 
     def all_compatible_gateways_for_client_and_resource(

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -108,7 +108,7 @@ defmodule PortalAPI.Client.Channel do
         cache: cache,
         authorizations_cache: authorizations_cache,
         pending_flows: %{},
-        iceless: false
+        iceless_capable: false
       )
       # Track client's presence and monitor tracker shard processes for crash recovery
       |> track_presence()
@@ -336,7 +336,7 @@ defmodule PortalAPI.Client.Channel do
   end
 
   # Backwards-compat: tolerate the pre-snownet-capabilities tuple from older
-  # gateway nodes during a rolling deploy. Default the iceless capability to `false`.
+  # gateway nodes during a rolling deploy. Default `use_iceless` to `false`.
   def handle_info(
         {:connect, socket_ref, rid_bytes, site_id, gateway_id, gateway_public_key, gateway_ipv4,
          gateway_ipv6, preshared_key, ice_credentials},
@@ -351,7 +351,7 @@ defmodule PortalAPI.Client.Channel do
 
   def handle_info(
         {:connect, _socket_ref, rid_bytes, site_id, gateway_id, gateway_public_key, gateway_ipv4,
-         gateway_ipv6, preshared_key, ice_credentials, iceless},
+         gateway_ipv6, preshared_key, ice_credentials, use_iceless},
         socket
       ) do
     resource_id = Ecto.UUID.load!(rid_bytes)
@@ -374,7 +374,7 @@ defmodule PortalAPI.Client.Channel do
             gateway_ipv4: gateway_ipv4,
             gateway_ipv6: gateway_ipv6,
             gateway_ice_credentials: ice_credentials.receiver,
-            snownet_capabilities: %{iceless: iceless}
+            use_iceless: use_iceless
           }
           |> put_site_id(site_id, socket.assigns.session)
 
@@ -405,14 +405,10 @@ defmodule PortalAPI.Client.Channel do
   # the initiator, because the target's data plane is guaranteed to receive
   # (and process) the authorization before any relayed ICE candidate, which
   # travels the same socket behind it. See `deliver_pool_target_authorized/8`.
-  # Backwards-compat: tolerate the pre-snownet-capabilities ack from older
-  # initiator targets during a rolling deploy. Default the iceless capability
-  # to `false`.
-  def handle_info({:device_access_acked, ref}, socket) do
-    handle_info({:device_access_acked, ref, false}, socket)
-  end
-
-  def handle_info({:device_access_acked, ref, target_iceless}, socket) do
+  # The target already resolved `use_iceless` (reading the flag once, with both
+  # peers' capabilities), so we apply it as-is rather than reading the flag a
+  # second time — a second read could race a mid-flow toggle and disagree.
+  def handle_info({:device_access_acked, ref, use_iceless}, socket) do
     case Map.pop(socket.assigns.pending_flows, ref) do
       {nil, _} ->
         {:noreply, socket}
@@ -420,10 +416,7 @@ defmodule PortalAPI.Client.Channel do
       {%{timer_ref: timer_ref, initiator_payload: initiator_payload}, remaining} ->
         Process.cancel_timer(timer_ref)
 
-        iceless = socket.assigns.iceless == true and target_iceless == true
-
-        initiator_payload =
-          Map.put(initiator_payload, :snownet_capabilities, %{iceless: iceless})
+        initiator_payload = Map.put(initiator_payload, :use_iceless, use_iceless)
 
         push(socket, "client_device_access_authorized", initiator_payload)
         {:noreply, assign(socket, :pending_flows, remaining)}
@@ -434,10 +427,13 @@ defmodule PortalAPI.Client.Channel do
     {policy_authorization_id, payload} = Map.pop(payload, :policy_authorization_id)
     {authorization_expires_at, payload} = Map.pop(payload, :authorization_expires_at)
     {policy_authorization, payload} = Map.pop(payload, :policy_authorization)
-    {initiator_iceless, payload} = Map.pop(payload, :initiator_iceless, false)
+    {initiator_iceless_capable, payload} = Map.pop(payload, :initiator_iceless_capable, false)
 
-    iceless = socket.assigns.iceless == true and initiator_iceless == true
-    payload = Map.put(payload, :snownet_capabilities, %{iceless: iceless})
+    use_iceless =
+      socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
+        Database.iceless_enabled?(socket.assigns.client.account_id)
+
+    payload = Map.put(payload, :use_iceless, use_iceless)
 
     authorizations_cache =
       maybe_put_authorization(
@@ -460,9 +456,10 @@ defmodule PortalAPI.Client.Channel do
     # Ack back to the initiator's channel that the authorization is on this
     # target's websocket. The initiator is released only after this, so the
     # initiator's ICE candidates (which traverse the same socket) can never
-    # overtake the authorization at the target's data plane. We report our own
-    # capabilities so the initiator can negotiate the same set on its side.
-    send(ack_to, {:device_access_acked, ref, socket.assigns.iceless})
+    # overtake the authorization at the target's data plane. We send the
+    # resolved `use_iceless` (not our capability) so the initiator applies the
+    # same decision without reading the flag again.
+    send(ack_to, {:device_access_acked, ref, use_iceless})
 
     cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
 
@@ -1195,7 +1192,7 @@ defmodule PortalAPI.Client.Channel do
   end
 
   def handle_in("set_snownet_capabilities", payload, socket) when is_map(payload) do
-    {:noreply, assign(socket, iceless: payload["iceless"] == true)}
+    {:noreply, assign(socket, iceless_capable: payload["iceless"] == true)}
   end
 
   def handle_in("no_relays", _payload, socket) do
@@ -1386,7 +1383,7 @@ defmodule PortalAPI.Client.Channel do
              authorization_expires_at: expires_at,
              ice_credentials: ice_credentials,
              preshared_key: preshared_key,
-             client_iceless: socket.assigns.iceless
+             client_iceless_capable: socket.assigns.iceless_capable
            }}
 
         attrs =
@@ -1631,7 +1628,7 @@ defmodule PortalAPI.Client.Channel do
     # `ref` correlates the target channel's ack back to this request. The
     # initiator is NOT released on `Queue.enqueue/3` returning `:ok` — it is
     # released only once the target's channel acks that it has pushed the
-    # authorization onto the target's websocket (`{:device_access_acked, ref}`).
+    # authorization onto the target's websocket (`{:device_access_acked, ref, _}`).
     # Until then the initiator must not start ICE, because its candidates
     # travel the same socket as the authorization and would otherwise race
     # ahead of it at the target's data plane.
@@ -1754,7 +1751,7 @@ defmodule PortalAPI.Client.Channel do
          subject: rendered_subject,
          policy_authorization_id: policy_authorization_id,
          authorization_expires_at: expires_at,
-         initiator_iceless: socket.assigns.iceless
+         initiator_iceless_capable: socket.assigns.iceless_capable
        }}
 
     initiator_payload = %{
@@ -2541,6 +2538,13 @@ defmodule PortalAPI.Client.Channel do
       account_feature_enabled? = account.features.client_to_client == true
 
       Portal.Safe.unscoped(query, :replica) |> Portal.Safe.exists?() and account_feature_enabled?
+    end
+
+    def iceless_enabled?(account_id) do
+      from(a in Portal.Account, where: a.id == ^account_id)
+      |> Portal.Safe.unscoped(:replica)
+      |> Portal.Safe.one!()
+      |> Portal.Account.iceless_enabled?()
     end
 
     def all_compatible_gateways_for_client_and_resource(

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -310,8 +310,8 @@ defmodule PortalAPI.Gateway.Channel do
     # ICE-less is used only when both peers support it and the account has the
     # feature flag enabled. The portal resolves this once, here, and ships the
     # decision (rather than the raw capabilities) so client and gateway agree.
-    # The account flag is read fresh (not cached at join) so a mid-session toggle
-    # takes effect immediately and can't drift between peers.
+    # The account flag is read fresh per flow (not cached at join), subject to
+    # replica lag, so a mid-session toggle applies without reconnects.
     use_iceless =
       socket.assigns.iceless_capable == true and client_iceless_capable == true and
         Database.iceless_enabled?(socket.assigns.gateway.account_id)

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -109,7 +109,7 @@ defmodule PortalAPI.Gateway.Channel do
     socket =
       assign(socket,
         cache: Cache.Gateway.hydrate(socket.assigns.gateway),
-        iceless: false
+        iceless_capable: false
       )
     Process.send_after(self(), :prune_cache, @prune_cache_every)
 
@@ -303,11 +303,18 @@ defmodule PortalAPI.Gateway.Channel do
       preshared_key: preshared_key
     } = payload
 
-    client_iceless = Map.get(payload, :client_iceless, false)
+    client_iceless_capable = Map.get(payload, :client_iceless_capable, false)
 
     rid_bytes = Ecto.UUID.dump!(resource.id)
 
-    iceless = socket.assigns.iceless == true and client_iceless == true
+    # ICE-less is used only when both peers support it and the account has the
+    # feature flag enabled. The portal resolves this once, here, and ships the
+    # decision (rather than the raw capabilities) so client and gateway agree.
+    # The account flag is read fresh (not cached at join) so a mid-session toggle
+    # takes effect immediately and can't drift between peers.
+    use_iceless =
+      socket.assigns.iceless_capable == true and client_iceless_capable == true and
+        Database.iceless_enabled?(socket.assigns.gateway.account_id)
 
     ref =
       encode_ref(socket, {
@@ -316,7 +323,7 @@ defmodule PortalAPI.Gateway.Channel do
         rid_bytes,
         preshared_key,
         ice_credentials,
-        iceless
+        use_iceless
       })
 
     push(socket, "authorize_flow", %{
@@ -327,7 +334,7 @@ defmodule PortalAPI.Gateway.Channel do
       client_ice_credentials: ice_credentials.initiator,
       expires_at: DateTime.to_unix(authorization_expires_at, :second),
       subject: subject,
-      snownet_capabilities: %{iceless: iceless}
+      use_iceless: use_iceless
     })
 
     cache =
@@ -567,18 +574,9 @@ defmodule PortalAPI.Gateway.Channel do
   @impl true
   def handle_in("flow_authorized", %{"ref" => signed_ref}, socket) do
     case decode_ref(socket, signed_ref) do
-      {:ok, ref_tuple} when tuple_size(ref_tuple) in [5, 6] ->
-        # 5-tuple is the legacy shape from before snownet capabilities;
-        # 6-tuple is the current one. Default the new field to `false` so
-        # in-flight refs across a rolling deploy don't fail to decode.
-        {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials, iceless} =
-          case ref_tuple do
-            {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials} ->
-              {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials, false}
-
-            {_, _, _, _, _, _} = full ->
-              full
-          end
+      {:ok, ref_tuple} ->
+        {channel_pid, socket_ref, resource_id, preshared_key, ice_credentials, use_iceless} =
+          ref_tuple
 
         send(
           channel_pid,
@@ -593,7 +591,7 @@ defmodule PortalAPI.Gateway.Channel do
             socket.assigns.gateway.ipv6,
             preshared_key,
             ice_credentials,
-            iceless
+            use_iceless
           }
         )
 
@@ -665,7 +663,7 @@ defmodule PortalAPI.Gateway.Channel do
   end
 
   def handle_in("set_snownet_capabilities", payload, socket) when is_map(payload) do
-    {:noreply, assign(socket, iceless: payload["iceless"] == true)}
+    {:noreply, assign(socket, iceless_capable: payload["iceless"] == true)}
   end
 
   def handle_in("no_relays", _payload, socket) do
@@ -1138,6 +1136,12 @@ defmodule PortalAPI.Gateway.Channel do
       from(a in Account, where: a.id == ^id)
       |> Safe.unscoped(:replica)
       |> Safe.one!()
+    end
+
+    def iceless_enabled?(account_id) do
+      account_id
+      |> get_account_by_id!()
+      |> Account.iceless_enabled?()
     end
   end
 end

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -4,6 +4,7 @@ defmodule PortalAPI.Gateway.Channel do
   alias __MODULE__.Database
 
   alias Portal.{
+    Account,
     Cache,
     Device,
     PG,
@@ -135,6 +136,8 @@ defmodule PortalAPI.Gateway.Channel do
     :ok = Presence.Relays.Global.subscribe()
 
     account = Database.get_account_by_id!(socket.assigns.gateway.account_id)
+
+    socket = assign(socket, :account, account)
 
     init(socket, account, relays)
 
@@ -303,18 +306,13 @@ defmodule PortalAPI.Gateway.Channel do
       preshared_key: preshared_key
     } = payload
 
-    client_iceless_capable = Map.get(payload, :client_iceless_capable, false)
+    initiator_iceless_capable = Map.get(payload, :initiator_iceless_capable, false)
 
     rid_bytes = Ecto.UUID.dump!(resource.id)
 
-    # ICE-less is used only when both peers support it and the account has the
-    # feature flag enabled. The portal resolves this once, here, and ships the
-    # decision (rather than the raw capabilities) so client and gateway agree.
-    # The account flag is read fresh per flow (not cached at join), subject to
-    # replica lag, so a mid-session toggle applies without reconnects.
     use_iceless =
-      socket.assigns.iceless_capable == true and client_iceless_capable == true and
-        Database.iceless_enabled?(socket.assigns.gateway.account_id)
+      socket.assigns.iceless_capable == true and initiator_iceless_capable == true and
+        Account.iceless_enabled?(socket.assigns.account)
 
     ref =
       encode_ref(socket, {
@@ -777,10 +775,13 @@ defmodule PortalAPI.Gateway.Channel do
            struct: %Portal.Account{slug: slug} = account
          },
          socket
-       )
-       when old_slug != slug do
-    {:ok, relays} = select_relays(socket)
-    init(socket, account, relays)
+       ) do
+    socket = assign(socket, :account, account)
+
+    if old_slug != slug do
+      {:ok, relays} = select_relays(socket)
+      init(socket, account, relays)
+    end
 
     {:noreply, socket}
   end
@@ -1136,12 +1137,6 @@ defmodule PortalAPI.Gateway.Channel do
       from(a in Account, where: a.id == ^id)
       |> Safe.unscoped(:replica)
       |> Safe.one!()
-    end
-
-    def iceless_enabled?(account_id) do
-      account_id
-      |> get_account_by_id!()
-      |> Account.iceless_enabled?()
     end
   end
 end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -285,7 +285,9 @@ defmodule Portal.Repo.Seeds do
         idp_sync: true,
         rest_api: true,
         internet_resource: true,
-        client_to_client: true
+        client_to_client: true,
+        # Let CI integration tests opt into ICE-less per run without a code change.
+        iceless: System.get_env("FEATURE_ICELESS_ENABLED") == "true"
       })
       |> put_change(:metadata, %{
         stripe: %{

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -286,8 +286,7 @@ defmodule Portal.Repo.Seeds do
         rest_api: true,
         internet_resource: true,
         client_to_client: true,
-        # Let CI integration tests opt into ICE-less per run without a code change.
-        iceless: System.get_env("FEATURE_ICELESS_ENABLED") == "true"
+        iceless: true
       })
       |> put_change(:metadata, %{
         stripe: %{

--- a/elixir/test/portal/account_test.exs
+++ b/elixir/test/portal/account_test.exs
@@ -59,6 +59,28 @@ defmodule Portal.AccountTest do
     end
   end
 
+  describe "iceless_enabled?/1" do
+    test "returns true when the account feature flag is set" do
+      account = %Account{features: %Portal.Accounts.Features{iceless: true}}
+      assert Account.iceless_enabled?(account)
+    end
+
+    test "returns false when the account feature flag is disabled" do
+      account = %Account{features: %Portal.Accounts.Features{iceless: false}}
+      refute Account.iceless_enabled?(account)
+    end
+
+    test "returns false when the account feature flag is unset" do
+      account = %Account{features: %Portal.Accounts.Features{}}
+      refute Account.iceless_enabled?(account)
+    end
+
+    test "returns false when the account has no features" do
+      account = %Account{features: nil}
+      refute Account.iceless_enabled?(account)
+    end
+  end
+
   describe "changeset/1 key validations" do
     test "rejects key with wrong length" do
       changeset = build_changeset(%{key: "abc"})

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -115,7 +115,8 @@ defmodule PortalAPI.Client.ChannelTest do
         },
         features: %{
           internet_resource: true,
-          client_to_client: true
+          client_to_client: true,
+          iceless: true
         }
       )
 
@@ -5754,7 +5755,7 @@ defmodule PortalAPI.Client.ChannelTest do
       }
     end
 
-    test "intersects iceless snownet_capabilities across both clients", %{
+    test "resolves use_iceless across both clients when both are capable", %{
       client: client,
       subject: subject,
       target_client: target_client,
@@ -5775,12 +5776,12 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         ice_role: :controlling,
-        snownet_capabilities: %{iceless: true}
+        use_iceless: true
       }
 
       assert_push "client_device_access_authorized", %{
         ice_role: :controlled,
-        snownet_capabilities: %{iceless: true}
+        use_iceless: true
       }
     end
 
@@ -5805,16 +5806,16 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         ice_role: :controlling,
-        snownet_capabilities: %{iceless: false}
+        use_iceless: false
       }
 
       assert_push "client_device_access_authorized", %{
         ice_role: :controlled,
-        snownet_capabilities: %{iceless: false}
+        use_iceless: false
       }
     end
 
-    test "client_device_access_authorized defaults snownet_capabilities to false when unset", %{
+    test "client_device_access_authorized defaults use_iceless to false when unset", %{
       client: client,
       subject: subject,
       target_client: target_client,
@@ -5831,7 +5832,43 @@ defmodule PortalAPI.Client.ChannelTest do
       push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
 
       assert_push "client_device_access_authorized", %{
-        snownet_capabilities: %{iceless: false}
+        use_iceless: false
+      }
+    end
+
+    test "does not use iceless when the account feature flag is disabled", %{
+      account: account,
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      # Turn the account-wide iceless flag off in the DB; it is read fresh per flow.
+      update_account(account, %{
+        features: %{internet_resource: true, client_to_client: true, iceless: false}
+      })
+
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      # Both clients are iceless-capable, but the account flag gates it off.
+      push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
+      push(target_socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlling,
+        use_iceless: false
+      }
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlled,
+        use_iceless: false
       }
     end
 
@@ -6295,7 +6332,7 @@ defmodule PortalAPI.Client.ChannelTest do
       # The initiator must not be released before the target acks.
       refute_push "client_device_access_authorized", _, 200
 
-      send(ack_to, {:device_access_acked, ref})
+      send(ack_to, {:device_access_acked, ref, false})
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5843,10 +5843,13 @@ defmodule PortalAPI.Client.ChannelTest do
       target_client: target_client,
       target_subject: target_subject
     } do
-      # Turn the account-wide iceless flag off in the DB; it is read fresh per flow.
-      update_account(account, %{
-        features: %{internet_resource: true, client_to_client: true, iceless: false}
-      })
+      account =
+        update_account(account, %{
+          features: %{internet_resource: true, client_to_client: true, iceless: false}
+        })
+
+      subject = %{subject | account: account}
+      target_subject = %{target_subject | account: account}
 
       initiating_socket = join_channel(client, subject)
       assert_push "init", _
@@ -5857,6 +5860,47 @@ defmodule PortalAPI.Client.ChannelTest do
       # Both clients are iceless-capable, but the account flag gates it off.
       push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
       push(target_socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      target_ip = Portal.Types.INET.to_string(target_client.ipv4)
+      push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlling,
+        use_iceless: false
+      }
+
+      assert_push "client_device_access_authorized", %{
+        ice_role: :controlled,
+        use_iceless: false
+      }
+    end
+
+    test "use_iceless picks up an account flag toggled off after join", %{
+      account: account,
+      client: client,
+      subject: subject,
+      target_client: target_client,
+      target_subject: target_subject
+    } do
+      initiating_socket = join_channel(client, subject)
+      assert_push "init", _
+
+      target_socket = join_channel(target_client, target_subject)
+      assert_push "init", _
+
+      push(initiating_socket, "set_snownet_capabilities", %{"iceless" => true})
+      push(target_socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      updated_account = %{account | features: %{account.features | iceless: false}}
+
+      send(target_socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :update,
+        old_struct: account,
+        struct: updated_account
+      })
+
+      :sys.get_state(target_socket.channel_pid)
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -3109,7 +3109,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         ^gateway_ipv6,
         ^preshared_key,
         ^ice_credentials,
-        _iceless
+        _use_iceless
       }
     end
 
@@ -3124,6 +3124,8 @@ defmodule PortalAPI.Gateway.ChannelTest do
       subject: subject,
       group: group
     } do
+      update_account(account, %{features: %{iceless: true}})
+
       socket = join_channel(gateway, site, token)
       assert_push "init", %{relays: _}
 
@@ -3169,20 +3171,20 @@ defmodule PortalAPI.Gateway.ChannelTest do
            authorization_expires_at: expires_at,
            ice_credentials: ice_credentials,
            preshared_key: preshared_key,
-           client_iceless: true
+           client_iceless_capable: true
          }}
       )
 
       assert_push "authorize_flow", %{
         ref: ref,
-        snownet_capabilities: %{iceless: true}
+        use_iceless: true
       }
 
       push_ref = push(socket, "flow_authorized", %{"ref" => ref})
       assert_reply push_ref, :ok
 
-      assert_receive {:connect, ^socket_ref, _, _, _, _, _, _, _, _, iceless}
-      assert iceless == true
+      assert_receive {:connect, ^socket_ref, _, _, _, _, _, _, _, _, use_iceless}
+      assert use_iceless == true
     end
 
     test "authorize_policy with mismatched iceless flag intersects to false", %{
@@ -3240,17 +3242,17 @@ defmodule PortalAPI.Gateway.ChannelTest do
            authorization_expires_at: expires_at,
            ice_credentials: ice_credentials,
            preshared_key: preshared_key,
-           client_iceless: false
+           client_iceless_capable: false
          }}
       )
 
       assert_push "authorize_flow", %{
         ref: _,
-        snownet_capabilities: %{iceless: false}
+        use_iceless: false
       }
     end
 
-    test "authorize_policy without client_iceless defaults to false", %{
+    test "authorize_policy without client_iceless_capable defaults to false", %{
       client: client,
       account: account,
       actor: actor,
@@ -3310,7 +3312,74 @@ defmodule PortalAPI.Gateway.ChannelTest do
 
       assert_push "authorize_flow", %{
         ref: _,
-        snownet_capabilities: %{iceless: false}
+        use_iceless: false
+      }
+    end
+
+    test "authorize_policy does not use iceless when account feature flag is disabled", %{
+      client: client,
+      account: account,
+      actor: actor,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token,
+      subject: subject,
+      group: group
+    } do
+      update_account(account, %{features: %{iceless: false}})
+
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      # Both peers are iceless-capable, but the account flag is off → no iceless.
+      push(socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          group: group
+        )
+
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      public_key = Portal.DeviceFixtures.generate_public_key()
+
+      ice_credentials = %{
+        initiator: %{username: "A", password: "B"},
+        receiver: %{username: "C", password: "D"}
+      }
+
+      send(
+        socket.channel_pid,
+        {:authorize_policy, {channel_pid, socket_ref},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               public_key,
+               preshared_key,
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key,
+           client_iceless_capable: true
+         }}
+      )
+
+      assert_push "authorize_flow", %{
+        ref: _,
+        use_iceless: false
       }
     end
 

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -3171,7 +3171,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
            authorization_expires_at: expires_at,
            ice_credentials: ice_credentials,
            preshared_key: preshared_key,
-           client_iceless_capable: true
+           initiator_iceless_capable: true
          }}
       )
 
@@ -3242,7 +3242,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
            authorization_expires_at: expires_at,
            ice_credentials: ice_credentials,
            preshared_key: preshared_key,
-           client_iceless_capable: false
+           initiator_iceless_capable: false
          }}
       )
 
@@ -3252,7 +3252,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
       }
     end
 
-    test "authorize_policy without client_iceless_capable defaults to false", %{
+    test "authorize_policy without initiator_iceless_capable defaults to false", %{
       client: client,
       account: account,
       actor: actor,
@@ -3373,13 +3373,88 @@ defmodule PortalAPI.Gateway.ChannelTest do
            authorization_expires_at: expires_at,
            ice_credentials: ice_credentials,
            preshared_key: preshared_key,
-           client_iceless_capable: true
+           initiator_iceless_capable: true
          }}
       )
 
       assert_push "authorize_flow", %{
         ref: _,
         use_iceless: false
+      }
+    end
+
+    test "use_iceless picks up an account flag toggled on after join", %{
+      client: client,
+      account: account,
+      actor: actor,
+      resource: resource,
+      gateway: gateway,
+      site: site,
+      token: token,
+      subject: subject,
+      group: group
+    } do
+      socket = join_channel(gateway, site, token)
+      assert_push "init", %{relays: _}
+
+      push(socket, "set_snownet_capabilities", %{"iceless" => true})
+
+      updated_account = %{account | features: %{account.features | iceless: true}}
+
+      send(socket.channel_pid, %Changes.Change{
+        lsn: System.unique_integer([:positive, :monotonic]),
+        op: :update,
+        old_struct: account,
+        struct: updated_account
+      })
+
+      :sys.get_state(socket.channel_pid)
+
+      policy_authorization =
+        policy_authorization_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          resource: resource,
+          group: group
+        )
+
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      public_key = Portal.DeviceFixtures.generate_public_key()
+
+      ice_credentials = %{
+        initiator: %{username: "A", password: "B"},
+        receiver: %{username: "C", password: "D"}
+      }
+
+      send(
+        socket.channel_pid,
+        {:authorize_policy, {channel_pid, socket_ref},
+         %{
+           client:
+             PortalAPI.Gateway.Views.Client.render(
+               client,
+               public_key,
+               preshared_key,
+               @test_user_agent
+             ),
+           subject: PortalAPI.Gateway.Views.Subject.render(subject),
+           resource: PortalAPI.Gateway.Views.Resource.render(to_cache(resource)),
+           resource_id: to_cache(resource).id,
+           policy_authorization_id: policy_authorization.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key,
+           initiator_iceless_capable: true
+         }}
+      )
+
+      assert_push "authorize_flow", %{
+        ref: _,
+        use_iceless: true
       }
     end
 

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -32,7 +32,8 @@ defmodule Portal.AccountFixtures do
         traffic_filters: true,
         idp_sync: true,
         rest_api: true,
-        client_to_client: false
+        client_to_client: false,
+        iceless: System.get_env("FEATURE_ICELESS_ENABLED") == "true"
       },
       limits: %{
         monthly_active_users_count: 100

--- a/elixir/test/support/fixtures/account_fixtures.ex
+++ b/elixir/test/support/fixtures/account_fixtures.ex
@@ -33,7 +33,7 @@ defmodule Portal.AccountFixtures do
         idp_sync: true,
         rest_api: true,
         client_to_client: false,
-        iceless: System.get_env("FEATURE_ICELESS_ENABLED") == "true"
+        iceless: false
       },
       limits: %{
         monthly_active_users_count: 100


### PR DESCRIPTION
ICE-less connections (#13088) were going to be gated by a device-local PostHog feature flag, which lets a client and gateway disagree about whether to use ICE-less. This moves the toggle into the portal as an account-wide feature so the portal is the single source of truth: ICE-less is used only when the account has it enabled and both peers advertise the capability. The portal resolves the decision once per flow and sends down a `use_iceless` flag instead of the raw capabilities, so the two ends can't drift and a mid-rollout toggle applies without reconnects.

Related: #13088