### PR TITLE
fix(portal): fix sync edge cases

### DIFF
--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -862,6 +862,13 @@ defmodule Portal.Entra.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
+      existing_directory_identities AS (
+        SELECT ei.id, ei.actor_id
+        FROM external_identities ei
+        WHERE ei.account_id = $#{account_id}
+          AND ei.directory_id = $#{directory_id}
+          AND ei.actor_id IN (SELECT actor_id FROM existing_actors_by_email)
+      ),
       actors_to_create AS (
         SELECT
           uuid_generate_v4() AS new_actor_id,
@@ -905,7 +912,7 @@ defmodule Portal.Entra.Sync do
           account_id, inserted_at, updated_at
         )
         SELECT
-          COALESCE(ei.id, uuid_generate_v4()),
+          COALESCE(ei.id, edi.id, uuid_generate_v4()),
           aam.actor_id,
           $#{issuer},
           aam.idp_id,
@@ -921,8 +928,10 @@ defmodule Portal.Entra.Sync do
           $#{last_synced_at}
         FROM all_actor_mappings aam
         LEFT JOIN pre_existing_identities ei ON ei.idp_id = aam.idp_id
-        ON CONFLICT (account_id, idp_id, issuer)
+        LEFT JOIN existing_directory_identities edi ON edi.actor_id = aam.actor_id
+        ON CONFLICT (account_id, id)
         DO UPDATE SET
+          idp_id = EXCLUDED.idp_id,
           directory_id = EXCLUDED.directory_id,
           email = EXCLUDED.email,
           name = EXCLUDED.name,
@@ -931,11 +940,11 @@ defmodule Portal.Entra.Sync do
           preferred_username = EXCLUDED.preferred_username,
           profile = EXCLUDED.profile,
           updated_at = EXCLUDED.updated_at
-        WHERE (external_identities.directory_id, external_identities.email, external_identities.name,
+        WHERE (external_identities.idp_id, external_identities.directory_id, external_identities.email, external_identities.name,
                external_identities.given_name, external_identities.family_name,
                external_identities.preferred_username, external_identities.profile)
               IS DISTINCT FROM
-              (EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
+              (EXCLUDED.idp_id, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
                EXCLUDED.given_name, EXCLUDED.family_name,
                EXCLUDED.preferred_username, EXCLUDED.profile)
           AND NOT EXISTS (

--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -819,9 +819,21 @@ defmodule Portal.Entra.Sync do
           identity_attrs
         )
 
+      run_identity_upsert(query, params)
+    end
+
+    # A concurrent OIDC sign-in can insert an identity for the same
+    # (account_id, idp_id, issuer) after this statement's snapshot is taken,
+    # which the (account_id, id) conflict target does not handle. Re-running
+    # picks up the now-committed row via pre_existing_identities and recycles
+    # it, so we retry once before surfacing the error.
+    defp run_identity_upsert(query, params, retry? \\ true) do
       case Safe.unscoped() |> Safe.query(query, params) do
         {:ok, %Postgrex.Result{rows: rows}} ->
           {:ok, %{upserted_identities: length(rows)}}
+
+        {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} when retry? ->
+          run_identity_upsert(query, params, false)
 
         {:error, reason} ->
           {:error, reason}
@@ -862,6 +874,11 @@ defmodule Portal.Entra.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
+      -- Recycles the actor's existing directory identity when its idp_id changed
+      -- (e.g. the IdP user was deleted and recreated with the same email). The
+      -- LEFT JOIN below assumes at most one row per actor here, which is
+      -- guaranteed by the partial unique index on (account_id, actor_id,
+      -- directory_id) from migration 20260506124134.
       existing_directory_identities AS (
         SELECT ei.id, ei.actor_id
         FROM external_identities ei
@@ -932,6 +949,7 @@ defmodule Portal.Entra.Sync do
         ON CONFLICT (account_id, id)
         DO UPDATE SET
           idp_id = EXCLUDED.idp_id,
+          issuer = EXCLUDED.issuer,
           directory_id = EXCLUDED.directory_id,
           email = EXCLUDED.email,
           name = EXCLUDED.name,
@@ -940,11 +958,11 @@ defmodule Portal.Entra.Sync do
           preferred_username = EXCLUDED.preferred_username,
           profile = EXCLUDED.profile,
           updated_at = EXCLUDED.updated_at
-        WHERE (external_identities.idp_id, external_identities.directory_id, external_identities.email, external_identities.name,
+        WHERE (external_identities.idp_id, external_identities.issuer, external_identities.directory_id, external_identities.email, external_identities.name,
                external_identities.given_name, external_identities.family_name,
                external_identities.preferred_username, external_identities.profile)
               IS DISTINCT FROM
-              (EXCLUDED.idp_id, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
+              (EXCLUDED.idp_id, EXCLUDED.issuer, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
                EXCLUDED.given_name, EXCLUDED.family_name,
                EXCLUDED.preferred_username, EXCLUDED.profile)
           AND NOT EXISTS (

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -1042,9 +1042,24 @@ defmodule Portal.Google.Sync do
           identity_attrs
         )
 
+      run_identity_upsert(query, params)
+    end
+
+    # A concurrent OIDC sign-in can insert an identity for the same
+    # (account_id, idp_id, issuer) after this statement's snapshot is taken,
+    # which the (account_id, id) conflict target does not handle. Re-running
+    # picks up the now-committed row via pre_existing_identities and recycles
+    # it, so we retry once before surfacing the error.
+    defp run_identity_upsert(query, params, retry? \\ true) do
       case Safe.unscoped() |> Safe.query(query, params) do
-        {:ok, %Postgrex.Result{rows: rows}} -> {:ok, %{upserted_identities: length(rows)}}
-        {:error, reason} -> {:error, reason}
+        {:ok, %Postgrex.Result{rows: rows}} ->
+          {:ok, %{upserted_identities: length(rows)}}
+
+        {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} when retry? ->
+          run_identity_upsert(query, params, false)
+
+        {:error, reason} ->
+          {:error, reason}
       end
     end
 
@@ -1082,6 +1097,11 @@ defmodule Portal.Google.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
+      -- Recycles the actor's existing directory identity when its idp_id changed
+      -- (e.g. the IdP user was deleted and recreated with the same email). The
+      -- LEFT JOIN below assumes at most one row per actor here, which is
+      -- guaranteed by the partial unique index on (account_id, actor_id,
+      -- directory_id) from migration 20260506124134.
       existing_directory_identities AS (
         SELECT ei.id, ei.actor_id
         FROM external_identities ei
@@ -1152,6 +1172,7 @@ defmodule Portal.Google.Sync do
         ON CONFLICT (account_id, id)
         DO UPDATE SET
           idp_id = EXCLUDED.idp_id,
+          issuer = EXCLUDED.issuer,
           directory_id = EXCLUDED.directory_id,
           email = EXCLUDED.email,
           name = EXCLUDED.name,
@@ -1160,11 +1181,11 @@ defmodule Portal.Google.Sync do
           preferred_username = EXCLUDED.preferred_username,
           picture = EXCLUDED.picture,
           updated_at = EXCLUDED.updated_at
-        WHERE (external_identities.idp_id, external_identities.directory_id, external_identities.email, external_identities.name,
+        WHERE (external_identities.idp_id, external_identities.issuer, external_identities.directory_id, external_identities.email, external_identities.name,
                external_identities.given_name, external_identities.family_name,
                external_identities.preferred_username, external_identities.picture)
               IS DISTINCT FROM
-              (EXCLUDED.idp_id, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
+              (EXCLUDED.idp_id, EXCLUDED.issuer, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
                EXCLUDED.given_name, EXCLUDED.family_name,
                EXCLUDED.preferred_username, EXCLUDED.picture)
           AND NOT EXISTS (

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -1082,6 +1082,13 @@ defmodule Portal.Google.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
+      existing_directory_identities AS (
+        SELECT ei.id, ei.actor_id
+        FROM external_identities ei
+        WHERE ei.account_id = $#{account_id}
+          AND ei.directory_id = $#{directory_id}
+          AND ei.actor_id IN (SELECT actor_id FROM existing_actors_by_email)
+      ),
       actors_to_create AS (
         SELECT
           uuid_generate_v4() AS new_actor_id,
@@ -1125,7 +1132,7 @@ defmodule Portal.Google.Sync do
           account_id, inserted_at, updated_at
         )
         SELECT
-          COALESCE(ei.id, uuid_generate_v4()),
+          COALESCE(ei.id, edi.id, uuid_generate_v4()),
           aam.actor_id,
           $#{issuer},
           aam.idp_id,
@@ -1141,8 +1148,10 @@ defmodule Portal.Google.Sync do
           $#{last_synced_at}
         FROM all_actor_mappings aam
         LEFT JOIN pre_existing_identities ei ON ei.idp_id = aam.idp_id
-        ON CONFLICT (account_id, idp_id, issuer)
+        LEFT JOIN existing_directory_identities edi ON edi.actor_id = aam.actor_id
+        ON CONFLICT (account_id, id)
         DO UPDATE SET
+          idp_id = EXCLUDED.idp_id,
           directory_id = EXCLUDED.directory_id,
           email = EXCLUDED.email,
           name = EXCLUDED.name,
@@ -1151,11 +1160,11 @@ defmodule Portal.Google.Sync do
           preferred_username = EXCLUDED.preferred_username,
           picture = EXCLUDED.picture,
           updated_at = EXCLUDED.updated_at
-        WHERE (external_identities.directory_id, external_identities.email, external_identities.name,
+        WHERE (external_identities.idp_id, external_identities.directory_id, external_identities.email, external_identities.name,
                external_identities.given_name, external_identities.family_name,
                external_identities.preferred_username, external_identities.picture)
               IS DISTINCT FROM
-              (EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
+              (EXCLUDED.idp_id, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
                EXCLUDED.given_name, EXCLUDED.family_name,
                EXCLUDED.preferred_username, EXCLUDED.picture)
           AND NOT EXISTS (

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -779,7 +779,7 @@ defmodule Portal.Okta.Sync do
         SELECT ei.id, ei.account_id, ei.actor_id, ei.idp_id
         FROM external_identities ei
         WHERE ei.account_id = $#{account_id}
-          AND ei.directory_id = $#{directory_id}
+          AND ei.issuer = $#{issuer}
           AND ei.idp_id IN (SELECT idp_id FROM input_data)
       ),
       existing_actors_by_email AS (
@@ -789,6 +789,13 @@ defmodule Portal.Okta.Sync do
         WHERE id.idp_id NOT IN (SELECT idp_id FROM pre_existing_identities)
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
+      ),
+      existing_directory_identities AS (
+        SELECT ei.id, ei.actor_id
+        FROM external_identities ei
+        WHERE ei.account_id = $#{account_id}
+          AND ei.directory_id = $#{directory_id}
+          AND ei.actor_id IN (SELECT actor_id FROM existing_actors_by_email)
       ),
       actors_to_create AS (
         SELECT
@@ -833,7 +840,7 @@ defmodule Portal.Okta.Sync do
           account_id, inserted_at, updated_at
         )
         SELECT
-          COALESCE(ei.id, uuid_generate_v4()),
+          COALESCE(ei.id, edi.id, uuid_generate_v4()),
           aam.actor_id,
           $#{issuer},
           aam.idp_id,
@@ -848,8 +855,10 @@ defmodule Portal.Okta.Sync do
           $#{last_synced_at}
         FROM all_actor_mappings aam
         LEFT JOIN pre_existing_identities ei ON ei.idp_id = aam.idp_id
-        ON CONFLICT (account_id, idp_id, issuer)
+        LEFT JOIN existing_directory_identities edi ON edi.actor_id = aam.actor_id
+        ON CONFLICT (account_id, id)
         DO UPDATE SET
+          idp_id = EXCLUDED.idp_id,
           directory_id = EXCLUDED.directory_id,
           email = EXCLUDED.email,
           name = EXCLUDED.name,
@@ -857,11 +866,11 @@ defmodule Portal.Okta.Sync do
           family_name = EXCLUDED.family_name,
           preferred_username = EXCLUDED.preferred_username,
           updated_at = EXCLUDED.updated_at
-        WHERE (external_identities.directory_id, external_identities.email, external_identities.name,
+        WHERE (external_identities.idp_id, external_identities.directory_id, external_identities.email, external_identities.name,
                external_identities.given_name, external_identities.family_name,
                external_identities.preferred_username)
               IS DISTINCT FROM
-              (EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
+              (EXCLUDED.idp_id, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
                EXCLUDED.given_name, EXCLUDED.family_name,
                EXCLUDED.preferred_username)
           AND NOT EXISTS (

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -750,9 +750,24 @@ defmodule Portal.Okta.Sync do
           identity_attrs
         )
 
+      run_identity_upsert(query, params)
+    end
+
+    # A concurrent OIDC sign-in can insert an identity for the same
+    # (account_id, idp_id, issuer) after this statement's snapshot is taken,
+    # which the (account_id, id) conflict target does not handle. Re-running
+    # picks up the now-committed row via pre_existing_identities and recycles
+    # it, so we retry once before surfacing the error.
+    defp run_identity_upsert(query, params, retry? \\ true) do
       case Safe.unscoped() |> Safe.query(query, params) do
-        {:ok, %Postgrex.Result{rows: rows}} -> {:ok, %{upserted_identities: length(rows)}}
-        {:error, reason} -> {:error, reason}
+        {:ok, %Postgrex.Result{rows: rows}} ->
+          {:ok, %{upserted_identities: length(rows)}}
+
+        {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} when retry? ->
+          run_identity_upsert(query, params, false)
+
+        {:error, reason} ->
+          {:error, reason}
       end
     end
 
@@ -790,6 +805,11 @@ defmodule Portal.Okta.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
+      -- Recycles the actor's existing directory identity when its idp_id changed
+      -- (e.g. the IdP user was deleted and recreated with the same email). The
+      -- LEFT JOIN below assumes at most one row per actor here, which is
+      -- guaranteed by the partial unique index on (account_id, actor_id,
+      -- directory_id) from migration 20260506124134.
       existing_directory_identities AS (
         SELECT ei.id, ei.actor_id
         FROM external_identities ei
@@ -859,6 +879,7 @@ defmodule Portal.Okta.Sync do
         ON CONFLICT (account_id, id)
         DO UPDATE SET
           idp_id = EXCLUDED.idp_id,
+          issuer = EXCLUDED.issuer,
           directory_id = EXCLUDED.directory_id,
           email = EXCLUDED.email,
           name = EXCLUDED.name,
@@ -866,11 +887,11 @@ defmodule Portal.Okta.Sync do
           family_name = EXCLUDED.family_name,
           preferred_username = EXCLUDED.preferred_username,
           updated_at = EXCLUDED.updated_at
-        WHERE (external_identities.idp_id, external_identities.directory_id, external_identities.email, external_identities.name,
+        WHERE (external_identities.idp_id, external_identities.issuer, external_identities.directory_id, external_identities.email, external_identities.name,
                external_identities.given_name, external_identities.family_name,
                external_identities.preferred_username)
               IS DISTINCT FROM
-              (EXCLUDED.idp_id, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
+              (EXCLUDED.idp_id, EXCLUDED.issuer, EXCLUDED.directory_id, EXCLUDED.email, EXCLUDED.name,
                EXCLUDED.given_name, EXCLUDED.family_name,
                EXCLUDED.preferred_username)
           AND NOT EXISTS (

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1436,15 +1436,7 @@ defmodule PortalWeb.OIDCController do
         |> with_cte("actor_lookup", as: ^actor_lookup_cte)
         |> with_cte("existing_identity", as: ^existing_identity_cte)
 
-      {count, rows} =
-        Safe.insert_all(
-          Safe.unscoped(),
-          ExternalIdentity,
-          query_with_ctes,
-          on_conflict: {:replace, replace_fields},
-          conflict_target: [:account_id, :id],
-          returning: true
-        )
+      {count, rows} = insert_identity(query_with_ctes, replace_fields)
 
       case {count, rows} do
         {0, _} ->
@@ -1455,6 +1447,31 @@ defmodule PortalWeb.OIDCController do
           # actor and account are long-lived records, safe to read from replica
           {:ok, Safe.preload(identity, [:actor, :account], :replica)}
       end
+    end
+
+    # Two concurrent sign-ins for the same brand-new (account_id, idp_id, issuer)
+    # can each generate a different id and race to insert. The (account_id, id)
+    # conflict target won't catch the loser, so it raises a unique violation on
+    # external_identities_account_idp_fields_index. On retry the committed row is
+    # found by existing_identity and recycled in place via the PK conflict.
+    defp insert_identity(query_with_ctes, replace_fields, retry? \\ true) do
+      Safe.insert_all(
+        Safe.unscoped(),
+        ExternalIdentity,
+        query_with_ctes,
+        on_conflict: {:replace, replace_fields},
+        conflict_target: [:account_id, :id],
+        returning: true
+      )
+    rescue
+      e in Postgrex.Error ->
+        case e do
+          %Postgrex.Error{postgres: %{code: :unique_violation}} when retry? ->
+            insert_identity(query_with_ctes, replace_fields, false)
+
+          _ ->
+            reraise e, __STACKTRACE__
+        end
     end
 
     defp fetch_related_pending_identity_ids(%PendingIdentity{} = pending_identity) do

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1360,6 +1360,7 @@ defmodule PortalWeb.OIDCController do
       account_id_bytes = Ecto.UUID.dump!(account_id)
 
       replace_fields = [
+        :idp_id,
         :email,
         :name,
         :given_name,
@@ -1382,6 +1383,13 @@ defmodule PortalWeb.OIDCController do
           limit: 1
         )
 
+      # Match the existing identity by idp_id (stable subject) or, since the
+      # email is verified on this path, by the actor's email. The latter lets a
+      # user who was deleted and recreated in the IdP (new idp_id, same email)
+      # overwrite their existing identity in place instead of inserting a second
+      # row, which would later collide with directory sync on the
+      # (account_id, actor_id, directory_id) unique index. Prefer the email
+      # match so a recreated user recycles their own row.
       existing_identity_cte =
         from(ei in "external_identities",
           join: a in "actors",
@@ -1389,9 +1397,10 @@ defmodule PortalWeb.OIDCController do
           where:
             ei.account_id == ^account_id_bytes and
               ei.issuer == ^issuer and
-              ei.idp_id == ^idp_id and
-              is_nil(a.disabled_at),
-          select: %{actor_id: ei.actor_id},
+              is_nil(a.disabled_at) and
+              (ei.idp_id == ^idp_id or a.email == ^email),
+          order_by: [desc: fragment("(? = ?)", a.email, ^email)],
+          select: %{id: ei.id, actor_id: ei.actor_id},
           limit: 1
         )
 
@@ -1403,7 +1412,7 @@ defmodule PortalWeb.OIDCController do
           on: true,
           where: not is_nil(al.id) or not is_nil(ei.actor_id),
           select: %{
-            id: fragment("uuid_generate_v4()"),
+            id: fragment("COALESCE(?.id, uuid_generate_v4())", ei),
             account_id: ^account_id_bytes,
             issuer: ^issuer,
             idp_id: ^idp_id,
@@ -1433,7 +1442,7 @@ defmodule PortalWeb.OIDCController do
           ExternalIdentity,
           query_with_ctes,
           on_conflict: {:replace, replace_fields},
-          conflict_target: [:account_id, :idp_id, :issuer],
+          conflict_target: [:account_id, :id],
           returning: true
         )
 

--- a/elixir/test/portal/entra/sync_test.exs
+++ b/elixir/test/portal/entra/sync_test.exs
@@ -2593,6 +2593,56 @@ defmodule Portal.Entra.SyncTest do
       assert identity.directory_id == directory.id
     end
 
+    test "recycled identity keeps a fresh sync state when seen twice in one run" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://login.microsoftonline.com/#{directory.tenant_id}/v2.0"
+
+      actor =
+        Portal.ActorFixtures.actor_fixture(account: account, email: "recreated@example.com")
+
+      stale_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          directory: base_directory,
+          issuer: issuer,
+          idp_id: "old-object-id",
+          email: "recreated@example.com",
+          synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+        )
+
+      synced_at = DateTime.utc_now()
+
+      attrs = [
+        %{
+          idp_id: "new-object-id",
+          email: "recreated@example.com",
+          name: "Recreated User",
+          given_name: "Recreated",
+          family_name: "User",
+          preferred_username: "recreated@example.com",
+          profile: nil
+        }
+      ]
+
+      # The same recreated user can appear in two batches of one sync run
+      # (e.g. direct assignment and group membership). The first call recycles
+      # the row; the second must still advance its sync state to the run's
+      # watermark so the later cleanup pass does not delete it.
+      assert {:ok, _} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, synced_at, attrs)
+
+      assert {:ok, _} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, synced_at, attrs)
+
+      sync_state =
+        Repo.get_by!(Portal.ExternalIdentitySyncState, external_identity_id: stale_identity.id)
+
+      assert DateTime.compare(sync_state.synced_at, synced_at) == :eq
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = entra_directory_fixture(account: account)

--- a/elixir/test/portal/entra/sync_test.exs
+++ b/elixir/test/portal/entra/sync_test.exs
@@ -2539,6 +2539,60 @@ defmodule Portal.Entra.SyncTest do
       assert DateTime.compare(sync_state_after_fresh.synced_at, future) == :eq
     end
 
+    test "identity upsert recycles stale identity when user is recreated with a new idp_id" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://login.microsoftonline.com/#{directory.tenant_id}/v2.0"
+
+      actor =
+        Portal.ActorFixtures.actor_fixture(account: account, email: "recreated@example.com")
+
+      # Identity left behind by the user's previous (now deleted) Entra object.
+      stale_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          directory: base_directory,
+          issuer: issuer,
+          idp_id: "old-object-id",
+          email: "recreated@example.com",
+          synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+        )
+
+      # The user is recreated in Entra: same UPN/email, brand new object id.
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(
+                 account.id,
+                 issuer,
+                 directory.id,
+                 DateTime.utc_now(),
+                 [
+                   %{
+                     idp_id: "new-object-id",
+                     email: "recreated@example.com",
+                     name: "Recreated User",
+                     given_name: "Recreated",
+                     family_name: "User",
+                     preferred_username: "recreated@example.com",
+                     profile: nil
+                   }
+                 ]
+               )
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      # The stale row is recycled in place rather than duplicated.
+      assert [identity] = identities
+      assert identity.id == stale_identity.id
+      assert identity.idp_id == "new-object-id"
+      assert identity.directory_id == directory.id
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = entra_directory_fixture(account: account)

--- a/elixir/test/portal/entra/sync_test.exs
+++ b/elixir/test/portal/entra/sync_test.exs
@@ -2643,6 +2643,143 @@ defmodule Portal.Entra.SyncTest do
       assert DateTime.compare(sync_state.synced_at, synced_at) == :eq
     end
 
+    test "identity upsert attaches the directory to an actor's pre-existing OIDC identity" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+      issuer = "https://login.microsoftonline.com/#{directory.tenant_id}/v2.0"
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "oidc@example.com")
+
+      # Identity created by an OIDC sign-in: same issuer, no directory yet.
+      auth_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          issuer: issuer,
+          idp_id: "subject-1",
+          email: "oidc@example.com"
+        )
+
+      assert auth_identity.directory_id == nil
+
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "subject-1",
+                   email: "oidc@example.com",
+                   name: "OIDC User",
+                   given_name: "OIDC",
+                   family_name: "User",
+                   preferred_username: "oidc@example.com",
+                   profile: nil
+                 }
+               ])
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      # The pre-existing identity is reused and gains the directory, not duplicated.
+      assert [identity] = identities
+      assert identity.id == auth_identity.id
+      assert identity.directory_id == directory.id
+    end
+
+    test "identity upsert errors when one batch maps two idp_ids to the same actor" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://login.microsoftonline.com/#{directory.tenant_id}/v2.0"
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "swap@example.com")
+
+      Portal.IdentityFixtures.identity_fixture(
+        account: account,
+        actor: actor,
+        directory: base_directory,
+        issuer: issuer,
+        idp_id: "old-object-id",
+        email: "swap@example.com",
+        synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+      )
+
+      # The IdP reports two distinct objects sharing one email in a single batch:
+      # the old object (email changed) and a new object that took the old email.
+      # Both resolve to the same actor and directory slot, which cannot be
+      # represented, so we let it surface as an error rather than corrupt state.
+      assert {:error, %Postgrex.Error{postgres: %{code: :cardinality_violation}}} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "old-object-id",
+                   email: "renamed@example.com",
+                   name: "Old",
+                   given_name: "Old",
+                   family_name: "User",
+                   preferred_username: "renamed@example.com",
+                   profile: nil
+                 },
+                 %{
+                   idp_id: "new-object-id",
+                   email: "swap@example.com",
+                   name: "New",
+                   given_name: "New",
+                   family_name: "User",
+                   preferred_username: "swap@example.com",
+                   profile: nil
+                 }
+               ])
+    end
+
+    test "identity upsert updates issuer when a directory is reverified against a new tenant" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = entra_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "moved@example.com")
+
+      # Identity recorded under the directory's previous Entra tenant/issuer.
+      stale_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          directory: base_directory,
+          issuer: "https://login.microsoftonline.com/old-tenant/v2.0",
+          idp_id: "entra-user",
+          email: "moved@example.com",
+          synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+        )
+
+      # The directory is reverified onto a new tenant, so the sync runs with a
+      # new issuer for the same Entra object id.
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(
+                 account.id,
+                 "https://login.microsoftonline.com/new-tenant/v2.0",
+                 directory.id,
+                 DateTime.utc_now(),
+                 [
+                   %{
+                     idp_id: "entra-user",
+                     email: "moved@example.com",
+                     name: "Moved User",
+                     given_name: "Moved",
+                     family_name: "User",
+                     preferred_username: "moved@example.com",
+                     profile: nil
+                   }
+                 ]
+               )
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == stale_identity.id
+      assert identity.issuer == "https://login.microsoftonline.com/new-tenant/v2.0"
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = entra_directory_fixture(account: account)

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -2,6 +2,7 @@ defmodule Portal.Google.SyncTest do
   use Portal.DataCase, async: true
   use Oban.Testing, repo: Portal.Repo
 
+  import Ecto.Query
   import Portal.AccountFixtures
   import Portal.GoogleDirectoryFixtures
   import Portal.ResourceFixtures
@@ -2324,6 +2325,51 @@ defmodule Portal.Google.SyncTest do
         Repo.get_by!(Portal.ExternalIdentitySyncState, external_identity_id: identity.id)
 
       assert DateTime.compare(sync_state_after_fresh.synced_at, future) == :eq
+    end
+
+    test "identity upsert recycles stale identity when user is recreated with a new idp_id" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = google_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://accounts.google.com"
+
+      actor =
+        Portal.ActorFixtures.actor_fixture(account: account, email: "recreated@example.com")
+
+      stale_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          directory: base_directory,
+          issuer: issuer,
+          idp_id: "old-subject-id",
+          email: "recreated@example.com",
+          synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+        )
+
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(account.id, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "new-subject-id",
+                   email: "recreated@example.com",
+                   name: "Recreated User",
+                   given_name: "Recreated",
+                   family_name: "User",
+                   preferred_username: "recreated@example.com",
+                   picture: nil
+                 }
+               ])
+
+      identities =
+        from(ei in Portal.ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == stale_identity.id
+      assert identity.idp_id == "new-subject-id"
+      assert identity.directory_id == directory.id
     end
 
     test "group upsert rejects stale synced_at and accepts fresh" do

--- a/elixir/test/portal/google/sync_test.exs
+++ b/elixir/test/portal/google/sync_test.exs
@@ -2372,6 +2372,87 @@ defmodule Portal.Google.SyncTest do
       assert identity.directory_id == directory.id
     end
 
+    test "identity upsert attaches the directory to an actor's pre-existing OIDC identity" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = google_directory_fixture(account: account)
+      issuer = "https://accounts.google.com"
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "oidc@example.com")
+
+      auth_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          issuer: issuer,
+          idp_id: "subject-1",
+          email: "oidc@example.com"
+        )
+
+      assert auth_identity.directory_id == nil
+
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(account.id, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "subject-1",
+                   email: "oidc@example.com",
+                   name: "OIDC User",
+                   given_name: "OIDC",
+                   family_name: "User",
+                   preferred_username: "oidc@example.com",
+                   picture: nil
+                 }
+               ])
+
+      identities =
+        from(ei in Portal.ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == auth_identity.id
+      assert identity.directory_id == directory.id
+    end
+
+    test "identity upsert errors when one batch maps two idp_ids to the same actor" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = google_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://accounts.google.com"
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "swap@example.com")
+
+      Portal.IdentityFixtures.identity_fixture(
+        account: account,
+        actor: actor,
+        directory: base_directory,
+        issuer: issuer,
+        idp_id: "old-subject-id",
+        email: "swap@example.com",
+        synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+      )
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :cardinality_violation}}} =
+               Database.batch_upsert_identities(account.id, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "old-subject-id",
+                   email: "renamed@example.com",
+                   name: "Old",
+                   given_name: "Old",
+                   family_name: "User",
+                   preferred_username: "renamed@example.com",
+                   picture: nil
+                 },
+                 %{
+                   idp_id: "new-subject-id",
+                   email: "swap@example.com",
+                   name: "New",
+                   given_name: "New",
+                   family_name: "User",
+                   preferred_username: "swap@example.com",
+                   picture: nil
+                 }
+               ])
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = google_directory_fixture(account: account)

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -2043,6 +2043,50 @@ defmodule Portal.Okta.SyncTest do
       assert DateTime.compare(sync_state_after_fresh.synced_at, future) == :eq
     end
 
+    test "identity upsert recycles stale identity when user is recreated with a new idp_id" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = okta_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://okta.example"
+
+      actor =
+        Portal.ActorFixtures.actor_fixture(account: account, email: "recreated@example.com")
+
+      stale_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          directory: base_directory,
+          issuer: issuer,
+          idp_id: "old-okta-id",
+          email: "recreated@example.com",
+          synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+        )
+
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "new-okta-id",
+                   email: "recreated@example.com",
+                   name: "Recreated User",
+                   given_name: "Recreated",
+                   family_name: "User",
+                   preferred_username: "recreated@example.com"
+                 }
+               ])
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == stale_identity.id
+      assert identity.idp_id == "new-okta-id"
+      assert identity.directory_id == directory.id
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = okta_directory_fixture(account: account)

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -2087,6 +2087,84 @@ defmodule Portal.Okta.SyncTest do
       assert identity.directory_id == directory.id
     end
 
+    test "identity upsert attaches the directory to an actor's pre-existing OIDC identity" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = okta_directory_fixture(account: account)
+      issuer = "https://okta.example"
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "oidc@example.com")
+
+      auth_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          issuer: issuer,
+          idp_id: "subject-1",
+          email: "oidc@example.com"
+        )
+
+      assert auth_identity.directory_id == nil
+
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "subject-1",
+                   email: "oidc@example.com",
+                   name: "OIDC User",
+                   given_name: "OIDC",
+                   family_name: "User",
+                   preferred_username: "oidc@example.com"
+                 }
+               ])
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == auth_identity.id
+      assert identity.directory_id == directory.id
+    end
+
+    test "identity upsert errors when one batch maps two idp_ids to the same actor" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = okta_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+      issuer = "https://okta.example"
+      actor = Portal.ActorFixtures.actor_fixture(account: account, email: "swap@example.com")
+
+      Portal.IdentityFixtures.identity_fixture(
+        account: account,
+        actor: actor,
+        directory: base_directory,
+        issuer: issuer,
+        idp_id: "old-okta-id",
+        email: "swap@example.com",
+        synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+      )
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :cardinality_violation}}} =
+               Database.batch_upsert_identities(account.id, issuer, directory.id, DateTime.utc_now(), [
+                 %{
+                   idp_id: "old-okta-id",
+                   email: "renamed@example.com",
+                   name: "Old",
+                   given_name: "Old",
+                   family_name: "User",
+                   preferred_username: "renamed@example.com"
+                 },
+                 %{
+                   idp_id: "new-okta-id",
+                   email: "swap@example.com",
+                   name: "New",
+                   given_name: "New",
+                   family_name: "User",
+                   preferred_username: "swap@example.com"
+                 }
+               ])
+    end
+
     test "identity upsert updates issuer when a directory is reverified against a new domain" do
       account = account_fixture(features: %{idp_sync: true})
       directory = okta_directory_fixture(account: account)

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -2087,6 +2087,57 @@ defmodule Portal.Okta.SyncTest do
       assert identity.directory_id == directory.id
     end
 
+    test "identity upsert updates issuer when a directory is reverified against a new domain" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = okta_directory_fixture(account: account)
+      base_directory = Repo.get_by!(Portal.Directory, id: directory.id, account_id: account.id)
+
+      actor =
+        Portal.ActorFixtures.actor_fixture(account: account, email: "moved@example.com")
+
+      # Identity recorded under the directory's previous Okta domain/issuer.
+      stale_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          directory: base_directory,
+          issuer: "https://old.okta.example",
+          idp_id: "okta-user",
+          email: "moved@example.com",
+          synced_at: DateTime.add(DateTime.utc_now(), -86_400, :second)
+        )
+
+      # The directory is reverified against a new domain, so the sync runs with
+      # a new issuer for the same Okta user id.
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(
+                 account.id,
+                 "https://new.okta.example",
+                 directory.id,
+                 DateTime.utc_now(),
+                 [
+                   %{
+                     idp_id: "okta-user",
+                     email: "moved@example.com",
+                     name: "Moved User",
+                     given_name: "Moved",
+                     family_name: "User",
+                     preferred_username: "moved@example.com"
+                   }
+                 ]
+               )
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == stale_identity.id
+      assert identity.issuer == "https://new.okta.example"
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = okta_directory_fixture(account: account)

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1008,6 +1008,72 @@ defmodule PortalWeb.OIDCControllerTest do
              )
     end
 
+    test "changed email with the same idp_id is matched by idp_id, not email", ctx do
+      actor = admin_actor_fixture(account: ctx.account, email: "old-address@example.com")
+
+      existing_identity =
+        identity_fixture(
+          account: ctx.account,
+          actor: actor,
+          issuer: ctx.provider.issuer,
+          idp_id: "stable-subject",
+          email: "old-address@example.com"
+        )
+
+      # Same subject, new email. The actor still carries the old email, so the
+      # match must fall back to idp_id rather than create a second identity.
+      setup_successful_auth(ctx, actor, sub: "stable-subject", email: "new-address@example.com")
+
+      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+
+      identity =
+        Repo.get_by!(Portal.ExternalIdentity,
+          account_id: ctx.account.id,
+          issuer: ctx.provider.issuer,
+          idp_id: "stable-subject"
+        )
+
+      assert identity.id == existing_identity.id
+      assert identity.email == "new-address@example.com"
+    end
+
+    test "sign-in does not overwrite an identity from a different issuer", ctx do
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+
+      other_issuer_identity =
+        identity_fixture(
+          account: ctx.account,
+          actor: actor,
+          issuer: "https://other-issuer.example",
+          idp_id: "stable-subject",
+          email: actor.email
+        )
+
+      # Same email and subject, but a different issuer. existing_identity is
+      # scoped by issuer, so this must create a new identity and leave the
+      # other issuer's identity untouched.
+      setup_successful_auth(ctx, actor, sub: "stable-subject", email: actor.email)
+
+      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+
+      assert new_identity =
+               Repo.get_by(Portal.ExternalIdentity,
+                 account_id: ctx.account.id,
+                 issuer: ctx.provider.issuer,
+                 idp_id: "stable-subject"
+               )
+
+      assert new_identity.id != other_issuer_identity.id
+
+      assert Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: "https://other-issuer.example",
+               idp_id: "stable-subject"
+             ).id == other_issuer_identity.id
+    end
+
     test "successful client sign-in for admin user creates token and renders redirect page",
          ctx do
       actor = admin_actor_fixture(account: ctx.account, email: unique_email())

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -975,6 +975,39 @@ defmodule PortalWeb.OIDCControllerTest do
       assert_portal_sign_in_success(ctx)
     end
 
+    test "recreated user with a new idp_id overwrites their identity in place", ctx do
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+
+      existing_identity =
+        identity_fixture(
+          account: ctx.account,
+          actor: actor,
+          issuer: ctx.provider.issuer,
+          idp_id: "old-object-id",
+          email: actor.email
+        )
+
+      # The user is deleted and recreated in the IdP: same verified email, brand
+      # new object id. Sign-in must recycle the existing row instead of inserting
+      # a second identity for the same actor.
+      setup_successful_auth(ctx, actor, sub: "new-object-id", email: actor.email)
+
+      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
+      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
+
+      assert Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer,
+               idp_id: "new-object-id"
+             ).id == existing_identity.id
+
+      refute Repo.get_by(Portal.ExternalIdentity,
+               account_id: ctx.account.id,
+               issuer: ctx.provider.issuer,
+               idp_id: "old-object-id"
+             )
+    end
+
     test "successful client sign-in for admin user creates token and renders redirect page",
          ctx do
       actor = admin_actor_fixture(account: ctx.account, email: unique_email())


### PR DESCRIPTION
Directory sync enforces one identity per provider-actor, with the actor's email as the unique roll-up key for attaching trusted external identities. Several flows could create a second identity for the same actor and crash the sync. When a new external identity arrives for an existing provider-actor, it now replaces the existing one in place rather than inserting a duplicate.

Edge cases fixed:

- Recreated IdP user with the same email now recycles the stale identity in place instead of crashing the sync.
- A user who signs in via OIDC before the next sync overwrites their identity rather than duplicating it.
- Reverifying a directory onto a new tenant or domain updates the issuer on recycled identities in place.
- A concurrent OIDC sign-in racing a running sync retries once so the upsert resolves instead of failing.
- Two concurrent OIDC callbacks for the same new subject retry once instead of raising a unique violation.

Fixes #13823
