### PR TITLE
fix(apple): handle installed but invalid vpn

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -101,7 +101,11 @@ public struct AppView: View {
         GrantVPNView()
       case (_, .notDetermined):
         GrantNotificationsView()
-      case (.disconnected, _):
+      case (.disconnected, _), (.invalid, _):
+        // A freshly installed configuration reports `.invalid` until the system
+        // finishes registering it. The `.invalid` + no-manager case is handled
+        // above, so reaching here means the configuration is installed and the
+        // user just needs to sign in (which enables it and settles the status).
         IOSNavigationView {
           WelcomeView()
         }


### PR DESCRIPTION
Follow up to #13822 - it's possible we briefly see this state after installing for the first time.