### PR TITLE
fix(gui-client): don't block shutdown on notification

### DIFF
--- a/rust/gui-client/src-tauri/src/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/gui/os_linux.rs
@@ -55,7 +55,7 @@ pub(crate) fn show_notification(title: String, body: String) -> Result<Notificat
 
         tracing::debug!(%title, %body, "Showing notification");
 
-        notification.on_close(|| {});
+        notification.wait_for_action_async(|_| {}).await;
     });
 
     Ok(NotificationHandle { on_click: rx })


### PR DESCRIPTION
In order to display notifications reliably on Linux, we need to attach a handler to it, otherwise the D-bus connection gets dropped immediately. Using `on_close` uses the blocking thread-pool internally however which can cause a dead-lock during runtime shutdown because tasks on the blocking thread-pool cannot be preempted, preventing the GUI process from exiting if there is still a not-dismissed notification.

To fix this, we use the `async` variant to wait for the notification action.