### PR TITLE
chore(gui-client): don't verify GUI path in debug-builds

### DIFF
--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -9,13 +9,22 @@ mod peer_check;
 
 use super::{NotFound, SocketId};
 use anyhow::{Context as _, Result};
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io::ErrorKind, os::unix::fs::PermissionsExt, path::PathBuf};
 use tokio::net::{UnixListener, UnixStream};
 
-/// No-op twin of the Windows function. Unix IPC uses filesystem permissions
-/// instead of an owner-SID check, so there is nothing to skip.
+/// Whether to skip the tunnel pipe owner check.
 #[cfg(debug_assertions)]
-pub fn skip_tunnel_pipe_owner_check() {}
+static SKIP_TUNNEL_PIPE_OWNER_CHECK: AtomicBool = AtomicBool::new(false);
+
+/// Set [`SKIP_TUNNEL_PIPE_OWNER_CHECK`].
+///
+/// Call once at process startup, before any `Server::new(SocketId::Tunnel)` or `connect_to_socket`.
+#[cfg(debug_assertions)]
+pub fn skip_tunnel_pipe_owner_check() {
+    SKIP_TUNNEL_PIPE_OWNER_CHECK.store(true, Ordering::Relaxed);
+}
 
 pub struct Server {
     listener: UnixListener,
@@ -109,6 +118,19 @@ impl Server {
         loop {
             let (stream, _) = self.listener.accept().await?;
             let cred = stream.peer_cred()?;
+
+            #[cfg(debug_assertions)]
+            if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) {
+                tracing::info!(
+                    uid = cred.uid(),
+                    gid = cred.gid(),
+                    pid = cred.pid(),
+                    "Accepted an IPC connection without stream owner check"
+                );
+                let pid = cred.pid().context("No PID")?.try_into()?;
+
+                return Ok((stream, pid));
+            }
 
             match self.allowed_peer.verify(stream) {
                 Ok(stream) => {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -845,7 +845,13 @@ pub fn run_smoke_test() -> Result<()> {
     // The smoke test runs this binary as an unprivileged subprocess of the
     // test runner — not as a Windows service under LocalSystem. Tell the IPC
     // layer to skip pinning/checking LocalSystem ownership on the Tunnel pipe;
-    // otherwise `CreateNamedPipeW` fails with `ERROR_INVALID_OWNER` on Windows.
+    // otherwise `CreateNamedPipeW` fails with `ERROR_INVALID_OWNER`.
+    //
+    // Windows-only: on Unix the same call disables peer-binary verification,
+    // which the smoke test exercises. It installs the GUI at the canonical path
+    // for the happy path and launches one from elsewhere to assert the tunnel
+    // rejects unrecognised binaries.
+    #[cfg(target_os = "windows")]
     ipc::skip_tunnel_pipe_owner_check();
 
     let log_filter_reloader = logging::setup_stdout()?;


### PR DESCRIPTION
When running the tunnel service interactively, we usually want to pair it with a non-installed version of the GUI client. Right now, the pipe owner check on Linux is a no-op stub, thus running the actual peer verification code, which refuses to accept connections binaries in places other than `/usr/bin/firezone-client-gui`.

To make local development easier, we implement the pipe owner check for Linux too and skip the binary verification altogether.