### PR TITLE
chore: increase the netem queue depth

### DIFF
--- a/scripts/router/router.sh
+++ b/scripts/router/router.sh
@@ -68,8 +68,8 @@ fi
 if [ -n "${NETWORK_LATENCY_MS:-}" ]; then
     LATENCY=$((NETWORK_LATENCY_MS / 2)) # Latency is only applied to outbound packets. To achieve the actual configured latency, we apply half of it to each interface.
 
-    tc qdisc add dev internet root netem delay "${LATENCY}ms"
-    tc qdisc add dev internal root netem delay "${LATENCY}ms"
+    tc qdisc add dev internet root netem delay "${LATENCY}ms" limit 100000
+    tc qdisc add dev internal root netem delay "${LATENCY}ms" limit 100000
 fi
 
 ip link set dev internal txqueuelen 100000


### PR DESCRIPTION
The default `netem` queue depth is only 1000. This can cause packet loss during testing in the local docker-compose environment.

The kernel enforces this queue depth in `netem_enqueue()`, which drops once `sch->q.qlen >= sch->limit`:
https://github.com/torvalds/linux/blob/master/net/sched/sch_netem.c

(The `1000` default itself is supplied by iproute2's `tc` when `limit` is omitted — `tc/q_netem.c`, `netem_parse_opt`.)
