### PR TITLE
fix(portal): prevent dupe identities

### DIFF
--- a/elixir/lib/portal/entra/sync.ex
+++ b/elixir/lib/portal/entra/sync.ex
@@ -874,17 +874,22 @@ defmodule Portal.Entra.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
-      -- Recycles the actor's existing directory identity when its idp_id changed
-      -- (e.g. the IdP user was deleted and recreated with the same email). The
-      -- LEFT JOIN below assumes at most one row per actor here, which is
-      -- guaranteed by the partial unique index on (account_id, actor_id,
-      -- directory_id) from migration 20260506124134.
+      -- Recycles the actor's existing identity for this directory so a changed
+      -- idp_id (issuer unchanged) or a changed issuer (directory reverified
+      -- against a new tenant) updates the row in place instead of inserting a
+      -- second one and tripping the (account_id, actor_id, issuer) unique index.
+      -- Matching on issuer OR directory_id covers both: issuer alone catches
+      -- legacy rows whose directory_id is NULL or differs; directory_id alone
+      -- catches the row whose issuer just changed. DISTINCT ON keeps one row per
+      -- actor, preferring the row that already holds the new issuer so updating
+      -- it cannot collide on that index.
       existing_directory_identities AS (
-        SELECT ei.id, ei.actor_id
+        SELECT DISTINCT ON (ei.actor_id) ei.id, ei.actor_id
         FROM external_identities ei
         WHERE ei.account_id = $#{account_id}
-          AND ei.directory_id = $#{directory_id}
           AND ei.actor_id IN (SELECT actor_id FROM existing_actors_by_email)
+          AND (ei.issuer = $#{issuer} OR ei.directory_id = $#{directory_id})
+        ORDER BY ei.actor_id, (ei.issuer = $#{issuer}) DESC
       ),
       actors_to_create AS (
         SELECT

--- a/elixir/lib/portal/external_identity.ex
+++ b/elixir/lib/portal/external_identity.ex
@@ -47,5 +47,6 @@ defmodule Portal.ExternalIdentity do
     |> assoc_constraint(:account)
     |> assoc_constraint(:directory)
     |> unique_constraint(:base, name: :external_identities_account_idp_fields_index)
+    |> unique_constraint(:base, name: :external_identities_account_id_actor_id_issuer_index)
   end
 end

--- a/elixir/lib/portal/google/sync.ex
+++ b/elixir/lib/portal/google/sync.ex
@@ -1097,17 +1097,22 @@ defmodule Portal.Google.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
-      -- Recycles the actor's existing directory identity when its idp_id changed
-      -- (e.g. the IdP user was deleted and recreated with the same email). The
-      -- LEFT JOIN below assumes at most one row per actor here, which is
-      -- guaranteed by the partial unique index on (account_id, actor_id,
-      -- directory_id) from migration 20260506124134.
+      -- Recycles the actor's existing identity for this directory so a changed
+      -- idp_id (issuer unchanged) or a changed issuer (directory reverified
+      -- against a new domain) updates the row in place instead of inserting a
+      -- second one and tripping the (account_id, actor_id, issuer) unique index.
+      -- Matching on issuer OR directory_id covers both: issuer alone catches
+      -- legacy rows whose directory_id is NULL or differs; directory_id alone
+      -- catches the row whose issuer just changed. DISTINCT ON keeps one row per
+      -- actor, preferring the row that already holds the new issuer so updating
+      -- it cannot collide on that index.
       existing_directory_identities AS (
-        SELECT ei.id, ei.actor_id
+        SELECT DISTINCT ON (ei.actor_id) ei.id, ei.actor_id
         FROM external_identities ei
         WHERE ei.account_id = $#{account_id}
-          AND ei.directory_id = $#{directory_id}
           AND ei.actor_id IN (SELECT actor_id FROM existing_actors_by_email)
+          AND (ei.issuer = $#{issuer} OR ei.directory_id = $#{directory_id})
+        ORDER BY ei.actor_id, (ei.issuer = $#{issuer}) DESC
       ),
       actors_to_create AS (
         SELECT

--- a/elixir/lib/portal/okta/sync.ex
+++ b/elixir/lib/portal/okta/sync.ex
@@ -805,17 +805,22 @@ defmodule Portal.Okta.Sync do
           AND id.email IS NOT NULL
         ORDER BY id.idp_id, a.inserted_at ASC
       ),
-      -- Recycles the actor's existing directory identity when its idp_id changed
-      -- (e.g. the IdP user was deleted and recreated with the same email). The
-      -- LEFT JOIN below assumes at most one row per actor here, which is
-      -- guaranteed by the partial unique index on (account_id, actor_id,
-      -- directory_id) from migration 20260506124134.
+      -- Recycles the actor's existing identity for this directory so a changed
+      -- idp_id (issuer unchanged) or a changed issuer (directory reverified
+      -- against a new domain) updates the row in place instead of inserting a
+      -- second one and tripping the (account_id, actor_id, issuer) unique index.
+      -- Matching on issuer OR directory_id covers both: issuer alone catches
+      -- legacy rows whose directory_id is NULL or differs; directory_id alone
+      -- catches the row whose issuer just changed. DISTINCT ON keeps one row per
+      -- actor, preferring the row that already holds the new issuer so updating
+      -- it cannot collide on that index.
       existing_directory_identities AS (
-        SELECT ei.id, ei.actor_id
+        SELECT DISTINCT ON (ei.actor_id) ei.id, ei.actor_id
         FROM external_identities ei
         WHERE ei.account_id = $#{account_id}
-          AND ei.directory_id = $#{directory_id}
           AND ei.actor_id IN (SELECT actor_id FROM existing_actors_by_email)
+          AND (ei.issuer = $#{issuer} OR ei.directory_id = $#{directory_id})
+        ORDER BY ei.actor_id, (ei.issuer = $#{issuer}) DESC
       ),
       actors_to_create AS (
         SELECT

--- a/elixir/lib/portal_web/controllers/oidc_controller.ex
+++ b/elixir/lib/portal_web/controllers/oidc_controller.ex
@@ -1550,20 +1550,50 @@ defmodule PortalWeb.OIDCController do
       end
     end
 
-    defp insert_external_identity_from_pending(%PendingIdentity{} = pending_identity) do
+    @pending_identity_replace_fields [
+      :idp_id,
+      :email,
+      :name,
+      :given_name,
+      :family_name,
+      :middle_name,
+      :nickname,
+      :preferred_username,
+      :profile,
+      :picture,
+      :updated_at
+    ]
+
+    defp insert_external_identity_from_pending(%PendingIdentity{} = pending_identity, retry? \\ true) do
       now = DateTime.utc_now()
+
+      # Recycle the actor's existing identity for this issuer, if any, so a
+      # changed subject updates that row in place rather than inserting a second
+      # one and tripping the (account_id, actor_id, issuer) unique index. When
+      # none exists, fall back to the pending identity's own id for a fresh row.
+      existing_id =
+        from(ei in ExternalIdentity,
+          where:
+            ei.account_id == ^pending_identity.account_id and
+              ei.actor_id == ^pending_identity.actor_id and
+              ei.issuer == ^pending_identity.issuer,
+          select: ei.id,
+          limit: 1
+        )
+        |> Safe.unscoped()
+        |> Safe.one()
 
       attrs =
         pending_identity
         |> Map.from_struct()
         |> Map.take([
-          :id,
           :account_id,
           :actor_id,
           :issuer,
           :idp_id,
           :directory_id | @pending_identity_profile_fields
         ])
+        |> Map.put(:id, existing_id || pending_identity.id)
         |> Map.put(:inserted_at, now)
         |> Map.put(:updated_at, now)
 
@@ -1571,33 +1601,40 @@ defmodule PortalWeb.OIDCController do
              Safe.unscoped(),
              ExternalIdentity,
              [attrs],
-             on_conflict: external_identity_conflict_query(pending_identity),
-             conflict_target: [:account_id, :idp_id, :issuer],
+             on_conflict: {:replace, @pending_identity_replace_fields},
+             conflict_target: [:account_id, :id],
              returning: true
            ) do
         {1, [%ExternalIdentity{} = identity]} -> {:ok, identity}
         {0, []} -> {:error, :invalid_code}
       end
-    end
+    rescue
+      e in Postgrex.Error ->
+        case e do
+          %Postgrex.Error{
+            postgres: %{
+              code: :unique_violation,
+              constraint: "external_identities_account_idp_fields_index"
+            }
+          } ->
+            # The incoming idp_id already belongs to another actor for this
+            # issuer; promoting would steal it, so reject the code instead.
+            {:error, :invalid_code}
 
-    defp external_identity_conflict_query(%PendingIdentity{} = pending_identity) do
-      from(identity in ExternalIdentity,
-        where: identity.actor_id == ^pending_identity.actor_id,
-        update: [
-          set: [
-            email: fragment("EXCLUDED.email"),
-            name: fragment("EXCLUDED.name"),
-            given_name: fragment("EXCLUDED.given_name"),
-            family_name: fragment("EXCLUDED.family_name"),
-            middle_name: fragment("EXCLUDED.middle_name"),
-            nickname: fragment("EXCLUDED.nickname"),
-            preferred_username: fragment("EXCLUDED.preferred_username"),
-            profile: fragment("EXCLUDED.profile"),
-            picture: fragment("EXCLUDED.picture"),
-            updated_at: fragment("EXCLUDED.updated_at")
-          ]
-        ]
-      )
+          %Postgrex.Error{
+            postgres: %{
+              code: :unique_violation,
+              constraint: "external_identities_account_id_actor_id_issuer_index"
+            }
+          }
+          when retry? ->
+            # A concurrent promotion created the actor's issuer row after our
+            # lookup; retry once to recycle it.
+            insert_external_identity_from_pending(pending_identity, false)
+
+          _ ->
+            reraise e, __STACKTRACE__
+        end
     end
 
     defp atomize_profile_attrs(attrs) do

--- a/elixir/priv/repo/migrations/20260624000001_dedup_external_identities_by_actor_issuer.exs
+++ b/elixir/priv/repo/migrations/20260624000001_dedup_external_identities_by_actor_issuer.exs
@@ -24,6 +24,10 @@ defmodule Portal.Repo.Migrations.DedupExternalIdentitiesByActorIssuer do
   #      already exists, created otherwise). If the target actor already has an
   #      identity for this issuer the relocated row is redundant and is deleted.
   #      A row with no email cannot own an account_user actor, so it is deleted.
+  #
+  #      Relocating only flips actor_id; group memberships and live sessions for
+  #      the relocated person are left for the next directory sign-in/sync to
+  #      reconcile rather than rebuilt here.
   def up do
     execute("""
     CREATE PROCEDURE pg_temp.collapse_same_email_identities()
@@ -69,6 +73,7 @@ defmodule Portal.Repo.Migrations.DedupExternalIdentitiesByActorIssuer do
       g RECORD;
       r RECORD;
       v_actor_email citext;
+      v_actor_disabled_at timestamptz;
       v_home_id uuid;
       v_target_actor uuid;
       v_new_actor uuid;
@@ -79,7 +84,7 @@ defmodule Portal.Repo.Migrations.DedupExternalIdentitiesByActorIssuer do
         GROUP BY account_id, actor_id, issuer
         HAVING COUNT(*) > 1
       LOOP
-        SELECT email INTO v_actor_email
+        SELECT email, disabled_at INTO v_actor_email, v_actor_disabled_at
         FROM actors
         WHERE account_id = g.account_id AND id = g.actor_id;
 
@@ -100,7 +105,7 @@ defmodule Portal.Repo.Migrations.DedupExternalIdentitiesByActorIssuer do
         END IF;
 
         FOR r IN
-          SELECT id, email, name
+          SELECT id, email, name, directory_id
           FROM external_identities
           WHERE account_id = g.account_id AND actor_id = g.actor_id AND issuer = g.issuer
             AND id <> v_home_id
@@ -117,15 +122,23 @@ defmodule Portal.Repo.Migrations.DedupExternalIdentitiesByActorIssuer do
           LIMIT 1;
 
           IF v_target_actor IS NULL THEN
-            v_new_actor := uuid_generate_v4();
+            v_new_actor := gen_random_uuid();
 
-            INSERT INTO actors (id, type, account_id, email, name, inserted_at, updated_at)
+            -- Carry over the merged actor's disabled_at so a relocated person is
+            -- not silently re-enabled, and created_by_directory_id from the
+            -- relocated identity so provider cleanup can later reap the actor if
+            -- the IdP user is removed. name is bounded to the actors.name 255
+            -- limit. Group memberships are left for the next directory sync to
+            -- reconcile rather than copied here.
+            INSERT INTO actors (id, type, account_id, email, name, created_by_directory_id, disabled_at, inserted_at, updated_at)
             VALUES (
               v_new_actor,
               'account_user',
               g.account_id,
               r.email,
-              COALESCE(NULLIF(r.name, ''), r.email::text),
+              LEFT(COALESCE(NULLIF(r.name, ''), r.email::text), 255),
+              r.directory_id,
+              v_actor_disabled_at,
               now(),
               now()
             );

--- a/elixir/priv/repo/migrations/20260624000001_dedup_external_identities_by_actor_issuer.exs
+++ b/elixir/priv/repo/migrations/20260624000001_dedup_external_identities_by_actor_issuer.exs
@@ -1,0 +1,161 @@
+defmodule Portal.Repo.Migrations.DedupExternalIdentitiesByActorIssuer do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  # Resolves duplicate external identities so that every (account_id, actor_id,
+  # issuer) holds at most one row, in preparation for a unique index on that
+  # tuple. directory_id has no bearing here.
+  #
+  # Duplicates arose because the value stored in idp_id for the same person
+  # changed over time (email -> provider subject, Entra sub -> oid, etc.) while
+  # the upsert keyed conflicts on idp_id, so each change inserted a fresh row
+  # instead of updating in place.
+  #
+  # Two phases:
+  #
+  #   1. Same email: collapse rows that share (account_id, actor_id, issuer,
+  #      email), keeping the most recently used row (greatest updated_at, then
+  #      inserted_at). This folds together the same person's stale idp_id rows.
+  #
+  #   2. Different emails on one actor: these are different people merged onto
+  #      one actor. The row whose email matches the actor's own email stays; each
+  #      other email is relocated to the actor that owns that email (reused if it
+  #      already exists, created otherwise). If the target actor already has an
+  #      identity for this issuer the relocated row is redundant and is deleted.
+  #      A row with no email cannot own an account_user actor, so it is deleted.
+  def up do
+    execute("""
+    CREATE PROCEDURE pg_temp.collapse_same_email_identities()
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      v_deleted integer;
+    BEGIN
+      LOOP
+        WITH ranked AS (
+          SELECT
+            ei.id,
+            ei.account_id,
+            ROW_NUMBER() OVER (
+              PARTITION BY ei.account_id, ei.actor_id, ei.issuer, ei.email
+              ORDER BY ei.updated_at DESC NULLS LAST, ei.inserted_at DESC, ei.id DESC
+            ) AS rn
+          FROM external_identities ei
+        ),
+        doomed AS (
+          SELECT id, account_id FROM ranked WHERE rn > 1 LIMIT 5000
+        )
+        DELETE FROM external_identities ei
+        USING doomed d
+        WHERE ei.account_id = d.account_id
+          AND ei.id = d.id;
+
+        GET DIAGNOSTICS v_deleted = ROW_COUNT;
+        EXIT WHEN v_deleted = 0;
+        COMMIT;
+      END LOOP;
+    END;
+    $$;
+    """)
+
+    execute("CALL pg_temp.collapse_same_email_identities()")
+
+    execute("""
+    CREATE PROCEDURE pg_temp.split_mixed_email_identities()
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      g RECORD;
+      r RECORD;
+      v_actor_email citext;
+      v_home_id uuid;
+      v_target_actor uuid;
+      v_new_actor uuid;
+    BEGIN
+      FOR g IN
+        SELECT account_id, actor_id, issuer
+        FROM external_identities
+        GROUP BY account_id, actor_id, issuer
+        HAVING COUNT(*) > 1
+      LOOP
+        SELECT email INTO v_actor_email
+        FROM actors
+        WHERE account_id = g.account_id AND id = g.actor_id;
+
+        -- Home row: the one matching the actor's own email, else the newest.
+        SELECT id INTO v_home_id
+        FROM external_identities
+        WHERE account_id = g.account_id AND actor_id = g.actor_id AND issuer = g.issuer
+          AND v_actor_email IS NOT NULL AND email = v_actor_email
+        ORDER BY updated_at DESC NULLS LAST, inserted_at DESC, id DESC
+        LIMIT 1;
+
+        IF v_home_id IS NULL THEN
+          SELECT id INTO v_home_id
+          FROM external_identities
+          WHERE account_id = g.account_id AND actor_id = g.actor_id AND issuer = g.issuer
+          ORDER BY updated_at DESC NULLS LAST, inserted_at DESC, id DESC
+          LIMIT 1;
+        END IF;
+
+        FOR r IN
+          SELECT id, email, name
+          FROM external_identities
+          WHERE account_id = g.account_id AND actor_id = g.actor_id AND issuer = g.issuer
+            AND id <> v_home_id
+        LOOP
+          IF r.email IS NULL THEN
+            DELETE FROM external_identities
+            WHERE account_id = g.account_id AND id = r.id;
+            CONTINUE;
+          END IF;
+
+          SELECT id INTO v_target_actor
+          FROM actors
+          WHERE account_id = g.account_id AND email = r.email AND id <> g.actor_id
+          LIMIT 1;
+
+          IF v_target_actor IS NULL THEN
+            v_new_actor := uuid_generate_v4();
+
+            INSERT INTO actors (id, type, account_id, email, name, inserted_at, updated_at)
+            VALUES (
+              v_new_actor,
+              'account_user',
+              g.account_id,
+              r.email,
+              COALESCE(NULLIF(r.name, ''), r.email::text),
+              now(),
+              now()
+            );
+
+            UPDATE external_identities
+            SET actor_id = v_new_actor
+            WHERE account_id = g.account_id AND id = r.id;
+          ELSIF EXISTS (
+            SELECT 1 FROM external_identities
+            WHERE account_id = g.account_id AND actor_id = v_target_actor AND issuer = g.issuer
+          ) THEN
+            DELETE FROM external_identities
+            WHERE account_id = g.account_id AND id = r.id;
+          ELSE
+            UPDATE external_identities
+            SET actor_id = v_target_actor
+            WHERE account_id = g.account_id AND id = r.id;
+          END IF;
+        END LOOP;
+
+        COMMIT;
+      END LOOP;
+    END;
+    $$;
+    """)
+
+    execute("CALL pg_temp.split_mixed_email_identities()")
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/elixir/priv/repo/migrations/20260624000002_add_actor_issuer_unique_index_to_external_identities.exs
+++ b/elixir/priv/repo/migrations/20260624000002_add_actor_issuer_unique_index_to_external_identities.exs
@@ -1,0 +1,48 @@
+defmodule Portal.Repo.Migrations.AddActorIssuerUniqueIndexToExternalIdentities do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  # Enforces one external identity per (account_id, actor_id, issuer). directory_id
+  # has no bearing on identity uniqueness.
+  #
+  # Requires the dedup migration (20260624000001) to have removed all existing
+  # violations, and the sync/interactive upserts to recycle the actor's identity
+  # by (account_id, actor_id, issuer) rather than by directory_id, or the next
+  # sync would insert a fresh row and trip this constraint.
+  #
+  # The previous partial unique index on (account_id, actor_id, directory_id) is
+  # subsumed by this one: a directory has a single issuer, so any pair it
+  # forbade (same actor + directory) is also forbidden here, regardless of
+  # directory_id.
+  def up do
+    create_if_not_exists(
+      index(:external_identities, [:account_id, :actor_id, :issuer],
+        unique: true,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:external_identities, [:account_id, :actor_id, :directory_id],
+        name: :external_identities_account_id_actor_id_directory_id_index,
+        concurrently: true
+      )
+    )
+  end
+
+  def down do
+    create_if_not_exists(
+      index(:external_identities, [:account_id, :actor_id, :directory_id],
+        unique: true,
+        where: "directory_id IS NOT NULL",
+        name: :external_identities_account_id_actor_id_directory_id_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:external_identities, [:account_id, :actor_id, :issuer], concurrently: true)
+    )
+  end
+end

--- a/elixir/test/portal/okta/sync_test.exs
+++ b/elixir/test/portal/okta/sync_test.exs
@@ -2216,6 +2216,56 @@ defmodule Portal.Okta.SyncTest do
       assert identity.issuer == "https://new.okta.example"
     end
 
+    test "identity upsert recycles a legacy same-issuer identity with a mismatched directory_id" do
+      account = account_fixture(features: %{idp_sync: true})
+      directory = okta_directory_fixture(account: account)
+
+      actor =
+        Portal.ActorFixtures.actor_fixture(account: account, email: "legacy@example.com")
+
+      # Legacy interactive identity for the same issuer but with no directory
+      # association, so recycling by directory_id alone would miss it.
+      legacy_identity =
+        Portal.IdentityFixtures.identity_fixture(
+          account: account,
+          actor: actor,
+          issuer: "https://test.okta.example",
+          idp_id: "old-okta-user",
+          email: "legacy@example.com"
+        )
+
+      # The same person is recreated in the IdP under a new id, so the sync runs
+      # with a new idp_id for the same issuer and email.
+      assert {:ok, %{upserted_identities: 1}} =
+               Database.batch_upsert_identities(
+                 account.id,
+                 "https://test.okta.example",
+                 directory.id,
+                 DateTime.utc_now(),
+                 [
+                   %{
+                     idp_id: "new-okta-user",
+                     email: "legacy@example.com",
+                     name: "Legacy User",
+                     given_name: "Legacy",
+                     family_name: "User",
+                     preferred_username: "legacy@example.com"
+                   }
+                 ]
+               )
+
+      identities =
+        from(ei in ExternalIdentity,
+          where: ei.account_id == ^account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == legacy_identity.id
+      assert identity.idp_id == "new-okta-user"
+      assert identity.directory_id == directory.id
+    end
+
     test "group upsert rejects stale synced_at and accepts fresh" do
       account = account_fixture(features: %{idp_sync: true})
       directory = okta_directory_fixture(account: account)

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1009,57 +1009,40 @@ defmodule PortalWeb.OIDCControllerTest do
              )
     end
 
-    test "sign-in recycles the row already holding the incoming idp_id, not a sibling sharing the email",
-         ctx do
+    test "rejects a second identity sharing the actor and issuer", ctx do
       actor = admin_actor_fixture(account: ctx.account, email: unique_email())
       directory = Portal.DirectoryFixtures.directory_fixture(account: ctx.account)
-      guid = Ecto.UUID.generate()
 
       # Interactive row keyed on the Entra `sub`, no directory association.
-      interactive_identity =
-        identity_fixture(
-          account: ctx.account,
-          actor: actor,
-          issuer: ctx.provider.issuer,
-          idp_id: "entra-sub-#{System.unique_integer([:positive])}",
-          email: actor.email
+      identity_fixture(
+        account: ctx.account,
+        actor: actor,
+        issuer: ctx.provider.issuer,
+        idp_id: "entra-sub-#{System.unique_integer([:positive])}",
+        email: actor.email
+      )
+
+      # A directory-synced row keyed on the Entra `oid` (GUID) used to be able to
+      # coexist with the interactive row, leaving two identities for the same
+      # actor and issuer. The unique index now forbids that second row outright.
+      changeset =
+        %Portal.ExternalIdentity{}
+        |> Ecto.Changeset.cast(
+          %{issuer: ctx.provider.issuer, idp_id: Ecto.UUID.generate(), email: actor.email},
+          [:issuer, :idp_id, :email]
         )
+        |> Ecto.Changeset.put_assoc(:account, ctx.account)
+        |> Ecto.Changeset.put_assoc(:actor, actor)
+        |> Ecto.Changeset.put_assoc(:directory, directory)
+        |> Portal.ExternalIdentity.changeset()
 
-      # Directory-synced row keyed on the Entra `oid` (GUID), with a directory.
-      synced_identity =
-        identity_fixture(
-          account: ctx.account,
-          actor: actor,
-          directory: directory,
-          issuer: ctx.provider.issuer,
-          idp_id: guid,
-          email: actor.email
-        )
+      assert {:error, changeset} = Repo.insert(changeset)
 
-      # The user signs in with the idp_id that already exists on the synced row.
-      # Both rows tie on the email match, so ranking the email first could pick
-      # the interactive row and overwrite its idp_id with the GUID, colliding on
-      # external_identities_account_idp_fields_index. The upsert must instead
-      # recycle the GUID-holding row in place.
-      setup_successful_auth(ctx, actor, sub: guid, email: actor.email)
+      assert {"has already been taken", constraint} = changeset.errors[:base]
+      assert constraint[:constraint] == :unique
 
-      conn = perform_callback(ctx.conn, build_oidc_auth_state(ctx.account, ctx.provider))
-      assert redirected_to(conn) =~ "/#{ctx.account.slug}/sites"
-
-      recycled =
-        Repo.get_by!(Portal.ExternalIdentity,
-          account_id: ctx.account.id,
-          issuer: ctx.provider.issuer,
-          idp_id: guid
-        )
-
-      assert recycled.id == synced_identity.id
-      assert recycled.directory_id == directory.id
-
-      assert Repo.get_by!(Portal.ExternalIdentity,
-               account_id: ctx.account.id,
-               id: interactive_identity.id
-             ).idp_id == interactive_identity.idp_id
+      assert constraint[:constraint_name] ==
+               "external_identities_account_id_actor_id_issuer_index"
 
       identity_count =
         Repo.aggregate(
@@ -1069,7 +1052,7 @@ defmodule PortalWeb.OIDCControllerTest do
           :count
         )
 
-      assert identity_count == 2
+      assert identity_count == 1
     end
 
     test "changed email with the same idp_id is matched by idp_id, not email", ctx do

--- a/elixir/test/portal_web/controllers/oidc_controller_test.exs
+++ b/elixir/test/portal_web/controllers/oidc_controller_test.exs
@@ -1355,6 +1355,65 @@ defmodule PortalWeb.OIDCControllerTest do
       refute Repo.get_by(Portal.OneTimePasscode, id: pending_identity.one_time_passcode_id)
     end
 
+    test "proof email verification recycles the actor's existing same-issuer identity", ctx do
+      Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      provider =
+        oidc_provider_fixture(:mock,
+          account: ctx.account,
+          email_verification_method: :proof
+        )
+
+      ctx = %{ctx | provider: provider}
+      actor = admin_actor_fixture(account: ctx.account, email: unique_email())
+
+      # The actor already holds an identity for this issuer under a previous
+      # subject. Promoting the pending identity with the new subject must recycle
+      # this row rather than insert a second one and trip the unique index.
+      existing_identity =
+        identity_fixture(
+          account: ctx.account,
+          actor: actor,
+          issuer: ctx.provider.issuer,
+          idp_id: "old-subject",
+          email: actor.email
+        )
+
+      setup_successful_auth(ctx, actor, email_verified: false)
+
+      cookie =
+        build_oidc_auth_state(ctx.account, ctx.provider,
+          params: %{"redirect_to" => "/#{ctx.account.slug}/actors"}
+        )
+
+      conn = perform_callback(ctx.conn, cookie)
+      pending_cookie = pending_identity_cookie_from_response(conn)
+
+      assert_received {:email, email}
+      [_, code] = Regex.run(~r/\n\n([a-z0-9]{6})\n/, email.text_body)
+
+      conn =
+        conn
+        |> recycle()
+        |> post(~p"/#{ctx.account}/sign_in/oidc/#{ctx.provider.id}/verify_identity", %{
+          "secret" => code,
+          "pending_identity_id" => pending_cookie.pending_identity_id,
+          "redirect_to" => "/#{ctx.account.slug}/actors"
+        })
+
+      assert conn.resp_cookies["sess_#{ctx.account.id}"]
+
+      identities =
+        from(ei in Portal.ExternalIdentity,
+          where: ei.account_id == ^ctx.account.id and ei.actor_id == ^actor.id
+        )
+        |> Repo.all()
+
+      assert [identity] = identities
+      assert identity.id == existing_identity.id
+      assert identity.idp_id == "admin-user-123"
+    end
+
     test "proof email verification uses original client params after valid code", ctx do
       Portal.Config.put_env_override(:outbound_email_adapter_configured?, true)
 

--- a/elixir/test/support/fixtures/identity_fixtures.ex
+++ b/elixir/test/support/fixtures/identity_fixtures.ex
@@ -15,7 +15,7 @@ defmodule Portal.IdentityFixtures do
     email = "user#{unique_num}@example.com"
 
     Enum.into(attrs, %{
-      issuer: "https://auth.example.com",
+      issuer: "https://auth#{unique_num}.example.com",
       idp_id: email,
       email: email,
       name: "Test User #{unique_num}",


### PR DESCRIPTION
Cleans up dupe identities from pre-idp-overhaul and prevents them from reoccurring. 
