### PR TITLE
feat(portal): show clients in device pool

### DIFF
--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -322,8 +322,12 @@ defmodule PortalWeb.Actors.Components do
                     <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />
                   </button>
                   <.icon
-                    name="ri-arrow-right-s-line"
-                    class="w-4 h-4 text-muted transition-transform group-open/details:rotate-90"
+                    name="ri-arrow-down-s-line"
+                    class="w-4 h-4 text-muted shrink-0 group-open/details:hidden"
+                  />
+                  <.icon
+                    name="ri-arrow-up-s-line"
+                    class="w-4 h-4 text-muted shrink-0 hidden group-open/details:block"
                   />
                 </div>
               </summary>
@@ -501,8 +505,12 @@ defmodule PortalWeb.Actors.Components do
                     <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />
                   </button>
                   <.icon
-                    name="ri-arrow-right-s-line"
-                    class="w-4 h-4 text-muted transition-transform group-open/details:rotate-90"
+                    name="ri-arrow-down-s-line"
+                    class="w-4 h-4 text-muted shrink-0 group-open/details:hidden"
+                  />
+                  <.icon
+                    name="ri-arrow-up-s-line"
+                    class="w-4 h-4 text-muted shrink-0 hidden group-open/details:block"
                   />
                 </div>
               </summary>
@@ -585,8 +593,12 @@ defmodule PortalWeb.Actors.Components do
                     <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />
                   </button>
                   <.icon
-                    name="ri-arrow-right-s-line"
-                    class="w-4 h-4 text-muted transition-transform group-open/details:rotate-90"
+                    name="ri-arrow-down-s-line"
+                    class="w-4 h-4 text-muted shrink-0 group-open/details:hidden"
+                  />
+                  <.icon
+                    name="ri-arrow-up-s-line"
+                    class="w-4 h-4 text-muted shrink-0 hidden group-open/details:block"
                   />
                 </div>
               </summary>
@@ -763,8 +775,12 @@ defmodule PortalWeb.Actors.Components do
                       <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />
                     </button>
                     <.icon
-                      name="ri-arrow-right-s-line"
-                      class="w-4 h-4 text-muted transition-transform group-open/details:rotate-90"
+                      name="ri-arrow-down-s-line"
+                      class="w-4 h-4 text-muted shrink-0 group-open/details:hidden"
+                    />
+                    <.icon
+                      name="ri-arrow-up-s-line"
+                      class="w-4 h-4 text-muted shrink-0 hidden group-open/details:block"
                     />
                   </div>
                 </summary>

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -45,6 +45,8 @@ defmodule PortalWeb.Resources do
       |> assign(
         selected_resource: nil,
         selected_resource_pool_member_ids: [],
+        selected_resource_pool_clients: [],
+        clients_expanded_id: nil,
         online_client_ids: MapSet.new(),
         selected_groups: [],
         policy_authorizations: [],
@@ -76,7 +78,7 @@ defmodule PortalWeb.Resources do
 
       resource ->
         page = parse_page(params)
-        tab = parse_show_tab(params)
+        tab = parse_show_tab(params, resource)
 
         groups = Database.list_groups_for_resource(resource, socket.assigns.subject)
 
@@ -85,9 +87,8 @@ defmodule PortalWeb.Resources do
 
         filter_site = filter_site_from_params(params, socket.assigns.subject)
 
-        pool_member_ids =
-          Database.pool_member_ids_for_resources([resource], socket.assigns.subject)
-          |> Map.get(resource.id, [])
+        pool_clients = Database.list_pool_members(resource, socket.assigns.subject)
+        pool_member_ids = Enum.map(pool_clients, & &1.id)
 
         {:noreply,
          socket
@@ -95,6 +96,8 @@ defmodule PortalWeb.Resources do
            filter_site: filter_site,
            selected_resource: resource,
            selected_resource_pool_member_ids: pool_member_ids,
+           selected_resource_pool_clients: pool_clients,
+           clients_expanded_id: nil,
            selected_groups: groups,
            policy_authorizations: policy_authorizations,
            policy_authorizations_page: page,
@@ -292,12 +295,23 @@ defmodule PortalWeb.Resources do
     end
   end
 
-  defp parse_show_tab(params) do
-    case Map.get(params, "tab", "groups") do
-      tab when tab in ~w[groups authorizations] -> String.to_existing_atom(tab)
-      _ -> :groups
+  defp parse_show_tab(params, resource) do
+    default = if device_pool?(resource), do: "clients", else: "groups"
+
+    case Map.get(params, "tab", default) do
+      "clients" ->
+        if device_pool?(resource), do: :clients, else: :groups
+
+      tab when tab in ~w[groups authorizations] ->
+        String.to_existing_atom(tab)
+
+      _ ->
+        String.to_existing_atom(default)
     end
   end
+
+  defp device_pool?(%{type: :static_device_pool}), do: true
+  defp device_pool?(_), do: false
 
   defp redirect_to_resources_index(socket, message) do
     {:noreply,
@@ -582,6 +596,8 @@ defmodule PortalWeb.Resources do
             account={@account}
             resource={@selected_resource}
             pool_member_ids={@selected_resource_pool_member_ids}
+            pool_clients={@selected_resource_pool_clients}
+            clients_expanded_id={@clients_expanded_id}
             online_client_ids={@online_client_ids}
             presence_tick={@presence_tick}
             groups={@selected_groups}
@@ -664,6 +680,13 @@ defmodule PortalWeb.Resources do
       if socket.assigns.policy_authorizations_expanded_id == id, do: nil, else: id
 
     {:noreply, assign(socket, policy_authorizations_expanded_id: expanded)}
+  end
+
+  def handle_event("toggle_pool_client_row", %{"id" => id}, socket) do
+    expanded =
+      if socket.assigns.clients_expanded_id == id, do: nil, else: id
+
+    {:noreply, assign(socket, clients_expanded_id: expanded)}
   end
 
   def handle_event("change_resource_form", %{"resource" => attrs} = payload, socket) do
@@ -1396,6 +1419,7 @@ defmodule PortalWeb.Resources do
     alias Portal.ClientToken
     alias Portal.Actor
     alias Portal.Device
+    alias Portal.ClientSession
     alias Portal.Site
     alias Portal.Group
     alias Portal.Directory
@@ -1513,18 +1537,60 @@ defmodule PortalWeb.Resources do
           ids -> ids
         end
 
-      from(c in Portal.Device, as: :devices)
+      from(c in Device, as: :devices)
+      |> join(
+        :left_lateral,
+        [devices: d],
+        s in subquery(
+          from(s in ClientSession,
+            where: s.device_id == parent_as(:devices).id,
+            where: s.account_id == parent_as(:devices).account_id,
+            order_by: [desc: s.inserted_at],
+            limit: 1
+          )
+        ),
+        on: true,
+        as: :latest_session
+      )
       |> where([devices: d], d.type == :client)
       |> where([devices: d], d.id in ^client_ids)
+      |> select_merge([latest_session: s], %{
+        latest_session_inserted_at: s.inserted_at,
+        latest_session_version: s.version,
+        latest_session_user_agent: s.user_agent
+      })
+      |> preload(:actor)
       |> Safe.scoped(subject, :replica)
       |> Safe.all()
       |> case do
-        {:error, _} -> []
-        clients -> Portal.Presence.Clients.preload_clients_presence(clients)
+        {:error, _} ->
+          []
+
+        clients ->
+          clients
+          |> build_latest_sessions()
+          |> Portal.Presence.Clients.preload_clients_presence()
       end
     end
 
     def list_pool_members(_resource, _subject), do: []
+
+    defp build_latest_sessions(clients) do
+      Enum.map(clients, fn client ->
+        if client.latest_session_inserted_at do
+          %{
+            client
+            | latest_session: %ClientSession{
+                version: client.latest_session_version,
+                inserted_at: client.latest_session_inserted_at,
+                user_agent: client.latest_session_user_agent
+              }
+          }
+        else
+          client
+        end
+      end)
+    end
 
     def get_resource(id, subject) do
       from(r in Resource, as: :resources)

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -8,6 +8,13 @@ defmodule PortalWeb.Resources.Components do
       condition_type_label: 1
     ]
 
+  import PortalWeb.Clients.Components,
+    only: [
+      client_status_badge: 1,
+      client_verified_badge: 1,
+      client_os: 1
+    ]
+
   alias __MODULE__.Database
   alias Portal.Presence
 
@@ -1018,6 +1025,8 @@ defmodule PortalWeb.Resources.Components do
   attr :account, :any, required: true
   attr :resource, :any, required: true
   attr :pool_member_ids, :list, default: []
+  attr :pool_clients, :list, default: []
+  attr :clients_expanded_id, :string, default: nil
   attr :online_client_ids, :any, default: %MapSet{}
   attr :presence_tick, :integer, default: 0
   attr :groups, :list, default: []
@@ -1074,9 +1083,19 @@ defmodule PortalWeb.Resources.Components do
       <div class="flex flex-1 min-h-0 divide-x divide-border">
         <div class="flex-1 flex flex-col overflow-hidden">
           <.resource_tabs
+            resource={@resource}
             tab={@tab}
             groups_count={length(@groups)}
+            clients_count={length(@pool_clients)}
             panel_view={@panel_view}
+          />
+          <.resource_clients_tab
+            :if={@tab == :clients}
+            account={@account}
+            clients={@pool_clients}
+            online_client_ids={@online_client_ids}
+            presence_tick={@presence_tick}
+            expanded_id={@clients_expanded_id}
           />
           <.resource_access_list
             :if={@tab == :groups && @panel_view == :list}
@@ -1111,8 +1130,10 @@ defmodule PortalWeb.Resources.Components do
     """
   end
 
+  attr :resource, :any, required: true
   attr :tab, :atom, required: true
   attr :groups_count, :integer, default: 0
+  attr :clients_count, :integer, default: 0
   attr :panel_view, :atom, required: true
 
   def resource_tabs(assigns) do
@@ -1121,6 +1142,31 @@ defmodule PortalWeb.Resources.Components do
       role="tablist"
       class="flex items-end gap-0 px-5 border-b border-border bg-raised shrink-0"
     >
+      <button
+        :if={@resource.type == :static_device_pool}
+        role="tab"
+        aria-selected={@tab == :clients}
+        phx-click="switch_resource_tab"
+        phx-value-tab="clients"
+        class={[
+          "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
+          if(@tab == :clients,
+            do: "border-brand text-brand",
+            else: "border-transparent text-body hover:text-heading"
+          )
+        ]}
+      >
+        Clients
+        <span class={[
+          "tabular-nums px-1.5 py-0.5 rounded text-[10px] font-semibold",
+          if(@tab == :clients,
+            do: "bg-brand-muted text-brand",
+            else: "bg-raised text-subtle"
+          )
+        ]}>
+          {@clients_count}
+        </span>
+      </button>
       <button
         role="tab"
         aria-selected={@tab == :groups}
@@ -1164,6 +1210,126 @@ defmodule PortalWeb.Resources.Components do
         <.button phx-click="open_grant_form" size="xs" icon="ri-add-line">
           Grant access
         </.button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :account, :any, required: true
+  attr :clients, :list, default: []
+  attr :online_client_ids, :any, default: %MapSet{}
+  attr :presence_tick, :integer, default: 0
+  attr :expanded_id, :string, default: nil
+
+  def resource_clients_tab(assigns) do
+    ~H"""
+    <div class="flex-1 flex flex-col overflow-hidden">
+      <div
+        :if={@clients == []}
+        class="flex flex-col items-center justify-center h-full gap-2 text-subtle"
+      >
+        <.icon name="ri-computer-line" class="w-8 h-8" />
+        <p class="text-sm">No clients in this pool</p>
+      </div>
+      <div :if={@clients != []} class="flex-1 overflow-y-auto">
+        <table class="w-full text-xs">
+          <thead class="sticky top-0 bg-surface z-10">
+            <tr class="border-b border-border text-subtle">
+              <th class="text-left px-4 py-2 font-medium">Status</th>
+              <th class="text-left px-4 py-2 font-medium">Name</th>
+              <th class="text-left px-4 py-2 font-medium">Owner</th>
+              <th class="text-left px-4 py-2 font-medium">Tunnel IPv4</th>
+              <th class="w-6"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for client <- @clients do %>
+              <tr
+                phx-click="toggle_pool_client_row"
+                phx-keydown="toggle_pool_client_row"
+                phx-key="Enter"
+                phx-value-id={client.id}
+                tabindex="0"
+                class="border-b border-border hover:bg-raised cursor-pointer focus:outline-none focus:bg-raised"
+              >
+                <td class="px-4 py-2">
+                  <.client_status_badge online?={MapSet.member?(@online_client_ids, client.id)} />
+                </td>
+                <td class="px-4 py-2 text-heading">
+                  <div class="flex items-center gap-1.5">
+                    <span class="truncate">{client.name}</span>
+                    <.client_verified_badge client={client} />
+                  </div>
+                </td>
+                <td class="px-4 py-2 text-body">
+                  {if client.actor, do: client.actor.name, else: "—"}
+                </td>
+                <td class="px-4 py-2 text-subtle font-mono">
+                  {client.ipv4}
+                </td>
+                <td class="px-4 py-2 text-subtle">
+                  <.icon
+                    name={
+                      if @expanded_id == client.id,
+                        do: "ri-arrow-up-s-line",
+                        else: "ri-arrow-down-s-line"
+                    }
+                    class="w-4 h-4"
+                  />
+                </td>
+              </tr>
+              <tr :if={@expanded_id == client.id} class="border-b border-border bg-raised">
+                <td colspan="5" class="px-4 py-3">
+                  <div class="grid grid-cols-2 gap-x-8 gap-y-3 text-xs">
+                    <div :if={client.actor}>
+                      <p class="text-subtle font-medium mb-1">Owner</p>
+                      <.link
+                        navigate={~p"/#{@account}/actors/#{client.actor.id}"}
+                        class="text-brand hover:underline"
+                      >
+                        {client.actor.name}
+                      </.link>
+                      <p :if={client.actor.email} class="text-subtle mt-0.5">
+                        {client.actor.email}
+                      </p>
+                    </div>
+                    <div :if={client.latest_session}>
+                      <p class="text-subtle font-medium mb-1">Operating System</p>
+                      <.client_os client={client} />
+                    </div>
+                    <div>
+                      <p class="text-subtle font-medium mb-1">Tunnel IPv4</p>
+                      <p class="text-heading font-mono">{client.ipv4}</p>
+                    </div>
+                    <div>
+                      <p class="text-subtle font-medium mb-1">Tunnel IPv6</p>
+                      <p class="text-heading font-mono break-all">{client.ipv6}</p>
+                    </div>
+                    <div :if={client.latest_session}>
+                      <p class="text-subtle font-medium mb-1">Last Seen</p>
+                      <p class="text-heading">
+                        <.relative_datetime datetime={client.latest_session.inserted_at} />
+                      </p>
+                    </div>
+                    <div :if={client.device_serial}>
+                      <p class="text-subtle font-medium mb-1">Serial Number</p>
+                      <p class="text-heading font-mono">{client.device_serial}</p>
+                    </div>
+                    <div>
+                      <p class="text-subtle font-medium mb-1">Client</p>
+                      <.link
+                        navigate={~p"/#{@account}/clients/#{client.id}"}
+                        class="text-brand hover:underline font-mono break-all"
+                      >
+                        {client.id}
+                      </.link>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
       </div>
     </div>
     """

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1156,7 +1156,7 @@ defmodule PortalWeb.Resources.Components do
           )
         ]}
       >
-        Clients
+        Pool Members
         <span class={[
           "tabular-nums px-1.5 py-0.5 rounded text-[10px] font-semibold",
           if(@tab == :clients,

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -1235,10 +1235,10 @@ defmodule PortalWeb.Resources.Components do
         <table class="w-full text-xs">
           <thead class="sticky top-0 bg-surface z-10">
             <tr class="border-b border-border text-subtle">
-              <th class="text-left px-4 py-2 font-medium">Status</th>
               <th class="text-left px-4 py-2 font-medium">Name</th>
               <th class="text-left px-4 py-2 font-medium">Owner</th>
               <th class="text-left px-4 py-2 font-medium">Tunnel IPv4</th>
+              <th class="text-left px-4 py-2 font-medium">Status</th>
               <th class="w-6"></th>
             </tr>
           </thead>
@@ -1252,9 +1252,6 @@ defmodule PortalWeb.Resources.Components do
                 tabindex="0"
                 class="border-b border-border hover:bg-raised cursor-pointer focus:outline-none focus:bg-raised"
               >
-                <td class="px-4 py-2">
-                  <.client_status_badge online?={MapSet.member?(@online_client_ids, client.id)} />
-                </td>
                 <td class="px-4 py-2 text-heading">
                   <div class="flex items-center gap-1.5">
                     <span class="truncate">{client.name}</span>
@@ -1266,6 +1263,9 @@ defmodule PortalWeb.Resources.Components do
                 </td>
                 <td class="px-4 py-2 text-subtle font-mono">
                   {client.ipv4}
+                </td>
+                <td class="px-4 py-2">
+                  <.client_status_badge online?={MapSet.member?(@online_client_ids, client.id)} />
                 </td>
                 <td class="px-4 py-2 text-subtle">
                   <.icon

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -370,8 +370,12 @@ defmodule PortalWeb.Sites.Components do
               </span>
             </span>
             <.icon
-              name="ri-arrow-right-s-line"
-              class={"w-4 h-4 text-subtle transition-transform shrink-0#{if @expanded_gateway_id == gateway.id, do: " rotate-90", else: ""}"}
+              name={
+                if @expanded_gateway_id == gateway.id,
+                  do: "ri-arrow-up-s-line",
+                  else: "ri-arrow-down-s-line"
+              }
+              class="w-4 h-4 text-subtle shrink-0"
             />
           </div>
           <div

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -1145,7 +1145,7 @@ defmodule PortalWeb.ResourcesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}")
 
-      assert has_element?(lv, "button[role='tab'][aria-selected]", "Clients")
+      assert has_element?(lv, "button[role='tab'][aria-selected]", "Pool Members")
     end
 
     test "lists pool clients with owner and tunnel IPs", %{
@@ -1299,7 +1299,7 @@ defmodule PortalWeb.ResourcesTest do
       render_click(lv, "switch_resource_tab", %{"tab" => "clients"})
       assert_patch(lv, ~p"/#{account}/resources/#{resource.id}?tab=clients")
 
-      assert has_element?(lv, "button[role='tab'][aria-selected]", "Clients")
+      assert has_element?(lv, "button[role='tab'][aria-selected]", "Pool Members")
     end
 
     test "does not show the clients tab for non-device-pool resources", %{
@@ -1314,7 +1314,7 @@ defmodule PortalWeb.ResourcesTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/resources/#{resource.id}")
 
-      refute has_element?(lv, "button[role='tab']", "Clients")
+      refute has_element?(lv, "button[role='tab']", "Pool Members")
       assert has_element?(lv, "button[role='tab'][aria-selected]", "Groups")
     end
 

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -7,6 +7,7 @@ defmodule PortalWeb.ResourcesTest do
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
+  import Portal.ClientSessionFixtures
   import Portal.DeviceFixtures
   import Portal.FeaturesFixtures
   import Portal.GroupFixtures
@@ -1125,6 +1126,211 @@ defmodule PortalWeb.ResourcesTest do
       html = render(lv)
       assert html =~ "0"
       assert html =~ "Total"
+    end
+  end
+
+  describe ":show clients tab (device pool)" do
+    test "defaults to the clients tab for device pool resources", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert has_element?(lv, "button[role='tab'][aria-selected]", "Clients")
+    end
+
+    test "lists pool clients with owner and tunnel IPs", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert html =~ client.name
+      assert html =~ client.actor.name
+      assert html =~ to_string(client.ipv4)
+    end
+
+    test "shows an offline status for clients without presence", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert html =~ "Offline"
+      assert html =~ "0 / 1 online"
+    end
+
+    test "shows an online status for connected clients", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      :ok = Portal.Presence.Clients.Account.track(account.id, client.id)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert html =~ "Online"
+      assert html =~ "1 / 1 online"
+    end
+
+    test "shows an empty state when the pool has no clients", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = static_device_pool_resource_fixture(account: account)
+
+      {:ok, _lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      assert html =~ "No clients in this pool"
+    end
+
+    test "expands and collapses a client row to reveal details", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client =
+        client_fixture(account: account, actor: actor, device_serial: "SERIAL-1234")
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      refute html =~ "Tunnel IPv6"
+
+      html = render_click(lv, "toggle_pool_client_row", %{"id" => client.id})
+      assert html =~ "Tunnel IPv6"
+      assert html =~ to_string(client.ipv6)
+      assert html =~ "SERIAL-1234"
+      assert has_element?(lv, ~s|a[href="/#{account.slug}/clients/#{client.id}"]|)
+
+      html = render_click(lv, "toggle_pool_client_row", %{"id" => client.id})
+      refute html =~ "Tunnel IPv6"
+    end
+
+    test "shows operating system and last seen from the latest session when expanded", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      _session =
+        client_session_fixture(
+          account: account,
+          actor: actor,
+          client: client,
+          user_agent: "Mac OS/14.0 connlib/1.3.0"
+        )
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      html = render_click(lv, "toggle_pool_client_row", %{"id" => client.id})
+
+      assert html =~ "Operating System"
+      assert html =~ "Mac OS 14.0"
+      assert html =~ "Last Seen"
+    end
+
+    test "switching to the clients tab patches the URL", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      resource =
+        static_device_pool_resource_fixture(account: account, clients: [client])
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}?tab=groups")
+
+      render_click(lv, "switch_resource_tab", %{"tab" => "clients"})
+      assert_patch(lv, ~p"/#{account}/resources/#{resource.id}?tab=clients")
+
+      assert has_element?(lv, "button[role='tab'][aria-selected]", "Clients")
+    end
+
+    test "does not show the clients tab for non-device-pool resources", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      refute has_element?(lv, "button[role='tab']", "Clients")
+      assert has_element?(lv, "button[role='tab'][aria-selected]", "Groups")
+    end
+
+    test "ignores the clients tab for non-device-pool resources and falls back to groups", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}?tab=clients")
+
+      assert has_element?(lv, "button[role='tab'][aria-selected]", "Groups")
     end
   end
 


### PR DESCRIPTION
Often times the admin will want to see which devices are in a pool at-a-glance without needing to edit the resource.

<img width="3120" height="1779" alt="Screenshot 2026-06-25 at 12 33 11 AM" src="https://github.com/user-attachments/assets/6fe94139-4db7-4837-9cc3-9cf6a5271366" />


---

Fixes #13249 