### PR TITLE
chore(rust): add memory profiling feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -225,7 +225,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_derive",
  "syn 2.0.117",
@@ -1807,6 +1807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2231,7 +2247,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2309,6 +2325,7 @@ dependencies = [
  "bin-shared",
  "caps",
  "clap",
+ "dhat",
  "dns-types",
  "futures",
  "futures-bounded",
@@ -2356,6 +2373,7 @@ dependencies = [
  "connlib-model",
  "dbus-secret-service-keyring-store",
  "derive_more",
+ "dhat",
  "dirs",
  "embed-resource",
  "fd-lock",
@@ -2430,6 +2448,7 @@ dependencies = [
  "bin-shared",
  "clap",
  "client-shared",
+ "dhat",
  "futures",
  "humantime",
  "ip-packet",
@@ -2504,6 +2523,7 @@ dependencies = [
  "bytes",
  "clap",
  "derive_more",
+ "dhat",
  "difference",
  "ebpf-shared",
  "eventloop-budget",
@@ -4177,7 +4197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4359,6 +4379,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -5659,7 +5685,7 @@ dependencies = [
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5980,6 +6006,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -6003,7 +6035,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6016,7 +6048,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6073,7 +6105,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6277,7 +6309,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "servo_arc",
  "smallvec",
 ]
@@ -7536,10 +7568,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7656,6 +7688,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
@@ -9041,7 +9079,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -83,6 +83,7 @@ crossbeam-queue = "0.3.12"
 dashmap = "6.2.1"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }
 derive_more = { version = "2.1.1", default-features = false }
+dhat = "0.3.3"
 difference = "2.0.0"
 dirs = "6.0.0"
 divan = "0.1.21"

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -23,11 +23,15 @@ assets = [
 ]
 depends = 'iptables,systemd'
 
+[features]
+dhat = ["dep:dhat"]
+
 [dependencies]
 anyhow = { workspace = true }
 backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true }
+dhat = { workspace = true, optional = true }
 dns-types = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -35,7 +35,14 @@ const RELEASE: &str = concat!("gateway@", env!("CARGO_PKG_VERSION"));
 
 const DEFAULT_MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> ExitCode {
+    #[cfg(feature = "dhat")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let cli = Cli::parse();
 
     #[expect(clippy::print_stderr, reason = "No logger has been set up yet")]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ enum_representation = "discriminated"
 # TODO: We can probably remove this, per <https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.0.0-beta.8>
 # I don't know how to verify this change, so I won't do it right now.
 custom-protocol = ["tauri/custom-protocol"]
+dhat = ["dep:dhat"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -29,6 +30,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 client-shared = { workspace = true }
 connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
+dhat = { workspace = true, optional = true }
 fd-lock = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
@@ -6,7 +6,14 @@ use clap::Parser as _;
 use firezone_gui_client::service;
 use std::path::PathBuf;
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "dhat")]
+    let _dhat = dhat::Profiler::new_heap();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .map_err(|_| anyhow!("Failed to install default crypto provider"))?;

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -26,7 +26,14 @@ enum LogGuard {
     Gui(logging::file::Handle, logging::CleanupHandle),
 }
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> ExitCode {
+    #[cfg(feature = "dhat")]
+    let _dhat = dhat::Profiler::new_heap();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Failed to install default crypto provider");

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -7,12 +7,16 @@ authors = ["Firezone, Inc."]
 license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+dhat = ["dep:dhat"]
+
 [dependencies]
 anyhow = { workspace = true }
 backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "string"] }
 client-shared = { workspace = true }
+dhat = { workspace = true, optional = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -39,6 +39,10 @@ mod platform;
 #[path = "macos.rs"]
 mod platform;
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 /// Command-line args for the headless Client
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -197,6 +201,9 @@ const RELEASE: &str = concat!("headless-client@", env!("CARGO_PKG_VERSION"));
     reason = "No logger is active when we are printing this error."
 )]
 fn main() {
+    #[cfg(feature = "dhat")]
+    let _dhat = dhat::Profiler::new_heap();
+
     match try_main() {
         Ok(()) => {}
         Err(e) => {

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 [features]
 default = ["ebpf"]
 ebpf = ["dep:aya", "dep:aya-log", "dep:ebpf-shared"]
+dhat = ["dep:dhat"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -19,6 +20,7 @@ bytecodec = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 derive_more = { workspace = true, features = ["from"] }
+dhat = { workspace = true, optional = true }
 eventloop-budget = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -32,6 +32,10 @@ use tracing_core::Dispatch;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 use url::Url;
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 const STATS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 
 const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
@@ -128,6 +132,9 @@ enum LogFormat {
 }
 
 fn main() -> ExitCode {
+    #[cfg(feature = "dhat")]
+    let _dhat = dhat::Profiler::new_heap();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");


### PR DESCRIPTION
In order to debug where memory is being used, we add the off-by-default `dhat` feature. Once the binary exits, it writes a JSON file to the current working dir with stats about which code path allocated how much memory.