### PR TITLE
fix(connlib): immediately return unused UDP buffers to pool

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6760,6 +6760,7 @@ dependencies = [
  "otel-instruments",
  "parking_lot",
  "quinn-udp",
+ "smallvec",
  "socket2",
  "tokio",
  "tracing",

--- a/rust/libs/connlib/socket-factory/Cargo.toml
+++ b/rust/libs/connlib/socket-factory/Cargo.toml
@@ -14,6 +14,7 @@ ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 otel-instruments = { workspace = true }
 quinn-udp = { workspace = true }
+smallvec = { workspace = true, features = ["const_generics"] }
 socket2 = { workspace = true, features = ["all"] }
 tokio = { workspace = true, features = ["net", "rt", "time"] }
 tracing = { workspace = true }

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -5,6 +5,7 @@ use gat_lending_iterator::LendingIterator;
 use ip_packet::{Ecn, Ipv4Header, Ipv6Header, UdpHeader};
 use opentelemetry::KeyValue;
 use quinn_udp::{EcnCodepoint, Transmit, UdpSockRef};
+use smallvec::SmallVec;
 use std::io;
 use std::io::IoSliceMut;
 use std::ops::Deref;
@@ -782,9 +783,8 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
 #[derive(derive_more::Debug)]
 pub struct DatagramSegmentIter<const N: usize = { quinn_udp::BATCH_SIZE }, B = Buffer<Vec<u8>>> {
     #[debug(skip)]
-    buffers: [B; N],
-    metas: [quinn_udp::RecvMeta; N],
-    len: usize,
+    buffers: SmallVec<[B; N]>,
+    metas: SmallVec<[quinn_udp::RecvMeta; N]>,
 
     port: u16,
 
@@ -802,6 +802,13 @@ impl<B, const N: usize> DatagramSegmentIter<N, B> {
         port: u16,
         len: usize,
     ) -> Self {
+        let mut buffers = SmallVec::from_buf(buffers);
+        let mut metas = SmallVec::from_buf(metas);
+
+        // Drop the unused buffers / metas.
+        buffers.truncate(len);
+        metas.truncate(len);
+
         let total_bytes = metas.iter().map(|m| m.len).sum::<usize>();
         let num_packets = metas
             .iter()
@@ -817,7 +824,6 @@ impl<B, const N: usize> DatagramSegmentIter<N, B> {
         Self {
             buffers,
             metas,
-            len,
             port,
             buf_index: 0,
             segment_index: 0,
@@ -835,7 +841,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         loop {
-            if self.buf_index >= N || self.buf_index >= self.len {
+            if self.buf_index >= self.buffers.len() {
                 return None;
             }
 


### PR DESCRIPTION
Currently, we are always passing 32 buffers to the UDP socket and then passing all of them to connlib's main thread for processing, even if 31 of them have not actually been filled. This massively increases the number of buffers in-flight, forcing the next poll to pull 32 new buffers from the pool.

Once the syscall returns, we already know how many of the buffers have been filled. We even pass this information already to the `DatagramSegmentIter`. We can truncate the list of buffers there and thus return the unused ones immediately to the pool.