### PR TITLE
fix(connlib): stop dropping datagrams on UDP socket errors

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -9,7 +9,7 @@ mod udp_dns;
 pub use device::{Device, TunChannelClosed};
 
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
-use anyhow::{Context as _, ErrorExt, Result};
+use anyhow::{ErrorExt, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
 use dns_types::DoHUrl;
 use futures_bounded::{FuturesMap, FuturesTupleSet};
@@ -289,18 +289,12 @@ impl Io {
             }
         }
 
-        let network = self.sockets.poll_recv_from(cx).map(|network| {
-            anyhow::Ok(
-                network
-                    .context("UDP socket failed")?
-                    .filter(is_max_wg_packet_size),
-            )
-        });
+        let network = self
+            .sockets
+            .poll_recv_from(cx)
+            .map(|network| network.filter(is_max_wg_packet_size));
 
-        // Drain send errors reported by the UDP socket threads. These are delivered on a dedicated
-        // channel so that reporting them never causes us to drop received datagrams. A
-        // `UdpSocketThreadStopped` among them will trigger a shutdown.
-        while let Poll::Ready(e) = self.sockets.poll_send_error(cx) {
+        while let Poll::Ready(e) = self.sockets.poll_error(cx) {
             error.push(e);
         }
 
@@ -412,7 +406,7 @@ impl Io {
             now: Instant::now(),
             timeout,
             device: poll_result_to_option(device, &mut error),
-            network: poll_result_to_option(network, &mut error),
+            network: poll_to_option(network),
             tcp_dns_queries,
             udp_dns_queries,
             dns_response: poll_to_option(dns_response),

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -297,6 +297,13 @@ impl Io {
             )
         });
 
+        // Drain send errors reported by the UDP socket threads. These are delivered on a dedicated
+        // channel so that reporting them never causes us to drop received datagrams. A
+        // `UdpSocketThreadStopped` among them will trigger a shutdown.
+        while let Poll::Ready(e) = self.sockets.poll_send_error(cx) {
+            error.push(e);
+        }
+
         let device = self
             .tun
             .poll_read_many(cx, &mut buffers.ip, MAX_INBOUND_PACKET_BATCH)

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -121,6 +121,22 @@ impl Sockets {
 
         Poll::Ready(Ok(iter))
     }
+
+    pub fn poll_send_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
+        if let Some(socket) = self.socket_v4.as_mut()
+            && let Poll::Ready(e) = socket.poll_send_error(cx)
+        {
+            return Poll::Ready(e);
+        }
+
+        if let Some(socket) = self.socket_v6.as_mut()
+            && let Poll::Ready(e) = socket.poll_send_error(cx)
+        {
+            return Poll::Ready(e);
+        }
+
+        Poll::Pending
+    }
 }
 
 struct PacketIter<T4, T6> {
@@ -181,13 +197,19 @@ struct ThreadedUdpSocket {
 struct Channels {
     outbound_tx: PollSender<DatagramOut>,
     inbound_rx: mpsc::Receiver<Result<DatagramSegmentIter>>,
+    /// Errors that occur while sending, plus a final [`UdpSocketThreadStopped`] once a thread dies.
+    ///
+    /// Kept separate from `inbound_rx` so that draining these errors never causes us to drop
+    /// received datagrams.
+    send_error_rx: mpsc::Receiver<anyhow::Error>,
 }
 
 impl ThreadedUdpSocket {
     fn new(sf: Arc<dyn SocketFactory<UdpSocket>>, preferred_addr: SocketAddr) -> io::Result<Self> {
         let (outbound_tx, mut outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (error_tx, error_rx) = std::sync::mpsc::sync_channel(0);
+        let (send_error_tx, send_error_rx) = mpsc::channel(QUEUE_SIZE);
+        let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(0);
 
         tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
@@ -217,7 +239,7 @@ impl ThreadedUdpSocket {
                 {
                     Ok(r) => r,
                     Err(e) => {
-                        let _ = error_tx.send(Err(e));
+                        let _ = startup_tx.send(Err(e));
                         return;
                     }
                 };
@@ -232,7 +254,7 @@ impl ThreadedUdpSocket {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        let _ = error_tx.send(Err(e));
+                        let _ = startup_tx.send(Err(e));
                         return;
                     }
                 };
@@ -258,7 +280,7 @@ impl ThreadedUdpSocket {
 
                 let send = runtime.spawn({
                     let io_error_counter = io_error_counter.clone();
-                    let inbound_tx = inbound_tx.clone();
+                    let send_error_tx = send_error_tx.clone();
                     let socket = socket.clone();
 
                     let mut pending_datagrams = Vec::with_capacity(UDP_SEND_BATCH_LIMIT);
@@ -290,16 +312,17 @@ impl ThreadedUdpSocket {
                                         );
                                     }
 
-                                    // We use the inbound_tx channel to send the error back to the main thread.
-                                    if inbound_tx.send(Err(e)).await.is_err() {
+                                    // Report send errors on a dedicated channel so that they don't
+                                    // interfere with the delivery of received datagrams.
+                                    if send_error_tx.send(e).await.is_err() {
                                         tracing::debug!(
-                                            "Channel for inbound datagrams closed; exiting UDP send task"
+                                            "Channel for send errors closed; exiting UDP send task"
                                         );
                                         return;
                                     }
                                 };
                             }
-                        };
+                        }
                     }
                 });
                 let receive = runtime.spawn(async move {
@@ -331,12 +354,18 @@ impl ThreadedUdpSocket {
                     }
                 });
 
-                let _ = error_tx.send(Ok(()));
+                let _ = startup_tx.send(Ok(()));
 
-                runtime.block_on(futures::future::select(send, receive));
+                runtime.block_on(async move {
+                    futures::future::select(send, receive).await;
+
+                    // One of the tasks stopped, which tears down the runtime and renders the socket
+                    // non-functional. Report it on the send-error channel so that `Io` shuts down.
+                    let _ = send_error_tx.send(UdpSocketThreadStopped.into()).await;
+                });
             })?;
 
-        error_rx.recv().map_err(io::Error::other)??;
+        startup_rx.recv().map_err(io::Error::other)??;
 
         Ok(Self {
             thread_name,
@@ -344,6 +373,7 @@ impl ThreadedUdpSocket {
             channels: Some(Channels {
                 outbound_tx: PollSender::new(outbound_tx),
                 inbound_rx,
+                send_error_rx,
             }),
         })
     }
@@ -365,10 +395,29 @@ impl ThreadedUdpSocket {
     }
 
     fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
-        let iter =
-            ready!(self.channels_mut()?.inbound_rx.poll_recv(cx)).ok_or(UdpSocketThreadStopped)?;
+        let Some(channels) = self.channels.as_mut() else {
+            return Poll::Pending;
+        };
 
-        Poll::Ready(iter)
+        // A closed channel means the thread stopped. We surface that via `poll_send_error` instead
+        // of erroring here so that we don't discard datagrams from the other socket on the way out.
+        let Some(result) = ready!(channels.inbound_rx.poll_recv(cx)) else {
+            return Poll::Pending;
+        };
+
+        Poll::Ready(result)
+    }
+
+    fn poll_send_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
+        let Some(channels) = self.channels.as_mut() else {
+            return Poll::Pending;
+        };
+
+        let Some(error) = ready!(channels.send_error_rx.poll_recv(cx)) else {
+            return Poll::Pending;
+        };
+
+        Poll::Ready(error)
     }
 
     fn channels_mut(&mut self) -> Result<&mut Channels> {

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -104,33 +104,33 @@ impl Sockets {
     pub fn poll_recv_from(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>>> {
+    ) -> Poll<impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>> {
         let mut iter = PacketIter::new();
 
         if let Some(Poll::Ready(packets)) = self.socket_v4.as_mut().map(|s| s.poll_recv_from(cx)) {
-            iter.ip4 = Some(packets?);
+            iter.ip4 = Some(packets);
         }
 
         if let Some(Poll::Ready(packets)) = self.socket_v6.as_mut().map(|s| s.poll_recv_from(cx)) {
-            iter.ip6 = Some(packets?);
+            iter.ip6 = Some(packets);
         }
 
         if iter.is_empty() {
             return Poll::Pending;
         }
 
-        Poll::Ready(Ok(iter))
+        Poll::Ready(iter)
     }
 
-    pub fn poll_send_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
+    pub fn poll_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
         if let Some(socket) = self.socket_v4.as_mut()
-            && let Poll::Ready(e) = socket.poll_send_error(cx)
+            && let Poll::Ready(e) = socket.poll_error(cx)
         {
             return Poll::Ready(e);
         }
 
         if let Some(socket) = self.socket_v6.as_mut()
-            && let Poll::Ready(e) = socket.poll_send_error(cx)
+            && let Poll::Ready(e) = socket.poll_error(cx)
         {
             return Poll::Ready(e);
         }
@@ -196,19 +196,16 @@ struct ThreadedUdpSocket {
 
 struct Channels {
     outbound_tx: PollSender<DatagramOut>,
-    inbound_rx: mpsc::Receiver<Result<DatagramSegmentIter>>,
-    /// Errors that occur while sending, plus a final [`UdpSocketThreadStopped`] once a thread dies.
-    ///
-    /// Kept separate from `inbound_rx` so that draining these errors never causes us to drop
-    /// received datagrams.
-    send_error_rx: mpsc::Receiver<anyhow::Error>,
+    inbound_rx: mpsc::Receiver<DatagramSegmentIter>,
+    /// Send/receive errors, plus a final [`UdpSocketThreadStopped`] when a thread dies.
+    error_rx: mpsc::Receiver<anyhow::Error>,
 }
 
 impl ThreadedUdpSocket {
     fn new(sf: Arc<dyn SocketFactory<UdpSocket>>, preferred_addr: SocketAddr) -> io::Result<Self> {
         let (outbound_tx, mut outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (send_error_tx, send_error_rx) = mpsc::channel(QUEUE_SIZE);
+        let (error_tx, error_rx) = mpsc::channel(QUEUE_SIZE);
         let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(0);
 
         tokio::spawn(otel_instruments::periodic_queue_length(
@@ -280,7 +277,7 @@ impl ThreadedUdpSocket {
 
                 let send = runtime.spawn({
                     let io_error_counter = io_error_counter.clone();
-                    let send_error_tx = send_error_tx.clone();
+                    let error_tx = error_tx.clone();
                     let socket = socket.clone();
 
                     let mut pending_datagrams = Vec::with_capacity(UDP_SEND_BATCH_LIMIT);
@@ -312,11 +309,10 @@ impl ThreadedUdpSocket {
                                         );
                                     }
 
-                                    // Report send errors on a dedicated channel so that they don't
-                                    // interfere with the delivery of received datagrams.
-                                    if send_error_tx.send(e).await.is_err() {
+                                    // Dedicated channel so errors can't hold up received datagrams.
+                                    if error_tx.send(e).await.is_err() {
                                         tracing::debug!(
-                                            "Channel for send errors closed; exiting UDP send task"
+                                            "Channel for errors closed; exiting UDP send task"
                                         );
                                         return;
                                     }
@@ -325,31 +321,43 @@ impl ThreadedUdpSocket {
                         }
                     }
                 });
-                let receive = runtime.spawn(async move {
-                    loop {
-                        let result = socket.recv_from().await;
+                let receive = runtime.spawn({
+                    let error_tx = error_tx.clone();
 
-                        if let Some(io) = result
-                            .as_ref()
-                            .err()
-                            .and_then(|e| e.any_downcast_ref::<io::Error>())
-                        {
-                            io_error_counter.add(
-                                1,
-                                &[
-                                    otel::attr::network_io_direction_receive(),
-                                    otel::attr::network_type_for_addr(preferred_addr),
-                                    otel::attr::io_error_type(io),
-                                    otel::attr::io_error_code(io),
-                                ],
-                            );
-                        }
+                    async move {
+                        loop {
+                            let datagrams = match socket.recv_from().await {
+                                Ok(datagrams) => datagrams,
+                                Err(e) => {
+                                    if let Some(io) = e.any_downcast_ref::<io::Error>() {
+                                        io_error_counter.add(
+                                            1,
+                                            &[
+                                                otel::attr::network_io_direction_receive(),
+                                                otel::attr::network_type_for_addr(preferred_addr),
+                                                otel::attr::io_error_type(io),
+                                                otel::attr::io_error_code(io),
+                                            ],
+                                        );
+                                    }
 
-                        if inbound_tx.send(result).await.is_err() {
-                            tracing::debug!(
-                                "Channel for inbound datagrams closed; exiting UDP recv task"
-                            );
-                            return;
+                                    if error_tx.send(e).await.is_err() {
+                                        tracing::debug!(
+                                            "Channel for errors closed; exiting UDP recv task"
+                                        );
+                                        return;
+                                    }
+
+                                    continue;
+                                }
+                            };
+
+                            if inbound_tx.send(datagrams).await.is_err() {
+                                tracing::debug!(
+                                    "Channel for inbound datagrams closed; exiting UDP recv task"
+                                );
+                                return;
+                            }
                         }
                     }
                 });
@@ -359,9 +367,8 @@ impl ThreadedUdpSocket {
                 runtime.block_on(async move {
                     futures::future::select(send, receive).await;
 
-                    // One of the tasks stopped, which tears down the runtime and renders the socket
-                    // non-functional. Report it on the send-error channel so that `Io` shuts down.
-                    let _ = send_error_tx.send(UdpSocketThreadStopped.into()).await;
+                    // A stopped task tears down the runtime; report it so `Io` shuts down.
+                    let _ = error_tx.send(UdpSocketThreadStopped.into()).await;
                 });
             })?;
 
@@ -373,7 +380,7 @@ impl ThreadedUdpSocket {
             channels: Some(Channels {
                 outbound_tx: PollSender::new(outbound_tx),
                 inbound_rx,
-                send_error_rx,
+                error_rx,
             }),
         })
     }
@@ -394,26 +401,26 @@ impl ThreadedUdpSocket {
         Ok(())
     }
 
-    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
+    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<DatagramSegmentIter> {
         let Some(channels) = self.channels.as_mut() else {
             return Poll::Pending;
         };
 
-        // A closed channel means the thread stopped. We surface that via `poll_send_error` instead
-        // of erroring here so that we don't discard datagrams from the other socket on the way out.
-        let Some(result) = ready!(channels.inbound_rx.poll_recv(cx)) else {
+        let Some(datagrams) = ready!(channels.inbound_rx.poll_recv(cx)) else {
+            // Thread stopped (reported via `poll_error`). `Pending` avoids dropping the other
+            // socket's datagrams; no waker on close, since we'll be shutting down anyway.
             return Poll::Pending;
         };
 
-        Poll::Ready(result)
+        Poll::Ready(datagrams)
     }
 
-    fn poll_send_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
+    fn poll_error(&mut self, cx: &mut Context<'_>) -> Poll<anyhow::Error> {
         let Some(channels) = self.channels.as_mut() else {
             return Poll::Pending;
         };
 
-        let Some(error) = ready!(channels.send_error_rx.poll_recv(cx)) else {
+        let Some(error) = ready!(channels.error_rx.poll_recv(cx)) else {
             return Poll::Pending;
         };
 


### PR DESCRIPTION
Errors from the UDP socket threads were reported to the event loop on the same channel as received datagrams. When one socket had datagrams ready and the other reported an error, the receive path short-circuited on that error and discarded the datagrams it had already collected for the batch.

Errors now travel on a dedicated channel that is drained independently of received datagrams, so an error on one socket can no longer drop datagrams from the other. A stopped socket thread reports `UdpSocketThreadStopped` on that channel, preserving the existing behaviour of shutting everything down when one of the UDP threads dies.