### PR TITLE
perf(connlib): batch-read and chain UDP datagram batches

### DIFF
--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -18,8 +18,8 @@ use tokio_util::sync::PollSender;
 const DEFAULT_LISTEN_PORT: u16 = EPHEMERAL_PORT_RANGE_START + FIRE;
 const EPHEMERAL_PORT_RANGE_START: u16 = 49152;
 const FIRE: u16 = 3473; // "FIRE" when typed on a phone pad.
-const UDP_SEND_BATCH_LIMIT: usize = 16;
-const UDP_RECV_BATCH_LIMIT: usize = 8;
+const UDP_SEND_BATCH_LIMIT: usize = 32;
+const UDP_RECV_BATCH_LIMIT: usize = 32;
 
 const UNSPECIFIED_V4_SOCKET: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_LISTEN_PORT);

--- a/rust/libs/connlib/tunnel/src/sockets.rs
+++ b/rust/libs/connlib/tunnel/src/sockets.rs
@@ -19,6 +19,7 @@ const DEFAULT_LISTEN_PORT: u16 = EPHEMERAL_PORT_RANGE_START + FIRE;
 const EPHEMERAL_PORT_RANGE_START: u16 = 49152;
 const FIRE: u16 = 3473; // "FIRE" when typed on a phone pad.
 const UDP_SEND_BATCH_LIMIT: usize = 16;
+const UDP_RECV_BATCH_LIMIT: usize = 8;
 
 const UNSPECIFIED_V4_SOCKET: SocketAddrV4 =
     SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, DEFAULT_LISTEN_PORT);
@@ -177,7 +178,37 @@ where
     }
 }
 
-/// How big the queue for incoming and outgoing UDP batches is at most.
+/// Chains up to [`UDP_RECV_BATCH_LIMIT`] datagram batches from a single `poll` into one iterator.
+///
+/// A linked list (not a `Vec`) so `next` can fall back from the drained `current` batch to `rest` as
+/// separate fields — the disjoint borrow that lets a runtime-length chain of lending iterators
+/// compile on stable Rust.
+struct ChainedDatagrams {
+    current: DatagramSegmentIter,
+    rest: Option<Box<ChainedDatagrams>>,
+}
+
+impl ChainedDatagrams {
+    fn new(batches: Vec<DatagramSegmentIter>) -> Option<Self> {
+        let mut rest = None;
+
+        for current in batches.into_iter().rev() {
+            rest = Some(Box::new(ChainedDatagrams { current, rest }));
+        }
+
+        rest.map(|boxed| *boxed)
+    }
+}
+
+impl LendingIterator for ChainedDatagrams {
+    type Item<'a> = DatagramIn<'a>;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        self.current.next().or_else(|| self.rest.as_mut()?.next())
+    }
+}
+
+/// How big the queue for outgoing UDP batches and socket errors is at most.
 ///
 /// On mobile platforms, we are memory-constrained and thus cannot afford to process big batches of packets.
 const QUEUE_SIZE: usize = {
@@ -185,6 +216,17 @@ const QUEUE_SIZE: usize = {
         10
     } else {
         1000
+    }
+};
+
+/// How big the queue for incoming UDP batches is at most.
+///
+/// Smaller than [`QUEUE_SIZE`] because we drain it in chunks of up to [`UDP_RECV_BATCH_LIMIT`].
+const INBOUND_QUEUE_SIZE: usize = {
+    if cfg!(any(target_os = "ios", target_os = "android")) {
+        10
+    } else {
+        100
     }
 };
 
@@ -204,7 +246,7 @@ struct Channels {
 impl ThreadedUdpSocket {
     fn new(sf: Arc<dyn SocketFactory<UdpSocket>>, preferred_addr: SocketAddr) -> io::Result<Self> {
         let (outbound_tx, mut outbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
+        let (inbound_tx, inbound_rx) = mpsc::channel(INBOUND_QUEUE_SIZE);
         let (error_tx, error_rx) = mpsc::channel(QUEUE_SIZE);
         let (startup_tx, startup_rx) = std::sync::mpsc::sync_channel(0);
 
@@ -401,14 +443,22 @@ impl ThreadedUdpSocket {
         Ok(())
     }
 
-    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<DatagramSegmentIter> {
+    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<ChainedDatagrams> {
         let Some(channels) = self.channels.as_mut() else {
             return Poll::Pending;
         };
 
-        let Some(datagrams) = ready!(channels.inbound_rx.poll_recv(cx)) else {
-            // Thread stopped (reported via `poll_error`). `Pending` avoids dropping the other
-            // socket's datagrams; no waker on close, since we'll be shutting down anyway.
+        let mut batches = Vec::with_capacity(UDP_RECV_BATCH_LIMIT);
+        ready!(
+            channels
+                .inbound_rx
+                .poll_recv_many(cx, &mut batches, UDP_RECV_BATCH_LIMIT)
+        );
+
+        let Some(datagrams) = ChainedDatagrams::new(batches) else {
+            // An empty read means a closed channel, i.e. the thread stopped (reported via
+            // `poll_error`). `Pending` avoids dropping the other socket's datagrams; no waker on
+            // close, since we'll be shutting down anyway.
             return Poll::Pending;
         };
 


### PR DESCRIPTION
The main event loop drains the inbound UDP channel one batch per loop iteration. Below the CPU ceiling the state machine keeps up easily, so the loop repeatedly catches up to an empty channel, runs dry and re-parks after each batch — and is then woken again by the very next batch from the UDP thread. The result is roughly one thread wakeup per arriving batch.

Pulling up to 8 batches per poll and chaining them into a single iterator makes each loop iteration absorb the whole current backlog instead of one batch. More datagrams pile up between polls, so the loop runs dry far less often and arriving batches increasingly land while the state thread is still running (where they cost nothing) rather than while it is parked (where they cost a wakeup).

The inbound channel is sized down to match, as it is now consumed in chunks rather than one batch per poll.

Local container speedtest (iperf3 UDP, 8 streams), comparing this branch against its rebase point on `main`.

At a fixed 1.6 Gbit/s load (well below the CPU ceiling, so the byte rate is identical on both branches), the state thread is woken roughly 3× less often on the receive path:

| receive path | main | this branch |
| --- | --- | --- |
| client (download) | 14.6k wakeups/s | 4.6k wakeups/s (−68%) |
| gateway (upload) | 10.7k wakeups/s | 3.3k wakeups/s (−69%) |

Whole-run context switches drop from 3.60M to 2.76M (−23%). The gain is smaller at saturation (~44%): when the state thread is already behind, the channel is rarely empty, so the loop seldom ran dry to begin with.

Per-byte compute is unchanged — state-thread cycles/byte are flat to within run-to-run noise and no hot function regressed. On-CPU time stays the same while wakeups drop ~68%, i.e. each wakeup simply does ~3× more work. The win is fewer wakeups and less scheduler churn at the same throughput, not cheaper crypto.
