### PR TITLE
fix(ci): sum rx_bytes arithmetically in download-rst test

### DIFF
--- a/scripts/tests/download-rst.sh
+++ b/scripts/tests/download-rst.sh
@@ -13,7 +13,7 @@ readarray -t flows < <(get_flow_logs "tcp")
 
 assert_gteq "${#flows[@]}" 1
 
-rx_bytes=0
+declare -i rx_bytes=0
 
 # All flows should have same inner_dst_ip
 for flow in "${flows[@]}"; do


### PR DESCRIPTION
The `rx_bytes` accumulator in `download-rst.sh` was a plain string, so `+=` concatenated the per-flow values instead of summing them. With a single flow it happened to still parse, but multiple flows would produce a garbage total. Declaring it as an integer makes `+=` perform arithmetic addition, matching the existing `declare -i` pattern in `download-roaming-network.sh`.