### PR TITLE
refactor(connlib): make data-plane RNG and clocks deterministic

### DIFF
--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -9,7 +9,7 @@ use hex_display::HexDisplayExt as _;
 use ip_packet::Ecn;
 use is::Candidate;
 use logging::err_with_src;
-use rand::{Rng, SeedableRng as _, rngs::StdRng};
+use rand::{SeedableRng as _, rngs::StdRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use smallvec::SmallVec;
 use std::{
@@ -37,6 +37,8 @@ use stun_codec::{
     rfc8656::attributes::AdditionalAddressFamily,
 };
 use tracing::{Span, field};
+
+use self::request::MessagePrototype;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
 const REQUEST_MAX_ELAPSED: Duration = Duration::from_secs(8);
@@ -103,11 +105,6 @@ pub struct Allocation {
 
     buffer_pool: BufferPool<Vec<u8>>,
 
-    /// Source of randomness for STUN transaction IDs.
-    ///
-    /// Seeded from the [`Node`](crate::Node)'s RNG so that transaction IDs are
-    /// a deterministic function of the node seed, which keeps tests (and fuzzing)
-    /// reproducible.
     rng: StdRng,
 }
 
@@ -313,7 +310,7 @@ impl Allocation {
         let backoff = backoff::new(now, REQUEST_TIMEOUT, REQUEST_TIMEOUT);
 
         self.authenticate_and_queue(
-            make_refresh_request(self.software.clone()),
+            MessagePrototype::refresh(self.software.clone()),
             Some(backoff),
             now,
         );
@@ -430,7 +427,11 @@ impl Allocation {
                     "Request failed, re-authenticating"
                 );
 
-                self.authenticate_and_queue(original_request, None, now);
+                self.authenticate_and_queue(
+                    MessagePrototype::from_request(&original_request),
+                    None,
+                    now,
+                );
 
                 return true;
             }
@@ -444,7 +445,7 @@ impl Allocation {
                         // AllocationMismatch during allocate means we already have an allocation.
                         // Delete it.
                         self.authenticate_and_queue(
-                            make_delete_allocation_request(self.software.clone()),
+                            MessagePrototype::delete_allocation(self.software.clone()),
                             None,
                             now,
                         );
@@ -455,7 +456,7 @@ impl Allocation {
                         // AllocationMismatch for refresh means we don't have an allocation.
                         // Make one.
                         self.authenticate_and_queue(
-                            make_allocate_request(self.software.clone()),
+                            MessagePrototype::allocate(self.software.clone()),
                             None,
                             now,
                         );
@@ -466,7 +467,7 @@ impl Allocation {
                         // AllocationMismatch for channel-bind means we don't have an allocation.
                         // Make one.
                         self.authenticate_and_queue(
-                            make_allocate_request(self.software.clone()),
+                            MessagePrototype::allocate(self.software.clone()),
                             None,
                             now,
                         );
@@ -589,13 +590,13 @@ impl Allocation {
 
                 if self.has_allocation() {
                     self.authenticate_and_queue(
-                        make_refresh_request(self.software.clone()),
+                        MessagePrototype::refresh(self.software.clone()),
                         None,
                         now,
                     );
                 } else {
                     self.authenticate_and_queue(
-                        make_allocate_request(self.software.clone()),
+                        MessagePrototype::allocate(self.software.clone()),
                         None,
                         now,
                     );
@@ -652,7 +653,7 @@ impl Allocation {
                 // Make a new one.
                 if lifetime.lifetime().is_zero() {
                     self.authenticate_and_queue(
-                        make_allocate_request(self.software.clone()),
+                        MessagePrototype::allocate(self.software.clone()),
                         None,
                         now,
                     );
@@ -734,7 +735,7 @@ impl Allocation {
         {
             tracing::debug!("Sending STUN binding as keep-alive");
 
-            let request = make_binding_request(&mut self.rng, self.software.clone());
+            let request = MessagePrototype::binding(self.software.clone()).seal(&mut self.rng);
             self.queue(addr, request, None, now);
         }
 
@@ -758,7 +759,7 @@ impl Allocation {
             let needs_auth = method != BINDING;
 
             let queued = if needs_auth {
-                self.authenticate_and_queue(request, Some(backoff), now)
+                self.authenticate_and_queue(MessagePrototype::from_request(&request), Some(backoff), now)
             } else {
                 self.queue(dst, request, Some(backoff), now)
             };
@@ -784,7 +785,7 @@ impl Allocation {
             && !self.refresh_in_flight()
         {
             tracing::debug!("Allocation is due for a refresh");
-            self.authenticate_and_queue(make_refresh_request(self.software.clone()), None, now);
+            self.authenticate_and_queue(MessagePrototype::refresh(self.software.clone()), None, now);
         }
 
         let channel_refresh_messages = self
@@ -795,7 +796,7 @@ impl Allocation {
             .inspect(|(number, peer)| {
                 tracing::debug!(%number, %peer, "Channel is due for a refresh");
             })
-            .map(|(number, peer)| make_channel_bind_request(peer, number, self.software.clone()))
+            .map(|(number, peer)| MessagePrototype::channel_bind(peer, number, self.software.clone()))
             .collect::<SmallVec<[_; 16]>>();
 
         for message in channel_refresh_messages {
@@ -881,7 +882,7 @@ impl Allocation {
         tracing::debug!(number = %channel, "Binding new channel");
 
         self.authenticate_and_queue(
-            make_channel_bind_request(peer, channel, self.software.clone()),
+            MessagePrototype::channel_bind(peer, channel, self.software.clone()),
             None,
             now,
         );
@@ -1121,12 +1122,12 @@ impl Allocation {
 
         if let Some(v4) = self.server.as_v4() {
             let dst: SocketAddr = (*v4).into();
-            let request = make_binding_request(&mut self.rng, self.software.clone());
+            let request = MessagePrototype::binding(self.software.clone()).seal(&mut self.rng);
             self.queue(dst, request, None, now);
         }
         if let Some(v6) = self.server.as_v6() {
             let dst: SocketAddr = (*v6).into();
-            let request = make_binding_request(&mut self.rng, self.software.clone());
+            let request = MessagePrototype::binding(self.software.clone()).seal(&mut self.rng);
             self.queue(dst, request, None, now);
         }
     }
@@ -1134,14 +1135,14 @@ impl Allocation {
     /// Returns: Whether we actually queued a message.
     fn authenticate_and_queue(
         &mut self,
-        message: Message<Attribute>,
+        request: MessagePrototype,
         backoff: Option<ExponentialBackoff>,
         now: Instant,
     ) -> bool {
         let Some(active_socket) = self.active_socket else {
             tracing::debug!(
                 "Unable to queue {} because we haven't nominated a socket yet",
-                message.method()
+                request.method()
             );
             return false;
         };
@@ -1149,12 +1150,12 @@ impl Allocation {
         let Some(credentials) = &self.credentials else {
             tracing::debug!(
                 "Unable to queue {} because we don't have credentials",
-                message.method()
+                request.method()
             );
             return false;
         };
 
-        let authenticated_message = authenticate(&mut self.rng, message, credentials);
+        let authenticated_message = request.authenticate(&mut self.rng, credentials);
         self.queue(active_socket.addr, authenticated_message, backoff, now)
     }
 
@@ -1250,44 +1251,6 @@ impl ActiveSocket {
     }
 }
 
-fn authenticate(
-    rng: &mut impl Rng,
-    message: Message<Attribute>,
-    credentials: &Credentials,
-) -> Message<Attribute> {
-    let attributes = message
-        .attributes()
-        .filter(|a| !matches!(a, Attribute::Nonce(_)))
-        .filter(|a| !matches!(a, Attribute::MessageIntegrity(_)))
-        .filter(|a| !matches!(a, Attribute::Realm(_)))
-        .filter(|a| !matches!(a, Attribute::Username(_)))
-        .cloned()
-        .chain([
-            Attribute::Username(credentials.username.clone()),
-            Attribute::Realm(credentials.realm.clone()),
-        ])
-        .chain(credentials.nonce.clone().map(Attribute::Nonce));
-
-    let transaction_id = TransactionId::new(rng.random());
-    let mut message = Message::new(MessageClass::Request, message.method(), transaction_id);
-
-    for attribute in attributes {
-        message.add_attribute(attribute.to_owned());
-    }
-
-    let message_integrity = MessageIntegrity::new_long_term_credential(
-        &message,
-        &credentials.username,
-        &credentials.realm,
-        &credentials.password,
-    )
-    .expect("signing never fails");
-
-    message.add_attribute(message_integrity);
-
-    message
-}
-
 /// Updates the current candidate to the new one if it differs.
 ///
 /// Returns whether the candidate got updated.
@@ -1315,72 +1278,146 @@ fn update_candidate(
     }
 }
 
-/// The transaction ID assigned to requests that are authenticated before being
-/// sent. [`authenticate`] always overwrites it with a fresh, random transaction
-/// ID, so this placeholder never reaches the wire.
-fn placeholder_transaction_id() -> TransactionId {
-    TransactionId::new([0; 12])
-}
+/// Construction of the STUN/TURN requests this module sends.
+///
+/// Every request is built as a [`MessagePrototype`] that does **not** carry a
+/// transaction ID. The only ways to turn it into a sendable [`Message`] are
+/// [`MessagePrototype::seal`] (unauthenticated `BINDING` requests) and
+/// [`MessagePrototype::authenticate`] (all other, authenticated requests). Both
+/// sample a fresh transaction ID, making it impossible to (re-)send a request
+/// without one.
+mod request {
+    use super::*;
+    use rand::RngCore;
+    use stun_codec::Method;
 
-fn make_binding_request(rng: &mut impl Rng, software: Software) -> Message<Attribute> {
-    let mut message = Message::new(MessageClass::Request, BINDING, TransactionId::new(rng.random()));
-    message.add_attribute(software);
+    pub(super) struct MessagePrototype {
+        method: Method,
+        attributes: Vec<Attribute>,
+    }
 
-    message
-}
+    impl MessagePrototype {
+        fn new(method: Method, attributes: Vec<Attribute>) -> Self {
+            Self { method, attributes }
+        }
 
-fn make_allocate_request(software: Software) -> Message<Attribute> {
-    let mut message = Message::new(
-        MessageClass::Request,
-        ALLOCATE,
-        placeholder_transaction_id(),
-    );
+        pub(super) fn binding(software: Software) -> Self {
+            Self::new(BINDING, vec![software.into()])
+        }
 
-    message.add_attribute(RequestedTransport::new(17));
-    message.add_attribute(AdditionalAddressFamily::new(
-        stun_codec::rfc8656::attributes::AddressFamily::V6,
-    ));
-    message.add_attribute(software);
+        pub(super) fn allocate(software: Software) -> Self {
+            Self::new(ALLOCATE, transport_attributes(software))
+        }
 
-    message
-}
+        pub(super) fn refresh(software: Software) -> Self {
+            Self::new(REFRESH, transport_attributes(software))
+        }
 
-/// To delete an allocation, we need to refresh it with a lifetime of 0.
-fn make_delete_allocation_request(software: Software) -> Message<Attribute> {
-    let mut refresh = make_refresh_request(software);
-    refresh.add_attribute(Lifetime::from_u32(0));
+        /// To delete an allocation, we refresh it with a lifetime of 0.
+        pub(super) fn delete_allocation(software: Software) -> Self {
+            let mut prototype = Self::refresh(software);
+            prototype.attributes.push(Lifetime::from_u32(0).into());
 
-    refresh
-}
+            prototype
+        }
 
-fn make_refresh_request(software: Software) -> Message<Attribute> {
-    let mut message = Message::new(MessageClass::Request, REFRESH, placeholder_transaction_id());
+        pub(super) fn channel_bind(target: SocketAddr, channel: u16, software: Software) -> Self {
+            Self::new(
+                CHANNEL_BIND,
+                vec![
+                    XorPeerAddress::new(target).into(),
+                    // Panic is fine here, because we control the channel number within this module.
+                    ChannelNumber::new(channel)
+                        .expect("channel number out of range")
+                        .into(),
+                    software.into(),
+                ],
+            )
+        }
 
-    message.add_attribute(RequestedTransport::new(17));
-    message.add_attribute(AdditionalAddressFamily::new(
-        stun_codec::rfc8656::attributes::AddressFamily::V6,
-    ));
-    message.add_attribute(software);
+        /// Reconstruct a prototype from a previously-sent request so it can be
+        /// re-authenticated, dropping any stale authentication attributes.
+        pub(super) fn from_request(message: &Message<Attribute>) -> Self {
+            let attributes = message
+                .attributes()
+                .filter(|a| !is_authentication_attribute(a))
+                .cloned()
+                .collect();
 
-    message
-}
+            Self::new(message.method(), attributes)
+        }
 
-fn make_channel_bind_request(
-    target: SocketAddr,
-    channel: u16,
-    software: Software,
-) -> Message<Attribute> {
-    let mut message = Message::new(
-        MessageClass::Request,
-        CHANNEL_BIND,
-        placeholder_transaction_id(),
-    );
+        pub(super) fn method(&self) -> Method {
+            self.method
+        }
 
-    message.add_attribute(XorPeerAddress::new(target));
-    message.add_attribute(ChannelNumber::new(channel).expect("channel number out of range")); // Panic is fine here, because we control the channel number within this module.
-    message.add_attribute(software);
+        /// Finalise an unauthenticated request (i.e. a `BINDING` request).
+        pub(super) fn seal(self, rng: &mut impl RngCore) -> Message<Attribute> {
+            let mut message =
+                Message::new(MessageClass::Request, self.method, new_transaction_id(rng));
 
-    message
+            for attribute in self.attributes {
+                message.add_attribute(attribute);
+            }
+
+            message
+        }
+
+        /// Finalise an authenticated request by attaching a long-term credential.
+        pub(super) fn authenticate(
+            self,
+            rng: &mut impl RngCore,
+            credentials: &Credentials,
+        ) -> Message<Attribute> {
+            let mut message =
+                Message::new(MessageClass::Request, self.method, new_transaction_id(rng));
+
+            for attribute in self.attributes {
+                message.add_attribute(attribute);
+            }
+            message.add_attribute(Attribute::Username(credentials.username.clone()));
+            message.add_attribute(Attribute::Realm(credentials.realm.clone()));
+            if let Some(nonce) = credentials.nonce.clone() {
+                message.add_attribute(Attribute::Nonce(nonce));
+            }
+
+            let message_integrity = MessageIntegrity::new_long_term_credential(
+                &message,
+                &credentials.username,
+                &credentials.realm,
+                &credentials.password,
+            )
+            .expect("signing never fails");
+            message.add_attribute(message_integrity);
+
+            message
+        }
+    }
+
+    fn transport_attributes(software: Software) -> Vec<Attribute> {
+        vec![
+            RequestedTransport::new(17).into(),
+            AdditionalAddressFamily::new(stun_codec::rfc8656::attributes::AddressFamily::V6).into(),
+            software.into(),
+        ]
+    }
+
+    fn new_transaction_id(rng: &mut impl RngCore) -> TransactionId {
+        let mut bytes = [0u8; 12];
+        rng.fill_bytes(&mut bytes);
+
+        TransactionId::new(bytes)
+    }
+
+    fn is_authentication_attribute(attribute: &Attribute) -> bool {
+        matches!(
+            attribute,
+            Attribute::Nonce(_)
+                | Attribute::MessageIntegrity(_)
+                | Attribute::Realm(_)
+                | Attribute::Username(_)
+        )
+    }
 }
 
 fn srflx_candidate(local: SocketAddr, attr: &Attribute) -> Option<Candidate> {

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -1288,7 +1288,7 @@ fn update_candidate(
 /// without one.
 mod request {
     use super::*;
-    use rand::RngCore;
+    use rand::Rng;
     use stun_codec::Method;
 
     pub(super) struct MessagePrototype {
@@ -1352,7 +1352,7 @@ mod request {
         }
 
         /// Finalise an unauthenticated request (i.e. a `BINDING` request).
-        pub(super) fn seal(self, rng: &mut impl RngCore) -> Message<Attribute> {
+        pub(super) fn seal(self, rng: &mut impl Rng) -> Message<Attribute> {
             let mut message =
                 Message::new(MessageClass::Request, self.method, new_transaction_id(rng));
 
@@ -1366,7 +1366,7 @@ mod request {
         /// Finalise an authenticated request by attaching a long-term credential.
         pub(super) fn authenticate(
             self,
-            rng: &mut impl RngCore,
+            rng: &mut impl Rng,
             credentials: &Credentials,
         ) -> Message<Attribute> {
             let mut message =
@@ -1402,7 +1402,7 @@ mod request {
         ]
     }
 
-    fn new_transaction_id(rng: &mut impl RngCore) -> TransactionId {
+    fn new_transaction_id(rng: &mut impl Rng) -> TransactionId {
         let mut bytes = [0u8; 12];
         rng.fill_bytes(&mut bytes);
 

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -759,7 +759,11 @@ impl Allocation {
             let needs_auth = method != BINDING;
 
             let queued = if needs_auth {
-                self.authenticate_and_queue(MessagePrototype::from_request(&request), Some(backoff), now)
+                self.authenticate_and_queue(
+                    MessagePrototype::from_request(&request),
+                    Some(backoff),
+                    now,
+                )
             } else {
                 self.queue(dst, request, Some(backoff), now)
             };
@@ -785,7 +789,11 @@ impl Allocation {
             && !self.refresh_in_flight()
         {
             tracing::debug!("Allocation is due for a refresh");
-            self.authenticate_and_queue(MessagePrototype::refresh(self.software.clone()), None, now);
+            self.authenticate_and_queue(
+                MessagePrototype::refresh(self.software.clone()),
+                None,
+                now,
+            );
         }
 
         let channel_refresh_messages = self
@@ -796,7 +804,9 @@ impl Allocation {
             .inspect(|(number, peer)| {
                 tracing::debug!(%number, %peer, "Channel is due for a refresh");
             })
-            .map(|(number, peer)| MessagePrototype::channel_bind(peer, number, self.software.clone()))
+            .map(|(number, peer)| {
+                MessagePrototype::channel_bind(peer, number, self.software.clone())
+            })
             .collect::<SmallVec<[_; 16]>>();
 
         for message in channel_refresh_messages {

--- a/rust/libs/connlib/snownet/src/allocation.rs
+++ b/rust/libs/connlib/snownet/src/allocation.rs
@@ -9,7 +9,7 @@ use hex_display::HexDisplayExt as _;
 use ip_packet::Ecn;
 use is::Candidate;
 use logging::err_with_src;
-use rand::random;
+use rand::{Rng, SeedableRng as _, rngs::StdRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use smallvec::SmallVec;
 use std::{
@@ -102,6 +102,13 @@ pub struct Allocation {
     rtt: Option<Duration>,
 
     buffer_pool: BufferPool<Vec<u8>>,
+
+    /// Source of randomness for STUN transaction IDs.
+    ///
+    /// Seeded from the [`Node`](crate::Node)'s RNG so that transaction IDs are
+    /// a deterministic function of the node seed, which keeps tests (and fuzzing)
+    /// reproducible.
+    rng: StdRng,
 }
 
 #[derive(derive_more::Debug, Clone, Copy)]
@@ -226,6 +233,7 @@ impl Allocation {
         realm: Realm,
         now: Instant,
         buffer_pool: BufferPool<Vec<u8>>,
+        seed: [u8; 32],
     ) -> Self {
         let mut allocation = Self {
             server,
@@ -253,6 +261,7 @@ impl Allocation {
             explicit_failure: Default::default(),
             rtt: None,
             buffer_pool,
+            rng: StdRng::from_seed(seed),
         };
 
         allocation.send_binding_requests(now);
@@ -725,7 +734,8 @@ impl Allocation {
         {
             tracing::debug!("Sending STUN binding as keep-alive");
 
-            self.queue(addr, make_binding_request(self.software.clone()), None, now);
+            let request = make_binding_request(&mut self.rng, self.software.clone());
+            self.queue(addr, request, None, now);
         }
 
         while let Some(timed_out_request) = self
@@ -1110,20 +1120,14 @@ impl Allocation {
         tracing::debug!(relay_socket = ?self.server, "Sending BINDING requests to pick active socket");
 
         if let Some(v4) = self.server.as_v4() {
-            self.queue(
-                (*v4).into(),
-                make_binding_request(self.software.clone()),
-                None,
-                now,
-            );
+            let dst: SocketAddr = (*v4).into();
+            let request = make_binding_request(&mut self.rng, self.software.clone());
+            self.queue(dst, request, None, now);
         }
         if let Some(v6) = self.server.as_v6() {
-            self.queue(
-                (*v6).into(),
-                make_binding_request(self.software.clone()),
-                None,
-                now,
-            );
+            let dst: SocketAddr = (*v6).into();
+            let request = make_binding_request(&mut self.rng, self.software.clone());
+            self.queue(dst, request, None, now);
         }
     }
 
@@ -1150,7 +1154,7 @@ impl Allocation {
             return false;
         };
 
-        let authenticated_message = authenticate(message, credentials);
+        let authenticated_message = authenticate(&mut self.rng, message, credentials);
         self.queue(active_socket.addr, authenticated_message, backoff, now)
     }
 
@@ -1246,7 +1250,11 @@ impl ActiveSocket {
     }
 }
 
-fn authenticate(message: Message<Attribute>, credentials: &Credentials) -> Message<Attribute> {
+fn authenticate(
+    rng: &mut impl Rng,
+    message: Message<Attribute>,
+    credentials: &Credentials,
+) -> Message<Attribute> {
     let attributes = message
         .attributes()
         .filter(|a| !matches!(a, Attribute::Nonce(_)))
@@ -1260,7 +1268,7 @@ fn authenticate(message: Message<Attribute>, credentials: &Credentials) -> Messa
         ])
         .chain(credentials.nonce.clone().map(Attribute::Nonce));
 
-    let transaction_id = TransactionId::new(random());
+    let transaction_id = TransactionId::new(rng.random());
     let mut message = Message::new(MessageClass::Request, message.method(), transaction_id);
 
     for attribute in attributes {
@@ -1307,8 +1315,15 @@ fn update_candidate(
     }
 }
 
-fn make_binding_request(software: Software) -> Message<Attribute> {
-    let mut message = Message::new(MessageClass::Request, BINDING, TransactionId::new(random()));
+/// The transaction ID assigned to requests that are authenticated before being
+/// sent. [`authenticate`] always overwrites it with a fresh, random transaction
+/// ID, so this placeholder never reaches the wire.
+fn placeholder_transaction_id() -> TransactionId {
+    TransactionId::new([0; 12])
+}
+
+fn make_binding_request(rng: &mut impl Rng, software: Software) -> Message<Attribute> {
+    let mut message = Message::new(MessageClass::Request, BINDING, TransactionId::new(rng.random()));
     message.add_attribute(software);
 
     message
@@ -1318,7 +1333,7 @@ fn make_allocate_request(software: Software) -> Message<Attribute> {
     let mut message = Message::new(
         MessageClass::Request,
         ALLOCATE,
-        TransactionId::new(random()),
+        placeholder_transaction_id(),
     );
 
     message.add_attribute(RequestedTransport::new(17));
@@ -1339,7 +1354,7 @@ fn make_delete_allocation_request(software: Software) -> Message<Attribute> {
 }
 
 fn make_refresh_request(software: Software) -> Message<Attribute> {
-    let mut message = Message::new(MessageClass::Request, REFRESH, TransactionId::new(random()));
+    let mut message = Message::new(MessageClass::Request, REFRESH, placeholder_transaction_id());
 
     message.add_attribute(RequestedTransport::new(17));
     message.add_attribute(AdditionalAddressFamily::new(
@@ -1358,7 +1373,7 @@ fn make_channel_bind_request(
     let mut message = Message::new(
         MessageClass::Request,
         CHANNEL_BIND,
-        TransactionId::new(random()),
+        placeholder_transaction_id(),
     );
 
     message.add_attribute(XorPeerAddress::new(target));
@@ -2997,6 +3012,7 @@ mod tests {
                 Realm::new("firezone".to_owned()).unwrap(),
                 start,
                 BufferPool::new(500, "test"),
+                [0; 32],
             )
         }
 
@@ -3011,6 +3027,7 @@ mod tests {
                 Realm::new("firezone".to_owned()).unwrap(),
                 start,
                 BufferPool::new(500, "test"),
+                [1; 32],
             )
         }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -707,7 +707,7 @@ where
 
             match self
                 .allocations
-                .upsert(*rid, *server, username, password.clone(), realm, now)
+                .upsert(*rid, *server, username, password.clone(), realm, now, &mut self.rng)
             {
                 allocations::UpsertResult::Added => {
                     tracing::info!(%rid, address = ?server, "Added new TURN server")

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -705,10 +705,15 @@ where
                 continue;
             };
 
-            match self
-                .allocations
-                .upsert(*rid, *server, username, password.clone(), realm, now, &mut self.rng)
-            {
+            match self.allocations.upsert(
+                *rid,
+                *server,
+                username,
+                password.clone(),
+                realm,
+                now,
+                &mut self.rng,
+            ) {
                 allocations::UpsertResult::Added => {
                     tracing::info!(%rid, address = ?server, "Added new TURN server")
                 }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -189,6 +189,7 @@ where
         let private_key = StaticSecret::random_from_rng(&mut rng);
         let public_key = &(&private_key).into();
         let index = IndexLfsr::new(&mut rng);
+        let allocations = Allocations::new(&mut rng);
 
         Self {
             rng,
@@ -199,7 +200,7 @@ where
             buffered_transmits: VecDeque::default(),
             next_rate_limiter_reset: None,
             pending_events: VecDeque::default(),
-            allocations: Default::default(),
+            allocations,
             inflight_stun_requests: Default::default(),
             connections: Default::default(),
             stats: Default::default(),
@@ -644,9 +645,8 @@ where
 
         self.connections.migrate_relays(
             removed_allocations,
-            &self.allocations,
+            &mut self.allocations,
             &mut self.pending_events,
-            &mut self.rng,
             now,
         );
         self.connections
@@ -705,15 +705,10 @@ where
                 continue;
             };
 
-            match self.allocations.upsert(
-                *rid,
-                *server,
-                username,
-                password.clone(),
-                realm,
-                now,
-                &mut self.rng,
-            ) {
+            match self
+                .allocations
+                .upsert(*rid, *server, username, password.clone(), realm, now)
+            {
                 allocations::UpsertResult::Added => {
                     tracing::info!(%rid, address = ?server, "Added new TURN server")
                 }
@@ -749,9 +744,8 @@ where
         // Fourth, migrate existing connections away from removed relays.
         self.connections.migrate_relays(
             to_remove.into_iter(),
-            &self.allocations,
+            &mut self.allocations,
             &mut self.pending_events,
-            &mut self.rng,
             now,
         );
     }
@@ -1072,10 +1066,7 @@ where
 
     /// Sample a relay to use for a new connection.
     fn sample_relay(&mut self) -> Result<RId, NoTurnServers> {
-        let (rid, _) = self
-            .allocations
-            .sample(&mut self.rng)
-            .ok_or(NoTurnServers {})?;
+        let (rid, _) = self.allocations.sample().ok_or(NoTurnServers {})?;
 
         tracing::debug!(%rid, "Sampled relay");
 

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -8,7 +8,7 @@ use std::{
 use bufferpool::BufferPool;
 use is::Candidate;
 use itertools::Itertools as _;
-use rand::{Rng, RngCore, seq::IteratorRandom as _};
+use rand::{Rng, seq::IteratorRandom as _};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use smallvec::SmallVec;
 use stun_codec::rfc5389::attributes::{Realm, Username};

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -8,7 +8,7 @@ use std::{
 use bufferpool::BufferPool;
 use is::Candidate;
 use itertools::Itertools as _;
-use rand::{Rng, seq::IteratorRandom as _};
+use rand::{Rng, RngCore, seq::IteratorRandom as _};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use smallvec::SmallVec;
 use stun_codec::rfc5389::attributes::{Realm, Username};
@@ -112,6 +112,9 @@ where
     ) -> UpsertResult {
         match self.inner.entry(rid) {
             Entry::Vacant(v) => {
+                let mut seed = [0u8; 32];
+                rng.fill_bytes(&mut seed);
+
                 v.insert(Allocation::new(
                     server,
                     username,
@@ -119,7 +122,7 @@ where
                     realm,
                     now,
                     self.buffer_pool.clone(),
-                    rng.random(),
+                    seed,
                 ));
 
                 UpsertResult::Added
@@ -133,6 +136,9 @@ where
                     return UpsertResult::Skipped;
                 }
 
+                let mut seed = [0u8; 32];
+                rng.fill_bytes(&mut seed);
+
                 let previous = o.insert(Allocation::new(
                     server,
                     username,
@@ -140,7 +146,7 @@ where
                     realm,
                     now,
                     self.buffer_pool.clone(),
-                    rng.random(),
+                    seed,
                 ));
 
                 self.previous_relays_by_ip
@@ -335,6 +341,7 @@ mod tests {
     #[test]
     fn manual_remove_remembers_address() {
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
         allocations.upsert(
             1,
             RelaySocket::from(SERVER_V4),
@@ -342,7 +349,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rand::rng(),
+            &mut rng,
         );
 
         allocations.remove_by_id(&1);
@@ -356,6 +363,7 @@ mod tests {
     #[test]
     fn clear_remembers_address() {
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
         allocations.upsert(
             1,
             RelaySocket::from(SERVER_V4),
@@ -363,7 +371,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rand::rng(),
+            &mut rng,
         );
 
         allocations.clear();
@@ -377,6 +385,7 @@ mod tests {
     #[test]
     fn replace_by_address_remembers_address() {
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
         allocations.upsert(
             1,
             RelaySocket::from(SERVER_V4),
@@ -384,7 +393,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rand::rng(),
+            &mut rng,
         );
 
         allocations.upsert(
@@ -394,7 +403,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rand::rng(),
+            &mut rng,
         );
 
         assert!(matches!(
@@ -457,6 +466,7 @@ mod tests {
     fn sample_excludes_outlier_relay_among_many_fast_ones() {
         let now = Instant::now();
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 
         for (rid, port, rtt_ms) in [
             (1u32, 11111u16, 30),
@@ -472,7 +482,7 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                &mut rand::rng(),
+                &mut rng,
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -492,6 +502,7 @@ mod tests {
     fn sample_distributes_load_across_similar_rtt_relays() {
         let now = Instant::now();
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 
         // 1ms apart: both relays should be picked roughly equally (uniform within bucket).
         for (rid, port, rtt_ms) in [(1u32, 11111u16, 30), (2, 22222, 31)] {
@@ -502,7 +513,7 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                &mut rand::rng(),
+                &mut rng,
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -529,6 +540,7 @@ mod tests {
     fn sample_excludes_n2_relay_when_much_slower() {
         let now = Instant::now();
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 
         // 30ms vs 200ms with n=2 ⇒ 200ms is 6.7x the leader, well outside 1.5x.
         for (rid, port, rtt_ms) in [(1u32, 11111u16, 30), (2, 22222, 200)] {
@@ -539,7 +551,7 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                &mut rand::rng(),
+                &mut rng,
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -559,6 +571,7 @@ mod tests {
     fn sample_falls_back_to_only_remaining_relay_even_if_high_rtt() {
         let now = Instant::now();
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 
         allocations.upsert(
             1,
@@ -567,7 +580,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            &mut rand::rng(),
+            &mut rng,
         );
         allocations
             .get_mut_by_id(&1)
@@ -584,6 +597,7 @@ mod tests {
     fn sample_excludes_allocations_without_rtt() {
         let now = Instant::now();
         let mut allocations = Allocations::default();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
 
         allocations.upsert(
             1,
@@ -592,7 +606,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            &mut rand::rng(),
+            &mut rng,
         );
 
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -8,7 +8,7 @@ use std::{
 use bufferpool::BufferPool;
 use is::Candidate;
 use itertools::Itertools as _;
-use rand::{Rng, seq::IteratorRandom as _};
+use rand::{Rng, SeedableRng as _, rngs::StdRng, seq::IteratorRandom as _};
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use smallvec::SmallVec;
 use stun_codec::rfc5389::attributes::{Realm, Username};
@@ -23,12 +23,31 @@ pub(crate) struct Allocations<RId> {
     previous_relays_by_ip: AllocRingBuffer<IpAddr>,
 
     buffer_pool: BufferPool<Vec<u8>>,
+
+    rng: StdRng,
 }
 
 impl<RId> Allocations<RId>
 where
     RId: Ord + fmt::Display + Copy,
 {
+    pub(crate) fn new(rng: &mut impl Rng) -> Self {
+        let mut seed = [0u8; 32];
+        rng.fill_bytes(&mut seed);
+
+        Self {
+            inner: BTreeMap::default(),
+            previous_relays_by_ip: AllocRingBuffer::with_capacity_power_of_2(6), // 64 entries
+            buffer_pool: BufferPool::new(ip_packet::MAX_FZ_PAYLOAD, "turn-clients"),
+            rng: StdRng::from_seed(seed),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self::new(&mut StdRng::seed_from_u64(0))
+    }
+
     pub(crate) fn clear(&mut self) {
         for (_, allocation) in std::mem::take(&mut self.inner) {
             self.previous_relays_by_ip
@@ -108,12 +127,11 @@ where
         password: String,
         realm: Realm,
         now: Instant,
-        rng: &mut impl Rng,
     ) -> UpsertResult {
         match self.inner.entry(rid) {
             Entry::Vacant(v) => {
                 let mut seed = [0u8; 32];
-                rng.fill_bytes(&mut seed);
+                self.rng.fill_bytes(&mut seed);
 
                 v.insert(Allocation::new(
                     server,
@@ -137,7 +155,7 @@ where
                 }
 
                 let mut seed = [0u8; 32];
-                rng.fill_bytes(&mut seed);
+                self.rng.fill_bytes(&mut seed);
 
                 let previous = o.insert(Allocation::new(
                     server,
@@ -163,7 +181,7 @@ where
     /// (see [`inclusion_threshold`]) and uniformly sample among the relays at
     /// or below it. Allocations without an RTT measurement are skipped: we
     /// don't know whether they are healthy yet.
-    pub(crate) fn sample(&self, rng: &mut impl Rng) -> Option<(RId, &Allocation)> {
+    pub(crate) fn sample(&mut self) -> Option<(RId, &Allocation)> {
         let candidates = self
             .inner
             .iter()
@@ -179,7 +197,7 @@ where
         candidates
             .iter()
             .filter(|(_, _, rtt)| *rtt <= threshold)
-            .choose(rng)
+            .choose(&mut self.rng)
             .map(|(id, a, _)| (*id, *a))
     }
 
@@ -320,28 +338,15 @@ pub(crate) enum UpsertResult {
     Replaced(Allocation),
 }
 
-impl<RId> Default for Allocations<RId> {
-    fn default() -> Self {
-        Self {
-            inner: Default::default(),
-            previous_relays_by_ip: AllocRingBuffer::with_capacity_power_of_2(6), // 64 entries,
-            buffer_pool: BufferPool::new(ip_packet::MAX_FZ_PAYLOAD, "turn-clients"),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
-
-    use rand::SeedableRng as _;
 
     use super::*;
 
     #[test]
     fn manual_remove_remembers_address() {
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
         allocations.upsert(
             1,
             RelaySocket::from(SERVER_V4),
@@ -349,7 +354,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rng,
         );
 
         allocations.remove_by_id(&1);
@@ -362,8 +366,7 @@ mod tests {
 
     #[test]
     fn clear_remembers_address() {
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
         allocations.upsert(
             1,
             RelaySocket::from(SERVER_V4),
@@ -371,7 +374,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rng,
         );
 
         allocations.clear();
@@ -384,8 +386,7 @@ mod tests {
 
     #[test]
     fn replace_by_address_remembers_address() {
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
         allocations.upsert(
             1,
             RelaySocket::from(SERVER_V4),
@@ -393,7 +394,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rng,
         );
 
         allocations.upsert(
@@ -403,7 +403,6 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
-            &mut rng,
         );
 
         assert!(matches!(
@@ -465,8 +464,7 @@ mod tests {
     #[test]
     fn sample_excludes_outlier_relay_among_many_fast_ones() {
         let now = Instant::now();
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
 
         for (rid, port, rtt_ms) in [
             (1u32, 11111u16, 30),
@@ -482,18 +480,14 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                &mut rng,
             );
             allocations
                 .get_mut_by_id(&rid)
                 .unwrap()
                 .set_rtt(Duration::from_millis(rtt_ms));
         }
-
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
         for _ in 0..1000 {
-            let (rid, _) = allocations.sample(&mut rng).unwrap();
+            let (rid, _) = allocations.sample().unwrap();
             assert_ne!(rid, 5, "outlier relay must not be selected");
         }
     }
@@ -501,8 +495,7 @@ mod tests {
     #[test]
     fn sample_distributes_load_across_similar_rtt_relays() {
         let now = Instant::now();
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
 
         // 1ms apart: both relays should be picked roughly equally (uniform within bucket).
         for (rid, port, rtt_ms) in [(1u32, 11111u16, 30), (2, 22222, 31)] {
@@ -513,19 +506,16 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                &mut rng,
             );
             allocations
                 .get_mut_by_id(&rid)
                 .unwrap()
                 .set_rtt(Duration::from_millis(rtt_ms));
         }
-
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
         let mut counts = [0u32; 2];
 
         for _ in 0..10_000 {
-            let (rid, _) = allocations.sample(&mut rng).unwrap();
+            let (rid, _) = allocations.sample().unwrap();
             counts[(rid - 1) as usize] += 1;
         }
 
@@ -539,8 +529,7 @@ mod tests {
     #[test]
     fn sample_excludes_n2_relay_when_much_slower() {
         let now = Instant::now();
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
 
         // 30ms vs 200ms with n=2 ⇒ 200ms is 6.7x the leader, well outside 1.5x.
         for (rid, port, rtt_ms) in [(1u32, 11111u16, 30), (2, 22222, 200)] {
@@ -551,18 +540,14 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
-                &mut rng,
             );
             allocations
                 .get_mut_by_id(&rid)
                 .unwrap()
                 .set_rtt(Duration::from_millis(rtt_ms));
         }
-
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
         for _ in 0..100 {
-            let (rid, _) = allocations.sample(&mut rng).unwrap();
+            let (rid, _) = allocations.sample().unwrap();
             assert_eq!(rid, 1);
         }
     }
@@ -570,8 +555,7 @@ mod tests {
     #[test]
     fn sample_falls_back_to_only_remaining_relay_even_if_high_rtt() {
         let now = Instant::now();
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
 
         allocations.upsert(
             1,
@@ -580,24 +564,19 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            &mut rng,
         );
         allocations
             .get_mut_by_id(&1)
             .unwrap()
             .set_rtt(Duration::from_millis(500));
-
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
-        let (rid, _) = allocations.sample(&mut rng).unwrap();
+        let (rid, _) = allocations.sample().unwrap();
         assert_eq!(rid, 1);
     }
 
     #[test]
     fn sample_excludes_allocations_without_rtt() {
         let now = Instant::now();
-        let mut allocations = Allocations::default();
-        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+        let mut allocations = Allocations::for_test();
 
         allocations.upsert(
             1,
@@ -606,13 +585,9 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            &mut rng,
         );
-
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
         assert_eq!(allocations.get_by_id(&1).unwrap().rtt(), None);
-        assert!(allocations.sample(&mut rng).is_none());
+        assert!(allocations.sample().is_none());
     }
 
     const SERVER_V4: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 11111));

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -108,6 +108,7 @@ where
         password: String,
         realm: Realm,
         now: Instant,
+        rng: &mut impl Rng,
     ) -> UpsertResult {
         match self.inner.entry(rid) {
             Entry::Vacant(v) => {
@@ -118,6 +119,7 @@ where
                     realm,
                     now,
                     self.buffer_pool.clone(),
+                    rng.random(),
                 ));
 
                 UpsertResult::Added
@@ -138,6 +140,7 @@ where
                     realm,
                     now,
                     self.buffer_pool.clone(),
+                    rng.random(),
                 ));
 
                 self.previous_relays_by_ip
@@ -339,6 +342,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
+            &mut rand::rng(),
         );
 
         allocations.remove_by_id(&1);
@@ -359,6 +363,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
+            &mut rand::rng(),
         );
 
         allocations.clear();
@@ -379,6 +384,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
+            &mut rand::rng(),
         );
 
         allocations.upsert(
@@ -388,6 +394,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             Instant::now(),
+            &mut rand::rng(),
         );
 
         assert!(matches!(
@@ -465,6 +472,7 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
+                &mut rand::rng(),
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -494,6 +502,7 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
+                &mut rand::rng(),
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -530,6 +539,7 @@ mod tests {
                 "password".to_owned(),
                 Realm::new("firezone".to_owned()).unwrap(),
                 now,
+                &mut rand::rng(),
             );
             allocations
                 .get_mut_by_id(&rid)
@@ -557,6 +567,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
+            &mut rand::rng(),
         );
         allocations
             .get_mut_by_id(&1)
@@ -581,6 +592,7 @@ mod tests {
             "password".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
+            &mut rand::rng(),
         );
 
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -528,6 +528,7 @@ mod tests {
             "pass".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
+            &mut rng,
         );
         // Simulate a successful response so the relay is eligible for sampling.
         allocations

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -9,7 +9,6 @@ use std::{
 use anyhow::{Context as _, Result, bail};
 use boringtun::noise::Index;
 use is::stun::{StunMessage, TransId};
-use rand::Rng;
 
 use crate::{
     ConnectionStats, Event,
@@ -101,9 +100,8 @@ where
     pub(crate) fn migrate_relays(
         &mut self,
         removed_allocations: impl Iterator<Item = RId>,
-        allocations: &Allocations<RId>,
+        allocations: &mut Allocations<RId>,
         pending_events: &mut VecDeque<Event<TId>>,
-        rng: &mut impl Rng,
         now: Instant,
     ) {
         // Temporarily take ownership of buffer to satisfy borrow-checker.
@@ -112,7 +110,7 @@ where
 
         for removed_relay in removed_allocations {
             for (cid, c) in self.iter_mut_by_relay(removed_relay) {
-                let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
+                let Some((new_relay, new_allocation)) = allocations.sample() else {
                     let was_inserted = connections_with_removed_relays.insert(cid);
 
                     if was_inserted {
@@ -127,7 +125,7 @@ where
         }
 
         for cid in connections_with_removed_relays {
-            let Some((new_relay, new_allocation)) = allocations.sample(rng) else {
+            let Some((new_relay, new_allocation)) = allocations.sample() else {
                 self.connections_with_removed_relays.insert(cid);
 
                 continue;
@@ -500,9 +498,8 @@ mod tests {
     #[test]
     fn migrate_relay_retries_connections_that_previously_had_no_allocation() {
         let mut connections: Connections<u32, u32> = Connections::default();
-        let mut allocations: Allocations<u32> = Allocations::default();
+        let mut allocations: Allocations<u32> = Allocations::for_test();
         let now = Instant::now();
-        let mut rng = rand::rng();
 
         // Insert a connection that is using relay id 1.
         let conn = new_connection(12345, 1, [1u8; 32]);
@@ -512,9 +509,8 @@ mod tests {
         let mut pending_events = VecDeque::new();
         connections.migrate_relays(
             std::iter::once(1u32),
-            &allocations,
+            &mut allocations,
             &mut pending_events,
-            &mut rng,
             now,
         );
 
@@ -528,7 +524,6 @@ mod tests {
             "pass".to_owned(),
             Realm::new("firezone".to_owned()).unwrap(),
             now,
-            &mut rng,
         );
         // Simulate a successful response so the relay is eligible for sampling.
         allocations
@@ -538,9 +533,8 @@ mod tests {
 
         connections.migrate_relays(
             std::iter::empty(),
-            &allocations,
+            &mut allocations,
             &mut pending_events,
-            &mut rng,
             now,
         );
 

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -76,7 +76,7 @@ impl GatewayState {
             node: Node::new(seed, now, unix_ts),
             buffered_events: VecDeque::default(),
             buffered_transmits: VecDeque::default(),
-            flow_tracker: FlowTracker::new(flow_logs, now),
+            flow_tracker: FlowTracker::new(flow_logs, now, unix_ts),
             tun_ip_config: None,
             unix_ts_clock: UnixTsClock::new(now, unix_ts),
             next_periodic_tick: None,

--- a/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
@@ -46,9 +46,6 @@ pub struct ClientProperties {
 
 impl FlowTracker {
     pub fn new(enabled: bool, now: Instant, unix_ts: Duration) -> Self {
-        // Anchor wall-clock time to the injected `unix_ts` (rather than
-        // `Utc::now()`) so flow timestamps are a deterministic function of the
-        // inputs, which keeps tests and fuzzing reproducible.
         let created_at_utc = i64::try_from(unix_ts.as_secs())
             .ok()
             .and_then(|secs| DateTime::from_timestamp(secs, unix_ts.subsec_nanos()))

--- a/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, TimeDelta, Utc};
 use connlib_model::{ClientId, ResourceId};
 use dns_types::DomainName;
 use ip_packet::{IcmpError, IpPacket, Protocol, UnsupportedProtocol};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 thread_local! {
     static CURRENT_FLOW: RefCell<Option<FlowData>> = const { RefCell::new(None) };
@@ -45,14 +45,21 @@ pub struct ClientProperties {
 }
 
 impl FlowTracker {
-    pub fn new(enabled: bool, now: Instant) -> Self {
+    pub fn new(enabled: bool, now: Instant, unix_ts: Duration) -> Self {
+        // Anchor wall-clock time to the injected `unix_ts` (rather than
+        // `Utc::now()`) so flow timestamps are a deterministic function of the
+        // inputs, which keeps tests and fuzzing reproducible.
+        let created_at_utc =
+            DateTime::from_timestamp(unix_ts.as_secs() as i64, unix_ts.subsec_nanos())
+                .unwrap_or(DateTime::UNIX_EPOCH);
+
         Self {
             active_tcp_flows: Default::default(),
             active_udp_flows: Default::default(),
             completed_flows: Default::default(),
             enabled,
             created_at: now,
-            created_at_utc: Utc::now(),
+            created_at_utc,
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/flow_tracker.rs
@@ -49,9 +49,10 @@ impl FlowTracker {
         // Anchor wall-clock time to the injected `unix_ts` (rather than
         // `Utc::now()`) so flow timestamps are a deterministic function of the
         // inputs, which keeps tests and fuzzing reproducible.
-        let created_at_utc =
-            DateTime::from_timestamp(unix_ts.as_secs() as i64, unix_ts.subsec_nanos())
-                .unwrap_or(DateTime::UNIX_EPOCH);
+        let created_at_utc = i64::try_from(unix_ts.as_secs())
+            .ok()
+            .and_then(|secs| DateTime::from_timestamp(secs, unix_ts.subsec_nanos()))
+            .unwrap_or(DateTime::UNIX_EPOCH);
 
         Self {
             active_tcp_flows: Default::default(),


### PR DESCRIPTION
Extending the `tunnel` proptest suite with a coverage-guided fuzzer requires the data plane to be deterministic: identical inputs must drive identical execution and produce identical bytes. Two ambient sources of non-determinism remained in the data plane.

- TURN/STUN transaction IDs were generated from the process-wide thread RNG. They end up as keys in a `BTreeMap` and on the wire, so different values change iteration order and packet contents across runs.
- The gateway flow-tracker anchored its wall-clock to `Utc::now()`.

Both are now derived from inputs already threaded into the state machine: each TURN `Allocation` seeds its transaction IDs from the `Node`'s RNG, and `FlowTracker` anchors wall-clock time to the injected `unix_ts`. Production behaviour is unchanged (the node RNG is still entropy-seeded); only the source of the values moves under the state machine's control.