### PR TITLE
chore(portal): relax sentry env determinator

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -550,9 +550,9 @@ if config_env() == :prod do
          env_var_to_config!(:api_external_url),
        api_external_url_host <- URI.parse(api_external_url).host,
        environment_name when environment_name in [:staging, :production] <-
-         (case api_external_url_host do
-            "api.firezone.dev" -> :production
-            "api.firez.one" -> :staging
+         (cond do
+            String.contains?(api_external_url_host, "firezone.dev") -> :production
+            String.contaains?(api_external_url_host, "firez.one") -> :staging
             _ -> :unknown
           end) do
     config :sentry,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -552,7 +552,7 @@ if config_env() == :prod do
        environment_name when environment_name in [:staging, :production] <-
          (cond do
             String.contains?(api_external_url_host, "firezone.dev") -> :production
-            String.contaains?(api_external_url_host, "firez.one") -> :staging
+            String.contains?(api_external_url_host, "firez.one") -> :staging
             true -> :unknown
           end) do
     config :sentry,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -553,7 +553,7 @@ if config_env() == :prod do
          (cond do
             String.contains?(api_external_url_host, "firezone.dev") -> :production
             String.contaains?(api_external_url_host, "firez.one") -> :staging
-            _ -> :unknown
+            true -> :unknown
           end) do
     config :sentry,
       environment_name: environment_name,


### PR DESCRIPTION
This is needed because we will be updating the published REST API URL to `rest-api.firezone.dev`.
