### PR TITLE
docs(portal): point rest api link to knowledge base

### DIFF
--- a/elixir/lib/portal_web/live/settings/api_clients/beta.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/beta.ex
@@ -23,8 +23,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
         assign(
           socket,
           page_title: "API Clients",
-          requested: Portal.Account.rest_api_access_requested?(socket.assigns.account),
-          api_url: Portal.Config.get_env(:portal, :api_external_url)
+          requested: Portal.Account.rest_api_access_requested?(socket.assigns.account)
         )
 
       {:ok, socket}
@@ -52,12 +51,7 @@ defmodule PortalWeb.Settings.ApiClients.Beta do
             <div class="flex flex-col items-center gap-1 text-center">
               <p class="text-sm font-medium text-heading">REST API is in closed beta</p>
               <p class="text-xs">
-                API Tokens are used to manage Firezone via the <.link
-                  navigate={"#{@api_url}/swaggerui"}
-                  class="text-brand hover:underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >REST API</.link>.
+                API Tokens are used to manage Firezone via the <.website_link path="/kb/reference/rest-api">REST API</.website_link>.
               </p>
             </div>
             <.button

--- a/elixir/lib/portal_web/live/settings/api_clients/index.ex
+++ b/elixir/lib/portal_web/live/settings/api_clients/index.ex
@@ -76,7 +76,6 @@ defmodule PortalWeb.Settings.ApiClients.Index do
       socket =
         socket
         |> assign(page_title: "API Tokens")
-        |> assign(api_url: Portal.Config.get_env(:portal, :api_external_url))
         |> assign(actors_with_tokens: actors_with_tokens)
         |> assign(selected_actor: nil)
         |> assign(form: nil, encoded_token: nil)

--- a/elixir/test/portal_web/live/settings/api_clients/beta_test.exs
+++ b/elixir/test/portal_web/live/settings/api_clients/beta_test.exs
@@ -48,7 +48,7 @@ defmodule PortalWeb.Settings.ApiClients.BetaTest do
 
       assert html =~ "REST API is in closed beta"
       assert html =~ "Request access"
-      assert html =~ "swaggerui"
+      assert html =~ "https://www.firezone.dev/kb/reference/rest-api"
     end
 
     test "shows access request submitted after requesting", %{


### PR DESCRIPTION
The KB is where our canonical REST API docs live and from there the user can jump off into Swagger or other resources.

This is to support the API generally moving to `https://rest-api.firezone.dev`.