### PR TITLE
fix(portal): specify REST API url in docs

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -437,7 +437,8 @@ if config_env() == :prod do
       capacity: env_var_to_config!(:api_ingestion_capacity)
 
     config :portal,
-      api_external_url: api_external_url
+      api_external_url: api_external_url,
+      rest_api_external_url: env_var_to_config!(:rest_api_external_url) || api_external_url
   end
 
   ###############################

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -122,6 +122,22 @@ defmodule Portal.Config.Definitions do
   )
 
   @doc """
+  The external URL the REST API will be accessible at.
+
+  Advertised as the server URL in the OpenAPI spec and SwaggerUI. If not set,
+  it falls back to `api_external_url`.
+  """
+
+  defconfig(:rest_api_external_url, :string,
+    default: nil,
+    changeset: fn changeset, key ->
+      changeset
+      |> Portal.Changeset.validate_uri(key, require_trailing_slash: true)
+      |> Portal.Changeset.normalize_url(key)
+    end
+  )
+
+  @doc """
   The API rate limiter uses a token bucket algorithm. This field sets the rate the bucket is refilled.
   """
   defconfig(:api_refill_rate, :integer, default: 10)

--- a/elixir/lib/portal_api/api_spec.ex
+++ b/elixir/lib/portal_api/api_spec.ex
@@ -6,10 +6,7 @@ defmodule PortalAPI.ApiSpec do
   @impl OpenApi
   def spec do
     %OpenApi{
-      servers: [
-        # Populate the Server info from a phoenix endpoint
-        Server.from_endpoint(Endpoint)
-      ],
+      servers: [server()],
       info: %Info{
         title: "Firezone API",
         version: "1.0",
@@ -29,5 +26,12 @@ defmodule PortalAPI.ApiSpec do
     }
     # Discover request/response schemas from path specs
     |> OpenApiSpex.resolve_schema_modules()
+  end
+
+  defp server do
+    case Portal.Config.get_env(:portal, :rest_api_external_url) do
+      nil -> Server.from_endpoint(Endpoint)
+      url -> %Server{url: String.trim_trailing(url, "/")}
+    end
   end
 end


### PR DESCRIPTION
This is taken from the `PortalAPI.Endpoint` by default which is `api.{domain}`.