### PR TITLE
refactor(gui-client): gate peer check behind CLI flag

### DIFF
--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -101,16 +101,17 @@ PowerShell 7 terminal. Make sure mise is activated in each (`mise activate pwsh 
    mise run tunnel
    ```
 
-   This runs `firezone-client-tunnel run-interactive`, which in a debug build serves
-   the Tunnel IPC pipe without pinning it to `LocalSystem`, so the unprivileged GUI
-   below can connect.
+   This runs `firezone-client-tunnel run-interactive --skip-peer-verification`, which in a
+   debug build serves the Tunnel IPC pipe without pinning it to `LocalSystem`, so the
+   unprivileged, non-installed GUI below can connect. Drop the flag to exercise the
+   pipe-owner check against an installed GUI.
 
 2. **GUI client** — from a normal (non-elevated) terminal. Connects to the Tunnel
    service above, skipping the pipe-owner check so it accepts the non-`LocalSystem` pipe:
 
    ```powershell
    mise run tauri-dev
-   # equivalent to: cargo tauri dev -- -- --skip-tunnel-pipe-owner-check
+   # equivalent to: cargo tauri dev -- -- --skip-peer-verification
 
    # You can call debug subcommands on the exe this way too, e.g.
    cargo tauri dev -- -- debug hostname
@@ -127,14 +128,14 @@ The app's config and logs will be stored at
 `C:\Users\$USER\AppData\Local\dev.firezone.client`.
 
 > Note: `pnpm dev` does **not** work for this flow. `dev.bat` hard-codes `tauri dev`
-> and forwards no arguments, so it can't pass `--skip-tunnel-pipe-owner-check`, and it
+> and forwards no arguments, so it can't pass `--skip-peer-verification`, and it
 > doesn't start an elevated Tunnel service.
 
 ### What this workflow can't test
 
-Running the GUI against a debug-build `run-interactive` Tunnel deliberately bypasses the named-pipe
-ownership check, so it does **not** exercise the production pipe-ownership security
-model (GUI ⇄ `LocalSystem` Tunnel service). It also doesn't cover MSI packaging, the
+Running the GUI against a debug-build `run-interactive --skip-peer-verification` Tunnel deliberately
+bypasses the named-pipe ownership check, so it does **not** exercise the production pipe-ownership
+security model (GUI ⇄ `LocalSystem` Tunnel service). It also doesn't cover MSI packaging, the
 bundled Windows service, sparse-package registration, or the installed app identity.
 
 To test installation end-to-end you need a real signed release MSI, which **cannot** be

--- a/rust/gui-client/src-tauri/build.rs
+++ b/rust/gui-client/src-tauri/build.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     // MSIX identity claim makes the kernel fail `CreateProcess` with
     // `APPMODEL_ERROR_NO_PACKAGE` (15700) before `main` even runs. The
     // runtime's debug-only `test_pipe_dacl` path (gated on
-    // `SKIP_TUNNEL_PIPE_OWNER_CHECK`) covers IPC without needing
+    // `SKIP_PEER_VERIFICATION`) covers IPC without needing
     // identity.
     //
     // We gate on Cargo's `PROFILE` env var rather than

--- a/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-client-tunnel.rs
@@ -26,7 +26,12 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         Cmd::Install => service::install(),
         Cmd::Run => service::run(cli.log_dir, cli.dns_control),
-        Cmd::RunInteractive => service::run_interactive(cli.dns_control),
+        #[cfg(debug_assertions)]
+        Cmd::RunInteractive {
+            skip_peer_verification,
+        } => service::run_interactive(cli.dns_control, skip_peer_verification),
+        #[cfg(not(debug_assertions))]
+        Cmd::RunInteractive {} => service::run_interactive(cli.dns_control, false),
         Cmd::RunSmokeTest => service::run_smoke_test(),
     }
 }
@@ -68,7 +73,15 @@ enum Cmd {
     Run,
     /// Run the Tunnel service in an interactive terminal instead of as a
     /// background service. Used for local development and debugging.
-    RunInteractive,
+    RunInteractive {
+        /// Skip verifying the identity of the connecting GUI (its installed
+        /// path on Linux, the pipe owner on Windows), so the interactive tunnel
+        /// service can be paired with a non-installed GUI build. Only exists in
+        /// debug builds, so release binaries can't disable the check.
+        #[cfg(debug_assertions)]
+        #[arg(long)]
+        skip_peer_verification: bool,
+    },
     RunSmokeTest,
 }
 
@@ -87,7 +100,7 @@ mod tests {
         let actual =
             Cli::try_parse_from([EXE_NAME, "--log-dir", "bogus_log_dir", "run-interactive"])
                 .unwrap();
-        assert!(matches!(actual.command, Cmd::RunInteractive));
+        assert!(matches!(actual.command, Cmd::RunInteractive { .. }));
         assert_eq!(actual.log_dir, Some(PathBuf::from("bogus_log_dir")));
 
         let actual = Cli::try_parse_from([EXE_NAME, "run"]).unwrap();

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -77,8 +77,8 @@ fn try_main(
     telemetry: Arc<Mutex<Telemetry>>,
 ) -> Result<()> {
     #[cfg(debug_assertions)]
-    if cli.skip_tunnel_pipe_owner_check {
-        firezone_gui_client::ipc::skip_tunnel_pipe_owner_check();
+    if cli.skip_peer_verification {
+        firezone_gui_client::ipc::skip_peer_verification();
     }
 
     #[cfg(debug_assertions)]
@@ -314,12 +314,12 @@ struct Cli {
     )]
     no_telemetry: bool,
 
-    /// Windows-only smoke-test escape hatch: skip the LocalSystem owner check
-    /// on the Tunnel named pipe. Only exists in debug builds, so release
-    /// binaries can't disable the check.
+    /// Skip verifying the identity of the Tunnel service we connect to (the
+    /// pipe owner on Windows). Local-dev / smoke-test escape hatch. Only exists
+    /// in debug builds, so release binaries can't disable the check.
     #[cfg(debug_assertions)]
     #[arg(long, hide = true)]
-    skip_tunnel_pipe_owner_check: bool,
+    skip_peer_verification: bool,
 
     /// Decouple sign-in from the portal: mint a fake session/token on the fly
     /// (never persisted) instead of opening the browser. Pairs with

--- a/rust/gui-client/src-tauri/src/ipc.rs
+++ b/rust/gui-client/src-tauri/src/ipc.rs
@@ -41,7 +41,7 @@ pub struct NotFound(String);
 pub struct WrongUser;
 
 #[cfg(debug_assertions)]
-pub use platform::skip_tunnel_pipe_owner_check;
+pub use platform::skip_peer_verification;
 
 /// A name that both the server and client can use to find each other
 ///

--- a/rust/gui-client/src-tauri/src/ipc/unix.rs
+++ b/rust/gui-client/src-tauri/src/ipc/unix.rs
@@ -14,16 +14,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io::ErrorKind, os::unix::fs::PermissionsExt, path::PathBuf};
 use tokio::net::{UnixListener, UnixStream};
 
-/// Whether to skip the tunnel pipe owner check.
+/// Whether to skip verifying the peer's binary on the Tunnel socket.
 #[cfg(debug_assertions)]
-static SKIP_TUNNEL_PIPE_OWNER_CHECK: AtomicBool = AtomicBool::new(false);
+static SKIP_PEER_VERIFICATION: AtomicBool = AtomicBool::new(false);
 
-/// Set [`SKIP_TUNNEL_PIPE_OWNER_CHECK`].
+/// Set [`SKIP_PEER_VERIFICATION`].
 ///
 /// Call once at process startup, before any `Server::new(SocketId::Tunnel)` or `connect_to_socket`.
 #[cfg(debug_assertions)]
-pub fn skip_tunnel_pipe_owner_check() {
-    SKIP_TUNNEL_PIPE_OWNER_CHECK.store(true, Ordering::Relaxed);
+pub fn skip_peer_verification() {
+    SKIP_PEER_VERIFICATION.store(true, Ordering::Relaxed);
 }
 
 pub struct Server {
@@ -120,12 +120,12 @@ impl Server {
             let cred = stream.peer_cred()?;
 
             #[cfg(debug_assertions)]
-            if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) {
+            if SKIP_PEER_VERIFICATION.load(Ordering::Relaxed) {
                 tracing::info!(
                     uid = cred.uid(),
                     gid = cred.gid(),
                     pid = cred.pid(),
-                    "Accepted an IPC connection without stream owner check"
+                    "Accepted an IPC connection without peer verification"
                 );
                 let pid = cred.pid().context("No PID")?.try_into()?;
 

--- a/rust/gui-client/src-tauri/src/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/ipc/windows.rs
@@ -44,7 +44,7 @@ use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
 /// process with the `SYSAPPID` attribute.
 ///
 /// In debug builds the Tunnel pipe may also be opened without the
-/// `Owner` pin — see [`skip_tunnel_pipe_owner_check`] — so the
+/// `Owner` pin — see [`skip_peer_verification`] — so the
 /// `gui-smoke-test`, which launches the Tunnel binary as a
 /// subprocess of the test runner (not as a service running under
 /// LocalSystem), doesn't fail `CreateNamedPipeW` with
@@ -84,16 +84,16 @@ fn test_pipe_dacl() -> PipeDacl {
         .allow(FileRights::ReadWrite, Trustee::builtin_users())
 }
 
-/// Whether to skip the tunnel pipe owner check.
+/// Whether to skip verifying the peer (the Tunnel pipe's `LocalSystem` owner).
 #[cfg(debug_assertions)]
-static SKIP_TUNNEL_PIPE_OWNER_CHECK: AtomicBool = AtomicBool::new(false);
+static SKIP_PEER_VERIFICATION: AtomicBool = AtomicBool::new(false);
 
-/// Set [`SKIP_TUNNEL_PIPE_OWNER_CHECK`].
+/// Set [`SKIP_PEER_VERIFICATION`].
 ///
 /// Call once at process startup, before any `Server::new(SocketId::Tunnel)` or `connect_to_socket`.
 #[cfg(debug_assertions)]
-pub fn skip_tunnel_pipe_owner_check() {
-    SKIP_TUNNEL_PIPE_OWNER_CHECK.store(true, Ordering::Relaxed);
+pub fn skip_peer_verification() {
+    SKIP_PEER_VERIFICATION.store(true, Ordering::Relaxed);
 }
 
 pub struct Server {
@@ -135,7 +135,7 @@ fn enforce_pipe_ownership(id: SocketId, handle: HANDLE) -> Result<()> {
         #[cfg(test)]
         SocketId::Test(_) => Ok(()),
         #[cfg(debug_assertions)]
-        SocketId::Tunnel if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) => Ok(()),
+        SocketId::Tunnel if SKIP_PEER_VERIFICATION.load(Ordering::Relaxed) => Ok(()),
         // Refuse to connect to tunnel pipes not owned by local system
         SocketId::Tunnel if !is_pipe_owned_by_local_system(handle)? => {
             bail!("Tunnel pipe owner is not LocalSystem; possible pipe-squatting attack")
@@ -160,9 +160,7 @@ impl Server {
             // flag, so reuse it to fall back to the relaxed test DACL
             // for both pipes.
             #[cfg(debug_assertions)]
-            SocketId::Tunnel | SocketId::Gui
-                if SKIP_TUNNEL_PIPE_OWNER_CHECK.load(Ordering::Relaxed) =>
-            {
+            SocketId::Tunnel | SocketId::Gui if SKIP_PEER_VERIFICATION.load(Ordering::Relaxed) => {
                 test_pipe_dacl()
             }
             SocketId::Tunnel => tunnel_pipe_dacl(),

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -799,7 +799,7 @@ impl<'a> Handler<'a> {
 ///
 /// Mostly used for debugging, but also handy for running a release build
 /// interactively, hence it remains available in release builds.
-pub fn run_interactive(dns_control: DnsControlMethod) -> Result<()> {
+pub fn run_interactive(dns_control: DnsControlMethod, skip_peer_verification: bool) -> Result<()> {
     let log_filter_reloader = logging::setup_stdout()?;
     tracing::info!(
         arch = std::env::consts::ARCH,
@@ -807,12 +807,19 @@ pub fn run_interactive(dns_control: DnsControlMethod) -> Result<()> {
         system_uptime_seconds = bin_shared::uptime::get().map(|dur| dur.as_secs()),
     );
 
-    // Run interactively (e.g. as the local Administrator) the process has
-    // neither the `LocalSystem` nor the MSIX package identity, so the
-    // production pipe-ownership check would reject the connection. Skip it in
-    // debug builds so local GUI dev works; release builds keep the check.
+    // Running interactively (e.g. as the local Administrator), the process has
+    // neither the `LocalSystem` nor the MSIX package identity, and on Linux the
+    // GUI binary usually isn't installed at the canonical path, so the
+    // production peer check would reject the connection. `--skip-peer-verification`
+    // opts out of that check to pair the interactive tunnel service with a
+    // non-installed GUI build. The check still runs by default so it stays
+    // testable in debug builds; release builds always keep it.
     #[cfg(debug_assertions)]
-    ipc::skip_tunnel_pipe_owner_check();
+    if skip_peer_verification {
+        ipc::skip_peer_verification();
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = skip_peer_verification;
 
     if !elevation_check()? {
         bail!("Tunnel service failed its elevation check, try running as admin / root");
@@ -852,7 +859,7 @@ pub fn run_smoke_test() -> Result<()> {
     // for the happy path and launches one from elsewhere to assert the tunnel
     // rejects unrecognised binaries.
     #[cfg(target_os = "windows")]
-    ipc::skip_tunnel_pipe_owner_check();
+    ipc::skip_peer_verification();
 
     let log_filter_reloader = logging::setup_stdout()?;
     if !elevation_check()? {

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -64,13 +64,13 @@ run = "cargo tauri dev -- -- --skip-portal-auth --mock-tunnel"
 description = "Run the GUI client in dev against a dev tunnel service"
 dir = "gui-client"
 raw = true
-run = "cargo tauri dev -- -- --skip-tunnel-pipe-owner-check"
+run = "cargo tauri dev -- -- --skip-peer-verification"
 
 [tasks.tunnel]
-description = "Run the Tunnel service interactively for local GUI dev. In debug builds `run-interactive` skips the LocalSystem pipe-owner check; must be run from an elevated (Administrator) shell."
+description = "Run the Tunnel service interactively for local GUI dev. `--skip-peer-verification` skips the peer check so it accepts a non-installed GUI build; must be run from an elevated shell (Administrator on Windows, root on Unix)."
 dir = "gui-client"
 raw = true
-run = "cargo run -p firezone-gui-client --bin firezone-client-tunnel -- run-interactive"
+run = "cargo run -p firezone-gui-client --bin firezone-client-tunnel -- run-interactive --skip-peer-verification"
 
 # =============================================================================
 # Profiling

--- a/rust/tests/gui-smoke-test/src/main.rs
+++ b/rust/tests/gui-smoke-test/src/main.rs
@@ -352,7 +352,7 @@ impl App {
             // pipe it creates legitimately has no `LocalSystem` owner. Tell
             // the GUI to skip that check. The flag only exists in debug
             // builds; release builds reject it.
-            .arg("--skip-tunnel-pipe-owner-check")
+            .arg("--skip-peer-verification")
             .args(args))
     }
 }


### PR DESCRIPTION
Running the tunnel service interactively skipped peer verification unconditionally on Linux in debug builds, which made the check impossible to exercise. `run-interactive` now verifies the peer by default and only skips it when passed `--skip-peer-verification` (which the `mise run tunnel` dev task sets so it keeps accepting a non-installed GUI build).

The toggle is also unified under a single, platform-neutral name across the GUI and tunnel binaries and both platforms — `skip_peer_verification` / `--skip-peer-verification` — replacing the Windows-centric `skip_tunnel_pipe_owner_check`.

Related: #13836