### PR TITLE
refactor(connlib): move pre-connection buffering to the client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#f1c65a468e6b65a9c69ac4676d6331e4990c4ece"
+source = "git+https://github.com/firezone/boringtun?branch=claude%2Fadoring-planck-c3ja2s#d879f6e9ee5b31c97cbde0bffd6fcf1c25e31516"
 dependencies = [
  "aead",
  "blake2",
@@ -2154,7 +2154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2231,7 +2231,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5659,7 +5659,7 @@ dependencies = [
  "libc",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6003,7 +6003,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6016,7 +6016,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6073,7 +6073,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7537,10 +7537,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9042,7 +9042,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=claude%2Fadoring-planck-c3ja2s#d879f6e9ee5b31c97cbde0bffd6fcf1c25e31516"
+source = "git+https://github.com/firezone/boringtun?branch=master#4ee1988944a8e6891e7ebd5198ed4502cc1c2766"
 dependencies = [
  "aead",
  "blake2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -258,7 +258,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 [patch.crates-io]
 sentry = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
 sentry-tracing = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
-boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
+boringtun = { git = "https://github.com/firezone/boringtun", branch = "claude/adoring-planck-c3ja2s" } # TODO: revert to `branch = "master"` once firezone/boringtun#203 merges.
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -258,7 +258,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 [patch.crates-io]
 sentry = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
 sentry-tracing = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
-boringtun = { git = "https://github.com/firezone/boringtun", branch = "claude/adoring-planck-c3ja2s" } # TODO: revert to `branch = "master"` once firezone/boringtun#203 merges.
+boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.

--- a/rust/libs/connlib/snownet/src/lib.rs
+++ b/rust/libs/connlib/snownet/src/lib.rs
@@ -13,7 +13,8 @@ mod utils;
 
 pub use allocation::RelaySocket;
 pub use node::{
-    Credentials, Event, IceConfig, IceRole, NoTurnServers, Node, Transmit, UnknownConnection,
+    Credentials, Event, IceConfig, IceRole, NoTurnServers, Node, StillConnecting, Transmit,
+    UnknownConnection,
 };
 pub use stats::{ConnectionStats, NodeStats};
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -540,10 +540,9 @@ where
         let socket = match &conn.state {
             ConnectionState::Connecting { .. } => {
                 // Packets are buffered by the client until the connection is established, so we
-                // should not be asked to encapsulate while ICE is still in progress.
-                tracing::debug!(%cid, "ICE is still in progress; dropping packet");
-
-                return Ok(None);
+                // should not be asked to encapsulate while ICE is still in progress. Surface this
+                // as an error so the event-loop logs and meters it.
+                return Err(anyhow!("Connection {cid} is still establishing"));
             }
             ConnectionState::Connected { peer_socket, .. } => *peer_socket,
             ConnectionState::Idle { peer_socket } => *peer_socket,
@@ -1624,9 +1623,8 @@ where
                 .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)
             {
                 Ok(len) => len,
-                // No usable session yet. The client only sends once the connection is established, so
-                // this is a rare re-key gap; drop the packet rather than buffering it.
-                Err(WireGuardError::NoCurrentSession) => return Ok(None),
+                // Surface the error (including `NoCurrentSession`, a rare re-key gap) so the
+                // event-loop logs and meters it instead of silently dropping the packet.
                 Err(e) => return Err(anyhow::Error::new(e)),
             };
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -537,9 +537,6 @@ where
         let conn = self.connections.get_mut(&cid, now)?;
 
         let socket = match &conn.state {
-            // ICE is still in progress: no socket has been nominated, so we cannot send yet.
-            // The caller is expected to buffer the packet and retry on `ConnectionEstablished`.
-            // This also means the controlled agent does not initiate a WireGuard session.
             ConnectionState::Connecting { .. } => {
                 return Err(StillConnecting.into());
             }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -539,9 +539,6 @@ where
 
         let socket = match &conn.state {
             ConnectionState::Connecting { .. } => {
-                // Packets are buffered by the client until the connection is established, so we
-                // should not be asked to encapsulate while ICE is still in progress. Surface this
-                // as an error so the event-loop logs and meters it.
                 return Err(anyhow!("Connection {cid} is still establishing"));
             }
             ConnectionState::Connected { peer_socket, .. } => *peer_socket,
@@ -1618,15 +1615,8 @@ where
         buffer.resize(ip_packet::MAX_FZ_PAYLOAD, 0);
 
         let len =
-            match self
-                .tunnel
-                .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)
-            {
-                Ok(len) => len,
-                // Surface the error (including `NoCurrentSession`, a rare re-key gap) so the
-                // event-loop logs and meters it instead of silently dropping the packet.
-                Err(e) => return Err(anyhow::Error::new(e)),
-            };
+            self.tunnel
+                .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)?;
 
         let packet_end = packet_start + len;
         buffer.truncate(packet_end);

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -537,12 +537,11 @@ where
             return Ok(None);
         }
 
-        let socket = match &mut conn.state {
-            ConnectionState::Connecting { ip_buffer, .. } => {
-                ip_buffer.enqueue(packet.clone());
-                let num_buffered = ip_buffer.len();
-
-                tracing::debug!(%num_buffered, %cid, "ICE is still in progress, buffering IP packet");
+        let socket = match &conn.state {
+            ConnectionState::Connecting { .. } => {
+                // Packets are buffered by the client until the connection is established, so we
+                // should not be asked to encapsulate while ICE is still in progress.
+                tracing::debug!(%cid, "ICE is still in progress; dropping packet");
 
                 return Ok(None);
             }
@@ -812,7 +811,6 @@ where
             relay: SelectedRelay { id: relay },
             state: ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(128),
-                ip_buffer: AllocRingBuffer::new(128),
             },
             disconnected_at: None,
             buffer_pool: self.buffer_pool.clone(),
@@ -1436,11 +1434,7 @@ where
                     };
 
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
-                        ConnectionState::Connecting {
-                            wg_buffer,
-                            ip_buffer,
-                            ..
-                        } => {
+                        ConnectionState::Connecting { wg_buffer } => {
                             tracing::debug!(
                                 num_buffered = %wg_buffer.len(),
                                 "Flushing WireGuard packets buffered during ICE"
@@ -1455,23 +1449,6 @@ where
                                     allocations,
                                     now,
                                 )
-                            }));
-
-                            tracing::debug!(
-                                num_buffered = %ip_buffer.len(),
-                                "Flushing IP packets buffered during ICE"
-                            );
-                            transmits.extend(ip_buffer.into_iter().flat_map(|packet| {
-                                let transmit = self
-                                    .encapsulate(cid, remote_socket, &packet, now, allocations)
-                                    .inspect_err(|e| {
-                                        tracing::debug!(
-                                            "Failed to encapsulate buffered IP packet: {e:#}"
-                                        )
-                                    })
-                                    .ok()??;
-
-                                Some(transmit)
                             }));
 
                             self.state = ConnectionState::Connected {
@@ -1644,14 +1621,13 @@ where
         let len =
             match self
                 .tunnel
-                .encapsulate_at(packet.packet(), &mut buffer[packet_start..], now)
+                .encapsulate_data_at(packet.packet(), &mut buffer[packet_start..], now)
             {
-                TunnResult::Done => return Ok(None),
-                TunnResult::Err(e) => return Err(anyhow::Error::new(e)),
-                TunnResult::WriteToNetwork(packet) => packet.len(),
-                TunnResult::WriteToTunnelV4(_, _) | TunnResult::WriteToTunnelV6(_, _) => {
-                    unreachable!("never returned from encapsulate")
-                }
+                Ok(len) => len,
+                // No usable session yet. The client only sends once the connection is established, so
+                // this is a rare re-key gap; drop the packet rather than buffering it.
+                Err(WireGuardError::NoCurrentSession) => return Ok(None),
+                Err(e) => return Err(anyhow::Error::new(e)),
             };
 
         let packet_end = packet_start + len;

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -118,6 +118,14 @@ pub struct Node<TId, RId> {
 #[error("No TURN servers available")]
 pub struct NoTurnServers {}
 
+/// The connection exists but is not yet ready to send application packets because ICE is
+/// still in progress (no socket has been nominated yet).
+///
+/// Callers should buffer the packet and retry once the connection is established.
+#[derive(thiserror::Error, Debug)]
+#[error("Connection is still establishing")]
+pub struct StillConnecting;
+
 #[derive(Debug, Clone, Copy)]
 pub struct IceConfig {
     max_retrans: usize,
@@ -528,18 +536,12 @@ where
     ) -> Result<Option<Transmit>> {
         let conn = self.connections.get_mut(&cid, now)?;
 
-        if !conn.agent.controlling() && !conn.state.has_nominated_socket() {
-            tracing::debug!(
-                ?packet,
-                "ICE is still in progress; dropping packet because controlled agent should not initiate WireGuard sessions"
-            );
-
-            return Ok(None);
-        }
-
         let socket = match &conn.state {
+            // ICE is still in progress: no socket has been nominated, so we cannot send yet.
+            // The caller is expected to buffer the packet and retry on `ConnectionEstablished`.
+            // This also means the controlled agent does not initiate a WireGuard session.
             ConnectionState::Connecting { .. } => {
-                return Err(anyhow!("Connection {cid} is still establishing"));
+                return Err(StillConnecting.into());
             }
             ConnectionState::Connected { peer_socket, .. } => *peer_socket,
             ConnectionState::Idle { peer_socket } => *peer_socket,
@@ -612,6 +614,7 @@ where
                 now,
                 &mut self.allocations,
                 &mut self.buffered_transmits,
+                &mut self.pending_events,
                 &mut self.inflight_stun_requests,
             );
 
@@ -1032,8 +1035,13 @@ where
 
             tracing::debug!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
 
-            self.pending_events
-                .push_back(Event::ConnectionEstablished(cid))
+            // Only signal establishment once we can actually send, i.e. ICE has nominated a
+            // socket. On the controlled side the handshake can complete before nomination, in
+            // which case the event is emitted from the `NominatedSend` handler instead.
+            if conn.state.has_nominated_socket() {
+                self.pending_events
+                    .push_back(Event::ConnectionEstablished(cid))
+            }
         }
 
         control_flow
@@ -1334,6 +1342,7 @@ where
         now: Instant,
         allocations: &mut Allocations<RId>,
         transmits: &mut VecDeque<Transmit>,
+        pending_events: &mut VecDeque<Event<TId>>,
         inflight_stun_requests: &mut InflightStunRequests<TId>,
     ) where
         TId: Copy + Ord + fmt::Display,
@@ -1451,6 +1460,14 @@ where
                                 peer_socket: remote_socket,
                                 last_activity: now,
                             };
+
+                            // If the WireGuard handshake already completed while we were still
+                            // running ICE, the connection only becomes usable now that a socket is
+                            // nominated, so this is when we signal establishment.
+                            if self.first_handshake_completed_at.is_some() {
+                                pending_events.push_back(Event::ConnectionEstablished(cid));
+                            }
+
                             None
                         }
                         ConnectionState::Connected {

--- a/rust/libs/connlib/snownet/src/node/connection_state.rs
+++ b/rust/libs/connlib/snownet/src/node/connection_state.rs
@@ -20,11 +20,6 @@ pub(crate) enum ConnectionState {
         /// This can happen if the remote's WG session initiation arrives at our socket before we nominate it.
         /// A session initiation requires a response that we must not drop, otherwise the connection setup experiences unnecessary delays.
         wg_buffer: AllocRingBuffer<Vec<u8>>,
-
-        /// Packets we are told to send whilst we are still running ICE.
-        ///
-        /// These need to be encrypted and sent once the tunnel is established.
-        ip_buffer: AllocRingBuffer<IpPacket>,
     },
     /// A socket has been nominated.
     Connected {

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -619,7 +619,6 @@ mod tests {
             relay: SelectedRelay { id: relay_id },
             state: crate::node::ConnectionState::Connecting {
                 wg_buffer: AllocRingBuffer::new(1),
-                ip_buffer: AllocRingBuffer::new(1),
             },
             disconnected_at: None,
             stats: Default::default(),

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -780,6 +780,8 @@ impl ClientState {
             return;
         };
 
+        tracing::debug!(%pid, num_buffered = %buffer.len(), "Flushing buffered packets");
+
         for packet in buffer {
             encapsulate_and_queue(
                 packet,
@@ -821,7 +823,10 @@ impl ClientState {
             }
         }
 
-        encapsulate_or_buffer(packet, pid, now, &mut self.node, &mut self.pending_packets)
+        let transmit =
+            encapsulate_or_buffer(packet, pid, now, &mut self.node, &mut self.pending_packets)?;
+
+        Ok(transmit)
     }
 
     /// Decide which connection a packet should be encapsulated through.

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -120,17 +120,14 @@ pub struct ClientState {
     /// Tracks pending access to other devices.
     pending_device_access: PendingDeviceAccessRequests,
 
-    /// Packets buffered per connection while it is still being established.
+    /// Per-connection buffering state, keyed by the peer.
     ///
-    /// An entry is created when we start connecting to a peer and is flushed and removed once the
-    /// connection is established (see [`snownet::Event::ConnectionEstablished`]). This is the single
-    /// place where we hold application packets between initiating a connection and it being usable.
-    pending_packets: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
-    /// Connections whose WireGuard handshake has completed.
-    ///
-    /// Used to decide, when access to a resource is authorized, whether the connection is already
-    /// usable (send directly) or still being established (buffer in `pending_packets`).
-    established_connections: BTreeSet<ClientOrGatewayId>,
+    /// While a connection is still being established, packets are held in
+    /// [`Connection::Connecting`]; once it is usable (on [`snownet::Event::ConnectionEstablished`])
+    /// they are drained and the entry becomes [`Connection::Connected`], after which packets are
+    /// sent straight away. This is the single place where the client holds application packets
+    /// between initiating a connection and it being usable.
+    connections: BTreeMap<ClientOrGatewayId, Connection>,
 
     dns_resource_nat: DnsResourceNat,
     /// Resources we have requested access to and the path that authorises
@@ -191,6 +188,14 @@ pub struct ClientState {
     dns_lookup_duration: opentelemetry::metrics::Histogram<f64>,
 }
 
+/// Buffering state of a connection to a peer.
+enum Connection {
+    /// The connection is still being established; packets are buffered here until it is usable.
+    Connecting(UniquePacketBuffer),
+    /// The connection is established; packets are sent straight away.
+    Connected,
+}
+
 impl ClientState {
     pub(crate) fn new(
         seed: [u8; 32],
@@ -226,8 +231,7 @@ impl ClientState {
             dns_streams_by_local_upstream_and_query_id: Default::default(),
             pending_flows: Default::default(),
             pending_device_access: Default::default(),
-            pending_packets: Default::default(),
-            established_connections: Default::default(),
+            connections: Default::default(),
             dns_resource_nat: Default::default(),
             resource_list: Default::default(),
             connected_pool_clients: Default::default(),
@@ -782,31 +786,30 @@ impl ClientState {
         }
     }
 
-    /// Capacity (as a power of two) of a per-connection [`ClientState::pending_packets`] buffer.
-    const PENDING_PACKETS_CAPACITY_POW_2: usize = 7; // 2^7 = 128
+    /// Capacity (as a power of two) of a per-connection packet buffer.
+    const CONNECTION_BUFFER_CAPACITY_POW_2: usize = 7; // 2^7 = 128
 
-    /// Ensure packets sent to `pid` are buffered until its connection is established.
+    /// Start buffering packets for `pid` until its connection is established.
     ///
-    /// Does nothing if the connection is already established — in that case packets are sent
-    /// straight away.
-    fn buffer_until_established(&mut self, pid: ClientOrGatewayId) {
-        if self.established_connections.contains(&pid) {
+    /// No-op if the connection is already established.
+    fn ensure_connecting(&mut self, pid: ClientOrGatewayId) {
+        if matches!(self.connections.get(&pid), Some(Connection::Connected)) {
             return;
         }
 
-        self.pending_packets.entry(pid).or_insert_with(|| {
-            UniquePacketBuffer::with_capacity_power_of_2(
-                Self::PENDING_PACKETS_CAPACITY_POW_2,
+        self.connections.entry(pid).or_insert_with(|| {
+            Connection::Connecting(UniquePacketBuffer::with_capacity_power_of_2(
+                Self::CONNECTION_BUFFER_CAPACITY_POW_2,
                 "pending-connection",
-            )
+            ))
         });
     }
 
     /// Flush all packets buffered for `pid` now that its connection is established.
-    fn flush_pending_packets(&mut self, pid: ClientOrGatewayId, now: Instant) {
-        self.established_connections.insert(pid);
-
-        let Some(buffer) = self.pending_packets.remove(&pid) else {
+    fn flush_connection(&mut self, pid: ClientOrGatewayId, now: Instant) {
+        let Some(Connection::Connecting(buffer)) =
+            self.connections.insert(pid, Connection::Connected)
+        else {
             return;
         };
 
@@ -823,8 +826,7 @@ impl ClientState {
 
     /// Forget any state we track for `pid`'s connection (e.g. when it failed or closed).
     fn forget_connection(&mut self, pid: ClientOrGatewayId) {
-        self.established_connections.remove(&pid);
-        self.pending_packets.remove(&pid);
+        self.connections.remove(&pid);
     }
 
     fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> Result<Option<snownet::Transmit>> {
@@ -858,7 +860,7 @@ impl ClientState {
 
         // Buffer the packet if the connection is still being established; it is flushed once we
         // receive `snownet::Event::ConnectionEstablished`.
-        if let Some(buffer) = self.pending_packets.get_mut(&pid) {
+        if let Some(Connection::Connecting(buffer)) = self.connections.get_mut(&pid) {
             buffer.push(packet);
             return Ok(None);
         }
@@ -1020,19 +1022,19 @@ impl ClientState {
             Ok(()) => {}
             Err(e) => return Ok(Err(e)),
         };
-        // Buffer packets to this Gateway until the connection is established. Inlined rather than
-        // `buffer_until_established` because `resource` still borrows `self.resources_by_id`.
-        if !self
-            .established_connections
-            .contains(&ClientOrGatewayId::Gateway(gid))
-        {
-            self.pending_packets
+        // Buffer packets to this Gateway until the connection is established (unless it already
+        // is). Inlined rather than a helper because `resource` still borrows `self.resources_by_id`.
+        if !matches!(
+            self.connections.get(&ClientOrGatewayId::Gateway(gid)),
+            Some(Connection::Connected)
+        ) {
+            self.connections
                 .entry(ClientOrGatewayId::Gateway(gid))
                 .or_insert_with(|| {
-                    UniquePacketBuffer::with_capacity_power_of_2(
-                        Self::PENDING_PACKETS_CAPACITY_POW_2,
+                    Connection::Connecting(UniquePacketBuffer::with_capacity_power_of_2(
+                        Self::CONNECTION_BUFFER_CAPACITY_POW_2,
                         "pending-connection",
-                    )
+                    ))
                 });
         }
         self.authorized_resources
@@ -1064,22 +1066,22 @@ impl ClientState {
                     peer.allow_ip_for_resource(address, rid);
                 }
 
-                // Buffer the packets until the connection is established (or send them straight
-                // away if it already is). Inlined rather than via `send_or_buffer` because `peer`
-                // still borrows `self.gateways`.
-                for packet in buffered_resource_packets {
-                    match self
-                        .pending_packets
-                        .get_mut(&ClientOrGatewayId::Gateway(gid))
-                    {
-                        Some(buffer) => buffer.push(packet),
-                        None => encapsulate_and_buffer(
-                            packet,
-                            ClientOrGatewayId::Gateway(gid),
-                            now,
-                            &mut self.node,
-                            &mut self.buffered_transmits,
-                        ),
+                // Buffer the packets until the connection is established, or send them straight
+                // away if it already is.
+                match self.connections.get_mut(&ClientOrGatewayId::Gateway(gid)) {
+                    Some(Connection::Connecting(buffer)) => {
+                        buffer.extend(buffered_resource_packets)
+                    }
+                    _ => {
+                        for packet in buffered_resource_packets {
+                            encapsulate_and_buffer(
+                                packet,
+                                ClientOrGatewayId::Gateway(gid),
+                                now,
+                                &mut self.node,
+                                &mut self.buffered_transmits,
+                            );
+                        }
                     }
                 }
             }
@@ -1135,7 +1137,7 @@ impl ClientState {
             snownet::IceConfig::client_default(),
             now,
         )?;
-        self.buffer_until_established(ClientOrGatewayId::Client(cid));
+        self.ensure_connecting(ClientOrGatewayId::Client(cid));
 
         let authorization = authorization.map(|auth| {
             let expires_at = auth
@@ -1178,12 +1180,9 @@ impl ClientState {
 
             for packet in pending_client_access.into_buffered_packets() {
                 peer.record_outbound(&packet, now);
-                match self
-                    .pending_packets
-                    .get_mut(&ClientOrGatewayId::Client(cid))
-                {
-                    Some(buffer) => buffer.push(packet),
-                    None => encapsulate_and_buffer(
+                match self.connections.get_mut(&ClientOrGatewayId::Client(cid)) {
+                    Some(Connection::Connecting(buffer)) => buffer.push(packet),
+                    _ => encapsulate_and_buffer(
                         packet,
                         ClientOrGatewayId::Client(cid),
                         now,
@@ -2070,11 +2069,11 @@ impl ClientState {
                         .insert(candidate.into());
                 }
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Gateway(id)) => {
-                    self.flush_pending_packets(ClientOrGatewayId::Gateway(id), now);
+                    self.flush_connection(ClientOrGatewayId::Gateway(id), now);
                     self.update_site_status_by_gateway(&id, ResourceStatus::Online, now);
                 }
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(id)) => {
-                    self.flush_pending_packets(ClientOrGatewayId::Client(id), now);
+                    self.flush_connection(ClientOrGatewayId::Client(id), now);
                     if self.connected_pool_clients.insert(id) {
                         self.resource_list.update(self.resource_list_snapshot());
                     }
@@ -2215,8 +2214,7 @@ impl ClientState {
         self.node.reset(now); // Clear all network connections.
         self.gateways.clear(); // Clear all state associated with Gateways.
         self.clients.clear(); // Clear all state associated with Clients.
-        self.pending_packets.clear(); // Drop packets buffered for pending connections.
-        self.established_connections.clear();
+        self.connections.clear(); // Drop packets buffered for pending connections.
 
         self.dns_resource_nat.clear(); // Clear all state related to DNS resource NATs.
         self.drain_node_events(now);

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -120,14 +120,11 @@ pub struct ClientState {
     /// Tracks pending access to other devices.
     pending_device_access: PendingDeviceAccessRequests,
 
-    /// Per-connection packet buffers, keyed by the peer.
+    /// Packets buffered per peer while its connection is still being established.
     ///
-    /// An entry exists only while a connection is still being established: packets we cannot send
-    /// yet (snownet returns [`snownet::StillConnecting`]) are held here and flushed once we receive
-    /// [`snownet::Event::ConnectionEstablished`], at which point the entry is removed. This is the
-    /// single place where the client holds application packets between initiating a connection and
-    /// it being usable.
-    connections: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
+    /// Flushed once we receive [`snownet::Event::ConnectionEstablished`]; the single place where
+    /// the client buffers application packets.
+    pending_packets: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 
     dns_resource_nat: DnsResourceNat,
     /// Resources we have requested access to and the path that authorises
@@ -223,7 +220,7 @@ impl ClientState {
             dns_streams_by_local_upstream_and_query_id: Default::default(),
             pending_flows: Default::default(),
             pending_device_access: Default::default(),
-            connections: Default::default(),
+            pending_packets: Default::default(),
             dns_resource_nat: Default::default(),
             resource_list: Default::default(),
             connected_pool_clients: Default::default(),
@@ -622,7 +619,7 @@ impl ClientState {
                             now,
                             &mut self.node,
                             &mut self.buffered_transmits,
-                            &mut self.connections,
+                            &mut self.pending_packets,
                         );
                     }
                 }
@@ -661,7 +658,7 @@ impl ClientState {
                             now,
                             &mut self.node,
                             &mut self.buffered_transmits,
-                            &mut self.connections,
+                            &mut self.pending_packets,
                         );
                         return Ok(None);
                     }
@@ -785,7 +782,7 @@ impl ClientState {
 
     /// Flush all packets buffered for `pid` now that its connection is established.
     fn flush_connection(&mut self, pid: ClientOrGatewayId, now: Instant) {
-        let Some(buffer) = self.connections.remove(&pid) else {
+        let Some(buffer) = self.pending_packets.remove(&pid) else {
             return;
         };
 
@@ -796,14 +793,9 @@ impl ClientState {
                 now,
                 &mut self.node,
                 &mut self.buffered_transmits,
-                &mut self.connections,
+                &mut self.pending_packets,
             );
         }
-    }
-
-    /// Forget any packets buffered for `pid`'s connection (e.g. when it failed or closed).
-    fn forget_connection(&mut self, pid: ClientOrGatewayId) {
-        self.connections.remove(&pid);
     }
 
     fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> Result<Option<snownet::Transmit>> {
@@ -835,36 +827,7 @@ impl ClientState {
             }
         }
 
-        // If we are already buffering for this connection, keep doing so to preserve ordering; the
-        // buffer is flushed once we receive `snownet::Event::ConnectionEstablished`.
-        if let Some(buffer) = self.connections.get_mut(&pid) {
-            buffer.push(packet);
-            return Ok(None);
-        }
-
-        let transmit = match self.node.encapsulate(pid, &packet, now) {
-            Ok(Some(transmit)) => transmit,
-            Ok(None) => return Ok(None),
-            // The connection is still establishing; start buffering until it is usable.
-            Err(e) if e.any_is::<snownet::StillConnecting>() => {
-                self.connections
-                    .entry(pid)
-                    .or_insert_with(|| {
-                        UniquePacketBuffer::with_capacity_power_of_2(
-                            Self::CONNECTION_BUFFER_CAPACITY_POW_2,
-                            "pending-connection",
-                        )
-                    })
-                    .push(packet);
-                return Ok(None);
-            }
-            Err(e) if e.any_is::<snownet::UnknownConnection>() => {
-                return Err(e.context(UnroutablePacket::not_connected(&packet)));
-            }
-            Err(e) => return Err(e),
-        };
-
-        Ok(Some(transmit))
+        encapsulate_or_buffer(packet, pid, now, &mut self.node, &mut self.pending_packets)
     }
 
     /// Decide which connection a packet should be encapsulated through.
@@ -1050,7 +1013,7 @@ impl ClientState {
                         now,
                         &mut self.node,
                         &mut self.buffered_transmits,
-                        &mut self.connections,
+                        &mut self.pending_packets,
                     );
                 }
             }
@@ -1154,7 +1117,7 @@ impl ClientState {
                     now,
                     &mut self.node,
                     &mut self.buffered_transmits,
-                    &mut self.connections,
+                    &mut self.pending_packets,
                 );
             }
         }
@@ -1698,7 +1661,7 @@ impl ClientState {
                 now,
                 &mut self.node,
                 &mut self.buffered_transmits,
-                &mut self.connections,
+                &mut self.pending_packets,
             );
         }
     }
@@ -2009,12 +1972,12 @@ impl ClientState {
             match event {
                 snownet::Event::ConnectionFailed(ClientOrGatewayId::Gateway(id))
                 | snownet::Event::ConnectionClosed(ClientOrGatewayId::Gateway(id)) => {
-                    self.forget_connection(ClientOrGatewayId::Gateway(id));
+                    self.pending_packets.remove(&ClientOrGatewayId::Gateway(id)); // Drop buffered packets.
                     self.cleanup_connected_gateway(&id, now);
                 }
                 snownet::Event::ConnectionFailed(ClientOrGatewayId::Client(id))
                 | snownet::Event::ConnectionClosed(ClientOrGatewayId::Client(id)) => {
-                    self.forget_connection(ClientOrGatewayId::Client(id));
+                    self.pending_packets.remove(&ClientOrGatewayId::Client(id)); // Drop buffered packets.
                     self.cleanup_connected_client(&id);
                 }
                 snownet::Event::NewIceCandidate {
@@ -2181,7 +2144,7 @@ impl ClientState {
         self.node.reset(now); // Clear all network connections.
         self.gateways.clear(); // Clear all state associated with Gateways.
         self.clients.clear(); // Clear all state associated with Clients.
-        self.connections.clear(); // Drop packets buffered for pending connections.
+        self.pending_packets.clear(); // Drop packets buffered for pending connections.
 
         self.dns_resource_nat.clear(); // Clear all state related to DNS resource NATs.
         self.drain_node_events(now);
@@ -2653,31 +2616,35 @@ fn filter_allows(filter: &FilterEngine, protocol: Protocol) -> bool {
     false
 }
 
-/// Encapsulate `packet` for `pid` and queue the resulting transmit, or buffer it if the connection
-/// is still being established.
+/// Encapsulate `packet` for `pid`, or buffer it if the connection is still being established.
 ///
 /// If we are already buffering for `pid`, the packet is appended to preserve ordering. A connection
 /// that is not yet usable makes `node.encapsulate` return [`snownet::StillConnecting`], in which
-/// case we start buffering. The buffer is flushed via [`ClientState::flush_connection`] once we
+/// case we start buffering; the buffer is flushed via [`ClientState::flush_connection`] once we
 /// receive [`snownet::Event::ConnectionEstablished`].
-fn encapsulate_and_buffer(
+///
+/// Returns the transmit to send, or `Ok(None)` if the packet was buffered. Queueing the transmit is
+/// left to the caller.
+fn encapsulate_or_buffer(
     packet: IpPacket,
     pid: ClientOrGatewayId,
     now: Instant,
     node: &mut Node<ClientOrGatewayId, RelayId>,
-    buffered_transmits: &mut VecDeque<Transmit>,
-    connections: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
-) {
-    if let Some(buffer) = connections.get_mut(&pid) {
+    pending_packets: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
+) -> Result<Option<Transmit>> {
+    // If we are already buffering for this connection, keep doing so to preserve ordering. The
+    // connection can be usable for ICE (nominated) but not yet have a WireGuard session, so we must
+    // keep buffering until `ConnectionEstablished` rather than relying on `StillConnecting` alone.
+    if let Some(buffer) = pending_packets.get_mut(&pid) {
         buffer.push(packet);
-        return;
+        return Ok(None);
     }
 
     match node.encapsulate(pid, &packet, now) {
-        Ok(Some(transmit)) => buffered_transmits.push_back(transmit),
-        Ok(None) => {}
+        Ok(maybe_transmit) => Ok(maybe_transmit),
+        // The connection is still establishing; start buffering until it is usable.
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
-            connections
+            pending_packets
                 .entry(pid)
                 .or_insert_with(|| {
                     UniquePacketBuffer::with_capacity_power_of_2(
@@ -2686,7 +2653,28 @@ fn encapsulate_and_buffer(
                     )
                 })
                 .push(packet);
+            Ok(None)
         }
+        Err(e) if e.any_is::<snownet::UnknownConnection>() => {
+            Err(e.context(UnroutablePacket::not_connected(&packet)))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Like [`encapsulate_or_buffer`], but queues the resulting transmit into `buffered_transmits` and
+/// drops (with a log) any error instead of returning it.
+fn encapsulate_and_buffer(
+    packet: IpPacket,
+    pid: ClientOrGatewayId,
+    now: Instant,
+    node: &mut Node<ClientOrGatewayId, RelayId>,
+    buffered_transmits: &mut VecDeque<Transmit>,
+    pending_packets: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
+) {
+    match encapsulate_or_buffer(packet, pid, now, node, pending_packets) {
+        Ok(Some(transmit)) => buffered_transmits.push_back(transmit),
+        Ok(None) => {}
         Err(e) => tracing::debug!(%pid, "Failed to encapsulate: {e:#}"),
     }
 }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -610,7 +610,7 @@ impl ClientState {
                     let buffered_packets = self.dns_resource_nat.on_domain_status(gid, res);
 
                     for packet in buffered_packets {
-                        encapsulate_and_buffer(
+                        encapsulate_and_queue(
                             packet,
                             ClientOrGatewayId::Gateway(gid),
                             now,
@@ -649,7 +649,7 @@ impl ClientState {
                 let packet = match peer.ensure_allowed_inbound(packet, now)? {
                     InboundResult::Send(p) => p,
                     InboundResult::Filtered(reply) => {
-                        encapsulate_and_buffer(
+                        encapsulate_and_queue(
                             reply,
                             ClientOrGatewayId::Client(cid),
                             now,
@@ -781,7 +781,7 @@ impl ClientState {
         };
 
         for packet in buffer {
-            encapsulate_and_buffer(
+            encapsulate_and_queue(
                 packet,
                 pid,
                 now,
@@ -1001,7 +1001,7 @@ impl ClientState {
                 // Send the buffered packets, or buffer them again if the connection is not yet
                 // established.
                 for packet in buffered_resource_packets {
-                    encapsulate_and_buffer(
+                    encapsulate_and_queue(
                         packet,
                         ClientOrGatewayId::Gateway(gid),
                         now,
@@ -1105,7 +1105,7 @@ impl ClientState {
 
             for packet in pending_client_access.into_buffered_packets() {
                 peer.record_outbound(&packet, now);
-                encapsulate_and_buffer(
+                encapsulate_and_queue(
                     packet,
                     ClientOrGatewayId::Client(cid),
                     now,
@@ -1653,7 +1653,7 @@ impl ClientState {
         while let Some((gid, domain, rid, packet)) = self.dns_resource_nat.poll_packet() {
             tracing::debug!(%gid, %domain, %rid, "Setting up DNS resource NAT");
 
-            encapsulate_and_buffer(
+            encapsulate_and_queue(
                 packet,
                 ClientOrGatewayId::Gateway(gid),
                 now,
@@ -2650,7 +2650,7 @@ fn encapsulate_or_buffer(
 
 /// Like [`encapsulate_or_buffer`], but queues the resulting transmit into `buffered_transmits` and
 /// drops (with a log) any error instead of returning it.
-fn encapsulate_and_buffer(
+fn encapsulate_and_queue(
     packet: IpPacket,
     pid: ClientOrGatewayId,
     now: Instant,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -120,14 +120,14 @@ pub struct ClientState {
     /// Tracks pending access to other devices.
     pending_device_access: PendingDeviceAccessRequests,
 
-    /// Per-connection buffering state, keyed by the peer.
+    /// Per-connection packet buffers, keyed by the peer.
     ///
-    /// While a connection is still being established, packets are held in
-    /// [`Connection::Connecting`]; once it is usable (on [`snownet::Event::ConnectionEstablished`])
-    /// they are drained and the entry becomes [`Connection::Connected`], after which packets are
-    /// sent straight away. This is the single place where the client holds application packets
-    /// between initiating a connection and it being usable.
-    connections: BTreeMap<ClientOrGatewayId, Connection>,
+    /// An entry exists only while a connection is still being established: packets we cannot send
+    /// yet (snownet returns [`snownet::StillConnecting`]) are held here and flushed once we receive
+    /// [`snownet::Event::ConnectionEstablished`], at which point the entry is removed. This is the
+    /// single place where the client holds application packets between initiating a connection and
+    /// it being usable.
+    connections: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 
     dns_resource_nat: DnsResourceNat,
     /// Resources we have requested access to and the path that authorises
@@ -186,14 +186,6 @@ pub struct ClientState {
     unix_ts_clock: UnixTsClock,
     buffered_dns_queries: VecDeque<dns::RecursiveQuery>,
     dns_lookup_duration: opentelemetry::metrics::Histogram<f64>,
-}
-
-/// Buffering state of a connection to a peer.
-enum Connection {
-    /// The connection is still being established; packets are buffered here until it is usable.
-    Connecting(UniquePacketBuffer),
-    /// The connection is established; packets are sent straight away.
-    Connected,
 }
 
 impl ClientState {
@@ -630,6 +622,7 @@ impl ClientState {
                             now,
                             &mut self.node,
                             &mut self.buffered_transmits,
+                            &mut self.connections,
                         );
                     }
                 }
@@ -668,6 +661,7 @@ impl ClientState {
                             now,
                             &mut self.node,
                             &mut self.buffered_transmits,
+                            &mut self.connections,
                         );
                         return Ok(None);
                     }
@@ -789,27 +783,9 @@ impl ClientState {
     /// Capacity (as a power of two) of a per-connection packet buffer.
     const CONNECTION_BUFFER_CAPACITY_POW_2: usize = 7; // 2^7 = 128
 
-    /// Start buffering packets for `pid` until its connection is established.
-    ///
-    /// No-op if the connection is already established.
-    fn ensure_connecting(&mut self, pid: ClientOrGatewayId) {
-        if matches!(self.connections.get(&pid), Some(Connection::Connected)) {
-            return;
-        }
-
-        self.connections.entry(pid).or_insert_with(|| {
-            Connection::Connecting(UniquePacketBuffer::with_capacity_power_of_2(
-                Self::CONNECTION_BUFFER_CAPACITY_POW_2,
-                "pending-connection",
-            ))
-        });
-    }
-
     /// Flush all packets buffered for `pid` now that its connection is established.
     fn flush_connection(&mut self, pid: ClientOrGatewayId, now: Instant) {
-        let Some(Connection::Connecting(buffer)) =
-            self.connections.insert(pid, Connection::Connected)
-        else {
+        let Some(buffer) = self.connections.remove(&pid) else {
             return;
         };
 
@@ -820,11 +796,12 @@ impl ClientState {
                 now,
                 &mut self.node,
                 &mut self.buffered_transmits,
+                &mut self.connections,
             );
         }
     }
 
-    /// Forget any state we track for `pid`'s connection (e.g. when it failed or closed).
+    /// Forget any packets buffered for `pid`'s connection (e.g. when it failed or closed).
     fn forget_connection(&mut self, pid: ClientOrGatewayId) {
         self.connections.remove(&pid);
     }
@@ -858,9 +835,9 @@ impl ClientState {
             }
         }
 
-        // Buffer the packet if the connection is still being established; it is flushed once we
-        // receive `snownet::Event::ConnectionEstablished`.
-        if let Some(Connection::Connecting(buffer)) = self.connections.get_mut(&pid) {
+        // If we are already buffering for this connection, keep doing so to preserve ordering; the
+        // buffer is flushed once we receive `snownet::Event::ConnectionEstablished`.
+        if let Some(buffer) = self.connections.get_mut(&pid) {
             buffer.push(packet);
             return Ok(None);
         }
@@ -868,6 +845,19 @@ impl ClientState {
         let transmit = match self.node.encapsulate(pid, &packet, now) {
             Ok(Some(transmit)) => transmit,
             Ok(None) => return Ok(None),
+            // The connection is still establishing; start buffering until it is usable.
+            Err(e) if e.any_is::<snownet::StillConnecting>() => {
+                self.connections
+                    .entry(pid)
+                    .or_insert_with(|| {
+                        UniquePacketBuffer::with_capacity_power_of_2(
+                            Self::CONNECTION_BUFFER_CAPACITY_POW_2,
+                            "pending-connection",
+                        )
+                    })
+                    .push(packet);
+                return Ok(None);
+            }
             Err(e) if e.any_is::<snownet::UnknownConnection>() => {
                 return Err(e.context(UnroutablePacket::not_connected(&packet)));
             }
@@ -1022,21 +1012,6 @@ impl ClientState {
             Ok(()) => {}
             Err(e) => return Ok(Err(e)),
         };
-        // Buffer packets to this Gateway until the connection is established (unless it already
-        // is). Inlined rather than a helper because `resource` still borrows `self.resources_by_id`.
-        if !matches!(
-            self.connections.get(&ClientOrGatewayId::Gateway(gid)),
-            Some(Connection::Connected)
-        ) {
-            self.connections
-                .entry(ClientOrGatewayId::Gateway(gid))
-                .or_insert_with(|| {
-                    Connection::Connecting(UniquePacketBuffer::with_capacity_power_of_2(
-                        Self::CONNECTION_BUFFER_CAPACITY_POW_2,
-                        "pending-connection",
-                    ))
-                });
-        }
         self.authorized_resources
             .insert(rid, AccessPath::Gateway(gid));
         self.gateways_by_site
@@ -1066,23 +1041,17 @@ impl ClientState {
                     peer.allow_ip_for_resource(address, rid);
                 }
 
-                // Buffer the packets until the connection is established, or send them straight
-                // away if it already is.
-                match self.connections.get_mut(&ClientOrGatewayId::Gateway(gid)) {
-                    Some(Connection::Connecting(buffer)) => {
-                        buffer.extend(buffered_resource_packets)
-                    }
-                    _ => {
-                        for packet in buffered_resource_packets {
-                            encapsulate_and_buffer(
-                                packet,
-                                ClientOrGatewayId::Gateway(gid),
-                                now,
-                                &mut self.node,
-                                &mut self.buffered_transmits,
-                            );
-                        }
-                    }
+                // Send the buffered packets, or buffer them again if the connection is not yet
+                // established.
+                for packet in buffered_resource_packets {
+                    encapsulate_and_buffer(
+                        packet,
+                        ClientOrGatewayId::Gateway(gid),
+                        now,
+                        &mut self.node,
+                        &mut self.buffered_transmits,
+                        &mut self.connections,
+                    );
                 }
             }
             Resource::Dns(_) => {
@@ -1137,7 +1106,6 @@ impl ClientState {
             snownet::IceConfig::client_default(),
             now,
         )?;
-        self.ensure_connecting(ClientOrGatewayId::Client(cid));
 
         let authorization = authorization.map(|auth| {
             let expires_at = auth
@@ -1180,16 +1148,14 @@ impl ClientState {
 
             for packet in pending_client_access.into_buffered_packets() {
                 peer.record_outbound(&packet, now);
-                match self.connections.get_mut(&ClientOrGatewayId::Client(cid)) {
-                    Some(Connection::Connecting(buffer)) => buffer.push(packet),
-                    _ => encapsulate_and_buffer(
-                        packet,
-                        ClientOrGatewayId::Client(cid),
-                        now,
-                        &mut self.node,
-                        &mut self.buffered_transmits,
-                    ),
-                }
+                encapsulate_and_buffer(
+                    packet,
+                    ClientOrGatewayId::Client(cid),
+                    now,
+                    &mut self.node,
+                    &mut self.buffered_transmits,
+                    &mut self.connections,
+                );
             }
         }
 
@@ -1732,6 +1698,7 @@ impl ClientState {
                 now,
                 &mut self.node,
                 &mut self.buffered_transmits,
+                &mut self.connections,
             );
         }
     }
@@ -2686,23 +2653,42 @@ fn filter_allows(filter: &FilterEngine, protocol: Protocol) -> bool {
     false
 }
 
+/// Encapsulate `packet` for `pid` and queue the resulting transmit, or buffer it if the connection
+/// is still being established.
+///
+/// If we are already buffering for `pid`, the packet is appended to preserve ordering. A connection
+/// that is not yet usable makes `node.encapsulate` return [`snownet::StillConnecting`], in which
+/// case we start buffering. The buffer is flushed via [`ClientState::flush_connection`] once we
+/// receive [`snownet::Event::ConnectionEstablished`].
 fn encapsulate_and_buffer(
     packet: IpPacket,
     pid: ClientOrGatewayId,
     now: Instant,
     node: &mut Node<ClientOrGatewayId, RelayId>,
     buffered_transmits: &mut VecDeque<Transmit>,
+    connections: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 ) {
-    let Some(transmit) = node
-        .encapsulate(pid, &packet, now)
-        .inspect_err(|e| tracing::debug!(%pid, "Failed to encapsulate: {e}"))
-        .ok()
-        .flatten()
-    else {
+    if let Some(buffer) = connections.get_mut(&pid) {
+        buffer.push(packet);
         return;
-    };
+    }
 
-    buffered_transmits.push_back(transmit);
+    match node.encapsulate(pid, &packet, now) {
+        Ok(Some(transmit)) => buffered_transmits.push_back(transmit),
+        Ok(None) => {}
+        Err(e) if e.any_is::<snownet::StillConnecting>() => {
+            connections
+                .entry(pid)
+                .or_insert_with(|| {
+                    UniquePacketBuffer::with_capacity_power_of_2(
+                        ClientState::CONNECTION_BUFFER_CAPACITY_POW_2,
+                        "pending-connection",
+                    )
+                })
+                .push(packet);
+        }
+        Err(e) => tracing::debug!(%pid, "Failed to encapsulate: {e:#}"),
+    }
 }
 
 fn gateway_by_resource_mut<'p>(

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -121,9 +121,6 @@ pub struct ClientState {
     pending_device_access: PendingDeviceAccessRequests,
 
     /// Packets buffered per peer while its connection is still being established.
-    ///
-    /// Flushed once we receive [`snownet::Event::ConnectionEstablished`]; the single place where
-    /// the client buffers application packets.
     pending_packets: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 
     dns_resource_nat: DnsResourceNat,
@@ -777,11 +774,8 @@ impl ClientState {
         }
     }
 
-    /// Capacity (as a power of two) of a per-connection packet buffer.
-    const CONNECTION_BUFFER_CAPACITY_POW_2: usize = 7; // 2^7 = 128
-
     /// Flush all packets buffered for `pid` now that its connection is established.
-    fn flush_connection(&mut self, pid: ClientOrGatewayId, now: Instant) {
+    fn flush_pending_packets(&mut self, pid: ClientOrGatewayId, now: Instant) {
         let Some(buffer) = self.pending_packets.remove(&pid) else {
             return;
         };
@@ -1307,6 +1301,8 @@ impl ClientState {
 
     #[tracing::instrument(level = "debug", skip_all, fields(gateway = %disconnected_gateway))]
     fn cleanup_connected_gateway(&mut self, disconnected_gateway: &GatewayId, now: Instant) {
+        self.pending_packets
+            .remove(&ClientOrGatewayId::Gateway(*disconnected_gateway));
         self.update_site_status_by_gateway(disconnected_gateway, ResourceStatus::Unknown, now);
         self.gateways.remove(disconnected_gateway);
         for _ in self
@@ -1318,6 +1314,8 @@ impl ClientState {
 
     #[tracing::instrument(level = "debug", skip_all, fields(client = %disconnected_client))]
     fn cleanup_connected_client(&mut self, disconnected_client: &ClientId) {
+        self.pending_packets
+            .remove(&ClientOrGatewayId::Client(*disconnected_client));
         self.clients.remove(disconnected_client);
         if self.connected_pool_clients.remove(disconnected_client) {
             self.resource_list.update(self.resource_list_snapshot());
@@ -1972,12 +1970,10 @@ impl ClientState {
             match event {
                 snownet::Event::ConnectionFailed(ClientOrGatewayId::Gateway(id))
                 | snownet::Event::ConnectionClosed(ClientOrGatewayId::Gateway(id)) => {
-                    self.pending_packets.remove(&ClientOrGatewayId::Gateway(id)); // Drop buffered packets.
                     self.cleanup_connected_gateway(&id, now);
                 }
                 snownet::Event::ConnectionFailed(ClientOrGatewayId::Client(id))
                 | snownet::Event::ConnectionClosed(ClientOrGatewayId::Client(id)) => {
-                    self.pending_packets.remove(&ClientOrGatewayId::Client(id)); // Drop buffered packets.
                     self.cleanup_connected_client(&id);
                 }
                 snownet::Event::NewIceCandidate {
@@ -1999,11 +1995,11 @@ impl ClientState {
                         .insert(candidate.into());
                 }
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Gateway(id)) => {
-                    self.flush_connection(ClientOrGatewayId::Gateway(id), now);
+                    self.flush_pending_packets(ClientOrGatewayId::Gateway(id), now);
                     self.update_site_status_by_gateway(&id, ResourceStatus::Online, now);
                 }
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(id)) => {
-                    self.flush_connection(ClientOrGatewayId::Client(id), now);
+                    self.flush_pending_packets(ClientOrGatewayId::Client(id), now);
                     if self.connected_pool_clients.insert(id) {
                         self.resource_list.update(self.resource_list_snapshot());
                     }
@@ -2617,14 +2613,6 @@ fn filter_allows(filter: &FilterEngine, protocol: Protocol) -> bool {
 }
 
 /// Encapsulate `packet` for `pid`, or buffer it if the connection is still being established.
-///
-/// If we are already buffering for `pid`, the packet is appended to preserve ordering. A connection
-/// that is not yet usable makes `node.encapsulate` return [`snownet::StillConnecting`], in which
-/// case we start buffering; the buffer is flushed via [`ClientState::flush_connection`] once we
-/// receive [`snownet::Event::ConnectionEstablished`].
-///
-/// Returns the transmit to send, or `Ok(None)` if the packet was buffered. Queueing the transmit is
-/// left to the caller.
 fn encapsulate_or_buffer(
     packet: IpPacket,
     pid: ClientOrGatewayId,
@@ -2632,9 +2620,8 @@ fn encapsulate_or_buffer(
     node: &mut Node<ClientOrGatewayId, RelayId>,
     pending_packets: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 ) -> Result<Option<Transmit>> {
-    // If we are already buffering for this connection, keep doing so to preserve ordering. The
-    // connection can be usable for ICE (nominated) but not yet have a WireGuard session, so we must
-    // keep buffering until `ConnectionEstablished` rather than relying on `StillConnecting` alone.
+    const CONNECTION_BUFFER_CAPACITY_POW_2: usize = 7; // 2^7 = 128
+
     if let Some(buffer) = pending_packets.get_mut(&pid) {
         buffer.push(packet);
         return Ok(None);
@@ -2642,13 +2629,12 @@ fn encapsulate_or_buffer(
 
     match node.encapsulate(pid, &packet, now) {
         Ok(maybe_transmit) => Ok(maybe_transmit),
-        // The connection is still establishing; start buffering until it is usable.
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
             pending_packets
                 .entry(pid)
                 .or_insert_with(|| {
                     UniquePacketBuffer::with_capacity_power_of_2(
-                        ClientState::CONNECTION_BUFFER_CAPACITY_POW_2,
+                        CONNECTION_BUFFER_CAPACITY_POW_2,
                         "pending-connection",
                     )
                 })
@@ -2673,8 +2659,7 @@ fn encapsulate_and_buffer(
     pending_packets: &mut BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 ) {
     match encapsulate_or_buffer(packet, pid, now, node, pending_packets) {
-        Ok(Some(transmit)) => buffered_transmits.push_back(transmit),
-        Ok(None) => {}
+        Ok(maybe_transmit) => buffered_transmits.extend(maybe_transmit),
         Err(e) => tracing::debug!(%pid, "Failed to encapsulate: {e:#}"),
     }
 }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -32,6 +32,7 @@ use crate::messages::{
 };
 use crate::peer_store::{Peer, PeerStore};
 use crate::routing_table::{RouteEntry, RoutingTable};
+use crate::unique_packet_buffer::UniquePacketBuffer;
 use crate::unix_ts::UnixTsClock;
 use crate::unroutable_packet::UnroutablePacket;
 use crate::{ClientEvent, FailedToDecapsulate, otel, packet_kind};
@@ -118,6 +119,18 @@ pub struct ClientState {
     pending_flows: PendingFlows,
     /// Tracks pending access to other devices.
     pending_device_access: PendingDeviceAccessRequests,
+
+    /// Packets buffered per connection while it is still being established.
+    ///
+    /// An entry is created when we start connecting to a peer and is flushed and removed once the
+    /// connection is established (see [`snownet::Event::ConnectionEstablished`]). This is the single
+    /// place where we hold application packets between initiating a connection and it being usable.
+    pending_packets: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
+    /// Connections whose WireGuard handshake has completed.
+    ///
+    /// Used to decide, when access to a resource is authorized, whether the connection is already
+    /// usable (send directly) or still being established (buffer in `pending_packets`).
+    established_connections: BTreeSet<ClientOrGatewayId>,
 
     dns_resource_nat: DnsResourceNat,
     /// Resources we have requested access to and the path that authorises
@@ -213,6 +226,8 @@ impl ClientState {
             dns_streams_by_local_upstream_and_query_id: Default::default(),
             pending_flows: Default::default(),
             pending_device_access: Default::default(),
+            pending_packets: Default::default(),
+            established_connections: Default::default(),
             dns_resource_nat: Default::default(),
             resource_list: Default::default(),
             connected_pool_clients: Default::default(),
@@ -767,6 +782,51 @@ impl ClientState {
         }
     }
 
+    /// Capacity (as a power of two) of a per-connection [`ClientState::pending_packets`] buffer.
+    const PENDING_PACKETS_CAPACITY_POW_2: usize = 7; // 2^7 = 128
+
+    /// Ensure packets sent to `pid` are buffered until its connection is established.
+    ///
+    /// Does nothing if the connection is already established — in that case packets are sent
+    /// straight away.
+    fn buffer_until_established(&mut self, pid: ClientOrGatewayId) {
+        if self.established_connections.contains(&pid) {
+            return;
+        }
+
+        self.pending_packets.entry(pid).or_insert_with(|| {
+            UniquePacketBuffer::with_capacity_power_of_2(
+                Self::PENDING_PACKETS_CAPACITY_POW_2,
+                "pending-connection",
+            )
+        });
+    }
+
+    /// Flush all packets buffered for `pid` now that its connection is established.
+    fn flush_pending_packets(&mut self, pid: ClientOrGatewayId, now: Instant) {
+        self.established_connections.insert(pid);
+
+        let Some(buffer) = self.pending_packets.remove(&pid) else {
+            return;
+        };
+
+        for packet in buffer {
+            encapsulate_and_buffer(
+                packet,
+                pid,
+                now,
+                &mut self.node,
+                &mut self.buffered_transmits,
+            );
+        }
+    }
+
+    /// Forget any state we track for `pid`'s connection (e.g. when it failed or closed).
+    fn forget_connection(&mut self, pid: ClientOrGatewayId) {
+        self.established_connections.remove(&pid);
+        self.pending_packets.remove(&pid);
+    }
+
     fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> Result<Option<snownet::Transmit>> {
         let dst = packet.destination();
         let dst_proto = packet.destination_protocol()?;
@@ -794,6 +854,13 @@ impl ClientState {
                 Some(p) => packet = p,
                 None => return Ok(None),
             }
+        }
+
+        // Buffer the packet if the connection is still being established; it is flushed once we
+        // receive `snownet::Event::ConnectionEstablished`.
+        if let Some(buffer) = self.pending_packets.get_mut(&pid) {
+            buffer.push(packet);
+            return Ok(None);
         }
 
         let transmit = match self.node.encapsulate(pid, &packet, now) {
@@ -953,6 +1020,21 @@ impl ClientState {
             Ok(()) => {}
             Err(e) => return Ok(Err(e)),
         };
+        // Buffer packets to this Gateway until the connection is established. Inlined rather than
+        // `buffer_until_established` because `resource` still borrows `self.resources_by_id`.
+        if !self
+            .established_connections
+            .contains(&ClientOrGatewayId::Gateway(gid))
+        {
+            self.pending_packets
+                .entry(ClientOrGatewayId::Gateway(gid))
+                .or_insert_with(|| {
+                    UniquePacketBuffer::with_capacity_power_of_2(
+                        Self::PENDING_PACKETS_CAPACITY_POW_2,
+                        "pending-connection",
+                    )
+                });
+        }
         self.authorized_resources
             .insert(rid, AccessPath::Gateway(gid));
         self.gateways_by_site
@@ -982,15 +1064,23 @@ impl ClientState {
                     peer.allow_ip_for_resource(address, rid);
                 }
 
-                // For CIDR and Internet resources, we can directly queue the buffered packets.
+                // Buffer the packets until the connection is established (or send them straight
+                // away if it already is). Inlined rather than via `send_or_buffer` because `peer`
+                // still borrows `self.gateways`.
                 for packet in buffered_resource_packets {
-                    encapsulate_and_buffer(
-                        packet,
-                        ClientOrGatewayId::Gateway(gid),
-                        now,
-                        &mut self.node,
-                        &mut self.buffered_transmits,
-                    );
+                    match self
+                        .pending_packets
+                        .get_mut(&ClientOrGatewayId::Gateway(gid))
+                    {
+                        Some(buffer) => buffer.push(packet),
+                        None => encapsulate_and_buffer(
+                            packet,
+                            ClientOrGatewayId::Gateway(gid),
+                            now,
+                            &mut self.node,
+                            &mut self.buffered_transmits,
+                        ),
+                    }
                 }
             }
             Resource::Dns(_) => {
@@ -1045,6 +1135,7 @@ impl ClientState {
             snownet::IceConfig::client_default(),
             now,
         )?;
+        self.buffer_until_established(ClientOrGatewayId::Client(cid));
 
         let authorization = authorization.map(|auth| {
             let expires_at = auth
@@ -1087,13 +1178,19 @@ impl ClientState {
 
             for packet in pending_client_access.into_buffered_packets() {
                 peer.record_outbound(&packet, now);
-                encapsulate_and_buffer(
-                    packet,
-                    ClientOrGatewayId::Client(cid),
-                    now,
-                    &mut self.node,
-                    &mut self.buffered_transmits,
-                );
+                match self
+                    .pending_packets
+                    .get_mut(&ClientOrGatewayId::Client(cid))
+                {
+                    Some(buffer) => buffer.push(packet),
+                    None => encapsulate_and_buffer(
+                        packet,
+                        ClientOrGatewayId::Client(cid),
+                        now,
+                        &mut self.node,
+                        &mut self.buffered_transmits,
+                    ),
+                }
             }
         }
 
@@ -1946,10 +2043,12 @@ impl ClientState {
             match event {
                 snownet::Event::ConnectionFailed(ClientOrGatewayId::Gateway(id))
                 | snownet::Event::ConnectionClosed(ClientOrGatewayId::Gateway(id)) => {
+                    self.forget_connection(ClientOrGatewayId::Gateway(id));
                     self.cleanup_connected_gateway(&id, now);
                 }
                 snownet::Event::ConnectionFailed(ClientOrGatewayId::Client(id))
                 | snownet::Event::ConnectionClosed(ClientOrGatewayId::Client(id)) => {
+                    self.forget_connection(ClientOrGatewayId::Client(id));
                     self.cleanup_connected_client(&id);
                 }
                 snownet::Event::NewIceCandidate {
@@ -1971,9 +2070,11 @@ impl ClientState {
                         .insert(candidate.into());
                 }
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Gateway(id)) => {
+                    self.flush_pending_packets(ClientOrGatewayId::Gateway(id), now);
                     self.update_site_status_by_gateway(&id, ResourceStatus::Online, now);
                 }
                 snownet::Event::ConnectionEstablished(ClientOrGatewayId::Client(id)) => {
+                    self.flush_pending_packets(ClientOrGatewayId::Client(id), now);
                     if self.connected_pool_clients.insert(id) {
                         self.resource_list.update(self.resource_list_snapshot());
                     }
@@ -2114,6 +2215,8 @@ impl ClientState {
         self.node.reset(now); // Clear all network connections.
         self.gateways.clear(); // Clear all state associated with Gateways.
         self.clients.clear(); // Clear all state associated with Clients.
+        self.pending_packets.clear(); // Drop packets buffered for pending connections.
+        self.established_connections.clear();
 
         self.dns_resource_nat.clear(); // Clear all state related to DNS resource NATs.
         self.drain_node_events(now);

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -129,6 +129,13 @@ impl GatewayState {
         let encrypted_packet = match self.node.encapsulate(cid, &packet, now) {
             Ok(Some(encrypted_packet)) => encrypted_packet,
             Ok(None) => return Ok(None),
+            // The Gateway does not buffer: it only sends in response to Client traffic. The WG
+            // handshake can complete (we just decrypted a Client packet) before ICE nominates a
+            // socket, so dropping the odd reply here is expected; the Client retransmits.
+            Err(e) if e.any_is::<snownet::StillConnecting>() => {
+                tracing::debug!(%cid, "Connection is still establishing; dropping packet");
+                return Ok(None);
+            }
             Err(e) if e.any_is::<snownet::UnknownConnection>() => {
                 return Err(e.context(UnroutablePacket::not_connected(&packet)));
             }
@@ -706,11 +713,15 @@ fn encrypt_packet(
     node: &mut Node<ClientId, RelayId>,
     now: Instant,
 ) -> Result<Option<Transmit>> {
-    let transmit = node
-        .encapsulate(cid, &packet, now)
-        .context("Failed to encapsulate")?;
-
-    Ok(transmit)
+    match node.encapsulate(cid, &packet, now) {
+        Ok(transmit) => Ok(transmit),
+        // The Gateway does not buffer; dropping a packet sent while still establishing is expected.
+        Err(e) if e.any_is::<snownet::StillConnecting>() => {
+            tracing::debug!(%cid, "Connection is still establishing; dropping packet");
+            Ok(None)
+        }
+        Err(e) => Err(e).context("Failed to encapsulate"),
+    }
 }
 
 /// Opaque request struct for when a domain name needs to be resolved.

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -126,20 +126,8 @@ impl GatewayState {
             .translate_inbound(packet, now)
             .context("Failed to translate inbound packet")?;
 
-        let encrypted_packet = match self.node.encapsulate(cid, &packet, now) {
-            Ok(Some(encrypted_packet)) => encrypted_packet,
-            Ok(None) => return Ok(None),
-            // The Gateway does not buffer: it only sends in response to Client traffic. The WG
-            // handshake can complete (we just decrypted a Client packet) before ICE nominates a
-            // socket, so dropping the odd reply here is expected; the Client retransmits.
-            Err(e) if e.any_is::<snownet::StillConnecting>() => {
-                tracing::debug!(%cid, "Connection is still establishing; dropping packet");
-                return Ok(None);
-            }
-            Err(e) if e.any_is::<snownet::UnknownConnection>() => {
-                return Err(e.context(UnroutablePacket::not_connected(&packet)));
-            }
-            Err(e) => return Err(e),
+        let Some(encrypted_packet) = encrypt_packet(packet, cid, &mut self.node, now)? else {
+            return Ok(None);
         };
 
         flow_tracker::inbound_tun::record_wireguard_packet(
@@ -715,10 +703,13 @@ fn encrypt_packet(
 ) -> Result<Option<Transmit>> {
     match node.encapsulate(cid, &packet, now) {
         Ok(transmit) => Ok(transmit),
-        // The Gateway does not buffer; dropping a packet sent while still establishing is expected.
+        // The Gateway does not buffer: it only sends in response to Client traffic.
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
             tracing::debug!(%cid, "Connection is still establishing; dropping packet");
             Ok(None)
+        }
+        Err(e) if e.any_is::<snownet::UnknownConnection>() => {
+            Err(e.context(UnroutablePacket::not_connected(&packet)))
         }
         Err(e) => Err(e).context("Failed to encapsulate"),
     }


### PR DESCRIPTION
Moves all pre-establishment packet buffering out of `snownet` (and out of boringtun) into a single place in the client, which holds packets per connection until the WireGuard connection is established and then flushes them. This makes the buffering location explicit and lets the client account for every packet it sends.

`snownet` now encapsulates exclusively via boringtun's `encapsulate_data_at` and no longer keeps an `ip_buffer`. The `wg_buffer` that holds handshake responses produced mid-ICE is intentionally left untouched and will be addressed separately.