### PR TITLE
feat(portal): redirect rest api reqs to rest-api.

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -438,7 +438,7 @@ if config_env() == :prod do
 
     config :portal,
       api_external_url: api_external_url,
-      rest_api_external_url: env_var_to_config!(:rest_api_external_url) || api_external_url
+      rest_api_url: env_var_to_config!(:rest_api_url) || api_external_url
   end
 
   ###############################

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -124,11 +124,12 @@ defmodule Portal.Config.Definitions do
   @doc """
   The external URL the REST API will be accessible at.
 
-  Advertised as the server URL in the OpenAPI spec and SwaggerUI. If not set,
-  it falls back to `api_external_url`.
+  Advertised as the server URL in the OpenAPI spec and SwaggerUI, and used to
+  permanent-redirect REST API requests that arrive on any other host. If not
+  set, it falls back to `api_external_url`.
   """
 
-  defconfig(:rest_api_external_url, :string,
+  defconfig(:rest_api_url, :string,
     default: nil,
     changeset: fn changeset, key ->
       changeset

--- a/elixir/lib/portal_api/api_spec.ex
+++ b/elixir/lib/portal_api/api_spec.ex
@@ -29,7 +29,7 @@ defmodule PortalAPI.ApiSpec do
   end
 
   defp server do
-    case Portal.Config.get_env(:portal, :rest_api_external_url) do
+    case Portal.Config.get_env(:portal, :rest_api_url) do
       nil -> Server.from_endpoint(Endpoint)
       url -> %Server{url: String.trim_trailing(url, "/")}
     end

--- a/elixir/lib/portal_api/endpoint.ex
+++ b/elixir/lib/portal_api/endpoint.ex
@@ -65,9 +65,17 @@ defmodule PortalAPI.Endpoint do
     drainer: []
 
   plug :fetch_user_agent
+  plug :redirect_to_rest_api_url
   plug PortalAPI.Router
 
   plug Sentry.PlugContext
+
+  def redirect_to_rest_api_url(%Plug.Conn{} = conn, _opts) do
+    case Portal.Config.get_env(:portal, :rest_api_url) do
+      nil -> conn
+      rest_api_url -> redirect_to_canonical_host(conn, URI.parse(rest_api_url))
+    end
+  end
 
   def fetch_user_agent(%Plug.Conn{} = conn, _opts) do
     case Plug.Conn.get_req_header(conn, "user-agent") do
@@ -109,5 +117,30 @@ defmodule PortalAPI.Endpoint do
   def clients do
     Portal.Config.fetch_env!(:portal, :private_clients)
     |> Enum.map(&to_string/1)
+  end
+
+  defp redirect_to_canonical_host(%Plug.Conn{host: host} = conn, %URI{host: host}), do: conn
+
+  defp redirect_to_canonical_host(conn, %URI{scheme: scheme, host: host, port: port}) do
+    query =
+      if conn.query_string == "" do
+        nil
+      else
+        conn.query_string
+      end
+
+    location =
+      URI.to_string(%URI{
+        scheme: scheme,
+        host: host,
+        port: port,
+        path: conn.request_path,
+        query: query
+      })
+
+    conn
+    |> put_resp_header("location", location)
+    |> send_resp(308, "")
+    |> halt()
   end
 end

--- a/elixir/test/portal_api/redirect_to_rest_api_url_test.exs
+++ b/elixir/test/portal_api/redirect_to_rest_api_url_test.exs
@@ -1,0 +1,97 @@
+defmodule PortalAPI.RedirectToRestApiUrlTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+  import Plug.Conn
+
+  alias PortalAPI.Endpoint
+
+  defp call(conn) do
+    Endpoint.redirect_to_rest_api_url(conn, [])
+  end
+
+  describe "redirect_to_rest_api_url/2" do
+    test "passes through when rest_api_url is not configured" do
+      conn = conn(:get, "https://api.firezone.dev/clients")
+
+      result = call(conn)
+
+      assert result == conn
+      refute result.halted
+    end
+
+    test "passes through when the request host already matches rest_api_url" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
+
+      conn = conn(:get, "https://rest-api.firezone.dev/clients?limit=5")
+
+      result = call(conn)
+
+      refute result.halted
+      assert result == conn
+    end
+
+    test "permanent-redirects requests on any other host preserving path and query" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
+
+      conn = conn(:get, "https://api.firezone.dev/clients?limit=5")
+
+      result = call(conn)
+
+      assert result.halted
+      assert result.status == 308
+
+      assert get_resp_header(result, "location") ==
+               ["https://rest-api.firezone.dev/clients?limit=5"]
+    end
+
+    test "preserves the request method for non-GET requests" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
+
+      conn = conn(:post, "https://api.firezone.dev/clients", "")
+
+      result = call(conn)
+
+      assert result.halted
+      assert result.status == 308
+      assert get_resp_header(result, "location") == ["https://rest-api.firezone.dev/clients"]
+    end
+
+    test "redirects before authentication, ignoring request headers" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
+
+      conn =
+        conn(:get, "https://api.firezone.dev/clients")
+        |> put_req_header("authorization", "Bearer some-token")
+
+      result = call(conn)
+
+      assert result.halted
+      assert result.status == 308
+      assert get_resp_header(result, "location") == ["https://rest-api.firezone.dev/clients"]
+    end
+
+    test "sends an empty body, leaving the client to replay the request" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firezone.dev/")
+
+      conn = conn(:post, "https://api.firezone.dev/clients", "request body")
+
+      result = call(conn)
+
+      assert result.status == 308
+      assert result.resp_body == ""
+    end
+
+    test "redirects to the configured staging host" do
+      Portal.Config.put_env_override(:rest_api_url, "https://rest-api.firez.one/")
+
+      conn = conn(:get, "https://api.firez.one/account")
+
+      result = call(conn)
+
+      assert result.halted
+      assert result.status == 308
+      assert get_resp_header(result, "location") == ["https://rest-api.firez.one/account"]
+    end
+  end
+end


### PR DESCRIPTION
This will cover any current clients hitting `api.` without needing explicit coms to be sent out.

Does not affect websocket connections.