### PR TITLE
feat(known-dirs): add flow-log spool directory

### DIFF
--- a/rust/libs/known-dirs/src/lib.rs
+++ b/rust/libs/known-dirs/src/lib.rs
@@ -10,7 +10,8 @@
 use std::path::PathBuf;
 
 pub use platform::{
-    logs, root_runtime, session, settings, tunnel_service_config, tunnel_service_logs, user_runtime,
+    flow_logs, logs, root_runtime, session, settings, tunnel_service_config, tunnel_service_logs,
+    user_runtime,
 };
 
 #[cfg(target_os = "linux")]

--- a/rust/libs/known-dirs/src/platform/linux.rs
+++ b/rust/libs/known-dirs/src/platform/linux.rs
@@ -25,6 +25,16 @@ pub fn tunnel_service_logs() -> Option<PathBuf> {
     Some(PathBuf::from("/var/log").join(BUNDLE_ID))
 }
 
+/// Spool directory for flow logs the Tunnel service writes and uploads.
+///
+/// A sibling of [`tunnel_service_config`] (host-specific state that persists across
+/// reboots, not user-facing), kept out of the log directory so an exported log
+/// bundle never sweeps it up. On Linux, `/var/lib/$BUNDLE_ID/flow_logs`.
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
+pub fn flow_logs() -> Option<PathBuf> {
+    Some(PathBuf::from("/var/lib").join(BUNDLE_ID).join("flow_logs"))
+}
+
 /// e.g. `/home/alice/.cache/dev.firezone.client/data/logs`
 ///
 /// Logs are considered cache because they're not configs and it's technically okay

--- a/rust/libs/known-dirs/src/platform/macos.rs
+++ b/rust/libs/known-dirs/src/platform/macos.rs
@@ -24,9 +24,7 @@ pub fn tunnel_service_logs() -> Option<PathBuf> {
 
 /// Spool directory for flow logs
 ///
-/// Returns `None` on macOS: spooling is owned by the Swift app, which passes its
-/// spool directory in over FFI (via `SharedAccess`). The headless and tauri clients
-/// that also compile for macOS therefore don't spool here.
+/// `None` on macOS: the Swift app owns spooling and passes its directory over FFI.
 pub fn flow_logs() -> Option<PathBuf> {
     None
 }

--- a/rust/libs/known-dirs/src/platform/macos.rs
+++ b/rust/libs/known-dirs/src/platform/macos.rs
@@ -22,9 +22,11 @@ pub fn tunnel_service_logs() -> Option<PathBuf> {
     Some(PathBuf::from("/Library/Logs").join(BUNDLE_ID))
 }
 
-/// Flow-log spooling on macOS is owned by the Swift app, which passes its spool
-/// directory in over FFI (via `SharedAccess`), so this returns `None`. The headless
-/// and tauri clients that also compile for macOS therefore don't spool here.
+/// Spool directory for flow logs
+///
+/// Returns `None` on macOS: spooling is owned by the Swift app, which passes its
+/// spool directory in over FFI (via `SharedAccess`). The headless and tauri clients
+/// that also compile for macOS therefore don't spool here.
 pub fn flow_logs() -> Option<PathBuf> {
     None
 }

--- a/rust/libs/known-dirs/src/platform/macos.rs
+++ b/rust/libs/known-dirs/src/platform/macos.rs
@@ -22,6 +22,13 @@ pub fn tunnel_service_logs() -> Option<PathBuf> {
     Some(PathBuf::from("/Library/Logs").join(BUNDLE_ID))
 }
 
+/// Flow-log spooling on macOS is owned by the Swift app, which passes its spool
+/// directory in over FFI (via `SharedAccess`), so this returns `None`. The headless
+/// and tauri clients that also compile for macOS therefore don't spool here.
+pub fn flow_logs() -> Option<PathBuf> {
+    None
+}
+
 /// User-specific logs directory
 pub fn logs() -> Option<PathBuf> {
     Some(

--- a/rust/libs/known-dirs/src/platform/windows.rs
+++ b/rust/libs/known-dirs/src/platform/windows.rs
@@ -37,6 +37,18 @@ pub fn tunnel_service_logs() -> Option<PathBuf> {
     )
 }
 
+/// Spool directory for flow logs the Tunnel service writes and uploads.
+///
+/// A sibling of [`tunnel_service_config`] under `ProgramData`, kept out of the log
+/// directory so an exported log bundle never sweeps it up.
+pub fn flow_logs() -> Option<PathBuf> {
+    Some(
+        get_known_folder_path(KnownFolder::ProgramData)?
+            .join(BUNDLE_ID)
+            .join("flow_logs"),
+    )
+}
+
 /// e.g. `C:\Users\Alice\AppData\Local\dev.firezone.client\data\logs`
 ///
 /// See connlib docs for details


### PR DESCRIPTION
Adds a per-platform resolver for the directory where flow-log records are spooled before upload. Linux and Windows return the spool path used by the headless client and the tauri GUI client; macOS returns nothing, since the Swift app owns macOS flow logs and passes its spool directory in over FFI.