### PR TITLE
refactor(telemetry): tie lifetime to process not session

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -246,11 +246,6 @@ class TunnelService : VpnService() {
         super.onCreate()
         registerReceiver(restrictionsReceiver, restrictionsFilter)
 
-        // Start connlib's (Rust) telemetry for the service-process lifetime, decoupled
-        // from any connlib session. It comes up in the `entrypoint` environment to
-        // capture early crashes; `connect` later re-points it at the session's
-        // environment, and `onDestroy` flushes it. It uses protected (tunnel-bypassing)
-        // sockets, so it never loops back through the VPN.
         startTelemetry(protectSocket)
     }
 
@@ -258,8 +253,6 @@ class TunnelService : VpnService() {
         unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
 
-        // Flush connlib's (Rust) telemetry as the service process tears down. It is
-        // process-lifetime, so it is not stopped per-session on disconnect.
         stopTelemetry()
         super.onDestroy()
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -56,6 +56,8 @@ import uniffi.connlib.enforceLogSizeCap
 import uniffi.connlib.isLogStreamingActive
 import uniffi.connlib.logCleanupDefaultIntervalSecs
 import uniffi.connlib.logCleanupDefaultMaxSizeMb
+import uniffi.connlib.startTelemetry
+import uniffi.connlib.stopTelemetry
 import uniffi.connlib.use
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -243,11 +245,22 @@ class TunnelService : VpnService() {
     override fun onCreate() {
         super.onCreate()
         registerReceiver(restrictionsReceiver, restrictionsFilter)
+
+        // Start connlib's (Rust) telemetry for the service-process lifetime, decoupled
+        // from any connlib session. It comes up in the `entrypoint` environment to
+        // capture early crashes; `connect` later re-points it at the session's
+        // environment, and `onDestroy` flushes it. It uses protected (tunnel-bypassing)
+        // sockets, so it never loops back through the VPN.
+        startTelemetry(protectSocket)
     }
 
     override fun onDestroy() {
         unregisterReceiver(restrictionsReceiver)
         serviceScope.cancel()
+
+        // Flush connlib's (Rust) telemetry as the service process tears down. It is
+        // process-lifetime, so it is not stopped per-session on disconnect.
+        stopTelemetry()
         super.onDestroy()
     }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "opentelemetry",
  "oslog",
  "otel-instruments",
+ "parking_lot",
  "phoenix-channel",
  "rustls",
  "rustls-platform-verifier",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1240,7 +1240,6 @@ dependencies = [
  "opentelemetry",
  "oslog",
  "otel-instruments",
- "parking_lot",
  "phoenix-channel",
  "rustls",
  "rustls-platform-verifier",

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -21,7 +21,6 @@ libc = { workspace = true }
 logging = { workspace = true }
 opentelemetry = { workspace = true }
 otel-instruments = { workspace = true }
-parking_lot = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -21,6 +21,7 @@ libc = { workspace = true }
 logging = { workspace = true }
 opentelemetry = { workspace = true }
 otel-instruments = { workspace = true }
+parking_lot = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -25,10 +25,7 @@ use tracing_subscriber::{Layer, layer::SubscriberExt as _};
 
 uniffi::setup_scaffolding!();
 
-/// The process-global telemetry guard.
-///
-/// `Some` between [`start_telemetry`] and [`stop_telemetry`]. [`connect`] re-points
-/// it at the active session's environment.
+/// The process-global telemetry guard, outliving individual connlib sessions.
 static TELEMETRY: LazyLock<std::sync::Mutex<Option<Telemetry>>> =
     LazyLock::new(|| std::sync::Mutex::new(None));
 
@@ -506,8 +503,6 @@ fn connect(
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
-    // Re-point the telemetry guard at this session's environment. A no-op if
-    // telemetry was never started.
     if let Some(telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).as_mut() {
         telemetry.start(&api_url, RELEASE, platform::DSN);
     }
@@ -557,7 +552,6 @@ fn connect(
     })
 }
 
-/// Brings up the telemetry guard in the neutral `entrypoint` environment.
 fn start_telemetry_inner(
     tcp: Arc<dyn SocketFactory<TcpSocket>>,
     udp: Arc<dyn SocketFactory<UdpSocket>>,
@@ -587,7 +581,6 @@ pub fn start_telemetry() {
     start_telemetry_inner(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
 }
 
-/// Flushes and tears down the telemetry guard.
 #[uniffi::export]
 pub fn stop_telemetry() {
     if let Some(mut telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).take() {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -6,7 +6,7 @@ use crate::fd::RawFd;
 use std::{
     fmt,
     path::{Path, PathBuf},
-    sync::{Arc, OnceLock},
+    sync::{Arc, LazyLock, OnceLock},
     time::Duration,
 };
 
@@ -25,11 +25,20 @@ use tracing_subscriber::{Layer, layer::SubscriberExt as _};
 
 uniffi::setup_scaffolding!();
 
+/// Process-lifetime telemetry, decoupled from any single connlib session.
+///
+/// Started once at provider/process start via [`start_telemetry`] (in the
+/// `entrypoint` environment, to capture early crashes), re-pointed at each
+/// session's environment in [`connect`], and flushed at process teardown via
+/// [`stop_telemetry`]. It deliberately outlives connlib sessions so the
+/// post-disconnect flow-log uploader and late crashes still report.
+static TELEMETRY: LazyLock<std::sync::Mutex<Option<Telemetry>>> =
+    LazyLock::new(|| std::sync::Mutex::new(None));
+
 #[derive(uniffi::Object)]
 pub struct Session {
     inner: client_shared::Session,
     events: Mutex<client_shared::EventStream>,
-    telemetry: Mutex<Telemetry>,
     runtime: Option<tokio::runtime::Runtime>,
 }
 
@@ -334,18 +343,10 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
 #[uniffi::export]
 impl Session {
     pub fn disconnect(&self) {
+        // Telemetry is intentionally *not* stopped here: it lives for the
+        // provider-process lifetime (see `TELEMETRY`), so crashes and the
+        // post-disconnect flow-log uploader keep reporting after the session ends.
         self.inner.stop();
-
-        let Some(runtime) = self.runtime.as_ref() else {
-            tracing::error!(
-                "No tokio runtime set! This should be impossible because we only clear it on `Drop`"
-            );
-            return;
-        };
-
-        runtime.block_on(async {
-            self.telemetry.lock().await.stop().await;
-        });
     }
 
     pub fn set_internet_resource_state(&self, active: bool) {
@@ -469,7 +470,8 @@ impl Drop for Session {
         self.inner.stop(); // Instruct the event-loop to shut down.
 
         runtime.block_on(async {
-            self.telemetry.lock().await.stop().await;
+            // Telemetry is process-lifetime (see `TELEMETRY`); it is flushed at
+            // process teardown via `stop_telemetry`, not here.
 
             // Draining the event-stream allows us to wait for the event-loop to finish its graceful shutdown.
             let drain = async { self.events.lock().await.drain().await };
@@ -513,12 +515,15 @@ fn connect(
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
-    let mut telemetry = Telemetry::new(tcp_socket_factory.clone(), udp_socket_factory.clone());
-    telemetry.start(&api_url, RELEASE, platform::DSN);
+    // Telemetry is started once at process start (`start_telemetry`) and lives for
+    // the provider-process lifetime. Re-point the process-global guard at this
+    // session's environment; if `start_telemetry` was never called (e.g. the
+    // Linux/Windows dummy path), telemetry simply stays off.
+    if let Some(telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).as_mut() {
+        telemetry.start(&api_url, RELEASE, platform::DSN);
+    }
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
-
-    opentelemetry::global::set_meter_provider(telemetry::SentryMeterProvider::default());
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
@@ -554,14 +559,79 @@ fn connect(
         runtime.handle().clone(),
     );
 
-    analytics::new_session(device_id, api_url.to_string());
+    analytics::new_session(device_id, api_url);
 
     Ok(Session {
         inner: session,
         events: Mutex::new(events),
-        telemetry: Mutex::new(telemetry),
         runtime: Some(runtime),
     })
+}
+
+/// Starts process-lifetime telemetry in the `entrypoint` environment.
+///
+/// Call this once at provider/process start, before any session. It configures
+/// the tunnel-bypassing ingest socket factories and brings up the Sentry guard so
+/// early crashes are captured; [`connect`] later re-points it at the session's
+/// environment, and [`stop_telemetry`] flushes it at teardown.
+fn start_telemetry_inner(
+    tcp: Arc<dyn SocketFactory<TcpSocket>>,
+    udp: Arc<dyn SocketFactory<UdpSocket>>,
+) {
+    install_rustls_crypto_provider();
+
+    let mut telemetry = Telemetry::new(tcp, udp);
+    telemetry.start("entrypoint", RELEASE, platform::DSN);
+
+    opentelemetry::global::set_meter_provider(telemetry::SentryMeterProvider::default());
+
+    *TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()) = Some(telemetry);
+}
+
+#[uniffi::export]
+#[cfg(target_os = "android")]
+pub fn start_telemetry(protect_socket: Arc<dyn ProtectSocket>) {
+    let tcp = Arc::new(protected_tcp_socket_factory(protect_socket.clone()));
+    let udp = Arc::new(protected_udp_socket_factory(protect_socket));
+
+    start_telemetry_inner(tcp, udp);
+}
+
+#[uniffi::export]
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+pub fn start_telemetry() {
+    start_telemetry_inner(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
+}
+
+#[uniffi::export]
+#[cfg(not(any(target_os = "android", target_os = "ios", target_os = "macos")))]
+pub fn start_telemetry() {
+    start_telemetry_inner(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
+}
+
+/// Flushes and stops process-lifetime telemetry.
+///
+/// Call this at provider/process teardown (after the last session has
+/// disconnected) for a graceful flush of any pending events.
+#[uniffi::export]
+pub fn stop_telemetry() {
+    let Some(mut telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).take() else {
+        return;
+    };
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to build runtime to stop telemetry: {e:#}");
+            return;
+        }
+    };
+
+    runtime.block_on(telemetry.stop());
 }
 
 static LOGGER_STATE: OnceLock<(logging::file::Handle, logging::FilterReloadHandle)> =

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -26,8 +26,8 @@ use tracing_subscriber::{Layer, layer::SubscriberExt as _};
 uniffi::setup_scaffolding!();
 
 /// The process-global telemetry guard, outliving individual connlib sessions.
-static TELEMETRY: LazyLock<std::sync::Mutex<Option<Telemetry>>> =
-    LazyLock::new(|| std::sync::Mutex::new(None));
+static TELEMETRY: LazyLock<parking_lot::Mutex<Option<Telemetry>>> =
+    LazyLock::new(|| parking_lot::Mutex::new(None));
 
 #[derive(uniffi::Object)]
 pub struct Session {
@@ -503,7 +503,7 @@ fn connect(
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
-    if let Some(telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).as_mut() {
+    if let Some(telemetry) = TELEMETRY.lock().as_mut() {
         telemetry.start(&api_url, RELEASE, platform::DSN);
     }
     runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
@@ -563,7 +563,7 @@ fn start_telemetry_inner(
 
     opentelemetry::global::set_meter_provider(telemetry::SentryMeterProvider::default());
 
-    *TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()) = Some(telemetry);
+    *TELEMETRY.lock() = Some(telemetry);
 }
 
 #[uniffi::export]
@@ -583,7 +583,7 @@ pub fn start_telemetry() {
 
 #[uniffi::export]
 pub fn stop_telemetry() {
-    if let Some(mut telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).take() {
+    if let Some(mut telemetry) = TELEMETRY.lock().take() {
         telemetry.stop_blocking();
     }
 }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -25,13 +25,10 @@ use tracing_subscriber::{Layer, layer::SubscriberExt as _};
 
 uniffi::setup_scaffolding!();
 
-/// Process-lifetime telemetry, decoupled from any single connlib session.
+/// The process-global telemetry guard.
 ///
-/// Started once at provider/process start via [`start_telemetry`] (in the
-/// `entrypoint` environment, to capture early crashes), re-pointed at each
-/// session's environment in [`connect`], and flushed at process teardown via
-/// [`stop_telemetry`]. It deliberately outlives connlib sessions so the
-/// post-disconnect flow-log uploader and late crashes still report.
+/// `Some` between [`start_telemetry`] and [`stop_telemetry`]. [`connect`] re-points
+/// it at the active session's environment.
 static TELEMETRY: LazyLock<std::sync::Mutex<Option<Telemetry>>> =
     LazyLock::new(|| std::sync::Mutex::new(None));
 
@@ -343,9 +340,6 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
 #[uniffi::export]
 impl Session {
     pub fn disconnect(&self) {
-        // Telemetry is intentionally *not* stopped here: it lives for the
-        // provider-process lifetime (see `TELEMETRY`), so crashes and the
-        // post-disconnect flow-log uploader keep reporting after the session ends.
         self.inner.stop();
     }
 
@@ -470,9 +464,6 @@ impl Drop for Session {
         self.inner.stop(); // Instruct the event-loop to shut down.
 
         runtime.block_on(async {
-            // Telemetry is process-lifetime (see `TELEMETRY`); it is flushed at
-            // process teardown via `stop_telemetry`, not here.
-
             // Draining the event-stream allows us to wait for the event-loop to finish its graceful shutdown.
             let drain = async { self.events.lock().await.drain().await };
             let _ = tokio::time::timeout(Duration::from_secs(1), drain).await;
@@ -515,10 +506,8 @@ fn connect(
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
-    // Telemetry is started once at process start (`start_telemetry`) and lives for
-    // the provider-process lifetime. Re-point the process-global guard at this
-    // session's environment; if `start_telemetry` was never called (e.g. the
-    // Linux/Windows dummy path), telemetry simply stays off.
+    // Re-point the telemetry guard at this session's environment. A no-op if
+    // telemetry was never started.
     if let Some(telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).as_mut() {
         telemetry.start(&api_url, RELEASE, platform::DSN);
     }
@@ -568,12 +557,7 @@ fn connect(
     })
 }
 
-/// Starts process-lifetime telemetry in the `entrypoint` environment.
-///
-/// Call this once at provider/process start, before any session. It configures
-/// the tunnel-bypassing ingest socket factories and brings up the Sentry guard so
-/// early crashes are captured; [`connect`] later re-points it at the session's
-/// environment, and [`stop_telemetry`] flushes it at teardown.
+/// Brings up the telemetry guard in the neutral `entrypoint` environment.
 fn start_telemetry_inner(
     tcp: Arc<dyn SocketFactory<TcpSocket>>,
     udp: Arc<dyn SocketFactory<UdpSocket>>,
@@ -598,40 +582,17 @@ pub fn start_telemetry(protect_socket: Arc<dyn ProtectSocket>) {
 }
 
 #[uniffi::export]
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(not(target_os = "android"))]
 pub fn start_telemetry() {
     start_telemetry_inner(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
 }
 
-#[uniffi::export]
-#[cfg(not(any(target_os = "android", target_os = "ios", target_os = "macos")))]
-pub fn start_telemetry() {
-    start_telemetry_inner(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
-}
-
-/// Flushes and stops process-lifetime telemetry.
-///
-/// Call this at provider/process teardown (after the last session has
-/// disconnected) for a graceful flush of any pending events.
+/// Flushes and tears down the telemetry guard.
 #[uniffi::export]
 pub fn stop_telemetry() {
-    let Some(mut telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).take() else {
-        return;
-    };
-
-    let runtime = match tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1)
-        .enable_all()
-        .build()
-    {
-        Ok(runtime) => runtime,
-        Err(e) => {
-            tracing::error!("Failed to build runtime to stop telemetry: {e:#}");
-            return;
-        }
-    };
-
-    runtime.block_on(telemetry.stop());
+    if let Some(mut telemetry) = TELEMETRY.lock().unwrap_or_else(|e| e.into_inner()).take() {
+        telemetry.stop_blocking();
+    }
 }
 
 static LOGGER_STATE: OnceLock<(logging::file::Handle, logging::FilterReloadHandle)> =

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -6,7 +6,7 @@ use crate::fd::RawFd;
 use std::{
     fmt,
     path::{Path, PathBuf},
-    sync::{Arc, LazyLock, OnceLock},
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
@@ -19,15 +19,11 @@ use phoenix_channel::{LoginUrl, PhoenixChannel, get_user_agent};
 use platform::RELEASE;
 use secrecy::SecretString;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
-use telemetry::{Telemetry, analytics};
+use telemetry::analytics;
 use tokio::sync::Mutex;
 use tracing_subscriber::{Layer, layer::SubscriberExt as _};
 
 uniffi::setup_scaffolding!();
-
-/// The process-global telemetry guard, outliving individual connlib sessions.
-static TELEMETRY: LazyLock<parking_lot::Mutex<Option<Telemetry>>> =
-    LazyLock::new(|| parking_lot::Mutex::new(None));
 
 #[derive(uniffi::Object)]
 pub struct Session {
@@ -503,11 +499,9 @@ fn connect(
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
-    if let Some(telemetry) = TELEMETRY.lock().as_mut() {
-        telemetry.start(&api_url, RELEASE, platform::DSN);
-    }
-    runtime.block_on(Telemetry::set_firezone_id(device_id.clone()));
-    Telemetry::set_account_slug(account_slug.clone());
+    telemetry::start(&api_url, RELEASE, platform::DSN);
+    runtime.block_on(telemetry::set_firezone_id(device_id.clone()));
+    telemetry::set_account_slug(account_slug.clone());
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
@@ -558,12 +552,10 @@ fn start_telemetry_inner(
 ) {
     install_rustls_crypto_provider();
 
-    let mut telemetry = Telemetry::new(tcp, udp);
-    telemetry.start("entrypoint", RELEASE, platform::DSN);
+    telemetry::configure(tcp, udp);
+    telemetry::start("entrypoint", RELEASE, platform::DSN);
 
     opentelemetry::global::set_meter_provider(telemetry::SentryMeterProvider::default());
-
-    *TELEMETRY.lock() = Some(telemetry);
 }
 
 #[uniffi::export]
@@ -583,9 +575,7 @@ pub fn start_telemetry() {
 
 #[uniffi::export]
 pub fn stop_telemetry() {
-    if let Some(mut telemetry) = TELEMETRY.lock().take() {
-        telemetry.stop_blocking();
-    }
+    telemetry::stop_blocking();
 }
 
 static LOGGER_STATE: OnceLock<(logging::file::Handle, logging::FilterReloadHandle)> =

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, ErrorExt, Result};
 use bin_shared::{TunDeviceManager, signals};
 use dns_types::DomainName;
-use telemetry::{Telemetry, analytics};
+use telemetry::analytics;
 
 use hickory_resolver::TokioResolver;
 use hickory_resolver::lookup::Lookup;
@@ -361,7 +361,7 @@ impl Eventloop {
                 authorizations,
             }) => {
                 if let Some(account_slug) = account_slug {
-                    Telemetry::set_account_slug(account_slug.clone());
+                    telemetry::set_account_slug(account_slug.clone());
 
                     analytics::identify(RELEASE.to_owned(), Some(account_slug))
                 }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -193,7 +193,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         .map(|ip| ip.into())
         .collect::<BTreeSet<_>>();
 
-    telemetry::update_system_resolvers(nameservers.iter().copied().collect());
+    telemetry::set_system_resolvers(nameservers.iter().copied().collect());
 
     let mut tunnel = GatewayTunnel::new(
         Arc::new(tcp_socket_factory),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -193,8 +193,6 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         .map(|ip| ip.into())
         .collect::<BTreeSet<_>>();
 
-    telemetry::set_system_resolvers(nameservers.iter().copied().collect());
-
     let mut tunnel = GatewayTunnel::new(
         Arc::new(tcp_socket_factory),
         Arc::new(UdpSocketFactory::default()),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -15,7 +15,7 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
 use phoenix_channel::get_user_agent;
-use telemetry::{SentryMeterProvider, Telemetry};
+use telemetry::SentryMeterProvider;
 use tokio_util::task::AbortOnDropHandle;
 use tunnel::GatewayTunnel;
 
@@ -51,7 +51,7 @@ fn main() -> ExitCode {
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");
 
-    let mut telemetry = Telemetry::new(
+    telemetry::configure(
         Arc::new(tcp_socket_factory),
         Arc::new(UdpSocketFactory::default()),
     );
@@ -61,22 +61,22 @@ fn main() -> ExitCode {
         .build()
         .expect("Failed to create tokio runtime");
 
-    match runtime.block_on(try_main(cli, &mut telemetry)) {
+    match runtime.block_on(try_main(cli)) {
         Ok(()) => {
             tracing::info!("Goodbye!");
-            runtime.block_on(telemetry.stop());
+            runtime.block_on(telemetry::stop());
 
             ExitCode::SUCCESS
         }
         Err(e) if e.any_is::<EventloopFailed>() => {
             tracing::error!("{e:#}");
-            runtime.block_on(telemetry.stop());
+            runtime.block_on(telemetry::stop());
 
             ExitCode::FAILURE
         }
         Err(e) => {
             tracing::info!("{e:#}");
-            runtime.block_on(telemetry.stop());
+            runtime.block_on(telemetry::stop());
 
             ExitCode::FAILURE
         }
@@ -97,7 +97,7 @@ fn has_necessary_permissions() -> bool {
     is_root || has_net_admin
 }
 
-async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
+async fn try_main(cli: Cli) -> Result<()> {
     logging::setup_global_subscriber(
         make_directives(std::env::var("RUST_LOG").ok(), cli.flow_logs),
         layer::Identity::default(),
@@ -143,8 +143,8 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     };
 
     if cli.is_telemetry_allowed() {
-        telemetry.start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
-        Telemetry::set_firezone_id(firezone_id.clone()).await;
+        telemetry::start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
+        telemetry::set_firezone_id(firezone_id.clone()).await;
     }
 
     if let Some(backend) = cli.metrics {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -10,8 +10,7 @@ use anyhow::{Context as _, ErrorExt, Result, bail};
 use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, dialog, elevation, gui, logging};
-use telemetry::Telemetry;
-use tokio::{runtime::Runtime, sync::Mutex};
+use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
 
 #[expect(
@@ -38,24 +37,21 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
     let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
-    let mut telemetry = if cli.is_telemetry_allowed() {
-        Telemetry::new(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp))
-    } else {
-        Telemetry::disabled()
-    };
+    if cli.is_telemetry_allowed() {
+        telemetry::configure(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
 
-    // Start telemetry in `entrypoint` mode so that crashes during settings
-    // load, Tauri setup, IPC connect, or the Hello-wait window are captured.
-    // The controller re-targets it at the real environment once `Hello`
-    // arrives; `main` keeps ownership so we can flush on every exit path.
-    telemetry.start(
-        "entrypoint",
-        firezone_gui_client::RELEASE,
-        telemetry::GUI_DSN,
-    );
-    let telemetry = Arc::new(Mutex::new(telemetry));
+        // Start telemetry in `entrypoint` mode so that crashes during settings
+        // load, Tauri setup, IPC connect, or the Hello-wait window are captured.
+        // The controller re-targets it at the real environment once `Hello`
+        // arrives; we flush on every exit path below.
+        telemetry::start(
+            "entrypoint",
+            firezone_gui_client::RELEASE,
+            telemetry::GUI_DSN,
+        );
+    }
 
-    let result = try_main(cli, &rt, &mut log_guard, Arc::clone(&telemetry));
+    let result = try_main(cli, &rt, &mut log_guard);
 
     let exit_code = match result {
         Ok(()) => ExitCode::SUCCESS,
@@ -65,17 +61,12 @@ fn main() -> ExitCode {
         }
     };
 
-    rt.block_on(async { telemetry.lock().await.stop().await });
+    rt.block_on(async { telemetry::stop().await });
 
     exit_code
 }
 
-fn try_main(
-    cli: Cli,
-    rt: &Runtime,
-    log_guard: &mut Option<LogGuard>,
-    telemetry: Arc<Mutex<Telemetry>>,
-) -> Result<()> {
+fn try_main(cli: Cli, rt: &Runtime, log_guard: &mut Option<LogGuard>) -> Result<()> {
     #[cfg(debug_assertions)]
     if cli.skip_tunnel_pipe_owner_check {
         firezone_gui_client::ipc::skip_tunnel_pipe_owner_check();
@@ -173,7 +164,7 @@ fn try_main(
         }
         Some(Cmd::SmokeTest) => {
             // Can't check elevation here because the Windows CI is always elevated
-            gui::run(rt, config, reloader, telemetry)?;
+            gui::run(rt, config, reloader)?;
 
             return Ok(());
         }
@@ -181,7 +172,7 @@ fn try_main(
 
     // Happy-path: Run the GUI.
 
-    match gui::run(rt, config, reloader, telemetry) {
+    match gui::run(rt, config, reloader) {
         Ok(()) => {}
         Err(anyhow) => {
             if cli.no_error_dialog {

--- a/rust/gui-client/src-tauri/src/bin/register-sparse.rs
+++ b/rust/gui-client/src-tauri/src/bin/register-sparse.rs
@@ -31,7 +31,6 @@ use anyhow::{Context, ErrorExt, Result};
 use clap::Parser;
 use firezone_gui_client::PACKAGE_FAMILY_NAME;
 use std::{fmt, process::ExitCode};
-use telemetry::Telemetry;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
@@ -39,11 +38,11 @@ async fn main() -> ExitCode {
         .install_default()
         .expect("Failed to install default crypto provider");
 
-    let mut telemetry = Telemetry::new(
+    telemetry::configure(
         std::sync::Arc::new(socket_factory::tcp),
         std::sync::Arc::new(socket_factory::udp),
     );
-    telemetry.start(
+    telemetry::start(
         "entrypoint",
         firezone_gui_client::RELEASE,
         telemetry::GUI_DSN,
@@ -51,7 +50,7 @@ async fn main() -> ExitCode {
 
     let exit_code = run();
 
-    telemetry.stop().await;
+    telemetry::stop().await;
     exit_code
 }
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -19,11 +19,9 @@ use secrecy::{ExposeSecret as _, SecretString};
 use std::{
     ops::ControlFlow,
     path::{Path, PathBuf},
-    sync::Arc,
     task::Poll,
     time::Duration,
 };
-use telemetry::Telemetry;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use url::Url;
@@ -52,7 +50,6 @@ pub struct Controller<I: GuiIntegration> {
     ctrl_rx: ReceiverStream<ControllerRequest>,
     status: Status,
     telemetry_allowed: bool,
-    telemetry: Arc<tokio::sync::Mutex<Telemetry>>,
     updates_rx: Option<ReceiverStream<Option<updates::Notification>>>,
     uptime: uptime::Tracker,
 
@@ -191,7 +188,6 @@ impl<I: GuiIntegration> Controller<I> {
         legacy_advanced_settings_path: PathBuf,
         log_filter_reloader: FilterReloadHandle,
         telemetry_allowed: bool,
-        telemetry: Arc<tokio::sync::Mutex<Telemetry>>,
         updates_rx: mpsc::Receiver<Option<updates::Notification>>,
         gui_ipc: ipc::Server,
     ) -> Result<()> {
@@ -220,7 +216,7 @@ impl<I: GuiIntegration> Controller<I> {
             Some(false) => None,
         };
 
-        Telemetry::set_firezone_id(firezone_id).await;
+        telemetry::set_firezone_id(firezone_id).await;
 
         let auth = auth::Auth::new()?;
 
@@ -246,7 +242,6 @@ impl<I: GuiIntegration> Controller<I> {
             ctrl_rx: ReceiverStream::new(ctrl_rx),
             status: Default::default(),
             telemetry_allowed,
-            telemetry,
             updates_rx,
             uptime: Default::default(),
             gui_ipc_clients: stream::unfold(gui_ipc, |mut gui_ipc| async move {
@@ -417,17 +412,14 @@ impl<I: GuiIntegration> Controller<I> {
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
         if let Some(account_slug) = account_slug.clone() {
-            Telemetry::set_account_slug(account_slug);
+            telemetry::set_account_slug(account_slug);
         }
 
         if !self.telemetry_allowed {
             return Ok(());
         }
 
-        self.telemetry
-            .lock()
-            .await
-            .start(&environment, crate::RELEASE, telemetry::GUI_DSN);
+        telemetry::start(&environment, crate::RELEASE, telemetry::GUI_DSN);
 
         self.send_ipc(&service::ClientMsg::StartTelemetry {
             environment: environment.clone(),
@@ -1691,7 +1683,6 @@ mod tests {
                 legacy_advanced_settings_path.clone(),
                 log_filter_reloader,
                 false,
-                Arc::new(tokio::sync::Mutex::new(Telemetry::disabled())),
                 updates_rx,
                 gui_ipc_server,
             ));

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -22,10 +22,9 @@ use crate::{
 use anyhow::{Context, Result, bail};
 use futures::SinkExt as _;
 use logging::err_with_src;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tauri::Manager;
 use tauri_specta::Event;
-use telemetry::Telemetry;
 use tokio::{runtime::Runtime, sync::mpsc};
 use tokio_stream::StreamExt;
 use tracing::instrument;
@@ -246,12 +245,7 @@ pub enum ServerMsg {
 
 /// Runs the Tauri GUI and returns on exit or unrecoverable error
 #[instrument(skip_all)]
-pub fn run(
-    rt: &Runtime,
-    config: RunConfig,
-    reloader: logging::FilterReloadHandle,
-    telemetry: Arc<tokio::sync::Mutex<Telemetry>>,
-) -> Result<()> {
+pub fn run(rt: &Runtime, config: RunConfig, reloader: logging::FilterReloadHandle) -> Result<()> {
     tauri::async_runtime::set(rt.handle().clone());
 
     #[cfg(not(debug_assertions))]
@@ -367,7 +361,6 @@ pub fn run(
             legacy_advanced_settings_path,
             reloader,
             config.telemetry_allowed,
-            telemetry,
             updates_rx,
             gui_ipc,
         ));

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -495,7 +495,7 @@ impl<'a> Handler<'a> {
             }
         };
 
-        self.telemetry.stop().await; // Stop the telemetry session once the client disconnects or we are shutting down.
+        self.telemetry.stop().await; // Flush telemetry as the service shuts down.
 
         ret
     }
@@ -543,7 +543,8 @@ impl<'a> Handler<'a> {
         match msg {
             client_shared::Event::Disconnected(error) => {
                 self.session = Session::None;
-                self.telemetry.stop().await;
+                // Telemetry is process-lifetime; it outlives sessions and is only
+                // flushed when the service itself shuts down.
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
@@ -621,7 +622,8 @@ impl<'a> Handler<'a> {
             }
             ClientMsg::Disconnect => {
                 self.session = Session::None;
-                self.telemetry.stop().await;
+                // Telemetry is process-lifetime; it outlives sessions and is only
+                // flushed when the service itself shuts down.
                 self.dns_controller.deactivate()?;
 
                 // Always send `DisconnectedGracefully` even if we weren't connected,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -497,7 +497,7 @@ impl<'a> Handler<'a> {
             }
         };
 
-        self.telemetry.stop().await;
+        self.telemetry.stop().await; // Flush telemetry as the service shuts down.
 
         ret
     }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -26,7 +26,7 @@ use logging::FilterReloadHandle;
 use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, get_user_agent};
 use secrecy::{ExposeSecret, SecretString};
 use std::{io, mem, panic::AssertUnwindSafe, pin::pin, sync::Arc, time::Duration};
-use telemetry::{Telemetry, analytics};
+use telemetry::analytics;
 use tokio::time::Instant;
 use tracing::Instrument as _;
 use tracing_subscriber::EnvFilter;
@@ -222,7 +222,6 @@ struct Handler<'a> {
     advanced_settings: AdvancedSettings,
     mdm_settings: MdmSettings,
     session: Session,
-    telemetry: Telemetry,
     telemetry_release: Option<String>,
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
@@ -333,7 +332,7 @@ impl<'a> Handler<'a> {
     ) -> Result<Self> {
         dns_controller.deactivate()?;
 
-        let telemetry = Telemetry::new(
+        telemetry::configure(
             Arc::new(tcp_socket_factory),
             Arc::new(UdpSocketFactory::default()),
         );
@@ -396,7 +395,6 @@ impl<'a> Handler<'a> {
             advanced_settings,
             mdm_settings,
             session: Session::None,
-            telemetry,
             telemetry_release: None,
             tun_device,
             dns_notifier,
@@ -497,7 +495,7 @@ impl<'a> Handler<'a> {
             }
         };
 
-        self.telemetry.stop().await; // Flush telemetry as the service shuts down.
+        telemetry::stop().await; // Flush telemetry as the service shuts down.
 
         ret
     }
@@ -545,8 +543,7 @@ impl<'a> Handler<'a> {
     /// disconnected aren't attributed to the ended session.
     fn reset_telemetry_environment(&mut self) {
         if let Some(release) = &self.telemetry_release {
-            self.telemetry
-                .start("entrypoint", release, telemetry::GUI_DSN);
+            telemetry::start("entrypoint", release, telemetry::GUI_DSN);
         }
     }
 
@@ -682,16 +679,15 @@ impl<'a> Handler<'a> {
 
                 if !no_telemetry {
                     self.telemetry_release = Some(release.clone());
-                    self.telemetry
-                        .start(&environment, &release, telemetry::GUI_DSN);
-                    Telemetry::set_firezone_id(self.device_id.id.clone()).await;
+                    telemetry::start(&environment, &release, telemetry::GUI_DSN);
+                    telemetry::set_firezone_id(self.device_id.id.clone()).await;
 
                     opentelemetry::global::set_meter_provider(
                         telemetry::SentryMeterProvider::default(),
                     );
 
                     if let Some(account_slug) = account_slug {
-                        Telemetry::set_account_slug(account_slug.clone());
+                        telemetry::set_account_slug(account_slug.clone());
 
                         analytics::identify(release, Some(account_slug));
                     }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -223,7 +223,7 @@ struct Handler<'a> {
     mdm_settings: MdmSettings,
     session: Session,
     telemetry: Telemetry,
-    telemetry_release: String,
+    telemetry_release: Option<String>,
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
     network_notifier: BoxStream<'static, Result<()>>,
@@ -397,7 +397,7 @@ impl<'a> Handler<'a> {
             mdm_settings,
             session: Session::None,
             telemetry,
-            telemetry_release: String::new(),
+            telemetry_release: None,
             tun_device,
             dns_notifier,
             network_notifier,
@@ -544,9 +544,9 @@ impl<'a> Handler<'a> {
     /// Re-points telemetry to the neutral environment so events emitted while
     /// disconnected aren't attributed to the ended session.
     fn reset_telemetry_environment(&mut self) {
-        if self.telemetry.is_active() {
+        if let Some(release) = &self.telemetry_release {
             self.telemetry
-                .start("entrypoint", &self.telemetry_release, telemetry::GUI_DSN);
+                .start("entrypoint", release, telemetry::GUI_DSN);
         }
     }
 
@@ -681,7 +681,7 @@ impl<'a> Handler<'a> {
                     std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true");
 
                 if !no_telemetry {
-                    self.telemetry_release = release.clone();
+                    self.telemetry_release = Some(release.clone());
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
                     Telemetry::set_firezone_id(self.device_id.id.clone()).await;

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -497,7 +497,7 @@ impl<'a> Handler<'a> {
             }
         };
 
-        self.telemetry.stop().await; // Flush telemetry as the service shuts down.
+        self.telemetry.stop().await;
 
         ret
     }
@@ -541,16 +541,20 @@ impl<'a> Handler<'a> {
         Poll::Pending
     }
 
+    /// Re-points telemetry to the neutral environment so events emitted while
+    /// disconnected aren't attributed to the ended session.
+    fn reset_telemetry_environment(&mut self) {
+        if self.telemetry.is_active() {
+            self.telemetry
+                .start("entrypoint", &self.telemetry_release, telemetry::GUI_DSN);
+        }
+    }
+
     async fn handle_connlib_event(&mut self, msg: client_shared::Event) -> Result<()> {
         match msg {
             client_shared::Event::Disconnected(error) => {
                 self.session = Session::None;
-                // Re-point telemetry to the neutral environment so events emitted
-                // while disconnected aren't attributed to the ended session.
-                if self.telemetry.is_active() {
-                    self.telemetry
-                        .start("entrypoint", &self.telemetry_release, telemetry::GUI_DSN);
-                }
+                self.reset_telemetry_environment();
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
@@ -628,8 +632,7 @@ impl<'a> Handler<'a> {
             }
             ClientMsg::Disconnect => {
                 self.session = Session::None;
-                // Telemetry is process-lifetime; it outlives sessions and is only
-                // flushed when the service itself shuts down.
+                self.reset_telemetry_environment();
                 self.dns_controller.deactivate()?;
 
                 // Always send `DisconnectedGracefully` even if we weren't connected,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -223,6 +223,7 @@ struct Handler<'a> {
     mdm_settings: MdmSettings,
     session: Session,
     telemetry: Telemetry,
+    telemetry_release: String,
     tun_device: TunDeviceManager,
     dns_notifier: BoxStream<'static, Result<()>>,
     network_notifier: BoxStream<'static, Result<()>>,
@@ -396,6 +397,7 @@ impl<'a> Handler<'a> {
             mdm_settings,
             session: Session::None,
             telemetry,
+            telemetry_release: String::new(),
             tun_device,
             dns_notifier,
             network_notifier,
@@ -543,8 +545,12 @@ impl<'a> Handler<'a> {
         match msg {
             client_shared::Event::Disconnected(error) => {
                 self.session = Session::None;
-                // Telemetry is process-lifetime; it outlives sessions and is only
-                // flushed when the service itself shuts down.
+                // Re-point telemetry to the neutral environment so events emitted
+                // while disconnected aren't attributed to the ended session.
+                if self.telemetry.is_active() {
+                    self.telemetry
+                        .start("entrypoint", &self.telemetry_release, telemetry::GUI_DSN);
+                }
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
@@ -672,6 +678,7 @@ impl<'a> Handler<'a> {
                     std::env::var("FIREZONE_NO_TELEMETRY").is_ok_and(|s| s == "true");
 
                 if !no_telemetry {
+                    self.telemetry_release = release.clone();
                     self.telemetry
                         .start(&environment, &release, telemetry::GUI_DSN);
                     Telemetry::set_firezone_id(self.device_id.id.clone()).await;

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -506,16 +506,11 @@ fn try_main() -> Result<()> {
             }
         };
 
-        // Closing the command channel shuts the event-loop down and restores the
-        // system resolver.
         drop(session);
 
         // Drain the event-stream to allow the event-loop to gracefully shutdown.
-        // This runs `shut_down_tunnel`, which clears the telemetry resolver override.
         let _ = tokio::time::timeout(Duration::from_secs(1), event_stream.drain()).await;
 
-        // Telemetry outlives the session: connlib has restored the system resolver,
-        // so this final flush resolves the sentry host via the default resolver.
         telemetry.stop().await;
 
         result

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -506,12 +506,17 @@ fn try_main() -> Result<()> {
             }
         };
 
-        telemetry.stop().await; // Stop telemetry before dropping session. `connlib` needs to be active for this, otherwise we won't be able to resolve the DNS name for sentry.
-
+        // Closing the command channel shuts the event-loop down and restores the
+        // system resolver.
         drop(session);
 
         // Drain the event-stream to allow the event-loop to gracefully shutdown.
+        // This runs `shut_down_tunnel`, which clears the telemetry resolver override.
         let _ = tokio::time::timeout(Duration::from_secs(1), event_stream.drain()).await;
+
+        // Telemetry outlives the session: connlib has restored the system resolver,
+        // so this final flush resolves the sentry host via the default resolver.
+        telemetry.stop().await;
 
         result
     })?;

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -24,7 +24,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use telemetry::{SentryMeterProvider, Telemetry, analytics, otel};
+use telemetry::{SentryMeterProvider, analytics, otel};
 use tokio::time::Instant;
 
 #[cfg(target_os = "linux")]
@@ -323,21 +323,17 @@ fn try_main() -> Result<()> {
         None => device_id::get_or_create_client().context("Could not get `firezone_id` from CLI, could not read it from disk, could not generate it and save it to disk")?.id,
     };
 
-    let mut telemetry = if cli.is_telemetry_allowed() {
-        let mut telemetry = Telemetry::new(
+    if cli.is_telemetry_allowed() {
+        telemetry::configure(
             Arc::new(tcp_socket_factory),
             Arc::new(UdpSocketFactory::default()),
         );
 
-        telemetry.start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
-        rt.block_on(Telemetry::set_firezone_id(firezone_id.clone()));
+        telemetry::start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
+        rt.block_on(telemetry::set_firezone_id(firezone_id.clone()));
 
         analytics::identify(RELEASE.to_owned(), None);
-
-        telemetry
-    } else {
-        Telemetry::disabled()
-    };
+    }
 
     tracing::info!(arch = std::env::consts::ARCH, version = VERSION);
 
@@ -511,7 +507,7 @@ fn try_main() -> Result<()> {
         // Drain the event-stream to allow the event-loop to gracefully shutdown.
         let _ = tokio::time::timeout(Duration::from_secs(1), event_stream.drain()).await;
 
-        telemetry.stop().await;
+        telemetry::stop().await;
 
         result
     })?;

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -698,10 +698,8 @@ impl Eventloop {
             .await
             .context("Failed to shut down tunnel")?;
 
-        // The session is over and connlib has restored the system resolver, so
-        // telemetry resolves ingest hosts via the default resolver again. Clearing
-        // only after `shut_down` avoids a window where the system resolver is still
-        // connlib's stub.
+        // Clear only after `shut_down` has restored the system resolver, else ingest
+        // lookups could briefly route through connlib's stub.
         telemetry::clear_system_resolvers();
 
         Ok(())

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -50,6 +50,8 @@ static DNS_RESOURCE_RECORDS_CACHE: Mutex<BTreeSet<DnsResourceRecord>> = Mutex::n
 pub struct Eventloop {
     tunnel: Option<ClientTunnel>,
 
+    telemetry_resolvers: telemetry::SystemResolvers,
+
     cmd_rx: mpsc::UnboundedReceiver<Command>,
     resource_list_sender: watch::Sender<ResourceList>,
     tun_config_sender: watch::Sender<Option<TunConfig>>,
@@ -127,7 +129,7 @@ impl Eventloop {
             is_internet_resource_active,
         );
         tunnel.update_system_resolvers(dns_servers.clone());
-        telemetry::set_system_resolvers(dns_servers.clone());
+        let telemetry_resolvers = telemetry::SystemResolvers::capture(dns_servers.clone());
 
         tokio::spawn(phoenix_channel_event_loop(
             portal,
@@ -141,6 +143,7 @@ impl Eventloop {
 
         Self {
             tunnel: Some(tunnel),
+            telemetry_resolvers,
             cmd_rx,
             logged_permission_denied: false,
             tunnel_errors: otel_instruments::tunnel_errors(),
@@ -217,7 +220,7 @@ impl Eventloop {
                 };
 
                 let dns = tunnel.update_system_resolvers(dns);
-                telemetry::set_system_resolvers(dns.clone());
+                self.telemetry_resolvers.set(dns.clone());
 
                 self.portal_cmd_tx
                     .send(PortalCommand::UpdateDnsServers(dns))
@@ -697,10 +700,6 @@ impl Eventloop {
             .shut_down()
             .await
             .context("Failed to shut down tunnel")?;
-
-        // Clear only after `shut_down` has restored the system resolver, else ingest
-        // lookups could briefly route through connlib's stub.
-        telemetry::clear_system_resolvers();
 
         Ok(())
     }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -127,7 +127,7 @@ impl Eventloop {
             is_internet_resource_active,
         );
         tunnel.update_system_resolvers(dns_servers.clone());
-        telemetry::update_system_resolvers(dns_servers.clone());
+        telemetry::set_system_resolvers(dns_servers.clone());
 
         tokio::spawn(phoenix_channel_event_loop(
             portal,
@@ -217,7 +217,7 @@ impl Eventloop {
                 };
 
                 let dns = tunnel.update_system_resolvers(dns);
-                telemetry::update_system_resolvers(dns.clone());
+                telemetry::set_system_resolvers(dns.clone());
 
                 self.portal_cmd_tx
                     .send(PortalCommand::UpdateDnsServers(dns))
@@ -697,6 +697,12 @@ impl Eventloop {
             .shut_down()
             .await
             .context("Failed to shut down tunnel")?;
+
+        // The session is over and connlib has restored the system resolver, so
+        // telemetry resolves ingest hosts via the default resolver again. Clearing
+        // only after `shut_down` avoids a window where the system resolver is still
+        // connlib's stub.
+        telemetry::clear_system_resolvers();
 
         Ok(())
     }

--- a/rust/libs/connlib/bootstrap-dns-client/lib.rs
+++ b/rust/libs/connlib/bootstrap-dns-client/lib.rs
@@ -26,6 +26,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 /// unanimous NXDOMAIN suppresses the retry because TCP cannot change a "name
 /// does not exist" answer; requiring consensus stops a single misbehaving
 /// resolver from blocking the fallback.
+#[derive(Clone)]
 pub struct BootstrapDnsClient {
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,

--- a/rust/libs/telemetry/src/analytics.rs
+++ b/rust/libs/telemetry/src/analytics.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, bail};
 use serde::Serialize;
 
-use crate::{ApiUrl, Env, Telemetry, ingest, posthog};
+use crate::{ApiUrl, Env, current_env, current_user, ingest, posthog};
 
 /// Records a `new_session` event for a particular user and API url.
 ///
@@ -27,11 +27,11 @@ pub fn new_session(maybe_legacy_id: String, api_url: String) {
 
 /// Associate several properties with the current telemetry user.
 pub fn identify(release: String, account_slug: Option<String>) {
-    let Some(env) = Telemetry::current_env() else {
+    let Some(env) = current_env() else {
         tracing::debug!("Cannot send $identify: Unknown env");
         return;
     };
-    let Some(distinct_id) = Telemetry::current_user() else {
+    let Some(distinct_id) = current_user() else {
         tracing::debug!("Cannot send $identify: Unknown user");
         return;
     };
@@ -59,11 +59,11 @@ pub fn identify(release: String, account_slug: Option<String>) {
 }
 
 pub fn feature_flag_called(name: impl Into<String>) {
-    let Some(env) = Telemetry::current_env() else {
+    let Some(env) = current_env() else {
         tracing::debug!("Cannot send $feature_flag_called: Unknown env");
         return;
     };
-    let Some(distinct_id) = Telemetry::current_user() else {
+    let Some(distinct_id) = current_user() else {
         tracing::debug!("Cannot send $feature_flag_called: Unknown user");
         return;
     };

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -26,7 +26,23 @@ pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
 /// loops back through connlib; the resolvers are the system's upstream DNS
 /// servers (never the system resolver itself, which may be connlib).
 static SOCKETS: LazyLock<Mutex<Option<SocketFactories>>> = LazyLock::new(|| Mutex::new(None));
-static SERVERS: LazyLock<Mutex<Vec<IpAddr>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// The resolvers used to look up all ingest hosts while a connlib session is
+/// active.
+///
+/// These are the system's upstream DNS servers that connlib captured (never the
+/// system resolver itself, which connlib has hijacked). We deliberately don't use
+/// the portal-configured `upstream_do53`/`upstream_doh` here; honouring those for
+/// telemetry is left to a future change.
+///
+/// - `Some(servers)`: a session is active and has hijacked the system resolver,
+///   so we resolve via these captured servers directly. If the list is empty,
+///   resolution fails and telemetry is effectively disabled until servers arrive;
+///   we never fall back to the system resolver, which would loop back through
+///   connlib.
+/// - `None`: no session is active, so the system resolver is the real OS
+///   resolver. We resolve ingest hosts via `getaddrinfo` directly.
+static SERVERS: LazyLock<Mutex<Option<Vec<IpAddr>>>> = LazyLock::new(|| Mutex::new(None));
 
 /// Configures the socket factories used to reach all ingest hosts.
 pub(crate) fn configure(
@@ -36,9 +52,15 @@ pub(crate) fn configure(
     *SOCKETS.lock() = Some((tcp, udp));
 }
 
-/// Updates the upstream resolvers used to look up all ingest hosts.
-pub(crate) fn update_system_resolvers(servers: Vec<IpAddr>) {
-    *SERVERS.lock() = servers;
+/// Sets the upstream resolvers used while a connlib session is active.
+pub(crate) fn set_system_resolvers(servers: Vec<IpAddr>) {
+    *SERVERS.lock() = Some(servers);
+}
+
+/// Clears the upstream resolvers when no connlib session is active, so ingest
+/// hosts are resolved via the default system resolver.
+pub(crate) fn clear_system_resolvers() {
+    *SERVERS.lock() = None;
 }
 
 /// Resets the shared socket factories so the next connection rebinds.
@@ -52,13 +74,13 @@ pub(crate) fn reset_sockets() {
 
 /// A self-healing HTTP/2 client for a single ingest host.
 ///
-/// The host is resolved via [`BootstrapDnsClient`] against the configured
-/// upstreams and connected through the shared, tunnel-bypassing socket factories,
-/// falling back to addresses seeded from the system resolver at startup. The
-/// connection is re-established on demand when it is closed.
+/// While a connlib session is active, the host is resolved via
+/// [`BootstrapDnsClient`] against the configured upstreams; otherwise it is
+/// resolved via the default system resolver. Either way the connection goes
+/// through the shared, tunnel-bypassing socket factories and is re-established
+/// on demand when it is closed.
 pub(crate) struct Client {
     host: &'static str,
-    seed_addresses: Mutex<Vec<IpAddr>>,
     connection: Mutex<Option<HttpClient>>,
     /// Serialises bootstrapping so concurrent senders share a single connection.
     bootstrap: tokio::sync::Mutex<()>,
@@ -68,29 +90,9 @@ impl Client {
     pub(crate) fn new(host: &'static str) -> Self {
         Self {
             host,
-            seed_addresses: Mutex::new(Vec::new()),
             connection: Mutex::new(None),
             bootstrap: tokio::sync::Mutex::new(()),
         }
-    }
-
-    /// Seeds the host addresses using the system resolver.
-    ///
-    /// Must run at startup, before connlib reconfigures the system resolver, so the
-    /// lookup reaches the real upstream and not connlib itself. Used as a fallback
-    /// until the bootstrap resolver has upstreams configured.
-    pub(crate) fn init_addresses(&self) {
-        let addresses = (self.host, 443u16)
-            .to_socket_addrs()
-            .inspect_err(|e| {
-                tracing::debug!(host = %self.host, "Failed to seed ingest host addresses: {e:#}")
-            })
-            .map(|addresses| addresses.map(|addr| addr.ip()).collect::<Vec<_>>())
-            .unwrap_or_default();
-
-        tracing::debug!(host = %self.host, ?addresses, "Seeded ingest host addresses from system resolver");
-
-        *self.seed_addresses.lock() = addresses;
     }
 
     /// Drops the current connection so the next request reconnects.
@@ -151,36 +153,33 @@ impl Client {
             .clone()
             .context("Ingest client has no socket factories configured")?;
         let servers = SERVERS.lock().clone();
-        let seed_addresses = self.seed_addresses.lock().clone();
 
         // Anchor the connection task on our own runtime so it outlives the caller,
         // which may be a short-lived `block_on` on another runtime.
         RUNTIME
             .spawn(async move {
-                // Resolve via the bootstrap resolver, which never uses the system
-                // resolver (i.e. connlib), and add the addresses seeded at startup as
-                // extra fallback candidates. `HttpClient` tries them in order and
-                // connects to the first that works.
-                //
-                // Skip the resolver while we have no upstreams yet (e.g. before
-                // connlib reports the system DNS servers); the seed covers that.
-                let mut addresses = if servers.is_empty() {
-                    Vec::new()
-                } else {
-                    BootstrapDnsClient::new(udp, tcp.clone(), servers)
-                        .resolve(host)
-                        .await
-                        .inspect_err(
-                            |e| tracing::debug!(%host, "Failed to resolve ingest host: {e:#}"),
-                        )
-                        .unwrap_or_default()
-                };
+                let addresses = match servers {
+                    // A connlib session is active and has hijacked the system
+                    // resolver. Resolve via the upstreams directly, never the system
+                    // resolver, which would loop back through connlib. With no
+                    // upstreams we cannot resolve at all and telemetry is disabled
+                    // until they arrive; don't fall back.
+                    Some(servers) => {
+                        anyhow::ensure!(
+                            !servers.is_empty(),
+                            "No upstream resolvers configured for ingest host {host}; \
+                             telemetry is disabled while the session is active"
+                        );
 
-                for address in seed_addresses {
-                    if !addresses.contains(&address) {
-                        addresses.push(address);
+                        BootstrapDnsClient::new(udp, tcp.clone(), servers)
+                            .resolve(host)
+                            .await
+                            .with_context(|| format!("Failed to resolve ingest host {host}"))?
                     }
-                }
+                    // No session is active, so the system resolver is the real OS
+                    // resolver. Resolve via `getaddrinfo` directly.
+                    None => resolve_via_system(host).await?,
+                };
 
                 anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
 
@@ -191,6 +190,24 @@ impl Client {
             .await
             .context("Bootstrap task failed")?
     }
+}
+
+/// Resolves a host via the default system resolver (`getaddrinfo`).
+///
+/// Only safe when no connlib session is active; otherwise the lookup would route
+/// through connlib's stub resolver and loop back into the tunnel.
+async fn resolve_via_system(host: &'static str) -> Result<Vec<IpAddr>> {
+    tokio::task::spawn_blocking(move || {
+        let addresses = (host, 443u16)
+            .to_socket_addrs()
+            .with_context(|| format!("Failed to resolve ingest host {host} via system resolver"))?
+            .map(|addr| addr.ip())
+            .collect::<Vec<_>>();
+
+        Ok(addresses)
+    })
+    .await
+    .context("System resolver task panicked")?
 }
 
 fn init_runtime() -> Runtime {

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -27,21 +27,14 @@ pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
 /// servers (never the system resolver itself, which may be connlib).
 static SOCKETS: LazyLock<Mutex<Option<SocketFactories>>> = LazyLock::new(|| Mutex::new(None));
 
-/// The resolvers used to look up all ingest hosts while a connlib session is
-/// active.
+/// Upstream resolvers for ingest-host lookups, tracking whether connlib owns the
+/// system resolver.
 ///
-/// These are the system's upstream DNS servers that connlib captured (never the
-/// system resolver itself, which connlib has hijacked). We deliberately don't use
-/// the portal-configured `upstream_do53`/`upstream_doh` here; honouring those for
-/// telemetry is left to a future change.
-///
-/// - `Some(servers)`: a session is active and has hijacked the system resolver,
-///   so we resolve via these captured servers directly. If the list is empty,
-///   resolution fails and telemetry is effectively disabled until servers arrive;
-///   we never fall back to the system resolver, which would loop back through
-///   connlib.
-/// - `None`: no session is active, so the system resolver is the real OS
-///   resolver. We resolve ingest hosts via `getaddrinfo` directly.
+/// - `Some`: a session is active and has hijacked the system resolver. Resolve via
+///   these captured upstreams directly; never `getaddrinfo`, which would loop back
+///   through connlib. An empty list disables telemetry until resolvers arrive.
+/// - `None`: no session is active, so `getaddrinfo` reaches the real OS resolver
+///   and reflects the current network.
 static SERVERS: LazyLock<Mutex<Option<Vec<IpAddr>>>> = LazyLock::new(|| Mutex::new(None));
 
 /// Configures the socket factories used to reach all ingest hosts.
@@ -159,16 +152,12 @@ impl Client {
         RUNTIME
             .spawn(async move {
                 let addresses = match servers {
-                    // A connlib session is active and has hijacked the system
-                    // resolver. Resolve via the upstreams directly, never the system
-                    // resolver, which would loop back through connlib. With no
-                    // upstreams we cannot resolve at all and telemetry is disabled
-                    // until they arrive; don't fall back.
+                    // Session active: resolve via captured upstreams, never `getaddrinfo`.
                     Some(servers) => {
                         anyhow::ensure!(
                             !servers.is_empty(),
-                            "No upstream resolvers configured for ingest host {host}; \
-                             telemetry is disabled while the session is active"
+                            "No upstream resolvers for ingest host {host}; \
+                             telemetry disabled while session is active"
                         );
 
                         BootstrapDnsClient::new(udp, tcp.clone(), servers)
@@ -176,8 +165,7 @@ impl Client {
                             .await
                             .with_context(|| format!("Failed to resolve ingest host {host}"))?
                     }
-                    // No session is active, so the system resolver is the real OS
-                    // resolver. Resolve via `getaddrinfo` directly.
+                    // No session: `getaddrinfo` reaches the real OS resolver.
                     None => resolve_via_system(host).await?,
                 };
 

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -20,22 +20,18 @@ type SocketFactories = (
 /// Runtime hosting all ingest connections and the feature-flag re-eval timer.
 pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
 
-/// Socket factories and upstream resolvers shared by all ingest hosts.
+/// Socket factories shared by all ingest hosts.
 ///
 /// connlib processes configure tunnel-bypassing factories so telemetry never
-/// loops back through connlib; the resolvers are the system's upstream DNS
-/// servers (never the system resolver itself, which may be connlib).
+/// loops back through connlib.
 static SOCKETS: LazyLock<Mutex<Option<SocketFactories>>> = LazyLock::new(|| Mutex::new(None));
 
-/// Upstream resolvers for ingest-host lookups, tracking whether connlib owns the
-/// system resolver.
+/// How ingest hosts are currently resolved.
 ///
-/// - `Some`: a session is active and has hijacked the system resolver. Resolve via
-///   these captured upstreams directly; never `getaddrinfo`, which would loop back
-///   through connlib. An empty list disables telemetry until resolvers arrive.
-/// - `None`: no session is active, so `getaddrinfo` reaches the real OS resolver
-///   and reflects the current network.
-static SERVERS: LazyLock<Mutex<Option<Vec<IpAddr>>>> = LazyLock::new(|| Mutex::new(None));
+/// Defaults to the system resolver and is swapped for connlib's upstreams while a
+/// session owns the system resolver (see [`SystemResolvers`]).
+static RESOLVER: LazyLock<Mutex<IngestResolver>> =
+    LazyLock::new(|| Mutex::new(IngestResolver::System(LibcDnsClient)));
 
 /// Configures the socket factories used to reach all ingest hosts.
 pub(crate) fn configure(
@@ -45,15 +41,56 @@ pub(crate) fn configure(
     *SOCKETS.lock() = Some((tcp, udp));
 }
 
-/// Sets the upstream resolvers used while a connlib session is active.
-pub(crate) fn set_system_resolvers(servers: Vec<IpAddr>) {
-    *SERVERS.lock() = Some(servers);
+/// Routes telemetry ingest-host lookups through connlib's upstream resolvers while
+/// a connlib session owns the system resolver.
+///
+/// connlib hijacks the system resolver for the lifetime of a session, so a plain
+/// `getaddrinfo` would loop ingest lookups back through connlib's stub. While the
+/// guard is held, lookups go through a [`BootstrapDnsClient`] against the captured
+/// upstreams. Dropping it restores resolution via the system resolver, tying the
+/// bypass to the session's lifetime.
+#[must_use = "dropping the guard restores system-resolver lookups for ingest hosts"]
+pub struct SystemResolvers {
+    _private: (),
 }
 
-/// Clears the upstream resolvers when no connlib session is active, so ingest
-/// hosts are resolved via the default system resolver.
-pub(crate) fn clear_system_resolvers() {
-    *SERVERS.lock() = None;
+impl SystemResolvers {
+    /// Captures `servers` as the ingest upstreams, bypassing the system resolver
+    /// until the guard is dropped.
+    pub fn capture(servers: Vec<IpAddr>) -> Self {
+        set_resolver(upstream(servers));
+
+        Self { _private: () }
+    }
+
+    /// Replaces the captured upstreams, e.g. when connlib learns updated resolvers.
+    pub fn set(&self, servers: Vec<IpAddr>) {
+        set_resolver(upstream(servers));
+    }
+}
+
+impl Drop for SystemResolvers {
+    fn drop(&mut self) {
+        set_resolver(IngestResolver::System(LibcDnsClient));
+    }
+}
+
+/// Swaps the active resolver and re-evaluates feature flags, which may have been
+/// disabled while (working) resolvers were missing.
+fn set_resolver(resolver: IngestResolver) {
+    *RESOLVER.lock() = resolver;
+    crate::feature_flags::reevaluate_current();
+}
+
+/// Builds an upstream resolver from `servers` and the configured socket factories.
+fn upstream(servers: Vec<IpAddr>) -> IngestResolver {
+    let Some((tcp, udp)) = SOCKETS.lock().clone() else {
+        // `configure` runs before any session captures resolvers; without socket
+        // factories telemetry cannot connect at all, so the resolver is moot.
+        return IngestResolver::System(LibcDnsClient);
+    };
+
+    IngestResolver::Upstream(BootstrapDnsClient::new(udp, tcp, servers))
 }
 
 /// Resets the shared socket factories so the next connection rebinds.
@@ -141,33 +178,17 @@ impl Client {
 
     async fn bootstrap(&self) -> Result<HttpClient> {
         let host = self.host;
-        let (tcp, udp) = SOCKETS
+        let (tcp, _) = SOCKETS
             .lock()
             .clone()
             .context("Ingest client has no socket factories configured")?;
-        let servers = SERVERS.lock().clone();
+        let resolver = RESOLVER.lock().clone();
 
         // Anchor the connection task on our own runtime so it outlives the caller,
         // which may be a short-lived `block_on` on another runtime.
         RUNTIME
             .spawn(async move {
-                let addresses = match servers {
-                    // Session active: resolve via captured upstreams, never `getaddrinfo`.
-                    Some(servers) => {
-                        anyhow::ensure!(
-                            !servers.is_empty(),
-                            "No upstream resolvers for ingest host {host}; \
-                             telemetry disabled while session is active"
-                        );
-
-                        BootstrapDnsClient::new(udp, tcp.clone(), servers)
-                            .resolve(host)
-                            .await
-                            .with_context(|| format!("Failed to resolve ingest host {host}"))?
-                    }
-                    // No session: `getaddrinfo` reaches the real OS resolver.
-                    None => resolve_via_system(host).await?,
-                };
+                let addresses = resolver.resolve(host).await?;
 
                 anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
 
@@ -180,22 +201,51 @@ impl Client {
     }
 }
 
-/// Resolves a host via the default system resolver (`getaddrinfo`).
-///
-/// Only safe when no connlib session is active; otherwise the lookup would route
-/// through connlib's stub resolver and loop back into the tunnel.
-async fn resolve_via_system(host: &'static str) -> Result<Vec<IpAddr>> {
-    tokio::task::spawn_blocking(move || {
-        let addresses = (host, 443u16)
-            .to_socket_addrs()
-            .with_context(|| format!("Failed to resolve ingest host {host} via system resolver"))?
-            .map(|addr| addr.ip())
-            .collect::<Vec<_>>();
+/// Resolves ingest hosts, either through connlib's upstreams or the system resolver.
+#[derive(Clone)]
+enum IngestResolver {
+    /// A connlib session owns the system resolver, so resolve via the captured
+    /// upstreams directly; `getaddrinfo` would loop back through connlib's stub.
+    Upstream(BootstrapDnsClient),
+    /// No session owns the system resolver, so resolve via libc (`getaddrinfo`).
+    System(LibcDnsClient),
+}
 
-        Ok(addresses)
-    })
-    .await
-    .context("System resolver task panicked")?
+impl IngestResolver {
+    async fn resolve(&self, host: &'static str) -> Result<Vec<IpAddr>> {
+        match self {
+            IngestResolver::Upstream(client) => client
+                .resolve(host)
+                .await
+                .with_context(|| format!("Failed to resolve ingest host {host}")),
+            IngestResolver::System(client) => client.resolve(host).await,
+        }
+    }
+}
+
+/// Resolves host names via the system resolver, i.e. libc's `getaddrinfo`.
+///
+/// Only safe when no connlib session owns the system resolver; otherwise the lookup
+/// would route through connlib's stub resolver and loop back into the tunnel.
+#[derive(Clone, Copy)]
+struct LibcDnsClient;
+
+impl LibcDnsClient {
+    async fn resolve(&self, host: &'static str) -> Result<Vec<IpAddr>> {
+        tokio::task::spawn_blocking(move || {
+            let addresses = (host, 443u16)
+                .to_socket_addrs()
+                .with_context(|| {
+                    format!("Failed to resolve ingest host {host} via system resolver")
+                })?
+                .map(|addr| addr.ip())
+                .collect::<Vec<_>>();
+
+            Ok(addresses)
+        })
+        .await
+        .context("System resolver task panicked")?
+    }
 }
 
 fn init_runtime() -> Runtime {
@@ -210,4 +260,23 @@ fn init_runtime() -> Runtime {
     runtime.spawn(crate::feature_flags::reeval_timer());
 
     runtime
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Exercises the shared `SOCKETS`/`RESOLVER` statics, so it stays a single test
+    // to avoid racing against parallel test threads.
+    #[test]
+    fn capture_switches_to_upstream_and_drop_restores_system() {
+        configure(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
+
+        {
+            let _guard = SystemResolvers::capture(vec![IpAddr::from([1, 1, 1, 1])]);
+            assert!(matches!(*RESOLVER.lock(), IngestResolver::Upstream(_)));
+        }
+
+        assert!(matches!(*RESOLVER.lock(), IngestResolver::System(_)));
+    }
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -40,13 +40,27 @@ pub fn maybe_hash_device_id(id: String) -> String {
     }
 }
 
-/// Updates the upstream DNS resolvers used to look up our telemetry ingest hosts.
+/// Sets the upstream DNS resolvers used to look up our telemetry ingest hosts
+/// while a connlib session is active.
 ///
-/// Call this wherever connlib's system resolvers are updated. Triggers a
+/// Call this wherever connlib's system resolvers are updated, while a session is
+/// active. While set, ingest hosts are resolved via these upstreams directly
+/// (never the system resolver, which connlib has hijacked). Triggers a
 /// feature-flag re-evaluation, since a prior attempt may have failed for lack of
 /// (working) resolvers.
-pub fn update_system_resolvers(servers: Vec<IpAddr>) {
-    ingest::update_system_resolvers(servers);
+pub fn set_system_resolvers(servers: Vec<IpAddr>) {
+    ingest::set_system_resolvers(servers);
+    feature_flags::reevaluate_current();
+}
+
+/// Clears the upstream DNS resolvers when no connlib session is active.
+///
+/// Call this when a session ends. Afterwards ingest hosts are resolved via the
+/// default system resolver, which is safe because connlib is no longer
+/// intercepting DNS. Triggers a feature-flag re-evaluation so flags refresh over
+/// the default-resolved connection.
+pub fn clear_system_resolvers() {
+    ingest::clear_system_resolvers();
     feature_flags::reevaluate_current();
 }
 
@@ -188,14 +202,9 @@ impl Telemetry {
         tcp: Arc<dyn SocketFactory<TcpSocket>>,
         udp: Arc<dyn SocketFactory<UdpSocket>>,
     ) -> Self {
-        // Configure the shared ingest socket factories and seed each ingest host's
-        // addresses via the system resolver. Seeding here, at telemetry construction,
-        // ensures the lookup happens before connlib reconfigures the system resolver
-        // (which would otherwise route it through connlib itself). The socket
-        // factories must bypass the tunnel so telemetry never loops through connlib.
+        // Configure the shared ingest socket factories. They must bypass the tunnel
+        // so telemetry never loops through connlib.
         ingest::configure(tcp, udp);
-        posthog::init_addresses();
-        sentry::init_addresses();
 
         Self { inner: None }
     }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -4,6 +4,7 @@ use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Durati
 
 use anyhow::{Context, Result, anyhow, bail};
 use api_url::ApiUrl;
+use parking_lot::Mutex;
 use sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, Metric},
@@ -170,159 +171,153 @@ impl fmt::Display for Env {
     }
 }
 
-pub struct Telemetry {
-    inner: Option<sentry::ClientInitGuard>,
+/// The process-global Sentry guard.
+///
+/// Sentry is one client per process, and the rest of this crate (the Hub,
+/// `SOCKETS`, `RESOLVER`, `RUNTIME`) is already global, so the guard is too. Every
+/// binary drives telemetry through the free functions below rather than holding an
+/// instance.
+static GUARD: Mutex<Option<sentry::ClientInitGuard>> = Mutex::new(None);
+
+/// Configures the shared, tunnel-bypassing ingest socket factories so telemetry
+/// never loops through connlib. Call once at process start before [`start`].
+pub fn configure(tcp: Arc<dyn SocketFactory<TcpSocket>>, udp: Arc<dyn SocketFactory<UdpSocket>>) {
+    ingest::configure(tcp, udp);
 }
 
-impl Telemetry {
-    pub fn new(
-        tcp: Arc<dyn SocketFactory<TcpSocket>>,
-        udp: Arc<dyn SocketFactory<UdpSocket>>,
-    ) -> Self {
-        // Configure the shared ingest socket factories. They must bypass the tunnel
-        // so telemetry never loops through connlib.
-        ingest::configure(tcp, udp);
+/// Starts (or re-points) the Sentry session for `env_or_api_url`.
+pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
+    let environment = Env::parse(env_or_api_url);
+    let mut guard = GUARD.lock();
 
-        Self { inner: None }
+    if guard
+        .as_ref()
+        .and_then(|i| i.options().environment.as_ref())
+        .is_some_and(|env| env == environment.as_str())
+    {
+        tracing::debug!(%environment, "Telemetry already initialised");
+
+        return;
     }
 
-    pub fn disabled() -> Self {
-        Self { inner: None }
+    // Stop any previous telemetry session.
+    if let Some(inner) = guard.take() {
+        tracing::debug!("Stopping previous telemetry session");
+
+        drop(inner);
+
+        set_current_user(None);
     }
 
-    /// Starts a Sentry session.
-    pub fn start(&mut self, env_or_api_url: &str, release: &str, dsn: Dsn) {
-        let environment = Env::parse(env_or_api_url);
+    if matches!(
+        environment,
+        Env::OnPrem | Env::Localhost | Env::DockerCompose
+    ) {
+        tracing::debug!(%env_or_api_url, "Telemetry won't start in unofficial environment");
+        return;
+    }
 
-        if self
-            .inner
-            .as_ref()
-            .and_then(|i| i.options().environment.as_ref())
-            .is_some_and(|env| env == environment.as_str())
-        {
-            tracing::debug!(%environment, "Telemetry already initialised");
+    tracing::info!(%environment, "Starting telemetry");
 
-            return;
+    let inner = sentry::init_sdk_client(dsn.to_string(), environment.as_str(), release);
+    // Configure scope on the main hub so that all threads will get the tags.
+    let api_url = (environment != Env::Entrypoint).then(|| env_or_api_url.to_owned());
+    sentry::Hub::main().configure_scope(move |scope| {
+        if let Some(api_url) = api_url {
+            scope.set_tag("api_url", api_url);
         }
+        let ctx = sentry::integrations::contexts::utils::device_context();
+        scope.set_context("device", ctx);
+        let ctx = sentry::integrations::contexts::utils::rust_context();
+        scope.set_context("rust", ctx);
 
-        // Stop any previous telemetry session.
-        if let Some(inner) = self.inner.take() {
-            tracing::debug!("Stopping previous telemetry session");
-
-            drop(inner);
-
-            set_current_user(None);
+        if let Some(ctx) = sentry::integrations::contexts::utils::os_context() {
+            scope.set_context("os", ctx);
         }
+    });
 
-        if matches!(
-            environment,
-            Env::OnPrem | Env::Localhost | Env::DockerCompose
-        ) {
-            tracing::debug!(%env_or_api_url, "Telemetry won't start in unofficial environment");
-            return;
-        }
+    guard.replace(inner);
+}
 
-        tracing::info!(%environment, "Starting telemetry");
-
-        let inner = sentry::init_sdk_client(dsn.to_string(), environment.as_str(), release);
-        // Configure scope on the main hub so that all threads will get the tags.
-        let api_url = (environment != Env::Entrypoint).then(|| env_or_api_url.to_owned());
-        sentry::Hub::main().configure_scope(move |scope| {
-            if let Some(api_url) = api_url {
-                scope.set_tag("api_url", api_url);
-            }
-            let ctx = sentry::integrations::contexts::utils::device_context();
-            scope.set_context("device", ctx);
-            let ctx = sentry::integrations::contexts::utils::rust_context();
-            scope.set_context("rust", ctx);
-
-            if let Some(ctx) = sentry::integrations::contexts::utils::os_context() {
-                scope.set_context("os", ctx);
-            }
-        });
-        self.inner.replace(inner);
+/// Flushes events to sentry.io and drops the guard. A no-op if not started.
+pub async fn stop() {
+    if let Err(e) = end_session().await {
+        tracing::error!("Failed to stop Sentry session on graceful exit: {e:#}")
     }
+}
 
-    /// Flushes events to sentry.io and drops the guard
-    pub async fn stop(&mut self) {
-        if let Err(e) = self.end_session().await {
-            tracing::error!("Failed to stop Sentry session on graceful exit: {e:#}")
-        }
-    }
+/// Blocking [`stop`] for teardown paths with no runtime of their own, run on
+/// telemetry's shared ingest runtime.
+pub fn stop_blocking() {
+    ingest::RUNTIME.block_on(stop());
+}
 
-    /// Blocking [`Self::stop`] for teardown paths with no runtime of their own,
-    /// run on telemetry's shared ingest runtime.
-    pub fn stop_blocking(&mut self) {
-        ingest::RUNTIME.block_on(self.stop());
-    }
+pub fn is_active() -> bool {
+    GUARD.lock().is_some()
+}
 
-    pub fn is_active(&self) -> bool {
-        self.inner.is_some()
-    }
+async fn end_session() -> Result<()> {
+    let Some(inner) = GUARD.lock().take() else {
+        return Ok(());
+    };
+    tracing::info!("Stopping telemetry");
 
-    async fn end_session(&mut self) -> Result<()> {
-        let Some(inner) = self.inner.take() else {
-            return Ok(());
+    // Sentry uses blocking IO for flushing ..
+    let task = tokio::task::spawn_blocking(move || {
+        if !inner.flush(Some(Duration::from_secs(1))) {
+            return Err(anyhow!("Failed to flush telemetry events to sentry.io"));
         };
-        tracing::info!("Stopping telemetry");
 
-        // Sentry uses blocking IO for flushing ..
-        let task = tokio::task::spawn_blocking(move || {
-            if !inner.flush(Some(Duration::from_secs(1))) {
-                return Err(anyhow!("Failed to flush telemetry events to sentry.io"));
-            };
-
-            tracing::debug!("Flushed telemetry");
-
-            Ok(())
-        });
-
-        tokio::time::timeout(Duration::from_secs(1), task)
-            .await
-            .context("Failed to end session within 1s")???;
+        tracing::debug!("Flushed telemetry");
 
         Ok(())
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .context("Failed to end session within 1s")???;
+
+    Ok(())
+}
+
+pub fn set_account_slug(slug: String) {
+    update_user(|user| {
+        user.other.insert("account_slug".to_owned(), slug.into());
+    });
+}
+
+/// Attaches the Firezone ID to the active Sentry session.
+pub async fn set_firezone_id(firezone_id: String) {
+    let new_user = compute_user(firezone_id);
+    update_user(|user| {
+        user.id = new_user.id;
+        user.other.extend(new_user.other);
+    });
+
+    // In case user and env are now available, re-eval feature-flags.
+    if let (Some(id), Some(env)) = (current_user(), current_env()) {
+        feature_flags::evaluate_now(id, env).await;
     }
+}
 
-    pub fn set_account_slug(slug: String) {
-        update_user(|user| {
-            user.other.insert("account_slug".to_owned(), slug.into());
-        });
-    }
+#[doc(hidden)] // Only public for testing.
+pub fn current_env() -> Option<Env> {
+    let client = sentry::Hub::main().client()?;
+    let env = client.options().environment.as_deref()?;
+    let env = Env::from_str(env).ok()?;
 
-    /// Attaches the Firezone ID to the active Sentry session.
-    pub async fn set_firezone_id(firezone_id: String) {
-        let new_user = compute_user(firezone_id);
-        update_user(|user| {
-            user.id = new_user.id;
-            user.other.extend(new_user.other);
-        });
+    Some(env)
+}
 
-        // In case user and env are now available, re-eval feature-flags.
-        if let (Some(id), Some(env)) = (Self::current_user(), Self::current_env()) {
-            feature_flags::evaluate_now(id, env).await;
-        }
-    }
+#[doc(hidden)] // Only public for testing.
+pub fn current_user() -> Option<String> {
+    sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
+}
 
-    #[doc(hidden)] // Only public for testing.
-    pub fn current_env() -> Option<Env> {
-        let client = sentry::Hub::main().client()?;
-        let env = client.options().environment.as_deref()?;
-        let env = Env::from_str(env).ok()?;
-
-        Some(env)
-    }
-
-    #[doc(hidden)] // Only public for testing.
-    pub fn current_user() -> Option<String> {
-        sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
-    }
-
-    #[doc(hidden)] // Only public for testing.
-    pub fn current_account_slug() -> Option<String> {
-        sentry::Hub::main()
-            .configure_scope(|s| Some(s.user()?.other.get("account_slug")?.as_str()?.to_owned()))
-    }
+#[doc(hidden)] // Only public for testing.
+pub fn current_account_slug() -> Option<String> {
+    sentry::Hub::main()
+        .configure_scope(|s| Some(s.user()?.other.get("account_slug")?.as_str()?.to_owned()))
 }
 
 /// Computes the [`User`] scope based on the contents of `firezone_id`.
@@ -417,7 +412,7 @@ fn append_tracing_fields_to_message(mut log: Log) -> Log {
 }
 
 fn insert_user_account_slug_into_log(mut log: Log) -> Log {
-    let Some(account_slug) = Telemetry::current_account_slug() else {
+    let Some(account_slug) = current_account_slug() else {
         return log;
     };
 
@@ -430,7 +425,7 @@ fn insert_user_account_slug_into_log(mut log: Log) -> Log {
 }
 
 fn insert_user_account_slug_into_metric(mut metric: Metric) -> Metric {
-    let Some(account_slug) = Telemetry::current_account_slug() else {
+    let Some(account_slug) = current_account_slug() else {
         return metric;
     };
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -273,6 +273,12 @@ impl Telemetry {
         }
     }
 
+    /// Blocking [`Self::stop`] for teardown paths with no runtime of their own,
+    /// run on telemetry's shared ingest runtime.
+    pub fn stop_blocking(&mut self) {
+        ingest::RUNTIME.block_on(self.stop());
+    }
+
     pub fn is_active(&self) -> bool {
         self.inner.is_some()
     }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::{collections::BTreeMap, fmt, mem, net::IpAddr, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result, anyhow, bail};
 use api_url::ApiUrl;
@@ -23,6 +23,7 @@ mod posthog;
 mod sentry;
 mod sentry_instrument_provider;
 
+pub use ingest::SystemResolvers;
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
 pub use sentry_instrument_provider::SentryMeterProvider;
 
@@ -38,30 +39,6 @@ pub fn maybe_hash_device_id(id: String) -> String {
     } else {
         id
     }
-}
-
-/// Sets the upstream DNS resolvers used to look up our telemetry ingest hosts
-/// while a connlib session is active.
-///
-/// Call this wherever connlib's system resolvers are updated, while a session is
-/// active. While set, ingest hosts are resolved via these upstreams directly
-/// (never the system resolver, which connlib has hijacked). Triggers a
-/// feature-flag re-evaluation, since a prior attempt may have failed for lack of
-/// (working) resolvers.
-pub fn set_system_resolvers(servers: Vec<IpAddr>) {
-    ingest::set_system_resolvers(servers);
-    feature_flags::reevaluate_current();
-}
-
-/// Clears the upstream DNS resolvers when no connlib session is active.
-///
-/// Call this when a session ends. Afterwards ingest hosts are resolved via the
-/// default system resolver, which is safe because connlib is no longer
-/// intercepting DNS. Triggers a feature-flag re-evaluation so flags refresh over
-/// the default-resolved connection.
-pub fn clear_system_resolvers() {
-    ingest::clear_system_resolvers();
-    feature_flags::reevaluate_current();
 }
 
 /// Drops the current telemetry ingest connections so they are re-established lazily.

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -24,11 +24,6 @@ pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     }
 }
 
-/// Seeds the PostHog ingest-host addresses via the system resolver.
-pub(crate) fn init_addresses() {
-    CLIENT.init_addresses();
-}
-
 /// Drops the current connection so the next request reconnects.
 pub(crate) fn reset_client() {
     CLIENT.reset();

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -17,11 +17,6 @@ pub(crate) const INGEST_HOST: &str = "sentry.firezone.dev";
 
 static CLIENT: LazyLock<ingest::Client> = LazyLock::new(|| ingest::Client::new(INGEST_HOST));
 
-/// Seeds the Sentry ingest-host addresses via the system resolver.
-pub(crate) fn init_addresses() {
-    CLIENT.init_addresses();
-}
-
 /// Drops the current connection so the next request reconnects.
 pub(crate) fn reset_client() {
     CLIENT.reset();

--- a/rust/libs/telemetry/tests/attach_firezone_id.rs
+++ b/rust/libs/telemetry/tests/attach_firezone_id.rs
@@ -1,16 +1,16 @@
-use telemetry::{TESTING, Telemetry};
+use telemetry::TESTING;
 
 #[tokio::test]
 async fn set_firezone_id_attaches_user_to_running_session() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new(
+    telemetry::configure(
         std::sync::Arc::new(socket_factory::tcp),
         std::sync::Arc::new(socket_factory::udp),
     );
-    telemetry.start("entrypoint", "1.0.0", TESTING);
+    telemetry::start("entrypoint", "1.0.0", TESTING);
 
-    Telemetry::set_firezone_id("device-abc".to_owned()).await;
+    telemetry::set_firezone_id("device-abc".to_owned()).await;
 
-    assert_eq!(Telemetry::current_user().as_deref(), Some("device-abc"));
+    assert_eq!(telemetry::current_user().as_deref(), Some("device-abc"));
 }

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -1,18 +1,18 @@
-use telemetry::{TESTING, Telemetry};
+use telemetry::TESTING;
 
 #[tokio::test]
 async fn set_account_slug_before_set_firezone_id_preserves_both() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new(
+    telemetry::configure(
         std::sync::Arc::new(socket_factory::tcp),
         std::sync::Arc::new(socket_factory::udp),
     );
-    telemetry.start("entrypoint", "1.0.0", TESTING);
+    telemetry::start("entrypoint", "1.0.0", TESTING);
 
-    Telemetry::set_account_slug("acme".to_owned());
-    Telemetry::set_firezone_id("device-xyz".to_owned()).await;
+    telemetry::set_account_slug("acme".to_owned());
+    telemetry::set_firezone_id("device-xyz".to_owned()).await;
 
-    assert_eq!(Telemetry::current_user().as_deref(), Some("device-xyz"));
-    assert_eq!(Telemetry::current_account_slug().as_deref(), Some("acme"));
+    assert_eq!(telemetry::current_user().as_deref(), Some("device-xyz"));
+    assert_eq!(telemetry::current_account_slug().as_deref(), Some("acme"));
 }

--- a/rust/libs/telemetry/tests/swap_env.rs
+++ b/rust/libs/telemetry/tests/swap_env.rs
@@ -1,16 +1,16 @@
-use telemetry::{Env, TESTING, Telemetry};
+use telemetry::{Env, TESTING};
 
 #[tokio::test]
 async fn entrypoint_then_real_env_swaps_running_session() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new(
+    telemetry::configure(
         std::sync::Arc::new(socket_factory::tcp),
         std::sync::Arc::new(socket_factory::udp),
     );
-    telemetry.start("entrypoint", "1.0.0", TESTING);
-    assert_eq!(Telemetry::current_env(), Some(Env::Entrypoint));
+    telemetry::start("entrypoint", "1.0.0", TESTING);
+    assert_eq!(telemetry::current_env(), Some(Env::Entrypoint));
 
-    telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
-    assert_eq!(Telemetry::current_env(), Some(Env::Staging));
+    telemetry::start("wss://api.firez.one", "1.0.0", TESTING);
+    assert_eq!(telemetry::current_env(), Some(Env::Staging));
 }

--- a/rust/libs/telemetry/tests/unsupported_disables_current.rs
+++ b/rust/libs/telemetry/tests/unsupported_disables_current.rs
@@ -1,15 +1,15 @@
-use telemetry::{TESTING, Telemetry};
+use telemetry::TESTING;
 
 #[tokio::test]
 async fn starting_session_for_unsupported_env_disables_current_one() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let mut telemetry = Telemetry::new(
+    telemetry::configure(
         std::sync::Arc::new(socket_factory::tcp),
         std::sync::Arc::new(socket_factory::udp),
     );
-    telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
-    telemetry.start("wss://example.com", "1.0.0", TESTING);
+    telemetry::start("wss://api.firez.one", "1.0.0", TESTING);
+    telemetry::start("wss://example.com", "1.0.0", TESTING);
 
-    assert!(!telemetry.is_active());
+    assert!(!telemetry::is_active());
 }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -25,7 +25,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Poll, ready};
 use std::time::{Duration, Instant};
 use stun_codec::rfc5766::attributes::ChannelNumber;
-use telemetry::{RELAY_DSN, Telemetry};
+use telemetry::RELAY_DSN;
 use tokio::sync::mpsc;
 use tracing::Subscriber;
 use tracing_core::Dispatch;
@@ -140,19 +140,17 @@ fn main() -> ExitCode {
         .build()
         .expect("Failed to build tokio runtime");
 
-    let mut telemetry = if args.telemetry {
-        Telemetry::new(
+    if args.telemetry {
+        telemetry::configure(
             std::sync::Arc::new(socket_factory::tcp),
             std::sync::Arc::new(socket_factory::udp),
-        )
-    } else {
-        Telemetry::disabled()
-    };
-    telemetry.start(
-        args.api_url.as_str(),
-        VERSION.unwrap_or("unknown"),
-        RELAY_DSN,
-    );
+        );
+        telemetry::start(
+            args.api_url.as_str(),
+            VERSION.unwrap_or("unknown"),
+            RELAY_DSN,
+        );
+    }
 
     let code = match runtime.block_on(try_main(args)) {
         Ok(()) => ExitCode::SUCCESS,
@@ -162,7 +160,7 @@ fn main() -> ExitCode {
         }
     };
 
-    runtime.block_on(telemetry.stop());
+    runtime.block_on(telemetry::stop());
 
     code
 }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -38,6 +38,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // on mach_msg when idle, causing false positive reports.
     Telemetry.start(enableAppHangTracking: false)
 
+    // Start connlib's (Rust) telemetry for the provider-process lifetime, decoupled
+    // from any connlib session. It comes up in the `entrypoint` environment to
+    // capture early crashes; `connect` later re-points it at the session's
+    // environment, and `deinit` flushes it.
+    startTelemetry()
+
     super.init()
 
     // Log version information immediately on startup
@@ -49,6 +55,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       "NetworkExtension starting - Version: \(version), Build: \(build), Bundle ID: \(bundleId)")
 
     migrateFirezoneId()
+  }
+
+  deinit {
+    // Flush connlib's (Rust) telemetry as the provider process tears down. It is
+    // process-lifetime, so it is not stopped per-session in `stopTunnel`.
+    stopTelemetry()
   }
 
   override func startTunnel(

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -38,10 +38,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // on mach_msg when idle, causing false positive reports.
     Telemetry.start(enableAppHangTracking: false)
 
-    // Start connlib's (Rust) telemetry for the provider-process lifetime, decoupled
-    // from any connlib session. It comes up in the `entrypoint` environment to
-    // capture early crashes; `connect` later re-points it at the session's
-    // environment, and `deinit` flushes it.
     startTelemetry()
 
     super.init()
@@ -58,8 +54,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   }
 
   deinit {
-    // Flush connlib's (Rust) telemetry as the provider process tears down. It is
-    // process-lifetime, so it is not stopped per-session in `stopTunnel`.
     stopTelemetry()
   }
 


### PR DESCRIPTION
Telemetry now starts once at provider/process start and is flushed only at process teardown, so crashes and post-disconnect work still report across connect/disconnect cycles. While a session is active, ingest hosts resolve through the captured upstream resolvers; otherwise they resolve via the default system resolver.

Stacked on #13916.