### PR TITLE
feat(flow-log-spool): add on-disk spool format crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2550,6 +2550,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flow-log-spool"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "crc32fast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
 name = "flow-log-spool"
 version = "0.1.0"
 dependencies = [
+ "anyhow-ext",
  "chrono",
  "crc32fast",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "libs/connlib/tun",
     "libs/connlib/tunnel",
     "libs/eventloop-budget",
+    "libs/flow-log-spool",
     "libs/http-client",
     "libs/known-dirs",
     "libs/logging",
@@ -79,6 +80,7 @@ chrono = { version = "0.4.44", default-features = false, features = ["std", "clo
 clap = "4.6.1"
 client-shared = { path = "libs/client-shared" }
 connlib-model = { path = "libs/connlib/model" }
+crc32fast = "1.5.0"
 crossbeam-queue = "0.3.12"
 dashmap = "6.2.1"
 dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rust"] }

--- a/rust/libs/flow-log-spool/Cargo.toml
+++ b/rust/libs/flow-log-spool/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 
-[lints]
-workspace = true
-
 [dependencies]
+anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 crc32fast = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/flow-log-spool/Cargo.toml
+++ b/rust/libs/flow-log-spool/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "flow-log-spool"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+chrono = { workspace = true, features = ["serde"] }
+crc32fast = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/rust/libs/flow-log-spool/src/lib.rs
+++ b/rust/libs/flow-log-spool/src/lib.rs
@@ -1,0 +1,159 @@
+//! The on-disk flow-log spool format, shared by the writer (`tunnel`) and every
+//! uploader (`flow-log-upload`, and the macOS daemon FFI).
+//!
+//! Keeping this tiny and dependency-light is the point: an uploader needs the spool
+//! format but none of the data plane, so it depends on this crate instead of pulling
+//! in all of connlib via `tunnel`.
+//!
+//! Each report on disk is `{ "checksum": <crc32 of the serialized payload>,
+//! "payload": <Payload> }`. The CRC lets a reader reject a torn / corrupted file
+//! rather than upload bad data.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::net::IpAddr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A flow-log payload: the network fields the data plane observes. Attribution
+/// lives in the authorization's token, never in the payload. `flow_end` and the
+/// counters are absent for an "open" report and present for a "completed" one.
+///
+/// Fields are public so the writer can build one directly; readers get one back
+/// from [`read_spooled_entry`].
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Payload {
+    pub protocol: String,
+    pub inner_src_ip: IpAddr,
+    pub inner_src_port: u16,
+    pub inner_dst_ip: IpAddr,
+    pub inner_dst_port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    pub outer_src_ip: IpAddr,
+    pub outer_src_port: u16,
+    pub outer_dst_ip: IpAddr,
+    pub outer_dst_port: u16,
+    pub flow_start: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flow_end: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_packet: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_packets: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_packets: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_bytes: Option<u64>,
+}
+
+/// One on-disk flow-log report: a CRC32 of the serialized `payload` and the payload
+/// itself. The Bearer token lives once per authorization in the directory's `token`
+/// file, not in each report.
+#[derive(Serialize)]
+struct Entry<'a> {
+    checksum: u32,
+    payload: &'a Payload,
+}
+
+#[derive(Deserialize)]
+struct StoredEntry {
+    checksum: u32,
+    payload: Payload,
+}
+
+/// A report that could not be parsed, or whose checksum did not match.
+#[derive(Debug)]
+pub struct CorruptEntry(String);
+
+impl std::fmt::Display for CorruptEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for CorruptEntry {}
+
+/// Serializes a payload into the on-disk report form, computing the CRC32 over the
+/// serialized payload so [`read_spooled_entry`] can verify it.
+pub fn serialize_entry(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> {
+    let body = serde_json::to_vec(payload)?;
+    let entry = Entry {
+        checksum: crc32fast::hash(&body),
+        payload,
+    };
+
+    serde_json::to_vec(&entry)
+}
+
+/// Parses and verifies a spooled flow-log report from its file bytes, returning the
+/// payload.
+///
+/// Returns [`CorruptEntry`] when the JSON is malformed or the CRC32 does not match
+/// the payload, so the uploader can drop the file rather than send bad data.
+pub fn read_spooled_entry(bytes: &[u8]) -> Result<Payload, CorruptEntry> {
+    let stored: StoredEntry = serde_json::from_slice(bytes)
+        .map_err(|e| CorruptEntry(format!("malformed report: {e}")))?;
+
+    // The payload serializes deterministically (fixed struct, compact), so the CRC
+    // of its re-serialization matches the one written alongside it.
+    let serialized = serde_json::to_vec(&stored.payload)
+        .map_err(|e| CorruptEntry(format!("could not re-serialize payload: {e}")))?;
+    let computed = crc32fast::hash(&serialized);
+    if computed != stored.checksum {
+        return Err(CorruptEntry(format!(
+            "checksum mismatch: stored {}, computed {computed}",
+            stored.checksum
+        )));
+    }
+
+    Ok(stored.payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+
+    fn payload() -> Payload {
+        Payload {
+            protocol: "tcp".to_owned(),
+            inner_src_ip: "100.64.0.1".parse().unwrap(),
+            inner_src_port: 1234,
+            inner_dst_ip: "10.0.0.5".parse().unwrap(),
+            inner_dst_port: 443,
+            domain: None,
+            outer_src_ip: "198.51.100.1".parse().unwrap(),
+            outer_src_port: 51820,
+            outer_dst_ip: "203.0.113.7".parse().unwrap(),
+            outer_dst_port: 51820,
+            flow_start: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            flow_end: None,
+            last_packet: None,
+            rx_packets: None,
+            tx_packets: None,
+            rx_bytes: None,
+            tx_bytes: None,
+        }
+    }
+
+    #[test]
+    fn round_trips_through_serialize_and_read() {
+        let bytes = serialize_entry(&payload()).unwrap();
+
+        assert_eq!(read_spooled_entry(&bytes).unwrap(), payload());
+    }
+
+    #[test]
+    fn detects_checksum_mismatch() {
+        let bytes = serialize_entry(&payload()).unwrap();
+        let tampered = String::from_utf8(bytes)
+            .unwrap()
+            .replace("\"inner_dst_port\":443", "\"inner_dst_port\":444");
+
+        assert!(read_spooled_entry(tampered.as_bytes()).is_err());
+    }
+}

--- a/rust/libs/flow-log-spool/src/lib.rs
+++ b/rust/libs/flow-log-spool/src/lib.rs
@@ -13,6 +13,7 @@
 
 use std::net::IpAddr;
 
+use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -21,7 +22,7 @@ use serde::{Deserialize, Serialize};
 /// counters are absent for an "open" report and present for a "completed" one.
 ///
 /// Fields are public so the writer can build one directly; readers get one back
-/// from [`read_spooled_entry`].
+/// from [`deserialize`].
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Payload {
     pub protocol: String,
@@ -65,21 +66,9 @@ struct StoredEntry {
     payload: Payload,
 }
 
-/// A report that could not be parsed, or whose checksum did not match.
-#[derive(Debug)]
-pub struct CorruptEntry(String);
-
-impl std::fmt::Display for CorruptEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl std::error::Error for CorruptEntry {}
-
 /// Serializes a payload into the on-disk report form, computing the CRC32 over the
-/// serialized payload so [`read_spooled_entry`] can verify it.
-pub fn serialize_entry(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> {
+/// serialized payload so [`deserialize`] can verify it.
+pub fn serialize(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> {
     let body = serde_json::to_vec(payload)?;
     let entry = Entry {
         checksum: crc32fast::hash(&body),
@@ -92,23 +81,21 @@ pub fn serialize_entry(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> 
 /// Parses and verifies a spooled flow-log report from its file bytes, returning the
 /// payload.
 ///
-/// Returns [`CorruptEntry`] when the JSON is malformed or the CRC32 does not match
-/// the payload, so the uploader can drop the file rather than send bad data.
-pub fn read_spooled_entry(bytes: &[u8]) -> Result<Payload, CorruptEntry> {
-    let stored: StoredEntry = serde_json::from_slice(bytes)
-        .map_err(|e| CorruptEntry(format!("malformed report: {e}")))?;
+/// Errors when the JSON is malformed or the CRC32 does not match the payload, so the
+/// uploader can drop the file rather than send bad data.
+pub fn deserialize(bytes: &[u8]) -> anyhow::Result<Payload> {
+    let stored: StoredEntry = serde_json::from_slice(bytes).context("Malformed report")?;
 
     // The payload serializes deterministically (fixed struct, compact), so the CRC
     // of its re-serialization matches the one written alongside it.
-    let serialized = serde_json::to_vec(&stored.payload)
-        .map_err(|e| CorruptEntry(format!("could not re-serialize payload: {e}")))?;
+    let serialized =
+        serde_json::to_vec(&stored.payload).context("Could not re-serialize payload")?;
     let computed = crc32fast::hash(&serialized);
-    if computed != stored.checksum {
-        return Err(CorruptEntry(format!(
-            "checksum mismatch: stored {}, computed {computed}",
-            stored.checksum
-        )));
-    }
+    anyhow::ensure!(
+        computed == stored.checksum,
+        "Checksum mismatch: stored {}, computed {computed}",
+        stored.checksum
+    );
 
     Ok(stored.payload)
 }
@@ -141,19 +128,19 @@ mod tests {
     }
 
     #[test]
-    fn round_trips_through_serialize_and_read() {
-        let bytes = serialize_entry(&payload()).unwrap();
+    fn round_trips_through_serialize_and_deserialize() {
+        let bytes = serialize(&payload()).unwrap();
 
-        assert_eq!(read_spooled_entry(&bytes).unwrap(), payload());
+        assert_eq!(deserialize(&bytes).unwrap(), payload());
     }
 
     #[test]
     fn detects_checksum_mismatch() {
-        let bytes = serialize_entry(&payload()).unwrap();
+        let bytes = serialize(&payload()).unwrap();
         let tampered = String::from_utf8(bytes)
             .unwrap()
             .replace("\"inner_dst_port\":443", "\"inner_dst_port\":444");
 
-        assert!(read_spooled_entry(tampered.as_bytes()).is_err());
+        assert!(deserialize(tampered.as_bytes()).is_err());
     }
 }


### PR DESCRIPTION
A small, dependency-light crate defining the flow-log spool entry format (a CRC32-checksummed payload), so an uploader can read the format without depending on the data plane. Shared by the writer and the uploader.