### PR TITLE
feat(flow-log-upload): add spool uploader crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2588,6 +2588,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket-factory",
+ "telemetry",
  "tempfile",
  "tokio",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2587,6 +2587,7 @@ dependencies = [
  "http-client",
  "serde",
  "serde_json",
+ "serde_with",
  "socket-factory",
  "telemetry",
  "tempfile",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "backoff",
  "base64 0.22.1",
  "bytes",
+ "chrono",
  "flow-log-spool",
  "http",
  "http-client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2575,6 +2575,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flow-log-upload"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "flow-log-spool",
+ "http",
+ "http-client",
+ "serde",
+ "serde_json",
+ "socket-factory",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+ "windows-security",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2567,7 +2567,6 @@ dependencies = [
 name = "flow-log-spool"
 version = "0.1.0"
 dependencies = [
- "anyhow-ext",
  "chrono",
  "crc32fast",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "libs/connlib/tunnel",
     "libs/eventloop-budget",
     "libs/flow-log-spool",
+    "libs/flow-log-upload",
     "libs/http-client",
     "libs/known-dirs",
     "libs/logging",
@@ -99,6 +100,7 @@ etherparse-ext = { path = "libs/connlib/etherparse-ext" }
 eventloop-budget = { path = "libs/eventloop-budget" }
 fd-lock = "4.0.4"
 filetime = "0.2.29"
+flow-log-spool = { path = "libs/flow-log-spool" }
 firezone-relay = { path = "relay/server", default-features = false }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -100,8 +100,8 @@ etherparse-ext = { path = "libs/connlib/etherparse-ext" }
 eventloop-budget = { path = "libs/eventloop-budget" }
 fd-lock = "4.0.4"
 filetime = "0.2.29"
-flow-log-spool = { path = "libs/flow-log-spool" }
 firezone-relay = { path = "relay/server", default-features = false }
+flow-log-spool = { path = "libs/flow-log-spool" }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"
 gat-lending-iterator = "0.1.8"

--- a/rust/libs/flow-log-spool/Cargo.toml
+++ b/rust/libs/flow-log-spool/Cargo.toml
@@ -5,7 +5,6 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 crc32fast = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/rust/libs/flow-log-spool/src/lib.rs
+++ b/rust/libs/flow-log-spool/src/lib.rs
@@ -13,7 +13,6 @@
 
 use std::net::IpAddr;
 
-use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -81,23 +80,54 @@ pub fn serialize(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> {
 /// Parses and verifies a spooled flow-log report from its file bytes, returning the
 /// payload.
 ///
-/// Errors when the JSON is malformed or the CRC32 does not match the payload, so the
-/// uploader can drop the file rather than send bad data.
-pub fn deserialize(bytes: &[u8]) -> anyhow::Result<Payload> {
-    let stored: StoredEntry = serde_json::from_slice(bytes).context("Malformed report")?;
+/// The error distinguishes malformed JSON (should be impossible under atomic
+/// writes) from a CRC32 mismatch (environmental corruption the checksum exists to
+/// catch), so the uploader can report them with different severity.
+pub fn deserialize(bytes: &[u8]) -> Result<Payload, Error> {
+    let stored: StoredEntry = serde_json::from_slice(bytes).map_err(Error::Malformed)?;
 
     // The payload serializes deterministically (fixed struct, compact), so the CRC
     // of its re-serialization matches the one written alongside it.
-    let serialized =
-        serde_json::to_vec(&stored.payload).context("Could not re-serialize payload")?;
+    let serialized = serde_json::to_vec(&stored.payload).map_err(Error::Malformed)?;
     let computed = crc32fast::hash(&serialized);
-    anyhow::ensure!(
-        computed == stored.checksum,
-        "Checksum mismatch: stored {}, computed {computed}",
-        stored.checksum
-    );
+
+    if computed != stored.checksum {
+        return Err(Error::ChecksumMismatch {
+            stored: stored.checksum,
+            computed,
+        });
+    }
 
     Ok(stored.payload)
+}
+
+/// Why a spooled report could not be read back.
+#[derive(Debug)]
+pub enum Error {
+    /// The JSON structure is broken.
+    Malformed(serde_json::Error),
+    /// The payload does not match its stored CRC32 (a torn or corrupted file).
+    ChecksumMismatch { stored: u32, computed: u32 },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Malformed(e) => write!(f, "Malformed report: {e}"),
+            Error::ChecksumMismatch { stored, computed } => {
+                write!(f, "Checksum mismatch: stored {stored}, computed {computed}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Malformed(e) => Some(e),
+            Error::ChecksumMismatch { .. } => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -141,6 +171,14 @@ mod tests {
             .unwrap()
             .replace("\"inner_dst_port\":443", "\"inner_dst_port\":444");
 
-        assert!(deserialize(tampered.as_bytes()).is_err());
+        assert!(matches!(
+            deserialize(tampered.as_bytes()),
+            Err(Error::ChecksumMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        assert!(matches!(deserialize(b"not json"), Err(Error::Malformed(_))));
     }
 }

--- a/rust/libs/flow-log-upload/Cargo.toml
+++ b/rust/libs/flow-log-upload/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "flow-log-upload"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+backoff = { workspace = true }
+base64 = { workspace = true, features = ["std"] }
+bytes = { workspace = true }
+flow-log-spool = { workspace = true }
+http = { workspace = true }
+http-client = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+socket-factory = { workspace = true }
+tokio = { workspace = true, features = ["rt", "net", "time"] }
+tracing = { workspace = true }
+url = { workspace = true }
+# Locks the spool (Bearer tokens) down to SYSTEM/Administrators on Windows; an
+# empty crate elsewhere.
+windows-security = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/rust/libs/flow-log-upload/Cargo.toml
+++ b/rust/libs/flow-log-upload/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 
-[lints]
-workspace = true
-
 [dependencies]
 anyhow = { workspace = true }
 backoff = { workspace = true }
@@ -17,14 +14,16 @@ http = { workspace = true }
 http-client = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 socket-factory = { workspace = true }
 telemetry = { workspace = true }
 tokio = { workspace = true, features = ["rt", "net", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }
-# Locks the spool (Bearer tokens) down to SYSTEM/Administrators on Windows; an
-# empty crate elsewhere.
-windows-security = { workspace = true }
+windows-security = { workspace = true } # Locks the spool (Bearer tokens) to SYSTEM/Administrators on Windows; empty crate elsewhere.
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/flow-log-upload/Cargo.toml
+++ b/rust/libs/flow-log-upload/Cargo.toml
@@ -18,6 +18,7 @@ http-client = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 socket-factory = { workspace = true }
+telemetry = { workspace = true }
 tokio = { workspace = true, features = ["rt", "net", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/rust/libs/flow-log-upload/Cargo.toml
+++ b/rust/libs/flow-log-upload/Cargo.toml
@@ -23,6 +23,7 @@ url = { workspace = true }
 windows-security = { workspace = true } # Locks the spool (Bearer tokens) to SYSTEM/Administrators on Windows; empty crate elsewhere.
 
 [dev-dependencies]
+chrono = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -8,13 +8,12 @@
 //! an upload pass:
 //!
 //! 1. reads the `token`,
-//! 2. groups reports by `<flow_identity>` (up to the configured batch size, oldest
-//!    first),
-//! 3. joins each flow into a single record — the `.end` if present (it is
-//!    self-describing), otherwise the `.start`,
-//! 4. POSTs the batch and, on success, deletes the files it sent (both halves of a
-//!    joined flow, or the lone `.start`). If a flow's `.end` arrives after its
-//!    `.start` was already sent and deleted, it ships as its own record next pass.
+//! 2. lists its report files oldest-first (up to the configured batch size),
+//!    skipping a `.start` whose `.end` is already on disk: the `.end` is
+//!    self-describing and supersedes it,
+//! 3. POSTs the batch and, on success, deletes the files it sent (a shipped `.end`
+//!    deletes its `.start` too). If a flow's `.end` arrives after its `.start` was
+//!    already sent and deleted, it ships as its own record next pass.
 //!
 //! The submit is idempotent (the portal upserts by flow identity), so any
 //! ambiguous failure retries the whole batch. Response handling:
@@ -43,7 +42,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use std::{
-    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -80,13 +78,17 @@ const MAX_UPLOAD_RETRY: Duration = Duration::from_secs(5 * 60);
 const INGEST_PATH: &str = "/ingestion/flow_logs";
 /// Name of the self-describing upload config file written into the spool root.
 const CONFIG_FILE: &str = "upload.json";
+/// Suffix of an "open" flow report (see `tunnel::FlowLogWriter`).
+const START_SUFFIX: &str = ".start.json";
+/// Suffix of a "completed" flow report.
+const END_SUFFIX: &str = ".end.json";
 
 /// The portal's flow-log upload config, persisted into the spool root so an uploader
 /// that runs independently of the session (a background task / daemon, or the
 /// service thread) can read it without a live connection to the portal.
 ///
 /// Only written while uploads are enabled: an `interval` of `0` is never persisted
-/// (see [`write_upload_config`]), so the file's presence alone means "enabled".
+/// (see [`set_upload_config`]), so the file's presence alone means "enabled".
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct UploadConfig {
@@ -104,13 +106,12 @@ fn default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE
 }
 
-/// Persists the portal's flow-log upload config into the spool root. Called by the
-/// session, which alone receives it via `init`, so a session-independent uploader
-/// can read it.
+/// Sets the upload config persisted in the spool root. Called by the session, which
+/// alone receives it via `init`, so a session-independent uploader can read it.
 ///
-/// An `interval_secs` of `0` means the portal disabled uploads: any persisted config
+/// An `interval_secs` of `0` means the portal disabled uploads: the persisted config
 /// is removed so a running uploader stops, rather than keeping the last one.
-pub fn write_upload_config(
+pub fn set_upload_config(
     spool_root: &Path,
     api_url: &str,
     interval_secs: u64,
@@ -142,7 +143,7 @@ pub fn write_upload_config(
 /// Spawns the flow-log uploader thread for an always-running process (the gateway,
 /// the desktop tunnel service) or a provider process. The thread reads the spool's
 /// config file each pass, so it picks up whatever the session persisted via
-/// [`write_upload_config`], and uploads over `socket_factory` so it bypasses the
+/// [`set_upload_config`], and uploads over `socket_factory` so it bypasses the
 /// tunnel. It runs until the process exits.
 pub fn spawn(
     spool_root: PathBuf,
@@ -183,7 +184,7 @@ pub async fn upload_once(
         return false;
     };
 
-    scan(spool_root, &config, socket_factory).await == ScanOutcome::RescanSoon
+    upload_pending(spool_root, &config, socket_factory).await
 }
 
 /// Removes spooled authorizations whose Bearer token has expired (their flows can
@@ -193,25 +194,14 @@ pub async fn upload_once(
 pub fn prune(spool_root: &Path) {
     let now = unix_now();
 
-    let Ok(role_dirs) = std::fs::read_dir(spool_root) else {
-        return;
-    };
-
-    for role_entry in role_dirs.flatten() {
-        let Ok(authz_dirs) = std::fs::read_dir(role_entry.path()) else {
+    for dir in authz_dirs(spool_root) {
+        if !should_prune(&dir, now) {
             continue;
-        };
+        }
 
-        for entry in authz_dirs.flatten() {
-            let dir = entry.path();
-            if !dir.is_dir() || !should_prune(&dir, now) {
-                continue;
-            }
-
-            match std::fs::remove_dir_all(&dir) {
-                Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
-                Err(e) => tracing::info!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
-            }
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
+            Err(e) => tracing::info!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
         }
     }
 }
@@ -355,18 +345,20 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
     tracing::info!("Flow-log uploader started");
 
     loop {
-        match read_upload_config(spool_root) {
+        let delay = match read_upload_config(spool_root) {
             Some(config) => {
-                let delay = match scan(spool_root, &config, socket_factory.clone()).await {
-                    ScanOutcome::RescanSoon => CATCHUP_POLL,
-                    ScanOutcome::Drained => config.interval,
-                };
-                tokio::time::sleep(delay).await;
+                if upload_pending(spool_root, &config, socket_factory.clone()).await {
+                    CATCHUP_POLL
+                } else {
+                    config.interval
+                }
             }
             // No config persisted yet, or uploads disabled by the portal: idle and
             // re-check the config shortly.
-            None => tokio::time::sleep(DISABLED_POLL).await,
-        }
+            None => DISABLED_POLL,
+        };
+
+        tokio::time::sleep(delay).await;
     }
 }
 
@@ -397,113 +389,101 @@ struct Pending {
     files: Vec<PathBuf>,
 }
 
-/// The on-disk `.start`/`.end` files discovered for one flow identity.
-#[derive(Default)]
-struct FlowFiles {
-    start: Option<PathBuf>,
-    end: Option<PathBuf>,
-    mtime: Option<SystemTime>,
-}
-
-/// Whether the uploader should scan again soon or wait the configured interval.
-#[derive(Clone, Copy, PartialEq)]
-enum ScanOutcome {
-    /// More work is pending: an authorization had more than one batch, or the
-    /// connection dropped mid-scan before everything was drained.
-    RescanSoon,
-    /// Everything pending was uploaded; wait the configured interval.
-    Drained,
-}
-
-/// Processes every authorization directory once.
+/// Uploads one batch of pending flows per authorization directory.
 ///
-/// The spool nests authorization directories one level under a `<role>` directory
-/// (`<root>/<role>/<policy_authorization_id>/`), so this walks both levels.
-async fn scan(
+/// Returns whether a backlog remains: an authorization had more than one batch
+/// pending, or the connection dropped before the pass finished. The caller can then
+/// schedule the next pass promptly instead of waiting the configured interval.
+async fn upload_pending(
     root: &Path,
     config: &UploadConfig,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> ScanOutcome {
+) -> bool {
     let Some(url) = ingest_endpoint(&config.api_url) else {
-        return ScanOutcome::Drained;
+        return false;
     };
 
     let client = match connect(&url, socket_factory).await {
         Ok(client) => client,
         Err(e) => {
             tracing::debug!("Failed to open flow-log ingest connection: {e:#}");
-            return ScanOutcome::Drained;
+            return false;
         }
-    };
-
-    let Ok(role_dirs) = std::fs::read_dir(root) else {
-        return ScanOutcome::Drained;
     };
 
     let mut backlog = false;
-    for role_entry in role_dirs.flatten() {
-        let role_dir = role_entry.path();
-        let Ok(authz_dirs) = std::fs::read_dir(&role_dir) else {
-            continue;
-        };
 
-        for entry in authz_dirs.flatten() {
-            let dir = entry.path();
-            if !dir.is_dir() {
-                continue;
-            }
-
-            // The connection died (e.g. roam) before we finished, so scan again soon
-            // to drain the rest; the next scan re-resolves and reconnects.
-            if client.is_closed() {
-                return ScanOutcome::RescanSoon;
-            }
-
-            backlog |= process_authz_dir(&client, &dir, &url, config.batch_size).await;
+    for dir in authz_dirs(root) {
+        // The connection died (e.g. roam) before we finished; the next pass
+        // re-resolves, reconnects, and drains the rest.
+        if client.is_closed() {
+            return true;
         }
+
+        backlog |= upload_authz_batch(&client, &dir, &url, config.batch_size).await;
     }
 
-    if backlog {
-        ScanOutcome::RescanSoon
-    } else {
-        ScanOutcome::Drained
-    }
+    backlog
 }
 
-/// Reads up to `batch_size` flows from one authorization's spool (oldest first),
-/// joins each into a record, and uploads them. Returns whether more than one batch
-/// was pending (a backlog), so the caller can rescan promptly.
-async fn process_authz_dir(client: &HttpClient, dir: &Path, url: &str, batch_size: usize) -> bool {
+/// Walks the spool's `<root>/<role>/<policy_authorization_id>` layout, yielding each
+/// authorization directory. An unreadable level yields nothing.
+fn authz_dirs(root: &Path) -> impl Iterator<Item = PathBuf> {
+    dir_entries(root)
+        .flat_map(|role| dir_entries(&role.path()))
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+}
+
+fn dir_entries(dir: &Path) -> impl Iterator<Item = std::fs::DirEntry> + use<> {
+    std::fs::read_dir(dir).into_iter().flatten().flatten()
+}
+
+/// Reads up to `batch_size` flows from one authorization's spool (oldest first) and
+/// uploads them as a single batch. Returns whether more than one batch was pending
+/// (a backlog).
+async fn upload_authz_batch(client: &HttpClient, dir: &Path, url: &str, batch_size: usize) -> bool {
     let token = match std::fs::read_to_string(dir.join("token")) {
         Ok(token) => token,
         // No token yet (or it was removed): nothing we can upload for this dir.
         Err(_) => return false,
     };
 
-    let mut flows = match group_flows(dir) {
-        Ok(flows) => flows,
+    let files = match report_files(dir) {
+        Ok(files) => files,
         Err(e) => {
             tracing::info!(?dir, "Failed to list flow-log spool directory: {e:#}");
             return false;
         }
     };
 
-    flows.sort_by_key(|files| files.mtime.unwrap_or(SystemTime::UNIX_EPOCH));
-    let backlog = flows.len() > batch_size;
-    flows.truncate(batch_size);
+    let mut batch = Vec::new();
+    let mut backlog = false;
 
-    let batch = flows.into_iter().filter_map(load_flow).collect::<Vec<_>>();
+    for path in files {
+        if batch.len() == batch_size {
+            backlog = true;
+            break;
+        }
+
+        batch.extend(load_flow(&path));
+    }
+
     if batch.is_empty() {
         return false;
     }
 
     submit(client, url, &token, &batch).await;
+
     backlog
 }
 
-/// Groups a directory's `.start`/`.end` report files by their flow-identity stem.
-fn group_flows(dir: &Path) -> std::io::Result<Vec<FlowFiles>> {
-    let mut flows = BTreeMap::<String, FlowFiles>::new();
+/// Lists a directory's report files, oldest first.
+///
+/// Directory iteration order is unspecified and report names are flow-identity
+/// hashes, so the ordering has to come from mtimes.
+fn report_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
 
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
@@ -511,50 +491,51 @@ fn group_flows(dir: &Path) -> std::io::Result<Vec<FlowFiles>> {
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-
-        let (stem, is_end) = if let Some(stem) = name.strip_suffix(".end.json") {
-            (stem, true)
-        } else if let Some(stem) = name.strip_suffix(".start.json") {
-            (stem, false)
-        } else {
+        if !name.ends_with(START_SUFFIX) && !name.ends_with(END_SUFFIX) {
             continue;
-        };
-
-        let mtime = entry.metadata()?.modified().ok();
-        let flow = flows.entry(stem.to_owned()).or_default();
-        if is_end {
-            flow.end = Some(path);
-        } else {
-            flow.start = Some(path);
         }
-        flow.mtime = [flow.mtime, mtime].into_iter().flatten().min();
+
+        let mtime = entry
+            .metadata()?
+            .modified()
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        files.push((mtime, path));
     }
 
-    Ok(flows.into_values().collect())
+    files.sort();
+
+    Ok(files.into_iter().map(|(_, path)| path).collect())
 }
 
-/// Loads one flow into a [`Pending`], preferring the self-describing `.end`.
-/// Corrupt files are reported and deleted; a flow with no readable report yields
-/// `None`.
-fn load_flow(files: FlowFiles) -> Option<Pending> {
-    // Prefer the self-describing `.end`; if it is missing or corrupt (and thus
-    // deleted by `read_report`), fall back to the `.start`.
-    if let Some(end) = &files.end
-        && let Some(payload) = read_report(end)
-    {
-        let mut to_delete = vec![end.clone()];
-        to_delete.extend(files.start);
+/// Loads the flow reported at `path` into a [`Pending`] upload.
+///
+/// A `.start` whose `.end` is already on disk yields `None`: the `.end` is
+/// self-describing and supersedes it, so only the `.end` ships (deleting both files
+/// once it lands). A corrupt report is deleted by [`read_report`] and yields `None`;
+/// a superseded `.start` then ships on a later pass.
+fn load_flow(path: &Path) -> Option<Pending> {
+    let name = path.file_name()?.to_str()?;
+
+    if let Some(stem) = name.strip_suffix(START_SUFFIX) {
+        if path.with_file_name(format!("{stem}{END_SUFFIX}")).exists() {
+            return None;
+        }
+
+        let payload = read_report(path)?;
+
         return Some(Pending {
             payload,
-            files: to_delete,
+            files: vec![path.to_owned()],
         });
     }
 
-    let start = files.start?;
-    let payload = read_report(&start)?;
+    let stem = name.strip_suffix(END_SUFFIX)?;
+    let payload = read_report(path)?;
+    let start = path.with_file_name(format!("{stem}{START_SUFFIX}"));
+
     Some(Pending {
         payload,
-        files: vec![start],
+        files: vec![path.to_owned(), start],
     })
 }
 
@@ -709,7 +690,10 @@ async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending
 fn delete_all(batch: &[Pending]) {
     for flow in batch {
         for path in &flow.files {
-            if let Err(e) = std::fs::remove_file(path) {
+            // A shipped `.end` lists its `.start` too, which may already be gone.
+            if let Err(e) = std::fs::remove_file(path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
                 tracing::info!(?path, "Failed to delete uploaded flow-log report: {e:#}");
             }
         }
@@ -762,10 +746,43 @@ mod tests {
         format!("header.{payload}.signature")
     }
 
+    fn write_report(path: &Path) {
+        let payload = Payload {
+            protocol: "tcp".to_owned(),
+            inner_src_ip: "10.0.0.1".parse().unwrap(),
+            inner_src_port: 1,
+            inner_dst_ip: "10.0.0.2".parse().unwrap(),
+            inner_dst_port: 2,
+            domain: None,
+            outer_src_ip: "192.0.2.1".parse().unwrap(),
+            outer_src_port: 3,
+            outer_dst_ip: "192.0.2.2".parse().unwrap(),
+            outer_dst_port: 4,
+            flow_start: chrono::Utc::now(),
+            flow_end: None,
+            last_packet: None,
+            rx_packets: None,
+            tx_packets: None,
+            rx_bytes: None,
+            tx_bytes: None,
+        };
+
+        std::fs::write(path, flow_log_spool::serialize(&payload).unwrap()).unwrap();
+    }
+
+    fn set_mtime(path: &Path, mtime: SystemTime) {
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+    }
+
     #[test]
-    fn write_then_read_config_roundtrips() {
+    fn set_then_read_config_roundtrips() {
         let root = tempfile::tempdir().unwrap();
-        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
+        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
 
         let config = read_upload_config(root.path()).expect("config present");
         assert_eq!(config.api_url, "https://flow-api.firezone.dev/");
@@ -785,7 +802,7 @@ mod tests {
     #[test]
     fn zero_batch_size_uses_default() {
         let root = tempfile::tempdir().unwrap();
-        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
+        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
 
         let config = read_upload_config(root.path()).expect("config present");
         assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
@@ -799,7 +816,7 @@ mod tests {
     #[test]
     fn zero_interval_disables_uploads() {
         let root = tempfile::tempdir().unwrap();
-        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 1000).unwrap();
+        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 1000).unwrap();
 
         assert!(read_upload_config(root.path()).is_none());
     }
@@ -807,10 +824,10 @@ mod tests {
     #[test]
     fn disabling_removes_an_existing_config() {
         let root = tempfile::tempdir().unwrap();
-        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 500).unwrap();
+        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 500).unwrap();
         assert!(read_upload_config(root.path()).is_some());
 
-        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 500).unwrap();
+        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 500).unwrap();
         assert!(read_upload_config(root.path()).is_none());
     }
 
@@ -860,6 +877,61 @@ mod tests {
             !orphan.exists(),
             "token-less authorization dir should be pruned"
         );
+    }
+
+    #[test]
+    fn report_files_lists_oldest_first_and_skips_the_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = SystemTime::now();
+
+        std::fs::write(dir.path().join("token"), "a-token").unwrap();
+        for (name, age_secs) in [("b.start.json", 10), ("a.end.json", 30), ("c.end.json", 20)] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, "{}").unwrap();
+            set_mtime(&path, now - Duration::from_secs(age_secs));
+        }
+
+        let files = report_files(dir.path()).unwrap();
+        let names = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_str().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["a.end.json", "c.end.json", "b.start.json"]);
+    }
+
+    #[test]
+    fn start_with_an_end_on_disk_ships_only_the_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let start = dir.path().join("f1.start.json");
+        let end = dir.path().join("f1.end.json");
+        write_report(&start);
+        write_report(&end);
+
+        assert!(load_flow(&start).is_none());
+
+        let pending = load_flow(&end).expect("end should load");
+        assert_eq!(pending.files, vec![end, start]);
+    }
+
+    #[test]
+    fn lone_start_ships_by_itself() {
+        let dir = tempfile::tempdir().unwrap();
+        let start = dir.path().join("f1.start.json");
+        write_report(&start);
+
+        let pending = load_flow(&start).expect("start should load");
+        assert_eq!(pending.files, vec![start]);
+    }
+
+    #[test]
+    fn corrupt_report_is_deleted_and_not_uploaded() {
+        let dir = tempfile::tempdir().unwrap();
+        let end = dir.path().join("f1.end.json");
+        std::fs::write(&end, "not a report").unwrap();
+
+        assert!(load_flow(&end).is_none());
+        assert!(!end.exists(), "corrupt report should be deleted");
     }
 
     #[test]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -20,12 +20,12 @@
 //! ambiguous failure retries the whole batch. Response handling:
 //! - 2xx: delete the sent files.
 //! - 422: the portal already persisted the valid records and the listed ones are
-//!   permanently invalid, so log the body (to Sentry) and drop the batch.
+//!   permanently invalid, so log the body and drop the batch.
 //! - 413: split the batch and retry each half.
 //! - 429: honor `Retry-After`, then retry the same batch.
 //! - 408 / 5xx / transport errors: exponential backoff, then retry; defer to the
 //!   next pass once the budget is spent (the files remain).
-//! - Other 4xx: permanent; log the status + body (to Sentry) and drop the batch.
+//! - Other 4xx: permanent; log the status + body and drop the batch.
 //!
 //! Uploads go through [`http_client::HttpClient`] over the caller's
 //! [`SocketFactory`], so they bypass the tunnel exactly like connlib's own traffic.
@@ -210,7 +210,7 @@ pub fn prune(spool_root: &Path) {
 
             match std::fs::remove_dir_all(&dir) {
                 Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
-                Err(e) => tracing::warn!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
+                Err(e) => tracing::info!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
             }
         }
     }
@@ -336,7 +336,7 @@ fn ingest_endpoint(base_url: &str) -> Option<String> {
     match Url::parse(base_url).and_then(|base| base.join(INGEST_PATH)) {
         Ok(url) => Some(url.to_string()),
         Err(e) => {
-            tracing::warn!(%base_url, "Invalid flow-log API URL; uploads disabled: {e}");
+            tracing::info!(%base_url, "Invalid flow-log API URL; uploads disabled: {e}");
             None
         }
     }
@@ -474,7 +474,7 @@ async fn process_authz_dir(client: &HttpClient, dir: &Path, url: &str, batch_siz
     let mut flows = match group_flows(dir) {
         Ok(flows) => flows,
         Err(e) => {
-            tracing::warn!(?dir, "Failed to list flow-log spool directory: {e:#}");
+            tracing::info!(?dir, "Failed to list flow-log spool directory: {e:#}");
             return false;
         }
     };
@@ -555,7 +555,7 @@ fn read_report(path: &Path) -> Option<Payload> {
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
         Err(e) => {
-            tracing::warn!(?path, "Failed to read flow-log report: {e:#}");
+            tracing::info!(?path, "Failed to read flow-log report: {e:#}");
             return None;
         }
     };
@@ -594,7 +594,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
         let response = match send(client, url, token, body.clone()).await {
             Ok(response) => response,
             Err(e) => {
-                tracing::warn!("Flow-log upload request failed: {e:#}");
+                tracing::info!("Flow-log upload request failed: {e:#}");
                 // A closed connection won't recover by retrying; defer to the next scan.
                 if client.is_closed() || !sleep_backoff(&mut backoff).await {
                     return; // the files remain on disk
@@ -604,45 +604,61 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
         };
 
         let status = response.status();
-        match status {
-            _ if status.is_success() => {
+        match classify_response(status) {
+            ResponseAction::Delete => {
                 delete_all(batch);
                 return;
             }
-            StatusCode::UNPROCESSABLE_ENTITY => {
-                let body = body_string(&response);
-                tracing::info!(%body, "Flow-log batch had validation errors; dropping batch");
-                delete_all(batch);
-                return;
-            }
-            StatusCode::PAYLOAD_TOO_LARGE => {
+            ResponseAction::Partition => {
                 partition(client, url, token, batch).await;
                 return;
             }
-            StatusCode::TOO_MANY_REQUESTS => {
+            ResponseAction::RateLimited => {
                 let wait = retry_after(&response).unwrap_or(CATCHUP_POLL);
                 tracing::debug!(?wait, "Flow-log upload rate-limited; waiting");
                 tokio::time::sleep(wait).await;
                 // Not a failure; keep retrying the same batch without spending the budget.
             }
-            StatusCode::REQUEST_TIMEOUT => {
+            ResponseAction::Retry => {
+                tracing::debug!(%status, "Flow-log upload transient failure; backing off");
                 if !sleep_backoff(&mut backoff).await {
                     return;
                 }
             }
-            _ if status.is_server_error() => {
-                tracing::debug!(%status, "Flow-log upload server error; backing off");
-                if !sleep_backoff(&mut backoff).await {
-                    return;
-                }
-            }
-            _ => {
+            ResponseAction::Drop => {
                 let body = body_string(&response);
                 tracing::info!(%status, %body, "Flow-log upload rejected; dropping batch");
                 delete_all(batch);
                 return;
             }
         }
+    }
+}
+
+/// What to do with a batch after a POST, decided from the response status.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum ResponseAction {
+    /// The batch was persisted (2xx); delete the sent files.
+    Delete,
+    /// The batch is too large (413); split it and retry each half.
+    Partition,
+    /// Rate-limited (429); honour `Retry-After`, then retry the same batch.
+    RateLimited,
+    /// Transient failure (408 / 5xx); back off, then retry the same batch.
+    Retry,
+    /// Permanently rejected (422 / other 4xx); log and drop the batch. The portal
+    /// upserts by flow identity, so a dropped batch is never a partial write.
+    Drop,
+}
+
+fn classify_response(status: StatusCode) -> ResponseAction {
+    match status {
+        s if s.is_success() => ResponseAction::Delete,
+        StatusCode::PAYLOAD_TOO_LARGE => ResponseAction::Partition,
+        StatusCode::TOO_MANY_REQUESTS => ResponseAction::RateLimited,
+        StatusCode::REQUEST_TIMEOUT => ResponseAction::Retry,
+        s if s.is_server_error() => ResponseAction::Retry,
+        _ => ResponseAction::Drop,
     }
 }
 
@@ -685,7 +701,7 @@ fn delete_all(batch: &[Pending]) {
     for flow in batch {
         for path in &flow.files {
             if let Err(e) = std::fs::remove_file(path) {
-                tracing::warn!(?path, "Failed to delete uploaded flow-log report: {e:#}");
+                tracing::info!(?path, "Failed to delete uploaded flow-log report: {e:#}");
             }
         }
     }
@@ -835,5 +851,44 @@ mod tests {
             !orphan.exists(),
             "token-less authorization dir should be pruned"
         );
+    }
+
+    #[test]
+    fn classify_response_maps_status_to_action() {
+        use ResponseAction::*;
+
+        assert_eq!(classify_response(StatusCode::OK), Delete);
+        assert_eq!(classify_response(StatusCode::ACCEPTED), Delete);
+        assert_eq!(classify_response(StatusCode::NO_CONTENT), Delete);
+        assert_eq!(classify_response(StatusCode::PAYLOAD_TOO_LARGE), Partition);
+        assert_eq!(
+            classify_response(StatusCode::TOO_MANY_REQUESTS),
+            RateLimited
+        );
+        assert_eq!(classify_response(StatusCode::REQUEST_TIMEOUT), Retry);
+        assert_eq!(classify_response(StatusCode::INTERNAL_SERVER_ERROR), Retry);
+        assert_eq!(classify_response(StatusCode::SERVICE_UNAVAILABLE), Retry);
+        assert_eq!(classify_response(StatusCode::UNPROCESSABLE_ENTITY), Drop);
+        assert_eq!(classify_response(StatusCode::BAD_REQUEST), Drop);
+        assert_eq!(classify_response(StatusCode::UNAUTHORIZED), Drop);
+        assert_eq!(classify_response(StatusCode::FORBIDDEN), Drop);
+    }
+
+    #[test]
+    fn retry_after_parses_the_seconds_header() {
+        let with_header = http::Response::builder()
+            .header(header::RETRY_AFTER, "30")
+            .body(Bytes::new())
+            .unwrap();
+        assert_eq!(retry_after(&with_header), Some(Duration::from_secs(30)));
+
+        let no_header = http::Response::builder().body(Bytes::new()).unwrap();
+        assert_eq!(retry_after(&no_header), None);
+
+        let non_numeric = http::Response::builder()
+            .header(header::RETRY_AFTER, "soon")
+            .body(Bytes::new())
+            .unwrap();
+        assert_eq!(retry_after(&non_numeric), None);
     }
 }

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -144,11 +144,22 @@ pub async fn upload_once(
     spool_root: &Path,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 ) -> bool {
-    let Some(config) = load_upload_config(spool_root).await else {
-        return false;
+    let config = match load_upload_config(spool_root).await {
+        Ok(Some(config)) => config,
+        Ok(None) => return false,
+        Err(e) => {
+            tracing::error!("Failed to load flow-log upload config: {e:#}");
+            return false;
+        }
     };
 
-    upload_pending(spool_root, &config, socket_factory).await
+    match upload_pending(spool_root, &config, socket_factory).await {
+        Ok(backlog) => backlog,
+        Err(e) => {
+            tracing::error!("Flow-log upload pass failed: {e:#}");
+            false
+        }
+    }
 }
 
 /// Removes authorization directories whose token has expired or is missing, since
@@ -159,48 +170,58 @@ pub async fn upload_once(
 pub fn prune(spool_root: &Path) {
     let now = unix_now();
 
-    for dir in authz_dirs(spool_root) {
+    let dirs = match authz_dirs(spool_root) {
+        Ok(dirs) => dirs,
+        Err(e) => {
+            tracing::warn!("Failed to walk flow-log spool: {e:#}");
+            return;
+        }
+    };
+
+    for dir in dirs {
         if !should_prune(&dir, now) {
             continue;
         }
 
         match std::fs::remove_dir_all(&dir) {
             Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
-            Err(e) => tracing::info!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
+            Err(e) => tracing::warn!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
         }
     }
 }
 
-/// Reads the persisted upload config, or `None` when none is present / valid.
-fn read_upload_config(spool_root: &Path) -> Option<UploadConfig> {
-    let bytes = std::fs::read(spool_root.join(CONFIG_FILE)).ok()?;
+/// Reads the persisted upload config; `Ok(None)` when uploads are not configured.
+fn read_upload_config(spool_root: &Path) -> Result<Option<UploadConfig>> {
+    let bytes = match std::fs::read(spool_root.join(CONFIG_FILE)) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).context("Failed to read upload config"),
+    };
 
-    serde_json::from_slice(&bytes).ok()
+    let config = serde_json::from_slice(&bytes).context("Failed to parse upload config")?;
+
+    Ok(Some(config))
 }
 
 /// [`read_upload_config`], off the runtime.
-async fn load_upload_config(spool_root: &Path) -> Option<UploadConfig> {
+async fn load_upload_config(spool_root: &Path) -> Result<Option<UploadConfig>> {
     let root = spool_root.to_owned();
 
-    blocking(move || read_upload_config(&root)).await.flatten()
+    blocking(move || read_upload_config(&root)).await?
 }
 
 /// Runs `f` on the blocking pool, so disk IO never stalls the runtime.
 ///
 /// Used instead of `tokio::fs`, which dispatches per syscall: a pass makes
 /// hundreds of small fs calls, so each phase does one hop as a whole.
-async fn blocking<T, F>(f: F) -> Option<T>
+async fn blocking<T, F>(f: F) -> Result<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    match tokio::task::spawn_blocking(f).await {
-        Ok(value) => Some(value),
-        Err(e) => {
-            tracing::error!("Flow-log blocking task failed: {e}");
-            None
-        }
-    }
+    tokio::task::spawn_blocking(f)
+        .await
+        .context("Blocking task failed")
 }
 
 fn clamp_batch_size(batch_size: u64) -> usize {
@@ -210,30 +231,48 @@ fn clamp_batch_size(batch_size: u64) -> usize {
     }
 }
 
-/// A missing token is pruned immediately; an undecodable one is kept, so a
-/// transient decode failure never deletes uploadable data.
+/// A missing token is pruned immediately; an unreadable or undecodable one is
+/// kept, so a transient failure never deletes uploadable data.
+///
+/// The writer creates a token before any report, so a missing or undecodable one
+/// is a bug.
 fn should_prune(dir: &Path, now: u64) -> bool {
-    let Ok(token) = std::fs::read_to_string(dir.join("token")) else {
-        return true;
+    let token = match std::fs::read_to_string(dir.join("token")) {
+        Ok(token) => token,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::error!(?dir, "Flow-log spool directory has no ingest token");
+            return true;
+        }
+        Err(e) => {
+            tracing::warn!(?dir, "Failed to read ingest token: {e:#}");
+            return false;
+        }
     };
 
-    token_expiry(&token).is_some_and(|exp| exp <= now)
+    match token_expiry(&token) {
+        Ok(exp) => exp <= now,
+        Err(e) => {
+            tracing::error!(?dir, "Failed to decode ingest token expiry: {e:#}");
+            false
+        }
+    }
 }
 
 /// Decodes the `exp` (unix seconds) claim from an ingest token's JWT payload
 /// without verifying its signature.
-fn token_expiry(token: &str) -> Option<u64> {
+fn token_expiry(token: &str) -> Result<u64> {
     #[derive(Deserialize)]
     struct Claims {
         exp: u64,
     }
 
-    let payload = token.split('.').nth(1)?;
+    let payload = token.split('.').nth(1).context("Token is not a JWT")?;
     let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(payload)
-        .ok()?;
+        .context("Failed to decode token payload")?;
+    let claims = serde_json::from_slice::<Claims>(&json).context("Failed to parse token claims")?;
 
-    serde_json::from_slice::<Claims>(&json).ok().map(|c| c.exp)
+    Ok(claims.exp)
 }
 
 fn unix_now() -> u64 {
@@ -312,14 +351,12 @@ fn apply_dacl(path: &Path, dacl: &windows_security::pipe_dacl::PipeDacl) -> std:
         .map_err(|e| std::io::Error::other(format!("{e:#}")))
 }
 
-fn ingest_endpoint(base_url: &str) -> Option<String> {
-    match Url::parse(base_url).and_then(|base| base.join(INGEST_PATH)) {
-        Ok(url) => Some(url.to_string()),
-        Err(e) => {
-            tracing::info!(%base_url, "Invalid flow-log API URL; uploads disabled: {e}");
-            None
-        }
-    }
+fn ingest_endpoint(base_url: &str) -> Result<String> {
+    let url = Url::parse(base_url)
+        .and_then(|base| base.join(INGEST_PATH))
+        .with_context(|| format!("Invalid flow-log API URL `{base_url}`"))?;
+
+    Ok(url.to_string())
 }
 
 async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) {
@@ -327,14 +364,21 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
 
     loop {
         let delay = match load_upload_config(spool_root).await {
-            Some(config) => {
-                if upload_pending(spool_root, &config, socket_factory.clone()).await {
-                    CATCHUP_POLL
-                } else {
-                    config.interval
+            Ok(Some(config)) => {
+                match upload_pending(spool_root, &config, socket_factory.clone()).await {
+                    Ok(true) => CATCHUP_POLL,
+                    Ok(false) => config.interval,
+                    Err(e) => {
+                        tracing::error!("Flow-log upload pass failed: {e:#}");
+                        config.interval
+                    }
                 }
             }
-            None => DISABLED_POLL,
+            Ok(None) => DISABLED_POLL,
+            Err(e) => {
+                tracing::error!("Failed to load flow-log upload config: {e:#}");
+                DISABLED_POLL
+            }
         };
 
         tokio::time::sleep(delay).await;
@@ -374,87 +418,116 @@ async fn upload_pending(
     root: &Path,
     config: &UploadConfig,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> bool {
-    let Some(url) = ingest_endpoint(&config.api_url) else {
-        return false;
-    };
+) -> Result<bool> {
+    let url = ingest_endpoint(&config.api_url)?;
 
+    // Routine while the device is offline or roaming; try again next pass.
     let client = match connect(&url, socket_factory).await {
         Ok(client) => client,
         Err(e) => {
-            tracing::debug!("Failed to open flow-log ingest connection: {e:#}");
-            return false;
+            tracing::info!("Failed to open flow-log ingest connection: {e:#}");
+            return Ok(false);
         }
     };
 
     let dirs = {
         let root = root.to_owned();
 
-        blocking(move || authz_dirs(&root).collect::<Vec<_>>()).await
+        match blocking(move || authz_dirs(&root)).await? {
+            Ok(dirs) => dirs,
+            Err(e) => {
+                tracing::warn!("Failed to walk flow-log spool: {e:#}");
+                return Ok(false);
+            }
+        }
     };
 
     let mut backlog = false;
 
-    for dir in dirs.unwrap_or_default() {
+    for dir in dirs {
         // The connection died (e.g. roam); the next pass reconnects and drains the rest.
         if client.is_closed() {
-            return true;
+            return Ok(true);
         }
 
-        backlog |= upload_authz_batch(&client, dir, &url, config.batch_size).await;
+        match upload_authz_batch(&client, &dir, &url, config.batch_size).await {
+            Ok(more) => backlog |= more,
+            // One broken directory must not block the others.
+            Err(e) => tracing::warn!(?dir, "Failed to upload flow-log batch: {e:#}"),
+        }
     }
 
-    backlog
+    Ok(backlog)
 }
 
-/// Walks the spool's `<root>/<role>/<policy_authorization_id>` layout, yielding each
-/// authorization directory. An unreadable level yields nothing.
-fn authz_dirs(root: &Path) -> impl Iterator<Item = PathBuf> {
-    dir_entries(root)
-        .flat_map(|role| dir_entries(&role.path()))
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
+/// Walks the spool's `<root>/<role>/<policy_authorization_id>` layout, listing each
+/// authorization directory. A missing level lists as empty (nothing spooled yet).
+fn authz_dirs(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+
+    for role in read_dir_or_empty(root)? {
+        if !role.is_dir() {
+            continue;
+        }
+
+        dirs.extend(read_dir_or_empty(&role)?.into_iter().filter(|p| p.is_dir()));
+    }
+
+    Ok(dirs)
 }
 
-fn dir_entries(dir: &Path) -> impl Iterator<Item = std::fs::DirEntry> + use<> {
-    std::fs::read_dir(dir).into_iter().flatten().flatten()
+fn read_dir_or_empty(dir: &Path) -> Result<Vec<PathBuf>> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("Failed to read {}", dir.display())),
+    };
+
+    entries
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()
+        .with_context(|| format!("Failed to read {}", dir.display()))
 }
 
 /// Uploads one batch from one authorization's spool. Returns whether more than one
 /// batch was pending (a backlog).
 async fn upload_authz_batch(
     client: &HttpClient,
-    dir: PathBuf,
+    dir: &Path,
     url: &str,
     batch_size: usize,
-) -> bool {
-    let collected = blocking(move || collect_batch(&dir, batch_size))
-        .await
-        .flatten();
+) -> Result<bool> {
+    let collected = {
+        let dir = dir.to_owned();
 
-    let Some((token, batch, backlog)) = collected else {
-        return false;
+        blocking(move || collect_batch(&dir, batch_size)).await??
     };
 
-    submit(client, url, &token, &batch).await;
+    let Some((token, batch, backlog)) = collected else {
+        return Ok(false);
+    };
 
-    backlog
+    submit(client, url, &token, &batch).await?;
+
+    Ok(backlog)
 }
 
 /// Reads one authorization's token and up to `batch_size` flows (oldest first), or
-/// `None` when there is nothing to upload. The `bool` reports whether more than one
-/// batch was pending.
-fn collect_batch(dir: &Path, batch_size: usize) -> Option<(String, Vec<Pending>, bool)> {
-    // No token yet: nothing can be uploaded.
-    let token = std::fs::read_to_string(dir.join("token")).ok()?;
-
-    let files = match report_files(dir) {
-        Ok(files) => files,
-        Err(e) => {
-            tracing::info!(?dir, "Failed to list flow-log spool directory: {e:#}");
-            return None;
+/// `Ok(None)` when there is nothing to upload. The `bool` reports whether more than
+/// one batch was pending.
+fn collect_batch(dir: &Path, batch_size: usize) -> Result<Option<(String, Vec<Pending>, bool)>> {
+    let token = match std::fs::read_to_string(dir.join("token")) {
+        Ok(token) => token,
+        // The writer creates the token before any report, so this is a bug.
+        // Nothing here can be uploaded; startup prune removes the directory.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::error!(?dir, "Flow-log spool directory has no ingest token");
+            return Ok(None);
         }
+        Err(e) => return Err(e).context("Failed to read ingest token"),
     };
+
+    let files = report_files(dir).context("Failed to list reports")?;
 
     let mut batch = Vec::new();
     let mut backlog = false;
@@ -465,14 +538,20 @@ fn collect_batch(dir: &Path, batch_size: usize) -> Option<(String, Vec<Pending>,
             break;
         }
 
-        batch.extend(load_flow(&path));
+        match load_flow(&path) {
+            Ok(Some(pending)) => batch.push(pending),
+            Ok(None) => {}
+            // One unreadable report must not block the rest; it stays on disk
+            // for the next pass.
+            Err(e) => tracing::warn!(?path, "Failed to load flow-log report: {e:#}"),
+        }
     }
 
     if batch.is_empty() {
-        return None;
+        return Ok(None);
     }
 
-    Some((token, batch, backlog))
+    Ok(Some((token, batch, backlog)))
 }
 
 /// Lists a directory's report files, oldest first.
@@ -501,72 +580,71 @@ fn report_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
 
 /// Loads the flow reported at `path` into a [`Pending`] upload.
 ///
-/// A `.start` whose `.end` is on disk yields `None`: the `.end` is self-describing
-/// and supersedes it, deleting both files when it ships.
-fn load_flow(path: &Path) -> Option<Pending> {
-    let name = path.file_name()?.to_str()?;
+/// `Ok(None)` when there is nothing to ship: a `.start` whose `.end` is on disk
+/// (the `.end` is self-describing and supersedes it, deleting both files when it
+/// ships), or a corrupt report.
+fn load_flow(path: &Path) -> Result<Option<Pending>> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("Invalid report file name")?;
 
     if let Some(stem) = name.strip_suffix(START_SUFFIX) {
         if path.with_file_name(format!("{stem}{END_SUFFIX}")).exists() {
-            return None;
+            return Ok(None);
         }
 
-        let payload = read_report(path)?;
-
-        return Some(Pending {
+        return Ok(read_report(path)?.map(|payload| Pending {
             payload,
             files: vec![path.to_owned()],
-        });
+        }));
     }
 
-    let stem = name.strip_suffix(END_SUFFIX)?;
-    let payload = read_report(path)?;
+    let stem = name.strip_suffix(END_SUFFIX).context("Not a report file")?;
     let start = path.with_file_name(format!("{stem}{START_SUFFIX}"));
 
-    Some(Pending {
+    Ok(read_report(path)?.map(|payload| Pending {
         payload,
         files: vec![path.to_owned(), start],
-    })
+    }))
 }
 
-/// Reads and verifies one report. A corrupt report is deleted (it can never be
-/// uploaded); a transient read error is left for the next pass.
-fn read_report(path: &Path) -> Option<Payload> {
-    let bytes = match std::fs::read(path) {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            tracing::info!(?path, "Failed to read flow-log report: {e:#}");
-            return None;
-        }
-    };
+/// Reads and verifies one report. A corrupt report yields `Ok(None)` and is
+/// deleted: it can never be uploaded, and leaving it would wedge the spool.
+///
+/// Malformed JSON is a bug (reports are written atomically); a CRC mismatch is
+/// the checksum catching environmental corruption, working as designed.
+fn read_report(path: &Path) -> Result<Option<Payload>> {
+    let bytes = std::fs::read(path).context("Failed to read report")?;
 
     match deserialize(&bytes) {
-        Ok(payload) => Some(payload),
-        Err(e) => {
+        Ok(payload) => Ok(Some(payload)),
+        Err(e @ flow_log_spool::Error::Malformed(_)) => {
             tracing::error!(?path, "Corrupt flow-log report, deleting: {e}");
             let _ = std::fs::remove_file(path);
-            None
+            Ok(None)
+        }
+        Err(e @ flow_log_spool::Error::ChecksumMismatch { .. }) => {
+            tracing::warn!(?path, "Flow-log report failed its checksum, deleting: {e}");
+            let _ = std::fs::remove_file(path);
+            Ok(None)
         }
     }
 }
 
 /// Submits one batch with response-specific handling. Idempotent, so transient
 /// failures retry the whole batch.
-async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) {
+async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) -> Result<()> {
     if batch.is_empty() {
-        return;
+        return Ok(());
     }
 
     let payloads = batch.iter().map(|flow| &flow.payload).collect::<Vec<_>>();
-    let body = match serde_json::to_vec(&Batch {
+    let body = serde_json::to_vec(&Batch {
         flow_logs: &payloads,
-    }) {
-        Ok(body) => Bytes::from(body),
-        Err(e) => {
-            tracing::error!("Failed to serialize flow-log batch: {e:#}");
-            return;
-        }
-    };
+    })
+    .context("Failed to serialize flow-log batch")?;
+    let body = Bytes::from(body);
 
     let mut backoff = upload_backoff();
 
@@ -577,7 +655,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
                 tracing::info!("Flow-log upload request failed: {e:#}");
                 // A closed connection won't recover by retrying; defer to the next pass.
                 if client.is_closed() || !sleep_backoff(&mut backoff).await {
-                    return; // the files remain on disk
+                    return Ok(()); // the files remain on disk
                 }
                 continue;
             }
@@ -586,12 +664,12 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
         let status = response.status();
         match classify_response(status) {
             ResponseAction::Delete => {
+                tracing::debug!(flows = batch.len(), "Uploaded flow-log batch");
                 delete_all(batch).await;
-                return;
+                return Ok(());
             }
             ResponseAction::Partition => {
-                partition(client, url, token, batch).await;
-                return;
+                return partition(client, url, token, batch).await;
             }
             ResponseAction::RateLimited => {
                 let wait = retry_after(&response).unwrap_or(CATCHUP_POLL);
@@ -600,16 +678,16 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
                 // Not a failure; keep retrying the same batch without spending the budget.
             }
             ResponseAction::Retry => {
-                tracing::debug!(%status, "Flow-log upload transient failure; backing off");
+                tracing::info!(%status, "Flow-log upload transient failure; backing off");
                 if !sleep_backoff(&mut backoff).await {
-                    return;
+                    return Ok(());
                 }
             }
             ResponseAction::Drop => {
                 let body = body_string(&response);
                 tracing::info!(%status, %body, "Flow-log upload rejected; dropping batch");
                 delete_all(batch).await;
-                return;
+                return Ok(());
             }
         }
     }
@@ -664,16 +742,18 @@ fn body_string(response: &http::Response<Bytes>) -> String {
 }
 
 /// Splits an over-sized batch in half and submits each.
-async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) {
+async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) -> Result<()> {
     if batch.len() <= 1 {
         tracing::error!("A single flow exceeds the upload size limit; dropping");
         delete_all(batch).await;
-        return;
+        return Ok(());
     }
 
     let mid = batch.len() / 2;
-    Box::pin(submit(client, url, token, &batch[..mid])).await;
-    Box::pin(submit(client, url, token, &batch[mid..])).await;
+    Box::pin(submit(client, url, token, &batch[..mid])).await?;
+    Box::pin(submit(client, url, token, &batch[mid..])).await?;
+
+    Ok(())
 }
 
 async fn delete_all(batch: &[Pending]) {
@@ -682,18 +762,24 @@ async fn delete_all(batch: &[Pending]) {
         .flat_map(|flow| flow.files.clone())
         .collect::<Vec<_>>();
 
-    let _ = blocking(move || delete_files(files)).await;
+    if let Err(e) = blocking(move || delete_files(files)).await {
+        tracing::warn!("Failed to delete uploaded flow-log reports: {e:#}");
+    }
 }
 
 fn delete_files(files: Vec<PathBuf>) {
+    let count = files.len();
+
     for path in files {
         // A shipped `.end` lists its `.start` too, which may already be gone.
         if let Err(e) = std::fs::remove_file(&path)
             && e.kind() != std::io::ErrorKind::NotFound
         {
-            tracing::info!(?path, "Failed to delete uploaded flow-log report: {e:#}");
+            tracing::warn!(?path, "Failed to delete uploaded flow-log report: {e:#}");
         }
     }
+
+    tracing::debug!(count, "Deleted uploaded flow-log reports");
 }
 
 fn retry_after(response: &http::Response<Bytes>) -> Option<Duration> {
@@ -771,7 +857,9 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         configure_uploads(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
 
-        let config = read_upload_config(root.path()).expect("config present");
+        let config = read_upload_config(root.path())
+            .unwrap()
+            .expect("config present");
         assert_eq!(config.api_url, "https://flow-api.firezone.dev/");
         assert_eq!(config.interval, Duration::from_secs(90));
         assert_eq!(config.batch_size, 500);
@@ -780,10 +868,10 @@ mod tests {
     #[test]
     fn ingest_endpoint_appends_the_ingest_path() {
         assert_eq!(
-            ingest_endpoint("https://flow-api.firezone.dev/").as_deref(),
-            Some("https://flow-api.firezone.dev/ingestion/flow_logs")
+            ingest_endpoint("https://flow-api.firezone.dev/").unwrap(),
+            "https://flow-api.firezone.dev/ingestion/flow_logs"
         );
-        assert_eq!(ingest_endpoint("not a url"), None);
+        assert!(ingest_endpoint("not a url").is_err());
     }
 
     #[test]
@@ -791,7 +879,9 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         configure_uploads(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
 
-        let config = read_upload_config(root.path()).expect("config present");
+        let config = read_upload_config(root.path())
+            .unwrap()
+            .expect("config present");
         assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
     }
 
@@ -805,33 +895,41 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         configure_uploads(root.path(), "https://flow-api.firezone.dev/", 0, 1000).unwrap();
 
-        assert!(read_upload_config(root.path()).is_none());
+        assert!(read_upload_config(root.path()).unwrap().is_none());
     }
 
     #[test]
     fn disabling_removes_an_existing_config() {
         let root = tempfile::tempdir().unwrap();
         configure_uploads(root.path(), "https://flow-api.firezone.dev/", 60, 500).unwrap();
-        assert!(read_upload_config(root.path()).is_some());
+        assert!(read_upload_config(root.path()).unwrap().is_some());
 
         configure_uploads(root.path(), "https://flow-api.firezone.dev/", 0, 500).unwrap();
-        assert!(read_upload_config(root.path()).is_none());
+        assert!(read_upload_config(root.path()).unwrap().is_none());
     }
 
     #[test]
     fn missing_config_disables_uploads() {
         let root = tempfile::tempdir().unwrap();
 
-        assert!(read_upload_config(root.path()).is_none());
+        assert!(read_upload_config(root.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn corrupt_config_is_an_error() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(CONFIG_FILE), "not json").unwrap();
+
+        assert!(read_upload_config(root.path()).is_err());
     }
 
     #[test]
     fn token_expiry_reads_exp_claim() {
         assert_eq!(
-            token_expiry(&token_expiring_at(1_700_000_000)),
-            Some(1_700_000_000)
+            token_expiry(&token_expiring_at(1_700_000_000)).unwrap(),
+            1_700_000_000
         );
-        assert_eq!(token_expiry("not-a-jwt"), None);
+        assert!(token_expiry("not-a-jwt").is_err());
     }
 
     #[test]
@@ -874,7 +972,7 @@ mod tests {
         write_report(&dir.path().join("f1.end.json"));
         write_report(&dir.path().join("f2.start.json"));
 
-        let (token, batch, backlog) = collect_batch(dir.path(), 1).expect("one batch");
+        let (token, batch, backlog) = collect_batch(dir.path(), 1).unwrap().expect("one batch");
 
         assert_eq!(token, "a-token");
         assert_eq!(batch.len(), 1);
@@ -886,7 +984,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write_report(&dir.path().join("f1.start.json"));
 
-        assert!(collect_batch(dir.path(), 10).is_none());
+        assert!(collect_batch(dir.path(), 10).unwrap().is_none());
     }
 
     #[test]
@@ -926,9 +1024,9 @@ mod tests {
         write_report(&start);
         write_report(&end);
 
-        assert!(load_flow(&start).is_none());
+        assert!(load_flow(&start).unwrap().is_none());
 
-        let pending = load_flow(&end).expect("end should load");
+        let pending = load_flow(&end).unwrap().expect("end should load");
         assert_eq!(pending.files, vec![end, start]);
     }
 
@@ -938,7 +1036,7 @@ mod tests {
         let start = dir.path().join("f1.start.json");
         write_report(&start);
 
-        let pending = load_flow(&start).expect("start should load");
+        let pending = load_flow(&start).unwrap().expect("start should load");
         assert_eq!(pending.files, vec![start]);
     }
 
@@ -948,7 +1046,7 @@ mod tests {
         let end = dir.path().join("f1.end.json");
         std::fs::write(&end, "not a report").unwrap();
 
-        assert!(load_flow(&end).is_none());
+        assert!(load_flow(&end).unwrap().is_none());
         assert!(!end.exists(), "corrupt report should be deleted");
     }
 

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -88,7 +88,7 @@ const END_SUFFIX: &str = ".end.json";
 /// service thread) can read it without a live connection to the portal.
 ///
 /// Only written while uploads are enabled: an `interval` of `0` is never persisted
-/// (see [`set_upload_config`]), so the file's presence alone means "enabled".
+/// (see [`configure_uploads`]), so the file's presence alone means "enabled".
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct UploadConfig {
@@ -111,7 +111,7 @@ fn default_batch_size() -> usize {
 ///
 /// An `interval_secs` of `0` means the portal disabled uploads: the persisted config
 /// is removed so a running uploader stops, rather than keeping the last one.
-pub fn set_upload_config(
+pub fn configure_uploads(
     spool_root: &Path,
     api_url: &str,
     interval_secs: u64,
@@ -143,7 +143,7 @@ pub fn set_upload_config(
 /// Spawns the flow-log uploader thread for an always-running process (the gateway,
 /// the desktop tunnel service) or a provider process. The thread reads the spool's
 /// config file each pass, so it picks up whatever the session persisted via
-/// [`set_upload_config`], and uploads over `socket_factory` so it bypasses the
+/// [`configure_uploads`], and uploads over `socket_factory` so it bypasses the
 /// tunnel. It runs until the process exits.
 pub fn spawn(
     spool_root: PathBuf,
@@ -780,9 +780,9 @@ mod tests {
     }
 
     #[test]
-    fn set_then_read_config_roundtrips() {
+    fn configure_then_read_config_roundtrips() {
         let root = tempfile::tempdir().unwrap();
-        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
+        configure_uploads(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
 
         let config = read_upload_config(root.path()).expect("config present");
         assert_eq!(config.api_url, "https://flow-api.firezone.dev/");
@@ -802,7 +802,7 @@ mod tests {
     #[test]
     fn zero_batch_size_uses_default() {
         let root = tempfile::tempdir().unwrap();
-        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
+        configure_uploads(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
 
         let config = read_upload_config(root.path()).expect("config present");
         assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
@@ -816,7 +816,7 @@ mod tests {
     #[test]
     fn zero_interval_disables_uploads() {
         let root = tempfile::tempdir().unwrap();
-        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 1000).unwrap();
+        configure_uploads(root.path(), "https://flow-api.firezone.dev/", 0, 1000).unwrap();
 
         assert!(read_upload_config(root.path()).is_none());
     }
@@ -824,10 +824,10 @@ mod tests {
     #[test]
     fn disabling_removes_an_existing_config() {
         let root = tempfile::tempdir().unwrap();
-        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 500).unwrap();
+        configure_uploads(root.path(), "https://flow-api.firezone.dev/", 60, 500).unwrap();
         assert!(read_upload_config(root.path()).is_some());
 
-        set_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 500).unwrap();
+        configure_uploads(root.path(), "https://flow-api.firezone.dev/", 0, 500).unwrap();
         assert!(read_upload_config(root.path()).is_none());
     }
 

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -29,7 +29,6 @@
 //!
 //! Uploads go through [`http_client::HttpClient`] over the caller's
 //! [`SocketFactory`], so they bypass the tunnel exactly like connlib's own traffic.
-//! The client negotiates HTTP/2 and falls back to HTTP/1.1.
 //!
 //! Two drivers share this logic so parsing / CRC / request handling is not
 //! duplicated across platforms:
@@ -54,10 +53,11 @@ use anyhow::{Context as _, Result};
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use base64::Engine as _;
 use bytes::Bytes;
-use flow_log_spool::{Payload, read_spooled_entry};
+use flow_log_spool::{Payload, deserialize};
 use http::{StatusCode, header};
 use http_client::HttpClient;
 use serde::{Deserialize, Serialize};
+use serde_with::{DurationSeconds, serde_as};
 use socket_factory::{SocketFactory, TcpSocket};
 use url::Url;
 
@@ -84,72 +84,59 @@ const CONFIG_FILE: &str = "upload.json";
 /// The portal's flow-log upload config, persisted into the spool root so an uploader
 /// that runs independently of the session (a background task / daemon, or the
 /// service thread) can read it without a live connection to the portal.
+///
+/// Only written while uploads are enabled: an `interval` of `0` is never persisted
+/// (see [`write_upload_config`]), so the file's presence alone means "enabled".
+#[serde_as]
 #[derive(Serialize, Deserialize)]
 struct UploadConfig {
     /// Base URL flow logs are POSTed to.
     api_url: String,
-    /// How often, in seconds, to upload batched flow logs. `0` disables uploads.
-    interval_secs: u64,
-    /// Maximum flows per upload request. `0` / absent uses [`DEFAULT_BATCH_SIZE`].
-    #[serde(default)]
-    batch_size: u64,
+    /// How often to upload batched flow logs.
+    #[serde_as(as = "DurationSeconds<u64>")]
+    interval: Duration,
+    /// Maximum flows per upload request. Absent uses [`DEFAULT_BATCH_SIZE`].
+    #[serde(default = "default_batch_size")]
+    batch_size: usize,
 }
 
-/// The resolved upload config: ingest endpoint, scan interval, and batch size.
-struct ResolvedConfig {
-    url: String,
-    interval: Duration,
-    batch_size: usize,
+fn default_batch_size() -> usize {
+    DEFAULT_BATCH_SIZE
 }
 
 /// Persists the portal's flow-log upload config into the spool root. Called by the
 /// session, which alone receives it via `init`, so a session-independent uploader
-/// can read it. An `interval_secs` of `0` disables uploads; a `batch_size` of `0`
-/// falls back to [`DEFAULT_BATCH_SIZE`].
+/// can read it.
+///
+/// An `interval_secs` of `0` means the portal disabled uploads: any persisted config
+/// is removed so a running uploader stops, rather than keeping the last one.
 pub fn write_upload_config(
     spool_root: &Path,
     api_url: &str,
     interval_secs: u64,
     batch_size: u64,
 ) -> std::io::Result<()> {
+    let config_path = spool_root.join(CONFIG_FILE);
+
+    if interval_secs == 0 {
+        return match std::fs::remove_file(&config_path) {
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+            _ => Ok(()),
+        };
+    }
+
     create_dir_secure(spool_root)?;
 
     let config = UploadConfig {
         api_url: api_url.to_owned(),
-        interval_secs,
-        batch_size,
+        interval: Duration::from_secs(interval_secs),
+        batch_size: clamp_batch_size(batch_size),
     };
     let body = serde_json::to_vec(&config).map_err(std::io::Error::other)?;
 
-    write_owner_only(&spool_root.join(CONFIG_FILE), &body)
-}
+    write_owner_only(&config_path, &body)?;
 
-/// Reads the persisted upload config. `None` when no (valid) config is present or
-/// uploads are disabled (interval `0`).
-fn read_upload_config(spool_root: &Path) -> Option<ResolvedConfig> {
-    let bytes = std::fs::read(spool_root.join(CONFIG_FILE)).ok()?;
-    let config: UploadConfig = serde_json::from_slice(&bytes).ok()?;
-
-    let url = ingest_endpoint(&config.api_url)?;
-    let interval = (config.interval_secs > 0).then(|| Duration::from_secs(config.interval_secs))?;
-    let batch_size = batch_size_or_default(config.batch_size);
-
-    Some(ResolvedConfig {
-        url,
-        interval,
-        batch_size,
-    })
-}
-
-/// Clamps the portal-provided batch size into `[1, MAX_BATCH_SIZE]`, defaulting when
-/// it is `0` / absent.
-fn batch_size_or_default(batch_size: u64) -> usize {
-    let batch_size = usize::try_from(batch_size).unwrap_or(MAX_BATCH_SIZE);
-
-    match batch_size {
-        0 => DEFAULT_BATCH_SIZE,
-        n => n.min(MAX_BATCH_SIZE),
-    }
+    Ok(())
 }
 
 /// Spawns the flow-log uploader thread for an always-running process (the gateway,
@@ -184,27 +171,19 @@ pub fn spawn(
 /// using the config persisted in the spool, over `socket_factory`. Intended for
 /// platforms that drive uploads from a short-lived OS background task / the
 /// provider process via FFI, so they can flush the spool independently of a
-/// long-running thread.
+/// long-running thread. The caller owns the runtime this runs on.
 ///
 /// Returns `true` when a backlog remained (an authorization had more than one batch
 /// pending), so the caller may schedule another pass sooner.
-pub fn upload_once(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> bool {
-    let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(runtime) => runtime,
-        Err(e) => {
-            tracing::error!("Failed to build flow-log uploader runtime; skipping upload: {e:#}");
-            return false;
-        }
-    };
-
+pub async fn upload_once(
+    spool_root: &Path,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> bool {
     let Some(config) = read_upload_config(spool_root) else {
         return false;
     };
 
-    runtime.block_on(scan(spool_root, &config, socket_factory))
+    scan(spool_root, &config, socket_factory).await == ScanOutcome::RescanSoon
 }
 
 /// Removes spooled authorizations whose Bearer token has expired (their flows can
@@ -225,13 +204,31 @@ pub fn prune(spool_root: &Path) {
 
         for entry in authz_dirs.flatten() {
             let dir = entry.path();
-            if dir.is_dir() && should_prune(&dir, now) {
-                match std::fs::remove_dir_all(&dir) {
-                    Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
-                    Err(e) => tracing::warn!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
-                }
+            if !dir.is_dir() || !should_prune(&dir, now) {
+                continue;
+            }
+
+            match std::fs::remove_dir_all(&dir) {
+                Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
+                Err(e) => tracing::warn!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
             }
         }
+    }
+}
+
+/// Reads the persisted upload config, or `None` when none is present / valid.
+fn read_upload_config(spool_root: &Path) -> Option<UploadConfig> {
+    let bytes = std::fs::read(spool_root.join(CONFIG_FILE)).ok()?;
+
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Clamps the portal-provided batch size into `[1, MAX_BATCH_SIZE]`, defaulting when
+/// it is `0`.
+fn clamp_batch_size(batch_size: u64) -> usize {
+    match usize::try_from(batch_size).unwrap_or(MAX_BATCH_SIZE) {
+        0 => DEFAULT_BATCH_SIZE,
+        n => n.min(MAX_BATCH_SIZE),
     }
 }
 
@@ -346,18 +343,16 @@ fn ingest_endpoint(base_url: &str) -> Option<String> {
 }
 
 async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) {
-    tracing::info!("Flow-log uploader thread started");
+    tracing::info!("Flow-log uploader started");
 
     loop {
         match read_upload_config(spool_root) {
             Some(config) => {
-                let backlog = scan(spool_root, &config, socket_factory.clone()).await;
-                tokio::time::sleep(if backlog {
-                    CATCHUP_POLL
-                } else {
-                    config.interval
-                })
-                .await;
+                let delay = match scan(spool_root, &config, socket_factory.clone()).await {
+                    ScanOutcome::RescanSoon => CATCHUP_POLL,
+                    ScanOutcome::Drained => config.interval,
+                };
+                tokio::time::sleep(delay).await;
             }
             // No config persisted yet, or uploads disabled by the portal: idle and
             // re-check the config shortly.
@@ -401,26 +396,39 @@ struct FlowFiles {
     mtime: Option<SystemTime>,
 }
 
-/// Processes every authorization directory once; returns whether any directory
-/// still has a backlog (more than one batch pending) that warrants a quick rescan.
+/// Whether the uploader should scan again soon or wait the configured interval.
+#[derive(Clone, Copy, PartialEq)]
+enum ScanOutcome {
+    /// More work is pending: an authorization had more than one batch, or the
+    /// connection dropped mid-scan before everything was drained.
+    RescanSoon,
+    /// Everything pending was uploaded; wait the configured interval.
+    Drained,
+}
+
+/// Processes every authorization directory once.
 ///
 /// The spool nests authorization directories one level under a `<role>` directory
 /// (`<root>/<role>/<policy_authorization_id>/`), so this walks both levels.
 async fn scan(
     root: &Path,
-    config: &ResolvedConfig,
+    config: &UploadConfig,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
-) -> bool {
-    let client = match connect(&config.url, socket_factory).await {
+) -> ScanOutcome {
+    let Some(url) = ingest_endpoint(&config.api_url) else {
+        return ScanOutcome::Drained;
+    };
+
+    let client = match connect(&url, socket_factory).await {
         Ok(client) => client,
         Err(e) => {
             tracing::debug!("Failed to open flow-log ingest connection: {e:#}");
-            return false;
+            return ScanOutcome::Drained;
         }
     };
 
     let Ok(role_dirs) = std::fs::read_dir(root) else {
-        return false;
+        return ScanOutcome::Drained;
     };
 
     let mut backlog = false;
@@ -436,15 +444,21 @@ async fn scan(
                 continue;
             }
 
-            // The connection died (e.g. roam); the next scan re-resolves and reconnects.
+            // The connection died (e.g. roam) before we finished, so scan again soon
+            // to drain the rest; the next scan re-resolves and reconnects.
             if client.is_closed() {
-                return backlog;
+                return ScanOutcome::RescanSoon;
             }
 
-            backlog |= process_authz_dir(&client, &dir, &config.url, config.batch_size).await;
+            backlog |= process_authz_dir(&client, &dir, &url, config.batch_size).await;
         }
     }
-    backlog
+
+    if backlog {
+        ScanOutcome::RescanSoon
+    } else {
+        ScanOutcome::Drained
+    }
 }
 
 /// Reads up to `batch_size` flows from one authorization's spool (oldest first),
@@ -546,7 +560,7 @@ fn read_report(path: &Path) -> Option<Payload> {
         }
     };
 
-    match read_spooled_entry(&bytes) {
+    match deserialize(&bytes) {
         Ok(payload) => Some(payload),
         Err(e) => {
             tracing::error!(?path, "Corrupt flow-log report, deleting: {e}");
@@ -597,7 +611,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
             }
             StatusCode::UNPROCESSABLE_ENTITY => {
                 let body = body_string(&response);
-                tracing::error!(%body, "Flow-log batch had validation errors; dropping batch");
+                tracing::warn!(%body, "Flow-log batch had validation errors; dropping batch");
                 delete_all(batch);
                 return;
             }
@@ -724,21 +738,27 @@ mod tests {
     }
 
     #[test]
-    fn write_then_read_config_builds_ingest_endpoint_interval_and_batch_size() {
+    fn write_then_read_config_roundtrips() {
         let root = tempfile::tempdir().unwrap();
         write_upload_config(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
 
         let config = read_upload_config(root.path()).expect("config present");
-        assert_eq!(
-            config.url,
-            "https://flow-api.firezone.dev/ingestion/flow_logs"
-        );
+        assert_eq!(config.api_url, "https://flow-api.firezone.dev/");
         assert_eq!(config.interval, Duration::from_secs(90));
         assert_eq!(config.batch_size, 500);
     }
 
     #[test]
-    fn zero_or_missing_batch_size_uses_default() {
+    fn ingest_endpoint_appends_the_ingest_path() {
+        assert_eq!(
+            ingest_endpoint("https://flow-api.firezone.dev/").as_deref(),
+            Some("https://flow-api.firezone.dev/ingestion/flow_logs")
+        );
+        assert_eq!(ingest_endpoint("not a url"), None);
+    }
+
+    #[test]
+    fn zero_batch_size_uses_default() {
         let root = tempfile::tempdir().unwrap();
         write_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
 
@@ -748,7 +768,7 @@ mod tests {
 
     #[test]
     fn batch_size_is_clamped_to_max() {
-        assert_eq!(batch_size_or_default(1_000_000), MAX_BATCH_SIZE);
+        assert_eq!(clamp_batch_size(1_000_000), MAX_BATCH_SIZE);
     }
 
     #[test]
@@ -760,10 +780,12 @@ mod tests {
     }
 
     #[test]
-    fn invalid_url_disables_uploads() {
+    fn disabling_removes_an_existing_config() {
         let root = tempfile::tempdir().unwrap();
-        write_upload_config(root.path(), "not a url", 60, 1000).unwrap();
+        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 500).unwrap();
+        assert!(read_upload_config(root.path()).is_some());
 
+        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 500).unwrap();
         assert!(read_upload_config(root.path()).is_none());
     }
 

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -1,0 +1,824 @@
+//! Uploads spooled flow logs to the portal ingest API.
+//!
+//! The spool, written by `tunnel::FlowLogWriter`, nests one directory per
+//! authorization under a role directory:
+//! `<root>/<role>/<policy_authorization_id>/`. Each holds that authorization's
+//! Bearer `token` plus per-flow reports split into `<flow_identity>.start.json`
+//! (open) and `<flow_identity>.end.json` (completed) files. For each authorization
+//! an upload pass:
+//!
+//! 1. reads the `token`,
+//! 2. groups reports by `<flow_identity>` (up to the configured batch size, oldest
+//!    first),
+//! 3. joins each flow into a single record — the `.end` if present (it is
+//!    self-describing), otherwise the `.start`,
+//! 4. POSTs the batch and, on success, deletes the files it sent (both halves of a
+//!    joined flow, or the lone `.start`). If a flow's `.end` arrives after its
+//!    `.start` was already sent and deleted, it ships as its own record next pass.
+//!
+//! The submit is idempotent (the portal upserts by flow identity), so any
+//! ambiguous failure retries the whole batch. Response handling:
+//! - 202: delete the sent files.
+//! - 422: the portal already persisted the valid records and the listed ones are
+//!   permanently invalid, so log the body (to Sentry) and drop the batch.
+//! - 413: split the batch and retry each half.
+//! - 429: honor `Retry-After`, then retry the same batch.
+//! - 408 / 5xx / transport errors: exponential backoff, then retry; defer to the
+//!   next pass once the budget is spent (the files remain).
+//! - Other 4xx: permanent; log the status + body (to Sentry) and drop the batch.
+//!
+//! Uploads go through [`http_client::HttpClient`] over the caller's
+//! [`SocketFactory`], so they bypass the tunnel exactly like connlib's own traffic
+//! (Apple NE process exclusion, Android `protect()`, Linux/Windows routing). The
+//! client negotiates HTTP/2 and falls back to HTTP/1.1.
+//!
+//! Two drivers share this logic so parsing / CRC / request handling is not
+//! duplicated across platforms:
+//! - [`spawn`] runs a long-lived thread (gateway and desktop clients, whose tunnel
+//!   service is always running).
+//! - [`upload_once`] runs a single pass for platforms that drive uploads from a
+//!   provider-process / OS background task via FFI.
+//!
+//! [`prune`] removes expired / orphaned spool directories on startup so the spool
+//! cannot grow without bound.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::{
+    collections::BTreeMap,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context as _, Result};
+use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
+use base64::Engine as _;
+use bytes::Bytes;
+use flow_log_spool::{Payload, read_spooled_entry};
+use http::{StatusCode, header};
+use http_client::HttpClient;
+use serde::{Deserialize, Serialize};
+use socket_factory::{SocketFactory, TcpSocket};
+use url::Url;
+
+/// Default flows per upload when the portal doesn't specify one.
+const DEFAULT_BATCH_SIZE: usize = 1_000;
+/// Hard ceiling on flows per upload (matches the portal's per-request limit), so a
+/// misconfigured batch size can never produce a request the portal rejects.
+const MAX_BATCH_SIZE: usize = 10_000;
+/// Used instead of the portal's scan interval when a scan left a backlog (an
+/// authorization had more than one batch pending) so we drain it without falling
+/// behind.
+const CATCHUP_POLL: Duration = Duration::from_secs(1);
+/// How long to wait before re-checking config while uploads are unconfigured or
+/// disabled by the portal.
+const DISABLED_POLL: Duration = Duration::from_secs(30);
+/// Total time spent retrying one batch on transient failures before deferring it
+/// to the next scan.
+const MAX_UPLOAD_RETRY: Duration = Duration::from_secs(5 * 60);
+/// Path appended to the portal's base flow-log API URL to form the ingest endpoint.
+const INGEST_PATH: &str = "/ingestion/flow_logs";
+/// Name of the self-describing upload config file written into the spool root.
+const CONFIG_FILE: &str = "upload.json";
+
+/// The portal's flow-log upload config, persisted into the spool root so an uploader
+/// that runs independently of the session (a background task / daemon, or the
+/// service thread) can read it without a live connection to the portal.
+#[derive(Serialize, Deserialize)]
+struct UploadConfig {
+    /// Base URL flow logs are POSTed to.
+    api_url: String,
+    /// How often, in seconds, to upload batched flow logs. `0` disables uploads.
+    interval_secs: u64,
+    /// Maximum flows per upload request. `0` / absent uses [`DEFAULT_BATCH_SIZE`].
+    #[serde(default)]
+    batch_size: u64,
+}
+
+/// The resolved upload config: ingest endpoint, scan interval, and batch size.
+struct ResolvedConfig {
+    url: String,
+    interval: Duration,
+    batch_size: usize,
+}
+
+/// Persists the portal's flow-log upload config into the spool root. Called by the
+/// session, which alone receives it via `init`, so a session-independent uploader
+/// can read it. An `interval_secs` of `0` disables uploads; a `batch_size` of `0`
+/// falls back to [`DEFAULT_BATCH_SIZE`].
+pub fn write_upload_config(
+    spool_root: &Path,
+    api_url: &str,
+    interval_secs: u64,
+    batch_size: u64,
+) -> std::io::Result<()> {
+    create_dir_secure(spool_root)?;
+
+    let config = UploadConfig {
+        api_url: api_url.to_owned(),
+        interval_secs,
+        batch_size,
+    };
+    let body = serde_json::to_vec(&config).map_err(std::io::Error::other)?;
+
+    write_owner_only(&spool_root.join(CONFIG_FILE), &body)
+}
+
+/// Reads the persisted upload config. `None` when no (valid) config is present or
+/// uploads are disabled (interval `0`).
+fn read_upload_config(spool_root: &Path) -> Option<ResolvedConfig> {
+    let bytes = std::fs::read(spool_root.join(CONFIG_FILE)).ok()?;
+    let config: UploadConfig = serde_json::from_slice(&bytes).ok()?;
+
+    let url = ingest_endpoint(&config.api_url)?;
+    let interval = (config.interval_secs > 0).then(|| Duration::from_secs(config.interval_secs))?;
+    let batch_size = batch_size_or_default(config.batch_size);
+
+    Some(ResolvedConfig {
+        url,
+        interval,
+        batch_size,
+    })
+}
+
+/// Clamps the portal-provided batch size into `[1, MAX_BATCH_SIZE]`, defaulting when
+/// it is `0` / absent.
+fn batch_size_or_default(batch_size: u64) -> usize {
+    let batch_size = usize::try_from(batch_size).unwrap_or(MAX_BATCH_SIZE);
+
+    match batch_size {
+        0 => DEFAULT_BATCH_SIZE,
+        n => n.min(MAX_BATCH_SIZE),
+    }
+}
+
+/// Spawns the flow-log uploader thread for an always-running process (the gateway,
+/// the desktop tunnel service) or a provider process. The thread reads the spool's
+/// config file each pass, so it picks up whatever the session persisted via
+/// [`write_upload_config`], and uploads over `socket_factory` so it bypasses the
+/// tunnel. It runs until the process exits.
+pub fn spawn(
+    spool_root: PathBuf,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("flow-log-uploader".to_owned())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(e) => {
+                    tracing::error!("Failed to build flow-log uploader runtime: {e:#}");
+                    return;
+                }
+            };
+
+            runtime.block_on(run(&spool_root, socket_factory));
+        })
+        .expect("Failed to spawn flow-log uploader thread")
+}
+
+/// Runs a single upload pass: scans the spool once and uploads any pending flows,
+/// using the config persisted in the spool, over `socket_factory`. Intended for
+/// platforms that drive uploads from a short-lived OS background task / the
+/// provider process via FFI, so they can flush the spool independently of a
+/// long-running thread.
+///
+/// Returns `true` when a backlog remained (an authorization had more than one batch
+/// pending), so the caller may schedule another pass sooner.
+pub fn upload_once(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) -> bool {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::error!("Failed to build flow-log uploader runtime; skipping upload: {e:#}");
+            return false;
+        }
+    };
+
+    let Some(config) = read_upload_config(spool_root) else {
+        return false;
+    };
+
+    runtime.block_on(scan(spool_root, &config, socket_factory))
+}
+
+/// Removes spooled authorizations whose Bearer token has expired (their flows can
+/// no longer be authenticated to the ingest API) and orphaned directories that have
+/// no token at all (nothing in them can ever be uploaded). Call on startup, where it
+/// never races a writer, so the spool cannot grow without bound.
+pub fn prune(spool_root: &Path) {
+    let now = unix_now();
+
+    let Ok(role_dirs) = std::fs::read_dir(spool_root) else {
+        return;
+    };
+
+    for role_entry in role_dirs.flatten() {
+        let Ok(authz_dirs) = std::fs::read_dir(role_entry.path()) else {
+            continue; // not a directory, or unreadable
+        };
+
+        for entry in authz_dirs.flatten() {
+            let dir = entry.path();
+            if dir.is_dir() && should_prune(&dir, now) {
+                match std::fs::remove_dir_all(&dir) {
+                    Ok(()) => tracing::debug!(?dir, "Pruned stale flow-log spool directory"),
+                    Err(e) => tracing::warn!(?dir, "Failed to prune flow-log spool dir: {e:#}"),
+                }
+            }
+        }
+    }
+}
+
+/// Whether an authorization directory should be pruned.
+///
+/// A directory with no `token` file can never be uploaded (the Bearer token is the
+/// only credential), so it is a leftover orphan and is pruned immediately. Otherwise
+/// it is pruned once its token has expired. An undecodable token is kept, so a
+/// transient decode failure never deletes uploadable data.
+fn should_prune(dir: &Path, now: u64) -> bool {
+    let Ok(token) = std::fs::read_to_string(dir.join("token")) else {
+        return true;
+    };
+
+    token_expiry(&token).is_some_and(|exp| exp <= now)
+}
+
+/// Decodes the `exp` (unix seconds) claim from an ingest token's JWT payload
+/// without verifying its signature.
+fn token_expiry(token: &str) -> Option<u64> {
+    #[derive(Deserialize)]
+    struct Claims {
+        exp: u64,
+    }
+
+    let payload = token.split('.').nth(1)?;
+    let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+
+    serde_json::from_slice::<Claims>(&json).ok().map(|c| c.exp)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Writes `bytes` to `path`, restricting it to the owner (the spool holds Bearer
+/// tokens and the API URL).
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, bytes)?;
+    set_owner_only(path)
+}
+
+#[cfg(unix)]
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt as _;
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(path)
+}
+
+#[cfg(windows)]
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+    apply_sddl(path, DIR_SDDL)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)
+}
+
+#[cfg(unix)]
+fn set_owner_only(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(windows)]
+fn set_owner_only(path: &Path) -> std::io::Result<()> {
+    apply_sddl(path, FILE_SDDL)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn set_owner_only(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// The spool holds Bearer tokens, so on Windows every spool directory and file is
+/// locked down to `LocalSystem` and `BUILTIN\Administrators` (the accounts the
+/// Gateway / Tunnel service runs as), the equivalent of `0700`/`0600` on Unix.
+/// `OICI` on the directory ACEs makes children inherit the same access.
+#[cfg(windows)]
+const DIR_SDDL: &str = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)";
+#[cfg(windows)]
+const FILE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)";
+
+#[cfg(windows)]
+fn apply_sddl(path: &Path, sddl: &str) -> std::io::Result<()> {
+    windows_security::SecurityDescriptor::from_sddl(sddl)
+        .and_then(|descriptor| descriptor.apply_to_path(path))
+        .map_err(|e| std::io::Error::other(format!("{e:#}")))
+}
+
+/// Builds the full ingest endpoint from the portal's base URL, or `None` when the
+/// base URL is missing / invalid.
+fn ingest_endpoint(base_url: &str) -> Option<String> {
+    match Url::parse(base_url).and_then(|base| base.join(INGEST_PATH)) {
+        Ok(url) => Some(url.to_string()),
+        Err(e) => {
+            tracing::warn!(%base_url, "Invalid flow-log API URL; uploads disabled: {e}");
+            None
+        }
+    }
+}
+
+async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>>) {
+    tracing::info!("Flow-log uploader thread started");
+
+    loop {
+        match read_upload_config(spool_root) {
+            Some(config) => {
+                let backlog = scan(spool_root, &config, socket_factory.clone()).await;
+                tokio::time::sleep(if backlog {
+                    CATCHUP_POLL
+                } else {
+                    config.interval
+                })
+                .await;
+            }
+            // No config persisted yet, or uploads disabled by the portal: idle and
+            // re-check the config shortly.
+            None => tokio::time::sleep(DISABLED_POLL).await,
+        }
+    }
+}
+
+/// Opens a tunnel-bypassing HTTP client to the ingest host. Re-resolved on every
+/// scan, so a roamed / changed flow-api address is picked up without a restart.
+async fn connect(
+    ingest_url: &str,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> Result<HttpClient> {
+    let url = Url::parse(ingest_url).context("Invalid ingest URL")?;
+    let host = url.host_str().context("Ingest URL has no host")?.to_owned();
+
+    let addresses = tokio::net::lookup_host((host.as_str(), 443))
+        .await
+        .with_context(|| format!("Failed to resolve ingest host {host}"))?
+        .map(|addr| addr.ip())
+        .collect::<Vec<IpAddr>>();
+
+    anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
+
+    HttpClient::new(host, addresses, socket_factory)
+        .await
+        .context("Failed to connect to ingest host")
+}
+
+/// One flow to upload: the record to send and the files to delete once it lands.
+struct Pending {
+    payload: Payload,
+    files: Vec<PathBuf>,
+}
+
+/// The on-disk `.start`/`.end` files discovered for one flow identity.
+#[derive(Default)]
+struct FlowFiles {
+    start: Option<PathBuf>,
+    end: Option<PathBuf>,
+    mtime: Option<SystemTime>,
+}
+
+/// Processes every authorization directory once; returns whether any directory
+/// still has a backlog (more than one batch pending) that warrants a quick rescan.
+///
+/// The spool nests authorization directories one level under a `<role>` directory
+/// (`<root>/<role>/<policy_authorization_id>/`), so this walks both levels.
+async fn scan(
+    root: &Path,
+    config: &ResolvedConfig,
+    socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
+) -> bool {
+    let client = match connect(&config.url, socket_factory).await {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::debug!("Failed to open flow-log ingest connection: {e:#}");
+            return false;
+        }
+    };
+
+    let Ok(role_dirs) = std::fs::read_dir(root) else {
+        return false;
+    };
+
+    let mut backlog = false;
+    for role_entry in role_dirs.flatten() {
+        let role_dir = role_entry.path();
+        let Ok(authz_dirs) = std::fs::read_dir(&role_dir) else {
+            continue; // not a directory, or unreadable
+        };
+
+        for entry in authz_dirs.flatten() {
+            let dir = entry.path();
+            if !dir.is_dir() {
+                continue;
+            }
+
+            // The connection died (e.g. roam); the next scan re-resolves and reconnects.
+            if client.is_closed() {
+                return backlog;
+            }
+
+            backlog |= process_authz_dir(&client, &dir, &config.url, config.batch_size).await;
+        }
+    }
+    backlog
+}
+
+/// Reads up to `batch_size` flows from one authorization's spool (oldest first),
+/// joins each into a record, and uploads them. Returns whether more than one batch
+/// was pending (a backlog), so the caller can rescan promptly.
+async fn process_authz_dir(client: &HttpClient, dir: &Path, url: &str, batch_size: usize) -> bool {
+    let token = match std::fs::read_to_string(dir.join("token")) {
+        Ok(token) => token,
+        // No token yet (or it was removed): nothing we can upload for this dir.
+        Err(_) => return false,
+    };
+
+    let mut flows = match group_flows(dir) {
+        Ok(flows) => flows,
+        Err(e) => {
+            tracing::warn!(?dir, "Failed to list flow-log spool directory: {e:#}");
+            return false;
+        }
+    };
+
+    // Oldest flows first, bounded to one request's worth.
+    flows.sort_by_key(|files| files.mtime.unwrap_or(SystemTime::UNIX_EPOCH));
+    let backlog = flows.len() > batch_size;
+    flows.truncate(batch_size);
+
+    let batch = flows.into_iter().filter_map(load_flow).collect::<Vec<_>>();
+    if batch.is_empty() {
+        return false;
+    }
+
+    submit(client, url, &token, &batch).await;
+    backlog
+}
+
+/// Groups a directory's `.start`/`.end` report files by their flow-identity stem.
+fn group_flows(dir: &Path) -> std::io::Result<Vec<FlowFiles>> {
+    let mut flows = BTreeMap::<String, FlowFiles>::new();
+
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        let (stem, is_end) = if let Some(stem) = name.strip_suffix(".end.json") {
+            (stem, true)
+        } else if let Some(stem) = name.strip_suffix(".start.json") {
+            (stem, false)
+        } else {
+            continue; // the `token` file or anything unexpected
+        };
+
+        let mtime = entry.metadata()?.modified().ok();
+        let flow = flows.entry(stem.to_owned()).or_default();
+        if is_end {
+            flow.end = Some(path);
+        } else {
+            flow.start = Some(path);
+        }
+        flow.mtime = [flow.mtime, mtime].into_iter().flatten().min();
+    }
+
+    Ok(flows.into_values().collect())
+}
+
+/// Loads one flow into a [`Pending`], preferring the self-describing `.end`.
+/// Corrupt files are reported and deleted; a flow with no readable report yields
+/// `None`.
+fn load_flow(files: FlowFiles) -> Option<Pending> {
+    // Prefer the self-describing `.end`; if it is missing or corrupt (and thus
+    // deleted by `read_report`), fall back to the `.start`.
+    if let Some(end) = &files.end
+        && let Some(payload) = read_report(end)
+    {
+        let mut to_delete = vec![end.clone()];
+        to_delete.extend(files.start);
+        return Some(Pending {
+            payload,
+            files: to_delete,
+        });
+    }
+
+    let start = files.start?;
+    let payload = read_report(&start)?;
+    Some(Pending {
+        payload,
+        files: vec![start],
+    })
+}
+
+/// Reads and verifies one report. A corrupt report is reported and deleted (it can
+/// never be uploaded); a transient read error is left for the next scan.
+fn read_report(path: &Path) -> Option<Payload> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(?path, "Failed to read flow-log report: {e:#}");
+            return None;
+        }
+    };
+
+    match read_spooled_entry(&bytes) {
+        Ok(payload) => Some(payload),
+        Err(e) => {
+            tracing::error!(?path, "Corrupt flow-log report, deleting: {e}");
+            let _ = std::fs::remove_file(path);
+            None
+        }
+    }
+}
+
+/// Submits one batch with response-specific handling. Idempotent, so transient
+/// failures retry the whole batch.
+async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) {
+    if batch.is_empty() {
+        return;
+    }
+
+    let payloads = batch.iter().map(|flow| &flow.payload).collect::<Vec<_>>();
+    let body = match serde_json::to_vec(&Batch {
+        flow_logs: &payloads,
+    }) {
+        Ok(body) => Bytes::from(body),
+        Err(e) => {
+            tracing::error!("Failed to serialize flow-log batch: {e:#}");
+            return;
+        }
+    };
+
+    let mut backoff = upload_backoff();
+
+    loop {
+        let response = match send(client, url, token, body.clone()).await {
+            Ok(response) => response,
+            Err(e) => {
+                tracing::warn!("Flow-log upload request failed: {e:#}");
+                // A closed connection won't recover by retrying; defer to the next scan.
+                if client.is_closed() || !sleep_backoff(&mut backoff).await {
+                    return; // the files remain on disk
+                }
+                continue;
+            }
+        };
+
+        let status = response.status();
+        match status {
+            StatusCode::ACCEPTED => {
+                delete_all(batch);
+                return;
+            }
+            StatusCode::UNPROCESSABLE_ENTITY => {
+                // The portal persisted the valid records and the listed ones are
+                // permanently invalid, so log and drop the whole batch.
+                let body = body_string(&response);
+                tracing::error!(%body, "Flow-log batch had validation errors; dropping batch");
+                delete_all(batch);
+                return;
+            }
+            StatusCode::PAYLOAD_TOO_LARGE => {
+                partition(client, url, token, batch).await;
+                return;
+            }
+            StatusCode::TOO_MANY_REQUESTS => {
+                let wait = retry_after(&response).unwrap_or(CATCHUP_POLL);
+                tracing::debug!(?wait, "Flow-log upload rate-limited; waiting");
+                tokio::time::sleep(wait).await;
+                // Not a failure; keep retrying the same batch without spending the budget.
+            }
+            StatusCode::REQUEST_TIMEOUT => {
+                if !sleep_backoff(&mut backoff).await {
+                    return;
+                }
+            }
+            _ if status.is_server_error() => {
+                tracing::debug!(%status, "Flow-log upload server error; backing off");
+                if !sleep_backoff(&mut backoff).await {
+                    return;
+                }
+            }
+            _ => {
+                // Other 4xx (400/401/403/...): permanent. Report and drop.
+                let body = body_string(&response);
+                tracing::error!(%status, %body, "Flow-log upload rejected; dropping batch");
+                delete_all(batch);
+                return;
+            }
+        }
+    }
+}
+
+/// Sends one batch and reads the full response.
+async fn send(
+    client: &HttpClient,
+    url: &str,
+    token: &str,
+    body: Bytes,
+) -> Result<http::Response<Bytes>> {
+    let request = http::Request::builder()
+        .method(http::Method::POST)
+        .uri(url)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .context("Failed to build flow-log request")?;
+
+    client.send_request(request)?.await
+}
+
+fn body_string(response: &http::Response<Bytes>) -> String {
+    String::from_utf8_lossy(response.body()).into_owned()
+}
+
+/// Splits an over-sized batch in half and submits each (req: partition-and-retry).
+async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) {
+    if batch.len() <= 1 {
+        tracing::error!("A single flow exceeds the upload size limit; dropping");
+        delete_all(batch);
+        return;
+    }
+
+    let mid = batch.len() / 2;
+    Box::pin(submit(client, url, token, &batch[..mid])).await;
+    Box::pin(submit(client, url, token, &batch[mid..])).await;
+}
+
+fn delete_all(batch: &[Pending]) {
+    for flow in batch {
+        for path in &flow.files {
+            if let Err(e) = std::fs::remove_file(path) {
+                tracing::warn!(?path, "Failed to delete uploaded flow-log report: {e:#}");
+            }
+        }
+    }
+}
+
+fn retry_after(response: &http::Response<Bytes>) -> Option<Duration> {
+    let seconds = response
+        .headers()
+        .get(header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .parse::<u64>()
+        .ok()?;
+
+    Some(Duration::from_secs(seconds))
+}
+
+fn upload_backoff() -> ExponentialBackoff {
+    ExponentialBackoffBuilder::default()
+        .with_max_interval(Duration::from_secs(60))
+        .with_max_elapsed_time(Some(MAX_UPLOAD_RETRY))
+        .build()
+}
+
+/// Sleeps for the next backoff interval; returns `false` once the budget is spent.
+async fn sleep_backoff(backoff: &mut ExponentialBackoff) -> bool {
+    match backoff.next_backoff() {
+        Some(interval) => {
+            tokio::time::sleep(interval).await;
+            true
+        }
+        None => false,
+    }
+}
+
+#[derive(Serialize)]
+struct Batch<'a> {
+    flow_logs: &'a [&'a Payload],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token_expiring_at(exp: u64) -> String {
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+
+        format!("header.{payload}.signature")
+    }
+
+    #[test]
+    fn write_then_read_config_builds_ingest_endpoint_interval_and_batch_size() {
+        let root = tempfile::tempdir().unwrap();
+        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 90, 500).unwrap();
+
+        let config = read_upload_config(root.path()).expect("config present");
+        assert_eq!(
+            config.url,
+            "https://flow-api.firezone.dev/ingestion/flow_logs"
+        );
+        assert_eq!(config.interval, Duration::from_secs(90));
+        assert_eq!(config.batch_size, 500);
+    }
+
+    #[test]
+    fn zero_or_missing_batch_size_uses_default() {
+        let root = tempfile::tempdir().unwrap();
+        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 60, 0).unwrap();
+
+        let config = read_upload_config(root.path()).expect("config present");
+        assert_eq!(config.batch_size, DEFAULT_BATCH_SIZE);
+    }
+
+    #[test]
+    fn batch_size_is_clamped_to_max() {
+        assert_eq!(batch_size_or_default(1_000_000), MAX_BATCH_SIZE);
+    }
+
+    #[test]
+    fn zero_interval_disables_uploads() {
+        let root = tempfile::tempdir().unwrap();
+        write_upload_config(root.path(), "https://flow-api.firezone.dev/", 0, 1000).unwrap();
+
+        assert!(read_upload_config(root.path()).is_none());
+    }
+
+    #[test]
+    fn invalid_url_disables_uploads() {
+        let root = tempfile::tempdir().unwrap();
+        write_upload_config(root.path(), "not a url", 60, 1000).unwrap();
+
+        assert!(read_upload_config(root.path()).is_none());
+    }
+
+    #[test]
+    fn missing_config_disables_uploads() {
+        let root = tempfile::tempdir().unwrap();
+
+        assert!(read_upload_config(root.path()).is_none());
+    }
+
+    #[test]
+    fn token_expiry_reads_exp_claim() {
+        assert_eq!(
+            token_expiry(&token_expiring_at(1_700_000_000)),
+            Some(1_700_000_000)
+        );
+        assert_eq!(token_expiry("not-a-jwt"), None);
+    }
+
+    #[test]
+    fn prune_removes_expired_authz_dirs_and_keeps_valid() {
+        let root = tempfile::tempdir().unwrap();
+        let now = unix_now();
+
+        let expired = root.path().join("responder").join("expired-pa");
+        std::fs::create_dir_all(&expired).unwrap();
+        std::fs::write(expired.join("token"), token_expiring_at(now - 60)).unwrap();
+        std::fs::write(expired.join("a.start.json"), "{}").unwrap();
+
+        let valid = root.path().join("responder").join("valid-pa");
+        std::fs::create_dir_all(&valid).unwrap();
+        std::fs::write(valid.join("token"), token_expiring_at(now + 3600)).unwrap();
+
+        // No token: can never be uploaded, so pruned immediately (no grace period).
+        let orphan = root.path().join("responder").join("orphan-pa");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join("a.start.json"), "{}").unwrap();
+
+        prune(root.path());
+
+        assert!(
+            !expired.exists(),
+            "expired authorization dir should be pruned"
+        );
+        assert!(valid.exists(), "unexpired authorization dir should be kept");
+        assert!(
+            !orphan.exists(),
+            "token-less authorization dir should be pruned"
+        );
+    }
+}

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -184,6 +184,9 @@ async fn load_upload_config(spool_root: &Path) -> Option<UploadConfig> {
 }
 
 /// Runs `f` on the blocking pool, so disk IO never stalls the runtime.
+///
+/// Used instead of `tokio::fs`, which dispatches per syscall: a pass makes
+/// hundreds of small fs calls, so each phase does one hop as a whole.
 async fn blocking<T, F>(f: F) -> Option<T>
 where
     F: FnOnce() -> T + Send + 'static,

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! The submit is idempotent (the portal upserts by flow identity), so any
 //! ambiguous failure retries the whole batch. Response handling:
-//! - 202: delete the sent files.
+//! - 2xx: delete the sent files.
 //! - 422: the portal already persisted the valid records and the listed ones are
 //!   permanently invalid, so log the body (to Sentry) and drop the batch.
 //! - 413: split the batch and retry each half.
@@ -28,9 +28,8 @@
 //! - Other 4xx: permanent; log the status + body (to Sentry) and drop the batch.
 //!
 //! Uploads go through [`http_client::HttpClient`] over the caller's
-//! [`SocketFactory`], so they bypass the tunnel exactly like connlib's own traffic
-//! (Apple NE process exclusion, Android `protect()`, Linux/Windows routing). The
-//! client negotiates HTTP/2 and falls back to HTTP/1.1.
+//! [`SocketFactory`], so they bypass the tunnel exactly like connlib's own traffic.
+//! The client negotiates HTTP/2 and falls back to HTTP/1.1.
 //!
 //! Two drivers share this logic so parsing / CRC / request handling is not
 //! duplicated across platforms:
@@ -221,7 +220,7 @@ pub fn prune(spool_root: &Path) {
 
     for role_entry in role_dirs.flatten() {
         let Ok(authz_dirs) = std::fs::read_dir(role_entry.path()) else {
-            continue; // not a directory, or unreadable
+            continue;
         };
 
         for entry in authz_dirs.flatten() {
@@ -428,7 +427,7 @@ async fn scan(
     for role_entry in role_dirs.flatten() {
         let role_dir = role_entry.path();
         let Ok(authz_dirs) = std::fs::read_dir(&role_dir) else {
-            continue; // not a directory, or unreadable
+            continue;
         };
 
         for entry in authz_dirs.flatten() {
@@ -466,7 +465,6 @@ async fn process_authz_dir(client: &HttpClient, dir: &Path, url: &str, batch_siz
         }
     };
 
-    // Oldest flows first, bounded to one request's worth.
     flows.sort_by_key(|files| files.mtime.unwrap_or(SystemTime::UNIX_EPOCH));
     let backlog = flows.len() > batch_size;
     flows.truncate(batch_size);
@@ -496,7 +494,7 @@ fn group_flows(dir: &Path) -> std::io::Result<Vec<FlowFiles>> {
         } else if let Some(stem) = name.strip_suffix(".start.json") {
             (stem, false)
         } else {
-            continue; // the `token` file or anything unexpected
+            continue;
         };
 
         let mtime = entry.metadata()?.modified().ok();
@@ -593,13 +591,11 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
 
         let status = response.status();
         match status {
-            StatusCode::ACCEPTED => {
+            _ if status.is_success() => {
                 delete_all(batch);
                 return;
             }
             StatusCode::UNPROCESSABLE_ENTITY => {
-                // The portal persisted the valid records and the listed ones are
-                // permanently invalid, so log and drop the whole batch.
                 let body = body_string(&response);
                 tracing::error!(%body, "Flow-log batch had validation errors; dropping batch");
                 delete_all(batch);
@@ -627,7 +623,6 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
                 }
             }
             _ => {
-                // Other 4xx (400/401/403/...): permanent. Report and drop.
                 let body = body_string(&response);
                 tracing::error!(%status, %body, "Flow-log upload rejected; dropping batch");
                 delete_all(batch);

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -3,44 +3,20 @@
 //! The spool, written by `tunnel::FlowLogWriter`, nests one directory per
 //! authorization under a role directory:
 //! `<root>/<role>/<policy_authorization_id>/`. Each holds that authorization's
-//! Bearer `token` plus per-flow reports split into `<flow_identity>.start.json`
-//! (open) and `<flow_identity>.end.json` (completed) files. For each authorization
-//! an upload pass:
+//! Bearer `token` plus per-flow reports: `<flow_identity>.start.json` (open) and
+//! `<flow_identity>.end.json` (completed). Each pass uploads one batch per
+//! authorization over the caller's tunnel-bypassing [`SocketFactory`] and deletes
+//! what it sent; submits are idempotent (the portal upserts by flow identity), so
+//! ambiguous failures retry the whole batch.
 //!
-//! 1. reads the `token`,
-//! 2. lists its report files oldest-first (up to the configured batch size),
-//!    skipping a `.start` whose `.end` is already on disk: the `.end` is
-//!    self-describing and supersedes it,
-//! 3. POSTs the batch and, on success, deletes the files it sent (a shipped `.end`
-//!    deletes its `.start` too). If a flow's `.end` arrives after its `.start` was
-//!    already sent and deleted, it ships as its own record next pass.
-//!
-//! The submit is idempotent (the portal upserts by flow identity), so any
-//! ambiguous failure retries the whole batch. Response handling:
-//! - 2xx: delete the sent files.
-//! - 422: the portal already persisted the valid records and the listed ones are
-//!   permanently invalid, so log the body and drop the batch.
-//! - 413: split the batch and retry each half.
-//! - 429: honor `Retry-After`, then retry the same batch.
-//! - 408 / 5xx / transport errors: exponential backoff, then retry; defer to the
-//!   next pass once the budget is spent (the files remain).
-//! - Other 4xx: permanent; log the status + body and drop the batch.
-//!
-//! Uploads go through [`http_client::HttpClient`] over the caller's
-//! [`SocketFactory`], so they bypass the tunnel exactly like connlib's own traffic.
-//!
-//! Two drivers share this logic so parsing / CRC / request handling is not
-//! duplicated across platforms:
+//! Two drivers share this logic:
 //! - [`spawn`] runs a long-lived thread (gateway and desktop clients, whose tunnel
 //!   service is always running).
-//! - [`upload_once`] runs a single pass for platforms that drive uploads from a
-//!   provider-process / OS background task via FFI.
+//! - [`upload_once`] runs a single pass for platforms that drive uploads from an
+//!   OS background task via FFI.
 //!
 //! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
 //! driver shares their runtime, so stalling it would starve the connection.
-//!
-//! [`prune`] removes expired / orphaned spool directories on startup so the spool
-//! cannot grow without bound.
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
@@ -64,34 +40,24 @@ use url::Url;
 
 /// Default flows per upload when the portal doesn't specify one.
 const DEFAULT_BATCH_SIZE: usize = 1_000;
-/// Hard ceiling on flows per upload (matches the portal's per-request limit), so a
-/// misconfigured batch size can never produce a request the portal rejects.
+/// Hard ceiling on flows per upload (the portal's per-request limit).
 const MAX_BATCH_SIZE: usize = 10_000;
-/// Used instead of the portal's scan interval when a scan left a backlog (an
-/// authorization had more than one batch pending) so we drain it without falling
-/// behind.
+/// Poll used instead of the configured interval while a backlog remains.
 const CATCHUP_POLL: Duration = Duration::from_secs(1);
-/// How long to wait before re-checking config while uploads are unconfigured or
-/// disabled by the portal.
+/// How often to re-check config while uploads are unconfigured or disabled.
 const DISABLED_POLL: Duration = Duration::from_secs(30);
 /// Total time spent retrying one batch on transient failures before deferring it
-/// to the next scan.
+/// to the next pass.
 const MAX_UPLOAD_RETRY: Duration = Duration::from_secs(5 * 60);
-/// Path appended to the portal's base flow-log API URL to form the ingest endpoint.
 const INGEST_PATH: &str = "/ingestion/flow_logs";
-/// Name of the self-describing upload config file written into the spool root.
 const CONFIG_FILE: &str = "upload.json";
-/// Suffix of an "open" flow report (see `tunnel::FlowLogWriter`).
 const START_SUFFIX: &str = ".start.json";
-/// Suffix of a "completed" flow report.
 const END_SUFFIX: &str = ".end.json";
 
-/// The portal's flow-log upload config, persisted into the spool root so an uploader
-/// that runs independently of the session (a background task / daemon, or the
-/// service thread) can read it without a live connection to the portal.
+/// The portal's upload config, persisted into the spool root so an uploader that
+/// runs independently of the session can read it.
 ///
-/// Only written while uploads are enabled: an `interval` of `0` is never persisted
-/// (see [`configure_uploads`]), so the file's presence alone means "enabled".
+/// Only present while uploads are enabled (see [`configure_uploads`]).
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 struct UploadConfig {
@@ -109,11 +75,10 @@ fn default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE
 }
 
-/// Sets the upload config persisted in the spool root. Called by the session, which
-/// alone receives it via `init`, so a session-independent uploader can read it.
+/// Persists the portal's upload config into the spool root.
 ///
-/// An `interval_secs` of `0` means the portal disabled uploads: the persisted config
-/// is removed so a running uploader stops, rather than keeping the last one.
+/// An `interval_secs` of `0` means uploads are disabled: any persisted config is
+/// removed so a running uploader stops.
 pub fn configure_uploads(
     spool_root: &Path,
     api_url: &str,
@@ -143,11 +108,8 @@ pub fn configure_uploads(
     Ok(())
 }
 
-/// Spawns the flow-log uploader thread for an always-running process (the gateway,
-/// the desktop tunnel service) or a provider process. The thread reads the spool's
-/// config file each pass, so it picks up whatever the session persisted via
-/// [`configure_uploads`], and uploads over `socket_factory` so it bypasses the
-/// tunnel. It runs until the process exits.
+/// Spawns the long-lived uploader thread. It re-reads the persisted config each
+/// pass and runs until the process exits.
 pub fn spawn(
     spool_root: PathBuf,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -171,14 +133,11 @@ pub fn spawn(
         .expect("Failed to spawn flow-log uploader thread")
 }
 
-/// Runs a single upload pass: scans the spool once and uploads any pending flows,
-/// using the config persisted in the spool, over `socket_factory`. Intended for
-/// platforms that drive uploads from a short-lived OS background task / the
-/// provider process via FFI, so they can flush the spool independently of a
-/// long-running thread. The caller owns the runtime this runs on.
+/// Runs a single upload pass on the caller's runtime, for platforms that drive
+/// uploads from an OS background task via FFI.
 ///
-/// Returns `true` when a backlog remained (an authorization had more than one batch
-/// pending), so the caller may schedule another pass sooner.
+/// Returns `true` when a backlog remained, so the caller may schedule another pass
+/// sooner.
 pub async fn upload_once(
     spool_root: &Path,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -190,13 +149,11 @@ pub async fn upload_once(
     upload_pending(spool_root, &config, socket_factory).await
 }
 
-/// Removes spooled authorizations whose Bearer token has expired (their flows can
-/// no longer be authenticated to the ingest API) and orphaned directories that have
-/// no token at all (nothing in them can ever be uploaded). Call on startup, where it
-/// never races a writer, so the spool cannot grow without bound.
+/// Removes authorization directories whose token has expired or is missing, since
+/// nothing in them can ever be uploaded. Call on startup, where it never races a
+/// writer, so the spool cannot grow without bound.
 ///
-/// Does blocking IO: call it off any async runtime, or wrap it in
-/// [`tokio::task::spawn_blocking`].
+/// Does blocking IO: call it off any async runtime.
 pub fn prune(spool_root: &Path) {
     let now = unix_now();
 
@@ -241,8 +198,6 @@ where
     }
 }
 
-/// Clamps the portal-provided batch size into `[1, MAX_BATCH_SIZE]`, defaulting when
-/// it is `0`.
 fn clamp_batch_size(batch_size: u64) -> usize {
     match usize::try_from(batch_size).unwrap_or(MAX_BATCH_SIZE) {
         0 => DEFAULT_BATCH_SIZE,
@@ -250,11 +205,7 @@ fn clamp_batch_size(batch_size: u64) -> usize {
     }
 }
 
-/// Whether an authorization directory should be pruned.
-///
-/// A directory with no `token` file can never be uploaded (the Bearer token is the
-/// only credential), so it is a leftover orphan and is pruned immediately. Otherwise
-/// it is pruned once its token has expired. An undecodable token is kept, so a
+/// A missing token is pruned immediately; an undecodable one is kept, so a
 /// transient decode failure never deletes uploadable data.
 fn should_prune(dir: &Path, now: u64) -> bool {
     let Ok(token) = std::fs::read_to_string(dir.join("token")) else {
@@ -287,8 +238,8 @@ fn unix_now() -> u64 {
         .unwrap_or(0)
 }
 
-/// Writes `bytes` to `path`, restricting it to the owner (the spool holds Bearer
-/// tokens and the API URL).
+/// Writes `bytes` to `path`, readable only by the owner (the spool holds Bearer
+/// tokens).
 fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     std::fs::write(path, bytes)?;
     set_owner_only(path)
@@ -304,10 +255,9 @@ fn create_dir_secure(path: &Path) -> std::io::Result<()> {
         .create(path)
 }
 
-/// The spool holds Bearer tokens, so on Windows every spool directory is locked
-/// down to `LocalSystem` and `BUILTIN\Administrators` (the accounts the Gateway /
-/// Tunnel service runs as), the equivalent of `0700` on Unix. The directory ACEs
-/// inherit, so children get the same access.
+/// Locks the directory down to `LocalSystem` and `BUILTIN\Administrators` (the
+/// service accounts), the equivalent of `0700` on Unix; the ACEs inherit to
+/// children.
 #[cfg(windows)]
 fn create_dir_secure(path: &Path) -> std::io::Result<()> {
     use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
@@ -357,8 +307,6 @@ fn apply_dacl(path: &Path, dacl: &windows_security::pipe_dacl::PipeDacl) -> std:
         .map_err(|e| std::io::Error::other(format!("{e:#}")))
 }
 
-/// Builds the full ingest endpoint from the portal's base URL, or `None` when the
-/// base URL is missing / invalid.
 fn ingest_endpoint(base_url: &str) -> Option<String> {
     match Url::parse(base_url).and_then(|base| base.join(INGEST_PATH)) {
         Ok(url) => Some(url.to_string()),
@@ -381,8 +329,6 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
                     config.interval
                 }
             }
-            // No config persisted yet, or uploads disabled by the portal: idle and
-            // re-check the config shortly.
             None => DISABLED_POLL,
         };
 
@@ -390,13 +336,11 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
     }
 }
 
-/// Opens a tunnel-bypassing HTTP client to the ingest host. Re-resolved on every
-/// scan, so a roamed / changed flow-api address is picked up without a restart.
+/// Opens a tunnel-bypassing HTTP client to the ingest host, re-resolved each pass
+/// so address changes are picked up.
 ///
-/// Resolution goes through [`telemetry::resolve_ingest_host`] so that, like
-/// telemetry, it uses connlib's captured upstream resolvers while a session is
-/// active rather than `getaddrinfo`, which would loop back through connlib's
-/// hijacked system resolver.
+/// Resolution goes through [`telemetry::resolve_ingest_host`]: while a session owns
+/// the system resolver, `getaddrinfo` would loop back through connlib.
 async fn connect(
     ingest_url: &str,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -420,8 +364,7 @@ struct Pending {
 /// Uploads one batch of pending flows per authorization directory.
 ///
 /// Returns whether a backlog remains: an authorization had more than one batch
-/// pending, or the connection dropped before the pass finished. The caller can then
-/// schedule the next pass promptly instead of waiting the configured interval.
+/// pending, or the connection dropped before the pass finished.
 async fn upload_pending(
     root: &Path,
     config: &UploadConfig,
@@ -448,8 +391,7 @@ async fn upload_pending(
     let mut backlog = false;
 
     for dir in dirs.unwrap_or_default() {
-        // The connection died (e.g. roam) before we finished; the next pass
-        // re-resolves, reconnects, and drains the rest.
+        // The connection died (e.g. roam); the next pass reconnects and drains the rest.
         if client.is_closed() {
             return true;
         }
@@ -498,7 +440,7 @@ async fn upload_authz_batch(
 /// `None` when there is nothing to upload. The `bool` reports whether more than one
 /// batch was pending.
 fn collect_batch(dir: &Path, batch_size: usize) -> Option<(String, Vec<Pending>, bool)> {
-    // No token yet (or it was removed): nothing we can upload for this dir.
+    // No token yet: nothing can be uploaded.
     let token = std::fs::read_to_string(dir.join("token")).ok()?;
 
     let files = match report_files(dir) {
@@ -559,10 +501,8 @@ fn report_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
 
 /// Loads the flow reported at `path` into a [`Pending`] upload.
 ///
-/// A `.start` whose `.end` is already on disk yields `None`: the `.end` is
-/// self-describing and supersedes it, so only the `.end` ships (deleting both files
-/// once it lands). A corrupt report is deleted by [`read_report`] and yields `None`;
-/// a superseded `.start` then ships on a later pass.
+/// A `.start` whose `.end` is on disk yields `None`: the `.end` is self-describing
+/// and supersedes it, deleting both files when it ships.
 fn load_flow(path: &Path) -> Option<Pending> {
     let name = path.file_name()?.to_str()?;
 
@@ -589,8 +529,8 @@ fn load_flow(path: &Path) -> Option<Pending> {
     })
 }
 
-/// Reads and verifies one report. A corrupt report is reported and deleted (it can
-/// never be uploaded); a transient read error is left for the next scan.
+/// Reads and verifies one report. A corrupt report is deleted (it can never be
+/// uploaded); a transient read error is left for the next pass.
 fn read_report(path: &Path) -> Option<Payload> {
     let bytes = match std::fs::read(path) {
         Ok(bytes) => bytes,
@@ -635,7 +575,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
             Ok(response) => response,
             Err(e) => {
                 tracing::info!("Flow-log upload request failed: {e:#}");
-                // A closed connection won't recover by retrying; defer to the next scan.
+                // A closed connection won't recover by retrying; defer to the next pass.
                 if client.is_closed() || !sleep_backoff(&mut backoff).await {
                     return; // the files remain on disk
                 }
@@ -702,7 +642,6 @@ fn classify_response(status: StatusCode) -> ResponseAction {
     }
 }
 
-/// Sends one batch and reads the full response.
 async fn send(
     client: &HttpClient,
     url: &str,
@@ -724,7 +663,7 @@ fn body_string(response: &http::Response<Bytes>) -> String {
     String::from_utf8_lossy(response.body()).into_owned()
 }
 
-/// Splits an over-sized batch in half and submits each (req: partition-and-retry).
+/// Splits an over-sized batch in half and submits each.
 async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) {
     if batch.len() <= 1 {
         tracing::error!("A single flow exceeds the upload size limit; dropping");

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -3,8 +3,10 @@
 //! The spool, written by `tunnel::FlowLogWriter`, nests one directory per
 //! authorization under a role directory:
 //! `<root>/<role>/<policy_authorization_id>/`. Each holds that authorization's
-//! Bearer `token` plus per-flow reports: `<flow_identity>.start.json` (open) and
-//! `<flow_identity>.end.json` (completed). Each pass uploads one batch per
+//! Bearer `token` plus per-flow reports: `<flow_start>-<flow_identity>.start.json`
+//! (open) and `<flow_start>-<flow_identity>.end.json` (completed), where
+//! `<flow_start>` is the flow's start time as zero-padded unix seconds, so lexical
+//! name order is oldest-first. Each pass uploads one batch per
 //! authorization over the caller's tunnel-bypassing [`SocketFactory`] and deletes
 //! what it sent; submits are idempotent (the portal upserts by flow identity), so
 //! ambiguous failures retry the whole batch.
@@ -475,14 +477,13 @@ fn collect_batch(dir: &Path, batch_size: usize) -> Option<(String, Vec<Pending>,
 
 /// Lists a directory's report files, oldest first.
 ///
-/// Directory iteration order is unspecified and report names are flow-identity
-/// hashes, so the ordering has to come from mtimes.
+/// Report names start with the flow's zero-padded start timestamp and `read_dir`
+/// order is unspecified, so a lexical sort of the names yields oldest-first.
 fn report_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();
 
     for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
+        let path = entry?.path();
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
@@ -490,16 +491,12 @@ fn report_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
             continue;
         }
 
-        let mtime = entry
-            .metadata()?
-            .modified()
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-        files.push((mtime, path));
+        files.push(path);
     }
 
     files.sort();
 
-    Ok(files.into_iter().map(|(_, path)| path).collect())
+    Ok(files)
 }
 
 /// Loads the flow reported at `path` into a [`Pending`] upload.
@@ -769,15 +766,6 @@ mod tests {
         std::fs::write(path, flow_log_spool::serialize(&payload).unwrap()).unwrap();
     }
 
-    fn set_mtime(path: &Path, mtime: SystemTime) {
-        std::fs::File::options()
-            .write(true)
-            .open(path)
-            .unwrap()
-            .set_modified(mtime)
-            .unwrap();
-    }
-
     #[test]
     fn configure_then_read_config_roundtrips() {
         let root = tempfile::tempdir().unwrap();
@@ -904,13 +892,14 @@ mod tests {
     #[test]
     fn report_files_lists_oldest_first_and_skips_the_token() {
         let dir = tempfile::tempdir().unwrap();
-        let now = SystemTime::now();
 
         std::fs::write(dir.path().join("token"), "a-token").unwrap();
-        for (name, age_secs) in [("b.start.json", 10), ("a.end.json", 30), ("c.end.json", 20)] {
-            let path = dir.path().join(name);
-            std::fs::write(&path, "{}").unwrap();
-            set_mtime(&path, now - Duration::from_secs(age_secs));
+        for name in [
+            "1700000030-bbb.start.json",
+            "1700000010-aaa.end.json",
+            "1700000020-ccc.end.json",
+        ] {
+            std::fs::write(dir.path().join(name), "{}").unwrap();
         }
 
         let files = report_files(dir.path()).unwrap();
@@ -919,7 +908,14 @@ mod tests {
             .map(|path| path.file_name().unwrap().to_str().unwrap())
             .collect::<Vec<_>>();
 
-        assert_eq!(names, ["a.end.json", "c.end.json", "b.start.json"]);
+        assert_eq!(
+            names,
+            [
+                "1700000010-aaa.end.json",
+                "1700000020-ccc.end.json",
+                "1700000030-bbb.start.json"
+            ]
+        );
     }
 
     #[test]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -286,10 +286,21 @@ fn create_dir_secure(path: &Path) -> std::io::Result<()> {
         .create(path)
 }
 
+/// The spool holds Bearer tokens, so on Windows every spool directory is locked
+/// down to `LocalSystem` and `BUILTIN\Administrators` (the accounts the Gateway /
+/// Tunnel service runs as), the equivalent of `0700` on Unix. The directory ACEs
+/// inherit, so children get the same access.
 #[cfg(windows)]
 fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
+
     std::fs::create_dir_all(path)?;
-    apply_sddl(path, DIR_SDDL)
+
+    let dacl = PipeDacl::new()
+        .allow_inheriting(FileRights::FullAccess, Trustee::local_system())
+        .allow_inheriting(FileRights::FullAccess, Trustee::builtin_administrators());
+
+    apply_dacl(path, &dacl)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -304,9 +315,16 @@ fn set_owner_only(path: &Path) -> std::io::Result<()> {
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
 }
 
+/// The equivalent of `0600` on Unix (see [`create_dir_secure`]).
 #[cfg(windows)]
 fn set_owner_only(path: &Path) -> std::io::Result<()> {
-    apply_sddl(path, FILE_SDDL)
+    use windows_security::pipe_dacl::{FileRights, PipeDacl, Trustee};
+
+    let dacl = PipeDacl::new()
+        .allow(FileRights::FullAccess, Trustee::local_system())
+        .allow(FileRights::FullAccess, Trustee::builtin_administrators());
+
+    apply_dacl(path, &dacl)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -314,18 +332,9 @@ fn set_owner_only(_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// The spool holds Bearer tokens, so on Windows every spool directory and file is
-/// locked down to `LocalSystem` and `BUILTIN\Administrators` (the accounts the
-/// Gateway / Tunnel service runs as), the equivalent of `0700`/`0600` on Unix.
-/// `OICI` on the directory ACEs makes children inherit the same access.
 #[cfg(windows)]
-const DIR_SDDL: &str = "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)";
-#[cfg(windows)]
-const FILE_SDDL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)";
-
-#[cfg(windows)]
-fn apply_sddl(path: &Path, sddl: &str) -> std::io::Result<()> {
-    windows_security::SecurityDescriptor::from_sddl(sddl)
+fn apply_dacl(path: &Path, dacl: &windows_security::pipe_dacl::PipeDacl) -> std::io::Result<()> {
+    dacl.build()
         .and_then(|descriptor| descriptor.apply_to_path(path))
         .map_err(|e| std::io::Error::other(format!("{e:#}")))
 }

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -46,7 +46,6 @@
 
 use std::{
     collections::BTreeMap,
-    net::IpAddr,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -370,6 +369,11 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
 
 /// Opens a tunnel-bypassing HTTP client to the ingest host. Re-resolved on every
 /// scan, so a roamed / changed flow-api address is picked up without a restart.
+///
+/// Resolution goes through [`telemetry::resolve_ingest_host`] so that, like
+/// telemetry, it uses connlib's captured upstream resolvers while a session is
+/// active rather than `getaddrinfo`, which would loop back through connlib's
+/// hijacked system resolver.
 async fn connect(
     ingest_url: &str,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
@@ -377,13 +381,7 @@ async fn connect(
     let url = Url::parse(ingest_url).context("Invalid ingest URL")?;
     let host = url.host_str().context("Ingest URL has no host")?.to_owned();
 
-    let addresses = tokio::net::lookup_host((host.as_str(), 443))
-        .await
-        .with_context(|| format!("Failed to resolve ingest host {host}"))?
-        .map(|addr| addr.ip())
-        .collect::<Vec<IpAddr>>();
-
-    anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
+    let addresses = telemetry::resolve_ingest_host(&host).await?;
 
     HttpClient::new(host, addresses, socket_factory)
         .await

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -611,7 +611,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
             }
             StatusCode::UNPROCESSABLE_ENTITY => {
                 let body = body_string(&response);
-                tracing::warn!(%body, "Flow-log batch had validation errors; dropping batch");
+                tracing::info!(%body, "Flow-log batch had validation errors; dropping batch");
                 delete_all(batch);
                 return;
             }
@@ -638,7 +638,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
             }
             _ => {
                 let body = body_string(&response);
-                tracing::error!(%status, %body, "Flow-log upload rejected; dropping batch");
+                tracing::info!(%status, %body, "Flow-log upload rejected; dropping batch");
                 delete_all(batch);
                 return;
             }

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -36,6 +36,9 @@
 //! - [`upload_once`] runs a single pass for platforms that drive uploads from a
 //!   provider-process / OS background task via FFI.
 //!
+//! The async fns offload all disk IO to the blocking pool: the HTTP/2 connection
+//! driver shares their runtime, so stalling it would starve the connection.
+//!
 //! [`prune`] removes expired / orphaned spool directories on startup so the spool
 //! cannot grow without bound.
 
@@ -180,7 +183,7 @@ pub async fn upload_once(
     spool_root: &Path,
     socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
 ) -> bool {
-    let Some(config) = read_upload_config(spool_root) else {
+    let Some(config) = load_upload_config(spool_root).await else {
         return false;
     };
 
@@ -191,6 +194,9 @@ pub async fn upload_once(
 /// no longer be authenticated to the ingest API) and orphaned directories that have
 /// no token at all (nothing in them can ever be uploaded). Call on startup, where it
 /// never races a writer, so the spool cannot grow without bound.
+///
+/// Does blocking IO: call it off any async runtime, or wrap it in
+/// [`tokio::task::spawn_blocking`].
 pub fn prune(spool_root: &Path) {
     let now = unix_now();
 
@@ -211,6 +217,28 @@ fn read_upload_config(spool_root: &Path) -> Option<UploadConfig> {
     let bytes = std::fs::read(spool_root.join(CONFIG_FILE)).ok()?;
 
     serde_json::from_slice(&bytes).ok()
+}
+
+/// [`read_upload_config`], off the runtime.
+async fn load_upload_config(spool_root: &Path) -> Option<UploadConfig> {
+    let root = spool_root.to_owned();
+
+    blocking(move || read_upload_config(&root)).await.flatten()
+}
+
+/// Runs `f` on the blocking pool, so disk IO never stalls the runtime.
+async fn blocking<T, F>(f: F) -> Option<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            tracing::error!("Flow-log blocking task failed: {e}");
+            None
+        }
+    }
 }
 
 /// Clamps the portal-provided batch size into `[1, MAX_BATCH_SIZE]`, defaulting when
@@ -345,7 +373,7 @@ async fn run(spool_root: &Path, socket_factory: Arc<dyn SocketFactory<TcpSocket>
     tracing::info!("Flow-log uploader started");
 
     loop {
-        let delay = match read_upload_config(spool_root) {
+        let delay = match load_upload_config(spool_root).await {
             Some(config) => {
                 if upload_pending(spool_root, &config, socket_factory.clone()).await {
                     CATCHUP_POLL
@@ -411,16 +439,22 @@ async fn upload_pending(
         }
     };
 
+    let dirs = {
+        let root = root.to_owned();
+
+        blocking(move || authz_dirs(&root).collect::<Vec<_>>()).await
+    };
+
     let mut backlog = false;
 
-    for dir in authz_dirs(root) {
+    for dir in dirs.unwrap_or_default() {
         // The connection died (e.g. roam) before we finished; the next pass
         // re-resolves, reconnects, and drains the rest.
         if client.is_closed() {
             return true;
         }
 
-        backlog |= upload_authz_batch(&client, &dir, &url, config.batch_size).await;
+        backlog |= upload_authz_batch(&client, dir, &url, config.batch_size).await;
     }
 
     backlog
@@ -439,21 +473,39 @@ fn dir_entries(dir: &Path) -> impl Iterator<Item = std::fs::DirEntry> + use<> {
     std::fs::read_dir(dir).into_iter().flatten().flatten()
 }
 
-/// Reads up to `batch_size` flows from one authorization's spool (oldest first) and
-/// uploads them as a single batch. Returns whether more than one batch was pending
-/// (a backlog).
-async fn upload_authz_batch(client: &HttpClient, dir: &Path, url: &str, batch_size: usize) -> bool {
-    let token = match std::fs::read_to_string(dir.join("token")) {
-        Ok(token) => token,
-        // No token yet (or it was removed): nothing we can upload for this dir.
-        Err(_) => return false,
+/// Uploads one batch from one authorization's spool. Returns whether more than one
+/// batch was pending (a backlog).
+async fn upload_authz_batch(
+    client: &HttpClient,
+    dir: PathBuf,
+    url: &str,
+    batch_size: usize,
+) -> bool {
+    let collected = blocking(move || collect_batch(&dir, batch_size))
+        .await
+        .flatten();
+
+    let Some((token, batch, backlog)) = collected else {
+        return false;
     };
+
+    submit(client, url, &token, &batch).await;
+
+    backlog
+}
+
+/// Reads one authorization's token and up to `batch_size` flows (oldest first), or
+/// `None` when there is nothing to upload. The `bool` reports whether more than one
+/// batch was pending.
+fn collect_batch(dir: &Path, batch_size: usize) -> Option<(String, Vec<Pending>, bool)> {
+    // No token yet (or it was removed): nothing we can upload for this dir.
+    let token = std::fs::read_to_string(dir.join("token")).ok()?;
 
     let files = match report_files(dir) {
         Ok(files) => files,
         Err(e) => {
             tracing::info!(?dir, "Failed to list flow-log spool directory: {e:#}");
-            return false;
+            return None;
         }
     };
 
@@ -470,12 +522,10 @@ async fn upload_authz_batch(client: &HttpClient, dir: &Path, url: &str, batch_si
     }
 
     if batch.is_empty() {
-        return false;
+        return None;
     }
 
-    submit(client, url, &token, &batch).await;
-
-    backlog
+    Some((token, batch, backlog))
 }
 
 /// Lists a directory's report files, oldest first.
@@ -596,7 +646,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
         let status = response.status();
         match classify_response(status) {
             ResponseAction::Delete => {
-                delete_all(batch);
+                delete_all(batch).await;
                 return;
             }
             ResponseAction::Partition => {
@@ -618,7 +668,7 @@ async fn submit(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) 
             ResponseAction::Drop => {
                 let body = body_string(&response);
                 tracing::info!(%status, %body, "Flow-log upload rejected; dropping batch");
-                delete_all(batch);
+                delete_all(batch).await;
                 return;
             }
         }
@@ -678,7 +728,7 @@ fn body_string(response: &http::Response<Bytes>) -> String {
 async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending]) {
     if batch.len() <= 1 {
         tracing::error!("A single flow exceeds the upload size limit; dropping");
-        delete_all(batch);
+        delete_all(batch).await;
         return;
     }
 
@@ -687,15 +737,22 @@ async fn partition(client: &HttpClient, url: &str, token: &str, batch: &[Pending
     Box::pin(submit(client, url, token, &batch[mid..])).await;
 }
 
-fn delete_all(batch: &[Pending]) {
-    for flow in batch {
-        for path in &flow.files {
-            // A shipped `.end` lists its `.start` too, which may already be gone.
-            if let Err(e) = std::fs::remove_file(path)
-                && e.kind() != std::io::ErrorKind::NotFound
-            {
-                tracing::info!(?path, "Failed to delete uploaded flow-log report: {e:#}");
-            }
+async fn delete_all(batch: &[Pending]) {
+    let files = batch
+        .iter()
+        .flat_map(|flow| flow.files.clone())
+        .collect::<Vec<_>>();
+
+    let _ = blocking(move || delete_files(files)).await;
+}
+
+fn delete_files(files: Vec<PathBuf>) {
+    for path in files {
+        // A shipped `.end` lists its `.start` too, which may already be gone.
+        if let Err(e) = std::fs::remove_file(&path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::info!(?path, "Failed to delete uploaded flow-log report: {e:#}");
         }
     }
 }
@@ -877,6 +934,29 @@ mod tests {
             !orphan.exists(),
             "token-less authorization dir should be pruned"
         );
+    }
+
+    #[test]
+    fn collect_batch_reports_backlog_beyond_batch_size() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("token"), "a-token").unwrap();
+        write_report(&dir.path().join("f1.start.json"));
+        write_report(&dir.path().join("f1.end.json"));
+        write_report(&dir.path().join("f2.start.json"));
+
+        let (token, batch, backlog) = collect_batch(dir.path(), 1).expect("one batch");
+
+        assert_eq!(token, "a-token");
+        assert_eq!(batch.len(), 1);
+        assert!(backlog, "second flow should count as backlog");
+    }
+
+    #[test]
+    fn collect_batch_without_token_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        write_report(&dir.path().join("f1.start.json"));
+
+        assert!(collect_batch(dir.path(), 10).is_none());
     }
 
     #[test]

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -188,7 +188,7 @@ impl Client {
         // which may be a short-lived `block_on` on another runtime.
         RUNTIME
             .spawn(async move {
-                let addresses = resolver.resolve(host).await?;
+                let addresses = resolver.resolve(host.to_owned()).await?;
 
                 anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
 
@@ -212,15 +212,25 @@ enum IngestResolver {
 }
 
 impl IngestResolver {
-    async fn resolve(&self, host: &'static str) -> Result<Vec<IpAddr>> {
+    async fn resolve(&self, host: String) -> Result<Vec<IpAddr>> {
         match self {
             IngestResolver::Upstream(client) => client
-                .resolve(host)
+                .resolve(host.clone())
                 .await
                 .with_context(|| format!("Failed to resolve ingest host {host}")),
             IngestResolver::System(client) => client.resolve(host).await,
         }
     }
+}
+
+/// Resolves an arbitrary ingest host through the active [`IngestResolver`], so the
+/// flow-log uploader shares telemetry's session-aware resolution.
+pub(crate) async fn resolve_host(host: String) -> Result<Vec<IpAddr>> {
+    let resolver = RESOLVER.lock().clone();
+    let addresses = resolver.resolve(host.clone()).await?;
+    anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
+
+    Ok(addresses)
 }
 
 /// Resolves host names via the system resolver, i.e. libc's `getaddrinfo`.
@@ -231,9 +241,9 @@ impl IngestResolver {
 struct LibcDnsClient;
 
 impl LibcDnsClient {
-    async fn resolve(&self, host: &'static str) -> Result<Vec<IpAddr>> {
+    async fn resolve(&self, host: String) -> Result<Vec<IpAddr>> {
         tokio::task::spawn_blocking(move || {
-            let addresses = (host, 443u16)
+            let addresses = (host.as_str(), 443u16)
                 .to_socket_addrs()
                 .with_context(|| {
                     format!("Failed to resolve ingest host {host} via system resolver")

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -188,7 +188,7 @@ impl Client {
         // which may be a short-lived `block_on` on another runtime.
         RUNTIME
             .spawn(async move {
-                let addresses = resolver.resolve(host.to_owned()).await?;
+                let addresses = resolver.resolve(host).await?;
 
                 anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
 
@@ -212,10 +212,10 @@ enum IngestResolver {
 }
 
 impl IngestResolver {
-    async fn resolve(&self, host: String) -> Result<Vec<IpAddr>> {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>> {
         match self {
             IngestResolver::Upstream(client) => client
-                .resolve(host.clone())
+                .resolve(host.to_owned())
                 .await
                 .with_context(|| format!("Failed to resolve ingest host {host}")),
             IngestResolver::System(client) => client.resolve(host).await,
@@ -225,9 +225,9 @@ impl IngestResolver {
 
 /// Resolves an arbitrary ingest host through the active [`IngestResolver`], so the
 /// flow-log uploader shares telemetry's session-aware resolution.
-pub(crate) async fn resolve_host(host: String) -> Result<Vec<IpAddr>> {
+pub(crate) async fn resolve_host(host: &str) -> Result<Vec<IpAddr>> {
     let resolver = RESOLVER.lock().clone();
-    let addresses = resolver.resolve(host.clone()).await?;
+    let addresses = resolver.resolve(host).await?;
     anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
 
     Ok(addresses)
@@ -241,7 +241,9 @@ pub(crate) async fn resolve_host(host: String) -> Result<Vec<IpAddr>> {
 struct LibcDnsClient;
 
 impl LibcDnsClient {
-    async fn resolve(&self, host: String) -> Result<Vec<IpAddr>> {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>> {
+        let host = host.to_owned();
+
         tokio::task::spawn_blocking(move || {
             let addresses = (host.as_str(), 443u16)
                 .to_socket_addrs()

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -42,6 +42,15 @@ pub fn maybe_hash_device_id(id: String) -> String {
     }
 }
 
+/// Resolves an ingest host through telemetry's resolver: connlib's captured
+/// upstreams while a session owns the system resolver, the system resolver
+/// otherwise.
+///
+/// Exposed for the flow-log uploader, whose ingest host has the same constraint.
+pub async fn resolve_ingest_host(host: &str) -> Result<Vec<std::net::IpAddr>> {
+    ingest::resolve_host(host.to_owned()).await
+}
+
 /// Drops the current telemetry ingest connections so they are re-established lazily.
 ///
 /// Call this on network changes, alongside resetting connlib. Triggers a

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -42,9 +42,6 @@ pub fn maybe_hash_device_id(id: String) -> String {
     }
 }
 
-/// Resolves an ingest host through telemetry's resolver: connlib's captured
-/// upstreams while a session owns the system resolver, the system resolver
-/// otherwise.
 pub async fn resolve_ingest_host(host: &str) -> Result<Vec<std::net::IpAddr>> {
     ingest::resolve_host(host).await
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -45,10 +45,8 @@ pub fn maybe_hash_device_id(id: String) -> String {
 /// Resolves an ingest host through telemetry's resolver: connlib's captured
 /// upstreams while a session owns the system resolver, the system resolver
 /// otherwise.
-///
-/// Exposed for the flow-log uploader, whose ingest host has the same constraint.
 pub async fn resolve_ingest_host(host: &str) -> Result<Vec<std::net::IpAddr>> {
-    ingest::resolve_host(host.to_owned()).await
+    ingest::resolve_host(host).await
 }
 
 /// Drops the current telemetry ingest connections so they are re-established lazily.


### PR DESCRIPTION
Reads the self-describing spool, batches reports, and POSTs them to the portal ingest API over tunnel-bypassing sockets, with retry/backoff and partition handling. Shared by the gateway, desktop clients, and the mobile FFI.