### PR TITLE
feat(portal): send flow-log upload batch size in init

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -33,6 +33,8 @@ config :portal, generators: [binary_id: true]
 config :portal, sql_sandbox: false
 config :portal, replica_repo: Portal.Repo.Replica
 
+config :portal, flow_logs_upload_batch_size: 1000
+
 # Don't run manual migrations by default
 config :portal, run_manual_migrations: false
 

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -177,6 +177,13 @@ defmodule Portal.Config.Definitions do
   defconfig(:flow_logs_upload_interval_secs, :integer, default: 60)
 
   @doc """
+  Maximum number of flow log records clients and gateways send per upload request.
+
+  Capped at 10,000 (the ingest API's per-request limit) by the data plane.
+  """
+  defconfig(:flow_logs_upload_batch_size, :integer, default: 1_000)
+
+  @doc """
   The base URL clients and gateways POST flow logs to.
   """
   defconfig(:flow_logs_api_url, :string,

--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -1837,6 +1837,7 @@ defmodule PortalAPI.Client.Channel do
     push(socket, "init", %{
       flow_logs_api_url: flow_logs_api_url(),
       flow_logs_upload_interval_secs: flow_logs_upload_interval_secs(),
+      flow_logs_upload_batch_size: flow_logs_upload_batch_size(),
       resources: Views.Resource.render_many(resources, socket.assigns.session),
       authorizations: Views.PolicyAuthorization.render_many(socket.assigns.authorizations_cache),
       # TODO: Re-enable after verifying compatibility with older clients
@@ -1867,6 +1868,9 @@ defmodule PortalAPI.Client.Channel do
 
   defp flow_logs_upload_interval_secs,
     do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_interval_secs)
+
+  defp flow_logs_upload_batch_size,
+    do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_batch_size)
 
   defp generate_preshared_key(client, client_public_key, gateway, gateway_public_key) do
     Portal.Crypto.psk(client, client_public_key, gateway, gateway_public_key)

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -734,6 +734,7 @@ defmodule PortalAPI.Gateway.Channel do
     push(socket, "init", %{
       flow_logs_api_url: flow_logs_api_url(),
       flow_logs_upload_interval_secs: flow_logs_upload_interval_secs(),
+      flow_logs_upload_batch_size: flow_logs_upload_batch_size(),
       authorizations: Views.PolicyAuthorization.render_many(socket.assigns.cache),
       account_slug: account.slug,
       interface: Views.Interface.render(socket.assigns.gateway),
@@ -755,6 +756,9 @@ defmodule PortalAPI.Gateway.Channel do
 
   defp flow_logs_upload_interval_secs,
     do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_interval_secs)
+
+  defp flow_logs_upload_batch_size,
+    do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_batch_size)
 
   defp reinitialize_gateway(socket) do
     {:ok, relays} = select_relays(socket)

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -462,7 +462,8 @@ defmodule PortalAPI.Client.ChannelTest do
         interface: interface,
         relays: relays,
         flow_logs_api_url: "https://flow-api.firezone.dev/",
-        flow_logs_upload_interval_secs: 60
+        flow_logs_upload_interval_secs: 60,
+        flow_logs_upload_batch_size: 1000
       }
 
       assert length(resources) == 4

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -305,6 +305,7 @@ defmodule PortalAPI.Gateway.ChannelTest do
         relays: relays,
         flow_logs_api_url: "https://flow-api.firezone.dev/",
         flow_logs_upload_interval_secs: 60,
+        flow_logs_upload_batch_size: 1000,
         config: %{
           ipv4_masquerade_enabled: true,
           ipv6_masquerade_enabled: true


### PR DESCRIPTION
Adds a configurable flow-log upload batch size (default 1,000) and sends it to clients and gateways in the channel init message so the data plane can size its upload batches without a hardcoded constant. Clients and gateways that don't parse the field yet ignore it, so this merges independently of the Rust stack.