### PR TITLE
build(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anyhow-ext"


### PR DESCRIPTION
`anyhow` 1.0.102 is flagged by RUSTSEC-2026-0190 — an unsoundness in `Error::downcast_mut()`. Bumping to 1.0.103 picks up the fix and clears the `cargo-deny` advisories check that is currently failing repo-wide.