### PR TITLE
chore: evaluate aws-lc-rs backend for boringtun

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=claude/boringtun-aws-lc-rs-mabvyb#437fc32a7006a2695c271264c4b64bfd4e7eca4c"
+source = "git+https://github.com/firezone/boringtun?branch=claude%2Fboringtun-aws-lc-rs-mabvyb#5c925b41b611eada5be081b8fd3534feb1c9a026"
 dependencies = [
  "aead",
  "aws-lc-rs",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -442,6 +442,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,9 +865,10 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#4ee1988944a8e6891e7ebd5198ed4502cc1c2766"
+source = "git+https://github.com/firezone/boringtun?branch=claude/boringtun-aws-lc-rs-mabvyb#437fc32a7006a2695c271264c4b64bfd4e7eca4c"
 dependencies = [
  "aead",
+ "aws-lc-rs",
  "blake2",
  "chacha20poly1305",
  "constant_time_eq",
@@ -852,7 +876,6 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rand 0.10.1",
- "ring",
  "tracing",
  "typenum",
  "x25519-dalek",
@@ -1287,6 +1310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2617,6 +2649,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -5915,7 +5953,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6090,7 +6128,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8534,6 +8572,12 @@ dependencies = [
  "crypto-common 0.1.6",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -258,7 +258,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 [patch.crates-io]
 sentry = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
 sentry-tracing = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
-boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
+boringtun = { git = "https://github.com/firezone/boringtun", branch = "claude/boringtun-aws-lc-rs-mabvyb" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -288,6 +288,7 @@ skip = [
     "toml",
     "toml_datetime",
     "toml_edit",
+    "untrusted", # aws-lc-rs 1.17 pulls untrusted 0.7.1; ring/rustls-webpki use 0.9.0.
     "webpki-roots",
     "windows-link",
     "windows-result",


### PR DESCRIPTION
Points the `boringtun` patch at the branch that swaps `ring` for `aws-lc-rs` (firezone/boringtun#204) so we can see what CI thinks across our target matrix. Draft / exploratory.

Two things worth knowing before reading the diff:

- **`ring` does not leave the tree.** `rustls` is pinned to its `ring` provider, and `hickory-proto` / `bin-shared` depend on `ring` directly. So this swap is **additive** — the binary gains `aws-lc-rs` + the AWS-LC C library *alongside* `ring`, i.e. two ChaCha20-Poly1305 implementations. Consolidating would also mean flipping rustls to the `aws-lc-rs` provider and migrating those crates.
- **No measured throughput win.** On an AVX-512 host, warm-key ChaCha20-Poly1305 is at parity with `ring` (ring marginally faster); see the numbers in firezone/boringtun#204. AWS-LC's AVX-512 gains are in AES-GCM, which WireGuard doesn't use.

`deny.toml` gains one `bans.skip` entry: `aws-lc-rs` pulls `untrusted 0.7.1` while `ring`/`rustls-webpki` are on `0.9.0`. The main open question this draft is meant to answer is the build cost of `aws-lc-sys` (C toolchain + CMake, NASM on Windows) across musl / Android / iOS / Windows.

---

Related: firezone/boringtun#204

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv1qFbfBQ5oU7RP8Wi2V4N)_