### PR TITLE
refactor: tie telemetry DNS resolution to session lifetime

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -193,8 +193,6 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         .map(|ip| ip.into())
         .collect::<BTreeSet<_>>();
 
-    telemetry::set_system_resolvers(nameservers.iter().copied().collect());
-
     let mut tunnel = GatewayTunnel::new(
         Arc::new(tcp_socket_factory),
         Arc::new(UdpSocketFactory::default()),

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -50,6 +50,8 @@ static DNS_RESOURCE_RECORDS_CACHE: Mutex<BTreeSet<DnsResourceRecord>> = Mutex::n
 pub struct Eventloop {
     tunnel: Option<ClientTunnel>,
 
+    telemetry_resolvers: telemetry::SystemResolvers,
+
     cmd_rx: mpsc::UnboundedReceiver<Command>,
     resource_list_sender: watch::Sender<ResourceList>,
     tun_config_sender: watch::Sender<Option<TunConfig>>,
@@ -127,7 +129,7 @@ impl Eventloop {
             is_internet_resource_active,
         );
         tunnel.update_system_resolvers(dns_servers.clone());
-        telemetry::set_system_resolvers(dns_servers.clone());
+        let telemetry_resolvers = telemetry::SystemResolvers::capture(dns_servers.clone());
 
         tokio::spawn(phoenix_channel_event_loop(
             portal,
@@ -141,6 +143,7 @@ impl Eventloop {
 
         Self {
             tunnel: Some(tunnel),
+            telemetry_resolvers,
             cmd_rx,
             logged_permission_denied: false,
             tunnel_errors: otel_instruments::tunnel_errors(),
@@ -217,7 +220,7 @@ impl Eventloop {
                 };
 
                 let dns = tunnel.update_system_resolvers(dns);
-                telemetry::set_system_resolvers(dns.clone());
+                self.telemetry_resolvers.set(dns.clone());
 
                 self.portal_cmd_tx
                     .send(PortalCommand::UpdateDnsServers(dns))
@@ -697,10 +700,6 @@ impl Eventloop {
             .shut_down()
             .await
             .context("Failed to shut down tunnel")?;
-
-        // Clear only after `shut_down` has restored the system resolver, else ingest
-        // lookups could briefly route through connlib's stub.
-        telemetry::clear_system_resolvers();
 
         Ok(())
     }

--- a/rust/libs/connlib/bootstrap-dns-client/lib.rs
+++ b/rust/libs/connlib/bootstrap-dns-client/lib.rs
@@ -26,6 +26,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 /// unanimous NXDOMAIN suppresses the retry because TCP cannot change a "name
 /// does not exist" answer; requiring consensus stops a single misbehaving
 /// resolver from blocking the fallback.
+#[derive(Clone)]
 pub struct BootstrapDnsClient {
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -20,22 +20,18 @@ type SocketFactories = (
 /// Runtime hosting all ingest connections and the feature-flag re-eval timer.
 pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
 
-/// Socket factories and upstream resolvers shared by all ingest hosts.
+/// Socket factories shared by all ingest hosts.
 ///
 /// connlib processes configure tunnel-bypassing factories so telemetry never
-/// loops back through connlib; the resolvers are the system's upstream DNS
-/// servers (never the system resolver itself, which may be connlib).
+/// loops back through connlib.
 static SOCKETS: LazyLock<Mutex<Option<SocketFactories>>> = LazyLock::new(|| Mutex::new(None));
 
-/// Upstream resolvers for ingest-host lookups, tracking whether connlib owns the
-/// system resolver.
+/// How ingest hosts are currently resolved.
 ///
-/// - `Some`: a session is active and has hijacked the system resolver. Resolve via
-///   these captured upstreams directly; never `getaddrinfo`, which would loop back
-///   through connlib. An empty list disables telemetry until resolvers arrive.
-/// - `None`: no session is active, so `getaddrinfo` reaches the real OS resolver
-///   and reflects the current network.
-static SERVERS: LazyLock<Mutex<Option<Vec<IpAddr>>>> = LazyLock::new(|| Mutex::new(None));
+/// Defaults to the system resolver and is swapped for connlib's upstreams while a
+/// session owns the system resolver (see [`SystemResolvers`]).
+static RESOLVER: LazyLock<Mutex<IngestResolver>> =
+    LazyLock::new(|| Mutex::new(IngestResolver::System(LibcDnsClient)));
 
 /// Configures the socket factories used to reach all ingest hosts.
 pub(crate) fn configure(
@@ -45,15 +41,56 @@ pub(crate) fn configure(
     *SOCKETS.lock() = Some((tcp, udp));
 }
 
-/// Sets the upstream resolvers used while a connlib session is active.
-pub(crate) fn set_system_resolvers(servers: Vec<IpAddr>) {
-    *SERVERS.lock() = Some(servers);
+/// Routes telemetry ingest-host lookups through connlib's upstream resolvers while
+/// a connlib session owns the system resolver.
+///
+/// connlib hijacks the system resolver for the lifetime of a session, so a plain
+/// `getaddrinfo` would loop ingest lookups back through connlib's stub. While the
+/// guard is held, lookups go through a [`BootstrapDnsClient`] against the captured
+/// upstreams. Dropping it restores resolution via the system resolver, tying the
+/// bypass to the session's lifetime.
+#[must_use = "dropping the guard restores system-resolver lookups for ingest hosts"]
+pub struct SystemResolvers {
+    _private: (),
 }
 
-/// Clears the upstream resolvers when no connlib session is active, so ingest
-/// hosts are resolved via the default system resolver.
-pub(crate) fn clear_system_resolvers() {
-    *SERVERS.lock() = None;
+impl SystemResolvers {
+    /// Captures `servers` as the ingest upstreams, bypassing the system resolver
+    /// until the guard is dropped.
+    pub fn capture(servers: Vec<IpAddr>) -> Self {
+        set_resolver(upstream(servers));
+
+        Self { _private: () }
+    }
+
+    /// Replaces the captured upstreams, e.g. when connlib learns updated resolvers.
+    pub fn set(&self, servers: Vec<IpAddr>) {
+        set_resolver(upstream(servers));
+    }
+}
+
+impl Drop for SystemResolvers {
+    fn drop(&mut self) {
+        set_resolver(IngestResolver::System(LibcDnsClient));
+    }
+}
+
+/// Swaps the active resolver and re-evaluates feature flags, which may have been
+/// disabled while (working) resolvers were missing.
+fn set_resolver(resolver: IngestResolver) {
+    *RESOLVER.lock() = resolver;
+    crate::feature_flags::reevaluate_current();
+}
+
+/// Builds an upstream resolver from `servers` and the configured socket factories.
+fn upstream(servers: Vec<IpAddr>) -> IngestResolver {
+    let Some((tcp, udp)) = SOCKETS.lock().clone() else {
+        // `configure` runs before any session captures resolvers; without socket
+        // factories telemetry cannot connect at all, so the resolver is moot.
+        return IngestResolver::System(LibcDnsClient);
+    };
+
+    IngestResolver::Upstream(BootstrapDnsClient::new(udp, tcp, servers))
 }
 
 /// Resets the shared socket factories so the next connection rebinds.
@@ -141,33 +178,17 @@ impl Client {
 
     async fn bootstrap(&self) -> Result<HttpClient> {
         let host = self.host;
-        let (tcp, udp) = SOCKETS
+        let (tcp, _) = SOCKETS
             .lock()
             .clone()
             .context("Ingest client has no socket factories configured")?;
-        let servers = SERVERS.lock().clone();
+        let resolver = RESOLVER.lock().clone();
 
         // Anchor the connection task on our own runtime so it outlives the caller,
         // which may be a short-lived `block_on` on another runtime.
         RUNTIME
             .spawn(async move {
-                let addresses = match servers {
-                    // Session active: resolve via captured upstreams, never `getaddrinfo`.
-                    Some(servers) => {
-                        anyhow::ensure!(
-                            !servers.is_empty(),
-                            "No upstream resolvers for ingest host {host}; \
-                             telemetry disabled while session is active"
-                        );
-
-                        BootstrapDnsClient::new(udp, tcp.clone(), servers)
-                            .resolve(host)
-                            .await
-                            .with_context(|| format!("Failed to resolve ingest host {host}"))?
-                    }
-                    // No session: `getaddrinfo` reaches the real OS resolver.
-                    None => resolve_via_system(host).await?,
-                };
+                let addresses = resolver.resolve(host).await?;
 
                 anyhow::ensure!(!addresses.is_empty(), "No addresses for ingest host {host}");
 
@@ -180,22 +201,51 @@ impl Client {
     }
 }
 
-/// Resolves a host via the default system resolver (`getaddrinfo`).
-///
-/// Only safe when no connlib session is active; otherwise the lookup would route
-/// through connlib's stub resolver and loop back into the tunnel.
-async fn resolve_via_system(host: &'static str) -> Result<Vec<IpAddr>> {
-    tokio::task::spawn_blocking(move || {
-        let addresses = (host, 443u16)
-            .to_socket_addrs()
-            .with_context(|| format!("Failed to resolve ingest host {host} via system resolver"))?
-            .map(|addr| addr.ip())
-            .collect::<Vec<_>>();
+/// Resolves ingest hosts, either through connlib's upstreams or the system resolver.
+#[derive(Clone)]
+enum IngestResolver {
+    /// A connlib session owns the system resolver, so resolve via the captured
+    /// upstreams directly; `getaddrinfo` would loop back through connlib's stub.
+    Upstream(BootstrapDnsClient),
+    /// No session owns the system resolver, so resolve via libc (`getaddrinfo`).
+    System(LibcDnsClient),
+}
 
-        Ok(addresses)
-    })
-    .await
-    .context("System resolver task panicked")?
+impl IngestResolver {
+    async fn resolve(&self, host: &'static str) -> Result<Vec<IpAddr>> {
+        match self {
+            IngestResolver::Upstream(client) => client
+                .resolve(host)
+                .await
+                .with_context(|| format!("Failed to resolve ingest host {host}")),
+            IngestResolver::System(client) => client.resolve(host).await,
+        }
+    }
+}
+
+/// Resolves host names via the system resolver, i.e. libc's `getaddrinfo`.
+///
+/// Only safe when no connlib session owns the system resolver; otherwise the lookup
+/// would route through connlib's stub resolver and loop back into the tunnel.
+#[derive(Clone, Copy)]
+struct LibcDnsClient;
+
+impl LibcDnsClient {
+    async fn resolve(&self, host: &'static str) -> Result<Vec<IpAddr>> {
+        tokio::task::spawn_blocking(move || {
+            let addresses = (host, 443u16)
+                .to_socket_addrs()
+                .with_context(|| {
+                    format!("Failed to resolve ingest host {host} via system resolver")
+                })?
+                .map(|addr| addr.ip())
+                .collect::<Vec<_>>();
+
+            Ok(addresses)
+        })
+        .await
+        .context("System resolver task panicked")?
+    }
 }
 
 fn init_runtime() -> Runtime {
@@ -210,4 +260,23 @@ fn init_runtime() -> Runtime {
     runtime.spawn(crate::feature_flags::reeval_timer());
 
     runtime
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Exercises the shared `SOCKETS`/`RESOLVER` statics, so it stays a single test
+    // to avoid racing against parallel test threads.
+    #[test]
+    fn capture_switches_to_upstream_and_drop_restores_system() {
+        configure(Arc::new(socket_factory::tcp), Arc::new(socket_factory::udp));
+
+        {
+            let _guard = SystemResolvers::capture(vec![IpAddr::from([1, 1, 1, 1])]);
+            assert!(matches!(*RESOLVER.lock(), IngestResolver::Upstream(_)));
+        }
+
+        assert!(matches!(*RESOLVER.lock(), IngestResolver::System(_)));
+    }
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::{collections::BTreeMap, fmt, mem, net::IpAddr, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result, anyhow, bail};
 use api_url::ApiUrl;
@@ -23,6 +23,7 @@ mod posthog;
 mod sentry;
 mod sentry_instrument_provider;
 
+pub use ingest::SystemResolvers;
 pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
 pub use sentry_instrument_provider::SentryMeterProvider;
 
@@ -38,30 +39,6 @@ pub fn maybe_hash_device_id(id: String) -> String {
     } else {
         id
     }
-}
-
-/// Sets the upstream DNS resolvers used to look up our telemetry ingest hosts
-/// while a connlib session is active.
-///
-/// Call this wherever connlib's system resolvers are updated, while a session is
-/// active. While set, ingest hosts are resolved via these upstreams directly
-/// (never the system resolver, which connlib has hijacked). Triggers a
-/// feature-flag re-evaluation, since a prior attempt may have failed for lack of
-/// (working) resolvers.
-pub fn set_system_resolvers(servers: Vec<IpAddr>) {
-    ingest::set_system_resolvers(servers);
-    feature_flags::reevaluate_current();
-}
-
-/// Clears the upstream DNS resolvers when no connlib session is active.
-///
-/// Call this when a session ends. Afterwards ingest hosts are resolved via the
-/// default system resolver, which is safe because connlib is no longer
-/// intercepting DNS. Triggers a feature-flag re-evaluation so flags refresh over
-/// the default-resolved connection.
-pub fn clear_system_resolvers() {
-    ingest::clear_system_resolvers();
-    feature_flags::reevaluate_current();
 }
 
 /// Drops the current telemetry ingest connections so they are re-established lazily.


### PR DESCRIPTION
Telemetry needs to resolve its ingest hosts whether or not a connlib session is active. While a session is up, connlib owns the system resolver, so resolving ingest hosts via `getaddrinfo` would loop back through connlib's stub; they must instead be resolved against connlib's upstream DNS servers directly. With no session, the system resolver is the correct, network-aware choice.

This ties that behaviour to ownership rather than global lifecycle hooks: the client event-loop holds a `SystemResolvers` guard for the duration of a session. Holding it routes ingest lookups through the captured upstreams; dropping it on shutdown restores system-resolver lookups. The active strategy is modelled as an enum over the two DNS clients instead of an optional list of resolver IPs, so the two modes are explicit at the lookup site.

The gateway always uses the system resolver, since it never intercepts DNS and has no stub to loop through.

Related: #13917