### PR TITLE
perf(tunnel): hint max level on `PanicOnErrorEvents` layer

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/libs/connlib/tunnel/src/tests/assertions.rs
@@ -734,6 +734,10 @@ impl<S> Layer<S> for PanicOnErrorEvents<S>
 where
     S: Subscriber,
 {
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        Some(tracing::level_filters::LevelFilter::ERROR)
+    }
+
     fn on_event(
         &self,
         _event: &tracing::Event<'_>,


### PR DESCRIPTION
The `PanicOnErrorEvents` test layer only acts on `ERROR` events but advertised no `max_level_hint`, so `tracing` kept the global max level at `TRACE` whenever it was the most verbose layer in a subscriber. The coverage-guided fuzzer installs it as the only layer and writes no logs, yet still paid to build and dispatch every `trace!`/`debug!` event on the hot path — a large share of fuzzing CPU in benchmarks. Advertising `ERROR` lets those callsites short-circuit. The proptest harness is unaffected, since its log-file layer keeps the level at `TRACE` by design.

Related: #13910