### PR TITLE
refactor(client): compact Resource tray submenu

### DIFF
--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -15,8 +15,8 @@ use crate::updates::Release;
 /// `builder::Icon` is the icon shown *inside* a menu item (e.g. Site status),
 /// distinct from the tray `Icon` defined in this module.
 pub(crate) use builder::Icon as MenuItemIcon;
-use builder::item;
 pub use builder::{Entry, Event, Item, Menu, Window};
+use builder::{INTERNET_RESOURCE_DESCRIPTION, item, resource_detail};
 
 mod builder;
 mod compositor;
@@ -50,13 +50,10 @@ const UPDATE_READY_LAYER: &[u8] = include_bytes!("../../icons/tray/Update ready 
 
 const QUIT_TEXT_SIGNED_OUT: &str = "Quit Firezone";
 
-const NO_ACTIVITY: &str = "No activity";
-const GATEWAY_CONNECTED: &str = "Gateway connected";
-const ALL_GATEWAYS_OFFLINE: &str = "All Gateways offline";
-
 const ENABLED_SYMBOL: &str = "<->";
 const DISABLED_SYMBOL: &str = "—";
 
+const COPY_ADDRESS: &str = "Copy address";
 const ADD_FAVORITE: &str = "Add to favorites";
 const REMOVE_FAVORITE: &str = "Remove from favorites";
 const FAVORITE_RESOURCES: &str = "Favorite Resources";
@@ -185,39 +182,49 @@ impl SignedIn {
         }
     }
 
-    /// Builds the submenu that has the resource address, name, desc,
-    /// sites online, etc.
+    /// Builds a Resource's submenu: its read-only details (address or
+    /// description, and Site status with a colored dot) above its actions (copy,
+    /// favorite, or enable / disable), separated by a divider.
     fn resource_submenu(&self, res: &ResourceView) -> Menu {
-        let mut submenu = Menu::default().resource_description(res);
+        let mut info = Menu::default();
 
         if res.is_internet_resource() {
-            submenu.add_separator();
-            if self.is_internet_resource_enabled() {
-                submenu.add_item(item(Event::DisableInternetResource, DISABLE));
-            } else {
-                submenu.add_item(item(Event::EnableInternetResource, ENABLE));
-            }
-        }
-
-        if !res.is_internet_resource() {
-            self.add_favorite_toggle(&mut submenu, res.id());
+            info = info.disabled(INTERNET_RESOURCE_DESCRIPTION);
+        } else if let Some(detail) = resource_detail(res) {
+            info.add_item(detail);
         }
 
         if let Some(site) = res.sites().first() {
-            let (status, icon) = match res.status() {
-                ResourceStatus::Unknown => (NO_ACTIVITY, MenuItemIcon::Grey),
-                ResourceStatus::Online => (GATEWAY_CONNECTED, MenuItemIcon::Green),
-                ResourceStatus::Offline => (ALL_GATEWAYS_OFFLINE, MenuItemIcon::Red),
+            let icon = match res.status() {
+                ResourceStatus::Unknown => MenuItemIcon::Grey,
+                ResourceStatus::Online => MenuItemIcon::Green,
+                ResourceStatus::Offline => MenuItemIcon::Red,
             };
-
-            submenu
-                .separator()
-                .disabled("Site")
-                .copyable(&site.name) // Hope this is okay - The code is simpler if every enabled item sends an `Event` on click
-                .copyable_with_icon(status, icon)
-        } else {
-            submenu
+            info = info.copyable_with_icon(&site.name, icon);
         }
+
+        let mut actions = Menu::default();
+
+        if res.is_internet_resource() {
+            if self.is_internet_resource_enabled() {
+                actions = actions.item(Event::DisableInternetResource, DISABLE);
+            } else {
+                actions = actions.item(Event::EnableInternetResource, ENABLE);
+            }
+        } else {
+            let address = res.pastable();
+            if !address.is_empty() {
+                actions = actions.item(Event::Copy(address.into_owned()), COPY_ADDRESS);
+            }
+            self.add_favorite_toggle(&mut actions, res.id());
+        }
+
+        let mut submenu = info;
+        if !submenu.entries.is_empty() && !actions.entries.is_empty() {
+            submenu = submenu.separator();
+        }
+        submenu.entries.extend(actions.entries);
+        submenu
     }
 
     fn is_internet_resource_enabled(&self) -> bool {
@@ -450,8 +457,6 @@ mod tests {
     use anyhow::Result;
     use std::str::FromStr as _;
 
-    use builder::INTERNET_RESOURCE_DESCRIPTION;
-
     impl Menu {
         fn checkable<E: Into<Option<Event>>, S: Into<String>>(
             mut self,
@@ -514,6 +519,42 @@ mod tests {
         ]"#;
 
         serde_json::from_str(s).unwrap()
+    }
+
+    /// Expected submenu for the `cidr resource` from [`resources`].
+    fn cidr_submenu(toggle: Event, label: &str, checked: bool) -> Menu {
+        Menu::default()
+            .disabled("cidr resource")
+            .copyable_with_icon("test", MenuItemIcon::Grey)
+            .separator()
+            .item(Event::Copy("172.172.0.0/16".to_string()), COPY_ADDRESS)
+            .checkable(toggle, label, checked)
+    }
+
+    /// Expected submenu for the `MyCorp GitLab` resource from [`resources`].
+    fn gitlab_submenu(toggle: Event, label: &str, checked: bool) -> Menu {
+        Menu::default()
+            .item(
+                Event::Url("https://gitlab.mycorp.com".parse().unwrap()),
+                "<https://gitlab.mycorp.com>",
+            )
+            .copyable_with_icon("test", MenuItemIcon::Green)
+            .separator()
+            .item(Event::Copy("gitlab.mycorp.com".to_string()), COPY_ADDRESS)
+            .checkable(toggle, label, checked)
+    }
+
+    /// Expected submenu for the Internet Resource from [`resources`].
+    fn internet_submenu() -> Menu {
+        Menu::default()
+            .disabled(INTERNET_RESOURCE_DESCRIPTION)
+            .copyable_with_icon("test", MenuItemIcon::Red)
+            .separator()
+            .item(Event::EnableInternetResource, ENABLE)
+    }
+
+    fn add_favorite(uuid: &str) -> Event {
+        Event::AddFavorite(ResourceId::from_str(uuid).unwrap())
     }
 
     #[test]
@@ -639,58 +680,21 @@ mod tests {
             .disabled(RESOURCES)
             .add_submenu(
                 "172.172.0.0/16",
-                Menu::default()
-                    .copyable("cidr resource")
-                    .separator()
-                    .disabled("Resource")
-                    .copyable("172.172.0.0/16")
-                    .copyable("172.172.0.0/16")
-                    .checkable(
-                        Event::AddFavorite(
-                            ResourceId::from_str("73037362-715d-4a83-a749-f18eadd970e6").unwrap(),
-                        ),
-                        ADD_FAVORITE,
-                        false,
-                    )
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(NO_ACTIVITY, MenuItemIcon::Grey),
+                cidr_submenu(
+                    add_favorite("73037362-715d-4a83-a749-f18eadd970e6"),
+                    ADD_FAVORITE,
+                    false,
+                ),
             )
             .add_submenu(
                 "MyCorp GitLab",
-                Menu::default()
-                    .item(
-                        Event::Url("https://gitlab.mycorp.com".parse().unwrap()),
-                        "<https://gitlab.mycorp.com>",
-                    )
-                    .separator()
-                    .disabled("Resource")
-                    .copyable("MyCorp GitLab")
-                    .copyable("gitlab.mycorp.com")
-                    .checkable(
-                        Event::AddFavorite(
-                            ResourceId::from_str("03000143-e25e-45c7-aafb-144990e57dcd").unwrap(),
-                        ),
-                        ADD_FAVORITE,
-                        false,
-                    )
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(GATEWAY_CONNECTED, MenuItemIcon::Green),
+                gitlab_submenu(
+                    add_favorite("03000143-e25e-45c7-aafb-144990e57dcd"),
+                    ADD_FAVORITE,
+                    false,
+                ),
             )
-            .add_submenu(
-                "— Internet Resource",
-                Menu::default()
-                    .disabled(INTERNET_RESOURCE_DESCRIPTION)
-                    .separator()
-                    .item(Event::EnableInternetResource, ENABLE)
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(ALL_GATEWAYS_OFFLINE, MenuItemIcon::Red),
-            )
+            .add_submenu("— Internet Resource", internet_submenu())
             .add_bottom_section(None, DISCONNECT_AND_QUIT, true, None); // Skip testing the bottom section, it's simple
 
         assert_eq!(
@@ -719,60 +723,25 @@ mod tests {
             .disabled(FAVORITE_RESOURCES)
             .add_submenu(
                 "MyCorp GitLab",
-                Menu::default()
-                    .item(
-                        Event::Url("https://gitlab.mycorp.com".parse()?),
-                        "<https://gitlab.mycorp.com>",
-                    )
-                    .separator()
-                    .disabled("Resource")
-                    .copyable("MyCorp GitLab")
-                    .copyable("gitlab.mycorp.com")
-                    .checkable(
-                        Event::RemoveFavorite(ResourceId::from_str(
-                            "03000143-e25e-45c7-aafb-144990e57dcd",
-                        )?),
-                        REMOVE_FAVORITE,
-                        true,
-                    )
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(GATEWAY_CONNECTED, MenuItemIcon::Green),
+                gitlab_submenu(
+                    Event::RemoveFavorite(ResourceId::from_str(
+                        "03000143-e25e-45c7-aafb-144990e57dcd",
+                    )?),
+                    REMOVE_FAVORITE,
+                    true,
+                ),
             )
-            .add_submenu(
-                "— Internet Resource",
-                Menu::default()
-                    .disabled(INTERNET_RESOURCE_DESCRIPTION)
-                    .separator()
-                    .item(Event::EnableInternetResource, ENABLE)
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(ALL_GATEWAYS_OFFLINE, MenuItemIcon::Red),
-            )
+            .add_submenu("— Internet Resource", internet_submenu())
             .separator()
             .add_submenu(
                 OTHER_RESOURCES,
                 Menu::default().add_submenu(
                     "172.172.0.0/16",
-                    Menu::default()
-                        .copyable("cidr resource")
-                        .separator()
-                        .disabled("Resource")
-                        .copyable("172.172.0.0/16")
-                        .copyable("172.172.0.0/16")
-                        .checkable(
-                            Event::AddFavorite(ResourceId::from_str(
-                                "73037362-715d-4a83-a749-f18eadd970e6",
-                            )?),
-                            ADD_FAVORITE,
-                            false,
-                        )
-                        .separator()
-                        .disabled("Site")
-                        .copyable("test")
-                        .copyable_with_icon(NO_ACTIVITY, MenuItemIcon::Grey),
+                    cidr_submenu(
+                        add_favorite("73037362-715d-4a83-a749-f18eadd970e6"),
+                        ADD_FAVORITE,
+                        false,
+                    ),
                 ),
             )
             .add_bottom_section(None, DISCONNECT_AND_QUIT, true, None); // Skip testing the bottom section, it's simple
@@ -805,58 +774,21 @@ mod tests {
             .disabled(RESOURCES)
             .add_submenu(
                 "172.172.0.0/16",
-                Menu::default()
-                    .copyable("cidr resource")
-                    .separator()
-                    .disabled("Resource")
-                    .copyable("172.172.0.0/16")
-                    .copyable("172.172.0.0/16")
-                    .checkable(
-                        Event::AddFavorite(ResourceId::from_str(
-                            "73037362-715d-4a83-a749-f18eadd970e6",
-                        )?),
-                        ADD_FAVORITE,
-                        false,
-                    )
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(NO_ACTIVITY, MenuItemIcon::Grey),
+                cidr_submenu(
+                    add_favorite("73037362-715d-4a83-a749-f18eadd970e6"),
+                    ADD_FAVORITE,
+                    false,
+                ),
             )
             .add_submenu(
                 "MyCorp GitLab",
-                Menu::default()
-                    .item(
-                        Event::Url("https://gitlab.mycorp.com".parse()?),
-                        "<https://gitlab.mycorp.com>",
-                    )
-                    .separator()
-                    .disabled("Resource")
-                    .copyable("MyCorp GitLab")
-                    .copyable("gitlab.mycorp.com")
-                    .checkable(
-                        Event::AddFavorite(ResourceId::from_str(
-                            "03000143-e25e-45c7-aafb-144990e57dcd",
-                        )?),
-                        ADD_FAVORITE,
-                        false,
-                    )
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(GATEWAY_CONNECTED, MenuItemIcon::Green),
+                gitlab_submenu(
+                    add_favorite("03000143-e25e-45c7-aafb-144990e57dcd"),
+                    ADD_FAVORITE,
+                    false,
+                ),
             )
-            .add_submenu(
-                "— Internet Resource",
-                Menu::default()
-                    .disabled(INTERNET_RESOURCE_DESCRIPTION)
-                    .separator()
-                    .item(Event::EnableInternetResource, ENABLE)
-                    .separator()
-                    .disabled("Site")
-                    .copyable("test")
-                    .copyable_with_icon(ALL_GATEWAYS_OFFLINE, MenuItemIcon::Red),
-            )
+            .add_submenu("— Internet Resource", internet_submenu())
             .add_bottom_section(None, DISCONNECT_AND_QUIT, true, None); // Skip testing the bottom section, it's simple
 
         assert_eq!(

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -324,7 +324,9 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
         {
             submenu = submenu.add_submenu(res.name(), signed_in.resource_submenu(res));
         }
-        menu = menu.separator().add_submenu(OTHER_RESOURCES, submenu);
+        if !submenu.entries.is_empty() {
+            menu = menu.separator().add_submenu(OTHER_RESOURCES, submenu);
+        }
     }
 
     if !connected_devices.is_empty() {
@@ -744,6 +746,56 @@ mod tests {
                     ),
                 ),
             )
+            .add_bottom_section(None, DISCONNECT_AND_QUIT, true, None); // Skip testing the bottom section, it's simple
+
+        assert_eq!(
+            actual,
+            expected,
+            "{}",
+            serde_json::to_string_pretty(&actual)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn all_resources_favorited_hides_other_resources() -> Result<()> {
+        let actual = signed_in(
+            resources(),
+            HashSet::from([
+                ResourceId::from_str("73037362-715d-4a83-a749-f18eadd970e6")?,
+                ResourceId::from_str("03000143-e25e-45c7-aafb-144990e57dcd")?,
+            ]),
+            None,
+        )
+        .into_menu();
+
+        let expected = Menu::default()
+            .disabled("Signed in as Jane Doe")
+            .item(Event::SignOut, SIGN_OUT)
+            .separator()
+            .disabled(FAVORITE_RESOURCES)
+            .add_submenu(
+                "172.172.0.0/16",
+                cidr_submenu(
+                    Event::RemoveFavorite(ResourceId::from_str(
+                        "73037362-715d-4a83-a749-f18eadd970e6",
+                    )?),
+                    REMOVE_FAVORITE,
+                    true,
+                ),
+            )
+            .add_submenu(
+                "MyCorp GitLab",
+                gitlab_submenu(
+                    Event::RemoveFavorite(ResourceId::from_str(
+                        "03000143-e25e-45c7-aafb-144990e57dcd",
+                    )?),
+                    REMOVE_FAVORITE,
+                    true,
+                ),
+            )
+            .add_submenu("— Internet Resource", internet_submenu())
             .add_bottom_section(None, DISCONNECT_AND_QUIT, true, None); // Skip testing the bottom section, it's simple
 
         assert_eq!(

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -183,8 +183,9 @@ impl SignedIn {
     }
 
     /// Builds a Resource's submenu: its read-only details (address or
-    /// description, and Site status with a colored dot) above its actions (copy,
-    /// favorite, or enable / disable), separated by a divider.
+    /// description, and the connection status as a colored dot plus a short
+    /// label) above its actions (copy, favorite, or enable / disable),
+    /// separated by a divider.
     fn resource_submenu(&self, res: &ResourceView) -> Menu {
         let mut info = Menu::default();
 
@@ -195,12 +196,14 @@ impl SignedIn {
         }
 
         if let Some(site) = res.sites().first() {
-            let icon = match res.status() {
-                ResourceStatus::Unknown => MenuItemIcon::Grey,
-                ResourceStatus::Online => MenuItemIcon::Green,
-                ResourceStatus::Offline => MenuItemIcon::Red,
+            let (label, icon) = match res.status() {
+                ResourceStatus::Unknown => ("Unknown".to_string(), MenuItemIcon::Grey),
+                ResourceStatus::Online => {
+                    (format!("Connected: {}", site.name), MenuItemIcon::Green)
+                }
+                ResourceStatus::Offline => ("Offline".to_string(), MenuItemIcon::Red),
             };
-            info = info.copyable_with_icon(&site.name, icon);
+            info = info.disabled_with_icon(label, icon);
         }
 
         let mut actions = Menu::default();
@@ -527,7 +530,7 @@ mod tests {
     fn cidr_submenu(toggle: Event, label: &str, checked: bool) -> Menu {
         Menu::default()
             .disabled("cidr resource")
-            .copyable_with_icon("test", MenuItemIcon::Grey)
+            .disabled_with_icon("Unknown", MenuItemIcon::Grey)
             .separator()
             .item(Event::Copy("172.172.0.0/16".to_string()), COPY_ADDRESS)
             .checkable(toggle, label, checked)
@@ -540,7 +543,7 @@ mod tests {
                 Event::Url("https://gitlab.mycorp.com".parse().unwrap()),
                 "<https://gitlab.mycorp.com>",
             )
-            .copyable_with_icon("test", MenuItemIcon::Green)
+            .disabled_with_icon("Connected: test", MenuItemIcon::Green)
             .separator()
             .item(Event::Copy("gitlab.mycorp.com".to_string()), COPY_ADDRESS)
             .checkable(toggle, label, checked)
@@ -550,9 +553,37 @@ mod tests {
     fn internet_submenu() -> Menu {
         Menu::default()
             .disabled(INTERNET_RESOURCE_DESCRIPTION)
-            .copyable_with_icon("test", MenuItemIcon::Red)
+            .disabled_with_icon("Offline", MenuItemIcon::Red)
             .separator()
             .item(Event::EnableInternetResource, ENABLE)
+    }
+
+    /// A URL description must stay clickable even when it is equal to the
+    /// name: the parent menu item is not clickable, so this link is the only
+    /// way to open it.
+    #[test]
+    fn url_description_is_shown_even_when_equal_to_the_name() {
+        let res: ResourceView = serde_json::from_str(
+            r#"{
+                "id": "03000143-e25e-45c7-aafb-144990e57dcd",
+                "type": "dns",
+                "name": "https://gitlab.mycorp.com",
+                "address": "gitlab.mycorp.com",
+                "address_description": "https://gitlab.mycorp.com",
+                "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
+                "status": "Online"
+            }"#,
+        )
+        .unwrap();
+
+        let actual = resource_detail(&res);
+
+        let expected = item(
+            Event::Url("https://gitlab.mycorp.com".parse().unwrap()),
+            "<https://gitlab.mycorp.com>",
+        );
+
+        assert_eq!(actual, Some(expected));
     }
 
     fn add_favorite(uuid: &str) -> Event {

--- a/rust/gui-client/src-tauri/src/gui/system_tray/builder.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray/builder.rs
@@ -2,6 +2,7 @@
 
 use connlib_model::{ResourceId, ResourceView};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use url::Url;
 
 pub const INTERNET_RESOURCE_DESCRIPTION: &str = "All network traffic";
@@ -92,20 +93,29 @@ pub enum Window {
     Settings,
 }
 
-fn resource_header(res: &ResourceView) -> Item {
-    let Some(address_description) = res.address_description() else {
-        return copyable(&res.pastable());
+/// The single detail line shown for a Resource: its description if present,
+/// otherwise its address. Returns `None` when that value is empty or identical
+/// to the `name` already shown by the parent menu item, so nothing is repeated.
+///
+/// A description that parses as a URL becomes a clickable link; anything else is
+/// shown greyed-out, since the address is copied via the explicit "Copy address"
+/// action instead.
+pub(crate) fn resource_detail(res: &ResourceView) -> Option<Item> {
+    let detail = match res.address_description() {
+        Some(description) if !description.is_empty() => Cow::from(description),
+        _ => res.pastable(),
     };
 
-    if address_description.is_empty() {
-        return copyable(&res.pastable());
+    if detail.is_empty() || &*detail == res.name() {
+        return None;
     }
 
-    let Ok(url) = Url::parse(address_description) else {
-        return copyable(address_description);
+    let detail = match Url::parse(&detail) {
+        Ok(url) => item(Event::Url(url), format!("<{detail}>")),
+        Err(_) => item(None, detail.into_owned()),
     };
 
-    item(Event::Url(url), format!("<{address_description}>"))
+    Some(detail)
 }
 
 impl Menu {
@@ -154,26 +164,6 @@ impl Menu {
     pub(crate) fn separator(mut self) -> Self {
         self.add_separator();
         self
-    }
-
-    fn internet_resource(self) -> Self {
-        self.disabled(INTERNET_RESOURCE_DESCRIPTION)
-    }
-
-    fn resource_body(self, resource: &ResourceView) -> Self {
-        self.separator()
-            .disabled("Resource")
-            .copyable(resource.name())
-            .copyable(resource.pastable().as_ref())
-    }
-
-    pub(crate) fn resource_description(mut self, resource: &ResourceView) -> Self {
-        if resource.is_internet_resource() {
-            self.internet_resource()
-        } else {
-            self.add_item(resource_header(resource));
-            self.resource_body(resource)
-        }
     }
 }
 

--- a/rust/gui-client/src-tauri/src/gui/system_tray/builder.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray/builder.rs
@@ -97,25 +97,30 @@ pub enum Window {
 /// otherwise its address. Returns `None` when that value is empty or identical
 /// to the `name` already shown by the parent menu item, so nothing is repeated.
 ///
-/// A description that parses as a URL becomes a clickable link; anything else is
-/// shown greyed-out, since the address is copied via the explicit "Copy address"
-/// action instead.
+/// A description that parses as a URL becomes a clickable link and is always
+/// shown — even when it is equal to the name — because the parent menu item is
+/// not clickable, making this link the only way to open it. Anything else is
+/// shown greyed-out, since the address is copied via the explicit "Copy
+/// address" action instead.
 pub(crate) fn resource_detail(res: &ResourceView) -> Option<Item> {
-    let detail = match res.address_description() {
-        Some(description) if !description.is_empty() => Cow::from(description),
-        _ => res.pastable(),
+    let description = res.address_description().filter(|d| !d.is_empty());
+
+    if let Some(description) = description
+        && let Ok(url) = Url::parse(description)
+    {
+        return Some(item(Event::Url(url), format!("<{description}>")));
+    }
+
+    let detail = match description {
+        Some(description) => Cow::from(description),
+        None => res.pastable(),
     };
 
     if detail.is_empty() || &*detail == res.name() {
         return None;
     }
 
-    let detail = match Url::parse(&detail) {
-        Ok(url) => item(Event::Url(url), format!("<{detail}>")),
-        Err(_) => item(None, detail.into_owned()),
-    };
-
-    Some(detail)
+    Some(item(None, detail.into_owned()))
 }
 
 impl Menu {
@@ -141,16 +146,15 @@ impl Menu {
         self
     }
 
-    /// Appends a menu item that copies its title when clicked and shows `icon`
-    /// to the left of the text.
-    pub(crate) fn copyable_with_icon(mut self, s: &str, icon: Icon) -> Self {
-        self.add_item(copyable(s).icon(icon));
-        self
-    }
-
     /// Appends a disabled item with no accelerator or event
     pub(crate) fn disabled<S: Into<String>>(mut self, title: S) -> Self {
         self.add_item(item(None, title).disabled());
+        self
+    }
+
+    /// Appends a disabled item that shows `icon` to the left of the text.
+    pub(crate) fn disabled_with_icon<S: Into<String>>(mut self, title: S, icon: Icon) -> Self {
+        self.add_item(item(None, title).disabled().icon(icon));
         self
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
@@ -37,40 +37,38 @@
 
     var body: some View {
       Group {
+        // Information: the description or address, and the Site status. The
+        // parent menu item already shows the name, so it isn't repeated here.
         if resource.isInternetResource() {
           Text("All network traffic")
             .foregroundStyle(.secondary)
+        } else if let detail = displayDetail {
+          if let url = URL(string: detail), url.scheme != nil {
+            Link(destination: url) {
+              Text(detail)
+                .foregroundColor(.blue)
+                .underline()
+            }
+          } else {
+            Text(detail)
+              .foregroundStyle(.secondary)
+          }
+        }
 
+        if let site = resource.sites.first {
+          siteStatus(site)
+        }
+
+        // Actions, separated from the information above.
+        if hasInfo {
           Divider()
+        }
 
+        if resource.isInternetResource() {
           Button(internetResourceToggleTitle) {
             store.configuration.internetResourceEnabled.toggle()
           }
         } else {
-          // Show address - clickable if it's a valid URL
-          if let displayAddress = resource.addressDescription ?? resource.address {
-            if let url = URL(string: displayAddress), url.scheme != nil {
-              Link(destination: url) {
-                Text(displayAddress)
-                  .foregroundColor(.blue)
-                  .underline()
-              }
-            } else {
-              Button(displayAddress) {
-                Clipboard.copy(displayAddress)
-              }
-            }
-          }
-
-          Divider()
-
-          Text("Resource")
-            .foregroundStyle(.secondary)
-
-          Button(resource.name) {
-            Clipboard.copy(resource.name)
-          }
-
           if let address = resource.address {
             Button("Copy address") {
               Clipboard.copy(address)
@@ -81,31 +79,40 @@
             toggleFavorite()
           }
         }
+      }
+    }
 
-        // Site information (if available)
-        if let site = resource.sites.first {
-          Divider()
+    /// The single detail line: the description if present, otherwise the
+    /// address. Hidden when empty or identical to the name shown by the parent.
+    private var displayDetail: String? {
+      let description = resource.addressDescription.flatMap { $0.isEmpty ? nil : $0 }
+      guard let detail = description ?? resource.address,
+        !detail.isEmpty,
+        detail != resource.name
+      else { return nil }
 
-          Text("Site")
-            .foregroundStyle(.secondary)
+      return detail
+    }
 
-          Button(site.name) {
-            Clipboard.copy(site.name)
+    private var hasInfo: Bool {
+      resource.isInternetResource() || displayDetail != nil || resource.sites.first != nil
+    }
+
+    /// The Site name with its status as a colored dot. The textual status is
+    /// kept in the tooltip so the menu stays compact.
+    @ViewBuilder
+    private func siteStatus(_ site: Site) -> some View {
+      Button {
+        Clipboard.copy(site.name)
+      } label: {
+        HStack {
+          if let icon = resource.status.statusIcon {
+            Image(nsImage: icon)
           }
-
-          Button {
-            Clipboard.copy(resource.status.toSiteStatus())
-          } label: {
-            HStack {
-              if let icon = resource.status.statusIcon {
-                Image(nsImage: icon)
-              }
-              Text(resource.status.toSiteStatus())
-            }
-          }
-          .help(resource.status.toSiteStatusTooltip())
+          Text(site.name)
         }
       }
+      .help(resource.status.toSiteStatusTooltip())
     }
 
     var internetResourceToggleTitle: String {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
@@ -184,8 +184,8 @@
           ResourceMenuItem(resource: resource)
         }
 
-        // Other Resources submenu (whenever favorites exist)
-        if resources.hasAnyFavorites {
+        // Other Resources submenu (only when there are non-favorites to list)
+        if !resources.others.isEmpty {
           Divider()
 
           Menu("Other Resources") {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
@@ -69,15 +69,15 @@
             store.configuration.internetResourceEnabled.toggle()
           }
         } else {
-          if let address = resource.address {
+          if let address = resource.address, !address.isEmpty {
             Button("Copy address") {
               Clipboard.copy(address)
             }
           }
 
-          Button(favoriteToggleTitle) {
-            toggleFavorite()
-          }
+          // A checkable item, ticked while the Resource is a favorite, like
+          // on Windows and Linux.
+          Toggle(favoriteToggleTitle, isOn: isFavorite)
         }
       }
     }
@@ -123,12 +123,17 @@
       store.favorites.contains(resource.id) ? "Remove from favorites" : "Add to favorites"
     }
 
-    func toggleFavorite() {
-      if store.favorites.contains(resource.id) {
-        store.favorites.remove(resource.id)
-      } else {
-        store.favorites.add(resource.id)
-      }
+    private var isFavorite: Binding<Bool> {
+      Binding(
+        get: { store.favorites.contains(resource.id) },
+        set: { isFavorite in
+          if isFavorite {
+            store.favorites.add(resource.id)
+          } else {
+            store.favorites.remove(resource.id)
+          }
+        }
+      )
     }
   }
 
@@ -136,14 +141,15 @@
   struct ResourcesSection: View {
     @EnvironmentObject var store: Store
 
-    /// Partitioned resources for display.
+    /// Partitioned resources for display, in the order they were received.
     /// If no resources are favorited, all resources show directly in the menu.
-    /// Otherwise, favorites show directly and others go in the "Other Resources" submenu.
+    /// Otherwise, favorites and the Internet Resource show directly and the
+    /// rest move to the "Other Resources" submenu.
     private var partitionedResources:
       (
-        internetResource: Resource?,
         directlyShown: [Resource],
-        others: [Resource]
+        others: [Resource],
+        hasAnyFavorites: Bool
       )
     {
       let allResources = store.resourceList.asArray()
@@ -153,22 +159,16 @@
         !$0.isInternetResource() && store.favorites.contains($0.id)
       }
 
-      return allResources.reduce(
-        into: (internetResource: nil, directlyShown: [], others: [])
-      ) { result, resource in
-        if resource.isInternetResource() {
-          result.internetResource = resource
-        } else if !hasAnyFavorites {
-          // No favorites: show all resources directly
-          result.directlyShown.append(resource)
-        } else if store.favorites.contains(resource.id) {
-          // Has favorites: show only favorites directly
-          result.directlyShown.append(resource)
-        } else {
-          // Has favorites: non-favorites go to submenu
-          result.others.append(resource)
-        }
+      guard hasAnyFavorites else {
+        // No favorites: show all resources directly
+        return (allResources, [], false)
       }
+
+      return (
+        allResources.filter { $0.isInternetResource() || store.favorites.contains($0.id) },
+        allResources.filter { !$0.isInternetResource() && !store.favorites.contains($0.id) },
+        true
+      )
     }
 
     var body: some View {
@@ -176,21 +176,18 @@
 
       Group {
         // Header text
-        Text(resourcesHeaderText)
+        Text(resourcesHeaderText(hasAnyFavorites: resources.hasAnyFavorites))
           .foregroundStyle(.secondary)
-
-        // Internet resource (always first if present)
-        if let internet = resources.internetResource {
-          ResourceMenuItem(resource: internet)
-        }
 
         // Directly shown resources (favorites, or all if no favorites)
         ForEach(resources.directlyShown) { resource in
           ResourceMenuItem(resource: resource)
         }
 
-        // Other Resources submenu (only when favorites exist and there are non-favorites)
-        if !resources.others.isEmpty {
+        // Other Resources submenu (whenever favorites exist)
+        if resources.hasAnyFavorites {
+          Divider()
+
           Menu("Other Resources") {
             ForEach(resources.others) { resource in
               ResourceMenuItem(resource: resource)
@@ -200,12 +197,16 @@
       }
     }
 
-    var resourcesHeaderText: String {
+    func resourcesHeaderText(hasAnyFavorites: Bool) -> String {
       switch store.resourceList {
       case .loading:
         return "Loading Resources..."
       case .loaded(let list):
-        return list.isEmpty ? "No Resources" : "Resources"
+        if list.isEmpty {
+          return "No Resources"
+        }
+
+        return hasAnyFavorites ? "Favorite Resources" : "Resources"
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceMenuSection.swift
@@ -37,22 +37,21 @@
 
     var body: some View {
       Group {
-        // Information: the description or address, and the Site status. The
-        // parent menu item already shows the name, so it isn't repeated here.
+        // Information: the description or address, and the connection status.
+        // The parent menu item already shows the name, so it isn't repeated
+        // here.
         if resource.isInternetResource() {
           Text("All network traffic")
             .foregroundStyle(.secondary)
-        } else if let detail = displayDetail {
-          if let url = URL(string: detail), url.scheme != nil {
-            Link(destination: url) {
-              Text(detail)
-                .foregroundColor(.blue)
-                .underline()
-            }
-          } else {
-            Text(detail)
-              .foregroundStyle(.secondary)
+        } else if let link = descriptionLink {
+          Link(destination: link.url) {
+            Text(link.text)
+              .foregroundColor(.blue)
+              .underline()
           }
+        } else if let detail = displayDetail {
+          Text(detail)
+            .foregroundStyle(.secondary)
         }
 
         if let site = resource.sites.first {
@@ -82,8 +81,21 @@
       }
     }
 
-    /// The single detail line: the description if present, otherwise the
-    /// address. Hidden when empty or identical to the name shown by the parent.
+    /// The description as a clickable link. Always shown — even when equal to
+    /// the name — because the parent menu item is not clickable, making this
+    /// link the only way to open it.
+    private var descriptionLink: (text: String, url: URL)? {
+      guard let description = resource.addressDescription,
+        let url = URL(string: description),
+        url.scheme != nil
+      else { return nil }
+
+      return (description, url)
+    }
+
+    /// The single non-link detail line: the description if present, otherwise
+    /// the address. Hidden when empty or identical to the name shown by the
+    /// parent.
     private var displayDetail: String? {
       let description = resource.addressDescription.flatMap { $0.isEmpty ? nil : $0 }
       guard let detail = description ?? resource.address,
@@ -95,24 +107,34 @@
     }
 
     private var hasInfo: Bool {
-      resource.isInternetResource() || displayDetail != nil || resource.sites.first != nil
+      resource.isInternetResource() || descriptionLink != nil || displayDetail != nil
+        || resource.sites.first != nil
     }
 
-    /// The Site name with its status as a colored dot. The textual status is
-    /// kept in the tooltip so the menu stays compact.
+    /// The connection status as a single line: a colored dot plus a short
+    /// label, with the Site name included when connected. The longer textual
+    /// explanation is kept in the tooltip so the menu stays compact.
     @ViewBuilder
     private func siteStatus(_ site: Site) -> some View {
-      Button {
-        Clipboard.copy(site.name)
-      } label: {
-        HStack {
-          if let icon = resource.status.statusIcon {
-            Image(nsImage: icon)
-          }
-          Text(site.name)
+      HStack {
+        if let icon = resource.status.statusIcon {
+          Image(nsImage: icon)
         }
+        Text(statusTitle(site))
+          .foregroundStyle(.secondary)
       }
       .help(resource.status.toSiteStatusTooltip())
+    }
+
+    private func statusTitle(_ site: Site) -> String {
+      switch resource.status {
+      case .online:
+        return "Connected: \(site.name)"
+      case .unknown:
+        return "Unknown"
+      case .offline:
+        return "Offline"
+      }
     }
 
     var internetResourceToggleTitle: String {


### PR DESCRIPTION
This PR reorganizes the resource menu across the macOS, Linux and Windows Client to use a more compact layout. In particular, we now follow these rules:

- Do not display duplicate information.
	- The resource name is always the tray menu entry.
	- If the address description is non-empty and different from the name, display it as a disabled entry in the sub-menu.
	- If the address description is empty and the address itself is different from the name, display it as a disabled entry in the sub-menu.
	- If all three are equal, no additional entries are displayed.
- Actions are explicit: "Copy to address" and "Add to favourites". Actions are also grouped together.
- Site status is now only displayed as an icon. On platforms that support it (macOS), also display a tooltip.

The resulting menu is now much more compact which primarily benefits Linux but also looks very clean on macOS and Windows.

|OS|Old layout|New layout|
|---|---|---|
|Windows|<img width="703" height="821" alt="Screenshot 2026-07-29 141404" src="https://github.com/user-attachments/assets/f2f55d89-bb28-477f-9c20-cbcc8f1e3acf" />|<img width="677" height="832" alt="Screenshot 2026-07-29 141021" src="https://github.com/user-attachments/assets/3805505e-4463-4740-a9f0-ec5450587c8a" />|
|Windows|<img width="703" height="825" alt="Screenshot 2026-07-29 141421" src="https://github.com/user-attachments/assets/bec8544e-5653-4c79-ab0c-7ea8ff1f9fb9" />|<img width="718" height="840" alt="Screenshot 2026-07-29 141053" src="https://github.com/user-attachments/assets/68c6ddce-fa78-470a-b2cb-1d20d108c3aa" />|
|macOS|<img width="547" height="523" alt="Screenshot 2026-07-29 at 14 19 20" src="https://github.com/user-attachments/assets/7641bb32-330f-4404-91ab-c4f1941f7482" />|<img width="547" height="523" alt="Screenshot 2026-07-29 at 15 15 29" src="https://github.com/user-attachments/assets/cb45b046-9395-40ff-a46b-b9c701e09e24" />|
|macOS|<img width="547" height="523" alt="Screenshot 2026-07-29 at 14 19 25" src="https://github.com/user-attachments/assets/15f26923-78d9-4709-88c6-7a14f2c175d4" />|<img width="547" height="523" alt="Screenshot 2026-07-29 at 15 24 04" src="https://github.com/user-attachments/assets/07de27b8-9c8b-4db5-b448-a1cfc8d64ca7" />|
|Linux|<img width="436" height="1808" alt="Screenshot From 2026-07-29 15-39-47" src="https://github.com/user-attachments/assets/f1b75967-fa03-419a-acf2-6dd09dcc2900" />|<img width="438" height="1544" alt="Screenshot From 2026-07-29 15-38-31" src="https://github.com/user-attachments/assets/bf608a2e-50e2-4a56-8a13-2e9aa31af4d3" />|
|Linux|<img width="433" height="1642" alt="Screenshot From 2026-07-29 15-39-56" src="https://github.com/user-attachments/assets/c4217acd-ec41-459a-9234-c3eb117eebd5" />|<img width="438" height="1544" alt="Screenshot From 2026-07-29 15-38-38" src="https://github.com/user-attachments/assets/d39651c6-7340-4de7-8d8a-fed148f94c67" />|

