### PR TITLE
perf(tunnel): skip idle ticks in test harness advance loop

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests/flux_capacitor.rs
+++ b/rust/libs/connlib/tunnel/src/tests/flux_capacitor.rs
@@ -45,8 +45,19 @@ impl FluxCapacitor {
         self.tick(Self::SMALL_TICK);
     }
 
-    pub(crate) fn large_tick(&self) {
-        self.tick(Self::LARGE_TICK);
+    /// Advance to the first `LARGE_TICK` grid point at or after `target` in a
+    /// single step. The landing point is identical to repeatedly calling
+    /// `tick(Self::LARGE_TICK)` until `now >= target`, so this only skips
+    /// intermediate stops at which nothing is due.
+    pub(crate) fn advance_until(&self, target: Instant) {
+        let elapsed = target.saturating_duration_since(self.now::<Instant>());
+        let ticks = elapsed
+            .as_nanos()
+            .div_ceil(Self::LARGE_TICK.as_nanos())
+            .max(1);
+        let ticks = u32::try_from(ticks).unwrap_or(u32::MAX);
+
+        self.tick(Self::LARGE_TICK * ticks);
     }
 
     pub(crate) fn tick(&self, tick: Duration) {

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -819,7 +819,10 @@ impl TunnelTest {
                 break; // Nothing to do before cut-off.
             }
 
-            self.flux_capacitor.large_tick(); // Large tick to more quickly advance to potential next timeout.
+            // The buffer is empty here (see the `is_empty` guard above), so nothing
+            // is in flight; jump straight to the next timeout instead of ticking
+            // there one `LARGE_TICK` at a time.
+            self.flux_capacitor.advance_until(time_to_next_action);
         }
 
         for (transmit, at) in buffered_transmits.drain() {


### PR DESCRIPTION
The proptest/fuzz harness advanced simulated time toward each timeout in fixed 100ms (`LARGE_TICK`) increments, re-running the full per-host timeout handling at every step even when nothing was due. `poll_timeout` already reports the next deadline, and this branch of the loop is only reached once `buffered_transmits` is empty (nothing in flight), so `advance` now jumps straight to it — rounded up to the same tick grid, so the landing point, and therefore behaviour, is unchanged. Confirmed by the `tunnel_test` proptest suite staying green.

Effect on the `tunnel-test` CI job (`main` @ a3fb65a8 vs this branch):

| | `Tunnel proptest` step | whole `tunnel-test` job |
|---|---|---|
| `main` | 13m36s | 17m22s |
| this branch | 9m51s | 12m12s |
| | **~28% faster** | **~30% faster** |

Related: #13910