### PR TITLE
test(tunnel): run `add_host` outside `debug_assert!`

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests/reference.rs
+++ b/rust/libs/connlib/tunnel/src/tests/reference.rs
@@ -907,7 +907,8 @@ impl ReferenceState {
                 state.network.remove_host(client);
                 client.ip4.clone_from(ip4);
                 client.ip6.clone_from(ip6);
-                debug_assert!(state.network.add_host(*client_id, client));
+                let added = state.network.add_host(*client_id, client);
+                debug_assert!(added);
 
                 // When roaming, we are not connected to any resource and wait for the next packet to re-establish a connection.
                 client.exec_mut(|client| {
@@ -1887,7 +1888,8 @@ impl ReferenceState {
 
         for (rid, new_relay) in new_relays {
             self.relays.insert(*rid, new_relay.clone());
-            debug_assert!(self.network.add_host(*rid, new_relay));
+            let added = self.network.add_host(*rid, new_relay);
+            debug_assert!(added);
         }
     }
 }

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -421,7 +421,8 @@ impl TunnelTest {
                 let ref_client = ref_state.clients.get(&client_id).unwrap();
                 state.network.remove_host(client);
                 client.update_interface(ip4, ip6);
-                debug_assert!(state.network.add_host(client_id, client));
+                let added = state.network.add_host(client_id, client);
+                debug_assert!(added);
 
                 client.exec_mut(|c| {
                     c.sut.reset(now, "roam");
@@ -1325,7 +1326,8 @@ impl TunnelTest {
             .collect::<BTreeMap<_, _>>();
 
         for (rid, relay) in &online {
-            debug_assert!(self.network.add_host(*rid, relay));
+            let added = self.network.add_host(*rid, relay);
+            debug_assert!(added);
         }
 
         for client in self.clients.values_mut() {


### PR DESCRIPTION
`debug_assert!` strips its expression in optimized builds, so the `network.add_host(...)` calls nested inside the test harness' assertions are silently dropped whenever it is compiled with `debug_assertions` off. The proptest suite runs in debug so the bug stays latent, but anything driving the harness in release — notably the upcoming coverage-guided fuzz target — leaves roamed clients and freshly-deployed relays out of the routing table, after which packets to them surface as "Unhandled packet" errors.

Pull the side-effecting call out of the assertion and assert the returned bool separately.

Related: #13910