### PR TITLE
ci(perf): tune Linux kernel parameters

### DIFF
--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -45,10 +45,12 @@ jobs:
       - uses: ./.github/actions/setup-scripts
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'mix ecto.migrate && mix ecto.seed'
-      - name: Increase max UDP buffer sizes
+      - name: Tune Linux kernel
         run: |
-          sudo sysctl -w net.core.wmem_max=16777216 # 16 MB
-          sudo sysctl -w net.core.rmem_max=134217728 # 128 MB
+          sudo sysctl -w net.core.wmem_max=16777216           # 16 MB
+          sudo sysctl -w net.core.rmem_max=134217728          # 128 MB
+          sudo sysctl -w net.core.netdev_max_backlog=100000   # matches the netem limit
+          sudo sysctl -w net.core.netdev_budget=5000          # drain more per softirq poll
       - name: Start docker compose in the background
         run: |
           if [ "${{ matrix.flavour }}" = "relayed" ]; then


### PR DESCRIPTION
Similar to #13839, the Linux kernel has additional queue limits for regular devices. The default here is also 1000 which we can easily saturate as soon as we run an iperf test locally.

With these limits applied, I can now (finally) run a TCP iperf across our docker stack reliably with 0 packet loss:

```
Connecting to host 172.20.0.110, port 5201
[  5] local 100.86.22.165 port 58010 connected to 172.20.0.110 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   115 MBytes   962 Mbits/sec    0   7.00 MBytes
[  5]   1.00-2.00   sec   128 MBytes  1.07 Gbits/sec    0   7.00 MBytes
[  5]   2.00-3.00   sec   136 MBytes  1.14 Gbits/sec    0   7.00 MBytes
[  5]   3.00-4.00   sec   132 MBytes  1.10 Gbits/sec    0   7.00 MBytes
[  5]   4.00-5.00   sec   132 MBytes  1.10 Gbits/sec    0   7.00 MBytes
[  5]   5.00-6.00   sec   133 MBytes  1.11 Gbits/sec    0   7.00 MBytes
[  5]   6.00-7.00   sec   132 MBytes  1.10 Gbits/sec    0   7.00 MBytes
[  5]   7.00-8.00   sec   130 MBytes  1.09 Gbits/sec    0   7.00 MBytes
[  5]   8.00-9.00   sec   133 MBytes  1.11 Gbits/sec    0   7.00 MBytes
[  5]   9.00-10.00  sec   133 MBytes  1.11 Gbits/sec    0   7.00 MBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  1.27 GBytes  1.09 Gbits/sec    0            sender
[  5]   0.00-10.02  sec  1.27 GBytes  1.09 Gbits/sec                  receiver

iperf Done.
```