### PR TITLE
refactor(telemetry): run teardown on the internal runtime

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -500,7 +500,7 @@ fn connect(
     init_logging(&PathBuf::from(log_dir), log_filter)?;
 
     telemetry::start(&api_url, RELEASE, platform::DSN);
-    runtime.block_on(telemetry::set_firezone_id(device_id.clone()));
+    telemetry::set_firezone_id(device_id.clone());
     telemetry::set_account_slug(account_slug.clone());
 
     analytics::identify(RELEASE.to_owned(), Some(account_slug));
@@ -575,7 +575,7 @@ pub fn start_telemetry() {
 
 #[uniffi::export]
 pub fn stop_telemetry() {
-    telemetry::stop_blocking();
+    telemetry::stop();
 }
 
 static LOGGER_STATE: OnceLock<(logging::file::Handle, logging::FilterReloadHandle)> =

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -64,19 +64,19 @@ fn main() -> ExitCode {
     match runtime.block_on(try_main(cli)) {
         Ok(()) => {
             tracing::info!("Goodbye!");
-            runtime.block_on(telemetry::stop());
+            telemetry::stop();
 
             ExitCode::SUCCESS
         }
         Err(e) if e.any_is::<EventloopFailed>() => {
             tracing::error!("{e:#}");
-            runtime.block_on(telemetry::stop());
+            telemetry::stop();
 
             ExitCode::FAILURE
         }
         Err(e) => {
             tracing::info!("{e:#}");
-            runtime.block_on(telemetry::stop());
+            telemetry::stop();
 
             ExitCode::FAILURE
         }
@@ -144,7 +144,7 @@ async fn try_main(cli: Cli) -> Result<()> {
 
     if cli.is_telemetry_allowed() {
         telemetry::start(cli.api_url.as_str(), RELEASE, telemetry::GATEWAY_DSN);
-        telemetry::set_firezone_id(firezone_id.clone()).await;
+        telemetry::set_firezone_id(firezone_id.clone());
     }
 
     if let Some(backend) = cli.metrics {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -61,7 +61,7 @@ fn main() -> ExitCode {
         }
     };
 
-    rt.block_on(async { telemetry::stop().await });
+    telemetry::stop();
 
     exit_code
 }

--- a/rust/gui-client/src-tauri/src/bin/register-sparse.rs
+++ b/rust/gui-client/src-tauri/src/bin/register-sparse.rs
@@ -50,7 +50,7 @@ async fn main() -> ExitCode {
 
     let exit_code = run();
 
-    telemetry::stop().await;
+    telemetry::stop();
     exit_code
 }
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -216,7 +216,7 @@ impl<I: GuiIntegration> Controller<I> {
             Some(false) => None,
         };
 
-        telemetry::set_firezone_id(firezone_id).await;
+        telemetry::set_firezone_id(firezone_id);
 
         let auth = auth::Auth::new()?;
 

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -495,7 +495,7 @@ impl<'a> Handler<'a> {
             }
         };
 
-        telemetry::stop().await; // Flush telemetry as the service shuts down.
+        telemetry::stop(); // Flush telemetry as the service shuts down.
 
         ret
     }
@@ -680,7 +680,7 @@ impl<'a> Handler<'a> {
                 if !no_telemetry {
                     self.telemetry_release = Some(release.clone());
                     telemetry::start(&environment, &release, telemetry::GUI_DSN);
-                    telemetry::set_firezone_id(self.device_id.id.clone()).await;
+                    telemetry::set_firezone_id(self.device_id.id.clone());
 
                     opentelemetry::global::set_meter_provider(
                         telemetry::SentryMeterProvider::default(),

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -330,7 +330,7 @@ fn try_main() -> Result<()> {
         );
 
         telemetry::start(cli.api_url.as_ref(), RELEASE, telemetry::HEADLESS_DSN);
-        rt.block_on(telemetry::set_firezone_id(firezone_id.clone()));
+        telemetry::set_firezone_id(firezone_id.clone());
 
         analytics::identify(RELEASE.to_owned(), None);
     }
@@ -507,7 +507,7 @@ fn try_main() -> Result<()> {
         // Drain the event-stream to allow the event-loop to gracefully shutdown.
         let _ = tokio::time::timeout(Duration::from_secs(1), event_stream.drain()).await;
 
-        telemetry::stop().await;
+        telemetry::stop();
 
         result
     })?;

--- a/rust/libs/telemetry/src/ingest.rs
+++ b/rust/libs/telemetry/src/ingest.rs
@@ -130,6 +130,10 @@ impl Client {
         *self.connection.lock() = None;
     }
 
+    pub(crate) async fn connect(&self) {
+        let _ = self.connection().await;
+    }
+
     /// Sends an HTTP request over a (re-)established connection to the host.
     pub(crate) async fn send_request(&self, request: Request<Bytes>) -> Result<Response<Bytes>> {
         let connection = self.connection().await?;

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -243,6 +243,9 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
     });
 
     guard.replace(inner);
+
+    sentry::warmup_connection();
+    posthog::warmup_connection();
 }
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
@@ -260,14 +263,14 @@ pub fn stop() {
     // thread, so delegate both to the blocking pool instead of the caller's thread.
     let (tx, rx) = mpsc::sync_channel(1);
     ingest::RUNTIME.spawn_blocking(move || {
-        let flushed = inner.flush(Some(Duration::from_secs(5)));
+        let flushed = inner.flush(Some(Duration::from_secs(1)));
         drop(inner);
         let _ = tx.send(flushed);
     });
 
     // Sentry's flush can block past its own timeout on a full transport queue;
     // this bound guarantees we return regardless.
-    match rx.recv_timeout(Duration::from_secs(5)) {
+    match rx.recv_timeout(Duration::from_secs(1)) {
         Ok(true) => tracing::debug!("Flushed telemetry"),
         Ok(false) => tracing::error!("Failed to flush telemetry events to sentry.io"),
         Err(_) => tracing::error!("Failed to stop telemetry session within 2s"),

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Duration};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, bail};
 use api_url::ApiUrl;
 use parking_lot::Mutex;
 use sentry::{
@@ -240,44 +240,25 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
 }
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
-pub async fn stop() {
-    if let Err(e) = end_session().await {
-        tracing::error!("Failed to stop Sentry session on graceful exit: {e:#}")
-    }
-}
+///
+/// Sentry's flush is blocking IO with its own timeout, so this needs no runtime and
+/// is safe to call from anywhere at teardown.
+pub fn stop() {
+    let Some(inner) = GUARD.lock().take() else {
+        return;
+    };
 
-/// Blocking [`stop`] for teardown paths with no runtime of their own, run on
-/// telemetry's shared ingest runtime.
-pub fn stop_blocking() {
-    ingest::RUNTIME.block_on(stop());
+    tracing::info!("Stopping telemetry");
+
+    if inner.flush(Some(Duration::from_secs(1))) {
+        tracing::debug!("Flushed telemetry");
+    } else {
+        tracing::error!("Failed to flush telemetry events to sentry.io");
+    }
 }
 
 pub fn is_active() -> bool {
     GUARD.lock().is_some()
-}
-
-async fn end_session() -> Result<()> {
-    let Some(inner) = GUARD.lock().take() else {
-        return Ok(());
-    };
-    tracing::info!("Stopping telemetry");
-
-    // Sentry uses blocking IO for flushing ..
-    let task = tokio::task::spawn_blocking(move || {
-        if !inner.flush(Some(Duration::from_secs(1))) {
-            return Err(anyhow!("Failed to flush telemetry events to sentry.io"));
-        };
-
-        tracing::debug!("Flushed telemetry");
-
-        Ok(())
-    });
-
-    tokio::time::timeout(Duration::from_secs(1), task)
-        .await
-        .context("Failed to end session within 1s")???;
-
-    Ok(())
 }
 
 pub fn set_account_slug(slug: String) {
@@ -287,17 +268,16 @@ pub fn set_account_slug(slug: String) {
 }
 
 /// Attaches the Firezone ID to the active Sentry session.
-pub async fn set_firezone_id(firezone_id: String) {
+pub fn set_firezone_id(firezone_id: String) {
     let new_user = compute_user(firezone_id);
     update_user(|user| {
         user.id = new_user.id;
         user.other.extend(new_user.other);
     });
 
-    // In case user and env are now available, re-eval feature-flags.
-    if let (Some(id), Some(env)) = (current_user(), current_env()) {
-        feature_flags::evaluate_now(id, env).await;
-    }
+    // The user (and maybe env) may now be available, so re-eval feature flags on
+    // telemetry's internal ingest runtime.
+    feature_flags::reevaluate_current();
 }
 
 #[doc(hidden)] // Only public for testing.

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,12 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::{
-    collections::BTreeMap,
-    fmt, mem,
-    str::FromStr,
-    sync::{Arc, mpsc},
-    time::Duration,
-};
+use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{Result, bail};
 use api_url::ApiUrl;
@@ -249,32 +243,15 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
 }
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
-///
-/// Runs on the ingest runtime's blocking pool with a bounded wait, so it needs no
-/// caller runtime, never enters a runtime context and is guaranteed to return.
 pub fn stop() {
     let Some(inner) = GUARD.lock().take() else {
         return;
     };
 
-    tracing::info!("Stopping telemetry");
+    // This blocks the current thread but the transport uses its own runtime so this is safe.
+    let flushed = inner.flush(Some(Duration::from_secs(1)));
 
-    // Sentry uses blocking IO for flushing and the guard-drop joins the transport
-    // thread, so delegate both to the blocking pool instead of the caller's thread.
-    let (tx, rx) = mpsc::sync_channel(1);
-    ingest::RUNTIME.spawn_blocking(move || {
-        let flushed = inner.flush(Some(Duration::from_secs(1)));
-        drop(inner);
-        let _ = tx.send(flushed);
-    });
-
-    // Sentry's flush can block past its own timeout on a full transport queue;
-    // this bound guarantees we return regardless.
-    match rx.recv_timeout(Duration::from_secs(1)) {
-        Ok(true) => tracing::debug!("Flushed telemetry"),
-        Ok(false) => tracing::error!("Failed to flush telemetry events to sentry.io"),
-        Err(_) => tracing::error!("Failed to stop telemetry session within 2s"),
-    }
+    tracing::info!(%flushed, "Stopped telemetry");
 }
 
 pub fn is_active() -> bool {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -1,6 +1,12 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    fmt, mem,
+    str::FromStr,
+    sync::{Arc, mpsc},
+    time::Duration,
+};
 
 use anyhow::{Result, bail};
 use api_url::ApiUrl;
@@ -241,8 +247,8 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
 ///
-/// Sentry's flush is blocking IO with its own timeout, so this needs no runtime and
-/// is safe to call from anywhere at teardown.
+/// Runs on the ingest runtime's blocking pool with a bounded wait, so it needs no
+/// caller runtime, never enters a runtime context and is guaranteed to return.
 pub fn stop() {
     let Some(inner) = GUARD.lock().take() else {
         return;
@@ -250,10 +256,21 @@ pub fn stop() {
 
     tracing::info!("Stopping telemetry");
 
-    if inner.flush(Some(Duration::from_secs(1))) {
-        tracing::debug!("Flushed telemetry");
-    } else {
-        tracing::error!("Failed to flush telemetry events to sentry.io");
+    // Sentry uses blocking IO for flushing and the guard-drop joins the transport
+    // thread, so delegate both to the blocking pool instead of the caller's thread.
+    let (tx, rx) = mpsc::sync_channel(1);
+    ingest::RUNTIME.spawn_blocking(move || {
+        let flushed = inner.flush(Some(Duration::from_secs(1)));
+        drop(inner);
+        let _ = tx.send(flushed);
+    });
+
+    // Sentry's flush can block past its own timeout on a full transport queue;
+    // this bound guarantees we return regardless.
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(true) => tracing::debug!("Flushed telemetry"),
+        Ok(false) => tracing::error!("Failed to flush telemetry events to sentry.io"),
+        Err(_) => tracing::error!("Failed to stop telemetry session within 2s"),
     }
 }
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -260,14 +260,14 @@ pub fn stop() {
     // thread, so delegate both to the blocking pool instead of the caller's thread.
     let (tx, rx) = mpsc::sync_channel(1);
     ingest::RUNTIME.spawn_blocking(move || {
-        let flushed = inner.flush(Some(Duration::from_secs(1)));
+        let flushed = inner.flush(Some(Duration::from_secs(5)));
         drop(inner);
         let _ = tx.send(flushed);
     });
 
     // Sentry's flush can block past its own timeout on a full transport queue;
     // this bound guarantees we return regardless.
-    match rx.recv_timeout(Duration::from_secs(2)) {
+    match rx.recv_timeout(Duration::from_secs(5)) {
         Ok(true) => tracing::debug!("Flushed telemetry"),
         Ok(false) => tracing::error!("Failed to flush telemetry events to sentry.io"),
         Err(_) => tracing::error!("Failed to stop telemetry session within 2s"),

--- a/rust/libs/telemetry/src/posthog.rs
+++ b/rust/libs/telemetry/src/posthog.rs
@@ -29,6 +29,10 @@ pub(crate) fn reset_client() {
     CLIENT.reset();
 }
 
+pub(crate) fn warmup_connection() {
+    ingest::RUNTIME.spawn(CLIENT.connect());
+}
+
 /// Sends a JSON `POST` to `path` on the PostHog ingest host and returns the response.
 pub(crate) async fn post_json<B>(path: &str, body: &B) -> Result<Response<Bytes>>
 where

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -22,6 +22,10 @@ pub(crate) fn reset_client() {
     CLIENT.reset();
 }
 
+pub(crate) fn warmup_connection() {
+    ingest::RUNTIME.spawn(CLIENT.connect());
+}
+
 /// Builds the Sentry [`ClientOptions`] with our [`Factory`] transport and starts the SDK.
 pub(crate) fn init_sdk_client(
     dsn: String,

--- a/rust/libs/telemetry/tests/attach_firezone_id.rs
+++ b/rust/libs/telemetry/tests/attach_firezone_id.rs
@@ -10,7 +10,7 @@ async fn set_firezone_id_attaches_user_to_running_session() {
     );
     telemetry::start("entrypoint", "1.0.0", TESTING);
 
-    telemetry::set_firezone_id("device-abc".to_owned()).await;
+    telemetry::set_firezone_id("device-abc".to_owned());
 
     assert_eq!(telemetry::current_user().as_deref(), Some("device-abc"));
 }

--- a/rust/libs/telemetry/tests/set_account_before_id.rs
+++ b/rust/libs/telemetry/tests/set_account_before_id.rs
@@ -11,7 +11,7 @@ async fn set_account_slug_before_set_firezone_id_preserves_both() {
     telemetry::start("entrypoint", "1.0.0", TESTING);
 
     telemetry::set_account_slug("acme".to_owned());
-    telemetry::set_firezone_id("device-xyz".to_owned()).await;
+    telemetry::set_firezone_id("device-xyz".to_owned());
 
     assert_eq!(telemetry::current_user().as_deref(), Some("device-xyz"));
     assert_eq!(telemetry::current_account_slug().as_deref(), Some("acme"));

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -160,7 +160,7 @@ fn main() -> ExitCode {
         }
     };
 
-    runtime.block_on(telemetry::stop());
+    telemetry::stop();
 
     code
 }


### PR DESCRIPTION
Stopping telemetry and attaching the Firezone ID previously required the caller to bring a tokio runtime. Both are now plain synchronous functions.

Sentry's transport uses the internal ingest runtime so blocking the current thread on that completion is safe, even if it is another tokio runtime thread. It will block all other async tasks that are currently running on that but telemetry is only shut down at the very end of each process so there isn't anything else left to do, plus we timeout after 1s.

`set_firezone_id` re-evaluates feature flags through `reevaluate_current`, which also runs on the internal runtime.

Callers no longer pass a runtime through either call.

Related: #13917