### PR TITLE
fix(portal): order pool members by online

### DIFF
--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -2146,6 +2146,7 @@ defmodule PortalWeb.Resources.Components do
 
     def search_clients(search_term, subject, selected_clients) do
       selected_ids = Enum.map(selected_clients, & &1.id)
+      online_ids = Portal.Presence.Clients.online_client_ids(subject.account.id)
       pattern = "%#{search_term}%"
 
       query =
@@ -2154,6 +2155,7 @@ defmodule PortalWeb.Resources.Components do
         |> join(:inner, [clients: c], a in assoc(c, :actor), as: :actors)
         |> where([clients: c], c.id not in ^selected_ids)
         |> where(^client_search_filter(pattern))
+        |> order_by([clients: c], desc: c.id in ^online_ids)
         |> limit(10)
 
       case query |> Safe.scoped(subject, :replica) |> Safe.all() do
@@ -2161,9 +2163,7 @@ defmodule PortalWeb.Resources.Components do
           []
 
         clients ->
-          clients
-          |> Portal.Presence.Clients.preload_clients_presence()
-          |> Enum.sort_by(&if &1.online?, do: 0, else: 1)
+          Enum.map(clients, &%{&1 | online?: &1.id in online_ids})
       end
     end
 

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -14,6 +14,7 @@ defmodule PortalWeb.ResourcesTest do
   import Portal.MembershipFixtures
   import Portal.PolicyAuthorizationFixtures
   import Portal.PolicyFixtures
+  import Portal.SubjectFixtures
   import Portal.TokenFixtures
   import Portal.ResourceFixtures
   import Portal.SiteFixtures
@@ -429,6 +430,26 @@ defmodule PortalWeb.ResourcesTest do
                lv,
                "button[phx-click='remove_client'][phx-value-client_id='#{client.id}']"
              )
+    end
+
+    test "client picker search surfaces online clients ahead of the result limit", %{
+      account: account,
+      actor: actor
+    } do
+      subject = admin_subject_fixture(account: account, actor: actor)
+
+      for i <- 1..10 do
+        client_fixture(account: account, actor: actor, name: "Bulk Offline #{i}")
+      end
+
+      online_client = client_fixture(account: account, actor: actor, name: "Bulk Online")
+      :ok = Portal.Presence.Clients.Account.track(account.id, online_client.id)
+
+      results = PortalWeb.Resources.Components.Database.search_clients("Bulk", subject, [])
+
+      assert length(results) == 10
+      assert [%{id: id, online?: true} | _] = results
+      assert id == online_client.id
     end
   end
 


### PR DESCRIPTION
When showing clients to select for a device pool it's helpful if the online devices are shown first because those are more likely to be the ones the admin is interested in connecting to.