### PR TITLE
chore: don't configure latency of 0ms

### DIFF
--- a/scripts/router/router.sh
+++ b/scripts/router/router.sh
@@ -64,8 +64,8 @@ if [ -n "${PORT_FORWARDS:-}" ]; then
     done
 fi
 
-# Add configurable latency if specified
-if [ -n "${NETWORK_LATENCY_MS:-}" ]; then
+# Add configurable latency if specified.
+if [ "${NETWORK_LATENCY_MS:-0}" -gt 0 ]; then
     LATENCY=$((NETWORK_LATENCY_MS / 2)) # Latency is only applied to outbound packets. To achieve the actual configured latency, we apply half of it to each interface.
 
     tc qdisc add dev internet root netem delay "${LATENCY}ms" limit 100000


### PR DESCRIPTION
A latency of 0 should disable the use of `qdisc` entirely. This is not the case though and we still burn unnecessary CPU cycles as part of the `ksoftirqd/4` kernel thread when it is configured. Under high load such as when profiling connlib, we need to make sure that connlib is always the bottleneck, otherwise we cannot effectively measure whether a given change is actually an improvement.