### PR TITLE
ci: only attach `xdp_pass` to relay veth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -418,25 +418,31 @@ services:
       - |
         set -e
 
-        VETHS=$$(ip -json link show type veth | jq -r '.[].ifname')
-
-        for dev in $$VETHS; do
-          echo "Attaching XDP to: $$dev"
-          ip link set dev $$dev xdpdrv off # Clear any existing XDP program.
-          ip link set dev $$dev xdpdrv obj /xdp/xdp_pass.o sec xdp
-
-          ethtool -K $$dev tx off # Disable offloading.
+        # Disable tx offload on all veths + bridges so that packets reaching the
+        # relay carry correct (software-computed) checksums.
+        for dev in $$(ip -json link show type veth | jq -r '.[].ifname'); do
+          ethtool -K $$dev tx off
         done
-
-        echo "Done configuring $$(echo "$$VETHS" | wc -w) veth interfaces"
-
-        BRIDGES=$$(ip -json link show type bridge | jq -r '.[].ifname')
-
-        for dev in $$BRIDGES; do
-          ethtool -K $$dev tx off # Disable offloading.
+        for dev in $$(ip -json link show type bridge | jq -r '.[].ifname'); do
+          ethtool -K $$dev tx off
         done
+        echo "Disabled tx offload on all veth + bridge devices"
 
-        echo "Done configuring $$(echo "$$BRIDGES" | wc -w) bridge interfaces"
+        # The relays do XDP_TX on eth0, so the host-side veth peering each relay must
+        # run an XDP program to receive those frames and pass them up to the bridge.
+        # Those peers are exactly the veths enslaved to the relay-internal bridges
+        # (the only docker networks in 172.29.0.0/16). Scoping xdp_pass to them keeps
+        # it off the client<->gateway path, where attaching to every veth would cost
+        # ~18% of the forwarding softirq (veth_xdp_rcv). This service depends on both
+        # relays being healthy, so their veths already exist on those bridges.
+        for br in $$(ip -json link show type bridge | jq -r '.[].ifname'); do
+          ip -json addr show dev $$br | jq -e '.[].addr_info[]? | select((.local // "") | startswith("172.29."))' >/dev/null || continue
+          for dev in $$(ip -json link show master $$br | jq -r '.[].ifname'); do
+            ip link set dev $$dev xdpdrv off 2>/dev/null || true
+            ip link set dev $$dev xdpdrv obj /xdp/xdp_pass.o sec xdp
+            echo "Attached xdp_pass to $$dev (relay-internal bridge $$br)"
+          done
+        done
     depends_on:
       relay-1:
         condition: "service_healthy"


### PR DESCRIPTION
To test our eBPF turn router program in the docker compose setup, we need to attach a dummy `xdp_pass` eBPF program to the "other end" of the veth interfaces that form the network connection to the relay. Without this program, the packets get black-holed (see https://fedepaol.github.io/blog/2023/09/11/xdp-ate-my-packets-and-how-i-debugged-it/ for details).

Despite being very simple, just the act of attaching a XDP program requires the kernel to spend some additional CPU cycles in invoking it. When running high-throughput benchmarks, doing this amounts to ~18% of CPU time. That is enough to make the kernel's softirqd thread consume more CPU than the connlib thread, leading to packet drops in the kernel.