### PR TITLE
feat(portal): otel metrics for portal app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -463,6 +463,9 @@ services:
 
   otel:
     image: otel/opentelemetry-collector:latest
+    ports:
+      - 127.0.0.1:4317:4317 # OTLP gRPC receiver
+      - 127.0.0.1:4318:4318 # OTLP http receiver
     networks:
       app-internal:
 

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -244,3 +244,18 @@ config :portal, Portal.Mailer.Secondary, adapter: Swoosh.Adapters.Local
 
 config :sentry,
   environment_name: :dev
+
+config :portal, Portal.Telemetry, metrics_debug: false
+
+if otlp_endpoint = System.get_env("OTLP_ENDPOINT") do
+  config :opentelemetry_experimental,
+    readers: [
+      %{
+        module: :otel_metric_reader,
+        config: %{
+          export_interval_ms: 30_000,
+          exporter: {:otel_exporter_metrics_otlp, %{endpoints: [otlp_endpoint]}}
+        }
+      }
+    ]
+end

--- a/elixir/lib/portal/telemetry.ex
+++ b/elixir/lib/portal/telemetry.ex
@@ -102,7 +102,7 @@ defmodule Portal.Telemetry do
       summary("portal.repo.query.idle_time", unit: {:native, :millisecond}),
 
       # Phoenix Metrics
-      counter("phoenix.router_dispatch.stop",
+      counter("phoenix.router_dispatch.stop.duration",
         tags: [:route],
         description: "HTTP request count by route"
       ),
@@ -570,7 +570,7 @@ defmodule Portal.Telemetry do
     attrs = %{
       "http.route" => route,
       "http.request.method" => conn.method,
-      "http.response.status_code" => to_string(conn.status || 0),
+      "http.response.status_code" => conn.status || 0,
       "http.endpoint" => endpoint_name(conn),
       "node_name" => config.node_name
     }

--- a/elixir/lib/portal/telemetry.ex
+++ b/elixir/lib/portal/telemetry.ex
@@ -3,6 +3,49 @@ defmodule Portal.Telemetry do
   import Telemetry.Metrics
   require Logger
 
+  @metric_groups %{
+    http: %{
+      handler_id: "portal-http-metrics",
+      events: [
+        [:phoenix, :router_dispatch, :stop],
+        [:phoenix, :endpoint, :start],
+        [:phoenix, :endpoint, :stop]
+      ]
+    },
+    db: %{
+      handler_id: "portal-db-metrics",
+      events: [
+        [:portal, :repo, :query],
+        [:portal, :repo, :replica, :query],
+        [:portal, :repo, :web, :query],
+        [:portal, :repo, :api, :query],
+        [:portal, :repo, :replica, :web, :query],
+        [:portal, :repo, :replica, :api, :query]
+      ]
+    },
+    liveview_lifecycle: %{
+      handler_id: "portal-liveview-lifecycle-metrics",
+      events: [
+        [:phoenix, :live_view, :mount, :stop],
+        [:phoenix, :live_view, :handle_params, :stop]
+      ]
+    },
+    liveview_events: %{
+      handler_id: "portal-liveview-event-metrics",
+      events: [
+        [:phoenix, :live_view, :handle_event, :stop],
+        [:phoenix, :live_component, :handle_event, :stop]
+      ]
+    },
+    channels: %{
+      handler_id: "portal-channel-metrics",
+      events: [
+        [:phoenix, :channel_joined],
+        [:phoenix, :channel_handled_in]
+      ]
+    }
+  }
+
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
@@ -11,24 +54,44 @@ defmodule Portal.Telemetry do
   def init(_arg) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
 
-    register_otel_instruments()
+    Enum.each(@metric_groups, fn {_group, %{handler_id: id}} -> :telemetry.detach(id) end)
 
-    children = [
-      # Telemetry poller will execute the given period measurements
-      # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
-      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
-    ]
-
-    reporter_children =
-      if metrics_reporter = Keyword.get(config, :metrics_reporter) do
-        [{metrics_reporter, metrics: metrics()}]
+    children =
+      if Keyword.get(config, :enabled, true) do
+        register_otel_instruments()
+        Enum.each(Map.keys(@metric_groups), &enable_metrics/1)
+        build_children(config)
       else
         []
       end
 
-    Supervisor.init(children ++ reporter_children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
+  defp build_children(config) do
+    [
+      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
+    ] ++
+      reporter_child(config) ++
+      dev_aggregator_child(config)
+  end
+
+  defp reporter_child(config) do
+    case Keyword.get(config, :metrics_reporter) do
+      nil -> []
+      reporter -> [{reporter, metrics: metrics()}]
+    end
+  end
+
+  defp dev_aggregator_child(config) do
+    if Keyword.get(config, :metrics_debug) do
+      [Portal.Telemetry.DevAggregator]
+    else
+      []
+    end
+  end
+
+  @spec metrics() :: [Telemetry.Metrics.t()]
   def metrics do
     [
       # Database Metrics
@@ -39,6 +102,10 @@ defmodule Portal.Telemetry do
       summary("portal.repo.query.idle_time", unit: {:native, :millisecond}),
 
       # Phoenix Metrics
+      counter("phoenix.router_dispatch.stop",
+        tags: [:route],
+        description: "HTTP request count by route"
+      ),
       summary("phoenix.endpoint.start.system_time",
         unit: {:native, :millisecond}
       ),
@@ -135,6 +202,7 @@ defmodule Portal.Telemetry do
   Emits comprehensive BEAM health metrics including process counts,
   atom usage, port usage, ETS tables, and detailed memory breakdown.
   """
+  @spec emit_beam_health_metrics() :: :ok
   def emit_beam_health_metrics do
     # Process counts and utilization
     process_count = :erlang.system_info(:process_count)
@@ -178,7 +246,7 @@ defmodule Portal.Telemetry do
     :telemetry.execute([:vm, :memory, :detailed], memory_info)
   rescue
     error ->
-      Logger.info("Error in emit_beam_health_metrics",
+      Logger.error("Error in emit_beam_health_metrics",
         reason: inspect(error)
       )
 
@@ -188,6 +256,7 @@ defmodule Portal.Telemetry do
   @doc """
   Emits garbage collection metrics across all processes.
   """
+  @spec emit_gc_metrics() :: :ok
   def emit_gc_metrics do
     gc_info = :erlang.statistics(:garbage_collection)
     {collections, words_reclaimed, _} = gc_info
@@ -200,7 +269,7 @@ defmodule Portal.Telemetry do
     })
   rescue
     error ->
-      Logger.info("Error in emit_gc_metrics",
+      Logger.error("Error in emit_gc_metrics",
         reason: inspect(error)
       )
 
@@ -210,6 +279,7 @@ defmodule Portal.Telemetry do
   @doc """
   Emits scheduler utilization metrics.
   """
+  @spec emit_scheduler_metrics() :: :ok
   def emit_scheduler_metrics do
     # Get total run queue length (single integer)
     total_run_queue = :erlang.statistics(:total_run_queue_lengths)
@@ -223,7 +293,7 @@ defmodule Portal.Telemetry do
       if run_queue_lengths != [] do
         Enum.sum(run_queue_lengths) / length(run_queue_lengths)
       else
-        0
+        0.0
       end
 
     :telemetry.execute([:vm, :scheduler_utilization], %{
@@ -234,7 +304,7 @@ defmodule Portal.Telemetry do
     })
   rescue
     error ->
-      Logger.info("Error in emit_scheduler_metrics",
+      Logger.error("Error in emit_scheduler_metrics",
         reason: inspect(error)
       )
 
@@ -243,12 +313,12 @@ defmodule Portal.Telemetry do
 
   defp register_otel_instruments do
     meter = :opentelemetry_experimental.get_meter()
+    node_attrs = %{"node_name" => System.get_env("NODE_NAME", to_string(node()))}
+    register_vm_instruments(meter, node_attrs)
+    register_application_instruments(meter)
+  end
 
-    # Common attributes for all metrics to enable splitting by node in Azure Monitor
-    node_attrs = %{
-      "node_name" => System.get_env("NODE_NAME", to_string(node()))
-    }
-
+  defp register_vm_instruments(meter, node_attrs) do
     # Observable gauges for BEAM health
     :otel_meter.create_observable_gauge(
       meter,
@@ -385,48 +455,359 @@ defmodule Portal.Telemetry do
     :ok
   rescue
     error ->
-      Logger.info("Failed to register OTEL instruments", reason: inspect(error))
-      :ok
+      Logger.error("Failed to register VM OTel instruments", reason: inspect(error))
   end
 
-  @doc """
-  Debug function to manually trigger and inspect all BEAM metrics.
-  Usage in IEx: Portal.Telemetry.debug_metrics()
-  """
-  def debug_metrics do
-    IO.puts("=== BEAM Health Metrics Debug ===")
-
-    # Manually emit and capture metrics
-    emit_beam_health_metrics()
-    emit_gc_metrics()
-    emit_scheduler_metrics()
-
-    # Display current system info
-    IO.puts("\n--- Process Info ---")
-
-    IO.puts(
-      "Processes: #{:erlang.system_info(:process_count)}/#{:erlang.system_info(:process_limit)}"
+  defp register_application_instruments(meter) do
+    :otel_meter.create_counter(
+      meter,
+      :"http.server.requests",
+      %{description: "Total HTTP requests by route, method, and status", unit: :"1"}
     )
 
-    IO.puts("\n--- Memory Info (MB) ---")
+    :otel_meter.create_histogram(
+      meter,
+      :"http.server.request.duration",
+      %{description: "HTTP request duration by route", unit: :ms}
+    )
 
-    :erlang.memory()
-    |> Enum.each(fn {key, value} ->
-      IO.puts("#{key}: #{Float.round(value / 1024 / 1024, 2)}")
-    end)
+    :otel_meter.create_updown_counter(
+      meter,
+      :"http.server.active_requests",
+      %{description: "Number of HTTP requests currently being processed"}
+    )
 
-    IO.puts("\n--- Atom Info ---")
-    IO.puts("Atoms: #{:erlang.system_info(:atom_count)}/#{:erlang.system_info(:atom_limit)}")
+    :otel_meter.create_histogram(
+      meter,
+      :"db.query.duration",
+      %{description: "Database query duration", unit: :ms}
+    )
 
-    IO.puts("\n--- Port Info ---")
-    IO.puts("Ports: #{:erlang.system_info(:port_count)}/#{:erlang.system_info(:port_limit)}")
+    :otel_meter.create_counter(
+      meter,
+      :"phoenix.live_view.mounts",
+      %{description: "Total LiveView mounts", unit: :"1"}
+    )
 
-    IO.puts("\n--- ETS Info ---")
-    IO.puts("ETS Tables: #{length(:ets.all())}")
+    :otel_meter.create_histogram(
+      meter,
+      :"phoenix.live_view.mount.duration",
+      %{description: "LiveView mount duration", unit: :ms}
+    )
 
-    IO.puts("\n--- Run Queue Info ---")
-    IO.puts("Total run queue: #{:erlang.statistics(:total_run_queue_lengths)}")
+    :otel_meter.create_counter(
+      meter,
+      :"phoenix.live_view.handle_params",
+      %{description: "Total LiveView handle_params calls", unit: :"1"}
+    )
+
+    :otel_meter.create_histogram(
+      meter,
+      :"phoenix.live_view.handle_params.duration",
+      %{description: "LiveView handle_params duration", unit: :ms}
+    )
+
+    :otel_meter.create_counter(
+      meter,
+      :"phoenix.live_view.handle_events",
+      %{description: "Total LiveView handle_event calls", unit: :"1"}
+    )
+
+    :otel_meter.create_histogram(
+      meter,
+      :"phoenix.live_view.handle_event.duration",
+      %{description: "LiveView handle_event duration", unit: :ms}
+    )
+
+    :otel_meter.create_counter(
+      meter,
+      :"phoenix.live_component.handle_events",
+      %{description: "Total LiveComponent handle_event calls", unit: :"1"}
+    )
+
+    :otel_meter.create_histogram(
+      meter,
+      :"phoenix.live_component.handle_event.duration",
+      %{description: "LiveComponent handle_event duration", unit: :ms}
+    )
+
+    :otel_meter.create_counter(
+      meter,
+      :"phoenix.channel.joins",
+      %{description: "Total channel join events", unit: :"1"}
+    )
+
+    :otel_meter.create_histogram(
+      meter,
+      :"phoenix.channel.join.duration",
+      %{description: "Channel join duration", unit: :ms}
+    )
+
+    :otel_meter.create_counter(
+      meter,
+      :"phoenix.channel.messages",
+      %{description: "Total channel messages handled", unit: :"1"}
+    )
+
+    :otel_meter.create_histogram(
+      meter,
+      :"phoenix.channel.message.duration",
+      %{description: "Channel message handling duration", unit: :ms}
+    )
 
     :ok
+  rescue
+    error ->
+      Logger.error("Failed to register application OTel instruments", reason: inspect(error))
+  end
+
+  @doc false
+  @spec handle_http_metric(list(), map(), map(), map()) :: :ok
+  def handle_http_metric([:phoenix, :router_dispatch, :stop], measurements, metadata, config) do
+    conn = metadata.conn
+    route = metadata[:route] || "(unrouted)"
+
+    attrs = %{
+      "http.route" => route,
+      "http.request.method" => conn.method,
+      "http.response.status_code" => to_string(conn.status || 0),
+      "http.endpoint" => endpoint_name(conn),
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"http.server.requests", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"http.server.request.duration", duration_ms, attrs)
+    :ok
+  end
+
+  def handle_http_metric([:phoenix, :endpoint, :start], _measurements, metadata, config) do
+    conn = metadata.conn
+
+    attrs = %{
+      "http.request.method" => conn.method,
+      "http.endpoint" => endpoint_name(conn),
+      "node_name" => config.node_name
+    }
+
+    meter = :opentelemetry_experimental.get_meter()
+    :otel_updown_counter.add(:otel_ctx.get_current(), meter, :"http.server.active_requests", 1, attrs)
+    :ok
+  end
+
+  def handle_http_metric([:phoenix, :endpoint, :stop], _measurements, metadata, config) do
+    conn = metadata.conn
+
+    attrs = %{
+      "http.request.method" => conn.method,
+      "http.endpoint" => endpoint_name(conn),
+      "node_name" => config.node_name
+    }
+
+    meter = :opentelemetry_experimental.get_meter()
+    :otel_updown_counter.add(:otel_ctx.get_current(), meter, :"http.server.active_requests", -1, attrs)
+    :ok
+  end
+
+  @doc false
+  @spec handle_db_metric(list(), map(), map(), map()) :: :ok
+  def handle_db_metric(_event, measurements, _metadata, config) do
+    case measurements[:total_time] do
+      total_time when is_integer(total_time) ->
+        duration_ms = System.convert_time_unit(total_time, :native, :millisecond)
+
+        attrs = %{
+          "db.system" => "postgresql",
+          "node_name" => config.node_name
+        }
+
+        meter = :opentelemetry_experimental.get_meter()
+        :otel_histogram.record(:otel_ctx.get_current(), meter, :"db.query.duration", duration_ms, attrs)
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
+  @spec handle_liveview_lifecycle_metric(list(), map(), map(), map()) :: :ok
+  def handle_liveview_lifecycle_metric([:phoenix, :live_view, :mount, :stop], measurements, metadata, config) do
+    attrs = %{
+      "live_view" => inspect(metadata.socket.view),
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"phoenix.live_view.mounts", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"phoenix.live_view.mount.duration", duration_ms, attrs)
+    :ok
+  end
+
+  def handle_liveview_lifecycle_metric(
+        [:phoenix, :live_view, :handle_params, :stop],
+        measurements,
+        metadata,
+        config
+      ) do
+    attrs = %{
+      "live_view" => inspect(metadata.socket.view),
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"phoenix.live_view.handle_params", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"phoenix.live_view.handle_params.duration", duration_ms, attrs)
+    :ok
+  end
+
+  @doc false
+  @spec handle_liveview_event_metric(list(), map(), map(), map()) :: :ok
+  def handle_liveview_event_metric([:phoenix, :live_view, :handle_event, :stop], measurements, metadata, config) do
+    attrs = %{
+      "live_view" => inspect(metadata.socket.view),
+      "event" => metadata.event,
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"phoenix.live_view.handle_events", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"phoenix.live_view.handle_event.duration", duration_ms, attrs)
+    :ok
+  end
+
+  def handle_liveview_event_metric(
+        [:phoenix, :live_component, :handle_event, :stop],
+        measurements,
+        metadata,
+        config
+      ) do
+    attrs = %{
+      "component" => inspect(metadata.component),
+      "event" => metadata.event,
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"phoenix.live_component.handle_events", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"phoenix.live_component.handle_event.duration", duration_ms, attrs)
+    :ok
+  end
+
+  @doc false
+  @spec handle_channel_metric(list(), map(), map(), map()) :: :ok
+  def handle_channel_metric([:phoenix, :channel_joined], measurements, metadata, config) do
+    socket = metadata.socket
+
+    attrs = %{
+      "channel" => inspect(socket.channel),
+      "transport" => to_string(socket.transport),
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"phoenix.channel.joins", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"phoenix.channel.join.duration", duration_ms, attrs)
+    :ok
+  end
+
+  def handle_channel_metric([:phoenix, :channel_handled_in], measurements, metadata, config) do
+    socket = metadata.socket
+
+    attrs = %{
+      "channel" => inspect(socket.channel),
+      "event" => metadata.event,
+      "transport" => to_string(socket.transport),
+      "node_name" => config.node_name
+    }
+
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    meter = :opentelemetry_experimental.get_meter()
+    ctx = :otel_ctx.get_current()
+
+    :otel_counter.add(ctx, meter, :"phoenix.channel.messages", 1, attrs)
+    :otel_histogram.record(ctx, meter, :"phoenix.channel.message.duration", duration_ms, attrs)
+    :ok
+  end
+
+  @spec enable_metrics(atom()) :: :ok | {:error, :already_enabled} | {:error, :unknown_group}
+  def enable_metrics(group) do
+    case Map.fetch(@metric_groups, group) do
+      {:ok, %{handler_id: id, events: events}} ->
+        node_name = System.get_env("NODE_NAME", to_string(node()))
+
+        case :telemetry.attach_many(id, events, metric_group_handler(group), %{node_name: node_name}) do
+          :ok -> :ok
+          {:error, :already_exists} -> {:error, :already_enabled}
+        end
+
+      :error ->
+        {:error, :unknown_group}
+    end
+  end
+
+  @spec disable_metrics(atom()) :: :ok | {:error, :unknown_group}
+  def disable_metrics(group) do
+    case Map.fetch(@metric_groups, group) do
+      {:ok, %{handler_id: id}} ->
+        :telemetry.detach(id)
+        :ok
+
+      :error ->
+        {:error, :unknown_group}
+    end
+  end
+
+  @spec metrics_enabled?(atom()) :: boolean()
+  def metrics_enabled?(group) do
+    case Map.fetch(@metric_groups, group) do
+      {:ok, %{handler_id: id, events: [first_event | _]}} ->
+        :telemetry.list_handlers(first_event)
+        |> Enum.any?(&(&1.id == id))
+
+      :error ->
+        false
+    end
+  end
+
+  @spec enabled_metrics() :: [atom()]
+  def enabled_metrics do
+    Enum.filter(Map.keys(@metric_groups), &metrics_enabled?/1)
+  end
+
+  defp metric_group_handler(:http), do: &__MODULE__.handle_http_metric/4
+  defp metric_group_handler(:db), do: &__MODULE__.handle_db_metric/4
+  defp metric_group_handler(:liveview_lifecycle), do: &__MODULE__.handle_liveview_lifecycle_metric/4
+  defp metric_group_handler(:liveview_events), do: &__MODULE__.handle_liveview_event_metric/4
+  defp metric_group_handler(:channels), do: &__MODULE__.handle_channel_metric/4
+
+  @doc false
+  @spec endpoint_name(Plug.Conn.t()) :: String.t()
+  def endpoint_name(conn) do
+    case Map.get(conn.private, :phoenix_endpoint) do
+      PortalWeb.Endpoint -> "web"
+      PortalAPI.Endpoint -> "api"
+      PortalOps.Endpoint -> "ops"
+      nil -> "unknown"
+      mod -> mod |> to_string() |> String.replace_prefix("Elixir.", "")
+    end
   end
 end

--- a/elixir/lib/portal/telemetry/dev_aggregator.ex
+++ b/elixir/lib/portal/telemetry/dev_aggregator.ex
@@ -1,0 +1,372 @@
+defmodule Portal.Telemetry.DevAggregator do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+
+  @report_interval_ms 30_000
+
+  @telemetry_events [
+    [:phoenix, :router_dispatch, :stop],
+    [:phoenix, :endpoint, :start],
+    [:phoenix, :endpoint, :stop],
+    [:phoenix, :live_view, :mount, :stop],
+    [:phoenix, :live_view, :handle_params, :stop],
+    [:phoenix, :live_view, :handle_event, :stop],
+    [:phoenix, :live_component, :handle_event, :stop],
+    [:phoenix, :channel_joined],
+    [:phoenix, :channel_handled_in],
+    [:portal, :repo, :query],
+    [:portal, :repo, :replica, :query],
+    [:portal, :repo, :web, :query],
+    [:portal, :repo, :api, :query],
+    [:portal, :repo, :replica, :web, :query],
+    [:portal, :repo, :replica, :api, :query]
+  ]
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec dump() :: :ok
+  def dump do
+    GenServer.call(__MODULE__, :dump)
+  end
+
+  @impl true
+  def init(_opts) do
+    pid = self()
+
+    :telemetry.detach("portal-dev-aggregator")
+
+    :ok =
+      :telemetry.attach_many(
+        "portal-dev-aggregator",
+        @telemetry_events,
+        &handle_telemetry_event/4,
+        %{pid: pid}
+      )
+
+    schedule_report()
+    {:ok, initial_state()}
+  end
+
+  @impl true
+  def handle_call(:dump, _from, state) do
+    print_report(state)
+    {:reply, :ok, reset_window(state)}
+  end
+
+  @impl true
+  def handle_info(:report, state) do
+    print_report(state)
+    schedule_report()
+    {:noreply, reset_window(state)}
+  end
+
+  def handle_info({:request, endpoint, route, method, status, duration_ms}, state) do
+    key = {endpoint, route, method, status}
+
+    requests =
+      Map.update(
+        state.requests,
+        key,
+        %{count: 1, total_ms: duration_ms, min_ms: duration_ms, max_ms: duration_ms},
+        fn prev ->
+          %{
+            count: prev.count + 1,
+            total_ms: prev.total_ms + duration_ms,
+            min_ms: min(prev.min_ms, duration_ms),
+            max_ms: max(prev.max_ms, duration_ms)
+          }
+        end
+      )
+
+    {:noreply, %{state | requests: requests}}
+  end
+
+  def handle_info({:endpoint_stop, method}, state) do
+    active = Map.update(state.active, method, 0, &max(&1 - 1, 0))
+    {:noreply, %{state | active: active, total: state.total + 1}}
+  end
+
+  def handle_info({:active, method, delta}, state) do
+    active = Map.update(state.active, method, max(delta, 0), &max(&1 + delta, 0))
+    {:noreply, %{state | active: active}}
+  end
+
+  def handle_info({:db_query, duration_ms}, state) do
+    db =
+      case state.db do
+        nil ->
+          %{count: 1, total_ms: duration_ms, min_ms: duration_ms, max_ms: duration_ms}
+
+        prev ->
+          %{
+            count: prev.count + 1,
+            total_ms: prev.total_ms + duration_ms,
+            min_ms: min(prev.min_ms, duration_ms),
+            max_ms: max(prev.max_ms, duration_ms)
+          }
+      end
+
+    {:noreply, %{state | db: db}}
+  end
+
+  def handle_info({:liveview_event, name, action, duration_ms}, state) do
+    key = {name, action}
+
+    liveview =
+      Map.update(
+        state.liveview,
+        key,
+        %{count: 1, total_ms: duration_ms, min_ms: duration_ms, max_ms: duration_ms},
+        fn prev ->
+          %{
+            count: prev.count + 1,
+            total_ms: prev.total_ms + duration_ms,
+            min_ms: min(prev.min_ms, duration_ms),
+            max_ms: max(prev.max_ms, duration_ms)
+          }
+        end
+      )
+
+    {:noreply, %{state | liveview: liveview}}
+  end
+
+  def handle_info({:channel_event, channel, event, duration_ms}, state) do
+    key = {channel, event}
+
+    channels =
+      Map.update(
+        state.channels,
+        key,
+        %{count: 1, total_ms: duration_ms, min_ms: duration_ms, max_ms: duration_ms},
+        fn prev ->
+          %{
+            count: prev.count + 1,
+            total_ms: prev.total_ms + duration_ms,
+            min_ms: min(prev.min_ms, duration_ms),
+            max_ms: max(prev.max_ms, duration_ms)
+          }
+        end
+      )
+
+    {:noreply, %{state | channels: channels}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, _state) do
+    :telemetry.detach("portal-dev-aggregator")
+  end
+
+  # Telemetry handler — runs in the calling process, not the GenServer
+
+  @doc false
+  def handle_telemetry_event(
+        [:phoenix, :router_dispatch, :stop],
+        measurements,
+        metadata,
+        %{pid: pid}
+      ) do
+    route = metadata[:route] || "(unrouted)"
+    endpoint = endpoint_name(metadata.conn)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:request, endpoint, route, metadata.conn.method, metadata.conn.status || 0, duration_ms})
+  end
+
+  def handle_telemetry_event([:phoenix, :endpoint, :start], _measurements, metadata, %{pid: pid}) do
+    send(pid, {:active, metadata.conn.method, 1})
+  end
+
+  def handle_telemetry_event([:phoenix, :endpoint, :stop], _measurements, metadata, %{pid: pid}) do
+    send(pid, {:endpoint_stop, metadata.conn.method})
+  end
+
+  def handle_telemetry_event(
+        [:phoenix, :live_view, :mount, :stop],
+        measurements,
+        metadata,
+        %{pid: pid}
+      ) do
+    name = view_name(metadata.socket.view)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:liveview_event, name, "mount", duration_ms})
+  end
+
+  def handle_telemetry_event(
+        [:phoenix, :live_view, :handle_params, :stop],
+        measurements,
+        metadata,
+        %{pid: pid}
+      ) do
+    name = view_name(metadata.socket.view)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:liveview_event, name, "handle_params", duration_ms})
+  end
+
+  def handle_telemetry_event(
+        [:phoenix, :live_view, :handle_event, :stop],
+        measurements,
+        metadata,
+        %{pid: pid}
+      ) do
+    name = view_name(metadata.socket.view)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:liveview_event, name, metadata.event, duration_ms})
+  end
+
+  def handle_telemetry_event(
+        [:phoenix, :live_component, :handle_event, :stop],
+        measurements,
+        metadata,
+        %{pid: pid}
+      ) do
+    name = view_name(metadata.component)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:liveview_event, name, metadata.event, duration_ms})
+  end
+
+  def handle_telemetry_event([:phoenix, :channel_joined], measurements, metadata, %{pid: pid}) do
+    channel = channel_name(metadata.socket.channel)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:channel_event, channel, "join", duration_ms})
+  end
+
+  def handle_telemetry_event([:phoenix, :channel_handled_in], measurements, metadata, %{pid: pid}) do
+    channel = channel_name(metadata.socket.channel)
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    send(pid, {:channel_event, channel, metadata.event, duration_ms})
+  end
+
+  def handle_telemetry_event([:portal, :repo | _], measurements, _metadata, %{pid: pid}) do
+    case measurements[:total_time] do
+      total_time when is_integer(total_time) ->
+        duration_ms = System.convert_time_unit(total_time, :native, :millisecond)
+        send(pid, {:db_query, duration_ms})
+
+      _ ->
+        :ok
+    end
+  end
+
+  def handle_telemetry_event(_event, _measurements, _metadata, _config), do: :ok
+
+  defp initial_state,
+    do: %{requests: %{}, active: %{}, db: nil, total: 0, channels: %{}, liveview: %{}}
+
+  defp reset_window(state),
+    do: %{state | requests: %{}, db: nil, total: 0, channels: %{}, liveview: %{}}
+
+  defp schedule_report do
+    Process.send_after(self(), :report, @report_interval_ms)
+  end
+
+  defp print_report(%{
+         requests: requests,
+         active: active,
+         db: db,
+         total: total,
+         channels: channels,
+         liveview: liveview
+       }) do
+    Logger.info(header("HTTP Requests (last 30s) — #{total} total"))
+
+    if map_size(requests) == 0 do
+      Logger.info("[metrics]   (none)")
+    else
+      requests
+      |> Enum.sort_by(fn {{endpoint, route, method, _}, _} -> {endpoint, route, method} end)
+      |> Enum.each(fn {{endpoint, route, method, status}, s} ->
+        avg = div(s.total_ms, s.count)
+
+        Logger.info(
+          "[metrics]   [#{pad(endpoint, 3)}] #{pad(method, 6)} #{status}  #{pad(route, 42)}" <>
+            "#{pad(s.count, 5)} reqs  avg=#{avg}ms min=#{s.min_ms}ms max=#{s.max_ms}ms"
+        )
+      end)
+    end
+
+    Logger.info(header("Active Requests"))
+
+    if map_size(active) == 0 do
+      Logger.info("[metrics]   (none)")
+    else
+      active
+      |> Enum.sort()
+      |> Enum.map_join("  ", fn {method, count} -> "#{method}: #{count}" end)
+      |> then(&Logger.info("[metrics]   #{&1}"))
+    end
+
+    Logger.info(header("Channel Activity (last 30s)"))
+
+    if map_size(channels) == 0 do
+      Logger.info("[metrics]   (none)")
+    else
+      channels
+      |> Enum.sort_by(fn {{channel, event}, _} -> {channel, event} end)
+      |> Enum.each(fn {{channel, event}, s} ->
+        avg = div(s.total_ms, s.count)
+
+        Logger.info(
+          "[metrics]   #{pad(channel, 30)} #{pad(event, 24)}" <>
+            "#{pad(s.count, 5)} msgs  avg=#{avg}ms min=#{s.min_ms}ms max=#{s.max_ms}ms"
+        )
+      end)
+    end
+
+    Logger.info(header("LiveView Activity (last 30s)"))
+
+    if map_size(liveview) == 0 do
+      Logger.info("[metrics]   (none)")
+    else
+      liveview
+      |> Enum.sort_by(fn {{name, action}, _} -> {name, action} end)
+      |> Enum.each(fn {{name, action}, s} ->
+        avg = div(s.total_ms, s.count)
+
+        Logger.info(
+          "[metrics]   #{pad(name, 36)} #{pad(action, 20)}" <>
+            "#{pad(s.count, 5)} calls  avg=#{avg}ms min=#{s.min_ms}ms max=#{s.max_ms}ms"
+        )
+      end)
+    end
+
+    Logger.info(header("DB Queries (last 30s)"))
+
+    case db do
+      nil ->
+        Logger.info("[metrics]   (none)")
+
+      s ->
+        avg = div(s.total_ms, s.count)
+        Logger.info("[metrics]   #{s.count} queries  avg=#{avg}ms  min=#{s.min_ms}ms  max=#{s.max_ms}ms")
+    end
+  end
+
+  @line_width 80
+
+  defp header(title) do
+    prefix = "━━━ #{title} "
+    fill = String.duplicate("━", max(@line_width - String.length(prefix), 0))
+    "[metrics] #{prefix}#{fill}"
+  end
+
+  defp endpoint_name(conn), do: Portal.Telemetry.endpoint_name(conn)
+
+  defp channel_name(module) do
+    module |> to_string() |> String.replace_prefix("Elixir.Portal.", "")
+  end
+
+  defp view_name(module) do
+    module |> to_string() |> String.replace_prefix("Elixir.PortalWeb.", "")
+  end
+
+  defp pad(value, len) do
+    str = to_string(value)
+    str <> String.duplicate(" ", max(len - String.length(str), 0))
+  end
+end

--- a/elixir/lib/portal/telemetry/dev_aggregator.ex
+++ b/elixir/lib/portal/telemetry/dev_aggregator.ex
@@ -273,7 +273,8 @@ defmodule Portal.Telemetry.DevAggregator do
          channels: channels,
          liveview: liveview
        }) do
-    Logger.info(header("HTTP Requests (last 30s) — #{total} total"))
+    routed = Enum.sum(for {_, s} <- requests, do: s.count)
+    Logger.info(header("HTTP Requests (last 30s) — #{routed} routed, #{total} total"))
 
     if map_size(requests) == 0 do
       Logger.info("[metrics]   (none)")

--- a/elixir/test/portal/telemetry_test.exs
+++ b/elixir/test/portal/telemetry_test.exs
@@ -1,7 +1,7 @@
 defmodule Portal.TelemetryTest do
   use ExUnit.Case, async: true
 
-  import ExUnit.CaptureIO
+  @config %{node_name: "test"}
 
   describe "metrics/0" do
     test "returns a non-empty list of metric definitions" do
@@ -25,6 +25,7 @@ defmodule Portal.TelemetryTest do
 
       assert [:phoenix, :endpoint, :start, :system_time] in metric_names
       assert [:phoenix, :endpoint, :stop, :duration] in metric_names
+      assert [:phoenix, :router_dispatch, :stop] in metric_names
       assert [:phoenix, :router_dispatch, :stop, :duration] in metric_names
       assert [:phoenix, :socket_connected, :duration] in metric_names
       assert [:phoenix, :channel_join, :duration] in metric_names
@@ -277,172 +278,176 @@ defmodule Portal.TelemetryTest do
     end
   end
 
-  describe "debug_metrics/0" do
-    test "prints all BEAM metric sections and returns :ok" do
-      output =
-        capture_io(fn ->
-          assert Portal.Telemetry.debug_metrics() == :ok
-        end)
+  describe "handle_http_metric/4" do
+    test "returns :ok for a routed request" do
+      conn = %Plug.Conn{method: "GET", status: 200, request_path: "/users/abc-123"}
+      metadata = %{conn: conn, route: "/users/:id"}
 
-      assert output =~ "=== BEAM Health Metrics Debug ==="
-      assert output =~ "--- Process Info ---"
-      assert output =~ "Processes:"
-      assert output =~ "--- Memory Info (MB) ---"
-      assert output =~ "total:"
-      assert output =~ "--- Atom Info ---"
-      assert output =~ "Atoms:"
-      assert output =~ "--- Port Info ---"
-      assert output =~ "Ports:"
-      assert output =~ "--- ETS Info ---"
-      assert output =~ "ETS Tables:"
-      assert output =~ "--- Run Queue Info ---"
-      assert output =~ "Total run queue:"
+      assert :ok =
+               Portal.Telemetry.handle_http_metric(
+                 [:phoenix, :router_dispatch, :stop],
+                 %{duration: 1_000},
+                 metadata,
+                 @config
+               )
+    end
+
+    test "falls back to (unrouted) when route metadata is absent" do
+      conn = %Plug.Conn{method: "GET", status: 404, request_path: "/unknown-path"}
+      metadata = %{conn: conn}
+
+      assert :ok =
+               Portal.Telemetry.handle_http_metric(
+                 [:phoenix, :router_dispatch, :stop],
+                 %{duration: 500},
+                 metadata,
+                 @config
+               )
+    end
+
+    test "handles nil conn status" do
+      conn = %Plug.Conn{method: "POST", status: nil, request_path: "/sign_in"}
+      metadata = %{conn: conn, route: "/sign_in"}
+
+      assert :ok =
+               Portal.Telemetry.handle_http_metric(
+                 [:phoenix, :router_dispatch, :stop],
+                 %{duration: 2_000},
+                 metadata,
+                 @config
+               )
+    end
+
+    test "returns :ok for endpoint start" do
+      conn = %Plug.Conn{method: "GET", request_path: "/users"}
+
+      assert :ok =
+               Portal.Telemetry.handle_http_metric(
+                 [:phoenix, :endpoint, :start],
+                 %{system_time: System.system_time()},
+                 %{conn: conn},
+                 @config
+               )
+    end
+
+    test "returns :ok for endpoint stop" do
+      conn = %Plug.Conn{method: "GET", status: 200, request_path: "/users"}
+
+      assert :ok =
+               Portal.Telemetry.handle_http_metric(
+                 [:phoenix, :endpoint, :stop],
+                 %{duration: 1_000},
+                 %{conn: conn},
+                 @config
+               )
     end
   end
 
-  describe "OTEL instrument registration" do
-    test "register_otel_instruments/0 does not raise with SDK disabled" do
-      # The experimental SDK is disabled in test config,
-      # so this exercises the noop meter path without errors
-      meter = :opentelemetry_experimental.get_meter()
-
-      assert :otel_meter.create_observable_gauge(
-               meter,
-               :"test.gauge.#{System.unique_integer([:positive])}",
-               fn _args -> [{1, %{}}] end,
-               [],
-               %{description: "test"}
-             )
+  describe "handle_db_metric/4" do
+    test "returns :ok for a normal query" do
+      assert :ok =
+               Portal.Telemetry.handle_db_metric(
+                 [:portal, :repo, :query],
+                 %{total_time: 500_000, query_time: 400_000, queue_time: 100_000},
+                 %{},
+                 @config
+               )
     end
 
-    test "process count callback returns valid observations" do
-      count = :erlang.system_info(:process_count)
-      limit = :erlang.system_info(:process_limit)
-      utilization = Float.round(count / limit * 100, 2)
-
-      observations = [
-        {count, %{"type" => "total"}},
-        {limit, %{"type" => "limit"}},
-        {utilization, %{"type" => "utilization_percent"}}
-      ]
-
-      assert length(observations) == 3
-      assert Enum.all?(observations, fn {val, attrs} -> is_number(val) and is_map(attrs) end)
-      assert count > 0
-      assert limit > count
-      assert utilization > 0.0 and utilization < 100.0
+    test "returns :ok when total_time is nil" do
+      assert :ok =
+               Portal.Telemetry.handle_db_metric(
+                 [:portal, :repo, :query],
+                 %{total_time: nil},
+                 %{},
+                 @config
+               )
     end
 
-    test "atom count callback returns valid observations" do
-      count = :erlang.system_info(:atom_count)
-      limit = :erlang.system_info(:atom_limit)
-      utilization = Float.round(count / limit * 100, 2)
+    test "handles replica repo event" do
+      assert :ok =
+               Portal.Telemetry.handle_db_metric(
+                 [:portal, :repo, :replica, :query],
+                 %{total_time: 200_000},
+                 %{},
+                 @config
+               )
+    end
+  end
 
-      observations = [
-        {count, %{"type" => "count"}},
-        {limit, %{"type" => "limit"}},
-        {utilization, %{"type" => "utilization_percent"}}
-      ]
+  describe "handle_liveview_lifecycle_metric/4" do
+    test "returns :ok for a LiveView mount" do
+      socket = %{view: PortalWeb.SignInLive}
 
-      assert length(observations) == 3
-      assert count > 0
-      assert limit > count
-      assert utilization > 0.0
+      assert :ok =
+               Portal.Telemetry.handle_liveview_lifecycle_metric(
+                 [:phoenix, :live_view, :mount, :stop],
+                 %{duration: 5_000},
+                 %{socket: socket, params: %{}, session: %{}, uri: "https://example.com"},
+                 @config
+               )
     end
 
-    test "port count callback returns valid observations" do
-      count = :erlang.system_info(:port_count)
-      limit = :erlang.system_info(:port_limit)
-      utilization = Float.round(count / limit * 100, 2)
+    test "returns :ok for handle_params" do
+      socket = %{view: PortalWeb.SignInLive}
 
-      observations = [
-        {count, %{"type" => "count"}},
-        {limit, %{"type" => "limit"}},
-        {utilization, %{"type" => "utilization_percent"}}
-      ]
+      assert :ok =
+               Portal.Telemetry.handle_liveview_lifecycle_metric(
+                 [:phoenix, :live_view, :handle_params, :stop],
+                 %{duration: 1_000},
+                 %{socket: socket, params: %{}, uri: "https://example.com"},
+                 @config
+               )
+    end
+  end
 
-      assert length(observations) == 3
-      assert is_integer(count)
-      assert limit > 0
-      assert utilization >= 0.0
+  describe "handle_liveview_event_metric/4" do
+    test "returns :ok for a LiveView handle_event" do
+      socket = %{view: PortalWeb.SignInLive}
+
+      assert :ok =
+               Portal.Telemetry.handle_liveview_event_metric(
+                 [:phoenix, :live_view, :handle_event, :stop],
+                 %{duration: 2_000},
+                 %{socket: socket, event: "save", params: %{}},
+                 @config
+               )
     end
 
-    test "ETS count callback returns valid observations" do
-      ets_count = length(:ets.all())
-      observations = [{ets_count, %{}}]
+    test "returns :ok for a LiveComponent handle_event" do
+      assert :ok =
+               Portal.Telemetry.handle_liveview_event_metric(
+                 [:phoenix, :live_component, :handle_event, :stop],
+                 %{duration: 1_500},
+                 %{component: PortalWeb.Components.ResourceForm, event: "save", params: %{}},
+                 @config
+               )
+    end
+  end
 
-      assert length(observations) == 1
-      assert ets_count > 0
+  describe "handle_channel_metric/4" do
+    test "returns :ok for a channel join" do
+      socket = %{channel: PortalAPI.Client.Channel, transport: :websocket}
+
+      assert :ok =
+               Portal.Telemetry.handle_channel_metric(
+                 [:phoenix, :channel_joined],
+                 %{duration: 5_000},
+                 %{socket: socket, result: :ok, params: %{}},
+                 @config
+               )
     end
 
-    test "memory callback returns valid observations for all types" do
-      memory = :erlang.memory() |> Enum.into(%{})
+    test "returns :ok for a channel message" do
+      socket = %{channel: PortalAPI.Client.Channel, transport: :websocket}
 
-      observations = [
-        {memory[:processes], %{"type" => "processes"}},
-        {memory[:system], %{"type" => "system"}},
-        {memory[:atom], %{"type" => "atom"}},
-        {memory[:binary], %{"type" => "binary"}},
-        {memory[:code], %{"type" => "code"}},
-        {memory[:ets], %{"type" => "ets"}}
-      ]
-
-      assert length(observations) == 6
-      assert Enum.all?(observations, fn {val, _} -> is_integer(val) and val > 0 end)
-    end
-
-    test "scheduler utilization callback returns valid observations" do
-      total_run_queue = :erlang.statistics(:total_run_queue_lengths)
-      run_queue_lengths = :erlang.statistics(:run_queue_lengths)
-      max_run_queue = Enum.max(run_queue_lengths, fn -> 0 end)
-
-      avg_run_queue =
-        if run_queue_lengths != [] do
-          Float.round(Enum.sum(run_queue_lengths) / length(run_queue_lengths), 2)
-        else
-          0.0
-        end
-
-      observations = [
-        {total_run_queue, %{"type" => "total_run_queue"}},
-        {max_run_queue, %{"type" => "max_run_queue"}},
-        {avg_run_queue, %{"type" => "avg_run_queue"}},
-        {length(run_queue_lengths), %{"type" => "scheduler_count"}}
-      ]
-
-      assert length(observations) == 4
-      assert total_run_queue >= 0
-      assert max_run_queue >= 0
-      assert avg_run_queue >= 0.0
-      assert length(run_queue_lengths) > 0
-    end
-
-    test "GC collections callback returns valid observations" do
-      {collections, _words_reclaimed, _} = :erlang.statistics(:garbage_collection)
-      observations = [{collections, %{}}]
-
-      assert length(observations) == 1
-      assert collections >= 0
-    end
-
-    test "GC words reclaimed callback returns valid observations" do
-      {_collections, words_reclaimed, _} = :erlang.statistics(:garbage_collection)
-      observations = [{words_reclaimed, %{}}]
-
-      assert length(observations) == 1
-      assert words_reclaimed >= 0
-    end
-
-    test "observable counter can be created with SDK disabled" do
-      meter = :opentelemetry_experimental.get_meter()
-
-      assert :otel_meter.create_observable_counter(
-               meter,
-               :"test.counter.#{System.unique_integer([:positive])}",
-               fn _args -> [{42, %{}}] end,
-               [],
-               %{description: "test counter"}
-             )
+      assert :ok =
+               Portal.Telemetry.handle_channel_metric(
+                 [:phoenix, :channel_handled_in],
+                 %{duration: 1_000},
+                 %{socket: socket, event: "update_resource", params: %{}, ref: "1"},
+                 @config
+               )
     end
   end
 

--- a/elixir/test/portal/telemetry_test.exs
+++ b/elixir/test/portal/telemetry_test.exs
@@ -25,7 +25,6 @@ defmodule Portal.TelemetryTest do
 
       assert [:phoenix, :endpoint, :start, :system_time] in metric_names
       assert [:phoenix, :endpoint, :stop, :duration] in metric_names
-      assert [:phoenix, :router_dispatch, :stop] in metric_names
       assert [:phoenix, :router_dispatch, :stop, :duration] in metric_names
       assert [:phoenix, :socket_connected, :duration] in metric_names
       assert [:phoenix, :channel_join, :duration] in metric_names

--- a/elixir/test/portal/telemetry_toggle_test.exs
+++ b/elixir/test/portal/telemetry_toggle_test.exs
@@ -1,0 +1,77 @@
+defmodule Portal.Telemetry.ToggleTest do
+  # Separated from telemetry_test.exs because enable_metrics/1 and disable_metrics/1
+  # call :telemetry.attach_many/:telemetry.detach, which mutate a global ETS table.
+  # Running these tests alongside async: true tests causes races on handler state.
+  use ExUnit.Case, async: false
+
+  setup do
+    Portal.Telemetry.disable_metrics(:liveview_events)
+    on_exit(fn -> Portal.Telemetry.disable_metrics(:liveview_events) end)
+  end
+
+  describe "enable_metrics/1, disable_metrics/1, metrics_enabled?/1, enabled_metrics/0" do
+    test "liveview_events is disabled after calling disable_metrics/1" do
+      refute Portal.Telemetry.metrics_enabled?(:liveview_events)
+    end
+
+    test "enable_metrics/1 returns :ok and enables the group" do
+      assert :ok = Portal.Telemetry.enable_metrics(:liveview_events)
+      assert Portal.Telemetry.metrics_enabled?(:liveview_events)
+    end
+
+    test "enable_metrics/1 returns :already_enabled when group is already enabled" do
+      Portal.Telemetry.enable_metrics(:liveview_events)
+      assert {:error, :already_enabled} = Portal.Telemetry.enable_metrics(:liveview_events)
+    end
+
+    test "disable_metrics/1 disables the group" do
+      Portal.Telemetry.enable_metrics(:liveview_events)
+      assert :ok = Portal.Telemetry.disable_metrics(:liveview_events)
+      refute Portal.Telemetry.metrics_enabled?(:liveview_events)
+    end
+
+    test "enable_metrics/1 returns :unknown_group for unknown group" do
+      assert {:error, :unknown_group} = Portal.Telemetry.enable_metrics(:nonexistent)
+    end
+
+    test "disable_metrics/1 returns :unknown_group for unknown group" do
+      assert {:error, :unknown_group} = Portal.Telemetry.disable_metrics(:nonexistent)
+    end
+
+    test "metrics_enabled?/1 returns false for unknown group" do
+      refute Portal.Telemetry.metrics_enabled?(:nonexistent)
+    end
+
+    test "enabled_metrics/0 excludes disabled groups" do
+      Portal.Telemetry.enable_metrics(:liveview_events)
+      enabled = Portal.Telemetry.enabled_metrics()
+      assert :liveview_events in enabled
+
+      Portal.Telemetry.disable_metrics(:liveview_events)
+      enabled = Portal.Telemetry.enabled_metrics()
+      refute :liveview_events in enabled
+    end
+
+    test "enable_metrics/1 wires handler so telemetry events are processed" do
+      assert :ok = Portal.Telemetry.enable_metrics(:liveview_events)
+
+      :telemetry.execute(
+        [:phoenix, :live_view, :handle_event, :stop],
+        %{duration: 1_000},
+        %{socket: %{view: PortalWeb.SignInLive}, event: "save", params: %{}}
+      )
+
+      # telemetry detaches handlers that raise, so still being enabled proves
+      # the handler ran successfully against a real event dispatch
+      assert Portal.Telemetry.metrics_enabled?(:liveview_events)
+    end
+
+    test "disable_metrics/1 removes handler so telemetry events are no longer processed" do
+      Portal.Telemetry.enable_metrics(:liveview_events)
+      Portal.Telemetry.disable_metrics(:liveview_events)
+
+      handlers = :telemetry.list_handlers([:phoenix, :live_view, :handle_event, :stop])
+      refute Enum.any?(handlers, &(&1.id == "portal-liveview-event-metrics"))
+    end
+  end
+end


### PR DESCRIPTION
* Instruments the portal with OpenTelemetry metrics covering HTTP requests, database queries, LiveView lifecycle, LiveView events, and Phoenix channels. Metrics are grouped and can be toggled on or off at runtime via Portal.Telemetry.enable_metrics/1 and disable_metrics/1

* Adds a dev-only DevAggregator GenServer that aggregates all metric events in memory and logs 30-second summary reports, giving a local view of request throughput, active connections, DB query times, and LiveView/channel activity without requiring an OTLP collector.

* All metric collection can be disabled entirely with enabled: false in config, which gates the telemetry poller, reporter, and all handlers. 

* Docker Compose is updated to expose the OTLP ports (4317/4318) for local collector use.