### PR TITLE
chore(rust): ignore `quick-xml` vulnerabilities

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -113,6 +113,11 @@ ignore = [
     "RUSTSEC-2025-0098",
     "RUSTSEC-2025-0100",
 
+    # `quick_xml` is coming in via `tauri-winrt-notification` and `tauri-utils` -> `plist`.
+    # `tauri-winrt-notification` only uses the `escape` module and `plist` is apparently also not affected (https://github.com/ebarnard/rust-plist/issues/190)
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
These need to be ignored to unblock CI. I've traced our usage and we are unaffected by the vulnerabilities.