### PR TITLE
fix(snownet): migrate iceless connections after roam

### DIFF
--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -232,11 +232,7 @@ where
         self.inflight_stun_requests.clear();
 
         if self.connections.all_iceless() {
-            let mut num_iceless = 0;
-            for (_, conn) in self.connections.iter_established_mut() {
-                conn.reset_for_roam(now);
-                num_iceless += 1;
-            }
+            let num_iceless = self.connections.reset_for_roam(now);
             tracing::debug!(
                 %num_iceless,
                 "Soft-reset iceless connections (path-agent reset, key kept)"
@@ -2170,7 +2166,7 @@ where
         &mut self,
         cid: TId,
         new_relay: RId,
-        new_allocation: &Allocation,
+        allocations: &Allocations<RId>,
         pending_events: &mut VecDeque<Event<TId>>,
         now: Instant,
     ) where
@@ -2180,7 +2176,10 @@ where
 
         self.relay.id = new_relay;
 
-        for candidate in new_allocation.current_relay_candidates() {
+        // The full set, not just the relay candidates: a roam wipes the agent's
+        // locals, so host and reflexive candidates need re-seeding too.
+        // The agent dedups, so candidates it already knows are not re-signalled.
+        for candidate in allocations.candidates_for_relay(&new_relay) {
             self.add_local_candidate(cid, &candidate, pending_events, now);
         }
     }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1104,7 +1104,7 @@ where
 
     /// Sample a relay to use for a new connection.
     fn sample_relay(&mut self) -> Result<RId, NoTurnServers> {
-        let (rid, _) = self.allocations.sample().ok_or(NoTurnServers {})?;
+        let rid = self.allocations.sample().ok_or(NoTurnServers {})?;
 
         tracing::debug!(%rid, "Sampled relay");
 

--- a/rust/libs/connlib/snownet/src/node/allocations.rs
+++ b/rust/libs/connlib/snownet/src/node/allocations.rs
@@ -175,30 +175,30 @@ where
         }
     }
 
-    /// Sample an allocation for a new connection, biased towards low RTT.
+    /// Sample a relay for a new connection, biased towards low RTT.
     ///
     /// We compute an inclusion threshold from the observed RTT distribution
     /// (see [`inclusion_threshold`]) and uniformly sample among the relays at
     /// or below it. Allocations without an RTT measurement are skipped: we
     /// don't know whether they are healthy yet.
-    pub(crate) fn sample(&mut self) -> Option<(RId, &Allocation)> {
+    pub(crate) fn sample(&mut self) -> Option<RId> {
         let candidates = self
             .inner
             .iter()
-            .filter_map(|(id, a)| Some((*id, a, a.rtt()?)))
+            .filter_map(|(id, a)| Some((*id, a.rtt()?)))
             .collect::<SmallVec<[_; 8]>>();
 
         let rtts = candidates
             .iter()
-            .map(|(_, _, rtt)| *rtt)
+            .map(|(_, rtt)| *rtt)
             .collect::<SmallVec<[_; 8]>>();
         let threshold = inclusion_threshold(&rtts)?;
 
         candidates
             .iter()
-            .filter(|(_, _, rtt)| *rtt <= threshold)
+            .filter(|(_, rtt)| *rtt <= threshold)
             .choose(&mut self.rng)
-            .map(|(id, a, _)| (*id, *a))
+            .map(|(id, _)| *id)
     }
 
     pub(crate) fn poll_timeout(&mut self) -> Option<(Instant, &'static str)> {
@@ -487,7 +487,7 @@ mod tests {
                 .set_rtt(Duration::from_millis(rtt_ms));
         }
         for _ in 0..1000 {
-            let (rid, _) = allocations.sample().unwrap();
+            let rid = allocations.sample().unwrap();
             assert_ne!(rid, 5, "outlier relay must not be selected");
         }
     }
@@ -515,7 +515,7 @@ mod tests {
         let mut counts = [0u32; 2];
 
         for _ in 0..10_000 {
-            let (rid, _) = allocations.sample().unwrap();
+            let rid = allocations.sample().unwrap();
             counts[(rid - 1) as usize] += 1;
         }
 
@@ -547,7 +547,7 @@ mod tests {
                 .set_rtt(Duration::from_millis(rtt_ms));
         }
         for _ in 0..100 {
-            let (rid, _) = allocations.sample().unwrap();
+            let rid = allocations.sample().unwrap();
             assert_eq!(rid, 1);
         }
     }
@@ -569,7 +569,7 @@ mod tests {
             .get_mut_by_id(&1)
             .unwrap()
             .set_rtt(Duration::from_millis(500));
-        let (rid, _) = allocations.sample().unwrap();
+        let rid = allocations.sample().unwrap();
         assert_eq!(rid, 1);
     }
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -100,8 +100,9 @@ where
         Some(connection)
     }
 
-    /// Soft-resets all connections for a roam and queues them for relay migration:
-    /// the roam clears all allocations, so every connection's relay is gone until
+    /// Soft-resets all connections for a roam and queues them for relay migration.
+    ///
+    /// The roam clears all allocations, so every connection's relay is gone until
     /// [`update_relays`](crate::Node::update_relays) provides new ones.
     pub(crate) fn reset_for_roam(&mut self, now: Instant) -> usize {
         let mut num_connections = 0;

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -130,7 +130,7 @@ where
 
         for removed_relay in removed_allocations {
             for (cid, c) in self.iter_mut_by_relay(removed_relay) {
-                let Some((new_relay, _)) = allocations.sample() else {
+                let Some(new_relay) = allocations.sample() else {
                     let was_inserted = connections_with_removed_relays.insert(cid);
 
                     if was_inserted {
@@ -145,7 +145,7 @@ where
         }
 
         for cid in connections_with_removed_relays {
-            let Some((new_relay, _)) = allocations.sample() else {
+            let Some(new_relay) = allocations.sample() else {
                 self.connections_with_removed_relays.insert(cid);
 
                 continue;

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -145,13 +145,13 @@ where
         }
 
         for cid in connections_with_removed_relays {
-            let Ok(c) = self.get_mut(&cid, now) else {
-                continue;
-            };
-
             let Some((new_relay, _)) = allocations.sample() else {
                 self.connections_with_removed_relays.insert(cid);
 
+                continue;
+            };
+
+            let Ok(c) = self.get_mut(&cid, now) else {
                 continue;
             };
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -100,6 +100,22 @@ where
         Some(connection)
     }
 
+    /// Soft-resets all connections for a roam and queues them for relay migration:
+    /// the roam clears all allocations, so every connection's relay is gone until
+    /// [`update_relays`](crate::Node::update_relays) provides new ones.
+    pub(crate) fn reset_for_roam(&mut self, now: Instant) -> usize {
+        let mut num_connections = 0;
+
+        for (cid, conn) in self.established.iter_mut() {
+            conn.reset_for_roam(now);
+            self.connections_with_removed_relays.insert(*cid);
+
+            num_connections += 1;
+        }
+
+        num_connections
+    }
+
     pub(crate) fn migrate_relays(
         &mut self,
         removed_allocations: impl Iterator<Item = RId>,
@@ -113,7 +129,7 @@ where
 
         for removed_relay in removed_allocations {
             for (cid, c) in self.iter_mut_by_relay(removed_relay) {
-                let Some((new_relay, new_allocation)) = allocations.sample() else {
+                let Some((new_relay, _)) = allocations.sample() else {
                     let was_inserted = connections_with_removed_relays.insert(cid);
 
                     if was_inserted {
@@ -123,22 +139,28 @@ where
                     continue;
                 };
 
-                c.migrate_relay(cid, new_relay, new_allocation, pending_events, now);
+                c.migrate_relay(cid, new_relay, allocations, pending_events, now);
             }
         }
 
         for cid in connections_with_removed_relays {
-            let Some((new_relay, new_allocation)) = allocations.sample() else {
+            let Ok(c) = self.get_mut(&cid, now) else {
+                continue;
+            };
+
+            // The relay may have come back under the same ID in the meantime,
+            // e.g. after a roam where the portal handed out the same relays.
+            if allocations.get_by_id(&c.relay.id).is_some() {
+                continue;
+            }
+
+            let Some((new_relay, _)) = allocations.sample() else {
                 self.connections_with_removed_relays.insert(cid);
 
                 continue;
             };
 
-            let Ok(c) = self.get_mut(&cid, now) else {
-                continue;
-            };
-
-            c.migrate_relay(cid, new_relay, new_allocation, pending_events, now);
+            c.migrate_relay(cid, new_relay, allocations, pending_events, now);
         }
     }
 
@@ -526,19 +548,7 @@ mod tests {
         // The connection still uses relay 1 because no new relay was available.
         assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 1);
 
-        allocations.upsert(
-            2,
-            RelaySocket::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478)),
-            Username::new("user".to_owned()).unwrap(),
-            "pass".to_owned(),
-            Realm::new("firezone".to_owned()).unwrap(),
-            now,
-        );
-        // Simulate a successful response so the relay is eligible for sampling.
-        allocations
-            .get_mut_by_id(&2)
-            .unwrap()
-            .set_rtt(Duration::from_millis(20));
+        add_sampleable_allocation(&mut allocations, 2, now);
 
         connections.migrate_relays(
             std::iter::empty(),
@@ -549,6 +559,77 @@ mod tests {
 
         // The connection should now be using the new relay (id 2).
         assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 2);
+    }
+
+    #[test]
+    fn roam_reset_queues_connections_for_relay_migration() {
+        // A roam clears all allocations and the portal may hand out relays
+        // under new IDs afterwards; connections must not stay pinned to relays
+        // that no longer exist.
+        let mut connections: Connections<u32, u32> = Connections::default();
+        let mut allocations: Allocations<u32> = Allocations::for_test();
+        let now = Instant::now();
+
+        let mut conn = new_connection(12345, 1, [1u8; 32]);
+        conn.agent = crate::agent::Agent::path();
+        connections.insert_established(1, conn.index, conn);
+
+        connections.reset_for_roam(now);
+        add_sampleable_allocation(&mut allocations, 2, now);
+
+        let mut pending_events = VecDeque::new();
+        connections.migrate_relays(
+            std::iter::empty(),
+            &mut allocations,
+            &mut pending_events,
+            now,
+        );
+
+        assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 2);
+    }
+
+    #[test]
+    fn does_not_migrate_connection_whose_relay_came_back() {
+        // After a roam, the portal may hand out the same relays again: the
+        // connection's relay re-appears under its old ID and must not be
+        // migrated away.
+        let mut connections: Connections<u32, u32> = Connections::default();
+        let mut allocations: Allocations<u32> = Allocations::for_test();
+        let now = Instant::now();
+
+        let mut conn = new_connection(12345, 1, [1u8; 32]);
+        conn.agent = crate::agent::Agent::path();
+        connections.insert_established(1, conn.index, conn);
+
+        connections.reset_for_roam(now);
+        add_sampleable_allocation(&mut allocations, 1, now);
+        add_sampleable_allocation(&mut allocations, 2, now);
+
+        let mut pending_events = VecDeque::new();
+        connections.migrate_relays(
+            std::iter::empty(),
+            &mut allocations,
+            &mut pending_events,
+            now,
+        );
+
+        assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 1);
+    }
+
+    fn add_sampleable_allocation(allocations: &mut Allocations<u32>, rid: u32, now: Instant) {
+        allocations.upsert(
+            rid,
+            RelaySocket::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478 + rid as u16)),
+            Username::new("user".to_owned()).unwrap(),
+            "pass".to_owned(),
+            Realm::new("firezone".to_owned()).unwrap(),
+            now,
+        );
+        // Simulate a successful response so the relay is eligible for sampling.
+        allocations
+            .get_mut_by_id(&rid)
+            .unwrap()
+            .set_rtt(Duration::from_millis(20));
     }
 
     fn insert_dummy_connection(connections: &mut Connections<u32, u32>) -> (u32, Index, PublicKey) {

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -141,6 +141,9 @@ where
                 };
 
                 c.migrate_relay(cid, new_relay, allocations, pending_events, now);
+
+                // Already migrated; don't migrate again in the retry loop below.
+                connections_with_removed_relays.remove(&cid);
             }
         }
 

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -148,12 +148,6 @@ where
                 continue;
             };
 
-            // The relay may have come back under the same ID in the meantime,
-            // e.g. after a roam where the portal handed out the same relays.
-            if allocations.get_by_id(&c.relay.id).is_some() {
-                continue;
-            }
-
             let Some((new_relay, _)) = allocations.sample() else {
                 self.connections_with_removed_relays.insert(cid);
 
@@ -586,34 +580,6 @@ mod tests {
         );
 
         assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 2);
-    }
-
-    #[test]
-    fn does_not_migrate_connection_whose_relay_came_back() {
-        // After a roam, the portal may hand out the same relays again: the
-        // connection's relay re-appears under its old ID and must not be
-        // migrated away.
-        let mut connections: Connections<u32, u32> = Connections::default();
-        let mut allocations: Allocations<u32> = Allocations::for_test();
-        let now = Instant::now();
-
-        let mut conn = new_connection(12345, 1, [1u8; 32]);
-        conn.agent = crate::agent::Agent::path();
-        connections.insert_established(1, conn.index, conn);
-
-        connections.reset_for_roam(now);
-        add_sampleable_allocation(&mut allocations, 1, now);
-        add_sampleable_allocation(&mut allocations, 2, now);
-
-        let mut pending_events = VecDeque::new();
-        connections.migrate_relays(
-            std::iter::empty(),
-            &mut allocations,
-            &mut pending_events,
-            now,
-        );
-
-        assert_eq!(connections.get_mut(&1, now).unwrap().relay.id, 1);
     }
 
     fn add_sampleable_allocation(allocations: &mut Allocations<u32>, rid: u32, now: Instant) {


### PR DESCRIPTION
After a roam, iceless connections are soft-reset but all allocations are cleared. If the portal then hands out relays under new IDs, the connections stay pinned to relay IDs without an allocation: candidate events are routed by relay ID, so they never receive the newly gathered candidates and fan out re-key handshakes with zero pairs until the WireGuard tunnel expires (~20s) and the flow is re-created from scratch.

Queue connections for relay migration when soft-resetting them, so the existing migration machinery re-points them to a freshly sampled relay as soon as one is reachable and candidates then stream in via the regular allocation events. Migration seeds the full candidate set since a roam wipes the agent's locals.

This only surfaces for iceless connections because those are retained during roaming.

Related: #13088