### PR TITLE
ci: add RPM repository management for GUI client

### DIFF
--- a/.github/workflows/_rpm.yml
+++ b/.github/workflows/_rpm.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/setup-gpg
         id: setup-gpg
         with:
-          key: ${{ secrets.APT_REPOSITORY_GPG_KEY }}
+          key: ${{ secrets.RPM_REPOSITORY_GPG_KEY }}
           email: packages@firezone.dev
 
       - run: scripts/sync-rpm.sh

--- a/.github/workflows/_rpm.yml
+++ b/.github/workflows/_rpm.yml
@@ -35,8 +35,6 @@ jobs:
           subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
           allow-no-subscriptions: true
 
-      # Reuses the same signing key as the APT repository so users only need to
-      # trust a single Firezone package-signing key.
       - uses: ./.github/actions/setup-gpg
         id: setup-gpg
         with:

--- a/.github/workflows/_rpm.yml
+++ b/.github/workflows/_rpm.yml
@@ -1,0 +1,49 @@
+name: Sync RPM repository metadata
+run-name: Triggered by ${{ github.actor }}
+on:
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: "create-rpm-repository" # Unique group name to force only a single job at a time.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # OIDC auth for Azure Storage
+
+jobs:
+  create-rpm-repository-metadata:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install createrepo_c
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes createrepo-c rpm
+
+      - uses: ./.github/actions/setup-azure-cli
+
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_ARTIFACTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_ARTIFACTS_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
+
+      # Reuses the same signing key as the APT repository so users only need to
+      # trust a single Firezone package-signing key.
+      - uses: ./.github/actions/setup-gpg
+        id: setup-gpg
+        with:
+          key: ${{ secrets.APT_REPOSITORY_GPG_KEY }}
+          email: packages@firezone.dev
+
+      - run: scripts/sync-rpm.sh
+        env:
+          AZURE_STORAGE_ACCOUNT: firezoneartifacts
+          GPG_KEY_ID: ${{ steps.setup-gpg.outputs.key_id }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -261,6 +261,20 @@ jobs:
             --auth-mode login \
             --account-name firezoneartifacts
 
+      - name: Upload to preview RPM repository
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          az storage blob upload-batch \
+            --destination rpm \
+            --source . \
+            --pattern "*.rpm" \
+            --destination-path import-preview \
+            --overwrite \
+            --no-progress \
+            --auth-mode login \
+            --account-name firezoneartifacts
+
       - name: Azure login (OIDC) for QA artifacts
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -315,4 +329,10 @@ jobs:
     needs: build-gui
     if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}
     uses: ./.github/workflows/_apt.yml
+    secrets: inherit
+
+  regenerate-rpm-index:
+    needs: build-gui
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}
+    uses: ./.github/workflows/_rpm.yml
     secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -363,3 +363,51 @@ jobs:
       id-token: write
     uses: ./.github/workflows/_apt.yml
     secrets: inherit
+
+  # Only the GUI client ships as an `.rpm`, so unlike the `.deb` promotion this
+  # is not a matrix.
+  promote-rpm-packages:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # OIDC auth for Azure Storage
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-azure-cli
+
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_ARTIFACTS_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_ARTIFACTS_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_ARTIFACTS_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
+
+      - name: Copy preview archive to import-stable
+        if: ${{ startsWith(inputs.release_name || github.event.release.name, 'gui-client') }}
+        run: |
+          set -e
+
+          # Extract version from release name
+          version=${{ inputs.release_name || github.event.release.name }}
+          version=${version#gui-client-}
+
+          # Copy `.rpm`s to `import-stable`
+          az storage blob copy start-batch \
+            --destination-container rpm \
+            --source-container rpm \
+            --pattern "preview/firezone-client-gui-$version-*" \
+            --destination-path import-stable \
+            --auth-mode login \
+            --account-name firezoneartifacts
+
+  regenerate-rpm-index:
+    needs: promote-rpm-packages
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/_rpm.yml
+    secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -365,8 +365,10 @@ jobs:
     secrets: inherit
 
   # Only the GUI client ships as an `.rpm`, so unlike the `.deb` promotion this
-  # is not a matrix.
+  # is not a matrix and the whole job is skipped for other releases (which also
+  # skips the dependent `regenerate-rpm-index`).
   promote-rpm-packages:
+    if: ${{ startsWith(inputs.release_name || github.event.release.name, 'gui-client') }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -387,7 +389,6 @@ jobs:
           allow-no-subscriptions: true
 
       - name: Copy preview archive to import-stable
-        if: ${{ startsWith(inputs.release_name || github.event.release.name, 'gui-client') }}
         run: |
           set -e
 

--- a/scripts/sync-rpm.sh
+++ b/scripts/sync-rpm.sh
@@ -2,10 +2,10 @@
 
 # Shell script for syncing the RPM (DNF/YUM) repository metadata from a set of `.rpm` files.
 #
-# This is the RPM counterpart to `sync-apt.sh`. It maintains two release channels: stable and preview.
+# It maintains two release channels: stable and preview.
 # To add new packages to the repository, upload them to the `import-stable` and `import-preview` directories NOT to the published channel directories.
 #
-# Unlike the APT layout, a DNF repository keeps the packages and the generated `repodata/` together in the directory pointed at by `baseurl`.
+# A DNF repository keeps the packages and the generated `repodata/` together in the directory pointed at by `baseurl`.
 # Each channel is therefore published under `<distribution>/` (holding the `.rpm` files and their `repodata/`) and the packages in there need to atomically change with the metadata.
 #
 # Every imported package is signed with the Firezone package-signing key so that clients work with DNF's default `gpgcheck=1`.

--- a/scripts/sync-rpm.sh
+++ b/scripts/sync-rpm.sh
@@ -7,6 +7,9 @@
 #
 # Unlike the APT layout, a DNF repository keeps the packages and the generated `repodata/` together in the directory pointed at by `baseurl`.
 # Each channel is therefore published under `<distribution>/` (holding the `.rpm` files and their `repodata/`) and the packages in there need to atomically change with the metadata.
+#
+# Every imported package is signed with the Firezone package-signing key so that clients work with DNF's default `gpgcheck=1`.
+# The armoured public key is published at the repository root (`firezone.gpg`) for use as the `gpgkey` in the client `.repo` file.
 
 set -euo pipefail
 shopt -s globstar
@@ -28,6 +31,15 @@ cleanup() {
 }
 
 trap cleanup EXIT
+
+# Configure `rpm --addsign` to sign non-interactively with our GnuPG key. The
+# loopback pinentry mirrors the GnuPG config set up by the `setup-gpg` action.
+cat >"${HOME}/.rpmmacros" <<EOF
+%_signature gpg
+%_gpg_name ${GPG_KEY_ID}
+%__gpg /usr/bin/gpg
+%__gpg_sign_cmd %{__gpg} --no-verbose --no-armor --batch --pinentry-mode loopback -u "%{_gpg_name}" --detach-sign --output %{__signature_filename} %{__plaintext_filename}
+EOF
 
 for DISTRIBUTION in "stable" "preview"; do
     REPO_DIR="${WORK_DIR}/${DISTRIBUTION}"
@@ -57,7 +69,7 @@ for DISTRIBUTION in "stable" "preview"; do
         2>&1 | grep -v "WARNING" || true
 
     if [ "$(ls -A "${IMPORT_DIR}")" ]; then
-        echo "Normalizing package names..."
+        echo "Normalizing and signing package names..."
 
         for pkg in "${IMPORT_DIR}"/**; do
             if [[ ! "$pkg" == *.rpm ]]; then
@@ -76,6 +88,9 @@ for DISTRIBUTION in "stable" "preview"; do
 
                 echo "Importing $(basename "$pkg") as ${NORMALIZED_NAME}"
                 mv --force "$pkg" "${REPO_DIR}/${NORMALIZED_NAME}"
+
+                # Sign so clients can verify with the default `gpgcheck=1`.
+                rpm --addsign "${REPO_DIR}/${NORMALIZED_NAME}"
             fi
         done
     fi
@@ -115,6 +130,18 @@ for DISTRIBUTION in "stable" "preview"; do
         --overwrite \
         --output table
 done
+
+# Publish the public key so it can be referenced as the `gpgkey` in the client `.repo`.
+echo "Uploading public signing key..."
+gpg --armor --export "${GPG_KEY_ID}" >"${WORK_DIR}/firezone.gpg"
+az storage blob upload \
+    --container-name rpm \
+    --name firezone.gpg \
+    --file "${WORK_DIR}/firezone.gpg" \
+    --auth-mode login \
+    --account-name "${AZURE_STORAGE_ACCOUNT}" \
+    --overwrite \
+    --output table
 
 # Delete import files
 az storage blob delete-batch \

--- a/scripts/sync-rpm.sh
+++ b/scripts/sync-rpm.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Shell script for syncing the RPM (DNF/YUM) repository metadata from a set of `.rpm` files.
+#
+# This is the RPM counterpart to `sync-apt.sh`. It maintains two release channels: stable and preview.
+# To add new packages to the repository, upload them to the `import-stable` and `import-preview` directories NOT to the published channel directories.
+#
+# Unlike the APT layout, a DNF repository keeps the packages and the generated `repodata/` together in the directory pointed at by `baseurl`.
+# Each channel is therefore published under `<distribution>/` (holding the `.rpm` files and their `repodata/`) and the packages in there need to atomically change with the metadata.
+
+set -euo pipefail
+shopt -s globstar
+
+WORK_DIR="$(mktemp -d)"
+
+if [ -z "${AZURE_STORAGE_ACCOUNT:-}" ]; then
+    echo "Error: AZURE_STORAGE_ACCOUNT not set"
+    exit 1
+fi
+
+if [ -z "${GPG_KEY_ID:-}" ]; then
+    echo "Error: GPG_KEY_ID not set"
+    exit 1
+fi
+
+cleanup() {
+    rm -rf "${WORK_DIR}"
+}
+
+trap cleanup EXIT
+
+for DISTRIBUTION in "stable" "preview"; do
+    REPO_DIR="${WORK_DIR}/${DISTRIBUTION}"
+    IMPORT_DIR="${WORK_DIR}/import-${DISTRIBUTION}"
+
+    mkdir --parents "${REPO_DIR}"
+    mkdir --parents "${IMPORT_DIR}"
+
+    echo "Downloading existing packages for distribution $DISTRIBUTION..."
+
+    az storage blob download-batch \
+        --destination "${WORK_DIR}" \
+        --source rpm \
+        --pattern "${DISTRIBUTION}/*.rpm" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
+        2>&1 | grep -v "WARNING" || true
+
+    echo "Downloading import packages for distribution $DISTRIBUTION..."
+
+    az storage blob download-batch \
+        --destination "${WORK_DIR}" \
+        --source rpm \
+        --pattern "import-${DISTRIBUTION}/*.rpm" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
+        2>&1 | grep -v "WARNING" || true
+
+    if [ "$(ls -A "${IMPORT_DIR}")" ]; then
+        echo "Normalizing package names..."
+
+        for pkg in "${IMPORT_DIR}"/**; do
+            if [[ ! "$pkg" == *.rpm ]]; then
+                continue
+            fi
+
+            if [ -f "$pkg" ]; then
+                # Derive the canonical NEVRA filename from the package metadata.
+                NORMALIZED_NAME=$(rpm --query --package --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}.rpm' "$pkg" 2>/dev/null)
+
+                # Skip if the metadata could not be read
+                if [ -z "$NORMALIZED_NAME" ]; then
+                    echo "Warning: Could not extract metadata from $(basename "$pkg"), skipping"
+                    continue
+                fi
+
+                echo "Importing $(basename "$pkg") as ${NORMALIZED_NAME}"
+                mv --force "$pkg" "${REPO_DIR}/${NORMALIZED_NAME}"
+            fi
+        done
+    fi
+
+    if [ -z "$(ls -A "${REPO_DIR}")" ]; then
+        echo "No packages for distribution ${DISTRIBUTION}"
+
+        continue
+    fi
+
+    echo "Generating metadata..."
+    createrepo_c "${REPO_DIR}"
+
+    echo "Signing metadata..."
+    gpg --default-key "${GPG_KEY_ID}" --detach-sign --armor "${REPO_DIR}/repodata/repomd.xml"
+
+    # Upload the packages first so they are in place before the metadata that
+    # references them goes live.
+    echo "Uploading packages..."
+    az storage blob upload-batch \
+        --destination rpm \
+        --destination-path "${DISTRIBUTION}" \
+        --source "${REPO_DIR}" \
+        --pattern "*.rpm" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
+        --overwrite \
+        --output table
+
+    echo "Uploading metadata..."
+    az storage blob upload-batch \
+        --destination rpm \
+        --destination-path "${DISTRIBUTION}/repodata" \
+        --source "${REPO_DIR}/repodata" \
+        --auth-mode login \
+        --account-name "${AZURE_STORAGE_ACCOUNT}" \
+        --overwrite \
+        --output table
+done
+
+# Delete import files
+az storage blob delete-batch \
+    --source rpm \
+    --pattern "import-*/*.rpm" \
+    --auth-mode login \
+    --account-name "${AZURE_STORAGE_ACCOUNT}" \
+    --output table

--- a/scripts/sync-rpm.sh
+++ b/scripts/sync-rpm.sh
@@ -78,7 +78,9 @@ for DISTRIBUTION in "stable" "preview"; do
 
             if [ -f "$pkg" ]; then
                 # Derive the canonical NEVRA filename from the package metadata.
-                NORMALIZED_NAME=$(rpm --query --package --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}.rpm' "$pkg" 2>/dev/null)
+                # `|| true` keeps a single unreadable package from aborting the
+                # whole sync under `set -e`; the `-z` check below skips it instead.
+                NORMALIZED_NAME=$(rpm --query --package --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}.rpm' "$pkg" 2>/dev/null || true)
 
                 # Skip if the metadata could not be read
                 if [ -z "$NORMALIZED_NAME" ]; then
@@ -102,7 +104,9 @@ for DISTRIBUTION in "stable" "preview"; do
     fi
 
     echo "Generating metadata..."
-    createrepo_c "${REPO_DIR}"
+    # Fixed metadata filenames (overwritten in place) so stale blobs do not
+    # accumulate in the `repodata/` prefix on every sync.
+    createrepo_c --simple-md-filenames "${REPO_DIR}"
 
     echo "Signing metadata..."
     gpg --default-key "${GPG_KEY_ID}" --detach-sign --armor "${REPO_DIR}/repodata/repomd.xml"


### PR DESCRIPTION
Adds infrastructure to manage RPM packages for the Firezone GUI client, including package signing, metadata generation, and promotion workflows.

The workflow maintains two release channels (stable and preview) with atomic updates to ensure packages and metadata stay in sync. All packages are signed with the Firezone package-signing key to work with DNF's default `gpgcheck=1` configuration.