### PR TITLE
feat(flow-log-writer): spool flow logs from tracing events

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2324,6 +2324,7 @@ dependencies = [
  "caps",
  "clap",
  "dns-types",
+ "flow-log-writer",
  "futures",
  "futures-bounded",
  "hickory-resolver",
@@ -2373,6 +2374,7 @@ dependencies = [
  "dirs",
  "embed-resource",
  "fd-lock",
+ "flow-log-writer",
  "futures",
  "hex",
  "humantime",
@@ -2444,6 +2446,7 @@ dependencies = [
  "bin-shared",
  "clap",
  "client-shared",
+ "flow-log-writer",
  "futures",
  "humantime",
  "ip-packet",
@@ -2594,6 +2597,23 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "windows-security",
+]
+
+[[package]]
+name = "flow-log-writer"
+version = "0.1.0"
+dependencies = [
+ "anyhow-ext",
+ "atomicwrites",
+ "base64 0.22.1",
+ "chrono",
+ "flow-log-spool",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
  "windows-security",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2570,7 +2570,6 @@ dependencies = [
 name = "flow-log-spool"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "crc32fast",
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2613,6 +2613,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "windows-security",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "libs/eventloop-budget",
     "libs/flow-log-spool",
     "libs/flow-log-upload",
+    "libs/flow-log-writer",
     "libs/http-client",
     "libs/known-dirs",
     "libs/logging",
@@ -102,6 +103,7 @@ fd-lock = "4.0.4"
 filetime = "0.2.29"
 firezone-relay = { path = "relay/server", default-features = false }
 flow-log-spool = { path = "libs/flow-log-spool" }
+flow-log-writer = { path = "libs/flow-log-writer" }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"
 gat-lending-iterator = "0.1.8"

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -29,6 +29,7 @@ backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true }
 dns-types = { workspace = true }
+flow-log-writer = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true }
 hickory-resolver = { workspace = true }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -35,6 +35,12 @@ const RELEASE: &str = concat!("gateway@", env!("CARGO_PKG_VERSION"));
 
 const DEFAULT_MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
 
+/// Spool directory for flow logs pending upload.
+///
+/// Holds Bearer tokens, so it lives outside the log directory and is written
+/// with 0700/0600 permissions.
+const FLOW_LOGS_DIR: &str = "/var/lib/firezone/flow_logs";
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -98,9 +104,12 @@ fn has_necessary_permissions() -> bool {
 }
 
 async fn try_main(cli: Cli) -> Result<()> {
+    let (flow_log_layer, _flow_log_guard) = flow_log_writer::layer(PathBuf::from(FLOW_LOGS_DIR));
+
     logging::setup_global_subscriber(
         make_directives(std::env::var("RUST_LOG").ok(), cli.flow_logs),
         layer::Identity::default(),
+        flow_log_layer,
         match cli.log_format {
             LogFormat::Json => true,
             LogFormat::Human => false,

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ client-shared = { workspace = true }
 connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 fd-lock = { workspace = true }
+flow-log-writer = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }

--- a/rust/gui-client/src-tauri/src/bin/register-sparse.rs
+++ b/rust/gui-client/src-tauri/src/bin/register-sparse.rs
@@ -129,8 +129,13 @@ fn init_tracing() -> Result<logging::file::Handle> {
 
     let (file_layer, file_handle) = logging::file::layer(&log_dir, "register-sparse");
     let directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "debug".to_string());
-    logging::setup_global_subscriber(directives, file_layer, false)
-        .context("setup_global_subscriber")?;
+    logging::setup_global_subscriber(
+        directives,
+        file_layer,
+        tracing_subscriber::layer::Identity::default(),
+        false,
+    )
+    .context("setup_global_subscriber")?;
 
     tracing::info!(log_dir = %log_dir.display(), "logging initialized");
 

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -117,7 +117,11 @@ pub fn setup_gui(directives: &str) -> Result<Handles> {
 /// and flushes the log file.
 pub fn setup_tunnel(
     log_path: Option<PathBuf>,
-) -> Result<(logging::file::Handle, logging::FilterReloadHandle)> {
+) -> Result<(
+    logging::file::Handle,
+    logging::FilterReloadHandle,
+    Option<flow_log_writer::Guard>,
+)> {
     // If `log_dir` is Some, use that. Else call `tunnel_service_logs`
     let log_path = log_path.map_or_else(
         || {
@@ -140,9 +144,13 @@ pub fn setup_tunnel(
         .with_ansi(logging::stdout_supports_ansi())
         .event_format(logging::Format::new().without_timestamp());
 
+    let (flow_log_layer, flow_log_guard) =
+        known_dirs::flow_logs().map(flow_log_writer::layer).unzip();
+
     let subscriber = Registry::default()
         .with(file_layer.with_filter(file_filter))
         .with(stdout_layer.with_filter(stdout_filter))
+        .with(flow_log_layer)
         .with(logging::sentry_layer());
     logging::init(subscriber)?;
 
@@ -156,7 +164,11 @@ pub fn setup_tunnel(
         "`tunnel service` started logging"
     );
 
-    Ok((file_handle, file_reloader.merge(stdout_reloader)))
+    Ok((
+        file_handle,
+        file_reloader.merge(stdout_reloader),
+        flow_log_guard,
+    ))
 }
 
 /// Sets up logging for stdout only, with INFO level by default

--- a/rust/gui-client/src-tauri/src/service/linux.rs
+++ b/rust/gui-client/src-tauri/src/service/linux.rs
@@ -9,7 +9,7 @@ use crate::ipc::SocketId;
 ///
 /// Linux uses the CLI args from here, Windows does not
 pub fn run(log_dir: Option<PathBuf>, dns_control: DnsControlMethod) -> Result<()> {
-    let (_handle, log_filter_reloader) = crate::logging::setup_tunnel(log_dir)?;
+    let (_handle, log_filter_reloader, _flow_log_guard) = crate::logging::setup_tunnel(log_dir)?;
     if !elevation_check()? {
         bail!("Tunnel service failed its elevation check, try running as admin / root");
     }

--- a/rust/gui-client/src-tauri/src/service/macos.rs
+++ b/rust/gui-client/src-tauri/src/service/macos.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 pub fn run(log_dir: Option<PathBuf>, _dns_control: DnsControlMethod) -> Result<()> {
     // We call this here to avoid a dead-code warning.
-    let (_handle, _log_filter_reloader) = crate::logging::setup_tunnel(log_dir)?;
+    let (_handle, _log_filter_reloader, _flow_log_guard) = crate::logging::setup_tunnel(log_dir)?;
 
     bail!("not implemented")
 }

--- a/rust/gui-client/src-tauri/src/service/windows.rs
+++ b/rust/gui-client/src-tauri/src/service/windows.rs
@@ -255,7 +255,7 @@ windows_service::define_windows_service!(run_service_ffi, run_service);
 fn run_service(arguments: Vec<OsString>) {
     // `arguments` doesn't seem to work right when running as a Windows service
     // (even though it's meant for that) so just use the default log dir.
-    let (_handle, log_filter_reloader) =
+    let (_handle, log_filter_reloader, _flow_log_guard) =
         crate::logging::setup_tunnel(None).expect("Should be able to set up logging");
 
     tracing::info!(?arguments, "run_service");

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -13,6 +13,7 @@ backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "string"] }
 client-shared = { workspace = true }
+flow-log-writer = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -257,9 +257,13 @@ fn try_main() -> Result<()> {
         .as_deref()
         .map(|dir| logging::file::layer(dir, "firezone-headless-client"))
         .unzip();
+    let (flow_log_layer, _flow_log_guard) =
+        known_dirs::flow_logs().map(flow_log_writer::layer).unzip();
+
     logging::setup_global_subscriber(
         std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()),
         layer,
+        flow_log_layer,
         false,
     )
     .context("Failed to set up logging")?;

--- a/rust/libs/flow-log-spool/Cargo.toml
+++ b/rust/libs/flow-log-spool/Cargo.toml
@@ -5,7 +5,6 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-chrono = { workspace = true, features = ["serde"] }
 crc32fast = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/rust/libs/flow-log-spool/src/lib.rs
+++ b/rust/libs/flow-log-spool/src/lib.rs
@@ -6,49 +6,14 @@
 //! in all of connlib via `tunnel`.
 //!
 //! Each report on disk is `{ "checksum": <crc32 of the serialized payload>,
-//! "payload": <Payload> }`. The CRC lets a reader reject a torn / corrupted file
-//! rather than upload bad data.
+//! "payload": <payload> }`. The payload is an opaque JSON object: the writer spools
+//! the flow-log event's fields as emitted and the portal validates them on ingest,
+//! so this crate imposes no schema. The CRC lets a reader reject a torn / corrupted
+//! file rather than upload bad data.
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::net::IpAddr;
-
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-
-/// A flow-log payload: the network fields the data plane observes. Attribution
-/// lives in the authorization's token, never in the payload. `flow_end` and the
-/// counters are absent for an "open" report and present for a "completed" one.
-///
-/// Fields are public so the writer can build one directly; readers get one back
-/// from [`deserialize`].
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct Payload {
-    pub protocol: String,
-    pub inner_src_ip: IpAddr,
-    pub inner_src_port: u16,
-    pub inner_dst_ip: IpAddr,
-    pub inner_dst_port: u16,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub domain: Option<String>,
-    pub outer_src_ip: IpAddr,
-    pub outer_src_port: u16,
-    pub outer_dst_ip: IpAddr,
-    pub outer_dst_port: u16,
-    pub flow_start: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub flow_end: Option<DateTime<Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_packet: Option<DateTime<Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rx_packets: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tx_packets: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rx_bytes: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tx_bytes: Option<u64>,
-}
 
 /// One on-disk flow-log report: a CRC32 of the serialized `payload` and the payload
 /// itself. The Bearer token lives once per authorization in the directory's `token`
@@ -56,18 +21,18 @@ pub struct Payload {
 #[derive(Serialize)]
 struct Entry<'a> {
     checksum: u32,
-    payload: &'a Payload,
+    payload: &'a serde_json::Value,
 }
 
 #[derive(Deserialize)]
 struct StoredEntry {
     checksum: u32,
-    payload: Payload,
+    payload: serde_json::Value,
 }
 
 /// Serializes a payload into the on-disk report form, computing the CRC32 over the
 /// serialized payload so [`deserialize`] can verify it.
-pub fn serialize(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> {
+pub fn serialize(payload: &serde_json::Value) -> Result<Vec<u8>, serde_json::Error> {
     let body = serde_json::to_vec(payload)?;
     let entry = Entry {
         checksum: crc32fast::hash(&body),
@@ -83,11 +48,11 @@ pub fn serialize(payload: &Payload) -> Result<Vec<u8>, serde_json::Error> {
 /// The error distinguishes malformed JSON (should be impossible under atomic
 /// writes) from a CRC32 mismatch (environmental corruption the checksum exists to
 /// catch), so the uploader can report them with different severity.
-pub fn deserialize(bytes: &[u8]) -> Result<Payload, Error> {
+pub fn deserialize(bytes: &[u8]) -> Result<serde_json::Value, Error> {
     let stored: StoredEntry = serde_json::from_slice(bytes).map_err(Error::Malformed)?;
 
-    // The payload serializes deterministically (fixed struct, compact), so the CRC
-    // of its re-serialization matches the one written alongside it.
+    // `serde_json::Value` objects sort their keys, so re-serialization is
+    // deterministic and the CRC matches the one written alongside the payload.
     let serialized = serde_json::to_vec(&stored.payload).map_err(Error::Malformed)?;
     let computed = crc32fast::hash(&serialized);
 
@@ -133,28 +98,16 @@ impl std::error::Error for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone as _;
 
-    fn payload() -> Payload {
-        Payload {
-            protocol: "tcp".to_owned(),
-            inner_src_ip: "100.64.0.1".parse().unwrap(),
-            inner_src_port: 1234,
-            inner_dst_ip: "10.0.0.5".parse().unwrap(),
-            inner_dst_port: 443,
-            domain: None,
-            outer_src_ip: "198.51.100.1".parse().unwrap(),
-            outer_src_port: 51820,
-            outer_dst_ip: "203.0.113.7".parse().unwrap(),
-            outer_dst_port: 51820,
-            flow_start: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-            flow_end: None,
-            last_packet: None,
-            rx_packets: None,
-            tx_packets: None,
-            rx_bytes: None,
-            tx_bytes: None,
-        }
+    fn payload() -> serde_json::Value {
+        serde_json::json!({
+            "protocol": "tcp",
+            "inner_src_ip": "100.64.0.1",
+            "inner_src_port": 1234,
+            "inner_dst_ip": "10.0.0.5",
+            "inner_dst_port": 443,
+            "flow_start": "2023-11-14T22:13:20Z",
+        })
     }
 
     #[test]

--- a/rust/libs/flow-log-upload/src/lib.rs
+++ b/rust/libs/flow-log-upload/src/lib.rs
@@ -32,7 +32,7 @@ use anyhow::{Context as _, Result};
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use base64::Engine as _;
 use bytes::Bytes;
-use flow_log_spool::{Payload, deserialize};
+use flow_log_spool::deserialize;
 use http::{StatusCode, header};
 use http_client::HttpClient;
 use serde::{Deserialize, Serialize};
@@ -406,7 +406,7 @@ async fn connect(
 
 /// One flow to upload: the record to send and the files to delete once it lands.
 struct Pending {
-    payload: Payload,
+    payload: serde_json::Value,
     files: Vec<PathBuf>,
 }
 
@@ -614,7 +614,7 @@ fn load_flow(path: &Path) -> Result<Option<Pending>> {
 ///
 /// Malformed JSON is a bug (reports are written atomically); a CRC mismatch is
 /// the checksum catching environmental corruption, working as designed.
-fn read_report(path: &Path) -> Result<Option<Payload>> {
+fn read_report(path: &Path) -> Result<Option<serde_json::Value>> {
     let bytes = std::fs::read(path).context("Failed to read report")?;
 
     match deserialize(&bytes) {
@@ -814,7 +814,7 @@ async fn sleep_backoff(backoff: &mut ExponentialBackoff) -> bool {
 
 #[derive(Serialize)]
 struct Batch<'a> {
-    flow_logs: &'a [&'a Payload],
+    flow_logs: &'a [&'a serde_json::Value],
 }
 
 #[cfg(test)]
@@ -829,25 +829,14 @@ mod tests {
     }
 
     fn write_report(path: &Path) {
-        let payload = Payload {
-            protocol: "tcp".to_owned(),
-            inner_src_ip: "10.0.0.1".parse().unwrap(),
-            inner_src_port: 1,
-            inner_dst_ip: "10.0.0.2".parse().unwrap(),
-            inner_dst_port: 2,
-            domain: None,
-            outer_src_ip: "192.0.2.1".parse().unwrap(),
-            outer_src_port: 3,
-            outer_dst_ip: "192.0.2.2".parse().unwrap(),
-            outer_dst_port: 4,
-            flow_start: chrono::Utc::now(),
-            flow_end: None,
-            last_packet: None,
-            rx_packets: None,
-            tx_packets: None,
-            rx_bytes: None,
-            tx_bytes: None,
-        };
+        let payload = serde_json::json!({
+            "protocol": "tcp",
+            "inner_src_ip": "10.0.0.1",
+            "inner_src_port": 1,
+            "inner_dst_ip": "10.0.0.2",
+            "inner_dst_port": 2,
+            "flow_start": chrono::Utc::now().to_rfc3339(),
+        });
 
         std::fs::write(path, flow_log_spool::serialize(&payload).unwrap()).unwrap();
     }

--- a/rust/libs/flow-log-writer/Cargo.toml
+++ b/rust/libs/flow-log-writer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "flow-log-writer"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+atomicwrites = { workspace = true }
+base64 = { workspace = true, features = ["std"] }
+chrono = { workspace = true }
+flow-log-spool = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-security = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/flow-log-writer/Cargo.toml
+++ b/rust/libs/flow-log-writer/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-security = { workspace = true }

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -55,7 +55,10 @@ use std::{
     io::Write as _,
     net::IpAddr,
     path::{Path, PathBuf},
-    sync::mpsc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        mpsc,
+    },
     thread::JoinHandle,
 };
 
@@ -71,21 +74,38 @@ use tracing_subscriber::registry::LookupSpan;
 ///
 /// Keep the guard alive until process exit; dropping it drains and joins the
 /// writer thread.
+/// How many reports may queue for the writer thread before new ones are dropped.
+///
+/// Reports are a few hundred bytes each, so this bounds worst-case memory while
+/// absorbing flow-churn bursts (e.g. a port scan opening many flows at once)
+/// faster than the per-report fsync can drain them. Mobile gets a smaller buffer;
+/// it has less memory headroom and the OS may kill the tunnel process under
+/// memory pressure.
+const CHANNEL_CAPACITY: usize = if cfg!(any(target_os = "ios", target_os = "android")) {
+    1_000
+} else {
+    10_000
+};
+
 pub fn layer<S>(spool_root: PathBuf) -> (impl tracing_subscriber::Layer<S>, Guard)
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
     use tracing_subscriber::Layer as _;
 
-    let (tx, rx) = mpsc::channel::<Command>();
+    let (tx, rx) = mpsc::sync_channel::<Command>(CHANNEL_CAPACITY);
     let handle = std::thread::Builder::new()
         .name("flow-log-writer".to_owned())
         .spawn(move || writer_loop(&spool_root, &rx))
         .expect("Failed to spawn flow-log writer thread");
 
-    let layer = FlowLogLayer { tx: tx.clone() }.with_filter(tracing_subscriber::filter::filter_fn(
-        |metadata| metadata.target().starts_with("flow_logs::"),
-    ));
+    let layer = FlowLogLayer {
+        tx: tx.clone(),
+        dropped: AtomicU64::new(0),
+    }
+    .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
+        metadata.target().starts_with("flow_logs::")
+    }));
 
     (
         layer,
@@ -144,7 +164,7 @@ pub fn write_token(spool_root: &Path, token: &str) -> anyhow::Result<()> {
 /// Dropping it drains the backlog and joins the thread, making every
 /// already-emitted report durable.
 pub struct Guard {
-    tx: mpsc::Sender<Command>,
+    tx: mpsc::SyncSender<Command>,
     handle: Option<JoinHandle<()>>,
 }
 
@@ -170,7 +190,9 @@ struct Report {
 }
 
 struct FlowLogLayer {
-    tx: mpsc::Sender<Command>,
+    tx: mpsc::SyncSender<Command>,
+    /// How many reports were dropped because the writer thread's queue was full.
+    dropped: AtomicU64,
 }
 
 impl<S> tracing_subscriber::Layer<S> for FlowLogLayer
@@ -192,11 +214,27 @@ where
             return;
         };
 
-        if self.tx.send(Command::Write(report)).is_err() {
-            tracing::debug!(
-                target: "flow_log_writer",
-                "Flow-log writer thread is gone; dropping report"
-            );
+        // Never block the packet-processing path on disk IO: when the writer
+        // thread cannot keep up, drop the report instead.
+        match self.tx.try_send(Command::Write(report)) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => {
+                let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+
+                if dropped == 1 || dropped.is_multiple_of(1_000) {
+                    tracing::warn!(
+                        target: "flow_log_writer",
+                        dropped,
+                        "Flow-log writer cannot keep up; dropping reports"
+                    );
+                }
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                tracing::debug!(
+                    target: "flow_log_writer",
+                    "Flow-log writer thread is gone; dropping report"
+                );
+            }
         }
     }
 }

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -60,6 +60,7 @@ use std::{
         mpsc,
     },
     thread::JoinHandle,
+    time::{Duration, Instant},
 };
 
 use anyhow::Context as _;
@@ -70,10 +71,6 @@ use flow_log_spool::{Payload, serialize};
 use tracing::field::{Field, Visit};
 use tracing_subscriber::registry::LookupSpan;
 
-/// Creates the flow-log spooling layer plus the [`Guard`] keeping it durable.
-///
-/// Keep the guard alive until process exit; dropping it drains and joins the
-/// writer thread.
 /// How many reports may queue for the writer thread before new ones are dropped.
 ///
 /// Reports are a few hundred bytes each, so this bounds worst-case memory while
@@ -87,6 +84,10 @@ const CHANNEL_CAPACITY: usize = if cfg!(any(target_os = "ios", target_os = "andr
     10_000
 };
 
+/// Creates the flow-log spooling layer plus the [`Guard`] keeping it durable.
+///
+/// Keep the guard alive until process exit; dropping it drains and joins the
+/// writer thread.
 pub fn layer<S>(spool_root: PathBuf) -> (impl tracing_subscriber::Layer<S>, Guard)
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
@@ -103,9 +104,9 @@ where
         tx: tx.clone(),
         dropped: AtomicU64::new(0),
     }
-    .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
-        metadata.target().starts_with("flow_logs::")
-    }));
+    .with_filter(
+        tracing_subscriber::filter::Targets::new().with_target("flow_logs", tracing::Level::TRACE),
+    );
 
     (
         layer,
@@ -150,11 +151,7 @@ pub fn write_token(spool_root: &Path, token: &str) -> anyhow::Result<()> {
 
     let dir = spool_root.join(&role).join(&authz_id);
     create_dir_secure(&dir)?;
-    write_file_secure(
-        &dir.join("token"),
-        token.as_bytes(),
-        OverwriteBehavior::AllowOverwrite,
-    )?;
+    write_file_secure(&dir.join("token"), token.as_bytes())?;
 
     Ok(())
 }
@@ -162,7 +159,8 @@ pub fn write_token(spool_root: &Path, token: &str) -> anyhow::Result<()> {
 /// Keeps the writer thread alive.
 ///
 /// Dropping it drains the backlog and joins the thread, making every
-/// already-emitted report durable.
+/// already-emitted report durable. The wait is bounded so a stalled disk
+/// cannot hang process exit.
 pub struct Guard {
     tx: mpsc::SyncSender<Command>,
     handle: Option<JoinHandle<()>>,
@@ -170,15 +168,35 @@ pub struct Guard {
 
 impl Drop for Guard {
     fn drop(&mut self) {
+        const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
         let _ = self.tx.send(Command::Shutdown);
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+
+        let deadline = Instant::now() + DRAIN_TIMEOUT;
+        while !handle.is_finished() {
+            if Instant::now() > deadline {
+                tracing::warn!(
+                    "Flow-log writer did not drain within {DRAIN_TIMEOUT:?}; abandoning it"
+                );
+
+                return;
+            }
+
+            std::thread::sleep(Duration::from_millis(10));
         }
+
+        let _ = handle.join();
     }
 }
 
 enum Command {
     Write(Report),
+    /// Explicit shutdown signal; the layer's sender clone lives in the global
+    /// subscriber for the rest of the process, so the channel never closes.
     Shutdown,
 }
 
@@ -206,10 +224,7 @@ where
         let Some(report) = visitor.into_report() else {
             // Flows without a portal-minted token (and thus no attribution claims)
             // are emitted for observability but not spooled.
-            tracing::debug!(
-                target: "flow_log_writer",
-                "Dropping flow-log event with missing or invalid fields"
-            );
+            tracing::debug!("Dropping flow-log event with missing or invalid fields");
 
             return;
         };
@@ -222,18 +237,11 @@ where
                 let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
 
                 if dropped == 1 || dropped.is_multiple_of(1_000) {
-                    tracing::warn!(
-                        target: "flow_log_writer",
-                        dropped,
-                        "Flow-log writer cannot keep up; dropping reports"
-                    );
+                    tracing::warn!(dropped, "Flow-log writer cannot keep up; dropping reports");
                 }
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
-                tracing::debug!(
-                    target: "flow_log_writer",
-                    "Flow-log writer thread is gone; dropping report"
-                );
+                tracing::debug!("Flow-log writer thread is gone; dropping report");
             }
         }
     }
@@ -359,7 +367,7 @@ fn write_report(root: &Path, report: &Report) -> anyhow::Result<()> {
         report.payload.flow_start.timestamp(),
         flow_identity(&report.payload)
     ));
-    write_file_secure(&path, &contents, OverwriteBehavior::AllowOverwrite)?;
+    write_file_secure(&path, &contents)?;
 
     Ok(())
 }
@@ -381,19 +389,15 @@ fn flow_identity(payload: &Payload) -> String {
     format!("{:016x}", hasher.finish())
 }
 
-fn write_file_secure(
-    path: &Path,
-    bytes: &[u8],
-    overwrite: OverwriteBehavior,
-) -> anyhow::Result<()> {
+fn write_file_secure(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     // `AtomicFile` writes to a temp file, fsyncs it, then renames into place, so a
     // reader never observes a partial file and a written file is durable.
-    AtomicFile::new(path, overwrite)
+    AtomicFile::new(path, OverwriteBehavior::AllowOverwrite)
         .write(|f| {
             set_owner_only(f)?;
             f.write_all(bytes)
         })
-        .map_err(|e| anyhow::anyhow!("atomic write of {} failed: {e}", path.display()))
+        .with_context(|| format!("Failed to atomically write {}", path.display()))
 }
 
 /// A policy-authorization id must be a hyphenated UUID; reject anything else so it
@@ -468,48 +472,6 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt as _;
 
     const AUTHZ_ID: &str = "11111111-1111-1111-1111-111111111111";
-
-    fn token_for(authz_id: &str) -> String {
-        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
-            r#"{{"policy_authorization_id":"{authz_id}","role":"responder"}}"#
-        ));
-
-        format!("header.{payload}.signature")
-    }
-
-    /// Emits a `flow_logs::tcp` event shaped like `tunnel`'s emission.
-    fn emit_event(completed: bool) {
-        let flow_start = Utc.timestamp_opt(1_700_000_000, 500).unwrap();
-        let flow_end = completed.then(|| Utc.timestamp_opt(1_700_000_060, 0).unwrap());
-
-        tracing::trace!(
-            target: "flow_logs::tcp",
-            protocol = "tcp",
-            role = "responder",
-            policy_authorization_id = AUTHZ_ID,
-            inner_src_ip = %"100.64.0.1",
-            inner_src_port = %1234,
-            inner_dst_ip = %"10.0.0.5",
-            inner_dst_port = %443,
-            outer_src_ip = %"198.51.100.1",
-            outer_src_port = %51820,
-            outer_dst_ip = %"203.0.113.7",
-            outer_dst_port = %51820,
-            flow_start = ?flow_start,
-            flow_end = flow_end.map(tracing::field::debug),
-            last_packet = flow_end.map(tracing::field::debug),
-            rx_packets = completed.then_some(10_u64),
-            tx_packets = completed.then_some(12_u64),
-            rx_bytes = completed.then_some(1024_u64),
-            tx_bytes = completed.then_some(2048_u64),
-            "TCP flow"
-        );
-    }
-
-    fn read_payload(path: &Path) -> Payload {
-        // `deserialize` verifies the CRC, so `unwrap` also asserts it.
-        deserialize(&std::fs::read(path).unwrap()).unwrap()
-    }
 
     #[test]
     fn spools_start_and_end_reports_sharing_a_stem() {
@@ -595,5 +557,47 @@ mod tests {
         assert!(!is_valid_authz_id("../../../../../../../etc/passwd"));
         assert!(!is_valid_authz_id("11111111-1111-1111-1111-11111111111g"));
         assert!(!is_valid_authz_id("11111111-1111-1111-1111-1111111111111"));
+    }
+
+    fn token_for(authz_id: &str) -> String {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
+            r#"{{"policy_authorization_id":"{authz_id}","role":"responder"}}"#
+        ));
+
+        format!("header.{payload}.signature")
+    }
+
+    /// Emits a `flow_logs::tcp` event shaped like `tunnel`'s emission.
+    fn emit_event(completed: bool) {
+        let flow_start = Utc.timestamp_opt(1_700_000_000, 500).unwrap();
+        let flow_end = completed.then(|| Utc.timestamp_opt(1_700_000_060, 0).unwrap());
+
+        tracing::trace!(
+            target: "flow_logs::tcp",
+            protocol = "tcp",
+            role = "responder",
+            policy_authorization_id = AUTHZ_ID,
+            inner_src_ip = %"100.64.0.1",
+            inner_src_port = %1234,
+            inner_dst_ip = %"10.0.0.5",
+            inner_dst_port = %443,
+            outer_src_ip = %"198.51.100.1",
+            outer_src_port = %51820,
+            outer_dst_ip = %"203.0.113.7",
+            outer_dst_port = %51820,
+            flow_start = ?flow_start,
+            flow_end = flow_end.map(tracing::field::debug),
+            last_packet = flow_end.map(tracing::field::debug),
+            rx_packets = completed.then_some(10_u64),
+            tx_packets = completed.then_some(12_u64),
+            rx_bytes = completed.then_some(1024_u64),
+            tx_bytes = completed.then_some(2048_u64),
+            "TCP flow"
+        );
+    }
+
+    fn read_payload(path: &Path) -> Payload {
+        // `deserialize` verifies the CRC, so `unwrap` also asserts it.
+        deserialize(&std::fs::read(path).unwrap()).unwrap()
     }
 }

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -23,8 +23,10 @@
 //! The Bearer token deliberately does NOT ride the tracing events (a broad `trace`
 //! directive would copy it into log files); the eventloops receive it in the
 //! portal's authorization messages and persist it via [`write_token`] instead.
-//! A report's payload is the event's fields as emitted; the portal validates them
-//! on ingest, so the writer only interprets what routing and naming need.
+//! A report's payload is the event's record fields as emitted (see
+//! [`RECORD_FIELDS`]); attribution deliberately rides only the token, and the
+//! portal validates the payload on ingest, so the writer only interprets what
+//! routing and naming need.
 //!
 //! `<flow_start>` is the flow's start time as zero-padded unix seconds, so a
 //! lexical sort of the report names is oldest-first and the uploader needs no
@@ -254,6 +256,29 @@ where
     }
 }
 
+/// The ingest API's record fields: the payload spooled for upload. Kept in sync
+/// with the portal's ingest schema, which any new record field must be
+/// coordinated with anyway.
+const RECORD_FIELDS: &[&str] = &[
+    "protocol",
+    "inner_src_ip",
+    "inner_src_port",
+    "inner_dst_ip",
+    "inner_dst_port",
+    "domain",
+    "outer_src_ip",
+    "outer_src_port",
+    "outer_dst_ip",
+    "outer_dst_port",
+    "flow_start",
+    "flow_end",
+    "last_packet",
+    "rx_packets",
+    "tx_packets",
+    "rx_bytes",
+    "tx_bytes",
+];
+
 /// Collects an event's fields as emitted.
 ///
 /// Strings arrive through `record_str`, `Display` / `Debug` values through
@@ -303,6 +328,11 @@ impl FieldVisitor {
         if !is_valid_role(&role) || !is_valid_authz_id(&authz_id) {
             return None;
         }
+
+        // Everything else on the event (attribution claims, the human message)
+        // is display-only or already carried by the token.
+        self.fields
+            .retain(|name, _| RECORD_FIELDS.contains(&name.as_str()));
 
         // The only field the writer interprets: the file name needs it so a
         // lexical sort of the reports is oldest-first.
@@ -492,6 +522,7 @@ mod tests {
         assert_eq!(start["flow_start"], "2023-11-14T22:13:20.000000500Z");
         assert!(start.get("role").is_none());
         assert!(start.get("message").is_none());
+        assert!(start.get("actor_id").is_none()); // attribution rides the token only
         assert_eq!(end["rx_bytes"], 1024); // the `.end` is a self-describing report
         assert_eq!(end["inner_dst_port"], "443");
     }
@@ -574,6 +605,7 @@ mod tests {
             outer_src_port = %51820,
             outer_dst_ip = %"203.0.113.7",
             outer_dst_port = %51820,
+            actor_id = "a-1",
             flow_start = ?flow_start,
             flow_end = flow_end.map(tracing::field::debug),
             last_packet = flow_end.map(tracing::field::debug),

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -1,0 +1,561 @@
+//! Spools flow-log records to disk for later upload to the portal ingest API.
+//!
+//! Flow logs travel from the data plane to this writer as structured `tracing`
+//! events (targets `flow_logs::tcp` / `flow_logs::udp`): [`layer`] returns a
+//! subscriber layer that each entrypoint installs as part of its tracing
+//! configuration, so the tunnel itself needs no knowledge of where (or whether)
+//! flow logs are persisted.
+//!
+//! Reports are grouped by the flow's `role` and `policy_authorization_id` into a
+//! per-authorization sub-directory holding that authorization's Bearer token and
+//! one file per flow report, split into an "open" and a "completed" report:
+//!
+//! ```text
+//! <root>/<role>/<policy_authorization_id>/
+//!   token                                    # the Bearer JWT for this authorization
+//!   <flow_start>-<flow_identity>.start.json  # { "checksum": <crc32>, "payload": { open report } }
+//!   <flow_start>-<flow_identity>.end.json    # { "checksum": <crc32>, "payload": { completed report } }
+//! ```
+//!
+//! The `<role>` level (`initiator` / `responder`) separates the two perspectives a
+//! single device can log: a Gateway is always the responder, while a Client can be
+//! the initiator of some flows and the responder of others.
+//!
+//! The Bearer token deliberately does NOT ride the tracing events (a broad `trace`
+//! directive would copy it into log files); the eventloops receive it in the
+//! portal's authorization messages and persist it via [`write_token`] instead.
+//! The events carry only the `role` / `policy_authorization_id` claims plus the
+//! network fields.
+//!
+//! `<flow_start>` is the flow's start time as zero-padded unix seconds, so a
+//! lexical sort of the report names is oldest-first and the uploader needs no
+//! per-file metadata. `<flow_identity>` hashes the fields that identify a flow
+//! within an authorization (protocol, inner 4-tuple, flow_start), so a flow's open
+//! and completed reports share a stem. The `.end` report is self-describing (it
+//! carries the full report, not just the closing fields), so the uploader can send
+//! it on its own even after the `.start` has already been uploaded and deleted.
+//! Writing the completed report to its own file (rather than overwriting the open
+//! one) keeps both write-once, so the uploader can delete one without racing a
+//! concurrent write of the other.
+//!
+//! Each report is written immediately as an atomic, fsync'd file, so nothing
+//! already produced is lost on an unclean exit. Writing happens on a dedicated
+//! thread fed by a channel so the per-file fsync never blocks the packet-processing
+//! event loop; hold the returned [`Guard`] until process exit so the thread's
+//! backlog is drained before shutdown. The spool holds Bearer tokens and flow
+//! payloads, so its directories and files get restrictive permissions (0700 /
+//! 0600) and it lives outside the log directory, so an exported log bundle never
+//! sweeps it up.
+
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::{
+    collections::HashMap,
+    hash::{Hash as _, Hasher as _},
+    io::Write as _,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    sync::mpsc,
+    thread::JoinHandle,
+};
+
+use anyhow::Context as _;
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use base64::Engine as _;
+use chrono::{DateTime, Utc};
+use flow_log_spool::{Payload, serialize};
+use tracing::field::{Field, Visit};
+use tracing_subscriber::registry::LookupSpan;
+
+/// Creates the flow-log spooling layer plus the [`Guard`] keeping it durable.
+///
+/// Keep the guard alive until process exit; dropping it drains and joins the
+/// writer thread.
+pub fn layer<S>(spool_root: PathBuf) -> (impl tracing_subscriber::Layer<S>, Guard)
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    use tracing_subscriber::Layer as _;
+
+    let (tx, rx) = mpsc::channel::<Command>();
+    let handle = std::thread::Builder::new()
+        .name("flow-log-writer".to_owned())
+        .spawn(move || writer_loop(&spool_root, &rx))
+        .expect("Failed to spawn flow-log writer thread");
+
+    let layer = FlowLogLayer { tx: tx.clone() }.with_filter(tracing_subscriber::filter::filter_fn(
+        |metadata| metadata.target().starts_with("flow_logs::"),
+    ));
+
+    (
+        layer,
+        Guard {
+            tx,
+            handle: Some(handle),
+        },
+    )
+}
+
+/// Persists an authorization's ingest token where the uploader expects it.
+///
+/// The spool path derives from the token's (unverified) `role` and
+/// `policy_authorization_id` claims, which are validated first.
+pub fn write_token(spool_root: &Path, token: &str) -> anyhow::Result<()> {
+    #[derive(serde::Deserialize)]
+    struct Claims {
+        role: Option<String>,
+        policy_authorization_id: Option<String>,
+    }
+
+    let payload = token
+        .split('.')
+        .nth(1)
+        .context("Token is not a JWT (no payload segment)")?;
+    let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .context("Token payload is not base64url")?;
+    let claims =
+        serde_json::from_slice::<Claims>(&json).context("Token payload is not valid JSON")?;
+
+    // The token is portal-issued but its signature is not verified here, so never
+    // trust a claim as a path component without validating it first.
+    let role = claims
+        .role
+        .filter(|role| is_valid_role(role))
+        .context("Token has a missing or invalid role")?;
+    let authz_id = claims
+        .policy_authorization_id
+        .filter(|id| is_valid_authz_id(id))
+        .context("Token has a missing or invalid policy_authorization_id")?;
+
+    let dir = spool_root.join(&role).join(&authz_id);
+    create_dir_secure(&dir)?;
+    write_file_secure(
+        &dir.join("token"),
+        token.as_bytes(),
+        OverwriteBehavior::AllowOverwrite,
+    )?;
+
+    Ok(())
+}
+
+/// Keeps the writer thread alive.
+///
+/// Dropping it drains the backlog and joins the thread, making every
+/// already-emitted report durable.
+pub struct Guard {
+    tx: mpsc::Sender<Command>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.tx.send(Command::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+enum Command {
+    Write(Report),
+    Shutdown,
+}
+
+/// One flow report reconstructed from a `flow_logs::*` tracing event.
+struct Report {
+    role: String,
+    authz_id: String,
+    payload: Payload,
+}
+
+struct FlowLogLayer {
+    tx: mpsc::Sender<Command>,
+}
+
+impl<S> tracing_subscriber::Layer<S> for FlowLogLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _: tracing_subscriber::layer::Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+
+        let Some(report) = visitor.into_report() else {
+            // Flows without a portal-minted token (and thus no attribution claims)
+            // are emitted for observability but not spooled.
+            tracing::debug!(
+                target: "flow_log_writer",
+                "Dropping flow-log event with missing or invalid fields"
+            );
+
+            return;
+        };
+
+        if self.tx.send(Command::Write(report)).is_err() {
+            tracing::debug!(
+                target: "flow_log_writer",
+                "Flow-log writer thread is gone; dropping report"
+            );
+        }
+    }
+}
+
+/// Collects an event's fields.
+///
+/// String-ish values (IPs, timestamps, `Display`-recorded ports) arrive through
+/// `record_debug` / `record_str`, counters as `u64`.
+#[derive(Default)]
+struct FieldVisitor {
+    strings: HashMap<&'static str, String>,
+    numbers: HashMap<&'static str, u64>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.strings.insert(field.name(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.strings.insert(field.name(), value.to_owned());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.numbers.insert(field.name(), value);
+    }
+}
+
+impl FieldVisitor {
+    /// Reassembles the [`Report`] from the recorded fields, or `None` if any
+    /// required field is missing or fails validation.
+    fn into_report(mut self) -> Option<Report> {
+        let role = self.strings.remove("role").filter(|r| is_valid_role(r))?;
+        let authz_id = self
+            .strings
+            .remove("policy_authorization_id")
+            .filter(|id| is_valid_authz_id(id))?;
+
+        let payload = Payload {
+            protocol: self.strings.remove("protocol")?,
+            inner_src_ip: self.ip("inner_src_ip")?,
+            inner_src_port: self.port("inner_src_port")?,
+            inner_dst_ip: self.ip("inner_dst_ip")?,
+            inner_dst_port: self.port("inner_dst_port")?,
+            domain: self.strings.remove("inner_domain"),
+            outer_src_ip: self.ip("outer_src_ip")?,
+            outer_src_port: self.port("outer_src_port")?,
+            outer_dst_ip: self.ip("outer_dst_ip")?,
+            outer_dst_port: self.port("outer_dst_port")?,
+            flow_start: self.timestamp("flow_start")?,
+            // A parse failure on a present closing field must fail the whole
+            // report rather than demote a completed flow to an open one.
+            flow_end: self.optional_timestamp("flow_end")?,
+            last_packet: self.optional_timestamp("last_packet")?,
+            rx_packets: self.numbers.remove("rx_packets"),
+            tx_packets: self.numbers.remove("tx_packets"),
+            rx_bytes: self.numbers.remove("rx_bytes"),
+            tx_bytes: self.numbers.remove("tx_bytes"),
+        };
+
+        Some(Report {
+            role,
+            authz_id,
+            payload,
+        })
+    }
+
+    fn ip(&mut self, name: &'static str) -> Option<IpAddr> {
+        self.strings.remove(name)?.parse().ok()
+    }
+
+    fn port(&mut self, name: &'static str) -> Option<u16> {
+        self.strings.remove(name)?.parse().ok()
+    }
+
+    /// Timestamps are emitted with `chrono`'s `Debug` representation, which is
+    /// RFC 3339 with nanosecond precision, so the round-trip is lossless.
+    fn timestamp(&mut self, name: &'static str) -> Option<DateTime<Utc>> {
+        parse_timestamp(&self.strings.remove(name)?)
+    }
+
+    fn optional_timestamp(&mut self, name: &'static str) -> Option<Option<DateTime<Utc>>> {
+        match self.strings.remove(name) {
+            None => Some(None),
+            Some(value) => parse_timestamp(&value).map(Some),
+        }
+    }
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn writer_loop(root: &Path, rx: &mpsc::Receiver<Command>) {
+    while let Ok(command) = rx.recv() {
+        let report = match command {
+            Command::Write(report) => report,
+            Command::Shutdown => break,
+        };
+
+        if let Err(e) = write_report(root, &report) {
+            tracing::warn!("Failed to write flow-log report: {e:#}");
+        }
+    }
+}
+
+fn write_report(root: &Path, report: &Report) -> anyhow::Result<()> {
+    let dir = root.join(&report.role).join(&report.authz_id);
+    create_dir_secure(&dir)?;
+
+    let contents = serialize(&report.payload)?;
+
+    let suffix = if report.payload.flow_end.is_some() {
+        "end"
+    } else {
+        "start"
+    };
+    let path = dir.join(format!(
+        "{:010}-{}.{suffix}.json",
+        report.payload.flow_start.timestamp(),
+        flow_identity(&report.payload)
+    ));
+    write_file_secure(&path, &contents, OverwriteBehavior::AllowOverwrite)?;
+
+    Ok(())
+}
+
+/// A stable hash of the fields identifying a flow within an authorization.
+///
+/// A flow's open and completed reports share this stem; a reused 4-tuple gets a
+/// fresh `flow_start`, so distinct flows never collide. Only within-process
+/// determinism is needed.
+fn flow_identity(payload: &Payload) -> String {
+    let mut hasher = std::hash::DefaultHasher::new();
+    payload.protocol.hash(&mut hasher);
+    payload.inner_src_ip.hash(&mut hasher);
+    payload.inner_src_port.hash(&mut hasher);
+    payload.inner_dst_ip.hash(&mut hasher);
+    payload.inner_dst_port.hash(&mut hasher);
+    payload.flow_start.hash(&mut hasher);
+
+    format!("{:016x}", hasher.finish())
+}
+
+fn write_file_secure(
+    path: &Path,
+    bytes: &[u8],
+    overwrite: OverwriteBehavior,
+) -> anyhow::Result<()> {
+    // `AtomicFile` writes to a temp file, fsyncs it, then renames into place, so a
+    // reader never observes a partial file and a written file is durable.
+    AtomicFile::new(path, overwrite)
+        .write(|f| {
+            set_owner_only(f)?;
+            f.write_all(bytes)
+        })
+        .map_err(|e| anyhow::anyhow!("atomic write of {} failed: {e}", path.display()))
+}
+
+/// A policy-authorization id must be a hyphenated UUID; reject anything else so it
+/// can never escape the spool root as a path component.
+fn is_valid_authz_id(id: &str) -> bool {
+    let bytes = id.as_bytes();
+
+    bytes.len() == 36
+        && bytes.iter().enumerate().all(|(idx, byte)| match idx {
+            8 | 13 | 18 | 23 => *byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        })
+}
+
+/// Only the portal's two flow roles are valid as a path component, so an unverified
+/// token can never inject an arbitrary directory name.
+fn is_valid_role(role: &str) -> bool {
+    matches!(role, "initiator" | "responder")
+}
+
+#[cfg(unix)]
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt as _;
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(path)
+}
+
+#[cfg(windows)]
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+
+    // The spool holds Bearer tokens, so lock each authorization directory down to
+    // `LocalSystem` and `BUILTIN\Administrators` (the accounts the Gateway / Tunnel
+    // service runs as), the equivalent of `0700` on Unix. `OICI` makes the token and
+    // report files inside inherit the same access, so `set_owner_only` is a no-op.
+    windows_security::SecurityDescriptor::from_sddl("D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)")
+        .and_then(|descriptor| descriptor.apply_to_path(path))
+        .map_err(|e| std::io::Error::other(format!("{e:#}")))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)
+}
+
+#[cfg(unix)]
+fn set_owner_only(f: &std::fs::File) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    f.set_permissions(std::fs::Permissions::from_mode(0o600))
+}
+
+// On Windows the files inherit their directory's DACL (see `create_dir_secure`), so
+// there is nothing to do here.
+#[cfg(not(unix))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature must match the unix version"
+)]
+fn set_owner_only(_f: &std::fs::File) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone as _, Utc};
+    use flow_log_spool::deserialize;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    const AUTHZ_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn token_for(authz_id: &str) -> String {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
+            r#"{{"policy_authorization_id":"{authz_id}","role":"responder"}}"#
+        ));
+
+        format!("header.{payload}.signature")
+    }
+
+    /// Emits a `flow_logs::tcp` event shaped like `tunnel`'s emission.
+    fn emit_event(completed: bool) {
+        let flow_start = Utc.timestamp_opt(1_700_000_000, 500).unwrap();
+        let flow_end = completed.then(|| Utc.timestamp_opt(1_700_000_060, 0).unwrap());
+
+        tracing::trace!(
+            target: "flow_logs::tcp",
+            protocol = "tcp",
+            role = "responder",
+            policy_authorization_id = AUTHZ_ID,
+            inner_src_ip = %"100.64.0.1",
+            inner_src_port = %1234,
+            inner_dst_ip = %"10.0.0.5",
+            inner_dst_port = %443,
+            outer_src_ip = %"198.51.100.1",
+            outer_src_port = %51820,
+            outer_dst_ip = %"203.0.113.7",
+            outer_dst_port = %51820,
+            flow_start = ?flow_start,
+            flow_end = flow_end.map(tracing::field::debug),
+            last_packet = flow_end.map(tracing::field::debug),
+            rx_packets = completed.then_some(10_u64),
+            tx_packets = completed.then_some(12_u64),
+            rx_bytes = completed.then_some(1024_u64),
+            tx_bytes = completed.then_some(2048_u64),
+            "TCP flow"
+        );
+    }
+
+    fn read_payload(path: &Path) -> Payload {
+        // `deserialize` verifies the CRC, so `unwrap` also asserts it.
+        deserialize(&std::fs::read(path).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn spools_start_and_end_reports_sharing_a_stem() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let (layer, guard) = layer(dir.path().to_owned());
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            emit_event(false);
+            emit_event(true);
+        });
+        drop(guard); // joins the writer thread, so everything is on disk
+
+        let authz_dir = dir.path().join("responder").join(AUTHZ_ID);
+        let stems = std::fs::read_dir(&authz_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        // Both reports share one `<flow_start>-<flow_identity>` stem.
+        let mut prefixes = stems
+            .iter()
+            .map(|name| name.split('.').next().unwrap())
+            .collect::<Vec<_>>();
+        prefixes.dedup();
+        assert_eq!(prefixes.len(), 1, "start and end share a stem: {stems:?}");
+
+        let start = read_payload(&authz_dir.join(format!("{}.start.json", prefixes[0])));
+        let end = read_payload(&authz_dir.join(format!("{}.end.json", prefixes[0])));
+        assert!(start.flow_end.is_none());
+        assert_eq!(start.flow_start.timestamp_subsec_nanos(), 500); // lossless round-trip
+        assert_eq!(end.rx_bytes, Some(1024)); // the `.end` is a self-describing report
+        assert_eq!(end.inner_dst_port, 443);
+    }
+
+    #[test]
+    fn drops_event_without_policy_authorization_id() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let (layer, guard) = layer(dir.path().to_owned());
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::trace!(
+                target: "flow_logs::tcp",
+                protocol = "tcp",
+                role = "responder",
+                "TCP flow started"
+            );
+        });
+        drop(guard);
+
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn writes_token_file_from_claims() {
+        let dir = tempfile::tempdir().unwrap();
+        let token = token_for(AUTHZ_ID);
+
+        write_token(dir.path(), &token).unwrap();
+
+        let path = dir.path().join("responder").join(AUTHZ_ID).join("token");
+        assert_eq!(std::fs::read_to_string(path).unwrap(), token);
+    }
+
+    #[test]
+    fn rejects_token_with_invalid_claims() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"policy_authorization_id":"../../evil","role":"responder"}"#);
+
+        assert!(write_token(dir.path(), &format!("h.{payload}.s")).is_err());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn authz_id_must_be_a_hyphenated_uuid() {
+        assert!(is_valid_authz_id("11111111-1111-1111-1111-111111111111"));
+        assert!(is_valid_authz_id("d31580cd-9c75-4eb1-93b0-1f43a68d5192"));
+
+        assert!(!is_valid_authz_id(""));
+        assert!(!is_valid_authz_id("11111111111111111111111111111111"));
+        assert!(!is_valid_authz_id("../../../../../../../etc/passwd"));
+        assert!(!is_valid_authz_id("11111111-1111-1111-1111-11111111111g"));
+        assert!(!is_valid_authz_id("11111111-1111-1111-1111-1111111111111"));
+    }
+}

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -419,13 +419,9 @@ fn write_file_secure(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
 /// A policy-authorization id must be a hyphenated UUID; reject anything else so it
 /// can never escape the spool root as a path component.
 fn is_valid_authz_id(id: &str) -> bool {
-    let bytes = id.as_bytes();
-
-    bytes.len() == 36
-        && bytes.iter().enumerate().all(|(idx, byte)| match idx {
-            8 | 13 | 18 | 23 => *byte == b'-',
-            _ => byte.is_ascii_hexdigit(),
-        })
+    // `Uuid` also parses the braced / urn / simple forms; 36 bytes pins it to
+    // the hyphenated one.
+    id.len() == 36 && uuid::Uuid::try_parse(id).is_ok()
 }
 
 /// Only the portal's two flow roles are valid as a path component, so an unverified

--- a/rust/libs/flow-log-writer/src/lib.rs
+++ b/rust/libs/flow-log-writer/src/lib.rs
@@ -1,10 +1,9 @@
 //! Spools flow-log records to disk for later upload to the portal ingest API.
 //!
 //! Flow logs travel from the data plane to this writer as structured `tracing`
-//! events (targets `flow_logs::tcp` / `flow_logs::udp`): [`layer`] returns a
-//! subscriber layer that each entrypoint installs as part of its tracing
-//! configuration, so the tunnel itself needs no knowledge of where (or whether)
-//! flow logs are persisted.
+//! events (target `flow_logs`): [`layer`] returns a subscriber layer that each
+//! entrypoint installs as part of its tracing configuration, so the tunnel itself
+//! needs no knowledge of where (or whether) flow logs are persisted.
 //!
 //! Reports are grouped by the flow's `role` and `policy_authorization_id` into a
 //! per-authorization sub-directory holding that authorization's Bearer token and
@@ -24,8 +23,8 @@
 //! The Bearer token deliberately does NOT ride the tracing events (a broad `trace`
 //! directive would copy it into log files); the eventloops receive it in the
 //! portal's authorization messages and persist it via [`write_token`] instead.
-//! The events carry only the `role` / `policy_authorization_id` claims plus the
-//! network fields.
+//! A report's payload is the event's fields as emitted; the portal validates them
+//! on ingest, so the writer only interprets what routing and naming need.
 //!
 //! `<flow_start>` is the flow's start time as zero-padded unix seconds, so a
 //! lexical sort of the report names is oldest-first and the uploader needs no
@@ -50,10 +49,8 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use std::{
-    collections::HashMap,
     hash::{Hash as _, Hasher as _},
     io::Write as _,
-    net::IpAddr,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -66,8 +63,8 @@ use std::{
 use anyhow::Context as _;
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use base64::Engine as _;
-use chrono::{DateTime, Utc};
-use flow_log_spool::{Payload, serialize};
+use chrono::DateTime;
+use flow_log_spool::serialize;
 use tracing::field::{Field, Visit};
 use tracing_subscriber::registry::LookupSpan;
 
@@ -200,11 +197,21 @@ enum Command {
     Shutdown,
 }
 
-/// One flow report reconstructed from a `flow_logs::*` tracing event.
+/// One flow report reconstructed from a `flow_logs` tracing event.
+///
+/// The payload is the event's fields as emitted (minus `role` /
+/// `policy_authorization_id`, which become the spool path, and the human
+/// `message`); the portal validates it on ingest, so nothing is re-parsed here
+/// beyond what the file name needs.
 struct Report {
     role: String,
     authz_id: String,
-    payload: Payload,
+    /// `flow_start` as unix seconds, for the lexically-sortable file name.
+    flow_start: i64,
+    /// Stable stem shared by a flow's open and completed reports.
+    identity: String,
+    completed: bool,
+    payload: serde_json::Map<String, serde_json::Value>,
 }
 
 struct FlowLogLayer {
@@ -222,7 +229,7 @@ where
         event.record(&mut visitor);
 
         let Some(report) = visitor.into_report() else {
-            // Flows without a portal-minted token (and thus no attribution claims)
+            // Flows without a portal-minted token (and thus no routing claims)
             // are emitted for observability but not spooled.
             tracing::debug!("Dropping flow-log event with missing or invalid fields");
 
@@ -247,95 +254,74 @@ where
     }
 }
 
-/// Collects an event's fields.
+/// Collects an event's fields as emitted.
 ///
-/// String-ish values (IPs, timestamps, `Display`-recorded ports) arrive through
-/// `record_debug` / `record_str`, counters as `u64`.
+/// Strings arrive through `record_str`, `Display` / `Debug` values through
+/// `record_debug` (as their rendered form), counters as numbers.
 #[derive(Default)]
 struct FieldVisitor {
-    strings: HashMap<&'static str, String>,
-    numbers: HashMap<&'static str, u64>,
+    fields: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Visit for FieldVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        self.strings.insert(field.name(), format!("{value:?}"));
+        self.fields
+            .insert(field.name().to_owned(), format!("{value:?}").into());
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        self.strings.insert(field.name(), value.to_owned());
+        self.fields.insert(field.name().to_owned(), value.into());
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.numbers.insert(field.name(), value);
+        self.fields.insert(field.name().to_owned(), value.into());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields.insert(field.name().to_owned(), value.into());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields.insert(field.name().to_owned(), value.into());
     }
 }
 
 impl FieldVisitor {
-    /// Reassembles the [`Report`] from the recorded fields, or `None` if any
-    /// required field is missing or fails validation.
+    /// Builds the [`Report`] from the recorded fields, or `None` if the routing /
+    /// naming fields are missing or fail validation.
     fn into_report(mut self) -> Option<Report> {
-        let role = self.strings.remove("role").filter(|r| is_valid_role(r))?;
-        let authz_id = self
-            .strings
-            .remove("policy_authorization_id")
-            .filter(|id| is_valid_authz_id(id))?;
+        self.fields.remove("message");
 
-        let payload = Payload {
-            protocol: self.strings.remove("protocol")?,
-            inner_src_ip: self.ip("inner_src_ip")?,
-            inner_src_port: self.port("inner_src_port")?,
-            inner_dst_ip: self.ip("inner_dst_ip")?,
-            inner_dst_port: self.port("inner_dst_port")?,
-            domain: self.strings.remove("inner_domain"),
-            outer_src_ip: self.ip("outer_src_ip")?,
-            outer_src_port: self.port("outer_src_port")?,
-            outer_dst_ip: self.ip("outer_dst_ip")?,
-            outer_dst_port: self.port("outer_dst_port")?,
-            flow_start: self.timestamp("flow_start")?,
-            // A parse failure on a present closing field must fail the whole
-            // report rather than demote a completed flow to an open one.
-            flow_end: self.optional_timestamp("flow_end")?,
-            last_packet: self.optional_timestamp("last_packet")?,
-            rx_packets: self.numbers.remove("rx_packets"),
-            tx_packets: self.numbers.remove("tx_packets"),
-            rx_bytes: self.numbers.remove("rx_bytes"),
-            tx_bytes: self.numbers.remove("tx_bytes"),
+        let serde_json::Value::String(role) = self.fields.remove("role")? else {
+            return None;
         };
+        let serde_json::Value::String(authz_id) = self.fields.remove("policy_authorization_id")?
+        else {
+            return None;
+        };
+
+        if !is_valid_role(&role) || !is_valid_authz_id(&authz_id) {
+            return None;
+        }
+
+        // The only field the writer interprets: the file name needs it so a
+        // lexical sort of the reports is oldest-first.
+        let flow_start = DateTime::parse_from_rfc3339(self.fields.get("flow_start")?.as_str()?)
+            .ok()?
+            .timestamp();
+
+        let identity = flow_identity(&self.fields);
+        let completed = self.fields.contains_key("flow_end");
 
         Some(Report {
             role,
             authz_id,
-            payload,
+            flow_start,
+            identity,
+            completed,
+            payload: self.fields,
         })
     }
-
-    fn ip(&mut self, name: &'static str) -> Option<IpAddr> {
-        self.strings.remove(name)?.parse().ok()
-    }
-
-    fn port(&mut self, name: &'static str) -> Option<u16> {
-        self.strings.remove(name)?.parse().ok()
-    }
-
-    /// Timestamps are emitted with `chrono`'s `Debug` representation, which is
-    /// RFC 3339 with nanosecond precision, so the round-trip is lossless.
-    fn timestamp(&mut self, name: &'static str) -> Option<DateTime<Utc>> {
-        parse_timestamp(&self.strings.remove(name)?)
-    }
-
-    fn optional_timestamp(&mut self, name: &'static str) -> Option<Option<DateTime<Utc>>> {
-        match self.strings.remove(name) {
-            None => Some(None),
-            Some(value) => parse_timestamp(&value).map(Some),
-        }
-    }
-}
-
-fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(value)
-        .ok()
-        .map(|dt| dt.with_timezone(&Utc))
 }
 
 fn writer_loop(root: &Path, rx: &mpsc::Receiver<Command>) {
@@ -355,17 +341,12 @@ fn write_report(root: &Path, report: &Report) -> anyhow::Result<()> {
     let dir = root.join(&report.role).join(&report.authz_id);
     create_dir_secure(&dir)?;
 
-    let contents = serialize(&report.payload)?;
+    let contents = serialize(&serde_json::Value::Object(report.payload.clone()))?;
 
-    let suffix = if report.payload.flow_end.is_some() {
-        "end"
-    } else {
-        "start"
-    };
+    let suffix = if report.completed { "end" } else { "start" };
     let path = dir.join(format!(
         "{:010}-{}.{suffix}.json",
-        report.payload.flow_start.timestamp(),
-        flow_identity(&report.payload)
+        report.flow_start, report.identity
     ));
     write_file_secure(&path, &contents)?;
 
@@ -377,14 +358,19 @@ fn write_report(root: &Path, report: &Report) -> anyhow::Result<()> {
 /// A flow's open and completed reports share this stem; a reused 4-tuple gets a
 /// fresh `flow_start`, so distinct flows never collide. Only within-process
 /// determinism is needed.
-fn flow_identity(payload: &Payload) -> String {
+fn flow_identity(fields: &serde_json::Map<String, serde_json::Value>) -> String {
     let mut hasher = std::hash::DefaultHasher::new();
-    payload.protocol.hash(&mut hasher);
-    payload.inner_src_ip.hash(&mut hasher);
-    payload.inner_src_port.hash(&mut hasher);
-    payload.inner_dst_ip.hash(&mut hasher);
-    payload.inner_dst_port.hash(&mut hasher);
-    payload.flow_start.hash(&mut hasher);
+
+    for name in [
+        "protocol",
+        "inner_src_ip",
+        "inner_src_port",
+        "inner_dst_ip",
+        "inner_dst_port",
+        "flow_start",
+    ] {
+        fields.get(name).map(|v| v.to_string()).hash(&mut hasher);
+    }
 
     format!("{:016x}", hasher.finish())
 }
@@ -501,10 +487,13 @@ mod tests {
 
         let start = read_payload(&authz_dir.join(format!("{}.start.json", prefixes[0])));
         let end = read_payload(&authz_dir.join(format!("{}.end.json", prefixes[0])));
-        assert!(start.flow_end.is_none());
-        assert_eq!(start.flow_start.timestamp_subsec_nanos(), 500); // lossless round-trip
-        assert_eq!(end.rx_bytes, Some(1024)); // the `.end` is a self-describing report
-        assert_eq!(end.inner_dst_port, 443);
+        assert!(start.get("flow_end").is_none());
+        // Fields are spooled as emitted; routing fields and the message are not.
+        assert_eq!(start["flow_start"], "2023-11-14T22:13:20.000000500Z");
+        assert!(start.get("role").is_none());
+        assert!(start.get("message").is_none());
+        assert_eq!(end["rx_bytes"], 1024); // the `.end` is a self-describing report
+        assert_eq!(end["inner_dst_port"], "443");
     }
 
     #[test]
@@ -515,7 +504,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(layer);
         tracing::subscriber::with_default(subscriber, || {
             tracing::trace!(
-                target: "flow_logs::tcp",
+                target: "flow_logs",
                 protocol = "tcp",
                 role = "responder",
                 "TCP flow started"
@@ -567,13 +556,13 @@ mod tests {
         format!("header.{payload}.signature")
     }
 
-    /// Emits a `flow_logs::tcp` event shaped like `tunnel`'s emission.
+    /// Emits a `flow_logs` event shaped like `tunnel`'s emission.
     fn emit_event(completed: bool) {
         let flow_start = Utc.timestamp_opt(1_700_000_000, 500).unwrap();
         let flow_end = completed.then(|| Utc.timestamp_opt(1_700_000_060, 0).unwrap());
 
         tracing::trace!(
-            target: "flow_logs::tcp",
+            target: "flow_logs",
             protocol = "tcp",
             role = "responder",
             policy_authorization_id = AUTHZ_ID,
@@ -596,7 +585,7 @@ mod tests {
         );
     }
 
-    fn read_payload(path: &Path) -> Payload {
+    fn read_payload(path: &Path) -> serde_json::Value {
         // `deserialize` verifies the CRC, so `unwrap` also asserts it.
         deserialize(&std::fs::read(path).unwrap()).unwrap()
     }

--- a/rust/libs/logging/src/lib.rs
+++ b/rust/libs/logging/src/lib.rs
@@ -41,14 +41,19 @@ pub use err_with_sources::{ErrorWithSources, err_with_src};
 pub use format::Format;
 pub use tracing_macros::trace_dbg as dbg;
 
-/// Registers a global subscriber with stdout logging and `additional_layer`
-pub fn setup_global_subscriber<L>(
+/// Registers a global subscriber with stdout logging and `additional_layer`.
+///
+/// `unfiltered_layer` bypasses the `directives`-based filter and is expected to
+/// bring its own (e.g. flow-log spooling).
+pub fn setup_global_subscriber<L, U>(
     directives: String,
     additional_layer: L,
+    unfiltered_layer: U,
     stdout_json: bool,
 ) -> Result<FilterReloadHandle>
 where
-    L: Layer<Registry> + Send + Sync,
+    L: Layer<Registry> + Send + Sync + 'static,
+    U: Layer<Registry> + Send + Sync + 'static,
 {
     if let Err(error) = output_vt100::try_init() {
         tracing::debug!("Failed to init terminal colors: {error}");
@@ -60,7 +65,10 @@ where
         try_filter(&directives).context("Failed to parse directives")?;
 
     let subscriber = Registry::default()
-        .with(additional_layer.with_filter(filter1))
+        .with(vec![
+            additional_layer.with_filter(filter1).boxed(),
+            unfiltered_layer.boxed(),
+        ])
         .with(sentry_layer())
         .with(match stdout_json {
             true => fmt::layer()


### PR DESCRIPTION
Adds a flow-log-writer crate: a tracing layer that spools flow logs to disk for upload. Each entrypoint installs it next to its log output. Ingest tokens are persisted separately and never ride tracing events, so they cannot leak into logs.

Related: #13920
Related: #13967 
Related: #13968 