### PR TITLE
feat(connlib): track flows on the client

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -548,6 +548,7 @@ fn connect(
         Vec::default(),
         // Mobile flow-log wiring (spool dir + uploader) comes separately.
         None,
+        false,
         runtime.handle().clone(),
     );
 

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -761,6 +761,7 @@ impl<'a> Handler<'a> {
             is_internet_resource_active,
             dns,
             known_dirs::flow_logs(),
+            false,
             tokio::runtime::Handle::current(),
         );
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -145,6 +145,14 @@ struct Cli {
     /// Increase the `core.rmem_max` and `core.wmem_max` kernel parameters.
     #[arg(long, env = "FIREZONE_INC_BUF", hide = true, default_value_t = false)]
     inc_buf: bool,
+
+    /// Track flow logs even when the portal has them disabled, and emit them
+    /// to the log output by adding the `flow_logs=trace` log directive.
+    ///
+    /// Flows tracked only because of this flag stay on the log output;
+    /// spooling and uploading them is always controlled by the portal.
+    #[arg(long, env = "FIREZONE_FLOW_LOGS", default_value_t = false)]
+    flow_logs: bool,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -260,17 +268,17 @@ fn try_main() -> Result<()> {
         .as_deref()
         .map(|dir| logging::file::layer(dir, "firezone-headless-client"))
         .unzip();
+    let mut directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+    if cli.flow_logs {
+        directives.push_str(",flow_logs=trace");
+    }
+
     let flow_logs_dir = known_dirs::flow_logs();
     let (flow_log_layer, _flow_log_guard) =
         flow_logs_dir.clone().map(flow_log_writer::layer).unzip();
 
-    logging::setup_global_subscriber(
-        std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()),
-        layer,
-        flow_log_layer,
-        false,
-    )
-    .context("Failed to set up logging")?;
+    logging::setup_global_subscriber(directives, layer, flow_log_layer, false)
+        .context("Failed to set up logging")?;
 
     tracing::info!(
         arch = std::env::consts::ARCH,
@@ -438,6 +446,7 @@ fn try_main() -> Result<()> {
             cli.activate_internet_resource,
             dns_controller.system_resolvers(),
             flow_logs_dir.clone(),
+            cli.flow_logs,
             rt.handle().clone(),
         );
 

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -59,6 +59,10 @@ pub struct Eventloop {
     /// entrypoint's `flow_log_writer` layer.
     flow_logs_dir: Option<std::path::PathBuf>,
 
+    /// The `--flow-logs` flag: keeps flow tracking on even when the portal has
+    /// uploads disabled.
+    local_flow_logs: bool,
+
     cmd_rx: mpsc::UnboundedReceiver<Command>,
     resource_list_sender: watch::Sender<ResourceList>,
     tun_config_sender: watch::Sender<Option<TunConfig>>,
@@ -121,6 +125,7 @@ impl Eventloop {
         is_internet_resource_active: bool,
         dns_servers: Vec<IpAddr>,
         flow_logs_dir: Option<std::path::PathBuf>,
+        local_flow_logs: bool,
         portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
         resource_list_sender: watch::Sender<ResourceList>,
@@ -156,6 +161,7 @@ impl Eventloop {
             tunnel: Some(tunnel),
             resolver_bypass,
             flow_logs_dir,
+            local_flow_logs,
             cmd_rx,
             logged_permission_denied: false,
             tunnel_errors: otel_instruments::tunnel_errors(),
@@ -479,6 +485,11 @@ impl Eventloop {
                     "Flow-log config received from portal init"
                 );
 
+                tunnel.state_mut().set_flow_logs_enabled(
+                    (flow_logs.upload_enabled() && self.flow_logs_dir.is_some())
+                        || self.local_flow_logs,
+                );
+
                 if let Some(spool_root) = &self.flow_logs_dir
                     && let Err(e) = flow_log_upload::configure_uploads(
                         spool_root,
@@ -575,6 +586,7 @@ impl Eventloop {
                     client_ice_credentials,
                     gateway_ice_credentials,
                     use_iceless,
+                    flow_logs_ingest_token,
                     now,
                 ) {
                     Ok(Ok(())) => {}
@@ -662,6 +674,7 @@ impl Eventloop {
                     use_iceless,
                     client_name,
                     authorization,
+                    flow_logs_ingest_token,
                     now,
                 ) {
                     Ok(()) => {}

--- a/rust/libs/client-shared/src/lib.rs
+++ b/rust/libs/client-shared/src/lib.rs
@@ -74,6 +74,7 @@ impl Session {
         is_internet_resource_active: bool,
         dns_servers: Vec<IpAddr>,
         flow_logs_dir: Option<PathBuf>,
+        local_flow_logs: bool,
         handle: tokio::runtime::Handle,
     ) -> (Self, EventStream) {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -85,6 +86,7 @@ impl Session {
                     is_internet_resource_active,
                     dns_servers,
                     flow_logs_dir,
+                    local_flow_logs,
                     portal,
                     cmd_rx,
                     resource_list_sender,

--- a/rust/libs/connlib/dns-over-tcp/src/client.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/client.rs
@@ -221,8 +221,10 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             return false;
         };
 
-        self.sockets_by_remote
-            .contains_key(&SocketAddr::new(packet.destination(), tcp.destination_port()))
+        self.sockets_by_remote.contains_key(&SocketAddr::new(
+            packet.destination(),
+            tcp.destination_port(),
+        ))
     }
 
     /// Handle the [`IpPacket`].

--- a/rust/libs/connlib/dns-over-tcp/src/client.rs
+++ b/rust/libs/connlib/dns-over-tcp/src/client.rs
@@ -202,6 +202,29 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         has_socket
     }
 
+    /// Checks whether the given outbound packet belongs to one of our upstream connections.
+    ///
+    /// Matches packets from our source interface to a connected DNS resolver,
+    /// i.e. the reverse direction of [`Client::accepts`].
+    pub fn owns_outbound(&self, packet: &IpPacket) -> bool {
+        let Some((ipv4_source, ipv6_source)) = self.source_ips else {
+            return false;
+        };
+
+        match packet.source() {
+            IpAddr::V4(v4) if v4 != ipv4_source => return false,
+            IpAddr::V6(v6) if v6 != ipv6_source => return false,
+            IpAddr::V4(_) | IpAddr::V6(_) => {}
+        }
+
+        let Some(tcp) = packet.as_tcp() else {
+            return false;
+        };
+
+        self.sockets_by_remote
+            .contains_key(&SocketAddr::new(packet.destination(), tcp.destination_port()))
+    }
+
     /// Handle the [`IpPacket`].
     ///
     /// This function only inserts the packet into a buffer.

--- a/rust/libs/connlib/l3-udp-dns-client/lib.rs
+++ b/rust/libs/connlib/l3-udp-dns-client/lib.rs
@@ -153,6 +153,23 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             .contains_key(&udp.destination_port())
     }
 
+    /// Checks whether the given outbound packet is one of our in-flight queries.
+    ///
+    /// Matches a pending query's local socket as the source and its server as
+    /// the destination, i.e. the reverse direction of [`Client::accepts`].
+    pub fn owns_outbound(&self, packet: &IpPacket) -> bool {
+        let Some(udp) = packet.as_udp() else {
+            return false;
+        };
+
+        let Some(pending) = self.pending_queries_by_local_port.get(&udp.source_port()) else {
+            return false;
+        };
+
+        pending.local == SocketAddr::new(packet.source(), udp.source_port())
+            && pending.server == SocketAddr::new(packet.destination(), udp.destination_port())
+    }
+
     pub fn handle_inbound(&mut self, packet: IpPacket) {
         debug_assert!(self.accepts(&packet));
 
@@ -448,6 +465,28 @@ mod tests {
         assert!(client.accepts(&late_response));
         client.handle_inbound(late_response);
         assert!(client.poll_query_result().is_none());
+    }
+
+    #[test]
+    fn owns_outbound_matches_only_pending_queries() {
+        let mut client = create_test_client();
+        let now = Instant::now();
+        let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53);
+
+        client.send_query(server, create_test_query(), now).unwrap();
+        let query_packet = client.poll_outbound().unwrap();
+
+        let unrelated_packet = ip_packet::make::udp_packet(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            50000,
+            53,
+            &[],
+        )
+        .unwrap();
+
+        assert!(client.owns_outbound(&query_packet));
+        assert!(!client.owns_outbound(&unrelated_packet));
     }
 
     fn create_test_client() -> Client {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -594,8 +594,8 @@ impl ClientState {
         // the DNS clients before any flow data is recorded.
         let is_recursive_dns_query = self.udp_dns_client.owns_outbound(&packet)
             || self.tcp_dns_client.owns_outbound(&packet);
-        let _guard = (!is_recursive_dns_query)
-            .then(|| self.flow_tracker.begin_tun_packet(&packet, now));
+        let _guard =
+            (!is_recursive_dns_query).then(|| self.flow_tracker.begin_tun_packet(&packet, now));
 
         let dst = packet.destination();
         let dst_proto = packet.destination_protocol()?;

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -27,6 +27,7 @@ use crate::dns::{
     resource_stub_resolver,
 };
 use crate::filter_engine::FilterEngine;
+use crate::messages::IngestToken;
 use crate::messages::{
     Filter, IceCredentials, IceRole, Interface as InterfaceConfig, SecretKey,
     client::{DevicePoolMember, FailReason},
@@ -116,13 +117,15 @@ pub struct ClientState {
     /// All clients we are connected to and the associated, connection-specific state.
     clients: PeerStore<ClientId, ClientOnClient>,
 
+    /// Tracks the flows tunneled through this Client.
+    flow_tracker: flow_tracker::Tracker<ClientOrGatewayId>,
     /// Tracks the authorizations we have requested but not yet been granted.
     pending_authorizations: PendingAuthorizations,
 
     /// Routed IP packets buffered per peer while its connection is still being established.
     ///
     /// These packets are replayed through normal routing when the connection is established so
-    /// their route is validated again.
+    /// their route is validated again and the successful send is included in flow tracking.
     pending_routed_packets: BTreeMap<ClientOrGatewayId, UniquePacketBuffer>,
 
     /// IP packets whose destination peer was selected by protocol context rather than routing.
@@ -203,6 +206,7 @@ impl ClientState {
             tun_config: Default::default(),
             buffered_packets: Default::default(),
             node: Node::new(seed, now, unix_ts),
+            flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
             sites_status: Default::default(),
             gateways_by_site: Default::default(),
             resource_stub_resolver: ResourceStubResolver::new(records),
@@ -432,8 +436,14 @@ impl ClientState {
         self.node.public_key()
     }
 
+    pub fn set_flow_logs_enabled(&mut self, enabled: bool) {
+        self.flow_tracker.set_enabled(enabled);
+    }
+
     pub fn shut_down(&mut self, now: Instant) {
         tracing::info!("Initiating graceful shutdown");
+
+        self.flow_tracker.close_all(now);
 
         self.clients.clear();
         self.gateways.clear();
@@ -571,13 +581,14 @@ impl ClientState {
             UnroutablePacket::packet_to_self(&packet)
         );
 
-        // DNS packets to our sentinel resolvers are handled before routing.
+        // DNS packets to our sentinel resolvers never become flows.
         let packet = match self.try_handle_dns(packet, now) {
             ControlFlow::Break(()) => return Ok(()),
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,
         };
 
         let internet_resource = self.active_internet_resource().map(|resource| resource.id);
+        let _guard = self.flow_tracker.begin_tun_packet(&packet, now);
 
         let dst = packet.destination();
         let dst_proto = packet.destination_protocol()?;
@@ -596,11 +607,15 @@ impl ClientState {
         let (packet, peer) = match (direct_gateway, peer_originated_client_flow, route) {
             (Some(gid), _, _) => {
                 // Traffic addressed directly to a Gateway's TUN IP bypasses resource routing.
+                flow_tracker::record_peer(gid, flow_tracker::Role::Initiator);
+
                 (packet, gid.into())
             }
             (None, Some(cid), _) => {
                 // A reply follows its peer-originated flow even if we have no outbound route to
                 // that peer.
+                flow_tracker::record_peer(cid, flow_tracker::Role::Responder);
+
                 (packet, cid.into())
             }
             (
@@ -636,6 +651,8 @@ impl ClientState {
                     .with_context(|| UnroutablePacket::no_peer_state(&packet))?;
 
                 peer.record_outbound_as_originator(&packet, now);
+                flow_tracker::record_peer(cid, flow_tracker::Role::Initiator);
+                flow_tracker::record_ingest_token(peer.ingest_token(&rid));
 
                 (packet, cid.into())
             }
@@ -664,7 +681,16 @@ impl ClientState {
                     return Ok(());
                 };
 
+                flow_tracker::record_peer(gid, flow_tracker::Role::Initiator);
+                let ingest_token = self
+                    .gateways
+                    .peer_by_id(&gid)
+                    .and_then(|peer| peer.ingest_token(&rid));
+                flow_tracker::record_ingest_token(ingest_token);
+
                 let packet = if let Some(domain) = domain {
+                    flow_tracker::record_domain(domain.clone());
+
                     let Some(packet) = self
                         .dns_resource_nat
                         .handle_outgoing(gid, &domain, rid, packet, now)
@@ -698,8 +724,8 @@ impl ClientState {
         Ok(())
     }
 
-    /// Feed an internally-produced or previously-buffered IP packet through normal TUN routing,
-    /// queueing any resulting network transmit.
+    /// Feed an internally-produced or previously-buffered IP packet through normal TUN routing
+    /// and flow tracking, queueing any resulting network transmit.
     fn handle_out_of_band_ip_packet(&mut self, packet: IpPacket, now: Instant) -> Result<()> {
         let mut buffered_transmits = std::mem::take(&mut self.buffered_transmits);
         let result = self.handle_tun_input(packet, now, &mut buffered_transmits);
@@ -721,6 +747,8 @@ impl ClientState {
         packet: &[u8],
         now: Instant,
     ) -> Result<Option<IpPacket>> {
+        let _guard = self.flow_tracker.begin_network_packet(local, from, now);
+
         let Some((pid, packet)) = self
             .node
             .decapsulate(local, from, packet.as_ref(), now)
@@ -728,6 +756,8 @@ impl ClientState {
         else {
             return Ok(None);
         };
+
+        flow_tracker::record_decrypted_packet(&packet);
 
         if matches!(pid, ClientOrGatewayId::Gateway(_)) && self.udp_dns_client.accepts(&packet) {
             self.udp_dns_client.handle_inbound(packet);
@@ -740,6 +770,10 @@ impl ClientState {
         }
 
         if let Some(fz_p2p_control) = packet.as_fz_p2p_control() {
+            // Control traffic is not a flow; release the tracker borrow for
+            // the `&mut self` calls below.
+            drop(_guard);
+
             match (fz_p2p_control.event_type(), pid) {
                 (p2p_control::DOMAIN_STATUS_EVENT, ClientOrGatewayId::Gateway(gid)) => {
                     let res = p2p_control::dns_resource_nat::decode_domain_status(fz_p2p_control)
@@ -808,6 +842,14 @@ impl ClientState {
                 };
 
                 peer.ensure_allowed_src(&packet)?;
+
+                // To a gateway we are always the one who opened the flow;
+                // this packet is a reply.
+                flow_tracker::record_peer(gid, flow_tracker::Role::Initiator);
+
+                // All facts are recorded; commit the flow so the tracker
+                // borrow is free for the `&mut self` calls below.
+                drop(_guard);
 
                 if feature_flags::icmp_error_unreachable_prohibited_create_new_flow()
                     && let Ok(Some((failed_packet, error))) = packet.icmp_error()
@@ -973,6 +1015,7 @@ impl ClientState {
         client_ice: IceCredentials,
         gateway_ice: IceCredentials,
         use_iceless: bool,
+        flow_logs_ingest_token: IngestToken,
         now: Instant,
     ) -> anyhow::Result<Result<(), NoTurnServers>> {
         tracing::debug!(%gid, "New resource access authorized");
@@ -1010,6 +1053,8 @@ impl ClientState {
         let peer = self
             .gateways
             .upsert(gid, || GatewayOnClient::new(gateway_tun));
+
+        peer.set_ingest_token(rid, flow_logs_ingest_token);
 
         // Deal with buffered packets
 
@@ -1075,6 +1120,7 @@ impl ClientState {
         use_iceless: bool,
         client_name: String,
         authorization: Option<crate::messages::client::ResourceAuthorization>,
+        flow_logs_ingest_token: IngestToken,
         now: Instant,
     ) -> Result<(), NoTurnServers> {
         tracing::debug!(%cid, "New device access authorized");
@@ -1117,6 +1163,8 @@ impl ClientState {
         // We only add the inbound resource and filters on the *target* side of the connection.
         // The initiating side does not request connections if the filters don't allow it.
         if let Some((resource_id, filters, expires_at)) = authorization {
+            // The token logs the peer's flows for this resource.
+            peer.set_ingest_token(resource_id, flow_logs_ingest_token.clone());
             peer.add_resource(resource_id, filters, expires_at, now);
         }
 
@@ -1149,6 +1197,12 @@ impl ClientState {
             }
 
             let (packets, _) = pending_authorization.into_buffered_packets();
+
+            // The token logs our flows for the resource we asked for.
+            self.clients
+                .peer_by_id_mut(&cid)
+                .expect("peer was just inserted")
+                .set_ingest_token(resource_id, flow_logs_ingest_token.clone());
 
             buffered_packets.extend(packets);
         }
@@ -1563,6 +1617,7 @@ impl ClientState {
 
     pub fn handle_timeout(&mut self, now: Instant) {
         self.node.handle_timeout(now);
+        self.flow_tracker.handle_timeout(now);
         self.dns_cache.handle_timeout(now);
         self.device_stub_resolver.handle_timeout(now);
 
@@ -2601,7 +2656,10 @@ fn encapsulate_or_buffer(
     }
 
     match node.encapsulate(pid, &packet, now, provider) {
-        Ok(Some(_)) => Ok(()),
+        Ok(Some(info)) => {
+            flow_tracker::record_transmit(info.src, info.dst);
+            Ok(())
+        }
         Ok(None) => Ok(()),
         Err(e) if e.any_is::<snownet::StillConnecting>() => {
             pending_packets

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -588,14 +588,15 @@ impl ClientState {
         };
 
         let internet_resource = self.active_internet_resource().map(|resource| resource.id);
+        let _guard = self.flow_tracker.begin_tun_packet(&packet, now);
 
         // Recursive DNS queries we tunnel to upstream resolvers are internal
-        // traffic and never become flows either; their responses are handed to
-        // the DNS clients before any flow data is recorded.
-        let is_recursive_dns_query = self.udp_dns_client.owns_outbound(&packet)
-            || self.tcp_dns_client.owns_outbound(&packet);
-        let _guard =
-            (!is_recursive_dns_query).then(|| self.flow_tracker.begin_tun_packet(&packet, now));
+        // traffic and never become flows either; dropping the guard before any
+        // fact is recorded discards the packet's flow data.
+        if self.udp_dns_client.owns_outbound(&packet) || self.tcp_dns_client.owns_outbound(&packet)
+        {
+            drop(_guard);
+        }
 
         let dst = packet.destination();
         let dst_proto = packet.destination_protocol()?;

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -588,7 +588,14 @@ impl ClientState {
         };
 
         let internet_resource = self.active_internet_resource().map(|resource| resource.id);
-        let _guard = self.flow_tracker.begin_tun_packet(&packet, now);
+
+        // Recursive DNS queries we tunnel to upstream resolvers are internal
+        // traffic and never become flows either; their responses are handed to
+        // the DNS clients before any flow data is recorded.
+        let is_recursive_dns_query = self.udp_dns_client.owns_outbound(&packet)
+            || self.tcp_dns_client.owns_outbound(&packet);
+        let _guard = (!is_recursive_dns_query)
+            .then(|| self.flow_tracker.begin_tun_packet(&packet, now));
 
         let dst = packet.destination();
         let dst_proto = packet.destination_protocol()?;

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -2,12 +2,13 @@ use crate::IpConfig;
 use crate::conn_track::{ConnTrack, Originator};
 use crate::expiring_map::{ExpiringMap, NEVER_EXPIRES_TTL};
 use crate::filter_engine::FilterEngine;
-use crate::messages::Filter;
+use crate::messages::{Filter, IngestToken};
+use crate::routing_table::{RouteEntry, RoutingTable};
 use anyhow::{Context, Result};
 use connlib_model::{ClientId, ResourceId};
 use ip_packet::IpPacket;
 use smallvec::SmallVec;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::time::Instant;
 
 /// Peer-level state of a connection with another Client.
@@ -36,6 +37,13 @@ pub(crate) struct ClientOnClient {
     inbound_filter: FilterEngine,
     /// Tracks outbound flows so legitimate return traffic is admitted.
     conn_track: ConnTrack,
+
+    /// The portal's per-flow ingest token for each resource of this peer, used
+    /// to attribute the client-to-client flow logs.
+    ingest_tokens: HashMap<ResourceId, IngestToken>,
+    /// Finds the resource an inbound packet belongs to; rebuilt whenever
+    /// `resources` changes.
+    inbound_resources: InboundResources,
 }
 
 /// An inbound resource: filters granted by a resource for traffic from the remote peer.
@@ -69,6 +77,8 @@ impl ClientOnClient {
             // No resources -> no allowed inbound traffic by default.
             inbound_filter: FilterEngine::DenyAll,
             conn_track: ConnTrack::default(),
+            ingest_tokens: HashMap::new(),
+            inbound_resources: InboundResources::default(),
         }
     }
 
@@ -86,6 +96,10 @@ impl ClientOnClient {
 
     pub(crate) fn set_remote_name(&mut self, name: String) {
         self.remote_name = name;
+    }
+
+    pub(crate) fn set_ingest_token(&mut self, resource_id: ResourceId, token: IngestToken) {
+        self.ingest_tokens.insert(resource_id, token);
     }
 
     /// Allow the remote peer to send us packets associated with `resource_id` limited by the given filter set.
@@ -119,6 +133,7 @@ impl ClientOnClient {
 
         for (resource_id, _) in self.resources.extract_if(|rid, _| !retain.contains(rid)) {
             tracing::info!(%resource_id, "Revoking peer authorization on resync");
+            self.ingest_tokens.remove(&resource_id);
             any_removed = true;
         }
 
@@ -156,6 +171,8 @@ impl ClientOnClient {
 
     /// Drop a previously-active resource.
     pub(crate) fn remove_resource(&mut self, resource_id: &ResourceId) {
+        self.ingest_tokens.remove(resource_id);
+
         let Some(_entry) = self.resources.remove(resource_id) else {
             return;
         };
@@ -165,6 +182,8 @@ impl ClientOnClient {
     }
 
     fn recompute_inbound_filter(&mut self) {
+        self.inbound_resources = InboundResources::new(&self.resources);
+
         if self.resources.is_empty() {
             // No resources -> deny all (except return traffic).
             self.inbound_filter = FilterEngine::DenyAll;
@@ -191,6 +210,10 @@ impl ClientOnClient {
         self.conn_track.record_outbound_as_originator(packet, now);
     }
 
+    pub(crate) fn ingest_token(&self, resource: &ResourceId) -> Option<IngestToken> {
+        self.ingest_tokens.get(resource).cloned()
+    }
+
     /// Returns the next instant at which one of this peer's inbound authorizations expires.
     pub(crate) fn poll_timeout(&self) -> Option<Instant> {
         self.resources.poll_timeout()
@@ -206,6 +229,7 @@ impl ClientOnClient {
             match event {
                 crate::expiring_map::Event::EntryExpired { key, .. } => {
                     tracing::info!(rid = %key, "Resource authorization expired, revoking");
+                    self.ingest_tokens.remove(&key);
                     any_expired = true;
                 }
             }
@@ -216,9 +240,9 @@ impl ClientOnClient {
         }
     }
 
-    /// Who opened the flow this *outbound* packet belongs to, if it is tracked.
-    /// Lets outbound routing send replies directly to the peer even when no
-    /// outbound route exists.
+    /// Who opened the flow this *outbound* packet belongs to, if it is
+    /// tracked. Lets outbound routing skip the per-(resource, peer) intent when
+    /// the connection is already established.
     pub(crate) fn outbound_flow_originator(&self, packet: &IpPacket) -> Option<Originator> {
         self.conn_track.outbound_flow_originator(packet)
     }
@@ -250,6 +274,9 @@ impl ClientOnClient {
         }
 
         if self.conn_track.is_return_traffic(&packet) {
+            // A reply to a flow we opened.
+            flow_tracker::record_peer(self.id, flow_tracker::Role::Initiator);
+
             return Ok(InboundResult::Send(packet));
         }
 
@@ -263,7 +290,70 @@ impl ClientOnClient {
         // The packet passed our filters, record as successful inbound packet.
         self.conn_track.record_inbound(&packet, now);
 
+        // The peer opened this flow towards us.
+        flow_tracker::record_peer(self.id, flow_tracker::Role::Responder);
+        flow_tracker::record_ingest_token(self.ingest_token_for_inbound(&packet));
+
         Ok(InboundResult::Send(packet))
+    }
+
+    /// Finds the token of the resource an inbound packet belongs to.
+    fn ingest_token_for_inbound(&mut self, packet: &IpPacket) -> Option<IngestToken> {
+        let resource = self.inbound_resources.resource_for(packet)?;
+
+        self.ingest_tokens.get(&resource).cloned()
+    }
+}
+
+/// Finds the inbound resource a packet belongs to.
+///
+/// Reuses the sender's routing-table selection rule, so both ends of a flow
+/// pick the same resource. Inbound packets all target our TUN address, so
+/// every resource matches every address and only its filter and id decide.
+#[derive(Default)]
+struct InboundResources {
+    table: RoutingTable<InboundEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct InboundEntry {
+    resource_id: ResourceId,
+    filter: FilterEngine,
+}
+
+impl RouteEntry for InboundEntry {
+    fn filter(&self) -> &FilterEngine {
+        &self.filter
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        self.resource_id
+    }
+}
+
+impl InboundResources {
+    fn new(resources: &ExpiringMap<ResourceId, ResourceOnClient>) -> Self {
+        let mut table = RoutingTable::new();
+
+        for (resource_id, resource) in resources.iter() {
+            table.upsert_for_all_addresses(InboundEntry {
+                resource_id: *resource_id,
+                filter: FilterEngine::new(&resource.filters),
+            });
+        }
+
+        Self { table }
+    }
+
+    fn resource_for(&mut self, packet: &IpPacket) -> Option<ResourceId> {
+        let entry = self
+            .table
+            .matches(packet.destination(), packet.destination_protocol())?;
+
+        // Only a resource whose filter admits the packet may claim it.
+        entry.filter.apply(packet.destination_protocol()).ok()?;
+
+        Some(entry.resource_id)
     }
 }
 
@@ -426,6 +516,68 @@ mod tests {
         assert!(is_filtered(
             peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
+    }
+
+    #[test]
+    fn inbound_resource_matches_like_the_sender() {
+        let now = Instant::now();
+        let r1 = ResourceId::from_u128(1);
+        let r2 = ResourceId::from_u128(2);
+
+        let tcp_443 = vec![Filter::Tcp(PortRange {
+            port_range_start: 443,
+            port_range_end: 443,
+        })];
+
+        // R1 admits only TCP 443; R2 has no filters and admits everything.
+        let mut resources = ExpiringMap::default();
+        resources.insert(
+            r1,
+            ResourceOnClient {
+                filters: tcp_443.clone(),
+            },
+            now,
+            NEVER_EXPIRES_TTL,
+        );
+        resources.insert(
+            r2,
+            ResourceOnClient { filters: vec![] },
+            now,
+            NEVER_EXPIRES_TTL,
+        );
+
+        let mut inbound = InboundResources::new(&resources);
+
+        // Both admit TCP 443; the highest id wins, like on the sender.
+        assert_eq!(inbound.resource_for(&tcp_packet_to_us(443)), Some(r2));
+        // Only R2 admits TCP 80.
+        assert_eq!(inbound.resource_for(&tcp_packet_to_us(80)), Some(r2));
+
+        // Alone, R1 only answers for its own port.
+        let mut resources = ExpiringMap::default();
+        resources.insert(
+            r1,
+            ResourceOnClient { filters: tcp_443 },
+            now,
+            NEVER_EXPIRES_TTL,
+        );
+
+        let mut inbound = InboundResources::new(&resources);
+
+        assert_eq!(inbound.resource_for(&tcp_packet_to_us(443)), Some(r1));
+        assert_eq!(inbound.resource_for(&tcp_packet_to_us(80)), None);
+    }
+
+    fn tcp_packet_to_us(dst_port: u16) -> IpPacket {
+        make::tcp_packet(
+            peer_v4(),
+            our_v4(),
+            50000,
+            dst_port,
+            Default::default(),
+            &[],
+        )
+        .unwrap()
     }
 
     fn peer() -> ClientOnClient {

--- a/rust/libs/connlib/tunnel/src/client/gateway_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/gateway_on_client.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     net::{IpAddr, SocketAddr},
 };
 
@@ -8,15 +8,28 @@ use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use ip_packet::IpPacket;
 
+use crate::messages::IngestToken;
 use crate::{IpConfig, NotAllowedResource};
 
 /// The state of one gateway on a client.
 pub(crate) struct GatewayOnClient {
     gateway_tun: IpConfig,
     allowed_ips: IpNetworkTable<HashSet<ResourceId>>,
+
+    /// The portal's per-flow ingest token for each authorized resource, used to
+    /// attribute the Client's (initiator) flow logs.
+    ingest_tokens: HashMap<ResourceId, IngestToken>,
 }
 
 impl GatewayOnClient {
+    pub(crate) fn set_ingest_token(&mut self, id: ResourceId, token: IngestToken) {
+        self.ingest_tokens.insert(id, token);
+    }
+
+    pub(crate) fn ingest_token(&self, id: &ResourceId) -> Option<IngestToken> {
+        self.ingest_tokens.get(id).cloned()
+    }
+
     pub(crate) fn allow_ip_for_resource(&mut self, ip: impl Into<IpNetwork>, id: ResourceId) {
         let ip = ip.into();
 
@@ -28,6 +41,8 @@ impl GatewayOnClient {
     }
 
     pub(crate) fn remove_resource(&mut self, id: ResourceId) {
+        self.ingest_tokens.remove(&id);
+
         // First we remove the id from all allowed ips
         for (_, resources) in self
             .allowed_ips
@@ -66,6 +81,7 @@ impl GatewayOnClient {
         GatewayOnClient {
             allowed_ips: IpNetworkTable::new(),
             gateway_tun,
+            ingest_tokens: HashMap::new(),
         }
     }
 }

--- a/rust/libs/connlib/tunnel/src/routing_table.rs
+++ b/rust/libs/connlib/tunnel/src/routing_table.rs
@@ -1,7 +1,12 @@
-use std::{cmp::Ordering, collections::BTreeSet, net::IpAddr, num::NonZeroUsize};
+use std::{
+    cmp::Ordering,
+    collections::BTreeSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    num::NonZeroUsize,
+};
 
 use connlib_model::ResourceId;
-use ip_network::IpNetwork;
+use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
 use ip_packet::{Protocol, UnsupportedProtocol};
 use lru::LruCache;
@@ -50,6 +55,25 @@ where
 {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Inserts `entry` so it matches every address, v4 and v6.
+    ///
+    /// Use this when only the entry's filter and id should decide the match,
+    /// not the address.
+    pub(crate) fn upsert_for_all_addresses(&mut self, entry: T) {
+        self.upsert(
+            Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0)
+                .expect("/0 is a valid prefix")
+                .into(),
+            entry.clone(),
+        );
+        self.upsert(
+            Ipv6Network::new(Ipv6Addr::UNSPECIFIED, 0)
+                .expect("/0 is a valid prefix")
+                .into(),
+            entry,
+        );
     }
 
     /// Inserts `entry` into the set associated with `network`.

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1197,6 +1197,7 @@ impl TunnelTest {
                             client_ice,
                             gateway_ice,
                             use_iceless,
+                            test_ingest_token(),
                             now,
                         )
                     })
@@ -1262,6 +1263,7 @@ impl TunnelTest {
                                     use_iceless,
                                     "initiating client".to_owned(),
                                     Some(remote_authorization),
+                                    test_ingest_token(),
                                     now,
                                 )
                                 .map_err(|error| ClientEventError::Client {
@@ -1288,6 +1290,7 @@ impl TunnelTest {
                                     use_iceless,
                                     "target client".to_owned(),
                                     None,
+                                    test_ingest_token(),
                                     now,
                                 )
                                 .map_err(|error| ClientEventError::Client { id: src, error })?;


### PR DESCRIPTION
The Client now tracks flows with the same tracker as the Gateway. For client-to-client traffic it tracks both sides: flows it opened and flows the other Client opened, and both ends attribute the flow to the same resource.

Tracking follows the portal-provided flow-log configuration. The headless Client also gains the Gateway's `--flow-logs` flag to keep tracking enabled and print flow logs when portal uploads are disabled.
