### PR TITLE
feat: show connected device names/ipv6s

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -422,7 +422,7 @@ defmodule PortalAPI.Client.Channel do
   # The target already resolved `use_iceless` (reading the flag once, with both
   # peers' capabilities), so we apply it as-is rather than reading the flag a
   # second time — a second read could race a mid-flow toggle and disagree.
-  def handle_info({:device_access_acked, ref, use_iceless}, socket) do
+  def handle_info({:device_access_acked, ref, use_iceless, client_name}, socket) do
     case Map.pop(socket.assigns.pending_flows, ref) do
       {nil, _} ->
         {:noreply, socket}
@@ -430,7 +430,10 @@ defmodule PortalAPI.Client.Channel do
       {%{timer_ref: timer_ref, initiator_payload: initiator_payload}, remaining} ->
         Process.cancel_timer(timer_ref)
 
-        initiator_payload = Map.put(initiator_payload, :use_iceless, use_iceless)
+        initiator_payload =
+          initiator_payload
+          |> Map.put(:use_iceless, use_iceless)
+          |> Map.put(:client_name, client_name)
 
         push(socket, "client_device_access_authorized", initiator_payload)
         {:noreply, assign(socket, :pending_flows, remaining)}
@@ -473,7 +476,7 @@ defmodule PortalAPI.Client.Channel do
     # overtake the authorization at the target's data plane. We send the
     # resolved `use_iceless` (not our capability) so the initiator applies the
     # same decision without reading the flag again.
-    send(ack_to, {:device_access_acked, ref, use_iceless})
+    send(ack_to, {:device_access_acked, ref, use_iceless, socket.assigns.client.name})
 
     cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
 
@@ -1644,7 +1647,7 @@ defmodule PortalAPI.Client.Channel do
     # `ref` correlates the target channel's ack back to this request. The
     # initiator is NOT released on `Queue.enqueue/3` returning `:ok` — it is
     # released only once the target's channel acks that it has pushed the
-    # authorization onto the target's websocket (`{:device_access_acked, ref, _}`).
+    # authorization onto the target's websocket (`{:device_access_acked, ref, _, _}`).
     # Until then the initiator must not start ICE, because its candidates
     # travel the same socket as the authorization and would otherwise race
     # ahead of it at the target's data plane.
@@ -1777,6 +1780,7 @@ defmodule PortalAPI.Client.Channel do
       {:client_device_access_authorized, {self(), ref},
        %{
          client_id: client.id,
+         client_name: client.name,
          client_public_key: client_public_key,
          client_ipv4: client.ipv4,
          client_ipv6: client.ipv6,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5365,7 +5365,9 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
+      target_client_name = target_client.name
       initiating_client_id = client.id
+      initiating_client_name = client.name
 
       push(initiating_socket, "create_flow", %{
         "resource_id" => pool_resource.id,
@@ -5374,6 +5376,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       } = source_payload
 
@@ -5384,11 +5387,11 @@ defmodule PortalAPI.Client.ChannelTest do
       refute Map.has_key?(source_payload, :resource)
       refute Map.has_key?(source_payload, :subject)
       refute Map.has_key?(source_payload, :expires_at)
-      refute Map.has_key?(source_payload, :client_name)
       refute Map.has_key?(source_payload, :client_fqdns)
 
       assert_push "client_device_access_authorized", %{
         client_id: ^initiating_client_id,
+        client_name: ^initiating_client_name,
         ice_role: :controlled,
         expires_at: target_expires_at
       } = target_payload
@@ -5412,7 +5415,6 @@ defmodule PortalAPI.Client.ChannelTest do
       assert actor_email == subject.actor.email
       assert actor_name == subject.actor.name
 
-      refute Map.has_key?(target_payload, :client_name)
       refute Map.has_key?(target_payload, :client_fqdns)
       assert is_integer(target_expires_at)
     end
@@ -5802,17 +5804,21 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
+      target_client_name = target_client.name
       initiating_client_id = client.id
+      initiating_client_name = client.name
 
       push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       }
 
       assert_push "client_device_access_authorized", %{
         client_id: ^initiating_client_id,
+        client_name: ^initiating_client_name,
         ice_role: :controlled
       }
     end
@@ -6191,6 +6197,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
+      target_client_name = target_client.name
 
       push(initiating_socket, "create_flow", %{
         "resource_id" => pool_resource.id,
@@ -6199,6 +6206,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       }
     end
@@ -6438,10 +6446,13 @@ defmodule PortalAPI.Client.ChannelTest do
       # The initiator must not be released before the target acks.
       refute_push "client_device_access_authorized", _, 200
 
-      send(ack_to, {:device_access_acked, ref, false})
+      target_client_name = target_client.name
+
+      send(ack_to, {:device_access_acked, ref, false, target_client_name})
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       }
     end

--- a/kotlin/android/app/src/debug/java/dev/firezone/android/features/session/ui/compose/SessionSamples.kt
+++ b/kotlin/android/app/src/debug/java/dev/firezone/android/features/session/ui/compose/SessionSamples.kt
@@ -57,7 +57,13 @@ internal val sampleConnectedDevices: ImmutableList<ConnectedDevice> =
         listOf("Sales Pool"),
         emptyList(),
     ).mapIndexed { index, pools ->
-        ConnectedDevice(id = "client-${index + 1}", tunIpv4 = "100.96.0.${index + 1}", pools = pools)
+        ConnectedDevice(
+            id = "client-${index + 1}",
+            name = "Demo Device ${index + 1}",
+            tunIpv4 = "100.96.0.${index + 1}",
+            tunIpv6 = "fd00:2021:1111::${(index + 1).toString(16)}",
+            pools = pools,
+        )
     }.toImmutableList()
 
 internal val sampleResources: ImmutableList<ResourceViewModel> =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/compose/ConnectedDeviceDetailsSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/compose/ConnectedDeviceDetailsSheet.kt
@@ -31,26 +31,53 @@ fun ConnectedDeviceDetailsSheet(
         Column(Modifier.fillMaxWidth().padding(16.dp)) {
             SectionLabel("Connected Device")
 
-            DetailRow(label = "Tunnel IPv4:") {
-                Text(
-                    text = device.tunIpv4,
-                    fontFamily = FontFamily.Monospace,
-                    modifier =
-                        Modifier.clickable {
-                            ClipboardUtils.copyToClipboard(context, "Tunnel IPv4", device.tunIpv4)
-                        },
-                )
+            DetailRow(label = "Tunnel IPs:") {
+                Column {
+                    Text(
+                        text = device.tunIpv4,
+                        fontFamily = FontFamily.Monospace,
+                        modifier =
+                            Modifier.clickable {
+                                ClipboardUtils.copyToClipboard(
+                                    context,
+                                    "Tunnel IPv4",
+                                    device.tunIpv4,
+                                )
+                            },
+                    )
+                    Text(
+                        text = device.tunIpv6,
+                        fontFamily = FontFamily.Monospace,
+                        modifier =
+                            Modifier.clickable {
+                                ClipboardUtils.copyToClipboard(
+                                    context,
+                                    "Tunnel IPv6",
+                                    device.tunIpv6,
+                                )
+                            },
+                    )
+                }
             }
 
-            DetailRow(label = "Client ID:") {
-                Text(
-                    text = device.id,
-                    fontFamily = FontFamily.Monospace,
-                    modifier =
-                        Modifier.clickable {
-                            ClipboardUtils.copyToClipboard(context, "Client ID", device.id)
-                        },
-                )
+            DetailRow(label = "Client Details:") {
+                Column {
+                    Text(
+                        text = device.id,
+                        fontFamily = FontFamily.Monospace,
+                        modifier =
+                            Modifier.clickable {
+                                ClipboardUtils.copyToClipboard(context, "Client ID", device.id)
+                            },
+                    )
+                    Text(
+                        text = device.name,
+                        modifier =
+                            Modifier.clickable {
+                                ClipboardUtils.copyToClipboard(context, "Client Name", device.name)
+                            },
+                    )
+                }
             }
 
             if (device.pools.isNotEmpty()) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/compose/ConnectedDeviceRow.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/compose/ConnectedDeviceRow.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.firezone.android.tunnel.model.ConnectedDevice
@@ -20,13 +19,11 @@ fun ConnectedDeviceRow(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Monospace keeps the octets aligned, but renders visually larger than the proportional resource
-    // names; bodyMedium brings it back in line. The row is a single line, so it needs less vertical
-    // padding than the two-line resource rows to avoid looking sparse.
+    // The row is a single line, so it needs less vertical padding than the two-line resource rows
+    // to avoid looking sparse.
     Text(
-        text = device.tunIpv4,
+        text = device.name,
         style = MaterialTheme.typography.bodyMedium,
-        fontFamily = FontFamily.Monospace,
         modifier = modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 12.dp),
     )
 }
@@ -36,9 +33,36 @@ fun ConnectedDeviceRow(
 private fun ConnectedDeviceRowPreview() {
     FirezoneTheme {
         Column {
-            ConnectedDeviceRow(ConnectedDevice("1", "100.96.0.12", listOf("engineering")), onClick = {})
-            ConnectedDeviceRow(ConnectedDevice("2", "100.96.0.30", listOf("engineering", "ops")), onClick = {})
-            ConnectedDeviceRow(ConnectedDevice("3", "100.96.0.41", emptyList()), onClick = {})
+            ConnectedDeviceRow(
+                ConnectedDevice(
+                    "1",
+                    "Device 1",
+                    "100.96.0.12",
+                    "fd00:2021:1111::1",
+                    listOf("engineering"),
+                ),
+                onClick = {},
+            )
+            ConnectedDeviceRow(
+                ConnectedDevice(
+                    "2",
+                    "Device 2",
+                    "100.96.0.30",
+                    "fd00:2021:1111::2",
+                    listOf("engineering", "ops"),
+                ),
+                onClick = {},
+            )
+            ConnectedDeviceRow(
+                ConnectedDevice(
+                    "3",
+                    "Device 3",
+                    "100.96.0.41",
+                    "fd00:2021:1111::3",
+                    emptyList(),
+                ),
+                onClick = {},
+            )
         }
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -737,7 +737,9 @@ class TunnelService : VpnService() {
     private fun convertConnectedDevice(device: uniffi.connlib.ConnectedDevice): ConnectedDevice =
         ConnectedDevice(
             id = device.id,
+            name = device.name,
             tunIpv4 = device.tunIpv4,
+            tunIpv6 = device.tunIpv6,
             pools = device.pools,
         )
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/ConnectedDevice.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/ConnectedDevice.kt
@@ -9,6 +9,8 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class ConnectedDevice(
     val id: String,
+    val name: String,
     val tunIpv4: String,
+    val tunIpv6: String,
     val pools: List<String>,
 ) : Parcelable

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -120,8 +120,12 @@ pub enum Resource {
 #[derive(uniffi::Record)]
 pub struct ConnectedDevice {
     pub id: String,
+    /// Name assigned to the connected client.
+    pub name: String,
     /// Tunnel IPv4 address the device is reachable on.
     pub tun_ipv4: String,
+    /// Tunnel IPv6 address the device is reachable on.
+    pub tun_ipv6: String,
     /// Names of the device pools this peer belongs to, sorted (typically one,
     /// but can be multiple).
     pub pools: Vec<String>,
@@ -746,7 +750,9 @@ impl From<connlib_model::ConnectedDeviceView> for ConnectedDevice {
     fn from(device: connlib_model::ConnectedDeviceView) -> Self {
         ConnectedDevice {
             id: device.id.to_string(),
+            name: device.name,
             tun_ipv4: device.tunneled_ipv4.to_string(),
+            tun_ipv6: device.tunneled_ipv6.to_string(),
             pools: device.pools,
         }
     }

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -751,8 +751,8 @@ impl From<connlib_model::ConnectedDeviceView> for ConnectedDevice {
         ConnectedDevice {
             id: device.id.to_string(),
             name: device.name,
-            tun_ipv4: device.tunneled_ipv4.to_string(),
-            tun_ipv6: device.tunneled_ipv6.to_string(),
+            tun_ipv4: device.tun_ipv4.to_string(),
+            tun_ipv6: device.tun_ipv6.to_string(),
             pools: device.pools,
         }
     }

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -355,8 +355,8 @@ fn device_submenu(device: &ConnectedDeviceView) -> Menu {
     menu = menu
         .separator()
         .disabled("Tunnel IPs")
-        .copyable(&device.tunneled_ipv4.to_string())
-        .copyable(&device.tunneled_ipv6.to_string())
+        .copyable(&device.tun_ipv4.to_string())
+        .copyable(&device.tun_ipv6.to_string())
         .separator()
         .disabled("Client Details")
         .copyable(&device.id.to_string())
@@ -883,15 +883,15 @@ mod tests {
             ConnectedDeviceView {
                 id: alpha,
                 name: "Alpha".into(),
-                tunneled_ipv4: alpha_ip,
-                tunneled_ipv6: alpha_ipv6,
+                tun_ipv4: alpha_ip,
+                tun_ipv6: alpha_ipv6,
                 pools: vec!["Engineering Pool".into()],
             },
             ConnectedDeviceView {
                 id: beta,
                 name: "Beta".into(),
-                tunneled_ipv4: beta_ip,
-                tunneled_ipv6: beta_ipv6,
+                tun_ipv4: beta_ip,
+                tun_ipv6: beta_ipv6,
                 pools: vec!["Engineering Pool".into(), "QA Pool".into()],
             },
         ];
@@ -949,8 +949,8 @@ mod tests {
             .map(|i| ConnectedDeviceView {
                 id: ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111 + i as u128),
                 name: format!("Device {i}"),
-                tunneled_ipv4: Ipv4Addr::new(100, 64, 0, i as u8),
-                tunneled_ipv6: Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, i as u16]),
+                tun_ipv4: Ipv4Addr::new(100, 64, 0, i as u8),
+                tun_ipv6: Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, i as u16]),
                 pools: vec!["Engineering Pool".into()],
             })
             .collect();
@@ -959,8 +959,8 @@ mod tests {
 
         let mut expected = Menu::default();
         for device in &connected_devices[..MAX_DEVICES_INLINE] {
-            let ip = device.tunneled_ipv4.to_string();
-            let ipv6 = device.tunneled_ipv6.to_string();
+            let ip = device.tun_ipv4.to_string();
+            let ipv6 = device.tun_ipv6.to_string();
             expected = expected.add_submenu(
                 device.name.clone(),
                 Menu::default()

--- a/rust/gui-client/src-tauri/src/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/gui/system_tray.rs
@@ -330,15 +330,11 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
     menu
 }
 
-fn device_label(device: &ConnectedDeviceView) -> String {
-    device.tunneled_ipv4.to_string()
-}
-
 fn devices_submenu(connected_devices: &[ConnectedDeviceView]) -> Menu {
     let mut menu = Menu::default();
     let visible = connected_devices.len().min(MAX_DEVICES_INLINE);
     for device in &connected_devices[..visible] {
-        menu = menu.add_submenu(device_label(device), device_submenu(device));
+        menu = menu.add_submenu(device.name.clone(), device_submenu(device));
     }
 
     let hidden = connected_devices.len() - visible;
@@ -358,11 +354,13 @@ fn device_submenu(device: &ConnectedDeviceView) -> Menu {
 
     menu = menu
         .separator()
-        .disabled("Tunnel IPv4")
+        .disabled("Tunnel IPs")
         .copyable(&device.tunneled_ipv4.to_string())
+        .copyable(&device.tunneled_ipv6.to_string())
         .separator()
-        .disabled("Client ID")
-        .copyable(&device.id.to_string());
+        .disabled("Client Details")
+        .copyable(&device.id.to_string())
+        .copyable(&device.name);
 
     if !device.pools.is_empty() {
         let label = if device.pools.len() == 1 {
@@ -874,20 +872,26 @@ mod tests {
     #[test]
     fn devices_submenu_lists_connected_devices_with_pool_labels() {
         use connlib_model::ClientId;
-        use std::net::Ipv4Addr;
+        use std::net::{Ipv4Addr, Ipv6Addr};
         let alpha = ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111);
         let beta = ClientId::from_u128(0x2222_2222_2222_2222_2222_2222_2222_2222);
         let alpha_ip = Ipv4Addr::new(100, 64, 0, 1);
+        let alpha_ipv6 = Ipv6Addr::LOCALHOST;
         let beta_ip = Ipv4Addr::new(100, 64, 0, 2);
+        let beta_ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 2]);
         let connected_devices = vec![
             ConnectedDeviceView {
                 id: alpha,
+                name: "Alpha".into(),
                 tunneled_ipv4: alpha_ip,
+                tunneled_ipv6: alpha_ipv6,
                 pools: vec!["Engineering Pool".into()],
             },
             ConnectedDeviceView {
                 id: beta,
+                name: "Beta".into(),
                 tunneled_ipv4: beta_ip,
+                tunneled_ipv6: beta_ipv6,
                 pools: vec!["Engineering Pool".into(), "QA Pool".into()],
             },
         ];
@@ -896,29 +900,33 @@ mod tests {
 
         let expected = Menu::default()
             .add_submenu(
-                alpha_ip.to_string(),
+                "Alpha",
                 Menu::default()
                     .disabled("Device")
                     .separator()
-                    .disabled("Tunnel IPv4")
+                    .disabled("Tunnel IPs")
                     .copyable(&alpha_ip.to_string())
+                    .copyable(&alpha_ipv6.to_string())
                     .separator()
-                    .disabled("Client ID")
+                    .disabled("Client Details")
                     .copyable(&alpha.to_string())
+                    .copyable("Alpha")
                     .separator()
                     .disabled("Pool")
                     .copyable("Engineering Pool"),
             )
             .add_submenu(
-                beta_ip.to_string(),
+                "Beta",
                 Menu::default()
                     .disabled("Device")
                     .separator()
-                    .disabled("Tunnel IPv4")
+                    .disabled("Tunnel IPs")
                     .copyable(&beta_ip.to_string())
+                    .copyable(&beta_ipv6.to_string())
                     .separator()
-                    .disabled("Client ID")
+                    .disabled("Client Details")
                     .copyable(&beta.to_string())
+                    .copyable("Beta")
                     .separator()
                     .disabled("Pools")
                     .copyable("Engineering Pool")
@@ -936,11 +944,13 @@ mod tests {
     #[test]
     fn devices_submenu_truncates_beyond_inline_limit() {
         use connlib_model::ClientId;
-        use std::net::Ipv4Addr;
+        use std::net::{Ipv4Addr, Ipv6Addr};
         let connected_devices: Vec<ConnectedDeviceView> = (0..MAX_DEVICES_INLINE + 3)
             .map(|i| ConnectedDeviceView {
                 id: ClientId::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111 + i as u128),
+                name: format!("Device {i}"),
                 tunneled_ipv4: Ipv4Addr::new(100, 64, 0, i as u8),
+                tunneled_ipv6: Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, i as u16]),
                 pools: vec!["Engineering Pool".into()],
             })
             .collect();
@@ -950,16 +960,19 @@ mod tests {
         let mut expected = Menu::default();
         for device in &connected_devices[..MAX_DEVICES_INLINE] {
             let ip = device.tunneled_ipv4.to_string();
+            let ipv6 = device.tunneled_ipv6.to_string();
             expected = expected.add_submenu(
-                ip.clone(),
+                device.name.clone(),
                 Menu::default()
                     .disabled("Device")
                     .separator()
-                    .disabled("Tunnel IPv4")
+                    .disabled("Tunnel IPs")
                     .copyable(&ip)
+                    .copyable(&ipv6)
                     .separator()
-                    .disabled("Client ID")
+                    .disabled("Client Details")
                     .copyable(&device.id.to_string())
+                    .copyable(&device.name)
                     .separator()
                     .disabled("Pool")
                     .copyable(&device.pools[0]),

--- a/rust/gui-client/src-tauri/src/mock_tunnel.rs
+++ b/rust/gui-client/src-tauri/src/mock_tunnel.rs
@@ -168,8 +168,8 @@ fn mock_resource_list() -> ResourceList {
         .map(|i| ConnectedDeviceView {
             id: ClientId::from_u128(i + 1),
             name: format!("Demo Device {}", i + 1),
-            tunneled_ipv4: Ipv4Addr::new(100, 96, 0, (i as u8) + 1),
-            tunneled_ipv6: Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, i as u16 + 1]),
+            tun_ipv4: Ipv4Addr::new(100, 96, 0, (i as u8) + 1),
+            tun_ipv6: Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, i as u16 + 1]),
             pools: POOL_PATTERNS[(i as usize) % POOL_PATTERNS.len()]
                 .iter()
                 .map(|name| (*name).to_string())

--- a/rust/gui-client/src-tauri/src/mock_tunnel.rs
+++ b/rust/gui-client/src-tauri/src/mock_tunnel.rs
@@ -20,7 +20,7 @@ use connlib_model::{
 use futures::{SinkExt as _, StreamExt as _};
 use ip_network::IpNetwork;
 use std::{
-    net::Ipv4Addr,
+    net::{Ipv4Addr, Ipv6Addr},
     sync::atomic::{AtomicBool, Ordering},
 };
 use tokio::io::DuplexStream;
@@ -167,7 +167,9 @@ fn mock_resource_list() -> ResourceList {
     let connected_devices = (0..22u128)
         .map(|i| ConnectedDeviceView {
             id: ClientId::from_u128(i + 1),
+            name: format!("Demo Device {}", i + 1),
             tunneled_ipv4: Ipv4Addr::new(100, 96, 0, (i as u8) + 1),
+            tunneled_ipv6: Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, i as u16 + 1]),
             pools: POOL_PATTERNS[(i as usize) % POOL_PATTERNS.len()]
                 .iter()
                 .map(|name| (*name).to_string())

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -566,6 +566,7 @@ impl Eventloop {
             }
             IngressMessages::ClientDeviceAccessAuthorized(ClientDeviceAccessAuthorized {
                 client_id,
+                client_name,
                 client_public_key,
                 client_ipv4,
                 client_ipv6,
@@ -598,6 +599,7 @@ impl Eventloop {
                     remote_ice_credentials,
                     ice_role,
                     use_iceless,
+                    client_name,
                     authorization,
                     Instant::now(),
                 ) {

--- a/rust/libs/connlib/model/src/view.rs
+++ b/rust/libs/connlib/model/src/view.rs
@@ -134,12 +134,12 @@ pub struct ConnectedDeviceView {
     ///
     /// Sourced from the live snownet connection state, so it is always known
     /// for a connected device regardless of pool membership.
-    pub tunneled_ipv4: Ipv4Addr,
+    pub tun_ipv4: Ipv4Addr,
     /// Tunnel IPv6 address the device is reachable on.
     ///
     /// Sourced from the live snownet connection state, so it is always known
     /// for a connected device regardless of pool membership.
-    pub tunneled_ipv6: Ipv6Addr,
+    pub tun_ipv6: Ipv6Addr,
     /// Names of the static device pools the device belongs to, sorted.
     pub pools: Vec<String>,
 }

--- a/rust/libs/connlib/model/src/view.rs
+++ b/rust/libs/connlib/model/src/view.rs
@@ -3,7 +3,7 @@ use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::ClientId;
 use crate::ResourceId;
@@ -128,11 +128,18 @@ pub struct CidrResourceView {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ConnectedDeviceView {
     pub id: ClientId,
+    /// Name assigned to the connected client.
+    pub name: String,
     /// Tunnel IPv4 address the device is reachable on.
     ///
     /// Sourced from the live snownet connection state, so it is always known
     /// for a connected device regardless of pool membership.
     pub tunneled_ipv4: Ipv4Addr,
+    /// Tunnel IPv6 address the device is reachable on.
+    ///
+    /// Sourced from the live snownet connection state, so it is always known
+    /// for a connected device regardless of pool membership.
+    pub tunneled_ipv6: Ipv6Addr,
     /// Names of the static device pools the device belongs to, sorted.
     pub pools: Vec<String>,
 }

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -267,36 +267,16 @@ impl ClientState {
                     );
                     return None;
                 };
-                let tunneled_ipv4 = peer.tun_ipv4();
-                let tunneled_ipv6 = peer.tun_ipv6();
+                let tun_ipv4 = peer.tun_ipv4();
+                let tun_ipv6 = peer.tun_ipv6();
                 let name = peer.remote_name().to_owned();
 
-                let mut pool_names = Vec::new();
-                for pool in &pools {
-                    if let Some(device) = pool.devices.iter().find(|d| d.id == *client_id) {
-                        if device.ipv4.network_address() != tunneled_ipv4 {
-                            tracing::debug!(
-                                %client_id,
-                                pool = %pool.name,
-                                pool_ipv4 = %device.ipv4.network_address(),
-                                %tunneled_ipv4,
-                                "Pool-provided IPv4 disagrees with the connection's tunnel IPv4"
-                            );
-                        }
-                        if device.ipv6.network_address() != tunneled_ipv6 {
-                            tracing::debug!(
-                                %client_id,
-                                pool = %pool.name,
-                                pool_ipv6 = %device.ipv6.network_address(),
-                                %tunneled_ipv6,
-                                "Pool-provided IPv6 disagrees with the connection's tunnel IPv6"
-                            );
-                        }
-                        pool_names.push(pool.name.clone());
-                    }
-                }
-
-                pool_names.sort();
+                let pool_names = pools
+                    .iter()
+                    .filter(|pool| pool.devices.iter().any(|d| d.id == *client_id))
+                    .map(|pool| pool.name.clone())
+                    .sorted()
+                    .collect_vec();
 
                 if pool_names.is_empty() {
                     tracing::debug!(
@@ -308,8 +288,8 @@ impl ClientState {
                 Some(ConnectedDeviceView {
                     id: *client_id,
                     name,
-                    tunneled_ipv4,
-                    tunneled_ipv6,
+                    tun_ipv4,
+                    tun_ipv6,
                     pools: pool_names,
                 })
             })

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1076,6 +1076,7 @@ impl ClientState {
         remote_client_ice: IceCredentials,
         ice_role: IceRole,
         use_iceless: bool,
+        client_name: String,
         authorization: Option<crate::messages::client::ResourceAuthorization>,
         now: Instant,
     ) -> Result<(), NoTurnServers> {
@@ -1103,7 +1104,11 @@ impl ClientState {
             (auth.resource_id, auth.filters, expires_at)
         });
 
-        let peer = self.clients.upsert(cid, || ClientOnClient::new(client_tun));
+        let peer = self
+            .clients
+            .upsert(cid, || ClientOnClient::new(client_tun, client_name.clone()));
+        peer.set_remote_name(client_name);
+        tracing::debug!(%cid, name = %peer.remote_name(), "Updated client peer name");
 
         // We only add the inbound resource and filters on the *target* side of the connection.
         // The initiating side does not request connections if the filters don't allow it.

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -251,9 +251,9 @@ impl ClientState {
             .collect_vec()
     }
 
-    /// Builds the list of currently-connected device peers. The tunnel IPv4 is
-    /// taken from the live connection state; static-pool resources are joined in
-    /// only to label which pool(s) each device belongs to.
+    /// Builds the list of currently-connected device peers. The name and tunnel
+    /// IPs are taken from the live connection state; static-pool resources are
+    /// joined in only to label which pool(s) each device belongs to.
     pub(crate) fn connected_devices(&self) -> Vec<ConnectedDeviceView> {
         let pools = self.static_device_pools().collect_vec();
 
@@ -268,6 +268,8 @@ impl ClientState {
                     return None;
                 };
                 let tunneled_ipv4 = peer.tun_ipv4();
+                let tunneled_ipv6 = peer.tun_ipv6();
+                let name = peer.remote_name().to_owned();
 
                 let mut pool_names = Vec::new();
                 for pool in &pools {
@@ -279,6 +281,15 @@ impl ClientState {
                                 pool_ipv4 = %device.ipv4.network_address(),
                                 %tunneled_ipv4,
                                 "Pool-provided IPv4 disagrees with the connection's tunnel IPv4"
+                            );
+                        }
+                        if device.ipv6.network_address() != tunneled_ipv6 {
+                            tracing::debug!(
+                                %client_id,
+                                pool = %pool.name,
+                                pool_ipv6 = %device.ipv6.network_address(),
+                                %tunneled_ipv6,
+                                "Pool-provided IPv6 disagrees with the connection's tunnel IPv6"
                             );
                         }
                         pool_names.push(pool.name.clone());
@@ -296,7 +307,9 @@ impl ClientState {
 
                 Some(ConnectedDeviceView {
                     id: *client_id,
+                    name,
                     tunneled_ipv4,
+                    tunneled_ipv6,
                     pools: pool_names,
                 })
             })

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -23,6 +23,7 @@ use std::time::Instant;
 /// isn't the return traffic of packets that we have sent.
 pub(crate) struct ClientOnClient {
     remote_tun: IpConfig,
+    remote_name: String,
     /// Inbound resources authorising the remote peer to send packets to us.
     ///
     /// When this map is empty, no inbound traffic from this peer is admitted
@@ -50,9 +51,10 @@ pub(crate) enum InboundResult {
 }
 
 impl ClientOnClient {
-    pub(crate) fn new(remote_tun: IpConfig) -> ClientOnClient {
+    pub(crate) fn new(remote_tun: IpConfig, remote_name: String) -> ClientOnClient {
         ClientOnClient {
             remote_tun,
+            remote_name,
             resources: ExpiringMap::default(),
             // No resources -> no allowed inbound traffic by default.
             inbound_filter: FilterEngine::DenyAll,
@@ -62,6 +64,14 @@ impl ClientOnClient {
 
     pub(crate) fn remote_tun(&self) -> IpConfig {
         self.remote_tun
+    }
+
+    pub(crate) fn remote_name(&self) -> &str {
+        &self.remote_name
+    }
+
+    pub(crate) fn set_remote_name(&mut self, name: String) {
+        self.remote_name = name;
     }
 
     /// Allow the remote peer to send us packets associated with `resource_id` limited by the given filter set.

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -158,6 +158,7 @@ pub struct FlowCreationFailed {
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClientDeviceAccessAuthorized {
     pub client_id: ClientId,
+    pub client_name: String,
     pub client_public_key: Key,
     pub client_ipv4: Ipv4Addr,
     pub client_ipv6: Ipv6Addr,

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1190,6 +1190,7 @@ impl TunnelTest {
                                     local_client_ice.clone(),
                                     crate::messages::IceRole::Controlled,
                                     use_iceless,
+                                    "initiating client".to_owned(),
                                     Some(remote_authorization),
                                     now,
                                 )
@@ -1215,6 +1216,7 @@ impl TunnelTest {
                                     remote_client_ice,
                                     crate::messages::IceRole::Controlling,
                                     use_iceless,
+                                    "target client".to_owned(),
                                     None,
                                     now,
                                 )

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Mocks/MockTunnel.swift
@@ -170,7 +170,9 @@
       return (0..<22).map { index in
         ConnectedDevice(
           id: "client-\(index + 1)",
+          name: "Demo Device \(index + 1)",
           tunIPv4: "100.96.0.\(index + 1)",
+          tunIPv6: "fd00:2021:1111::\(String(index + 1, radix: 16))",
           pools: poolPatterns[index % poolPatterns.count]
         )
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ConnectedDevice.swift
@@ -10,12 +10,16 @@ import Foundation
 
 public struct ConnectedDevice: Codable, Identifiable, Hashable, Sendable {
   public let id: String
+  public let name: String
   public let tunIPv4: String
+  public let tunIPv6: String
   public let pools: [String]
 
-  public init(id: String, tunIPv4: String, pools: [String]) {
+  public init(id: String, name: String, tunIPv4: String, tunIPv6: String, pools: [String]) {
     self.id = id
+    self.name = name
     self.tunIPv4 = tunIPv4
+    self.tunIPv6 = tunIPv6
     self.pools = pools
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesMenuSection.swift
@@ -35,35 +35,41 @@
     }
   }
 
-  /// A single connected device, labelled by its tunnel IPv4, with details in a submenu.
+  /// A single connected device, labelled by name, with details in a submenu.
   struct ConnectedDeviceMenuItem: View {
     let device: ConnectedDevice
 
     var body: some View {
-      Menu(device.tunIPv4) {
+      Menu(device.name) {
         ConnectedDeviceDetailsSubmenu(device: device)
       }
     }
   }
 
-  /// Copyable details for a connected device: tunnel IPv4, client ID, and pools.
+  /// Copyable details for a connected device: tunnel IPs, client details, and pools.
   struct ConnectedDeviceDetailsSubmenu: View {
     let device: ConnectedDevice
 
     var body: some View {
       Group {
-        Text("Tunnel IPv4")
+        Text("Tunnel IPs")
           .foregroundStyle(.secondary)
         Button(device.tunIPv4) {
           Clipboard.copy(device.tunIPv4)
         }
+        Button(device.tunIPv6) {
+          Clipboard.copy(device.tunIPv6)
+        }
 
         Divider()
 
-        Text("Client ID")
+        Text("Client Details")
           .foregroundStyle(.secondary)
         Button(device.id) {
           Clipboard.copy(device.id)
+        }
+        Button(device.name) {
+          Clipboard.copy(device.name)
         }
 
         if !device.pools.isEmpty {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ConnectedDevicesSection.swift
@@ -20,7 +20,7 @@
         Section("Connected Devices (\(store.connectedDevices.count))") {
           ForEach(store.connectedDevices) { device in
             NavigationLink(value: device) {
-              Text(device.tunIPv4)
+              Text(device.name)
             }
           }
         }
@@ -28,19 +28,21 @@
     }
   }
 
-  /// Detail screen for a connected device: tunnel IPv4, client ID, and pools,
+  /// Detail screen for a connected device: tunnel IPs, client details, and pools,
   /// each copyable via a long-press context menu.
   struct ConnectedDeviceView: View {
     let device: ConnectedDevice
 
     var body: some View {
       List {
-        Section(header: Text("Tunnel IPv4")) {
+        Section(header: Text("Tunnel IPs")) {
           copyableRow(device.tunIPv4)
+          copyableRow(device.tunIPv6)
         }
 
-        Section(header: Text("Client ID")) {
+        Section(header: Text("Client Details")) {
           copyableRow(device.id)
+          copyableRow(device.name)
         }
 
         if !device.pools.isEmpty {

--- a/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
+++ b/swift/apple/FirezoneKit/Tests/FirezoneKitTests/ConnlibStateTests.swift
@@ -239,7 +239,9 @@ struct ConnlibStateTests {
 
     #expect(state.connectedDevices.count == 1)
     #expect(state.connectedDevices[0].id == "device-1")
+    #expect(state.connectedDevices[0].name == "Device device-1")
     #expect(state.connectedDevices[0].tunIPv4 == "100.64.0.1")
+    #expect(state.connectedDevices[0].tunIPv6 == "fd00:2021:1111::1")
     #expect(state.connectedDevices[0].pools == ["pool-a"])
   }
 
@@ -284,6 +286,12 @@ struct ConnlibStateTests {
   }
 
   private func makeTestConnectedDevice(id: String) -> FirezoneKit.ConnectedDevice {
-    FirezoneKit.ConnectedDevice(id: id, tunIPv4: "100.64.0.1", pools: ["pool-a"])
+    FirezoneKit.ConnectedDevice(
+      id: id,
+      name: "Device \(id)",
+      tunIPv4: "100.64.0.1",
+      tunIPv6: "fd00:2021:1111::1",
+      pools: ["pool-a"]
+    )
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -575,7 +575,13 @@ extension FirezoneKit.Site {
 
 extension FirezoneKit.ConnectedDevice {
   init(_ device: ConnectedDevice) {
-    self.init(id: device.id, tunIPv4: device.tunIpv4, pools: device.pools)
+    self.init(
+      id: device.id,
+      name: device.name,
+      tunIPv4: device.tunIpv4,
+      tunIPv6: device.tunIpv6,
+      pools: device.pools
+    )
   }
 }
 


### PR DESCRIPTION
Upon trying to use the device pool feature, I realized I quickly lost track of which devices I was "connected" to because it's hard to remember devices by tunnel IPv4 only.

Rather than use that to represent the device in the intermediate connected devices menu, in this PR we use the device's name instead. Yes on mobile platforms we'll get generic names like `iPhone` and `iPad`, but seeing a few of these duplicated in the list is preferable over the more cryptic tunnel IPv4s.

Also updates the connected device sub-menu to show the tunnel IPv6 as well.