### PR TITLE
feat(portal): include client `name` in authz msg

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -422,7 +422,7 @@ defmodule PortalAPI.Client.Channel do
   # The target already resolved `use_iceless` (reading the flag once, with both
   # peers' capabilities), so we apply it as-is rather than reading the flag a
   # second time — a second read could race a mid-flow toggle and disagree.
-  def handle_info({:device_access_acked, ref, use_iceless}, socket) do
+  def handle_info({:device_access_acked, ref, use_iceless, client_name}, socket) do
     case Map.pop(socket.assigns.pending_flows, ref) do
       {nil, _} ->
         {:noreply, socket}
@@ -430,7 +430,10 @@ defmodule PortalAPI.Client.Channel do
       {%{timer_ref: timer_ref, initiator_payload: initiator_payload}, remaining} ->
         Process.cancel_timer(timer_ref)
 
-        initiator_payload = Map.put(initiator_payload, :use_iceless, use_iceless)
+        initiator_payload =
+          initiator_payload
+          |> Map.put(:use_iceless, use_iceless)
+          |> Map.put(:client_name, client_name)
 
         push(socket, "client_device_access_authorized", initiator_payload)
         {:noreply, assign(socket, :pending_flows, remaining)}
@@ -473,7 +476,7 @@ defmodule PortalAPI.Client.Channel do
     # overtake the authorization at the target's data plane. We send the
     # resolved `use_iceless` (not our capability) so the initiator applies the
     # same decision without reading the flag again.
-    send(ack_to, {:device_access_acked, ref, use_iceless})
+    send(ack_to, {:device_access_acked, ref, use_iceless, socket.assigns.client.name})
 
     cache = Cache.Client.track_authorized_device_ipv4(socket.assigns.cache, payload.client_ipv4)
 
@@ -1644,7 +1647,7 @@ defmodule PortalAPI.Client.Channel do
     # `ref` correlates the target channel's ack back to this request. The
     # initiator is NOT released on `Queue.enqueue/3` returning `:ok` — it is
     # released only once the target's channel acks that it has pushed the
-    # authorization onto the target's websocket (`{:device_access_acked, ref, _}`).
+    # authorization onto the target's websocket (`{:device_access_acked, ref, _, _}`).
     # Until then the initiator must not start ICE, because its candidates
     # travel the same socket as the authorization and would otherwise race
     # ahead of it at the target's data plane.
@@ -1777,6 +1780,7 @@ defmodule PortalAPI.Client.Channel do
       {:client_device_access_authorized, {self(), ref},
        %{
          client_id: client.id,
+         client_name: client.name,
          client_public_key: client_public_key,
          client_ipv4: client.ipv4,
          client_ipv6: client.ipv6,

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -5365,7 +5365,9 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
+      target_client_name = target_client.name
       initiating_client_id = client.id
+      initiating_client_name = client.name
 
       push(initiating_socket, "create_flow", %{
         "resource_id" => pool_resource.id,
@@ -5374,6 +5376,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       } = source_payload
 
@@ -5384,11 +5387,11 @@ defmodule PortalAPI.Client.ChannelTest do
       refute Map.has_key?(source_payload, :resource)
       refute Map.has_key?(source_payload, :subject)
       refute Map.has_key?(source_payload, :expires_at)
-      refute Map.has_key?(source_payload, :client_name)
       refute Map.has_key?(source_payload, :client_fqdns)
 
       assert_push "client_device_access_authorized", %{
         client_id: ^initiating_client_id,
+        client_name: ^initiating_client_name,
         ice_role: :controlled,
         expires_at: target_expires_at
       } = target_payload
@@ -5412,7 +5415,6 @@ defmodule PortalAPI.Client.ChannelTest do
       assert actor_email == subject.actor.email
       assert actor_name == subject.actor.name
 
-      refute Map.has_key?(target_payload, :client_name)
       refute Map.has_key?(target_payload, :client_fqdns)
       assert is_integer(target_expires_at)
     end
@@ -5802,17 +5804,21 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
+      target_client_name = target_client.name
       initiating_client_id = client.id
+      initiating_client_name = client.name
 
       push(initiating_socket, "request_device_access", %{"ipv4" => target_ip})
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       }
 
       assert_push "client_device_access_authorized", %{
         client_id: ^initiating_client_id,
+        client_name: ^initiating_client_name,
         ice_role: :controlled
       }
     end
@@ -6191,6 +6197,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       target_ip = Portal.Types.INET.to_string(target_client.ipv4)
       target_client_id = target_client.id
+      target_client_name = target_client.name
 
       push(initiating_socket, "create_flow", %{
         "resource_id" => pool_resource.id,
@@ -6199,6 +6206,7 @@ defmodule PortalAPI.Client.ChannelTest do
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       }
     end
@@ -6438,10 +6446,13 @@ defmodule PortalAPI.Client.ChannelTest do
       # The initiator must not be released before the target acks.
       refute_push "client_device_access_authorized", _, 200
 
-      send(ack_to, {:device_access_acked, ref, false})
+      target_client_name = target_client.name
+
+      send(ack_to, {:device_access_acked, ref, false, target_client_name})
 
       assert_push "client_device_access_authorized", %{
         client_id: ^target_client_id,
+        client_name: ^target_client_name,
         ice_role: :controlling
       }
     end

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -566,6 +566,7 @@ impl Eventloop {
             }
             IngressMessages::ClientDeviceAccessAuthorized(ClientDeviceAccessAuthorized {
                 client_id,
+                client_name,
                 client_public_key,
                 client_ipv4,
                 client_ipv6,
@@ -598,6 +599,7 @@ impl Eventloop {
                     remote_ice_credentials,
                     ice_role,
                     use_iceless,
+                    client_name,
                     authorization,
                     Instant::now(),
                 ) {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -1076,6 +1076,7 @@ impl ClientState {
         remote_client_ice: IceCredentials,
         ice_role: IceRole,
         use_iceless: bool,
+        client_name: String,
         authorization: Option<crate::messages::client::ResourceAuthorization>,
         now: Instant,
     ) -> Result<(), NoTurnServers> {
@@ -1103,7 +1104,11 @@ impl ClientState {
             (auth.resource_id, auth.filters, expires_at)
         });
 
-        let peer = self.clients.upsert(cid, || ClientOnClient::new(client_tun));
+        let peer = self
+            .clients
+            .upsert(cid, || ClientOnClient::new(client_tun, client_name.clone()));
+        peer.set_remote_name(client_name);
+        tracing::debug!(%cid, name = %peer.remote_name(), "Updated client peer name");
 
         // We only add the inbound resource and filters on the *target* side of the connection.
         // The initiating side does not request connections if the filters don't allow it.

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -23,6 +23,7 @@ use std::time::Instant;
 /// isn't the return traffic of packets that we have sent.
 pub(crate) struct ClientOnClient {
     remote_tun: IpConfig,
+    remote_name: String,
     /// Inbound resources authorising the remote peer to send packets to us.
     ///
     /// When this map is empty, no inbound traffic from this peer is admitted
@@ -50,9 +51,10 @@ pub(crate) enum InboundResult {
 }
 
 impl ClientOnClient {
-    pub(crate) fn new(remote_tun: IpConfig) -> ClientOnClient {
+    pub(crate) fn new(remote_tun: IpConfig, remote_name: String) -> ClientOnClient {
         ClientOnClient {
             remote_tun,
+            remote_name,
             resources: ExpiringMap::default(),
             // No resources -> no allowed inbound traffic by default.
             inbound_filter: FilterEngine::DenyAll,
@@ -62,6 +64,14 @@ impl ClientOnClient {
 
     pub(crate) fn remote_tun(&self) -> IpConfig {
         self.remote_tun
+    }
+
+    pub(crate) fn remote_name(&self) -> &str {
+        &self.remote_name
+    }
+
+    pub(crate) fn set_remote_name(&mut self, name: String) {
+        self.remote_name = name;
     }
 
     /// Allow the remote peer to send us packets associated with `resource_id` limited by the given filter set.

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -158,6 +158,7 @@ pub struct FlowCreationFailed {
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClientDeviceAccessAuthorized {
     pub client_id: ClientId,
+    pub client_name: String,
     pub client_public_key: Key,
     pub client_ipv4: Ipv4Addr,
     pub client_ipv6: Ipv6Addr,

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1190,6 +1190,7 @@ impl TunnelTest {
                                     local_client_ice.clone(),
                                     crate::messages::IceRole::Controlled,
                                     use_iceless,
+                                    "initiating client".to_owned(),
                                     Some(remote_authorization),
                                     now,
                                 )
@@ -1215,6 +1216,7 @@ impl TunnelTest {
                                     remote_client_ice,
                                     crate::messages::IceRole::Controlling,
                                     use_iceless,
+                                    "target client".to_owned(),
                                     None,
                                     now,
                                 )


### PR DESCRIPTION

- sends `client_name` on `client_device_access_authorized` payloads using live channel socket state
- includes the initiator name for the target peer and carries the target name back to the initiator through the existing target ack
- deserializes `client_name` in connlib and stores it on client-to-client peer state