### PR TITLE
fix(portal): add 'id' to all phx-change els

### DIFF
--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -129,7 +129,7 @@ defmodule PortalWeb.NavigationComponents do
     </ul>
     <ul class="py-1 text-body" aria-labelledby="user-menu-dropdown">
       <li>
-        <form action={~p"/#{@subject.account}/sign_out"} method="post">
+        <form id="sign-out-form" action={~p"/#{@subject.account}/sign_out"} method="post">
           <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
           <button
             type="submit"

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -674,7 +674,7 @@ defmodule PortalWeb.Actors.Components do
 
         <div :if={is_nil(@created_token) and @adding_token} class="px-5 py-4 space-y-4">
           <p class="text-sm font-medium text-heading">New Token</p>
-          <form phx-change="validate_token" phx-submit="create_token" class="space-y-4">
+          <form id="create-token-form" phx-change="validate_token" phx-submit="create_token" class="space-y-4">
             <div>
               <label class="block text-xs font-medium text-body mb-1.5">
                 Token expiration
@@ -1018,6 +1018,7 @@ defmodule PortalWeb.Actors.Components do
 
     ~H"""
     <.form
+      id="actor-edit-form"
       for={@form}
       phx-change="validate"
       phx-submit="save"
@@ -1240,6 +1241,7 @@ defmodule PortalWeb.Actors.Components do
 
       <.form
         :if={@new_actor_type == :user and @form}
+        id="create-user-form"
         for={@form}
         phx-change="validate"
         phx-submit="create_user"
@@ -1351,6 +1353,7 @@ defmodule PortalWeb.Actors.Components do
 
       <.form
         :if={@new_actor_type == :service_account and @form}
+        id="create-service-account-form"
         for={@form}
         phx-change="validate"
         phx-submit="create_service_account"

--- a/elixir/lib/portal_web/live/clients/components.ex
+++ b/elixir/lib/portal_web/live/clients/components.ex
@@ -257,6 +257,7 @@ defmodule PortalWeb.Clients.Components do
       <.client_edit_header />
       <.form
         :if={@client_edit_form}
+        id="client-edit-form"
         for={@client_edit_form}
         phx-submit="submit_client_edit_form"
         phx-change="change_client_edit_form"

--- a/elixir/lib/portal_web/live/find_account.ex
+++ b/elixir/lib/portal_web/live/find_account.ex
@@ -90,7 +90,7 @@ defmodule PortalWeb.FindAccount do
       </div>
     </div>
 
-    <.form for={@form} phx-submit="submit_email" phx-change="validate_email">
+    <.form id="find-account-form" for={@form} phx-submit="submit_email" phx-change="validate_email">
       <label class="block text-xs font-semibold text-body mb-1.5">
         Work email
       </label>

--- a/elixir/lib/portal_web/live/groups/components.ex
+++ b/elixir/lib/portal_web/live/groups/components.ex
@@ -392,7 +392,7 @@ defmodule PortalWeb.Groups.Components do
         </.button>
       </div>
       <div :if={@tab == :members} class="ml-auto pb-2 flex items-center">
-        <form phx-change="filter_show_members">
+        <form id="filter-members-form" phx-change="filter_show_members">
           <div class="relative">
             <.icon
               name="ri-search-line"

--- a/elixir/lib/portal_web/live/policies/components.ex
+++ b/elixir/lib/portal_web/live/policies/components.ex
@@ -256,6 +256,7 @@ defmodule PortalWeb.Policies.Components do
     <div class="flex flex-col h-full overflow-hidden">
       <.policy_form_header mode={@mode} />
       <.form
+        id="policy-form"
         for={@panel_form}
         phx-submit="submit_policy_form"
         phx-change="change_policy_form"

--- a/elixir/lib/portal_web/live/resources/components.ex
+++ b/elixir/lib/portal_web/live/resources/components.ex
@@ -970,6 +970,7 @@ defmodule PortalWeb.Resources.Components do
         </div>
       </div>
       <.form
+        id="resource-form"
         for={@resource_form}
         phx-submit="submit_resource_form"
         phx-change="change_resource_form"

--- a/elixir/lib/portal_web/live/settings/account.ex
+++ b/elixir/lib/portal_web/live/settings/account.ex
@@ -188,7 +188,7 @@ defmodule PortalWeb.Settings.Account do
               <p class="text-xs text-error/70 mb-1.5">
                 Type <strong>{@account.slug}</strong> to confirm:
               </p>
-              <form phx-change="update_slug_confirmation" phx-submit="delete_account">
+              <form id="delete-account-form" phx-change="update_slug_confirmation" phx-submit="delete_account">
                 <input
                   type="text"
                   name="slug_confirmation"
@@ -395,6 +395,7 @@ defmodule PortalWeb.Settings.Account do
       </div>
 
       <.form
+        id="account-name-form"
         for={@form}
         phx-change="change_account_name"
         phx-submit="submit_account_name"

--- a/elixir/lib/portal_web/live/sign_up.ex
+++ b/elixir/lib/portal_web/live/sign_up.ex
@@ -174,7 +174,7 @@ defmodule PortalWeb.SignUp do
       </div>
     </div>
 
-    <.form for={@form} phx-submit="submit" phx-change="validate" class="flex flex-col gap-3">
+    <.form id="sign-up-form" for={@form} phx-submit="submit" phx-change="validate" class="flex flex-col gap-3">
       <.input
         field={@form[:email]}
         type="email"

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -23,7 +23,7 @@ defmodule PortalWeb.Sites.Components do
           <.icon_button icon="ri-close-line" title="Close (Esc)" phx-click="close_new_site_panel" />
         </div>
         <div class="flex-1 overflow-y-auto px-5 py-4">
-          <.form for={@form} phx-change="new_site_change" phx-submit="new_site_submit">
+          <.form id="new-site-form" for={@form} phx-change="new_site_change" phx-submit="new_site_submit">
             <div class="space-y-4">
               <.input
                 label="Name"
@@ -865,6 +865,7 @@ defmodule PortalWeb.Sites.Components do
       <.site_add_resource_header />
       <.form
         :if={@resource_form}
+        id="site-add-resource-form"
         for={@resource_form}
         phx-submit="resource_submit"
         phx-change="resource_change"
@@ -1280,6 +1281,7 @@ defmodule PortalWeb.Sites.Components do
       </div>
       <.form
         :if={@form}
+        id="site-edit-form"
         for={@form}
         phx-submit="submit_site_edit_form"
         phx-change="change_site_edit_form"


### PR DESCRIPTION
Fixes a warning shown now in newer versions of LiveView about a missing `id`.