### PR TITLE
feat(android): apply log filter changes to live session

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -11,9 +11,11 @@ import dev.firezone.android.BuildConfig
 import dev.firezone.android.core.data.model.Config
 import dev.firezone.android.core.data.model.ManagedConfigStatus
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.security.MessageDigest
@@ -118,6 +120,20 @@ class Repository
         fun getConfig(): Flow<Config> =
             flow {
                 emit(getConfigSync())
+            }.flowOn(coroutineDispatcher)
+
+        // Emits the effective log filter whenever it changes in storage, whether the user edited it
+        // or an MDM pushed a new managed value, so a running session can re-apply it live.
+        fun observeLogFilter(): Flow<String> =
+            callbackFlow {
+                val listener =
+                    SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+                        if (key == LOG_FILTER_KEY || key == MANAGED_LOG_FILTER_KEY) {
+                            trySend(getConfigSync().logFilter)
+                        }
+                    }
+                sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
+                awaitClose { sharedPreferences.unregisterOnSharedPreferenceChangeListener(listener) }
             }.flowOn(coroutineDispatcher)
 
         fun getDefaultConfigSync(): Config =

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -98,12 +98,12 @@ internal class SettingsActivity : AppCompatActivity() {
             }.attach()
 
             val isUserSignedIn = intent.getBooleanExtra("isUserSignedIn", false)
-            if (isUserSignedIn) {
-                btSaveSettings.setOnClickListener {
+            btSaveSettings.setOnClickListener {
+                // The tunnel service applies the log filter live once it's persisted, so only warn
+                // about a re-login when a setting that actually invalidates the session changed.
+                if (isUserSignedIn && viewModel.requiresReLogin()) {
                     showSaveWarningDialog()
-                }
-            } else {
-                btSaveSettings.setOnClickListener {
+                } else {
                     viewModel.onSaveSettingsCompleted()
                 }
             }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -50,6 +50,10 @@ internal class SettingsViewModel
                 connectOnStart = false,
             )
 
+        // Snapshot of the persisted config as it was loaded, used to detect which
+        // fields the user actually changed when saving.
+        private var savedConfig = config
+
         // StateFlow that emits config only on load/reset, not during editing
         private val _configStateFlow = MutableStateFlow(config)
         val configStateFlow: StateFlow<Config> = _configStateFlow
@@ -61,12 +65,21 @@ internal class SettingsViewModel
             viewModelScope.launch {
                 repo.getConfig().collect {
                     config = it
+                    savedConfig = it
                     _configStateFlow.value = it
                     _managedStatusStateFlow.value = repo.getManagedStatus()
                     onFieldUpdated()
                 }
             }
         }
+
+        // The log filter is applied live by the tunnel service, so it never requires a re-login.
+        // Changing the account or the portal endpoints invalidates the current session and only
+        // takes effect after signing out and back in.
+        fun requiresReLogin(): Boolean =
+            config.authUrl != savedConfig.authUrl ||
+                config.apiUrl != savedConfig.apiUrl ||
+                config.accountSlug != savedConfig.accountSlug
 
         fun onViewResume(context: Context) {
             val directory = File(context.cacheDir.absolutePath + "/logs")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -43,8 +43,6 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
@@ -496,10 +494,11 @@ class TunnelService : VpnService() {
     // settings edits take effect live without signing out and reconnecting.
     private fun startLogFilterMonitoring() {
         logFilterJob =
-            repo
-                .observeLogFilter()
-                .onEach { directives -> sendTunnelCommand(TunnelCommand.SetLogDirectives(directives)) }
-                .launchIn(serviceScope)
+            serviceScope.launch {
+                repo.observeLogFilter().collect { directives ->
+                    sendTunnelCommand(TunnelCommand.SetLogDirectives(directives))
+                }
+            }
     }
 
     private fun stopLogFilterMonitoring() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
@@ -95,6 +97,7 @@ class TunnelService : VpnService() {
 
     private var logCleanupJob: Job? = null
     private var featureFlagPollJob: Job? = null
+    private var logFilterJob: Job? = null
 
     var startedByUser: Boolean = false
     private var commandChannel: Channel<TunnelCommand>? = null
@@ -348,6 +351,7 @@ class TunnelService : VpnService() {
                             startDisconnectMonitoring()
                             startLogCleanup()
                             startFeatureFlagPoll()
+                            startLogFilterMonitoring()
 
                             val stopReason = eventLoop(session, commandChannel!!)
 
@@ -368,6 +372,7 @@ class TunnelService : VpnService() {
                     stopNetworkMonitoring()
                     stopDisconnectMonitoring()
                     stopFeatureFlagPoll()
+                    stopLogFilterMonitoring()
 
                     // Stop the foreground notification
                     stopForeground(STOP_FOREGROUND_REMOVE)
@@ -485,6 +490,21 @@ class TunnelService : VpnService() {
         featureFlagPollJob?.cancel()
         featureFlagPollJob = null
         Log.setStreamingActive(false)
+    }
+
+    // Re-applies the log filter to the running session whenever the stored value changes, so
+    // settings edits take effect live without signing out and reconnecting.
+    private fun startLogFilterMonitoring() {
+        logFilterJob =
+            repo
+                .observeLogFilter()
+                .onEach { directives -> sendTunnelCommand(TunnelCommand.SetLogDirectives(directives)) }
+                .launchIn(serviceScope)
+    }
+
+    private fun stopLogFilterMonitoring() {
+        logFilterJob?.cancel()
+        logFilterJob = null
     }
 
     fun setServiceStateMutableStateFlow(stateFlow: MutableStateFlow<State?>) {
@@ -635,7 +655,13 @@ class TunnelService : VpnService() {
                             }
 
                             is TunnelCommand.SetLogDirectives -> {
-                                session.setLogDirectives(command.directives)
+                                // A malformed filter must not tear down the tunnel, so swallow the
+                                // error here instead of letting it bubble up to the event loop.
+                                try {
+                                    session.setLogDirectives(command.directives)
+                                } catch (e: ConnlibException) {
+                                    Log.w(TAG, "Failed to apply log directives '${command.directives}'", e)
+                                }
                             }
 
                             is TunnelCommand.SetTun -> {


### PR DESCRIPTION
Enable live log filter updates by monitoring storage changes and re-applying the filter to the active tunnel session. This allows users to adjust logging settings without signing out and reconnecting.

The tunnel service now observes log filter changes and sends them to the active session via `SetLogDirectives` commands. Error handling prevents malformed filters from disrupting the tunnel. Settings validation is updated to only require re-login when account or portal endpoint changes occur, since log filter changes take effect immediately.