### PR TITLE
feat(portal): add gateway token ui

### DIFF
--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -499,7 +499,7 @@ defmodule PortalWeb.Actors.Components do
                     type="button"
                     phx-click="confirm_delete_token"
                     phx-value-id={token.id}
-                    class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors opacity-0 group-hover/item:opacity-100"
+                    class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors"
                     title="Revoke session"
                   >
                     <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />
@@ -587,7 +587,7 @@ defmodule PortalWeb.Actors.Components do
                     type="button"
                     phx-click="confirm_delete_session"
                     phx-value-id={session.id}
-                    class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors opacity-0 group-hover/item:opacity-100"
+                    class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors"
                     title="Revoke session"
                   >
                     <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />

--- a/elixir/lib/portal_web/live/actors/components.ex
+++ b/elixir/lib/portal_web/live/actors/components.ex
@@ -316,7 +316,7 @@ defmodule PortalWeb.Actors.Components do
                     type="button"
                     phx-click="confirm_delete_identity"
                     phx-value-id={identity.id}
-                    class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors opacity-0 group-hover/item:opacity-100"
+                    class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors"
                     title="Delete identity"
                   >
                     <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />
@@ -769,7 +769,7 @@ defmodule PortalWeb.Actors.Components do
                       type="button"
                       phx-click="confirm_delete_token"
                       phx-value-id={token.id}
-                      class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors opacity-0 group-hover/item:opacity-100"
+                      class="flex items-center justify-center w-6 h-6 rounded text-subtle hover:text-error hover:bg-surface transition-colors"
                       title="Delete token"
                     >
                       <.icon name="ri-delete-bin-line" class="w-3.5 h-3.5" />

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -626,28 +626,28 @@ defmodule PortalWeb.Sites do
   end
 
   def handle_event("confirm_delete_gateway", %{"id" => gateway_id}, socket) do
-    with {:ok, gateway} <- Database.fetch_gateway(gateway_id, socket.assigns.subject),
-         {:ok, _} <- Database.delete_gateway(gateway, socket.assigns.subject) do
-      all_gateways =
-        socket.assigns.selected_site.id
-        |> Database.list_gateways_for_site(socket.assigns.subject)
-        |> Presence.Gateways.preload_gateways_presence()
+    case Database.delete_gateway_by_id(gateway_id, socket.assigns.subject) do
+      {count, _} when count > 0 ->
+        all_gateways =
+          socket.assigns.selected_site.id
+          |> Database.list_gateways_for_site(socket.assigns.subject)
+          |> Presence.Gateways.preload_gateways_presence()
 
-      gateways =
-        if socket.assigns.site_panel.show_all_gateways,
-          do: all_gateways,
-          else: Enum.filter(all_gateways, & &1.online?)
+        gateways =
+          if socket.assigns.site_panel.show_all_gateways,
+            do: all_gateways,
+            else: Enum.filter(all_gateways, & &1.online?)
 
-      {:noreply,
-       socket
-       |> put_flash(:success, "Gateway deleted.")
-       |> merge_state(:site_panel, %{
-         gateways: gateways,
-         total_gateway_count: length(all_gateways),
-         confirm_delete_gateway_id: nil,
-         expanded_gateway_id: nil
-       })}
-    else
+        {:noreply,
+         socket
+         |> put_flash(:success, "Gateway deleted.")
+         |> merge_state(:site_panel, %{
+           gateways: gateways,
+           total_gateway_count: length(all_gateways),
+           confirm_delete_gateway_id: nil,
+           expanded_gateway_id: nil
+         })}
+
       _ ->
         {:noreply,
          socket
@@ -884,19 +884,19 @@ defmodule PortalWeb.Sites do
   end
 
   def handle_event("confirm_revoke_gateway_token", %{"id" => token_id}, socket) do
-    with {:ok, token} <- Database.fetch_gateway_token(token_id, socket.assigns.subject),
-         {:ok, _} <- Database.delete_gateway_token(token, socket.assigns.subject) do
-      tokens =
-        Database.list_gateway_tokens_for_site(
-          socket.assigns.selected_site.id,
-          socket.assigns.subject
-        )
+    case Database.delete_gateway_token_by_id(token_id, socket.assigns.subject) do
+      {count, _} when count > 0 ->
+        tokens =
+          Database.list_gateway_tokens_for_site(
+            socket.assigns.selected_site.id,
+            socket.assigns.subject
+          )
 
-      {:noreply,
-       socket
-       |> put_flash(:success, "Token revoked.")
-       |> merge_state(:site_panel, %{gateway_tokens: tokens, confirm_revoke_token_id: nil})}
-    else
+        {:noreply,
+         socket
+         |> put_flash(:success, "Token revoked.")
+         |> merge_state(:site_panel, %{gateway_tokens: tokens, confirm_revoke_token_id: nil})}
+
       _ ->
         {:noreply,
          socket
@@ -915,6 +915,7 @@ defmodule PortalWeb.Sites do
 
   def handle_event("revoke_all_gateway_tokens", _params, socket) do
     site = socket.assigns.selected_site
+
     {_count, _} = Database.delete_all_gateway_tokens(site, socket.assigns.subject)
 
     {:noreply,
@@ -1216,26 +1217,20 @@ defmodule PortalWeb.Sites do
       end
     end
 
-    @spec fetch_gateway(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
-            {:ok, Device.t()} | {:error, :not_found}
-    def fetch_gateway(id, subject) do
-      result =
-        from(d in Device, as: :devices)
-        |> where([devices: d], d.id == ^id and d.type == :gateway)
-        |> Safe.scoped(subject, :replica)
-        |> Safe.one(fallback_to_primary: true)
-
-      case result do
-        nil -> {:error, :not_found}
-        gateway -> {:ok, gateway}
-      end
-    end
-
     @spec delete_gateway(Device.t(), Portal.Authentication.Subject.t()) ::
             {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
     def delete_gateway(gateway, subject) do
       Safe.scoped(gateway, subject)
       |> Safe.delete()
+    end
+
+    @spec delete_gateway_by_id(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
+            {non_neg_integer(), nil} | {:error, :unauthorized}
+    def delete_gateway_by_id(id, subject) do
+      from(d in Device, as: :devices)
+      |> where([devices: d], d.id == ^id and d.type == :gateway)
+      |> Safe.scoped(subject)
+      |> Safe.delete_all()
     end
 
     @spec list_gateway_tokens_for_site(Ecto.UUID.t(), Portal.Authentication.Subject.t()) :: [
@@ -1249,31 +1244,17 @@ defmodule PortalWeb.Sites do
       |> Safe.all()
     end
 
-    @spec fetch_gateway_token(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
-            {:ok, GatewayToken.t()} | {:error, :not_found}
-    def fetch_gateway_token(token_id, subject) do
-      result =
-        from(t in GatewayToken, as: :gateway_tokens)
-        |> where([gateway_tokens: t], t.id == ^token_id)
-        |> Safe.scoped(subject, :replica)
-        |> Safe.one(fallback_to_primary: true)
-
-      case result do
-        nil -> {:error, :not_found}
-        token -> {:ok, token}
-      end
-    end
-
-    @spec delete_gateway_token(GatewayToken.t(), Portal.Authentication.Subject.t()) ::
-            {:ok, GatewayToken.t()} | {:error, Ecto.Changeset.t()}
-    def delete_gateway_token(token, subject) do
-      token
+    @spec delete_gateway_token_by_id(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
+            {non_neg_integer(), nil} | {:error, :unauthorized}
+    def delete_gateway_token_by_id(token_id, subject) do
+      from(t in GatewayToken, as: :gateway_tokens)
+      |> where([gateway_tokens: t], t.id == ^token_id)
       |> Safe.scoped(subject)
-      |> Safe.delete()
+      |> Safe.delete_all()
     end
 
     @spec delete_all_gateway_tokens(Site.t(), Portal.Authentication.Subject.t()) ::
-            {non_neg_integer(), nil}
+            {non_neg_integer(), nil} | {:error, :unauthorized}
     def delete_all_gateway_tokens(site, subject) do
       from(t in GatewayToken, where: t.site_id == ^site.id)
       |> Safe.scoped(subject)

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -120,11 +120,12 @@ defmodule PortalWeb.Sites do
   end
 
   defp site_panel_assigns(site, params, socket) do
-    gateways =
+    all_gateways =
       site.id
       |> Database.list_gateways_for_site(socket.assigns.subject)
       |> Presence.Gateways.preload_gateways_presence()
-      |> Enum.filter(& &1.online?)
+
+    gateways = Enum.filter(all_gateways, & &1.online?)
 
     resources =
       if site.managed_by == :account do
@@ -139,13 +140,17 @@ defmodule PortalWeb.Sites do
         end
       end
 
+    gateway_tokens = Database.list_gateway_tokens_for_site(site.id, socket.assigns.subject)
+
     [
       selected_site: site,
       site_panel:
         Map.merge(base_site_panel_state(), %{
           tab: parse_site_tab(Map.get(params, "tab", "gateways")),
           gateways: gateways,
-          resources: resources
+          total_gateway_count: length(all_gateways),
+          resources: resources,
+          gateway_tokens: gateway_tokens
         }),
       site_deploy: base_site_deploy_state(),
       site_resource_form: base_site_resource_form_state(),
@@ -421,7 +426,6 @@ defmodule PortalWeb.Sites do
         account={@account}
         resources_counts={@resources_counts}
         policies_counts={@policies_counts}
-        gateway_counts={@gateway_counts}
         panel={@site_panel}
         deploy_state={@site_deploy}
         resource_form_state={@site_resource_form}
@@ -437,10 +441,15 @@ defmodule PortalWeb.Sites do
     %{
       tab: :gateways,
       gateways: [],
+      total_gateway_count: 0,
       resources: [],
+      gateway_tokens: [],
       show_all_gateways: false,
       view: :gateways,
       confirm_delete_site: false,
+      confirm_delete_gateway_id: nil,
+      confirm_revoke_token_id: nil,
+      confirm_revoke_all_tokens: false,
       expanded_gateway_id: nil
     }
   end
@@ -608,6 +617,45 @@ defmodule PortalWeb.Sites do
     {:noreply, merge_state(socket, :site_panel, %{expanded_gateway_id: expanded})}
   end
 
+  def handle_event("delete_gateway", %{"id" => gateway_id}, socket) do
+    {:noreply, merge_state(socket, :site_panel, %{confirm_delete_gateway_id: gateway_id})}
+  end
+
+  def handle_event("cancel_delete_gateway", _params, socket) do
+    {:noreply, merge_state(socket, :site_panel, %{confirm_delete_gateway_id: nil})}
+  end
+
+  def handle_event("confirm_delete_gateway", %{"id" => gateway_id}, socket) do
+    with {:ok, gateway} <- Database.fetch_gateway(gateway_id, socket.assigns.subject),
+         {:ok, _} <- Database.delete_gateway(gateway, socket.assigns.subject) do
+      all_gateways =
+        socket.assigns.selected_site.id
+        |> Database.list_gateways_for_site(socket.assigns.subject)
+        |> Presence.Gateways.preload_gateways_presence()
+
+      gateways =
+        if socket.assigns.site_panel.show_all_gateways,
+          do: all_gateways,
+          else: Enum.filter(all_gateways, & &1.online?)
+
+      {:noreply,
+       socket
+       |> put_flash(:success, "Gateway deleted.")
+       |> merge_state(:site_panel, %{
+         gateways: gateways,
+         total_gateway_count: length(all_gateways),
+         confirm_delete_gateway_id: nil,
+         expanded_gateway_id: nil
+       })}
+    else
+      _ ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Failed to delete gateway.")
+         |> merge_state(:site_panel, %{confirm_delete_gateway_id: nil})}
+    end
+  end
+
   def handle_event("show_all_gateways", _params, socket) do
     gateways =
       socket.assigns.selected_site.id
@@ -631,6 +679,8 @@ defmodule PortalWeb.Sites do
     site = socket.assigns.selected_site
     {:ok, token, encoded_token} = Database.create_gateway_token(site, socket.assigns.subject)
 
+    gateway_tokens = Database.list_gateway_tokens_for_site(site.id, socket.assigns.subject)
+
     socket =
       socket
       |> unsubscribe_deploy_site_presence()
@@ -647,7 +697,7 @@ defmodule PortalWeb.Sites do
 
     {:noreply,
      socket
-     |> merge_state(:site_panel, %{view: :deploy})
+     |> merge_state(:site_panel, %{view: :deploy, gateway_tokens: gateway_tokens})
      |> put_state(:site_deploy, %{
        env: env,
        tab: "debian-instructions",
@@ -825,6 +875,54 @@ defmodule PortalWeb.Sites do
     end
   end
 
+  def handle_event("revoke_gateway_token", %{"id" => token_id}, socket) do
+    {:noreply, merge_state(socket, :site_panel, %{confirm_revoke_token_id: token_id})}
+  end
+
+  def handle_event("cancel_revoke_gateway_token", _params, socket) do
+    {:noreply, merge_state(socket, :site_panel, %{confirm_revoke_token_id: nil})}
+  end
+
+  def handle_event("confirm_revoke_gateway_token", %{"id" => token_id}, socket) do
+    with {:ok, token} <- Database.fetch_gateway_token(token_id, socket.assigns.subject),
+         {:ok, _} <- Database.delete_gateway_token(token, socket.assigns.subject) do
+      tokens =
+        Database.list_gateway_tokens_for_site(
+          socket.assigns.selected_site.id,
+          socket.assigns.subject
+        )
+
+      {:noreply,
+       socket
+       |> put_flash(:success, "Token revoked.")
+       |> merge_state(:site_panel, %{gateway_tokens: tokens, confirm_revoke_token_id: nil})}
+    else
+      _ ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Failed to revoke token.")
+         |> merge_state(:site_panel, %{confirm_revoke_token_id: nil})}
+    end
+  end
+
+  def handle_event("confirm_revoke_all_tokens", _params, socket) do
+    {:noreply, merge_state(socket, :site_panel, %{confirm_revoke_all_tokens: true})}
+  end
+
+  def handle_event("cancel_revoke_all_tokens", _params, socket) do
+    {:noreply, merge_state(socket, :site_panel, %{confirm_revoke_all_tokens: false})}
+  end
+
+  def handle_event("revoke_all_gateway_tokens", _params, socket) do
+    site = socket.assigns.selected_site
+    {_count, _} = Database.delete_all_gateway_tokens(site, socket.assigns.subject)
+
+    {:noreply,
+     socket
+     |> put_flash(:success, "All tokens revoked.")
+     |> merge_state(:site_panel, %{gateway_tokens: [], confirm_revoke_all_tokens: false})}
+  end
+
   def handle_event("toggle_resource_filters_dropdown", _params, socket) do
     {:noreply,
      update(
@@ -883,22 +981,28 @@ defmodule PortalWeb.Sites do
       ) do
     socket = load_sites_index_data(socket)
 
-    panel_gateways =
+    {panel_gateways, total_gateway_count} =
       if socket.assigns.selected_site do
         all =
           socket.assigns.selected_site.id
           |> Database.list_gateways_for_site(socket.assigns.subject)
           |> Presence.Gateways.preload_gateways_presence()
 
-        if socket.assigns.site_panel.show_all_gateways,
-          do: all,
-          else: Enum.filter(all, & &1.online?)
+        gateways =
+          if socket.assigns.site_panel.show_all_gateways,
+            do: all,
+            else: Enum.filter(all, & &1.online?)
+
+        {gateways, length(all)}
       else
-        socket.assigns.site_panel.gateways
+        {socket.assigns.site_panel.gateways, socket.assigns.site_panel.total_gateway_count}
       end
 
     socket =
-      merge_state(socket, :site_panel, %{gateways: panel_gateways})
+      merge_state(socket, :site_panel, %{
+        gateways: panel_gateways,
+        total_gateway_count: total_gateway_count
+      })
 
     {:noreply, socket}
   end
@@ -930,6 +1034,7 @@ defmodule PortalWeb.Sites do
 
   defp parse_site_tab("resources"), do: :resources
   defp parse_site_tab("gateways"), do: :gateways
+  defp parse_site_tab("tokens"), do: :tokens
   defp parse_site_tab(_), do: :gateways
 
   defp site_deploy_connection_status(%{connected?: true}, _joins), do: :noop
@@ -979,7 +1084,7 @@ defmodule PortalWeb.Sites do
   defmodule Database do
     import Ecto.Query
     import Ecto.Changeset
-    alias Portal.{Safe, Site, Resource, Device}
+    alias Portal.{Safe, Site, Resource, Device, GatewayToken}
 
     @spec list_all_sites(Portal.Authentication.Subject.t()) :: [Site.t()]
     def list_all_sites(subject, repo \\ :replica) do
@@ -1109,6 +1214,70 @@ defmodule PortalWeb.Sites do
       with {:ok, token} <- Portal.Authentication.create_gateway_token(site, subject) do
         {:ok, %{token | secret_fragment: nil}, Portal.Authentication.encode_fragment!(token)}
       end
+    end
+
+    @spec fetch_gateway(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
+            {:ok, Device.t()} | {:error, :not_found}
+    def fetch_gateway(id, subject) do
+      result =
+        from(d in Device, as: :devices)
+        |> where([devices: d], d.id == ^id and d.type == :gateway)
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one(fallback_to_primary: true)
+
+      case result do
+        nil -> {:error, :not_found}
+        gateway -> {:ok, gateway}
+      end
+    end
+
+    @spec delete_gateway(Device.t(), Portal.Authentication.Subject.t()) ::
+            {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
+    def delete_gateway(gateway, subject) do
+      Safe.scoped(gateway, subject)
+      |> Safe.delete()
+    end
+
+    @spec list_gateway_tokens_for_site(Ecto.UUID.t(), Portal.Authentication.Subject.t()) :: [
+            GatewayToken.t()
+          ]
+    def list_gateway_tokens_for_site(site_id, subject) do
+      from(t in GatewayToken, as: :gateway_tokens)
+      |> where([gateway_tokens: t], t.site_id == ^site_id)
+      |> order_by([gateway_tokens: t], desc: t.inserted_at)
+      |> Safe.scoped(subject, :replica)
+      |> Safe.all()
+    end
+
+    @spec fetch_gateway_token(Ecto.UUID.t(), Portal.Authentication.Subject.t()) ::
+            {:ok, GatewayToken.t()} | {:error, :not_found}
+    def fetch_gateway_token(token_id, subject) do
+      result =
+        from(t in GatewayToken, as: :gateway_tokens)
+        |> where([gateway_tokens: t], t.id == ^token_id)
+        |> Safe.scoped(subject, :replica)
+        |> Safe.one(fallback_to_primary: true)
+
+      case result do
+        nil -> {:error, :not_found}
+        token -> {:ok, token}
+      end
+    end
+
+    @spec delete_gateway_token(GatewayToken.t(), Portal.Authentication.Subject.t()) ::
+            {:ok, GatewayToken.t()} | {:error, Ecto.Changeset.t()}
+    def delete_gateway_token(token, subject) do
+      token
+      |> Safe.scoped(subject)
+      |> Safe.delete()
+    end
+
+    @spec delete_all_gateway_tokens(Site.t(), Portal.Authentication.Subject.t()) ::
+            {non_neg_integer(), nil}
+    def delete_all_gateway_tokens(site, subject) do
+      from(t in GatewayToken, where: t.site_id == ^site.id)
+      |> Safe.scoped(subject)
+      |> Safe.delete_all()
     end
 
     # credo:disable-for-next-line Credo.Check.Warning.SpecWithStruct

--- a/elixir/lib/portal_web/live/sites/components.ex
+++ b/elixir/lib/portal_web/live/sites/components.ex
@@ -63,7 +63,6 @@ defmodule PortalWeb.Sites.Components do
   attr :account, :any, required: true
   attr :resources_counts, :map, required: true
   attr :policies_counts, :map, required: true
-  attr :gateway_counts, :map, required: true
   attr :panel, :map, required: true
   attr :deploy_state, :map, required: true
   attr :resource_form_state, :map, required: true
@@ -97,13 +96,9 @@ defmodule PortalWeb.Sites.Components do
 
     assigns =
       if assigns.site do
-        assigns
-        |> assign(:total_count, Map.get(assigns.gateway_counts, assigns.site.id, 0))
-        |> assign(:status, site_status(assigns.gateways, assigns.site.health_threshold))
+        assign(assigns, :status, site_status(assigns.gateways, assigns.site.health_threshold))
       else
-        assigns
-        |> assign(:total_count, 0)
-        |> assign(:status, :offline)
+        assign(assigns, :status, :offline)
       end
 
     ~H"""
@@ -132,7 +127,6 @@ defmodule PortalWeb.Sites.Components do
           panel={@panel}
           gateways={@gateways}
           resources={@resources}
-          gateway_counts={@gateway_counts}
           resources_counts={@resources_counts}
         />
 
@@ -193,7 +187,6 @@ defmodule PortalWeb.Sites.Components do
   attr :panel, :map, required: true
   attr :gateways, :list, required: true
   attr :resources, :list, required: true
-  attr :gateway_counts, :map, required: true
   attr :resources_counts, :map, required: true
 
   def site_overview_view(assigns) do
@@ -206,16 +199,19 @@ defmodule PortalWeb.Sites.Components do
           site={@site}
           tab={@tab}
           show_all_gateways={@show_all_gateways}
-          total_count={Map.get(@gateway_counts, @site.id, 0)}
+          total_count={@total_gateway_count}
           resource_count={length(@resources)}
+          gateway_tokens={@gateway_tokens}
+          confirm_revoke_all_tokens={@confirm_revoke_all_tokens}
         />
 
         <.site_gateways_tab
           :if={@tab == :gateways}
           site={@site}
           gateways={@gateways}
-          gateway_counts={@gateway_counts}
+          total_gateway_count={@total_gateway_count}
           expanded_gateway_id={@expanded_gateway_id}
+          confirm_delete_gateway_id={@confirm_delete_gateway_id}
         />
 
         <.site_resources_tab
@@ -223,6 +219,14 @@ defmodule PortalWeb.Sites.Components do
           site={@site}
           account={@account}
           resources={@resources}
+        />
+
+        <.site_tokens_tab
+          :if={@tab == :tokens}
+          site={@site}
+          gateway_tokens={@gateway_tokens}
+          confirm_revoke_token_id={@confirm_revoke_token_id}
+          confirm_revoke_all_tokens={@confirm_revoke_all_tokens}
         />
       </div>
 
@@ -236,6 +240,8 @@ defmodule PortalWeb.Sites.Components do
   attr :show_all_gateways, :boolean, required: true
   attr :total_count, :integer, required: true
   attr :resource_count, :integer, required: true
+  attr :gateway_tokens, :list, required: true
+  attr :confirm_revoke_all_tokens, :boolean, required: true
 
   def site_panel_tabs(assigns) do
     ~H"""
@@ -286,6 +292,25 @@ defmodule PortalWeb.Sites.Components do
           {@resource_count}
         </span>
       </button>
+      <button
+        phx-click="switch_panel_tab"
+        phx-value-tab="tokens"
+        class={[
+          "flex items-center gap-1.5 px-1 py-2.5 mr-5 text-xs font-medium border-b-2 transition-colors",
+          if(@tab == :tokens,
+            do: "border-brand text-brand",
+            else: "border-transparent text-body hover:text-heading hover:border-border-strong"
+          )
+        ]}
+      >
+        Tokens
+        <span class={[
+          "tabular-nums px-1.5 py-0.5 rounded text-[10px] font-semibold",
+          if(@tab == :tokens, do: "bg-brand-muted text-brand", else: "bg-raised text-subtle")
+        ]}>
+          {length(@gateway_tokens)}
+        </span>
+      </button>
       <div class="ml-auto pb-2 flex items-center gap-2">
         <.button :if={@tab == :gateways} phx-click="deploy_gateway" size="xs">
           <.icon name="ri-add-line" class="w-3 h-3" /> Deploy gateway
@@ -311,6 +336,27 @@ defmodule PortalWeb.Sites.Components do
         >
           Online only
         </.button>
+        <.button
+          :if={@tab == :tokens and @gateway_tokens != [] and not @confirm_revoke_all_tokens}
+          type="button"
+          style="danger"
+          size="xs"
+          phx-click="confirm_revoke_all_tokens"
+        >
+          <.icon name="ri-delete-bin-line" class="w-3 h-3" /> Revoke all tokens
+        </.button>
+        <div
+          :if={@tab == :tokens and @confirm_revoke_all_tokens}
+          class="flex items-center gap-2"
+        >
+          <span class="text-xs text-error">Revoke all tokens?</span>
+          <.button type="button" phx-click="cancel_revoke_all_tokens" size="xs">
+            Cancel
+          </.button>
+          <.button type="button" phx-click="revoke_all_gateway_tokens" style="danger" size="xs">
+            Revoke all
+          </.button>
+        </div>
       </div>
     </div>
     """
@@ -318,8 +364,9 @@ defmodule PortalWeb.Sites.Components do
 
   attr :site, :any, required: true
   attr :gateways, :list, required: true
-  attr :gateway_counts, :map, required: true
+  attr :total_gateway_count, :integer, required: true
   attr :expanded_gateway_id, :string, default: nil
+  attr :confirm_delete_gateway_id, :string, default: nil
 
   def site_gateways_tab(assigns) do
     ~H"""
@@ -327,11 +374,25 @@ defmodule PortalWeb.Sites.Components do
       <ul>
         <li
           :for={gateway <- @gateways}
-          phx-click="toggle_gateway_expand"
-          phx-value-id={gateway.id}
-          class="border-b border-border hover:bg-raised cursor-pointer transition-colors group"
+          class={[
+            "border-b border-border transition-colors",
+            if(@confirm_delete_gateway_id == gateway.id,
+              do: "bg-error-light",
+              else: ""
+            )
+          ]}
         >
-          <div class="flex items-center gap-3 px-5 py-3">
+          <%!-- Normal clickable row --%>
+          <div
+            :if={@confirm_delete_gateway_id != gateway.id}
+            phx-click="toggle_gateway_expand"
+            phx-value-id={gateway.id}
+            class="flex items-center gap-3 px-5 py-3 cursor-pointer hover:bg-raised transition-colors group"
+          >
+            <.ping_icon
+              color={if gateway.online?, do: "success", else: "danger"}
+              title={if gateway.online?, do: "Online", else: "Offline"}
+            />
             <div class="flex items-center justify-center w-7 h-7 rounded border border-border-strong bg-raised shrink-0">
               <svg
                 class="w-3.5 h-3.5 text-subtle"
@@ -350,25 +411,17 @@ defmodule PortalWeb.Sites.Components do
               <p class="font-mono text-sm font-medium text-heading truncate group-hover:text-brand transition-colors">
                 {gateway.name}
               </p>
-              <p
-                :if={gateway.latest_session}
-                class="font-mono text-xs text-subtle mt-0.5"
-              >
+              <p :if={gateway.latest_session} class="font-mono text-xs text-subtle mt-0.5">
                 {gateway.latest_session.remote_ip}
               </p>
             </div>
-            <span :if={gateway.online?} class="inline-flex items-center gap-1.5 shrink-0">
-              <span class="relative flex items-center justify-center w-1.5 h-1.5">
-                <span class="absolute inline-flex rounded-full opacity-60 animate-ping w-1.5 h-1.5 bg-success">
-                </span>
-                <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-success">
-                </span>
-              </span>
-            </span>
-            <span :if={not gateway.online?} class="inline-flex items-center gap-1.5 shrink-0">
-              <span class="relative inline-flex rounded-full w-1.5 h-1.5 bg-neutral-status">
-              </span>
-            </span>
+            <.icon_button
+              icon="ri-delete-bin-line"
+              title="Delete gateway"
+              phx-click="delete_gateway"
+              phx-value-id={gateway.id}
+              class="text-subtle hover:text-error shrink-0"
+            />
             <.icon
               name={
                 if @expanded_gateway_id == gateway.id,
@@ -378,8 +431,52 @@ defmodule PortalWeb.Sites.Components do
               class="w-4 h-4 text-subtle shrink-0"
             />
           </div>
+          <%!-- Confirm delete row --%>
           <div
-            :if={@expanded_gateway_id == gateway.id}
+            :if={@confirm_delete_gateway_id == gateway.id}
+            class="flex items-center gap-3 px-5 py-3"
+          >
+            <.ping_icon
+              color={if gateway.online?, do: "success", else: "danger"}
+              title={if gateway.online?, do: "Online", else: "Offline"}
+            />
+            <div class="flex items-center justify-center w-7 h-7 rounded border border-border-strong bg-raised shrink-0">
+              <svg
+                class="w-3.5 h-3.5 text-subtle"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <rect x="1.5" y="4" width="13" height="8" rx="1" />
+                <circle cx="4" cy="8" r="0.75" fill="currentColor" stroke="none" />
+                <circle cx="6.5" cy="8" r="0.75" fill="currentColor" stroke="none" />
+                <path d="M10 8h3.5" />
+              </svg>
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="font-mono text-sm font-medium text-heading truncate">{gateway.name}</p>
+              <p :if={gateway.latest_session} class="font-mono text-xs text-subtle mt-0.5">
+                {gateway.latest_session.remote_ip}
+              </p>
+            </div>
+            <span class="text-xs text-error shrink-0">Delete this gateway?</span>
+            <.button type="button" phx-click="cancel_delete_gateway" size="xs">
+              Cancel
+            </.button>
+            <.button
+              type="button"
+              style="danger"
+              size="xs"
+              phx-click="confirm_delete_gateway"
+              phx-value-id={gateway.id}
+            >
+              Delete
+            </.button>
+          </div>
+          <%!-- Expanded details --%>
+          <div
+            :if={@expanded_gateway_id == gateway.id and @confirm_delete_gateway_id != gateway.id}
             class="px-5 pb-3 pt-1 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5"
           >
             <span class="text-xs text-subtle">Last started</span>
@@ -414,7 +511,7 @@ defmodule PortalWeb.Sites.Components do
         </li>
       </ul>
       <div
-        :if={@gateways == [] and Map.get(@gateway_counts, @site.id, 0) == 0}
+        :if={@gateways == [] and @total_gateway_count == 0}
         class="flex flex-col items-center justify-center gap-3 py-16"
       >
         <p class="text-sm text-subtle">No gateways deployed to this site.</p>
@@ -426,7 +523,7 @@ defmodule PortalWeb.Sites.Components do
         </button>
       </div>
       <div
-        :if={@gateways == [] and Map.get(@gateway_counts, @site.id, 0) > 0}
+        :if={@gateways == [] and @total_gateway_count > 0}
         class="flex items-center justify-center py-16"
       >
         <p class="text-sm text-subtle">
@@ -469,6 +566,65 @@ defmodule PortalWeb.Sites.Components do
         <.button :if={@site.managed_by == :account} phx-click="add_resource" size="xs">
           <.icon name="ri-add-line" class="w-3.5 h-3.5" /> Add a resource
         </.button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :site, :any, required: true
+  attr :gateway_tokens, :list, required: true
+  attr :confirm_revoke_token_id, :string, default: nil
+  attr :confirm_revoke_all_tokens, :boolean, required: true
+
+  def site_tokens_tab(assigns) do
+    ~H"""
+    <div class="flex-1 overflow-y-auto">
+      <ul>
+        <li
+          :for={token <- @gateway_tokens}
+          class={[
+            "border-b border-border px-5 py-3 transition-colors",
+            if(@confirm_revoke_token_id == token.id, do: "bg-error-light", else: "")
+          ]}
+        >
+          <div class="flex items-center gap-3">
+            <div class="flex items-center justify-center w-7 h-7 rounded border border-border-strong bg-raised shrink-0">
+              <.icon name="ri-key-line" class="w-3.5 h-3.5 text-subtle" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="font-mono text-xs text-body truncate">{token.id}</p>
+              <p class="text-[10px] text-subtle mt-0.5">
+                Created <.relative_datetime datetime={token.inserted_at} popover={false} />
+              </p>
+            </div>
+            <.icon_button
+              :if={@confirm_revoke_token_id != token.id}
+              icon="ri-delete-bin-line"
+              title="Revoke token"
+              phx-click="revoke_gateway_token"
+              phx-value-id={token.id}
+              class="text-subtle hover:text-error shrink-0"
+            />
+            <div :if={@confirm_revoke_token_id == token.id} class="flex items-center gap-2 shrink-0">
+              <span class="text-xs text-error">Revoke this token?</span>
+              <.button type="button" phx-click="cancel_revoke_gateway_token" size="xs">
+                Cancel
+              </.button>
+              <.button
+                type="button"
+                style="danger"
+                size="xs"
+                phx-click="confirm_revoke_gateway_token"
+                phx-value-id={token.id}
+              >
+                Revoke
+              </.button>
+            </div>
+          </div>
+        </li>
+      </ul>
+      <div :if={@gateway_tokens == []} class="flex flex-col items-center justify-center gap-3 py-16">
+        <p class="text-sm text-subtle">No tokens for this site.</p>
       </div>
     </div>
     """

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -1,13 +1,14 @@
 defmodule PortalWeb.SitesTest do
   use PortalWeb.ConnCase, async: true
 
-  alias Portal.{Device, Repo, Resource, Site}
+  alias Portal.{Device, GatewayToken, Repo, Resource, Site}
 
   import Portal.AccountFixtures
   import Portal.ActorFixtures
   import Portal.DeviceFixtures
   import Portal.ResourceFixtures
   import Portal.SiteFixtures
+  import Portal.TokenFixtures
 
   setup do
     account = account_fixture()
@@ -418,6 +419,167 @@ defmodule PortalWeb.SitesTest do
 
       assert to == ~p"/#{account}/sites"
       assert flash["error"] =~ "Site does not exist"
+    end
+  end
+
+  describe "gateways tab" do
+    test "deletes a gateway via inline confirmation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}")
+
+      render_click(lv, "show_all_gateways")
+      html = render_click(lv, "delete_gateway", %{"id" => gateway.id})
+      assert html =~ "Delete this gateway?"
+
+      html = render_click(lv, "confirm_delete_gateway", %{"id" => gateway.id})
+      assert html =~ "Gateway deleted."
+      refute html =~ gateway.name
+      assert is_nil(Repo.get_by(Device, account_id: account.id, id: gateway.id))
+    end
+
+    test "cancel delete gateway dismisses the inline confirmation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      gateway = gateway_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}")
+
+      render_click(lv, "show_all_gateways")
+      render_click(lv, "delete_gateway", %{"id" => gateway.id})
+      assert has_element?(lv, "span", "Delete this gateway?")
+
+      html = render_click(lv, "cancel_delete_gateway")
+      refute html =~ "Delete this gateway?"
+      assert html =~ gateway.name
+      assert Repo.get_by(Device, account_id: account.id, id: gateway.id)
+    end
+  end
+
+  describe "tokens tab" do
+    test "renders existing tokens on the tokens tab", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      token1 = gateway_token_fixture(account: account, site: site)
+      token2 = gateway_token_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}?tab=tokens")
+
+      html = render(lv)
+      assert html =~ token1.id
+      assert html =~ token2.id
+      assert html =~ "Tokens"
+    end
+
+    test "revokes a single gateway token via inline confirmation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      token = gateway_token_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}?tab=tokens")
+
+      html = render_click(lv, "revoke_gateway_token", %{"id" => token.id})
+      assert html =~ "Revoke this token?"
+
+      html = render_click(lv, "confirm_revoke_gateway_token", %{"id" => token.id})
+      assert html =~ "Token revoked."
+      refute html =~ token.id
+      refute Repo.get_by(GatewayToken, account_id: account.id, id: token.id)
+    end
+
+    test "cancel revoke single token dismisses the inline confirmation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      token = gateway_token_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}?tab=tokens")
+
+      render_click(lv, "revoke_gateway_token", %{"id" => token.id})
+      assert has_element?(lv, "span", "Revoke this token?")
+
+      html = render_click(lv, "cancel_revoke_gateway_token")
+      refute html =~ "Revoke this token?"
+      assert html =~ token.id
+      assert Repo.get_by(GatewayToken, account_id: account.id, id: token.id)
+    end
+
+    test "revoke all tokens shows confirmation then deletes all", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      token1 = gateway_token_fixture(account: account, site: site)
+      token2 = gateway_token_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}?tab=tokens")
+
+      html = render_click(lv, "confirm_revoke_all_tokens")
+      assert html =~ "Revoke all tokens?"
+
+      html = render_click(lv, "revoke_all_gateway_tokens")
+      assert html =~ "All tokens revoked."
+      refute html =~ token1.id
+      refute html =~ token2.id
+      refute Repo.get_by(GatewayToken, account_id: account.id, id: token1.id)
+      refute Repo.get_by(GatewayToken, account_id: account.id, id: token2.id)
+    end
+
+    test "cancel revoke all tokens dismisses the confirmation", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+      token = gateway_token_fixture(account: account, site: site)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}?tab=tokens")
+
+      render_click(lv, "confirm_revoke_all_tokens")
+      assert has_element?(lv, "span", "Revoke all tokens?")
+
+      html = render_click(lv, "cancel_revoke_all_tokens")
+      refute html =~ "Revoke all tokens?"
+      assert html =~ token.id
+      assert Repo.get_by(GatewayToken, account_id: account.id, id: token.id)
     end
   end
 


### PR DESCRIPTION
Add a UI tab on the Sites show panel to allow admins to see all gateway tokens they've provisioned, delete a specific gateway token, or delete all provisioned gateway tokens for a Site.