### PR TITLE
refactor(connlib): do not re-evaluate path on WireGuard re-key

### DIFF
--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -21,6 +21,9 @@ pub struct PathAgent {
     /// `true` once the first handshake has been taken over — later
     /// inits are re-keys.
     established: bool,
+    /// `true` while an outbound re-key init awaits its response; a second
+    /// init in this state is an unanswered retry, i.e. failure evidence.
+    awaiting_rekey_response: bool,
 
     window: EvaluationWindow,
     responder: Responder,
@@ -132,6 +135,7 @@ impl PathAgent {
             pairs: BTreeMap::new(),
             primary: None,
             established: false,
+            awaiting_rekey_response: false,
             window: EvaluationWindow::Pending,
             responder: Responder::default(),
             outbound_init: None,
@@ -350,14 +354,21 @@ impl PathAgent {
                 self.established = true;
             }
             Ok(Packet::HandshakeInit(_)) => {
-                tracing::debug!(
-                    bytes = bytes.len(),
-                    "Re-key HandshakeInit; restarting probes"
-                );
-
-                self.reopen_evaluation_window(now);
+                let is_retry = std::mem::replace(&mut self.awaiting_rekey_response, true);
 
                 if let Some((local, remote)) = self.primary {
+                    // A routine re-key rides the primary without restarting
+                    // probes; an unanswered one is failure evidence.
+                    if is_retry {
+                        tracing::debug!(
+                            bytes = bytes.len(),
+                            "Unanswered re-key HandshakeInit; restarting probes"
+                        );
+                        self.reopen_evaluation_window(now);
+                    } else {
+                        tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
+                    }
+
                     self.pending_transmits.push_back(Transmit {
                         local,
                         remote,
@@ -366,6 +377,7 @@ impl PathAgent {
                 } else {
                     // Lost the primary mid-session (roam, candidate
                     // retraction); fan out like the initial bootstrap.
+                    self.reopen_evaluation_window(now);
                     self.outbound_init = Some(OutboundInit {
                         bytes,
                         retransmits: BTreeMap::new(),
@@ -492,12 +504,16 @@ impl PathAgent {
                 // against `last_init`/`last_init_path`.
                 self.responder.last_init = Some(bytes.to_vec());
                 self.responder.last_init_path = Some(path);
-                // A fresh inbound init (a roam re-keys to a new address)
-                // restarts evaluation unconditionally, even mid-window:
-                // the previous window's RTTs are stale and must not keep
-                // a now-dead pair as primary. Duplicates were dropped above.
-                self.restart_evaluation(now);
-                self.maybe_adopt_handshake_primary(is_handshake, path, now);
+                self.awaiting_rekey_response = false;
+                // An init on the current primary is a routine re-key. Only an
+                // init from a new path (a roam re-keys to a new address)
+                // restarts evaluation, even mid-window: the previous window's
+                // RTTs are stale and must not keep a now-dead pair as primary.
+                // Duplicates were dropped above.
+                if self.primary != Some(path) {
+                    self.restart_evaluation(now);
+                    self.maybe_adopt_handshake_primary(is_handshake, path, now);
+                }
 
                 for b in outbound {
                     self.handle_outbound(b, now);
@@ -538,8 +554,13 @@ impl PathAgent {
 
                 self.outbound_init = None;
                 self.forwarded_response = Some(bytes.to_vec());
-                self.reopen_evaluation_window(now);
-                self.maybe_adopt_handshake_primary(is_handshake, path, now);
+                self.awaiting_rekey_response = false;
+                // A response on the current primary completes a routine
+                // re-key; only one from a new path re-evaluates.
+                if self.primary != Some(path) {
+                    self.reopen_evaluation_window(now);
+                    self.maybe_adopt_handshake_primary(is_handshake, path, now);
+                }
 
                 for b in outbound {
                     self.handle_outbound(b, now);

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -81,11 +81,6 @@ struct InflightProbe {
     sent_at: Instant,
 }
 
-/// An outbound `HandshakeInit`, stored until its response arrives.
-///
-/// With a primary, `drive_handshake_retransmits` stays quiet and the
-/// stored init only tracks whether a response arrived. Without one,
-/// it fans out on the relay pairs like the initial bootstrap.
 struct OutboundInit {
     bytes: Vec<u8>,
     retransmits: BTreeMap<(SocketAddr, SocketAddr), PairRetransmit>,
@@ -361,7 +356,7 @@ impl PathAgent {
 
                 self.forwarded_response = None;
                 self.established = true;
-                *outbound_init = Some(OutboundInit::new(bytes, now));
+                outbound_init.replace(OutboundInit::new(bytes, now));
             }
             // A still-stored init means the previous one went unanswered:
             // failure evidence. Retry on the incumbent while probes
@@ -372,7 +367,7 @@ impl PathAgent {
                     "Unanswered re-key HandshakeInit; restarting probes"
                 );
 
-                *outbound_init = Some(OutboundInit::new(bytes.clone(), now));
+                outbound_init.replace(OutboundInit::new(bytes.clone(), now));
                 self.pending_transmits.push_back(Transmit {
                     local,
                     remote,
@@ -384,7 +379,7 @@ impl PathAgent {
             (Ok(Packet::HandshakeInit(_)), outbound_init @ None, Some((local, remote))) => {
                 tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
 
-                *outbound_init = Some(OutboundInit::new(bytes.clone(), now));
+                outbound_init.replace(OutboundInit::new(bytes.clone(), now));
                 self.pending_transmits.push_back(Transmit {
                     local,
                     remote,
@@ -399,7 +394,7 @@ impl PathAgent {
                     "Re-key HandshakeInit without a primary; fanning out"
                 );
 
-                *outbound_init = Some(OutboundInit::new(bytes, now));
+                outbound_init.replace(OutboundInit::new(bytes, now));
                 self.reopen_evaluation_window(now);
             }
             (Ok(Packet::HandshakeResponse(_)), _, _) => {

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -342,27 +342,49 @@ impl PathAgent {
 
                 self.forwarded_response = None;
                 self.established = true;
-                self.record_outbound_init(bytes, now);
+                self.store_outbound_init(bytes, now);
             }
-            // A still-stored init means the previous one went unanswered,
-            // and a lost primary (roam, candidate retraction) has nothing
-            // to ride: both are failure evidence.
-            Ok(Packet::HandshakeInit(_))
-                if self.outbound_init.is_some() || self.primary.is_none() =>
-            {
-                tracing::debug!(
-                    bytes = bytes.len(),
-                    "Re-key HandshakeInit; restarting probes"
-                );
+            Ok(Packet::HandshakeInit(_)) => match self.primary {
+                // A still-stored init means the previous one went unanswered:
+                // failure evidence. Retry on the incumbent while probes
+                // re-evaluate.
+                Some((local, remote)) if self.outbound_init.is_some() => {
+                    tracing::debug!(
+                        bytes = bytes.len(),
+                        "Unanswered re-key HandshakeInit; restarting probes"
+                    );
 
-                self.reopen_evaluation_window(now);
-                self.record_outbound_init(bytes, now);
-            }
-            Ok(Packet::HandshakeInit(_)) => {
-                tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
+                    self.reopen_evaluation_window(now);
+                    self.pending_transmits.push_back(Transmit {
+                        local,
+                        remote,
+                        payload: Payload::Ciphertext(bytes.clone()),
+                    });
+                    self.store_outbound_init(bytes, now);
+                }
+                // A routine re-key rides the primary without restarting probes.
+                Some((local, remote)) => {
+                    tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
 
-                self.record_outbound_init(bytes, now);
-            }
+                    self.pending_transmits.push_back(Transmit {
+                        local,
+                        remote,
+                        payload: Payload::Ciphertext(bytes.clone()),
+                    });
+                    self.store_outbound_init(bytes, now);
+                }
+                // Lost the primary mid-session (roam, candidate retraction):
+                // fan out like the initial bootstrap.
+                None => {
+                    tracing::debug!(
+                        bytes = bytes.len(),
+                        "Re-key HandshakeInit without a primary; fanning out"
+                    );
+
+                    self.reopen_evaluation_window(now);
+                    self.store_outbound_init(bytes, now);
+                }
+            },
             Ok(Packet::HandshakeResponse(_)) => {
                 if let (Some(init_bytes), Some(path)) = (
                     self.responder.last_init.take(),
@@ -399,21 +421,12 @@ impl PathAgent {
         }
     }
 
-    /// Sends the init on the primary (if any) and stores it until the
-    /// response arrives.
+    /// Stores the init until its response arrives.
     ///
     /// With a primary, `drive_handshake_retransmits` stays quiet and the
     /// stored init only tracks whether a response arrived. Without one,
-    /// it fans out like the initial bootstrap.
-    fn record_outbound_init(&mut self, bytes: Vec<u8>, now: Instant) {
-        if let Some((local, remote)) = self.primary {
-            self.pending_transmits.push_back(Transmit {
-                local,
-                remote,
-                payload: Payload::Ciphertext(bytes.clone()),
-            });
-        }
-
+    /// it fans out on the relay pairs like the initial bootstrap.
+    fn store_outbound_init(&mut self, bytes: Vec<u8>, now: Instant) {
         self.outbound_init = Some(OutboundInit {
             bytes,
             retransmits: BTreeMap::new(),

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -344,47 +344,48 @@ impl PathAgent {
                 self.established = true;
                 self.store_outbound_init(bytes, now);
             }
-            Ok(Packet::HandshakeInit(_)) => match self.primary {
-                // A still-stored init means the previous one went unanswered:
-                // failure evidence. Retry on the incumbent while probes
-                // re-evaluate.
-                Some((local, remote)) if self.outbound_init.is_some() => {
-                    tracing::debug!(
-                        bytes = bytes.len(),
-                        "Unanswered re-key HandshakeInit; restarting probes"
-                    );
+            // A still-stored init means the previous one went unanswered:
+            // failure evidence. Retry on the incumbent while probes
+            // re-evaluate.
+            Ok(Packet::HandshakeInit(_))
+                if let Some((local, remote)) = self.primary
+                    && self.outbound_init.is_some() =>
+            {
+                tracing::debug!(
+                    bytes = bytes.len(),
+                    "Unanswered re-key HandshakeInit; restarting probes"
+                );
 
-                    self.reopen_evaluation_window(now);
-                    self.pending_transmits.push_back(Transmit {
-                        local,
-                        remote,
-                        payload: Payload::Ciphertext(bytes.clone()),
-                    });
-                    self.store_outbound_init(bytes, now);
-                }
-                // A routine re-key rides the primary without restarting probes.
-                Some((local, remote)) => {
-                    tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
+                self.reopen_evaluation_window(now);
+                self.pending_transmits.push_back(Transmit {
+                    local,
+                    remote,
+                    payload: Payload::Ciphertext(bytes.clone()),
+                });
+                self.store_outbound_init(bytes, now);
+            }
+            // A routine re-key rides the primary without restarting probes.
+            Ok(Packet::HandshakeInit(_)) if let Some((local, remote)) = self.primary => {
+                tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
 
-                    self.pending_transmits.push_back(Transmit {
-                        local,
-                        remote,
-                        payload: Payload::Ciphertext(bytes.clone()),
-                    });
-                    self.store_outbound_init(bytes, now);
-                }
-                // Lost the primary mid-session (roam, candidate retraction):
-                // fan out like the initial bootstrap.
-                None => {
-                    tracing::debug!(
-                        bytes = bytes.len(),
-                        "Re-key HandshakeInit without a primary; fanning out"
-                    );
+                self.pending_transmits.push_back(Transmit {
+                    local,
+                    remote,
+                    payload: Payload::Ciphertext(bytes.clone()),
+                });
+                self.store_outbound_init(bytes, now);
+            }
+            // Lost the primary mid-session (roam, candidate retraction):
+            // fan out like the initial bootstrap.
+            Ok(Packet::HandshakeInit(_)) => {
+                tracing::debug!(
+                    bytes = bytes.len(),
+                    "Re-key HandshakeInit without a primary; fanning out"
+                );
 
-                    self.reopen_evaluation_window(now);
-                    self.store_outbound_init(bytes, now);
-                }
-            },
+                self.reopen_evaluation_window(now);
+                self.store_outbound_init(bytes, now);
+            }
             Ok(Packet::HandshakeResponse(_)) => {
                 if let (Some(init_bytes), Some(path)) = (
                     self.responder.last_init.take(),

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -21,9 +21,6 @@ pub struct PathAgent {
     /// `true` once the first handshake has been taken over — later
     /// inits are re-keys.
     established: bool,
-    /// `true` while an outbound re-key init awaits its response; a second
-    /// init in this state is an unanswered retry, i.e. failure evidence.
-    awaiting_rekey_response: bool,
 
     window: EvaluationWindow,
     responder: Responder,
@@ -135,7 +132,6 @@ impl PathAgent {
             pairs: BTreeMap::new(),
             primary: None,
             established: false,
-            awaiting_rekey_response: false,
             window: EvaluationWindow::Pending,
             responder: Responder::default(),
             outbound_init: None,
@@ -354,36 +350,39 @@ impl PathAgent {
                 self.established = true;
             }
             Ok(Packet::HandshakeInit(_)) => {
-                let is_retry = std::mem::replace(&mut self.awaiting_rekey_response, true);
+                // A still-stored init means the previous one went unanswered:
+                // failure evidence. A routine re-key rides the primary without
+                // restarting probes.
+                let unanswered = self.outbound_init.is_some();
+
+                if unanswered || self.primary.is_none() {
+                    tracing::debug!(
+                        bytes = bytes.len(),
+                        "Re-key HandshakeInit; restarting probes"
+                    );
+
+                    self.reopen_evaluation_window(now);
+                } else {
+                    tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
+                }
 
                 if let Some((local, remote)) = self.primary {
-                    // A routine re-key rides the primary without restarting
-                    // probes; an unanswered one is failure evidence.
-                    if is_retry {
-                        tracing::debug!(
-                            bytes = bytes.len(),
-                            "Unanswered re-key HandshakeInit; restarting probes"
-                        );
-                        self.reopen_evaluation_window(now);
-                    } else {
-                        tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
-                    }
-
                     self.pending_transmits.push_back(Transmit {
                         local,
                         remote,
-                        payload: Payload::Ciphertext(bytes),
-                    });
-                } else {
-                    // Lost the primary mid-session (roam, candidate
-                    // retraction); fan out like the initial bootstrap.
-                    self.reopen_evaluation_window(now);
-                    self.outbound_init = Some(OutboundInit {
-                        bytes,
-                        retransmits: BTreeMap::new(),
-                        started_at: now,
+                        payload: Payload::Ciphertext(bytes.clone()),
                     });
                 }
+
+                // With a primary, `drive_handshake_retransmits` stays quiet;
+                // the stored init only tracks whether a response arrived.
+                // Without one (roam, candidate retraction), it fans out like
+                // the initial bootstrap.
+                self.outbound_init = Some(OutboundInit {
+                    bytes,
+                    retransmits: BTreeMap::new(),
+                    started_at: now,
+                });
             }
             Ok(Packet::HandshakeResponse(_)) => {
                 if let (Some(init_bytes), Some(path)) = (
@@ -504,7 +503,6 @@ impl PathAgent {
                 // against `last_init`/`last_init_path`.
                 self.responder.last_init = Some(bytes.to_vec());
                 self.responder.last_init_path = Some(path);
-                self.awaiting_rekey_response = false;
                 // An init on the current primary is a routine re-key. Only an
                 // init from a new path (a roam re-keys to a new address)
                 // restarts evaluation, even mid-window: the previous window's
@@ -554,7 +552,6 @@ impl PathAgent {
 
                 self.outbound_init = None;
                 self.forwarded_response = Some(bytes.to_vec());
-                self.awaiting_rekey_response = false;
                 // A response on the current primary completes a routine
                 // re-key; only one from a new path re-evaluates.
                 if self.primary != Some(path) {
@@ -704,13 +701,20 @@ impl PathAgent {
             .and_then(|i| i.retransmits.values().map(|r| r.next_fire_at).min());
         let next_probe = self.pairs.values().filter_map(|s| s.next_probe_at).min();
         // Wake immediately if a buffered init is waiting on a relay
-        // pair that landed after the initial fanout.
-        let pending_fanout = self.outbound_init.as_ref().and_then(|i| {
-            self.pairs
-                .iter()
-                .any(|(addrs, state)| state.involves_relay() && !i.retransmits.contains_key(addrs))
-                .then_some(i.started_at)
-        });
+        // pair that landed after the initial fanout. With a primary, the
+        // init rode it directly and there is nothing to fan out.
+        let pending_fanout = self
+            .outbound_init
+            .as_ref()
+            .filter(|_| self.primary.is_none())
+            .and_then(|i| {
+                self.pairs
+                    .iter()
+                    .any(|(addrs, state)| {
+                        state.involves_relay() && !i.retransmits.contains_key(addrs)
+                    })
+                    .then_some(i.started_at)
+            });
         let dedup_expiry = self
             .responder
             .dedup
@@ -767,6 +771,12 @@ impl PathAgent {
     }
 
     fn drive_handshake_retransmits(&mut self, now: Instant) {
+        // With a primary, the init rode it directly; boringtun's re-key
+        // timer is the retry mechanism, not the fanout ladder.
+        if self.primary.is_some() {
+            return;
+        }
+
         let pending = &mut self.pending_transmits;
         let Some(outbound) = self.outbound_init.as_mut() else {
             return;

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -81,12 +81,27 @@ struct InflightProbe {
     sent_at: Instant,
 }
 
+/// An outbound `HandshakeInit`, stored until its response arrives.
+///
+/// With a primary, `drive_handshake_retransmits` stays quiet and the
+/// stored init only tracks whether a response arrived. Without one,
+/// it fans out on the relay pairs like the initial bootstrap.
 struct OutboundInit {
     bytes: Vec<u8>,
     retransmits: BTreeMap<(SocketAddr, SocketAddr), PairRetransmit>,
     /// Reset when relay pairs arrive late so `EVALUATION_WINDOW`
     /// doesn't count waiting time.
     started_at: Instant,
+}
+
+impl OutboundInit {
+    fn new(bytes: Vec<u8>, started_at: Instant) -> Self {
+        Self {
+            bytes,
+            retransmits: BTreeMap::new(),
+            started_at,
+        }
+    }
 }
 
 struct ResponderDedup {
@@ -336,57 +351,58 @@ impl PathAgent {
     }
 
     pub fn handle_outbound(&mut self, bytes: Vec<u8>, now: Instant) {
-        match Tunn::parse_incoming_packet(&bytes) {
-            Ok(Packet::HandshakeInit(_)) if !self.established => {
+        match (
+            Tunn::parse_incoming_packet(&bytes),
+            &mut self.outbound_init,
+            self.primary,
+        ) {
+            (Ok(Packet::HandshakeInit(_)), outbound_init, _) if !self.established => {
                 tracing::debug!(bytes = bytes.len(), "Buffered initial HandshakeInit");
 
                 self.forwarded_response = None;
                 self.established = true;
-                self.store_outbound_init(bytes, now);
+                *outbound_init = Some(OutboundInit::new(bytes, now));
             }
             // A still-stored init means the previous one went unanswered:
             // failure evidence. Retry on the incumbent while probes
             // re-evaluate.
-            Ok(Packet::HandshakeInit(_))
-                if let Some((local, remote)) = self.primary
-                    && self.outbound_init.is_some() =>
-            {
+            (Ok(Packet::HandshakeInit(_)), outbound_init @ Some(_), Some((local, remote))) => {
                 tracing::debug!(
                     bytes = bytes.len(),
                     "Unanswered re-key HandshakeInit; restarting probes"
                 );
 
-                self.reopen_evaluation_window(now);
+                *outbound_init = Some(OutboundInit::new(bytes.clone(), now));
                 self.pending_transmits.push_back(Transmit {
                     local,
                     remote,
-                    payload: Payload::Ciphertext(bytes.clone()),
+                    payload: Payload::Ciphertext(bytes),
                 });
-                self.store_outbound_init(bytes, now);
+                self.reopen_evaluation_window(now);
             }
             // A routine re-key rides the primary without restarting probes.
-            Ok(Packet::HandshakeInit(_)) if let Some((local, remote)) = self.primary => {
+            (Ok(Packet::HandshakeInit(_)), outbound_init @ None, Some((local, remote))) => {
                 tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
 
+                *outbound_init = Some(OutboundInit::new(bytes.clone(), now));
                 self.pending_transmits.push_back(Transmit {
                     local,
                     remote,
-                    payload: Payload::Ciphertext(bytes.clone()),
+                    payload: Payload::Ciphertext(bytes),
                 });
-                self.store_outbound_init(bytes, now);
             }
             // Lost the primary mid-session (roam, candidate retraction):
             // fan out like the initial bootstrap.
-            Ok(Packet::HandshakeInit(_)) => {
+            (Ok(Packet::HandshakeInit(_)), outbound_init, None) => {
                 tracing::debug!(
                     bytes = bytes.len(),
                     "Re-key HandshakeInit without a primary; fanning out"
                 );
 
+                *outbound_init = Some(OutboundInit::new(bytes, now));
                 self.reopen_evaluation_window(now);
-                self.store_outbound_init(bytes, now);
             }
-            Ok(Packet::HandshakeResponse(_)) => {
+            (Ok(Packet::HandshakeResponse(_)), _, _) => {
                 if let (Some(init_bytes), Some(path)) = (
                     self.responder.last_init.take(),
                     self.responder.last_init_path.take(),
@@ -410,29 +426,16 @@ impl PathAgent {
                     self.established = true;
                 }
             }
-            _ => {
-                if let Some((local, remote)) = self.primary {
-                    self.pending_transmits.push_back(Transmit {
-                        local,
-                        remote,
-                        payload: Payload::Ciphertext(bytes),
-                    });
-                }
+            // Probes and data ride the primary; nothing to send without one.
+            (_, _, Some((local, remote))) => {
+                self.pending_transmits.push_back(Transmit {
+                    local,
+                    remote,
+                    payload: Payload::Ciphertext(bytes),
+                });
             }
+            (_, _, None) => {}
         }
-    }
-
-    /// Stores the init until its response arrives.
-    ///
-    /// With a primary, `drive_handshake_retransmits` stays quiet and the
-    /// stored init only tracks whether a response arrived. Without one,
-    /// it fans out on the relay pairs like the initial bootstrap.
-    fn store_outbound_init(&mut self, bytes: Vec<u8>, now: Instant) {
-        self.outbound_init = Some(OutboundInit {
-            bytes,
-            retransmits: BTreeMap::new(),
-            started_at: now,
-        });
     }
 
     /// Handshake bytes run through `tunnel` to authenticate before

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -338,51 +338,30 @@ impl PathAgent {
     pub fn handle_outbound(&mut self, bytes: Vec<u8>, now: Instant) {
         match Tunn::parse_incoming_packet(&bytes) {
             Ok(Packet::HandshakeInit(_)) if !self.established => {
-                self.forwarded_response = None;
-
                 tracing::debug!(bytes = bytes.len(), "Buffered initial HandshakeInit");
 
-                self.outbound_init = Some(OutboundInit {
-                    bytes,
-                    retransmits: BTreeMap::new(),
-                    started_at: now,
-                });
+                self.forwarded_response = None;
                 self.established = true;
+                self.record_outbound_init(bytes, now);
+            }
+            // A still-stored init means the previous one went unanswered,
+            // and a lost primary (roam, candidate retraction) has nothing
+            // to ride: both are failure evidence.
+            Ok(Packet::HandshakeInit(_))
+                if self.outbound_init.is_some() || self.primary.is_none() =>
+            {
+                tracing::debug!(
+                    bytes = bytes.len(),
+                    "Re-key HandshakeInit; restarting probes"
+                );
+
+                self.reopen_evaluation_window(now);
+                self.record_outbound_init(bytes, now);
             }
             Ok(Packet::HandshakeInit(_)) => {
-                // A still-stored init means the previous one went unanswered:
-                // failure evidence. A routine re-key rides the primary without
-                // restarting probes.
-                let unanswered = self.outbound_init.is_some();
+                tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
 
-                if unanswered || self.primary.is_none() {
-                    tracing::debug!(
-                        bytes = bytes.len(),
-                        "Re-key HandshakeInit; restarting probes"
-                    );
-
-                    self.reopen_evaluation_window(now);
-                } else {
-                    tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
-                }
-
-                if let Some((local, remote)) = self.primary {
-                    self.pending_transmits.push_back(Transmit {
-                        local,
-                        remote,
-                        payload: Payload::Ciphertext(bytes.clone()),
-                    });
-                }
-
-                // With a primary, `drive_handshake_retransmits` stays quiet;
-                // the stored init only tracks whether a response arrived.
-                // Without one (roam, candidate retraction), it fans out like
-                // the initial bootstrap.
-                self.outbound_init = Some(OutboundInit {
-                    bytes,
-                    retransmits: BTreeMap::new(),
-                    started_at: now,
-                });
+                self.record_outbound_init(bytes, now);
             }
             Ok(Packet::HandshakeResponse(_)) => {
                 if let (Some(init_bytes), Some(path)) = (
@@ -418,6 +397,28 @@ impl PathAgent {
                 }
             }
         }
+    }
+
+    /// Sends the init on the primary (if any) and stores it until the
+    /// response arrives.
+    ///
+    /// With a primary, `drive_handshake_retransmits` stays quiet and the
+    /// stored init only tracks whether a response arrived. Without one,
+    /// it fans out like the initial bootstrap.
+    fn record_outbound_init(&mut self, bytes: Vec<u8>, now: Instant) {
+        if let Some((local, remote)) = self.primary {
+            self.pending_transmits.push_back(Transmit {
+                local,
+                remote,
+                payload: Payload::Ciphertext(bytes.clone()),
+            });
+        }
+
+        self.outbound_init = Some(OutboundInit {
+            bytes,
+            retransmits: BTreeMap::new(),
+            started_at: now,
+        });
     }
 
     /// Handshake bytes run through `tunnel` to authenticate before

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -394,8 +394,8 @@ fn inbound_handshake_reopens_evaluation_window_after_settle() {
 }
 
 #[test]
-fn new_handshake_inside_open_window_restarts_evaluation() {
-    // A roam re-keys to a new address while the *initial* evaluation
+fn new_path_handshake_inside_open_window_restarts_evaluation() {
+    // A roam re-keys from a new address while the *initial* evaluation
     // window is still open. The new handshake must restart the window so
     // stale RTTs are cleared; otherwise the original window settles on a
     // pre-roam pair that is now dead.
@@ -407,11 +407,11 @@ fn new_handshake_inside_open_window_restarts_evaluation() {
     let _ = a.handle_inbound_network(&mut hs1.responder, &hs1.init, (addr(2), addr(4)), now);
     a.drain_events();
 
-    // A *different* handshake arrives late in the window (a roam re-key
-    // to a new address), still inside the original deadline.
+    // A *different* handshake arrives late in the window from a new path
+    // (a roam re-key), still inside the original deadline.
     let t2 = now + Duration::from_secs(8);
     let mut hs2 = Handshake::new(t2);
-    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(4)), t2);
+    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(3)), t2);
     a.drain_events();
 
     // At the *original* deadline a non-restarted window settles and drops
@@ -427,7 +427,53 @@ fn new_handshake_inside_open_window_restarts_evaluation() {
     let probes = a.transmits();
     assert!(
         probes.len() > 1,
-        "a new handshake inside the open window must restart it (re-probe all pairs), got {probes:?}"
+        "a handshake from a new path inside the open window must restart it (re-probe all pairs), got {probes:?}"
+    );
+}
+
+#[test]
+fn same_path_rekey_does_not_restart_evaluation() {
+    // A routine re-key arrives on the current primary: the path evidently
+    // works, so probing must not restart — neither mid-window nor after
+    // settling.
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+
+    let mut hs1 = Handshake::new(now);
+    let _ = a.handle_inbound_network(&mut hs1.responder, &hs1.init, (addr(2), addr(4)), now);
+    a.drain_events();
+
+    // A re-key arrives on the same path (= the adopted primary),
+    // still inside the original deadline.
+    let t2 = now + Duration::from_secs(8);
+    let mut hs2 = Handshake::new(t2);
+    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(4)), t2);
+    a.drain_events();
+
+    // The window settles at the *original* deadline; nothing re-probes.
+    a.handle_timeout(now + EVALUATION_WINDOW);
+    let _ = a.transmits();
+
+    a.handle_timeout(now + EVALUATION_WINDOW + PROBE_TIMEOUT + Duration::from_secs(1));
+    let probes = a.transmits();
+    assert!(
+        probes.is_empty(),
+        "a same-path re-key must not restart evaluation, got {probes:?}"
+    );
+
+    // Another re-key on the primary after settling stays quiet, too: only
+    // the live-cadence probe of the primary remains scheduled.
+    let t3 = now + EVALUATION_WINDOW + Duration::from_secs(10);
+    let mut hs3 = Handshake::new(t3);
+    let _ = a.handle_inbound_network(&mut hs3.responder, &hs3.init, (addr(2), addr(4)), t3);
+    a.drain_events();
+    let _ = a.transmits(); // Drop the HandshakeResponse.
+
+    a.handle_timeout(t3 + Duration::from_secs(1));
+    let probes = a.transmits();
+    assert!(
+        probes.is_empty(),
+        "a post-settle same-path re-key must not restart evaluation, got {probes:?}"
     );
 }
 
@@ -815,6 +861,47 @@ fn rekey_handshake_init_rides_primary_instead_of_re_fanning_out() {
     let rekey = a.transmits();
     assert_eq!(rekey.len(), 1, "re-key rides the primary: {rekey:?}");
     assert_eq!((rekey[0].local, rekey[0].remote), recv_path);
+}
+
+#[test]
+fn unanswered_rekey_retry_restarts_probing() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    let recv_path = (addr(2), addr(4));
+
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+    let mut hs = Handshake::new(now).with_response(now);
+    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, recv_path, now);
+    a.drain_events();
+    let _ = a.transmits();
+
+    a.handle_timeout(now + EVALUATION_WINDOW);
+    let _ = a.transmits();
+
+    // A routine re-key rides the primary; at most the live-cadence probe
+    // of the primary fires alongside it.
+    let rekey_at = now + Duration::from_secs(120);
+    a.handle_outbound(handshake_init_bytes(), rekey_at);
+    let _ = a.transmits();
+    a.handle_timeout(rekey_at);
+    let probes = a.transmits();
+    assert!(
+        probes.len() <= 1,
+        "a routine re-key must not burst probes, got {probes:?}"
+    );
+
+    // The unanswered retry is failure evidence: probing restarts on all pairs.
+    let retry_at = rekey_at + Duration::from_secs(5);
+    a.handle_outbound(handshake_init_bytes(), retry_at);
+    let _ = a.transmits();
+    a.handle_timeout(retry_at);
+    let probes = a.transmits();
+    assert!(
+        probes.len() > 1,
+        "an unanswered re-key must restart probing on all pairs, got {probes:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Re-opening the path-evaluation window on every routine WireGuard re-key bursts probes across all pairs every ~2 minutes on both peers — pure chatter when the primary is healthy, and a constant source of radio wake-ups and NAT churn on mobile (322 window re-opens in a 9-hour Android log). Probing now restarts only on failure evidence: a handshake arriving on a non-primary path (the roam case), an outbound re-key going unanswered, or losing the primary.

Trade-off: alternate paths are no longer periodically re-scored, so a better path that only becomes viable later is not discovered until something fails.

Related: #13088