### PR TITLE
feat(connlib): score iceless paths on both ends' tiers 

### DIFF
--- a/rust/libs/connlib/path-agent/src/score.rs
+++ b/rust/libs/connlib/path-agent/src/score.rs
@@ -27,8 +27,10 @@ pub(crate) enum LocalFamily {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct Bucket {
-    /// `Host < ServerReflexive < Relayed`; `max` of the two ends.
-    pub(crate) tier: crate::CandidateKind,
+    /// `Host < ServerReflexive < Relayed`; the worse end, then the better
+    /// end. Comparing both ends keeps e.g. relay->srflx (one relay hop)
+    /// ahead of relay->relay (two) instead of tying them on RTT.
+    pub(crate) tier: (crate::CandidateKind, crate::CandidateKind),
     pub(crate) relay_end: RelayEnd,
     pub(crate) family_match: FamilyMatch,
     pub(crate) local_family: LocalFamily,
@@ -43,7 +45,11 @@ pub(crate) struct PairScore {
 pub(crate) fn pair_score(pair: (SocketAddr, SocketAddr), state: &PairState) -> PairScore {
     PairScore {
         bucket: Bucket {
-            tier: state.kinds.0.max(state.kinds.1),
+            tier: {
+                let (local, remote) = state.kinds;
+
+                (local.max(remote), local.min(remote))
+            },
             relay_end: if matches!(state.kinds.0, crate::CandidateKind::Relayed) {
                 RelayEnd::Local
             } else {

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -569,6 +569,35 @@ fn primary_prefers_local_relay_over_remote_relay_at_same_tier() {
 }
 
 #[test]
+fn primary_prefers_single_relay_hop_over_double_regardless_of_rtt() {
+    // Scoring compares both ends' tiers: (relay, srflx) traverses one
+    // relay, (relay, relay) two — the former must win on tier, not flap
+    // on RTT jitter.
+    let mut a = PathAgent::new();
+    let now = Instant::now();
+    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)));
+    a.add_remote_candidate(Candidate::server_reflexive(addr(3), addr(3)), now);
+    a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
+
+    let double_hop = (addr(2), addr(4));
+    bootstrap_primary(&mut a, double_hop, now);
+
+    let probes = a.tick(now);
+    a.ack_probe(&probes, double_hop, now + ms(20));
+    assert_eq!(a.primary(), Some(double_hop));
+    a.drain_events();
+
+    // Even with a much worse RTT, one relay hop beats two.
+    let single_hop = (addr(2), addr(3));
+    a.ack_probe(&probes, single_hop, now + ms(500));
+    assert_eq!(
+        a.primary(),
+        Some(single_hop),
+        "single-relay-hop pair should beat double-relay-hop pair",
+    );
+}
+
+#[test]
 fn primary_prefers_ipv6_over_ipv4_at_same_tier() {
     let mut a = PathAgent::new();
     let now = Instant::now();


### PR DESCRIPTION
Ranking pairs by only the worse end's tier ties relay→srflx with relay→relay: both fall through to smoothed RTT, and on high-jitter links the primary flips between them every few seconds despite the RTT hysteresis (observed on Android over cellular with 300–700ms RTTs), churning peer sockets and gateway flow contexts. Compare the ordered pair (worse end, better end) instead so one relay hop always beats two; the our-relay-over-theirs preference still breaks the remaining tie.

Related: #13088