### PR TITLE
fix(telemetry): restore feature-flag evaluation on mobile

### DIFF
--- a/rust/libs/telemetry/src/feature_flags.rs
+++ b/rust/libs/telemetry/src/feature_flags.rs
@@ -126,34 +126,17 @@ pub(crate) async fn evaluate_now(user_id: String, env: Env) {
     tracing::debug!(%env, flags = ?FEATURE_FLAGS, "Evaluated feature-flags");
 }
 
-pub(crate) fn reevaluate(user_id: String, env: &str) {
-    let Ok(env) = env.parse() else {
+/// Re-evaluates feature flags using the current telemetry user and environment.
+///
+/// Does nothing until telemetry is active and both are known. Lets us refresh
+/// flags promptly when the network situation changes instead of waiting for the
+/// next periodic re-evaluation.
+pub(crate) fn reevaluate_current() {
+    let Some((user_id, env)) = crate::current_identity() else {
         return;
     };
 
     ingest::RUNTIME.spawn(evaluate_now(user_id, env));
-}
-
-/// Re-evaluates feature flags using the current telemetry user and environment.
-///
-/// Does nothing until both are known. Lets us refresh flags promptly when the
-/// network situation changes instead of waiting for the next periodic re-evaluation.
-pub(crate) fn reevaluate_current() {
-    let Some(client) = sentry::Hub::main().client() else {
-        return;
-    };
-
-    let Some(env) = client.options().environment.as_ref() else {
-        return; // Nothing to do if we don't have an environment set.
-    };
-
-    let Some(user_id) =
-        sentry::Hub::main().configure_scope(|scope| scope.user().and_then(|u| u.id.clone()))
-    else {
-        return; // Nothing to do if we don't have a user-id set.
-    };
-
-    reevaluate(user_id, env);
 }
 
 pub(crate) async fn reeval_timer() {

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -182,26 +182,13 @@ impl fmt::Display for Env {
 /// `SOCKETS`, `RESOLVER`, `RUNTIME`) is already global, so the state is too. Every
 /// binary drives telemetry through the free functions below rather than holding an
 /// instance.
-///
-/// This struct is the single source of truth: Sentry's client options and scope
-/// are only ever written to, never read back, so no code path depends on which
-/// thread's hub the client happens to be bound to. Sentry's `before_send` hooks
-/// call back into this crate (e.g. [`current_account_slug`]), so to avoid
-/// lock-order inversions with Sentry's internal locks, never call into Sentry
-/// while holding this lock.
 static STATE: Mutex<State> = Mutex::new(State::new());
-
-/// Serialises [`start`] and [`stop`] so concurrent session swaps cannot interleave.
-///
-/// Held across calls into Sentry, so it must never be acquired while holding
-/// [`STATE`].
-static SESSION_SWAP: Mutex<()> = Mutex::new(());
 
 struct State {
     env: Option<Env>,
     firezone_id: Option<String>,
     account_slug: Option<String>,
-    guard: Option<sentry::ClientInitGuard>,
+    sentry_guard: Option<sentry::ClientInitGuard>,
 }
 
 impl State {
@@ -210,7 +197,7 @@ impl State {
             env: None,
             firezone_id: None,
             account_slug: None,
-            guard: None,
+            sentry_guard: None,
         }
     }
 }
@@ -223,33 +210,23 @@ pub fn configure(tcp: Arc<dyn SocketFactory<TcpSocket>>, udp: Arc<dyn SocketFact
 
 /// Starts (or re-points) the Sentry session for `env_or_api_url`.
 pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
-    let _swap = SESSION_SWAP.lock();
-
     let environment = Env::parse(env_or_api_url);
+    let mut state = STATE.lock();
 
-    let previous = {
-        let mut state = STATE.lock();
+    if state.sentry_guard.is_some() && state.env == Some(environment) {
+        tracing::debug!(%environment, "Telemetry already initialised");
 
-        if state.guard.is_some() && state.env == Some(environment) {
-            tracing::debug!(%environment, "Telemetry already initialised");
-
-            return;
-        }
-
-        state.guard.take()
-    };
+        return;
+    }
 
     // Stop any previous telemetry session.
-    if let Some(previous) = previous {
+    if let Some(previous) = state.sentry_guard.take() {
         tracing::debug!("Stopping previous telemetry session");
 
         drop(previous);
 
-        {
-            let mut state = STATE.lock();
-            state.firezone_id = None;
-            state.account_slug = None;
-        }
+        state.firezone_id = None;
+        state.account_slug = None;
         set_current_user(None);
     }
 
@@ -257,7 +234,7 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
         environment,
         Env::OnPrem | Env::Localhost | Env::DockerCompose
     ) {
-        STATE.lock().env = None;
+        state.env = None;
 
         tracing::debug!(%env_or_api_url, "Telemetry won't start in unofficial environment");
         return;
@@ -282,11 +259,8 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
         }
     });
 
-    {
-        let mut state = STATE.lock();
-        state.env = Some(environment);
-        state.guard = Some(inner);
-    }
+    state.env = Some(environment);
+    state.sentry_guard = Some(inner);
 
     sentry::warmup_connection();
     posthog::warmup_connection();
@@ -294,9 +268,7 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
 pub fn stop() {
-    let _swap = SESSION_SWAP.lock();
-
-    let Some(inner) = STATE.lock().guard.take() else {
+    let Some(inner) = STATE.lock().sentry_guard.take() else {
         return;
     };
 
@@ -307,7 +279,7 @@ pub fn stop() {
 }
 
 pub fn is_active() -> bool {
-    STATE.lock().guard.is_some()
+    STATE.lock().sentry_guard.is_some()
 }
 
 pub fn set_account_slug(slug: String) {
@@ -355,7 +327,7 @@ pub fn current_account_slug() -> Option<String> {
 pub(crate) fn current_identity() -> Option<(String, Env)> {
     let state = STATE.lock();
 
-    state.guard.as_ref()?;
+    state.sentry_guard.as_ref()?;
 
     Some((state.firezone_id.clone()?, state.env?))
 }

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, fmt, mem, str::FromStr, sync::Arc, time::Durati
 
 use anyhow::{Result, bail};
 use api_url::ApiUrl;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use sentry::{
     BeforeCallback, User,
     protocol::{Event, Log, LogAttribute, Metric},
@@ -182,7 +182,7 @@ impl fmt::Display for Env {
 /// `SOCKETS`, `RESOLVER`, `RUNTIME`) is already global, so the state is too. Every
 /// binary drives telemetry through the free functions below rather than holding an
 /// instance.
-static STATE: Mutex<State> = Mutex::new(State::new());
+static STATE: RwLock<State> = RwLock::new(State::new());
 
 struct State {
     env: Option<Env>,
@@ -211,7 +211,7 @@ pub fn configure(tcp: Arc<dyn SocketFactory<TcpSocket>>, udp: Arc<dyn SocketFact
 /// Starts (or re-points) the Sentry session for `env_or_api_url`.
 pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
     let environment = Env::parse(env_or_api_url);
-    let mut state = STATE.lock();
+    let mut state = STATE.write();
 
     if state.sentry_guard.is_some() && state.env == Some(environment) {
         tracing::debug!(%environment, "Telemetry already initialised");
@@ -268,7 +268,7 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
 pub fn stop() {
-    let Some(inner) = STATE.lock().sentry_guard.take() else {
+    let Some(inner) = STATE.write().sentry_guard.take() else {
         return;
     };
 
@@ -279,11 +279,11 @@ pub fn stop() {
 }
 
 pub fn is_active() -> bool {
-    STATE.lock().sentry_guard.is_some()
+    STATE.read().sentry_guard.is_some()
 }
 
 pub fn set_account_slug(slug: String) {
-    STATE.lock().account_slug = Some(slug.clone());
+    STATE.write().account_slug = Some(slug.clone());
 
     update_user(|user| {
         user.other.insert("account_slug".to_owned(), slug.into());
@@ -294,7 +294,7 @@ pub fn set_account_slug(slug: String) {
 pub fn set_firezone_id(firezone_id: String) {
     let new_user = compute_user(firezone_id);
 
-    STATE.lock().firezone_id = new_user.id.clone();
+    STATE.write().firezone_id = new_user.id.clone();
 
     update_user(|user| {
         user.id = new_user.id;
@@ -308,24 +308,24 @@ pub fn set_firezone_id(firezone_id: String) {
 
 #[doc(hidden)] // Only public for testing.
 pub fn current_env() -> Option<Env> {
-    STATE.lock().env
+    STATE.read().env
 }
 
 #[doc(hidden)] // Only public for testing.
 pub fn current_user() -> Option<String> {
-    STATE.lock().firezone_id.clone()
+    STATE.read().firezone_id.clone()
 }
 
 #[doc(hidden)] // Only public for testing.
 pub fn current_account_slug() -> Option<String> {
-    STATE.lock().account_slug.clone()
+    STATE.read().account_slug.clone()
 }
 
 /// The identity feature flags are evaluated for: the current user and environment.
 ///
 /// `None` unless telemetry is active and both are known.
 pub(crate) fn current_identity() -> Option<(String, Env)> {
-    let state = STATE.lock();
+    let state = STATE.read();
 
     state.sentry_guard.as_ref()?;
 

--- a/rust/libs/telemetry/src/lib.rs
+++ b/rust/libs/telemetry/src/lib.rs
@@ -175,13 +175,45 @@ impl fmt::Display for Env {
     }
 }
 
-/// The process-global Sentry guard.
+/// The process-global telemetry state: the active session's environment, user
+/// identity and the Sentry guard keeping the client alive.
 ///
 /// Sentry is one client per process, and the rest of this crate (the Hub,
-/// `SOCKETS`, `RESOLVER`, `RUNTIME`) is already global, so the guard is too. Every
+/// `SOCKETS`, `RESOLVER`, `RUNTIME`) is already global, so the state is too. Every
 /// binary drives telemetry through the free functions below rather than holding an
 /// instance.
-static GUARD: Mutex<Option<sentry::ClientInitGuard>> = Mutex::new(None);
+///
+/// This struct is the single source of truth: Sentry's client options and scope
+/// are only ever written to, never read back, so no code path depends on which
+/// thread's hub the client happens to be bound to. Sentry's `before_send` hooks
+/// call back into this crate (e.g. [`current_account_slug`]), so to avoid
+/// lock-order inversions with Sentry's internal locks, never call into Sentry
+/// while holding this lock.
+static STATE: Mutex<State> = Mutex::new(State::new());
+
+/// Serialises [`start`] and [`stop`] so concurrent session swaps cannot interleave.
+///
+/// Held across calls into Sentry, so it must never be acquired while holding
+/// [`STATE`].
+static SESSION_SWAP: Mutex<()> = Mutex::new(());
+
+struct State {
+    env: Option<Env>,
+    firezone_id: Option<String>,
+    account_slug: Option<String>,
+    guard: Option<sentry::ClientInitGuard>,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            env: None,
+            firezone_id: None,
+            account_slug: None,
+            guard: None,
+        }
+    }
+}
 
 /// Configures the shared, tunnel-bypassing ingest socket factories so telemetry
 /// never loops through connlib. Call once at process start before [`start`].
@@ -191,25 +223,33 @@ pub fn configure(tcp: Arc<dyn SocketFactory<TcpSocket>>, udp: Arc<dyn SocketFact
 
 /// Starts (or re-points) the Sentry session for `env_or_api_url`.
 pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
+    let _swap = SESSION_SWAP.lock();
+
     let environment = Env::parse(env_or_api_url);
-    let mut guard = GUARD.lock();
 
-    if guard
-        .as_ref()
-        .and_then(|i| i.options().environment.as_ref())
-        .is_some_and(|env| env == environment.as_str())
-    {
-        tracing::debug!(%environment, "Telemetry already initialised");
+    let previous = {
+        let mut state = STATE.lock();
 
-        return;
-    }
+        if state.guard.is_some() && state.env == Some(environment) {
+            tracing::debug!(%environment, "Telemetry already initialised");
+
+            return;
+        }
+
+        state.guard.take()
+    };
 
     // Stop any previous telemetry session.
-    if let Some(inner) = guard.take() {
+    if let Some(previous) = previous {
         tracing::debug!("Stopping previous telemetry session");
 
-        drop(inner);
+        drop(previous);
 
+        {
+            let mut state = STATE.lock();
+            state.firezone_id = None;
+            state.account_slug = None;
+        }
         set_current_user(None);
     }
 
@@ -217,6 +257,8 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
         environment,
         Env::OnPrem | Env::Localhost | Env::DockerCompose
     ) {
+        STATE.lock().env = None;
+
         tracing::debug!(%env_or_api_url, "Telemetry won't start in unofficial environment");
         return;
     }
@@ -240,7 +282,11 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
         }
     });
 
-    guard.replace(inner);
+    {
+        let mut state = STATE.lock();
+        state.env = Some(environment);
+        state.guard = Some(inner);
+    }
 
     sentry::warmup_connection();
     posthog::warmup_connection();
@@ -248,7 +294,9 @@ pub fn start(env_or_api_url: &str, release: &str, dsn: Dsn) {
 
 /// Flushes events to sentry.io and drops the guard. A no-op if not started.
 pub fn stop() {
-    let Some(inner) = GUARD.lock().take() else {
+    let _swap = SESSION_SWAP.lock();
+
+    let Some(inner) = STATE.lock().guard.take() else {
         return;
     };
 
@@ -259,10 +307,12 @@ pub fn stop() {
 }
 
 pub fn is_active() -> bool {
-    GUARD.lock().is_some()
+    STATE.lock().guard.is_some()
 }
 
 pub fn set_account_slug(slug: String) {
+    STATE.lock().account_slug = Some(slug.clone());
+
     update_user(|user| {
         user.other.insert("account_slug".to_owned(), slug.into());
     });
@@ -271,6 +321,9 @@ pub fn set_account_slug(slug: String) {
 /// Attaches the Firezone ID to the active Sentry session.
 pub fn set_firezone_id(firezone_id: String) {
     let new_user = compute_user(firezone_id);
+
+    STATE.lock().firezone_id = new_user.id.clone();
+
     update_user(|user| {
         user.id = new_user.id;
         user.other.extend(new_user.other);
@@ -283,22 +336,28 @@ pub fn set_firezone_id(firezone_id: String) {
 
 #[doc(hidden)] // Only public for testing.
 pub fn current_env() -> Option<Env> {
-    let client = sentry::Hub::main().client()?;
-    let env = client.options().environment.as_deref()?;
-    let env = Env::from_str(env).ok()?;
-
-    Some(env)
+    STATE.lock().env
 }
 
 #[doc(hidden)] // Only public for testing.
 pub fn current_user() -> Option<String> {
-    sentry::Hub::main().configure_scope(|s| s.user()?.id.clone())
+    STATE.lock().firezone_id.clone()
 }
 
 #[doc(hidden)] // Only public for testing.
 pub fn current_account_slug() -> Option<String> {
-    sentry::Hub::main()
-        .configure_scope(|s| Some(s.user()?.other.get("account_slug")?.as_str()?.to_owned()))
+    STATE.lock().account_slug.clone()
+}
+
+/// The identity feature flags are evaluated for: the current user and environment.
+///
+/// `None` unless telemetry is active and both are known.
+pub(crate) fn current_identity() -> Option<(String, Env)> {
+    let state = STATE.lock();
+
+    state.guard.as_ref()?;
+
+    Some((state.firezone_id.clone()?, state.env?))
 }
 
 /// Computes the [`User`] scope based on the contents of `firezone_id`.

--- a/rust/libs/telemetry/src/sentry.rs
+++ b/rust/libs/telemetry/src/sentry.rs
@@ -32,7 +32,7 @@ pub(crate) fn init_sdk_client(
     environment: &'static str,
     release: &str,
 ) -> ClientInitGuard {
-    init((
+    let guard = init((
         dsn,
         ClientOptions {
             environment: Some(Cow::Borrowed(environment)),
@@ -65,7 +65,16 @@ pub(crate) fn init_sdk_client(
             transport: Some(Arc::new(Factory)),
             ..Default::default()
         },
-    ))
+    ));
+
+    // `init` binds the client to the calling thread's hub, which coincides with
+    // `Hub::main()` only on the first thread that ever used Sentry. This crate
+    // reads and configures `Hub::main()` throughout, so bind the client there
+    // explicitly to keep this function thread-agnostic; mobile clients call it
+    // from arbitrary dispatcher threads.
+    Hub::main().bind_client(Hub::current().client());
+
+    guard
 }
 
 /// Creates [`SentryTransport`]s for the Sentry SDK.

--- a/rust/libs/telemetry/tests/stop_deactivates_session.rs
+++ b/rust/libs/telemetry/tests/stop_deactivates_session.rs
@@ -1,0 +1,18 @@
+use telemetry::{Env, TESTING};
+
+#[tokio::test]
+async fn stop_deactivates_but_remembers_env() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    telemetry::configure(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
+    telemetry::start("wss://api.firez.one", "1.0.0", TESTING);
+    assert!(telemetry::is_active());
+
+    telemetry::stop();
+
+    assert!(!telemetry::is_active());
+    assert_eq!(telemetry::current_env(), Some(Env::Staging));
+}

--- a/rust/libs/telemetry/tests/swap_env_across_threads.rs
+++ b/rust/libs/telemetry/tests/swap_env_across_threads.rs
@@ -1,0 +1,19 @@
+use telemetry::{Env, TESTING};
+
+#[tokio::test]
+async fn start_on_other_thread_swaps_env_on_main_hub() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    telemetry::configure(
+        std::sync::Arc::new(socket_factory::tcp),
+        std::sync::Arc::new(socket_factory::udp),
+    );
+    telemetry::start("entrypoint", "1.0.0", TESTING);
+    assert_eq!(telemetry::current_env(), Some(Env::Entrypoint));
+
+    std::thread::spawn(|| telemetry::start("wss://api.firezone.dev", "1.0.0", TESTING))
+        .join()
+        .expect("`start` should not panic");
+
+    assert_eq!(telemetry::current_env(), Some(Env::Production));
+}


### PR DESCRIPTION
Since telemetry is tied to the process lifetime, mobile clients start it twice: once at process boot with the `entrypoint` environment and again at connect time with the real environment — on Android these two calls run on different threads (service main thread vs. coroutine worker). `sentry::init` binds the new client only to the calling thread's hub, which coincides with `Hub::main()` only on the first thread that ever used Sentry. The re-initialised client therefore landed on a throwaway thread-local hub while `Hub::main()` — which the telemetry crate read its state back from — kept the closed entrypoint client. As a result, `$identify` was skipped and feature flags were silently never evaluated (`entrypoint` has no PostHog API key), so `stream_logs` never activated even when enabled for the account.

Two changes: bind the client to `Hub::main()` explicitly when starting telemetry so event capture works from any thread, and stop using Sentry as the store for session state altogether. Environment, user id and account slug now live in the crate's own process-wide state next to the client guard, and Sentry is only ever written to, so no internal logic depends on hub bindings anymore. This also turns the per-log-record account-slug lookup into a plain field read and stops feature-flag re-evaluation from phoning home after telemetry is stopped.

Related: #13917