### PR TITLE
feat(connlib): enable GRO/GSO on the Linux TUN device

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8281,6 +8281,7 @@ dependencies = [
  "libc",
  "opentelemetry",
  "otel-instruments",
+ "smallvec",
  "tokio",
  "tracing",
 ]

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -762,13 +762,15 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
         .context("Failed to set flags on TUN device")?;
     }
 
-    let offloads = offloads_supported();
+    // A successful `TUNSETOFFLOAD` is the kernel promising it handles these offloads on both the
+    // read (GRO) and write (GSO) side, so we use it directly as the capability probe rather than
+    // gating on a kernel version. It fails on kernels without UDP segmentation offload (added in
+    // Linux 6.2), where we run without offloads and exchange plain packets.
+    let offloads = try_enable_offloads(fd);
 
-    if offloads {
-        enable_offloads(fd).context("Failed to enable TUN offloads")?;
-    } else {
+    if !offloads {
         tracing::info!(
-            "Kernel does not support TUN segmentation offloads (requires Linux 6.2); packets will not be coalesced"
+            "Kernel does not support TUN segmentation offloads; packets will not be coalesced"
         );
     }
 
@@ -780,58 +782,17 @@ fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
     Ok(tun::linux::TunFd::new(Arc::new(fd), offloads))
 }
 
-/// Whether the running kernel supports the segmentation offloads we rely on.
+/// Enables checksum and segmentation offloads on the TUN device, returning whether the kernel
+/// accepted them.
 ///
-/// UDP segmentation offload (`TUN_F_USO4` / `TUN_F_USO6`) requires Linux 6.2.
-/// Offloads are all-or-nothing: on older kernels, we fall back to per-packet
-/// TUN I/O via [`tun::unix`].
-fn offloads_supported() -> bool {
-    match kernel_version() {
-        Some((major, minor)) => (major, minor) >= (6, 2),
-        None => {
-            tracing::warn!("Failed to determine kernel version; disabling TUN offloads");
-
-            false
-        }
-    }
-}
-
-fn kernel_version() -> Option<(u64, u64)> {
-    // Safety: An all-zeroes `utsname` is valid.
-    let mut utsname = unsafe { std::mem::zeroed::<libc::utsname>() };
-
-    // Safety: `utsname` is a valid struct for the kernel to write into.
-    if unsafe { libc::uname(&mut utsname) } != 0 {
-        return None;
-    }
-
-    // Safety: The kernel null-terminates `release`.
-    let release = unsafe { CStr::from_ptr(utsname.release.as_ptr()) };
-
-    parse_kernel_version(release.to_str().ok()?)
-}
-
-fn parse_kernel_version(release: &str) -> Option<(u64, u64)> {
-    let mut parts = release.split(['.', '-', '+']);
-
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-
-    Some((major, minor))
-}
-
-/// Enables checksum and segmentation offloads on the TUN device.
-///
-/// UDP segmentation offload (`TUN_F_USO*`) requires Linux 6.2.
-fn enable_offloads(fd: RawFd) -> io::Result<()> {
+/// A successful `TUNSETOFFLOAD` is the kernel's promise that it handles these offloads on both the
+/// read (GRO) and write (GSO) side. They are all-or-nothing: if any is unsupported - UDP
+/// segmentation offload in particular needs Linux 6.2 - the ioctl fails and we run without them.
+fn try_enable_offloads(fd: RawFd) -> bool {
     const OFFLOADS: libc::c_uint = TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6 | TUN_F_USO4 | TUN_F_USO6;
 
     // Safety: The file descriptor is valid.
-    if unsafe { libc::ioctl(fd, TUNSETOFFLOAD as _, OFFLOADS as libc::c_ulong) } < 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    Ok(())
+    unsafe { libc::ioctl(fd, TUNSETOFFLOAD as _, OFFLOADS as libc::c_ulong) >= 0 }
 }
 
 impl tun::Tun for Tun {
@@ -887,19 +848,4 @@ fn create_tun_device() -> io::Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod kernel_version_tests {
-    use super::*;
-
-    #[test]
-    fn parses_common_release_strings() {
-        assert_eq!(parse_kernel_version("6.2.0"), Some((6, 2)));
-        assert_eq!(parse_kernel_version("6.8.0-45-generic"), Some((6, 8)));
-        assert_eq!(parse_kernel_version("5.15.0-1051-aws"), Some((5, 15)));
-        assert_eq!(parse_kernel_version("4.19.0-25-amd64"), Some((4, 19)));
-        assert_eq!(parse_kernel_version("6.18.5"), Some((6, 18)));
-        assert_eq!(parse_kernel_version("garbage"), None);
-    }
 }

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -7,7 +7,6 @@ use futures::{
     future::{self, Either},
 };
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
-use ip_packet::{IpPacket, IpPacketBuf};
 use libc::{
     EEXIST, ENOENT, ESRCH, F_GETFL, F_SETFL, O_NONBLOCK, O_RDWR, S_IFCHR, fcntl, makedev, mknod,
     open,
@@ -42,6 +41,14 @@ use tokio::time::Instant;
 use tun::ioctl;
 
 const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
+const TUNSETOFFLOAD: libc::c_ulong = 0x4004_54d0;
+
+const TUN_F_CSUM: libc::c_uint = 0x01;
+const TUN_F_TSO4: libc::c_uint = 0x02;
+const TUN_F_TSO6: libc::c_uint = 0x04;
+const TUN_F_USO4: libc::c_uint = 0x20;
+const TUN_F_USO6: libc::c_uint = 0x40;
+
 const TUN_DEV_MAJOR: u32 = 10;
 const TUN_DEV_MINOR: u32 = 200;
 
@@ -703,7 +710,7 @@ impl Tun {
             ],
         ));
 
-        let fd = Arc::new(open_tun()?);
+        let fd = open_tun()?;
 
         std::thread::Builder::new()
             .name("TUN send".to_owned())
@@ -712,7 +719,7 @@ impl Tun {
 
                 move || {
                     logging::unwrap_or_warn!(
-                        tun::unix::tun_send(fd, outbound_rx, write),
+                        tun::linux::tun_send(fd, outbound_rx),
                         "Failed to send to TUN device: {}"
                     )
                 }
@@ -722,7 +729,7 @@ impl Tun {
             .name("TUN recv".to_owned())
             .spawn(move || {
                 logging::unwrap_or_warn!(
-                    tun::unix::tun_recv(fd, inbound_tx, read),
+                    tun::linux::tun_recv(fd, inbound_tx),
                     "Failed to recv from TUN device: {}"
                 )
             })
@@ -735,7 +742,7 @@ impl Tun {
     }
 }
 
-fn open_tun() -> Result<OwnedFd> {
+fn open_tun() -> Result<tun::linux::TunFd<Arc<OwnedFd>>> {
     let fd = match unsafe { open(TUN_FILE.as_ptr() as _, O_RDWR) } {
         -1 => {
             let file = TUN_FILE.to_str()?;
@@ -755,12 +762,76 @@ fn open_tun() -> Result<OwnedFd> {
         .context("Failed to set flags on TUN device")?;
     }
 
+    let offloads = offloads_supported();
+
+    if offloads {
+        enable_offloads(fd).context("Failed to enable TUN offloads")?;
+    } else {
+        tracing::info!(
+            "Kernel does not support TUN segmentation offloads (requires Linux 6.2); packets will not be coalesced"
+        );
+    }
+
     set_non_blocking(fd).context("Failed to make TUN device non-blocking")?;
 
     // Safety: We are not closing the FD.
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
 
-    Ok(fd)
+    Ok(tun::linux::TunFd::new(Arc::new(fd), offloads))
+}
+
+/// Whether the running kernel supports the segmentation offloads we rely on.
+///
+/// UDP segmentation offload (`TUN_F_USO4` / `TUN_F_USO6`) requires Linux 6.2.
+/// Offloads are all-or-nothing: on older kernels, we fall back to per-packet
+/// TUN I/O via [`tun::unix`].
+fn offloads_supported() -> bool {
+    match kernel_version() {
+        Some((major, minor)) => (major, minor) >= (6, 2),
+        None => {
+            tracing::warn!("Failed to determine kernel version; disabling TUN offloads");
+
+            false
+        }
+    }
+}
+
+fn kernel_version() -> Option<(u64, u64)> {
+    // Safety: An all-zeroes `utsname` is valid.
+    let mut utsname = unsafe { std::mem::zeroed::<libc::utsname>() };
+
+    // Safety: `utsname` is a valid struct for the kernel to write into.
+    if unsafe { libc::uname(&mut utsname) } != 0 {
+        return None;
+    }
+
+    // Safety: The kernel null-terminates `release`.
+    let release = unsafe { CStr::from_ptr(utsname.release.as_ptr()) };
+
+    parse_kernel_version(release.to_str().ok()?)
+}
+
+fn parse_kernel_version(release: &str) -> Option<(u64, u64)> {
+    let mut parts = release.split(['.', '-', '+']);
+
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+
+    Some((major, minor))
+}
+
+/// Enables checksum and segmentation offloads on the TUN device.
+///
+/// UDP segmentation offload (`TUN_F_USO*`) requires Linux 6.2.
+fn enable_offloads(fd: RawFd) -> io::Result<()> {
+    const OFFLOADS: libc::c_uint = TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6 | TUN_F_USO4 | TUN_F_USO6;
+
+    // Safety: The file descriptor is valid.
+    if unsafe { libc::ioctl(fd, TUNSETOFFLOAD as _, OFFLOADS as libc::c_ulong) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
 }
 
 impl tun::Tun for Tun {
@@ -818,24 +889,17 @@ fn create_tun_device() -> io::Result<()> {
     Ok(())
 }
 
-/// Read from the given file descriptor in the buffer.
-fn read(fd: RawFd, dst: &mut IpPacketBuf) -> io::Result<usize> {
-    let dst = dst.buf();
+#[cfg(test)]
+mod kernel_version_tests {
+    use super::*;
 
-    // Safety: Within this module, the file descriptor is always valid.
-    match unsafe { libc::read(fd, dst.as_mut_ptr() as _, dst.len()) } {
-        -1 => Err(io::Error::last_os_error()),
-        n => Ok(n as usize),
-    }
-}
-
-/// Write the packet to the given file descriptor.
-fn write(fd: RawFd, packet: &IpPacket) -> io::Result<usize> {
-    let buf = packet.packet();
-
-    // Safety: Within this module, the file descriptor is always valid.
-    match unsafe { libc::write(fd, buf.as_ptr() as _, buf.len() as _) } {
-        -1 => Err(io::Error::last_os_error()),
-        n => Ok(n as usize),
+    #[test]
+    fn parses_common_release_strings() {
+        assert_eq!(parse_kernel_version("6.2.0"), Some((6, 2)));
+        assert_eq!(parse_kernel_version("6.8.0-45-generic"), Some((6, 8)));
+        assert_eq!(parse_kernel_version("5.15.0-1051-aws"), Some((5, 15)));
+        assert_eq!(parse_kernel_version("4.19.0-25-amd64"), Some((4, 19)));
+        assert_eq!(parse_kernel_version("6.18.5"), Some((6, 18)));
+        assert_eq!(parse_kernel_version("garbage"), None);
     }
 }

--- a/rust/libs/connlib/tun/Cargo.toml
+++ b/rust/libs/connlib/tun/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 anyhow = { workspace = true }
 bufferpool = { workspace = true }
 ip-packet = { workspace = true }
+smallvec = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync"] }
 
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/rust/libs/connlib/tun/src/apple.rs
+++ b/rust/libs/connlib/tun/src/apple.rs
@@ -18,10 +18,8 @@ mod tests;
 use anyhow::Result;
 use std::os::fd::RawFd;
 
-use crate::{InboundTx, OutboundRx};
-
 /// Sends packets from `outbound_rx` to the TUN `fd` until the channel closes.
-pub fn send(fd: RawFd, outbound_rx: OutboundRx) -> Result<()> {
+pub fn send(fd: RawFd, outbound_rx: crate::OutboundRx) -> Result<()> {
     match sys::batch_syscalls() {
         Some(syscalls) => bulk::send(fd, syscalls, outbound_rx),
         None => crate::unix::tun_send(fd, outbound_rx, per_packet::write),
@@ -29,7 +27,7 @@ pub fn send(fd: RawFd, outbound_rx: OutboundRx) -> Result<()> {
 }
 
 /// Receives packets from the TUN `fd` into `inbound_tx` until the fd closes.
-pub fn recv(fd: RawFd, inbound_tx: InboundTx) -> Result<()> {
+pub fn recv(fd: RawFd, inbound_tx: crate::InboundTx) -> Result<()> {
     match sys::batch_syscalls() {
         Some(syscalls) => bulk::recv(fd, syscalls, inbound_tx),
         None => crate::unix::tun_recv(fd, inbound_tx, per_packet::read),

--- a/rust/libs/connlib/tun/src/ioctl.rs
+++ b/rust/libs/connlib/tun/src/ioctl.rs
@@ -36,7 +36,10 @@ impl Request<SetTunFlagsPayload> {
         Self {
             name,
             payload: SetTunFlagsPayload {
-                flags: (libc::IFF_TUN | libc::IFF_NO_PI | libc::IFF_MULTI_QUEUE) as _,
+                flags: (libc::IFF_TUN
+                    | libc::IFF_NO_PI
+                    | libc::IFF_MULTI_QUEUE
+                    | libc::IFF_VNET_HDR) as _,
             },
         }
     }

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -7,6 +7,8 @@ use tokio::sync::mpsc;
 
 #[cfg(target_family = "unix")]
 pub mod ioctl;
+#[cfg(target_os = "linux")]
+pub mod linux;
 #[cfg(target_family = "unix")]
 pub mod unix;
 
@@ -132,7 +134,8 @@ pub fn outbound_channel_for_test(capacity: usize) -> (OutboundTx, OutboundRx) {
 
 /// The sending half of the channel to the thread writing to the TUN device.
 ///
-/// Each item is one batch of packets that were processed together upstream.
+/// Each item is one batch of packets; the end of a batch marks the boundary
+/// up to which the TUN thread may coalesce packets before writing them out.
 #[derive(Clone)]
 pub struct OutboundTx(mpsc::Sender<PacketBatch>);
 

--- a/rust/libs/connlib/tun/src/linux.rs
+++ b/rust/libs/connlib/tun/src/linux.rs
@@ -1,0 +1,292 @@
+//! Linux-specific TUN I/O using segmentation offloads (`IFF_VNET_HDR` + `TUNSETOFFLOAD`).
+//!
+//! With offloads enabled, the kernel exchanges "super packets" of up to 64 KiB with us:
+//!
+//! - Reads may return a single TSO / USO packet that we split into MTU-sized [`IpPacket`](ip_packet::IpPacket)s
+//!   before handing them to the main thread ([`split`]).
+//! - Writes may combine multiple same-flow packets into one GSO write that traverses the
+//!   kernel's network stack as a single skb ([`coalesce`]).
+//!
+//! Each item on the outbound channel is one batch of packets that arrived together
+//! upstream; coalescing extends across exactly that batch.
+
+mod checksum;
+mod coalesce;
+mod split;
+mod virtio;
+
+#[cfg(test)]
+mod tests;
+
+use anyhow::{Context as _, ErrorExt as _, Result, bail};
+use coalesce::{Outgoing, TunGsoQueue};
+use opentelemetry::KeyValue;
+use std::collections::VecDeque;
+use std::io;
+use std::mem;
+use std::os::fd::{AsRawFd, RawFd};
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use virtio::VNET_HDR_LEN;
+
+use crate::{InboundTx, OutboundRx, PacketBatch};
+
+/// Size of the buffer for reading super packets: a `virtio_net_hdr` plus the largest
+/// possible IP packet.
+const READ_BUFFER_SIZE: usize = VNET_HDR_LEN + u16::MAX as usize;
+
+/// A TUN device file descriptor together with whether segmentation offloads are enabled on it.
+///
+/// The device always has `IFF_VNET_HDR` set, so reads and writes carry a
+/// `virtio_net_hdr` either way; without offloads it is simply always trivial
+/// (`VIRTIO_NET_HDR_GSO_NONE`) and writes must not use GSO.
+#[derive(Clone)]
+pub struct TunFd<T> {
+    fd: T,
+    offloads: bool,
+}
+
+impl<T> TunFd<T> {
+    pub fn new(fd: T, offloads: bool) -> Self {
+        Self { fd, offloads }
+    }
+}
+
+/// Sends packets from `outbound_rx` to the TUN device, coalescing where possible.
+pub fn tun_send<T>(tun_fd: TunFd<T>, mut outbound_rx: OutboundRx) -> Result<()>
+where
+    T: AsRawFd,
+{
+    let batch_size_histogram = otel_instruments::network_packets_batch_count();
+    let dropped_packets_counter = otel_instruments::network_packet_dropped();
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to create runtime")?
+        .block_on(async move {
+            let fd = AsyncFd::with_interest(tun_fd.fd, Interest::WRITABLE)?;
+
+            let mut ready = Vec::new();
+            // `None` when the kernel does not support GSO writes or rejected one at
+            // runtime; packets then pass through 1:1.
+            let mut queue = tun_fd.offloads.then(TunGsoQueue::new);
+
+            while let Some(mut batch) = outbound_rx.recv().await {
+                for packet in batch.drain() {
+                    #[cfg(debug_assertions)]
+                    tracing::trace!(target: "wire::dev::send", ?packet);
+
+                    match &mut queue {
+                        Some(queue) => queue.enqueue(packet),
+                        None => ready.push(Outgoing::from(packet)),
+                    }
+                }
+
+                if let Some(queue) = &mut queue {
+                    ready.extend(queue.drain());
+                }
+
+                let gso_failed = write_all(
+                    &fd,
+                    &mut ready,
+                    &batch_size_histogram,
+                    &dropped_packets_counter,
+                )
+                .await;
+
+                if gso_failed {
+                    // Some kernel versions carry a bug that makes them reject GSO writes
+                    // with `EINVAL`. Stop coalescing for the remainder of the session;
+                    // the dropped segments are re-sent by the endpoints.
+                    tracing::info!("Kernel rejected GSO write; disabling TUN segmentation offload");
+
+                    queue = None;
+                }
+            }
+
+            tracing::debug!("Outbound packet sender gone, shutting down task");
+
+            anyhow::Ok(())
+        })?;
+
+    Ok(())
+}
+
+/// Writes out all ready packets; returns `true` if the kernel rejected a GSO write.
+async fn write_all<T>(
+    fd: &AsyncFd<T>,
+    ready: &mut Vec<Outgoing>,
+    batch_size_histogram: &opentelemetry::metrics::Histogram<u64>,
+    dropped_packets_counter: &opentelemetry::metrics::Counter<u64>,
+) -> bool
+where
+    T: AsRawFd,
+{
+    let mut gso_failed = false;
+
+    for outgoing in ready.drain(..) {
+        let num_segments = outgoing.num_segments();
+
+        match write(fd, &outgoing).await {
+            Ok(_) => {
+                if num_segments > 1 {
+                    batch_size_histogram.record(num_segments as u64, &send_metric_attributes());
+                }
+            }
+            Err(e) if num_segments > 1 && e.raw_os_error() == Some(libc::EINVAL) => {
+                dropped_packets_counter.add(num_segments as u64, &drop_attributes(&e));
+
+                gso_failed = true;
+            }
+            Err(e) => {
+                dropped_packets_counter.add(num_segments as u64, &drop_attributes(&e));
+                tracing::warn!("Failed to write to TUN FD: {e}");
+            }
+        }
+    }
+
+    gso_failed
+}
+
+/// Writes a single [`Outgoing`] (its `virtio_net_hdr` plus packet bytes) to the TUN device.
+async fn write<T>(fd: &AsyncFd<T>, outgoing: &Outgoing) -> io::Result<usize>
+where
+    T: AsRawFd,
+{
+    let [hdr, packet] = outgoing.bufs();
+
+    let iov = [
+        libc::iovec {
+            iov_base: hdr.as_ptr() as *mut _,
+            iov_len: hdr.len(),
+        },
+        libc::iovec {
+            iov_base: packet.as_ptr() as *mut _,
+            iov_len: packet.len(),
+        },
+    ];
+
+    fd.async_io(Interest::WRITABLE, |fd| {
+        // Safety: Both iovecs point at valid memory of the given lengths.
+        match unsafe { libc::writev(fd.as_raw_fd(), iov.as_ptr(), iov.len() as _) } {
+            -1 => Err(io::Error::last_os_error()),
+            n => Ok(n as usize),
+        }
+    })
+    .await
+}
+
+/// Receives packets from the TUN device, splitting super packets into individual [`IpPacket`](ip_packet::IpPacket)s.
+pub fn tun_recv<T>(tun_fd: TunFd<T>, inbound_tx: InboundTx) -> Result<()>
+where
+    T: AsRawFd,
+{
+    let batch_size_histogram = otel_instruments::network_packets_batch_count();
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to create runtime")?
+        .block_on(async move {
+            let fd = AsyncFd::with_interest(tun_fd.fd, Interest::READABLE)?;
+            let mut buf = vec![0u8; READ_BUFFER_SIZE];
+            let mut batch = PacketBatch::default();
+            let mut overflow = VecDeque::new();
+
+            loop {
+                let mut guard = fd.readable().await?;
+
+                loop {
+                    // A full batch spills the rest of its super packet into `overflow`:
+                    // hand off the batch and continue the drain with the spilled packets.
+                    while !overflow.is_empty() {
+                        if inbound_tx.send(mem::take(&mut batch)).await.is_err() {
+                            tracing::debug!("Inbound packet receiver gone, shutting down task");
+
+                            return anyhow::Ok(());
+                        }
+
+                        while let Some(packet) = overflow.pop_front() {
+                            if let Err(packet) = batch.try_push(packet) {
+                                overflow.push_front(packet);
+                                break;
+                            }
+                        }
+                    }
+
+                    let len = match guard.try_io(|fd| read(fd.get_ref().as_raw_fd(), &mut buf)) {
+                        Ok(Ok(0)) => bail!("TUN file descriptor is closed"),
+                        Ok(Ok(len)) => len,
+                        Ok(Err(e)) => {
+                            return Err(anyhow::Error::new(e))
+                                .context("Failed to read from TUN FD");
+                        }
+                        Err(_would_block) => break, // FD is drained; hand off what we have.
+                    };
+
+                    match split::split(&buf[..len]) {
+                        Ok(mut segments) => {
+                            batch_size_histogram
+                                .record(segments.len() as u64, &recv_metric_attributes());
+
+                            for packet in segments.drain(..) {
+                                #[cfg(debug_assertions)]
+                                tracing::trace!(target: "wire::dev::recv", ?packet);
+
+                                if let Err(packet) = batch.try_push(packet) {
+                                    overflow.push_back(packet);
+                                }
+                            }
+                        }
+                        Err(e) if e.any_is::<ip_packet::Fragmented>() => {
+                            tracing::debug!("{e:#}"); // Log on debug to be less noisy.
+                        }
+                        Err(e) => tracing::warn!("{e:#}"),
+                    }
+                }
+
+                if batch.is_empty() {
+                    continue;
+                }
+
+                if inbound_tx.send(mem::take(&mut batch)).await.is_err() {
+                    tracing::debug!("Inbound packet receiver gone, shutting down task");
+
+                    return anyhow::Ok(());
+                }
+            }
+        })?;
+
+    Ok(())
+}
+
+fn read(fd: RawFd, dst: &mut [u8]) -> io::Result<usize> {
+    // Safety: The buffer is valid for the given length.
+    match unsafe { libc::read(fd, dst.as_mut_ptr() as _, dst.len()) } {
+        -1 => Err(io::Error::last_os_error()),
+        n => Ok(n as usize),
+    }
+}
+
+fn send_metric_attributes() -> [KeyValue; 2] {
+    [
+        KeyValue::new("system.device", "tun"),
+        KeyValue::new("network.io.direction", "transmit"),
+    ]
+}
+
+fn recv_metric_attributes() -> [KeyValue; 2] {
+    [
+        KeyValue::new("system.device", "tun"),
+        KeyValue::new("network.io.direction", "receive"),
+    ]
+}
+
+fn drop_attributes(e: &io::Error) -> [KeyValue; 3] {
+    [
+        KeyValue::new("system.device", "tun"),
+        KeyValue::new("network.io.direction", "transmit"),
+        KeyValue::new("error.code", e.raw_os_error().unwrap_or_default() as i64),
+    ]
+}

--- a/rust/libs/connlib/tun/src/linux/checksum.rs
+++ b/rust/libs/connlib/tun/src/linux/checksum.rs
@@ -8,12 +8,23 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 pub fn sum(bytes: &[u8], initial: u64) -> u64 {
     let mut acc = initial;
 
-    let mut chunks = bytes.chunks_exact(2);
+    // Sum eight bytes at a time. Folding a wider big-endian word is equivalent to summing its
+    // 16-bit halves separately: the high bits just carry down later in [`fold`]. A `u64`
+    // accumulator holds the sum of ~8k such words without overflowing, so no intermediate
+    // fold is needed for a single packet (at most 65535 bytes).
+    let mut chunks = bytes.chunks_exact(8);
     for chunk in chunks.by_ref() {
+        let word = u64::from_be_bytes(chunk.try_into().expect("chunk is 8 bytes"));
+        acc += word >> 32;
+        acc += word & 0xFFFF_FFFF;
+    }
+
+    let mut tail = chunks.remainder().chunks_exact(2);
+    for chunk in tail.by_ref() {
         acc += u64::from(u16::from_be_bytes([chunk[0], chunk[1]]));
     }
 
-    if let [last] = chunks.remainder() {
+    if let [last] = tail.remainder() {
         acc += u64::from(u16::from_be_bytes([*last, 0]));
     }
 
@@ -68,5 +79,30 @@ mod tests {
         let acc = sum(&[0xab], 0);
 
         assert_eq!(fold(acc), 0xab00);
+    }
+
+    #[test]
+    fn matches_naive_sum_over_varied_lengths() {
+        // The straightforward 16-bit-word sum, against which the wide-word `sum` must agree
+        // across every chunk / tail / remainder combination.
+        fn naive(bytes: &[u8]) -> u16 {
+            let mut acc = 0u64;
+            let mut words = bytes.chunks_exact(2);
+            for word in words.by_ref() {
+                acc += u64::from(u16::from_be_bytes([word[0], word[1]]));
+            }
+            if let [last] = words.remainder() {
+                acc += u64::from(u16::from_be_bytes([*last, 0]));
+            }
+            fold(acc)
+        }
+
+        for len in 0..40usize {
+            let bytes: Vec<u8> = (0..len)
+                .map(|i| (i as u8).wrapping_mul(37).wrapping_add(3))
+                .collect();
+
+            assert_eq!(fold(sum(&bytes, 0)), naive(&bytes), "len={len}");
+        }
     }
 }

--- a/rust/libs/connlib/tun/src/linux/checksum.rs
+++ b/rust/libs/connlib/tun/src/linux/checksum.rs
@@ -1,0 +1,72 @@
+//! Internet checksum (RFC 1071) helpers for fixing up split / coalesced segments.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Sums `bytes` as big-endian 16-bit words into a ones-complement accumulator.
+///
+/// The result is unfolded; combine multiple sums by addition and finish with [`fold`].
+pub fn sum(bytes: &[u8], initial: u64) -> u64 {
+    let mut acc = initial;
+
+    let mut chunks = bytes.chunks_exact(2);
+    for chunk in chunks.by_ref() {
+        acc += u64::from(u16::from_be_bytes([chunk[0], chunk[1]]));
+    }
+
+    if let [last] = chunks.remainder() {
+        acc += u64::from(u16::from_be_bytes([*last, 0]));
+    }
+
+    acc
+}
+
+/// Folds a ones-complement accumulator into a 16-bit checksum value (without complementing).
+pub fn fold(mut acc: u64) -> u16 {
+    while acc > 0xFFFF {
+        acc = (acc & 0xFFFF) + (acc >> 16);
+    }
+
+    acc as u16
+}
+
+/// The pseudo-header sum for an IPv4 TCP / UDP checksum.
+pub fn pseudo_header_sum_v4(src: Ipv4Addr, dst: Ipv4Addr, protocol: u8, l4_len: usize) -> u64 {
+    let mut acc = 0;
+    acc = sum(&src.octets(), acc);
+    acc = sum(&dst.octets(), acc);
+    acc += u64::from(protocol);
+    acc += l4_len as u64;
+
+    acc
+}
+
+/// The pseudo-header sum for an IPv6 TCP / UDP checksum.
+pub fn pseudo_header_sum_v6(src: Ipv6Addr, dst: Ipv6Addr, protocol: u8, l4_len: usize) -> u64 {
+    let mut acc = 0;
+    acc = sum(&src.octets(), acc);
+    acc = sum(&dst.octets(), acc);
+    acc += u64::from(protocol);
+    acc += l4_len as u64;
+
+    acc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_rfc1071_example() {
+        // Example from RFC 1071: 00 01 f2 03 f4 f5 f6 f7 -> sum ddf2 (before complement).
+        let acc = sum(&[0x00, 0x01, 0xf2, 0x03, 0xf4, 0xf5, 0xf6, 0xf7], 0);
+
+        assert_eq!(fold(acc), 0xddf2);
+    }
+
+    #[test]
+    fn handles_odd_length() {
+        let acc = sum(&[0xab], 0);
+
+        assert_eq!(fold(acc), 0xab00);
+    }
+}

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -28,47 +28,6 @@ const TCP_FLAG_PSH: u8 = 0x08;
 
 const ZEROED_VNET_HDR: [u8; VNET_HDR_LEN] = [0; VNET_HDR_LEN];
 
-/// A pending write to the TUN device.
-pub struct Outgoing(Inner);
-
-enum Inner {
-    /// An individual IP packet; written with a zeroed [`VirtioNetHdr`].
-    Packet(IpPacket),
-    /// A coalesced batch of packets, including its [`VirtioNetHdr`].
-    Batch {
-        buf: Buffer<Vec<u8>>,
-        num_segments: usize,
-    },
-}
-
-impl Outgoing {
-    /// How many IP packets this write carries.
-    pub fn num_segments(&self) -> usize {
-        match &self.0 {
-            Inner::Packet(_) => 1,
-            Inner::Batch { num_segments, .. } => *num_segments,
-        }
-    }
-
-    /// The [`VirtioNetHdr`] and packet bytes of this write, ready for `writev`.
-    pub fn bufs(&self) -> [&[u8]; 2] {
-        match &self.0 {
-            Inner::Packet(packet) => [ZEROED_VNET_HDR.as_slice(), packet.packet()],
-            Inner::Batch { buf, .. } => {
-                let (hdr, packet) = buf.split_at(VNET_HDR_LEN);
-
-                [hdr, packet]
-            }
-        }
-    }
-}
-
-impl From<IpPacket> for Outgoing {
-    fn from(packet: IpPacket) -> Self {
-        Self(Inner::Packet(packet))
-    }
-}
-
 /// Coalesces IP packets into GSO super packets.
 pub struct TunGsoQueue {
     /// Queued items, in write order.
@@ -121,6 +80,47 @@ impl TunGsoQueue {
     /// Drains all queued packets, in write order.
     pub fn drain(&mut self) -> impl Iterator<Item = Outgoing> + '_ {
         self.items.drain(..).map(Item::into_outgoing)
+    }
+}
+
+/// A pending write to the TUN device.
+pub struct Outgoing(Inner);
+
+enum Inner {
+    /// An individual IP packet; written with a zeroed [`VirtioNetHdr`].
+    Packet(IpPacket),
+    /// A coalesced batch of packets, including its [`VirtioNetHdr`].
+    Batch {
+        buf: Buffer<Vec<u8>>,
+        num_segments: usize,
+    },
+}
+
+impl Outgoing {
+    /// How many IP packets this write carries.
+    pub fn num_segments(&self) -> usize {
+        match &self.0 {
+            Inner::Packet(_) => 1,
+            Inner::Batch { num_segments, .. } => *num_segments,
+        }
+    }
+
+    /// The [`VirtioNetHdr`] and packet bytes of this write, ready for `writev`.
+    pub fn bufs(&self) -> [&[u8]; 2] {
+        match &self.0 {
+            Inner::Packet(packet) => [ZEROED_VNET_HDR.as_slice(), packet.packet()],
+            Inner::Batch { buf, .. } => {
+                let (hdr, packet) = buf.split_at(VNET_HDR_LEN);
+
+                [hdr, packet]
+            }
+        }
+    }
+}
+
+impl From<IpPacket> for Outgoing {
+    fn from(packet: IpPacket) -> Self {
+        Self(Inner::Packet(packet))
     }
 }
 
@@ -451,7 +451,11 @@ impl Batch {
             return false;
         }
 
-        if candidate.ip_hdr_len != self.ip_hdr_len || candidate.l4_hdr_len != self.l4_hdr_len {
+        if candidate.ip_hdr_len != self.ip_hdr_len {
+            return false;
+        }
+
+        if candidate.l4_hdr_len != self.l4_hdr_len {
             return false;
         }
 
@@ -472,13 +476,22 @@ impl Batch {
             return false;
         }
 
-        headers_compatible(
-            self.template(),
-            packet.packet(),
-            self.key.version(),
-            self.ip_hdr_len,
-            self.l4_hdr_len,
-        )
+        if !ip_headers_compatible(self.template(), packet.packet(), self.key.version()) {
+            return false;
+        }
+
+        if candidate.key.protocol == IpNumber::TCP
+            && !tcp_headers_compatible(
+                self.template(),
+                packet.packet(),
+                self.ip_hdr_len,
+                self.l4_hdr_len,
+            )
+        {
+            return false;
+        }
+
+        true
     }
 
     /// The first packet of the batch; all compatibility checks compare against its headers.
@@ -490,23 +503,16 @@ impl Batch {
     }
 }
 
-/// Whether the (non-key) header fields of `packet` match the batch `template`.
-fn headers_compatible(
-    template: &[u8],
-    packet: &[u8],
-    version: IpVersion,
-    ip_hdr_len: usize,
-    l4_hdr_len: usize,
-) -> bool {
+/// Whether the IP-header fields that must match for coalescing are equal in `packet` and the
+/// batch `template`.
+fn ip_headers_compatible(template: &[u8], packet: &[u8], version: IpVersion) -> bool {
     match version {
         IpVersion::V4 => {
             let tos_matches = template[1] == packet[1];
             let fragment_flags_match = template[6] >> 5 == packet[6] >> 5;
             let ttl_matches = template[8] == packet[8];
 
-            if !tos_matches || !fragment_flags_match || !ttl_matches {
-                return false;
-            }
+            tos_matches && fragment_flags_match && ttl_matches
         }
         IpVersion::V6 => {
             // The flow label is allowed to differ.
@@ -514,23 +520,26 @@ fn headers_compatible(
                 template[0] == packet[0] && template[1] >> 4 == packet[1] >> 4;
             let hop_limit_matches = template[7] == packet[7];
 
-            if !traffic_class_matches || !hop_limit_matches {
-                return false;
-            }
+            traffic_class_matches && hop_limit_matches
         }
     }
+}
 
-    if l4_hdr_len > 20 {
-        // TCP options must be byte-identical.
-        let start = ip_hdr_len + 20;
-        let end = ip_hdr_len + l4_hdr_len;
+/// Whether the TCP options of `packet` are byte-identical to the batch `template`.
+///
+/// The rest of the TCP header is either part of the [`FlowKey`] or checked separately (the
+/// sequence number and the PSH flag), so only the options can still differ. For a header
+/// without options the compared range is empty and this trivially holds.
+fn tcp_headers_compatible(
+    template: &[u8],
+    packet: &[u8],
+    ip_hdr_len: usize,
+    l4_hdr_len: usize,
+) -> bool {
+    let start = ip_hdr_len + 20;
+    let end = ip_hdr_len + l4_hdr_len;
 
-        if template[start..end] != packet[start..end] {
-            return false;
-        }
-    }
-
-    true
+    template[start..end] == packet[start..end]
 }
 
 /// Writes the [`VirtioNetHdr`] and fixes up the outer headers of a coalesced super packet.

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -1,0 +1,637 @@
+//! Coalesces individual IP packets into GSO "super packets" for writing to the TUN device.
+//!
+//! Writing one large packet with a [`VirtioNetHdr`] describing its segmentation lets the
+//! entire batch traverse the kernel's network stack as a single skb, which is where the
+//! bulk of the per-packet cost lives.
+//!
+//! Only packets that the kernel's own GRO would merge are combined, everything else is
+//! passed through untouched.
+
+use bufferpool::{Buffer, BufferPool};
+use ip_packet::{IpNumber, IpPacket, IpVersion, Ipv6Header, TcpSlice, UdpSlice};
+use std::net::IpAddr;
+
+use super::checksum;
+use super::virtio::*;
+
+/// The maximum size of a coalesced packet.
+///
+/// IP packets cannot be larger than 65535 bytes (the total-length / payload-length fields
+/// are 16 bits wide), and so neither can our super packets.
+const MAX_COALESCED_PACKET: usize = u16::MAX as usize;
+
+/// The kernel rejects `VIRTIO_NET_HDR_GSO_UDP_L4` writes with more segments than this
+/// (`UDP_MAX_SEGMENTS` in `linux/udp.h`).
+const MAX_UDP_SEGMENTS: usize = 128;
+
+const TCP_FLAG_PSH: u8 = 0x08;
+
+const ZEROED_VNET_HDR: [u8; VNET_HDR_LEN] = [0; VNET_HDR_LEN];
+
+/// A pending write to the TUN device.
+pub struct Outgoing(Inner);
+
+enum Inner {
+    /// An individual IP packet; written with a zeroed [`VirtioNetHdr`].
+    Packet(IpPacket),
+    /// A coalesced batch of packets, including its [`VirtioNetHdr`].
+    Batch {
+        buf: Buffer<Vec<u8>>,
+        num_segments: usize,
+    },
+}
+
+impl Outgoing {
+    /// How many IP packets this write carries.
+    pub fn num_segments(&self) -> usize {
+        match &self.0 {
+            Inner::Packet(_) => 1,
+            Inner::Batch { num_segments, .. } => *num_segments,
+        }
+    }
+
+    /// The [`VirtioNetHdr`] and packet bytes of this write, ready for `writev`.
+    pub fn bufs(&self) -> [&[u8]; 2] {
+        match &self.0 {
+            Inner::Packet(packet) => [ZEROED_VNET_HDR.as_slice(), packet.packet()],
+            Inner::Batch { buf, .. } => {
+                let (hdr, packet) = buf.split_at(VNET_HDR_LEN);
+
+                [hdr, packet]
+            }
+        }
+    }
+}
+
+impl From<IpPacket> for Outgoing {
+    fn from(packet: IpPacket) -> Self {
+        Self(Inner::Packet(packet))
+    }
+}
+
+/// Coalesces IP packets into GSO super packets.
+pub struct TunGsoQueue {
+    /// Queued items, in write order.
+    ///
+    /// Non-coalescable packets flow through this queue too: a segment may only merge
+    /// into the most recent item of its connection, so per-flow ordering is preserved
+    /// by construction.
+    items: Vec<Item>,
+    buffer_pool: BufferPool<Vec<u8>>,
+}
+
+impl Default for TunGsoQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TunGsoQueue {
+    pub fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            buffer_pool: BufferPool::new(VNET_HDR_LEN + MAX_COALESCED_PACKET, "tun-gso-queue"),
+        }
+    }
+
+    /// Queues a single packet, coalescing it with already queued ones where possible.
+    pub fn enqueue(&mut self, packet: IpPacket) {
+        let Some(candidate) = Candidate::from_packet(&packet) else {
+            self.items.push(Item::Packet(packet));
+            return;
+        };
+
+        // A segment may only merge into the most recent item of its connection;
+        // merging into anything older would reorder the flow.
+        match self
+            .items
+            .iter_mut()
+            .rev()
+            .find(|i| i.same_connection(&packet))
+        {
+            Some(Item::Batch(batch))
+                if batch.key == candidate.key && batch.can_append(&candidate, &packet) =>
+            {
+                batch.append(&candidate, &packet, &self.buffer_pool)
+            }
+            _ => self.items.push(Item::Batch(Batch::new(candidate, packet))),
+        }
+    }
+
+    /// Drains all queued packets, in write order.
+    pub fn drain(&mut self) -> impl Iterator<Item = Outgoing> + '_ {
+        self.items.drain(..).map(Item::into_outgoing)
+    }
+}
+
+/// An entry in the [`TunGsoQueue`].
+enum Item {
+    /// A packet that cannot participate in coalescing, passed through as-is.
+    Packet(IpPacket),
+    /// One or more coalesced segments of a single flow.
+    Batch(Batch),
+}
+
+impl Item {
+    /// Whether this item carries traffic of the same connection as `packet`.
+    fn same_connection(&self, packet: &IpPacket) -> bool {
+        match self {
+            Item::Packet(existing) => same_connection(existing, packet),
+            Item::Batch(batch) => batch.key.same_connection(packet),
+        }
+    }
+
+    fn into_outgoing(self) -> Outgoing {
+        match self {
+            Item::Packet(packet) => Outgoing::from(packet),
+            Item::Batch(batch) => batch.into_outgoing(),
+        }
+    }
+}
+
+/// Whether two packets belong to the same connection.
+fn same_connection(a: &IpPacket, b: &IpPacket) -> bool {
+    if a.source() != b.source() || a.destination() != b.destination() {
+        return false;
+    }
+
+    if let (Some(a), Some(b)) = (a.as_tcp(), b.as_tcp()) {
+        return a.source_port() == b.source_port() && a.destination_port() == b.destination_port();
+    }
+
+    if let (Some(a), Some(b)) = (a.as_udp(), b.as_udp()) {
+        return a.source_port() == b.source_port() && a.destination_port() == b.destination_port();
+    }
+
+    false
+}
+
+struct Candidate {
+    key: FlowKey,
+    ip_hdr_len: usize,
+    l4_hdr_len: usize,
+    payload_len: usize,
+    seq: u32,
+    psh: bool,
+}
+
+impl Candidate {
+    /// Classifies a packet: `Some` if it may participate in coalescing.
+    fn from_packet(packet: &IpPacket) -> Option<Self> {
+        let ip_hdr_len = ip_layout(packet)?;
+
+        let candidate = if let Some(tcp) = packet.as_tcp() {
+            Self::try_from_tcp(packet, &tcp, ip_hdr_len)?
+        } else if let Some(udp) = packet.as_udp() {
+            Self::from_udp(packet, &udp, ip_hdr_len)
+        } else {
+            return None;
+        };
+
+        if candidate.payload_len == 0 {
+            return None;
+        }
+
+        // Appending copies `&bytes[ip_hdr_len + l4_hdr_len..]`, so the parsed layout
+        // must cover the buffer exactly.
+        if ip_hdr_len + candidate.l4_hdr_len + candidate.payload_len != packet.packet().len() {
+            return None;
+        }
+
+        // Merging into a NEEDS_CSUM super packet makes the kernel compute the checksum,
+        // which would silently "repair" a corrupt packet. Only coalesce valid ones.
+        if !l4_checksum_is_valid(
+            packet.packet(),
+            candidate.key.src,
+            candidate.key.dst,
+            candidate.key.protocol,
+            ip_hdr_len,
+        ) {
+            return None;
+        }
+
+        Some(candidate)
+    }
+
+    fn try_from_tcp(packet: &IpPacket, tcp: &TcpSlice, ip_hdr_len: usize) -> Option<Self> {
+        // Only plain data segments coalesce: exactly ACK, or ACK|PSH.
+        if !tcp.ack() || tcp.syn() || tcp.fin() || tcp.rst() || tcp.urg() || tcp.ece() || tcp.cwr()
+        {
+            return None;
+        }
+
+        Some(Self {
+            key: FlowKey::from_tcp(packet, tcp),
+            ip_hdr_len,
+            l4_hdr_len: tcp.header_len(),
+            payload_len: tcp.payload().len(),
+            seq: tcp.sequence_number(),
+            psh: tcp.psh(),
+        })
+    }
+
+    fn from_udp(packet: &IpPacket, udp: &UdpSlice, ip_hdr_len: usize) -> Self {
+        Self {
+            key: FlowKey::from_udp(packet, udp),
+            ip_hdr_len,
+            l4_hdr_len: 8,
+            payload_len: udp.payload().len(),
+            seq: 0,
+            psh: false,
+        }
+    }
+}
+
+/// Validates the IP layer for coalescing, returning the IP header length.
+fn ip_layout(packet: &IpPacket) -> Option<usize> {
+    let total_len = packet.packet().len();
+
+    match (packet.ipv4_header(), packet.ipv6_header()) {
+        (Some(header), _) => {
+            // IP options never coalesce.
+            if !header.options.is_empty() {
+                return None;
+            }
+
+            // The IP length must describe the entire buffer for byte-level coalescing to be sound.
+            if header.total_len as usize != total_len {
+                return None;
+            }
+
+            Some(header.header_len())
+        }
+        (_, Some(header)) => {
+            if header.payload_length as usize + Ipv6Header::LEN != total_len {
+                return None;
+            }
+
+            // Extension headers never coalesce.
+            if !matches!(header.next_header, IpNumber::TCP | IpNumber::UDP) {
+                return None;
+            }
+
+            Some(Ipv6Header::LEN)
+        }
+        (None, None) => None,
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+struct FlowKey {
+    protocol: IpNumber,
+    src: IpAddr,
+    dst: IpAddr,
+    sport: u16,
+    dport: u16,
+    /// Segments with differing ACK numbers must not be coalesced.
+    ///
+    /// Always zero for UDP.
+    ack: u32,
+}
+
+impl FlowKey {
+    fn from_tcp(packet: &IpPacket, tcp: &TcpSlice) -> Self {
+        Self {
+            protocol: IpNumber::TCP,
+            src: packet.source(),
+            dst: packet.destination(),
+            sport: tcp.source_port(),
+            dport: tcp.destination_port(),
+            ack: tcp.acknowledgment_number(),
+        }
+    }
+
+    fn from_udp(packet: &IpPacket, udp: &UdpSlice) -> Self {
+        Self {
+            protocol: IpNumber::UDP,
+            src: packet.source(),
+            dst: packet.destination(),
+            sport: udp.source_port(),
+            dport: udp.destination_port(),
+            ack: 0,
+        }
+    }
+
+    fn version(&self) -> IpVersion {
+        match self.src {
+            IpAddr::V4(_) => IpVersion::V4,
+            IpAddr::V6(_) => IpVersion::V6,
+        }
+    }
+
+    /// Whether `packet` belongs to the same connection (ignoring the ACK number).
+    fn same_connection(&self, packet: &IpPacket) -> bool {
+        if packet.source() != self.src || packet.destination() != self.dst {
+            return false;
+        }
+
+        if let Some(tcp) = packet.as_tcp() {
+            return self.protocol == IpNumber::TCP
+                && tcp.source_port() == self.sport
+                && tcp.destination_port() == self.dport;
+        }
+
+        if let Some(udp) = packet.as_udp() {
+            return self.protocol == IpNumber::UDP
+                && udp.source_port() == self.sport
+                && udp.destination_port() == self.dport;
+        }
+
+        false
+    }
+}
+
+struct Batch {
+    key: FlowKey,
+    state: BatchState,
+
+    ip_hdr_len: usize,
+    l4_hdr_len: usize,
+    /// The gso_size of the super packet: the payload length of the first segment.
+    seg_size: usize,
+    /// Total IP packet length accumulated so far (headers + all payloads).
+    total_len: usize,
+    /// The expected sequence number of the next segment (TCP only).
+    next_seq: u32,
+    num_segs: usize,
+    psh: bool,
+}
+
+enum BatchState {
+    /// A single packet; not copied anywhere yet.
+    Single(IpPacket),
+    /// Two or more segments coalesced into a buffer, prefixed by space for the [`VirtioNetHdr`].
+    Coalesced(Buffer<Vec<u8>>),
+}
+
+impl BatchState {
+    /// The coalescing buffer, converting from [`BatchState::Single`] on first use.
+    fn coalesced(&mut self, pool: &BufferPool<Vec<u8>>) -> &mut Buffer<Vec<u8>> {
+        if let BatchState::Single(first) = &*self {
+            let mut buf = pool.pull();
+            buf.clear();
+            buf.resize(VNET_HDR_LEN, 0);
+            buf.extend_from_slice(first.packet());
+
+            *self = BatchState::Coalesced(buf);
+        }
+
+        match self {
+            BatchState::Coalesced(buf) => buf,
+            BatchState::Single(_) => unreachable!("converted to `Coalesced` above"),
+        }
+    }
+}
+
+impl Batch {
+    fn new(candidate: Candidate, packet: IpPacket) -> Self {
+        Self {
+            key: candidate.key,
+            ip_hdr_len: candidate.ip_hdr_len,
+            l4_hdr_len: candidate.l4_hdr_len,
+            seg_size: candidate.payload_len,
+            total_len: packet.packet().len(),
+            next_seq: candidate.seq.wrapping_add(candidate.payload_len as u32),
+            num_segs: 1,
+            psh: candidate.psh,
+            state: BatchState::Single(packet),
+        }
+    }
+
+    /// Appends the packet's payload to this batch.
+    fn append(&mut self, candidate: &Candidate, packet: &IpPacket, pool: &BufferPool<Vec<u8>>) {
+        let bytes = packet.packet();
+        let payload = &bytes[candidate.ip_hdr_len + candidate.l4_hdr_len..];
+
+        self.state.coalesced(pool).extend_from_slice(payload);
+
+        self.total_len += payload.len();
+        self.next_seq = self.next_seq.wrapping_add(payload.len() as u32);
+        self.num_segs += 1;
+        self.psh |= candidate.psh;
+    }
+
+    /// Whether further segments may be appended.
+    ///
+    /// A pushed or short segment ends the stream of coalescable data: GSO requires
+    /// equal-size segments with at most one shorter, final one.
+    fn is_ongoing(&self) -> bool {
+        let payload_len = self.total_len - self.ip_hdr_len - self.l4_hdr_len;
+
+        !self.psh && payload_len == self.num_segs * self.seg_size
+    }
+
+    fn into_outgoing(self) -> Outgoing {
+        let Batch {
+            key,
+            state,
+            ip_hdr_len,
+            l4_hdr_len,
+            seg_size,
+            num_segs,
+            psh,
+            ..
+        } = self;
+
+        match state {
+            BatchState::Single(packet) => Outgoing::from(packet),
+            BatchState::Coalesced(mut buf) => {
+                finalize(&mut buf, &key, ip_hdr_len, l4_hdr_len, seg_size, psh);
+
+                Outgoing(Inner::Batch {
+                    buf,
+                    num_segments: num_segs,
+                })
+            }
+        }
+    }
+
+    fn can_append(&self, candidate: &Candidate, packet: &IpPacket) -> bool {
+        if !self.is_ongoing() {
+            return false;
+        }
+
+        if candidate.ip_hdr_len != self.ip_hdr_len || candidate.l4_hdr_len != self.l4_hdr_len {
+            return false;
+        }
+
+        // Only equal-size segments plus at most one shorter, final one form a valid GSO batch.
+        if candidate.payload_len > self.seg_size {
+            return false;
+        }
+
+        if self.total_len + candidate.payload_len > MAX_COALESCED_PACKET {
+            return false;
+        }
+
+        if candidate.key.protocol == IpNumber::TCP && candidate.seq != self.next_seq {
+            return false;
+        }
+
+        if candidate.key.protocol == IpNumber::UDP && self.num_segs >= MAX_UDP_SEGMENTS {
+            return false;
+        }
+
+        headers_compatible(
+            self.template(),
+            packet.packet(),
+            self.key.version(),
+            self.ip_hdr_len,
+            self.l4_hdr_len,
+        )
+    }
+
+    /// The first packet of the batch; all compatibility checks compare against its headers.
+    fn template(&self) -> &[u8] {
+        match &self.state {
+            BatchState::Single(packet) => packet.packet(),
+            BatchState::Coalesced(buf) => &buf[VNET_HDR_LEN..],
+        }
+    }
+}
+
+/// Whether the (non-key) header fields of `packet` match the batch `template`.
+fn headers_compatible(
+    template: &[u8],
+    packet: &[u8],
+    version: IpVersion,
+    ip_hdr_len: usize,
+    l4_hdr_len: usize,
+) -> bool {
+    match version {
+        IpVersion::V4 => {
+            let tos_matches = template[1] == packet[1];
+            let fragment_flags_match = template[6] >> 5 == packet[6] >> 5;
+            let ttl_matches = template[8] == packet[8];
+
+            if !tos_matches || !fragment_flags_match || !ttl_matches {
+                return false;
+            }
+        }
+        IpVersion::V6 => {
+            // The flow label is allowed to differ.
+            let traffic_class_matches =
+                template[0] == packet[0] && template[1] >> 4 == packet[1] >> 4;
+            let hop_limit_matches = template[7] == packet[7];
+
+            if !traffic_class_matches || !hop_limit_matches {
+                return false;
+            }
+        }
+    }
+
+    if l4_hdr_len > 20 {
+        // TCP options must be byte-identical.
+        let start = ip_hdr_len + 20;
+        let end = ip_hdr_len + l4_hdr_len;
+
+        if template[start..end] != packet[start..end] {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Writes the [`VirtioNetHdr`] and fixes up the outer headers of a coalesced super packet.
+fn finalize(
+    buf: &mut [u8],
+    key: &FlowKey,
+    ip_hdr_len: usize,
+    l4_hdr_len: usize,
+    seg_size: usize,
+    psh: bool,
+) {
+    let total_len = buf.len() - VNET_HDR_LEN;
+    let l4_len = total_len - ip_hdr_len;
+
+    let (gso_type, csum_offset) = match (key.protocol, key.version()) {
+        (IpNumber::TCP, IpVersion::V4) => (VIRTIO_NET_HDR_GSO_TCPV4, 16),
+        (IpNumber::TCP, IpVersion::V6) => (VIRTIO_NET_HDR_GSO_TCPV6, 16),
+        (IpNumber::UDP, _) => (VIRTIO_NET_HDR_GSO_UDP_L4, 6),
+        _ => unreachable!("only TCP and UDP packets are coalesced"),
+    };
+
+    VirtioNetHdr {
+        flags: VIRTIO_NET_HDR_F_NEEDS_CSUM,
+        gso_type,
+        hdr_len: (ip_hdr_len + l4_hdr_len) as u16,
+        gso_size: seg_size as u16,
+        csum_start: ip_hdr_len as u16,
+        csum_offset: csum_offset as u16,
+    }
+    .write_to(buf);
+
+    let packet = &mut buf[VNET_HDR_LEN..];
+
+    match key.version() {
+        IpVersion::V4 => {
+            packet[2..4].copy_from_slice(&(total_len as u16).to_be_bytes());
+
+            packet[10] = 0;
+            packet[11] = 0;
+            let ip_checksum = !checksum::fold(checksum::sum(&packet[..ip_hdr_len], 0));
+            packet[10..12].copy_from_slice(&ip_checksum.to_be_bytes());
+        }
+        IpVersion::V6 => {
+            packet[4..6].copy_from_slice(&(l4_len as u16).to_be_bytes());
+        }
+    }
+
+    let l4 = &mut packet[ip_hdr_len..];
+
+    let pseudo_sum = match (key.src, key.dst) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => {
+            checksum::pseudo_header_sum_v4(src, dst, key.protocol.0, l4_len)
+        }
+        (IpAddr::V6(src), IpAddr::V6(dst)) => {
+            checksum::pseudo_header_sum_v6(src, dst, key.protocol.0, l4_len)
+        }
+        _ => unreachable!("src and dst are always the same IP version"),
+    };
+
+    match key.protocol {
+        IpNumber::TCP => {
+            if psh {
+                l4[13] |= TCP_FLAG_PSH;
+            }
+
+            // For a NEEDS_CSUM (i.e. CHECKSUM_PARTIAL) packet, the checksum field must
+            // hold the folded, *uncomplemented* pseudo-header sum.
+            l4[16..18].copy_from_slice(&checksum::fold(pseudo_sum).to_be_bytes());
+        }
+        IpNumber::UDP => {
+            l4[4..6].copy_from_slice(&(l4_len as u16).to_be_bytes());
+            l4[6..8].copy_from_slice(&checksum::fold(pseudo_sum).to_be_bytes());
+        }
+        _ => unreachable!("only TCP and UDP packets are coalesced"),
+    }
+}
+
+/// Whether the packet's transport checksum is valid.
+fn l4_checksum_is_valid(
+    bytes: &[u8],
+    src: IpAddr,
+    dst: IpAddr,
+    protocol: IpNumber,
+    ip_hdr_len: usize,
+) -> bool {
+    let l4_len = bytes.len() - ip_hdr_len;
+
+    let pseudo_sum = match (src, dst) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => {
+            // A zero UDP checksum means "not computed" and cannot be validated (nor coalesced).
+            if protocol == IpNumber::UDP && bytes[ip_hdr_len + 6..ip_hdr_len + 8] == [0, 0] {
+                return false;
+            }
+
+            checksum::pseudo_header_sum_v4(src, dst, protocol.0, l4_len)
+        }
+        (IpAddr::V6(src), IpAddr::V6(dst)) => {
+            checksum::pseudo_header_sum_v6(src, dst, protocol.0, l4_len)
+        }
+        _ => return false,
+    };
+
+    checksum::fold(checksum::sum(&bytes[ip_hdr_len..], pseudo_sum)) == 0xFFFF
+}

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -198,18 +198,6 @@ impl Candidate {
             return None;
         }
 
-        // Merging into a NEEDS_CSUM super packet makes the kernel compute the checksum,
-        // which would silently "repair" a corrupt packet. Only coalesce valid ones.
-        if !l4_checksum_is_valid(
-            packet.packet(),
-            candidate.key.src,
-            candidate.key.dst,
-            candidate.key.protocol,
-            ip_hdr_len,
-        ) {
-            return None;
-        }
-
         Some(candidate)
     }
 
@@ -615,32 +603,4 @@ fn finalize(
         }
         _ => unreachable!("only TCP and UDP packets are coalesced"),
     }
-}
-
-/// Whether the packet's transport checksum is valid.
-fn l4_checksum_is_valid(
-    bytes: &[u8],
-    src: IpAddr,
-    dst: IpAddr,
-    protocol: IpNumber,
-    ip_hdr_len: usize,
-) -> bool {
-    let l4_len = bytes.len() - ip_hdr_len;
-
-    let pseudo_sum = match (src, dst) {
-        (IpAddr::V4(src), IpAddr::V4(dst)) => {
-            // A zero UDP checksum means "not computed" and cannot be validated (nor coalesced).
-            if protocol == IpNumber::UDP && bytes[ip_hdr_len + 6..ip_hdr_len + 8] == [0, 0] {
-                return false;
-            }
-
-            checksum::pseudo_header_sum_v4(src, dst, protocol.0, l4_len)
-        }
-        (IpAddr::V6(src), IpAddr::V6(dst)) => {
-            checksum::pseudo_header_sum_v6(src, dst, protocol.0, l4_len)
-        }
-        _ => return false,
-    };
-
-    checksum::fold(checksum::sum(&bytes[ip_hdr_len..], pseudo_sum)) == 0xFFFF
 }

--- a/rust/libs/connlib/tun/src/linux/split.rs
+++ b/rust/libs/connlib/tun/src/linux/split.rs
@@ -1,0 +1,286 @@
+//! Splits "super packets" read from a TUN fd with offloads enabled into individual IP packets.
+//!
+//! With `TUNSETOFFLOAD` active, the kernel hands us TSO / USO packets of up to 64 KiB
+//! together with a [`VirtioNetHdr`] describing how to segment them.
+//! Additionally, locally-generated packets arrive with *partial* checksums
+//! ([`VIRTIO_NET_HDR_F_NEEDS_CSUM`]): the transport checksum field only contains the
+//! pseudo-header sum and we have to complete it.
+
+use anyhow::{Context as _, Result, bail, ensure};
+use ip_packet::{IpNumber, IpPacket, IpPacketBuf, IpVersion};
+use smallvec::SmallVec;
+use std::net::IpAddr;
+
+use super::checksum;
+use super::virtio::*;
+
+/// The most segments a single super packet can split into.
+///
+/// The kernel bounds TSO / USO packets to 65535 bytes and the minimum sensible
+/// gso_size is in the hundreds; 256 is a generous upper bound that protects us
+/// from allocating unbounded numbers of buffers on malformed headers.
+const MAX_SEGMENTS: usize = 256;
+
+/// How many segments we hold inline when splitting a super packet.
+///
+/// Segments of a super packet are packed by payload, i.e. the headers only count
+/// once: a maximally-sized train of MTU-sized TCP segments splits into up to 54
+/// packets. Rounding up to the next power of two gives some headroom.
+const INLINE_SEGMENTS: usize = (u16::MAX as usize / ip_packet::MAX_IP_SIZE).next_power_of_two();
+
+/// Splits the given TUN read (starting with a [`VirtioNetHdr`]) into individual [`IpPacket`]s.
+///
+/// The returned `SmallVec` holds a super packet of MTU-sized segments inline; only
+/// smaller (and thus more) segments spill to the heap.
+pub fn split(buf: &[u8]) -> Result<SmallVec<[IpPacket; INLINE_SEGMENTS]>> {
+    let (hdr, packet) = VirtioNetHdr::parse(buf).context("Read is too short for virtio hdr")?;
+
+    match hdr.gso_type {
+        VIRTIO_NET_HDR_GSO_NONE => {
+            let packet = copy_single(&hdr, packet)?;
+
+            Ok(smallvec::smallvec![packet])
+        }
+        VIRTIO_NET_HDR_GSO_TCPV4 | VIRTIO_NET_HDR_GSO_TCPV6 | VIRTIO_NET_HDR_GSO_UDP_L4 => {
+            split_gso(&hdr, packet)
+        }
+        other => bail!("Unsupported GSO type: {other:#x}"),
+    }
+}
+
+/// Copies a non-GSO packet into an [`IpPacket`], completing a partial checksum if necessary.
+fn copy_single(hdr: &VirtioNetHdr, packet: &[u8]) -> Result<IpPacket> {
+    let len = packet.len();
+
+    let mut ip_packet_buf = IpPacketBuf::new();
+    let dst = ip_packet_buf.buf();
+    ensure!(len <= dst.len(), "Packet too large (len: {len})");
+    dst[..len].copy_from_slice(packet);
+
+    if hdr.flags & VIRTIO_NET_HDR_F_NEEDS_CSUM != 0 {
+        complete_partial_checksum(
+            &mut dst[..len],
+            hdr.csum_start as usize,
+            hdr.csum_offset as usize,
+        )?;
+    }
+
+    let packet = IpPacket::new(ip_packet_buf, len).context("Failed to parse IP packet")?;
+
+    Ok(packet)
+}
+
+/// Completes a partial checksum: the field at `csum_start + csum_offset` holds the
+/// pseudo-header sum and the bytes from `csum_start` onwards still need to be summed into it.
+fn complete_partial_checksum(packet: &mut [u8], start: usize, offset: usize) -> Result<()> {
+    let at = start
+        .checked_add(offset)
+        .context("Checksum position overflows")?;
+    let len = packet.len();
+    ensure!(
+        at + 2 <= len && start <= len,
+        "Checksum region out of bounds (len={len}, csum_start={start}, csum_offset={offset})"
+    );
+
+    let pseudo_sum = u64::from(u16::from_be_bytes([packet[at], packet[at + 1]]));
+    packet[at] = 0;
+    packet[at + 1] = 0;
+
+    let sum = !checksum::fold(checksum::sum(&packet[start..], pseudo_sum));
+    packet[at..at + 2].copy_from_slice(&sum.to_be_bytes());
+
+    Ok(())
+}
+
+/// Splits a TSO / USO super packet into individual, fully check-summed segments.
+fn split_gso(hdr: &VirtioNetHdr, packet: &[u8]) -> Result<SmallVec<[IpPacket; INLINE_SEGMENTS]>> {
+    let gso_size = hdr.gso_size as usize;
+    ensure!(gso_size > 0, "gso_size must not be zero");
+
+    let (version, protocol, ip_hdr_len) = parse_ip_header(packet)?;
+
+    // `hdr.hdr_len` cannot be trusted: on the forward path, the kernel sets it to the
+    // length of the entire linear skb section. Compute it from the packet instead.
+    let l4_hdr_len = match (hdr.gso_type, protocol) {
+        (VIRTIO_NET_HDR_GSO_TCPV4 | VIRTIO_NET_HDR_GSO_TCPV6, IpNumber::TCP) => {
+            ensure!(
+                packet.len() >= ip_hdr_len + 20,
+                "Packet too short for TCP header"
+            );
+
+            let data_offset = ((packet[ip_hdr_len + 12] >> 4) & 0x0F) as usize * 4;
+            ensure!((20..=60).contains(&data_offset), "Invalid TCP data offset");
+
+            data_offset
+        }
+        (VIRTIO_NET_HDR_GSO_UDP_L4, IpNumber::UDP) => 8,
+        (gso_type, protocol) => {
+            bail!("Mismatch between GSO type ({gso_type:#x}) and IP protocol ({protocol:?})")
+        }
+    };
+
+    let headers_len = ip_hdr_len + l4_hdr_len;
+    ensure!(packet.len() > headers_len, "GSO packet has no payload");
+
+    let (headers, payload) = packet.split_at(headers_len);
+    let num_segments = payload.len().div_ceil(gso_size);
+    ensure!(
+        num_segments <= MAX_SEGMENTS,
+        "Too many segments ({num_segments})"
+    );
+
+    let (src, dst) = addresses(packet, version)?;
+
+    let mut segments = SmallVec::new();
+
+    for (index, segment) in payload.chunks(gso_size).enumerate() {
+        let len = headers_len + segment.len();
+
+        let mut ip_packet_buf = IpPacketBuf::new();
+        let buf = ip_packet_buf.buf();
+        ensure!(len <= buf.len(), "Segment too large (len: {len})");
+
+        buf[..headers_len].copy_from_slice(headers);
+        buf[headers_len..len].copy_from_slice(segment);
+        let buf = &mut buf[..len];
+
+        match version {
+            IpVersion::V4 => {
+                buf[2..4].copy_from_slice(&(len as u16).to_be_bytes());
+
+                let identification =
+                    u16::from_be_bytes([headers[4], headers[5]]).wrapping_add(index as u16);
+                buf[4..6].copy_from_slice(&identification.to_be_bytes());
+
+                buf[10] = 0;
+                buf[11] = 0;
+                let ip_checksum = !checksum::fold(checksum::sum(&buf[..ip_hdr_len], 0));
+                buf[10..12].copy_from_slice(&ip_checksum.to_be_bytes());
+            }
+            IpVersion::V6 => {
+                let payload_len = (l4_hdr_len + segment.len()) as u16;
+                buf[4..6].copy_from_slice(&payload_len.to_be_bytes());
+            }
+        }
+
+        let is_last = index == num_segments - 1;
+
+        match protocol {
+            IpNumber::TCP => {
+                let seq = u32::from_be_bytes([
+                    headers[ip_hdr_len + 4],
+                    headers[ip_hdr_len + 5],
+                    headers[ip_hdr_len + 6],
+                    headers[ip_hdr_len + 7],
+                ])
+                .wrapping_add((index * gso_size) as u32);
+                buf[ip_hdr_len + 4..ip_hdr_len + 8].copy_from_slice(&seq.to_be_bytes());
+
+                // FIN and PSH only apply to the last segment of the original stream.
+                if !is_last {
+                    buf[ip_hdr_len + 13] &= !0x09;
+                }
+
+                write_l4_checksum(buf, src, dst, protocol, ip_hdr_len, 16)?;
+            }
+            IpNumber::UDP => {
+                let udp_len = (8 + segment.len()) as u16;
+                buf[ip_hdr_len + 4..ip_hdr_len + 6].copy_from_slice(&udp_len.to_be_bytes());
+
+                write_l4_checksum(buf, src, dst, protocol, ip_hdr_len, 6)?;
+            }
+            _ => unreachable!("protocol is validated above"),
+        }
+
+        let len = buf.len();
+
+        match IpPacket::new(ip_packet_buf, len)
+            .with_context(|| format!("Failed to parse segment {index}"))
+        {
+            Ok(packet) => segments.push(packet),
+            Err(e) => tracing::warn!("{e:#}"),
+        }
+    }
+
+    Ok(segments)
+}
+
+/// Computes the full transport checksum (pseudo-header + header + payload) in place.
+fn write_l4_checksum(
+    buf: &mut [u8],
+    src: IpAddr,
+    dst: IpAddr,
+    protocol: IpNumber,
+    ip_hdr_len: usize,
+    csum_offset: usize,
+) -> Result<()> {
+    let l4_len = buf.len() - ip_hdr_len;
+
+    let at = ip_hdr_len + csum_offset;
+    buf[at] = 0;
+    buf[at + 1] = 0;
+
+    let pseudo_sum = match (src, dst) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => {
+            checksum::pseudo_header_sum_v4(src, dst, protocol.0, l4_len)
+        }
+        (IpAddr::V6(src), IpAddr::V6(dst)) => {
+            checksum::pseudo_header_sum_v6(src, dst, protocol.0, l4_len)
+        }
+        _ => bail!("Mismatched IP versions"),
+    };
+
+    let mut sum = !checksum::fold(checksum::sum(&buf[ip_hdr_len..], pseudo_sum));
+
+    // A UDP checksum of zero means "no checksum"; a computed zero is transmitted as all-ones.
+    if protocol == IpNumber::UDP && sum == 0 {
+        sum = 0xFFFF;
+    }
+
+    buf[at..at + 2].copy_from_slice(&sum.to_be_bytes());
+
+    Ok(())
+}
+
+fn parse_ip_header(packet: &[u8]) -> Result<(IpVersion, IpNumber, usize)> {
+    ensure!(!packet.is_empty(), "Empty packet");
+
+    match packet[0] >> 4 {
+        4 => {
+            ensure!(packet.len() >= 20, "Packet too short for IPv4 header");
+
+            let ip_hdr_len = (packet[0] & 0x0F) as usize * 4;
+            ensure!(
+                (20..=60).contains(&ip_hdr_len),
+                "Invalid IPv4 header length"
+            );
+
+            Ok((IpVersion::V4, IpNumber(packet[9]), ip_hdr_len))
+        }
+        6 => {
+            ensure!(packet.len() >= 40, "Packet too short for IPv6 header");
+
+            // GSO packets carry the transport header directly after the fixed IPv6 header;
+            // extension headers don't occur on TSO / USO packets.
+            Ok((IpVersion::V6, IpNumber(packet[6]), 40))
+        }
+        other => bail!("Not an IP packet (version: {other})"),
+    }
+}
+
+fn addresses(packet: &[u8], version: IpVersion) -> Result<(IpAddr, IpAddr)> {
+    match version {
+        IpVersion::V4 => {
+            let src: [u8; 4] = packet[12..16].try_into()?;
+            let dst: [u8; 4] = packet[16..20].try_into()?;
+
+            Ok((IpAddr::from(src), IpAddr::from(dst)))
+        }
+        IpVersion::V6 => {
+            let src: [u8; 16] = packet[8..24].try_into()?;
+            let dst: [u8; 16] = packet[24..40].try_into()?;
+
+            Ok((IpAddr::from(src), IpAddr::from(dst)))
+        }
+    }
+}

--- a/rust/libs/connlib/tun/src/linux/tests.rs
+++ b/rust/libs/connlib/tun/src/linux/tests.rs
@@ -197,23 +197,6 @@ fn coalesces_udp_datagrams() {
 }
 
 #[test]
-fn corrupt_checksum_is_not_coalesced() {
-    let mut queue = TunGsoQueue::new();
-
-    let good = tcp4(1000, &[1; 100]);
-    let mut corrupt = tcp4(1100, &[2; 100]);
-    corrupt_tcp_checksum(&mut corrupt);
-
-    queue.enqueue(good);
-    queue.enqueue(corrupt);
-
-    let out = queue.drain().collect::<Vec<_>>();
-
-    assert_eq!(out.len(), 2);
-    assert_eq!(out[1].num_segments(), 1); // Passed through for the kernel to drop.
-}
-
-#[test]
 fn completes_partial_checksum_of_non_gso_packet() {
     let packet = udp4(&[7; 32]);
     let bytes = packet.packet();
@@ -320,11 +303,4 @@ fn packet_from_bytes(bytes: &[u8]) -> IpPacket {
     buf.buf()[..bytes.len()].copy_from_slice(bytes);
 
     IpPacket::new(buf, bytes.len()).unwrap()
-}
-
-fn corrupt_tcp_checksum(packet: &mut IpPacket) {
-    let mut bytes = packet.packet().to_vec();
-    *bytes.last_mut().unwrap() ^= 0xFF; // Flip payload bits without updating the checksum.
-
-    *packet = packet_from_bytes(&bytes);
 }

--- a/rust/libs/connlib/tun/src/linux/tests.rs
+++ b/rust/libs/connlib/tun/src/linux/tests.rs
@@ -1,0 +1,330 @@
+use std::net::Ipv4Addr;
+
+use ip_packet::{IpHeaders, IpPacket, IpPacketBuf, Ipv4Header, PacketBuilder, ip_number};
+
+use super::coalesce::TunGsoQueue;
+use super::split::split;
+use super::virtio::*;
+use super::{checksum, virtio};
+
+const SRC: [u8; 4] = [10, 0, 0, 1];
+const DST: [u8; 4] = [10, 0, 0, 2];
+
+#[test]
+fn coalesces_sequential_tcp_segments() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4(1100, &[2; 100]));
+    queue.enqueue(tcp4(1200, &[3; 100]));
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    let [super_packet] = out.as_slice() else {
+        panic!("Expected a single super packet");
+    };
+    assert_eq!(super_packet.num_segments(), 3);
+
+    let buf = super_packet.bufs().concat();
+    let (hdr, packet) = VirtioNetHdr::parse(&buf).unwrap();
+
+    assert_eq!(hdr.flags, VIRTIO_NET_HDR_F_NEEDS_CSUM);
+    assert_eq!(hdr.gso_type, VIRTIO_NET_HDR_GSO_TCPV4);
+    assert_eq!(hdr.gso_size, 100);
+    assert_eq!(hdr.csum_start, 20);
+    assert_eq!(hdr.csum_offset, 16);
+    assert_eq!(hdr.hdr_len, 40);
+
+    assert_eq!(packet.len(), 20 + 20 + 300);
+    assert_eq!(
+        u16::from_be_bytes([packet[2], packet[3]]) as usize,
+        packet.len(),
+        "IPv4 total length must cover all segments"
+    );
+
+    // The payloads must be concatenated in order.
+    assert_eq!(&packet[40..140], &[1; 100]);
+    assert_eq!(&packet[140..240], &[2; 100]);
+    assert_eq!(&packet[240..340], &[3; 100]);
+}
+
+#[test]
+fn coalesced_tcp_packet_splits_back_into_segments() {
+    let mut queue = TunGsoQueue::new();
+
+    let segments = [
+        tcp4_id(10, 1000, &[1; 100]),
+        tcp4_id(11, 1100, &[2; 100]),
+        tcp4_id(12, 1200, &[3; 50]),
+    ];
+
+    for segment in segments.clone() {
+        queue.enqueue(segment);
+    }
+    let out = queue.drain().collect::<Vec<_>>();
+
+    let [super_packet] = out.as_slice() else {
+        panic!("Expected a single super packet");
+    };
+
+    let roundtripped = split(&super_packet.bufs().concat()).unwrap();
+
+    assert_eq!(roundtripped.len(), 3);
+
+    for (original, roundtripped) in segments.iter().zip(&roundtripped) {
+        assert_eq!(original.packet(), roundtripped.packet());
+    }
+}
+
+#[test]
+fn does_not_coalesce_across_flows() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4_ports(7000, 8000, 9999, &[9; 100]));
+    queue.enqueue(tcp4(1100, &[2; 100]));
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].num_segments(), 2);
+    assert_eq!(out[1].num_segments(), 1);
+}
+
+#[test]
+fn out_of_order_segment_starts_new_batch() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4(1500, &[2; 100])); // Gap in sequence numbers.
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].num_segments(), 1);
+    assert_eq!(out[1].num_segments(), 1);
+}
+
+#[test]
+fn psh_closes_the_batch() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4_psh(1100, &[2; 100]));
+    queue.enqueue(tcp4(1200, &[3; 100])); // Must not join the batch closed by the PSH.
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    let [super_packet, segment] = out.as_slice() else {
+        panic!("Expected a super packet followed by the post-PSH segment");
+    };
+    assert_eq!(super_packet.num_segments(), 2);
+    assert_eq!(segment.num_segments(), 1);
+
+    let buf = super_packet.bufs().concat();
+    let (_, packet) = VirtioNetHdr::parse(&buf).unwrap();
+    assert_eq!(
+        packet[33] & 0x08,
+        0x08,
+        "PSH must be set on the super packet"
+    );
+}
+
+#[test]
+fn short_segment_closes_the_batch() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4(1100, &[2; 40]));
+    queue.enqueue(tcp4(1140, &[3; 100])); // Must not join the batch closed by the short segment.
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    assert_eq!(out.len(), 2, "A shorter segment must close the batch");
+    assert_eq!(out[0].num_segments(), 2);
+    assert_eq!(out[1].num_segments(), 1);
+}
+
+#[test]
+fn non_candidate_flushes_same_flow_first() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4(1100, &[2; 100]));
+    queue.enqueue(tcp4(1200, &[])); // Pure ACK, not a candidate.
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    // Ordering within the flow must be preserved: batch first, then the ACK.
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].num_segments(), 2);
+    assert_eq!(out[1].num_segments(), 1);
+}
+
+#[test]
+fn coalesces_udp_datagrams() {
+    let mut queue = TunGsoQueue::new();
+
+    let datagrams = [
+        udp4_id(20, &[1; 100]),
+        udp4_id(21, &[2; 100]),
+        udp4_id(22, &[3; 30]),
+    ];
+
+    for datagram in datagrams.clone() {
+        queue.enqueue(datagram);
+    }
+    let out = queue.drain().collect::<Vec<_>>();
+
+    let [super_packet] = out.as_slice() else {
+        panic!("Expected a single super packet");
+    };
+    assert_eq!(super_packet.num_segments(), 3);
+
+    let buf = super_packet.bufs().concat();
+    let (hdr, _) = VirtioNetHdr::parse(&buf).unwrap();
+    assert_eq!(hdr.gso_type, VIRTIO_NET_HDR_GSO_UDP_L4);
+    assert_eq!(hdr.gso_size, 100);
+    assert_eq!(hdr.csum_offset, 6);
+
+    let roundtripped = split(&buf).unwrap();
+
+    assert_eq!(roundtripped.len(), 3);
+
+    for (original, roundtripped) in datagrams.iter().zip(&roundtripped) {
+        assert_eq!(original.packet(), roundtripped.packet());
+    }
+}
+
+#[test]
+fn corrupt_checksum_is_not_coalesced() {
+    let mut queue = TunGsoQueue::new();
+
+    let good = tcp4(1000, &[1; 100]);
+    let mut corrupt = tcp4(1100, &[2; 100]);
+    corrupt_tcp_checksum(&mut corrupt);
+
+    queue.enqueue(good);
+    queue.enqueue(corrupt);
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[1].num_segments(), 1); // Passed through for the kernel to drop.
+}
+
+#[test]
+fn completes_partial_checksum_of_non_gso_packet() {
+    let packet = udp4(&[7; 32]);
+    let bytes = packet.packet();
+
+    // Emulate what the kernel hands us for a locally-generated packet with TUN_F_CSUM:
+    // the UDP checksum field holds only the folded pseudo-header sum.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(
+        &VirtioNetHdr {
+            flags: VIRTIO_NET_HDR_F_NEEDS_CSUM,
+            gso_type: VIRTIO_NET_HDR_GSO_NONE,
+            hdr_len: 0,
+            gso_size: 0,
+            csum_start: 20,
+            csum_offset: 6,
+        }
+        .to_bytes(),
+    );
+    buf.extend_from_slice(bytes);
+
+    let l4_len = bytes.len() - 20;
+    let pseudo = checksum::fold(checksum::pseudo_header_sum_v4(
+        Ipv4Addr::from(SRC),
+        Ipv4Addr::from(DST),
+        17,
+        l4_len,
+    ));
+    buf[virtio::VNET_HDR_LEN + 26..virtio::VNET_HDR_LEN + 28]
+        .copy_from_slice(&pseudo.to_be_bytes());
+
+    let out = split(&buf).unwrap();
+
+    let [completed] = out.as_slice() else {
+        panic!("Expected a single packet")
+    };
+
+    assert_eq!(
+        completed.packet(),
+        packet.packet(),
+        "Completing the partial checksum must reproduce the full checksum"
+    );
+}
+
+fn tcp4(seq: u32, payload: &[u8]) -> IpPacket {
+    tcp4_id(0, seq, payload)
+}
+
+fn tcp4_id(id: u16, seq: u32, payload: &[u8]) -> IpPacket {
+    let builder = PacketBuilder::ip(ipv4_header(id, ip_number::TCP))
+        .tcp(5000, 6000, seq, 64000)
+        .ack(42);
+
+    let mut bytes = Vec::new();
+    builder.write(&mut bytes, payload).unwrap();
+
+    packet_from_bytes(&bytes)
+}
+
+fn tcp4_ports(sport: u16, dport: u16, seq: u32, payload: &[u8]) -> IpPacket {
+    let builder = PacketBuilder::ipv4(SRC, DST, 64)
+        .tcp(sport, dport, seq, 64000)
+        .ack(42);
+
+    let mut bytes = Vec::new();
+    builder.write(&mut bytes, payload).unwrap();
+
+    packet_from_bytes(&bytes)
+}
+
+fn tcp4_psh(seq: u32, payload: &[u8]) -> IpPacket {
+    let builder = PacketBuilder::ipv4(SRC, DST, 64)
+        .tcp(5000, 6000, seq, 64000)
+        .ack(42)
+        .psh();
+
+    let mut bytes = Vec::new();
+    builder.write(&mut bytes, payload).unwrap();
+
+    packet_from_bytes(&bytes)
+}
+
+fn udp4(payload: &[u8]) -> IpPacket {
+    udp4_id(0, payload)
+}
+
+fn udp4_id(id: u16, payload: &[u8]) -> IpPacket {
+    let builder = PacketBuilder::ip(ipv4_header(id, ip_number::UDP)).udp(5000, 6000);
+
+    let mut bytes = Vec::new();
+    builder.write(&mut bytes, payload).unwrap();
+
+    packet_from_bytes(&bytes)
+}
+
+fn ipv4_header(id: u16, protocol: ip_packet::IpNumber) -> IpHeaders {
+    let mut header = Ipv4Header::new(0, 64, protocol, SRC, DST).unwrap();
+    header.identification = id;
+
+    IpHeaders::Ipv4(header, Default::default())
+}
+
+fn packet_from_bytes(bytes: &[u8]) -> IpPacket {
+    let mut buf = IpPacketBuf::new();
+    buf.buf()[..bytes.len()].copy_from_slice(bytes);
+
+    IpPacket::new(buf, bytes.len()).unwrap()
+}
+
+fn corrupt_tcp_checksum(packet: &mut IpPacket) {
+    let mut bytes = packet.packet().to_vec();
+    *bytes.last_mut().unwrap() ^= 0xFF; // Flip payload bits without updating the checksum.
+
+    *packet = packet_from_bytes(&bytes);
+}

--- a/rust/libs/connlib/tun/src/linux/virtio.rs
+++ b/rust/libs/connlib/tun/src/linux/virtio.rs
@@ -1,0 +1,66 @@
+//! The `virtio_net_hdr` exchanged with the kernel on every read / write of a TUN fd
+//! that has `IFF_VNET_HDR` set.
+//!
+//! See `include/uapi/linux/virtio_net.h` and `include/linux/virtio_net.h` in the kernel sources.
+
+/// `virtio_net_hdr` is 10 bytes; the TUN driver defaults to this size for `IFF_VNET_HDR`
+/// unless changed via `TUNSETVNETHDRSZ`.
+pub const VNET_HDR_LEN: usize = 10;
+
+/// The checksum starting at [`VirtioNetHdr::csum_start`] must be completed by the receiver.
+///
+/// The field at `csum_start + csum_offset` holds the (folded, uncomplemented) pseudo-header
+/// checksum; the payload checksum still needs to be summed into it.
+pub const VIRTIO_NET_HDR_F_NEEDS_CSUM: u8 = 1;
+
+pub const VIRTIO_NET_HDR_GSO_NONE: u8 = 0;
+pub const VIRTIO_NET_HDR_GSO_TCPV4: u8 = 1;
+pub const VIRTIO_NET_HDR_GSO_TCPV6: u8 = 4;
+pub const VIRTIO_NET_HDR_GSO_UDP_L4: u8 = 5;
+
+/// The TUN driver interprets the multi-byte fields as `__virtio16`,
+/// which is native endian for the "legacy" virtio interface the driver defaults to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct VirtioNetHdr {
+    pub flags: u8,
+    pub gso_type: u8,
+    pub hdr_len: u16,
+    pub gso_size: u16,
+    pub csum_start: u16,
+    pub csum_offset: u16,
+}
+
+impl VirtioNetHdr {
+    pub fn parse(buf: &[u8]) -> Option<(Self, &[u8])> {
+        let (hdr, packet) = buf.split_at_checked(VNET_HDR_LEN)?;
+
+        Some((
+            Self {
+                flags: hdr[0],
+                gso_type: hdr[1],
+                hdr_len: u16::from_ne_bytes([hdr[2], hdr[3]]),
+                gso_size: u16::from_ne_bytes([hdr[4], hdr[5]]),
+                csum_start: u16::from_ne_bytes([hdr[6], hdr[7]]),
+                csum_offset: u16::from_ne_bytes([hdr[8], hdr[9]]),
+            },
+            packet,
+        ))
+    }
+
+    pub fn write_to(&self, buf: &mut [u8]) {
+        buf[0] = self.flags;
+        buf[1] = self.gso_type;
+        buf[2..4].copy_from_slice(&self.hdr_len.to_ne_bytes());
+        buf[4..6].copy_from_slice(&self.gso_size.to_ne_bytes());
+        buf[6..8].copy_from_slice(&self.csum_start.to_ne_bytes());
+        buf[8..10].copy_from_slice(&self.csum_offset.to_ne_bytes());
+    }
+
+    #[cfg(test)]
+    pub fn to_bytes(self) -> [u8; VNET_HDR_LEN] {
+        let mut buf = [0u8; VNET_HDR_LEN];
+        self.write_to(&mut buf);
+
+        buf
+    }
+}


### PR DESCRIPTION
We read from and write to the Linux TUN device one IP packet at a time. For a data plane that moves a lot of small packets, that per-packet syscall — and the full traversal of the kernel network stack it triggers — is the single largest cost. Linux offers a way out: with `IFF_VNET_HDR` and `TUNSETOFFLOAD`, the kernel coalesces consecutive segments of the same flow into one large buffer on read (GRO) and splits a large buffer back into MTU-sized packets on write (GSO). A whole run of packets then crosses the TUN boundary in a single syscall, described by a small `virtio_net_hdr`.

We enable the offloads when opening the device. On the read path, we split incoming super packets back into individual `IpPacket`s, fixing up the per-segment lengths, IPv4 IDs, TCP flags and checksums and completing the partial checksums that come with `TUN_F_CSUM`. On the write path, we coalesce same-flow packets into a single GSO write, using the packet-batch boundary from #14030 as the coalescing window and only merging packets that the kernel's own GRO would have merged anyway.

The offloads we rely on (USO in particular) only landed in Linux 6.2, so we gate the whole thing behind a kernel-version check and keep exchanging plain packets on older kernels. A kernel that rejects a GSO write at runtime disables coalescing on the fly and falls back to per-packet writes.

In a local benchmark, this roughly doubles single-stream TCP throughput through the tunnel; the kernel's own GRO/TSO on the surrounding interfaces then carries the coalesced packets through the rest of the stack.

Related: #14030
Related: #14013