### PR TITLE
refactor(connlib): extract TUN channel newtypes

### DIFF
--- a/rust/client-ffi/src/platform/android/tun.rs
+++ b/rust/client-ffi/src/platform/android/tun.rs
@@ -2,24 +2,21 @@ use ip_packet::{IpPacket, IpPacketBuf};
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::{io, os::fd::RawFd};
 use telemetry::otel;
-use tokio::sync::mpsc;
 use tun::ioctl;
-
-const QUEUE_SIZE: usize = 1000;
 
 pub struct Tun {
     name: String,
-    outbound_tx: mpsc::Sender<IpPacket>,
-    inbound_rx: mpsc::Receiver<IpPacket>,
+    outbound_tx: tun::OutboundTx,
+    inbound_rx: tun::InboundRx,
     _fd: OwnedFd,
 }
 
 impl tun::Tun for Tun {
-    fn sender(&self) -> &mpsc::Sender<IpPacket> {
+    fn sender(&self) -> &tun::OutboundTx {
         &self.outbound_tx
     }
 
-    fn receiver(&mut self) -> &mut mpsc::Receiver<IpPacket> {
+    fn receiver(&mut self) -> &mut tun::InboundRx {
         &mut self.inbound_rx
     }
 
@@ -38,8 +35,8 @@ impl Tun {
     pub unsafe fn from_fd(fd: RawFd, runtime: &tokio::runtime::Handle) -> io::Result<Self> {
         let name = unsafe { interface_name(fd)? };
 
-        let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
+        let (inbound_tx, inbound_rx) = tun::inbound_channel();
+        let (outbound_tx, outbound_rx) = tun::outbound_channel();
 
         runtime.spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -1,10 +1,6 @@
-use ip_packet::IpPacket;
 use libc::{F_GETFL, F_SETFL, O_NONBLOCK, fcntl};
 use std::{io, os::fd::RawFd};
 use telemetry::otel;
-use tokio::sync::mpsc;
-
-const QUEUE_SIZE: usize = 10_000;
 
 /// Receive buffer we request for the utun control socket via `SO_RCVBUF`.
 ///
@@ -33,8 +29,8 @@ const UTUN_OPT_MAX_PENDING_PACKETS: libc::c_int = 16;
 
 pub struct Tun {
     name: String,
-    outbound_tx: mpsc::Sender<IpPacket>,
-    inbound_rx: mpsc::Receiver<IpPacket>,
+    outbound_tx: tun::OutboundTx,
+    inbound_rx: tun::InboundRx,
 }
 
 impl Tun {
@@ -62,8 +58,8 @@ impl Tun {
         raise_recv_buffer(fd);
         raise_max_pending_packets(fd);
 
-        let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
+        let (inbound_tx, inbound_rx) = tun::inbound_channel();
+        let (outbound_tx, outbound_rx) = tun::outbound_channel();
 
         runtime.spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
@@ -108,11 +104,11 @@ impl Tun {
 }
 
 impl tun::Tun for Tun {
-    fn sender(&self) -> &mpsc::Sender<IpPacket> {
+    fn sender(&self) -> &tun::OutboundTx {
         &self.outbound_tx
     }
 
-    fn receiver(&mut self) -> &mut mpsc::Receiver<IpPacket> {
+    fn receiver(&mut self) -> &mut tun::InboundRx {
         &mut self.inbound_rx
     }
 

--- a/rust/client-ffi/src/platform/fallback.rs
+++ b/rust/client-ffi/src/platform/fallback.rs
@@ -48,11 +48,11 @@ impl Tun {
 }
 
 impl tun::Tun for Tun {
-    fn sender(&self) -> &tokio::sync::mpsc::Sender<ip_packet::IpPacket> {
+    fn sender(&self) -> &tun::OutboundTx {
         todo!()
     }
 
-    fn receiver(&mut self) -> &mut tokio::sync::mpsc::Receiver<ip_packet::IpPacket> {
+    fn receiver(&mut self) -> &mut tun::InboundRx {
         todo!()
     }
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -10,7 +10,6 @@ use bin_shared::{
 use clap::Parser;
 
 use hickory_resolver::config::ResolveHosts;
-use ip_packet::IpPacket;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
@@ -414,18 +413,18 @@ impl Cli {
 
 /// An adapter struct around [`Tun`] that validates IPv4, UDP and TCP checksums.
 struct ValidateChecksumAdapter {
-    outbound_tx: tokio::sync::mpsc::Sender<IpPacket>,
-    inbound_rx: tokio::sync::mpsc::Receiver<IpPacket>,
+    outbound_tx: tun::OutboundTx,
+    inbound_rx: tun::InboundRx,
     name: String,
     _task: AbortOnDropHandle<()>,
 }
 
 impl Tun for ValidateChecksumAdapter {
-    fn sender(&self) -> &tokio::sync::mpsc::Sender<IpPacket> {
+    fn sender(&self) -> &tun::OutboundTx {
         &self.outbound_tx
     }
 
-    fn receiver(&mut self) -> &mut tokio::sync::mpsc::Receiver<IpPacket> {
+    fn receiver(&mut self) -> &mut tun::InboundRx {
         &mut self.inbound_rx
     }
 
@@ -439,7 +438,7 @@ impl ValidateChecksumAdapter {
         let name = inner.name().to_string();
 
         // Channel for inbound packets (from TUN device to gateway)
-        let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel(1000);
+        let (inbound_tx, inbound_rx) = tun::inbound_channel();
 
         // Get reference to inner TUN's sender for outbound packets
         let outbound_tx = inner.sender().clone();

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -38,7 +38,6 @@ use std::{
 };
 use std::{net::IpAddr, time::Duration};
 use telemetry::otel;
-use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tun::ioctl;
 
@@ -677,19 +676,17 @@ async fn link_states(handle: &Handle, link_scope_routes: &[RouteMessage]) -> Has
     link_state
 }
 
-const QUEUE_SIZE: usize = 10_000;
-
 pub struct Tun {
-    outbound_tx: mpsc::Sender<IpPacket>,
-    inbound_rx: mpsc::Receiver<IpPacket>,
+    outbound_tx: tun::OutboundTx,
+    inbound_rx: tun::InboundRx,
 }
 
 impl Tun {
     pub fn new() -> Result<Self> {
         create_tun_device()?;
 
-        let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
+        let (inbound_tx, inbound_rx) = tun::inbound_channel();
+        let (outbound_tx, outbound_rx) = tun::outbound_channel();
 
         tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
@@ -767,11 +764,11 @@ fn open_tun() -> Result<OwnedFd> {
 }
 
 impl tun::Tun for Tun {
-    fn sender(&self) -> &mpsc::Sender<IpPacket> {
+    fn sender(&self) -> &tun::OutboundTx {
         &self.outbound_tx
     }
 
-    fn receiver(&mut self) -> &mut mpsc::Receiver<IpPacket> {
+    fn receiver(&mut self) -> &mut tun::InboundRx {
         &mut self.inbound_rx
     }
 

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -20,7 +20,6 @@ use std::{
     sync::Arc,
 };
 use telemetry::otel;
-use tokio::sync::mpsc;
 use windows::Win32::NetworkManagement::IpHelper::{
     CreateUnicastIpAddressEntry, InitializeUnicastIpAddressEntry, MIB_UNICASTIPADDRESS_ROW,
 };
@@ -46,8 +45,6 @@ use wintun::Adapter;
 /// We think 1 MiB is similar to the buffer size on Linux / macOS but we're not sure
 /// where that is configured.
 const RING_BUFFER_SIZE: u32 = 0x10_0000;
-
-const QUEUE_SIZE: usize = 1000;
 
 pub struct TunDeviceManager {
     mtu: u32,
@@ -214,8 +211,8 @@ pub struct Tun {
 struct TunState {
     session: Arc<wintun::Session>,
 
-    outbound_tx: mpsc::Sender<IpPacket>,
-    inbound_rx: mpsc::Receiver<IpPacket>,
+    outbound_tx: tun::OutboundTx,
+    inbound_rx: tun::InboundRx,
 }
 
 impl Drop for Tun {
@@ -303,8 +300,8 @@ impl Tun {
                 .start_session(capacity)
                 .context("Failed to start session")?,
         );
-        let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
-        let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE); // We want to be able to batch-receive from this.
+        let (outbound_tx, outbound_rx) = tun::outbound_channel();
+        let (inbound_tx, inbound_rx) = tun::inbound_channel();
 
         tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
@@ -345,7 +342,7 @@ impl Tun {
 }
 
 impl tun::Tun for Tun {
-    fn sender(&self) -> &mpsc::Sender<IpPacket> {
+    fn sender(&self) -> &tun::OutboundTx {
         &self
             .state
             .as_ref()
@@ -353,7 +350,7 @@ impl tun::Tun for Tun {
             .outbound_tx
     }
 
-    fn receiver(&mut self) -> &mut mpsc::Receiver<IpPacket> {
+    fn receiver(&mut self) -> &mut tun::InboundRx {
         &mut self
             .state
             .as_mut()
@@ -380,7 +377,7 @@ const SPIN_LIMIT: u32 = 6;
 
 // Moves packets from Internet towards the user
 fn start_send_thread(
-    mut packet_rx: mpsc::Receiver<IpPacket>,
+    mut packet_rx: tun::OutboundRx,
     session: Weak<wintun::Session>,
 ) -> io::Result<std::thread::JoinHandle<()>> {
     let write_retry_histogram = otel_instruments::network_retries();
@@ -512,7 +509,7 @@ fn drop_attributes(e: &wintun::Error) -> [KeyValue; 3] {
 }
 
 fn start_recv_thread(
-    packet_tx: mpsc::Sender<IpPacket>,
+    packet_tx: tun::InboundTx,
     session: Weak<wintun::Session>,
 ) -> io::Result<std::thread::JoinHandle<()>> {
     std::thread::Builder::new()

--- a/rust/libs/connlib/tun/src/apple.rs
+++ b/rust/libs/connlib/tun/src/apple.rs
@@ -16,12 +16,12 @@ mod sys;
 mod tests;
 
 use anyhow::Result;
-use ip_packet::IpPacket;
 use std::os::fd::RawFd;
-use tokio::sync::mpsc;
+
+use crate::{InboundTx, OutboundRx};
 
 /// Sends packets from `outbound_rx` to the TUN `fd` until the channel closes.
-pub fn send(fd: RawFd, outbound_rx: mpsc::Receiver<IpPacket>) -> Result<()> {
+pub fn send(fd: RawFd, outbound_rx: OutboundRx) -> Result<()> {
     match sys::batch_syscalls() {
         Some(syscalls) => bulk::send(fd, syscalls, outbound_rx),
         None => crate::unix::tun_send(fd, outbound_rx, per_packet::write),
@@ -29,7 +29,7 @@ pub fn send(fd: RawFd, outbound_rx: mpsc::Receiver<IpPacket>) -> Result<()> {
 }
 
 /// Receives packets from the TUN `fd` into `inbound_tx` until the fd closes.
-pub fn recv(fd: RawFd, inbound_tx: mpsc::Sender<IpPacket>) -> Result<()> {
+pub fn recv(fd: RawFd, inbound_tx: InboundTx) -> Result<()> {
     match sys::batch_syscalls() {
         Some(syscalls) => bulk::recv(fd, syscalls, inbound_tx),
         None => crate::unix::tun_recv(fd, inbound_tx, per_packet::read),

--- a/rust/libs/connlib/tun/src/apple/bulk.rs
+++ b/rust/libs/connlib/tun/src/apple/bulk.rs
@@ -13,9 +13,9 @@ use std::ffi::c_void;
 use std::io;
 use std::os::fd::{AsRawFd as _, RawFd};
 use tokio::io::{Interest, unix::AsyncFd};
-use tokio::sync::mpsc;
 
 use super::sys;
+use crate::{InboundTx, OutboundRx};
 
 /// How many packets we exchange with the kernel per syscall.
 ///
@@ -33,7 +33,7 @@ const EMPTY_IOVEC: iovec = iovec {
 pub fn send(
     fd: RawFd,
     syscalls: &'static sys::BatchSyscalls,
-    mut outbound_rx: mpsc::Receiver<IpPacket>,
+    mut outbound_rx: OutboundRx,
 ) -> Result<()> {
     let batch_count = otel_instruments::network_packets_batch_count();
     let dropped_packets = otel_instruments::network_packet_dropped();
@@ -105,11 +105,7 @@ pub fn send(
 }
 
 /// Receives batches of packets from the TUN device into `inbound_tx`.
-pub fn recv(
-    fd: RawFd,
-    syscalls: &'static sys::BatchSyscalls,
-    inbound_tx: mpsc::Sender<IpPacket>,
-) -> Result<()> {
+pub fn recv(fd: RawFd, syscalls: &'static sys::BatchSyscalls, inbound_tx: InboundTx) -> Result<()> {
     let batch_count = otel_instruments::network_packets_batch_count();
 
     tokio::runtime::Builder::new_current_thread()

--- a/rust/libs/connlib/tun/src/apple/tests.rs
+++ b/rust/libs/connlib/tun/src/apple/tests.rs
@@ -9,8 +9,6 @@ use std::net::{IpAddr, Ipv4Addr, UdpSocket};
 use std::os::fd::RawFd;
 use std::time::{Duration, Instant};
 
-use ip_packet::IpPacket;
-
 /// From XNU's `bsd/net/if_utun.h`.
 const UTUN_OPT_MAX_PENDING_PACKETS: libc::c_int = 16;
 
@@ -28,7 +26,7 @@ fn recv_reads_packets_routed_through_the_interface() {
     raise_max_pending_packets(fd, 64);
     configure(&name);
 
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<IpPacket>(1024);
+    let (tx, mut rx) = crate::inbound_channel_for_test(1024);
     std::thread::Builder::new()
         .name("test TUN recv".to_owned())
         .spawn(move || {

--- a/rust/libs/connlib/tun/src/apple/tests.rs
+++ b/rust/libs/connlib/tun/src/apple/tests.rs
@@ -26,7 +26,7 @@ fn recv_reads_packets_routed_through_the_interface() {
     raise_max_pending_packets(fd, 64);
     configure(&name);
 
-    let (tx, mut rx) = crate::inbound_channel_for_test(1024);
+    let (tx, mut rx) = crate::inbound_channel();
     std::thread::Builder::new()
         .name("test TUN recv".to_owned())
         .spawn(move || {

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -11,7 +11,11 @@ pub mod apple;
 
 /// Capacity of the channels connecting the TUN device threads to the main thread.
 const CHANNEL_CAPACITY: usize = cfg_select! {
-    any(target_os = "linux", target_os = "macos", target_os = "ios") => { 10_000 }
+    target_os = "linux" => { 10_000 }
+    target_os = "windows" => { 10_000 }
+    target_os = "macos" => { 10_000 }
+    target_os = "ios" => { 1_000 }
+    target_os = "android" => { 1_000 }
     _ => { 1_000 }
 };
 
@@ -45,13 +49,6 @@ pub fn outbound_channel_for_test(capacity: usize) -> (OutboundTx, OutboundRx) {
     let (tx, rx) = mpsc::channel(capacity);
 
     (OutboundTx(tx), OutboundRx(rx))
-}
-
-/// Creates an inbound channel with an explicit capacity; only meant for tests.
-pub fn inbound_channel_for_test(capacity: usize) -> (InboundTx, InboundRx) {
-    let (tx, rx) = mpsc::channel(capacity);
-
-    (InboundTx(tx), InboundRx(rx))
 }
 
 /// The sending half of the channel to the thread writing to the TUN device.

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -1,4 +1,5 @@
 use ip_packet::IpPacket;
+use tokio::sync::mpsc;
 
 #[cfg(target_family = "unix")]
 pub mod ioctl;
@@ -8,13 +9,144 @@ pub mod unix;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub mod apple;
 
+/// Capacity of the channels connecting the TUN device threads to the main thread.
+const CHANNEL_CAPACITY: usize = cfg_select! {
+    any(target_os = "linux", target_os = "macos", target_os = "ios") => { 10_000 }
+    _ => { 1_000 }
+};
+
 pub trait Tun: Send + Sync + 'static {
     /// Get a reference to the sender for outbound packets.
-    fn sender(&self) -> &tokio::sync::mpsc::Sender<IpPacket>;
+    fn sender(&self) -> &OutboundTx;
 
     /// Get a mutable reference to the receiver for inbound packets.
-    fn receiver(&mut self) -> &mut tokio::sync::mpsc::Receiver<IpPacket>;
+    fn receiver(&mut self) -> &mut InboundRx;
 
     /// The name of the TUN device.
     fn name(&self) -> &str;
+}
+
+/// Creates the channel connecting the main thread to the thread writing to the TUN device.
+pub fn outbound_channel() -> (OutboundTx, OutboundRx) {
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+
+    (OutboundTx(tx), OutboundRx(rx))
+}
+
+/// Creates the channel connecting the thread reading from the TUN device to the main thread.
+pub fn inbound_channel() -> (InboundTx, InboundRx) {
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+
+    (InboundTx(tx), InboundRx(rx))
+}
+
+/// Creates an outbound channel with an explicit capacity; only meant for tests.
+pub fn outbound_channel_for_test(capacity: usize) -> (OutboundTx, OutboundRx) {
+    let (tx, rx) = mpsc::channel(capacity);
+
+    (OutboundTx(tx), OutboundRx(rx))
+}
+
+/// Creates an inbound channel with an explicit capacity; only meant for tests.
+pub fn inbound_channel_for_test(capacity: usize) -> (InboundTx, InboundRx) {
+    let (tx, rx) = mpsc::channel(capacity);
+
+    (InboundTx(tx), InboundRx(rx))
+}
+
+/// The sending half of the channel to the thread writing to the TUN device.
+#[derive(Clone)]
+pub struct OutboundTx(mpsc::Sender<IpPacket>);
+
+impl OutboundTx {
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error carries the unsent packet by design"
+    )]
+    pub fn try_send(&self, packet: IpPacket) -> Result<(), mpsc::error::TrySendError<IpPacket>> {
+        self.0.try_send(packet)
+    }
+
+    pub async fn send(&self, packet: IpPacket) -> Result<(), mpsc::error::SendError<IpPacket>> {
+        self.0.send(packet).await
+    }
+
+    pub fn downgrade(&self) -> mpsc::WeakSender<IpPacket> {
+        self.0.downgrade()
+    }
+}
+
+/// The receiving half of the channel to the thread writing to the TUN device.
+pub struct OutboundRx(mpsc::Receiver<IpPacket>);
+
+impl OutboundRx {
+    pub async fn recv(&mut self) -> Option<IpPacket> {
+        self.0.recv().await
+    }
+
+    pub async fn recv_many(&mut self, buffer: &mut Vec<IpPacket>, limit: usize) -> usize {
+        self.0.recv_many(buffer, limit).await
+    }
+
+    pub fn blocking_recv(&mut self) -> Option<IpPacket> {
+        self.0.blocking_recv()
+    }
+}
+
+/// The sending half of the channel of [`IpPacket`]s read from the TUN device.
+#[derive(Clone)]
+pub struct InboundTx(mpsc::Sender<IpPacket>);
+
+impl InboundTx {
+    pub async fn reserve_many(
+        &self,
+        n: usize,
+    ) -> Result<mpsc::PermitIterator<'_, IpPacket>, mpsc::error::SendError<()>> {
+        self.0.reserve_many(n).await
+    }
+
+    pub async fn send(&self, packet: IpPacket) -> Result<(), mpsc::error::SendError<IpPacket>> {
+        self.0.send(packet).await
+    }
+
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error carries the unsent packet by design"
+    )]
+    pub fn blocking_send(&self, packet: IpPacket) -> Result<(), mpsc::error::SendError<IpPacket>> {
+        self.0.blocking_send(packet)
+    }
+
+    pub fn downgrade(&self) -> mpsc::WeakSender<IpPacket> {
+        self.0.downgrade()
+    }
+}
+
+/// The receiving half of the channel of [`IpPacket`]s read from the TUN device.
+pub struct InboundRx(mpsc::Receiver<IpPacket>);
+
+impl InboundRx {
+    pub fn poll_recv_many(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        buffer: &mut Vec<IpPacket>,
+        limit: usize,
+    ) -> std::task::Poll<usize> {
+        self.0.poll_recv_many(cx, buffer, limit)
+    }
+
+    pub fn poll_recv(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<IpPacket>> {
+        self.0.poll_recv(cx)
+    }
+
+    pub async fn recv(&mut self) -> Option<IpPacket> {
+        self.0.recv().await
+    }
+
+    pub fn try_recv(&mut self) -> Result<IpPacket, mpsc::error::TryRecvError> {
+        self.0.try_recv()
+    }
 }

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -44,7 +44,9 @@ pub fn inbound_channel() -> (InboundTx, InboundRx) {
     (InboundTx(tx), InboundRx(rx))
 }
 
-/// Creates an outbound channel with an explicit capacity; only meant for tests.
+/// Creates an outbound channel with an explicit capacity.
+///
+/// Only meant for tests that need to exercise behaviour on a full channel.
 pub fn outbound_channel_for_test(capacity: usize) -> (OutboundTx, OutboundRx) {
     let (tx, rx) = mpsc::channel(capacity);
 

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -147,3 +147,27 @@ impl InboundRx {
         self.0.try_recv()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Worst-case memory usage of the two TUN channels: every slot filled with a
+    /// packet, each of which owns a pooled buffer of [`ip_packet::MAX_FZ_PAYLOAD`] bytes.
+    const MAX_CHANNEL_MEMORY: usize =
+        2 * CHANNEL_CAPACITY * (size_of::<IpPacket>() + ip_packet::MAX_FZ_PAYLOAD);
+
+    /// iOS network extensions are limited to 50 MB of memory; the channels must only
+    /// ever use a small fraction of that.
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    #[test]
+    fn channel_memory_fits_mobile_budget() {
+        const { assert!(MAX_CHANNEL_MEMORY <= 4 * 1024 * 1024) }
+    }
+
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    #[test]
+    fn channel_memory_fits_desktop_budget() {
+        const { assert!(MAX_CHANNEL_MEMORY <= 32 * 1024 * 1024) }
+    }
+}

--- a/rust/libs/connlib/tun/src/unix.rs
+++ b/rust/libs/connlib/tun/src/unix.rs
@@ -4,7 +4,6 @@ use opentelemetry::KeyValue;
 use std::io;
 use std::os::fd::AsRawFd;
 use tokio::io::unix::AsyncFd;
-use tokio::sync::mpsc;
 
 /// How many times we at most try to re-write a packet if the TUN queue is full (`ENOSPC` on MacOS / iOS).
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -27,7 +26,7 @@ const MAX_TUN_BATCH: usize = if cfg!(any(target_os = "ios", target_os = "android
 
 pub fn tun_send<T>(
     fd: T,
-    mut outbound_rx: mpsc::Receiver<IpPacket>,
+    mut outbound_rx: crate::OutboundRx,
     write: impl Fn(i32, &IpPacket) -> std::result::Result<usize, io::Error>,
 ) -> Result<()>
 where
@@ -165,7 +164,7 @@ fn drop_attributes(e: &io::Error) -> [KeyValue; 3] {
 
 pub fn tun_recv<T>(
     fd: T,
-    inbound_tx: mpsc::Sender<IpPacket>,
+    inbound_tx: crate::InboundTx,
     read: impl Fn(i32, &mut IpPacketBuf) -> std::result::Result<usize, io::Error>,
 ) -> Result<()>
 where

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -843,23 +843,30 @@ mod tests {
     }
 
     struct DummyTun {
-        tx: tokio::sync::mpsc::Sender<IpPacket>,
-        rx: tokio::sync::mpsc::Receiver<IpPacket>,
+        tx: tun::OutboundTx,
+        rx: tun::InboundRx,
+        _keep_alive: (tun::OutboundRx, tun::InboundTx),
     }
 
     impl DummyTun {
         fn new() -> Self {
-            let (tx, rx) = tokio::sync::mpsc::channel(1);
-            Self { tx, rx }
+            let (tx, outbound_rx) = tun::outbound_channel_for_test(1);
+            let (inbound_tx, rx) = tun::inbound_channel_for_test(1);
+
+            Self {
+                tx,
+                rx,
+                _keep_alive: (outbound_rx, inbound_tx),
+            }
         }
     }
 
     impl Tun for DummyTun {
-        fn sender(&self) -> &tokio::sync::mpsc::Sender<IpPacket> {
+        fn sender(&self) -> &tun::OutboundTx {
             &self.tx
         }
 
-        fn receiver(&mut self) -> &mut tokio::sync::mpsc::Receiver<IpPacket> {
+        fn receiver(&mut self) -> &mut tun::InboundRx {
             &mut self.rx
         }
 

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -850,7 +850,7 @@ mod tests {
 
     impl DummyTun {
         fn new() -> Self {
-            let (tx, outbound_rx) = tun::outbound_channel_for_test(1);
+            let (tx, outbound_rx) = tun::outbound_channel();
             let (inbound_tx, rx) = tun::inbound_channel();
 
             Self {

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -851,7 +851,7 @@ mod tests {
     impl DummyTun {
         fn new() -> Self {
             let (tx, outbound_rx) = tun::outbound_channel_for_test(1);
-            let (inbound_tx, rx) = tun::inbound_channel_for_test(1);
+            let (inbound_tx, rx) = tun::inbound_channel();
 
             Self {
                 tx,

--- a/rust/libs/connlib/tunnel/src/io/device.rs
+++ b/rust/libs/connlib/tunnel/src/io/device.rs
@@ -147,7 +147,6 @@ mod tests {
     use super::*;
     use anyhow::ErrorExt;
     use std::net::Ipv4Addr;
-    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn flush_returns_error_when_sender_channel_closed() {
@@ -259,25 +258,25 @@ mod tests {
     }
 
     struct TestTun {
-        send_tx: mpsc::Sender<IpPacket>,
-        recv_rx: mpsc::Receiver<IpPacket>,
+        send_tx: tun::OutboundTx,
+        recv_rx: tun::InboundRx,
     }
 
     impl TestTun {
-        fn new() -> (Self, mpsc::Receiver<IpPacket>, mpsc::Sender<IpPacket>) {
-            let (send_tx, send_rx) = mpsc::channel(1);
-            let (recv_tx, recv_rx) = mpsc::channel(1);
+        fn new() -> (Self, tun::OutboundRx, tun::InboundTx) {
+            let (send_tx, send_rx) = tun::outbound_channel_for_test(1);
+            let (recv_tx, recv_rx) = tun::inbound_channel_for_test(1);
 
             (Self { send_tx, recv_rx }, send_rx, recv_tx)
         }
     }
 
     impl Tun for TestTun {
-        fn sender(&self) -> &mpsc::Sender<IpPacket> {
+        fn sender(&self) -> &tun::OutboundTx {
             &self.send_tx
         }
 
-        fn receiver(&mut self) -> &mut mpsc::Receiver<IpPacket> {
+        fn receiver(&mut self) -> &mut tun::InboundRx {
             &mut self.recv_rx
         }
 

--- a/rust/libs/connlib/tunnel/src/io/device.rs
+++ b/rust/libs/connlib/tunnel/src/io/device.rs
@@ -265,7 +265,7 @@ mod tests {
     impl TestTun {
         fn new() -> (Self, tun::OutboundRx, tun::InboundTx) {
             let (send_tx, send_rx) = tun::outbound_channel_for_test(1);
-            let (recv_tx, recv_rx) = tun::inbound_channel_for_test(1);
+            let (recv_tx, recv_rx) = tun::inbound_channel();
 
             (Self { send_tx, recv_rx }, send_rx, recv_tx)
         }


### PR DESCRIPTION
Wraps the mpsc channel ends connecting the TUN threads to the main thread in dedicated types (`OutboundTx`/`OutboundRx`, `InboundTx`/`InboundRx`) and moves channel construction into the `tun` crate. The channel capacity is now defined in a single place, selected per platform via `cfg_select!`, instead of at every call site. As a consequence, the gateway's checksum-validation adapter now uses the platform capacity instead of its own.

Related: #14011