### PR TITLE
ci: only disable checksum offload on the relay XDP boundary

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -287,12 +287,6 @@ jobs:
 
           sleep 3 # Let everything settle for a bit
 
-      - name: Disable checksum offloading
-        run: |
-          # Force checksum calculation on the host since some tests run on the host
-          sudo ethtool -K eth0 tx off
-          sudo ethtool -K docker0 tx off
-
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
         if: ${{ steps.client_version_check.outcome != 'failure' && steps.gateway_version_check.outcome != 'failure' }} # Run the script if version checks succeed or are skipped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,12 +139,6 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.30.0.254
         ip -6 route add 203:0:113::/64 via 172:30:0::254
 
-        # Enable TCP & UDP segmentation offload. This requires checksum offload
-        # to stay on; relay-bound packets still get software-computed checksums
-        # on the relays' host-side veths (see the network-config service).
-        apk add --no-cache ethtool iproute2
-        ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
-
         ip link set dev eth0 txqueuelen 100000
 
         exec firezone-headless-client
@@ -187,12 +181,6 @@ services:
         # Add static route to internet subnet via router
         ip -4 route add 203.0.113.0/24 via 172.32.0.254
         ip -6 route add 203:0:113::/64 via 172:32:0::254
-
-        # Enable TCP & UDP segmentation offload. This requires checksum offload
-        # to stay on; relay-bound packets still get software-computed checksums
-        # on the relays' host-side veths (see the network-config service).
-        apk add --no-cache ethtool iproute2
-        ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
         ip link set dev eth0 txqueuelen 100000
 
@@ -239,14 +227,6 @@ services:
         # Add static route to internet subnet via router
         ip -4 route add 203.0.113.0/24 via 172.31.0.254
         ip -6 route add 203:0:113::/64 via 172:31:0::254 || true
-
-        # Enable TCP & UDP segmentation offload. This requires checksum offload
-        # to stay on; relay-bound packets still get software-computed checksums
-        # on the relays' host-side veths (see the network-config service).
-        apk add --no-cache ethtool iproute2
-        ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
-        ethtool -K eth1 tx on tx-tcp-segmentation on tx-udp-segmentation on
-        ethtool -K eth2 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
         ip link set dev eth0 txqueuelen 100000
         ip link set dev eth1 txqueuelen 100000
@@ -414,10 +394,10 @@ services:
   # that does XDP_PASS to the host side veth interface. The GRO method is not reliable and was shown to
   # only pass packets in large bursts every 15-20 seconds which breaks ICE setup, so we use the XDP method.
   #
-  # For correct behaviour, we also disable any kind of offloading for the relay-internal veth and
-  # bridge devices. This forces the kernel to segment packets and calculate their checksums in
-  # software before they reach the XDP programs. All other devices keep their default offloads
-  # so packets traverse the rest of the compose networks coalesced.
+  # For correct behaviour, we also disable tx offload (checksumming and, by dependency, TSO/USO)
+  # on the relay-internal veth and bridge devices. This forces the kernel to segment packets and
+  # calculate their checksums in software before they reach the XDP programs. All other devices
+  # keep their default offloads so packets traverse the rest of the compose networks coalesced.
   network-config:
     image: ghcr.io/firezone/xdp-pass
     pid: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,9 +139,11 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.30.0.254
         ip -6 route add 203:0:113::/64 via 172:30:0::254
 
-        # Disable checksum offloading so that checksums are correct when they reach the relay
+        # Enable TCP & UDP segmentation offload. This requires checksum offload
+        # to stay on; relay-bound packets still get software-computed checksums
+        # on the host-side veths (see the network-config service).
         apk add --no-cache ethtool iproute2
-        ethtool -K eth0 tx off
+        ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
         ip link set dev eth0 txqueuelen 100000
 
@@ -186,9 +188,11 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.32.0.254
         ip -6 route add 203:0:113::/64 via 172:32:0::254
 
-        # Disable checksum offloading so that checksums are correct when they reach the relay
+        # Enable TCP & UDP segmentation offload. This requires checksum offload
+        # to stay on; relay-bound packets still get software-computed checksums
+        # on the host-side veths (see the network-config service).
         apk add --no-cache ethtool iproute2
-        ethtool -K eth0 tx off
+        ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
         ip link set dev eth0 txqueuelen 100000
 
@@ -236,11 +240,13 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.31.0.254
         ip -6 route add 203:0:113::/64 via 172:31:0::254 || true
 
-        # Disable checksum offloading so that checksums are correct when they reach the relay
+        # Enable TCP & UDP segmentation offload. This requires checksum offload
+        # to stay on; relay-bound packets still get software-computed checksums
+        # on the host-side veths (see the network-config service).
         apk add --no-cache ethtool iproute2
-        ethtool -K eth0 tx off
-        ethtool -K eth1 tx off
-        ethtool -K eth2 tx off
+        ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
+        ethtool -K eth1 tx on tx-tcp-segmentation on tx-udp-segmentation on
+        ethtool -K eth2 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
         ip link set dev eth0 txqueuelen 100000
         ip link set dev eth1 txqueuelen 100000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,7 @@ services:
 
         # Enable TCP & UDP segmentation offload. This requires checksum offload
         # to stay on; relay-bound packets still get software-computed checksums
-        # on the host-side veths (see the network-config service).
+        # on the relays' host-side veths (see the network-config service).
         apk add --no-cache ethtool iproute2
         ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
@@ -190,7 +190,7 @@ services:
 
         # Enable TCP & UDP segmentation offload. This requires checksum offload
         # to stay on; relay-bound packets still get software-computed checksums
-        # on the host-side veths (see the network-config service).
+        # on the relays' host-side veths (see the network-config service).
         apk add --no-cache ethtool iproute2
         ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
 
@@ -242,7 +242,7 @@ services:
 
         # Enable TCP & UDP segmentation offload. This requires checksum offload
         # to stay on; relay-bound packets still get software-computed checksums
-        # on the host-side veths (see the network-config service).
+        # on the relays' host-side veths (see the network-config service).
         apk add --no-cache ethtool iproute2
         ethtool -K eth0 tx on tx-tcp-segmentation on tx-udp-segmentation on
         ethtool -K eth1 tx on tx-tcp-segmentation on tx-udp-segmentation on
@@ -410,8 +410,10 @@ services:
   # that does XDP_PASS to the host side veth interface. The GRO method is not reliable and was shown to
   # only pass packets in large bursts every 15-20 seconds which breaks ICE setup, so we use the XDP method.
   #
-  # For correct behaviour, we also disable any kind of offloading for all veth and bridge devices.
-  # This forces the kernel to calculate all checksums in software.
+  # For correct behaviour, we also disable any kind of offloading for the relay-internal veth and
+  # bridge devices. This forces the kernel to segment packets and calculate their checksums in
+  # software before they reach the XDP programs. All other devices keep their default offloads
+  # so packets traverse the rest of the compose networks coalesced.
   network-config:
     image: ghcr.io/firezone/xdp-pass
     pid: host
@@ -424,16 +426,6 @@ services:
       - |
         set -e
 
-        # Disable tx offload on all veths + bridges so that packets reaching the
-        # relay carry correct (software-computed) checksums.
-        for dev in $$(ip -json link show type veth | jq -r '.[].ifname'); do
-          ethtool -K $$dev tx off
-        done
-        for dev in $$(ip -json link show type bridge | jq -r '.[].ifname'); do
-          ethtool -K $$dev tx off
-        done
-        echo "Disabled tx offload on all veth + bridge devices"
-
         # The relays do XDP_TX on eth0, so the host-side veth peering each relay must
         # run an XDP program to receive those frames and pass them up to the bridge.
         # Those peers are exactly the veths enslaved to the relay-internal bridges
@@ -441,12 +433,18 @@ services:
         # it off the client<->gateway path, where attaching to every veth would cost
         # ~18% of the forwarding softirq (veth_xdp_rcv). This service depends on both
         # relays being healthy, so their veths already exist on those bridges.
+        #
+        # XDP sees raw frames, so packets crossing these devices must be segmented and
+        # carry software-computed checksums. Disabling tx offload on the relay-internal
+        # bridges and their veths forces both at this last hop into the relay.
         for br in $$(ip -json link show type bridge | jq -r '.[].ifname'); do
           ip -json addr show dev $$br | jq -e '.[].addr_info[]? | select((.local // "") | startswith("172.29."))' >/dev/null || continue
+          ethtool -K $$br tx off
           for dev in $$(ip -json link show master $$br | jq -r '.[].ifname'); do
+            ethtool -K $$dev tx off
             ip link set dev $$dev xdpdrv off 2>/dev/null || true
             ip link set dev $$dev xdpdrv obj /xdp/xdp_pass.o sec xdp
-            echo "Attached xdp_pass to $$dev (relay-internal bridge $$br)"
+            echo "Disabled tx offload and attached xdp_pass to $$dev (relay-internal bridge $$br)"
           done
         done
     depends_on:
@@ -457,14 +455,6 @@ services:
       relay-1-router:
         condition: "service_healthy"
       relay-2-router:
-        condition: "service_healthy"
-      gateway-router:
-        condition: "service_healthy"
-      client-1-router:
-        condition: "service_healthy"
-      gateway:
-        condition: "service_healthy"
-      client-1:
         condition: "service_healthy"
 
   otel:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.30.0.254
         ip -6 route add 203:0:113::/64 via 172:30:0::254
 
-        ip link set dev eth0 txqueuelen 100000
+        ip link set dev eth0 qlen 100000
 
         exec firezone-headless-client
     depends_on:
@@ -182,7 +182,7 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.32.0.254
         ip -6 route add 203:0:113::/64 via 172:32:0::254
 
-        ip link set dev eth0 txqueuelen 100000
+        ip link set dev eth0 qlen 100000
 
         exec firezone-headless-client
     depends_on:
@@ -228,9 +228,9 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.31.0.254
         ip -6 route add 203:0:113::/64 via 172:31:0::254 || true
 
-        ip link set dev eth0 txqueuelen 100000
-        ip link set dev eth1 txqueuelen 100000
-        ip link set dev eth2 txqueuelen 100000
+        ip link set dev eth0 qlen 100000
+        ip link set dev eth1 qlen 100000
+        ip link set dev eth2 qlen 100000
 
         exec firezone-gateway
     init: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -318,6 +318,8 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.29.1.254
         ip -6 route add 203:0:113::/64 via 172:29:1::254
 
+        # Our own packets cross the xdp_pass program on the host-side veth peer,
+        # which requires segmented frames with software-computed checksums.
         apk add --no-cache ethtool
         ethtool -K eth0 tx off
 
@@ -368,6 +370,8 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.29.2.254
         ip -6 route add 203:0:113::/64 via 172:29:2::254
 
+        # Our own packets cross the xdp_pass program on the host-side veth peer,
+        # which requires segmented frames with software-computed checksums.
         apk add --no-cache ethtool
         ethtool -K eth0 tx off
 

--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -2,7 +2,7 @@
 
 source "./scripts/tests/lib.sh"
 
-# Download 10MB at a max rate of 1MB/s. The first two UDP socket writes will fail as checksum offload is disabled.
+# Download 10MB at a max rate of 1MB/s.
 # Budget: 10s for the download + 5s pre-roam wait + ~7s reconnect overhead + buffer.
 client sh -c \
     "curl \
@@ -24,9 +24,6 @@ docker network connect firezone_client-1-internal firezone-client-1-1 --ip 172.3
 # Add static route to internet subnet via router; they get removed when the network interface disappears
 client ip -4 route add 203.0.113.0/24 via 172.30.0.254
 client ip -6 route add 203:0:113::/64 via 172:30:0::254
-
-# Disable checksum offload again to calculate checksums in software so that checksum verification passes
-client ethtool -K eth0 tx off
 
 # Send SIGHUP, triggering `reconnect` internally
 sudo kill -s HUP "$(ps -C firezone-headless-client -o pid=)"


### PR DESCRIPTION
The relay XDP programs are the only consumers that need segmented frames with software-computed checksums, and every path into them crosses either a relay-internal veth or the `xdp_pass` program on the relays' host-side peers. Scoping the tx-offload disable to that boundary lets every other device keep its default offloads, which on veth devices include TCP & UDP segmentation offload. Coalesced packets from the TUN segmentation offload work thus traverse the compose networks unsegmented until the last hop into a relay, giving us the full benefit of that work in CI.

Related: #14011