### PR TITLE
test(tunnel): tolerate re-key dead-window packet drop

### DIFF
--- a/rust/libs/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/libs/connlib/tunnel/src/tests/assertions.rs
@@ -23,18 +23,21 @@ use std::{
 use tracing::{Level, Span, Subscriber};
 use tracing_subscriber::Layer;
 
-/// How long a client→gateway connection must have been idle before we tolerate
-/// a single dropped packet caused by the WireGuard re-key "dead window".
+/// Minimum idle time on a client→gateway connection before we tolerate a single
+/// dropped packet caused by a WireGuard re-key.
 ///
-/// While idle, boringtun only re-keys a session once it expires at
-/// `REJECT_AFTER_TIME` (180s), but the session already stops being usable
-/// `KEEPALIVE_TIMEOUT` (10s) earlier. A packet sent in that ~10s gap hits
+/// This is a *threshold*, not the width of the dead window. A session is usable
+/// for `REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT` (170s); it then spends the
+/// remaining `KEEPALIVE_TIMEOUT` (10s) in a "dead window" where it is no longer
+/// usable but, while idle, is not re-keyed until it fully expires at
+/// `REJECT_AFTER_TIME` (180s). A packet sent in that ~10s dead window hits
 /// `NoCurrentSession` in the side-effect-free `encapsulate_data_at` path and is
 /// dropped without being re-queued; the connection re-keys ~1 RTT later, so only
-/// the triggering packet is lost. The window recurs every `REJECT_AFTER_TIME`,
-/// so any packet sent at least this long after the previous one on the same
+/// the triggering packet is lost. The dead window recurs every
+/// `REJECT_AFTER_TIME` while idle, so any packet sent at least one usable
+/// session lifetime (this threshold) after the previous one on the same
 /// connection may land in it. See #13957.
-const REKEY_DEAD_WINDOW: Duration = Duration::from_secs(180 - 10);
+const MIN_IDLE_FOR_REKEY_DROP: Duration = Duration::from_secs(180 - 10);
 
 /// Asserts the following properties for all ICMP handshakes:
 /// 1. An ICMP request on the client MUST result in an ICMP response using the same sequence, identifier and flipped src & dst IP.
@@ -229,7 +232,7 @@ fn assert_packets_properties<T, U>(
 
     // Per client→gateway connection, the instants at which the client sent a
     // packet. Used to tolerate a packet dropped in the WireGuard re-key dead
-    // window (see `REKEY_DEAD_WINDOW`).
+    // window (see `MIN_IDLE_FOR_REKEY_DROP`).
     let gateway_send_times: BTreeMap<(ClientId, GatewayId), BTreeSet<Instant>> = {
         let all_sent_requests = &all_sent_requests;
         all_expected_gateway_handshakes
@@ -277,13 +280,13 @@ fn assert_packets_properties<T, U>(
             else {
                 // A client→gateway connection that was idle long enough for its
                 // WireGuard session to enter the re-key dead window drops this
-                // one packet without a reply (see `REKEY_DEAD_WINDOW`). Tolerate
+                // one packet without a reply (see `MIN_IDLE_FOR_REKEY_DROP`). Tolerate
                 // it when the previous packet on this connection was sent at
-                // least `REKEY_DEAD_WINDOW` earlier.
+                // least `MIN_IDLE_FOR_REKEY_DROP` earlier.
                 if gateway_send_times
                     .get(&(*cid, *gateway))
                     .and_then(|times| times.range(..*sent_at).next_back())
-                    .is_some_and(|prev| sent_at.duration_since(*prev) >= REKEY_DEAD_WINDOW)
+                    .is_some_and(|prev| sent_at.duration_since(*prev) >= MIN_IDLE_FOR_REKEY_DROP)
                 {
                     tracing::debug!(target: "assertions", %cid, "Tolerating {packet_protocol} packet dropped in the WireGuard re-key window");
                     num_expected_handshakes -= 1;

--- a/rust/libs/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/libs/connlib/tunnel/src/tests/assertions.rs
@@ -12,16 +12,29 @@ use connlib_model::{ClientId, GatewayId};
 use ip_packet::IpPacket;
 use itertools::Itertools;
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque, hash_map::Entry},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque, hash_map::Entry},
     hash::Hash,
     iter,
     marker::PhantomData,
     net::{IpAddr, SocketAddr},
     sync::atomic::{AtomicBool, Ordering},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tracing::{Level, Span, Subscriber};
 use tracing_subscriber::Layer;
+
+/// How long a client→gateway connection must have been idle before we tolerate
+/// a single dropped packet caused by the WireGuard re-key "dead window".
+///
+/// While idle, boringtun only re-keys a session once it expires at
+/// `REJECT_AFTER_TIME` (180s), but the session already stops being usable
+/// `KEEPALIVE_TIMEOUT` (10s) earlier. A packet sent in that ~10s gap hits
+/// `NoCurrentSession` in the side-effect-free `encapsulate_data_at` path and is
+/// dropped without being re-queued; the connection re-keys ~1 RTT later, so only
+/// the triggering packet is lost. The window recurs every `REJECT_AFTER_TIME`,
+/// so any packet sent at least this long after the previous one on the same
+/// connection may land in it. See #13957.
+const REKEY_DEAD_WINDOW: Duration = Duration::from_secs(180 - 10);
 
 /// Asserts the following properties for all ICMP handshakes:
 /// 1. An ICMP request on the client MUST result in an ICMP response using the same sequence, identifier and flipped src & dst IP.
@@ -214,6 +227,28 @@ fn assert_packets_properties<T, U>(
 
     let mut mappings = HashMap::new();
 
+    // Per client→gateway connection, the instants at which the client sent a
+    // packet. Used to tolerate a packet dropped in the WireGuard re-key dead
+    // window (see `REKEY_DEAD_WINDOW`).
+    let gateway_send_times: BTreeMap<(ClientId, GatewayId), BTreeSet<Instant>> = {
+        let all_sent_requests = &all_sent_requests;
+        all_expected_gateway_handshakes
+            .iter()
+            .flat_map(|(gateway, handshakes)| {
+                handshakes.iter().filter_map(move |(_, (cid, _, t, u))| {
+                    let (sent_at, _) = all_sent_requests.get(&(*cid, (*t, *u)))?;
+                    Some(((*cid, *gateway), *sent_at))
+                })
+            })
+            .fold(
+                BTreeMap::new(),
+                |mut acc: BTreeMap<_, BTreeSet<_>>, (key, at)| {
+                    acc.entry(key).or_default().insert(at);
+                    acc
+                },
+            )
+    };
+
     // Assert properties of the individual handshakes per gateway.
     // Due to connlib's implementation of NAT64, we cannot match the packets sent by the client to the packets arriving at the resource by port or ICMP identifier.
     // Thus, we rely on a custom u64 payload attached to all packets to uniquely identify every individual packet.
@@ -232,13 +267,29 @@ fn assert_packets_properties<T, U>(
 
             let ref_client = ref_clients.get(cid).unwrap();
 
-            let Some((_, client_sent_request)) = all_sent_requests.get(&(*cid, (*t, *u))) else {
+            let Some((sent_at, client_sent_request)) = all_sent_requests.get(&(*cid, (*t, *u)))
+            else {
                 tracing::error!(target: "assertions", %cid, "❌ Missing {packet_protocol} request on client");
                 continue;
             };
             let Some(client_received_reply) =
                 all_received_replies_on_client.get(&(*cid, (*t, *u).reply_to()))
             else {
+                // A client→gateway connection that was idle long enough for its
+                // WireGuard session to enter the re-key dead window drops this
+                // one packet without a reply (see `REKEY_DEAD_WINDOW`). Tolerate
+                // it when the previous packet on this connection was sent at
+                // least `REKEY_DEAD_WINDOW` earlier.
+                if gateway_send_times
+                    .get(&(*cid, *gateway))
+                    .and_then(|times| times.range(..*sent_at).next_back())
+                    .is_some_and(|prev| sent_at.duration_since(*prev) >= REKEY_DEAD_WINDOW)
+                {
+                    tracing::debug!(target: "assertions", %cid, "Tolerating {packet_protocol} packet dropped in the WireGuard re-key window");
+                    num_expected_handshakes -= 1;
+                    continue;
+                }
+
                 tracing::error!(target: "assertions", %cid, "❌ Missing {packet_protocol} reply on client");
                 continue;
             };


### PR DESCRIPTION
An idle client→gateway connection drops the single packet that wakes it when its WireGuard session is in the re-key "dead window" — the `KEEPALIVE_TIMEOUT` before `REJECT_AFTER_TIME` in which the session is no longer usable but has not yet re-keyed. boringtun's side-effect-free `encapsulate_data_at` returns `NoCurrentSession`, so `snownet` drops the packet without re-queuing it; the connection re-keys ~1 RTT later, so only the triggering packet is lost. This is benign and self-healing in production, but the proptest reference model assumes lossless delivery to an active resource and over-counts the expected handshake, surfacing as a low-probability flake.

Teach the reference to tolerate a missing client→gateway handshake when the connection had been idle for at least one usable session lifetime before the packet was sent, mirroring the existing post-reset tolerance that already covers client→client flows.

Resolves: #13957
Resolves: #13948