### PR TITLE
refactor(portal): nest flow-log init config

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -1839,9 +1839,7 @@ defmodule PortalAPI.Client.Channel do
 
   defp init(socket, resources, relays) do
     push(socket, "init", %{
-      flow_logs_api_url: flow_logs_api_url(),
-      flow_logs_upload_interval_secs: flow_logs_upload_interval_secs(),
-      flow_logs_upload_batch_size: flow_logs_upload_batch_size(),
+      flow_logs: flow_logs_config(),
       resources: Views.Resource.render_many(resources, socket.assigns.session),
       authorizations: Views.PolicyAuthorization.render_many(socket.assigns.authorizations_cache),
       # TODO: Re-enable after verifying compatibility with older clients
@@ -1868,13 +1866,13 @@ defmodule PortalAPI.Client.Channel do
     track_presence(socket)
   end
 
-  defp flow_logs_api_url, do: Portal.Config.fetch_env!(:portal, :flow_logs_api_url)
-
-  defp flow_logs_upload_interval_secs,
-    do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_interval_secs)
-
-  defp flow_logs_upload_batch_size,
-    do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_batch_size)
+  defp flow_logs_config do
+    %{
+      api_url: Portal.Config.fetch_env!(:portal, :flow_logs_api_url),
+      upload_interval_secs: Portal.Config.fetch_env!(:portal, :flow_logs_upload_interval_secs),
+      upload_batch_size: Portal.Config.fetch_env!(:portal, :flow_logs_upload_batch_size)
+    }
+  end
 
   defp generate_preshared_key(client, client_public_key, gateway, gateway_public_key) do
     Portal.Crypto.psk(client, client_public_key, gateway, gateway_public_key)

--- a/elixir/lib/portal_api/gateway/channel.ex
+++ b/elixir/lib/portal_api/gateway/channel.ex
@@ -732,9 +732,7 @@ defmodule PortalAPI.Gateway.Channel do
 
   defp init(socket, account, relays) do
     push(socket, "init", %{
-      flow_logs_api_url: flow_logs_api_url(),
-      flow_logs_upload_interval_secs: flow_logs_upload_interval_secs(),
-      flow_logs_upload_batch_size: flow_logs_upload_batch_size(),
+      flow_logs: flow_logs_config(),
       authorizations: Views.PolicyAuthorization.render_many(socket.assigns.cache),
       account_slug: account.slug,
       interface: Views.Interface.render(socket.assigns.gateway),
@@ -752,13 +750,13 @@ defmodule PortalAPI.Gateway.Channel do
     })
   end
 
-  defp flow_logs_api_url, do: Portal.Config.fetch_env!(:portal, :flow_logs_api_url)
-
-  defp flow_logs_upload_interval_secs,
-    do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_interval_secs)
-
-  defp flow_logs_upload_batch_size,
-    do: Portal.Config.fetch_env!(:portal, :flow_logs_upload_batch_size)
+  defp flow_logs_config do
+    %{
+      api_url: Portal.Config.fetch_env!(:portal, :flow_logs_api_url),
+      upload_interval_secs: Portal.Config.fetch_env!(:portal, :flow_logs_upload_interval_secs),
+      upload_batch_size: Portal.Config.fetch_env!(:portal, :flow_logs_upload_batch_size)
+    }
+  end
 
   defp reinitialize_gateway(socket) do
     {:ok, relays} = select_relays(socket)

--- a/elixir/test/portal_api/client/channel_test.exs
+++ b/elixir/test/portal_api/client/channel_test.exs
@@ -461,9 +461,11 @@ defmodule PortalAPI.Client.ChannelTest do
         resources: resources,
         interface: interface,
         relays: relays,
-        flow_logs_api_url: "https://flow-api.firezone.dev/",
-        flow_logs_upload_interval_secs: 60,
-        flow_logs_upload_batch_size: 1000
+        flow_logs: %{
+          api_url: "https://flow-api.firezone.dev/",
+          upload_interval_secs: 60,
+          upload_batch_size: 1000
+        }
       }
 
       assert length(resources) == 4

--- a/elixir/test/portal_api/gateway/channel_test.exs
+++ b/elixir/test/portal_api/gateway/channel_test.exs
@@ -303,9 +303,11 @@ defmodule PortalAPI.Gateway.ChannelTest do
         account_slug: account_slug,
         interface: interface,
         relays: relays,
-        flow_logs_api_url: "https://flow-api.firezone.dev/",
-        flow_logs_upload_interval_secs: 60,
-        flow_logs_upload_batch_size: 1000,
+        flow_logs: %{
+          api_url: "https://flow-api.firezone.dev/",
+          upload_interval_secs: 60,
+          upload_batch_size: 1000
+        },
         config: %{
           ipv4_masquerade_enabled: true,
           ipv6_masquerade_enabled: true


### PR DESCRIPTION
The init messages sent the flow-log upload settings as three flat, prefixed fields. They are now nested under a single flow_logs object on both the client and gateway channels so connlib can parse them as one config struct.

Split out of #13967 so the portal-side wire change merges first.

Related: #13967