### PR TITLE
ci: assert no TCP reordering after perf runs

### DIFF
--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -117,48 +117,9 @@ jobs:
             grep --invert "Object BTF couldn't be loaded in the kernel: the BPF_BTF_LOAD syscall failed." | \
             grep "WARN" && exit 1 || exit 0
 
-      - name: Ensure no UDP socket errors
+      - name: Ensure no socket errors or TCP reordering
         if: "!cancelled() && startsWith(matrix.test, 'tcp')"
-        run: |
-          docker compose exec client-1 /bin/sh -c 'nstat -s' |
-            grep -i "error" && exit 1 || exit 0
-
-          docker compose exec gateway /bin/sh -c 'nstat -s' |
-            grep -i "error" && exit 1 || exit 0
-
-      - name: Ensure no TCP packets were re-ordered
-        if: "!cancelled() && startsWith(matrix.test, 'tcp')"
-        run: |
-          # Preserving packet order end-to-end is a deliberate goal of the data
-          # plane (see `scripts/router/router.sh`), so any reordering is a regression.
-          #
-          # The `TCP*Reorder` counters are what we want: they increment on the TCP
-          # *sender* when the peer's SACKs reveal that a segment presumed lost was
-          # merely reordered. We deliberately avoid `TCPOFOQueue`, which also counts
-          # loss-induced gaps and would flake whenever the run has retransmits.
-          #
-          # Detection is sender-side, so we check every TCP endpoint of the flow --
-          # the iperf3 clients and the iperf3 server -- each of which is the sender
-          # in one direction. The gateway only forwards IP for this flow, so it has
-          # no TCP state to inspect. We read the counters straight from
-          # `/proc/net/netstat` (raw counters need no `nstat`, which the iperf3
-          # image lacks). Endpoints that aren't running for a given test are skipped.
-          reorders() {
-            docker compose exec -T "$1" cat /proc/net/netstat | awk '
-              $1 == "TcpExt:" && !seen { for (i = 2; i <= NF; i++) col[$i] = i; seen = 1; next }
-              $1 == "TcpExt:" { print $(col["TCPSACKReorder"]) + $(col["TCPRenoReorder"]) + $(col["TCPTSReorder"]) }
-            '
-          }
-
-          for endpoint in client-1 client-2 iperf3; do
-            [ -n "$(docker compose ps -q "$endpoint")" ] || continue
-
-            count=$(reorders "$endpoint")
-            if [ "${count:-0}" -ne 0 ]; then
-              echo "$endpoint detected ${count} TCP reordering event(s)"
-              exit 1
-            fi
-          done
+        run: ./scripts/tests/perf/assert-clean-netstat.sh client-1 client-2 gateway iperf3
 
   upload-bencher:
     continue-on-error: true

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -137,26 +137,28 @@ jobs:
           # merely reordered. We deliberately avoid `TCPOFOQueue`, which also counts
           # loss-induced gaps and would flake whenever the run has retransmits.
           #
-          # Detection is sender-side, so we check both TCP endpoints -- the iperf3
-          # client (`client-1`) and the iperf3 server -- each of which is the sender
+          # Detection is sender-side, so we check every TCP endpoint of the flow --
+          # the iperf3 clients and the iperf3 server -- each of which is the sender
           # in one direction. The gateway only forwards IP for this flow, so it has
-          # no TCP state to inspect. `-a` prints absolute counters, ignoring nstat's
-          # history file, so this is independent of the `nstat` call above.
-          if docker compose exec client-1 /bin/sh -c 'nstat -as' | grep -iq "reorder"; then
-            echo "client-1 detected TCP reordering"
-            exit 1
-          fi
+          # no TCP state to inspect. We read the counters straight from
+          # `/proc/net/netstat` (raw counters need no `nstat`, which the iperf3
+          # image lacks). Endpoints that aren't running for a given test are skipped.
+          reorders() {
+            docker compose exec -T "$1" cat /proc/net/netstat | awk '
+              $1 == "TcpExt:" && !seen { for (i = 2; i <= NF; i++) col[$i] = i; seen = 1; next }
+              $1 == "TcpExt:" { print $(col["TCPSACKReorder"]) + $(col["TCPRenoReorder"]) + $(col["TCPTSReorder"]) }
+            '
+          }
 
-          # The iperf3 server image ships no `nstat`, so read the counters straight
-          # from `/proc/net/netstat` and sum the reorder columns on the runner.
-          reorder=$(docker compose exec -T iperf3 cat /proc/net/netstat | awk '
-            $1 == "TcpExt:" && !seen { for (i = 2; i <= NF; i++) col[$i] = i; seen = 1; next }
-            $1 == "TcpExt:" { print $(col["TCPSACKReorder"]) + $(col["TCPRenoReorder"]) + $(col["TCPTSReorder"]) }
-          ')
-          if [ "${reorder:-0}" -ne 0 ]; then
-            echo "iperf3 server detected ${reorder} TCP reordering event(s)"
-            exit 1
-          fi
+          for endpoint in client-1 client-2 iperf3; do
+            [ -n "$(docker compose ps -q "$endpoint")" ] || continue
+
+            count=$(reorders "$endpoint")
+            if [ "${count:-0}" -ne 0 ]; then
+              echo "$endpoint detected ${count} TCP reordering event(s)"
+              exit 1
+            fi
+          done
 
   upload-bencher:
     continue-on-error: true

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -126,6 +126,21 @@ jobs:
           docker compose exec gateway /bin/sh -c 'nstat -s' |
             grep -i "error" && exit 1 || exit 0
 
+      - name: Ensure no TCP packets were re-ordered
+        if: "!cancelled() && startsWith(matrix.test, 'tcp')"
+        run: |
+          # The client is a TCP endpoint in both directions: it receives the bulk
+          # transfer for `server2client` (out-of-order arrivals bump `TCPOFOQueue`)
+          # and sends it for `client2server` (the peer's SACKs make the sender flag
+          # reordering via `TCP*Reorder`). Preserving packet order end-to-end is a
+          # deliberate goal of the data plane (see `scripts/router/router.sh`), so
+          # any reordering counter here is a regression.
+          #
+          # `-a` prints absolute values, ignoring nstat's history file, so this is
+          # independent of the `nstat` call in the step above.
+          docker compose exec client-1 /bin/sh -c 'nstat -as' |
+            grep -iE "reorder|ofoqueue" && exit 1 || exit 0
+
   upload-bencher:
     continue-on-error: true
     needs: perf-tests

--- a/.github/workflows/_perf_tests.yml
+++ b/.github/workflows/_perf_tests.yml
@@ -129,17 +129,34 @@ jobs:
       - name: Ensure no TCP packets were re-ordered
         if: "!cancelled() && startsWith(matrix.test, 'tcp')"
         run: |
-          # The client is a TCP endpoint in both directions: it receives the bulk
-          # transfer for `server2client` (out-of-order arrivals bump `TCPOFOQueue`)
-          # and sends it for `client2server` (the peer's SACKs make the sender flag
-          # reordering via `TCP*Reorder`). Preserving packet order end-to-end is a
-          # deliberate goal of the data plane (see `scripts/router/router.sh`), so
-          # any reordering counter here is a regression.
+          # Preserving packet order end-to-end is a deliberate goal of the data
+          # plane (see `scripts/router/router.sh`), so any reordering is a regression.
           #
-          # `-a` prints absolute values, ignoring nstat's history file, so this is
-          # independent of the `nstat` call in the step above.
-          docker compose exec client-1 /bin/sh -c 'nstat -as' |
-            grep -iE "reorder|ofoqueue" && exit 1 || exit 0
+          # The `TCP*Reorder` counters are what we want: they increment on the TCP
+          # *sender* when the peer's SACKs reveal that a segment presumed lost was
+          # merely reordered. We deliberately avoid `TCPOFOQueue`, which also counts
+          # loss-induced gaps and would flake whenever the run has retransmits.
+          #
+          # Detection is sender-side, so we check both TCP endpoints -- the iperf3
+          # client (`client-1`) and the iperf3 server -- each of which is the sender
+          # in one direction. The gateway only forwards IP for this flow, so it has
+          # no TCP state to inspect. `-a` prints absolute counters, ignoring nstat's
+          # history file, so this is independent of the `nstat` call above.
+          if docker compose exec client-1 /bin/sh -c 'nstat -as' | grep -iq "reorder"; then
+            echo "client-1 detected TCP reordering"
+            exit 1
+          fi
+
+          # The iperf3 server image ships no `nstat`, so read the counters straight
+          # from `/proc/net/netstat` and sum the reorder columns on the runner.
+          reorder=$(docker compose exec -T iperf3 cat /proc/net/netstat | awk '
+            $1 == "TcpExt:" && !seen { for (i = 2; i <= NF; i++) col[$i] = i; seen = 1; next }
+            $1 == "TcpExt:" { print $(col["TCPSACKReorder"]) + $(col["TCPRenoReorder"]) + $(col["TCPTSReorder"]) }
+          ')
+          if [ "${reorder:-0}" -ne 0 ]; then
+            echo "iperf3 server detected ${reorder} TCP reordering event(s)"
+            exit 1
+          fi
 
   upload-bencher:
     continue-on-error: true

--- a/scripts/tests/perf/assert-clean-netstat.sh
+++ b/scripts/tests/perf/assert-clean-netstat.sh
@@ -29,18 +29,18 @@ for container in "$@"; do
   # layout. A `---` marker separates the two so one awk pass handles both.
   anomalies=$(
     docker compose exec -T "$container" sh -c \
-      'cat /proc/net/snmp /proc/net/netstat; echo ---; cat /proc/net/snmp6 2>/dev/null || true' |
+      'set -e; cat /proc/net/snmp /proc/net/netstat; echo ---; cat /proc/net/snmp6 2>/dev/null || true' |
       awk '
         /^---$/ { flat = 1; next }
         !flat {
           if ($1 != hdr) { hdr = $1; delete name; for (i = 2; i <= NF; i++) name[i] = $i; next }
           for (i = 2; i <= NF; i++)
-            if ((name[i] ~ /[Ee]rror/ || name[i] ~ /Reorder/) && $i + 0 != 0)
+            if ((name[i] ~ /[Ee]rror/ || name[i] ~ /^TCP.*Reorder$/) && $i + 0 != 0)
               printf "%s %s = %d\n", $1, name[i], $i
           hdr = ""
           next
         }
-        (($1 ~ /[Ee]rror/ || $1 ~ /Reorder/) && $2 + 0 != 0) { printf "%s = %d\n", $1, $2 }
+        (($1 ~ /[Ee]rror/ || $1 ~ /^TCP.*Reorder$/) && $2 + 0 != 0) { printf "%s = %d\n", $1, $2 }
       '
   )
 

--- a/scripts/tests/perf/assert-clean-netstat.sh
+++ b/scripts/tests/perf/assert-clean-netstat.sh
@@ -16,6 +16,26 @@
 
 set -euo pipefail
 
+# `/proc/net/snmp` and `/proc/net/netstat` use a "header line / value line"
+# layout: for each protocol one line names the counters, the next lists their
+# values. Emit "<proto> <name> = <value>" for every flagged, non-zero counter.
+paired_anomalies() {
+  awk '
+    $1 != hdr { hdr = $1; delete name; for (i = 2; i <= NF; i++) name[i] = $i; next }
+    {
+      for (i = 2; i <= NF; i++)
+        if ((name[i] ~ /[Ee]rror/ || name[i] ~ /^TCP.*Reorder$/) && $i + 0 != 0)
+          printf "%s %s = %d\n", $1, name[i], $i
+      hdr = ""
+    }
+  '
+}
+
+# `/proc/net/snmp6` uses a flat "name value" layout, one counter per line.
+flat_anomalies() {
+  awk '($1 ~ /[Ee]rror/ || $1 ~ /^TCP.*Reorder$/) && $2 + 0 != 0 { printf "%s = %d\n", $1, $2 }'
+}
+
 status=0
 
 for container in "$@"; do
@@ -24,24 +44,15 @@ for container in "$@"; do
     continue
   fi
 
-  # `/proc/net/snmp` and `/proc/net/netstat` share a "header line / value line"
-  # layout; `/proc/net/snmp6` (when the netns has IPv6) is a flat "name value"
-  # layout. A `---` marker separates the two so one awk pass handles both.
+  # Fetch first, then parse. snmp and netstat are required, so a failed read
+  # aborts the script (`set -e` on the assignment). snmp6 only exists when the
+  # netns has IPv6, so its read is best-effort.
+  paired=$(docker compose exec -T "$container" cat /proc/net/snmp /proc/net/netstat)
+  snmp6=$(docker compose exec -T "$container" cat /proc/net/snmp6 2>/dev/null || true)
+
   anomalies=$(
-    docker compose exec -T "$container" sh -c \
-      'set -e; cat /proc/net/snmp /proc/net/netstat; echo ---; cat /proc/net/snmp6 2>/dev/null || true' |
-      awk '
-        /^---$/ { flat = 1; next }
-        !flat {
-          if ($1 != hdr) { hdr = $1; delete name; for (i = 2; i <= NF; i++) name[i] = $i; next }
-          for (i = 2; i <= NF; i++)
-            if ((name[i] ~ /[Ee]rror/ || name[i] ~ /^TCP.*Reorder$/) && $i + 0 != 0)
-              printf "%s %s = %d\n", $1, name[i], $i
-          hdr = ""
-          next
-        }
-        (($1 ~ /[Ee]rror/ || $1 ~ /^TCP.*Reorder$/) && $2 + 0 != 0) { printf "%s = %d\n", $1, $2 }
-      '
+    printf '%s\n' "$paired" | paired_anomalies
+    printf '%s\n' "$snmp6" | flat_anomalies
   )
 
   if [ -n "$anomalies" ]; then

--- a/scripts/tests/perf/assert-clean-netstat.sh
+++ b/scripts/tests/perf/assert-clean-netstat.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Assert that the given containers show no socket errors and no TCP packet
+# reordering in their kernel network counters after a perf run.
+#
+# Counters are read straight from /proc so the same check works everywhere,
+# including the iperf3 resource image, which ships no `nstat`. A counter fails
+# the check when its name contains "Error" (any protocol, mirroring the previous
+# `nstat | grep error`) or is one of the TCP `*Reorder` counters. `TCPOFOQueue`
+# is deliberately ignored: it also counts loss-induced gaps and would flake
+# whenever a run legitimately retransmits.
+#
+# Reorder detection is sender-side, so we check every TCP endpoint of the flow;
+# the UDP error counters matter on the WireGuard (tunnel) endpoints. Containers
+# that aren't running for the current test are skipped.
+
+set -euo pipefail
+
+status=0
+
+for container in "$@"; do
+  if [ -z "$(docker compose ps -q "$container")" ]; then
+    echo "skipping ${container} (not running)"
+    continue
+  fi
+
+  # `/proc/net/snmp` and `/proc/net/netstat` share a "header line / value line"
+  # layout; `/proc/net/snmp6` (when the netns has IPv6) is a flat "name value"
+  # layout. A `---` marker separates the two so one awk pass handles both.
+  anomalies=$(
+    docker compose exec -T "$container" sh -c \
+      'cat /proc/net/snmp /proc/net/netstat; echo ---; cat /proc/net/snmp6 2>/dev/null || true' |
+      awk '
+        /^---$/ { flat = 1; next }
+        !flat {
+          if ($1 != hdr) { hdr = $1; delete name; for (i = 2; i <= NF; i++) name[i] = $i; next }
+          for (i = 2; i <= NF; i++)
+            if ((name[i] ~ /[Ee]rror/ || name[i] ~ /Reorder/) && $i + 0 != 0)
+              printf "%s %s = %d\n", $1, name[i], $i
+          hdr = ""
+          next
+        }
+        (($1 ~ /[Ee]rror/ || $1 ~ /Reorder/) && $2 + 0 != 0) { printf "%s = %d\n", $1, $2 }
+      '
+  )
+
+  if [ -n "$anomalies" ]; then
+    echo "${container}: socket anomalies detected after perf run:"
+    echo "$anomalies" | sed 's/^/    /'
+    status=1
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
After the perf runs we already assert that no socket errors occurred; this extends that to also assert that no TCP packets were re-ordered. Preserving packet order end-to-end is a deliberate goal of the data plane (single-threaded per-flow processing, per-router RPS pinning), so a non-zero TCP reorder counter is a regression worth failing on. We look at the `TCP*Reorder` counters specifically rather than `TCPOFOQueue`, which also counts loss-induced gaps and would flake on ordinary retransmits.

Both assertions now share a small script that reads the counters straight from `/proc`, which lets the same check cover the iperf3 server (whose image ships no `nstat`) and, as a side effect, makes the error check actually run on the gateway instead of being short-circuited away.