### PR TITLE
fix(connlib): don't split TCP flows on retransmitted SYNs

### DIFF
--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -100,6 +100,7 @@ struct TxPacket<S> {
     src_proto: Protocol,
     dst_proto: Protocol,
     tcp_syn: bool,
+    tcp_ack: bool,
     tcp_fin: bool,
     tcp_rst: bool,
     payload_len: usize,
@@ -192,6 +193,7 @@ where
                     src_proto: Ok(src_proto),
                     dst_proto: Ok(dst_proto),
                     tcp_syn,
+                    tcp_ack,
                     tcp_fin,
                     tcp_rst,
                     payload_len,
@@ -245,6 +247,7 @@ where
                         src_proto,
                         dst_proto,
                         tcp_syn,
+                        tcp_ack,
                         tcp_fin,
                         tcp_rst,
                         payload_len,
@@ -274,6 +277,7 @@ where
                         src_proto,
                         dst_proto,
                         tcp_syn,
+                        tcp_ack,
                         tcp_fin,
                         tcp_rst,
                         payload_len,
@@ -383,6 +387,7 @@ where
             src_proto,
             dst_proto,
             tcp_syn,
+            tcp_ack,
             tcp_fin,
             tcp_rst,
             payload_len,
@@ -404,6 +409,13 @@ where
                     hash_map::Entry::Vacant(vacant) => {
                         if tcp_fin || tcp_rst {
                             // Don't create new flows for FIN/RST packets.
+                            return;
+                        }
+
+                        // A bare ACK cannot start a connection; it is the tail
+                        // of a flow that was already closed, e.g. the final ACK
+                        // of a FIN handshake arriving after the close sweep.
+                        if tcp_ack && !tcp_syn && payload_len == 0 {
                             return;
                         }
 
@@ -851,6 +863,7 @@ struct InnerFlow {
     dst_proto: Result<Protocol, UnsupportedProtocol>,
 
     tcp_syn: bool,
+    tcp_ack: bool,
     tcp_fin: bool,
     tcp_rst: bool,
 
@@ -865,6 +878,7 @@ impl From<&IpPacket> for InnerFlow {
             src_proto: packet.source_protocol(),
             dst_proto: packet.destination_protocol(),
             tcp_syn: packet.as_tcp().map(|tcp| tcp.syn()).unwrap_or(false),
+            tcp_ack: packet.as_tcp().map(|tcp| tcp.ack()).unwrap_or(false),
             tcp_fin: packet.as_tcp().map(|tcp| tcp.fin()).unwrap_or(false),
             tcp_rst: packet.as_tcp().map(|tcp| tcp.rst()).unwrap_or(false),
             payload_len: packet.layer4_payload_len(),

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -451,7 +451,12 @@ where
 
                         self.active_tcp_flows.insert(key, value);
                     }
-                    hash_map::Entry::Occupied(occupied) if tcp_syn => {
+                    // A SYN only starts a new connection if the existing flow has
+                    // seen return traffic; on a half-open flow it is a
+                    // retransmission and just counts as another packet.
+                    hash_map::Entry::Occupied(occupied)
+                        if tcp_syn && occupied.get().stats.rx_packets > 0 =>
+                    {
                         let (key, value) = occupied.remove_entry();
 
                         tracing::debug!(?key, "Splitting existing TCP flow; new TCP SYN");

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -5,7 +5,6 @@
 
 use std::{
     net::{Ipv4Addr, SocketAddr},
-    path::Path,
     time::{Duration, Instant},
 };
 
@@ -44,16 +43,10 @@ fn emitted_records_spool_via_flow_log_writer_layer() {
         }),
     };
 
-    let dir = tempfile::tempdir().unwrap();
-    flow_log_writer::write_token(dir.path(), record.ingest_token.as_str()).unwrap();
+    let spool = SpoolObserver::new(authz_id);
+    spool.observe(|| flow_tracker::emit(&record));
 
-    let (layer, guard) = flow_log_writer::layer(dir.path().to_owned());
-    let subscriber = tracing_subscriber::registry().with(layer);
-    tracing::subscriber::with_default(subscriber, || flow_tracker::emit(&record));
-    drop(guard); // joins the writer thread, so the report is on disk
-
-    let authz_dir = dir.path().join("responder").join(authz_id);
-    let payload = read_report(&authz_dir, ".end.json");
+    let payload = spool.report(".end.json");
 
     assert_eq!(payload["protocol"], "tcp");
     assert_eq!(payload["inner_src_ip"], record.inner_src_ip.to_string());
@@ -85,16 +78,9 @@ fn tracked_packets_spool_open_and_completed_reports() {
     let authz_id = "22222222-2222-2222-2222-222222222222";
     let token = test_token(authz_id, "responder");
 
-    let dir = tempfile::tempdir().unwrap();
-    flow_log_writer::write_token(dir.path(), token.as_str()).unwrap();
-
-    let (layer, guard) = flow_log_writer::layer(dir.path().to_owned());
-    let subscriber = tracing_subscriber::registry().with(layer);
-
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker::<(ClientId, ResourceId)>();
     let now = Instant::now();
-    let mut tracker =
-        Tracker::<(ClientId, ResourceId)>::new(now, Duration::from_secs(1_700_000_000));
-    tracker.set_enabled(true);
 
     let client = ClientId::from_u128(1);
     let resource = ResourceId::from_u128(2);
@@ -109,7 +95,7 @@ fn tracked_packets_spool_open_and_completed_reports() {
         ip_packet::make::udp_packet(client_ip, resource_ip, 1234, 5201, b"hello").unwrap();
     let reply = ip_packet::make::udp_packet(resource_ip, client_ip, 5201, 1234, b"world!").unwrap();
 
-    tracing::subscriber::with_default(subscriber, || {
+    spool.observe(|| {
         {
             let flow = tracker.begin_network_packet(local, remote, now);
             flow_tracker::record_decrypted_packet(&request);
@@ -129,11 +115,8 @@ fn tracked_packets_spool_open_and_completed_reports() {
 
         tracker.close_all(now);
     });
-    drop(guard); // joins the writer thread, so the reports are on disk
 
-    let authz_dir = dir.path().join("responder").join(authz_id);
-
-    let open = read_report(&authz_dir, ".start.json");
+    let open = spool.report(".start.json");
     assert_eq!(open["protocol"], "udp");
     assert_eq!(open["inner_src_ip"], "100.64.0.1");
     assert_eq!(open["inner_src_port"], 1234);
@@ -145,7 +128,7 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(open["outer_dst_port"], 51820);
     assert!(open.get("flow_end").is_none());
 
-    let completed = read_report(&authz_dir, ".end.json");
+    let completed = spool.report(".end.json");
     assert_eq!(completed["inner_src_ip"], "100.64.0.1");
     assert_eq!(completed["tx_packets"], 1);
     assert_eq!(completed["tx_bytes"], 5);
@@ -240,7 +223,7 @@ fn data_packet_creates_flow_without_syn() {
     assert_eq!(packet_counts(&spool.completed_flows()), vec![(1, 0)]);
 }
 
-fn enabled_tracker() -> Tracker<ClientOrGatewayId> {
+fn enabled_tracker<S>() -> Tracker<S> {
     let mut tracker = Tracker::new(Instant::now(), Duration::from_secs(1_700_000_000));
     tracker.set_enabled(true);
 
@@ -353,6 +336,19 @@ impl SpoolObserver {
             .map(|path| flow_log_spool::deserialize(&std::fs::read(path).unwrap()).unwrap())
             .collect()
     }
+
+    /// Reads the payload of the only report whose name ends in `suffix`.
+    fn report(&self, suffix: &str) -> serde_json::Value {
+        let authz_dir = self.dir.path().join("responder").join(&self.authz_id);
+
+        let report = std::fs::read_dir(&authz_dir)
+            .expect("spooled report dir exists")
+            .map(|entry| entry.unwrap().path())
+            .find(|path| path.to_string_lossy().ends_with(suffix))
+            .expect("report exists");
+
+        flow_log_spool::deserialize(&std::fs::read(report).unwrap()).unwrap()
+    }
 }
 
 /// The `(tx_packets, rx_packets)` of each completed flow, in stable order.
@@ -387,15 +383,4 @@ fn test_token(authz_id: &str, role: &str) -> IngestToken {
     let token = format!("{header}.{payload}.{}", encode(b"signature"));
 
     serde_json::from_value(serde_json::Value::String(token)).unwrap()
-}
-
-/// Reads the payload of the only report in `authz_dir` whose name ends in `suffix`.
-fn read_report(authz_dir: &Path, suffix: &str) -> serde_json::Value {
-    let report = std::fs::read_dir(authz_dir)
-        .expect("spooled report dir exists")
-        .map(|entry| entry.unwrap().path())
-        .find(|path| path.to_string_lossy().ends_with(suffix))
-        .expect("report exists");
-
-    flow_log_spool::deserialize(&std::fs::read(report).unwrap()).unwrap()
 }

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -11,8 +11,9 @@ use std::{
 
 use base64::Engine as _;
 use chrono::TimeZone as _;
-use connlib_model::{ClientId, ResourceId};
+use connlib_model::{ClientId, ClientOrGatewayId, ResourceId};
 use flow_tracker::{FlowClose, FlowProtocol, IngestToken, Record, Role, Tracker};
+use ip_packet::IpPacket;
 use tracing_subscriber::layer::SubscriberExt as _;
 
 /// Guards the field contract between [`flow_tracker::emit`] and the writer's
@@ -150,6 +151,183 @@ fn tracked_packets_spool_open_and_completed_reports() {
     assert_eq!(completed["tx_bytes"], 5);
     assert_eq!(completed["rx_packets"], 1);
     assert_eq!(completed["rx_bytes"], 6);
+}
+
+#[test]
+fn syn_retransmit_updates_flow_instead_of_splitting() {
+    let authz_id = "33333333-3333-3333-3333-333333333333";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(true, &[]), authz_id, t0);
+        drive_tx(
+            &mut tracker,
+            &tcp_packet(true, &[]),
+            authz_id,
+            t0 + Duration::from_secs(1),
+        );
+        tracker.close_all(t0 + Duration::from_secs(2));
+    });
+
+    let flows = spool.completed_flows();
+    assert_eq!(
+        packet_counts(&flows),
+        vec![(2, 0)],
+        "retransmitted SYN counts into the same flow"
+    );
+}
+
+#[test]
+fn syn_after_return_traffic_splits_flow() {
+    let authz_id = "44444444-4444-4444-4444-444444444444";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(true, &[]), authz_id, t0);
+        drive_rx(
+            &mut tracker,
+            &tcp_return_packet(&[0; 100]),
+            t0 + Duration::from_secs(1),
+        );
+        drive_tx(
+            &mut tracker,
+            &tcp_packet(true, &[]),
+            authz_id,
+            t0 + Duration::from_secs(2),
+        );
+        tracker.close_all(t0 + Duration::from_secs(3));
+    });
+
+    let flows = spool.completed_flows();
+    assert_eq!(
+        packet_counts(&flows),
+        vec![(1, 0), (1, 1)],
+        "a new SYN closes the old flow and starts a fresh one"
+    );
+}
+
+fn enabled_tracker() -> Tracker<ClientOrGatewayId> {
+    let mut tracker = Tracker::new(Instant::now(), Duration::from_secs(1_700_000_000));
+    tracker.set_enabled(true);
+
+    tracker
+}
+
+/// Runs the initiator-to-responder packet through the tracker's public
+/// entry points, as the gateway does for a packet arriving over the network.
+fn drive_tx(
+    tracker: &mut Tracker<ClientOrGatewayId>,
+    packet: &IpPacket,
+    authz_id: &str,
+    now: Instant,
+) {
+    let _flow = tracker.begin_network_packet(
+        "198.51.100.1:51820".parse().unwrap(),
+        "203.0.113.7:51820".parse().unwrap(),
+        now,
+    );
+    flow_tracker::record_decrypted_packet(packet);
+    flow_tracker::record_peer(ClientId::from_u128(1), Role::Responder);
+    flow_tracker::record_ingest_token(Some(test_token(authz_id, "responder")));
+}
+
+/// Runs the responder-to-initiator return packet through the tracker's
+/// public entry points, as the gateway does for a packet read from TUN.
+fn drive_rx(tracker: &mut Tracker<ClientOrGatewayId>, packet: &IpPacket, now: Instant) {
+    let _flow = tracker.begin_tun_packet(packet, now);
+    flow_tracker::record_peer(ClientId::from_u128(1), Role::Responder);
+    flow_tracker::record_transmit(
+        Some("198.51.100.1:51820".parse().unwrap()),
+        "203.0.113.7:51820".parse().unwrap(),
+    );
+}
+
+fn tcp_packet(syn: bool, payload: &[u8]) -> IpPacket {
+    ip_packet::make::tcp_packet(
+        "100.64.0.1".parse::<Ipv4Addr>().unwrap(),
+        "10.0.0.5".parse::<Ipv4Addr>().unwrap(),
+        1234,
+        443,
+        ip_packet::make::TcpFlags {
+            syn,
+            ..Default::default()
+        },
+        payload,
+    )
+    .unwrap()
+}
+
+/// The matching return packet for [`tcp_packet`], in its natural
+/// (responder-to-initiator) orientation.
+fn tcp_return_packet(payload: &[u8]) -> IpPacket {
+    ip_packet::make::tcp_packet(
+        "10.0.0.5".parse::<Ipv4Addr>().unwrap(),
+        "100.64.0.1".parse::<Ipv4Addr>().unwrap(),
+        443,
+        1234,
+        ip_packet::make::TcpFlags::default(),
+        payload,
+    )
+    .unwrap()
+}
+
+/// Observes the tracker's only public output: the records it emits, spooled
+/// to disk by `flow-log-writer`'s layer.
+struct SpoolObserver {
+    dir: tempfile::TempDir,
+    authz_id: String,
+}
+
+impl SpoolObserver {
+    fn new(authz_id: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        flow_log_writer::write_token(dir.path(), test_token(authz_id, "responder").as_str())
+            .unwrap();
+
+        Self {
+            dir,
+            authz_id: authz_id.to_owned(),
+        }
+    }
+
+    fn observe(&self, f: impl FnOnce()) {
+        let (layer, guard) = flow_log_writer::layer(self.dir.path().to_owned());
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, f);
+        drop(guard); // joins the writer thread, so the reports are on disk
+    }
+
+    fn completed_flows(&self) -> Vec<serde_json::Value> {
+        let authz_dir = self.dir.path().join("responder").join(&self.authz_id);
+
+        std::fs::read_dir(&authz_dir)
+            .expect("spooled report dir exists")
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.to_string_lossy().ends_with(".end.json"))
+            .map(|path| flow_log_spool::deserialize(&std::fs::read(path).unwrap()).unwrap())
+            .collect()
+    }
+}
+
+/// The `(tx_packets, rx_packets)` of each completed flow, in stable order.
+fn packet_counts(flows: &[serde_json::Value]) -> Vec<(u64, u64)> {
+    let mut counts = flows
+        .iter()
+        .map(|flow| {
+            (
+                flow["tx_packets"].as_u64().unwrap(),
+                flow["rx_packets"].as_u64().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    counts.sort_unstable();
+
+    counts
 }
 
 /// A JWT payload carrying every claim the portal guarantees on a token.

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -161,10 +161,10 @@ fn syn_retransmit_updates_flow_instead_of_splitting() {
     let t0 = Instant::now();
 
     spool.observe(|| {
-        drive_tx(&mut tracker, &tcp_packet(true, &[]), authz_id, t0);
+        drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
         drive_tx(
             &mut tracker,
-            &tcp_packet(true, &[]),
+            &tcp_packet(syn(), &[]),
             authz_id,
             t0 + Duration::from_secs(1),
         );
@@ -187,7 +187,7 @@ fn syn_after_return_traffic_splits_flow() {
     let t0 = Instant::now();
 
     spool.observe(|| {
-        drive_tx(&mut tracker, &tcp_packet(true, &[]), authz_id, t0);
+        drive_tx(&mut tracker, &tcp_packet(syn(), &[]), authz_id, t0);
         drive_rx(
             &mut tracker,
             &tcp_return_packet(&[0; 100]),
@@ -195,7 +195,7 @@ fn syn_after_return_traffic_splits_flow() {
         );
         drive_tx(
             &mut tracker,
-            &tcp_packet(true, &[]),
+            &tcp_packet(syn(), &[]),
             authz_id,
             t0 + Duration::from_secs(2),
         );
@@ -208,6 +208,36 @@ fn syn_after_return_traffic_splits_flow() {
         vec![(1, 0), (1, 1)],
         "a new SYN closes the old flow and starts a fresh one"
     );
+}
+
+#[test]
+fn bare_ack_does_not_create_flow() {
+    let authz_id = "55555555-5555-5555-5555-555555555555";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(ack(), &[]), authz_id, t0);
+        tracker.close_all(t0 + Duration::from_secs(1));
+    });
+
+    assert_eq!(packet_counts(&spool.completed_flows()), vec![]);
+}
+
+#[test]
+fn data_packet_creates_flow_without_syn() {
+    let authz_id = "66666666-6666-6666-6666-666666666666";
+    let spool = SpoolObserver::new(authz_id);
+    let mut tracker = enabled_tracker();
+    let t0 = Instant::now();
+
+    spool.observe(|| {
+        drive_tx(&mut tracker, &tcp_packet(ack(), &[0; 100]), authz_id, t0);
+        tracker.close_all(t0 + Duration::from_secs(1));
+    });
+
+    assert_eq!(packet_counts(&spool.completed_flows()), vec![(1, 0)]);
 }
 
 fn enabled_tracker() -> Tracker<ClientOrGatewayId> {
@@ -246,16 +276,27 @@ fn drive_rx(tracker: &mut Tracker<ClientOrGatewayId>, packet: &IpPacket, now: In
     );
 }
 
-fn tcp_packet(syn: bool, payload: &[u8]) -> IpPacket {
+fn syn() -> ip_packet::make::TcpFlags {
+    ip_packet::make::TcpFlags {
+        syn: true,
+        ..Default::default()
+    }
+}
+
+fn ack() -> ip_packet::make::TcpFlags {
+    ip_packet::make::TcpFlags {
+        ack: true,
+        ..Default::default()
+    }
+}
+
+fn tcp_packet(flags: ip_packet::make::TcpFlags, payload: &[u8]) -> IpPacket {
     ip_packet::make::tcp_packet(
         "100.64.0.1".parse::<Ipv4Addr>().unwrap(),
         "10.0.0.5".parse::<Ipv4Addr>().unwrap(),
         1234,
         443,
-        ip_packet::make::TcpFlags {
-            syn,
-            ..Default::default()
-        },
+        flags,
         payload,
     )
     .unwrap()

--- a/rust/libs/connlib/ip-packet/src/make.rs
+++ b/rust/libs/connlib/ip-packet/src/make.rs
@@ -116,7 +116,7 @@ pub fn tcp_packet<IP>(
 where
     IP: Into<IpAddr>,
 {
-    let TcpFlags { syn, rst } = flags;
+    let TcpFlags { syn, ack, rst } = flags;
 
     match (saddr.into(), daddr.into()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
@@ -125,6 +125,10 @@ where
 
             if syn {
                 packet = packet.syn();
+            }
+
+            if ack {
+                packet = packet.ack(0);
             }
 
             if rst {
@@ -141,6 +145,10 @@ where
                 packet = packet.syn();
             }
 
+            if ack {
+                packet = packet.ack(0);
+            }
+
             if rst {
                 packet = packet.rst();
             }
@@ -154,6 +162,7 @@ where
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TcpFlags {
     pub syn: bool,
+    pub ack: bool,
     pub rst: bool,
 }
 

--- a/rust/libs/connlib/ip-packet/src/make.rs
+++ b/rust/libs/connlib/ip-packet/src/make.rs
@@ -116,12 +116,16 @@ pub fn tcp_packet<IP>(
 where
     IP: Into<IpAddr>,
 {
-    let TcpFlags { rst } = flags;
+    let TcpFlags { syn, rst } = flags;
 
     match (saddr.into(), daddr.into()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             let mut packet =
                 PacketBuilder::ipv4(src.octets(), dst.octets(), 64).tcp(sport, dport, 0, 128);
+
+            if syn {
+                packet = packet.syn();
+            }
 
             if rst {
                 packet = packet.rst();
@@ -132,6 +136,10 @@ where
         (IpAddr::V6(src), IpAddr::V6(dst)) => {
             let mut packet =
                 PacketBuilder::ipv6(src.octets(), dst.octets(), 64).tcp(sport, dport, 0, 128);
+
+            if syn {
+                packet = packet.syn();
+            }
 
             if rst {
                 packet = packet.rst();
@@ -145,6 +153,7 @@ where
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TcpFlags {
+    pub syn: bool,
     pub rst: bool,
 }
 

--- a/rust/libs/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/nat_table.rs
@@ -455,7 +455,8 @@ mod tests {
     #[test_strategy::proptest]
     fn outgoing_tcp_rst_removes_nat_mapping(
         #[strategy(tcp_packet(Just(TcpFlags::default())))] req: IpPacket,
-        #[strategy(tcp_packet(Just(TcpFlags { rst: true })))] mut rst: IpPacket,
+        #[strategy(tcp_packet(Just(TcpFlags { rst: true, ..Default::default() })))]
+        mut rst: IpPacket,
         #[strategy(any::<IpAddr>())] outside_dst: IpAddr,
     ) {
         let _guard = logging::test("trace");


### PR DESCRIPTION
A SYN on an occupied flow entry always split the flow, so a client retrying against an unresponsive resource emitted an open/close record pair per retransmission, inflating flow counts for what is a single connection attempt. Only treat a SYN as a new connection when the existing flow has seen return traffic; on a half-open flow it is a retransmission and just counts as another packet. The same behavior exists in the flow tracker this stack replaces.

Related: #13920