### PR TITLE
perf(connlib): batch IP packets across the TUN channels

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8276,6 +8276,7 @@ name = "tun"
 version = "0.1.0"
 dependencies = [
  "anyhow-ext",
+ "bufferpool",
  "ip-packet",
  "libc",
  "opentelemetry",

--- a/rust/client-ffi/src/platform/android/tun.rs
+++ b/rust/client-ffi/src/platform/android/tun.rs
@@ -41,14 +41,14 @@ impl Tun {
         runtime.spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
         runtime.spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_receive(),
             ],
         ));

--- a/rust/client-ffi/src/platform/apple/tun.rs
+++ b/rust/client-ffi/src/platform/apple/tun.rs
@@ -64,14 +64,14 @@ impl Tun {
         runtime.spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
         runtime.spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_receive(),
             ],
         ));

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -447,36 +447,13 @@ impl ValidateChecksumAdapter {
 
         // Spawn task to validate and forward inbound packets from TUN device
         let task = tokio::spawn(async move {
-            while let Some(packet) = inner.receiver().recv().await {
-                if let Some(ipv4) = packet.ipv4_header() {
-                    let expected = ipv4.calc_header_checksum();
-                    let actual = ipv4.header_checksum;
-
-                    if expected != actual {
-                        tracing::warn!(?packet, %expected, %actual, "IPv4 checksum invalid");
-                    }
+            while let Some(batch) = inner.receiver().recv().await {
+                for packet in batch.iter() {
+                    validate_checksums(packet);
                 }
 
-                if let Some(udp) = packet.as_udp() {
-                    let actual = udp.checksum();
-                    if let Ok(expected) = packet.calculate_udp_checksum()
-                        && expected != actual
-                    {
-                        tracing::warn!(?packet, %expected, %actual, "UDP checksum invalid");
-                    }
-                }
-
-                if let Some(tcp) = packet.as_tcp() {
-                    let actual = tcp.checksum();
-                    if let Ok(expected) = packet.calculate_tcp_checksum()
-                        && expected != actual
-                    {
-                        tracing::warn!(?packet, %expected, %actual, "TCP checksum invalid");
-                    }
-                }
-
-                // Forward the validated packet to our inbound channel
-                if inbound_tx.send(packet).await.is_err() {
+                // Forward the validated batch to our inbound channel
+                if inbound_tx.send(batch).await.is_err() {
                     break;
                 }
             }
@@ -488,6 +465,35 @@ impl ValidateChecksumAdapter {
             name,
             _task: AbortOnDropHandle::new(task),
         })
+    }
+}
+
+fn validate_checksums(packet: &ip_packet::IpPacket) {
+    if let Some(ipv4) = packet.ipv4_header() {
+        let expected = ipv4.calc_header_checksum();
+        let actual = ipv4.header_checksum;
+
+        if expected != actual {
+            tracing::warn!(?packet, %expected, %actual, "IPv4 checksum invalid");
+        }
+    }
+
+    if let Some(udp) = packet.as_udp() {
+        let actual = udp.checksum();
+        if let Ok(expected) = packet.calculate_udp_checksum()
+            && expected != actual
+        {
+            tracing::warn!(?packet, %expected, %actual, "UDP checksum invalid");
+        }
+    }
+
+    if let Some(tcp) = packet.as_tcp() {
+        let actual = tcp.checksum();
+        if let Ok(expected) = packet.calculate_tcp_checksum()
+            && expected != actual
+        {
+            tracing::warn!(?packet, %expected, %actual, "TCP checksum invalid");
+        }
     }
 }
 

--- a/rust/libs/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/linux.rs
@@ -691,14 +691,14 @@ impl Tun {
         tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
         tokio::spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_receive(),
             ],
         ));

--- a/rust/libs/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/libs/bin-shared/src/tun_device_manager/windows.rs
@@ -306,14 +306,14 @@ impl Tun {
         tokio::spawn(otel_instruments::periodic_queue_length(
             outbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
         tokio::spawn(otel_instruments::periodic_queue_length(
             inbound_tx.downgrade(),
             [
-                otel::attr::queue_item_ip_packet(),
+                otel::attr::queue_item_ip_packet_batch(),
                 otel::attr::network_io_direction_receive(),
             ],
         ));
@@ -385,68 +385,67 @@ fn start_send_thread(
 
     std::thread::Builder::new()
         .name("TUN send".into())
-        .spawn(move || 'next_packet: loop {
-            let Some(packet) = packet_rx.blocking_recv() else {
-                tracing::debug!(
-                    "Stopping TUN send worker thread because the packet channel closed"
-                );
-                break 'next_packet;
-            };
+        .spawn(move || {
+            while let Some(mut batch) = packet_rx.blocking_recv() {
+                'next_packet: for packet in batch.drain() {
+                    let bytes = packet.packet();
 
-            let bytes = packet.packet();
-
-            let Ok(len) = bytes.len().try_into() else {
-                tracing::warn!("Packet too large; length does not fit into u16");
-                continue 'next_packet;
-            };
-
-            let mut attempt = 0;
-
-            loop {
-                let Some(session) = session.upgrade() else {
-                    tracing::debug!(
-                        "Stopping TUN send worker thread because the `wintun::Session` was dropped"
-                    );
-                    return;
-                };
-
-                match session.allocate_send_packet(len) {
-                    Ok(mut pkt) => {
-                        pkt.bytes_mut().copy_from_slice(bytes);
-                        // `send_packet` cannot fail to enqueue the packet, since we already allocated
-                        // space in the ring buffer.
-                        #[cfg(debug_assertions)]
-                        tracing::trace!(target: "wire::dev::send", ?packet);
-                        session.send_packet(pkt);
-
-                        record_write_retries(&write_retry_histogram, attempt);
-
+                    let Ok(len) = bytes.len().try_into() else {
+                        tracing::warn!("Packet too large; length does not fit into u16");
                         continue 'next_packet;
-                    }
-                    Err(e) if is_ring_full(&e) && attempt < MAX_RING_FULL_RETRIES => {
-                        if attempt == 0 {
-                            tracing::trace!("WinTUN ring buffer is full");
+                    };
+
+                    let mut attempt = 0;
+
+                    loop {
+                        let Some(session) = session.upgrade() else {
+                            tracing::debug!(
+                                "Stopping TUN send worker thread because the `wintun::Session` was dropped"
+                            );
+                            return;
+                        };
+
+                        match session.allocate_send_packet(len) {
+                            Ok(mut pkt) => {
+                                pkt.bytes_mut().copy_from_slice(bytes);
+                                // `send_packet` cannot fail to enqueue the packet, since we already allocated
+                                // space in the ring buffer.
+                                #[cfg(debug_assertions)]
+                                tracing::trace!(target: "wire::dev::send", ?packet);
+                                session.send_packet(pkt);
+
+                                record_write_retries(&write_retry_histogram, attempt);
+
+                                continue 'next_packet;
+                            }
+                            Err(e) if is_ring_full(&e) && attempt < MAX_RING_FULL_RETRIES => {
+                                if attempt == 0 {
+                                    tracing::trace!("WinTUN ring buffer is full");
+                                }
+
+                                spin_and_yield(attempt);
+
+                                attempt += 1;
+                            }
+                            Err(e) => {
+                                record_write_retries(&write_retry_histogram, attempt);
+                                dropped_packets_counter.add(1, &drop_attributes(&e));
+
+                                if is_ring_full(&e) {
+                                    // The ring buffer is still full after all retries; dropping is by design, like for any congested network device.
+                                    tracing::debug!("Failed to write to WinTUN ring buffer: {e}");
+                                } else {
+                                    tracing::warn!("Failed to allocate WinTUN packet: {e}");
+                                }
+
+                                continue 'next_packet;
+                            }
                         }
-
-                        spin_and_yield(attempt);
-
-                        attempt += 1;
-                    }
-                    Err(e) => {
-                        record_write_retries(&write_retry_histogram, attempt);
-                        dropped_packets_counter.add(1, &drop_attributes(&e));
-
-                        if is_ring_full(&e) {
-                            // The ring buffer is still full after all retries; dropping is by design, like for any congested network device.
-                            tracing::debug!("Failed to write to WinTUN ring buffer: {e}");
-                        } else {
-                            tracing::warn!("Failed to allocate WinTUN packet: {e}");
-                        }
-
-                        continue 'next_packet;
                     }
                 }
             }
+
+            tracing::debug!("Stopping TUN send worker thread because the packet channel closed");
         })
 }
 
@@ -515,15 +514,18 @@ fn start_recv_thread(
     std::thread::Builder::new()
         .name("TUN recv".into())
         .spawn(move || {
-            loop {
-                let Some(receive_result) = session.upgrade().map(|s| s.receive_blocking()) else {
+            let mut batch = tun::PacketBatch::default();
+
+            'recv: loop {
+                let Some(session) = session.upgrade() else {
                     tracing::debug!(
                         "Stopping TUN recv worker thread because the `wintun::Session` was dropped"
                     );
                     break;
                 };
 
-                let pkt = match receive_result {
+                // Block for the first packet of a batch.
+                let pkt = match session.receive_blocking() {
                     Ok(pkt) => pkt,
                     Err(wintun::Error::ShuttingDown) => {
                         tracing::debug!(
@@ -537,45 +539,97 @@ fn start_recv_thread(
                     }
                 };
 
-                let mut ip_packet_buf = IpPacketBuf::new();
+                if let Some(packet) = parse_packet(&pkt)
+                    && push_or_start_new_batch(&mut batch, packet, &packet_tx).is_err()
+                {
+                    break 'recv;
+                }
 
-                let src = pkt.bytes();
-                let dst = ip_packet_buf.buf();
+                // Drain whatever else is already in the ring buffer, so one channel item
+                // carries the whole burst.
+                loop {
+                    match session.try_receive() {
+                        Ok(Some(pkt)) => {
+                            if let Some(packet) = parse_packet(&pkt)
+                                && push_or_start_new_batch(&mut batch, packet, &packet_tx).is_err()
+                            {
+                                break 'recv;
+                            }
+                        }
+                        // Ring buffer is drained; hand off what we have.
+                        Ok(None) => break,
+                        // Any genuine error will surface via `receive_blocking` above.
+                        Err(_) => break,
+                    }
+                }
 
-                if src.len() > dst.len() {
-                    tracing::warn!(len = %src.len(), "Received too large packet");
+                if batch.is_empty() {
                     continue;
                 }
 
-                dst[..src.len()].copy_from_slice(src);
-
-                let pkt = match IpPacket::new(ip_packet_buf, src.len()) {
-                    Ok(pkt) => pkt,
-                    Err(e) => {
-                        tracing::debug!("Failed to parse IP packet: {e:#}");
-                        continue;
-                    }
-                };
-
-                #[cfg(debug_assertions)]
-                tracing::trace!(target: "wire::dev::recv", ?pkt);
-
-                // Use `blocking_send` so that if connlib is behind by a few packets,
-                // Wintun will queue up new packets in its ring buffer while we
-                // wait for our MPSC channel to clear.
-                // Unfortunately we don't know if Wintun is dropping packets, since
-                // it doesn't expose a sequence number or anything.
-                match packet_tx.blocking_send(pkt) {
-                    Ok(()) => {}
-                    Err(_) => {
-                        tracing::debug!(
-                            "Stopping TUN recv worker thread because the packet channel closed"
-                        );
-                        break;
-                    }
-                };
+                if packet_tx.blocking_send(std::mem::take(&mut batch)).is_err() {
+                    tracing::debug!(
+                        "Stopping TUN recv worker thread because the packet channel closed"
+                    );
+                    break 'recv;
+                }
             }
         })
+}
+
+/// Appends the packet to the batch; if the batch is full, hands it off and starts a
+/// new one with the packet.
+///
+/// Uses `blocking_send` so that if connlib is behind by a few packets, Wintun will
+/// queue up new packets in its ring buffer while we wait for our MPSC channel to
+/// clear. Unfortunately we don't know if Wintun is dropping packets, since it
+/// doesn't expose a sequence number or anything.
+///
+/// Errors if the channel is closed.
+fn push_or_start_new_batch(
+    batch: &mut tun::PacketBatch,
+    packet: IpPacket,
+    packet_tx: &tun::InboundTx,
+) -> Result<(), ()> {
+    let Err(packet) = batch.try_push(packet) else {
+        return Ok(());
+    };
+
+    packet_tx
+        .blocking_send(std::mem::replace(
+            &mut *batch,
+            tun::PacketBatch::new(packet),
+        ))
+        .map_err(|_| {
+            tracing::debug!("Stopping TUN recv worker thread because the packet channel closed");
+        })
+}
+
+fn parse_packet(pkt: &wintun::Packet) -> Option<IpPacket> {
+    let mut ip_packet_buf = IpPacketBuf::new();
+
+    let src = pkt.bytes();
+    let dst = ip_packet_buf.buf();
+
+    if src.len() > dst.len() {
+        tracing::warn!(len = %src.len(), "Received too large packet");
+        return None;
+    }
+
+    dst[..src.len()].copy_from_slice(src);
+
+    let pkt = match IpPacket::new(ip_packet_buf, src.len()) {
+        Ok(pkt) => pkt,
+        Err(e) => {
+            tracing::debug!("Failed to parse IP packet: {e:#}");
+            return None;
+        }
+    };
+
+    #[cfg(debug_assertions)]
+    tracing::trace!(target: "wire::dev::recv", ?pkt);
+
+    Some(pkt)
 }
 
 /// Sets MTU on the interface

--- a/rust/libs/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/libs/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -103,12 +103,23 @@ impl Eventloop {
 
     fn poll(&mut self, cx: &mut Context) -> Poll<()> {
         loop {
-            // Send all outbound DNS packets
+            // Send all outbound DNS packets as one batch.
+            let mut batch = tun::PacketBatch::default();
+
             while let Some(packet) = self.dns_server.poll_outbound() {
+                if let Err(packet) = batch.try_push(packet) {
+                    self.tun
+                        .sender()
+                        .try_send(std::mem::replace(&mut batch, tun::PacketBatch::new(packet)))
+                        .expect("channels should be able to buffer all batches in this test");
+                }
+            }
+
+            if !batch.is_empty() {
                 self.tun
                     .sender()
-                    .try_send(packet)
-                    .expect("channels should be able to buffer all packets we send in this test")
+                    .try_send(batch)
+                    .expect("channels should be able to buffer all batches in this test");
             }
 
             // Handle DNS queries and generate responses
@@ -122,11 +133,13 @@ impl Eventloop {
                     .unwrap();
             }
 
-            let ip_packet = ready!(self.tun.receiver().poll_recv(cx)).unwrap();
+            let mut packets = ready!(self.tun.receiver().poll_recv(cx)).unwrap();
 
-            if self.dns_server.accepts(&ip_packet) {
-                self.dns_server.handle_inbound(ip_packet);
-                self.dns_server.handle_timeout(Instant::now());
+            for ip_packet in packets.drain() {
+                if self.dns_server.accepts(&ip_packet) {
+                    self.dns_server.handle_inbound(ip_packet);
+                    self.dns_server.handle_timeout(Instant::now());
+                }
             }
         }
     }

--- a/rust/libs/connlib/tun/Cargo.toml
+++ b/rust/libs/connlib/tun/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bufferpool = { workspace = true }
 ip-packet = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync"] }
 

--- a/rust/libs/connlib/tun/src/apple/bulk.rs
+++ b/rust/libs/connlib/tun/src/apple/bulk.rs
@@ -15,14 +15,7 @@ use std::os::fd::{AsRawFd as _, RawFd};
 use tokio::io::{Interest, unix::AsyncFd};
 
 use super::sys;
-use crate::{InboundTx, OutboundRx};
-
-/// How many packets we exchange with the kernel per syscall.
-///
-/// Mirrors the rationale of `MAX_INBOUND_PACKET_BATCH` in the `tunnel` crate: mobile
-/// is memory-constrained, so we keep the batch (and the buffers we pull for it) small
-/// there. The desktop value stays below the kernel's `kern.ipc.somaxrecvmsgx` clamp.
-const BATCH_SIZE: usize = if cfg!(target_os = "ios") { 25 } else { 100 };
+use crate::{MAX_BATCH_SIZE, PacketBatch};
 
 const EMPTY_IOVEC: iovec = iovec {
     iov_base: std::ptr::null_mut(),
@@ -33,7 +26,7 @@ const EMPTY_IOVEC: iovec = iovec {
 pub fn send(
     fd: RawFd,
     syscalls: &'static sys::BatchSyscalls,
-    mut outbound_rx: OutboundRx,
+    mut outbound_rx: crate::OutboundRx,
 ) -> Result<()> {
     let batch_count = otel_instruments::network_packets_batch_count();
     let dropped_packets = otel_instruments::network_packet_dropped();
@@ -44,19 +37,14 @@ pub fn send(
         .context("Failed to create runtime")?
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, Interest::WRITABLE)?;
-            let mut batch = Vec::with_capacity(BATCH_SIZE);
 
-            loop {
-                if outbound_rx.recv_many(&mut batch, BATCH_SIZE).await == 0 {
-                    break; // Channel closed.
-                }
-
+            while let Some(packets) = outbound_rx.recv().await {
                 let mut offset = 0;
-                while offset < batch.len() {
+                while offset < packets.len() {
                     let result = fd
                         .async_io(Interest::WRITABLE, |fd| {
                             // Safety: The file descriptor is valid within this module.
-                            unsafe { send_batch(syscalls, fd.as_raw_fd(), &batch[offset..]) }
+                            unsafe { send_batch(syscalls, fd.as_raw_fd(), &packets[offset..]) }
                         })
                         .await;
 
@@ -80,7 +68,7 @@ pub fn send(
                             // `sendmsg_x` does not report how many datagrams it sent before
                             // failing, so we cannot resubmit the tail without risking a
                             // re-injection of an already-sent prefix. Drop the rest of the batch.
-                            let dropped = batch.len() - offset;
+                            let dropped = packets.len() - offset;
                             dropped_packets.add(dropped as u64, &drop_attributes(&e));
 
                             if e.raw_os_error() == Some(libc::ENOSPC) {
@@ -94,8 +82,6 @@ pub fn send(
                         }
                     }
                 }
-
-                batch.clear();
             }
 
             anyhow::Ok(())
@@ -105,7 +91,11 @@ pub fn send(
 }
 
 /// Receives batches of packets from the TUN device into `inbound_tx`.
-pub fn recv(fd: RawFd, syscalls: &'static sys::BatchSyscalls, inbound_tx: InboundTx) -> Result<()> {
+pub fn recv(
+    fd: RawFd,
+    syscalls: &'static sys::BatchSyscalls,
+    inbound_tx: crate::InboundTx,
+) -> Result<()> {
     let batch_count = otel_instruments::network_packets_batch_count();
 
     tokio::runtime::Builder::new_current_thread()
@@ -115,10 +105,10 @@ pub fn recv(fd: RawFd, syscalls: &'static sys::BatchSyscalls, inbound_tx: Inboun
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, Interest::READABLE)?;
 
-            loop {
+            'recv: loop {
                 let mut bufs: Vec<IpPacketBuf> =
-                    (0..BATCH_SIZE).map(|_| IpPacketBuf::new()).collect();
-                let mut lens = [0usize; BATCH_SIZE];
+                    (0..MAX_BATCH_SIZE).map(|_| IpPacketBuf::new()).collect();
+                let mut lens = [0usize; MAX_BATCH_SIZE];
 
                 let n = fd
                     .async_io(Interest::READABLE, |fd| {
@@ -142,10 +132,7 @@ pub fn recv(fd: RawFd, syscalls: &'static sys::BatchSyscalls, inbound_tx: Inboun
                     ],
                 );
 
-                let Ok(mut permits) = inbound_tx.reserve_many(n).await else {
-                    tracing::debug!("Inbound packet receiver gone, shutting down task");
-                    break;
-                };
+                let mut batch = PacketBatch::default();
 
                 for (buf, len) in bufs.into_iter().zip(lens).take(n) {
                     if len == 0 {
@@ -157,13 +144,33 @@ pub fn recv(fd: RawFd, syscalls: &'static sys::BatchSyscalls, inbound_tx: Inboun
                             #[cfg(debug_assertions)]
                             tracing::trace!(target: "wire::dev::recv", ?packet);
 
-                            // We reserved `n` permits and send at most `n`, so this is always `Some`.
-                            let Some(permit) = permits.next() else { break };
-                            permit.send(packet);
+                            let Err(packet) = batch.try_push(packet) else {
+                                continue;
+                            };
+
+                            // Unreachable in practice: we read at most `MAX_BATCH_SIZE`
+                            // packets per syscall, but a full batch is handed off all the same.
+                            if inbound_tx
+                                .send(std::mem::replace(&mut batch, PacketBatch::new(packet)))
+                                .await
+                                .is_err()
+                            {
+                                tracing::debug!("Inbound packet receiver gone, shutting down task");
+                                break 'recv;
+                            }
                         }
                         Err(e) if e.any_is::<ip_packet::Fragmented>() => tracing::debug!("{e:#}"),
                         Err(e) => tracing::warn!("{e:#}"),
                     }
+                }
+
+                if batch.is_empty() {
+                    continue;
+                }
+
+                if inbound_tx.send(batch).await.is_err() {
+                    tracing::debug!("Inbound packet receiver gone, shutting down task");
+                    break;
                 }
             }
 
@@ -183,12 +190,12 @@ unsafe fn send_batch(
     fd: RawFd,
     batch: &[IpPacket],
 ) -> io::Result<usize> {
-    let count = batch.len().min(BATCH_SIZE);
+    let count = batch.len().min(MAX_BATCH_SIZE);
 
     // The first 4 bytes of each datagram carry the address family in network byte order.
-    let mut afs = [[0u8; 4]; BATCH_SIZE];
-    let mut iovs = [[EMPTY_IOVEC; 2]; BATCH_SIZE];
-    let mut msgs = [sys::msghdr_x::ZEROED; BATCH_SIZE];
+    let mut afs = [[0u8; 4]; MAX_BATCH_SIZE];
+    let mut iovs = [[EMPTY_IOVEC; 2]; MAX_BATCH_SIZE];
+    let mut msgs = [sys::msghdr_x::ZEROED; MAX_BATCH_SIZE];
 
     for i in 0..count {
         #[cfg(debug_assertions)]
@@ -238,11 +245,11 @@ unsafe fn recv_batch(
     bufs: &mut [IpPacketBuf],
     lens: &mut [usize],
 ) -> io::Result<usize> {
-    let count = bufs.len().min(BATCH_SIZE);
+    let count = bufs.len().min(MAX_BATCH_SIZE);
 
-    let mut afs = [[0u8; 4]; BATCH_SIZE];
-    let mut iovs = [[EMPTY_IOVEC; 2]; BATCH_SIZE];
-    let mut msgs = [sys::msghdr_x::ZEROED; BATCH_SIZE];
+    let mut afs = [[0u8; 4]; MAX_BATCH_SIZE];
+    let mut iovs = [[EMPTY_IOVEC; 2]; MAX_BATCH_SIZE];
+    let mut msgs = [sys::msghdr_x::ZEROED; MAX_BATCH_SIZE];
 
     for i in 0..count {
         let dst = bufs[i].buf();

--- a/rust/libs/connlib/tun/src/apple/tests.rs
+++ b/rust/libs/connlib/tun/src/apple/tests.rs
@@ -50,10 +50,11 @@ fn recv_reads_packets_routed_through_the_interface() {
     let deadline = Instant::now() + Duration::from_secs(5);
     while matched < COUNT && Instant::now() < deadline {
         match rx.try_recv() {
-            Ok(packet) => {
-                if packet.destination() == IpAddr::V4(PEER) && packet.as_udp().is_some() {
-                    matched += 1;
-                }
+            Ok(batch) => {
+                matched += batch
+                    .iter()
+                    .filter(|p| p.destination() == IpAddr::V4(PEER) && p.as_udp().is_some())
+                    .count();
             }
             Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
                 std::thread::sleep(Duration::from_millis(10));

--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -1,4 +1,8 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use bufferpool::{Buffer, BufferPool, VecBuf};
 use ip_packet::IpPacket;
+use std::sync::LazyLock;
 use tokio::sync::mpsc;
 
 #[cfg(target_family = "unix")]
@@ -9,15 +13,88 @@ pub mod unix;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub mod apple;
 
-/// Capacity of the channels connecting the TUN device threads to the main thread.
-const CHANNEL_CAPACITY: usize = cfg_select! {
-    target_os = "linux" => { 10_000 }
-    target_os = "windows" => { 10_000 }
-    target_os = "macos" => { 10_000 }
-    target_os = "ios" => { 1_000 }
-    target_os = "android" => { 1_000 }
-    _ => { 1_000 }
+/// How many packets a single item on the TUN channels may at most hold.
+///
+/// The channels exchange whole batches of packets, so the cost of a channel
+/// send / receive (and the associated task wake-up) is paid once per batch
+/// rather than once per packet.
+///
+/// Mobile platforms are memory-constrained and cannot afford to buffer big
+/// batches of packets, so we use a smaller limit there. The desktop value also
+/// stays below the kernel's `kern.ipc.somaxrecvmsgx` clamp on Apple platforms.
+pub const MAX_BATCH_SIZE: usize = cfg_select! {
+    target_os = "ios" => { 25 }
+    target_os = "android" => { 25 }
+    _ => { 100 }
 };
+
+/// Capacity (in batches) of the channels connecting the TUN device threads to the main thread.
+const CHANNEL_CAPACITY: usize = cfg_select! {
+    target_os = "linux" => { 100 }
+    target_os = "windows" => { 100 }
+    target_os = "macos" => { 100 }
+    target_os = "ios" => { 40 }
+    target_os = "android" => { 40 }
+    _ => { 40 }
+};
+
+static BATCH_POOL: LazyLock<BufferPool<VecBuf<IpPacket>>> =
+    LazyLock::new(|| BufferPool::new(MAX_BATCH_SIZE, "ip-packet-batch"));
+
+/// A batch of packets, exchanged over the TUN channels as a single item.
+///
+/// A batch holds at most [`MAX_BATCH_SIZE`] packets in a pooled buffer:
+/// [`PacketBatch::try_push`] hands the packet back once the batch is full, so the
+/// storage never grows and moving a batch only copies a pointer. Callers send off
+/// a full batch and start a new one with [`PacketBatch::new`]. Emptied batches are
+/// cleared on return to the pool by [`VecBuf`]'s `reset`, so stale packets don't
+/// keep their pooled payload buffers alive.
+#[derive(Debug)]
+pub struct PacketBatch {
+    inner: Buffer<VecBuf<IpPacket>>,
+}
+
+impl Default for PacketBatch {
+    fn default() -> Self {
+        Self {
+            inner: BATCH_POOL.pull(),
+        }
+    }
+}
+
+impl PacketBatch {
+    /// Starts a new batch containing the given packet.
+    pub fn new(first: IpPacket) -> Self {
+        let mut batch = Self::default();
+        batch.inner.push(first);
+
+        batch
+    }
+
+    /// Appends a packet to the batch, handing it back if the batch is full.
+    pub fn try_push(&mut self, packet: IpPacket) -> Result<(), IpPacket> {
+        if self.inner.len() == MAX_BATCH_SIZE {
+            return Err(packet);
+        }
+
+        self.inner.push(packet);
+
+        Ok(())
+    }
+
+    /// Removes all packets from the batch, in order.
+    pub fn drain(&mut self) -> impl Iterator<Item = IpPacket> + '_ {
+        self.inner.drain(..)
+    }
+}
+
+impl std::ops::Deref for PacketBatch {
+    type Target = [IpPacket];
+
+    fn deref(&self) -> &[IpPacket] {
+        self.inner.as_slice()
+    }
+}
 
 pub trait Tun: Send + Sync + 'static {
     /// Get a reference to the sender for outbound packets.
@@ -54,90 +131,84 @@ pub fn outbound_channel_for_test(capacity: usize) -> (OutboundTx, OutboundRx) {
 }
 
 /// The sending half of the channel to the thread writing to the TUN device.
+///
+/// Each item is one batch of packets that were processed together upstream.
 #[derive(Clone)]
-pub struct OutboundTx(mpsc::Sender<IpPacket>);
+pub struct OutboundTx(mpsc::Sender<PacketBatch>);
 
 impl OutboundTx {
-    pub fn try_send(&self, packet: IpPacket) -> Result<(), mpsc::error::TrySendError<IpPacket>> {
-        self.0.try_send(packet)
+    pub fn try_send(
+        &self,
+        batch: PacketBatch,
+    ) -> Result<(), mpsc::error::TrySendError<PacketBatch>> {
+        self.0.try_send(batch)
     }
 
-    pub async fn send(&self, packet: IpPacket) -> Result<(), mpsc::error::SendError<IpPacket>> {
-        self.0.send(packet).await
+    pub async fn send(
+        &self,
+        batch: PacketBatch,
+    ) -> Result<(), mpsc::error::SendError<PacketBatch>> {
+        self.0.send(batch).await
     }
 
-    pub fn downgrade(&self) -> mpsc::WeakSender<IpPacket> {
+    pub fn downgrade(&self) -> mpsc::WeakSender<PacketBatch> {
         self.0.downgrade()
     }
 }
 
 /// The receiving half of the channel to the thread writing to the TUN device.
-pub struct OutboundRx(mpsc::Receiver<IpPacket>);
+pub struct OutboundRx(mpsc::Receiver<PacketBatch>);
 
 impl OutboundRx {
-    pub async fn recv(&mut self) -> Option<IpPacket> {
+    pub async fn recv(&mut self) -> Option<PacketBatch> {
         self.0.recv().await
     }
 
-    pub async fn recv_many(&mut self, buffer: &mut Vec<IpPacket>, limit: usize) -> usize {
-        self.0.recv_many(buffer, limit).await
-    }
-
-    pub fn blocking_recv(&mut self) -> Option<IpPacket> {
+    pub fn blocking_recv(&mut self) -> Option<PacketBatch> {
         self.0.blocking_recv()
     }
 }
 
-/// The sending half of the channel of [`IpPacket`]s read from the TUN device.
+/// The sending half of the channel of packet batches read from the TUN device.
 #[derive(Clone)]
-pub struct InboundTx(mpsc::Sender<IpPacket>);
+pub struct InboundTx(mpsc::Sender<PacketBatch>);
 
 impl InboundTx {
-    pub async fn reserve_many(
+    pub async fn send(
         &self,
-        n: usize,
-    ) -> Result<mpsc::PermitIterator<'_, IpPacket>, mpsc::error::SendError<()>> {
-        self.0.reserve_many(n).await
+        batch: PacketBatch,
+    ) -> Result<(), mpsc::error::SendError<PacketBatch>> {
+        self.0.send(batch).await
     }
 
-    pub async fn send(&self, packet: IpPacket) -> Result<(), mpsc::error::SendError<IpPacket>> {
-        self.0.send(packet).await
+    pub fn blocking_send(
+        &self,
+        batch: PacketBatch,
+    ) -> Result<(), mpsc::error::SendError<PacketBatch>> {
+        self.0.blocking_send(batch)
     }
 
-    pub fn blocking_send(&self, packet: IpPacket) -> Result<(), mpsc::error::SendError<IpPacket>> {
-        self.0.blocking_send(packet)
-    }
-
-    pub fn downgrade(&self) -> mpsc::WeakSender<IpPacket> {
+    pub fn downgrade(&self) -> mpsc::WeakSender<PacketBatch> {
         self.0.downgrade()
     }
 }
 
-/// The receiving half of the channel of [`IpPacket`]s read from the TUN device.
-pub struct InboundRx(mpsc::Receiver<IpPacket>);
+/// The receiving half of the channel of packet batches read from the TUN device.
+pub struct InboundRx(mpsc::Receiver<PacketBatch>);
 
 impl InboundRx {
-    pub fn poll_recv_many(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-        buffer: &mut Vec<IpPacket>,
-        limit: usize,
-    ) -> std::task::Poll<usize> {
-        self.0.poll_recv_many(cx, buffer, limit)
-    }
-
     pub fn poll_recv(
         &mut self,
         cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<IpPacket>> {
+    ) -> std::task::Poll<Option<PacketBatch>> {
         self.0.poll_recv(cx)
     }
 
-    pub async fn recv(&mut self) -> Option<IpPacket> {
+    pub async fn recv(&mut self) -> Option<PacketBatch> {
         self.0.recv().await
     }
 
-    pub fn try_recv(&mut self) -> Result<IpPacket, mpsc::error::TryRecvError> {
+    pub fn try_recv(&mut self) -> Result<PacketBatch, mpsc::error::TryRecvError> {
         self.0.try_recv()
     }
 }
@@ -147,9 +218,12 @@ mod tests {
     use super::*;
 
     /// Worst-case memory usage of the two TUN channels: every slot filled with a
-    /// packet, each of which owns a pooled buffer of [`ip_packet::MAX_FZ_PAYLOAD`] bytes.
-    const MAX_CHANNEL_MEMORY: usize =
-        2 * CHANNEL_CAPACITY * (size_of::<IpPacket>() + ip_packet::MAX_FZ_PAYLOAD);
+    /// full batch of packets, each of which owns a pooled buffer of
+    /// [`ip_packet::MAX_FZ_PAYLOAD`] bytes.
+    const MAX_CHANNEL_MEMORY: usize = 2
+        * CHANNEL_CAPACITY
+        * (size_of::<PacketBatch>()
+            + MAX_BATCH_SIZE * (size_of::<IpPacket>() + ip_packet::MAX_FZ_PAYLOAD));
 
     /// iOS network extensions are limited to 50 MB of memory; the channels must only
     /// ever use a small fraction of that.
@@ -163,5 +237,23 @@ mod tests {
     #[test]
     fn channel_memory_fits_desktop_budget() {
         const { assert!(MAX_CHANNEL_MEMORY <= 32 * 1024 * 1024) }
+    }
+
+    #[test]
+    fn batches_return_to_the_pool_empty() {
+        let packet = ip_packet::make::udp_packet(
+            std::net::Ipv4Addr::LOCALHOST,
+            std::net::Ipv4Addr::LOCALHOST,
+            1234,
+            5678,
+            &[],
+        )
+        .unwrap();
+
+        drop(PacketBatch::new(packet));
+
+        // The dropped batch's storage is recycled; it must come back empty.
+        let batch = PacketBatch::default();
+        assert!(batch.is_empty());
     }
 }

--- a/rust/libs/connlib/tun/src/unix.rs
+++ b/rust/libs/connlib/tun/src/unix.rs
@@ -2,8 +2,11 @@ use anyhow::{Context as _, ErrorExt, Result, bail};
 use ip_packet::{IpPacket, IpPacketBuf};
 use opentelemetry::KeyValue;
 use std::io;
+use std::mem;
 use std::os::fd::AsRawFd;
 use tokio::io::unix::AsyncFd;
+
+use crate::PacketBatch;
 
 /// How many times we at most try to re-write a packet if the TUN queue is full (`ENOSPC` on MacOS / iOS).
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -13,16 +16,6 @@ const MAX_ENOSPC_RETRIES: u32 = 24;
 ///
 /// `2^6 = 64` iterations of [`std::hint::spin_loop`] stay well below a microsecond.
 const SPIN_LIMIT: u32 = 6;
-
-/// How many packets we at most pull from the outbound channel in one batch before
-/// writing them, amortising task wake-ups across the batch.
-///
-/// Mobile platforms are memory-constrained, so we use a smaller batch there.
-const MAX_TUN_BATCH: usize = if cfg!(any(target_os = "ios", target_os = "android")) {
-    25
-} else {
-    100
-};
 
 pub fn tun_send<T>(
     fd: T,
@@ -41,12 +34,9 @@ where
         .context("Failed to create runtime")?
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, tokio::io::Interest::WRITABLE)?;
-            let mut packets = Vec::with_capacity(MAX_TUN_BATCH);
 
-            // Pull as many packets as are queued (up to `MAX_TUN_BATCH`) per wake-up,
-            // so the cost of being scheduled is amortised across the whole batch.
-            while outbound_rx.recv_many(&mut packets, MAX_TUN_BATCH).await > 0 {
-                for packet in packets.drain(..) {
+            while let Some(mut batch) = outbound_rx.recv().await {
+                for packet in batch.drain() {
                     #[cfg(debug_assertions)]
                     tracing::trace!(target: "wire::dev::send", ?packet);
 
@@ -176,14 +166,15 @@ where
         .context("Failed to create runtime")?
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, tokio::io::Interest::READABLE)?;
-            let mut packets = Vec::with_capacity(MAX_TUN_BATCH);
+            let mut batch = PacketBatch::default();
 
             loop {
                 let mut guard = fd.readable().await?;
 
-                // Drain up to `MAX_TUN_BATCH` packets from the FD before handing them off,
-                // so a single wake-up feeds a batch into the state loop instead of one packet.
-                while packets.len() < MAX_TUN_BATCH {
+                // Drain the FD before handing the packets off as a single batch, so one
+                // channel item feeds a whole read burst into the state loop instead of
+                // one packet.
+                loop {
                     let mut ip_packet_buf = IpPacketBuf::new();
 
                     let len = match guard
@@ -203,7 +194,20 @@ where
                             #[cfg(debug_assertions)]
                             tracing::trace!(target: "wire::dev::recv", ?packet);
 
-                            packets.push(packet);
+                            let Err(packet) = batch.try_push(packet) else {
+                                continue;
+                            };
+
+                            // The batch is full: hand it off and start a new one.
+                            if inbound_tx
+                                .send(mem::replace(&mut batch, PacketBatch::new(packet)))
+                                .await
+                                .is_err()
+                            {
+                                tracing::debug!("Inbound packet receiver gone, shutting down task");
+
+                                return anyhow::Ok(());
+                            }
                         }
                         Err(e) if e.any_is::<ip_packet::Fragmented>() => {
                             tracing::debug!("{e:#}") // Log on debug to be less noisy.
@@ -212,18 +216,14 @@ where
                     }
                 }
 
-                if packets.is_empty() {
+                if batch.is_empty() {
                     continue;
                 }
 
-                let Ok(permits) = inbound_tx.reserve_many(packets.len()).await else {
+                if inbound_tx.send(mem::take(&mut batch)).await.is_err() {
                     tracing::debug!("Inbound packet receiver gone, shutting down task");
 
                     return anyhow::Ok(());
-                };
-
-                for (permit, packet) in permits.zip(packets.drain(..)) {
-                    permit.send(packet);
                 }
             }
         })?;

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -30,21 +30,6 @@ use std::{
 use tracing::Level;
 use tun::Tun;
 
-/// How many IP packets we will at most read from the MPSC-channel connected to our TUN device thread.
-///
-/// Reading IP packets from the channel in batches allows us to process (i.e. encrypt) them as a batch.
-/// UDP datagrams of the same size and destination can then be sent in a single syscall using GSO.
-///
-/// On mobile platforms, we are memory-constrained and thus cannot afford to process big batches of packets.
-/// Thus, we limit the batch-size there to 25.
-const MAX_INBOUND_PACKET_BATCH: usize = {
-    if cfg!(any(target_os = "ios", target_os = "android")) {
-        25
-    } else {
-        100
-    }
-};
-
 const DEFAULT_TIME_ADVANCE: Duration = Duration::from_secs(10);
 
 /// Bundles together all side-effects that connlib needs to have access to.
@@ -83,18 +68,6 @@ struct DnsQueryMetaData {
     remote: SocketAddr,
     transport: dns::Transport,
     started_at: Instant,
-}
-
-pub(crate) struct Buffers {
-    ip: Vec<IpPacket>,
-}
-
-impl Default for Buffers {
-    fn default() -> Self {
-        Self {
-            ip: Vec::with_capacity(MAX_INBOUND_PACKET_BATCH),
-        }
-    }
 }
 
 /// Represents all IO sources that may be ready during a single event-loop tick.
@@ -256,15 +229,11 @@ impl Io {
         self.nameservers.fastest()
     }
 
-    pub fn poll<'b>(
+    pub fn poll(
         &mut self,
         cx: &mut Context<'_>,
-        buffers: &'b mut Buffers,
     ) -> Poll<
-        Input<
-            impl Iterator<Item = IpPacket> + use<'b>,
-            impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
-        >,
+        Input<tun::PacketBatch, impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>>,
     > {
         if let Err(e) = ready!(self.flush(cx)) {
             return Poll::Ready(Input::error(e));
@@ -298,33 +267,27 @@ impl Io {
             error.push(e);
         }
 
-        let device = self
-            .tun
-            .poll_read_many(cx, &mut buffers.ip, MAX_INBOUND_PACKET_BATCH)
-            .map_ok(|num_packets| {
-                let num_ipv4 = buffers.ip[..num_packets]
-                    .iter()
-                    .filter(|p| p.ipv4_header().is_some())
-                    .count();
-                let num_ipv6 = num_packets - num_ipv4;
+        let device = self.tun.poll_read(cx).map_ok(|batch| {
+            let num_ipv4 = batch.iter().filter(|p| p.ipv4_header().is_some()).count();
+            let num_ipv6 = batch.len() - num_ipv4;
 
-                self.packet_counter.add(
-                    num_ipv4 as u64,
-                    &[
-                        otel::attr::network_type_ipv4(),
-                        otel::attr::network_io_direction_receive(),
-                    ],
-                );
-                self.packet_counter.add(
-                    num_ipv6 as u64,
-                    &[
-                        otel::attr::network_type_ipv6(),
-                        otel::attr::network_io_direction_receive(),
-                    ],
-                );
+            self.packet_counter.add(
+                num_ipv4 as u64,
+                &[
+                    otel::attr::network_type_ipv4(),
+                    otel::attr::network_io_direction_receive(),
+                ],
+            );
+            self.packet_counter.add(
+                num_ipv6 as u64,
+                &[
+                    otel::attr::network_type_ipv6(),
+                    otel::attr::network_io_direction_receive(),
+                ],
+            );
 
-                buffers.ip.drain(..num_packets)
-            });
+            batch
+        });
 
         let udp_dns_queries = self
             .udp_dns_server
@@ -463,7 +426,7 @@ impl Io {
         self.tun.set_tun(tun);
     }
 
-    pub fn send_tun(&mut self, packet: IpPacket) {
+    pub fn queue_tun(&mut self, packet: IpPacket) {
         self.packet_counter.add(
             1,
             &[
@@ -472,7 +435,12 @@ impl Io {
             ],
         );
 
-        self.tun.send(packet);
+        self.tun.queue(packet);
+    }
+
+    /// Marks the end of the current batch of packets queued via [`Io::queue_tun`].
+    pub fn flush_tun_batch(&mut self) {
+        self.tun.flush_batch();
     }
 
     pub fn reset(&mut self) {
@@ -639,7 +607,7 @@ fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
 #[cfg(test)]
 mod tests {
     use futures::task::noop_waker_ref;
-    use std::{future::poll_fn, net::Ipv4Addr, ptr::addr_of_mut};
+    use std::{future::poll_fn, net::Ipv4Addr};
 
     use super::*;
 
@@ -795,8 +763,6 @@ mod tests {
         }
     }
 
-    static mut DUMMY_BUF: Buffers = Buffers { ip: Vec::new() };
-
     /// Helper functions to make the test more concise.
     impl Io {
         fn for_test() -> Io {
@@ -812,33 +778,20 @@ mod tests {
 
         async fn next(
             &mut self,
-        ) -> Input<
-            impl Iterator<Item = IpPacket> + use<>,
-            impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>,
-        > {
-            poll_fn(|cx| {
-                self.poll(
-                    cx,
-                    // SAFETY: This is a test and we never receive packets here.
-                    unsafe { &mut *addr_of_mut!(DUMMY_BUF) },
-                )
-            })
-            .await
+        ) -> Input<tun::PacketBatch, impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>>
+        {
+            poll_fn(|cx| self.poll(cx)).await
         }
 
         fn poll_test(
             &mut self,
         ) -> Poll<
             Input<
-                impl Iterator<Item = IpPacket> + use<>,
+                tun::PacketBatch,
                 impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
             >,
         > {
-            self.poll(
-                &mut Context::from_waker(noop_waker_ref()),
-                // SAFETY: This is a test and we never receive packets here.
-                unsafe { &mut *addr_of_mut!(DUMMY_BUF) },
-            )
+            self.poll(&mut Context::from_waker(noop_waker_ref()))
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/io/device.rs
+++ b/rust/libs/connlib/tunnel/src/io/device.rs
@@ -2,27 +2,20 @@ use anyhow::Result;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use ip_packet::IpPacket;
-use smallvec::SmallVec;
+use std::collections::VecDeque;
 use std::mem;
 use std::task::ready;
 use std::task::{Context, Poll, Waker};
-use tun::Tun;
-
-/// How many packets we at most expect to buffer on the stack.
-///
-/// Assuming the channel to our TUN send thread is completely full, we should at most get one more batch of packets from the UDP thread.
-/// How many packets we get there in one batch is platform-dependent but even on platforms like Linux where GSO is well supported,
-/// it shouldn't be more than 64 (32 for each IP version).
-///
-/// Using 128 here is already conservative and in case we exceed it, `SmallVec` will just allocate and not panic.
-/// Thus, in the happy path, this will be very efficient and only use stack-space.
-const MAX_BUFFERED_PACKETS: usize = 128;
+use tun::{PacketBatch, Tun};
 
 pub struct Device {
     tun: Option<Box<dyn Tun>>,
     waker: Option<Waker>,
 
-    outbound_buffer: SmallVec<[IpPacket; MAX_BUFFERED_PACKETS]>,
+    /// The batch of packets queued since the last call to [`Device::flush_batch`].
+    current_batch: PacketBatch,
+    /// Completed batches that did not fit into the channel yet.
+    pending_batches: VecDeque<PacketBatch>,
     flush_future: Option<BoxFuture<'static, Result<()>>>,
 }
 
@@ -31,7 +24,8 @@ impl Device {
         Self {
             tun: None,
             waker: None,
-            outbound_buffer: SmallVec::new(),
+            current_batch: PacketBatch::default(),
+            pending_batches: VecDeque::new(),
             flush_future: None,
         }
     }
@@ -46,24 +40,17 @@ impl Device {
         }
     }
 
-    pub(crate) fn poll_read_many(
-        &mut self,
-        cx: &mut Context<'_>,
-        buf: &mut Vec<IpPacket>,
-        max: usize,
-    ) -> Poll<Result<usize>> {
+    pub(crate) fn poll_read(&mut self, cx: &mut Context<'_>) -> Poll<Result<PacketBatch>> {
         let Some(tun) = self.tun.as_mut() else {
             self.waker = Some(cx.waker().clone());
             return Poll::Pending;
         };
 
-        let n = ready!(tun.receiver().poll_recv_many(cx, buf, max));
-
-        if n == 0 {
+        let Some(batch) = ready!(tun.receiver().poll_recv(cx)) else {
             return Poll::Ready(Err(anyhow::Error::new(TunChannelClosed)));
-        }
+        };
 
-        Poll::Ready(Ok(n))
+        Poll::Ready(Ok(batch))
     }
 
     pub fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
@@ -72,19 +59,19 @@ impl Device {
         };
 
         let Some(fut) = self.flush_future.as_mut() else {
-            if self.outbound_buffer.is_empty() {
+            if self.pending_batches.is_empty() {
                 return Poll::Ready(Ok(()));
             }
 
-            tracing::trace!("Got buffered packets, building flush future");
+            tracing::trace!("Got pending batches, building flush future");
 
-            let buffered_packets = mem::take(&mut self.outbound_buffer);
+            let batches = mem::take(&mut self.pending_batches);
             let tx = tun.sender().clone();
 
             self.flush_future = Some(
                 async move {
-                    for packet in buffered_packets {
-                        tx.send(packet).await.map_err(|_| TunChannelClosed)?;
+                    for batch in batches {
+                        tx.send(batch).await.map_err(|_| TunChannelClosed)?;
                     }
 
                     Ok(())
@@ -105,35 +92,58 @@ impl Device {
         Poll::Ready(res)
     }
 
-    pub fn send(&mut self, packet: IpPacket) {
+    /// Queues a packet for the TUN device.
+    ///
+    /// Queued packets are buffered until the current batch is completed with
+    /// [`Device::flush_batch`].
+    pub fn queue(&mut self, packet: IpPacket) {
         debug_assert!(
             !packet.is_fz_p2p_control(),
             "FZ p2p control protocol packets should never leave `connlib`"
         );
 
+        if self.tun.is_none() {
+            return;
+        }
+
+        if let Err(packet) = self.current_batch.try_push(packet) {
+            // The batch is full: hand it off and start a new one.
+            let batch = mem::replace(&mut self.current_batch, PacketBatch::new(packet));
+
+            self.enqueue_batch(batch);
+        }
+    }
+
+    /// Marks the end of the current batch of packets, handing it to the TUN thread
+    /// as a single channel item.
+    pub fn flush_batch(&mut self) {
+        if self.current_batch.is_empty() {
+            return;
+        }
+
+        let batch = mem::take(&mut self.current_batch);
+
+        self.enqueue_batch(batch);
+    }
+
+    fn enqueue_batch(&mut self, batch: PacketBatch) {
         let Some(tun) = self.tun.as_ref() else {
             return;
         };
 
-        // Preserve ordering: if a flush is already in flight, this packet must queue behind the
-        // packets being flushed. Otherwise a `try_send` here could slip it into the channel ahead
-        // of them, reordering the stream we write to the TUN device.
-        if self.flush_future.is_some() {
-            self.outbound_buffer.push(packet);
-            return;
-        }
-
-        // Likewise, if we haven't started flushing yet but are already buffering (a previous
-        // `try_send` hit a full channel), this packet must queue behind those buffered packets.
-        if !self.outbound_buffer.is_empty() {
-            self.outbound_buffer.push(packet);
+        // Preserve ordering: if a flush is already in flight or batches are pending,
+        // this batch must queue behind them. Otherwise a `try_send` here could slip
+        // it into the channel ahead of them, reordering the stream we write to the
+        // TUN device.
+        if self.flush_future.is_some() || !self.pending_batches.is_empty() {
+            self.pending_batches.push_back(batch);
             return;
         }
 
         // Fast path: nothing queued, send immediately if the channel has capacity.
-        if let Err(packet) = tun.sender().try_send(packet).map_err(|e| e.into_inner()) {
-            tracing::trace!(?packet, "Unable to send packet into channel, buffering");
-            self.outbound_buffer.push(packet);
+        if let Err(batch) = tun.sender().try_send(batch).map_err(|e| e.into_inner()) {
+            tracing::trace!("Unable to send batch into channel, buffering");
+            self.pending_batches.push_back(batch);
         }
     }
 }
@@ -159,7 +169,8 @@ mod tests {
             ip_packet::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 1234, 5678, &[])
                 .unwrap();
 
-        device.send(packet);
+        device.queue(packet);
+        device.flush_batch();
 
         let err = std::future::poll_fn(|cx| device.poll_flush(cx))
             .await
@@ -186,8 +197,10 @@ mod tests {
 
         // We cycle 3 times to ensure we can send and flush again repeatedly.
         for _ in 0..3 {
-            device.send(packet.clone());
-            device.send(packet.clone()); // This one should get buffered.
+            device.queue(packet.clone());
+            device.flush_batch();
+            device.queue(packet.clone());
+            device.flush_batch(); // This batch should get buffered.
 
             let poll = device.poll_flush_noop_waker();
             assert!(poll.is_pending(), "Flush should suspend if channel is full");
@@ -203,7 +216,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn packets_do_not_overtake_buffered_packets_while_flushing() {
+    async fn batches_do_not_overtake_pending_batches_while_flushing() {
         let _guard = logging::test("trace");
 
         let mut device = Device::new();
@@ -215,9 +228,11 @@ mod tests {
         let packet_c = test_packet(3);
 
         // A claims the single channel slot via the `try_send` fast-path.
-        device.send(packet_a.clone());
+        device.queue(packet_a.clone());
+        device.flush_batch();
         // B finds the channel full and gets buffered.
-        device.send(packet_b.clone());
+        device.queue(packet_b.clone());
+        device.flush_batch();
 
         // Start flushing B. It can't make progress while the channel is still full, so the flush
         // stays in-flight (`flush_future` is `Some`).
@@ -229,21 +244,48 @@ mod tests {
 
         // C arrives while the flush is in-flight. It must queue behind B rather than racing ahead
         // through `try_send`.
-        device.send(packet_c.clone());
+        device.queue(packet_c.clone());
+        device.flush_batch();
 
         // Drain the channel and finish flushing. The receiver must observe A, then B, then C, and
         // never A, C, B.
-        assert_eq!(send_rx.recv().await.unwrap(), packet_a);
+        assert_eq!(expect_single(send_rx.recv().await.unwrap()), packet_a);
 
         std::future::poll_fn(|cx| device.poll_flush(cx))
             .await
             .unwrap();
-        assert_eq!(send_rx.recv().await.unwrap(), packet_b);
+        assert_eq!(expect_single(send_rx.recv().await.unwrap()), packet_b);
 
         std::future::poll_fn(|cx| device.poll_flush(cx))
             .await
             .unwrap();
-        assert_eq!(send_rx.recv().await.unwrap(), packet_c);
+        assert_eq!(expect_single(send_rx.recv().await.unwrap()), packet_c);
+    }
+
+    #[tokio::test]
+    async fn queue_starts_new_batch_when_full() {
+        let mut device = Device::new();
+        let (test_tun, mut send_rx, _send_tx) = TestTun::with_capacity(3);
+        device.set_tun(Box::new(test_tun));
+
+        for i in 0..(2 * tun::MAX_BATCH_SIZE + 50) {
+            device.queue(test_packet(i as u16));
+        }
+        device.flush_batch();
+
+        std::future::poll_fn(|cx| device.poll_flush(cx))
+            .await
+            .unwrap();
+
+        assert_eq!(send_rx.recv().await.unwrap().len(), tun::MAX_BATCH_SIZE);
+        assert_eq!(send_rx.recv().await.unwrap().len(), tun::MAX_BATCH_SIZE);
+        assert_eq!(send_rx.recv().await.unwrap().len(), 50);
+    }
+
+    fn expect_single(mut batch: PacketBatch) -> IpPacket {
+        assert_eq!(batch.len(), 1, "Expected exactly one packet in the batch");
+
+        batch.drain().next().unwrap()
     }
 
     fn test_packet(dst_port: u16) -> IpPacket {
@@ -264,7 +306,11 @@ mod tests {
 
     impl TestTun {
         fn new() -> (Self, tun::OutboundRx, tun::InboundTx) {
-            let (send_tx, send_rx) = tun::outbound_channel_for_test(1);
+            Self::with_capacity(1)
+        }
+
+        fn with_capacity(capacity: usize) -> (Self, tun::OutboundRx, tun::InboundTx) {
+            let (send_tx, send_rx) = tun::outbound_channel_for_test(capacity);
             let (recv_tx, recv_rx) = tun::inbound_channel();
 
             (Self { send_tx, recv_rx }, send_rx, recv_tx)

--- a/rust/libs/connlib/tunnel/src/io/udp_gso_queue.rs
+++ b/rust/libs/connlib/tunnel/src/io/udp_gso_queue.rs
@@ -9,8 +9,6 @@ use ip_packet::Ecn;
 use snownet::{BufferProvider, Reservation};
 use socket_factory::DatagramOut;
 
-use super::MAX_INBOUND_PACKET_BATCH;
-
 const MAX_SEGMENT_SIZE: usize =
     ip_packet::MAX_IP_SIZE + ip_packet::WG_OVERHEAD + ip_packet::DATA_CHANNEL_OVERHEAD;
 
@@ -27,7 +25,7 @@ impl UdpGsoQueue {
     pub fn new() -> Self {
         Self {
             inner: Default::default(),
-            buffer_pool: BufferPool::new(MAX_SEGMENT_SIZE * MAX_INBOUND_PACKET_BATCH, "gso-queue"),
+            buffer_pool: BufferPool::new(MAX_SEGMENT_SIZE * tun::MAX_BATCH_SIZE, "gso-queue"),
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -16,7 +16,7 @@ use dns_types::DomainName;
 use eventloop_budget::Budget;
 use futures::{FutureExt, future::BoxFuture};
 use gat_lending_iterator::LendingIterator;
-use io::{Buffers, Io};
+use io::Io;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use logging::DisplayBTreeSet;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
@@ -100,7 +100,6 @@ pub struct Tunnel<TRoleState> {
     ///
     /// Handles all side-effects.
     io: Io,
-    buffers: Buffers,
 
     packet_counter: opentelemetry::metrics::Counter<u64>,
 }
@@ -141,7 +140,6 @@ impl ClientTunnel {
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("Should be able to compute UNIX timestamp"),
             ),
-            buffers: Buffers::default(),
             packet_counter: otel_instruments::network_packets(),
         }
     }
@@ -210,9 +208,11 @@ impl ClientTunnel {
 
             // Drain all buffered IP packets.
             while let Some(packet) = self.role_state.poll_packets() {
-                self.io.send_tun(packet);
+                self.io.queue_tun(packet);
                 tick.want_continue();
             }
+
+            self.io.flush_tun_batch();
 
             // Drain all buffered transmits.
             while let Some(trans) = self.role_state.poll_transmit() {
@@ -237,7 +237,7 @@ impl ClientTunnel {
                 device,
                 network,
                 mut error,
-            }) = self.io.poll(cx, &mut self.buffers)
+            }) = self.io.poll(cx)
             {
                 if let Some(response) = dns_response {
                     self.role_state.handle_dns_response(response, now);
@@ -251,8 +251,8 @@ impl ClientTunnel {
                     tick.want_continue();
                 }
 
-                if let Some(packets) = device {
-                    for packet in packets {
+                if let Some(mut packets) = device {
+                    for packet in packets.drain() {
                         match self
                             .role_state
                             .handle_tun_input(packet, now, self.io.gso_queue_mut())
@@ -298,11 +298,13 @@ impl ClientTunnel {
                             }) {
                             Ok(Some(packet)) => self
                                 .io
-                                .send_tun(packet.with_ecn_from_transport(received.ecn)),
+                                .queue_tun(packet.with_ecn_from_transport(received.ecn)),
                             Ok(None) => self.io.schedule_timeout(now),
                             Err(e) => error.push(e),
                         };
                     }
+
+                    self.io.flush_tun_batch();
 
                     tick.want_continue();
                 }
@@ -339,7 +341,6 @@ impl GatewayTunnel {
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("Should be able to compute UNIX timestamp"),
             ),
-            buffers: Buffers::default(),
             packet_counter: otel_instruments::network_packets(),
         }
     }
@@ -402,7 +403,7 @@ impl GatewayTunnel {
                 device,
                 network,
                 mut error,
-            }) = self.io.poll(cx, &mut self.buffers)
+            }) = self.io.poll(cx)
             {
                 if let Some(response) = dns_response {
                     let message = response.message.unwrap_or_else(|e| {
@@ -440,8 +441,8 @@ impl GatewayTunnel {
                     tick.want_continue();
                 }
 
-                if let Some(packets) = device {
-                    for packet in packets {
+                if let Some(mut packets) = device {
+                    for packet in packets.drain() {
                         match self
                             .role_state
                             .handle_tun_input(packet, now, self.io.gso_queue_mut())
@@ -500,11 +501,13 @@ impl GatewayTunnel {
                             }) {
                             Ok(Some(packet)) => self
                                 .io
-                                .send_tun(packet.with_ecn_from_transport(received.ecn)),
+                                .queue_tun(packet.with_ecn_from_transport(received.ecn)),
                             Ok(None) => self.io.schedule_timeout(now),
                             Err(e) => error.push(e),
                         };
                     }
+
+                    self.io.flush_tun_batch();
 
                     tick.want_continue();
                 }

--- a/rust/libs/telemetry/src/otel.rs
+++ b/rust/libs/telemetry/src/otel.rs
@@ -86,8 +86,8 @@ pub mod attr {
         KeyValue::new("error.type", value)
     }
 
-    pub fn queue_item_ip_packet() -> KeyValue {
-        KeyValue::new("queue.item", "ip-packet")
+    pub fn queue_item_ip_packet_batch() -> KeyValue {
+        KeyValue::new("queue.item", "ip-packet-batch")
     }
 
     pub fn queue_item_gro_batch() -> KeyValue {


### PR DESCRIPTION
The channels connecting the TUN threads to the main thread carry a single IP packet per item. Every packet therefore pays for a channel send, a channel receive and the task wake-up that comes with rousing the thread on the other end. We pay this per packet even though we almost always have a whole burst of packets to move per event-loop tick.

We now exchange a whole batch of packets as a single channel item. The TUN threads accumulate packets into a `PacketBatch` — draining the device until it would block or the batch is full — and hand the whole batch over at once. The wake-up and channel overhead is thereby amortised across the batch instead of being paid per packet.

The end of a batch also gives us a natural boundary up to which the receiving side may coalesce packets before writing them out, which the offloading work builds on top of.

On Linux, we cannot measure a performance improvement here because we don't (yet) do anything with the batches in the TUN thread. This however is a worth-while and independently reviewable piece. It has been tested to not regress in performance.

Related: #14011