### PR TITLE
refactor(connlib): rework iceless path-agent to a simpler model

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#4ee1988944a8e6891e7ebd5198ed4502cc1c2766"
+source = "git+https://github.com/firezone/boringtun?branch=master#74acc48217c96653d6d8efdf490d17e14f2a1ace"
 dependencies = [
  "aead",
  "blake2",

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -1,29 +1,9 @@
-//! Probe-driven path selection.
+//! Implementation of the path-selection model; see the crate-level docs for
+//! how the pieces fit together.
 //!
-//! Each layer has exactly one job:
-//!
-//! - **WireGuard is the liveness authority.** Only its state machine kills a
-//!   connection ([`boringtun`]'s `ConnectionExpired`) and only its signals mark
-//!   a path as suspect: our own re-key going unanswered, or the peer re-keying
-//!   early (it evidently isn't hearing us).
-//! - **Probes discover and rank paths.** They open NAT filters, measure RTTs
-//!   and find better pairs. A probe result can only ever improve things; probe
-//!   loss never demotes or kills anything (a busy node drops probes while its
-//!   data flows just fine).
-//! - **Selection is local.** WireGuard encrypts to a key, not to an address,
-//!   so each side picks where *it* sends independently; paths may be
-//!   asymmetric and there are no roles and no nomination.
-//!
-//! Every pair probes in a short, front-loaded burst when it is created and
-//! whenever a re-evaluation signal fires: remote candidates arrived, an
-//! inbound probe proved the reverse filter is open (we immediately probe back,
-//! cf. "triggered checks" in ICE), or WireGuard signalled distress. The
-//! primary pair additionally probes at a slow live cadence to keep its RTT
-//! comparable and its NAT mappings warm.
-//!
-//! Handshakes are path-dumb: the response is sent on the path the init
-//! arrived on and a handshake only ever *nominates* a path when we don't
-//! have one. Everything else is probes.
+//! Handshakes are path-dumb: the response is sent on the path the init arrived
+//! on, and a handshake only ever *nominates* a path when we don't have one.
+//! Everything else is probes.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
@@ -85,64 +65,93 @@ pub(crate) struct PairState {
     /// high-RTT path because the burst fires faster than one round trip.
     inflight_probes: Vec<InflightProbe>,
     probes: Probes,
+    /// Positive RTT samples collected since the last (re)start. Once this
+    /// reaches [`PROBE_SAMPLES`] the pair has settled and stops probing.
+    samples: u32,
+    /// When the current probing window opened, for the give-up bound.
+    probing_since: Option<Instant>,
     next_probe_seq: u16,
 }
 
-/// A pair's probe schedule: a front-loaded burst, optionally followed by the
-/// live cadence once the pair becomes the primary.
+impl PairState {
+    /// (Re)opens a probing window on this pair: a fresh burst and a fresh
+    /// sample count, so it probes until it settles — or, once we have a path,
+    /// until it gives up ([`PROBE_GIVE_UP`]).
+    fn restart_probes(&mut self, at: Instant) {
+        self.probes.start(at);
+        self.samples = 0;
+        self.probing_since = Some(at);
+    }
+
+    /// Whether this pair has probed past the give-up bound without settling.
+    fn gave_up(&self, now: Instant) -> bool {
+        self.probing_since
+            .is_some_and(|since| now.duration_since(since) >= PROBE_GIVE_UP)
+    }
+
+    /// Records a positive RTT sample and settles the pair (stops probing) once
+    /// [`PROBE_SAMPLES`] have arrived.
+    fn record_sample(&mut self) {
+        self.samples = self.samples.saturating_add(1);
+        if self.samples >= PROBE_SAMPLES {
+            self.probes.stop();
+        }
+    }
+}
+
+/// The gaps between a pair's probes: the front-loaded [`PROBE_BURST_GAPS`]
+/// followed by an endless steady [`PROBE_INTERVAL`].
+type ProbeGaps =
+    iter::Chain<iter::Copied<std::slice::Iter<'static, Duration>>, iter::Repeat<Duration>>;
+
+fn probe_gaps() -> ProbeGaps {
+    PROBE_BURST_GAPS
+        .iter()
+        .copied()
+        .chain(iter::repeat(PROBE_INTERVAL))
+}
+
+/// A pair's probe schedule: front-loaded at first, then a steady cadence that
+/// never runs out. Whether the pair keeps probing is decided by the *settle*
+/// rule (see [`PairState::record_sample`]), not by the schedule — the gaps are
+/// endless so an unanswered pair keeps probing until WireGuard, the liveness
+/// authority, tears the connection down.
 struct Probes {
-    /// Remaining probe times of the current burst, earliest first.
-    burst: std::vec::IntoIter<Instant>,
-    /// Next live-cadence probe. Set only for the primary once its burst is done.
-    live: Option<Instant>,
+    /// Next probe deadline. `None` once the pair has settled or before it starts.
+    next: Option<Instant>,
+    gaps: ProbeGaps,
 }
 
 impl Default for Probes {
     fn default() -> Self {
         Self {
-            burst: Vec::new().into_iter(),
-            live: None,
+            next: None,
+            gaps: probe_gaps(),
         }
     }
 }
 
 impl Probes {
-    /// (Re)starts the front-loaded burst at `at`.
+    /// (Re)starts probing at `at` with a fresh schedule.
     fn start(&mut self, at: Instant) {
-        self.burst = iter::once(at)
-            .chain(PROBE_BURST_GAPS.iter().scan(at, |t, gap| {
-                *t += *gap;
-                Some(*t)
-            }))
-            .collect::<Vec<_>>()
-            .into_iter();
+        self.next = Some(at);
+        self.gaps = probe_gaps();
     }
 
-    /// The next scheduled probe, if any.
+    /// Stops probing (the pair has settled).
+    fn stop(&mut self) {
+        self.next = None;
+    }
+
+    /// The next scheduled probe, if the pair is still probing.
     fn due(&self) -> Option<Instant> {
-        self.burst.as_slice().first().copied().or(self.live)
+        self.next
     }
 
     /// Records that the due probe fired at `now` and schedules the next one.
-    /// `keep_live` requests the live cadence once the burst is exhausted.
-    fn fire(&mut self, now: Instant, keep_live: bool) {
-        self.burst.next();
-
-        if self.burst.as_slice().is_empty() {
-            self.live = keep_live.then(|| now + PROBE_INTERVAL_LIVE);
-        }
-    }
-
-    fn in_burst(&self) -> bool {
-        !self.burst.as_slice().is_empty()
-    }
-
-    fn arm_live(&mut self, at: Instant) {
-        self.live = Some(at);
-    }
-
-    fn disarm_live(&mut self) {
-        self.live = None;
+    fn fire(&mut self, now: Instant) {
+        let gap = self.gaps.next().expect("probe gaps are endless");
+        self.next = Some(now + gap);
     }
 }
 
@@ -188,24 +197,38 @@ struct ResponderDedup {
     cached_at: Instant,
 }
 
-/// Gaps between the probes of one burst: front-loaded so a NAT filter opened
-/// by the peer's burst moments after our first probe is caught by the next
-/// one, then backing off. A burst is `PROBE_BURST_GAPS.len() + 1` probes.
+/// Front-loaded gaps at the start of a pair's probing, before it settles into
+/// the steady [`PROBE_INTERVAL`] cadence: short at first so a NAT filter the
+/// peer opens moments after our first probe is caught quickly.
 pub const PROBE_BURST_GAPS: &[Duration] = &[
     Duration::from_millis(200),
     Duration::from_millis(300),
     Duration::from_millis(500),
-    Duration::from_millis(1000),
 ];
 
 /// Inflight probes older than this are forgotten; a reply that late is not
 /// meaningful anymore.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Cadence at which the primary keeps probing after its burst: RTT freshness
-/// for comparisons against challengers and NAT keepalive, with no liveness
-/// semantics whatsoever.
-pub const PROBE_INTERVAL_LIVE: Duration = Duration::from_secs(25);
+/// Steady cadence a pair falls back to once its front-loaded burst is spent,
+/// while it is still trying to settle (or hunting a path that never answers).
+pub const PROBE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Positive RTT samples a pair collects before it settles and stops probing.
+///
+/// An answered pair reaches this and goes quiet. A handful of samples is enough
+/// for the smoothed RTT to be a fair basis for selection without spending
+/// probes forever.
+pub const PROBE_SAMPLES: u32 = 5;
+
+/// How long a pair keeps probing without settling once we already have a
+/// primary, before it gives up.
+///
+/// While we have no path we hunt every pair indefinitely (bounded only by
+/// WireGuard retiring the connection). But once a path exists, a pair that
+/// won't settle is a dead end — e.g. a direct pair that can never punch a
+/// symmetric NAT — and probing it forever is pure waste, so we stop.
+pub const PROBE_GIVE_UP: Duration = Duration::from_secs(10);
 
 /// Only RTTs measured within this window are eligible in the selection scan.
 ///
@@ -344,7 +367,7 @@ impl PathAgent {
         // over without waiting for WireGuard's escalation.
         if let Some(primary) = self.primary {
             if let Some(state) = self.pairs.get_mut(&primary) {
-                state.probes.start(now);
+                state.restart_probes(now);
             }
 
             self.suspend_guard(now);
@@ -367,9 +390,11 @@ impl PathAgent {
             rtt: None,
             inflight_probes: Vec::new(),
             probes: Probes::default(),
+            samples: 0,
+            probing_since: None,
             next_probe_seq: 0,
         };
-        state.probes.start(burst_at);
+        state.restart_probes(burst_at);
 
         self.pairs.insert(pair, state);
     }
@@ -827,13 +852,12 @@ impl PathAgent {
                 // Triggered check (cf. RFC 8445, section 7.3.1.4): the
                 // inbound probe proves the reverse NAT filter is open right
                 // now, so probing back completes the hole punch in one round
-                // trip. Only for unvalidated pairs — probing back
-                // unconditionally would ping-pong bursts between the peers
-                // forever, at RTT cadence.
+                // trip. Only for unvalidated pairs — probing back a settled
+                // pair would ping-pong bursts between the peers forever.
                 if let Some(state) = self.pairs.get_mut(&pair)
                     && !state.rtt.is_some_and(|rtt| rtt.is_fresh(now))
                 {
-                    state.probes.start(now);
+                    state.restart_probes(now);
                 }
             }
             crate::icmpv6::Echo::Reply => {
@@ -853,6 +877,7 @@ impl PathAgent {
                         },
                         measured_at: now,
                     });
+                    state.record_sample();
 
                     tracing::trace!(local = %pair.0, remote = %pair.1, ?rtt, "Probe reply received");
 
@@ -978,7 +1003,7 @@ impl PathAgent {
             return;
         }
 
-        let primary = self.primary;
+        let has_primary = self.primary.is_some();
         let pending = &mut self.pending_transmits;
 
         for ((local, remote), state) in self.pairs.iter_mut() {
@@ -987,6 +1012,14 @@ impl PathAgent {
             };
 
             if now < deadline {
+                continue;
+            }
+
+            // Once we have a path, stop probing a pair that won't settle
+            // (e.g. a direct pair behind a symmetric NAT); while we have none,
+            // keep hunting until WireGuard retires the connection.
+            if has_primary && state.gave_up(now) {
+                state.probes.stop();
                 continue;
             }
 
@@ -1000,10 +1033,7 @@ impl PathAgent {
             state
                 .inflight_probes
                 .push(InflightProbe { seq, sent_at: now });
-            // Once the burst is done, the primary keeps its RTT fresh and its
-            // NAT mappings warm; everything else goes dormant until the next
-            // re-evaluation signal.
-            state.probes.fire(now, primary == Some((*local, *remote)));
+            state.probes.fire(now);
 
             tracing::trace!(%local, %remote, seq, "Probe send");
 
@@ -1017,7 +1047,7 @@ impl PathAgent {
 
     fn probe_all_pairs(&mut self, now: Instant) {
         for state in self.pairs.values_mut() {
-            state.probes.start(now);
+            state.restart_probes(now);
         }
     }
 
@@ -1108,23 +1138,8 @@ impl PathAgent {
 
         self.primary = Some(path);
 
-        // The old primary's live cadence retires with it; an unfinished
-        // burst keeps running.
-        if let Some(old) = from
-            && old != path
-            && let Some(state) = self.pairs.get_mut(&old)
-            && !state.probes.in_burst()
-        {
-            state.probes.disarm_live();
-        }
-
-        // Keep the new primary on the live cadence once it has nothing else
-        // scheduled.
-        if let Some(state) = self.pairs.get_mut(&path)
-            && state.probes.due().is_none()
-        {
-            state.probes.arm_live(now + PROBE_INTERVAL_LIVE);
-        }
+        // Every pair probes at the steady cadence regardless of which is
+        // primary, so there is no per-pair cadence to arm or retire here.
 
         tracing::debug!(
             ?from,

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -910,8 +910,11 @@ impl PathAgent {
                 // The burst is done: the primary keeps its RTT fresh and its
                 // NAT mappings warm, everything else goes dormant until the
                 // next re-evaluation signal.
-                None if primary == Some((*local, *remote)) => Some(now + PROBE_INTERVAL_LIVE),
-                None => None,
+                None => {
+                    state.burst_step = PROBE_BURST_GAPS.len() + 1;
+
+                    (primary == Some((*local, *remote))).then(|| now + PROBE_INTERVAL_LIVE)
+                }
             };
 
             tracing::trace!(%local, %remote, seq, "Probe send");
@@ -1017,6 +1020,16 @@ impl PathAgent {
         let from = self.primary;
 
         self.primary = Some(path);
+
+        // The old primary's live cadence retires with it; an unfinished
+        // burst keeps running.
+        if let Some(old) = from
+            && old != path
+            && let Some(state) = self.pairs.get_mut(&old)
+            && state.burst_step > PROBE_BURST_GAPS.len()
+        {
+            state.next_probe_at = None;
+        }
 
         // Keep the new primary on the live cadence once its burst is done.
         if let Some(state) = self.pairs.get_mut(&path)

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -159,9 +159,15 @@ struct InflightProbe {
 
 struct OutboundInit {
     bytes: Vec<u8>,
-    retransmits: BTreeMap<(SocketAddr, SocketAddr), PairRetransmit>,
-    /// Reset when relay pairs arrive late so waiting time doesn't count against
-    /// the retransmit ladder.
+    /// Relay pairs the current `bytes` have been fanned out to. Cleared when a
+    /// boringtun re-init replaces `bytes`, so the fresh init reaches every pair.
+    fanned: BTreeSet<(SocketAddr, SocketAddr)>,
+    /// One-time fast-retransmit ladder, armed per relay pair on its first
+    /// fan-out to win the channel-bind race. Not re-armed on a re-init;
+    /// boringtun's own cadence drives retransmission after the head.
+    ladder: BTreeMap<(SocketAddr, SocketAddr), PairRetransmit>,
+    /// When bootstrap began; wakes `poll_timeout` to fan a relay pair that
+    /// arrives after the initial fan-out.
     started_at: Instant,
 }
 
@@ -169,7 +175,8 @@ impl OutboundInit {
     fn new(bytes: Vec<u8>, started_at: Instant) -> Self {
         Self {
             bytes,
-            retransmits: BTreeMap::new(),
+            fanned: BTreeSet::new(),
+            ladder: BTreeMap::new(),
             started_at,
         }
     }
@@ -438,7 +445,16 @@ impl PathAgent {
             Ok(Packet::HandshakeInit(_)) if !self.has_session => {
                 tracing::debug!(bytes = bytes.len(), "Buffered bootstrap HandshakeInit");
                 self.forwarded_response = None;
-                self.outbound_init = Some(OutboundInit::new(bytes, now));
+                match &mut self.outbound_init {
+                    // A boringtun re-init: carry the fresh bytes and re-fan them
+                    // once to every relay pair. The fast ladder is a one-time
+                    // head armed on the first init, so it is not restarted here.
+                    Some(init) => {
+                        init.bytes = bytes;
+                        init.fanned.clear();
+                    }
+                    None => self.outbound_init = Some(OutboundInit::new(bytes, now)),
+                }
             }
             // Established: the re-key rides the primary and counts toward distress.
             Ok(Packet::HandshakeInit(_)) => {
@@ -789,7 +805,7 @@ impl PathAgent {
             .outbound_init
             .as_ref()
             .filter(|_| !self.has_session)
-            .and_then(|i| i.retransmits.values().map(|r| r.next_fire_at).min());
+            .and_then(|i| i.ladder.values().filter_map(|r| r.next_fire_at).min());
         // Probes wait for the first handshake exchange; see `drive_probes`.
         let next_probe = self
             .has_session
@@ -804,9 +820,7 @@ impl PathAgent {
             .and_then(|i| {
                 self.pairs
                     .iter()
-                    .any(|(addrs, state)| {
-                        state.involves_relay() && !i.retransmits.contains_key(addrs)
-                    })
+                    .any(|(addrs, state)| state.involves_relay() && !i.fanned.contains(addrs))
                     .then_some(i.started_at)
             });
         let dedup_expiry = self
@@ -851,20 +865,17 @@ impl PathAgent {
             return;
         };
 
-        let new_relay_pairs: Vec<_> = self
+        // Relay pairs the current init hasn't reached yet: every pair on the
+        // first init, every pair again on a re-init (`fanned` was cleared), plus
+        // any relay pair that arrives mid-bootstrap.
+        let unfanned: Vec<_> = self
             .pairs
             .iter()
-            .filter(|(addrs, state)| {
-                state.involves_relay() && !outbound.retransmits.contains_key(*addrs)
-            })
+            .filter(|(addrs, state)| state.involves_relay() && !outbound.fanned.contains(*addrs))
             .map(|(addrs, _)| *addrs)
             .collect();
 
-        if !new_relay_pairs.is_empty() && outbound.retransmits.is_empty() {
-            outbound.started_at = now;
-        }
-
-        for (local, remote) in new_relay_pairs {
+        for (local, remote) in unfanned {
             tracing::debug!(%local, %remote, "Fanning out HandshakeInit on relay pair");
 
             pending.push_back(Transmit {
@@ -872,13 +883,21 @@ impl PathAgent {
                 remote,
                 payload: Payload::Ciphertext(outbound.bytes.clone()),
             });
+            outbound.fanned.insert((local, remote));
+            // Arm the one-time fast head the first time we send to this pair; a
+            // pair already laddered keeps its (spent) entry, so a re-init does
+            // not restart it.
             outbound
-                .retransmits
-                .insert((local, remote), PairRetransmit::new(now));
+                .ladder
+                .entry((local, remote))
+                .or_insert_with(|| PairRetransmit::new(now));
         }
 
-        for ((local, remote), state) in outbound.retransmits.iter_mut() {
-            if now >= state.next_fire_at {
+        for ((local, remote), state) in outbound.ladder.iter_mut() {
+            let Some(fire_at) = state.next_fire_at else {
+                continue;
+            };
+            if now >= fire_at {
                 tracing::trace!(%local, %remote, step = state.step, "WG init retransmit");
 
                 pending.push_back(Transmit {

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -59,8 +59,11 @@ pub(crate) struct PairState {
     /// Positive RTT samples collected since the last (re)start. Once this
     /// reaches [`PROBE_SAMPLES`] the pair has settled and stops probing.
     samples: u32,
-    /// When the current probing window opened, for the give-up bound.
-    probing_since: Option<Instant>,
+    /// Probes fired since the last (re)start, for the give-up bound. Counting
+    /// fires rather than elapsed time makes "we gave it a fair chance"
+    /// independent of when probing actually began (probes only fire once the
+    /// session is established) and of the burst schedule.
+    probes_sent: u32,
     next_probe_seq: u16,
 }
 
@@ -71,7 +74,7 @@ impl PairState {
     fn restart_probes(&mut self, at: Instant) {
         self.probes.hunt(at);
         self.samples = 0;
-        self.probing_since = Some(at);
+        self.probes_sent = 0;
         self.rtt = None;
     }
 
@@ -92,14 +95,17 @@ impl PairState {
         self.samples >= PROBE_SAMPLES
     }
 
-    /// Whether this pair has probed past the give-up bound without settling.
-    fn gave_up(&self, now: Instant) -> bool {
-        self.probing_since
-            .is_some_and(|since| now.duration_since(since) >= PROBE_GIVE_UP)
+    /// Whether this pair has fired its whole give-up budget without settling.
+    fn gave_up(&self) -> bool {
+        self.probes_sent >= PROBE_GIVE_UP_ATTEMPTS
     }
 
     fn record_sample(&mut self) {
         self.samples = self.samples.saturating_add(1);
+    }
+
+    fn record_probe_sent(&mut self) {
+        self.probes_sent = self.probes_sent.saturating_add(1);
     }
 }
 
@@ -223,14 +229,20 @@ pub const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 /// probes forever.
 pub const PROBE_SAMPLES: u32 = 5;
 
-/// How long a pair keeps probing without settling once we already have a
+/// How many probes a pair fires without settling, once we already have a
 /// primary, before it gives up.
 ///
 /// While we have no path we hunt every pair indefinitely (bounded only by
 /// WireGuard retiring the connection). But once a path exists, a pair that
 /// won't settle is a dead end — e.g. a direct pair that can never punch a
 /// symmetric NAT — and probing it forever is pure waste, so we stop.
-pub const PROBE_GIVE_UP: Duration = Duration::from_secs(10);
+///
+/// Counting fires rather than elapsed time means the budget is a fixed number
+/// of hole-punch attempts regardless of how long the session took to establish
+/// (probes only fire once it is) or how the burst is timed. A punchable NAT
+/// opens within the first attempt or two, so this many unanswered probes is
+/// firm evidence the pair is a dead end.
+pub const PROBE_GIVE_UP_ATTEMPTS: u32 = 12;
 
 /// Slow cadence the primary keeps after it settles, so its RTT stays current
 /// for the next comparison and its NAT mapping warm. This is what lets us drop
@@ -381,7 +393,7 @@ impl PathAgent {
             inflight_probes: Vec::new(),
             probes: Probes::default(),
             samples: 0,
-            probing_since: None,
+            probes_sent: 0,
             next_probe_seq: 0,
         };
         state.restart_probes(burst_at);
@@ -537,7 +549,12 @@ impl PathAgent {
                 // primary to protect the bucket veto lifts and the first pair to
                 // answer wins — even a worse bucket, so we fail over from a
                 // direct path to a relayed one if that is all that works.
-                if self.unanswered_rekeys >= REKEY_DISTRESS_ATTEMPTS {
+                //
+                // Fire exactly on the crossing, not on every retransmit past it:
+                // once we have dropped the primary, probing recovers the path
+                // and the re-key rides it. Re-dropping the primary on the next
+                // retransmit would just flap the data path.
+                if self.unanswered_rekeys == REKEY_DISTRESS_ATTEMPTS {
                     tracing::debug!(bytes = bytes_len, "Unanswered re-keys; re-evaluating paths");
 
                     self.primary = None;
@@ -561,12 +578,14 @@ impl PathAgent {
                     payload: Payload::Ciphertext(bytes),
                 });
             }
-            // Lost the primary mid-session (roam, candidate retraction):
-            // fan out like the initial bootstrap, with probes racing it.
+            // Re-key arriving with no primary. At bootstrap (no session yet) the
+            // buffered init fans out over relay pairs; mid-session (a transient
+            // primary loss) the session is still valid, so we only re-probe and
+            // let the init ride the primary once probing recovers it.
             (Ok(Packet::HandshakeInit(_)), outbound_init, None) => {
                 tracing::debug!(
                     bytes = bytes.len(),
-                    "Re-key HandshakeInit without a primary; fanning out"
+                    "Re-key HandshakeInit without a primary; re-probing"
                 );
 
                 outbound_init.replace(OutboundInit::new(bytes, now));
@@ -676,7 +695,7 @@ impl PathAgent {
                 // every few seconds. Duplicates of the same init were dropped
                 // above, so every increment here is a genuinely new attempt.
                 self.peer_rekeys = self.peer_rekeys.saturating_add(1);
-                if self.peer_rekeys >= REKEY_DISTRESS_ATTEMPTS {
+                if self.peer_rekeys == REKEY_DISTRESS_ATTEMPTS {
                     tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed without hearing us; re-evaluating paths");
 
                     // Same as an unanswered outbound re-key: the peer isn't
@@ -926,13 +945,14 @@ impl PathAgent {
             .established
             .then(|| self.pairs.values().filter_map(|s| s.probes.due()).min())
             .flatten();
-        // Wake immediately if a buffered init is waiting on a relay
-        // pair that landed after the initial fanout. With a primary, the
-        // init rode it directly and there is nothing to fan out.
+        // Wake immediately if a buffered bootstrap init is waiting on a relay
+        // pair that landed after the initial fanout. The fanout is bootstrap
+        // only (see `drive_handshake_retransmits`), so once established there is
+        // nothing to fan out — a re-key rides the primary.
         let pending_fanout = self
             .outbound_init
             .as_ref()
-            .filter(|_| self.primary.is_none())
+            .filter(|_| self.primary.is_none() && !self.established)
             .and_then(|i| {
                 self.pairs
                     .iter()
@@ -971,9 +991,14 @@ impl PathAgent {
     }
 
     fn drive_handshake_retransmits(&mut self, now: Instant) {
-        // With a primary, the init rode it directly; boringtun's re-key
-        // timer is the retry mechanism, not the fanout ladder.
-        if self.primary.is_some() {
+        // The relay fan-out is purely the bootstrap mechanism: it lands the very
+        // first handshake when no session exists yet and we therefore cannot
+        // probe. Once established, a re-key rides the primary, and if a distress
+        // signal has dropped the primary, probing (not a fan-out) recovers the
+        // path over the still-valid session — a handshake could not do more,
+        // since a peer that has truly lost the session no longer has our key
+        // and needs a full re-setup via the signalling layer.
+        if self.established || self.primary.is_some() {
             return;
         }
 
@@ -1048,7 +1073,7 @@ impl PathAgent {
             // is exempt — probe loss must never retire it — and while we have
             // no path at all we hunt every pair until WireGuard gives up.
             let is_primary = primary == Some((*local, *remote));
-            if primary.is_some() && !is_primary && state.gave_up(now) {
+            if primary.is_some() && !is_primary && state.gave_up() {
                 state.retire();
                 continue;
             }
@@ -1064,6 +1089,7 @@ impl PathAgent {
                 .inflight_probes
                 .push(InflightProbe { seq, sent_at: now });
             state.probes.fire(now);
+            state.record_probe_sent();
 
             tracing::trace!(%local, %remote, seq, "Probe send");
 

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -26,8 +26,12 @@ pub struct PathAgent {
     responder: Responder,
 
     outbound_init: Option<OutboundInit>,
-    /// Arrival time of the last accepted inbound init, for distress detection.
-    last_inbound_init_at: Option<Instant>,
+    /// Consecutive re-key retransmits of our own that went unanswered. Reset
+    /// when a response clears `outbound_init` or a fresh fanout starts.
+    unanswered_rekeys: u32,
+    /// Distinct accepted inbound inits since we last saw peer data. Reset by any
+    /// inbound data packet, which proves the peer is hearing us.
+    peer_rekeys: u32,
     forwarded_response: Option<Vec<u8>>,
 
     pending_transmits: VecDeque<Transmit>,
@@ -234,16 +238,16 @@ pub const PROBE_GIVE_UP: Duration = Duration::from_secs(10);
 /// it is never stale.
 pub const PROBE_KEEPALIVE: Duration = Duration::from_secs(5);
 
-/// An accepted inbound init this soon after the previous one means the peer
-/// keeps re-keying: it isn't hearing our responses or data.
+/// Repeated re-keys — our own retransmits going unanswered, or distinct peer
+/// inits with no data in between — that count as WireGuard distress and trigger
+/// a path re-evaluation.
 ///
-/// The signal being detected is boringtun's `REKEY_TIMEOUT` retry pacing (a
-/// stuck peer formats a new init every 5s); a few multiples of that catches
-/// it reliably. Routine re-keys arrive at `REKEY_AFTER_TIME` (120s) — using
-/// that as the threshold would classify roughly every other routine re-key
-/// as distress (arrival jitter around exactly 120s) and re-introduce
-/// re-evaluation chatter on every re-key.
-pub const REKEY_DISTRESS_INTERVAL: Duration = Duration::from_secs(15);
+/// Counting rather than timing decouples the signal from boringtun's now-tunable
+/// `REKEY_TIMEOUT` retry pacing. A single stray re-key is ordinary loss; a
+/// second one with no progress in between is the peer (or us) stuck on a dead
+/// path. Routine re-keys never reach the threshold because data flows between
+/// them, resetting the count.
+pub const REKEY_DISTRESS_ATTEMPTS: u32 = 2;
 
 pub const RESPONDER_DEDUP_TTL: Duration = Duration::from_secs(10);
 
@@ -279,7 +283,8 @@ impl PathAgent {
             established: false,
             responder: Responder::default(),
             outbound_init: None,
-            last_inbound_init_at: None,
+            unanswered_rekeys: 0,
+            peer_rekeys: 0,
             forwarded_response: None,
             pending_transmits: VecDeque::new(),
             events: VecDeque::new(),
@@ -447,12 +452,12 @@ impl PathAgent {
             .collect();
         let remotes = std::mem::take(&mut self.remotes);
         let established = self.established;
-        let last_inbound_init_at = self.last_inbound_init_at;
+        let peer_rekeys = self.peer_rekeys;
 
         *self = Self::new();
 
         self.established = established;
-        self.last_inbound_init_at = last_inbound_init_at;
+        self.peer_rekeys = peer_rekeys;
 
         for local in locals {
             self.add_local_candidate(local, now);
@@ -512,13 +517,10 @@ impl PathAgent {
                 outbound_init.replace(OutboundInit::new(bytes, now));
             }
             // A still-stored init means the previous one went unanswered:
-            // WireGuard-level failure evidence. Retry on the incumbent while
-            // an unguarded re-evaluation runs.
+            // WireGuard-level failure evidence. Always retry on the incumbent;
+            // only re-evaluate once enough retransmits have piled up unanswered.
             (Ok(Packet::HandshakeInit(_)), outbound_init @ Some(_), Some((local, remote))) => {
-                tracing::debug!(
-                    bytes = bytes.len(),
-                    "Unanswered re-key HandshakeInit; re-evaluating paths"
-                );
+                let bytes_len = bytes.len();
 
                 outbound_init.replace(OutboundInit::new(bytes.clone(), now));
                 self.pending_transmits.push_back(Transmit {
@@ -526,14 +528,27 @@ impl PathAgent {
                     remote,
                     payload: Payload::Ciphertext(bytes),
                 });
-                // Drop the primary pointer: an unanswered re-key is WireGuard
-                // telling us the path may be dead, so we re-evaluate from
-                // scratch. With no primary to protect, the bucket veto lifts and
-                // the first pair to answer wins — even a worse bucket, so we can
-                // fail over from direct to relayed if that is all that works.
-                self.primary = None;
-                self.probe_all_pairs(now);
-                self.select_primary(now);
+
+                self.unanswered_rekeys = self.unanswered_rekeys.saturating_add(1);
+
+                // A lone unanswered retransmit can be ordinary loss. Only once
+                // the peer has ignored `REKEY_DISTRESS_ATTEMPTS` of them do we
+                // treat the path as dead and drop the primary pointer: with no
+                // primary to protect the bucket veto lifts and the first pair to
+                // answer wins — even a worse bucket, so we fail over from a
+                // direct path to a relayed one if that is all that works.
+                if self.unanswered_rekeys >= REKEY_DISTRESS_ATTEMPTS {
+                    tracing::debug!(bytes = bytes_len, "Unanswered re-keys; re-evaluating paths");
+
+                    self.primary = None;
+                    self.probe_all_pairs(now);
+                    self.select_primary(now);
+                } else {
+                    tracing::debug!(
+                        bytes = bytes_len,
+                        "Unanswered re-key; retrying on incumbent"
+                    );
+                }
             }
             // A routine re-key rides the primary without restarting probes.
             (Ok(Packet::HandshakeInit(_)), outbound_init @ None, Some((local, remote))) => {
@@ -555,6 +570,7 @@ impl PathAgent {
                 );
 
                 outbound_init.replace(OutboundInit::new(bytes, now));
+                self.unanswered_rekeys = 0;
                 self.probe_all_pairs(now);
             }
             (Ok(Packet::HandshakeResponse(_)), _, _) => {
@@ -653,16 +669,15 @@ impl PathAgent {
                 self.register_peer_reflexive(path, now);
                 self.established = true;
 
-                // Distinct inits minutes apart are routine re-keys; in quick
-                // succession they mean the peer isn't hearing our responses
-                // or data (its passive-keepalive escalation formats a new
-                // init every few seconds). Duplicates of the same init were
-                // dropped above.
-                let previous_init_at = self.last_inbound_init_at.replace(now);
-                if previous_init_at
-                    .is_some_and(|prev| now.duration_since(prev) < REKEY_DISTRESS_INTERVAL)
-                {
-                    tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed early; re-evaluating paths");
+                // A re-key with peer data flowing in between is routine (the
+                // count was reset by that data). Several distinct inits with no
+                // data between them mean the peer isn't hearing our responses or
+                // data — its passive-keepalive escalation formats a new init
+                // every few seconds. Duplicates of the same init were dropped
+                // above, so every increment here is a genuinely new attempt.
+                self.peer_rekeys = self.peer_rekeys.saturating_add(1);
+                if self.peer_rekeys >= REKEY_DISTRESS_ATTEMPTS {
+                    tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed without hearing us; re-evaluating paths");
 
                     // Same as an unanswered outbound re-key: the peer isn't
                     // hearing us on the current primary, so drop the pointer and
@@ -690,6 +705,7 @@ impl PathAgent {
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse accepted");
 
                 self.outbound_init = None;
+                self.unanswered_rekeys = 0;
                 self.forwarded_response = Some(bytes.to_vec());
                 self.established = true;
 
@@ -703,9 +719,14 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
-            (Packet::PacketCookieReply(_) | Packet::PacketData(_), _) => {
+            // Peer data proves the peer is hearing us, so the connection isn't
+            // in distress: clear the re-key counter that would otherwise build
+            // toward a false failover.
+            (Packet::PacketData(_), _) => {
+                self.peer_rekeys = 0;
                 ControlFlow::Continue(bytes)
             }
+            (Packet::PacketCookieReply(_), _) => ControlFlow::Continue(bytes),
         }
     }
 

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -11,27 +11,31 @@ use crate::event::{Event, Payload, Transmit};
 use crate::retransmit::PairRetransmit;
 use crate::score::pair_score;
 
-/// Path-selection state machine for ICE-less snownet connections.
+/// Iceless path selection for a single WireGuard connection.
+#[derive(Default)]
 pub struct PathAgent {
     locals: Vec<Candidate>,
     remotes: Vec<Candidate>,
     pairs: BTreeMap<(SocketAddr, SocketAddr), PairState>,
     primary: Option<(SocketAddr, SocketAddr)>,
 
-    /// `true` once a handshake has been accepted from the peer. Probes ride
-    /// the session, so they wait for this; it survives a [`Self::rebuild`]
-    /// because the session does, too.
-    established: bool,
+    /// `true` once a handshake (init or response) has been seen and a WireGuard
+    /// session therefore exists, so probes can ride it. Survives a
+    /// [`Self::rebuild`] because the session key does.
+    has_session: bool,
+
+    /// Buffered `init` fanned out over relay pairs during bootstrap only. Once
+    /// established, a re-key rides the primary instead.
+    outbound_init: Option<OutboundInit>,
+
+    /// Our own re-keys sent since the last one was answered. The second one
+    /// unanswered is WireGuard distress: the primary path is dead.
+    unanswered_rekeys: u32,
+    /// Distinct peer inits since we last saw peer data. The second with no data
+    /// in between means the peer isn't hearing us: the primary path is dead.
+    peer_rekeys: u32,
 
     responder: Responder,
-
-    outbound_init: Option<OutboundInit>,
-    /// Consecutive re-key retransmits of our own that went unanswered. Reset
-    /// when a response clears `outbound_init` or a fresh fanout starts.
-    unanswered_rekeys: u32,
-    /// Distinct accepted inbound inits since we last saw peer data. Reset by any
-    /// inbound data packet, which proves the peer is hearing us.
-    peer_rekeys: u32,
     forwarded_response: Option<Vec<u8>>,
 
     pending_transmits: VecDeque<Transmit>,
@@ -39,12 +43,12 @@ pub struct PathAgent {
     events_queued_at: Option<Instant>,
 
     peer_reflexive_addrs: BTreeSet<SocketAddr>,
+    next_pair_id: u16,
 }
 
 #[derive(Default)]
 struct Responder {
     last_init: Option<Vec<u8>>,
-    last_init_path: Option<(SocketAddr, SocketAddr)>,
     dedup: Option<ResponderDedup>,
 }
 
@@ -52,81 +56,55 @@ pub(crate) struct PairState {
     pub(crate) kinds: (crate::CandidateKind, crate::CandidateKind),
     pub(crate) local_family_matched: bool,
     pub(crate) rtt: Option<Rtt>,
-    /// Probes awaiting their reply. Several can be outstanding on a
-    /// high-RTT path because the burst fires faster than one round trip.
-    inflight_probes: Vec<InflightProbe>,
+    /// Probes awaiting a reply. Several can be outstanding on a high-RTT path
+    /// because the burst fires faster than one round trip.
+    inflight: Vec<InflightProbe>,
     probes: Probes,
-    /// Positive RTT samples collected since the last (re)start. Once this
-    /// reaches [`PROBE_SAMPLES`] the pair has settled and stops probing.
-    samples: u32,
-    /// Probes fired since the last (re)start, for the give-up bound. Counting
-    /// fires rather than elapsed time makes "we gave it a fair chance"
-    /// independent of when probing actually began (probes only fire once the
-    /// session is established) and of the burst schedule.
+    /// Probes fired since the last (re)start. Past [`PROBE_BUDGET`] the pair
+    /// goes quiet — unless there is no primary, in which case it hunts forever.
     probes_sent: u32,
-    next_probe_seq: u16,
+    /// Identifies this pair in the ICMP `id` field, so a reply to a pair that
+    /// has since been recreated (same addresses, fresh id) is ignored.
+    id: u16,
+    next_seq: u16,
 }
 
 impl PairState {
-    /// (Re)opens a probing window: a fresh burst, a fresh sample count, and a
-    /// cleared RTT — so the pair earns a new measurement rather than carrying a
-    /// stale one. It probes until it settles, or (once we have a path) gives up.
-    fn restart_probes(&mut self, at: Instant) {
+    /// (Re)opens a probing window: a fresh burst, cleared count, cleared RTT and
+    /// no stale inflight probes. The pair re-earns its measurement.
+    fn restart(&mut self, at: Instant) {
         self.probes.hunt(at);
-        self.samples = 0;
         self.probes_sent = 0;
         self.rtt = None;
+        self.inflight.clear();
     }
 
-    /// Drops the pair's data and stops probing it. Used when a settled pair
-    /// isn't the primary, or a pair gives up — either way we keep no stale RTT
-    /// around, which is what lets selection skip a freshness check.
-    fn retire(&mut self) {
-        self.probes.stop();
-        self.rtt = None;
+    fn is_probing(&self) -> bool {
+        self.probes.due().is_some()
     }
 
-    /// Keeps the pair on the slow keepalive cadence (it's the primary).
-    fn keep_fresh(&mut self, now: Instant) {
-        self.probes.keepalive(now);
-    }
-
-    fn is_settled(&self) -> bool {
-        self.samples >= PROBE_SAMPLES
-    }
-
-    /// Whether this pair has fired its whole give-up budget without settling.
-    fn gave_up(&self) -> bool {
-        self.probes_sent >= PROBE_GIVE_UP_ATTEMPTS
-    }
-
-    fn record_sample(&mut self) {
-        self.samples = self.samples.saturating_add(1);
-    }
-
-    fn record_probe_sent(&mut self) {
-        self.probes_sent = self.probes_sent.saturating_add(1);
+    fn involves_relay(&self) -> bool {
+        matches!(self.kinds.0, crate::CandidateKind::Relayed)
+            || matches!(self.kinds.1, crate::CandidateKind::Relayed)
     }
 }
 
-/// The gaps between a pair's probes: a front-loaded burst followed by an
-/// endless steady interval.
+/// The gaps between a pair's probes: a front-loaded burst then an endless
+/// steady interval.
 type ProbeGaps =
     iter::Chain<iter::Copied<std::slice::Iter<'static, Duration>>, iter::Repeat<Duration>>;
 
-const NO_BURST: &[Duration] = &[];
-
-fn probe_gaps(burst: &'static [Duration], steady: Duration) -> ProbeGaps {
-    burst.iter().copied().chain(iter::repeat(steady))
+fn probe_gaps() -> ProbeGaps {
+    PROBE_BURST_GAPS
+        .iter()
+        .copied()
+        .chain(iter::repeat(PROBE_INTERVAL))
 }
 
-/// A pair's probe schedule. In its `hunt` phase it front-loads a burst then
-/// settles to [`PROBE_INTERVAL`]; the primary switches to the slow
-/// [`PROBE_KEEPALIVE`] cadence via `keepalive`. `stop` ends it (settled loser,
-/// or given up). The gaps are endless, so an unanswered pair keeps probing
-/// until WireGuard, the liveness authority, retires the connection.
+/// A pair's probe schedule. `hunt` (re)starts the burst-then-interval cadence;
+/// `stop` ends it (budget spent while a primary exists). The gaps are endless,
+/// so a pathless agent keeps probing until WireGuard retires the connection.
 struct Probes {
-    /// Next probe deadline. `None` when the pair isn't probing.
     next: Option<Instant>,
     gaps: ProbeGaps,
 }
@@ -135,35 +113,31 @@ impl Default for Probes {
     fn default() -> Self {
         Self {
             next: None,
-            gaps: probe_gaps(PROBE_BURST_GAPS, PROBE_INTERVAL),
+            gaps: probe_gaps(),
         }
     }
 }
 
 impl Probes {
-    /// (Re)starts the burst-then-interval hunt at `at`.
     fn hunt(&mut self, at: Instant) {
         self.next = Some(at);
-        self.gaps = probe_gaps(PROBE_BURST_GAPS, PROBE_INTERVAL);
+        self.gaps = probe_gaps();
     }
 
-    /// Switches to the slow keepalive cadence, next probe one interval out.
-    fn keepalive(&mut self, now: Instant) {
-        self.next = Some(now + PROBE_KEEPALIVE);
-        self.gaps = probe_gaps(NO_BURST, PROBE_KEEPALIVE);
-    }
-
-    /// Stops probing.
     fn stop(&mut self) {
         self.next = None;
     }
 
-    /// The next scheduled probe, if the pair is still probing.
+    /// Slow cadence the primary keeps after its discovery budget is spent, so an
+    /// idle connection's NAT bindings and tunnel stay alive.
+    fn keepalive(&mut self, now: Instant) {
+        self.next = Some(now + PRIMARY_KEEPALIVE);
+    }
+
     fn due(&self) -> Option<Instant> {
         self.next
     }
 
-    /// Records that the due probe fired at `now` and schedules the next one.
     fn fire(&mut self, now: Instant) {
         let gap = self.gaps.next().expect("probe gaps are endless");
         self.next = Some(now + gap);
@@ -184,8 +158,8 @@ struct InflightProbe {
 struct OutboundInit {
     bytes: Vec<u8>,
     retransmits: BTreeMap<(SocketAddr, SocketAddr), PairRetransmit>,
-    /// Reset when relay pairs arrive late so waiting time doesn't count
-    /// against the retransmit ladder.
+    /// Reset when relay pairs arrive late so waiting time doesn't count against
+    /// the retransmit ladder.
     started_at: Instant,
 }
 
@@ -205,104 +179,50 @@ struct ResponderDedup {
     cached_at: Instant,
 }
 
-/// Front-loaded gaps at the start of a pair's probing, before it settles into
-/// the steady [`PROBE_INTERVAL`] cadence: short at first so a NAT filter the
-/// peer opens moments after our first probe is caught quickly.
+/// Front-loaded gaps before a pair settles into the steady [`PROBE_INTERVAL`]:
+/// short at first so a NAT filter the peer opens moments after our first probe
+/// is caught quickly.
 pub const PROBE_BURST_GAPS: &[Duration] = &[
     Duration::from_millis(200),
     Duration::from_millis(300),
     Duration::from_millis(500),
 ];
 
-/// Inflight probes older than this are forgotten; a reply that late is not
-/// meaningful anymore.
-pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-
-/// Steady cadence a pair falls back to once its front-loaded burst is spent,
-/// while it is still trying to settle (or hunting a path that never answers).
+/// Steady cadence once the burst is spent.
 pub const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Positive RTT samples a pair collects before it settles and stops probing.
-///
-/// An answered pair reaches this and goes quiet. A handful of samples is enough
-/// for the smoothed RTT to be a fair basis for selection without spending
-/// probes forever.
-pub const PROBE_SAMPLES: u32 = 5;
+/// Probes a pair fires before it goes quiet — as long as a primary exists. A
+/// punchable path answers within the first attempt or two, so this many
+/// unanswered probes is firm evidence it is a dead end. Without a primary the
+/// budget does not apply: every pair hunts forever until one is selected.
+pub const PROBE_BUDGET: u32 = 12;
 
-/// How many probes a pair fires without settling, once we already have a
-/// primary, before it gives up.
-///
-/// While we have no path we hunt every pair indefinitely (bounded only by
-/// WireGuard retiring the connection). But once a path exists, a pair that
-/// won't settle is a dead end — e.g. a direct pair that can never punch a
-/// symmetric NAT — and probing it forever is pure waste, so we stop.
-///
-/// Counting fires rather than elapsed time means the budget is a fixed number
-/// of hole-punch attempts regardless of how long the session took to establish
-/// (probes only fire once it is) or how the burst is timed. A punchable NAT
-/// opens within the first attempt or two, so this many unanswered probes is
-/// firm evidence the pair is a dead end.
-pub const PROBE_GIVE_UP_ATTEMPTS: u32 = 12;
+/// Cadence the primary keeps probing at once its discovery budget is spent.
+/// Iceless runs no WireGuard persistent keepalive, so this lone probe is what
+/// keeps an idle primary's NAT bindings and tunnel warm. On a busy connection a
+/// single probe every 25s is negligible.
+pub const PRIMARY_KEEPALIVE: Duration = Duration::from_secs(25);
 
-/// Slow cadence the primary keeps after it settles, so its RTT stays current
-/// for the next comparison and its NAT mapping warm. This is what lets us drop
-/// a time-based freshness check: the primary is the only long-lived pair, and
-/// it is never stale.
-pub const PROBE_KEEPALIVE: Duration = Duration::from_secs(5);
-
-/// Repeated re-keys — our own retransmits going unanswered, or distinct peer
-/// inits with no data in between — that count as WireGuard distress and trigger
-/// a path re-evaluation.
-///
-/// Counting rather than timing decouples the signal from boringtun's now-tunable
-/// `REKEY_TIMEOUT` retry pacing. A single stray re-key is ordinary loss; a
-/// second one with no progress in between is the peer (or us) stuck on a dead
-/// path. Routine re-keys never reach the threshold because data flows between
-/// them, resetting the count.
+/// Repeated re-keys with no progress in between that count as WireGuard
+/// distress and clear the primary: our own retransmit going unanswered, or a
+/// second distinct peer init with no data in between. The first re-key is
+/// ordinary (it may still be answered); the second is the distress signal.
 pub const REKEY_DISTRESS_ATTEMPTS: u32 = 2;
 
 pub const RESPONDER_DEDUP_TTL: Duration = Duration::from_secs(10);
 
 const MAX_PEER_REFLEXIVE: usize = 4;
 
-/// Per-kind FIFO cap on remote candidates, bounding `pairs` growth
-/// across portal-driven relay rotations.
+/// Per-kind FIFO cap on remote candidates, bounding `pairs` growth across
+/// portal-driven relay rotations.
 const MAX_REMOTE_PER_KIND: usize = 6;
 
 const PRIMARY_HYSTERESIS_FRACTION: f64 = 0.2;
 const PRIMARY_HYSTERESIS_FLOOR: Duration = Duration::from_millis(10);
 
-impl PairState {
-    fn involves_relay(&self) -> bool {
-        matches!(self.kinds.0, crate::CandidateKind::Relayed)
-            || matches!(self.kinds.1, crate::CandidateKind::Relayed)
-    }
-}
-
-impl Default for PathAgent {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl PathAgent {
     pub fn new() -> Self {
-        Self {
-            locals: Vec::new(),
-            remotes: Vec::new(),
-            pairs: BTreeMap::new(),
-            primary: None,
-            established: false,
-            responder: Responder::default(),
-            outbound_init: None,
-            unanswered_rekeys: 0,
-            peer_rekeys: 0,
-            forwarded_response: None,
-            pending_transmits: VecDeque::new(),
-            events: VecDeque::new(),
-            events_queued_at: None,
-            peer_reflexive_addrs: BTreeSet::new(),
-        }
+        Self::default()
     }
 
     /// Returns whether the candidate was newly added (`false` if already known).
@@ -317,22 +237,24 @@ impl PathAgent {
             self.add_pair(c, remote, now);
         }
 
+        // A new candidate may offer a better path than the incumbent; re-probe.
+        self.clear_and_reprobe(now);
+
         true
     }
 
     pub fn add_remote_candidate(&mut self, c: Candidate, now: Instant) {
-        // Promote a previously-registered peer-reflexive in place so
-        // the existing `PairState` (RTT, inflight probe, schedule)
-        // survives.
+        // Promote a previously-registered peer-reflexive in place so the
+        // existing `PairState` (RTT, inflight, schedule) survives.
         if self.peer_reflexive_addrs.remove(&c.addr())
-            && let Some(i) = self.remotes.iter().position(|x| x.addr() == c.addr())
+            && let Some(existing) = self.remotes.iter_mut().find(|x| x.addr() == c.addr())
         {
             tracing::debug!(
                 remote = %c.addr(),
                 kind = ?c.kind(),
                 "Promoting peer-reflexive remote to signaled candidate",
             );
-            self.remotes[i] = c;
+            *existing = c;
             for ((_, remote_addr), state) in self.pairs.iter_mut() {
                 if *remote_addr == c.addr() {
                     state.kinds.1 = c.kind();
@@ -363,40 +285,35 @@ impl PathAgent {
             self.add_pair(local, c, now);
         }
 
-        // Candidate arrival hints that the current primary may be dead: the
-        // most common reason for new candidates mid-session is that the peer
-        // roamed away from the address our primary points at. Re-probe the
-        // primary and re-measure it: `restart_probes` clears its RTT, so if it
-        // is dead it drops out of selection and a fresh pair takes over; if it
-        // is alive its new measurement keeps it winning on bucket.
-        if let Some(primary) = self.primary
-            && let Some(state) = self.pairs.get_mut(&primary)
-        {
-            state.restart_probes(now);
-        }
+        self.clear_and_reprobe(now);
     }
 
-    /// Every new pair immediately probes in a burst, regardless of any other
-    /// state: candidates are the only signal about new paths we get.
-    fn add_pair(&mut self, local: Candidate, remote: Candidate, burst_at: Instant) {
+    /// Creates a pair. It probes once there is a session to ride: if one exists
+    /// it starts hunting now, otherwise `on_session_established` starts it when
+    /// the session appears. Cross-family pairs are unusable.
+    fn add_pair(&mut self, local: Candidate, remote: Candidate, now: Instant) {
         let pair = (local.local(), remote.addr());
 
-        // Cross-family pairs are unusable.
         if pair.0.is_ipv4() != pair.1.is_ipv4() {
             return;
         }
+
+        let id = self.next_pair_id;
+        self.next_pair_id = self.next_pair_id.wrapping_add(1);
 
         let mut state = PairState {
             kinds: (local.kind(), remote.kind()),
             local_family_matched: local.is_family_matched(),
             rtt: None,
-            inflight_probes: Vec::new(),
+            inflight: Vec::new(),
             probes: Probes::default(),
-            samples: 0,
             probes_sent: 0,
-            next_probe_seq: 0,
+            id,
+            next_seq: 0,
         };
-        state.restart_probes(burst_at);
+        if self.has_session {
+            state.restart(now);
+        }
 
         self.pairs.insert(pair, state);
     }
@@ -406,14 +323,11 @@ impl PathAgent {
             return false;
         };
 
-        let removed_local = self.locals.remove(i).local();
-        self.pairs.retain(|(local, _), _| *local != removed_local);
+        let removed = self.locals.remove(i).local();
+        self.pairs.retain(|(local, _), _| *local != removed);
 
-        if let Some((local, _)) = self.primary
-            && local == removed_local
-        {
-            self.primary = None;
-            self.probe_all_pairs(now);
+        if self.primary.is_some_and(|(local, _)| local == removed) {
+            self.clear_and_reprobe(now);
         }
 
         true
@@ -424,15 +338,12 @@ impl PathAgent {
             return false;
         };
 
-        let removed_addr = self.remotes.remove(i).addr();
-        self.pairs.retain(|(_, remote), _| *remote != removed_addr);
-        self.peer_reflexive_addrs.remove(&removed_addr);
+        let removed = self.remotes.remove(i).addr();
+        self.pairs.retain(|(_, remote), _| *remote != removed);
+        self.peer_reflexive_addrs.remove(&removed);
 
-        if let Some((_, remote)) = self.primary
-            && remote == removed_addr
-        {
-            self.primary = None;
-            self.probe_all_pairs(now);
+        if self.primary.is_some_and(|(_, remote)| remote == removed) {
+            self.clear_and_reprobe(now);
         }
 
         true
@@ -453,8 +364,8 @@ impl PathAgent {
     /// Drops locals matching `drop_local` and rebuilds from scratch, preserving
     /// every remote. Re-seeds after a roam or relay replacement.
     ///
-    /// The session survives a rebuild (the WireGuard key is kept), so probing
-    /// resumes as soon as pairs exist again — no handshake required.
+    /// The session survives (the WireGuard key is kept), so probing resumes as
+    /// soon as pairs exist again — no handshake required.
     pub fn rebuild(&mut self, mut drop_local: impl FnMut(&Candidate) -> bool, now: Instant) {
         let locals: Vec<Candidate> = self
             .locals
@@ -463,13 +374,11 @@ impl PathAgent {
             .filter(|c| !drop_local(c))
             .collect();
         let remotes = std::mem::take(&mut self.remotes);
-        let established = self.established;
-        let peer_rekeys = self.peer_rekeys;
+        let had_session = self.has_session;
 
         *self = Self::new();
 
-        self.established = established;
-        self.peer_rekeys = peer_rekeys;
+        self.has_session = had_session;
 
         for local in locals {
             self.add_local_candidate(local, now);
@@ -501,13 +410,13 @@ impl PathAgent {
             .any(|c| c.addr() == addr && c.is_relayed())
     }
 
-    pub fn initiate_handshake(&mut self, tunnel: &mut Tunn, force_resend: bool, now: Instant) {
+    pub fn initiate_handshake(&mut self, tunnel: &mut Tunn, now: Instant) {
         const MAX_SCRATCH_SPACE: usize = 148;
 
         let mut buf = [0u8; MAX_SCRATCH_SPACE];
 
         let TunnResult::WriteToNetwork(bytes) =
-            tunnel.format_handshake_initiation_at(&mut buf, force_resend, now)
+            tunnel.format_handshake_initiation_at(&mut buf, false, now)
         else {
             tracing::debug!("boringtun declined to emit a HandshakeInit");
             return;
@@ -517,118 +426,56 @@ impl PathAgent {
     }
 
     pub fn handle_outbound(&mut self, bytes: Vec<u8>, now: Instant) {
-        match (
-            Tunn::parse_incoming_packet(&bytes),
-            &mut self.outbound_init,
-            self.primary,
-        ) {
-            (Ok(Packet::HandshakeInit(_)), outbound_init @ None, _) if !self.established => {
-                tracing::debug!(bytes = bytes.len(), "Buffered initial HandshakeInit");
-
+        match Tunn::parse_incoming_packet(&bytes) {
+            // Before a session exists we cannot probe: fan the init out over the
+            // relay pairs to bootstrap one. This is the *only* use of the fan-out.
+            Ok(Packet::HandshakeInit(_)) if !self.has_session => {
+                tracing::debug!(bytes = bytes.len(), "Buffered bootstrap HandshakeInit");
                 self.forwarded_response = None;
-                outbound_init.replace(OutboundInit::new(bytes, now));
+                self.outbound_init = Some(OutboundInit::new(bytes, now));
             }
-            // A still-stored init means the previous one went unanswered:
-            // WireGuard-level failure evidence. Always retry on the incumbent;
-            // only re-evaluate once enough retransmits have piled up unanswered.
-            (Ok(Packet::HandshakeInit(_)), outbound_init @ Some(_), Some((local, remote))) => {
-                let bytes_len = bytes.len();
-
-                outbound_init.replace(OutboundInit::new(bytes.clone(), now));
-                self.pending_transmits.push_back(Transmit {
-                    local,
-                    remote,
-                    payload: Payload::Ciphertext(bytes),
-                });
-
+            // Established: the re-key rides the primary and counts toward distress.
+            Ok(Packet::HandshakeInit(_)) => {
                 self.unanswered_rekeys = self.unanswered_rekeys.saturating_add(1);
 
-                // A lone unanswered retransmit can be ordinary loss. Only once
-                // the peer has ignored `REKEY_DISTRESS_ATTEMPTS` of them do we
-                // treat the path as dead and drop the primary pointer: with no
-                // primary to protect the bucket veto lifts and the first pair to
-                // answer wins — even a worse bucket, so we fail over from a
-                // direct path to a relayed one if that is all that works.
-                //
-                // Fire exactly on the crossing, not on every retransmit past it:
-                // once we have dropped the primary, probing recovers the path
-                // and the re-key rides it. Re-dropping the primary on the next
-                // retransmit would just flap the data path.
-                if self.unanswered_rekeys == REKEY_DISTRESS_ATTEMPTS {
-                    tracing::debug!(bytes = bytes_len, "Unanswered re-keys; re-evaluating paths");
-
-                    self.primary = None;
-                    self.probe_all_pairs(now);
-                    self.select_primary(now);
-                } else {
-                    tracing::debug!(
-                        bytes = bytes_len,
-                        "Unanswered re-key; retrying on incumbent"
-                    );
-                }
-            }
-            // A routine re-key rides the primary without restarting probes.
-            (Ok(Packet::HandshakeInit(_)), outbound_init @ None, Some((local, remote))) => {
-                tracing::debug!(bytes = bytes.len(), "Re-key HandshakeInit");
-
-                outbound_init.replace(OutboundInit::new(bytes.clone(), now));
-                self.pending_transmits.push_back(Transmit {
-                    local,
-                    remote,
-                    payload: Payload::Ciphertext(bytes),
-                });
-            }
-            // Re-key arriving with no primary. At bootstrap (no session yet) the
-            // buffered init fans out over relay pairs; mid-session (a transient
-            // primary loss) the session is still valid, so we only re-probe and
-            // let the init ride the primary once probing recovers it.
-            (Ok(Packet::HandshakeInit(_)), outbound_init, None) => {
-                tracing::debug!(
-                    bytes = bytes.len(),
-                    "Re-key HandshakeInit without a primary; re-probing"
-                );
-
-                outbound_init.replace(OutboundInit::new(bytes, now));
-                self.unanswered_rekeys = 0;
-                self.probe_all_pairs(now);
-            }
-            (Ok(Packet::HandshakeResponse(_)), _, _) => {
-                if let (Some(init_bytes), Some(path)) = (
-                    self.responder.last_init.take(),
-                    self.responder.last_init_path.take(),
-                ) {
-                    tracing::debug!(
-                        local = %path.0,
-                        remote = %path.1,
-                        "Sending HandshakeResponse on init's recv path",
-                    );
-
+                if let Some((local, remote)) = self.primary {
                     self.pending_transmits.push_back(Transmit {
-                        local: path.0,
-                        remote: path.1,
-                        payload: Payload::Ciphertext(bytes.clone()),
+                        local,
+                        remote,
+                        payload: Payload::Ciphertext(bytes),
                     });
-                    self.responder.dedup = Some(ResponderDedup {
-                        init_bytes,
-                        response_bytes: bytes,
-                        cached_at: now,
+                }
+
+                // The second unanswered re-key is WireGuard telling us the path
+                // is dead: drop the primary and re-probe. Fire once on the
+                // crossing — once the primary is cleared, probing recovers it
+                // and the re-key rides the new path; re-firing would flap. The
+                // count resets when a response finally lands (see
+                // `handle_inbound_network`).
+                if self.primary.is_some() && self.unanswered_rekeys == REKEY_DISTRESS_ATTEMPTS {
+                    tracing::debug!("Unanswered re-keys; clearing primary and re-probing");
+                    self.clear_and_reprobe(now);
+                }
+            }
+            // Handshake responses are sent inline where their init is handled
+            // (`handle_inbound_network`), on the init's arrival path, so they
+            // never reach here. Data and everything else ride the primary;
+            // without one there is nothing to send (WireGuard buffers it and
+            // re-sends once a path exists).
+            _ => {
+                if let Some((local, remote)) = self.primary {
+                    self.pending_transmits.push_back(Transmit {
+                        local,
+                        remote,
+                        payload: Payload::Ciphertext(bytes),
                     });
                 }
             }
-            // Probes and data ride the primary; nothing to send without one.
-            (_, _, Some((local, remote))) => {
-                self.pending_transmits.push_back(Transmit {
-                    local,
-                    remote,
-                    payload: Payload::Ciphertext(bytes),
-                });
-            }
-            (_, _, None) => {}
         }
     }
 
-    /// Handshake bytes run through `tunnel` to authenticate before
-    /// any state mutation; dedup hits short-circuit before the call.
+    /// Handshake bytes run through `tunnel` to authenticate before any state
+    /// mutation; dedup hits short-circuit before the call.
     pub fn handle_inbound_network<'b>(
         &mut self,
         tunnel: &mut Tunn,
@@ -640,13 +487,9 @@ impl PathAgent {
             return ControlFlow::Continue(bytes);
         };
 
-        match (parsed, self.primary) {
-            // Replays and duplicates short-circuit before touching the session.
-            //
+        match parsed {
             // A replayed init is served from the cache without touching boringtun.
-            (Packet::HandshakeInit(_), _)
-                if let Some(response) = self.cached_response(bytes, now) =>
-            {
+            Packet::HandshakeInit(_) if let Some(response) = self.cached_response(bytes, now) => {
                 tracing::trace!(local = %path.0, remote = %path.1, "Replaying cached HandshakeResponse");
 
                 let response_bytes = response.to_vec();
@@ -658,79 +501,94 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
-            // Drop dups arriving on multiple pairs in one tick so
-            // boringtun doesn't reject as WrongTai64nTimestamp.
-            (Packet::HandshakeInit(_), _) if self.responder.last_init.as_deref() == Some(bytes) => {
+            // Drop dups arriving on multiple pairs in one tick so boringtun
+            // doesn't reject them as WrongTai64nTimestamp.
+            Packet::HandshakeInit(_) if self.responder.last_init.as_deref() == Some(bytes) => {
                 tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate inbound HandshakeInit");
 
                 ControlFlow::Break(())
             }
-            (Packet::HandshakeResponse(_), _)
-                if self.forwarded_response.as_deref() == Some(bytes) =>
-            {
+            Packet::HandshakeResponse(_) if self.forwarded_response.as_deref() == Some(bytes) => {
                 tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate HandshakeResponse");
 
                 ControlFlow::Break(())
             }
-            // Accepts: authenticate, then adopt or re-evaluate.
-            (Packet::HandshakeInit(_), primary) => {
-                let Some(outbound) = self.decapsulate_init(tunnel, bytes, path, now) else {
+            Packet::HandshakeInit(_) => {
+                let Some(response) = self.decapsulate_init(tunnel, bytes, path, now) else {
                     return ControlFlow::Break(());
                 };
 
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeInit accepted");
 
-                // `handle_outbound` for the response below pairs
-                // against `last_init`/`last_init_path`.
+                let had_session = self.has_session;
+
+                // Remembered so fanned-out duplicates arriving on other pairs in
+                // this tick are dropped (see the duplicate-init arm above).
                 self.responder.last_init = Some(bytes.to_vec());
-                self.responder.last_init_path = Some(path);
 
                 self.register_peer_reflexive(path, now);
-                self.established = true;
+                self.on_session_established(now);
 
-                // A re-key with peer data flowing in between is routine (the
-                // count was reset by that data). Several distinct inits with no
-                // data between them mean the peer isn't hearing our responses or
-                // data — its passive-keepalive escalation formats a new init
-                // every few seconds. Duplicates of the same init were dropped
-                // above, so every increment here is a genuinely new attempt.
-                self.peer_rekeys = self.peer_rekeys.saturating_add(1);
-                if self.peer_rekeys == REKEY_DISTRESS_ATTEMPTS {
-                    tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed without hearing us; re-evaluating paths");
-
-                    // Same as an unanswered outbound re-key: the peer isn't
-                    // hearing us on the current primary, so drop the pointer and
-                    // let the bucket veto lift for a clean failover.
-                    self.primary = None;
-                    self.probe_all_pairs(now);
-                    self.select_primary(now);
-                }
-
-                if primary.is_none() {
+                // The init that *establishes* the session hands us a working
+                // path for free: it arrived over the relay fan-out (the worst
+                // tier), so adopting it as the preliminary primary is sound —
+                // probing can only promote away from a relay, never get trapped.
+                // Without this the responder stays pathless until its first
+                // probe reply and its connection drops inbound data until then.
+                //
+                // A *mid-session* init (a re-key) is different: it rides the
+                // peer's primary, which may be a better tier we haven't validated
+                // for our own sending, so it must not move our primary — probing
+                // decides. Hence we only adopt on the establishing init.
+                if !had_session && self.primary.is_none() && self.pairs.contains_key(&path) {
                     self.set_primary(path, now);
                 }
 
-                for b in outbound {
-                    self.handle_outbound(b, now);
+                // Distinct inits with no data in between mean the peer isn't
+                // hearing us: WireGuard distress.
+                self.peer_rekeys = self.peer_rekeys.saturating_add(1);
+                if self.primary.is_some() && self.peer_rekeys == REKEY_DISTRESS_ATTEMPTS {
+                    tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed without hearing us; clearing primary and re-probing");
+                    self.clear_and_reprobe(now);
+                }
+
+                // boringtun's response MUST go back on the path the init arrived
+                // on, never the primary — otherwise bootstrap (and re-keys)
+                // can't complete. Cache it so a retransmitted init is answered
+                // from memory without re-decapsulating.
+                if let Some(response) = response {
+                    tracing::debug!(local = %path.0, remote = %path.1, "Sending HandshakeResponse on init's recv path");
+
+                    self.responder.dedup = Some(ResponderDedup {
+                        init_bytes: bytes.to_vec(),
+                        response_bytes: response.clone(),
+                        cached_at: now,
+                    });
+                    self.pending_transmits.push_back(Transmit {
+                        local: path.0,
+                        remote: path.1,
+                        payload: Payload::Ciphertext(response),
+                    });
                 }
 
                 ControlFlow::Break(())
             }
-            (Packet::HandshakeResponse(_), primary) => {
+            Packet::HandshakeResponse(_) => {
                 let Some(outbound) = self.decapsulate_response(tunnel, bytes, path, now) else {
                     return ControlFlow::Break(());
                 };
 
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse accepted");
 
+                // Our re-key was answered: the path works both ways.
                 self.outbound_init = None;
                 self.unanswered_rekeys = 0;
                 self.forwarded_response = Some(bytes.to_vec());
-                self.established = true;
+                self.on_session_established(now);
 
-                if primary.is_none() {
-                    self.set_primary(path, now);
-                }
+                // A response is bidirectionally validated, so it is safe to
+                // adopt as a (tier-ranked) preliminary primary before probing.
+                self.promote_from_handshake(path, now);
 
                 for b in outbound {
                     self.handle_outbound(b, now);
@@ -738,14 +596,12 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
-            // Peer data proves the peer is hearing us, so the connection isn't
-            // in distress: clear the re-key counter that would otherwise build
-            // toward a false failover.
-            (Packet::PacketData(_), _) => {
+            // Peer data proves the peer is hearing us: not in distress.
+            Packet::PacketData(_) => {
                 self.peer_rekeys = 0;
                 ControlFlow::Continue(bytes)
             }
-            (Packet::PacketCookieReply(_), _) => ControlFlow::Continue(bytes),
+            Packet::PacketCookieReply(_) => ControlFlow::Continue(bytes),
         }
     }
 
@@ -763,21 +619,23 @@ impl PathAgent {
         Some(d.response_bytes.as_slice())
     }
 
-    /// Authenticates an inbound init, returning the packets boringtun wants
-    /// to send in response. `None` means the packet was fully handled
-    /// (rejected, or answered with a cookie under load).
+    /// Authenticates an inbound init. An init yields at most one packet in
+    /// return, so this is `Some(Some(response))` when boringtun wants a
+    /// handshake response sent back, or `Some(None)` when it accepts the init
+    /// silently. The outer `None` means the packet was fully handled here
+    /// (rejected, or answered with a cookie under load) and the caller does
+    /// nothing further.
     fn decapsulate_init(
         &mut self,
         tunnel: &mut Tunn,
         bytes: &[u8],
         path: (SocketAddr, SocketAddr),
         now: Instant,
-    ) -> Option<Vec<Vec<u8>>> {
-        // Source IP must be set so boringtun can emit cookie replies under load.
+    ) -> Option<Option<Vec<u8>>> {
         let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
-        let outbound = match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now) {
-            TunnResult::Done => Vec::new(),
-            TunnResult::WriteToNetwork(response) => vec![response.to_vec()],
+        let response = match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now) {
+            TunnResult::Done => None,
+            TunnResult::WriteToNetwork(response) => Some(response.to_vec()),
             TunnResult::Err(e) => {
                 tracing::debug!(local = %path.0, remote = %path.1, error = ?e, "Inbound HandshakeInit rejected");
                 return None;
@@ -788,8 +646,8 @@ impl PathAgent {
             }
         };
 
-        // Cookie replies don't establish a session; return them without touching state.
-        if let Some(reply) = outbound.first()
+        // Cookie replies don't establish a session; send them without touching state.
+        if let Some(reply) = &response
             && matches!(
                 Tunn::parse_incoming_packet(reply),
                 Ok(Packet::PacketCookieReply(_))
@@ -806,12 +664,11 @@ impl PathAgent {
             return None;
         }
 
-        Some(outbound)
+        Some(response)
     }
 
-    /// Authenticates an inbound response, returning the packets boringtun
-    /// wants to send afterwards (e.g. queued data). `None` means the packet
-    /// was rejected.
+    /// Authenticates an inbound response, returning the packets boringtun wants
+    /// to send afterwards (e.g. queued data). `None` means it was rejected.
     fn decapsulate_response(
         &mut self,
         tunnel: &mut Tunn,
@@ -882,30 +739,31 @@ impl PathAgent {
 
                 self.register_peer_reflexive(pair, now);
 
-                // Triggered check (cf. RFC 8445, section 7.3.1.4): the
-                // inbound probe proves the reverse NAT filter is open right
-                // now, so probing back completes the hole punch in one round
-                // trip. Only for pairs we haven't measured — probing back one
-                // we already track would ping-pong bursts between the peers.
+                // Triggered check (cf. RFC 8445 §7.3.1.4): the inbound probe
+                // proves the reverse filter is open now, so probing back
+                // completes the punch. Only for a pair we've gone quiet on
+                // without measuring — one we're already probing would ping-pong.
                 if let Some(state) = self.pairs.get_mut(&pair)
+                    && !state.is_probing()
                     && state.rtt.is_none()
                 {
-                    state.restart_probes(now);
+                    state.restart(now);
                 }
             }
             crate::icmpv6::Echo::Reply => {
                 let Some(state) = self.pairs.get_mut(&pair) else {
                     return ControlFlow::Break(());
                 };
-                let Some(i) = state
-                    .inflight_probes
-                    .iter()
-                    .position(|inflight| inflight.seq == probe.seq)
-                else {
+                // The id is scoped to the pair: a reply carrying a stale id
+                // (a pair recreated at the same address) is not ours.
+                if probe.id != state.id {
+                    return ControlFlow::Break(());
+                }
+                let Some(i) = state.inflight.iter().position(|p| p.seq == probe.seq) else {
                     return ControlFlow::Break(());
                 };
 
-                let inflight = state.inflight_probes.remove(i);
+                let inflight = state.inflight.remove(i);
                 let rtt = now.saturating_duration_since(inflight.sent_at);
 
                 state.rtt = Some(Rtt {
@@ -914,22 +772,11 @@ impl PathAgent {
                         Some(prev) => (prev.smoothed + rtt) / 2,
                     },
                 });
-                state.record_sample();
 
                 tracing::trace!(local = %pair.0, remote = %pair.1, ?rtt, "Probe reply received");
 
+                // A probe reply is bidirectionally validated: it may promote.
                 self.select_primary(now);
-
-                // A pair that has settled either becomes the long-lived primary
-                // (kept fresh on the keepalive cadence) or is a loser whose data
-                // we drop, so no stale RTT lingers for selection to trip over.
-                if self.pairs.get(&pair).is_some_and(PairState::is_settled) {
-                    if self.primary == Some(pair) {
-                        self.pairs.get_mut(&pair).unwrap().keep_fresh(now);
-                    } else {
-                        self.pairs.get_mut(&pair).unwrap().retire();
-                    }
-                }
             }
         }
         ControlFlow::Break(())
@@ -939,20 +786,19 @@ impl PathAgent {
         let next_retransmit = self
             .outbound_init
             .as_ref()
+            .filter(|_| !self.has_session)
             .and_then(|i| i.retransmits.values().map(|r| r.next_fire_at).min());
         // Probes wait for the first handshake exchange; see `drive_probes`.
         let next_probe = self
-            .established
+            .has_session
             .then(|| self.pairs.values().filter_map(|s| s.probes.due()).min())
             .flatten();
         // Wake immediately if a buffered bootstrap init is waiting on a relay
-        // pair that landed after the initial fanout. The fanout is bootstrap
-        // only (see `drive_handshake_retransmits`), so once established there is
-        // nothing to fan out — a re-key rides the primary.
+        // pair that landed after the initial fanout.
         let pending_fanout = self
             .outbound_init
             .as_ref()
-            .filter(|_| self.primary.is_none() && !self.established)
+            .filter(|_| !self.has_session)
             .and_then(|i| {
                 self.pairs
                     .iter()
@@ -977,7 +823,7 @@ impl PathAgent {
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {
-        self.drive_handshake_retransmits(now);
+        self.drive_bootstrap_fanout(now);
         self.drive_probes(now);
         self.expire_dedup(now);
     }
@@ -990,15 +836,11 @@ impl PathAgent {
         }
     }
 
-    fn drive_handshake_retransmits(&mut self, now: Instant) {
-        // The relay fan-out is purely the bootstrap mechanism: it lands the very
-        // first handshake when no session exists yet and we therefore cannot
-        // probe. Once established, a re-key rides the primary, and if a distress
-        // signal has dropped the primary, probing (not a fan-out) recovers the
-        // path over the still-valid session — a handshake could not do more,
-        // since a peer that has truly lost the session no longer has our key
-        // and needs a full re-setup via the signalling layer.
-        if self.established || self.primary.is_some() {
+    /// Fans the buffered init out over relay pairs — bootstrap only. Once
+    /// established the re-key rides the primary, and a distress-cleared primary
+    /// is recovered by probing over the still-valid session, not a fan-out.
+    fn drive_bootstrap_fanout(&mut self, now: Instant) {
+        if self.has_session {
             return;
         }
 
@@ -1049,10 +891,9 @@ impl PathAgent {
     }
 
     fn drive_probes(&mut self, now: Instant) {
-        // Probes ride the session (they are encapsulated); encapsulating
-        // before the first handshake exchange would make boringtun queue
-        // them and initiate handshakes on its own.
-        if !self.established {
+        // Probes ride the session; encapsulating before the first handshake
+        // would make boringtun queue them and initiate handshakes on its own.
+        if !self.has_session {
             return;
         }
 
@@ -1063,53 +904,61 @@ impl PathAgent {
             let Some(deadline) = state.probes.due() else {
                 continue;
             };
-
             if now < deadline {
                 continue;
             }
 
-            // Once we have a path, stop probing a non-primary pair that won't
-            // settle (e.g. a direct pair behind a symmetric NAT). The primary
-            // is exempt — probe loss must never retire it — and while we have
-            // no path at all we hunt every pair until WireGuard gives up.
-            let is_primary = primary == Some((*local, *remote));
-            if primary.is_some() && !is_primary && state.gave_up() {
-                state.retire();
-                continue;
-            }
-
-            // A reply past this age wouldn't be fresh enough to matter.
-            state
-                .inflight_probes
-                .retain(|p| now.saturating_duration_since(p.sent_at) < PROBE_TIMEOUT);
-
-            let seq = state.next_probe_seq;
-            state.next_probe_seq = state.next_probe_seq.wrapping_add(1);
-            state
-                .inflight_probes
-                .push(InflightProbe { seq, sent_at: now });
-            state.probes.fire(now);
-            state.record_probe_sent();
+            let seq = state.next_seq;
+            state.next_seq = state.next_seq.wrapping_add(1);
+            state.inflight.push(InflightProbe { seq, sent_at: now });
+            state.probes_sent = state.probes_sent.saturating_add(1);
 
             tracing::trace!(%local, %remote, seq, "Probe send");
 
             pending.push_back(Transmit {
                 local: *local,
                 remote: *remote,
-                payload: Payload::Plaintext(Box::new(crate::icmpv6::build_echo_request(0, seq))),
+                payload: Payload::Plaintext(Box::new(crate::icmpv6::build_echo_request(
+                    state.id, seq,
+                ))),
             });
+
+            // Within the discovery budget — or while we have no path at all —
+            // keep the fast burst-then-interval cadence.
+            if primary.is_none() || state.probes_sent < PROBE_BUDGET {
+                state.probes.fire(now);
+            } else if primary == Some((*local, *remote)) {
+                // The primary keepalives; every other pair goes quiet.
+                state.probes.keepalive(now);
+            } else {
+                state.probes.stop();
+            }
         }
     }
 
-    fn probe_all_pairs(&mut self, now: Instant) {
-        for state in self.pairs.values_mut() {
-            state.restart_probes(now);
+    /// Clears the primary and re-probes: WireGuard distress or a new candidate.
+    /// A pair mid-discovery-burst keeps its state so the burst isn't disturbed;
+    /// everything else restarts (fresh burst, cleared RTT). The former primary
+    /// always restarts — it is the suspect path and must re-earn its place, so a
+    /// still-valid one re-confirms within a round trip and a dead one drops out.
+    fn clear_and_reprobe(&mut self, now: Instant) {
+        let former = self.primary.take();
+        // Before a session exists there is nothing to probe;
+        // `on_session_established` starts every pair once one appears.
+        if !self.has_session {
+            return;
+        }
+        for (pair, state) in self.pairs.iter_mut() {
+            let discovering = state.probes.due().is_some() && state.probes_sent < PROBE_BUDGET;
+            if Some(*pair) == former || !discovering {
+                state.restart(now);
+            }
         }
     }
 
     fn register_peer_reflexive(&mut self, pair: (SocketAddr, SocketAddr), now: Instant) {
-        // The peer reached us from a mapping they didn't advertise
-        // (symmetric NAT).
+        // The peer reached us from a mapping they didn't advertise (symmetric
+        // NAT). Registering it is a new candidate, which re-probes.
         if self.peer_reflexive_addrs.len() < MAX_PEER_REFLEXIVE
             && !self.remotes.iter().any(|c| c.addr() == pair.1)
         {
@@ -1123,91 +972,98 @@ impl PathAgent {
         }
     }
 
+    /// A session now exists (a handshake was accepted). This is the single place
+    /// probing begins — probes ride the session, so they can't run before it. It
+    /// runs on every accepted handshake, but the transition (and the probe
+    /// kick-off) only fires the first time, when the session first appears.
+    fn on_session_established(&mut self, now: Instant) {
+        if self.has_session {
+            return;
+        }
+        self.has_session = true;
+        // Bootstrap is over; a re-key now rides the primary, not the fan-out.
+        self.outbound_init = None;
+        // Every pair was created without a schedule (probing waits for a
+        // session); now that we have one, start them all hunting.
+        for state in self.pairs.values_mut() {
+            state.restart(now);
+        }
+    }
+
+    /// A handshake proves its path works both ways but carries no RTT, so it can
+    /// only seed or improve the primary *by tier* — never displace a
+    /// better-tier incumbent.
+    fn promote_from_handshake(&mut self, path: (SocketAddr, SocketAddr), now: Instant) {
+        if !self.pairs.contains_key(&path) {
+            return;
+        }
+        match self.primary {
+            None => self.set_primary(path, now),
+            Some(primary) if primary != path => {
+                let new = pair_score(path, &self.pairs[&path]);
+                let cur = pair_score(primary, &self.pairs[&primary]);
+                if new.bucket < cur.bucket {
+                    self.set_primary(path, now);
+                }
+            }
+            Some(_) => {}
+        }
+    }
+
+    /// Runs on every probe reply. Probes can only *promote*: the best measured
+    /// pair takes over an empty primary, or displaces the incumbent only when it
+    /// scores strictly better (a better tier, or the same tier by a clear RTT
+    /// margin). A worse pair never demotes a working primary.
     fn select_primary(&mut self, now: Instant) {
-        // Only pairs with an RTT are candidates. Every RTT we hold is current
-        // by construction — the primary is kept fresh on its keepalive cadence,
-        // an actively-probing pair is measuring right now, and a settled loser
-        // or a re-probed pair has its RTT cleared — so there is no stale
-        // measurement to filter out. Selection is bucket-dominant, so a live
-        // primary naturally wins over any worse-bucket challenger; a *dead*
-        // primary has no RTT (a distress or candidate signal cleared it by
-        // re-probing) and drops out, letting a fresh pair take over.
-        let best = self
+        let Some(best) = self
             .pairs
             .iter()
             .filter(|(_, s)| s.rtt.is_some())
             .min_by_key(|(k, s)| pair_score(**k, s))
-            .map(|(k, _)| *k);
+            .map(|(k, _)| *k)
+        else {
+            return;
+        };
 
-        let Some(new) = best else { return };
+        let Some(primary) = self.primary else {
+            self.set_primary(best, now);
+            return;
+        };
 
-        if self.primary == Some(new) {
+        if best == primary {
             return;
         }
 
-        // The current primary keeps its place unless a challenger clearly wins.
-        // A worse bucket never displaces it — even a primary without a fresh
-        // RTT holds by candidate kind, so a fresh worse-bucket pair can't steal
-        // it while it is being re-measured. Failing over to a *worse* bucket
-        // happens only after WireGuard distress, which drops the primary
-        // pointer entirely (there is then no primary to protect).
-        if let Some(primary) = self.primary
-            && let Some(prev) = self.pairs.get(&primary)
-        {
-            let new_score = pair_score(new, &self.pairs[&new]);
-            let prev_score = pair_score(primary, prev);
+        let new = pair_score(best, &self.pairs[&best]);
+        let cur = pair_score(primary, &self.pairs[&primary]);
 
-            if prev_score.bucket < new_score.bucket {
-                return;
-            }
-
-            // Same bucket: keep the primary unless the challenger beats its RTT
-            // by a clear margin — no needless hop for a marginal gain, and no
-            // flap between two live same-bucket pairs on jitter.
-            if prev_score.bucket == new_score.bucket
-                && let Some(prev_rtt) = prev.rtt
-            {
-                let new_rtt = new_score.rtt.unwrap_or_default();
-                let margin = PRIMARY_HYSTERESIS_FLOOR
-                    .max(prev_rtt.smoothed.mul_f64(PRIMARY_HYSTERESIS_FRACTION));
-
-                if new_rtt + margin >= prev_rtt.smoothed {
-                    return;
-                }
-            }
+        if new.bucket < cur.bucket {
+            self.set_primary(best, now);
+            return;
         }
 
-        self.set_primary(new, now);
+        // Same bucket: only switch on a clear RTT win, so jitter between two
+        // live same-tier pairs doesn't flap the primary.
+        if new.bucket == cur.bucket
+            && let Some(cur_rtt) = self.pairs[&primary].rtt
+        {
+            let new_rtt = self.pairs[&best]
+                .rtt
+                .map(|r| r.smoothed)
+                .unwrap_or_default();
+            let margin =
+                PRIMARY_HYSTERESIS_FLOOR.max(cur_rtt.smoothed.mul_f64(PRIMARY_HYSTERESIS_FRACTION));
+            if new_rtt + margin < cur_rtt.smoothed {
+                self.set_primary(best, now);
+            }
+        }
     }
 
     fn set_primary(&mut self, path: (SocketAddr, SocketAddr), now: Instant) {
         let from = self.primary;
-
         self.primary = Some(path);
 
-        // The old primary is now a loser: drop its data so nothing stale
-        // lingers (a later signal re-probes it if it becomes relevant again).
-        if let Some(old) = from
-            && old != path
-            && let Some(state) = self.pairs.get_mut(&old)
-        {
-            state.retire();
-        }
-
-        // A new primary that has already settled moves to the keepalive cadence
-        // to stay fresh; one still hunting keeps bursting until it settles.
-        if let Some(state) = self.pairs.get_mut(&path)
-            && state.is_settled()
-        {
-            state.keep_fresh(now);
-        }
-
-        tracing::debug!(
-            ?from,
-            local = %path.0,
-            remote = %path.1,
-            "Iceless primary changed",
-        );
+        tracing::debug!(?from, local = %path.0, remote = %path.1, "Iceless primary changed");
 
         self.queue_event(
             Event::PrimaryChanged {

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -23,12 +23,6 @@ pub struct PathAgent {
     /// because the session does, too.
     established: bool,
 
-    /// While set (and in the future), WireGuard signalled that the current
-    /// path is suspect: the bucket veto lifts so we can fail over to a worse
-    /// bucket (e.g. direct to relayed). The same-bucket RTT hysteresis still
-    /// protects a primary that is answering probes.
-    guard_suspended_until: Option<Instant>,
-
     responder: Responder,
 
     outbound_init: Option<OutboundInit>,
@@ -67,13 +61,31 @@ pub(crate) struct PairState {
 }
 
 impl PairState {
-    /// (Re)opens a probing window on this pair: a fresh burst and a fresh
-    /// sample count, so it probes until it settles — or, once we have a path,
-    /// until it gives up ([`PROBE_GIVE_UP`]).
+    /// (Re)opens a probing window: a fresh burst, a fresh sample count, and a
+    /// cleared RTT — so the pair earns a new measurement rather than carrying a
+    /// stale one. It probes until it settles, or (once we have a path) gives up.
     fn restart_probes(&mut self, at: Instant) {
-        self.probes.start(at);
+        self.probes.hunt(at);
         self.samples = 0;
         self.probing_since = Some(at);
+        self.rtt = None;
+    }
+
+    /// Drops the pair's data and stops probing it. Used when a settled pair
+    /// isn't the primary, or a pair gives up — either way we keep no stale RTT
+    /// around, which is what lets selection skip a freshness check.
+    fn retire(&mut self) {
+        self.probes.stop();
+        self.rtt = None;
+    }
+
+    /// Keeps the pair on the slow keepalive cadence (it's the primary).
+    fn keep_fresh(&mut self, now: Instant) {
+        self.probes.keepalive(now);
+    }
+
+    fn is_settled(&self) -> bool {
+        self.samples >= PROBE_SAMPLES
     }
 
     /// Whether this pair has probed past the give-up bound without settling.
@@ -82,35 +94,29 @@ impl PairState {
             .is_some_and(|since| now.duration_since(since) >= PROBE_GIVE_UP)
     }
 
-    /// Records a positive RTT sample and settles the pair (stops probing) once
-    /// [`PROBE_SAMPLES`] have arrived.
     fn record_sample(&mut self) {
         self.samples = self.samples.saturating_add(1);
-        if self.samples >= PROBE_SAMPLES {
-            self.probes.stop();
-        }
     }
 }
 
-/// The gaps between a pair's probes: the front-loaded [`PROBE_BURST_GAPS`]
-/// followed by an endless steady [`PROBE_INTERVAL`].
+/// The gaps between a pair's probes: a front-loaded burst followed by an
+/// endless steady interval.
 type ProbeGaps =
     iter::Chain<iter::Copied<std::slice::Iter<'static, Duration>>, iter::Repeat<Duration>>;
 
-fn probe_gaps() -> ProbeGaps {
-    PROBE_BURST_GAPS
-        .iter()
-        .copied()
-        .chain(iter::repeat(PROBE_INTERVAL))
+const NO_BURST: &[Duration] = &[];
+
+fn probe_gaps(burst: &'static [Duration], steady: Duration) -> ProbeGaps {
+    burst.iter().copied().chain(iter::repeat(steady))
 }
 
-/// A pair's probe schedule: front-loaded at first, then a steady cadence that
-/// never runs out. Whether the pair keeps probing is decided by the *settle*
-/// rule (see [`PairState::record_sample`]), not by the schedule — the gaps are
-/// endless so an unanswered pair keeps probing until WireGuard, the liveness
-/// authority, tears the connection down.
+/// A pair's probe schedule. In its `hunt` phase it front-loads a burst then
+/// settles to [`PROBE_INTERVAL`]; the primary switches to the slow
+/// [`PROBE_KEEPALIVE`] cadence via `keepalive`. `stop` ends it (settled loser,
+/// or given up). The gaps are endless, so an unanswered pair keeps probing
+/// until WireGuard, the liveness authority, retires the connection.
 struct Probes {
-    /// Next probe deadline. `None` once the pair has settled or before it starts.
+    /// Next probe deadline. `None` when the pair isn't probing.
     next: Option<Instant>,
     gaps: ProbeGaps,
 }
@@ -119,19 +125,25 @@ impl Default for Probes {
     fn default() -> Self {
         Self {
             next: None,
-            gaps: probe_gaps(),
+            gaps: probe_gaps(PROBE_BURST_GAPS, PROBE_INTERVAL),
         }
     }
 }
 
 impl Probes {
-    /// (Re)starts probing at `at` with a fresh schedule.
-    fn start(&mut self, at: Instant) {
+    /// (Re)starts the burst-then-interval hunt at `at`.
+    fn hunt(&mut self, at: Instant) {
         self.next = Some(at);
-        self.gaps = probe_gaps();
+        self.gaps = probe_gaps(PROBE_BURST_GAPS, PROBE_INTERVAL);
     }
 
-    /// Stops probing (the pair has settled).
+    /// Switches to the slow keepalive cadence, next probe one interval out.
+    fn keepalive(&mut self, now: Instant) {
+        self.next = Some(now + PROBE_KEEPALIVE);
+        self.gaps = probe_gaps(NO_BURST, PROBE_KEEPALIVE);
+    }
+
+    /// Stops probing.
     fn stop(&mut self) {
         self.next = None;
     }
@@ -151,13 +163,6 @@ impl Probes {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Rtt {
     pub(crate) smoothed: Duration,
-    measured_at: Instant,
-}
-
-impl Rtt {
-    fn is_fresh(&self, now: Instant) -> bool {
-        now.saturating_duration_since(self.measured_at) < RTT_FRESHNESS
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -223,21 +228,11 @@ pub const PROBE_SAMPLES: u32 = 5;
 /// symmetric NAT — and probing it forever is pure waste, so we stop.
 pub const PROBE_GIVE_UP: Duration = Duration::from_secs(10);
 
-/// Only RTTs measured within this window are eligible in the selection scan.
-///
-/// The bound is wedged between two failure modes: shorter than one full burst
-/// and replies racing in from the same round stop comparing fairly ("last to
-/// answer" would win instead of "best score"); much longer and a ghost pair —
-/// a good bucket toward an address the peer roamed away from — displaces a
-/// freshly-validated primary on a meaningless measurement.
-pub const RTT_FRESHNESS: Duration = Duration::from_secs(10);
-
-/// How long the primary's selection guard stays suspended after a
-/// re-evaluation signal: long enough for the triggered burst's replies to
-/// arrive and be compared, short enough that hysteresis is back before RTT
-/// jitter can flap two live same-bucket pairs. Persistent distress keeps
-/// re-suspending (boringtun retries an unanswered re-key every few seconds).
-pub const GUARD_SUSPENSION: Duration = Duration::from_secs(10);
+/// Slow cadence the primary keeps after it settles, so its RTT stays current
+/// for the next comparison and its NAT mapping warm. This is what lets us drop
+/// a time-based freshness check: the primary is the only long-lived pair, and
+/// it is never stale.
+pub const PROBE_KEEPALIVE: Duration = Duration::from_secs(5);
 
 /// An accepted inbound init this soon after the previous one means the peer
 /// keeps re-keying: it isn't hearing our responses or data.
@@ -282,7 +277,6 @@ impl PathAgent {
             pairs: BTreeMap::new(),
             primary: None,
             established: false,
-            guard_suspended_until: None,
             responder: Responder::default(),
             outbound_init: None,
             last_inbound_init_at: None,
@@ -355,15 +349,13 @@ impl PathAgent {
         // Candidate arrival hints that the current primary may be dead: the
         // most common reason for new candidates mid-session is that the peer
         // roamed away from the address our primary points at. Re-probe the
-        // primary and lift the bucket veto — if the primary is alive, its
-        // reply keeps it winning the scan; if it is dead, a fresh pair takes
-        // over without waiting for WireGuard's escalation.
-        if let Some(primary) = self.primary {
-            if let Some(state) = self.pairs.get_mut(&primary) {
-                state.restart_probes(now);
-            }
-
-            self.suspend_guard(now);
+        // primary and re-measure it: `restart_probes` clears its RTT, so if it
+        // is dead it drops out of selection and a fresh pair takes over; if it
+        // is alive its new measurement keeps it winning on bucket.
+        if let Some(primary) = self.primary
+            && let Some(state) = self.pairs.get_mut(&primary)
+        {
+            state.restart_probes(now);
         }
     }
 
@@ -534,7 +526,12 @@ impl PathAgent {
                     remote,
                     payload: Payload::Ciphertext(bytes),
                 });
-                self.suspend_guard(now);
+                // Drop the primary pointer: an unanswered re-key is WireGuard
+                // telling us the path may be dead, so we re-evaluate from
+                // scratch. With no primary to protect, the bucket veto lifts and
+                // the first pair to answer wins — even a worse bucket, so we can
+                // fail over from direct to relayed if that is all that works.
+                self.primary = None;
                 self.probe_all_pairs(now);
                 self.select_primary(now);
             }
@@ -667,7 +664,10 @@ impl PathAgent {
                 {
                     tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed early; re-evaluating paths");
 
-                    self.suspend_guard(now);
+                    // Same as an unanswered outbound re-key: the peer isn't
+                    // hearing us on the current primary, so drop the pointer and
+                    // let the bucket veto lift for a clean failover.
+                    self.primary = None;
                     self.probe_all_pairs(now);
                     self.select_primary(now);
                 }
@@ -845,36 +845,50 @@ impl PathAgent {
                 // Triggered check (cf. RFC 8445, section 7.3.1.4): the
                 // inbound probe proves the reverse NAT filter is open right
                 // now, so probing back completes the hole punch in one round
-                // trip. Only for unvalidated pairs — probing back a settled
-                // pair would ping-pong bursts between the peers forever.
+                // trip. Only for pairs we haven't measured — probing back one
+                // we already track would ping-pong bursts between the peers.
                 if let Some(state) = self.pairs.get_mut(&pair)
-                    && !state.rtt.is_some_and(|rtt| rtt.is_fresh(now))
+                    && state.rtt.is_none()
                 {
                     state.restart_probes(now);
                 }
             }
             crate::icmpv6::Echo::Reply => {
-                if let Some(state) = self.pairs.get_mut(&pair)
-                    && let Some(i) = state
-                        .inflight_probes
-                        .iter()
-                        .position(|inflight| inflight.seq == probe.seq)
-                {
-                    let inflight = state.inflight_probes.remove(i);
-                    let rtt = now.saturating_duration_since(inflight.sent_at);
+                let Some(state) = self.pairs.get_mut(&pair) else {
+                    return ControlFlow::Break(());
+                };
+                let Some(i) = state
+                    .inflight_probes
+                    .iter()
+                    .position(|inflight| inflight.seq == probe.seq)
+                else {
+                    return ControlFlow::Break(());
+                };
 
-                    state.rtt = Some(Rtt {
-                        smoothed: match state.rtt {
-                            None => rtt,
-                            Some(prev) => (prev.smoothed + rtt) / 2,
-                        },
-                        measured_at: now,
-                    });
-                    state.record_sample();
+                let inflight = state.inflight_probes.remove(i);
+                let rtt = now.saturating_duration_since(inflight.sent_at);
 
-                    tracing::trace!(local = %pair.0, remote = %pair.1, ?rtt, "Probe reply received");
+                state.rtt = Some(Rtt {
+                    smoothed: match state.rtt {
+                        None => rtt,
+                        Some(prev) => (prev.smoothed + rtt) / 2,
+                    },
+                });
+                state.record_sample();
 
-                    self.select_primary(now);
+                tracing::trace!(local = %pair.0, remote = %pair.1, ?rtt, "Probe reply received");
+
+                self.select_primary(now);
+
+                // A pair that has settled either becomes the long-lived primary
+                // (kept fresh on the keepalive cadence) or is a loser whose data
+                // we drop, so no stale RTT lingers for selection to trip over.
+                if self.pairs.get(&pair).is_some_and(PairState::is_settled) {
+                    if self.primary == Some(pair) {
+                        self.pairs.get_mut(&pair).unwrap().keep_fresh(now);
+                    } else {
+                        self.pairs.get_mut(&pair).unwrap().retire();
+                    }
                 }
             }
         }
@@ -996,7 +1010,7 @@ impl PathAgent {
             return;
         }
 
-        let has_primary = self.primary.is_some();
+        let primary = self.primary;
         let pending = &mut self.pending_transmits;
 
         for ((local, remote), state) in self.pairs.iter_mut() {
@@ -1008,11 +1022,13 @@ impl PathAgent {
                 continue;
             }
 
-            // Once we have a path, stop probing a pair that won't settle
-            // (e.g. a direct pair behind a symmetric NAT); while we have none,
-            // keep hunting until WireGuard retires the connection.
-            if has_primary && state.gave_up(now) {
-                state.probes.stop();
+            // Once we have a path, stop probing a non-primary pair that won't
+            // settle (e.g. a direct pair behind a symmetric NAT). The primary
+            // is exempt — probe loss must never retire it — and while we have
+            // no path at all we hunt every pair until WireGuard gives up.
+            let is_primary = primary == Some((*local, *remote));
+            if primary.is_some() && !is_primary && state.gave_up(now) {
+                state.retire();
                 continue;
             }
 
@@ -1060,24 +1076,19 @@ impl PathAgent {
         }
     }
 
-    /// WireGuard signalled that the current path is suspect: the bucket veto
-    /// lifts so we can fail over to a worse bucket (e.g. direct to relayed)
-    /// and a stale primary stops being defended, so a fresh pair can take
-    /// over. A primary that is still answering probes keeps its same-bucket
-    /// hysteresis, so two live pairs don't flap.
-    fn suspend_guard(&mut self, now: Instant) {
-        self.guard_suspended_until = Some(now + GUARD_SUSPENSION);
-    }
-
-    fn guard_active(&self, now: Instant) -> bool {
-        self.guard_suspended_until.is_none_or(|until| now >= until)
-    }
-
     fn select_primary(&mut self, now: Instant) {
+        // Only pairs with an RTT are candidates. Every RTT we hold is current
+        // by construction — the primary is kept fresh on its keepalive cadence,
+        // an actively-probing pair is measuring right now, and a settled loser
+        // or a re-probed pair has its RTT cleared — so there is no stale
+        // measurement to filter out. Selection is bucket-dominant, so a live
+        // primary naturally wins over any worse-bucket challenger; a *dead*
+        // primary has no RTT (a distress or candidate signal cleared it by
+        // re-probing) and drops out, letting a fresh pair take over.
         let best = self
             .pairs
             .iter()
-            .filter(|(_, s)| s.rtt.is_some_and(|rtt| rtt.is_fresh(now)))
+            .filter(|(_, s)| s.rtt.is_some())
             .min_by_key(|(k, s)| pair_score(**k, s))
             .map(|(k, _)| *k);
 
@@ -1087,31 +1098,27 @@ impl PathAgent {
             return;
         }
 
-        // The current primary keeps its place unless a challenger clearly
-        // wins.
+        // The current primary keeps its place unless a challenger clearly wins.
+        // A worse bucket never displaces it — even a primary without a fresh
+        // RTT holds by candidate kind, so a fresh worse-bucket pair can't steal
+        // it while it is being re-measured. Failing over to a *worse* bucket
+        // happens only after WireGuard distress, which drops the primary
+        // pointer entirely (there is then no primary to protect).
         if let Some(primary) = self.primary
             && let Some(prev) = self.pairs.get(&primary)
         {
             let new_score = pair_score(new, &self.pairs[&new]);
             let prev_score = pair_score(primary, prev);
 
-            // A worse bucket only displaces the primary while WireGuard
-            // signalled distress; otherwise probe results alone must never
-            // demote a working path (a busy node drops probes while its data
-            // flows just fine).
-            if prev_score.bucket < new_score.bucket && self.guard_active(now) {
+            if prev_score.bucket < new_score.bucket {
                 return;
             }
 
-            // Same bucket: keep the primary unless the challenger beats its
-            // RTT by a clear margin — no needless hop for a marginal gain,
-            // distress or not. While the guard holds this protects even a
-            // momentarily-stale primary; under distress we only defend one
-            // that is still answering, so a dead primary yields to a fresh
-            // same-bucket pair.
+            // Same bucket: keep the primary unless the challenger beats its RTT
+            // by a clear margin — no needless hop for a marginal gain, and no
+            // flap between two live same-bucket pairs on jitter.
             if prev_score.bucket == new_score.bucket
                 && let Some(prev_rtt) = prev.rtt
-                && (self.guard_active(now) || prev_rtt.is_fresh(now))
             {
                 let new_rtt = new_score.rtt.unwrap_or_default();
                 let margin = PRIMARY_HYSTERESIS_FLOOR
@@ -1131,8 +1138,22 @@ impl PathAgent {
 
         self.primary = Some(path);
 
-        // Every pair probes at the steady cadence regardless of which is
-        // primary, so there is no per-pair cadence to arm or retire here.
+        // The old primary is now a loser: drop its data so nothing stale
+        // lingers (a later signal re-probes it if it becomes relevant again).
+        if let Some(old) = from
+            && old != path
+            && let Some(state) = self.pairs.get_mut(&old)
+        {
+            state.retire();
+        }
+
+        // A new primary that has already settled moves to the keepalive cadence
+        // to stay fresh; one still hunting keeps bursting until it settles.
+        if let Some(state) = self.pairs.get_mut(&path)
+            && state.is_settled()
+        {
+            state.keep_fresh(now);
+        }
 
         tracing::debug!(
             ?from,

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -1,10 +1,3 @@
-//! Implementation of the path-selection model; see the crate-level docs for
-//! how the pieces fit together.
-//!
-//! Handshakes are path-dumb: the response is sent on the path the init arrived
-//! on, and a handshake only ever *nominates* a path when we don't have one.
-//! Everything else is probes.
-
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
 use std::net::SocketAddr;

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -45,9 +45,6 @@ pub struct PathAgent {
     pairs: BTreeMap<(SocketAddr, SocketAddr), PairState>,
     primary: Option<(SocketAddr, SocketAddr)>,
 
-    /// `true` once the first handshake has been taken over — later
-    /// inits are re-keys.
-    established: bool,
     /// `true` once a handshake has been accepted from the peer. Probes ride
     /// the session, so they wait for this; it survives a [`Self::rebuild`]
     /// because the session does, too.
@@ -86,8 +83,8 @@ pub(crate) struct PairState {
     /// Probes awaiting their reply. Several can be outstanding on a
     /// high-RTT path because the burst fires faster than one round trip.
     inflight_probes: Vec<InflightProbe>,
-    /// Index into [`PROBE_BURST_GAPS`]; past the end means the burst is done.
-    burst_step: usize,
+    /// The remaining probe times of the current burst.
+    burst: std::vec::IntoIter<Instant>,
     next_probe_at: Option<Instant>,
     next_probe_seq: u16,
 }
@@ -144,10 +141,6 @@ pub const PROBE_BURST_GAPS: &[Duration] = &[
     Duration::from_millis(1000),
 ];
 
-/// Stagger between pair burst starts so a burst over many pairs doesn't hit
-/// NAT rate limits or congest itself (cf. ICE's pacing timer `Ta`).
-pub const PROBE_PACING: Duration = Duration::from_millis(50);
-
 /// Inflight probes older than this are forgotten; a reply that late is not
 /// meaningful anymore.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -174,9 +167,15 @@ pub const RTT_FRESHNESS: Duration = Duration::from_secs(10);
 pub const GUARD_SUSPENSION: Duration = Duration::from_secs(10);
 
 /// An accepted inbound init this soon after the previous one means the peer
-/// keeps re-keying: it isn't hearing our responses or data. Routine re-keys
-/// are minutes apart.
-pub const REKEY_DISTRESS_INTERVAL: Duration = Duration::from_secs(30);
+/// keeps re-keying: it isn't hearing our responses or data.
+///
+/// The signal being detected is boringtun's `REKEY_TIMEOUT` retry pacing (a
+/// stuck peer formats a new init every 5s); a few multiples of that catches
+/// it reliably. Routine re-keys arrive at `REKEY_AFTER_TIME` (120s) — using
+/// that as the threshold would classify roughly every other routine re-key
+/// as distress (arrival jitter around exactly 120s) and re-introduce
+/// re-evaluation chatter on every re-key.
+pub const REKEY_DISTRESS_INTERVAL: Duration = Duration::from_secs(15);
 
 pub const RESPONDER_DEDUP_TTL: Duration = Duration::from_secs(10);
 
@@ -196,8 +195,20 @@ impl PairState {
     }
 
     fn start_burst(&mut self, at: Instant) {
-        self.burst_step = 0;
-        self.next_probe_at = Some(at);
+        let mut schedule = iter::once(at)
+            .chain(PROBE_BURST_GAPS.iter().scan(at, |t, gap| {
+                *t += *gap;
+                Some(*t)
+            }))
+            .collect::<Vec<_>>()
+            .into_iter();
+
+        self.next_probe_at = schedule.next();
+        self.burst = schedule;
+    }
+
+    fn is_bursting(&self) -> bool {
+        self.burst.len() > 0
     }
 }
 
@@ -214,7 +225,6 @@ impl PathAgent {
             remotes: Vec::new(),
             pairs: BTreeMap::new(),
             primary: None,
-            established: false,
             handshake_exchanged: false,
             guard_suspended_until: None,
             last_inbound_init_at: None,
@@ -236,8 +246,8 @@ impl PathAgent {
 
         self.locals.push(c);
 
-        for (i, &remote) in self.remotes.clone().iter().enumerate() {
-            self.add_pair(c, remote, now + PROBE_PACING * i as u32);
+        for &remote in &self.remotes.clone() {
+            self.add_pair(c, remote, now);
         }
 
         true
@@ -282,8 +292,8 @@ impl PathAgent {
 
         self.remotes.push(c);
 
-        for (i, &local) in self.locals.clone().iter().enumerate() {
-            self.add_pair(local, c, now + PROBE_PACING * i as u32);
+        for &local in &self.locals.clone() {
+            self.add_pair(local, c, now);
         }
 
         // Candidate arrival hints that the incumbent may be dead: the most
@@ -316,7 +326,7 @@ impl PathAgent {
             local_family_matched: local.is_family_matched(),
             rtt: None,
             inflight_probes: Vec::new(),
-            burst_step: 0,
+            burst: Vec::new().into_iter(),
             next_probe_at: None,
             next_probe_seq: 0,
         };
@@ -387,13 +397,11 @@ impl PathAgent {
             .filter(|c| !drop_local(c))
             .collect();
         let remotes = std::mem::take(&mut self.remotes);
-        let established = self.established;
         let handshake_exchanged = self.handshake_exchanged;
         let last_inbound_init_at = self.last_inbound_init_at;
 
         *self = Self::new();
 
-        self.established = established;
         self.handshake_exchanged = handshake_exchanged;
         self.last_inbound_init_at = last_inbound_init_at;
 
@@ -448,11 +456,12 @@ impl PathAgent {
             &mut self.outbound_init,
             self.primary,
         ) {
-            (Ok(Packet::HandshakeInit(_)), outbound_init, _) if !self.established => {
+            (Ok(Packet::HandshakeInit(_)), outbound_init @ None, _)
+                if !self.handshake_exchanged =>
+            {
                 tracing::debug!(bytes = bytes.len(), "Buffered initial HandshakeInit");
 
                 self.forwarded_response = None;
-                self.established = true;
                 outbound_init.replace(OutboundInit::new(bytes, now));
             }
             // A still-stored init means the previous one went unanswered:
@@ -517,7 +526,6 @@ impl PathAgent {
                         response_bytes: bytes,
                         cached_at: now,
                     });
-                    self.established = true;
                 }
             }
             // Probes and data ride the primary; nothing to send without one.
@@ -545,64 +553,34 @@ impl PathAgent {
             return ControlFlow::Continue(bytes);
         };
 
-        match parsed {
-            Packet::HandshakeInit(_) => {
-                if let Some(d) = self.responder.dedup.as_ref()
-                    && now.duration_since(d.cached_at) < RESPONDER_DEDUP_TTL
-                    && d.init_bytes == bytes
-                {
-                    tracing::trace!(local = %path.0, remote = %path.1, "Replaying cached HandshakeResponse");
+        match (parsed, self.primary) {
+            // A replayed init is served from the cache without touching boringtun.
+            (Packet::HandshakeInit(_), _) if self.cached_response(bytes, now).is_some() => {
+                tracing::trace!(local = %path.0, remote = %path.1, "Replaying cached HandshakeResponse");
 
-                    self.pending_transmits.push_back(Transmit {
-                        local: path.0,
-                        remote: path.1,
-                        payload: Payload::Ciphertext(d.response_bytes.clone()),
-                    });
+                let response_bytes = self
+                    .cached_response(bytes, now)
+                    .expect("checked in the guard")
+                    .to_vec();
+                self.pending_transmits.push_back(Transmit {
+                    local: path.0,
+                    remote: path.1,
+                    payload: Payload::Ciphertext(response_bytes),
+                });
 
+                ControlFlow::Break(())
+            }
+            // Drop dups arriving on multiple pairs in one tick so
+            // boringtun doesn't reject as WrongTai64nTimestamp.
+            (Packet::HandshakeInit(_), _) if self.responder.last_init.as_deref() == Some(bytes) => {
+                tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate inbound HandshakeInit");
+
+                ControlFlow::Break(())
+            }
+            (Packet::HandshakeInit(_), primary) => {
+                let Some(outbound) = self.decapsulate_init(tunnel, bytes, path, now) else {
                     return ControlFlow::Break(());
-                }
-
-                // Drop dups arriving on multiple pairs in one tick so
-                // boringtun doesn't reject as WrongTai64nTimestamp.
-                if self.responder.last_init.as_deref() == Some(bytes) {
-                    tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate inbound HandshakeInit");
-
-                    return ControlFlow::Break(());
-                }
-
-                // Source IP must be set so boringtun can emit cookie replies under load.
-                let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
-                let outbound = match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now)
-                {
-                    TunnResult::Done => Vec::new(),
-                    TunnResult::WriteToNetwork(response) => vec![response.to_vec()],
-                    TunnResult::Err(e) => {
-                        tracing::debug!(local = %path.0, remote = %path.1, error = ?e, "Inbound HandshakeInit rejected");
-                        return ControlFlow::Break(());
-                    }
-                    TunnResult::WriteToTunnelV4(_, _) | TunnResult::WriteToTunnelV6(_, _) => {
-                        tracing::warn!(local = %path.0, remote = %path.1, "Unexpected data packet from HandshakeInit");
-                        return ControlFlow::Break(());
-                    }
                 };
-
-                // Cookie replies don't establish a session; return them without touching state.
-                if let Some(reply) = outbound.first()
-                    && matches!(
-                        Tunn::parse_incoming_packet(reply),
-                        Ok(Packet::PacketCookieReply(_))
-                    )
-                {
-                    tracing::debug!(local = %path.0, remote = %path.1, "Replying with cookie under load");
-
-                    self.pending_transmits.push_back(Transmit {
-                        local: path.0,
-                        remote: path.1,
-                        payload: Payload::Ciphertext(reply.clone()),
-                    });
-
-                    return ControlFlow::Break(());
-                }
 
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeInit accepted");
 
@@ -630,7 +608,7 @@ impl PathAgent {
                     self.select_primary(now);
                 }
 
-                if self.primary.is_none() {
+                if primary.is_none() {
                     self.set_primary(path, now);
                 }
 
@@ -640,45 +618,25 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
-            Packet::HandshakeResponse(_) => {
-                if self.forwarded_response.as_deref() == Some(bytes) {
-                    tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate HandshakeResponse");
+            (Packet::HandshakeResponse(_), _)
+                if self.forwarded_response.as_deref() == Some(bytes) =>
+            {
+                tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate HandshakeResponse");
 
+                ControlFlow::Break(())
+            }
+            (Packet::HandshakeResponse(_), primary) => {
+                let Some(outbound) = self.decapsulate_response(tunnel, bytes, path, now) else {
                     return ControlFlow::Break(());
-                }
-
-                let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
-                let mut outbound = Vec::<Vec<u8>>::new();
-                match tunnel.decapsulate_at(None, bytes, &mut buf, now) {
-                    TunnResult::Done => {}
-                    TunnResult::WriteToNetwork(first) => {
-                        outbound.push(first.to_vec());
-                        while let TunnResult::WriteToNetwork(more) =
-                            tunnel.decapsulate_at(None, &[], &mut buf, now)
-                        {
-                            outbound.push(more.to_vec());
-                        }
-                    }
-                    TunnResult::Err(e) => {
-                        tracing::debug!(local = %path.0, remote = %path.1, error = ?e, "Inbound HandshakeResponse rejected");
-                        return ControlFlow::Break(());
-                    }
-                    TunnResult::WriteToTunnelV4(_, _) | TunnResult::WriteToTunnelV6(_, _) => {
-                        tracing::warn!(local = %path.0, remote = %path.1, "Unexpected data packet from HandshakeResponse");
-                        return ControlFlow::Break(());
-                    }
-                }
+                };
 
                 tracing::debug!(local = %path.0, remote = %path.1, "Inbound HandshakeResponse accepted");
 
                 self.outbound_init = None;
                 self.forwarded_response = Some(bytes.to_vec());
-                // A response only authenticates if we initiated: the first
-                // handshake is done, later inits are re-keys.
-                self.established = true;
                 self.handshake_exchanged = true;
 
-                if self.primary.is_none() {
+                if primary.is_none() {
                     self.set_primary(path, now);
                 }
 
@@ -688,8 +646,98 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
-            Packet::PacketCookieReply(_) | Packet::PacketData(_) => ControlFlow::Continue(bytes),
+            (Packet::PacketCookieReply(_) | Packet::PacketData(_), _) => {
+                ControlFlow::Continue(bytes)
+            }
         }
+    }
+
+    fn cached_response(&self, init: &[u8], now: Instant) -> Option<&[u8]> {
+        let d = self.responder.dedup.as_ref()?;
+
+        (now.duration_since(d.cached_at) < RESPONDER_DEDUP_TTL && d.init_bytes == init)
+            .then_some(d.response_bytes.as_slice())
+    }
+
+    /// Authenticates an inbound init, returning the packets boringtun wants
+    /// to send in response. `None` means the packet was fully handled
+    /// (rejected, or answered with a cookie under load).
+    fn decapsulate_init(
+        &mut self,
+        tunnel: &mut Tunn,
+        bytes: &[u8],
+        path: (SocketAddr, SocketAddr),
+        now: Instant,
+    ) -> Option<Vec<Vec<u8>>> {
+        // Source IP must be set so boringtun can emit cookie replies under load.
+        let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
+        let outbound = match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now) {
+            TunnResult::Done => Vec::new(),
+            TunnResult::WriteToNetwork(response) => vec![response.to_vec()],
+            TunnResult::Err(e) => {
+                tracing::debug!(local = %path.0, remote = %path.1, error = ?e, "Inbound HandshakeInit rejected");
+                return None;
+            }
+            TunnResult::WriteToTunnelV4(_, _) | TunnResult::WriteToTunnelV6(_, _) => {
+                tracing::warn!(local = %path.0, remote = %path.1, "Unexpected data packet from HandshakeInit");
+                return None;
+            }
+        };
+
+        // Cookie replies don't establish a session; return them without touching state.
+        if let Some(reply) = outbound.first()
+            && matches!(
+                Tunn::parse_incoming_packet(reply),
+                Ok(Packet::PacketCookieReply(_))
+            )
+        {
+            tracing::debug!(local = %path.0, remote = %path.1, "Replying with cookie under load");
+
+            self.pending_transmits.push_back(Transmit {
+                local: path.0,
+                remote: path.1,
+                payload: Payload::Ciphertext(reply.clone()),
+            });
+
+            return None;
+        }
+
+        Some(outbound)
+    }
+
+    /// Authenticates an inbound response, returning the packets boringtun
+    /// wants to send afterwards (e.g. queued data). `None` means the packet
+    /// was rejected.
+    fn decapsulate_response(
+        &mut self,
+        tunnel: &mut Tunn,
+        bytes: &[u8],
+        path: (SocketAddr, SocketAddr),
+        now: Instant,
+    ) -> Option<Vec<Vec<u8>>> {
+        let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
+        let mut outbound = Vec::<Vec<u8>>::new();
+        match tunnel.decapsulate_at(None, bytes, &mut buf, now) {
+            TunnResult::Done => {}
+            TunnResult::WriteToNetwork(first) => {
+                outbound.push(first.to_vec());
+                while let TunnResult::WriteToNetwork(more) =
+                    tunnel.decapsulate_at(None, &[], &mut buf, now)
+                {
+                    outbound.push(more.to_vec());
+                }
+            }
+            TunnResult::Err(e) => {
+                tracing::debug!(local = %path.0, remote = %path.1, error = ?e, "Inbound HandshakeResponse rejected");
+                return None;
+            }
+            TunnResult::WriteToTunnelV4(_, _) | TunnResult::WriteToTunnelV6(_, _) => {
+                tracing::warn!(local = %path.0, remote = %path.1, "Unexpected data packet from HandshakeResponse");
+                return None;
+            }
+        }
+
+        Some(outbound)
     }
 
     pub fn poll_transmit(&mut self) -> Option<Transmit> {
@@ -733,8 +781,12 @@ impl PathAgent {
                 // Triggered check (cf. RFC 8445, section 7.3.1.4): the
                 // inbound probe proves the reverse NAT filter is open right
                 // now, so probing back completes the hole punch in one round
-                // trip.
-                if let Some(state) = self.pairs.get_mut(&pair) {
+                // trip. Only for unvalidated pairs — probing back
+                // unconditionally would ping-pong bursts between the peers
+                // forever, at RTT cadence.
+                if let Some(state) = self.pairs.get_mut(&pair)
+                    && !state.rtt.is_some_and(|rtt| rtt.is_fresh(now))
+                {
                     state.start_burst(now);
                 }
             }
@@ -902,20 +954,12 @@ impl PathAgent {
             state
                 .inflight_probes
                 .push(InflightProbe { seq, sent_at: now });
-            state.next_probe_at = match PROBE_BURST_GAPS.get(state.burst_step) {
-                Some(gap) => {
-                    state.burst_step += 1;
-                    Some(now + *gap)
-                }
-                // The burst is done: the primary keeps its RTT fresh and its
-                // NAT mappings warm, everything else goes dormant until the
-                // next re-evaluation signal.
-                None => {
-                    state.burst_step = PROBE_BURST_GAPS.len() + 1;
-
-                    (primary == Some((*local, *remote))).then(|| now + PROBE_INTERVAL_LIVE)
-                }
-            };
+            // Once the burst is done, the primary keeps its RTT fresh and
+            // its NAT mappings warm, everything else goes dormant until the
+            // next re-evaluation signal.
+            state.next_probe_at = state.burst.next().or_else(|| {
+                (primary == Some((*local, *remote))).then(|| now + PROBE_INTERVAL_LIVE)
+            });
 
             tracing::trace!(%local, %remote, seq, "Probe send");
 
@@ -928,8 +972,8 @@ impl PathAgent {
     }
 
     fn burst_all_pairs(&mut self, now: Instant) {
-        for (i, state) in self.pairs.values_mut().enumerate() {
-            state.start_burst(now + PROBE_PACING * i as u32);
+        for state in self.pairs.values_mut() {
+            state.start_burst(now);
         }
     }
 
@@ -1026,7 +1070,7 @@ impl PathAgent {
         if let Some(old) = from
             && old != path
             && let Some(state) = self.pairs.get_mut(&old)
-            && state.burst_step > PROBE_BURST_GAPS.len()
+            && !state.is_bursting()
         {
             state.next_probe_at = None;
         }

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -57,7 +57,9 @@ pub(crate) struct PairState {
     pub(crate) local_family_matched: bool,
     pub(crate) rtt: Option<Rtt>,
     /// Probes awaiting a reply. Several can be outstanding on a high-RTT path
-    /// because the burst fires faster than one round trip.
+    /// because the burst fires faster than one round trip. Bounded to
+    /// [`PROBE_BUDGET`] (oldest dropped first) so a pathless pair probing forever
+    /// without replies can't grow it without bound.
     inflight: Vec<InflightProbe>,
     probes: Probes,
     /// Probes fired since the last (re)start. Past [`PROBE_BUDGET`] the pair
@@ -245,8 +247,11 @@ impl PathAgent {
 
     pub fn add_remote_candidate(&mut self, c: Candidate, now: Instant) {
         // Promote a previously-registered peer-reflexive in place so the
-        // existing `PairState` (RTT, inflight, schedule) survives.
-        if self.peer_reflexive_addrs.remove(&c.addr())
+        // existing `PairState` (RTT, inflight, schedule) survives. Only consume
+        // the marker once we actually promote: at registration time the srflx
+        // candidate is not in `remotes` yet, so `find` is `None` and we must
+        // leave the marker for the later signaled candidate.
+        if self.peer_reflexive_addrs.contains(&c.addr())
             && let Some(existing) = self.remotes.iter_mut().find(|x| x.addr() == c.addr())
         {
             tracing::debug!(
@@ -254,6 +259,7 @@ impl PathAgent {
                 kind = ?c.kind(),
                 "Promoting peer-reflexive remote to signaled candidate",
             );
+            self.peer_reflexive_addrs.remove(&c.addr());
             *existing = c;
             for ((_, remote_addr), state) in self.pairs.iter_mut() {
                 if *remote_addr == c.addr() {
@@ -907,6 +913,12 @@ impl PathAgent {
             let seq = state.next_seq;
             state.next_seq = state.next_seq.wrapping_add(1);
             state.inflight.push(InflightProbe { seq, sent_at: now });
+            // A pathless pair hunts forever; without a reply to drain them, cap
+            // the outstanding set at one budget's worth by forgetting the oldest.
+            // A reply that late no longer matters for path selection.
+            if state.inflight.len() > PROBE_BUDGET as usize {
+                state.inflight.remove(0);
+            }
             state.probes_sent = state.probes_sent.saturating_add(1);
 
             tracing::trace!(%local, %remote, seq, "Probe send");
@@ -1069,5 +1081,57 @@ impl PathAgent {
     fn queue_event(&mut self, event: Event, now: Instant) {
         self.events.push_back(event);
         self.events_queued_at = self.events_queued_at.or(Some(now));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CandidateKind;
+
+    #[test]
+    fn inflight_probes_stay_capped_while_hunting_forever() {
+        let mut a = PathAgent {
+            has_session: true,
+            ..Default::default()
+        };
+
+        let pair: (SocketAddr, SocketAddr) = (
+            "127.0.0.1:1".parse().unwrap(),
+            "127.0.0.1:2".parse().unwrap(),
+        );
+        let t0 = Instant::now();
+        let mut state = PairState {
+            kinds: (CandidateKind::Host, CandidateKind::Host),
+            local_family_matched: true,
+            rtt: None,
+            inflight: Vec::new(),
+            probes: Probes::default(),
+            probes_sent: 0,
+            id: 0,
+            next_seq: 0,
+        };
+        state.restart(t0);
+        a.pairs.insert(pair, state);
+
+        // No primary, so the pair hunts forever. Drive many probe rounds without
+        // ever replying, which would otherwise let `inflight` grow unbounded.
+        let mut now = t0;
+        for _ in 0..100 {
+            a.handle_timeout(now);
+            a.pending_transmits.clear();
+            now += PROBE_INTERVAL;
+        }
+
+        assert!(a.primary.is_none());
+        assert!(
+            a.pairs[&pair].probes_sent > PROBE_BUDGET * 2,
+            "the pair kept probing past its budget while pathless",
+        );
+        assert!(
+            a.pairs[&pair].inflight.len() <= PROBE_BUDGET as usize,
+            "inflight probes must stay bounded when hunting forever, got {}",
+            a.pairs[&pair].inflight.len(),
+        );
     }
 }

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -674,12 +674,12 @@ impl PathAgent {
     ) -> Option<Vec<Vec<u8>>> {
         let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
         let mut outbound = Vec::<Vec<u8>>::new();
-        match tunnel.decapsulate_at(None, bytes, &mut buf, now) {
+        match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now) {
             TunnResult::Done => {}
             TunnResult::WriteToNetwork(first) => {
                 outbound.push(first.to_vec());
                 while let TunnResult::WriteToNetwork(more) =
-                    tunnel.decapsulate_at(None, &[], &mut buf, now)
+                    tunnel.decapsulate_at(Some(path.1.ip()), &[], &mut buf, now)
                 {
                     outbound.push(more.to_vec());
                 }

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -48,18 +48,19 @@ pub struct PathAgent {
     /// `true` once a handshake has been accepted from the peer. Probes ride
     /// the session, so they wait for this; it survives a [`Self::rebuild`]
     /// because the session does, too.
-    handshake_exchanged: bool,
+    established: bool,
 
-    /// While set (and in the future), the primary loses its selection guard
-    /// (bucket veto + hysteresis): WireGuard signalled that the path is
-    /// suspect, so the best *fresh* pair wins outright.
+    /// While set (and in the future), WireGuard signalled that the current
+    /// path is suspect: the bucket veto lifts so we can fail over to a worse
+    /// bucket (e.g. direct to relayed). The same-bucket RTT hysteresis still
+    /// protects a primary that is answering probes.
     guard_suspended_until: Option<Instant>,
-    /// Arrival time of the last accepted inbound init, for distress detection.
-    last_inbound_init_at: Option<Instant>,
 
     responder: Responder,
 
     outbound_init: Option<OutboundInit>,
+    /// Arrival time of the last accepted inbound init, for distress detection.
+    last_inbound_init_at: Option<Instant>,
     forwarded_response: Option<Vec<u8>>,
 
     pending_transmits: VecDeque<Transmit>,
@@ -83,10 +84,66 @@ pub(crate) struct PairState {
     /// Probes awaiting their reply. Several can be outstanding on a
     /// high-RTT path because the burst fires faster than one round trip.
     inflight_probes: Vec<InflightProbe>,
-    /// The remaining probe times of the current burst.
-    burst: std::vec::IntoIter<Instant>,
-    next_probe_at: Option<Instant>,
+    probes: Probes,
     next_probe_seq: u16,
+}
+
+/// A pair's probe schedule: a front-loaded burst, optionally followed by the
+/// live cadence once the pair becomes the primary.
+struct Probes {
+    /// Remaining probe times of the current burst, earliest first.
+    burst: std::vec::IntoIter<Instant>,
+    /// Next live-cadence probe. Set only for the primary once its burst is done.
+    live: Option<Instant>,
+}
+
+impl Default for Probes {
+    fn default() -> Self {
+        Self {
+            burst: Vec::new().into_iter(),
+            live: None,
+        }
+    }
+}
+
+impl Probes {
+    /// (Re)starts the front-loaded burst at `at`.
+    fn start(&mut self, at: Instant) {
+        self.burst = iter::once(at)
+            .chain(PROBE_BURST_GAPS.iter().scan(at, |t, gap| {
+                *t += *gap;
+                Some(*t)
+            }))
+            .collect::<Vec<_>>()
+            .into_iter();
+    }
+
+    /// The next scheduled probe, if any.
+    fn due(&self) -> Option<Instant> {
+        self.burst.as_slice().first().copied().or(self.live)
+    }
+
+    /// Records that the due probe fired at `now` and schedules the next one.
+    /// `keep_live` requests the live cadence once the burst is exhausted.
+    fn fire(&mut self, now: Instant, keep_live: bool) {
+        self.burst.next();
+
+        if self.burst.as_slice().is_empty() {
+            self.live = keep_live.then(|| now + PROBE_INTERVAL_LIVE);
+        }
+    }
+
+    fn in_burst(&self) -> bool {
+        !self.burst.as_slice().is_empty()
+    }
+
+    fn arm_live(&mut self, at: Instant) {
+        self.live = Some(at);
+    }
+
+    fn disarm_live(&mut self) {
+        self.live = None;
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -193,23 +250,6 @@ impl PairState {
         matches!(self.kinds.0, crate::CandidateKind::Relayed)
             || matches!(self.kinds.1, crate::CandidateKind::Relayed)
     }
-
-    fn start_burst(&mut self, at: Instant) {
-        let mut schedule = iter::once(at)
-            .chain(PROBE_BURST_GAPS.iter().scan(at, |t, gap| {
-                *t += *gap;
-                Some(*t)
-            }))
-            .collect::<Vec<_>>()
-            .into_iter();
-
-        self.next_probe_at = schedule.next();
-        self.burst = schedule;
-    }
-
-    fn is_bursting(&self) -> bool {
-        self.burst.len() > 0
-    }
 }
 
 impl Default for PathAgent {
@@ -225,11 +265,11 @@ impl PathAgent {
             remotes: Vec::new(),
             pairs: BTreeMap::new(),
             primary: None,
-            handshake_exchanged: false,
+            established: false,
             guard_suspended_until: None,
-            last_inbound_init_at: None,
             responder: Responder::default(),
             outbound_init: None,
+            last_inbound_init_at: None,
             forwarded_response: None,
             pending_transmits: VecDeque::new(),
             events: VecDeque::new(),
@@ -296,15 +336,15 @@ impl PathAgent {
             self.add_pair(local, c, now);
         }
 
-        // Candidate arrival hints that the incumbent may be dead: the most
-        // common reason for new candidates mid-session is that the peer
+        // Candidate arrival hints that the current primary may be dead: the
+        // most common reason for new candidates mid-session is that the peer
         // roamed away from the address our primary points at. Re-probe the
-        // primary and let selection run unguarded — if the primary is alive,
-        // its burst reply keeps it winning the scan; if it is dead, a fresh
-        // pair takes over without waiting for WireGuard's escalation.
+        // primary and lift the bucket veto — if the primary is alive, its
+        // reply keeps it winning the scan; if it is dead, a fresh pair takes
+        // over without waiting for WireGuard's escalation.
         if let Some(primary) = self.primary {
             if let Some(state) = self.pairs.get_mut(&primary) {
-                state.start_burst(now);
+                state.probes.start(now);
             }
 
             self.suspend_guard(now);
@@ -326,11 +366,10 @@ impl PathAgent {
             local_family_matched: local.is_family_matched(),
             rtt: None,
             inflight_probes: Vec::new(),
-            burst: Vec::new().into_iter(),
-            next_probe_at: None,
+            probes: Probes::default(),
             next_probe_seq: 0,
         };
-        state.start_burst(burst_at);
+        state.probes.start(burst_at);
 
         self.pairs.insert(pair, state);
     }
@@ -347,7 +386,7 @@ impl PathAgent {
             && local == removed_local
         {
             self.primary = None;
-            self.burst_all_pairs(now);
+            self.probe_all_pairs(now);
         }
 
         true
@@ -366,7 +405,7 @@ impl PathAgent {
             && remote == removed_addr
         {
             self.primary = None;
-            self.burst_all_pairs(now);
+            self.probe_all_pairs(now);
         }
 
         true
@@ -397,12 +436,12 @@ impl PathAgent {
             .filter(|c| !drop_local(c))
             .collect();
         let remotes = std::mem::take(&mut self.remotes);
-        let handshake_exchanged = self.handshake_exchanged;
+        let established = self.established;
         let last_inbound_init_at = self.last_inbound_init_at;
 
         *self = Self::new();
 
-        self.handshake_exchanged = handshake_exchanged;
+        self.established = established;
         self.last_inbound_init_at = last_inbound_init_at;
 
         for local in locals {
@@ -456,9 +495,7 @@ impl PathAgent {
             &mut self.outbound_init,
             self.primary,
         ) {
-            (Ok(Packet::HandshakeInit(_)), outbound_init @ None, _)
-                if !self.handshake_exchanged =>
-            {
+            (Ok(Packet::HandshakeInit(_)), outbound_init @ None, _) if !self.established => {
                 tracing::debug!(bytes = bytes.len(), "Buffered initial HandshakeInit");
 
                 self.forwarded_response = None;
@@ -480,7 +517,7 @@ impl PathAgent {
                     payload: Payload::Ciphertext(bytes),
                 });
                 self.suspend_guard(now);
-                self.burst_all_pairs(now);
+                self.probe_all_pairs(now);
                 self.select_primary(now);
             }
             // A routine re-key rides the primary without restarting probes.
@@ -503,7 +540,7 @@ impl PathAgent {
                 );
 
                 outbound_init.replace(OutboundInit::new(bytes, now));
-                self.burst_all_pairs(now);
+                self.probe_all_pairs(now);
             }
             (Ok(Packet::HandshakeResponse(_)), _, _) => {
                 if let (Some(init_bytes), Some(path)) = (
@@ -554,14 +591,15 @@ impl PathAgent {
         };
 
         match (parsed, self.primary) {
+            // Replays and duplicates short-circuit before touching the session.
+            //
             // A replayed init is served from the cache without touching boringtun.
-            (Packet::HandshakeInit(_), _) if self.cached_response(bytes, now).is_some() => {
+            (Packet::HandshakeInit(_), _)
+                if let Some(response) = self.cached_response(bytes, now) =>
+            {
                 tracing::trace!(local = %path.0, remote = %path.1, "Replaying cached HandshakeResponse");
 
-                let response_bytes = self
-                    .cached_response(bytes, now)
-                    .expect("checked in the guard")
-                    .to_vec();
+                let response_bytes = response.to_vec();
                 self.pending_transmits.push_back(Transmit {
                     local: path.0,
                     remote: path.1,
@@ -577,6 +615,14 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
+            (Packet::HandshakeResponse(_), _)
+                if self.forwarded_response.as_deref() == Some(bytes) =>
+            {
+                tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate HandshakeResponse");
+
+                ControlFlow::Break(())
+            }
+            // Accepts: authenticate, then adopt or re-evaluate.
             (Packet::HandshakeInit(_), primary) => {
                 let Some(outbound) = self.decapsulate_init(tunnel, bytes, path, now) else {
                     return ControlFlow::Break(());
@@ -590,7 +636,7 @@ impl PathAgent {
                 self.responder.last_init_path = Some(path);
 
                 self.register_peer_reflexive(path, now);
-                self.handshake_exchanged = true;
+                self.established = true;
 
                 // Distinct inits minutes apart are routine re-keys; in quick
                 // succession they mean the peer isn't hearing our responses
@@ -604,7 +650,7 @@ impl PathAgent {
                     tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed early; re-evaluating paths");
 
                     self.suspend_guard(now);
-                    self.burst_all_pairs(now);
+                    self.probe_all_pairs(now);
                     self.select_primary(now);
                 }
 
@@ -618,13 +664,6 @@ impl PathAgent {
 
                 ControlFlow::Break(())
             }
-            (Packet::HandshakeResponse(_), _)
-                if self.forwarded_response.as_deref() == Some(bytes) =>
-            {
-                tracing::trace!(local = %path.0, remote = %path.1, "Dropped duplicate HandshakeResponse");
-
-                ControlFlow::Break(())
-            }
             (Packet::HandshakeResponse(_), primary) => {
                 let Some(outbound) = self.decapsulate_response(tunnel, bytes, path, now) else {
                     return ControlFlow::Break(());
@@ -634,7 +673,7 @@ impl PathAgent {
 
                 self.outbound_init = None;
                 self.forwarded_response = Some(bytes.to_vec());
-                self.handshake_exchanged = true;
+                self.established = true;
 
                 if primary.is_none() {
                     self.set_primary(path, now);
@@ -655,8 +694,15 @@ impl PathAgent {
     fn cached_response(&self, init: &[u8], now: Instant) -> Option<&[u8]> {
         let d = self.responder.dedup.as_ref()?;
 
-        (now.duration_since(d.cached_at) < RESPONDER_DEDUP_TTL && d.init_bytes == init)
-            .then_some(d.response_bytes.as_slice())
+        if now.duration_since(d.cached_at) >= RESPONDER_DEDUP_TTL {
+            return None;
+        }
+
+        if d.init_bytes != init {
+            return None;
+        }
+
+        Some(d.response_bytes.as_slice())
     }
 
     /// Authenticates an inbound init, returning the packets boringtun wants
@@ -787,7 +833,7 @@ impl PathAgent {
                 if let Some(state) = self.pairs.get_mut(&pair)
                     && !state.rtt.is_some_and(|rtt| rtt.is_fresh(now))
                 {
-                    state.start_burst(now);
+                    state.probes.start(now);
                 }
             }
             crate::icmpv6::Echo::Reply => {
@@ -824,8 +870,8 @@ impl PathAgent {
             .and_then(|i| i.retransmits.values().map(|r| r.next_fire_at).min());
         // Probes wait for the first handshake exchange; see `drive_probes`.
         let next_probe = self
-            .handshake_exchanged
-            .then(|| self.pairs.values().filter_map(|s| s.next_probe_at).min())
+            .established
+            .then(|| self.pairs.values().filter_map(|s| s.probes.due()).min())
             .flatten();
         // Wake immediately if a buffered init is waiting on a relay
         // pair that landed after the initial fanout. With a primary, the
@@ -928,7 +974,7 @@ impl PathAgent {
         // Probes ride the session (they are encapsulated); encapsulating
         // before the first handshake exchange would make boringtun queue
         // them and initiate handshakes on its own.
-        if !self.handshake_exchanged {
+        if !self.established {
             return;
         }
 
@@ -936,7 +982,7 @@ impl PathAgent {
         let pending = &mut self.pending_transmits;
 
         for ((local, remote), state) in self.pairs.iter_mut() {
-            let Some(deadline) = state.next_probe_at else {
+            let Some(deadline) = state.probes.due() else {
                 continue;
             };
 
@@ -954,12 +1000,10 @@ impl PathAgent {
             state
                 .inflight_probes
                 .push(InflightProbe { seq, sent_at: now });
-            // Once the burst is done, the primary keeps its RTT fresh and
-            // its NAT mappings warm, everything else goes dormant until the
-            // next re-evaluation signal.
-            state.next_probe_at = state.burst.next().or_else(|| {
-                (primary == Some((*local, *remote))).then(|| now + PROBE_INTERVAL_LIVE)
-            });
+            // Once the burst is done, the primary keeps its RTT fresh and its
+            // NAT mappings warm; everything else goes dormant until the next
+            // re-evaluation signal.
+            state.probes.fire(now, primary == Some((*local, *remote)));
 
             tracing::trace!(%local, %remote, seq, "Probe send");
 
@@ -971,9 +1015,9 @@ impl PathAgent {
         }
     }
 
-    fn burst_all_pairs(&mut self, now: Instant) {
+    fn probe_all_pairs(&mut self, now: Instant) {
         for state in self.pairs.values_mut() {
-            state.start_burst(now);
+            state.probes.start(now);
         }
     }
 
@@ -993,9 +1037,11 @@ impl PathAgent {
         }
     }
 
-    /// WireGuard signalled that the current path is suspect: selection runs
-    /// unguarded so the best fresh pair wins outright, allowing a fail-over
-    /// to a worse bucket (e.g. direct to relayed).
+    /// WireGuard signalled that the current path is suspect: the bucket veto
+    /// lifts so we can fail over to a worse bucket (e.g. direct to relayed)
+    /// and a stale primary stops being defended, so a fresh pair can take
+    /// over. A primary that is still answering probes keeps its same-bucket
+    /// hysteresis, so two live pairs don't flap.
     fn suspend_guard(&mut self, now: Instant) {
         self.guard_suspended_until = Some(now + GUARD_SUSPENSION);
     }
@@ -1018,24 +1064,31 @@ impl PathAgent {
             return;
         }
 
-        // The incumbent's guard: a worse bucket never displaces it and a
-        // same-bucket challenger must beat it by a clear margin. Only while
-        // WireGuard considers the path healthy — probe results alone must
-        // never demote a working primary (a busy node drops probes while its
-        // data flows just fine).
-        if self.guard_active(now)
-            && let Some(primary) = self.primary
+        // The current primary keeps its place unless a challenger clearly
+        // wins.
+        if let Some(primary) = self.primary
             && let Some(prev) = self.pairs.get(&primary)
         {
             let new_score = pair_score(new, &self.pairs[&new]);
             let prev_score = pair_score(primary, prev);
 
-            if prev_score.bucket < new_score.bucket {
+            // A worse bucket only displaces the primary while WireGuard
+            // signalled distress; otherwise probe results alone must never
+            // demote a working path (a busy node drops probes while its data
+            // flows just fine).
+            if prev_score.bucket < new_score.bucket && self.guard_active(now) {
                 return;
             }
 
+            // Same bucket: keep the primary unless the challenger beats its
+            // RTT by a clear margin — no needless hop for a marginal gain,
+            // distress or not. While the guard holds this protects even a
+            // momentarily-stale primary; under distress we only defend one
+            // that is still answering, so a dead primary yields to a fresh
+            // same-bucket pair.
             if prev_score.bucket == new_score.bucket
                 && let Some(prev_rtt) = prev.rtt
+                && (self.guard_active(now) || prev_rtt.is_fresh(now))
             {
                 let new_rtt = new_score.rtt.unwrap_or_default();
                 let margin = PRIMARY_HYSTERESIS_FLOOR
@@ -1047,17 +1100,7 @@ impl PathAgent {
             }
         }
 
-        let recovered = self.primary.is_none() && self.handshake_exchanged;
-
         self.set_primary(new, now);
-
-        // The remote can't observe us settling on a new path; the re-key is
-        // the authenticated "my situation changed" signal that reaches it on
-        // the recovered path. Silent switches between working paths don't
-        // re-key: sessions are path-agnostic.
-        if recovered {
-            self.queue_event(Event::PathRecovered, now);
-        }
     }
 
     fn set_primary(&mut self, path: (SocketAddr, SocketAddr), now: Instant) {
@@ -1070,16 +1113,17 @@ impl PathAgent {
         if let Some(old) = from
             && old != path
             && let Some(state) = self.pairs.get_mut(&old)
-            && !state.is_bursting()
+            && !state.probes.in_burst()
         {
-            state.next_probe_at = None;
+            state.probes.disarm_live();
         }
 
-        // Keep the new primary on the live cadence once its burst is done.
+        // Keep the new primary on the live cadence once it has nothing else
+        // scheduled.
         if let Some(state) = self.pairs.get_mut(&path)
-            && state.next_probe_at.is_none()
+            && state.probes.due().is_none()
         {
-            state.next_probe_at = Some(now + PROBE_INTERVAL_LIVE);
+            state.probes.arm_live(now + PROBE_INTERVAL_LIVE);
         }
 
         tracing::debug!(

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -923,20 +923,19 @@ impl PathAgent {
             // keep the fast burst-then-interval cadence.
             if primary.is_none() || state.probes_sent < PROBE_BUDGET {
                 state.probes.fire(now);
-            } else if primary == Some((*local, *remote)) {
-                // The primary keepalives; every other pair goes quiet.
-                state.probes.keepalive(now);
-            } else {
-                state.probes.stop();
+                continue;
             }
+
+            // The primary keepalives; every other pair goes quiet.
+            if primary == Some((*local, *remote)) {
+                state.probes.keepalive(now);
+                continue;
+            }
+
+            state.probes.stop();
         }
     }
 
-    /// Clears the primary and re-probes: WireGuard distress or a new candidate.
-    /// A pair mid-discovery-burst keeps its state so the burst isn't disturbed;
-    /// everything else restarts (fresh burst, cleared RTT). The former primary
-    /// always restarts — it is the suspect path and must re-earn its place, so a
-    /// still-valid one re-confirms within a round trip and a dead one drops out.
     fn clear_and_reprobe(&mut self, now: Instant) {
         let former = self.primary.take();
         // Before a session exists there is nothing to probe;
@@ -944,6 +943,7 @@ impl PathAgent {
         if !self.has_session {
             return;
         }
+
         for (pair, state) in self.pairs.iter_mut() {
             let discovering = state.probes.due().is_some() && state.probes_sent < PROBE_BUDGET;
             if Some(*pair) == former || !discovering {
@@ -968,10 +968,6 @@ impl PathAgent {
         }
     }
 
-    /// A session now exists (a handshake was accepted). This is the single place
-    /// probing begins — probes ride the session, so they can't run before it. It
-    /// runs on every accepted handshake, but the transition (and the probe
-    /// kick-off) only fires the first time, when the session first appears.
     fn on_session_established(&mut self, now: Instant) {
         if self.has_session {
             return;

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -1086,6 +1086,13 @@ impl PathAgent {
         let from = self.primary;
         self.primary = Some(path);
 
+        // Distress is measured per primary: a fresh one starts with a clean
+        // slate so a count that climbed on a previous (or no) primary — e.g.
+        // while pathless — can't leak in and trip `== REKEY_DISTRESS_ATTEMPTS`
+        // on the wrong path.
+        self.unanswered_rekeys = 0;
+        self.peer_rekeys = 0;
+
         tracing::debug!(?from, local = %path.0, remote = %path.1, "Iceless primary changed");
 
         self.queue_event(

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -1,3 +1,30 @@
+//! Probe-driven path selection.
+//!
+//! Each layer has exactly one job:
+//!
+//! - **WireGuard is the liveness authority.** Only its state machine kills a
+//!   connection ([`boringtun`]'s `ConnectionExpired`) and only its signals mark
+//!   a path as suspect: our own re-key going unanswered, or the peer re-keying
+//!   early (it evidently isn't hearing us).
+//! - **Probes discover and rank paths.** They open NAT filters, measure RTTs
+//!   and find better pairs. A probe result can only ever improve things; probe
+//!   loss never demotes or kills anything (a busy node drops probes while its
+//!   data flows just fine).
+//! - **Selection is local.** WireGuard encrypts to a key, not to an address,
+//!   so each side picks where *it* sends independently; paths may be
+//!   asymmetric and there are no roles and no nomination.
+//!
+//! Every pair probes in a short, front-loaded burst when it is created and
+//! whenever a re-evaluation signal fires: remote candidates arrived, an
+//! inbound probe proved the reverse filter is open (we immediately probe back,
+//! cf. "triggered checks" in ICE), or WireGuard signalled distress. The
+//! primary pair additionally probes at a slow live cadence to keep its RTT
+//! comparable and its NAT mappings warm.
+//!
+//! Handshakes are path-dumb: the response is sent on the path the init
+//! arrived on and a handshake only ever *nominates* a path when we don't
+//! have one. Everything else is probes.
+
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
 use std::net::SocketAddr;
@@ -21,8 +48,18 @@ pub struct PathAgent {
     /// `true` once the first handshake has been taken over — later
     /// inits are re-keys.
     established: bool,
+    /// `true` once a handshake has been accepted from the peer. Probes ride
+    /// the session, so they wait for this; it survives a [`Self::rebuild`]
+    /// because the session does, too.
+    handshake_exchanged: bool,
 
-    window: EvaluationWindow,
+    /// While set (and in the future), the primary loses its selection guard
+    /// (bucket veto + hysteresis): WireGuard signalled that the path is
+    /// suspect, so the best *fresh* pair wins outright.
+    guard_suspended_until: Option<Instant>,
+    /// Arrival time of the last accepted inbound init, for distress detection.
+    last_inbound_init_at: Option<Instant>,
+
     responder: Responder,
 
     outbound_init: Option<OutboundInit>,
@@ -35,29 +72,6 @@ pub struct PathAgent {
     peer_reflexive_addrs: BTreeSet<SocketAddr>,
 }
 
-enum EvaluationWindow {
-    Pending,
-    Open { until: Instant },
-    Settled,
-}
-
-impl EvaluationWindow {
-    fn deadline(&self) -> Option<Instant> {
-        match self {
-            Self::Open { until } => Some(*until),
-            Self::Pending | Self::Settled => None,
-        }
-    }
-
-    fn is_open(&self) -> bool {
-        matches!(self, Self::Open { .. })
-    }
-
-    fn is_settled(&self) -> bool {
-        matches!(self, Self::Settled)
-    }
-}
-
 #[derive(Default)]
 struct Responder {
     last_init: Option<Vec<u8>>,
@@ -68,11 +82,26 @@ struct Responder {
 pub(crate) struct PairState {
     pub(crate) kinds: (crate::CandidateKind, crate::CandidateKind),
     pub(crate) local_family_matched: bool,
-    pub(crate) smoothed_rtt: Option<Duration>,
-    inflight_probe: Option<InflightProbe>,
-    /// `None` until `drive_probes` lazy-seeds during the open window.
+    pub(crate) rtt: Option<Rtt>,
+    /// Probes awaiting their reply. Several can be outstanding on a
+    /// high-RTT path because the burst fires faster than one round trip.
+    inflight_probes: Vec<InflightProbe>,
+    /// Index into [`PROBE_BURST_GAPS`]; past the end means the burst is done.
+    burst_step: usize,
     next_probe_at: Option<Instant>,
     next_probe_seq: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Rtt {
+    pub(crate) smoothed: Duration,
+    measured_at: Instant,
+}
+
+impl Rtt {
+    fn is_fresh(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.measured_at) < RTT_FRESHNESS
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -84,8 +113,8 @@ struct InflightProbe {
 struct OutboundInit {
     bytes: Vec<u8>,
     retransmits: BTreeMap<(SocketAddr, SocketAddr), PairRetransmit>,
-    /// Reset when relay pairs arrive late so `EVALUATION_WINDOW`
-    /// doesn't count waiting time.
+    /// Reset when relay pairs arrive late so waiting time doesn't count
+    /// against the retransmit ladder.
     started_at: Instant,
 }
 
@@ -105,10 +134,49 @@ struct ResponderDedup {
     cached_at: Instant,
 }
 
-pub const PROBE_INTERVAL: Duration = Duration::from_millis(500);
+/// Gaps between the probes of one burst: front-loaded so a NAT filter opened
+/// by the peer's burst moments after our first probe is caught by the next
+/// one, then backing off. A burst is `PROBE_BURST_GAPS.len() + 1` probes.
+pub const PROBE_BURST_GAPS: &[Duration] = &[
+    Duration::from_millis(200),
+    Duration::from_millis(300),
+    Duration::from_millis(500),
+    Duration::from_millis(1000),
+];
+
+/// Stagger between pair burst starts so a burst over many pairs doesn't hit
+/// NAT rate limits or congest itself (cf. ICE's pacing timer `Ta`).
+pub const PROBE_PACING: Duration = Duration::from_millis(50);
+
+/// Inflight probes older than this are forgotten; a reply that late is not
+/// meaningful anymore.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Cadence at which the primary keeps probing after its burst: RTT freshness
+/// for comparisons against challengers and NAT keepalive, with no liveness
+/// semantics whatsoever.
 pub const PROBE_INTERVAL_LIVE: Duration = Duration::from_secs(25);
-pub const EVALUATION_WINDOW: Duration = Duration::from_secs(10);
+
+/// Only RTTs measured within this window are eligible in the selection scan.
+///
+/// The bound is wedged between two failure modes: shorter than one full burst
+/// and replies racing in from the same round stop comparing fairly ("last to
+/// answer" would win instead of "best score"); much longer and a ghost pair —
+/// a good bucket toward an address the peer roamed away from — displaces a
+/// freshly-validated primary on a meaningless measurement.
+pub const RTT_FRESHNESS: Duration = Duration::from_secs(10);
+
+/// How long the primary's selection guard stays suspended after a
+/// re-evaluation signal: long enough for the triggered burst's replies to
+/// arrive and be compared, short enough that hysteresis is back before RTT
+/// jitter can flap two live same-bucket pairs. Persistent distress keeps
+/// re-suspending (boringtun retries an unanswered re-key every few seconds).
+pub const GUARD_SUSPENSION: Duration = Duration::from_secs(10);
+
+/// An accepted inbound init this soon after the previous one means the peer
+/// keeps re-keying: it isn't hearing our responses or data. Routine re-keys
+/// are minutes apart.
+pub const REKEY_DISTRESS_INTERVAL: Duration = Duration::from_secs(30);
 
 pub const RESPONDER_DEDUP_TTL: Duration = Duration::from_secs(10);
 
@@ -126,6 +194,11 @@ impl PairState {
         matches!(self.kinds.0, crate::CandidateKind::Relayed)
             || matches!(self.kinds.1, crate::CandidateKind::Relayed)
     }
+
+    fn start_burst(&mut self, at: Instant) {
+        self.burst_step = 0;
+        self.next_probe_at = Some(at);
+    }
 }
 
 impl Default for PathAgent {
@@ -142,7 +215,9 @@ impl PathAgent {
             pairs: BTreeMap::new(),
             primary: None,
             established: false,
-            window: EvaluationWindow::Pending,
+            handshake_exchanged: false,
+            guard_suspended_until: None,
+            last_inbound_init_at: None,
             responder: Responder::default(),
             outbound_init: None,
             forwarded_response: None,
@@ -153,21 +228,16 @@ impl PathAgent {
         }
     }
 
-    fn queue_event(&mut self, event: Event, now: Instant) {
-        self.events.push_back(event);
-        self.events_queued_at = self.events_queued_at.or(Some(now));
-    }
-
     /// Returns whether the candidate was newly added (`false` if already known).
-    pub fn add_local_candidate(&mut self, c: Candidate) -> bool {
+    pub fn add_local_candidate(&mut self, c: Candidate, now: Instant) -> bool {
         if self.locals.contains(&c) {
             return false;
         }
 
         self.locals.push(c);
 
-        for &remote in &self.remotes.clone() {
-            self.add_pair(c, remote);
+        for (i, &remote) in self.remotes.clone().iter().enumerate() {
+            self.add_pair(c, remote, now + PROBE_PACING * i as u32);
         }
 
         true
@@ -212,12 +282,28 @@ impl PathAgent {
 
         self.remotes.push(c);
 
-        for &local in &self.locals.clone() {
-            self.add_pair(local, c);
+        for (i, &local) in self.locals.clone().iter().enumerate() {
+            self.add_pair(local, c, now + PROBE_PACING * i as u32);
+        }
+
+        // Candidate arrival hints that the incumbent may be dead: the most
+        // common reason for new candidates mid-session is that the peer
+        // roamed away from the address our primary points at. Re-probe the
+        // primary and let selection run unguarded — if the primary is alive,
+        // its burst reply keeps it winning the scan; if it is dead, a fresh
+        // pair takes over without waiting for WireGuard's escalation.
+        if let Some(primary) = self.primary {
+            if let Some(state) = self.pairs.get_mut(&primary) {
+                state.start_burst(now);
+            }
+
+            self.suspend_guard(now);
         }
     }
 
-    fn add_pair(&mut self, local: Candidate, remote: Candidate) {
+    /// Every new pair immediately probes in a burst, regardless of any other
+    /// state: candidates are the only signal about new paths we get.
+    fn add_pair(&mut self, local: Candidate, remote: Candidate, burst_at: Instant) {
         let pair = (local.local(), remote.addr());
 
         // Cross-family pairs are unusable.
@@ -225,17 +311,18 @@ impl PathAgent {
             return;
         }
 
-        self.pairs.insert(
-            pair,
-            PairState {
-                kinds: (local.kind(), remote.kind()),
-                local_family_matched: local.is_family_matched(),
-                smoothed_rtt: None,
-                inflight_probe: None,
-                next_probe_at: None,
-                next_probe_seq: 0,
-            },
-        );
+        let mut state = PairState {
+            kinds: (local.kind(), remote.kind()),
+            local_family_matched: local.is_family_matched(),
+            rtt: None,
+            inflight_probes: Vec::new(),
+            burst_step: 0,
+            next_probe_at: None,
+            next_probe_seq: 0,
+        };
+        state.start_burst(burst_at);
+
+        self.pairs.insert(pair, state);
     }
 
     pub fn remove_local_candidate(&mut self, c: &Candidate, now: Instant) -> bool {
@@ -250,7 +337,7 @@ impl PathAgent {
             && local == removed_local
         {
             self.primary = None;
-            self.reopen_evaluation_window(now);
+            self.burst_all_pairs(now);
         }
 
         true
@@ -269,7 +356,7 @@ impl PathAgent {
             && remote == removed_addr
         {
             self.primary = None;
-            self.reopen_evaluation_window(now);
+            self.burst_all_pairs(now);
         }
 
         true
@@ -289,6 +376,9 @@ impl PathAgent {
 
     /// Drops locals matching `drop_local` and rebuilds from scratch, preserving
     /// every remote. Re-seeds after a roam or relay replacement.
+    ///
+    /// The session survives a rebuild (the WireGuard key is kept), so probing
+    /// resumes as soon as pairs exist again — no handshake required.
     pub fn rebuild(&mut self, mut drop_local: impl FnMut(&Candidate) -> bool, now: Instant) {
         let locals: Vec<Candidate> = self
             .locals
@@ -297,11 +387,18 @@ impl PathAgent {
             .filter(|c| !drop_local(c))
             .collect();
         let remotes = std::mem::take(&mut self.remotes);
+        let established = self.established;
+        let handshake_exchanged = self.handshake_exchanged;
+        let last_inbound_init_at = self.last_inbound_init_at;
 
         *self = Self::new();
 
+        self.established = established;
+        self.handshake_exchanged = handshake_exchanged;
+        self.last_inbound_init_at = last_inbound_init_at;
+
         for local in locals {
-            self.add_local_candidate(local);
+            self.add_local_candidate(local, now);
         }
         for remote in remotes {
             self.add_remote_candidate(remote, now);
@@ -359,12 +456,12 @@ impl PathAgent {
                 outbound_init.replace(OutboundInit::new(bytes, now));
             }
             // A still-stored init means the previous one went unanswered:
-            // failure evidence. Retry on the incumbent while probes
-            // re-evaluate.
+            // WireGuard-level failure evidence. Retry on the incumbent while
+            // an unguarded re-evaluation runs.
             (Ok(Packet::HandshakeInit(_)), outbound_init @ Some(_), Some((local, remote))) => {
                 tracing::debug!(
                     bytes = bytes.len(),
-                    "Unanswered re-key HandshakeInit; restarting probes"
+                    "Unanswered re-key HandshakeInit; re-evaluating paths"
                 );
 
                 outbound_init.replace(OutboundInit::new(bytes.clone(), now));
@@ -373,7 +470,9 @@ impl PathAgent {
                     remote,
                     payload: Payload::Ciphertext(bytes),
                 });
-                self.reopen_evaluation_window(now);
+                self.suspend_guard(now);
+                self.burst_all_pairs(now);
+                self.select_primary(now);
             }
             // A routine re-key rides the primary without restarting probes.
             (Ok(Packet::HandshakeInit(_)), outbound_init @ None, Some((local, remote))) => {
@@ -387,7 +486,7 @@ impl PathAgent {
                 });
             }
             // Lost the primary mid-session (roam, candidate retraction):
-            // fan out like the initial bootstrap.
+            // fan out like the initial bootstrap, with probes racing it.
             (Ok(Packet::HandshakeInit(_)), outbound_init, None) => {
                 tracing::debug!(
                     bytes = bytes.len(),
@@ -395,7 +494,7 @@ impl PathAgent {
                 );
 
                 outbound_init.replace(OutboundInit::new(bytes, now));
-                self.reopen_evaluation_window(now);
+                self.burst_all_pairs(now);
             }
             (Ok(Packet::HandshakeResponse(_)), _, _) => {
                 if let (Some(init_bytes), Some(path)) = (
@@ -445,11 +544,6 @@ impl PathAgent {
         let Ok(parsed) = Tunn::parse_incoming_packet(bytes) else {
             return ControlFlow::Continue(bytes);
         };
-
-        let is_handshake = matches!(
-            parsed,
-            Packet::HandshakeInit(_) | Packet::HandshakeResponse(_)
-        );
 
         match parsed {
             Packet::HandshakeInit(_) => {
@@ -516,14 +610,28 @@ impl PathAgent {
                 // against `last_init`/`last_init_path`.
                 self.responder.last_init = Some(bytes.to_vec());
                 self.responder.last_init_path = Some(path);
-                // An init on the current primary is a routine re-key. Only an
-                // init from a new path (a roam re-keys to a new address)
-                // restarts evaluation, even mid-window: the previous window's
-                // RTTs are stale and must not keep a now-dead pair as primary.
-                // Duplicates were dropped above.
-                if self.primary != Some(path) {
-                    self.restart_evaluation(now);
-                    self.maybe_adopt_handshake_primary(is_handshake, path, now);
+
+                self.register_peer_reflexive(path, now);
+                self.handshake_exchanged = true;
+
+                // Distinct inits minutes apart are routine re-keys; in quick
+                // succession they mean the peer isn't hearing our responses
+                // or data (its passive-keepalive escalation formats a new
+                // init every few seconds). Duplicates of the same init were
+                // dropped above.
+                let previous_init_at = self.last_inbound_init_at.replace(now);
+                if previous_init_at
+                    .is_some_and(|prev| now.duration_since(prev) < REKEY_DISTRESS_INTERVAL)
+                {
+                    tracing::debug!(local = %path.0, remote = %path.1, "Peer re-keyed early; re-evaluating paths");
+
+                    self.suspend_guard(now);
+                    self.burst_all_pairs(now);
+                    self.select_primary(now);
+                }
+
+                if self.primary.is_none() {
+                    self.set_primary(path, now);
                 }
 
                 for b in outbound {
@@ -565,11 +673,13 @@ impl PathAgent {
 
                 self.outbound_init = None;
                 self.forwarded_response = Some(bytes.to_vec());
-                // A response on the current primary completes a routine
-                // re-key; only one from a new path re-evaluates.
-                if self.primary != Some(path) {
-                    self.reopen_evaluation_window(now);
-                    self.maybe_adopt_handshake_primary(is_handshake, path, now);
+                // A response only authenticates if we initiated: the first
+                // handshake is done, later inits are re-keys.
+                self.established = true;
+                self.handshake_exchanged = true;
+
+                if self.primary.is_none() {
+                    self.set_primary(path, now);
                 }
 
                 for b in outbound {
@@ -580,58 +690,6 @@ impl PathAgent {
             }
             Packet::PacketCookieReply(_) | Packet::PacketData(_) => ControlFlow::Continue(bytes),
         }
-    }
-
-    /// Debounced restart: no-op while a window is already open, so an
-    /// outbound re-key and the inbound response 1 RTT later (or a burst
-    /// of candidate changes) don't repeatedly wipe RTTs mid-evaluation.
-    fn reopen_evaluation_window(&mut self, now: Instant) {
-        if let Some(deadline) = self.window.deadline()
-            && now < deadline
-        {
-            return;
-        }
-
-        self.restart_evaluation(now);
-    }
-
-    /// Discard every pair's RTT and open a fresh evaluation window.
-    ///
-    /// A new handshake means the peer's situation changed (e.g. a roam
-    /// to a new address), so a stale RTT must not keep an old, now-dead
-    /// pair as primary. Unlike [`Self::reopen_evaluation_window`] this
-    /// restarts unconditionally, even mid-window — duplicate handshakes
-    /// are already filtered out before we get here.
-    fn restart_evaluation(&mut self, now: Instant) {
-        for state in self.pairs.values_mut() {
-            state.smoothed_rtt = None;
-            state.inflight_probe = None;
-        }
-
-        self.window = EvaluationWindow::Pending;
-
-        self.seed_probe_schedule(now);
-    }
-
-    fn maybe_adopt_handshake_primary(
-        &mut self,
-        is_handshake: bool,
-        path: (SocketAddr, SocketAddr),
-        now: Instant,
-    ) {
-        if !is_handshake || self.primary == Some(path) {
-            return;
-        }
-
-        self.primary = Some(path);
-
-        self.queue_event(
-            Event::PrimaryChanged {
-                local: path.0,
-                remote: path.1,
-            },
-            now,
-        );
     }
 
     pub fn poll_transmit(&mut self) -> Option<Transmit> {
@@ -670,32 +728,32 @@ impl PathAgent {
                     ))),
                 });
 
-                // Peer-reflexive discovery for the symmetric-NAT case:
-                // the peer reached us from a mapping they didn't
-                // advertise.
-                if self.peer_reflexive_addrs.len() < MAX_PEER_REFLEXIVE
-                    && !self.remotes.iter().any(|c| c.addr() == pair.1)
-                {
-                    tracing::debug!(
-                        local = %pair.0,
-                        remote = %pair.1,
-                        "Discovered peer-reflexive remote candidate",
-                    );
-                    self.peer_reflexive_addrs.insert(pair.1);
-                    self.add_remote_candidate(Candidate::server_reflexive(pair.1, pair.1), now);
+                self.register_peer_reflexive(pair, now);
+
+                // Triggered check (cf. RFC 8445, section 7.3.1.4): the
+                // inbound probe proves the reverse NAT filter is open right
+                // now, so probing back completes the hole punch in one round
+                // trip.
+                if let Some(state) = self.pairs.get_mut(&pair) {
+                    state.start_burst(now);
                 }
             }
             crate::icmpv6::Echo::Reply => {
                 if let Some(state) = self.pairs.get_mut(&pair)
-                    && let Some(inflight) = state.inflight_probe
-                    && inflight.seq == probe.seq
+                    && let Some(i) = state
+                        .inflight_probes
+                        .iter()
+                        .position(|inflight| inflight.seq == probe.seq)
                 {
+                    let inflight = state.inflight_probes.remove(i);
                     let rtt = now.saturating_duration_since(inflight.sent_at);
 
-                    state.inflight_probe = None;
-                    state.smoothed_rtt = Some(match state.smoothed_rtt {
-                        None => rtt,
-                        Some(prev) => (prev + rtt) / 2,
+                    state.rtt = Some(Rtt {
+                        smoothed: match state.rtt {
+                            None => rtt,
+                            Some(prev) => (prev.smoothed + rtt) / 2,
+                        },
+                        measured_at: now,
                     });
 
                     tracing::trace!(local = %pair.0, remote = %pair.1, ?rtt, "Probe reply received");
@@ -712,7 +770,11 @@ impl PathAgent {
             .outbound_init
             .as_ref()
             .and_then(|i| i.retransmits.values().map(|r| r.next_fire_at).min());
-        let next_probe = self.pairs.values().filter_map(|s| s.next_probe_at).min();
+        // Probes wait for the first handshake exchange; see `drive_probes`.
+        let next_probe = self
+            .handshake_exchanged
+            .then(|| self.pairs.values().filter_map(|s| s.next_probe_at).min())
+            .flatten();
         // Wake immediately if a buffered init is waiting on a relay
         // pair that landed after the initial fanout. With a primary, the
         // init rode it directly and there is nothing to fan out.
@@ -738,7 +800,6 @@ impl PathAgent {
             .chain(self.events_queued_at)
             .chain(next_retransmit)
             .chain(next_probe)
-            .chain(self.window.deadline())
             .chain(pending_fanout)
             .chain(dedup_expiry)
             .min()
@@ -747,7 +808,6 @@ impl PathAgent {
     pub fn handle_timeout(&mut self, now: Instant) {
         self.drive_handshake_retransmits(now);
         self.drive_probes(now);
-        self.maybe_settle(now);
         self.expire_dedup(now);
     }
 
@@ -757,30 +817,6 @@ impl PathAgent {
         {
             self.responder.dedup = None;
         }
-    }
-
-    fn maybe_settle(&mut self, now: Instant) {
-        let Some(deadline) = self.window.deadline() else {
-            return;
-        };
-
-        if now < deadline {
-            return;
-        }
-
-        for (pair, state) in self.pairs.iter_mut() {
-            state.inflight_probe = None;
-            state.next_probe_at =
-                (Some(*pair) == self.primary).then_some(now + PROBE_INTERVAL_LIVE);
-        }
-
-        self.window = EvaluationWindow::Settled;
-
-        tracing::info!(
-            primary = ?self.primary,
-            interval = ?PROBE_INTERVAL_LIVE,
-            "Iceless path-evaluation window closed; settling on primary",
-        );
     }
 
     fn drive_handshake_retransmits(&mut self, now: Instant) {
@@ -836,50 +872,19 @@ impl PathAgent {
         }
     }
 
-    fn seed_probe_schedule(&mut self, now: Instant) {
-        if self.window.is_settled() {
+    fn drive_probes(&mut self, now: Instant) {
+        // Probes ride the session (they are encapsulated); encapsulating
+        // before the first handshake exchange would make boringtun queue
+        // them and initiate handshakes on its own.
+        if !self.handshake_exchanged {
             return;
         }
 
-        if !self.window.is_open() {
-            self.window = EvaluationWindow::Open {
-                until: now + EVALUATION_WINDOW,
-            };
-
-            tracing::info!(
-                pairs = self.pairs.len(),
-                window = ?EVALUATION_WINDOW,
-                "Iceless path-evaluation window opened",
-            );
-        }
-
-        for state in self.pairs.values_mut() {
-            if state.next_probe_at.is_none() {
-                state.next_probe_at = Some(now);
-            }
-        }
-    }
-
-    fn drive_probes(&mut self, now: Instant) {
-        let (interval, only_primary) = if self.window.is_settled() {
-            (PROBE_INTERVAL_LIVE, true)
-        } else {
-            (PROBE_INTERVAL, false)
-        };
-
-        // Pairs trickled in after the initial seed get probed
-        // immediately while the window is open; pre-handshake stays
-        // dormant.
-        let window_open = self.window.is_open();
         let primary = self.primary;
         let pending = &mut self.pending_transmits;
 
         for ((local, remote), state) in self.pairs.iter_mut() {
-            if only_primary && primary != Some((*local, *remote)) {
-                continue;
-            }
-
-            let Some(deadline) = state.next_probe_at.or(window_open.then_some(now)) else {
+            let Some(deadline) = state.next_probe_at else {
                 continue;
             };
 
@@ -887,20 +892,27 @@ impl PathAgent {
                 continue;
             }
 
-            // Hold off while a probe is inflight so a late reply on a
-            // high-RTT path can still match by seq.
-            if let Some(inflight) = state.inflight_probe {
-                if now.saturating_duration_since(inflight.sent_at) < PROBE_TIMEOUT {
-                    state.next_probe_at = Some(inflight.sent_at + PROBE_TIMEOUT);
-                    continue;
-                }
-                state.inflight_probe = None;
-            }
+            // A reply past this age wouldn't be fresh enough to matter.
+            state
+                .inflight_probes
+                .retain(|p| now.saturating_duration_since(p.sent_at) < PROBE_TIMEOUT);
 
             let seq = state.next_probe_seq;
             state.next_probe_seq = state.next_probe_seq.wrapping_add(1);
-            state.inflight_probe = Some(InflightProbe { seq, sent_at: now });
-            state.next_probe_at = Some(now + interval);
+            state
+                .inflight_probes
+                .push(InflightProbe { seq, sent_at: now });
+            state.next_probe_at = match PROBE_BURST_GAPS.get(state.burst_step) {
+                Some(gap) => {
+                    state.burst_step += 1;
+                    Some(now + *gap)
+                }
+                // The burst is done: the primary keeps its RTT fresh and its
+                // NAT mappings warm, everything else goes dormant until the
+                // next re-evaluation signal.
+                None if primary == Some((*local, *remote)) => Some(now + PROBE_INTERVAL_LIVE),
+                None => None,
+            };
 
             tracing::trace!(%local, %remote, seq, "Probe send");
 
@@ -912,11 +924,44 @@ impl PathAgent {
         }
     }
 
+    fn burst_all_pairs(&mut self, now: Instant) {
+        for (i, state) in self.pairs.values_mut().enumerate() {
+            state.start_burst(now + PROBE_PACING * i as u32);
+        }
+    }
+
+    fn register_peer_reflexive(&mut self, pair: (SocketAddr, SocketAddr), now: Instant) {
+        // The peer reached us from a mapping they didn't advertise
+        // (symmetric NAT).
+        if self.peer_reflexive_addrs.len() < MAX_PEER_REFLEXIVE
+            && !self.remotes.iter().any(|c| c.addr() == pair.1)
+        {
+            tracing::debug!(
+                local = %pair.0,
+                remote = %pair.1,
+                "Discovered peer-reflexive remote candidate",
+            );
+            self.peer_reflexive_addrs.insert(pair.1);
+            self.add_remote_candidate(Candidate::server_reflexive(pair.1, pair.1), now);
+        }
+    }
+
+    /// WireGuard signalled that the current path is suspect: selection runs
+    /// unguarded so the best fresh pair wins outright, allowing a fail-over
+    /// to a worse bucket (e.g. direct to relayed).
+    fn suspend_guard(&mut self, now: Instant) {
+        self.guard_suspended_until = Some(now + GUARD_SUSPENSION);
+    }
+
+    fn guard_active(&self, now: Instant) -> bool {
+        self.guard_suspended_until.is_none_or(|until| now >= until)
+    }
+
     fn select_primary(&mut self, now: Instant) {
         let best = self
             .pairs
             .iter()
-            .filter(|(_, s)| s.smoothed_rtt.is_some())
+            .filter(|(_, s)| s.rtt.is_some_and(|rtt| rtt.is_fresh(now)))
             .min_by_key(|(k, s)| pair_score(**k, s))
             .map(|(k, _)| *k);
 
@@ -926,7 +971,13 @@ impl PathAgent {
             return;
         }
 
-        if let Some(primary) = self.primary
+        // The incumbent's guard: a worse bucket never displaces it and a
+        // same-bucket challenger must beat it by a clear margin. Only while
+        // WireGuard considers the path healthy — probe results alone must
+        // never demote a working primary (a busy node drops probes while its
+        // data flows just fine).
+        if self.guard_active(now)
+            && let Some(primary) = self.primary
             && let Some(prev) = self.pairs.get(&primary)
         {
             let new_score = pair_score(new, &self.pairs[&new]);
@@ -937,41 +988,61 @@ impl PathAgent {
             }
 
             if prev_score.bucket == new_score.bucket
-                && let Some(prev_rtt) = prev.smoothed_rtt
+                && let Some(prev_rtt) = prev.rtt
             {
                 let new_rtt = new_score.rtt.unwrap_or_default();
-                let margin =
-                    PRIMARY_HYSTERESIS_FLOOR.max(prev_rtt.mul_f64(PRIMARY_HYSTERESIS_FRACTION));
+                let margin = PRIMARY_HYSTERESIS_FLOOR
+                    .max(prev_rtt.smoothed.mul_f64(PRIMARY_HYSTERESIS_FRACTION));
 
-                if new_rtt + margin >= prev_rtt {
+                if new_rtt + margin >= prev_rtt.smoothed {
                     return;
                 }
             }
         }
 
-        let new_rtt = self
-            .pairs
-            .get(&new)
-            .and_then(|s| s.smoothed_rtt)
-            .unwrap_or_default();
+        let recovered = self.primary.is_none() && self.handshake_exchanged;
+
+        self.set_primary(new, now);
+
+        // The remote can't observe us settling on a new path; the re-key is
+        // the authenticated "my situation changed" signal that reaches it on
+        // the recovered path. Silent switches between working paths don't
+        // re-key: sessions are path-agnostic.
+        if recovered {
+            self.queue_event(Event::PathRecovered, now);
+        }
+    }
+
+    fn set_primary(&mut self, path: (SocketAddr, SocketAddr), now: Instant) {
         let from = self.primary;
 
-        self.primary = Some(new);
+        self.primary = Some(path);
+
+        // Keep the new primary on the live cadence once its burst is done.
+        if let Some(state) = self.pairs.get_mut(&path)
+            && state.next_probe_at.is_none()
+        {
+            state.next_probe_at = Some(now + PROBE_INTERVAL_LIVE);
+        }
 
         tracing::debug!(
             ?from,
-            local = %new.0,
-            remote = %new.1,
-            rtt = ?new_rtt,
+            local = %path.0,
+            remote = %path.1,
             "Iceless primary changed",
         );
 
         self.queue_event(
             Event::PrimaryChanged {
-                local: new.0,
-                remote: new.1,
+                local: path.0,
+                remote: path.1,
             },
             now,
         );
+    }
+
+    fn queue_event(&mut self, event: Event, now: Instant) {
+        self.events.push_back(event);
+        self.events_queued_at = self.events_queued_at.or(Some(now));
     }
 }

--- a/rust/libs/connlib/path-agent/src/agent.rs
+++ b/rust/libs/connlib/path-agent/src/agent.rs
@@ -556,20 +556,18 @@ impl PathAgent {
                 // on, never the primary — otherwise bootstrap (and re-keys)
                 // can't complete. Cache it so a retransmitted init is answered
                 // from memory without re-decapsulating.
-                if let Some(response) = response {
-                    tracing::debug!(local = %path.0, remote = %path.1, "Sending HandshakeResponse on init's recv path");
+                tracing::debug!(local = %path.0, remote = %path.1, "Sending HandshakeResponse on init's recv path");
 
-                    self.responder.dedup = Some(ResponderDedup {
-                        init_bytes: bytes.to_vec(),
-                        response_bytes: response.clone(),
-                        cached_at: now,
-                    });
-                    self.pending_transmits.push_back(Transmit {
-                        local: path.0,
-                        remote: path.1,
-                        payload: Payload::Ciphertext(response),
-                    });
-                }
+                self.responder.dedup = Some(ResponderDedup {
+                    init_bytes: bytes.to_vec(),
+                    response_bytes: response.clone(),
+                    cached_at: now,
+                });
+                self.pending_transmits.push_back(Transmit {
+                    local: path.0,
+                    remote: path.1,
+                    payload: Payload::Ciphertext(response),
+                });
 
                 ControlFlow::Break(())
             }
@@ -631,11 +629,11 @@ impl PathAgent {
         bytes: &[u8],
         path: (SocketAddr, SocketAddr),
         now: Instant,
-    ) -> Option<Option<Vec<u8>>> {
+    ) -> Option<Vec<u8>> {
         let mut buf = [0u8; ip_packet::MAX_FZ_PAYLOAD];
-        let response = match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now) {
-            TunnResult::Done => None,
-            TunnResult::WriteToNetwork(response) => Some(response.to_vec()),
+        let reply = match tunnel.decapsulate_at(Some(path.1.ip()), bytes, &mut buf, now) {
+            TunnResult::Done => return None,
+            TunnResult::WriteToNetwork(response) => response,
             TunnResult::Err(e) => {
                 tracing::debug!(local = %path.0, remote = %path.1, error = ?e, "Inbound HandshakeInit rejected");
                 return None;
@@ -647,24 +645,22 @@ impl PathAgent {
         };
 
         // Cookie replies don't establish a session; send them without touching state.
-        if let Some(reply) = &response
-            && matches!(
-                Tunn::parse_incoming_packet(reply),
-                Ok(Packet::PacketCookieReply(_))
-            )
-        {
+        if matches!(
+            Tunn::parse_incoming_packet(reply),
+            Ok(Packet::PacketCookieReply(_))
+        ) {
             tracing::debug!(local = %path.0, remote = %path.1, "Replying with cookie under load");
 
             self.pending_transmits.push_back(Transmit {
                 local: path.0,
                 remote: path.1,
-                payload: Payload::Ciphertext(reply.clone()),
+                payload: Payload::Ciphertext(reply.to_vec()),
             });
 
             return None;
         }
 
-        Some(response)
+        Some(reply.to_vec())
     }
 
     /// Authenticates an inbound response, returning the packets boringtun wants

--- a/rust/libs/connlib/path-agent/src/event.rs
+++ b/rust/libs/connlib/path-agent/src/event.rs
@@ -19,4 +19,9 @@ pub enum Event {
         local: SocketAddr,
         remote: SocketAddr,
     },
+    /// Probes regained a path after we had none (e.g. after a roam).
+    ///
+    /// The kept session already flows again; a re-key on the new primary lets
+    /// the remote know our situation changed so it can re-evaluate, too.
+    PathRecovered,
 }

--- a/rust/libs/connlib/path-agent/src/event.rs
+++ b/rust/libs/connlib/path-agent/src/event.rs
@@ -19,9 +19,4 @@ pub enum Event {
         local: SocketAddr,
         remote: SocketAddr,
     },
-    /// Probes regained a path after we had none (e.g. after a roam).
-    ///
-    /// The kept session already flows again; a re-key on the new primary lets
-    /// the remote know our situation changed so it can re-evaluate, too.
-    PathRecovered,
 }

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -43,11 +43,14 @@
 //!
 //! ## Selection
 //!
-//! Given the pairs with a fresh RTT, scoring ranks them by candidate kind,
-//! relay placement and address family, with RTT only as a tie-breaker under
-//! hysteresis so a working primary isn't displaced by a marginal gain. A
-//! WireGuard distress signal briefly lifts the bucket veto so we can fail over
-//! to a worse-but-working path (e.g. direct to relayed).
+//! Given the pairs with an RTT, scoring ranks them by candidate kind, relay
+//! placement and address family, with RTT only as a tie-breaker under
+//! hysteresis so a working primary isn't displaced by a marginal gain. A worse
+//! bucket never displaces the primary — it holds by candidate kind even while
+//! being re-measured. Failing over to a worse-but-working path (e.g. direct to
+//! relayed) happens only on a WireGuard distress signal, which drops the
+//! primary pointer entirely so there is no longer a pair to protect and the
+//! best surviving path wins.
 
 mod agent;
 mod candidate;
@@ -57,8 +60,8 @@ mod retransmit;
 mod score;
 
 pub use agent::{
-    GUARD_SUSPENSION, PROBE_BURST_GAPS, PROBE_GIVE_UP, PROBE_INTERVAL, PROBE_SAMPLES,
-    PROBE_TIMEOUT, PathAgent, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, RTT_FRESHNESS,
+    PROBE_BURST_GAPS, PROBE_GIVE_UP, PROBE_INTERVAL, PROBE_KEEPALIVE, PROBE_SAMPLES, PROBE_TIMEOUT,
+    PathAgent, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -8,8 +8,8 @@ mod retransmit;
 mod score;
 
 pub use agent::{
-    GUARD_SUSPENSION, PROBE_BURST_GAPS, PROBE_INTERVAL_LIVE, PROBE_PACING, PROBE_TIMEOUT,
-    PathAgent, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, RTT_FRESHNESS,
+    GUARD_SUSPENSION, PROBE_BURST_GAPS, PROBE_INTERVAL_LIVE, PROBE_TIMEOUT, PathAgent,
+    REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, RTT_FRESHNESS,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -1,57 +1,52 @@
-//! Path selection for iceless snownet connections.
+//! Path selection for iceless WireGuard connections.
 //!
-//! A [`PathAgent`] picks which local/remote address pair a connection sends on
-//! (its *primary*) and keeps that choice current as candidates come and go. It
-//! replaces ICE for iceless connections: no roles, no nomination, no consent
-//! checks. The model is a handful of orthogonal, composable pieces.
+//! ICEless is inspired by ICE but optimised for WireGuard. A [`PathAgent`]
+//! only *selects* a path (which local/remote address pair a connection sends
+//! on — its *primary*); WireGuard owns the session and liveness.
 //!
-//! ## WireGuard owns liveness
+//! ## Bootstrap
 //!
-//! Probes never kill a connection. A busy or spotty node drops probes while its
-//! data still flows, and we must not retire it for that. The only authority on
-//! whether a connection is dead is WireGuard's own state machine (an unanswered
-//! re-key hitting its attempt timeout, or the session aging out). Everything
-//! here only ever *informs* selection; it never tears a connection down.
+//! Probes ride the WireGuard session, so a session must exist before any path
+//! can be probed. To get one, the agent fans a boringtun `init` out over every
+//! pair that involves a relay candidate — relays are always reachable, even
+//! behind double symmetric NAT. A session is *established* the moment we see a
+//! handshake (an init or a response), and the establishing handshake seeds a
+//! preliminary primary: the relay pair it arrived on. That is sound because the
+//! fan-out only uses relays (the worst tier), so probing can only promote away
+//! from it, and it gives both ends a working path — and thus a connection that
+//! carries data — the instant the session exists, rather than after the first
+//! probe reply. A mid-session re-key never moves the primary; probing decides.
 //!
-//! ## Probing and the settle rule
+//! Handshakes are always answered on the path they arrived on, never on the
+//! primary — routine re-keys included.
 //!
-//! Probes are ICMP echoes sent *inside* the WireGuard session, so a reply is
-//! proof the tunnel works on that pair. Each pair probes in a front-loaded
-//! burst that settles into a steady cadence (see the [`PROBE_BURST_GAPS`] /
-//! [`PROBE_INTERVAL`] schedule), and one rule decides how long it probes:
+//! ## Probing and selection
 //!
-//! - it collects positive RTT samples until it has [`PROBE_SAMPLES`] of them,
-//!   then **settles** and goes quiet — this is why a converged connection stops
-//!   probing;
-//! - a pair that never gets a reply never settles, so it **keeps probing** —
-//!   until WireGuard retires the connection. Hunting for a path and going quiet
-//!   after converging are the same rule seen from two sides.
+//! Once established, every pair probes with ICMPv6 echo requests (the `id` is
+//! scoped to the pair). A reply is proof the path works both ways and carries
+//! its RTT. Pairs are ranked by tier then RTT, and **probes can only promote
+//! the primary, never demote it**: the best measured pair takes an empty
+//! primary or displaces the incumbent only when it scores strictly better.
 //!
-//! With one exception: once we already have a primary, a pair that won't settle
-//! within [`PROBE_GIVE_UP_ATTEMPTS`] probes is a dead end (e.g. a direct pair
-//! that can never punch a symmetric NAT) and stops. We hunt indefinitely only
-//! while we have no path at all.
+//! A pair goes quiet after [`PROBE_BUDGET`] probes — *unless* it is the primary
+//! (which keeps a slow [`PRIMARY_KEEPALIVE`] cadence so an idle connection's NAT
+//! bindings and tunnel stay alive; iceless runs no WireGuard persistent
+//! keepalive), or there is no primary at all (in which case every pair hunts
+//! forever until one is found). The agent never declares the connection broken;
+//! without a path WireGuard simply can't re-key and the connection is torn down
+//! after ~180s.
 //!
-//! ## Re-evaluation (the scoped eval window)
+//! ## Distress and re-probing
 //!
-//! A settled pair is re-armed only by a signal that something may have changed:
-//! a newly-signalled or peer-reflexive candidate arrives, or WireGuard shows
-//! distress (several of our re-keys going unanswered, or the peer re-keying
-//! repeatedly with no data in between — see [`REKEY_DISTRESS_ATTEMPTS`]). The
-//! old global evaluation window still exists — but now it's implicit and scoped
-//! to just the pairs a signal touches, e.g. the current primary and a freshly
-//! arrived candidate, rather than a timer over all of them.
+//! The primary is dropped only on a signal that it is dead. WireGuard re-keys
+//! when its data goes unanswered; because every WireGuard packet flows through
+//! the agent, a second unanswered re-key (ours) — or a second distinct peer
+//! init with no data in between — is taken as distress ([`REKEY_DISTRESS_ATTEMPTS`]),
+//! clearing the primary and re-probing every pair. A new candidate is the same
+//! kind of signal and does the same. Pairs already probing keep their state.
 //!
-//! ## Selection
-//!
-//! Given the pairs with an RTT, scoring ranks them by candidate kind, relay
-//! placement and address family, with RTT only as a tie-breaker under
-//! hysteresis so a working primary isn't displaced by a marginal gain. A worse
-//! bucket never displaces the primary — it holds by candidate kind even while
-//! being re-measured. Failing over to a worse-but-working path (e.g. direct to
-//! relayed) happens only on a WireGuard distress signal, which drops the
-//! primary pointer entirely so there is no longer a pair to protect and the
-//! best surviving path wins.
+//! NAT bindings along the primary are kept warm by WireGuard's persistent
+//! keepalive, not by probes.
 
 mod agent;
 mod candidate;
@@ -61,8 +56,8 @@ mod retransmit;
 mod score;
 
 pub use agent::{
-    PROBE_BURST_GAPS, PROBE_GIVE_UP_ATTEMPTS, PROBE_INTERVAL, PROBE_KEEPALIVE, PROBE_SAMPLES,
-    PROBE_TIMEOUT, PathAgent, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
+    PRIMARY_KEEPALIVE, PROBE_BUDGET, PROBE_BURST_GAPS, PROBE_INTERVAL, PathAgent,
+    REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -44,9 +44,6 @@
 //! init with no data in between — is taken as distress ([`REKEY_DISTRESS_ATTEMPTS`]),
 //! clearing the primary and re-probing every pair. A new candidate is the same
 //! kind of signal and does the same. Pairs already probing keep their state.
-//!
-//! NAT bindings along the primary are kept warm by WireGuard's persistent
-//! keepalive, not by probes.
 
 mod agent;
 mod candidate;

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -8,8 +8,8 @@ mod retransmit;
 mod score;
 
 pub use agent::{
-    EVALUATION_WINDOW, PROBE_INTERVAL, PROBE_INTERVAL_LIVE, PROBE_TIMEOUT, PathAgent,
-    RESPONDER_DEDUP_TTL,
+    GUARD_SUSPENSION, PROBE_BURST_GAPS, PROBE_INTERVAL_LIVE, PROBE_PACING, PROBE_TIMEOUT,
+    PathAgent, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, RTT_FRESHNESS,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -36,7 +36,8 @@
 //!
 //! A settled pair is re-armed only by a signal that something may have changed:
 //! a newly-signalled or peer-reflexive candidate arrives, or WireGuard shows
-//! distress (a re-key we can't get answered, or the peer re-keying early). The
+//! distress (several of our re-keys going unanswered, or the peer re-keying
+//! repeatedly with no data in between — see [`REKEY_DISTRESS_ATTEMPTS`]). The
 //! old global evaluation window still exists — but now it's implicit and scoped
 //! to just the pairs a signal touches, e.g. the current primary and a freshly
 //! arrived candidate, rather than a timer over all of them.
@@ -61,7 +62,7 @@ mod score;
 
 pub use agent::{
     PROBE_BURST_GAPS, PROBE_GIVE_UP, PROBE_INTERVAL, PROBE_KEEPALIVE, PROBE_SAMPLES, PROBE_TIMEOUT,
-    PathAgent, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL,
+    PathAgent, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -28,9 +28,9 @@
 //!   after converging are the same rule seen from two sides.
 //!
 //! With one exception: once we already have a primary, a pair that won't settle
-//! within [`PROBE_GIVE_UP`] is a dead end (e.g. a direct pair that can never
-//! punch a symmetric NAT) and stops. We hunt indefinitely only while we have no
-//! path at all.
+//! within [`PROBE_GIVE_UP_ATTEMPTS`] probes is a dead end (e.g. a direct pair
+//! that can never punch a symmetric NAT) and stops. We hunt indefinitely only
+//! while we have no path at all.
 //!
 //! ## Re-evaluation (the scoped eval window)
 //!
@@ -61,8 +61,8 @@ mod retransmit;
 mod score;
 
 pub use agent::{
-    PROBE_BURST_GAPS, PROBE_GIVE_UP, PROBE_INTERVAL, PROBE_KEEPALIVE, PROBE_SAMPLES, PROBE_TIMEOUT,
-    PathAgent, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
+    PROBE_BURST_GAPS, PROBE_GIVE_UP_ATTEMPTS, PROBE_INTERVAL, PROBE_KEEPALIVE, PROBE_SAMPLES,
+    PROBE_TIMEOUT, PathAgent, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/lib.rs
+++ b/rust/libs/connlib/path-agent/src/lib.rs
@@ -1,4 +1,53 @@
-//! Path-selection state machine for iceless snownet connections.
+//! Path selection for iceless snownet connections.
+//!
+//! A [`PathAgent`] picks which local/remote address pair a connection sends on
+//! (its *primary*) and keeps that choice current as candidates come and go. It
+//! replaces ICE for iceless connections: no roles, no nomination, no consent
+//! checks. The model is a handful of orthogonal, composable pieces.
+//!
+//! ## WireGuard owns liveness
+//!
+//! Probes never kill a connection. A busy or spotty node drops probes while its
+//! data still flows, and we must not retire it for that. The only authority on
+//! whether a connection is dead is WireGuard's own state machine (an unanswered
+//! re-key hitting its attempt timeout, or the session aging out). Everything
+//! here only ever *informs* selection; it never tears a connection down.
+//!
+//! ## Probing and the settle rule
+//!
+//! Probes are ICMP echoes sent *inside* the WireGuard session, so a reply is
+//! proof the tunnel works on that pair. Each pair probes in a front-loaded
+//! burst that settles into a steady cadence (see the [`PROBE_BURST_GAPS`] /
+//! [`PROBE_INTERVAL`] schedule), and one rule decides how long it probes:
+//!
+//! - it collects positive RTT samples until it has [`PROBE_SAMPLES`] of them,
+//!   then **settles** and goes quiet — this is why a converged connection stops
+//!   probing;
+//! - a pair that never gets a reply never settles, so it **keeps probing** —
+//!   until WireGuard retires the connection. Hunting for a path and going quiet
+//!   after converging are the same rule seen from two sides.
+//!
+//! With one exception: once we already have a primary, a pair that won't settle
+//! within [`PROBE_GIVE_UP`] is a dead end (e.g. a direct pair that can never
+//! punch a symmetric NAT) and stops. We hunt indefinitely only while we have no
+//! path at all.
+//!
+//! ## Re-evaluation (the scoped eval window)
+//!
+//! A settled pair is re-armed only by a signal that something may have changed:
+//! a newly-signalled or peer-reflexive candidate arrives, or WireGuard shows
+//! distress (a re-key we can't get answered, or the peer re-keying early). The
+//! old global evaluation window still exists — but now it's implicit and scoped
+//! to just the pairs a signal touches, e.g. the current primary and a freshly
+//! arrived candidate, rather than a timer over all of them.
+//!
+//! ## Selection
+//!
+//! Given the pairs with a fresh RTT, scoring ranks them by candidate kind,
+//! relay placement and address family, with RTT only as a tie-breaker under
+//! hysteresis so a working primary isn't displaced by a marginal gain. A
+//! WireGuard distress signal briefly lifts the bucket veto so we can fail over
+//! to a worse-but-working path (e.g. direct to relayed).
 
 mod agent;
 mod candidate;
@@ -8,8 +57,8 @@ mod retransmit;
 mod score;
 
 pub use agent::{
-    GUARD_SUSPENSION, PROBE_BURST_GAPS, PROBE_INTERVAL_LIVE, PROBE_TIMEOUT, PathAgent,
-    REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, RTT_FRESHNESS,
+    GUARD_SUSPENSION, PROBE_BURST_GAPS, PROBE_GIVE_UP, PROBE_INTERVAL, PROBE_SAMPLES,
+    PROBE_TIMEOUT, PathAgent, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, RTT_FRESHNESS,
 };
 pub use candidate::{Candidate, CandidateKind, ParseCandidateError};
 pub use event::{Event, Payload, Transmit};

--- a/rust/libs/connlib/path-agent/src/retransmit.rs
+++ b/rust/libs/connlib/path-agent/src/retransmit.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, Instant};
 
 pub(crate) struct PairRetransmit {
-    pub(crate) next_fire_at: Instant,
+    /// `None` once the ladder is spent: it runs once and stops, leaving further
+    /// retransmission to boringtun's own re-init cadence.
+    pub(crate) next_fire_at: Option<Instant>,
     pub(crate) step: usize,
 }
 
@@ -12,13 +14,15 @@ impl PairRetransmit {
 
     pub(crate) fn new(now: Instant) -> Self {
         Self {
-            next_fire_at: now + Duration::from_millis(Self::LADDER_MS[0]),
+            next_fire_at: Some(now + Duration::from_millis(Self::LADDER_MS[0])),
             step: 0,
         }
     }
 
     pub(crate) fn advance(&mut self, now: Instant) {
-        self.step = (self.step + 1).min(Self::LADDER_MS.len() - 1);
-        self.next_fire_at = now + Duration::from_millis(Self::LADDER_MS[self.step]);
+        self.step += 1;
+        self.next_fire_at = Self::LADDER_MS
+            .get(self.step)
+            .map(|ms| now + Duration::from_millis(*ms));
     }
 }

--- a/rust/libs/connlib/path-agent/src/score.rs
+++ b/rust/libs/connlib/path-agent/src/score.rs
@@ -66,6 +66,6 @@ pub(crate) fn pair_score(pair: (SocketAddr, SocketAddr), state: &PairState) -> P
                 LocalFamily::V4
             },
         },
-        rtt: state.smoothed_rtt,
+        rtt: state.rtt.map(|rtt| rtt.smoothed),
     }
 }

--- a/rust/libs/connlib/path-agent/src/score.rs
+++ b/rust/libs/connlib/path-agent/src/score.rs
@@ -39,7 +39,10 @@ pub(crate) struct Bucket {
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct PairScore {
     pub(crate) bucket: Bucket,
-    pub(crate) rtt: Option<Duration>,
+    /// An unmeasured pair sorts *last* within its bucket (`Duration::MAX`), not
+    /// first: a tier-based preliminary primary must be refinable by the first
+    /// real measurement, never treated as the best just because it has no RTT.
+    pub(crate) rtt: Duration,
 }
 
 pub(crate) fn pair_score(pair: (SocketAddr, SocketAddr), state: &PairState) -> PairScore {
@@ -66,6 +69,6 @@ pub(crate) fn pair_score(pair: (SocketAddr, SocketAddr), state: &PairState) -> P
                 LocalFamily::V4
             },
         },
-        rtt: state.rtt.map(|rtt| rtt.smoothed),
+        rtt: state.rtt.map(|rtt| rtt.smoothed).unwrap_or(Duration::MAX),
     }
 }

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -2,7 +2,7 @@
 //!
 //! Layout follows the model's life-cycle: bootstrap via handshake fan-out,
 //! probing (bursts, triggered checks, peer-reflexive discovery), selection
-//! (scoring, hysteresis, freshness), and failure handling (roam recovery,
+//! (scoring, hysteresis, settle-and-retire), and failure handling (roam recovery,
 //! WireGuard distress signals). Flow-level coverage lives in the tunnel
 //! proptest.
 
@@ -275,30 +275,35 @@ fn unanswered_pairs_burst_then_hunt_at_the_steady_interval() {
 }
 
 #[test]
-fn an_answered_pair_settles_and_goes_quiet() {
+fn an_answered_non_primary_pair_settles_and_goes_quiet() {
     let mut a = PathAgent::new();
     let t0 = Instant::now();
     a.add_local_candidate(Candidate::host(addr(1)), t0);
     a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    // A worse-bucket relay pair that answers but can never steal the primary.
+    a.add_remote_candidate(Candidate::relayed(addr(3), addr(3)), t0);
     bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
     a.drain_events();
 
-    let pair = (addr(1), addr(2));
+    let loser = (addr(1), addr(3));
 
-    // Answer every probe as it goes out; after PROBE_SAMPLES replies the pair
-    // has a stable RTT and stops probing.
+    // Answer every probe on the loser as it goes out; after PROBE_SAMPLES
+    // replies it has a stable RTT and — being a non-primary — stops probing.
     let mut sent = 0u32;
     let mut now = t0;
     for _ in 0..200 {
         for t in a.tick(now) {
-            if (t.local, t.remote) == pair
+            if (t.local, t.remote) == loser
                 && let Payload::Plaintext(p) = &t.payload
                 && let Some(probe) = parse_probe(p)
                 && probe.kind == EchoKind::Request
             {
                 sent += 1;
-                let _ =
-                    a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
+                let _ = a.handle_inbound_tun(
+                    build_echo_reply(probe.id, probe.seq),
+                    loser,
+                    now + ms(20),
+                );
             }
         }
         match a.poll_timeout() {
@@ -308,12 +313,13 @@ fn an_answered_pair_settles_and_goes_quiet() {
     }
 
     assert_eq!(
-        sent, PROBE_SAMPLES,
-        "a pair must stop probing after {PROBE_SAMPLES} positive samples, sent {sent}",
+        a.primary(),
+        Some((addr(1), addr(2))),
+        "the worse-bucket loser must not steal the primary",
     );
-    assert!(
-        a.poll_timeout().is_none(),
-        "a settled connection has no pending probe timeout",
+    assert_eq!(
+        sent, PROBE_SAMPLES,
+        "a non-primary pair must stop probing after {PROBE_SAMPLES} positive samples, sent {sent}",
     );
 }
 
@@ -996,7 +1002,7 @@ fn roam_recovers_the_data_path_via_probes_without_a_handshake() {
 }
 
 #[test]
-fn probing_is_independent_of_primary_status() {
+fn settled_primary_keepalives_while_loser_goes_quiet() {
     let mut a = PathAgent::new();
     let t0 = Instant::now();
     a.add_local_candidate(Candidate::host(addr(1)), t0);
@@ -1005,17 +1011,23 @@ fn probing_is_independent_of_primary_status() {
     bootstrap_primary(&mut a, (addr(1), addr(3)), t0);
     a.drain_events();
 
-    // Answer both pairs to convergence. One is the primary, the other is not —
-    // yet both settle and go quiet the same way; there is no primary-only
-    // cadence keeping the winner probing.
+    // Answer both pairs to convergence. (1,3) is the primary, (1,4) a
+    // same-bucket loser that stays behind it under hysteresis.
     let settled_at = answer_until_settled(&mut a, &[(addr(1), addr(3)), (addr(1), addr(4))], t0);
+    assert_eq!(a.primary(), Some((addr(1), addr(3))));
 
     let after = a.advance(settled_at, settled_at + secs(60));
-    assert_eq!(after.probe_times((addr(1), addr(3))), vec![]);
-    assert_eq!(after.probe_times((addr(1), addr(4))), vec![]);
+    // The primary keeps the slow keepalive cadence so its RTT stays current
+    // for the next comparison...
     assert!(
-        a.poll_timeout().is_none(),
-        "both pairs settled, so nothing is scheduled",
+        !after.probe_times((addr(1), addr(3))).is_empty(),
+        "the settled primary keepalives",
+    );
+    // ...while the settled loser is dropped and goes silent.
+    assert_eq!(
+        after.probe_times((addr(1), addr(4))),
+        vec![],
+        "a settled loser goes quiet",
     );
 }
 
@@ -1439,12 +1451,14 @@ fn parse_probe(packet: &IpPacket) -> Option<ProbeFields> {
 }
 
 fn extract_probe_for(transmits: &[Transmit], pair: Pair) -> ProbeFields {
+    // A pair can carry both a probe and (mid-failover, while re-keying) a
+    // fanned-out handshake init in the same tick; pick the probe.
     let t = transmits
         .iter()
-        .find(|t| (t.local, t.remote) == pair)
-        .unwrap_or_else(|| panic!("no transmit for {pair:?}"));
+        .find(|t| (t.local, t.remote) == pair && matches!(t.payload, Payload::Plaintext(_)))
+        .unwrap_or_else(|| panic!("no probe transmit for {pair:?}"));
     let Payload::Plaintext(ref packet) = t.payload else {
-        panic!("expected Plaintext probe, got {:?}", t.payload);
+        unreachable!()
     };
     parse_probe(packet).expect("parses as probe")
 }

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -382,6 +382,34 @@ fn an_answered_rekey_resets_the_distress_count() {
 }
 
 #[test]
+fn a_primary_change_resets_the_distress_count() {
+    // Distress is scoped to the current primary: a count that climbed on the
+    // previous primary must not carry over and trip distress early on the next.
+    let mut a = agent_with_relay_pairs();
+    let t0 = Instant::now();
+    bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
+    assert_eq!(a.primary(), Some((addr(2), addr(4))));
+
+    // One unanswered re-key on the relay primary: the count is now 1.
+    a.handle_outbound(handshake_init_bytes(), t0);
+    let _ = a.transmits();
+
+    // A host probe reply promotes the primary, which resets the count.
+    let probes = a.tick(t0);
+    a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(30));
+    assert_eq!(a.primary(), Some((addr(1), addr(3))));
+
+    // The first unanswered re-key on the new primary is only the first again;
+    // without the reset the carried-over count would clear it here.
+    a.handle_outbound(handshake_init_bytes(), t0 + secs(1));
+    assert_eq!(
+        a.primary(),
+        Some((addr(1), addr(3))),
+        "the distress count restarts with the new primary",
+    );
+}
+
+#[test]
 fn a_second_peer_rekey_without_data_clears_the_primary() {
     let (mut a, t0) = direct_primary_with_relay_fallback();
 

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -986,7 +986,7 @@ fn retired_primary_stops_live_probing() {
 }
 
 #[test]
-fn recovering_a_path_requests_a_rekey_to_notify_the_remote() {
+fn recovering_a_path_is_a_plain_primary_switch_without_a_rekey() {
     let mut a = PathAgent::new();
     let t0 = Instant::now();
     a.add_local_candidate(Candidate::host(addr(1)), t0);
@@ -1006,10 +1006,24 @@ fn recovering_a_path_requests_a_rekey_to_notify_the_remote() {
         t1 + ms(50),
     );
 
+    // Our probe already reached the peer (it replied), so the peer registered
+    // our new address as peer-reflexive and is re-evaluating on its own.
+    // Recovery is therefore a plain local primary switch — no re-key, no
+    // handshake traffic.
     let events: Vec<_> = std::iter::from_fn(|| a.poll_event()).collect();
+    assert_eq!(
+        events,
+        vec![Event::PrimaryChanged {
+            local: addr(5),
+            remote: addr(9),
+        }],
+        "recovery must only switch the primary, got {events:?}",
+    );
     assert!(
-        events.contains(&Event::PathRecovered),
-        "the remote can't observe our recovery; a re-key is the signal, got {events:?}",
+        a.transmits()
+            .iter()
+            .all(|t| matches!(t.payload, Payload::Plaintext(_))),
+        "recovery must not emit any handshake traffic",
     );
 }
 

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -15,7 +15,7 @@ use boringtun::x25519::{PublicKey, StaticSecret};
 use ip_packet::{Icmpv6Type, IpPacket};
 use path_agent::{
     Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL, PROBE_SAMPLES, PROBE_SRC,
-    PathAgent, Payload, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, Transmit,
+    PathAgent, Payload, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL, Transmit,
 };
 
 // --- bootstrap: handshake fan-out and nomination ---
@@ -842,16 +842,20 @@ fn unanswered_rekey_fails_over_to_a_fresh_pair() {
     let _ = a.advance(t0, t0 + secs(60));
     let t1 = t0 + secs(60);
 
-    // boringtun re-keys (rides the primary), gets no answer and retries:
-    // WireGuard-level failure evidence.
+    // boringtun re-keys (rides the primary), gets no answer and retries.
+    // A lone retransmit is ordinary loss; only after REKEY_DISTRESS_ATTEMPTS
+    // unanswered retransmits is it WireGuard-level failure evidence.
     a.handle_outbound(handshake_init_bytes(), t1);
     let _ = a.transmits();
-    a.handle_outbound(handshake_init_bytes(), t1 + secs(5));
-    let _ = a.transmits();
+    let mut t = t1;
+    for _ in 0..REKEY_DISTRESS_ATTEMPTS {
+        t += secs(5);
+        a.handle_outbound(handshake_init_bytes(), t);
+        let _ = a.transmits();
+    }
 
     // The re-evaluation bursts every pair; the relay pair answers.
-    let t2 = t1 + secs(5);
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t2);
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t);
 
     assert_eq!(
         a.primary(),
@@ -866,24 +870,24 @@ fn peer_rekeying_early_fails_over_too() {
 
     // The peer stops hearing us (one-way blackhole): our WireGuard state
     // stays healthy (we keep receiving), but the peer's escalation shows as
-    // repeated distinct inits in quick succession.
+    // REKEY_DISTRESS_ATTEMPTS distinct inits with no data in between.
     let _ = a.advance(t0, t0 + secs(60));
-    let t1 = t0 + secs(60);
+    let mut t = t0 + secs(60);
 
-    let mut hs1 = Handshake::new(t1);
-    let _ = a.handle_inbound_network(&mut hs1.responder, &hs1.init, (addr(2), addr(4)), t1);
-    let t2 = t1 + REKEY_DISTRESS_INTERVAL / 2;
-    let mut hs2 = Handshake::new(t2);
-    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(4)), t2);
+    for _ in 0..REKEY_DISTRESS_ATTEMPTS {
+        let mut hs = Handshake::new(t);
+        let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), t);
+        t += secs(5);
+    }
     a.drain_events();
     let _ = a.transmits();
 
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t2);
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t);
 
     assert_eq!(
         a.primary(),
         Some((addr(2), addr(4))),
-        "repeated early re-keys are peer distress; the fresh pair must take over",
+        "repeated re-keys with no data are peer distress; the fresh pair must take over",
     );
 }
 
@@ -908,20 +912,32 @@ fn routine_rekeys_do_not_restart_probing() {
 }
 
 #[test]
-fn peer_rekeys_minutes_apart_are_not_distress() {
+fn peer_rekeys_with_data_in_between_are_not_distress() {
     let (mut a, t0) = direct_primary_with_relay_fallback();
     let _ = a.advance(t0, t0 + secs(10));
 
-    let t1 = t0 + secs(120);
-    let mut hs = Handshake::new(t1);
-    let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(1), addr(3)), t1);
+    // Routine re-keys arrive one at a time with peer data flowing in between.
+    // Each data packet resets the re-key count, so it never reaches the
+    // distress threshold no matter how many routine re-keys go by.
+    let mut t = t0 + secs(120);
+    for _ in 0..(REKEY_DISTRESS_ATTEMPTS + 2) {
+        let mut hs = Handshake::new(t);
+        let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(1), addr(3)), t);
+        let _ = a.handle_inbound_network(
+            &mut reject_all(),
+            &data_packet_bytes(),
+            (addr(1), addr(3)),
+            t,
+        );
+        t += secs(120);
+    }
     a.drain_events();
     let _ = a.transmits();
 
-    let activity = a.advance(t1, t1 + secs(3));
+    let activity = a.advance(t, t + secs(3));
     assert!(
         activity.probes_for((addr(2), addr(4))).is_empty(),
-        "a lone re-key minutes after the last one must not burst probes",
+        "routine re-keys with data in between must not burst probes",
     );
 }
 
@@ -934,9 +950,13 @@ fn dead_pair_with_stale_rtt_does_not_win_back_the_primary() {
     let t1 = t0 + secs(60);
     a.handle_outbound(handshake_init_bytes(), t1);
     let _ = a.transmits();
-    a.handle_outbound(handshake_init_bytes(), t1 + secs(5));
-    let _ = a.transmits();
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t1 + secs(5));
+    let mut t = t1;
+    for _ in 0..REKEY_DISTRESS_ATTEMPTS {
+        t += secs(5);
+        a.handle_outbound(handshake_init_bytes(), t);
+        let _ = a.transmits();
+    }
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t);
     assert_eq!(a.primary(), Some((addr(2), addr(4))));
     a.drain_events();
 
@@ -1311,6 +1331,14 @@ fn answer_until_settled(a: &mut PathAgent, pairs: &[Pair], start: Instant) -> In
 fn handshake_init_bytes() -> Vec<u8> {
     let mut bytes = vec![0u8; 148];
     bytes[0] = 1;
+    bytes
+}
+
+/// Synthetic data packet: only the type byte and a length past the data
+/// overhead matter for it to parse as `PacketData`.
+fn data_packet_bytes() -> Vec<u8> {
+    let mut bytes = vec![0u8; 32];
+    bytes[0] = 4;
     bytes
 }
 

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -14,8 +14,8 @@ use boringtun::noise::{Index, Tunn, TunnResult};
 use boringtun::x25519::{PublicKey, StaticSecret};
 use ip_packet::{Icmpv6Type, IpPacket};
 use path_agent::{
-    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL_LIVE, PROBE_PACING, PROBE_SRC,
-    PathAgent, Payload, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, Transmit,
+    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL_LIVE, PROBE_SRC, PathAgent,
+    Payload, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, Transmit,
 };
 
 // --- bootstrap: handshake fan-out and nomination ---
@@ -439,6 +439,60 @@ fn signaled_candidate_promotes_peer_reflexive_in_place() {
     assert_eq!(count_at_99_again, 2, "second signal must not duplicate");
 }
 
+#[test]
+fn two_connected_agents_go_quiet_after_converging() {
+    // Regression test for a probe storm: every inbound probe used to
+    // trigger a probe back unconditionally, so two agents ping-ponged
+    // bursts at RTT cadence, forever.
+    let t0 = Instant::now();
+    let mut hs = Handshake::new(t0).with_response(t0);
+    let mut a = PathAgent::new();
+    let mut b = PathAgent::new();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    b.add_local_candidate(Candidate::host(addr(2)), t0);
+    b.add_remote_candidate(Candidate::host(addr(1)), t0);
+    let _ = b.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(1)), t0);
+    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, (addr(1), addr(2)), t0);
+
+    // Pump both agents against each other with instant delivery.
+    let mut sent_by_a = 0;
+    let mut now = t0;
+    while now < t0 + secs(60) {
+        now += ms(10);
+        a.handle_timeout(now);
+        b.handle_timeout(now);
+
+        for t in a.transmits() {
+            if matches!(t.payload, Payload::Plaintext(_)) {
+                sent_by_a += 1;
+            }
+            deliver(t, &mut b, now);
+        }
+        for t in b.transmits() {
+            deliver(t, &mut a, now);
+        }
+        a.drain_events();
+        b.drain_events();
+    }
+
+    // One burst plus live-cadence probes and the occasional triggered
+    // re-validation — orders of magnitude below a storm.
+    assert!(
+        sent_by_a < 30,
+        "expected probing to go quiet after convergence, got {sent_by_a} packets in 60s",
+    );
+}
+
+/// Deliver a plaintext transmit to the other agent, from its point of view.
+fn deliver(t: Transmit, to: &mut PathAgent, now: Instant) {
+    let Payload::Plaintext(packet) = t.payload else {
+        return;
+    };
+
+    let _ = to.handle_inbound_tun(*packet, (t.remote, t.local), now);
+}
+
 // --- selection: scoring, hysteresis, freshness ---
 
 #[test]
@@ -447,7 +501,7 @@ fn inbound_echo_reply_updates_rtt_and_selects_primary() {
     let now = Instant::now();
     bootstrap_primary(&mut a, (addr(2), addr(4)), now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     let probe = extract_probe_for(&probes, (addr(1), addr(3)));
     let reply = build_echo_reply(probe.id, probe.seq);
     let handled = a.handle_inbound_tun(reply, (addr(1), addr(3)), now + ms(50));
@@ -468,7 +522,7 @@ fn primary_changes_when_lower_tier_pair_becomes_alive() {
     let now = Instant::now();
     bootstrap_primary(&mut a, (addr(2), addr(4)), now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, (addr(2), addr(4)), now + ms(100));
     assert_eq!(a.primary(), Some((addr(2), addr(4))));
     a.drain_events();
@@ -495,7 +549,7 @@ fn primary_prefers_local_relay_over_remote_relay_at_same_tier() {
     let remote_relay_pair = (addr(1), addr(4));
     bootstrap_primary(&mut a, remote_relay_pair, now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, remote_relay_pair, now + ms(50));
     assert_eq!(a.primary(), Some(remote_relay_pair));
     a.drain_events();
@@ -523,7 +577,7 @@ fn primary_prefers_single_relay_hop_over_double_regardless_of_rtt() {
     let double_hop = (addr(2), addr(4));
     bootstrap_primary(&mut a, double_hop, now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, double_hop, now + ms(20));
     assert_eq!(a.primary(), Some(double_hop));
     a.drain_events();
@@ -548,7 +602,7 @@ fn primary_prefers_ipv6_over_ipv4_at_same_tier() {
     a.add_remote_candidate(Candidate::host(addr_v6(12)), now);
     bootstrap_primary(&mut a, (addr(1), addr(2)), now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, (addr(1), addr(2)), now + ms(50));
     assert_eq!(a.primary(), Some((addr(1), addr(2))));
     a.drain_events();
@@ -574,7 +628,7 @@ fn primary_holds_better_bucket_when_incumbent_has_no_rtt() {
     bootstrap_primary(&mut a, v6_pair, now);
     assert_eq!(a.primary(), Some(v6_pair));
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, (addr(1), addr(2)), now + ms(40));
 
     assert_eq!(
@@ -596,7 +650,7 @@ fn primary_prefers_family_matched_relay_within_same_v6_bucket() {
     let mismatched_pair = (mismatched_local_alloc, addr_v6(20));
     bootstrap_primary(&mut a, mismatched_pair, now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, mismatched_pair, now + ms(50));
     assert_eq!(a.primary(), Some(mismatched_pair));
     a.drain_events();
@@ -626,7 +680,7 @@ fn family_match_dominates_ipv6_preference() {
     let v6_pair = (v6_mismatched_local_alloc, addr_v6(20));
     bootstrap_primary(&mut a, v6_pair, now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, v6_pair, now + ms(50));
     assert_eq!(a.primary(), Some(v6_pair));
     a.drain_events();
@@ -650,7 +704,7 @@ fn primary_holds_when_rtt_gain_is_within_hysteresis_margin() {
 
     bootstrap_primary(&mut a, (addr(1), addr(3)), now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, (addr(1), addr(3)), now + ms(50));
     assert_eq!(a.primary(), Some((addr(1), addr(3))));
     a.drain_events();
@@ -678,7 +732,7 @@ fn primary_switches_when_rtt_gain_exceeds_hysteresis_margin() {
     a.add_remote_candidate(Candidate::host(addr(4)), now);
     bootstrap_primary(&mut a, (addr(1), addr(3)), now);
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     a.ack_probe(&probes, (addr(1), addr(3)), now + ms(50));
     assert_eq!(a.primary(), Some((addr(1), addr(3))));
     a.drain_events();
@@ -910,7 +964,7 @@ fn retired_primary_stops_live_probing() {
     a.add_remote_candidate(Candidate::host(addr(4)), t0);
     bootstrap_primary(&mut a, (addr(1), addr(3)), t0);
 
-    let probes = a.probe_round(t0);
+    let probes = a.tick(t0);
     a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(50));
     a.ack_probe(&probes, (addr(1), addr(4)), t0 + ms(10));
     assert_eq!(a.primary(), Some((addr(1), addr(4))));
@@ -1064,9 +1118,6 @@ trait AgentExt {
     fn drain_events(&mut self);
     /// `handle_timeout(now)`, then collect the transmits it produced.
     fn tick(&mut self, now: Instant) -> Vec<Transmit>;
-    /// Fire the first probe of every pair, stepping across the pacing
-    /// stagger between pairs.
-    fn probe_round(&mut self, now: Instant) -> Vec<Transmit>;
     /// Reply to `pair`'s probe (looked up in `transmits`) at `reply_at`. Does not
     /// drain events, so callers can still assert on `PrimaryChanged`.
     fn ack_probe(&mut self, transmits: &[Transmit], pair: Pair, reply_at: Instant);
@@ -1087,19 +1138,6 @@ impl AgentExt for PathAgent {
     fn tick(&mut self, now: Instant) -> Vec<Transmit> {
         self.handle_timeout(now);
         self.transmits()
-    }
-
-    fn probe_round(&mut self, now: Instant) -> Vec<Transmit> {
-        // Enough pacing slots for every fixture's pair count while staying
-        // below the first burst gap, so no pair fires twice.
-        let slots = u32::try_from(PROBE_BURST_GAPS[0].as_millis() / PROBE_PACING.as_millis())
-            .expect("pacing slots fit into u32");
-
-        let mut out = Vec::new();
-        for slot in 0..slots {
-            out.extend(self.tick(now + PROBE_PACING * slot));
-        }
-        out
     }
 
     fn ack_probe(&mut self, transmits: &[Transmit], pair: Pair, reply_at: Instant) {
@@ -1154,7 +1192,7 @@ fn direct_primary_with_relay_fallback() -> (PathAgent, Instant) {
     let t0 = Instant::now();
     bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
 
-    let probes = a.probe_round(t0);
+    let probes = a.tick(t0);
     a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(30));
     assert_eq!(a.primary(), Some((addr(1), addr(3))));
     a.drain_events();
@@ -1169,7 +1207,7 @@ fn prove_pair_alive(a: &mut PathAgent, pair: Pair, now: Instant) {
     let _ = a.handle_inbound_tun(build_echo_request(0, 999), pair, now);
     let _ = a.transmits();
 
-    let probes = a.probe_round(now);
+    let probes = a.tick(now);
     let probe = extract_probe_for(&probes, pair);
     let _ = a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
 }

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -14,8 +14,9 @@ use boringtun::noise::{Index, Tunn, TunnResult};
 use boringtun::x25519::{PublicKey, StaticSecret};
 use ip_packet::{Icmpv6Type, IpPacket};
 use path_agent::{
-    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL, PROBE_SAMPLES, PROBE_SRC,
-    PathAgent, Payload, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL, Transmit,
+    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_GIVE_UP_ATTEMPTS, PROBE_INTERVAL,
+    PROBE_SAMPLES, PROBE_SRC, PathAgent, Payload, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
+    Transmit,
 };
 
 // --- bootstrap: handshake fan-out and nomination ---
@@ -265,13 +266,42 @@ fn unanswered_pairs_burst_then_hunt_at_the_steady_interval() {
     assert_eq!(burst.probe_times((addr(1), addr(3))), expected);
 
     // Neither pair answers, so neither settles: they keep probing at the steady
-    // interval (hunting). This stays under PROBE_GIVE_UP, where — because a
-    // primary exists — an unsettled pair would otherwise stop.
+    // interval (hunting). This stays under PROBE_GIVE_UP_ATTEMPTS, where —
+    // because a primary exists — an unsettled pair would otherwise stop.
     let last_burst = *expected.last().unwrap();
     let hunt = a.advance(last_burst, last_burst + secs(5));
     let steady: Vec<Instant> = (1..=5).map(|i| last_burst + PROBE_INTERVAL * i).collect();
     assert_eq!(hunt.probe_times((addr(1), addr(2))), steady);
     assert_eq!(hunt.probe_times((addr(1), addr(3))), steady);
+}
+
+#[test]
+fn a_non_primary_pair_that_never_answers_gives_up() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    a.add_remote_candidate(Candidate::host(addr(3)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+    a.drain_events();
+
+    // (1,3) never answers. Because we already hold a primary (1,2) as a
+    // fallback, the dead pair hole-punches for a bounded budget of attempts and
+    // then stops — it does not probe a symmetric NAT forever.
+    let dead = (addr(1), addr(3));
+    let activity = a.advance(t0, t0 + secs(60));
+    assert_eq!(
+        activity.probes_for(dead).len() as u32,
+        PROBE_GIVE_UP_ATTEMPTS,
+        "a non-primary pair fires exactly its give-up budget, then stops",
+    );
+
+    // The primary is exempt: it keeps hunting (it never settled here) and is
+    // never reaped by the give-up rule.
+    assert!(
+        activity.probes_for((addr(1), addr(2))).len() as u32 > PROBE_GIVE_UP_ATTEMPTS,
+        "the primary is exempt from give-up",
+    );
 }
 
 #[test]
@@ -1094,10 +1124,11 @@ fn recovering_a_path_is_a_plain_primary_switch_without_a_rekey() {
 }
 
 #[test]
-fn rekey_without_a_primary_buffers_for_relay_fanout() {
-    // If probes can't find any path (e.g. no relays yet after a roam and
-    // direct is filtered), the buffered re-key fans out on relay pairs as
-    // soon as they exist — the bootstrap mechanism doubles as the fallback.
+fn mid_session_rekey_recovers_via_probing_not_fanout() {
+    // Losing the primary mid-session must NOT re-handshake: the session is
+    // still valid, so a fan-out would be pointless (a peer that truly lost the
+    // session needs a full re-setup via signalling, not a handshake). Recovery
+    // is by probing, and the buffered re-key then rides the recovered primary.
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
     bootstrap_primary(&mut a, (addr(2), addr(4)), now);
@@ -1105,21 +1136,39 @@ fn rekey_without_a_primary_buffers_for_relay_fanout() {
 
     assert!(a.remove_local_candidate(&Candidate::relayed(addr(2), addr(2)), now + secs(10)));
     assert_eq!(a.primary(), None, "removing primary's local must clear it");
+    let _ = a.transmits();
 
+    // A re-key with no primary must not fan out over relays while established —
+    // only probes go out.
     let rekey_at = now + secs(120);
     a.handle_outbound(handshake_init_bytes(), rekey_at);
+    a.handle_timeout(rekey_at);
     assert!(
-        a.poll_transmit().is_none(),
-        "buffered re-key must not transmit before the timer fires"
+        a.transmits()
+            .iter()
+            .all(|t| matches!(t.payload, Payload::Plaintext(_))),
+        "no handshake fan-out mid-session; recovery is by probing",
     );
 
-    a.handle_timeout(rekey_at);
-    let outbound = a.transmits();
-    assert!(
-        outbound
-            .iter()
-            .any(|t| t.remote == addr(4) && matches!(t.payload, Payload::Ciphertext(_))),
-        "buffered re-key must fan out on a relay-involving pair: {outbound:?}"
+    // Probing brings the surviving relay pair back; it becomes the primary...
+    prove_pair_alive(&mut a, (addr(1), addr(4)), rekey_at);
+    assert_eq!(a.primary(), Some((addr(1), addr(4))));
+
+    // ...and the next re-key attempt rides it as a single transmit, not a burst.
+    a.handle_outbound(handshake_init_bytes(), rekey_at + secs(5));
+    let rekey = a.transmits();
+    let ciphertext: Vec<_> = rekey
+        .iter()
+        .filter(|t| matches!(t.payload, Payload::Ciphertext(_)))
+        .collect();
+    assert_eq!(
+        ciphertext.len(),
+        1,
+        "re-key rides the recovered primary: {rekey:?}"
+    );
+    assert_eq!(
+        (ciphertext[0].local, ciphertext[0].remote),
+        (addr(1), addr(4))
     );
 }
 

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -898,6 +898,37 @@ fn roam_recovers_the_data_path_via_probes_without_a_handshake() {
             .all(|(_, t)| matches!(t.payload, Payload::Plaintext(_))),
         "recovery must not require any handshake traffic",
     );
+    assert_eq!(recovery.events, vec![], "no path until the reply arrives");
+}
+
+#[test]
+fn retired_primary_stops_live_probing() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(3)), t0);
+    a.add_remote_candidate(Candidate::host(addr(4)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(3)), t0);
+
+    let probes = a.probe_round(t0);
+    a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(50));
+    a.ack_probe(&probes, (addr(1), addr(4)), t0 + ms(10));
+    assert_eq!(a.primary(), Some((addr(1), addr(4))));
+    a.drain_events();
+
+    // Finish the bursts, then watch the live cadence.
+    let _ = a.advance(t0, t0 + secs(3));
+    let live = a.advance(t0 + secs(3), t0 + secs(60));
+
+    assert_eq!(
+        live.probe_times((addr(1), addr(3))),
+        vec![],
+        "the retired primary must not keep probing at the live cadence",
+    );
+    assert!(
+        !live.probe_times((addr(1), addr(4))).is_empty(),
+        "the new primary keeps probing at the live cadence",
+    );
 }
 
 #[test]
@@ -988,10 +1019,11 @@ fn burst_ladder(start: Instant) -> Vec<Instant> {
         .collect()
 }
 
-/// Everything an agent did while time advanced: transmits and events,
-/// stamped with the instant they were produced at.
+/// Everything an agent did while time advanced.
 struct Activity {
+    /// Transmits, stamped with the instant they were produced at.
     transmits: Vec<(Instant, Transmit)>,
+    events: Vec<Event>,
 }
 
 impl Activity {
@@ -1058,9 +1090,15 @@ impl AgentExt for PathAgent {
     }
 
     fn probe_round(&mut self, now: Instant) -> Vec<Transmit> {
-        let mut out = self.tick(now);
-        out.extend(self.tick(now + PROBE_PACING));
-        out.extend(self.tick(now + PROBE_PACING * 2));
+        // Enough pacing slots for every fixture's pair count while staying
+        // below the first burst gap, so no pair fires twice.
+        let slots = u32::try_from(PROBE_BURST_GAPS[0].as_millis() / PROBE_PACING.as_millis())
+            .expect("pacing slots fit into u32");
+
+        let mut out = Vec::new();
+        for slot in 0..slots {
+            out.extend(self.tick(now + PROBE_PACING * slot));
+        }
         out
     }
 
@@ -1072,6 +1110,7 @@ impl AgentExt for PathAgent {
     fn advance(&mut self, start: Instant, end: Instant) -> Activity {
         let mut activity = Activity {
             transmits: Vec::new(),
+            events: Vec::new(),
         };
         let mut now = start;
 
@@ -1080,6 +1119,11 @@ impl AgentExt for PathAgent {
             activity
                 .transmits
                 .extend(std::iter::from_fn(|| self.poll_transmit()).map(|t| (now, t)));
+            // Queued events keep `poll_timeout` at `now`; collect them so
+            // time can move on.
+            activity
+                .events
+                .extend(std::iter::from_fn(|| self.poll_event()));
 
             match self.poll_timeout() {
                 Some(next) if next <= end => now = next.max(now),

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -1,6 +1,10 @@
-//! Scoring, timing, peer-reflexive discovery, and the
-//! validate-then-commit regression. Flow-level coverage lives in the
-//! tunnel proptest.
+//! Scenario coverage for the probe-driven path model.
+//!
+//! Layout follows the model's life-cycle: bootstrap via handshake fan-out,
+//! probing (bursts, triggered checks, peer-reflexive discovery), selection
+//! (scoring, hysteresis, freshness), and failure handling (roam recovery,
+//! WireGuard distress signals). Flow-level coverage lives in the tunnel
+//! proptest.
 
 use std::net::{IpAddr, SocketAddr};
 use std::ops::ControlFlow;
@@ -10,20 +14,130 @@ use boringtun::noise::{Index, Tunn, TunnResult};
 use boringtun::x25519::{PublicKey, StaticSecret};
 use ip_packet::{Icmpv6Type, IpPacket};
 use path_agent::{
-    Candidate, EVALUATION_WINDOW, Event, PROBE_DST, PROBE_INTERVAL, PROBE_INTERVAL_LIVE, PROBE_SRC,
-    PROBE_TIMEOUT, PathAgent, Payload, RESPONDER_DEDUP_TTL, Transmit,
+    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL_LIVE, PROBE_PACING, PROBE_SRC,
+    PathAgent, Payload, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, Transmit,
 };
 
-fn addr(p: u16) -> SocketAddr {
-    format!("127.0.0.1:{p}").parse().unwrap()
-}
+// --- bootstrap: handshake fan-out and nomination ---
 
-fn addr_v6(p: u16) -> SocketAddr {
-    format!("[::1]:{p}").parse().unwrap()
+#[test]
+fn outbound_handshake_init_fans_out_on_every_relay_pair() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+
+    let transmits = a.transmits();
+    assert_eq!(transmits.len(), 3);
+    let payload = Payload::Ciphertext(handshake_init_bytes());
+    for t in &transmits {
+        assert_eq!(t.payload, payload);
+    }
 }
 
 #[test]
-fn inbound_handshake_init_validates_then_adopts_primary() {
+fn outbound_handshake_init_arms_retransmits_with_initial_50ms_deadline() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+    let next = a.poll_timeout().expect("retransmit deadline");
+    assert_eq!(next, now + Duration::from_millis(50));
+}
+
+#[test]
+fn handle_timeout_at_or_after_deadline_re_emits_init_per_pair() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    let init = handshake_init_bytes();
+
+    a.handle_outbound(init.clone(), now);
+    a.handle_timeout(now);
+    let initial_count = std::iter::from_fn(|| a.poll_transmit()).count();
+    assert_eq!(initial_count, 3);
+
+    let later = now + Duration::from_millis(50);
+    a.handle_timeout(later);
+
+    let retransmits = a.transmits();
+    assert_eq!(retransmits.len(), 3);
+    for t in &retransmits {
+        assert_eq!(t.payload, Payload::Ciphertext(init.clone()));
+    }
+}
+
+#[test]
+fn handle_timeout_before_deadline_does_not_emit() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+    a.handle_timeout(now + Duration::from_millis(25));
+    assert!(a.poll_transmit().is_none());
+}
+
+#[test]
+fn retransmit_ladder_bursts_then_doubles_to_cap() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+
+    let mut t = now + Duration::from_millis(50);
+    let expected_step_ms: [u64; 8] = [50, 50, 100, 200, 400, 800, 1600, 1600];
+    for &expected_ms in &expected_step_ms {
+        a.handle_timeout(t);
+        let _ = a.transmits();
+        let next = a.poll_timeout().expect("deadline");
+        assert_eq!(next, t + Duration::from_millis(expected_ms));
+        t = next;
+    }
+}
+
+#[test]
+fn outbound_init_keeps_retransmitting_until_answered() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+
+    a.handle_timeout(now + Duration::from_secs(11));
+    assert!(a.poll_event().is_none(), "no BootstrapFailed-style event");
+    assert!(
+        a.poll_transmit().is_some(),
+        "retransmits should still be firing"
+    );
+}
+
+#[test]
+fn inbound_handshake_response_clears_retransmits() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+    let init_deadline = a.poll_timeout().expect("init armed retransmits");
+
+    let mut hs = Handshake::new(now).with_response(now);
+    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, (addr(2), addr(4)), now);
+    a.drain_events();
+
+    let post_deadline = a.poll_timeout();
+    assert!(
+        post_deadline.is_none_or(|t| t != init_deadline),
+        "retransmit deadline should have cleared",
+    );
+}
+
+#[test]
+fn inbound_handshake_init_validates_then_nominates_when_pathless() {
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
     let mut hs = Handshake::new(now);
@@ -107,98 +221,14 @@ fn responder_dedup_replays_within_window_then_expires() {
 }
 
 #[test]
-fn outbound_handshake_init_arms_retransmits_with_initial_50ms_deadline() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    let next = a.poll_timeout().expect("retransmit deadline");
-    assert_eq!(next, now + Duration::from_millis(50));
-}
-
-#[test]
-fn handle_timeout_at_or_after_deadline_re_emits_init_per_pair() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let init = handshake_init_bytes();
-
-    a.handle_outbound(init.clone(), now);
-    a.handle_timeout(now);
-    let initial_count = std::iter::from_fn(|| a.poll_transmit()).count();
-    assert_eq!(initial_count, 3);
-
-    let later = now + Duration::from_millis(50);
-    a.handle_timeout(later);
-
-    let retransmits = a.transmits();
-    assert_eq!(retransmits.len(), 3);
-    for t in &retransmits {
-        assert_eq!(t.payload, Payload::Ciphertext(init.clone()));
-    }
-}
-
-#[test]
-fn retransmit_ladder_bursts_then_doubles_to_cap() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-
-    let mut t = now + Duration::from_millis(50);
-    let expected_step_ms: [u64; 8] = [50, 50, 100, 200, 400, 800, 1600, 1600];
-    for &expected_ms in &expected_step_ms {
-        a.handle_timeout(t);
-        let _ = a.transmits();
-        let next = a.poll_timeout().expect("deadline");
-        assert_eq!(next, t + Duration::from_millis(expected_ms));
-        t = next;
-    }
-}
-
-#[test]
-fn inbound_handshake_response_clears_retransmits() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    let init_deadline = a.poll_timeout().expect("init armed retransmits");
-
-    let mut hs = Handshake::new(now).with_response(now);
-    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, (addr(2), addr(4)), now);
-    a.drain_events();
-
-    let post_deadline = a.poll_timeout();
-    assert!(
-        post_deadline.is_none_or(|t| t != init_deadline),
-        "retransmit deadline should have cleared",
-    );
-}
-
-#[test]
-fn handle_timeout_before_deadline_does_not_emit() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    a.handle_timeout(now + Duration::from_millis(25));
-    assert!(a.poll_transmit().is_none());
-}
-
-#[test]
 fn srflx_local_uses_base_as_send_from_address() {
     let mut a = PathAgent::new();
     let now = Instant::now();
 
     let mapped = addr(10);
     let base = addr(11);
-    a.add_local_candidate(Candidate::server_reflexive(mapped, base));
-    a.add_local_candidate(Candidate::relayed(addr(20), addr(20)));
+    a.add_local_candidate(Candidate::server_reflexive(mapped, base), now);
+    a.add_local_candidate(Candidate::relayed(addr(20), addr(20)), now);
     a.add_remote_candidate(Candidate::relayed(addr(30), addr(30)), now);
 
     a.handle_outbound(handshake_init_bytes(), now);
@@ -213,320 +243,162 @@ fn srflx_local_uses_base_as_send_from_address() {
     assert_eq!(emitted, expected);
 }
 
-#[test]
-fn outbound_handshake_init_fans_out_on_every_relay_pair() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
+// --- probing: bursts, triggered checks, peer-reflexive discovery ---
 
-    let transmits = a.transmits();
-    assert_eq!(transmits.len(), 3);
-    let payload = Payload::Ciphertext(handshake_init_bytes());
-    for t in &transmits {
-        assert_eq!(t.payload, payload);
-    }
+#[test]
+fn pairs_probe_in_a_front_loaded_burst_then_only_the_primary_stays_on_live_cadence() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    a.add_remote_candidate(Candidate::host(addr(3)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+
+    let burst = a.advance(t0, t0 + secs(5));
+
+    // Both pairs fire the full front-loaded ladder without waiting for
+    // replies — after a roam, the peer's NAT filter may open between two
+    // probes and the next one must follow promptly.
+    let expected = burst_ladder(t0);
+    assert_eq!(burst.probe_times((addr(1), addr(2))), expected);
+    assert_eq!(burst.probe_times((addr(1), addr(3))), expected);
+
+    let after_burst = a.advance(t0 + secs(5), t0 + secs(60));
+
+    // Dormant pairs stay quiet; the primary keeps its RTT fresh and its NAT
+    // mappings warm.
+    assert_eq!(after_burst.probe_times((addr(1), addr(3))), vec![]);
+    assert_eq!(
+        after_burst.probe_times((addr(1), addr(2))),
+        vec![
+            t0 + secs(2) + PROBE_INTERVAL_LIVE,
+            t0 + secs(2) + PROBE_INTERVAL_LIVE * 2
+        ],
+    );
+}
+
+#[test]
+fn late_reply_to_an_earlier_burst_probe_still_measures_rtt() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    a.add_remote_candidate(Candidate::host(addr(3)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+
+    let pair = (addr(1), addr(3));
+    let burst = a.advance(t0, t0 + ms(300));
+    let probes = burst.probes_for(pair);
+    assert_eq!(probes.len(), 2, "two ladder steps within 300ms");
+
+    // The reply to the *first* probe arrives after the second was sent.
+    let first = probes[0];
+    let _ = a.handle_inbound_tun(build_echo_reply(first.id, first.seq), pair, t0 + ms(400));
+
+    assert_eq!(
+        a.primary(),
+        Some(pair),
+        "the late reply must measure and win against the reply-less incumbent"
+    );
 }
 
 #[test]
 fn probe_seq_advances_per_pair_per_fire() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    a.add_remote_candidate(Candidate::host(addr(3)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
 
-    a.handle_timeout(now);
-    let first = a.transmits();
-    let first_probe = extract_probe_for(&first, (addr(1), addr(3)));
-    let first_seq = first_probe.seq;
-
-    let _ = a.handle_inbound_tun(
-        build_echo_reply(first_probe.id, first_probe.seq),
-        (addr(1), addr(3)),
-        now + Duration::from_millis(50),
-    );
-
-    a.handle_timeout(now + PROBE_INTERVAL);
-    let second = a.transmits();
-    let second_seq = extract_probe_for(&second, (addr(1), addr(3))).seq;
-
-    assert_eq!(second_seq, first_seq.wrapping_add(1));
-}
-
-#[test]
-fn probe_skips_while_inflight_until_probe_timeout_lapses() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    a.handle_timeout(now);
-    let first = a.transmits();
-    let pair = (addr(1), addr(3));
-    let first_seq = extract_probe_for(&first, pair).seq;
-
-    a.handle_timeout(now + PROBE_INTERVAL);
-    let mid: Vec<_> = std::iter::from_fn(|| a.poll_transmit())
-        .filter(|t| (t.local, t.remote) == pair)
+    let burst = a.advance(t0, t0 + secs(3));
+    let seqs: Vec<u16> = burst
+        .probes_for((addr(1), addr(3)))
+        .iter()
+        .map(|p| p.seq)
         .collect();
-    assert!(
-        mid.is_empty(),
-        "expected no probe re-fire while previous is inflight: {mid:?}"
-    );
 
-    a.handle_timeout(now + PROBE_TIMEOUT);
-    let after: Vec<_> = std::iter::from_fn(|| a.poll_transmit())
-        .filter(|t| (t.local, t.remote) == pair)
+    let first = seqs[0];
+    let expected: Vec<u16> = (0..seqs.len() as u16)
+        .map(|i| first.wrapping_add(i))
         .collect();
-    assert_eq!(
-        after.len(),
-        1,
-        "expected fresh probe after timeout: {after:?}"
-    );
-    let next_seq = extract_probe_for(&after, pair).seq;
-    assert_eq!(next_seq, first_seq.wrapping_add(1));
+    assert_eq!(seqs, expected);
 }
 
 #[test]
-fn drive_probes_only_emits_on_primary_after_settle() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let primary = (addr(1), addr(3));
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
+fn trickled_candidate_probes_immediately_even_while_dormant() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), t0);
+    a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), t0);
+    bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
 
-    let inside = a.tick(now);
-    assert!(!inside.is_empty(), "expected probes inside window");
-    a.ack_probe(&inside, primary, now + ms(50));
-    assert_eq!(a.primary(), Some(primary));
-    a.drain_events();
+    // Exhaust every burst; the agent is dormant except for the primary.
+    let _ = a.advance(t0, t0 + secs(10));
 
-    a.handle_timeout(now + EVALUATION_WINDOW);
-    let _ = a.transmits();
+    let t1 = t0 + secs(10);
+    a.add_remote_candidate(Candidate::host(addr(3)), t1);
 
-    a.handle_timeout(now + EVALUATION_WINDOW + PROBE_INTERVAL_LIVE - ms(1));
-    assert!(a.poll_transmit().is_none(), "before live deadline");
-
-    let live = a.tick(now + EVALUATION_WINDOW + PROBE_INTERVAL_LIVE);
-    assert_eq!(live.len(), 1, "expected primary-only probe: {live:?}");
-    assert_eq!((live[0].local, live[0].remote), primary);
+    let activity = a.advance(t1, t1 + secs(1));
+    assert!(!activity.probes_for((addr(1), addr(3))).is_empty());
+    assert!(!activity.probes_for((addr(2), addr(3))).is_empty());
 }
 
 #[test]
-fn settle_keeps_poll_timeout_armed_for_primary_probes() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let primary = (addr(1), addr(3));
-    settle_with_primary(&mut a, (addr(2), addr(4)), primary, now);
+fn candidate_arrival_reprobes_the_current_primary() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+    let _ = a.advance(t0, t0 + secs(10));
 
-    assert_eq!(
-        a.poll_timeout(),
-        Some(now + EVALUATION_WINDOW + PROBE_INTERVAL_LIVE),
-    );
-}
+    // New candidates usually mean the peer's situation changed — the
+    // incumbent might be dead now.
+    let t1 = t0 + secs(10);
+    a.add_remote_candidate(Candidate::host(addr(3)), t1);
 
-#[test]
-fn settle_is_sticky_across_later_handshakes() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let primary = (addr(1), addr(3));
-    let mut hs = Handshake::new(now).with_response(now);
-
-    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, (addr(2), addr(4)), now);
-    a.drain_events();
-
-    a.handle_timeout(now);
-    let outbound = a.transmits();
-    let host_probe = extract_probe_for(&outbound, primary);
-    let _ = a.handle_inbound_tun(
-        build_echo_reply(host_probe.id, host_probe.seq),
-        primary,
-        now + Duration::from_millis(50),
-    );
-    a.drain_events();
-
-    a.handle_timeout(now + EVALUATION_WINDOW);
-    let _ = a.transmits();
-
-    let live_deadline = a.poll_timeout().expect("live cadence");
-
-    // Re-feeding the same bytes hits the dedup before Tunn runs;
-    // `reject_all()` proves it didn't.
-    let _ = a.handle_inbound_network(
-        &mut reject_all(),
-        &hs.response,
-        (addr(2), addr(4)),
-        now + EVALUATION_WINDOW + Duration::from_secs(60),
-    );
-    a.drain_events();
-
-    assert_eq!(a.poll_timeout(), Some(live_deadline));
-}
-
-#[test]
-fn inbound_handshake_reopens_evaluation_window_after_settle() {
-    // Reopen even when the recv path is already known — catches the
-    // roam case where signalling beats the data plane.
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let primary = (addr(1), addr(3));
-    settle_with_primary(&mut a, (addr(2), addr(4)), primary, now);
-
-    let live_tick = now + EVALUATION_WINDOW + PROBE_INTERVAL_LIVE;
-    let live_probes = a.tick(live_tick);
-    assert_eq!(
-        live_probes.len(),
-        1,
-        "post-settle only primary probes, got {live_probes:?}"
-    );
-
-    let reopen_at = live_tick + Duration::from_secs(1);
-    let mut hs2 = Handshake::new(reopen_at).with_response(reopen_at);
-    let _ = a.handle_inbound_network(
-        &mut hs2.initiator,
-        &hs2.response,
-        (addr(2), addr(4)),
-        reopen_at,
-    );
-    a.drain_events();
-    let reopened_probes = a.tick(reopen_at);
+    let activity = a.advance(t1, t1 + secs(1));
     assert!(
-        reopened_probes.len() > 1,
-        "all pairs should probe after reopen, got {reopened_probes:?}"
+        !activity.probes_for((addr(1), addr(2))).is_empty(),
+        "candidate arrival must re-probe the primary"
     );
 }
 
 #[test]
-fn new_path_handshake_inside_open_window_restarts_evaluation() {
-    // A roam re-keys from a new address while the *initial* evaluation
-    // window is still open. The new handshake must restart the window so
-    // stale RTTs are cleared; otherwise the original window settles on a
-    // pre-roam pair that is now dead.
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
+fn inbound_probe_triggers_a_probe_back_on_the_same_pair() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    a.add_remote_candidate(Candidate::host(addr(3)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+    let _ = a.advance(t0, t0 + secs(10));
 
-    // Handshake 1 opens the window (deadline now + EVALUATION_WINDOW).
-    let mut hs1 = Handshake::new(now);
-    let _ = a.handle_inbound_network(&mut hs1.responder, &hs1.init, (addr(2), addr(4)), now);
-    a.drain_events();
+    // An inbound probe proves the reverse NAT filter is open right now;
+    // probing back completes the hole punch in one round trip.
+    let t1 = t0 + secs(10);
+    let _ = a.handle_inbound_tun(build_echo_request(0, 7), (addr(1), addr(3)), t1);
 
-    // A *different* handshake arrives late in the window from a new path
-    // (a roam re-key), still inside the original deadline.
-    let t2 = now + Duration::from_secs(8);
-    let mut hs2 = Handshake::new(t2);
-    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(3)), t2);
-    a.drain_events();
+    let reply = a.poll_transmit().expect("echo reply queued");
+    assert_eq!((reply.local, reply.remote), (addr(1), addr(3)));
 
-    // At the *original* deadline a non-restarted window settles and drops
-    // to the live cadence (primary-only, +25s). The restart pushed the
-    // deadline out to t2 + EVALUATION_WINDOW, so it stays open and probes.
-    a.handle_timeout(now + EVALUATION_WINDOW);
-    let _ = a.transmits();
-
-    // Past the inflight-probe timeout but well before the restarted
-    // deadline: an open window re-probes *every* pair; a settled window
-    // probes nothing (its primary isn't due for another ~25s).
-    a.handle_timeout(now + EVALUATION_WINDOW + PROBE_TIMEOUT + Duration::from_secs(1));
-    let probes = a.transmits();
+    let activity = a.advance(t1, t1 + secs(1));
     assert!(
-        probes.len() > 1,
-        "a handshake from a new path inside the open window must restart it (re-probe all pairs), got {probes:?}"
+        !activity.probes_for((addr(1), addr(3))).is_empty(),
+        "inbound probe must trigger a probe back"
     );
 }
 
 #[test]
-fn same_path_rekey_does_not_restart_evaluation() {
-    // A routine re-key arrives on the current primary: the path evidently
-    // works, so probing must not restart — neither mid-window nor after
-    // settling.
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-
-    let mut hs1 = Handshake::new(now);
-    let _ = a.handle_inbound_network(&mut hs1.responder, &hs1.init, (addr(2), addr(4)), now);
-    a.drain_events();
-
-    // A re-key arrives on the same path (= the adopted primary),
-    // still inside the original deadline.
-    let t2 = now + Duration::from_secs(8);
-    let mut hs2 = Handshake::new(t2);
-    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(4)), t2);
-    a.drain_events();
-
-    // The window settles at the *original* deadline; nothing re-probes.
-    a.handle_timeout(now + EVALUATION_WINDOW);
-    let _ = a.transmits();
-
-    a.handle_timeout(now + EVALUATION_WINDOW + PROBE_TIMEOUT + Duration::from_secs(1));
-    let probes = a.transmits();
-    assert!(
-        probes.is_empty(),
-        "a same-path re-key must not restart evaluation, got {probes:?}"
-    );
-
-    // Another re-key on the primary after settling stays quiet, too: only
-    // the live-cadence probe of the primary remains scheduled.
-    let t3 = now + EVALUATION_WINDOW + Duration::from_secs(10);
-    let mut hs3 = Handshake::new(t3);
-    let _ = a.handle_inbound_network(&mut hs3.responder, &hs3.init, (addr(2), addr(4)), t3);
-    a.drain_events();
-    let _ = a.transmits(); // Drop the HandshakeResponse.
-
-    a.handle_timeout(t3 + Duration::from_secs(1));
-    let probes = a.transmits();
-    assert!(
-        probes.is_empty(),
-        "a post-settle same-path re-key must not restart evaluation, got {probes:?}"
-    );
-}
-
-#[test]
-fn inbound_echo_reply_updates_smoothed_rtt_and_selects_primary() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    let probes = a.tick(now);
-    let probe = extract_probe_for(&probes, (addr(1), addr(3)));
-    let reply = build_echo_reply(probe.id, probe.seq);
-    let handled = a.handle_inbound_tun(reply, (addr(1), addr(3)), now + ms(50));
-    assert!(matches!(handled, ControlFlow::Break(())));
-
-    assert_eq!(a.primary(), Some((addr(1), addr(3))));
-    match a.poll_event() {
-        Some(Event::PrimaryChanged { local, remote }) => {
-            assert_eq!((local, remote), (addr(1), addr(3)));
-        }
-        other => panic!("expected PrimaryChanged, got {other:?}"),
-    }
-}
-
-#[test]
-fn inbound_echo_request_queues_reply_on_same_pair() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-
-    let request = build_echo_request(0, 42);
-    let handled = a.handle_inbound_tun(request, (addr(2), addr(4)), now);
-    assert!(matches!(handled, ControlFlow::Break(())));
-
-    let reply_transmit = a.poll_transmit().expect("queued reply");
-    assert_eq!(reply_transmit.local, addr(2));
-    assert_eq!(reply_transmit.remote, addr(4));
-    let Payload::Plaintext(packet) = reply_transmit.payload else {
-        panic!("expected Plaintext reply");
-    };
-    let parsed = parse_probe(&packet).expect("parses");
-    assert_eq!(parsed.kind, EchoKind::Reply);
-    assert_eq!(parsed.seq, 42);
-}
-
-#[test]
-fn inbound_echo_request_from_unknown_source_registers_peer_reflexive() {
+fn inbound_probe_from_unknown_source_registers_peer_reflexive_and_probes_it() {
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
     bootstrap_primary(&mut a, (addr(2), addr(4)), now);
 
     let request = build_echo_request(0, 1);
     let _ = a.handle_inbound_tun(request, (addr(1), addr(99)), now);
-
     let _ = a.transmits();
 
     a.handle_timeout(now);
@@ -547,7 +419,7 @@ fn signaled_candidate_promotes_peer_reflexive_in_place() {
     a.handle_timeout(now);
     let probes = a.transmits();
     let probe = extract_probe_for(&probes, (addr(1), addr(99)));
-    let later = now + Duration::from_millis(50);
+    let later = now + ms(50);
     let _ = a.handle_inbound_tun(
         build_echo_reply(probe.id, probe.seq),
         (addr(1), addr(99)),
@@ -567,13 +439,36 @@ fn signaled_candidate_promotes_peer_reflexive_in_place() {
     assert_eq!(count_at_99_again, 2, "second signal must not duplicate");
 }
 
+// --- selection: scoring, hysteresis, freshness ---
+
+#[test]
+fn inbound_echo_reply_updates_rtt_and_selects_primary() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
+
+    let probes = a.probe_round(now);
+    let probe = extract_probe_for(&probes, (addr(1), addr(3)));
+    let reply = build_echo_reply(probe.id, probe.seq);
+    let handled = a.handle_inbound_tun(reply, (addr(1), addr(3)), now + ms(50));
+    assert!(matches!(handled, ControlFlow::Break(())));
+
+    assert_eq!(a.primary(), Some((addr(1), addr(3))));
+    match a.poll_event() {
+        Some(Event::PrimaryChanged { local, remote }) => {
+            assert_eq!((local, remote), (addr(1), addr(3)));
+        }
+        other => panic!("expected PrimaryChanged, got {other:?}"),
+    }
+}
+
 #[test]
 fn primary_changes_when_lower_tier_pair_becomes_alive() {
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
     bootstrap_primary(&mut a, (addr(2), addr(4)), now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, (addr(2), addr(4)), now + ms(100));
     assert_eq!(a.primary(), Some((addr(2), addr(4))));
     a.drain_events();
@@ -592,15 +487,15 @@ fn primary_changes_when_lower_tier_pair_becomes_alive() {
 fn primary_prefers_local_relay_over_remote_relay_at_same_tier() {
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)));
+    a.add_local_candidate(Candidate::host(addr(1)), now);
+    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), now);
     a.add_remote_candidate(Candidate::host(addr(3)), now);
     a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
 
     let remote_relay_pair = (addr(1), addr(4));
     bootstrap_primary(&mut a, remote_relay_pair, now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, remote_relay_pair, now + ms(50));
     assert_eq!(a.primary(), Some(remote_relay_pair));
     a.drain_events();
@@ -621,14 +516,14 @@ fn primary_prefers_single_relay_hop_over_double_regardless_of_rtt() {
     // on RTT jitter.
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)));
+    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), now);
     a.add_remote_candidate(Candidate::server_reflexive(addr(3), addr(3)), now);
     a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
 
     let double_hop = (addr(2), addr(4));
     bootstrap_primary(&mut a, double_hop, now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, double_hop, now + ms(20));
     assert_eq!(a.primary(), Some(double_hop));
     a.drain_events();
@@ -647,13 +542,13 @@ fn primary_prefers_single_relay_hop_over_double_regardless_of_rtt() {
 fn primary_prefers_ipv6_over_ipv4_at_same_tier() {
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
-    a.add_local_candidate(Candidate::host(addr_v6(11)));
+    a.add_local_candidate(Candidate::host(addr(1)), now);
+    a.add_local_candidate(Candidate::host(addr_v6(11)), now);
     a.add_remote_candidate(Candidate::host(addr(2)), now);
     a.add_remote_candidate(Candidate::host(addr_v6(12)), now);
     bootstrap_primary(&mut a, (addr(1), addr(2)), now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, (addr(1), addr(2)), now + ms(50));
     assert_eq!(a.primary(), Some((addr(1), addr(2))));
     a.drain_events();
@@ -670,8 +565,8 @@ fn primary_prefers_ipv6_over_ipv4_at_same_tier() {
 fn primary_holds_better_bucket_when_incumbent_has_no_rtt() {
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
-    a.add_local_candidate(Candidate::host(addr_v6(11)));
+    a.add_local_candidate(Candidate::host(addr(1)), now);
+    a.add_local_candidate(Candidate::host(addr_v6(11)), now);
     a.add_remote_candidate(Candidate::host(addr(2)), now);
     a.add_remote_candidate(Candidate::host(addr_v6(12)), now);
     let v6_pair = (addr_v6(11), addr_v6(12));
@@ -679,7 +574,7 @@ fn primary_holds_better_bucket_when_incumbent_has_no_rtt() {
     bootstrap_primary(&mut a, v6_pair, now);
     assert_eq!(a.primary(), Some(v6_pair));
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, (addr(1), addr(2)), now + ms(40));
 
     assert_eq!(
@@ -695,13 +590,13 @@ fn primary_prefers_family_matched_relay_within_same_v6_bucket() {
     let now = Instant::now();
     let matched_local_alloc = addr_v6(10);
     let mismatched_local_alloc = addr_v6(11);
-    a.add_local_candidate(Candidate::relayed(matched_local_alloc, addr_v6(100)));
-    a.add_local_candidate(Candidate::relayed(mismatched_local_alloc, addr(101)));
+    a.add_local_candidate(Candidate::relayed(matched_local_alloc, addr_v6(100)), now);
+    a.add_local_candidate(Candidate::relayed(mismatched_local_alloc, addr(101)), now);
     a.add_remote_candidate(Candidate::relayed(addr_v6(20), addr_v6(20)), now);
     let mismatched_pair = (mismatched_local_alloc, addr_v6(20));
     bootstrap_primary(&mut a, mismatched_pair, now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, mismatched_pair, now + ms(50));
     assert_eq!(a.primary(), Some(mismatched_pair));
     a.drain_events();
@@ -721,14 +616,17 @@ fn family_match_dominates_ipv6_preference() {
     let now = Instant::now();
     let v6_mismatched_local_alloc = addr_v6(10);
     let v4_matched_local_alloc = addr(11);
-    a.add_local_candidate(Candidate::relayed(v6_mismatched_local_alloc, addr(100)));
-    a.add_local_candidate(Candidate::relayed(v4_matched_local_alloc, addr(101)));
+    a.add_local_candidate(
+        Candidate::relayed(v6_mismatched_local_alloc, addr(100)),
+        now,
+    );
+    a.add_local_candidate(Candidate::relayed(v4_matched_local_alloc, addr(101)), now);
     a.add_remote_candidate(Candidate::relayed(addr_v6(20), addr_v6(20)), now);
     a.add_remote_candidate(Candidate::relayed(addr(30), addr(30)), now);
     let v6_pair = (v6_mismatched_local_alloc, addr_v6(20));
     bootstrap_primary(&mut a, v6_pair, now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, v6_pair, now + ms(50));
     assert_eq!(a.primary(), Some(v6_pair));
     a.drain_events();
@@ -746,13 +644,13 @@ fn family_match_dominates_ipv6_preference() {
 fn primary_holds_when_rtt_gain_is_within_hysteresis_margin() {
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
+    a.add_local_candidate(Candidate::host(addr(1)), now);
     a.add_remote_candidate(Candidate::host(addr(3)), now);
     a.add_remote_candidate(Candidate::host(addr(4)), now);
 
     bootstrap_primary(&mut a, (addr(1), addr(3)), now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, (addr(1), addr(3)), now + ms(50));
     assert_eq!(a.primary(), Some((addr(1), addr(3))));
     a.drain_events();
@@ -775,12 +673,12 @@ fn primary_holds_when_rtt_gain_is_within_hysteresis_margin() {
 fn primary_switches_when_rtt_gain_exceeds_hysteresis_margin() {
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
+    a.add_local_candidate(Candidate::host(addr(1)), now);
     a.add_remote_candidate(Candidate::host(addr(3)), now);
     a.add_remote_candidate(Candidate::host(addr(4)), now);
     bootstrap_primary(&mut a, (addr(1), addr(3)), now);
 
-    let probes = a.tick(now);
+    let probes = a.probe_round(now);
     a.ack_probe(&probes, (addr(1), addr(3)), now + ms(50));
     assert_eq!(a.primary(), Some((addr(1), addr(3))));
     a.drain_events();
@@ -815,143 +713,235 @@ fn stale_echo_reply_is_ignored() {
     assert_eq!(a.primary(), Some((addr(2), addr(4))));
 }
 
-#[test]
-fn outbound_init_keeps_retransmitting_past_evaluation_window_without_response() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-
-    a.handle_timeout(now + EVALUATION_WINDOW + Duration::from_secs(1));
-    assert!(a.poll_event().is_none(), "no BootstrapFailed-style event");
-    assert!(
-        a.poll_transmit().is_some(),
-        "retransmits should still be firing"
-    );
-}
+// --- WireGuard-signalled failure handling ---
 
 #[test]
-fn fresh_handshake_clears_stale_rtt_so_old_pair_does_not_win_against_new_one() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let initial_path = (addr(2), addr(4));
-    let roam_path = (addr(1), addr(3));
+fn probe_loss_alone_never_demotes_the_primary() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
 
-    bootstrap_primary(&mut a, initial_path, now);
-    a.handle_timeout(now);
-    let outbound = a.transmits();
-    let initial_probe = extract_probe_for(&outbound, initial_path);
-    let _ = a.handle_inbound_tun(
-        build_echo_reply(initial_probe.id, initial_probe.seq),
-        initial_path,
-        now + Duration::from_millis(40),
-    );
-    assert_eq!(a.primary(), Some(initial_path));
-    a.drain_events();
-    let _ = a.transmits();
+    // The primary's live probes go unanswered for a minute (e.g. the peer is
+    // busy and drops probes while data flows fine): no WireGuard signal, no
+    // demotion — even when a relay pair proves alive via a triggered check.
+    let _ = a.advance(t0, t0 + secs(60));
+    let t1 = t0 + secs(60);
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t1);
 
-    let roam_at = now + Duration::from_secs(60);
-    let mut hs2 = Handshake::new(roam_at).with_response(roam_at);
-    let _ = a.handle_inbound_network(&mut hs2.initiator, &hs2.response, roam_path, roam_at);
-    assert_eq!(a.primary(), Some(roam_path));
-    a.drain_events();
-
-    let _ = a.handle_inbound_tun(
-        build_echo_reply(initial_probe.id, initial_probe.seq),
-        initial_path,
-        roam_at + Duration::from_millis(10),
-    );
     assert_eq!(
         a.primary(),
-        Some(roam_path),
-        "stale reply on the old path must not flip primary back"
+        Some((addr(1), addr(3))),
+        "probe loss without a WireGuard signal must not demote the primary",
+    );
+    assert!(a.poll_event().is_none());
+}
+
+#[test]
+fn unanswered_rekey_fails_over_to_a_fresh_pair() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
+
+    // The primary dies silently; its RTT goes stale.
+    let _ = a.advance(t0, t0 + secs(60));
+    let t1 = t0 + secs(60);
+
+    // boringtun re-keys (rides the primary), gets no answer and retries:
+    // WireGuard-level failure evidence.
+    a.handle_outbound(handshake_init_bytes(), t1);
+    let _ = a.transmits();
+    a.handle_outbound(handshake_init_bytes(), t1 + secs(5));
+    let _ = a.transmits();
+
+    // The re-evaluation bursts every pair; the relay pair answers.
+    let t2 = t1 + secs(5);
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t2);
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(2), addr(4))),
+        "with WireGuard distress, the fresh relay pair must displace the dead direct primary",
     );
 }
 
 #[test]
-fn rekey_handshake_init_rides_primary_instead_of_re_fanning_out() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let recv_path = (addr(2), addr(4));
+fn peer_rekeying_early_fails_over_too() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
 
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let initial = a.transmits();
-    assert_eq!(initial.len(), 3, "handshake fans out on every relay pair");
+    // The peer stops hearing us (one-way blackhole): our WireGuard state
+    // stays healthy (we keep receiving), but the peer's escalation shows as
+    // repeated distinct inits in quick succession.
+    let _ = a.advance(t0, t0 + secs(60));
+    let t1 = t0 + secs(60);
 
-    let mut hs = Handshake::new(now).with_response(now);
-    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, recv_path, now);
+    let mut hs1 = Handshake::new(t1);
+    let _ = a.handle_inbound_network(&mut hs1.responder, &hs1.init, (addr(2), addr(4)), t1);
+    let t2 = t1 + REKEY_DISTRESS_INTERVAL / 2;
+    let mut hs2 = Handshake::new(t2);
+    let _ = a.handle_inbound_network(&mut hs2.responder, &hs2.init, (addr(2), addr(4)), t2);
     a.drain_events();
     let _ = a.transmits();
 
-    a.handle_outbound(handshake_init_bytes(), now + Duration::from_secs(120));
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t2);
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(2), addr(4))),
+        "repeated early re-keys are peer distress; the fresh pair must take over",
+    );
+}
+
+#[test]
+fn routine_rekeys_do_not_restart_probing() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
+    let _ = a.advance(t0, t0 + secs(10));
+
+    // An answered re-key minutes later is routine: it rides the primary and
+    // must not burst probes.
+    let t1 = t0 + secs(120);
+    a.handle_outbound(handshake_init_bytes(), t1);
     let rekey = a.transmits();
     assert_eq!(rekey.len(), 1, "re-key rides the primary: {rekey:?}");
-    assert_eq!((rekey[0].local, rekey[0].remote), recv_path);
-}
+    assert_eq!((rekey[0].local, rekey[0].remote), (addr(1), addr(3)));
 
-#[test]
-fn unanswered_rekey_retry_restarts_probing() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let recv_path = (addr(2), addr(4));
-
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    let mut hs = Handshake::new(now).with_response(now);
-    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, recv_path, now);
-    a.drain_events();
-    let _ = a.transmits();
-
-    a.handle_timeout(now + EVALUATION_WINDOW);
-    let _ = a.transmits();
-
-    // A routine re-key rides the primary; at most the live-cadence probe
-    // of the primary fires alongside it.
-    let rekey_at = now + Duration::from_secs(120);
-    a.handle_outbound(handshake_init_bytes(), rekey_at);
-    let _ = a.transmits();
-    a.handle_timeout(rekey_at);
-    let probes = a.transmits();
+    let activity = a.advance(t1, t1 + secs(3));
     assert!(
-        probes.len() <= 1,
-        "a routine re-key must not burst probes, got {probes:?}"
-    );
-
-    // The unanswered retry is failure evidence: probing restarts on all pairs.
-    let retry_at = rekey_at + Duration::from_secs(5);
-    a.handle_outbound(handshake_init_bytes(), retry_at);
-    let _ = a.transmits();
-    a.handle_timeout(retry_at);
-    let probes = a.transmits();
-    assert!(
-        probes.len() > 1,
-        "an unanswered re-key must restart probing on all pairs, got {probes:?}"
+        activity.probes_for((addr(2), addr(4))).is_empty(),
+        "a routine re-key must not burst probes on other pairs",
     );
 }
 
 #[test]
-fn rekey_without_primary_buffers_for_relay_fanout() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let recv_path = (addr(2), addr(4));
+fn peer_rekeys_minutes_apart_are_not_distress() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
+    let _ = a.advance(t0, t0 + secs(10));
 
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    let mut hs = Handshake::new(now).with_response(now);
-    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, recv_path, now);
+    let t1 = t0 + secs(120);
+    let mut hs = Handshake::new(t1);
+    let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(1), addr(3)), t1);
     a.drain_events();
     let _ = a.transmits();
 
-    // Roam: the primary's local candidate goes away mid-session.
-    assert!(a.remove_local_candidate(&Candidate::relayed(addr(2), addr(2)), now));
+    let activity = a.advance(t1, t1 + secs(3));
+    assert!(
+        activity.probes_for((addr(2), addr(4))).is_empty(),
+        "a lone re-key minutes after the last one must not burst probes",
+    );
+}
+
+#[test]
+fn dead_pair_with_stale_rtt_does_not_win_back_the_primary() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
+
+    // Fail over to the relay pair via WireGuard distress.
+    let _ = a.advance(t0, t0 + secs(60));
+    let t1 = t0 + secs(60);
+    a.handle_outbound(handshake_init_bytes(), t1);
+    let _ = a.transmits();
+    a.handle_outbound(handshake_init_bytes(), t1 + secs(5));
+    let _ = a.transmits();
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t1 + secs(5));
+    assert_eq!(a.primary(), Some((addr(2), addr(4))));
+    a.drain_events();
+
+    // Later replies on the (still alive) relay pair re-run selection. The
+    // dead direct pair has a better bucket but only a stale RTT — it must
+    // not hijack the primary on a meaningless measurement.
+    let t2 = t1 + secs(30);
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t2);
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(2), addr(4))),
+        "a stale RTT must not put the dead direct pair back in charge",
+    );
+}
+
+// --- roam recovery ---
+
+#[test]
+fn roam_recovers_the_data_path_via_probes_without_a_handshake() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(9)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(9)), t0);
+    let _ = a.advance(t0, t0 + secs(10));
+
+    // Roam: all local candidates are gone; the WireGuard session is kept.
+    let t1 = t0 + secs(60);
+    a.rebuild(|_| true, t1);
+    assert_eq!(a.primary(), None);
+
+    // The new socket produces a new host candidate; the peer's candidates
+    // survived the rebuild, so pairs form and probe immediately.
+    a.add_local_candidate(Candidate::host(addr(5)), t1);
+
+    let recovery = a.advance(t1, t1 + secs(1));
+    let probes = recovery.probes_for((addr(5), addr(9)));
+    assert!(
+        !probes.is_empty(),
+        "roamed pair must probe without any handshake"
+    );
+
+    let _ = a.handle_inbound_tun(
+        build_echo_reply(probes[0].id, probes[0].seq),
+        (addr(5), addr(9)),
+        t1 + ms(50),
+    );
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(5), addr(9))),
+        "first probe reply must restore the data path",
+    );
+    assert!(
+        recovery
+            .transmits
+            .iter()
+            .all(|(_, t)| matches!(t.payload, Payload::Plaintext(_))),
+        "recovery must not require any handshake traffic",
+    );
+}
+
+#[test]
+fn recovering_a_path_requests_a_rekey_to_notify_the_remote() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(9)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(9)), t0);
+    a.drain_events();
+    let _ = a.advance(t0, t0 + secs(10));
+
+    let t1 = t0 + secs(60);
+    a.rebuild(|_| true, t1);
+    a.add_local_candidate(Candidate::host(addr(5)), t1);
+    let recovery = a.advance(t1, t1 + secs(1));
+    let probes = recovery.probes_for((addr(5), addr(9)));
+    let _ = a.handle_inbound_tun(
+        build_echo_reply(probes[0].id, probes[0].seq),
+        (addr(5), addr(9)),
+        t1 + ms(50),
+    );
+
+    let events: Vec<_> = std::iter::from_fn(|| a.poll_event()).collect();
+    assert!(
+        events.contains(&Event::PathRecovered),
+        "the remote can't observe our recovery; a re-key is the signal, got {events:?}",
+    );
+}
+
+#[test]
+fn rekey_without_a_primary_buffers_for_relay_fanout() {
+    // If probes can't find any path (e.g. no relays yet after a roam and
+    // direct is filtered), the buffered re-key fans out on relay pairs as
+    // soon as they exist — the bootstrap mechanism doubles as the fallback.
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
+    let _ = a.advance(now, now + secs(10));
+
+    assert!(a.remove_local_candidate(&Candidate::relayed(addr(2), addr(2)), now + secs(10)));
     assert_eq!(a.primary(), None, "removing primary's local must clear it");
 
-    let rekey_at = now + Duration::from_secs(120);
+    let rekey_at = now + secs(120);
     a.handle_outbound(handshake_init_bytes(), rekey_at);
     assert!(
         a.poll_transmit().is_none(),
@@ -961,36 +951,75 @@ fn rekey_without_primary_buffers_for_relay_fanout() {
     a.handle_timeout(rekey_at);
     let outbound = a.transmits();
     assert!(
-        outbound.iter().any(|t| t.remote == addr(4)),
+        outbound
+            .iter()
+            .any(|t| t.remote == addr(4) && matches!(t.payload, Payload::Ciphertext(_))),
         "buffered re-key must fan out on a relay-involving pair: {outbound:?}"
     );
-}
-
-#[test]
-fn trickled_candidate_after_handshake_still_gets_probed() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)));
-    a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
-
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    a.add_remote_candidate(Candidate::host(addr(3)), now);
-
-    a.handle_timeout(now);
-    let transmits = a.transmits();
-
-    let _ = extract_probe_for(&transmits, (addr(1), addr(3)));
-    let _ = extract_probe_for(&transmits, (addr(2), addr(3)));
 }
 
 // --- test harness ---
 
 type Pair = (SocketAddr, SocketAddr);
 
+fn addr(p: u16) -> SocketAddr {
+    format!("127.0.0.1:{p}").parse().unwrap()
+}
+
+fn addr_v6(p: u16) -> SocketAddr {
+    format!("[::1]:{p}").parse().unwrap()
+}
+
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
+}
+
+fn secs(n: u64) -> Duration {
+    Duration::from_secs(n)
+}
+
+/// The probe send times of one burst starting at `start`.
+fn burst_ladder(start: Instant) -> Vec<Instant> {
+    std::iter::once(start)
+        .chain(PROBE_BURST_GAPS.iter().scan(start, |at, gap| {
+            *at += *gap;
+            Some(*at)
+        }))
+        .collect()
+}
+
+/// Everything an agent did while time advanced: transmits and events,
+/// stamped with the instant they were produced at.
+struct Activity {
+    transmits: Vec<(Instant, Transmit)>,
+}
+
+impl Activity {
+    fn probes_for(&self, pair: Pair) -> Vec<ProbeFields> {
+        self.transmits
+            .iter()
+            .filter(|(_, t)| (t.local, t.remote) == pair)
+            .filter_map(|(_, t)| match &t.payload {
+                Payload::Plaintext(packet) => parse_probe(packet),
+                Payload::Ciphertext(_) => None,
+            })
+            .filter(|p| p.kind == EchoKind::Request)
+            .collect()
+    }
+
+    fn probe_times(&self, pair: Pair) -> Vec<Instant> {
+        self.transmits
+            .iter()
+            .filter(|(_, t)| (t.local, t.remote) == pair)
+            .filter(|(_, t)| match &t.payload {
+                Payload::Plaintext(packet) => {
+                    parse_probe(packet).is_some_and(|p| p.kind == EchoKind::Request)
+                }
+                Payload::Ciphertext(_) => false,
+            })
+            .map(|(at, _)| *at)
+            .collect()
+    }
 }
 
 /// Ergonomic wrappers over the poll-based `PathAgent` API used throughout the
@@ -1003,9 +1032,15 @@ trait AgentExt {
     fn drain_events(&mut self);
     /// `handle_timeout(now)`, then collect the transmits it produced.
     fn tick(&mut self, now: Instant) -> Vec<Transmit>;
+    /// Fire the first probe of every pair, stepping across the pacing
+    /// stagger between pairs.
+    fn probe_round(&mut self, now: Instant) -> Vec<Transmit>;
     /// Reply to `pair`'s probe (looked up in `transmits`) at `reply_at`. Does not
     /// drain events, so callers can still assert on `PrimaryChanged`.
     fn ack_probe(&mut self, transmits: &[Transmit], pair: Pair, reply_at: Instant);
+    /// Step the agent from `start` to `end`, firing every deadline in
+    /// between and collecting the transmits it produces along the way.
+    fn advance(&mut self, start: Instant, end: Instant) -> Activity;
 }
 
 impl AgentExt for PathAgent {
@@ -1022,21 +1057,38 @@ impl AgentExt for PathAgent {
         self.transmits()
     }
 
+    fn probe_round(&mut self, now: Instant) -> Vec<Transmit> {
+        let mut out = self.tick(now);
+        out.extend(self.tick(now + PROBE_PACING));
+        out.extend(self.tick(now + PROBE_PACING * 2));
+        out
+    }
+
     fn ack_probe(&mut self, transmits: &[Transmit], pair: Pair, reply_at: Instant) {
         let probe = extract_probe_for(transmits, pair);
         let _ = self.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, reply_at);
     }
-}
 
-/// Bootstrap on `recv_path`, select `primary` by ack'ing its probe, then settle
-/// the evaluation window. Leaves the agent settled on `primary`.
-fn settle_with_primary(a: &mut PathAgent, recv_path: Pair, primary: Pair, now: Instant) {
-    bootstrap_primary(a, recv_path, now);
-    let probes = a.tick(now);
-    a.ack_probe(&probes, primary, now + ms(50));
-    a.drain_events();
-    a.handle_timeout(now + EVALUATION_WINDOW);
-    let _ = a.transmits();
+    fn advance(&mut self, start: Instant, end: Instant) -> Activity {
+        let mut activity = Activity {
+            transmits: Vec::new(),
+        };
+        let mut now = start;
+
+        for _ in 0..10_000 {
+            self.handle_timeout(now);
+            activity
+                .transmits
+                .extend(std::iter::from_fn(|| self.poll_transmit()).map(|t| (now, t)));
+
+            match self.poll_timeout() {
+                Some(next) if next <= end => now = next.max(now),
+                _ => return activity,
+            }
+        }
+
+        panic!("agent did not go quiet between {start:?} and {end:?}");
+    }
 }
 
 // --- shared fixtures ---
@@ -1044,11 +1096,38 @@ fn settle_with_primary(a: &mut PathAgent, recv_path: Pair, primary: Pair, now: I
 fn agent_with_relay_pairs() -> PathAgent {
     let mut a = PathAgent::new();
     let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)));
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)));
+    a.add_local_candidate(Candidate::host(addr(1)), now);
+    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), now);
     a.add_remote_candidate(Candidate::host(addr(3)), now);
     a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
     a
+}
+
+/// A host↔host primary at `(1, 3)` with a fresh RTT plus a relay pair
+/// `(2, 4)` as the potential fail-over target.
+fn direct_primary_with_relay_fallback() -> (PathAgent, Instant) {
+    let mut a = agent_with_relay_pairs();
+    let t0 = Instant::now();
+    bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
+
+    let probes = a.probe_round(t0);
+    a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(30));
+    assert_eq!(a.primary(), Some((addr(1), addr(3))));
+    a.drain_events();
+    let _ = a.transmits();
+
+    (a, t0)
+}
+
+/// Simulate the peer probing us on `pair` and us measuring it: the inbound
+/// request triggers a probe back, which we then answer.
+fn prove_pair_alive(a: &mut PathAgent, pair: Pair, now: Instant) {
+    let _ = a.handle_inbound_tun(build_echo_request(0, 999), pair, now);
+    let _ = a.transmits();
+
+    let probes = a.probe_round(now);
+    let probe = extract_probe_for(&probes, pair);
+    let _ = a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
 }
 
 /// Synthetic — only the type byte matters to `handle_outbound`.
@@ -1058,7 +1137,7 @@ fn handshake_init_bytes() -> Vec<u8> {
     bytes
 }
 
-fn bootstrap_primary(a: &mut PathAgent, recv_path: (SocketAddr, SocketAddr), now: Instant) {
+fn bootstrap_primary(a: &mut PathAgent, recv_path: Pair, now: Instant) {
     let mut hs = Handshake::new(now).with_response(now);
     let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, recv_path, now);
     a.drain_events();
@@ -1194,7 +1273,7 @@ fn parse_probe(packet: &IpPacket) -> Option<ProbeFields> {
     })
 }
 
-fn extract_probe_for(transmits: &[Transmit], pair: (SocketAddr, SocketAddr)) -> ProbeFields {
+fn extract_probe_for(transmits: &[Transmit], pair: Pair) -> ProbeFields {
     let t = transmits
         .iter()
         .find(|t| (t.local, t.remote) == pair)

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -1,25 +1,22 @@
-//! Scenario coverage for the probe-driven path model.
+//! Scenario coverage for the iceless path model.
 //!
 //! Layout follows the model's life-cycle: bootstrap via handshake fan-out,
-//! probing (bursts, triggered checks, peer-reflexive discovery), selection
-//! (scoring, hysteresis, settle-and-retire), and failure handling (roam recovery,
-//! WireGuard distress signals). Flow-level coverage lives in the tunnel
-//! proptest.
+//! session establishment, probing and (promote-only) selection, and failure
+//! handling (WireGuard distress, new candidates, roam). Flow-level coverage
+//! lives in the tunnel proptest.
 
 use std::net::{IpAddr, SocketAddr};
-use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
 
 use boringtun::noise::{Index, Tunn, TunnResult};
 use boringtun::x25519::{PublicKey, StaticSecret};
 use ip_packet::{Icmpv6Type, IpPacket};
 use path_agent::{
-    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_GIVE_UP_ATTEMPTS, PROBE_INTERVAL,
-    PROBE_SAMPLES, PROBE_SRC, PathAgent, Payload, REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL,
-    Transmit,
+    Candidate, Event, PROBE_BUDGET, PROBE_BURST_GAPS, PROBE_DST, PROBE_SRC, PathAgent, Payload,
+    REKEY_DISTRESS_ATTEMPTS, RESPONDER_DEDUP_TTL, Transmit,
 };
 
-// --- bootstrap: handshake fan-out and nomination ---
+// --- bootstrap: handshake fan-out ---
 
 #[test]
 fn outbound_handshake_init_fans_out_on_every_relay_pair() {
@@ -29,7 +26,7 @@ fn outbound_handshake_init_fans_out_on_every_relay_pair() {
     a.handle_timeout(now);
 
     let transmits = a.transmits();
-    assert_eq!(transmits.len(), 3);
+    assert_eq!(transmits.len(), 3, "one per relay-involving pair");
     let payload = Payload::Ciphertext(handshake_init_bytes());
     for t in &transmits {
         assert_eq!(t.payload, payload);
@@ -44,39 +41,7 @@ fn outbound_handshake_init_arms_retransmits_with_initial_50ms_deadline() {
     a.handle_timeout(now);
     let _ = a.transmits();
     let next = a.poll_timeout().expect("retransmit deadline");
-    assert_eq!(next, now + Duration::from_millis(50));
-}
-
-#[test]
-fn handle_timeout_at_or_after_deadline_re_emits_init_per_pair() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let init = handshake_init_bytes();
-
-    a.handle_outbound(init.clone(), now);
-    a.handle_timeout(now);
-    let initial_count = std::iter::from_fn(|| a.poll_transmit()).count();
-    assert_eq!(initial_count, 3);
-
-    let later = now + Duration::from_millis(50);
-    a.handle_timeout(later);
-
-    let retransmits = a.transmits();
-    assert_eq!(retransmits.len(), 3);
-    for t in &retransmits {
-        assert_eq!(t.payload, Payload::Ciphertext(init.clone()));
-    }
-}
-
-#[test]
-fn handle_timeout_before_deadline_does_not_emit() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    a.handle_timeout(now + Duration::from_millis(25));
-    assert!(a.poll_transmit().is_none());
+    assert_eq!(next, now + ms(50));
 }
 
 #[test]
@@ -88,97 +53,53 @@ fn retransmit_ladder_bursts_then_doubles_to_cap() {
     a.handle_timeout(now);
     let _ = a.transmits();
 
-    let mut t = now + Duration::from_millis(50);
+    let mut t = now + ms(50);
     let expected_step_ms: [u64; 8] = [50, 50, 100, 200, 400, 800, 1600, 1600];
     for &expected_ms in &expected_step_ms {
         a.handle_timeout(t);
         let _ = a.transmits();
         let next = a.poll_timeout().expect("deadline");
-        assert_eq!(next, t + Duration::from_millis(expected_ms));
+        assert_eq!(next, t + ms(expected_ms));
         t = next;
     }
 }
 
 #[test]
-fn outbound_init_keeps_retransmitting_until_answered() {
+fn inbound_handshake_response_stops_the_fanout() {
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
 
     a.handle_outbound(handshake_init_bytes(), now);
     a.handle_timeout(now);
     let _ = a.transmits();
-
-    a.handle_timeout(now + Duration::from_secs(11));
-    assert!(a.poll_event().is_none(), "no BootstrapFailed-style event");
-    assert!(
-        a.poll_transmit().is_some(),
-        "retransmits should still be firing"
-    );
-}
-
-#[test]
-fn inbound_handshake_response_clears_retransmits() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-    let _ = a.transmits();
-    let init_deadline = a.poll_timeout().expect("init armed retransmits");
 
     let mut hs = Handshake::new(now).with_response(now);
     let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, (addr(2), addr(4)), now);
     a.drain_events();
+    let _ = a.transmits();
 
-    let post_deadline = a.poll_timeout();
+    // Established: no more init retransmits, only probes now.
+    let later = a.advance(now, now + secs(3));
     assert!(
-        post_deadline.is_none_or(|t| t != init_deadline),
-        "retransmit deadline should have cleared",
+        later
+            .transmits
+            .iter()
+            .all(|(_, t)| matches!(t.payload, Payload::Plaintext(_))),
+        "after establishment nothing re-handshakes; only probes go out",
     );
-}
-
-#[test]
-fn inbound_handshake_init_validates_then_nominates_when_pathless() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    let mut hs = Handshake::new(now);
-
-    assert!(
-        a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), now)
-            .is_break()
-    );
-
-    match a.poll_event() {
-        Some(Event::PrimaryChanged { local, remote }) => {
-            assert_eq!((local, remote), (addr(2), addr(4)));
-        }
-        other => panic!("expected PrimaryChanged, got {other:?}"),
-    }
 }
 
 #[test]
 fn rejected_handshake_leaves_state_untouched() {
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
-    let mut hs = Handshake::new(now);
+    let hs = Handshake::new(now);
 
     let _ = a.handle_inbound_network(&mut reject_all(), &hs.init, (addr(2), addr(4)), now);
 
-    assert!(
-        a.poll_event().is_none(),
-        "rejected bytes must not adopt a primary"
-    );
-    assert!(
-        a.poll_transmit().is_none(),
-        "rejected bytes must not queue any outbound"
-    );
-
-    // The earlier rejection must not pollute responder dedup.
-    let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), now);
-    assert!(
-        matches!(a.poll_event(), Some(Event::PrimaryChanged { .. })),
-        "legitimate retry must adopt a primary"
-    );
+    assert!(a.poll_event().is_none());
+    assert!(a.poll_transmit().is_none());
+    assert_eq!(a.primary(), None);
 }
 
 #[test]
@@ -195,812 +116,282 @@ fn responder_dedup_replays_within_window_then_expires() {
     a.drain_events();
     let _ = a.transmits();
 
-    // Within the window, a replayed init must be served from the
-    // cache without touching boringtun; `reject_all()` proves it.
-    let replay_at = now + RESPONDER_DEDUP_TTL - Duration::from_millis(1);
+    // A replay inside the window is served from the cache; `reject_all` proves
+    // boringtun isn't touched.
+    let replay_at = now + RESPONDER_DEDUP_TTL - ms(1);
     let _ = a.handle_inbound_network(&mut reject_all(), &hs.init, path, replay_at);
-    assert!(
-        a.poll_transmit().is_some(),
-        "replay inside the window must produce a cached response"
-    );
+    assert!(a.poll_transmit().is_some(), "cached response replayed");
 
     a.handle_timeout(now + RESPONDER_DEDUP_TTL);
     let _ = a.transmits();
 
-    // Past the window the cache must be gone — `reject_all()` runs
-    // again and emits no response.
     let _ = a.handle_inbound_network(
         &mut reject_all(),
         &hs.init,
         path,
-        now + RESPONDER_DEDUP_TTL + Duration::from_secs(1),
+        now + RESPONDER_DEDUP_TTL + secs(1),
     );
-    assert!(
-        a.poll_transmit().is_none(),
-        "replay past the window must not produce a cached response"
-    );
+    assert!(a.poll_transmit().is_none(), "cache expired");
 }
 
+// --- session establishment and preliminary primary ---
+
 #[test]
-fn srflx_local_uses_base_as_send_from_address() {
-    let mut a = PathAgent::new();
+fn establishing_init_adopts_its_relay_path_as_the_primary() {
+    // The init that establishes the session arrives over the relay fan-out;
+    // adopting its path gives the responder a working primary immediately, so
+    // its connection carries data before the first probe reply. Probing then
+    // promotes away from the relay.
+    let mut a = agent_with_relay_pairs();
     let now = Instant::now();
+    let mut hs = Handshake::new(now);
 
-    let mapped = addr(10);
-    let base = addr(11);
-    a.add_local_candidate(Candidate::server_reflexive(mapped, base), now);
-    a.add_local_candidate(Candidate::relayed(addr(20), addr(20)), now);
-    a.add_remote_candidate(Candidate::relayed(addr(30), addr(30)), now);
+    let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), now);
 
-    a.handle_outbound(handshake_init_bytes(), now);
-    a.handle_timeout(now);
-
-    let mut emitted: Vec<_> = std::iter::from_fn(|| a.poll_transmit())
-        .map(|t| (t.local, t.remote))
-        .collect();
-    emitted.sort();
-    let mut expected = vec![(base, addr(30)), (addr(20), addr(30))];
-    expected.sort();
-    assert_eq!(emitted, expected);
-}
-
-// --- probing: bursts, triggered checks, peer-reflexive discovery ---
-
-#[test]
-fn unanswered_pairs_burst_then_hunt_at_the_steady_interval() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    a.add_remote_candidate(Candidate::host(addr(3)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
-
-    // Only the burst — stop before the first steady probe (at +2s).
-    let burst = a.advance(t0, t0 + ms(1500));
-
-    // Both pairs fire the full front-loaded ladder without waiting for
-    // replies — after a roam, the peer's NAT filter may open between two
-    // probes and the next one must follow promptly.
-    let expected = burst_ladder(t0);
-    assert_eq!(burst.probe_times((addr(1), addr(2))), expected);
-    assert_eq!(burst.probe_times((addr(1), addr(3))), expected);
-
-    // Neither pair answers, so neither settles: they keep probing at the steady
-    // interval (hunting). This stays under PROBE_GIVE_UP_ATTEMPTS, where —
-    // because a primary exists — an unsettled pair would otherwise stop.
-    let last_burst = *expected.last().unwrap();
-    let hunt = a.advance(last_burst, last_burst + secs(5));
-    let steady: Vec<Instant> = (1..=5).map(|i| last_burst + PROBE_INTERVAL * i).collect();
-    assert_eq!(hunt.probe_times((addr(1), addr(2))), steady);
-    assert_eq!(hunt.probe_times((addr(1), addr(3))), steady);
+    assert_eq!(
+        a.primary(),
+        Some((addr(2), addr(4))),
+        "the establishing init's path becomes the preliminary primary",
+    );
+    match a.poll_event() {
+        Some(Event::PrimaryChanged { local, remote }) => {
+            assert_eq!((local, remote), (addr(2), addr(4)));
+        }
+        other => panic!("expected PrimaryChanged, got {other:?}"),
+    }
 }
 
 #[test]
-fn a_non_primary_pair_that_never_answers_gives_up() {
-    let mut a = PathAgent::new();
+fn handshake_response_seeds_preliminary_primary_by_tier() {
+    let mut a = agent_with_relay_pairs();
     let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    a.add_remote_candidate(Candidate::host(addr(3)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+
+    // A response on the relay pair adopts it (no other primary yet).
+    bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
+    assert_eq!(a.primary(), Some((addr(2), addr(4))));
+}
+
+// --- probing and promote-only selection ---
+
+#[test]
+fn probe_reply_promotes_to_a_better_tier() {
+    // Relay preliminary, then a host probe reply promotes (host beats relay).
+    let mut a = agent_with_relay_pairs();
+    let t0 = Instant::now();
+    bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
+    assert_eq!(a.primary(), Some((addr(2), addr(4))));
     a.drain_events();
 
-    // (1,3) never answers. Because we already hold a primary (1,2) as a
-    // fallback, the dead pair hole-punches for a bounded budget of attempts and
-    // then stops — it does not probe a symmetric NAT forever.
+    let probes = a.tick(t0);
+    a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(30));
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(1), addr(3))),
+        "a host probe reply promotes over the relay preliminary",
+    );
+}
+
+#[test]
+fn a_worse_tier_probe_never_demotes_the_primary() {
+    let (mut a, t0) = direct_primary_with_relay_fallback(); // primary (1,3), host
+    prove_pair_alive(&mut a, (addr(2), addr(4)), t0 + secs(1)); // relay answers
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(1), addr(3))),
+        "a worse-tier reply must not demote the host primary",
+    );
+}
+
+#[test]
+fn a_non_primary_pair_goes_quiet_after_its_probe_budget() {
+    let mut a = agent_with_relay_pairs();
+    let t0 = Instant::now();
+    // Adopt (2,4) as primary so the budget applies to the other pairs.
+    bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
+    a.drain_events();
+
+    // (1,3) never answers; with a primary in hand it hunts only PROBE_BUDGET
+    // times, then stops.
     let dead = (addr(1), addr(3));
     let activity = a.advance(t0, t0 + secs(60));
     assert_eq!(
         activity.probes_for(dead).len() as u32,
-        PROBE_GIVE_UP_ATTEMPTS,
-        "a non-primary pair fires exactly its give-up budget, then stops",
-    );
-
-    // The primary is exempt: it keeps hunting (it never settled here) and is
-    // never reaped by the give-up rule.
-    assert!(
-        activity.probes_for((addr(1), addr(2))).len() as u32 > PROBE_GIVE_UP_ATTEMPTS,
-        "the primary is exempt from give-up",
+        PROBE_BUDGET,
+        "a non-primary pair fires exactly its budget then goes quiet",
     );
 }
 
 #[test]
-fn an_answered_non_primary_pair_settles_and_goes_quiet() {
-    let mut a = PathAgent::new();
+fn a_pathless_agent_probes_forever() {
+    // Establish (adopting the init's relay path), then lose the primary by
+    // dropping its remote candidate, with nothing else answering.
+    let mut a = agent_with_relay_pairs();
     let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    // A worse-bucket relay pair that answers but can never steal the primary.
-    a.add_remote_candidate(Candidate::relayed(addr(3), addr(3)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+    let mut hs = Handshake::new(t0);
+    let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), t0);
+    assert_eq!(a.primary(), Some((addr(2), addr(4))));
     a.drain_events();
+    let _ = a.transmits();
 
-    let loser = (addr(1), addr(3));
+    assert!(a.remove_remote_candidate(&Candidate::relayed(addr(4), addr(4)), t0));
+    assert_eq!(a.primary(), None, "losing the primary's remote clears it");
 
-    // Answer every probe on the loser as it goes out; after PROBE_SAMPLES
-    // replies it has a stable RTT and — being a non-primary — stops probing.
-    let mut sent = 0u32;
-    let mut now = t0;
-    for _ in 0..200 {
-        for t in a.tick(now) {
-            if (t.local, t.remote) == loser
-                && let Payload::Plaintext(p) = &t.payload
-                && let Some(probe) = parse_probe(p)
-                && probe.kind == EchoKind::Request
-            {
-                sent += 1;
-                let _ = a.handle_inbound_tun(
-                    build_echo_reply(probe.id, probe.seq),
-                    loser,
-                    now + ms(20),
-                );
-            }
-        }
-        match a.poll_timeout() {
-            Some(next) => now = next.max(now),
-            None => break,
-        }
-    }
-
-    assert_eq!(
-        a.primary(),
-        Some((addr(1), addr(2))),
-        "the worse-bucket loser must not steal the primary",
-    );
-    assert_eq!(
-        sent, PROBE_SAMPLES,
-        "a non-primary pair must stop probing after {PROBE_SAMPLES} positive samples, sent {sent}",
+    // With no primary, probing never stops.
+    let activity = a.advance(t0, t0 + secs(30));
+    assert!(
+        activity.probes_for((addr(1), addr(3))).len() as u32 > PROBE_BUDGET,
+        "without a primary, pairs keep probing past the budget",
     );
 }
 
 #[test]
-fn late_reply_to_an_earlier_burst_probe_still_measures_rtt() {
-    let mut a = PathAgent::new();
+fn a_reply_with_a_stale_pair_id_is_ignored() {
+    let mut a = agent_with_relay_pairs();
     let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    a.add_remote_candidate(Candidate::host(addr(3)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
-
-    let pair = (addr(1), addr(3));
-    let burst = a.advance(t0, t0 + ms(300));
-    let probes = burst.probes_for(pair);
-    assert_eq!(probes.len(), 2, "two ladder steps within 300ms");
-
-    // The reply to the *first* probe arrives after the second was sent.
-    let first = probes[0];
-    let _ = a.handle_inbound_tun(build_echo_reply(first.id, first.seq), pair, t0 + ms(400));
-
-    assert_eq!(
-        a.primary(),
-        Some(pair),
-        "the late reply must measure and win against the reply-less incumbent"
-    );
-}
-
-#[test]
-fn probe_seq_advances_per_pair_per_fire() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    a.add_remote_candidate(Candidate::host(addr(3)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
-
-    let burst = a.advance(t0, t0 + secs(3));
-    let seqs: Vec<u16> = burst
-        .probes_for((addr(1), addr(3)))
-        .iter()
-        .map(|p| p.seq)
-        .collect();
-
-    let first = seqs[0];
-    let expected: Vec<u16> = (0..seqs.len() as u16)
-        .map(|i| first.wrapping_add(i))
-        .collect();
-    assert_eq!(seqs, expected);
-}
-
-#[test]
-fn trickled_candidate_probes_immediately() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), t0);
-    a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), t0);
     bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
-    let _ = a.advance(t0, t0 + secs(10));
+    a.drain_events();
 
-    // A late candidate seeds new pairs that probe right away — no waiting for
-    // any global window or the existing pairs' cadence.
-    let t1 = t0 + secs(10);
-    a.add_remote_candidate(Candidate::host(addr(3)), t1);
-
-    let activity = a.advance(t1, t1 + secs(1));
-    assert!(!activity.probes_for((addr(1), addr(3))).is_empty());
-    assert!(!activity.probes_for((addr(2), addr(3))).is_empty());
-}
-
-#[test]
-fn candidate_arrival_reprobes_the_current_primary() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
-    let _ = a.advance(t0, t0 + secs(10));
-
-    // New candidates usually mean the peer's situation changed — the
-    // incumbent might be dead now.
-    let t1 = t0 + secs(10);
-    a.add_remote_candidate(Candidate::host(addr(3)), t1);
-
-    let activity = a.advance(t1, t1 + secs(1));
-    assert!(
-        !activity.probes_for((addr(1), addr(2))).is_empty(),
-        "candidate arrival must re-probe the primary"
-    );
-}
-
-#[test]
-fn inbound_probe_triggers_a_probe_back_on_the_same_pair() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    a.add_remote_candidate(Candidate::host(addr(3)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
-    let _ = a.advance(t0, t0 + secs(10));
-
-    // An inbound probe proves the reverse NAT filter is open right now;
-    // probing back completes the hole punch in one round trip.
-    let t1 = t0 + secs(10);
-    let _ = a.handle_inbound_tun(build_echo_request(0, 7), (addr(1), addr(3)), t1);
-
-    let reply = a.poll_transmit().expect("echo reply queued");
-    assert_eq!((reply.local, reply.remote), (addr(1), addr(3)));
-
-    let activity = a.advance(t1, t1 + secs(1));
-    assert!(
-        !activity.probes_for((addr(1), addr(3))).is_empty(),
-        "inbound probe must trigger a probe back"
-    );
-}
-
-#[test]
-fn inbound_probe_from_unknown_source_registers_peer_reflexive_and_probes_it() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    let request = build_echo_request(0, 1);
-    let _ = a.handle_inbound_tun(request, (addr(1), addr(99)), now);
-    let _ = a.transmits();
-
-    a.handle_timeout(now);
-    let probes = a.transmits();
-
-    let _ = extract_probe_for(&probes, (addr(1), addr(99)));
-}
-
-#[test]
-fn signaled_candidate_promotes_peer_reflexive_in_place() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    let _ = a.handle_inbound_tun(build_echo_request(0, 1), (addr(1), addr(99)), now);
-    let _ = a.transmits();
-
-    a.handle_timeout(now);
-    let probes = a.transmits();
-    let probe = extract_probe_for(&probes, (addr(1), addr(99)));
-    let later = now + ms(50);
-    let _ = a.handle_inbound_tun(
-        build_echo_reply(probe.id, probe.seq),
-        (addr(1), addr(99)),
-        later,
-    );
-
-    assert!(a.pairs().any(|p| p == (addr(1), addr(99))));
-
-    a.add_remote_candidate(Candidate::server_reflexive(addr(99), addr(98)), now);
-
-    assert!(a.pairs().any(|p| p == (addr(1), addr(99))));
-    let count_at_99 = a.pairs().filter(|(_, r)| *r == addr(99)).count();
-    assert_eq!(count_at_99, 2, "pairs at addr(99): one per local");
-
-    a.add_remote_candidate(Candidate::server_reflexive(addr(99), addr(98)), now);
-    let count_at_99_again = a.pairs().filter(|(_, r)| *r == addr(99)).count();
-    assert_eq!(count_at_99_again, 2, "second signal must not duplicate");
-}
-
-#[test]
-fn two_connected_agents_go_quiet_after_converging() {
-    // Regression test for a probe storm: every inbound probe used to
-    // trigger a probe back unconditionally, so two agents ping-ponged
-    // bursts at RTT cadence, forever.
-    let t0 = Instant::now();
-    let mut hs = Handshake::new(t0).with_response(t0);
-    let mut a = PathAgent::new();
-    let mut b = PathAgent::new();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(2)), t0);
-    b.add_local_candidate(Candidate::host(addr(2)), t0);
-    b.add_remote_candidate(Candidate::host(addr(1)), t0);
-    let _ = b.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(1)), t0);
-    let _ = a.handle_inbound_network(&mut hs.initiator, &hs.response, (addr(1), addr(2)), t0);
-
-    // Pump both agents against each other with instant delivery.
-    let mut sent_by_a = 0;
-    let mut now = t0;
-    while now < t0 + secs(60) {
-        now += ms(10);
-        a.handle_timeout(now);
-        b.handle_timeout(now);
-
-        for t in a.transmits() {
-            if matches!(t.payload, Payload::Plaintext(_)) {
-                sent_by_a += 1;
-            }
-            deliver(t, &mut b, now);
-        }
-        for t in b.transmits() {
-            deliver(t, &mut a, now);
-        }
-        a.drain_events();
-        b.drain_events();
-    }
-
-    // One burst plus live-cadence probes and the occasional triggered
-    // re-validation — orders of magnitude below a storm.
-    assert!(
-        sent_by_a < 30,
-        "expected probing to go quiet after convergence, got {sent_by_a} packets in 60s",
-    );
-}
-
-/// Deliver a plaintext transmit to the other agent, from its point of view.
-fn deliver(t: Transmit, to: &mut PathAgent, now: Instant) {
-    let Payload::Plaintext(packet) = t.payload else {
-        return;
-    };
-
-    let _ = to.handle_inbound_tun(*packet, (t.remote, t.local), now);
-}
-
-// --- selection: scoring, hysteresis, freshness ---
-
-#[test]
-fn inbound_echo_reply_updates_rtt_and_selects_primary() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    let probes = a.tick(now);
+    let probes = a.tick(t0);
     let probe = extract_probe_for(&probes, (addr(1), addr(3)));
-    let reply = build_echo_reply(probe.id, probe.seq);
-    let handled = a.handle_inbound_tun(reply, (addr(1), addr(3)), now + ms(50));
-    assert!(matches!(handled, ControlFlow::Break(())));
 
-    assert_eq!(a.primary(), Some((addr(1), addr(3))));
-    match a.poll_event() {
-        Some(Event::PrimaryChanged { local, remote }) => {
-            assert_eq!((local, remote), (addr(1), addr(3)));
-        }
-        other => panic!("expected PrimaryChanged, got {other:?}"),
-    }
-}
-
-#[test]
-fn primary_changes_when_lower_tier_pair_becomes_alive() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, (addr(2), addr(4)), now + ms(100));
-    assert_eq!(a.primary(), Some((addr(2), addr(4))));
-    a.drain_events();
-
-    a.ack_probe(&probes, (addr(1), addr(3)), now + ms(150));
-    assert_eq!(a.primary(), Some((addr(1), addr(3))));
-    match a.poll_event() {
-        Some(Event::PrimaryChanged { local, remote }) => {
-            assert_eq!((local, remote), (addr(1), addr(3)));
-        }
-        other => panic!("expected PrimaryChanged, got {other:?}"),
-    }
-}
-
-#[test]
-fn primary_prefers_local_relay_over_remote_relay_at_same_tier() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), now);
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), now);
-    a.add_remote_candidate(Candidate::host(addr(3)), now);
-    a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
-
-    let remote_relay_pair = (addr(1), addr(4));
-    bootstrap_primary(&mut a, remote_relay_pair, now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, remote_relay_pair, now + ms(50));
-    assert_eq!(a.primary(), Some(remote_relay_pair));
-    a.drain_events();
-
-    let local_relay_pair = (addr(2), addr(3));
-    a.ack_probe(&probes, local_relay_pair, now + ms(100));
-    assert_eq!(
-        a.primary(),
-        Some(local_relay_pair),
-        "local-relay pair should beat remote-relay pair at the same tier",
+    // Reply carrying a different id than the pair was probed with.
+    let stale_id = probe.id.wrapping_add(1);
+    let _ = a.handle_inbound_tun(
+        build_echo_reply(stale_id, probe.seq),
+        (addr(1), addr(3)),
+        t0 + ms(30),
     );
-}
-
-#[test]
-fn primary_prefers_single_relay_hop_over_double_regardless_of_rtt() {
-    // Scoring compares both ends' tiers: (relay, srflx) traverses one
-    // relay, (relay, relay) two — the former must win on tier, not flap
-    // on RTT jitter.
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), now);
-    a.add_remote_candidate(Candidate::server_reflexive(addr(3), addr(3)), now);
-    a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), now);
-
-    let double_hop = (addr(2), addr(4));
-    bootstrap_primary(&mut a, double_hop, now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, double_hop, now + ms(20));
-    assert_eq!(a.primary(), Some(double_hop));
-    a.drain_events();
-
-    // Even with a much worse RTT, one relay hop beats two.
-    let single_hop = (addr(2), addr(3));
-    a.ack_probe(&probes, single_hop, now + ms(500));
-    assert_eq!(
-        a.primary(),
-        Some(single_hop),
-        "single-relay-hop pair should beat double-relay-hop pair",
-    );
-}
-
-#[test]
-fn primary_prefers_ipv6_over_ipv4_at_same_tier() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), now);
-    a.add_local_candidate(Candidate::host(addr_v6(11)), now);
-    a.add_remote_candidate(Candidate::host(addr(2)), now);
-    a.add_remote_candidate(Candidate::host(addr_v6(12)), now);
-    bootstrap_primary(&mut a, (addr(1), addr(2)), now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, (addr(1), addr(2)), now + ms(50));
-    assert_eq!(a.primary(), Some((addr(1), addr(2))));
-    a.drain_events();
-
-    a.ack_probe(&probes, (addr_v6(11), addr_v6(12)), now + ms(100));
-    assert_eq!(
-        a.primary(),
-        Some((addr_v6(11), addr_v6(12))),
-        "v6 pair should beat v4 pair at the same tier",
-    );
-}
-
-#[test]
-fn primary_holds_better_bucket_when_incumbent_has_no_rtt() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), now);
-    a.add_local_candidate(Candidate::host(addr_v6(11)), now);
-    a.add_remote_candidate(Candidate::host(addr(2)), now);
-    a.add_remote_candidate(Candidate::host(addr_v6(12)), now);
-    let v6_pair = (addr_v6(11), addr_v6(12));
-
-    bootstrap_primary(&mut a, v6_pair, now);
-    assert_eq!(a.primary(), Some(v6_pair));
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, (addr(1), addr(2)), now + ms(40));
 
     assert_eq!(
         a.primary(),
-        Some(v6_pair),
-        "v4 must not displace a no-RTT v6 incumbent — discrete prefix wins",
+        Some((addr(2), addr(4))),
+        "a reply whose id doesn't match the pair must not measure it",
     );
 }
 
-#[test]
-fn primary_prefers_family_matched_relay_within_same_v6_bucket() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    let matched_local_alloc = addr_v6(10);
-    let mismatched_local_alloc = addr_v6(11);
-    a.add_local_candidate(Candidate::relayed(matched_local_alloc, addr_v6(100)), now);
-    a.add_local_candidate(Candidate::relayed(mismatched_local_alloc, addr(101)), now);
-    a.add_remote_candidate(Candidate::relayed(addr_v6(20), addr_v6(20)), now);
-    let mismatched_pair = (mismatched_local_alloc, addr_v6(20));
-    bootstrap_primary(&mut a, mismatched_pair, now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, mismatched_pair, now + ms(50));
-    assert_eq!(a.primary(), Some(mismatched_pair));
-    a.drain_events();
-
-    let matched_pair = (matched_local_alloc, addr_v6(20));
-    a.ack_probe(&probes, matched_pair, now + ms(100));
-    assert_eq!(
-        a.primary(),
-        Some(matched_pair),
-        "matched-family relay pair should beat mismatched-family at same v6 tier",
-    );
-}
+// --- WireGuard distress ---
 
 #[test]
-fn family_match_dominates_ipv6_preference() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    let v6_mismatched_local_alloc = addr_v6(10);
-    let v4_matched_local_alloc = addr(11);
-    a.add_local_candidate(
-        Candidate::relayed(v6_mismatched_local_alloc, addr(100)),
-        now,
-    );
-    a.add_local_candidate(Candidate::relayed(v4_matched_local_alloc, addr(101)), now);
-    a.add_remote_candidate(Candidate::relayed(addr_v6(20), addr_v6(20)), now);
-    a.add_remote_candidate(Candidate::relayed(addr(30), addr(30)), now);
-    let v6_pair = (v6_mismatched_local_alloc, addr_v6(20));
-    bootstrap_primary(&mut a, v6_pair, now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, v6_pair, now + ms(50));
-    assert_eq!(a.primary(), Some(v6_pair));
-    a.drain_events();
-
-    let v4_pair = (v4_matched_local_alloc, addr(30));
-    a.ack_probe(&probes, v4_pair, now + ms(100));
-    assert_eq!(
-        a.primary(),
-        Some(v4_pair),
-        "fully-matched v4 pair should outrank a mismatched-family v6 pair",
-    );
-}
-
-#[test]
-fn primary_holds_when_rtt_gain_is_within_hysteresis_margin() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), now);
-    a.add_remote_candidate(Candidate::host(addr(3)), now);
-    a.add_remote_candidate(Candidate::host(addr(4)), now);
-
-    bootstrap_primary(&mut a, (addr(1), addr(3)), now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, (addr(1), addr(3)), now + ms(50));
-    assert_eq!(a.primary(), Some((addr(1), addr(3))));
-    a.drain_events();
-
-    // 45ms is a 5ms gain over the 50ms incumbent — inside the 10ms floor.
-    a.ack_probe(&probes, (addr(1), addr(4)), now + ms(45));
-
+fn a_single_unanswered_rekey_is_not_distress() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
+    a.handle_outbound(handshake_init_bytes(), t0 + secs(1));
     assert_eq!(
         a.primary(),
         Some((addr(1), addr(3))),
-        "a sub-margin RTT gain must not unseat the incumbent primary",
-    );
-    assert!(
-        a.poll_event().is_none(),
-        "no PrimaryChanged should be emitted while the primary holds",
+        "one re-key can be ordinary loss; it must not clear the primary",
     );
 }
 
 #[test]
-fn primary_switches_when_rtt_gain_exceeds_hysteresis_margin() {
-    let mut a = PathAgent::new();
-    let now = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), now);
-    a.add_remote_candidate(Candidate::host(addr(3)), now);
-    a.add_remote_candidate(Candidate::host(addr(4)), now);
-    bootstrap_primary(&mut a, (addr(1), addr(3)), now);
-
-    let probes = a.tick(now);
-    a.ack_probe(&probes, (addr(1), addr(3)), now + ms(50));
-    assert_eq!(a.primary(), Some((addr(1), addr(3))));
-    a.drain_events();
-
-    a.ack_probe(&probes, (addr(1), addr(4)), now + ms(30));
-
-    assert_eq!(
-        a.primary(),
-        Some((addr(1), addr(4))),
-        "an RTT gain past the margin should switch the primary",
-    );
-    match a.poll_event() {
-        Some(Event::PrimaryChanged { local, remote }) => {
-            assert_eq!((local, remote), (addr(1), addr(4)));
-        }
-        other => panic!("expected PrimaryChanged, got {other:?}"),
-    }
-}
-
-#[test]
-fn stale_echo_reply_is_ignored() {
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-
-    a.handle_timeout(now);
-    let _ = a.transmits();
-
-    let stale_reply = build_echo_reply(0, 0xdead);
-    let _ = a.handle_inbound_tun(stale_reply, (addr(1), addr(3)), now);
-
-    assert_eq!(a.primary(), Some((addr(2), addr(4))));
-}
-
-// --- WireGuard-signalled failure handling ---
-
-#[test]
-fn probe_loss_alone_never_demotes_the_primary() {
+fn a_second_unanswered_rekey_clears_the_primary_and_reprobes() {
     let (mut a, t0) = direct_primary_with_relay_fallback();
 
-    // The primary's live probes go unanswered for a minute (e.g. the peer is
-    // busy and drops probes while data flows fine): no WireGuard signal, no
-    // demotion — even when a relay pair proves alive via a triggered check.
-    let _ = a.advance(t0, t0 + secs(60));
-    let t1 = t0 + secs(60);
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t1);
-
-    assert_eq!(
-        a.primary(),
-        Some((addr(1), addr(3))),
-        "probe loss without a WireGuard signal must not demote the primary",
-    );
-    assert!(a.poll_event().is_none());
-}
-
-#[test]
-fn unanswered_rekey_fails_over_to_a_fresh_pair() {
-    let (mut a, t0) = direct_primary_with_relay_fallback();
-
-    // The primary dies silently; its RTT goes stale.
-    let _ = a.advance(t0, t0 + secs(60));
-    let t1 = t0 + secs(60);
-
-    // boringtun re-keys (rides the primary), gets no answer and retries.
-    // A lone retransmit is ordinary loss; only after REKEY_DISTRESS_ATTEMPTS
-    // unanswered retransmits is it WireGuard-level failure evidence.
-    a.handle_outbound(handshake_init_bytes(), t1);
-    let _ = a.transmits();
-    let mut t = t1;
+    let mut t = t0;
     for _ in 0..REKEY_DISTRESS_ATTEMPTS {
-        t += secs(5);
+        t += secs(1);
         a.handle_outbound(handshake_init_bytes(), t);
         let _ = a.transmits();
     }
+    assert_eq!(a.primary(), None, "the distress re-key cleared the primary");
 
-    // The re-evaluation bursts every pair; the relay pair answers.
+    // The relay pair answers a probe and takes over.
     prove_pair_alive(&mut a, (addr(2), addr(4)), t);
+    assert_eq!(a.primary(), Some((addr(2), addr(4))));
+}
 
+#[test]
+fn an_answered_rekey_resets_the_distress_count() {
+    let (mut a, t0) = direct_primary_with_relay_fallback();
+
+    a.handle_outbound(handshake_init_bytes(), t0 + secs(1));
+    let _ = a.transmits();
+
+    // A response answers it, resetting the count.
+    let mut hs = Handshake::new(t0).with_response(t0);
+    let _ = a.handle_inbound_network(
+        &mut hs.initiator,
+        &hs.response,
+        (addr(1), addr(3)),
+        t0 + secs(1),
+    );
+    a.drain_events();
+    let _ = a.transmits();
+
+    // The next unanswered re-key is only the first again: no distress.
+    a.handle_outbound(handshake_init_bytes(), t0 + secs(2));
     assert_eq!(
         a.primary(),
-        Some((addr(2), addr(4))),
-        "with WireGuard distress, the fresh relay pair must displace the dead direct primary",
+        Some((addr(1), addr(3))),
+        "an answered re-key reset the count, so this lone one is not distress",
     );
 }
 
 #[test]
-fn peer_rekeying_early_fails_over_too() {
+fn a_second_peer_rekey_without_data_clears_the_primary() {
     let (mut a, t0) = direct_primary_with_relay_fallback();
 
-    // The peer stops hearing us (one-way blackhole): our WireGuard state
-    // stays healthy (we keep receiving), but the peer's escalation shows as
-    // REKEY_DISTRESS_ATTEMPTS distinct inits with no data in between.
-    let _ = a.advance(t0, t0 + secs(60));
-    let mut t = t0 + secs(60);
-
-    for _ in 0..REKEY_DISTRESS_ATTEMPTS {
-        let mut hs = Handshake::new(t);
+    let mut t = t0;
+    for i in 0..REKEY_DISTRESS_ATTEMPTS {
+        t += secs(1);
+        let mut hs = Handshake::new_seeded(t0, u64::from(i));
         let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), t);
-        t += secs(5);
     }
     a.drain_events();
     let _ = a.transmits();
 
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t);
-
     assert_eq!(
         a.primary(),
-        Some((addr(2), addr(4))),
-        "repeated re-keys with no data are peer distress; the fresh pair must take over",
+        None,
+        "repeated peer re-keys with no data are distress; the primary is cleared",
     );
 }
 
 #[test]
-fn routine_rekeys_do_not_restart_probing() {
+fn peer_data_resets_the_peer_rekey_count() {
     let (mut a, t0) = direct_primary_with_relay_fallback();
-    let _ = a.advance(t0, t0 + secs(10));
 
-    // An answered re-key minutes later is routine: it rides the primary and
-    // must not burst probes.
-    let t1 = t0 + secs(120);
-    a.handle_outbound(handshake_init_bytes(), t1);
-    let rekey = a.transmits();
-    assert_eq!(rekey.len(), 1, "re-key rides the primary: {rekey:?}");
-    assert_eq!((rekey[0].local, rekey[0].remote), (addr(1), addr(3)));
-
-    let activity = a.advance(t1, t1 + secs(3));
-    assert!(
-        activity.probes_for((addr(2), addr(4))).is_empty(),
-        "a routine re-key must not burst probes on other pairs",
-    );
-}
-
-#[test]
-fn peer_rekeys_with_data_in_between_are_not_distress() {
-    let (mut a, t0) = direct_primary_with_relay_fallback();
-    let _ = a.advance(t0, t0 + secs(10));
-
-    // Routine re-keys arrive one at a time with peer data flowing in between.
-    // Each data packet resets the re-key count, so it never reaches the
-    // distress threshold no matter how many routine re-keys go by.
-    let mut t = t0 + secs(120);
-    for _ in 0..(REKEY_DISTRESS_ATTEMPTS + 2) {
-        let mut hs = Handshake::new(t);
-        let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(1), addr(3)), t);
+    // Many peer re-keys, but data flows in between each: never distress.
+    let mut t = t0;
+    for i in 0..(REKEY_DISTRESS_ATTEMPTS + 2) {
+        t += secs(1);
+        let mut hs = Handshake::new_seeded(t0, u64::from(i));
+        let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(2), addr(4)), t);
         let _ = a.handle_inbound_network(
             &mut reject_all(),
             &data_packet_bytes(),
-            (addr(1), addr(3)),
+            (addr(2), addr(4)),
             t,
         );
-        t += secs(120);
     }
     a.drain_events();
     let _ = a.transmits();
-
-    let activity = a.advance(t, t + secs(3));
-    assert!(
-        activity.probes_for((addr(2), addr(4))).is_empty(),
-        "routine re-keys with data in between must not burst probes",
-    );
-}
-
-#[test]
-fn dead_pair_with_stale_rtt_does_not_win_back_the_primary() {
-    let (mut a, t0) = direct_primary_with_relay_fallback();
-
-    // Fail over to the relay pair via WireGuard distress.
-    let _ = a.advance(t0, t0 + secs(60));
-    let t1 = t0 + secs(60);
-    a.handle_outbound(handshake_init_bytes(), t1);
-    let _ = a.transmits();
-    let mut t = t1;
-    for _ in 0..REKEY_DISTRESS_ATTEMPTS {
-        t += secs(5);
-        a.handle_outbound(handshake_init_bytes(), t);
-        let _ = a.transmits();
-    }
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t);
-    assert_eq!(a.primary(), Some((addr(2), addr(4))));
-    a.drain_events();
-
-    // Later replies on the (still alive) relay pair re-run selection. The
-    // dead direct pair has a better bucket but only a stale RTT — it must
-    // not hijack the primary on a meaningless measurement.
-    let t2 = t1 + secs(30);
-    prove_pair_alive(&mut a, (addr(2), addr(4)), t2);
 
     assert_eq!(
         a.primary(),
-        Some((addr(2), addr(4))),
-        "a stale RTT must not put the dead direct pair back in charge",
+        Some((addr(1), addr(3))),
+        "data between re-keys resets the count, so it never reaches distress",
     );
+}
+
+// --- new candidate ---
+
+#[test]
+fn a_new_candidate_clears_the_primary_and_reprobes() {
+    let (mut a, t0) = direct_primary_with_relay_fallback(); // primary (1,3)
+    a.drain_events();
+
+    a.add_remote_candidate(Candidate::host(addr(5)), t0 + secs(1));
+    assert_eq!(
+        a.primary(),
+        None,
+        "a new candidate may be a better path; the primary is re-evaluated",
+    );
+
+    // The old primary re-confirms within a round trip.
+    prove_pair_alive(&mut a, (addr(1), addr(3)), t0 + secs(1));
+    assert_eq!(a.primary(), Some((addr(1), addr(3))));
 }
 
 // --- roam recovery ---
@@ -1012,163 +403,36 @@ fn roam_recovers_the_data_path_via_probes_without_a_handshake() {
     a.add_local_candidate(Candidate::host(addr(1)), t0);
     a.add_remote_candidate(Candidate::host(addr(9)), t0);
     bootstrap_primary(&mut a, (addr(1), addr(9)), t0);
-    let _ = a.advance(t0, t0 + secs(10));
+    assert_eq!(a.primary(), Some((addr(1), addr(9))));
+    a.drain_events();
 
-    // Roam: all local candidates are gone; the WireGuard session is kept.
+    // Roam: local candidates gone, session kept.
     let t1 = t0 + secs(60);
     a.rebuild(|_| true, t1);
     assert_eq!(a.primary(), None);
 
-    // The new socket produces a new host candidate; the peer's candidates
-    // survived the rebuild, so pairs form and probe immediately.
+    // A new local candidate pairs with the surviving remote and probes.
     a.add_local_candidate(Candidate::host(addr(5)), t1);
-
     let recovery = a.advance(t1, t1 + secs(1));
     let probes = recovery.probes_for((addr(5), addr(9)));
-    assert!(
-        !probes.is_empty(),
-        "roamed pair must probe without any handshake"
-    );
+    assert!(!probes.is_empty(), "roamed pair probes without a handshake");
 
     let _ = a.handle_inbound_tun(
         build_echo_reply(probes[0].id, probes[0].seq),
         (addr(5), addr(9)),
         t1 + ms(50),
     );
-
     assert_eq!(
         a.primary(),
         Some((addr(5), addr(9))),
-        "first probe reply must restore the data path",
+        "the first probe reply restores the data path",
     );
     assert!(
         recovery
             .transmits
             .iter()
             .all(|(_, t)| matches!(t.payload, Payload::Plaintext(_))),
-        "recovery must not require any handshake traffic",
-    );
-    assert_eq!(recovery.events, vec![], "no path until the reply arrives");
-}
-
-#[test]
-fn settled_primary_keepalives_while_loser_goes_quiet() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(3)), t0);
-    a.add_remote_candidate(Candidate::host(addr(4)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(3)), t0);
-    a.drain_events();
-
-    // Answer both pairs to convergence. (1,3) is the primary, (1,4) a
-    // same-bucket loser that stays behind it under hysteresis.
-    let settled_at = answer_until_settled(&mut a, &[(addr(1), addr(3)), (addr(1), addr(4))], t0);
-    assert_eq!(a.primary(), Some((addr(1), addr(3))));
-
-    let after = a.advance(settled_at, settled_at + secs(60));
-    // The primary keeps the slow keepalive cadence so its RTT stays current
-    // for the next comparison...
-    assert!(
-        !after.probe_times((addr(1), addr(3))).is_empty(),
-        "the settled primary keepalives",
-    );
-    // ...while the settled loser is dropped and goes silent.
-    assert_eq!(
-        after.probe_times((addr(1), addr(4))),
-        vec![],
-        "a settled loser goes quiet",
-    );
-}
-
-#[test]
-fn recovering_a_path_is_a_plain_primary_switch_without_a_rekey() {
-    let mut a = PathAgent::new();
-    let t0 = Instant::now();
-    a.add_local_candidate(Candidate::host(addr(1)), t0);
-    a.add_remote_candidate(Candidate::host(addr(9)), t0);
-    bootstrap_primary(&mut a, (addr(1), addr(9)), t0);
-    a.drain_events();
-    let _ = a.advance(t0, t0 + secs(10));
-
-    let t1 = t0 + secs(60);
-    a.rebuild(|_| true, t1);
-    a.add_local_candidate(Candidate::host(addr(5)), t1);
-    let recovery = a.advance(t1, t1 + secs(1));
-    let probes = recovery.probes_for((addr(5), addr(9)));
-    let _ = a.handle_inbound_tun(
-        build_echo_reply(probes[0].id, probes[0].seq),
-        (addr(5), addr(9)),
-        t1 + ms(50),
-    );
-
-    // Our probe already reached the peer (it replied), so the peer registered
-    // our new address as peer-reflexive and is re-evaluating on its own.
-    // Recovery is therefore a plain local primary switch — no re-key, no
-    // handshake traffic.
-    let events: Vec<_> = std::iter::from_fn(|| a.poll_event()).collect();
-    assert_eq!(
-        events,
-        vec![Event::PrimaryChanged {
-            local: addr(5),
-            remote: addr(9),
-        }],
-        "recovery must only switch the primary, got {events:?}",
-    );
-    assert!(
-        a.transmits()
-            .iter()
-            .all(|t| matches!(t.payload, Payload::Plaintext(_))),
-        "recovery must not emit any handshake traffic",
-    );
-}
-
-#[test]
-fn mid_session_rekey_recovers_via_probing_not_fanout() {
-    // Losing the primary mid-session must NOT re-handshake: the session is
-    // still valid, so a fan-out would be pointless (a peer that truly lost the
-    // session needs a full re-setup via signalling, not a handshake). Recovery
-    // is by probing, and the buffered re-key then rides the recovered primary.
-    let mut a = agent_with_relay_pairs();
-    let now = Instant::now();
-    bootstrap_primary(&mut a, (addr(2), addr(4)), now);
-    let _ = a.advance(now, now + secs(10));
-
-    assert!(a.remove_local_candidate(&Candidate::relayed(addr(2), addr(2)), now + secs(10)));
-    assert_eq!(a.primary(), None, "removing primary's local must clear it");
-    let _ = a.transmits();
-
-    // A re-key with no primary must not fan out over relays while established —
-    // only probes go out.
-    let rekey_at = now + secs(120);
-    a.handle_outbound(handshake_init_bytes(), rekey_at);
-    a.handle_timeout(rekey_at);
-    assert!(
-        a.transmits()
-            .iter()
-            .all(|t| matches!(t.payload, Payload::Plaintext(_))),
-        "no handshake fan-out mid-session; recovery is by probing",
-    );
-
-    // Probing brings the surviving relay pair back; it becomes the primary...
-    prove_pair_alive(&mut a, (addr(1), addr(4)), rekey_at);
-    assert_eq!(a.primary(), Some((addr(1), addr(4))));
-
-    // ...and the next re-key attempt rides it as a single transmit, not a burst.
-    a.handle_outbound(handshake_init_bytes(), rekey_at + secs(5));
-    let rekey = a.transmits();
-    let ciphertext: Vec<_> = rekey
-        .iter()
-        .filter(|t| matches!(t.payload, Payload::Ciphertext(_)))
-        .collect();
-    assert_eq!(
-        ciphertext.len(),
-        1,
-        "re-key rides the recovered primary: {rekey:?}"
-    );
-    assert_eq!(
-        (ciphertext[0].local, ciphertext[0].remote),
-        (addr(1), addr(4))
+        "recovery needs no handshake traffic",
     );
 }
 
@@ -1180,10 +444,6 @@ fn addr(p: u16) -> SocketAddr {
     format!("127.0.0.1:{p}").parse().unwrap()
 }
 
-fn addr_v6(p: u16) -> SocketAddr {
-    format!("[::1]:{p}").parse().unwrap()
-}
-
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }
@@ -1192,7 +452,49 @@ fn secs(n: u64) -> Duration {
     Duration::from_secs(n)
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EchoKind {
+    Request,
+    Reply,
+}
+
+#[derive(Clone, Copy)]
+struct ProbeFields {
+    kind: EchoKind,
+    id: u16,
+    seq: u16,
+}
+
+fn parse_probe(packet: &IpPacket) -> Option<ProbeFields> {
+    if packet.source() != IpAddr::V6(PROBE_SRC) || packet.destination() != IpAddr::V6(PROBE_DST) {
+        return None;
+    }
+    let icmp = packet.as_icmpv6()?;
+    let (kind, header) = match icmp.icmp_type() {
+        Icmpv6Type::EchoRequest(h) => (EchoKind::Request, h),
+        Icmpv6Type::EchoReply(h) => (EchoKind::Reply, h),
+        _ => return None,
+    };
+    Some(ProbeFields {
+        kind,
+        id: header.id,
+        seq: header.seq,
+    })
+}
+
+fn extract_probe_for(transmits: &[Transmit], pair: Pair) -> ProbeFields {
+    let t = transmits
+        .iter()
+        .find(|t| (t.local, t.remote) == pair && matches!(t.payload, Payload::Plaintext(_)))
+        .unwrap_or_else(|| panic!("no probe transmit for {pair:?}"));
+    let Payload::Plaintext(ref packet) = t.payload else {
+        unreachable!()
+    };
+    parse_probe(packet).expect("parses as probe")
+}
+
 /// The probe send times of one burst starting at `start`.
+#[allow(dead_code)]
 fn burst_ladder(start: Instant) -> Vec<Instant> {
     std::iter::once(start)
         .chain(PROBE_BURST_GAPS.iter().scan(start, |at, gap| {
@@ -1202,10 +504,9 @@ fn burst_ladder(start: Instant) -> Vec<Instant> {
         .collect()
 }
 
-/// Everything an agent did while time advanced.
 struct Activity {
-    /// Transmits, stamped with the instant they were produced at.
     transmits: Vec<(Instant, Transmit)>,
+    #[allow(dead_code)]
     events: Vec<Event>,
 }
 
@@ -1221,37 +522,13 @@ impl Activity {
             .filter(|p| p.kind == EchoKind::Request)
             .collect()
     }
-
-    fn probe_times(&self, pair: Pair) -> Vec<Instant> {
-        self.transmits
-            .iter()
-            .filter(|(_, t)| (t.local, t.remote) == pair)
-            .filter(|(_, t)| match &t.payload {
-                Payload::Plaintext(packet) => {
-                    parse_probe(packet).is_some_and(|p| p.kind == EchoKind::Request)
-                }
-                Payload::Ciphertext(_) => false,
-            })
-            .map(|(at, _)| *at)
-            .collect()
-    }
 }
 
-/// Ergonomic wrappers over the poll-based `PathAgent` API used throughout the
-/// tests, so each test reads as the sequence of events it exercises rather than
-/// the drain/collect boilerplate.
 trait AgentExt {
-    /// Collect every queued transmit.
     fn transmits(&mut self) -> Vec<Transmit>;
-    /// Drop every queued event.
     fn drain_events(&mut self);
-    /// `handle_timeout(now)`, then collect the transmits it produced.
     fn tick(&mut self, now: Instant) -> Vec<Transmit>;
-    /// Reply to `pair`'s probe (looked up in `transmits`) at `reply_at`. Does not
-    /// drain events, so callers can still assert on `PrimaryChanged`.
     fn ack_probe(&mut self, transmits: &[Transmit], pair: Pair, reply_at: Instant);
-    /// Step the agent from `start` to `end`, firing every deadline in
-    /// between and collecting the transmits it produces along the way.
     fn advance(&mut self, start: Instant, end: Instant) -> Activity;
 }
 
@@ -1286,8 +563,6 @@ impl AgentExt for PathAgent {
             activity
                 .transmits
                 .extend(std::iter::from_fn(|| self.poll_transmit()).map(|t| (now, t)));
-            // Queued events keep `poll_timeout` at `now`; collect them so
-            // time can move on.
             activity
                 .events
                 .extend(std::iter::from_fn(|| self.poll_event()));
@@ -1314,8 +589,8 @@ fn agent_with_relay_pairs() -> PathAgent {
     a
 }
 
-/// A host↔host primary at `(1, 3)` with a fresh RTT plus a relay pair
-/// `(2, 4)` as the potential fail-over target.
+/// A host↔host primary at `(1, 3)` (promoted over a relay preliminary) with a
+/// relay pair `(2, 4)` as the fail-over target.
 fn direct_primary_with_relay_fallback() -> (PathAgent, Instant) {
     let mut a = agent_with_relay_pairs();
     let t0 = Instant::now();
@@ -1339,41 +614,6 @@ fn prove_pair_alive(a: &mut PathAgent, pair: Pair, now: Instant) {
     let probes = a.tick(now);
     let probe = extract_probe_for(&probes, pair);
     let _ = a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
-}
-
-/// Drives the agent, replying to every probe on `pairs`, until each has been
-/// answered [`PROBE_SAMPLES`] times (i.e. settled). Returns the final instant.
-fn answer_until_settled(a: &mut PathAgent, pairs: &[Pair], start: Instant) -> Instant {
-    let mut replies: std::collections::BTreeMap<Pair, u32> =
-        pairs.iter().map(|p| (*p, 0)).collect();
-    let mut now = start;
-
-    for _ in 0..1000 {
-        for t in a.tick(now) {
-            let pair = (t.local, t.remote);
-            if let Some(count) = replies.get_mut(&pair)
-                && *count < PROBE_SAMPLES
-                && let Payload::Plaintext(p) = &t.payload
-                && let Some(probe) = parse_probe(p)
-                && probe.kind == EchoKind::Request
-            {
-                let _ =
-                    a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
-                *count += 1;
-            }
-        }
-
-        if replies.values().all(|c| *c >= PROBE_SAMPLES) {
-            return now;
-        }
-
-        match a.poll_timeout() {
-            Some(next) => now = next.max(now),
-            None => return now,
-        }
-    }
-
-    panic!("pairs did not settle");
 }
 
 /// Synthetic — only the type byte matters to `handle_outbound`.
@@ -1406,8 +646,13 @@ struct Handshake {
 }
 
 impl Handshake {
-    /// Initiator has emitted its init; responder hasn't consumed it.
     fn new(now: Instant) -> Self {
+        Self::new_seeded(now, 0)
+    }
+
+    /// `seed` varies the initiator's ephemeral so distinct handshakes produce
+    /// distinct init bytes (else they'd be dropped as duplicates).
+    fn new_seeded(now: Instant, seed: u64) -> Self {
         let priv_a = StaticSecret::from([1u8; 32]);
         let pub_a = PublicKey::from(&priv_a);
         let priv_b = StaticSecret::from([2u8; 32]);
@@ -1419,9 +664,9 @@ impl Handshake {
             pub_b,
             None,
             None,
-            Index::new_local(0),
+            Index::new_local(seed as u32 * 2),
             None,
-            0,
+            seed * 2,
             now,
             now,
             unix,
@@ -1431,9 +676,9 @@ impl Handshake {
             pub_a,
             None,
             None,
-            Index::new_local(1),
+            Index::new_local(seed as u32 * 2 + 1),
             None,
-            1,
+            seed * 2 + 1,
             now,
             now,
             unix,
@@ -1455,8 +700,6 @@ impl Handshake {
         }
     }
 
-    /// Consumes the init on the responder; `initiator` is then ready
-    /// to authenticate `response`.
     fn with_response(mut self, now: Instant) -> Self {
         let mut buf = [0u8; 148];
         let TunnResult::WriteToNetwork(response) = self
@@ -1478,9 +721,9 @@ fn reject_all() -> Tunn {
         PublicKey::from(&StaticSecret::from([4u8; 32])),
         None,
         None,
-        Index::new_local(2),
+        Index::new_local(99),
         None,
-        2,
+        99,
         now,
         now,
         Duration::from_secs(1),
@@ -1495,47 +738,4 @@ fn build_echo_request(id: u16, seq: u16) -> IpPacket {
 fn build_echo_reply(id: u16, seq: u16) -> IpPacket {
     ip_packet::make::icmp_reply_packet(IpAddr::V6(PROBE_SRC), IpAddr::V6(PROBE_DST), seq, id, &[])
         .expect("magic addresses always fit")
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EchoKind {
-    Request,
-    Reply,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct ProbeFields {
-    kind: EchoKind,
-    id: u16,
-    seq: u16,
-}
-
-fn parse_probe(packet: &IpPacket) -> Option<ProbeFields> {
-    if packet.source() != IpAddr::V6(PROBE_SRC) || packet.destination() != IpAddr::V6(PROBE_DST) {
-        return None;
-    }
-    let icmp = packet.as_icmpv6()?;
-    let (kind, header) = match icmp.icmp_type() {
-        Icmpv6Type::EchoRequest(h) => (EchoKind::Request, h),
-        Icmpv6Type::EchoReply(h) => (EchoKind::Reply, h),
-        _ => return None,
-    };
-    Some(ProbeFields {
-        kind,
-        id: header.id,
-        seq: header.seq,
-    })
-}
-
-fn extract_probe_for(transmits: &[Transmit], pair: Pair) -> ProbeFields {
-    // A pair can carry both a probe and (mid-failover, while re-keying) a
-    // fanned-out handshake init in the same tick; pick the probe.
-    let t = transmits
-        .iter()
-        .find(|t| (t.local, t.remote) == pair && matches!(t.payload, Payload::Plaintext(_)))
-        .unwrap_or_else(|| panic!("no probe transmit for {pair:?}"));
-    let Payload::Plaintext(ref packet) = t.payload else {
-        unreachable!()
-    };
-    parse_probe(packet).expect("parses as probe")
 }

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -436,6 +436,45 @@ fn roam_recovers_the_data_path_via_probes_without_a_handshake() {
     );
 }
 
+#[test]
+fn signaled_candidate_promotes_a_peer_reflexive_remote_in_place() {
+    // A peer behind symmetric NAT reaches us from an unadvertised mapping; we
+    // register it peer-reflexive and measure it. When the portal later signals
+    // the peer's real candidate for that same address, it must promote the
+    // existing pair in place — keeping its primary/RTT/schedule — not treat it
+    // as new, which would overwrite the pair's `PairState` and re-probe.
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+
+    // An inbound init from an unadvertised address registers it peer-reflexive
+    // and, as the establishing init, adopts the pair as the primary.
+    let mut hs = Handshake::new(t0);
+    let _ = a.handle_inbound_network(&mut hs.responder, &hs.init, (addr(1), addr(9)), t0);
+    assert_eq!(a.primary(), Some((addr(1), addr(9))));
+
+    // Measure the pair so it carries an RTT worth preserving.
+    prove_pair_alive(&mut a, (addr(1), addr(9)), t0 + secs(1));
+    a.drain_events();
+    let _ = a.transmits();
+
+    // The portal signals the peer's real srflx candidate for the same address
+    // (same public addr, a distinct base), so it differs from the stored
+    // peer-reflexive candidate and would otherwise be treated as brand-new.
+    a.add_remote_candidate(Candidate::server_reflexive(addr(9), addr(99)), t0 + secs(2));
+
+    assert_eq!(
+        a.primary(),
+        Some((addr(1), addr(9))),
+        "the signaled candidate promotes the peer-reflexive pair in place, \
+         keeping the primary rather than clearing and re-probing",
+    );
+    assert!(
+        a.poll_event().is_none(),
+        "promotion in place changes no primary and emits no event",
+    );
+}
+
 // --- test harness ---
 
 type Pair = (SocketAddr, SocketAddr);

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -45,7 +45,7 @@ fn outbound_handshake_init_arms_retransmits_with_initial_50ms_deadline() {
 }
 
 #[test]
-fn retransmit_ladder_bursts_then_doubles_to_cap() {
+fn retransmit_ladder_runs_once_then_stops() {
     let mut a = agent_with_relay_pairs();
     let now = Instant::now();
 
@@ -53,15 +53,68 @@ fn retransmit_ladder_bursts_then_doubles_to_cap() {
     a.handle_timeout(now);
     let _ = a.transmits();
 
+    // Gaps after the first 50ms fire. The ladder ends at 1600ms and stops —
+    // boringtun's own re-init drives retransmission after that, so it does not
+    // repeat the tail.
     let mut t = now + ms(50);
-    let expected_step_ms: [u64; 8] = [50, 50, 100, 200, 400, 800, 1600, 1600];
-    for &expected_ms in &expected_step_ms {
+    let gaps: [u64; 7] = [50, 50, 100, 200, 400, 800, 1600];
+    for &gap in &gaps {
         a.handle_timeout(t);
         let _ = a.transmits();
         let next = a.poll_timeout().expect("deadline");
-        assert_eq!(next, t + ms(expected_ms));
+        assert_eq!(next, t + ms(gap));
         t = next;
     }
+
+    // The final step fires; the one-time ladder is now spent.
+    a.handle_timeout(t);
+    let _ = a.transmits();
+    assert_eq!(
+        a.poll_timeout(),
+        None,
+        "the ladder does not repeat its tail"
+    );
+}
+
+#[test]
+fn a_boringtun_reinit_refans_once_without_re_arming_the_ladder() {
+    let mut a = agent_with_relay_pairs();
+    let now = Instant::now();
+
+    // First init arms the one-time fast ladder on each relay pair.
+    a.handle_outbound(handshake_init_bytes(), now);
+    a.handle_timeout(now);
+    let _ = a.transmits();
+
+    // Drain the fast head to exhaustion.
+    let mut t = now + ms(50);
+    while let Some(next) = a.poll_timeout() {
+        t = next;
+        a.handle_timeout(t);
+        let _ = a.transmits();
+    }
+
+    // A boringtun re-init (fresh bytes, still no session) re-fans to every relay
+    // pair once but does not restart the fast ladder.
+    let mut reinit = handshake_init_bytes();
+    reinit[4] = 7;
+    a.handle_outbound(reinit.clone(), t + secs(2));
+    a.handle_timeout(t + secs(2));
+
+    let transmits = a.transmits();
+    assert_eq!(
+        transmits.len(),
+        3,
+        "the re-init fans out once per relay pair"
+    );
+    for tr in &transmits {
+        assert_eq!(tr.payload, Payload::Ciphertext(reinit.clone()));
+    }
+    assert_eq!(
+        a.poll_timeout(),
+        None,
+        "the re-init does not re-arm the fast ladder",
+    );
 }
 
 #[test]

--- a/rust/libs/connlib/path-agent/tests/agent.rs
+++ b/rust/libs/connlib/path-agent/tests/agent.rs
@@ -14,8 +14,8 @@ use boringtun::noise::{Index, Tunn, TunnResult};
 use boringtun::x25519::{PublicKey, StaticSecret};
 use ip_packet::{Icmpv6Type, IpPacket};
 use path_agent::{
-    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL_LIVE, PROBE_SRC, PathAgent,
-    Payload, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, Transmit,
+    Candidate, Event, PROBE_BURST_GAPS, PROBE_DST, PROBE_INTERVAL, PROBE_SAMPLES, PROBE_SRC,
+    PathAgent, Payload, REKEY_DISTRESS_INTERVAL, RESPONDER_DEDUP_TTL, Transmit,
 };
 
 // --- bootstrap: handshake fan-out and nomination ---
@@ -246,7 +246,7 @@ fn srflx_local_uses_base_as_send_from_address() {
 // --- probing: bursts, triggered checks, peer-reflexive discovery ---
 
 #[test]
-fn pairs_probe_in_a_front_loaded_burst_then_only_the_primary_stays_on_live_cadence() {
+fn unanswered_pairs_burst_then_hunt_at_the_steady_interval() {
     let mut a = PathAgent::new();
     let t0 = Instant::now();
     a.add_local_candidate(Candidate::host(addr(1)), t0);
@@ -254,7 +254,8 @@ fn pairs_probe_in_a_front_loaded_burst_then_only_the_primary_stays_on_live_caden
     a.add_remote_candidate(Candidate::host(addr(3)), t0);
     bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
 
-    let burst = a.advance(t0, t0 + secs(5));
+    // Only the burst — stop before the first steady probe (at +2s).
+    let burst = a.advance(t0, t0 + ms(1500));
 
     // Both pairs fire the full front-loaded ladder without waiting for
     // replies — after a roam, the peer's NAT filter may open between two
@@ -263,17 +264,56 @@ fn pairs_probe_in_a_front_loaded_burst_then_only_the_primary_stays_on_live_caden
     assert_eq!(burst.probe_times((addr(1), addr(2))), expected);
     assert_eq!(burst.probe_times((addr(1), addr(3))), expected);
 
-    let after_burst = a.advance(t0 + secs(5), t0 + secs(60));
+    // Neither pair answers, so neither settles: they keep probing at the steady
+    // interval (hunting). This stays under PROBE_GIVE_UP, where — because a
+    // primary exists — an unsettled pair would otherwise stop.
+    let last_burst = *expected.last().unwrap();
+    let hunt = a.advance(last_burst, last_burst + secs(5));
+    let steady: Vec<Instant> = (1..=5).map(|i| last_burst + PROBE_INTERVAL * i).collect();
+    assert_eq!(hunt.probe_times((addr(1), addr(2))), steady);
+    assert_eq!(hunt.probe_times((addr(1), addr(3))), steady);
+}
 
-    // Dormant pairs stay quiet; the primary keeps its RTT fresh and its NAT
-    // mappings warm.
-    assert_eq!(after_burst.probe_times((addr(1), addr(3))), vec![]);
+#[test]
+fn an_answered_pair_settles_and_goes_quiet() {
+    let mut a = PathAgent::new();
+    let t0 = Instant::now();
+    a.add_local_candidate(Candidate::host(addr(1)), t0);
+    a.add_remote_candidate(Candidate::host(addr(2)), t0);
+    bootstrap_primary(&mut a, (addr(1), addr(2)), t0);
+    a.drain_events();
+
+    let pair = (addr(1), addr(2));
+
+    // Answer every probe as it goes out; after PROBE_SAMPLES replies the pair
+    // has a stable RTT and stops probing.
+    let mut sent = 0u32;
+    let mut now = t0;
+    for _ in 0..200 {
+        for t in a.tick(now) {
+            if (t.local, t.remote) == pair
+                && let Payload::Plaintext(p) = &t.payload
+                && let Some(probe) = parse_probe(p)
+                && probe.kind == EchoKind::Request
+            {
+                sent += 1;
+                let _ =
+                    a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
+            }
+        }
+        match a.poll_timeout() {
+            Some(next) => now = next.max(now),
+            None => break,
+        }
+    }
+
     assert_eq!(
-        after_burst.probe_times((addr(1), addr(2))),
-        vec![
-            t0 + secs(2) + PROBE_INTERVAL_LIVE,
-            t0 + secs(2) + PROBE_INTERVAL_LIVE * 2
-        ],
+        sent, PROBE_SAMPLES,
+        "a pair must stop probing after {PROBE_SAMPLES} positive samples, sent {sent}",
+    );
+    assert!(
+        a.poll_timeout().is_none(),
+        "a settled connection has no pending probe timeout",
     );
 }
 
@@ -326,17 +366,17 @@ fn probe_seq_advances_per_pair_per_fire() {
 }
 
 #[test]
-fn trickled_candidate_probes_immediately_even_while_dormant() {
+fn trickled_candidate_probes_immediately() {
     let mut a = PathAgent::new();
     let t0 = Instant::now();
     a.add_local_candidate(Candidate::host(addr(1)), t0);
     a.add_local_candidate(Candidate::relayed(addr(2), addr(2)), t0);
     a.add_remote_candidate(Candidate::relayed(addr(4), addr(4)), t0);
     bootstrap_primary(&mut a, (addr(2), addr(4)), t0);
-
-    // Exhaust every burst; the agent is dormant except for the primary.
     let _ = a.advance(t0, t0 + secs(10));
 
+    // A late candidate seeds new pairs that probe right away — no waiting for
+    // any global window or the existing pairs' cadence.
     let t1 = t0 + secs(10);
     a.add_remote_candidate(Candidate::host(addr(3)), t1);
 
@@ -956,32 +996,26 @@ fn roam_recovers_the_data_path_via_probes_without_a_handshake() {
 }
 
 #[test]
-fn retired_primary_stops_live_probing() {
+fn probing_is_independent_of_primary_status() {
     let mut a = PathAgent::new();
     let t0 = Instant::now();
     a.add_local_candidate(Candidate::host(addr(1)), t0);
     a.add_remote_candidate(Candidate::host(addr(3)), t0);
     a.add_remote_candidate(Candidate::host(addr(4)), t0);
     bootstrap_primary(&mut a, (addr(1), addr(3)), t0);
-
-    let probes = a.tick(t0);
-    a.ack_probe(&probes, (addr(1), addr(3)), t0 + ms(50));
-    a.ack_probe(&probes, (addr(1), addr(4)), t0 + ms(10));
-    assert_eq!(a.primary(), Some((addr(1), addr(4))));
     a.drain_events();
 
-    // Finish the bursts, then watch the live cadence.
-    let _ = a.advance(t0, t0 + secs(3));
-    let live = a.advance(t0 + secs(3), t0 + secs(60));
+    // Answer both pairs to convergence. One is the primary, the other is not —
+    // yet both settle and go quiet the same way; there is no primary-only
+    // cadence keeping the winner probing.
+    let settled_at = answer_until_settled(&mut a, &[(addr(1), addr(3)), (addr(1), addr(4))], t0);
 
-    assert_eq!(
-        live.probe_times((addr(1), addr(3))),
-        vec![],
-        "the retired primary must not keep probing at the live cadence",
-    );
+    let after = a.advance(settled_at, settled_at + secs(60));
+    assert_eq!(after.probe_times((addr(1), addr(3))), vec![]);
+    assert_eq!(after.probe_times((addr(1), addr(4))), vec![]);
     assert!(
-        !live.probe_times((addr(1), addr(4))).is_empty(),
-        "the new primary keeps probing at the live cadence",
+        a.poll_timeout().is_none(),
+        "both pairs settled, so nothing is scheduled",
     );
 }
 
@@ -1224,6 +1258,41 @@ fn prove_pair_alive(a: &mut PathAgent, pair: Pair, now: Instant) {
     let probes = a.tick(now);
     let probe = extract_probe_for(&probes, pair);
     let _ = a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
+}
+
+/// Drives the agent, replying to every probe on `pairs`, until each has been
+/// answered [`PROBE_SAMPLES`] times (i.e. settled). Returns the final instant.
+fn answer_until_settled(a: &mut PathAgent, pairs: &[Pair], start: Instant) -> Instant {
+    let mut replies: std::collections::BTreeMap<Pair, u32> =
+        pairs.iter().map(|p| (*p, 0)).collect();
+    let mut now = start;
+
+    for _ in 0..1000 {
+        for t in a.tick(now) {
+            let pair = (t.local, t.remote);
+            if let Some(count) = replies.get_mut(&pair)
+                && *count < PROBE_SAMPLES
+                && let Payload::Plaintext(p) = &t.payload
+                && let Some(probe) = parse_probe(p)
+                && probe.kind == EchoKind::Request
+            {
+                let _ =
+                    a.handle_inbound_tun(build_echo_reply(probe.id, probe.seq), pair, now + ms(20));
+                *count += 1;
+            }
+        }
+
+        if replies.values().all(|c| *c >= PROBE_SAMPLES) {
+            return now;
+        }
+
+        match a.poll_timeout() {
+            Some(next) => now = next.max(now),
+            None => return now,
+        }
+    }
+
+    panic!("pairs did not settle");
 }
 
 /// Synthetic — only the type byte matters to `handle_outbound`.

--- a/rust/libs/connlib/snownet/src/agent.rs
+++ b/rust/libs/connlib/snownet/src/agent.rs
@@ -246,14 +246,9 @@ impl Agent {
         }
     }
 
-    pub(crate) fn initiate_handshake(
-        &mut self,
-        tunnel: &mut Tunn,
-        force_resend: bool,
-        now: Instant,
-    ) {
+    pub(crate) fn initiate_handshake(&mut self, tunnel: &mut Tunn, now: Instant) {
         if let Self::Path(path) = self {
-            path.initiate_handshake(tunnel, force_resend, now);
+            path.initiate_handshake(tunnel, now);
         }
     }
 

--- a/rust/libs/connlib/snownet/src/agent.rs
+++ b/rust/libs/connlib/snownet/src/agent.rs
@@ -108,11 +108,11 @@ impl Agent {
         }
     }
 
-    pub(crate) fn add_local_candidate(&mut self, c: Candidate) -> Option<Candidate> {
+    pub(crate) fn add_local_candidate(&mut self, c: Candidate, now: Instant) -> Option<Candidate> {
         match self {
             Self::Ice(a) => a.add_local_candidate(c).cloned(),
             Self::Path(path) => path
-                .add_local_candidate(crate::candidate::to_path_agent(&c))
+                .add_local_candidate(crate::candidate::to_path_agent(&c), now)
                 .then_some(c),
         }
     }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -825,12 +825,19 @@ where
         // Iceless has no such gap — probes ride the session, so a stuck
         // handshake means the path is genuinely down, and probe loss must not
         // retire a connection (WireGuard is the sole liveness authority). We
-        // therefore keep boringtun's 90s default so a transient outage (a relay
-        // partition, a roam) doesn't discard session state before the path can
-        // be probed back to life. The primary's NAT bindings are kept warm by
-        // the path-agent's own passive keepalive, not WireGuard's.
+        // keep boringtun's 90s rekey-attempt default so a transient outage (a
+        // relay partition, a roam) doesn't discard session state before the path
+        // can be probed back to life. We do tighten two timers: a 5s
+        // keepalive-timeout, so WireGuard sends a passive keepalive when 5s pass
+        // after it receives data without sending anything back (keeping the
+        // reverse path warm during one-way traffic), and a 2s rekey-timeout, so
+        // an unanswered handshake init is retried every 2s and distress surfaces
+        // within a couple of round trips.
         if !agent.is_iceless() {
             tunnel.set_rekey_attempt_time(WG_REKEY_ATTEMPT_TIME);
+        } else {
+            tunnel.set_keepalive_timeout(Duration::from_secs(5));
+            tunnel.set_rekey_timeout(Duration::from_secs(2));
         }
 
         Connection {
@@ -1985,9 +1992,6 @@ where
         self.agent.initiate_handshake(&mut self.tunnel, now);
     }
 
-    /// Iceless-only soft roam: drop all locals. Connection state
-    /// (peer_socket, WG session keys) stays put; new candidates probe the
-    /// kept session back to life, so no handshake is needed.
     fn reset_for_roam(&mut self, now: Instant)
     where
         RId: Ord + fmt::Display + Copy,

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -1567,9 +1567,6 @@ where
                         now,
                     );
                 }
-                path_agent::Event::PathRecovered => {
-                    self.initiate_wg_session_for_path(now);
-                }
             }
         }
 

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -818,17 +818,19 @@ where
             self.unix_now,
             self.unix_ts,
         );
-        // By default, boringtun has a rekey attempt time of 90(!) seconds.
-        // In case of a state de-sync or other issues, this means we try for
-        // 90s to make a handshake, all whilst our ICE layer thinks the connection
-        // is working perfectly fine.
-        // This results in a bad UX as the user has to essentially wait for 90s
-        // before Firezone can fix the state and make a new connection.
+        // With classic ICE, a 90s rekey-attempt time is bad UX: ICE can think
+        // the pair is fine while WireGuard is desynced and stuck, so we shorten
+        // it to roughly our ICE timeout to fail fast and re-establish.
         //
-        // By aligning the rekey-attempt-time roughly with our ICE timeout, we ensure
-        // that even if the hole-punch was successful, it will take at most 20s
-        // until we have a WireGuard tunnel to send packets into.
-        tunnel.set_rekey_attempt_time(WG_REKEY_ATTEMPT_TIME);
+        // Iceless has no such gap — probes ride the session, so a stuck
+        // handshake means the path is genuinely down, and probe loss must not
+        // retire a connection (WireGuard is the sole liveness authority). We
+        // therefore keep boringtun's 90s default so a transient outage (a relay
+        // partition, a roam) doesn't discard session state before the path can
+        // be probed back to life.
+        if !agent.is_iceless() {
+            tunnel.set_rekey_attempt_time(WG_REKEY_ATTEMPT_TIME);
+        }
 
         Connection {
             agent,

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -312,7 +312,7 @@ where
 
             // Re-seed connection with all candidates.
             let new_candidates =
-                seed_agent_with_local_candidates(c.relay.id, &mut c.agent, &self.allocations);
+                seed_agent_with_local_candidates(c.relay.id, &mut c.agent, &self.allocations, now);
 
             // Tell the remote about all of them.
             self.pending_events.extend(
@@ -362,7 +362,7 @@ where
             self.allocations
                 .candidates_for_relay(&selected_relay)
                 .filter_map(|candidate| {
-                    let candidate = agent.add_local_candidate(candidate)?;
+                    let candidate = agent.add_local_candidate(candidate, now)?;
                     let event = new_ice_candidate_event(cid, candidate, use_iceless);
 
                     Some(event)
@@ -1117,13 +1117,14 @@ fn seed_agent_with_local_candidates<'a, RId>(
     selected_relay: RId,
     agent: &'a mut Agent,
     allocations: &Allocations<RId>,
+    now: Instant,
 ) -> impl Iterator<Item = Candidate> + use<'a, RId>
 where
     RId: Ord + fmt::Display + Copy,
 {
     allocations
         .candidates_for_relay(&selected_relay)
-        .filter_map(move |c| agent.add_local_candidate(c))
+        .filter_map(move |c| agent.add_local_candidate(c, now))
 }
 
 /// Generate optimistic candidates based on the ones we have already received.
@@ -1566,6 +1567,9 @@ where
                         now,
                     );
                 }
+                path_agent::Event::PathRecovered => {
+                    self.initiate_wg_session_for_path(now);
+                }
             }
         }
 
@@ -1981,14 +1985,14 @@ where
         self.agent.initiate_handshake(&mut self.tunnel, false, now);
     }
 
-    /// Iceless-only soft roam: drop all locals, force-resend the init.
-    /// Connection state (peer_socket, WG session keys) stays put.
+    /// Iceless-only soft roam: drop all locals. Connection state
+    /// (peer_socket, WG session keys) stays put; new candidates probe the
+    /// kept session back to life, so no handshake is needed.
     fn reset_for_roam(&mut self, now: Instant)
     where
         RId: Ord + fmt::Display + Copy,
     {
         self.agent.rebuild_path(|_| true, now);
-        self.agent.initiate_handshake(&mut self.tunnel, true, now);
     }
 
     /// Iceless-only. Receiver rediscovers the connection by the
@@ -2013,8 +2017,6 @@ where
             .map(|c| crate::candidate::to_path_agent(&c))
             .collect::<SmallVec<[_; 2]>>();
         self.agent.rebuild_path(|c| dropped.contains(c), now);
-
-        self.agent.initiate_handshake(&mut self.tunnel, true, now);
 
         tracing::info!(%cid, "Reset iceless path-agent after relay invalidation");
     }
@@ -2084,7 +2086,7 @@ where
     ) where
         TId: fmt::Display + Copy,
     {
-        if let Some(candidate) = self.agent.add_local_candidate(candidate.clone()) {
+        if let Some(candidate) = self.agent.add_local_candidate(candidate.clone(), now) {
             let iceless = self.agent.is_iceless();
             pending_events.push_back(new_ice_candidate_event(cid, candidate, iceless));
         }

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -827,7 +827,8 @@ where
         // retire a connection (WireGuard is the sole liveness authority). We
         // therefore keep boringtun's 90s default so a transient outage (a relay
         // partition, a roam) doesn't discard session state before the path can
-        // be probed back to life.
+        // be probed back to life. The primary's NAT bindings are kept warm by
+        // the path-agent's own passive keepalive, not WireGuard's.
         if !agent.is_iceless() {
             tunnel.set_rekey_attempt_time(WG_REKEY_ATTEMPT_TIME);
         }
@@ -1981,7 +1982,7 @@ where
     where
         RId: Ord + fmt::Display + Copy,
     {
-        self.agent.initiate_handshake(&mut self.tunnel, false, now);
+        self.agent.initiate_handshake(&mut self.tunnel, now);
     }
 
     /// Iceless-only soft roam: drop all locals. Connection state

--- a/rust/libs/connlib/tunnel/src/tests/reference.rs
+++ b/rust/libs/connlib/tunnel/src/tests/reference.rs
@@ -937,7 +937,11 @@ impl ReferenceState {
             }
             Transition::Idle => {}
             Transition::PartitionRelaysFromPortal => {
-                if state.drop_direct_client_traffic {
+                // With ICE-less connections, losing all relays does not fail
+                // the connection: the WG session idles until the relays return
+                // and probes revive the path. Classic ICE flows disconnect if
+                // direct traffic is dropped.
+                if state.drop_direct_client_traffic && !state.portal.iceless() {
                     for client in state.clients.values_mut() {
                         client.exec_mut(|c| c.reset_connections(now));
                     }


### PR DESCRIPTION
The fundamental idea of our iceless path selection algorithm is to replace ICE with a mechanism that relies entirely on WireGuard packets for hole-punching. That idea is still the same, even with this PR. The probes which end up doing the hole-punching are still synthetical ICMPv6 packets that get exchanged as WireGuard data packets. The bootstrap algorithm of fanning out the initial handshake across relay pairs also remains the same.

What is changing in this PR is how and when we update the *primary* path, i.e. the socket pair used by connlib to send application data.

We used to have an "evaluation window" during which we'd send probes and then settle on the best one. Various events would "open" this evaluation window so we could re-evaluate the primary path. This idea proved to be brittle. For one, a time-based window can expire without a result if the network conditions are hostile and e.g. a roaming condition takes longer to complete than intended. Two, we'd somehow have to communicate to the other side that we are re-evaluating because they should likely do so too. Three, one of the core problems from ICE we wanted to solve was to remove false-positive disconnects from probe loss. The question of "how do we detect a broken connection" still remained unsolved in the previous model.

Field testing the current model revealed the above problems. We are thus changing a few things fundamentally on how the _inside_ of our path agent works:

1. Probes continue forever until we have found a working path. Once we have a path, we send at most 12 probes. As a result, the path agent goes almost entirely quiet once it has done its job.
2. The path can be promoted at any point if a probe confirms a better path. No more evaluation window. In practice, because probes go silent after 12 messages, there is only a limited amount of time where it does get updated. The main difference is that we always give the opportunity for an upgrade implicitly when there are probes.
3. Repeated rekeys are taken as a distress signal and clear the current path.
4. New candidates also clear the current path.
5. An empty path can automatically be promoted to any working path.