### PR TITLE
fix(relay): drop client packets from UDP source port 0

### DIFF
--- a/rust/relay/server/src/proptest.rs
+++ b/rust/relay/server/src/proptest.rs
@@ -4,6 +4,7 @@ use proptest::arbitrary::any;
 use proptest::strategy::Just;
 use proptest::strategy::Strategy;
 use proptest::string::string_regex;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::time::Duration;
 use stun_codec::TransactionId;
 use stun_codec::rfc5766::attributes::{ChannelNumber, Lifetime, RequestedTransport};
@@ -55,6 +56,16 @@ pub fn channel_data() -> impl Strategy<Value = ChannelData<'static>> {
 
         ChannelData::parse(payload).unwrap()
     })
+}
+
+/// A client source address the relay can reply to, i.e. one with a non-zero port.
+pub fn source_v4() -> impl Strategy<Value = SocketAddrV4> {
+    (any::<Ipv4Addr>(), 1..=u16::MAX).prop_map(|(ip, port)| SocketAddrV4::new(ip, port))
+}
+
+/// A client source address the relay can reply to, i.e. one with a non-zero port.
+pub fn source_v6() -> impl Strategy<Value = SocketAddrV6> {
+    (any::<Ipv6Addr>(), 1..=u16::MAX).prop_map(|(ip, port)| SocketAddrV6::new(ip, port, 0, 0))
 }
 
 pub fn username_salt() -> impl Strategy<Value = String> {

--- a/rust/relay/server/src/server.rs
+++ b/rust/relay/server/src/server.rs
@@ -259,6 +259,13 @@ where
     ) -> Option<(AllocationPort, PeerSocket)> {
         tracing::trace!(target: "wire", num_bytes = %bytes.len());
 
+        // We cannot reply to port 0; only crafted packets (e.g. from Internet scanners) carry such a source.
+        if sender.into_socket().port() == 0 {
+            tracing::debug!(target: "relay", %sender, "Dropping packet from UDP source port 0");
+
+            return None;
+        }
+
         match client_message::decode(bytes) {
             Ok(Ok(message)) => {
                 return self.handle_client_message(message, sender, now);

--- a/rust/relay/server/tests/regression.rs
+++ b/rust/relay/server/tests/regression.rs
@@ -75,6 +75,28 @@ fn can_answer_stun_request_from_ip4_address(
 }
 
 #[proptest]
+fn ignores_stun_request_from_port_0(
+    #[strategy(firezone_relay::proptest::transaction_id())] transaction_id: TransactionId,
+    source: Ipv4Addr,
+    public_relay_addr: Ipv4Addr,
+) {
+    let _guard = logging::test("debug");
+    let mut server = TestServer::new(public_relay_addr);
+
+    let request = Message::<Attribute>::new(MessageClass::Request, BINDING, transaction_id);
+    let bytes = MessageEncoder::new().encode_into_bytes(request).unwrap();
+
+    let maybe_forward = server.server.handle_client_input(
+        &bytes,
+        ClientSocket::new(SocketAddrV4::new(source, 0).into()),
+        Instant::now(),
+    );
+
+    assert_eq!(maybe_forward, None);
+    assert!(server.server.next_command().is_none());
+}
+
+#[proptest]
 fn deallocate_once_time_expired(
     #[strategy(firezone_relay::proptest::transaction_id())] transaction_id: TransactionId,
     #[strategy(firezone_relay::proptest::allocation_lifetime())] lifetime: Lifetime,
@@ -414,7 +436,7 @@ fn ping_pong_relay(
     #[strategy(firezone_relay::proptest::transaction_id())]
     channel_bind_transaction_id: TransactionId,
     #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
-    source: SocketAddrV4,
+    #[strategy(firezone_relay::proptest::source_v4())] source: SocketAddrV4,
     peer: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
     peer_to_client_ping: [u8; 32],
@@ -647,7 +669,7 @@ fn ping_pong_ip6_relay(
     channel_bind_transaction_id: TransactionId,
     #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
     #[strategy(firezone_relay::proptest::channel_number())] channel: ChannelNumber,
-    source: SocketAddrV6,
+    #[strategy(firezone_relay::proptest::source_v6())] source: SocketAddrV6,
     peer: SocketAddrV6,
     public_relay_ip4_addr: Ipv4Addr,
     public_relay_ip6_addr: Ipv6Addr,


### PR DESCRIPTION
Staging and production relays both showed bursts of logs indicating `os error 22`. Upon checking these it was determined these are being caused by STUN binding requests that arrive with a source port of 0, which we cannot reply to.

To reduce the log noise we simply ignore these requests.

Fixes #14035 