### PR TITLE
feat(portal): add entra auth for postgres

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -49,7 +49,7 @@ config :portal, Portal.Repo,
   queue_interval: 1000,
   migration_timestamps: [type: :timestamptz],
   migration_lock: :pg_advisory_lock,
-  start_apps_before_migration: [:ssl, :logger_json],
+  start_apps_before_migration: [:ssl, :logger_json, :req],
   parameters: [application_name: "portal"]
 
 config :portal, Portal.Repo.Replica,
@@ -225,6 +225,15 @@ config :portal, Portal.Health,
   ops_endpoint: PortalOps.Endpoint,
   # TODO: Remove draining_file_path after Azure migration is complete
   draining_file_path: "/var/run/firezone/draining"
+
+config :portal, Portal.Azure.ManagedIdentity,
+  endpoint: "http://169.254.169.254",
+  client_id: nil,
+  req_opts: [
+    connect_options: [timeout: 1_000],
+    receive_timeout: 5_000,
+    retry: :transient
+  ]
 
 config :portal, Portal.Entra.APIClient,
   client_id: System.get_env("ENTRA_SYNC_CLIENT_ID"),

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -7,6 +7,42 @@ if config_env() == :prod do
   ##### Portal ##################
   ###############################
 
+  config :portal, Portal.Azure.ManagedIdentity,
+    client_id: env_var_to_config!(:azure_client_id)
+
+  if env_var_to_config!(:database_entra_auth) && !env_var_to_config(:azure_client_id) do
+    raise "AZURE_CLIENT_ID must be set when DATABASE_ENTRA_AUTH is enabled"
+  end
+
+  # With Entra auth the "password" is a short-lived Entra access token for the
+  # VM's managed identity, fetched before every connect attempt.
+  database_password_opts =
+    cond do
+      env_var_to_config!(:database_entra_auth) ->
+        [{:configure, {Portal.Azure.ManagedIdentity, :put_database_token, []}}]
+
+      env_var_to_config(:database_password) ->
+        [{:password, env_var_to_config!(:database_password)}]
+
+      true ->
+        []
+    end
+
+  # Postgrex.ReplicationConnection has no :configure hook, so it takes the
+  # password as an MFA that Portal.Replication.Manager resolves right before
+  # each connection attempt.
+  replication_password_opts =
+    cond do
+      env_var_to_config!(:database_entra_auth) ->
+        [{:password, {Portal.Azure.ManagedIdentity, :database_access_token!, []}}]
+
+      env_var_to_config(:database_password) ->
+        [{:password, env_var_to_config!(:database_password)}]
+
+      true ->
+        []
+    end
+
   config :portal,
          Portal.Repo,
          [
@@ -23,10 +59,7 @@ if config_env() == :prod do
              do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
              else: []
            ) ++
-           if(env_var_to_config(:database_password),
-             do: [{:password, env_var_to_config!(:database_password)}],
-             else: []
-           ) ++
+           database_password_opts ++
            if(env_var_to_config(:database_socket_dir),
              do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
              else: [{:hostname, env_var_to_config!(:database_host)}]
@@ -48,10 +81,7 @@ if config_env() == :prod do
              do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
              else: []
            ) ++
-           if(env_var_to_config(:database_password),
-             do: [{:password, env_var_to_config!(:database_password)}],
-             else: []
-           ) ++
+           database_password_opts ++
            if(env_var_to_config(:database_socket_dir),
              do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
              else: [{:hostname, env_var_to_config!(:database_host_replica)}]
@@ -71,10 +101,7 @@ if config_env() == :prod do
         do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
         else: []
       ) ++
-      if(env_var_to_config(:database_password),
-        do: [{:password, env_var_to_config!(:database_password)}],
-        else: []
-      ) ++
+      database_password_opts ++
       if(env_var_to_config(:database_socket_dir),
         do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
         else: [{:hostname, env_var_to_config!(:database_host)}]
@@ -94,10 +121,7 @@ if config_env() == :prod do
         do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
         else: []
       ) ++
-      if(env_var_to_config(:database_password),
-        do: [{:password, env_var_to_config!(:database_password)}],
-        else: []
-      ) ++
+      database_password_opts ++
       if(env_var_to_config(:database_socket_dir),
         do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
         else: [{:hostname, env_var_to_config!(:database_host_replica)}]
@@ -147,10 +171,7 @@ if config_env() == :prod do
           do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
           else: []
         ) ++
-        if(env_var_to_config(:database_password),
-          do: [{:password, env_var_to_config!(:database_password)}],
-          else: []
-        ) ++
+        replication_password_opts ++
         if(env_var_to_config(:database_socket_dir),
           do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
           else: [{:hostname, env_var_to_config!(:database_host_replica)}]
@@ -173,10 +194,7 @@ if config_env() == :prod do
           do: [{:socket_options, env_var_to_config!(:database_socket_options)}],
           else: []
         ) ++
-        if(env_var_to_config(:database_password),
-          do: [{:password, env_var_to_config!(:database_password)}],
-          else: []
-        ) ++
+        replication_password_opts ++
         if(env_var_to_config(:database_socket_dir),
           do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
           else: [{:hostname, env_var_to_config!(:database_host_replica)}]

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -112,6 +112,13 @@ config :portal, Portal.Okta.APIClient,
     retry: false
   ]
 
+config :portal, Portal.Azure.ManagedIdentity,
+  client_id: "test-azure-client-id",
+  req_opts: [
+    plug: {Req.Test, Portal.Azure.ManagedIdentity},
+    retry: false
+  ]
+
 config :portal, Portal.Entra.APIClient,
   client_id: "test_client_id",
   client_secret: "test_client_secret",

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -35,7 +35,9 @@ defmodule Portal.Application do
   end
 
   defp children do
-    base_children = [
+    # Must start before the repos: they fetch Entra access tokens from it
+    # when connecting with DATABASE_ENTRA_AUTH enabled
+    base_children = managed_identity() ++ [
       # Core services
       Portal.Repo,
       Portal.Repo.Replica,
@@ -130,6 +132,14 @@ defmodule Portal.Application do
 
     if Keyword.get(config, :enabled, true) do
       [{Portal.Queue, opts}]
+    else
+      []
+    end
+  end
+
+  defp managed_identity do
+    if Portal.Config.env_var_to_config!(:database_entra_auth) do
+      [Portal.Azure.ManagedIdentity]
     else
       []
     end

--- a/elixir/lib/portal/azure/managed_identity.ex
+++ b/elixir/lib/portal/azure/managed_identity.ex
@@ -1,0 +1,105 @@
+defmodule Portal.Azure.ManagedIdentity do
+  @moduledoc """
+  Fetches Microsoft Entra access tokens for the VM's user-assigned managed
+  identity from the Azure Instance Metadata Service (IMDS).
+
+  Azure Database for PostgreSQL accepts an Entra access token as the connection
+  password, which is how database connections are authenticated when
+  DATABASE_ENTRA_AUTH is enabled. The GenServer serializes IMDS requests and
+  caches the token until shortly before it expires; tokens are only needed to
+  establish new connections, so a refresh happens at most once per token
+  lifetime (24 hours for managed identity tokens).
+  """
+  use GenServer
+
+  @database_resource "https://ossrdbms-aad.database.windows.net"
+
+  # Refresh this many seconds before the token expires so a connection attempt
+  # never presents a token that expires mid-handshake.
+  @expiry_margin_seconds 300
+
+  # Covers the worst-case IMDS fetch (connect/receive timeouts across Req's
+  # default retries)
+  @call_timeout :timer.seconds(60)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, nil, Keyword.put_new(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  `DBConnection` `:configure` hook that replaces the connection password with a
+  fresh Entra access token before every connect attempt.
+  """
+  def put_database_token(connection_opts) do
+    Keyword.put(connection_opts, :password, database_access_token!())
+  end
+
+  @doc """
+  Returns a Microsoft Entra access token for Azure Database for PostgreSQL,
+  fetching a new one from IMDS if the cached one is missing or about to expire.
+
+  Falls back to fetching directly when the GenServer is not running, e.g. for
+  release migrations, which connect without starting the supervision tree.
+  """
+  def database_access_token! do
+    case GenServer.whereis(__MODULE__) do
+      nil ->
+        %{token: token} = fetch_token!()
+        token
+
+      server ->
+        case GenServer.call(server, :database_access_token, @call_timeout) do
+          {:ok, token} -> token
+          {:error, exception} -> raise exception
+        end
+    end
+  end
+
+  @impl true
+  def init(nil) do
+    {:ok, %{token: nil, expires_at: 0}}
+  end
+
+  @impl true
+  def handle_call(:database_access_token, _from, state) do
+    if state.expires_at - @expiry_margin_seconds > System.system_time(:second) do
+      {:reply, {:ok, state.token}, state}
+    else
+      try do
+        state = fetch_token!()
+        {:reply, {:ok, state.token}, state}
+      rescue
+        # Reply with the error instead of crashing so that an IMDS outage
+        # surfaces in the calling connection process (which DBConnection
+        # retries with backoff) without crash-looping this server
+        exception -> {:reply, {:error, exception}, state}
+      end
+    end
+  end
+
+  defp fetch_token! do
+    config = Portal.Config.fetch_env!(:portal, __MODULE__)
+    req_opts = config[:req_opts] || []
+
+    response =
+      Req.get!(
+        "#{config[:endpoint]}/metadata/identity/oauth2/token",
+        [
+          headers: [{"Metadata", "true"}],
+          params: [
+            "api-version": "2018-02-01",
+            resource: @database_resource,
+            client_id: config[:client_id]
+          ]
+        ] ++ req_opts
+      )
+
+    %Req.Response{status: 200, body: %{"access_token" => token, "expires_on" => expires_on}} =
+      response
+
+    %{token: token, expires_at: expires_at(expires_on)}
+  end
+
+  defp expires_at(unix_seconds) when is_integer(unix_seconds), do: unix_seconds
+  defp expires_at(unix_seconds) when is_binary(unix_seconds), do: String.to_integer(unix_seconds)
+end

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -365,6 +365,21 @@ defmodule Portal.Config.Definitions do
   defconfig(:database_password, :string, default: nil, sensitive: true)
 
   @doc """
+  Authenticate database connections using Microsoft Entra instead of a password.
+
+  When enabled, DATABASE_PASSWORD is ignored and every connection attempt uses
+  a Microsoft Entra access token fetched from the Azure Instance Metadata
+  Service for the managed identity selected by AZURE_CLIENT_ID.
+  """
+  defconfig(:database_entra_auth, :boolean, default: false)
+
+  @doc """
+  Client ID of the Azure user-assigned managed identity used to fetch Microsoft
+  Entra access tokens when DATABASE_ENTRA_AUTH is enabled.
+  """
+  defconfig(:azure_client_id, :string, default: nil)
+
+  @doc """
   Size of the connection pool to the PostgreSQL database.
   """
   defconfig(:database_pool_size, :integer,

--- a/elixir/lib/portal/replication/manager.ex
+++ b/elixir/lib/portal/replication/manager.ex
@@ -92,6 +92,9 @@ defmodule Portal.Replication.Manager do
       {:error, reason} ->
         handle_start_error(reason, state)
     end
+  rescue
+    error ->
+      handle_start_error(error, state)
   end
 
   defp link_existing_pid(pid, state) do
@@ -128,6 +131,17 @@ defmodule Portal.Replication.Manager do
     {connection_opts, config} =
       Application.fetch_env!(:portal, connection_module)
       |> Keyword.pop(:connection_opts)
+
+    # A password configured as an MFA (e.g. an Entra access token fetcher) is
+    # resolved fresh for every connection attempt since tokens expire.
+    connection_opts =
+      case Keyword.get(connection_opts, :password) do
+        {module, function, args} ->
+          Keyword.put(connection_opts, :password, apply(module, function, args))
+
+        _ ->
+          connection_opts
+      end
 
     %{
       connection_opts: connection_opts,

--- a/elixir/test/portal/azure/managed_identity_test.exs
+++ b/elixir/test/portal/azure/managed_identity_test.exs
@@ -1,0 +1,134 @@
+defmodule Portal.Azure.ManagedIdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Azure.ManagedIdentity
+
+  # The GenServer is not started in the test environment (DATABASE_ENTRA_AUTH
+  # is disabled), so database_access_token!/0 uses the direct-fetch fallback
+  # unless a test starts the server itself.
+
+  describe "database_access_token!/0 without the GenServer" do
+    test "fetches a token for the managed identity from IMDS" do
+      test_pid = self()
+
+      Req.Test.expect(ManagedIdentity, fn conn ->
+        send(test_pid, {:imds_request, conn})
+
+        Req.Test.json(conn, %{
+          "access_token" => "imds_token",
+          "expires_on" => Integer.to_string(System.system_time(:second) + 3600)
+        })
+      end)
+
+      assert ManagedIdentity.database_access_token!() == "imds_token"
+
+      assert_received {:imds_request, conn}
+      assert conn.method == "GET"
+      assert conn.request_path == "/metadata/identity/oauth2/token"
+      assert Plug.Conn.get_req_header(conn, "metadata") == ["true"]
+
+      params = URI.decode_query(conn.query_string)
+      assert params["api-version"] == "2018-02-01"
+      assert params["resource"] == "https://ossrdbms-aad.database.windows.net"
+      assert params["client_id"] == "test-azure-client-id"
+    end
+
+    test "raises when IMDS returns an error" do
+      Req.Test.expect(ManagedIdentity, fn conn ->
+        conn
+        |> Plug.Conn.put_status(400)
+        |> Req.Test.json(%{"error" => "invalid_request"})
+      end)
+
+      assert_raise MatchError, fn ->
+        ManagedIdentity.database_access_token!()
+      end
+    end
+  end
+
+  describe "database_access_token!/0 with the GenServer" do
+    setup do
+      server = start_supervised!(ManagedIdentity)
+
+      # Establish stub ownership before allowing the server process to use it
+      Req.Test.stub(ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{"error" => "not mocked"})
+      end)
+
+      Req.Test.allow(ManagedIdentity, self(), server)
+      %{server: server}
+    end
+
+    test "caches the token until it is about to expire" do
+      Req.Test.expect(ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "cached_token",
+          "expires_on" => System.system_time(:second) + 3600
+        })
+      end)
+
+      assert ManagedIdentity.database_access_token!() == "cached_token"
+      # A second IMDS request would exceed the expectation above and raise
+      assert ManagedIdentity.database_access_token!() == "cached_token"
+    end
+
+    test "fetches a new token when the cached one is about to expire" do
+      test_pid = self()
+
+      Req.Test.expect(ManagedIdentity, 2, fn conn ->
+        send(test_pid, :imds_request)
+
+        Req.Test.json(conn, %{
+          "access_token" => "short_lived_token",
+          "expires_on" => System.system_time(:second) + 60
+        })
+      end)
+
+      # The token expires within the refresh margin, so each call fetches
+      assert ManagedIdentity.database_access_token!() == "short_lived_token"
+      assert ManagedIdentity.database_access_token!() == "short_lived_token"
+
+      assert_received :imds_request
+      assert_received :imds_request
+    end
+
+    test "stays alive after a fetch error and recovers", %{server: server} do
+      Req.Test.expect(ManagedIdentity, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => "server_error"})
+      end)
+
+      assert_raise MatchError, fn ->
+        ManagedIdentity.database_access_token!()
+      end
+
+      assert Process.alive?(server)
+
+      Req.Test.expect(ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "recovered_token",
+          "expires_on" => System.system_time(:second) + 3600
+        })
+      end)
+
+      assert ManagedIdentity.database_access_token!() == "recovered_token"
+    end
+  end
+
+  describe "put_database_token/1" do
+    test "replaces the connection password with a fresh token" do
+      Req.Test.expect(ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "configure_token",
+          "expires_on" => System.system_time(:second) + 3600
+        })
+      end)
+
+      opts = ManagedIdentity.put_database_token(username: "apps-identity", password: "stale")
+
+      assert opts[:password] == "configure_token"
+      assert opts[:username] == "apps-identity"
+    end
+  end
+end


### PR DESCRIPTION
Compliance requires us to use short-lived Entra auth tokens for DB access instead of the more traditional long-lived app credentials. We can do this quite readily by requesting a token each time a DB connection made using Ecto's built in facilities.

Since Postgres only checks auth on connection establishment [1](https://www.postgresql.org/docs/current/protocol-flow.html) [2](https://learn.microsoft.com/en-us/answers/questions/2242405/automating-session-termination-for-expired-access), we simply need to refresh this token 5 minutes before it expires so that any reconnections always use a valid token.

Note: this needs to be merged and deployed (and is safe to do so) BEFORE https://github.com/firezone/infra/pull/733 is applied
