### PR TITLE
perf(connlib): pool the storage of UDP receive batches

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -322,7 +322,10 @@ impl PerfUdpSocket {
     /// Returns `WouldBlock` if the socket is not readable, clearing tokio's cached
     /// readiness in the process so that waiting for readiness actually suspends.
     fn try_recv_batch(&self, socket: Socket<'_>) -> io::Result<DatagramSegmentIter> {
-        let (mut buffers, mut metas) = self.recv_buffers.pull_batch();
+        let RecvBatch {
+            mut buffers,
+            mut metas,
+        } = self.recv_buffers.pull_batch();
 
         let len = socket.inner.try_io(Interest::READABLE, || {
             // The loop only re-iterates on Apple, where connected sockets surface (one-shot)
@@ -778,10 +781,11 @@ pub(crate) struct RecvBuffers {
     metas: BufferPool<VecBuf<quinn_udp::RecvMeta>>,
 }
 
-/// The pooled datagram buffers of one receive batch.
-type BatchBuffers = Buffer<VecBuf<Buffer<Vec<u8>>>>;
-/// The pooled metadata of one receive batch.
-type BatchMetas = Buffer<VecBuf<quinn_udp::RecvMeta>>;
+/// The pooled storage for one receive batch: a datagram buffer plus its metadata per slot.
+pub(crate) struct RecvBatch {
+    buffers: Buffer<VecBuf<Buffer<Vec<u8>>>>,
+    metas: Buffer<VecBuf<quinn_udp::RecvMeta>>,
+}
 
 impl RecvBuffers {
     fn new(recv_buf_size: usize, tag: &'static str) -> Self {
@@ -793,14 +797,14 @@ impl RecvBuffers {
     }
 
     /// Pulls the storage for one receive batch, sized and ready for a `recv` call.
-    pub(crate) fn pull_batch(&self) -> (BatchBuffers, BatchMetas) {
+    pub(crate) fn pull_batch(&self) -> RecvBatch {
         let mut buffers = self.buffers.pull();
         let mut metas = self.metas.pull();
 
         buffers.extend(std::iter::repeat_with(|| self.bytes.pull()).take(quinn_udp::BATCH_SIZE));
         metas.resize(quinn_udp::BATCH_SIZE, quinn_udp::RecvMeta::default());
 
-        (buffers, metas)
+        RecvBatch { buffers, metas }
     }
 }
 
@@ -960,6 +964,16 @@ mod tests {
         fn clone(&self) -> Self {
             Self(self.0.clone())
         }
+    }
+
+    /// The iterator is the item of the channel to the main thread; keeping it small is
+    /// the whole point of storing the batch in pooled `Vec`s rather than inline. tokio
+    /// allocates channel slots in blocks, so a large item would cross musl's mmap
+    /// threshold and thrash the allocator (see the pooling that produced this type).
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn iter_is_a_small_channel_item() {
+        assert_eq!(size_of::<DatagramSegmentIter>(), 104);
     }
 
     #[test]

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context as _, Result};
-use bufferpool::{Buffer, BufferPool};
+use bufferpool::{Buffer, BufferPool, VecBuf};
 use bytes::{Buf as _, BytesMut};
 use gat_lending_iterator::LendingIterator;
 use ip_packet::{Ecn, Ipv4Header, Ipv6Header, UdpHeader};
@@ -200,8 +200,8 @@ pub struct PerfUdpSocket {
     /// The socket(s) we send and receive on; see [`SocketPool`].
     pool: SocketPool,
 
-    /// A buffer pool for batches of incoming UDP packets.
-    buffer_pool: BufferPool<Vec<u8>>,
+    /// The pools backing batched receives; see [`RecvBuffers`].
+    recv_buffers: RecvBuffers,
 
     batch_histogram: opentelemetry::metrics::Histogram<u64>,
     send_retry_histogram: opentelemetry::metrics::Histogram<u64>,
@@ -246,7 +246,7 @@ impl UdpSocket {
 
         Ok(PerfUdpSocket {
             pool: SocketPool::new(wildcard),
-            buffer_pool: BufferPool::new(
+            recv_buffers: RecvBuffers::new(
                 recv_buf_size,
                 match socket_addr.ip() {
                     IpAddr::V4(_) => "udp-socket-v4",
@@ -322,21 +322,22 @@ impl PerfUdpSocket {
     /// Returns `WouldBlock` if the socket is not readable, clearing tokio's cached
     /// readiness in the process so that waiting for readiness actually suspends.
     fn try_recv_batch(&self, socket: Socket<'_>) -> io::Result<DatagramSegmentIter> {
-        // Stack-allocate arrays for buffers and meta. The size is implied from the const-generic default on `DatagramSegmentIter`.
-        let mut bufs = std::array::from_fn(|_| self.buffer_pool.pull());
-        let mut meta = std::array::from_fn(|_| quinn_udp::RecvMeta::default());
+        let (mut buffers, mut metas) = self.recv_buffers.pull_batch();
 
         let len = socket.inner.try_io(Interest::READABLE, || {
             // The loop only re-iterates on Apple, where connected sockets surface (one-shot)
             // ICMP errors on receive that we skip past; hence the `never_loop` allow elsewhere.
             #[cfg_attr(not(apple), allow(clippy::never_loop))]
             loop {
-                // Fancy std-functions ahead: `each_mut` transforms our array into an array of references to our items and `map` allows us to create an `IoSliceMut` out of each element.
-                // `state.recv` requires us to pass `IoSliceMut` but later on, we need the original buffer again because `DatagramSegmentIter` needs to own them.
+                // `state.recv` requires us to pass `IoSliceMut` but later on, we need the
+                // original buffer again because `DatagramSegmentIter` needs to own them.
                 // That is why we cannot just create an `IoSliceMut` to begin with.
-                let mut io_bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
+                let mut io_bufs = buffers
+                    .iter_mut()
+                    .map(|b| IoSliceMut::new(b))
+                    .collect::<SmallVec<[_; quinn_udp::BATCH_SIZE]>>();
 
-                match socket.recv(&mut io_bufs, &mut meta) {
+                match socket.recv(&mut io_bufs, &mut metas) {
                     // Connected sockets surface (one-shot) ICMP errors on receive; they are not fatal.
                     #[cfg(apple)]
                     Err(e) if socket.connected && is_icmp_unreachable(&e) => {
@@ -356,7 +357,7 @@ impl PerfUdpSocket {
             ],
         );
 
-        Ok(DatagramSegmentIter::new(bufs, meta, self.port, len))
+        Ok(DatagramSegmentIter::new(buffers, metas, self.port, len))
     }
 
     pub async fn send(&self, datagram: DatagramOut) -> Result<()> {
@@ -370,7 +371,7 @@ impl PerfUdpSocket {
 
         let pooled = self
             .pool
-            .get_send_socket(transmit.src_ip, datagram.dst, &self.buffer_pool);
+            .get_send_socket(transmit.src_ip, datagram.dst, &self.recv_buffers);
 
         self.send_transmit(pooled.as_socket(), &transmit).await
     }
@@ -764,9 +765,48 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
     let _ = tokio::time::timeout(timeout, socket.writable()).await;
 }
 
-/// An iterator that segments an array of buffers into individual datagrams.
+/// The pools backing a batched receive: scratch space for the datagrams themselves
+/// plus containers for the buffers and metas that make up one batch.
 ///
-/// This iterator is generic over its buffer type and the number of buffers to allow easier testing without a buffer pool.
+/// The buffers and metas live in pooled, heap-allocated `Vec`s rather than inline in
+/// [`DatagramSegmentIter`]: the iterator is sent over a channel and inline storage
+/// would make every channel slot (and thus tokio's block allocations) carry the full
+/// batch size.
+pub(crate) struct RecvBuffers {
+    bytes: BufferPool<Vec<u8>>,
+    buffers: BufferPool<VecBuf<Buffer<Vec<u8>>>>,
+    metas: BufferPool<VecBuf<quinn_udp::RecvMeta>>,
+}
+
+/// The pooled datagram buffers of one receive batch.
+type BatchBuffers = Buffer<VecBuf<Buffer<Vec<u8>>>>;
+/// The pooled metadata of one receive batch.
+type BatchMetas = Buffer<VecBuf<quinn_udp::RecvMeta>>;
+
+impl RecvBuffers {
+    fn new(recv_buf_size: usize, tag: &'static str) -> Self {
+        Self {
+            bytes: BufferPool::new(recv_buf_size, tag),
+            buffers: BufferPool::new(quinn_udp::BATCH_SIZE, "udp-recv-buffers"),
+            metas: BufferPool::new(quinn_udp::BATCH_SIZE, "udp-recv-metas"),
+        }
+    }
+
+    /// Pulls the storage for one receive batch, sized and ready for a `recv` call.
+    pub(crate) fn pull_batch(&self) -> (BatchBuffers, BatchMetas) {
+        let mut buffers = self.buffers.pull();
+        let mut metas = self.metas.pull();
+
+        buffers.extend(std::iter::repeat_with(|| self.bytes.pull()).take(quinn_udp::BATCH_SIZE));
+        metas.resize(quinn_udp::BATCH_SIZE, quinn_udp::RecvMeta::default());
+
+        (buffers, metas)
+    }
+}
+
+/// An iterator that segments a batch of buffers into individual datagrams.
+///
+/// This iterator is generic over its buffer type to allow easier testing without a buffer pool.
 ///
 /// This implementation might look like dark arts but it is actually quite simple.
 /// Its design is driven by two main ideas:
@@ -781,10 +821,11 @@ async fn wait_for_send_capacity(socket: &tokio::net::UdpSocket) {
 /// When [`quinn_udp`] returns us the buffers, it will have populated the [`quinn_udp::RecvMeta`]s accordingly.
 /// Thus, our main job within this iterator is to loop over the `buffers` and `meta` pair-wise, inspect the `meta` and segment the data within the buffer accordingly.
 #[derive(derive_more::Debug)]
-pub struct DatagramSegmentIter<const N: usize = { quinn_udp::BATCH_SIZE }, B = Buffer<Vec<u8>>> {
+pub struct DatagramSegmentIter<B = Buffer<Vec<u8>>> {
     #[debug(skip)]
-    buffers: SmallVec<[B; N]>,
-    metas: SmallVec<[quinn_udp::RecvMeta; N]>,
+    buffers: Buffer<VecBuf<B>>,
+    #[debug(skip)]
+    metas: Buffer<VecBuf<quinn_udp::RecvMeta>>,
 
     port: u16,
 
@@ -795,16 +836,13 @@ pub struct DatagramSegmentIter<const N: usize = { quinn_udp::BATCH_SIZE }, B = B
     _num_packets: usize,
 }
 
-impl<B, const N: usize> DatagramSegmentIter<N, B> {
+impl<B> DatagramSegmentIter<B> {
     pub(crate) fn new(
-        buffers: [B; N],
-        metas: [quinn_udp::RecvMeta; N],
+        mut buffers: Buffer<VecBuf<B>>,
+        mut metas: Buffer<VecBuf<quinn_udp::RecvMeta>>,
         port: u16,
         len: usize,
     ) -> Self {
-        let mut buffers = SmallVec::from_buf(buffers);
-        let mut metas = SmallVec::from_buf(metas);
-
         // Drop the unused buffers / metas.
         buffers.truncate(len);
         metas.truncate(len);
@@ -833,7 +871,7 @@ impl<B, const N: usize> DatagramSegmentIter<N, B> {
     }
 }
 
-impl<B, const N: usize> LendingIterator for DatagramSegmentIter<N, B>
+impl<B> LendingIterator for DatagramSegmentIter<B>
 where
     B: Deref<Target = Vec<u8>> + 'static,
 {
@@ -918,32 +956,42 @@ mod tests {
     #[derive(derive_more::Deref)]
     struct DummyBuffer(Vec<u8>);
 
+    impl Clone for DummyBuffer {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
     #[test]
     fn datagram_iter_segments_buffer_correctly() {
-        let mut iter = DatagramSegmentIter::new(
-            [
-                DummyBuffer(b"foobar1foobar2foobar3foobar4foobar5foo                 ".to_vec()),
-                DummyBuffer(b"baz1baz2baz3baz4baz5foo       ".to_vec()),
-                DummyBuffer(b"".to_vec()),
-            ],
-            [
-                recv_meta(
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-                    IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    38,
-                    7,
-                ),
-                recv_meta(
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-                    IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    23,
-                    4,
-                ),
-                quinn_udp::RecvMeta::default(),
-            ],
-            0,
-            3,
-        );
+        let buffer_pool = BufferPool::<VecBuf<DummyBuffer>>::new(3, "test");
+        let meta_pool = BufferPool::<VecBuf<quinn_udp::RecvMeta>>::new(3, "test");
+
+        let mut buffers = buffer_pool.pull();
+        buffers.extend([
+            DummyBuffer(b"foobar1foobar2foobar3foobar4foobar5foo                 ".to_vec()),
+            DummyBuffer(b"baz1baz2baz3baz4baz5foo       ".to_vec()),
+            DummyBuffer(b"".to_vec()),
+        ]);
+
+        let mut metas = meta_pool.pull();
+        metas.extend([
+            recv_meta(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                38,
+                7,
+            ),
+            recv_meta(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                23,
+                4,
+            ),
+            quinn_udp::RecvMeta::default(),
+        ]);
+
+        let mut iter = DatagramSegmentIter::new(buffers, metas, 0, 3);
 
         assert_eq!(iter.next().unwrap().packet, b"foobar1");
         assert_eq!(iter.next().unwrap().packet, b"foobar2");

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -322,25 +322,16 @@ impl PerfUdpSocket {
     /// Returns `WouldBlock` if the socket is not readable, clearing tokio's cached
     /// readiness in the process so that waiting for readiness actually suspends.
     fn try_recv_batch(&self, socket: Socket<'_>) -> io::Result<DatagramSegmentIter> {
-        let RecvBatch {
-            mut buffers,
-            mut metas,
-        } = self.recv_buffers.pull_batch();
+        let mut batch = self.recv_buffers.pull_batch();
 
         let len = socket.inner.try_io(Interest::READABLE, || {
             // The loop only re-iterates on Apple, where connected sockets surface (one-shot)
             // ICMP errors on receive that we skip past; hence the `never_loop` allow elsewhere.
             #[cfg_attr(not(apple), allow(clippy::never_loop))]
             loop {
-                // `state.recv` requires us to pass `IoSliceMut` but later on, we need the
-                // original buffer again because `DatagramSegmentIter` needs to own them.
-                // That is why we cannot just create an `IoSliceMut` to begin with.
-                let mut io_bufs = buffers
-                    .iter_mut()
-                    .map(|b| IoSliceMut::new(b))
-                    .collect::<SmallVec<[_; quinn_udp::BATCH_SIZE]>>();
+                let (mut io_bufs, metas) = batch.recv_slices();
 
-                match socket.recv(&mut io_bufs, &mut metas) {
+                match socket.recv(&mut io_bufs, metas) {
                     // Connected sockets surface (one-shot) ICMP errors on receive; they are not fatal.
                     #[cfg(apple)]
                     Err(e) if socket.connected && is_icmp_unreachable(&e) => {
@@ -360,7 +351,12 @@ impl PerfUdpSocket {
             ],
         );
 
-        Ok(DatagramSegmentIter::new(buffers, metas, self.port, len))
+        Ok(DatagramSegmentIter::new(
+            batch.buffers,
+            batch.metas,
+            self.port,
+            len,
+        ))
     }
 
     pub async fn send(&self, datagram: DatagramOut) -> Result<()> {
@@ -785,6 +781,27 @@ pub(crate) struct RecvBuffers {
 pub(crate) struct RecvBatch {
     buffers: Buffer<VecBuf<Buffer<Vec<u8>>>>,
     metas: Buffer<VecBuf<quinn_udp::RecvMeta>>,
+}
+
+impl RecvBatch {
+    /// The batch's datagram buffers as scatter slices, paired with the meta array the
+    /// kernel fills in — the two arguments a `recvmmsg`-style read expects. Borrows the
+    /// batch for the duration of the read; afterwards the buffers are handed to a
+    /// [`DatagramSegmentIter`].
+    fn recv_slices(
+        &mut self,
+    ) -> (
+        SmallVec<[IoSliceMut<'_>; quinn_udp::BATCH_SIZE]>,
+        &mut [quinn_udp::RecvMeta],
+    ) {
+        let io_bufs = self
+            .buffers
+            .iter_mut()
+            .map(|b| IoSliceMut::new(b))
+            .collect();
+
+        (io_bufs, &mut self.metas)
+    }
 }
 
 impl RecvBuffers {

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -27,11 +27,10 @@ use std::{
 };
 
 use anyhow::Result;
-use bufferpool::BufferPool;
 use parking_lot::{Mutex, MutexGuard};
 use quinn_udp::UdpSockRef;
 
-use crate::DatagramSegmentIter;
+use crate::{DatagramSegmentIter, RecvBuffers};
 
 use super::{OwnedSocket, Socket, poll_recv_ready};
 
@@ -116,9 +115,9 @@ impl SocketPool {
         &self,
         src: Option<IpAddr>,
         dst: SocketAddr,
-        buffer_pool: &BufferPool<Vec<u8>>,
+        recv_buffers: &RecvBuffers,
     ) -> Arc<OwnedSocket> {
-        self.get_or_connect(src, dst, buffer_pool)
+        self.get_or_connect(src, dst, recv_buffers)
             .unwrap_or_else(|| self.wildcard.clone())
     }
 
@@ -189,7 +188,7 @@ impl SocketPool {
         &self,
         src: Option<IpAddr>,
         dst: SocketAddr,
-        pool: &BufferPool<Vec<u8>>,
+        recv_buffers: &RecvBuffers,
     ) -> Option<Arc<OwnedSocket>> {
         let key = (src, dst);
         let mut inner = self.lock();
@@ -203,7 +202,7 @@ impl SocketPool {
         }
 
         if inner.flows.len() >= MAX_FLOW_SOCKETS {
-            evict_one(&mut inner, self.local.port(), pool);
+            evict_one(&mut inner, self.local.port(), recv_buffers);
         }
 
         match connect(self.local, src, dst, inner.buffer_sizes) {
@@ -277,7 +276,7 @@ impl Flow {
 }
 
 /// Evicts the flow socket that is least likely to still be useful.
-fn evict_one(inner: &mut Inner, port: u16, pool: &BufferPool<Vec<u8>>) {
+fn evict_one(inner: &mut Inner, port: u16, recv_buffers: &RecvBuffers) {
     let Some(key) = inner
         .flows
         .iter()
@@ -295,7 +294,7 @@ fn evict_one(inner: &mut Inner, port: u16, pool: &BufferPool<Vec<u8>>) {
         return;
     };
 
-    drain(&victim, port, pool, &mut inner.drained);
+    drain(&victim, port, recv_buffers, &mut inner.drained);
 
     if !inner.drained.is_empty()
         && let Some(waker) = inner.recv_waker.take()
@@ -327,17 +326,19 @@ fn eviction_rank(last_received: Option<Instant>, created_at: Instant) -> (bool, 
 fn drain(
     victim: &Flow,
     port: u16,
-    pool: &BufferPool<Vec<u8>>,
+    recv_buffers: &RecvBuffers,
     out: &mut VecDeque<DatagramSegmentIter>,
 ) {
     let socket = victim.socket.as_socket();
 
     loop {
-        let mut bufs = std::array::from_fn(|_| pool.pull());
-        let mut metas = std::array::from_fn(|_| quinn_udp::RecvMeta::default());
+        let (mut buffers, mut metas) = recv_buffers.pull_batch();
 
         let len = {
-            let mut io_bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
+            let mut io_bufs = buffers
+                .iter_mut()
+                .map(|b| IoSliceMut::new(b))
+                .collect::<smallvec::SmallVec<[_; quinn_udp::BATCH_SIZE]>>();
 
             match socket.recv(&mut io_bufs, &mut metas) {
                 Ok(len) => len,
@@ -345,7 +346,7 @@ fn drain(
             }
         };
 
-        out.push_back(DatagramSegmentIter::new(bufs, metas, port, len));
+        out.push_back(DatagramSegmentIter::new(buffers, metas, port, len));
     }
 }
 

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -30,7 +30,7 @@ use anyhow::Result;
 use parking_lot::{Mutex, MutexGuard};
 use quinn_udp::UdpSockRef;
 
-use crate::{DatagramSegmentIter, RecvBuffers};
+use crate::{DatagramSegmentIter, RecvBatch, RecvBuffers};
 
 use super::{OwnedSocket, Socket, poll_recv_ready};
 
@@ -332,7 +332,10 @@ fn drain(
     let socket = victim.socket.as_socket();
 
     loop {
-        let (mut buffers, mut metas) = recv_buffers.pull_batch();
+        let RecvBatch {
+            mut buffers,
+            mut metas,
+        } = recv_buffers.pull_batch();
 
         let len = {
             let mut io_bufs = buffers

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -19,7 +19,7 @@
 
 use std::{
     collections::{BTreeMap, VecDeque},
-    io::{self, IoSliceMut},
+    io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, Waker},
@@ -30,7 +30,7 @@ use anyhow::Result;
 use parking_lot::{Mutex, MutexGuard};
 use quinn_udp::UdpSockRef;
 
-use crate::{DatagramSegmentIter, RecvBatch, RecvBuffers};
+use crate::{DatagramSegmentIter, RecvBuffers};
 
 use super::{OwnedSocket, Socket, poll_recv_ready};
 
@@ -332,24 +332,23 @@ fn drain(
     let socket = victim.socket.as_socket();
 
     loop {
-        let RecvBatch {
-            mut buffers,
-            mut metas,
-        } = recv_buffers.pull_batch();
+        let mut batch = recv_buffers.pull_batch();
 
         let len = {
-            let mut io_bufs = buffers
-                .iter_mut()
-                .map(|b| IoSliceMut::new(b))
-                .collect::<smallvec::SmallVec<[_; quinn_udp::BATCH_SIZE]>>();
+            let (mut io_bufs, metas) = batch.recv_slices();
 
-            match socket.recv(&mut io_bufs, &mut metas) {
+            match socket.recv(&mut io_bufs, metas) {
                 Ok(len) => len,
                 Err(_) => break, // Typically `WouldBlock`: the socket is dry.
             }
         };
 
-        out.push_back(DatagramSegmentIter::new(buffers, metas, port, len));
+        out.push_back(DatagramSegmentIter::new(
+            batch.buffers,
+            batch.metas,
+            port,
+            len,
+        ));
     }
 }
 

--- a/rust/libs/connlib/socket-factory/src/pool/fallback.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/fallback.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use anyhow::Result;
-use bufferpool::BufferPool;
 
 use crate::DatagramSegmentIter;
 
@@ -32,7 +31,7 @@ impl SocketPool {
         &self,
         _src: Option<IpAddr>,
         _dst: SocketAddr,
-        _buffer_pool: &BufferPool<Vec<u8>>,
+        _recv_buffers: &crate::RecvBuffers,
     ) -> Arc<OwnedSocket> {
         self.wildcard.clone()
     }


### PR DESCRIPTION
When we read a batch of datagrams from a UDP socket, we hand them to the main thread as a single `DatagramSegmentIter`. That iterator keeps the datagram buffers and their metadata inline via `SmallVec`, each sized for the largest batch a single `recvmmsg` can return. Even with the slim buffer handles from #14039, the receive metadata dominates and the iterator still comes to ~3.6 KB.

The iterator is the item of an `mpsc` channel and tokio allocates the channel's slots in blocks of 32. At this size the block (~116 KB) is large enough to cross musl's `mmap` threshold, so under load we `mmap` and `munmap` a fresh block many times a second, each `munmap` costing a cross-CPU TLB shootdown — and we copy the whole iterator every time it moves through the channel.

We now keep the buffers and metadata in pooled `VecBuf`s and only give the iterator a handle to them. This shrinks the channel item to a couple of pointers, so the blocks stay small enough to be reused instead of being handed back to the OS.

Measured under a fixed-rate UDP flow, this stops the churn: the Gateway goes from roughly 90 `mmap`/`munmap` cycles of the ~116 KB block per second to none, and the share of CPU time spent in `memcpy` drops from 3.4% to 2.0% on the Client and from 2.0% to 1.6% on the Gateway.

Related: #14039