### PR TITLE
refactor(connlib): rename `GsoQueue` to `UdpGsoQueue`

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -1,13 +1,13 @@
 mod device;
 mod doh;
-mod gso_queue;
 mod nameserver_set;
 mod tcp_dns;
 mod timeout;
 mod udp_dns;
+mod udp_gso_queue;
 
 pub use device::{Device, TunChannelClosed};
-pub(crate) use gso_queue::GsoQueue;
+pub(crate) use udp_gso_queue::UdpGsoQueue;
 
 use crate::{TunnelError, dns, io::timeout::Timeout, otel, sockets::Sockets};
 use anyhow::{ErrorExt, Result};
@@ -51,7 +51,7 @@ const DEFAULT_TIME_ADVANCE: Duration = Duration::from_secs(10);
 pub struct Io {
     /// The UDP sockets used to send & receive packets from the network.
     sockets: Sockets,
-    gso_queue: GsoQueue,
+    gso_queue: UdpGsoQueue,
 
     nameservers: NameserverSet,
     reval_nameserver_interval: tokio::time::Interval,
@@ -189,7 +189,7 @@ impl Io {
                 || futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT),
                 10,
             ),
-            gso_queue: GsoQueue::new(),
+            gso_queue: UdpGsoQueue::new(),
             tun: Device::new(),
             udp_dns_server: Default::default(),
             tcp_dns_server: Default::default(),
@@ -507,7 +507,7 @@ impl Io {
     }
 
     /// The GSO queue used as the destination buffer when encapsulating packets in place.
-    pub fn gso_queue_mut(&mut self) -> &mut GsoQueue {
+    pub fn gso_queue_mut(&mut self) -> &mut UdpGsoQueue {
         &mut self.gso_queue
     }
 

--- a/rust/libs/connlib/tunnel/src/io/udp_gso_queue.rs
+++ b/rust/libs/connlib/tunnel/src/io/udp_gso_queue.rs
@@ -18,12 +18,12 @@ const MAX_SEGMENT_SIZE: usize =
 ///
 /// Calling [`Io::send_network`](super::Io::send_network) will copy the provided payload into this buffer.
 /// The buffer is then flushed using GSO in a single syscall.
-pub struct GsoQueue {
+pub struct UdpGsoQueue {
     inner: BTreeMap<Connection, VecDeque<(usize, Buffer<BytesMut>)>>,
     buffer_pool: BufferPool<BytesMut>,
 }
 
-impl GsoQueue {
+impl UdpGsoQueue {
     pub fn new() -> Self {
         Self {
             inner: Default::default(),
@@ -73,7 +73,7 @@ impl GsoQueue {
     }
 }
 
-impl BufferProvider for GsoQueue {
+impl BufferProvider for UdpGsoQueue {
     type Reservation<'a> = GsoReservation<'a>;
 
     fn reserve(
@@ -118,9 +118,9 @@ impl BufferProvider for GsoQueue {
     }
 }
 
-/// A [`Reservation`] into a [`GsoQueue`], pointing at the tail of the current batch.
+/// A [`Reservation`] into a [`UdpGsoQueue`], pointing at the tail of the current batch.
 pub struct GsoReservation<'a> {
-    queue: &'a mut GsoQueue,
+    queue: &'a mut UdpGsoQueue,
     connection: Connection,
     len: usize,
     committed: bool,
@@ -161,9 +161,9 @@ struct Connection {
     ecn: Ecn,
 }
 
-/// An [`Iterator`] that drains datagrams from the [`GsoQueue`].
+/// An [`Iterator`] that drains datagrams from the [`UdpGsoQueue`].
 struct DrainDatagramsIter<'a> {
-    queue: &'a mut GsoQueue,
+    queue: &'a mut UdpGsoQueue,
 }
 
 impl Iterator for DrainDatagramsIter<'_> {
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn dropping_datagram_iterator_does_not_drop_items() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
 
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn appends_items_of_same_batch() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
         send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn starts_new_batch_for_new_dst() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
         send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn continues_batch_for_old_dst() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
         send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn starts_new_batch_after_single_item_less_than_segment_length() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
         send_queue.enqueue(None, DST_1, b"barbaz", Ecn::NonEct);
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn committing_a_reservation_keeps_the_datagram() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         {
             let mut reservation = send_queue.reserve(None, DST_1, Ecn::NonEct, 6);
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn dropping_a_reservation_without_committing_rolls_it_back() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         send_queue.enqueue(None, DST_1, b"foobar", Ecn::NonEct);
 
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn dropping_the_only_reservation_leaves_the_queue_empty() {
-        let mut send_queue = GsoQueue::new();
+        let mut send_queue = UdpGsoQueue::new();
 
         {
             let mut reservation = send_queue.reserve(None, DST_1, Ecn::NonEct, 6);


### PR DESCRIPTION
The socket send path's GSO queue is about to be joined by a TUN-side GSO queue (Linux TUN offloading). Rename the existing `GsoQueue` to `UdpGsoQueue` first so the two are unambiguous.