### PR TITLE
perf(connlib): patch checksums incrementally on mutation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "aya-log-ebpf",
  "ebpf-shared",
  "hex-literal",
+ "incremental-inet-checksum",
  "ip-packet",
  "network-types",
  "which",
@@ -3736,6 +3737,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "incremental-inet-checksum"
+version = "0.1.0"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,6 +3801,7 @@ dependencies = [
  "bufferpool",
  "etherparse",
  "etherparse-ext",
+ "incremental-inet-checksum",
  "proptest",
  "test-strategy",
  "thiserror 2.0.18",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "libs/flow-log-upload",
     "libs/flow-log-writer",
     "libs/http-client",
+    "libs/incremental-inet-checksum",
     "libs/known-dirs",
     "libs/logging",
     "libs/telemetry",
@@ -121,6 +122,7 @@ http-client = { path = "libs/http-client" }
 humantime = "2.3.0"
 hyper = "1.9.0"
 hyper-util = "0.1.20"
+incremental-inet-checksum = { path = "libs/incremental-inet-checksum" }
 ip-packet = { path = "libs/connlib/ip-packet" }
 ip_network = { version = "0.4.1", default-features = false }
 ip_network_table = { version = "0.2.0", default-features = false }

--- a/rust/libs/connlib/etherparse-ext/src/icmpv4_header_slice_mut.rs
+++ b/rust/libs/connlib/etherparse-ext/src/icmpv4_header_slice_mut.rs
@@ -16,6 +16,19 @@ impl<'a> Icmpv4HeaderSliceMut<'a> {
         Ok(Self { slice })
     }
 
+    pub fn get_checksum(&self) -> u16 {
+        u16::from_be_bytes([self.slice[2], self.slice[3]])
+    }
+
+    pub fn get_identifier(&self) -> u16 {
+        debug_assert!(
+            self.is_echo_request_or_reply(),
+            "ICMP identifier only exists for echo requests and replies"
+        );
+
+        u16::from_be_bytes([self.slice[4], self.slice[5]])
+    }
+
     pub fn set_checksum(&mut self, checksum: u16) {
         // Safety: Slice is at least of length 8 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 2, checksum.to_be_bytes()) };
@@ -41,7 +54,7 @@ impl<'a> Icmpv4HeaderSliceMut<'a> {
         unsafe { write_to_offset_unchecked(self.slice, 6, seq.to_be_bytes()) };
     }
 
-    fn is_echo_request_or_reply(&self) -> bool {
+    pub fn is_echo_request_or_reply(&self) -> bool {
         let ty = self.slice[0];
 
         ty == TYPE_ECHO_REPLY || ty == TYPE_ECHO_REQUEST

--- a/rust/libs/connlib/etherparse-ext/src/icmpv6_header_slice_mut.rs
+++ b/rust/libs/connlib/etherparse-ext/src/icmpv6_header_slice_mut.rs
@@ -16,6 +16,19 @@ impl<'a> Icmpv6EchoHeaderSliceMut<'a> {
         Ok(Self { slice })
     }
 
+    pub fn get_checksum(&self) -> u16 {
+        u16::from_be_bytes([self.slice[2], self.slice[3]])
+    }
+
+    pub fn get_identifier(&self) -> u16 {
+        debug_assert!(
+            self.is_echo_request_or_reply(),
+            "ICMP identifier only exists for echo requests and replies"
+        );
+
+        u16::from_be_bytes([self.slice[4], self.slice[5]])
+    }
+
     pub fn set_checksum(&mut self, checksum: u16) {
         // Safety: Slice is at least of length 8 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 2, checksum.to_be_bytes()) };
@@ -41,7 +54,7 @@ impl<'a> Icmpv6EchoHeaderSliceMut<'a> {
         unsafe { write_to_offset_unchecked(self.slice, 6, seq.to_be_bytes()) };
     }
 
-    fn is_echo_request_or_reply(&self) -> bool {
+    pub fn is_echo_request_or_reply(&self) -> bool {
         let ty = self.slice[0];
 
         ty == TYPE_ECHO_REPLY || ty == TYPE_ECHO_REQUEST

--- a/rust/libs/connlib/etherparse-ext/src/ipv4_header_slice_mut.rs
+++ b/rust/libs/connlib/etherparse-ext/src/ipv4_header_slice_mut.rs
@@ -24,8 +24,30 @@ impl<'a> Ipv4HeaderSliceMut<'a> {
         Self { slice }
     }
 
+    pub fn get_checksum(&self) -> u16 {
+        u16::from_be_bytes([self.slice[10], self.slice[11]])
+    }
+
+    pub fn get_source(&self) -> [u8; 4] {
+        [
+            self.slice[12],
+            self.slice[13],
+            self.slice[14],
+            self.slice[15],
+        ]
+    }
+
+    pub fn get_destination(&self) -> [u8; 4] {
+        [
+            self.slice[16],
+            self.slice[17],
+            self.slice[18],
+            self.slice[19],
+        ]
+    }
+
     pub fn set_checksum(&mut self, checksum: u16) {
-        // Safety: Slice it at least of length 40 as checked in the ctor.
+        // Safety: Slice it at least of length 20 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 10, checksum.to_be_bytes()) };
     }
 

--- a/rust/libs/connlib/etherparse-ext/src/ipv6_header_slice_mut.rs
+++ b/rust/libs/connlib/etherparse-ext/src/ipv6_header_slice_mut.rs
@@ -15,6 +15,14 @@ impl<'a> Ipv6HeaderSliceMut<'a> {
         Ok(Self { slice })
     }
 
+    pub fn get_source(&self) -> [u8; 16] {
+        self.slice[8..24].try_into().expect("slice is 16 bytes")
+    }
+
+    pub fn get_destination(&self) -> [u8; 16] {
+        self.slice[24..40].try_into().expect("slice is 16 bytes")
+    }
+
     pub fn set_source(&mut self, src: [u8; 16]) {
         // Safety: Slice it at least of length 40 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 8, src) };

--- a/rust/libs/connlib/etherparse-ext/src/tcp_header_slice_mut.rs
+++ b/rust/libs/connlib/etherparse-ext/src/tcp_header_slice_mut.rs
@@ -21,6 +21,10 @@ impl<'a> TcpHeaderSliceMut<'a> {
         u16::from_be_bytes([self.slice[2], self.slice[3]])
     }
 
+    pub fn get_checksum(&self) -> u16 {
+        u16::from_be_bytes([self.slice[16], self.slice[17]])
+    }
+
     pub fn set_source_port(&mut self, src: u16) {
         // Safety: Slice it at least of length 20 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 0, src.to_be_bytes()) };

--- a/rust/libs/connlib/etherparse-ext/src/udp_header_slice_mut.rs
+++ b/rust/libs/connlib/etherparse-ext/src/udp_header_slice_mut.rs
@@ -30,6 +30,10 @@ impl<'a> UdpHeaderSliceMut<'a> {
         u16::from_be_bytes([self.slice[2], self.slice[3]])
     }
 
+    pub fn get_checksum(&self) -> u16 {
+        u16::from_be_bytes([self.slice[6], self.slice[7]])
+    }
+
     pub fn set_source_port(&mut self, src: u16) {
         // Safety: Slice it at least of length 8 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 0, src.to_be_bytes()) };

--- a/rust/libs/connlib/ip-packet/Cargo.toml
+++ b/rust/libs/connlib/ip-packet/Cargo.toml
@@ -17,6 +17,7 @@ arbitrary = { workspace = true, optional = true, features = ["derive"] }
 bufferpool = { workspace = true }
 etherparse = { workspace = true, features = ["std"] }
 etherparse-ext = { workspace = true }
+incremental-inet-checksum = { workspace = true }
 proptest = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/rust/libs/connlib/ip-packet/src/lib.rs
+++ b/rust/libs/connlib/ip-packet/src/lib.rs
@@ -18,6 +18,7 @@ pub use fz_p2p_control_slice::FzP2pControlSlice;
 pub use icmp_error::{FailedPacket, IcmpError};
 
 use anyhow::{Context as _, Result, bail};
+use incremental_inet_checksum::ChecksumUpdate;
 use std::net::IpAddr;
 use std::sync::LazyLock;
 
@@ -376,11 +377,23 @@ impl IpPacket {
 
     pub fn set_source_protocol(&mut self, v: u16) {
         if let Some(mut p) = self.as_tcp_mut() {
+            let checksum = ChecksumUpdate::new(p.get_checksum())
+                .remove_u16(p.get_source_port())
+                .add_u16(v)
+                .into_ip_checksum();
+
             p.set_source_port(v);
+            p.set_checksum(checksum);
         }
 
         if let Some(mut p) = self.as_udp_mut() {
+            let checksum = ChecksumUpdate::new(p.get_checksum())
+                .remove_u16(p.get_source_port())
+                .add_u16(v)
+                .into_udp_checksum();
+
             p.set_source_port(v);
+            set_udp_checksum_if_computed(&mut p, checksum);
         }
 
         self.set_icmp_identifier(v);
@@ -388,42 +401,61 @@ impl IpPacket {
 
     pub fn set_destination_protocol(&mut self, v: u16) {
         if let Some(mut p) = self.as_tcp_mut() {
+            let checksum = ChecksumUpdate::new(p.get_checksum())
+                .remove_u16(p.get_destination_port())
+                .add_u16(v)
+                .into_ip_checksum();
+
             p.set_destination_port(v);
+            p.set_checksum(checksum);
         }
 
         if let Some(mut p) = self.as_udp_mut() {
+            let checksum = ChecksumUpdate::new(p.get_checksum())
+                .remove_u16(p.get_destination_port())
+                .add_u16(v)
+                .into_udp_checksum();
+
             p.set_destination_port(v);
+            set_udp_checksum_if_computed(&mut p, checksum);
         }
 
         self.set_icmp_identifier(v);
     }
 
     fn set_icmp_identifier(&mut self, v: u16) {
-        if let Some(icmpv4) = self.as_icmpv4()
-            && matches!(
-                icmpv4.icmp_type(),
-                Icmpv4Type::EchoRequest(_) | Icmpv4Type::EchoReply(_)
-            )
+        if let Some(mut p) = self.as_icmpv4_mut()
+            && p.is_echo_request_or_reply()
         {
-            self.as_icmpv4_mut()
-                .expect("Not an ICMPv4 packet")
-                .set_identifier(v);
+            let checksum = ChecksumUpdate::new(p.get_checksum())
+                .remove_u16(p.get_identifier())
+                .add_u16(v)
+                .into_ip_checksum();
+
+            p.set_identifier(v);
+            p.set_checksum(checksum);
         }
 
-        if let Some(icmpv6) = self.as_icmpv6()
-            && matches!(
-                icmpv6.icmp_type(),
-                Icmpv6Type::EchoRequest(_) | Icmpv6Type::EchoReply(_)
-            )
+        if let Some(mut p) = self.as_icmpv6_mut()
+            && p.is_echo_request_or_reply()
         {
-            self.as_icmpv6_mut()
-                .expect("Not an ICMPv6 packet")
-                .set_identifier(v);
+            let checksum = ChecksumUpdate::new(p.get_checksum())
+                .remove_u16(p.get_identifier())
+                .add_u16(v)
+                .into_ip_checksum();
+
+            p.set_identifier(v);
+            p.set_checksum(checksum);
         }
     }
 
-    #[inline]
-    pub fn update_checksum(&mut self) {
+    /// Computes all checksums of this packet from scratch.
+    ///
+    /// The mutators on [`IpPacket`] maintain checksums incrementally, so regular packet
+    /// processing never needs this. It exists for packets whose bytes were serialized by
+    /// an external stack: smoltcp emits TCP segments with incorrect checksums through our
+    /// in-memory device, so `l3-tcp` has to finalize them with a full computation.
+    pub fn compute_checksums(&mut self) {
         // Note: ipv6 doesn't have a checksum.
         self.set_icmpv6_checksum();
         self.set_icmpv4_checksum();
@@ -432,6 +464,28 @@ impl IpPacket {
         // Note: Ipv4 checksum should be set after the others,
         // since it's in an upper layer.
         self.set_ipv4_checksum();
+    }
+
+    /// Patches all transport checksums that cover the IP pseudo-header.
+    ///
+    /// `patch` receives the running update of each affected checksum and must apply the
+    /// diff of the changed pseudo-header words to it. ICMPv4 is deliberately absent:
+    /// its checksum does not cover a pseudo-header, so address changes don't affect it.
+    fn patch_pseudo_header_checksums(&mut self, patch: impl Fn(ChecksumUpdate) -> ChecksumUpdate) {
+        if let Some(mut p) = self.as_tcp_mut() {
+            let checksum = patch(ChecksumUpdate::new(p.get_checksum())).into_ip_checksum();
+            p.set_checksum(checksum);
+        }
+
+        if let Some(mut p) = self.as_udp_mut() {
+            let checksum = patch(ChecksumUpdate::new(p.get_checksum())).into_udp_checksum();
+            set_udp_checksum_if_computed(&mut p, checksum);
+        }
+
+        if let Some(mut p) = self.as_icmpv6_mut() {
+            let checksum = patch(ChecksumUpdate::new(p.get_checksum())).into_ip_checksum();
+            p.set_checksum(checksum);
+        }
     }
 
     fn as_ipv4(&self) -> Option<Ipv4Slice<'_>> {
@@ -781,14 +835,40 @@ impl IpPacket {
     #[inline]
     pub fn set_dst(&mut self, dst: IpAddr) -> Result<()> {
         match dst {
-            IpAddr::V4(addr) => self
-                .as_ipv4_header_mut()
-                .context("Not an IPv4 packet")?
-                .set_destination(addr.octets()),
-            IpAddr::V6(addr) => self
-                .as_ipv6_header_mut()
-                .context("Not an IPv6 packet")?
-                .set_destination(addr.octets()),
+            IpAddr::V4(addr) => {
+                let (old, new) = {
+                    let mut hdr = self.as_ipv4_header_mut().context("Not an IPv4 packet")?;
+
+                    let old = u32::from_be_bytes(hdr.get_destination());
+                    let new = addr.to_bits();
+
+                    hdr.set_destination(addr.octets());
+
+                    let checksum = ChecksumUpdate::new(hdr.get_checksum())
+                        .remove_u32(old)
+                        .add_u32(new)
+                        .into_ip_checksum();
+                    hdr.set_checksum(checksum);
+
+                    (old, new)
+                };
+
+                self.patch_pseudo_header_checksums(|u| u.remove_u32(old).add_u32(new));
+            }
+            IpAddr::V6(addr) => {
+                let (old, new) = {
+                    let mut hdr = self.as_ipv6_header_mut().context("Not an IPv6 packet")?;
+
+                    let old = u128::from_be_bytes(hdr.get_destination());
+                    let new = addr.to_bits();
+
+                    hdr.set_destination(addr.octets());
+
+                    (old, new)
+                };
+
+                self.patch_pseudo_header_checksums(|u| u.remove_u128(old).add_u128(new));
+            }
         }
 
         Ok(())
@@ -797,14 +877,40 @@ impl IpPacket {
     #[inline]
     pub fn set_src(&mut self, src: IpAddr) -> Result<()> {
         match src {
-            IpAddr::V4(addr) => self
-                .as_ipv4_header_mut()
-                .context("Not an IPv4 packet")?
-                .set_source(addr.octets()),
-            IpAddr::V6(addr) => self
-                .as_ipv6_header_mut()
-                .context("Not an IPv6 packet")?
-                .set_source(addr.octets()),
+            IpAddr::V4(addr) => {
+                let (old, new) = {
+                    let mut hdr = self.as_ipv4_header_mut().context("Not an IPv4 packet")?;
+
+                    let old = u32::from_be_bytes(hdr.get_source());
+                    let new = addr.to_bits();
+
+                    hdr.set_source(addr.octets());
+
+                    let checksum = ChecksumUpdate::new(hdr.get_checksum())
+                        .remove_u32(old)
+                        .add_u32(new)
+                        .into_ip_checksum();
+                    hdr.set_checksum(checksum);
+
+                    (old, new)
+                };
+
+                self.patch_pseudo_header_checksums(|u| u.remove_u32(old).add_u32(new));
+            }
+            IpAddr::V6(addr) => {
+                let (old, new) = {
+                    let mut hdr = self.as_ipv6_header_mut().context("Not an IPv6 packet")?;
+
+                    let old = u128::from_be_bytes(hdr.get_source());
+                    let new = addr.to_bits();
+
+                    hdr.set_source(addr.octets());
+
+                    (old, new)
+                };
+
+                self.patch_pseudo_header_checksums(|u| u.remove_u128(old).add_u128(new));
+            }
         }
 
         Ok(())
@@ -850,10 +956,25 @@ impl IpPacket {
     /// This is most likely not what you want unless you know what you're doing or you are writing a test.
     fn with_ecn(mut self, ecn: Ecn) -> Self {
         match &mut self.version {
-            IpVersion::V4 => self.as_ipv4_header_mut_unchecked().set_ecn(ecn as u8),
+            IpVersion::V4 => {
+                // The ECN bits are part of the checksummed word formed by the first two
+                // header bytes; the L4 checksums don't cover them.
+                let old = u16::from_be_bytes([self.buf[0], self.buf[1]]);
+                let new = (old & !0b11) | ecn as u16;
+
+                let mut hdr = self.as_ipv4_header_mut_unchecked();
+                hdr.set_ecn(ecn as u8);
+
+                let checksum = ChecksumUpdate::new(hdr.get_checksum())
+                    .remove_u16(old)
+                    .add_u16(new)
+                    .into_ip_checksum();
+                hdr.set_checksum(checksum);
+            }
+            // IPv6 has no header checksum and the traffic class is not part of the
+            // pseudo-header, so no checksum needs updating.
             IpVersion::V6 => self.as_ipv6_header_mut_unchecked().set_ecn(ecn as u8),
         }
-        self.update_checksum();
 
         self
     }
@@ -927,6 +1048,17 @@ impl IpPacket {
 #[derive(Debug, thiserror::Error)]
 #[error("Fragmented IP packets are unsupported")]
 pub struct Fragmented;
+
+/// Writes `checksum` to the packet unless its current checksum is zero.
+///
+/// A zero UDP checksum means "not computed" (IPv4); translation must preserve that.
+fn set_udp_checksum_if_computed(p: &mut UdpHeaderSliceMut<'_>, checksum: u16) {
+    if p.get_checksum() == 0 {
+        return;
+    }
+
+    p.set_checksum(checksum);
+}
 
 fn extract_l4_proto(payload: &[u8], protocol: IpNumber) -> Result<Layer4Protocol> {
     // ICMP messages SHOULD always contain at least 8 bytes of the original L4 payload.

--- a/rust/libs/connlib/l3-tcp/src/stub_device.rs
+++ b/rust/libs/connlib/l3-tcp/src/stub_device.rs
@@ -78,6 +78,9 @@ impl smoltcp::phy::TxToken for SmolTxToken<'_> {
         let mut ip_packet_buf = IpPacketBuf::new();
         let result = f(ip_packet_buf.buf());
 
+        // smoltcp is configured to compute checksums but the TCP checksums of the
+        // packets it emits through this device are empirically wrong, so we have to
+        // compute all of them from scratch before handing the packet on.
         let mut ip_packet = match IpPacket::new(ip_packet_buf, len) {
             Ok(p) => p,
             Err(e) => {
@@ -86,7 +89,8 @@ impl smoltcp::phy::TxToken for SmolTxToken<'_> {
             }
         };
 
-        ip_packet.update_checksum();
+        ip_packet.compute_checksums();
+
         self.outbound_packets.push_back(ip_packet);
 
         result

--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -410,7 +410,6 @@ impl ClientOnGateway {
         packet
             .translate_destination(source_protocol, real_ip)
             .context("Failed to translate packet to new destination")?;
-        packet.update_checksum();
 
         Ok(TranslateOutboundResult::Send(packet))
     }
@@ -444,7 +443,6 @@ impl ClientOnGateway {
         packet
             .translate_source(proto, ip)
             .context("Failed to translate packet to new source")?;
-        packet.update_checksum();
 
         Ok(packet)
     }

--- a/rust/libs/incremental-inet-checksum/Cargo.toml
+++ b/rust/libs/incremental-inet-checksum/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "incremental-inet-checksum"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/incremental-inet-checksum/src/lib.rs
+++ b/rust/libs/incremental-inet-checksum/src/lib.rs
@@ -1,0 +1,149 @@
+//! Incremental updates to Internet checksums (RFC 1071 / RFC 1624).
+//!
+//! The Internet checksum is the one's complement of the one's complement sum of certain 16-bit words.
+//! The use of one's complement arithmetic allows us to make incremental updates to a checksum without requiring a full re-computation.
+//!
+//! That is what we are implementing in this module.
+//! There are three things you need to know:
+//!
+//! 1. The one's complement of a number `x` is `!x`.
+//! 2. Addition in one's complement arithmetic is the same as regular addition, except that upon overflow, we add an additional bit.
+//! 3. Subtraction in one's complement arithmetic is implemented as the addition of the one's complement of the number to be subtracted.
+//!
+//! This allows us to e.g. take an existing IP header checksum and update it to account for just the destination address changing.
+//!
+//! To use this module, create a new instance of [`ChecksumUpdate`] from the old checksum and then chain the appropriate functions on it.
+//! For example, if you are changing the source port of a UDP packet, you want to:
+//! - [`remove_u16`](ChecksumUpdate::remove_u16) the old port
+//! - [`add_u16`](ChecksumUpdate::add_u16) the new port
+//!
+//! This will adjust the checksum as if it would have been computed for the packet with the new port.
+//!
+//! When re-routing packets, we often send from our own address.
+//! In other words, the previous destination becomes the new source.
+//! In that case, it is common to optimise the checksum update by not removing the old destination at all.
+//! Instead we are basically replacing the old source with the new destination.
+//! Checksum computation is commutative, i.e. it doesn't care in which order the individual fields got added.
+//!
+//! This crate is `no_std` and free of unbounded loops so that it can also be used from eBPF programs.
+
+#![no_std]
+
+#[derive(Default)]
+#[repr(transparent)]
+pub struct ChecksumUpdate {
+    inner: u16,
+}
+
+impl ChecksumUpdate {
+    pub fn new(checksum: u16) -> Self {
+        Self { inner: !checksum }
+    }
+
+    #[must_use]
+    pub fn remove_u16(self, val: u16) -> Self {
+        self.ones_complement_add(!val)
+    }
+
+    #[must_use]
+    pub fn remove_u32(self, val: u32) -> Self {
+        self.remove_u16(fold_u32_into_u16(val))
+    }
+
+    #[must_use]
+    pub fn remove_u128(self, val: u128) -> Self {
+        self.remove_u16(fold_u128_into_u16(val))
+    }
+
+    #[must_use]
+    pub fn add_u16(self, val: u16) -> Self {
+        self.ones_complement_add(val)
+    }
+
+    #[must_use]
+    pub fn add_u32(self, val: u32) -> Self {
+        self.add_u16(fold_u32_into_u16(val))
+    }
+
+    #[must_use]
+    pub fn add_u128(self, val: u128) -> Self {
+        self.add_u16(fold_u128_into_u16(val))
+    }
+
+    #[inline(always)]
+    fn ones_complement_add(self, val: u16) -> Self {
+        let (res, carry) = self.inner.overflowing_add(val);
+
+        Self {
+            inner: res + (carry as u16),
+        }
+    }
+
+    pub fn into_ip_checksum(self) -> u16 {
+        !self.inner
+    }
+
+    pub fn into_udp_checksum(self) -> u16 {
+        // RFC 768, Section 3.1 states that we must invert the final computed checksum if it came
+        // out to be zero.
+        let check = !self.inner;
+
+        if check == 0 { 0xFFFF } else { check }
+    }
+}
+
+#[inline(always)]
+fn fold_u32_into_u16(mut csum: u32) -> u16 {
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+
+    csum as u16
+}
+
+#[inline(never)]
+fn fold_u128_into_u16(mut csum: u128) -> u16 {
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+
+    csum as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn updates_word_like_rfc1624() {
+        // Example from RFC 1624, section 4: checksum 0xdd2f, word 0x5555 becomes 0x3285.
+        let updated = ChecksumUpdate::new(0xdd2f)
+            .remove_u16(0x5555)
+            .add_u16(0x3285)
+            .into_ip_checksum();
+
+        assert_eq!(updated, 0x0000);
+    }
+
+    #[test]
+    fn remove_then_add_same_value_is_noop() {
+        let updated = ChecksumUpdate::new(0xabcd)
+            .remove_u16(0x1234)
+            .add_u16(0x1234)
+            .into_ip_checksum();
+
+        assert_eq!(updated, 0xabcd);
+    }
+
+    #[test]
+    fn udp_checksum_never_returns_zero() {
+        // A patch whose result is zero must be transmitted as all-ones for UDP.
+        let updated = ChecksumUpdate::new(0xFFFF).into_udp_checksum();
+
+        assert_eq!(updated, 0xFFFF);
+    }
+}

--- a/rust/relay/ebpf-turn-router/Cargo.toml
+++ b/rust/relay/ebpf-turn-router/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 aya-ebpf = { workspace = true }
 aya-log-ebpf = { workspace = true }
 ebpf-shared = { workspace = true }
+incremental-inet-checksum = { workspace = true }
 network-types = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.build-dependencies]

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn/checksum.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn/checksum.rs
@@ -1,110 +1,11 @@
-//! Incremental updates to Internet checksums.
+//! Checksum helpers for the TURN router.
 //!
-//! The Internet checksum is the one's complement of the one's complement sum of certain 16-bit words.
-//! The use of one's complement arithmetic allows us to make incremental updates to a checksum without requiring a full re-computation.
-//!
-//! That is what we are implementing in this module.
-//! There are three things you need to know:
-//!
-//! 1. The one's complement of a number `x` is `!x`.
-//! 2. Addition in one's complement arithmetic is the same as regular addition, except that upon overflow, we add an additional bit.
-//! 3. Subtraction in one's complement arithmetic is implemented as the addition of the one's complement of the number to be subtracted.
-//!
-//! This allows us to e.g. take an existing IP header checksum and update it to account for just the destination address changing.
-//!
-//! To use this module, create a new instance of [`ChecksumUpdate`] from the old checksum and then chain the appropriate functions on it.
-//! For example, if you are changing the source port of a UDP packet, you want to:
-//! - [`remove_u16`](ChecksumUpdate::remove_u16) the old port
-//! - [`add_u16`](ChecksumUpdate::add_u16) the new port
-//!
-//! This will adjust the checksum as if it would have been computed for the packet with the new port.
-//!
-//! When re-routing packets, we often send from our own address.
-//! In other words, the previous destination becomes the new source.
-//! In that case, it is common to optimise the checksum update by not removing the old destination at all.
-//! Instead we are basically replacing the old source with the new destination.
-//! Checksum computation is commutative, i.e. it doesn't care in which order the individual fields got added.
+//! Incremental checksum updates live in the shared [`incremental_inet_checksum`] crate;
+//! this module re-exports them and adds the eBPF-specific helpers.
+
+pub use incremental_inet_checksum::ChecksumUpdate;
 
 use network_types::ip::Ipv4Hdr;
-
-#[derive(Default)]
-#[repr(transparent)]
-pub struct ChecksumUpdate {
-    inner: u16,
-}
-
-impl ChecksumUpdate {
-    pub fn new(checksum: u16) -> Self {
-        Self { inner: !checksum }
-    }
-
-    pub fn remove_u16(self, val: u16) -> Self {
-        self.ones_complement_add(!val)
-    }
-
-    pub fn remove_u32(self, val: u32) -> Self {
-        self.remove_u16(fold_u32_into_u16(val))
-    }
-
-    pub fn remove_u128(self, val: u128) -> Self {
-        self.remove_u16(fold_u128_into_u16(val))
-    }
-
-    pub fn add_u16(self, val: u16) -> Self {
-        self.ones_complement_add(val)
-    }
-
-    pub fn add_u32(self, val: u32) -> Self {
-        self.add_u16(fold_u32_into_u16(val))
-    }
-
-    pub fn add_u128(self, val: u128) -> Self {
-        self.add_u16(fold_u128_into_u16(val))
-    }
-
-    #[inline(always)]
-    fn ones_complement_add(self, val: u16) -> Self {
-        let (res, carry) = self.inner.overflowing_add(val);
-
-        Self {
-            inner: res + (carry as u16),
-        }
-    }
-
-    pub fn into_ip_checksum(self) -> u16 {
-        !self.inner
-    }
-
-    pub fn into_udp_checksum(self) -> u16 {
-        // RFC 768, Section 3.1 states that we must invert the final computed checksum if it came
-        // out to be zero.
-        let check = !self.inner;
-
-        if check == 0 { 0xFFFF } else { check }
-    }
-}
-
-#[inline(always)]
-fn fold_u32_into_u16(mut csum: u32) -> u16 {
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-
-    csum as u16
-}
-
-#[inline(never)]
-fn fold_u128_into_u16(mut csum: u128) -> u16 {
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-    csum = (csum & 0xffff) + (csum >> 16);
-
-    csum as u16
-}
 
 /// Calculate a fresh IPv4 header checksum
 #[inline(always)]

--- a/rust/tests/fuzz/fuzz_targets/ip_packet.rs
+++ b/rust/tests/fuzz/fuzz_targets/ip_packet.rs
@@ -18,6 +18,11 @@ fuzz_target!(|input: Input| {
     if let Ok(mut packet) = IpPacket::new(buf, len) {
         test_all_getters(&packet);
 
+        // The mutators patch checksums incrementally: a packet with correct checksums
+        // must still have correct checksums after any sequence of mutations. Arbitrary
+        // input rarely has correct checksums to begin with, so fix them up first.
+        packet.compute_checksums();
+
         for action in input.setters {
             match action {
                 Setter::Src(ip_addr) => {
@@ -44,9 +49,83 @@ fuzz_target!(|input: Input| {
             }
 
             test_all_getters(&packet);
+
+            let errors = checksum_errors(&packet);
+            assert!(
+                errors.is_empty(),
+                "mutators broke checksums: {errors:?}\npacket: {packet:?}"
+            );
         }
     }
 });
+
+/// Compares all stored checksums of the packet against a full recomputation.
+fn checksum_errors(packet: &IpPacket) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if let Some(hdr) = packet.ipv4_header() {
+        let expected = hdr.calc_header_checksum();
+
+        if hdr.header_checksum != expected {
+            errors.push(format!(
+                "IPv4 header checksum: stored {:#06x}, expected {expected:#06x}",
+                hdr.header_checksum
+            ));
+        }
+    }
+
+    if let (Some(udp), Ok(expected)) = (packet.as_udp(), packet.calculate_udp_checksum()) {
+        let stored = udp.checksum();
+
+        // Over IPv4 a zero checksum means "not computed" and the mutators leave it as such.
+        // Over IPv6 the checksum is mandatory, so zero is always a bug there.
+        let ipv4_not_computed = matches!(packet.source(), IpAddr::V4(_)) && stored == 0;
+
+        if !ipv4_not_computed && stored != expected {
+            errors.push(format!(
+                "UDP checksum: stored {stored:#06x}, expected {expected:#06x}"
+            ));
+        }
+    }
+
+    if let (Some(tcp), Ok(expected)) = (packet.as_tcp(), packet.calculate_tcp_checksum()) {
+        let stored = tcp.checksum();
+
+        if stored != expected {
+            errors.push(format!(
+                "TCP checksum: stored {stored:#06x}, expected {expected:#06x}"
+            ));
+        }
+    }
+
+    if let Some(icmp) = packet.as_icmpv4() {
+        let stored = icmp.checksum();
+        let expected = icmp.icmp_type().calc_checksum(icmp.payload());
+
+        if stored != expected {
+            errors.push(format!(
+                "ICMPv4 checksum: stored {stored:#06x}, expected {expected:#06x}"
+            ));
+        }
+    }
+
+    if let Some(icmp) = packet.as_icmpv6()
+        && let (IpAddr::V6(src), IpAddr::V6(dst)) = (packet.source(), packet.destination())
+        && let Ok(expected) =
+            icmp.icmp_type()
+                .calc_checksum(src.octets(), dst.octets(), icmp.payload())
+    {
+        let stored = icmp.checksum();
+
+        if stored != expected {
+            errors.push(format!(
+                "ICMPv6 checksum: stored {stored:#06x}, expected {expected:#06x}"
+            ));
+        }
+    }
+
+    errors
+}
 
 #[derive(Arbitrary, Debug)]
 struct Input<'a> {


### PR DESCRIPTION
Whenever we modify a packet - NAT rewrites on the gateway, ECN updates after decapsulation - we call `update_checksum` afterwards, which recomputes the transport checksum over the entire payload even though only a handful of header words changed. The Internet checksum is a one's complement sum, so it can instead be updated with just the diff of the old and new values (RFC 1624), turning translation from O(payload) into O(1).

Each mutator now patches the affected checksums itself, using the `ChecksumUpdate` abstraction we had already built for the eBPF TURN router. Forgetting to update a checksum after a mutation is no longer possible, and the fuzzer now verifies that any sequence of mutations keeps all checksums intact.

Measured on the gateway while pushing a fixed-rate UDP flow through a DNS resource, the checksum work of the translation disappears from the profile: the share of CPU samples in checksum code drops from ~1.5% to ~1.1% on the forward path and from ~1.5% to ~0.5% on the return path, and everything that remains is the kernel's own checksum handling - the same ~0.8-1.0% a flow to a CIDR resource (no translation) shows. `calculate_udp_checksum` no longer appears at all.

Resolves: #9006