### PR TITLE
fix(portal): relax replication poller cadence

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -141,7 +141,7 @@ config :portal, Portal.ChangeLogs.Consumer,
   error_threshold: :timer.hours(30 * 24),
 
   # The audit trail tolerates more latency in exchange for fewer poll queries
-  poll_interval: :timer.seconds(1),
+  poll_interval: :timer.seconds(30),
   batch_size: 500
 
 config :portal, Portal.Changes.Consumer,
@@ -188,8 +188,8 @@ config :portal, Portal.Changes.Consumer,
   # Allow up to 30 minutes of lag before bypassing hooks
   error_threshold: :timer.minutes(30),
 
-  # Changes power cache invalidation, so poll aggressively
-  poll_interval: 250,
+  # Changes power cache invalidation; balance broadcast latency against poll query volume
+  poll_interval: :timer.seconds(5),
   batch_size: 500
 
 config :portal, Portal.Tokens,

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -32,13 +32,16 @@ config :portal, Portal.Repo.Api, db_opts
 config :portal, Portal.Repo.Replica.Web, db_opts
 config :portal, Portal.Repo.Replica.Api, db_opts
 
+# Poll fast locally so live updates and change logs appear without a wait
 config :portal, Portal.ChangeLogs.Consumer,
   replication_slot_name: db_opts[:database] <> "_clog_slot",
-  publication_name: db_opts[:database] <> "_clog_pub"
+  publication_name: db_opts[:database] <> "_clog_pub",
+  poll_interval: :timer.seconds(1)
 
 config :portal, Portal.Changes.Consumer,
   replication_slot_name: db_opts[:database] <> "_changes_slot",
-  publication_name: db_opts[:database] <> "_changes_pub"
+  publication_name: db_opts[:database] <> "_changes_pub",
+  poll_interval: 250
 
 config :portal, outbound_email_adapter_configured?: true
 


### PR DESCRIPTION
Staging logs showed frequent "replication poll cycle failed" errors. The pollers ran every 250ms and 1s, so even a moment of pool contention, like reconnecting after a dropped cross-region connection, failed a cycle and logged an error.

Changes now polls every 5 seconds and change logs every 30 seconds, cutting idle replication query volume by an order of magnitude. Dev keeps the fast intervals so live updates stay snappy locally.

Related: firezone/infra#735