### PR TITLE
chore(connlib): extract flow tracker into dedicated crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2628,6 +2628,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "flow-tracker"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "connlib-model",
+ "dns-types",
+ "flow-log-spool",
+ "flow-log-writer",
+ "ip-packet",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8324,8 +8342,7 @@ dependencies = [
  "dns-types",
  "eventloop-budget",
  "firezone-relay",
- "flow-log-spool",
- "flow-log-writer",
+ "flow-tracker",
  "futures",
  "futures-bounded",
  "gat-lending-iterator",
@@ -8359,7 +8376,6 @@ dependencies = [
  "snownet",
  "socket-factory",
  "telemetry",
- "tempfile",
  "test-case",
  "test-strategy",
  "thiserror 2.0.18",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "libs/connlib/dns-types",
     "libs/connlib/etc-hosts-dns-client",
     "libs/connlib/etherparse-ext",
+    "libs/connlib/flow-tracker",
     "libs/connlib/ip-packet",
     "libs/connlib/l3-tcp",
     "libs/connlib/l3-udp-dns-client",
@@ -106,6 +107,7 @@ firezone-relay = { path = "relay/server", default-features = false }
 flow-log-spool = { path = "libs/flow-log-spool" }
 flow-log-upload = { path = "libs/flow-log-upload" }
 flow-log-writer = { path = "libs/flow-log-writer" }
+flow-tracker = { path = "libs/connlib/flow-tracker" }
 futures = { version = "0.3.32" }
 futures-bounded = "0.3.0"
 gat-lending-iterator = "0.1.8"

--- a/rust/libs/connlib/flow-tracker/Cargo.toml
+++ b/rust/libs/connlib/flow-tracker/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "flow-tracker"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+base64 = { workspace = true, features = ["std"] }
+chrono = { workspace = true }
+connlib-model = { workspace = true }
+dns-types = { workspace = true }
+ip-packet = { workspace = true }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+flow-log-spool = { workspace = true }
+flow-log-writer = { workspace = true }
+tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/connlib/flow-tracker/src/lib.rs
+++ b/rust/libs/connlib/flow-tracker/src/lib.rs
@@ -21,6 +21,8 @@
 //! the gathered data on every exit path; incomplete data (e.g. because packet
 //! processing bailed early or the packet was internal traffic) is discarded.
 
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use std::{
     cell::RefCell,
     collections::{HashMap, hash_map},
@@ -32,10 +34,12 @@ use std::{
 
 use chrono::{DateTime, TimeDelta, Utc};
 use connlib_model::{ClientId, ClientOrGatewayId, ResourceId};
-
-use crate::messages::IngestToken;
 use dns_types::DomainName;
 use ip_packet::{IcmpError, IpPacket, Protocol, UnsupportedProtocol};
+
+mod token;
+
+pub use token::{IngestToken, IngestTokenClaims, IngestTokenRole, TEST_INGEST_TOKEN};
 
 /// A flow is closed if no packet is seen for this long.
 const FLOW_TIMEOUT: TimeDelta = TimeDelta::minutes(2);
@@ -661,7 +665,6 @@ impl<S: Scope> Drop for CurrentFlowGuard<'_, S> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
     /// We initiated the flow, i.e. we requested access to the peer / resource.
-    #[expect(dead_code, reason = "constructed once the Client tracks flows")]
     Initiator,
     /// The remote peer initiated the flow towards us.
     Responder,
@@ -1247,94 +1250,6 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use super::*;
-    use base64::Engine as _;
-    use chrono::TimeZone as _;
-    use tracing_subscriber::layer::SubscriberExt as _;
-
-    /// A JWT payload carrying every claim the portal guarantees on a token.
-    fn required_claims(policy_authorization_id: &str, role: &str) -> String {
-        format!(
-            r#"{{"account_id":"c1e296cd-b8ff-4565-8a4c-b6023a4a4b10","iat":1782756000,"exp":1785434400,"uploads_enabled":true,"role":"{role}","device_id":"d-1","policy_authorization_id":"{policy_authorization_id}","policy_id":"p-1","resource_id":"r-1","resource_name":"web","actor_id":"a-1","actor_name":"Alice","authorized_at":"2026-07-01T00:00:00Z","authorization_expires_at":"2026-07-02T00:00:00Z"}}"#
-        )
-    }
-
-    /// Assembles and parses a well-formed ingest token for `authz_id`.
-    fn test_token(authz_id: &str, role: &str) -> IngestToken {
-        let encode = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
-
-        let header = encode(br#"{"alg":"HS256"}"#);
-        let payload = encode(required_claims(authz_id, role).as_bytes());
-        let token = format!("{header}.{payload}.{}", encode(b"signature"));
-
-        serde_json::from_value(serde_json::Value::String(token)).unwrap()
-    }
-
-    /// Guards the field contract between [`emit`] and `flow-log-writer`'s layer:
-    /// an emitted record must round-trip losslessly into a spooled report.
-    #[test]
-    fn emitted_records_spool_via_flow_log_writer_layer() {
-        let authz_id = "11111111-1111-1111-1111-111111111111";
-        let record = Record {
-            ingest_token: test_token(authz_id, "responder"),
-            protocol: FlowProtocol::Tcp,
-            inner_src_ip: "100.64.0.1".parse().unwrap(),
-            inner_src_port: 1234,
-            inner_dst_ip: "10.0.0.5".parse().unwrap(),
-            inner_dst_port: 443,
-            domain: Some("download.httpbin".parse().unwrap()),
-            outer_src_ip: "198.51.100.1".parse().unwrap(),
-            outer_src_port: 51820,
-            outer_dst_ip: "203.0.113.7".parse().unwrap(),
-            outer_dst_port: 51820,
-            flow_start: chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
-            close: Some(FlowClose {
-                flow_end: chrono::Utc.timestamp_opt(1_700_000_060, 0).unwrap(),
-                last_packet: chrono::Utc.timestamp_opt(1_700_000_059, 0).unwrap(),
-                rx_packets: 10,
-                tx_packets: 12,
-                rx_bytes: 1024,
-                tx_bytes: 2048,
-            }),
-        };
-
-        let dir = tempfile::tempdir().unwrap();
-        flow_log_writer::write_token(dir.path(), record.ingest_token.as_str()).unwrap();
-
-        let (layer, guard) = flow_log_writer::layer(dir.path().to_owned());
-        let subscriber = tracing_subscriber::registry().with(layer);
-        tracing::subscriber::with_default(subscriber, || emit(&record));
-        drop(guard); // joins the writer thread, so the report is on disk
-
-        let authz_dir = dir.path().join("responder").join(authz_id);
-        let report = std::fs::read_dir(&authz_dir)
-            .expect("spooled report dir exists")
-            .map(|entry| entry.unwrap().path())
-            .find(|path| path.to_string_lossy().ends_with(".end.json"))
-            .expect("completed report exists");
-        let payload = flow_log_spool::deserialize(&std::fs::read(report).unwrap()).unwrap();
-
-        assert_eq!(payload["protocol"], "tcp");
-        assert_eq!(payload["inner_src_ip"], record.inner_src_ip.to_string());
-        assert_eq!(payload["inner_src_port"], record.inner_src_port);
-        assert_eq!(payload["inner_dst_ip"], record.inner_dst_ip.to_string());
-        assert_eq!(payload["inner_dst_port"], record.inner_dst_port);
-        assert_eq!(payload["domain"], "download.httpbin");
-        assert_eq!(payload["outer_src_ip"], record.outer_src_ip.to_string());
-        assert_eq!(payload["outer_src_port"], record.outer_src_port);
-        assert_eq!(payload["outer_dst_ip"], record.outer_dst_ip.to_string());
-        assert_eq!(payload["outer_dst_port"], record.outer_dst_port);
-        assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
-        // Attribution rides the token, not the spooled record.
-        assert!(payload.get("actor_id").is_none());
-
-        let close = record.close.as_ref().unwrap();
-        assert_eq!(payload["flow_end"], format!("{:?}", close.flow_end));
-        assert_eq!(payload["last_packet"], format!("{:?}", close.last_packet));
-        assert_eq!(payload["rx_packets"], close.rx_packets);
-        assert_eq!(payload["tx_packets"], close.tx_packets);
-        assert_eq!(payload["rx_bytes"], close.rx_bytes);
-        assert_eq!(payload["tx_bytes"], close.tx_bytes);
-    }
 
     #[test]
     fn flow_context_diff_rendering() {

--- a/rust/libs/connlib/flow-tracker/src/token.rs
+++ b/rust/libs/connlib/flow-tracker/src/token.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+/// A per-authorization flow-log ingest token minted by the portal: an HS256
+/// JWT carrying the attribution claims, used as the `Bearer` credential when
+/// uploading that authorization's flow logs.
+///
+/// Deserializing parses and retains the claims; the signature is not
+/// verified because only the portal and the ingest API hold the key.
+/// Internally reference-counted: cloning is a refcount bump, so the token can
+/// be recorded into per-packet flow data without copying it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IngestToken(Arc<IngestTokenInner>);
+
+#[derive(Debug, PartialEq, Eq)]
+struct IngestTokenInner {
+    raw: String,
+    claims: IngestTokenClaims,
+}
+
+impl IngestToken {
+    pub fn as_str(&self) -> &str {
+        &self.0.raw
+    }
+
+    pub fn claims(&self) -> &IngestTokenClaims {
+        &self.0.claims
+    }
+}
+
+impl<'de> Deserialize<'de> for IngestToken {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+
+        let claims = parse_ingest_token_claims(&raw).map_err(serde::de::Error::custom)?;
+
+        Ok(Self(Arc::new(IngestTokenInner { raw, claims })))
+    }
+}
+
+fn parse_ingest_token_claims(token: &str) -> Result<IngestTokenClaims, String> {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let [header, payload, signature]: [&str; 3] =
+        token
+            .split('.')
+            .collect::<Vec<_>>()
+            .try_into()
+            .map_err(|_| "ingest token is not made of three JWT segments".to_owned())?;
+
+    let header = URL_SAFE_NO_PAD
+        .decode(header)
+        .map_err(|e| format!("ingest token header is not base64url: {e}"))?;
+    let header = serde_json::from_slice::<JwtHeader>(&header)
+        .map_err(|e| format!("ingest token header is invalid: {e}"))?;
+
+    if header.alg != "HS256" {
+        return Err(format!("ingest token alg is not HS256: {}", header.alg));
+    }
+
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| format!("ingest token payload is not base64url: {e}"))?;
+    let claims = serde_json::from_slice::<IngestTokenClaims>(&payload)
+        .map_err(|e| format!("ingest token claims are invalid: {e}"))?;
+
+    let signature = URL_SAFE_NO_PAD
+        .decode(signature)
+        .map_err(|e| format!("ingest token signature is not base64url: {e}"))?;
+
+    if signature.is_empty() {
+        return Err("ingest token signature is empty".to_owned());
+    }
+
+    Ok(claims)
+}
+
+#[derive(Deserialize)]
+struct JwtHeader {
+    alg: String,
+}
+
+/// The claims the portal stamps into every ingest token. The `Option`s are
+/// nullable attribution claims, and unknown claims are tolerated.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct IngestTokenClaims {
+    pub account_id: String,
+    pub iat: u64,
+    pub exp: u64,
+    /// Whether this authorization's flow logs (and this token) are spooled to
+    /// disk for upload.
+    pub uploads_enabled: bool,
+    pub role: IngestTokenRole,
+    pub device_id: String,
+    pub policy_authorization_id: String,
+    pub policy_id: String,
+    pub resource_id: String,
+    pub resource_name: String,
+    pub actor_id: String,
+    pub actor_name: String,
+    pub authorized_at: String,
+    pub authorization_expires_at: String,
+    pub resource_address: Option<String>,
+    pub actor_email: Option<String>,
+    pub auth_provider_id: Option<String>,
+    pub client_version: Option<String>,
+    pub device_os_name: Option<String>,
+    pub device_os_version: Option<String>,
+    pub device_serial: Option<String>,
+    pub device_uuid: Option<String>,
+    pub device_identifier_for_vendor: Option<String>,
+    pub device_firebase_installation_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum IngestTokenRole {
+    Initiator,
+    Responder,
+}
+
+impl IngestTokenRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IngestTokenRole::Initiator => "initiator",
+            IngestTokenRole::Responder => "responder",
+        }
+    }
+}
+
+/// A portal-minted ingest token for tests, signed with a throwaway key.
+pub const TEST_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicG9saWN5X2lkIjoiNDRmMTljMzctY2Y2Mi00YjE5LWIxNTgtNmY4NmJkY2QyYjU3IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIiwicmVzb3VyY2VfYWRkcmVzcyI6ImdpdGxhYi5teWNvcnAuY29tIiwiYWN0b3JfZW1haWwiOiJqYW5lQG15Y29ycC5jb20iLCJhdXRoX3Byb3ZpZGVyX2lkIjoiZjk1ZWYxYTUtYjc2Yi00ZDU5LTliNGItNmIwYzJkNDdlMTI4IiwiY2xpZW50X3ZlcnNpb24iOiIxLjUuMTEiLCJkZXZpY2Vfb3NfbmFtZSI6Im1hY09TIiwiZGV2aWNlX29zX3ZlcnNpb24iOiIxNS41IiwiZGV2aWNlX3NlcmlhbCI6IkMwMlhMMEdZSkdINSIsImRldmljZV91dWlkIjoiMGYwYzIyYjEtNjRmYS00YTA0LWExYzEtNWI0YjZjMGMyZDQ3IiwiZGV2aWNlX2lkZW50aWZpZXJfZm9yX3ZlbmRvciI6IjVhYzM0N2Y4LWNiYjYtNGIwZi04ZjBlLTFmNGQ0N2ExYzE1YiIsImRldmljZV9maXJlYmFzZV9pbnN0YWxsYXRpb25faWQiOiJjQW1wMWVGMXJlQmFzZUlkIn0.aHR1FGQ-cqGS2PZQP5iePtTSUc1kRI6Xj9RWvpqIw_A";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicG9saWN5X2lkIjoiNDRmMTljMzctY2Y2Mi00YjE5LWIxNTgtNmY4NmJkY2QyYjU3IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIn0.9kV77S1jxTqOo8xLjwxS0eBWOPR1lI68DlGK9eC_80g";
+    const UNKNOWN_CLAIM_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicG9saWN5X2lkIjoiNDRmMTljMzctY2Y2Mi00YjE5LWIxNTgtNmY4NmJkY2QyYjU3IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIiwiYnJhbmRfbmV3X2NsYWltIjoidG9sZXJhdGVkIn0.qwJhdnQviEc6oj2iAlPVDZvJwgShU_KuCpCfJhacmeA";
+    const MISSING_POLICY_ID_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIn0.M_OCjGvDSQPvdMN3kwFePSTMhocxzakwIz_PrvWPdsU";
+
+    fn parse_ingest_token(token: &str) -> Result<IngestToken, serde_json::Error> {
+        serde_json::from_str::<IngestToken>(&format!("\"{token}\""))
+    }
+
+    #[test]
+    fn accepts_portal_minted_ingest_token() {
+        let token = parse_ingest_token(TEST_INGEST_TOKEN).unwrap();
+
+        assert_eq!(token.as_str(), TEST_INGEST_TOKEN);
+        assert_eq!(token.claims().role, IngestTokenRole::Initiator);
+        assert!(token.claims().uploads_enabled);
+        assert_eq!(token.claims().resource_name, "GitLab");
+        assert_eq!(
+            token.claims().actor_email.as_deref(),
+            Some("jane@mycorp.com")
+        );
+    }
+
+    #[test]
+    fn accepts_ingest_token_without_nullable_claims() {
+        parse_ingest_token(MINIMAL_INGEST_TOKEN).unwrap();
+    }
+
+    #[test]
+    fn accepts_ingest_token_with_unknown_claims() {
+        parse_ingest_token(UNKNOWN_CLAIM_INGEST_TOKEN).unwrap();
+    }
+
+    #[test]
+    fn rejects_ingest_token_missing_a_guaranteed_claim() {
+        parse_ingest_token(MISSING_POLICY_ID_INGEST_TOKEN).unwrap_err();
+    }
+
+    #[test]
+    fn rejects_structurally_invalid_ingest_token() {
+        parse_ingest_token("header.payload.signature").unwrap_err();
+        parse_ingest_token("not-a-jwt").unwrap_err();
+    }
+}

--- a/rust/libs/connlib/flow-tracker/tests/writer.rs
+++ b/rust/libs/connlib/flow-tracker/tests/writer.rs
@@ -1,0 +1,182 @@
+//! Integration tests of the tracker with `flow-log-writer`: the tracker's
+//! records, emitted as tracing events, must spool losslessly into reports.
+
+#![allow(clippy::unwrap_used)]
+
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use base64::Engine as _;
+use chrono::TimeZone as _;
+use connlib_model::{ClientId, ResourceId};
+use flow_tracker::{FlowClose, FlowProtocol, IngestToken, Record, Role, Tracker};
+use tracing_subscriber::layer::SubscriberExt as _;
+
+/// Guards the field contract between [`flow_tracker::emit`] and the writer's
+/// layer: an emitted record must round-trip losslessly into a spooled report.
+#[test]
+fn emitted_records_spool_via_flow_log_writer_layer() {
+    let authz_id = "11111111-1111-1111-1111-111111111111";
+    let record = Record {
+        ingest_token: test_token(authz_id, "responder"),
+        protocol: FlowProtocol::Tcp,
+        inner_src_ip: "100.64.0.1".parse().unwrap(),
+        inner_src_port: 1234,
+        inner_dst_ip: "10.0.0.5".parse().unwrap(),
+        inner_dst_port: 443,
+        domain: Some("download.httpbin".parse().unwrap()),
+        outer_src_ip: "198.51.100.1".parse().unwrap(),
+        outer_src_port: 51820,
+        outer_dst_ip: "203.0.113.7".parse().unwrap(),
+        outer_dst_port: 51820,
+        flow_start: chrono::Utc.timestamp_opt(1_700_000_000, 500).unwrap(),
+        close: Some(FlowClose {
+            flow_end: chrono::Utc.timestamp_opt(1_700_000_060, 0).unwrap(),
+            last_packet: chrono::Utc.timestamp_opt(1_700_000_059, 0).unwrap(),
+            rx_packets: 10,
+            tx_packets: 12,
+            rx_bytes: 1024,
+            tx_bytes: 2048,
+        }),
+    };
+
+    let dir = tempfile::tempdir().unwrap();
+    flow_log_writer::write_token(dir.path(), record.ingest_token.as_str()).unwrap();
+
+    let (layer, guard) = flow_log_writer::layer(dir.path().to_owned());
+    let subscriber = tracing_subscriber::registry().with(layer);
+    tracing::subscriber::with_default(subscriber, || flow_tracker::emit(&record));
+    drop(guard); // joins the writer thread, so the report is on disk
+
+    let authz_dir = dir.path().join("responder").join(authz_id);
+    let payload = read_report(&authz_dir, ".end.json");
+
+    assert_eq!(payload["protocol"], "tcp");
+    assert_eq!(payload["inner_src_ip"], record.inner_src_ip.to_string());
+    assert_eq!(payload["inner_src_port"], record.inner_src_port);
+    assert_eq!(payload["inner_dst_ip"], record.inner_dst_ip.to_string());
+    assert_eq!(payload["inner_dst_port"], record.inner_dst_port);
+    assert_eq!(payload["domain"], "download.httpbin");
+    assert_eq!(payload["outer_src_ip"], record.outer_src_ip.to_string());
+    assert_eq!(payload["outer_src_port"], record.outer_src_port);
+    assert_eq!(payload["outer_dst_ip"], record.outer_dst_ip.to_string());
+    assert_eq!(payload["outer_dst_port"], record.outer_dst_port);
+    assert_eq!(payload["flow_start"], format!("{:?}", record.flow_start));
+    // Attribution rides the token, not the spooled record.
+    assert!(payload.get("actor_id").is_none());
+
+    let close = record.close.as_ref().unwrap();
+    assert_eq!(payload["flow_end"], format!("{:?}", close.flow_end));
+    assert_eq!(payload["last_packet"], format!("{:?}", close.last_packet));
+    assert_eq!(payload["rx_packets"], close.rx_packets);
+    assert_eq!(payload["tx_packets"], close.tx_packets);
+    assert_eq!(payload["rx_bytes"], close.rx_bytes);
+    assert_eq!(payload["tx_bytes"], close.tx_bytes);
+}
+
+/// Drives the tracker as a Gateway would and asserts that both halves of the
+/// flow's report end up in the spool.
+#[test]
+fn tracked_packets_spool_open_and_completed_reports() {
+    let authz_id = "22222222-2222-2222-2222-222222222222";
+    let token = test_token(authz_id, "responder");
+
+    let dir = tempfile::tempdir().unwrap();
+    flow_log_writer::write_token(dir.path(), token.as_str()).unwrap();
+
+    let (layer, guard) = flow_log_writer::layer(dir.path().to_owned());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    let now = Instant::now();
+    let mut tracker =
+        Tracker::<(ClientId, ResourceId)>::new(now, Duration::from_secs(1_700_000_000));
+    tracker.set_enabled(true);
+
+    let client = ClientId::from_u128(1);
+    let resource = ResourceId::from_u128(2);
+
+    // The Gateway's socket and the Client's public endpoint.
+    let local = "203.0.113.1:51820".parse::<SocketAddr>().unwrap();
+    let remote = "198.51.100.1:45000".parse::<SocketAddr>().unwrap();
+
+    let client_ip = "100.64.0.1".parse::<Ipv4Addr>().unwrap();
+    let resource_ip = "10.0.0.5".parse::<Ipv4Addr>().unwrap();
+    let request =
+        ip_packet::make::udp_packet(client_ip, resource_ip, 1234, 5201, b"hello").unwrap();
+    let reply = ip_packet::make::udp_packet(resource_ip, client_ip, 5201, 1234, b"world!").unwrap();
+
+    tracing::subscriber::with_default(subscriber, || {
+        {
+            let flow = tracker.begin_network_packet(local, remote, now);
+            flow_tracker::record_decrypted_packet(&request);
+            flow_tracker::record_peer(client, Role::Responder);
+            flow_tracker::record_resource(resource);
+            flow_tracker::record_ingest_token(Some(token.clone()));
+            drop(flow);
+        }
+
+        {
+            let flow = tracker.begin_tun_packet(&reply, now);
+            flow_tracker::record_peer(client, Role::Responder);
+            flow_tracker::record_resource(resource);
+            flow_tracker::record_transmit(Some(local), remote);
+            drop(flow);
+        }
+
+        tracker.close_all(now);
+    });
+    drop(guard); // joins the writer thread, so the reports are on disk
+
+    let authz_dir = dir.path().join("responder").join(authz_id);
+
+    let open = read_report(&authz_dir, ".start.json");
+    assert_eq!(open["protocol"], "udp");
+    assert_eq!(open["inner_src_ip"], "100.64.0.1");
+    assert_eq!(open["inner_src_port"], 1234);
+    assert_eq!(open["inner_dst_ip"], "10.0.0.5");
+    assert_eq!(open["inner_dst_port"], 5201);
+    assert_eq!(open["outer_src_ip"], "198.51.100.1");
+    assert_eq!(open["outer_src_port"], 45000);
+    assert_eq!(open["outer_dst_ip"], "203.0.113.1");
+    assert_eq!(open["outer_dst_port"], 51820);
+    assert!(open.get("flow_end").is_none());
+
+    let completed = read_report(&authz_dir, ".end.json");
+    assert_eq!(completed["inner_src_ip"], "100.64.0.1");
+    assert_eq!(completed["tx_packets"], 1);
+    assert_eq!(completed["tx_bytes"], 5);
+    assert_eq!(completed["rx_packets"], 1);
+    assert_eq!(completed["rx_bytes"], 6);
+}
+
+/// A JWT payload carrying every claim the portal guarantees on a token.
+fn required_claims(policy_authorization_id: &str, role: &str) -> String {
+    format!(
+        r#"{{"account_id":"c1e296cd-b8ff-4565-8a4c-b6023a4a4b10","iat":1782756000,"exp":1785434400,"uploads_enabled":true,"role":"{role}","device_id":"d-1","policy_authorization_id":"{policy_authorization_id}","policy_id":"p-1","resource_id":"r-1","resource_name":"web","actor_id":"a-1","actor_name":"Alice","authorized_at":"2026-07-01T00:00:00Z","authorization_expires_at":"2026-07-02T00:00:00Z"}}"#
+    )
+}
+
+/// Assembles and parses a well-formed ingest token for `authz_id`.
+fn test_token(authz_id: &str, role: &str) -> IngestToken {
+    let encode = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+
+    let header = encode(br#"{"alg":"HS256"}"#);
+    let payload = encode(required_claims(authz_id, role).as_bytes());
+    let token = format!("{header}.{payload}.{}", encode(b"signature"));
+
+    serde_json::from_value(serde_json::Value::String(token)).unwrap()
+}
+
+/// Reads the payload of the only report in `authz_dir` whose name ends in `suffix`.
+fn read_report(authz_dir: &Path, suffix: &str) -> serde_json::Value {
+    let report = std::fs::read_dir(authz_dir)
+        .expect("spooled report dir exists")
+        .map(|entry| entry.unwrap().path())
+        .find(|path| path.to_string_lossy().ends_with(suffix))
+        .expect("report exists");
+
+    flow_log_spool::deserialize(&std::fs::read(report).unwrap()).unwrap()
+}

--- a/rust/libs/connlib/tunnel/Cargo.toml
+++ b/rust/libs/connlib/tunnel/Cargo.toml
@@ -23,6 +23,7 @@ divan = { workspace = true, optional = true }
 dns-over-tcp = { workspace = true }
 dns-types = { workspace = true }
 eventloop-budget = { workspace = true }
+flow-tracker = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true, features = ["tokio"] }
 gat-lending-iterator = { workspace = true }
@@ -60,15 +61,12 @@ tun = { workspace = true }
 
 [dev-dependencies]
 firezone-relay = { workspace = true, features = ["proptest"] }
-flow-log-spool = { workspace = true }
-flow-log-writer = { workspace = true }
 ip-packet = { workspace = true, features = ["proptest"] }
 l3-tcp = { workspace = true }
 proptest-state-machine = { workspace = true }
 rand = { workspace = true }
 rustls = { workspace = true }
 sha2 = { workspace = true }
-tempfile = { workspace = true }
 test-case = { workspace = true }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["process", "test-util"] }

--- a/rust/libs/connlib/tunnel/src/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway.rs
@@ -3,7 +3,6 @@ mod nat_table;
 
 pub(crate) use crate::gateway::client_on_gateway::ClientOnGateway;
 
-use crate::flow_log;
 use crate::gateway::client_on_gateway::TranslateOutboundResult;
 use crate::messages::gateway::{Client, ResourceDescription};
 use crate::messages::{IceCredentials, IngestToken, ResolveRequest};
@@ -36,7 +35,7 @@ pub struct GatewayState {
     peers: PeerStore<ClientId, ClientOnGateway>,
 
     /// Tracks the flows tunneled through this Gateway.
-    flow_tracker: flow_log::Tracker<(ClientId, ResourceId)>,
+    flow_tracker: flow_tracker::Tracker<(ClientId, ResourceId)>,
 
     tun_ip_config: Option<IpConfig>,
 
@@ -76,7 +75,7 @@ impl GatewayState {
             node: Node::new(seed, now, unix_ts),
             buffered_events: VecDeque::default(),
             buffered_transmits: snownet::TransmitBuffer::default(),
-            flow_tracker: flow_log::Tracker::new(now, unix_ts),
+            flow_tracker: flow_tracker::Tracker::new(now, unix_ts),
             tun_ip_config: None,
             unix_ts_clock: UnixTsClock::new(now, unix_ts),
             next_periodic_tick: None,
@@ -126,7 +125,7 @@ impl GatewayState {
             .peer_by_ip_mut(dst)
             .with_context(|| UnroutablePacket::no_peer_state(&packet))?;
 
-        flow_log::record_peer(cid, flow_log::Role::Responder);
+        flow_tracker::record_peer(cid, flow_tracker::Role::Responder);
 
         let packet = peer
             .translate_inbound(packet, now)
@@ -136,7 +135,7 @@ impl GatewayState {
             return Ok(());
         };
 
-        flow_log::record_transmit(info.src, info.dst);
+        flow_tracker::record_transmit(info.src, info.dst);
 
         Ok(())
     }
@@ -168,14 +167,14 @@ impl GatewayState {
             return Ok(None);
         }
 
-        flow_log::record_decrypted_packet(&packet);
+        flow_tracker::record_decrypted_packet(&packet);
 
         let peer = self
             .peers
             .peer_by_id_mut(&cid)
             .with_context(|| format!("No peer for connection {cid}"))?;
 
-        flow_log::record_peer(cid, flow_log::Role::Responder);
+        flow_tracker::record_peer(cid, flow_tracker::Role::Responder);
 
         if let Some(fz_p2p_control) = packet.as_fz_p2p_control() {
             let immediate_response = match fz_p2p_control.event_type() {
@@ -215,13 +214,13 @@ impl GatewayState {
             .context("Failed to translate outbound packet")?
         {
             TranslateOutboundResult::Send(packet) => {
-                flow_log::record_translated_packet(&packet);
+                flow_tracker::record_translated_packet(&packet);
 
                 Ok(Some(packet))
             }
             TranslateOutboundResult::DestinationUnreachable(reply)
             | TranslateOutboundResult::Filtered(reply) => {
-                flow_log::record_icmp_error(&reply);
+                flow_tracker::record_icmp_error(&reply);
 
                 encrypt_packet(
                     reply,

--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -12,7 +12,6 @@ use crate::client::{IPV4_RESOURCES, IPV6_RESOURCES};
 use crate::expiring_map;
 use crate::expiring_map::{ExpiringMap, NEVER_EXPIRES_TTL};
 use crate::filter_engine::FilterEngine;
-use crate::flow_log;
 use crate::gateway::nat_table::{NatTable, TranslateIncomingResult};
 use crate::messages::gateway::ResourceDescription;
 use crate::messages::{Filter, IngestToken};
@@ -364,7 +363,7 @@ impl ClientOnGateway {
             .classify_resource(packet.source(), packet.source_protocol())
             .with_context(|| UnroutablePacket::not_allowed(&packet))?;
 
-        flow_log::record_resource(rid);
+        flow_tracker::record_resource(rid);
 
         Ok(packet)
     }
@@ -412,7 +411,7 @@ impl ClientOnGateway {
             ));
         }
 
-        flow_log::record_domain(state.domain.clone());
+        flow_tracker::record_domain(state.domain.clone());
 
         let (source_protocol, real_ip) =
             self.nat_table
@@ -478,8 +477,8 @@ impl ClientOnGateway {
             tracing::warn!(%rid, "Internal state mismatch: No resource for ID");
             return Ok(());
         }
-        flow_log::record_resource(rid);
-        flow_log::record_ingest_token(self.ingest_tokens.get(&rid).cloned());
+        flow_tracker::record_resource(rid);
+        flow_tracker::record_ingest_token(self.ingest_tokens.get(&rid).cloned());
 
         Ok(())
     }

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -35,7 +35,6 @@ mod conn_track;
 mod dns;
 mod expiring_map;
 mod filter_engine;
-mod flow_log;
 mod gateway;
 mod io;
 #[cfg(test)]

--- a/rust/libs/connlib/tunnel/src/messages.rs
+++ b/rust/libs/connlib/tunnel/src/messages.rs
@@ -1,6 +1,5 @@
 //! Message types that are used by both the gateway and client.
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::sync::Arc;
 
 use chrono::{DateTime, Utc, serde::ts_seconds};
 use connlib_model::RelayId;
@@ -13,6 +12,7 @@ pub mod client;
 pub mod gateway;
 mod key;
 
+pub use flow_tracker::IngestToken;
 pub use key::{Key, SecretKey};
 
 /// Represents a wireguard peer.
@@ -224,141 +224,6 @@ impl FlowLogsConfig {
     }
 }
 
-/// A per-authorization flow-log ingest token minted by the portal: an HS256
-/// JWT carrying the attribution claims, used as the `Bearer` credential when
-/// uploading that authorization's flow logs.
-///
-/// Deserializing parses and retains the claims; the signature is not
-/// verified because only the portal and the ingest API hold the key.
-/// Internally reference-counted: cloning is a refcount bump, so the token can
-/// be recorded into per-packet flow data without copying it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IngestToken(Arc<IngestTokenInner>);
-
-#[derive(Debug, PartialEq, Eq)]
-struct IngestTokenInner {
-    raw: String,
-    claims: IngestTokenClaims,
-}
-
-impl IngestToken {
-    pub fn as_str(&self) -> &str {
-        &self.0.raw
-    }
-
-    pub fn claims(&self) -> &IngestTokenClaims {
-        &self.0.claims
-    }
-}
-
-impl<'de> Deserialize<'de> for IngestToken {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let raw = String::deserialize(deserializer)?;
-
-        let claims = parse_ingest_token_claims(&raw).map_err(serde::de::Error::custom)?;
-
-        Ok(Self(Arc::new(IngestTokenInner { raw, claims })))
-    }
-}
-
-fn parse_ingest_token_claims(token: &str) -> Result<IngestTokenClaims, String> {
-    use base64::Engine as _;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-
-    let [header, payload, signature]: [&str; 3] =
-        token
-            .split('.')
-            .collect::<Vec<_>>()
-            .try_into()
-            .map_err(|_| "ingest token is not made of three JWT segments".to_owned())?;
-
-    let header = URL_SAFE_NO_PAD
-        .decode(header)
-        .map_err(|e| format!("ingest token header is not base64url: {e}"))?;
-    let header = serde_json::from_slice::<JwtHeader>(&header)
-        .map_err(|e| format!("ingest token header is invalid: {e}"))?;
-
-    if header.alg != "HS256" {
-        return Err(format!("ingest token alg is not HS256: {}", header.alg));
-    }
-
-    let payload = URL_SAFE_NO_PAD
-        .decode(payload)
-        .map_err(|e| format!("ingest token payload is not base64url: {e}"))?;
-    let claims = serde_json::from_slice::<IngestTokenClaims>(&payload)
-        .map_err(|e| format!("ingest token claims are invalid: {e}"))?;
-
-    let signature = URL_SAFE_NO_PAD
-        .decode(signature)
-        .map_err(|e| format!("ingest token signature is not base64url: {e}"))?;
-
-    if signature.is_empty() {
-        return Err("ingest token signature is empty".to_owned());
-    }
-
-    Ok(claims)
-}
-
-#[derive(Deserialize)]
-struct JwtHeader {
-    alg: String,
-}
-
-/// The claims the portal stamps into every ingest token. The `Option`s are
-/// nullable attribution claims, and unknown claims are tolerated.
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-pub struct IngestTokenClaims {
-    pub account_id: String,
-    pub iat: u64,
-    pub exp: u64,
-    /// Whether this authorization's flow logs (and this token) are spooled to
-    /// disk for upload.
-    pub uploads_enabled: bool,
-    pub role: IngestTokenRole,
-    pub device_id: String,
-    pub policy_authorization_id: String,
-    pub policy_id: String,
-    pub resource_id: String,
-    pub resource_name: String,
-    pub actor_id: String,
-    pub actor_name: String,
-    pub authorized_at: String,
-    pub authorization_expires_at: String,
-    pub resource_address: Option<String>,
-    pub actor_email: Option<String>,
-    pub auth_provider_id: Option<String>,
-    pub client_version: Option<String>,
-    pub device_os_name: Option<String>,
-    pub device_os_version: Option<String>,
-    pub device_serial: Option<String>,
-    pub device_uuid: Option<String>,
-    pub device_identifier_for_vendor: Option<String>,
-    pub device_firebase_installation_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum IngestTokenRole {
-    Initiator,
-    Responder,
-}
-
-impl IngestTokenRole {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            IngestTokenRole::Initiator => "initiator",
-            IngestTokenRole::Responder => "responder",
-        }
-    }
-}
-
-/// A portal-minted ingest token for tests, signed with a throwaway key.
-#[cfg(test)]
-pub(crate) const TEST_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicG9saWN5X2lkIjoiNDRmMTljMzctY2Y2Mi00YjE5LWIxNTgtNmY4NmJkY2QyYjU3IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIiwicmVzb3VyY2VfYWRkcmVzcyI6ImdpdGxhYi5teWNvcnAuY29tIiwiYWN0b3JfZW1haWwiOiJqYW5lQG15Y29ycC5jb20iLCJhdXRoX3Byb3ZpZGVyX2lkIjoiZjk1ZWYxYTUtYjc2Yi00ZDU5LTliNGItNmIwYzJkNDdlMTI4IiwiY2xpZW50X3ZlcnNpb24iOiIxLjUuMTEiLCJkZXZpY2Vfb3NfbmFtZSI6Im1hY09TIiwiZGV2aWNlX29zX3ZlcnNpb24iOiIxNS41IiwiZGV2aWNlX3NlcmlhbCI6IkMwMlhMMEdZSkdINSIsImRldmljZV91dWlkIjoiMGYwYzIyYjEtNjRmYS00YTA0LWExYzEtNWI0YjZjMGMyZDQ3IiwiZGV2aWNlX2lkZW50aWZpZXJfZm9yX3ZlbmRvciI6IjVhYzM0N2Y4LWNiYjYtNGIwZi04ZjBlLTFmNGQ0N2ExYzE1YiIsImRldmljZV9maXJlYmFzZV9pbnN0YWxsYXRpb25faWQiOiJjQW1wMWVGMXJlQmFzZUlkIn0.aHR1FGQ-cqGS2PZQP5iePtTSUc1kRI6Xj9RWvpqIw_A";
-
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct UpstreamDoH {
     pub url: DoHUrl,
@@ -439,49 +304,6 @@ fn max_port() -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const MINIMAL_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicG9saWN5X2lkIjoiNDRmMTljMzctY2Y2Mi00YjE5LWIxNTgtNmY4NmJkY2QyYjU3IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIn0.9kV77S1jxTqOo8xLjwxS0eBWOPR1lI68DlGK9eC_80g";
-    const UNKNOWN_CLAIM_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicG9saWN5X2lkIjoiNDRmMTljMzctY2Y2Mi00YjE5LWIxNTgtNmY4NmJkY2QyYjU3IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIiwiYnJhbmRfbmV3X2NsYWltIjoidG9sZXJhdGVkIn0.qwJhdnQviEc6oj2iAlPVDZvJwgShU_KuCpCfJhacmeA";
-    const MISSING_POLICY_ID_INGEST_TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X2lkIjoiMTJmMjA3ZTAtM2I2Yy00ZjBmLTlkMGYtY2MyMmNmOWZiZjNjIiwiaWF0IjoxNzgyNzU2MDAwLCJleHAiOjE3ODU0MzQ0MDAsInVwbG9hZHNfZW5hYmxlZCI6dHJ1ZSwicm9sZSI6ImluaXRpYXRvciIsImRldmljZV9pZCI6ImQyNjNkNDkwLWEwYmItNDUyYS04OTkwLTAxZDI3YTFmMTE0NCIsInBvbGljeV9hdXRob3JpemF0aW9uX2lkIjoiZWViNjYyMDUtNWY1My00ZjY0LWFjYmMtZGVlZDQ3MjkzZjA0IiwicmVzb3VyY2VfaWQiOiI3MzNlOGQxNC1jMThkLTQ5MzEtYWYzMC0zNjM5ZmEwOWMwYzAiLCJyZXNvdXJjZV9uYW1lIjoiR2l0TGFiIiwiYWN0b3JfaWQiOiIyNGViNjMxZS1jNTI5LTQxODItYTc0Ni1kOTllZTY2Zjc0MjYiLCJhY3Rvcl9uYW1lIjoiSmFuZSBEb2UiLCJhdXRob3JpemVkX2F0IjoiMjAyNi0wNy0wNlQxMjowMDowMC4wMDAwMDBaIiwiYXV0aG9yaXphdGlvbl9leHBpcmVzX2F0IjoiMjAyNi0wNy0wN1QxMjowMDowMC4wMDAwMDBaIn0.M_OCjGvDSQPvdMN3kwFePSTMhocxzakwIz_PrvWPdsU";
-
-    fn parse_ingest_token(token: &str) -> Result<IngestToken, serde_json::Error> {
-        serde_json::from_str::<IngestToken>(&format!("\"{token}\""))
-    }
-
-    #[test]
-    fn accepts_portal_minted_ingest_token() {
-        let token = parse_ingest_token(TEST_INGEST_TOKEN).unwrap();
-
-        assert_eq!(token.as_str(), TEST_INGEST_TOKEN);
-        assert_eq!(token.claims().role, IngestTokenRole::Initiator);
-        assert!(token.claims().uploads_enabled);
-        assert_eq!(token.claims().resource_name, "GitLab");
-        assert_eq!(
-            token.claims().actor_email.as_deref(),
-            Some("jane@mycorp.com")
-        );
-    }
-
-    #[test]
-    fn accepts_ingest_token_without_nullable_claims() {
-        parse_ingest_token(MINIMAL_INGEST_TOKEN).unwrap();
-    }
-
-    #[test]
-    fn accepts_ingest_token_with_unknown_claims() {
-        parse_ingest_token(UNKNOWN_CLAIM_INGEST_TOKEN).unwrap();
-    }
-
-    #[test]
-    fn rejects_ingest_token_missing_a_guaranteed_claim() {
-        parse_ingest_token(MISSING_POLICY_ID_INGEST_TOKEN).unwrap_err();
-    }
-
-    #[test]
-    fn rejects_structurally_invalid_ingest_token() {
-        parse_ingest_token("header.payload.signature").unwrap_err();
-        parse_ingest_token("not-a-jwt").unwrap_err();
-    }
 
     #[test]
     fn flow_logs_config_ignores_unknown_fields() {

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_flow_created() {
-        let token = crate::messages::TEST_INGEST_TOKEN;
+        let token = flow_tracker::TEST_INGEST_TOKEN;
         let json = format!(
             r#"{{"event":"flow_created","ref":null,"topic":"client","payload":{{"gateway_group_id":"ef42a07f-87d0-40da-baa7-e881e619ea1c","gateway_id":"d263d490-a0bb-452a-8990-01d27a1f1144","resource_id":"733e8d14-c18d-4931-af30-3639fa09c0c0","preshared_key":"anX2T9RH9mimT5Xd5+HqNGV0bfCodWDHQch1DLiFNls=","client_ice_credentials":{{"username":"resc","password":"rqi3ibvfikfaxj3wgp7muh"}},"gateway_ice_credentials":{{"username":"jbi4","password":"a6oeevhlutevykcifd5r2a"}},"gateway_public_key":"uMBCkAxTewfSgypIyxdQ18uCi84HLtKmQJy0wvQrYWY=","gateway_ipv4":"100.72.145.83","gateway_ipv6":"fd00:2021:1111::5:bcfd","flow_logs_ingest_token":"{token}"}}}}"#
         );
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn flow_created_picks_up_use_iceless() {
-        let token = crate::messages::TEST_INGEST_TOKEN;
+        let token = flow_tracker::TEST_INGEST_TOKEN;
         let json = format!(
             r#"{{"event":"flow_created","ref":null,"topic":"client","payload":{{"gateway_group_id":"ef42a07f-87d0-40da-baa7-e881e619ea1c","gateway_id":"d263d490-a0bb-452a-8990-01d27a1f1144","resource_id":"733e8d14-c18d-4931-af30-3639fa09c0c0","preshared_key":"anX2T9RH9mimT5Xd5+HqNGV0bfCodWDHQch1DLiFNls=","client_ice_credentials":{{"username":"resc","password":"rqi3ibvfikfaxj3wgp7muh"}},"gateway_ice_credentials":{{"username":"jbi4","password":"a6oeevhlutevykcifd5r2a"}},"gateway_public_key":"uMBCkAxTewfSgypIyxdQ18uCi84HLtKmQJy0wvQrYWY=","gateway_ipv4":"100.72.145.83","gateway_ipv6":"fd00:2021:1111::5:bcfd","use_iceless":true,"flow_logs_ingest_token":"{token}"}}}}"#
         );
@@ -553,7 +553,7 @@ mod tests {
 
     #[test]
     fn flow_created_carries_ingest_token() {
-        let token = crate::messages::TEST_INGEST_TOKEN;
+        let token = flow_tracker::TEST_INGEST_TOKEN;
         let json = format!(
             r#"{{"event":"flow_created","ref":null,"topic":"client","payload":{{"gateway_group_id":"ef42a07f-87d0-40da-baa7-e881e619ea1c","gateway_id":"d263d490-a0bb-452a-8990-01d27a1f1144","resource_id":"733e8d14-c18d-4931-af30-3639fa09c0c0","preshared_key":"anX2T9RH9mimT5Xd5+HqNGV0bfCodWDHQch1DLiFNls=","client_ice_credentials":{{"username":"resc","password":"rqi3ibvfikfaxj3wgp7muh"}},"gateway_ice_credentials":{{"username":"jbi4","password":"a6oeevhlutevykcifd5r2a"}},"gateway_public_key":"uMBCkAxTewfSgypIyxdQ18uCi84HLtKmQJy0wvQrYWY=","gateway_ipv4":"100.72.145.83","gateway_ipv6":"fd00:2021:1111::5:bcfd","flow_logs_ingest_token":"{token}"}}}}"#
         );
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn client_device_access_authorized_carries_ingest_token() {
-        let token = crate::messages::TEST_INGEST_TOKEN;
+        let token = flow_tracker::TEST_INGEST_TOKEN;
         let json = format!(
             r#"{{"event":"client_device_access_authorized","ref":null,"topic":"client","payload":{{"client_id":"d263d490-a0bb-452a-8990-01d27a1f1144","client_name":"Test Device","client_public_key":"uMBCkAxTewfSgypIyxdQ18uCi84HLtKmQJy0wvQrYWY=","client_ipv4":"100.72.145.83","client_ipv6":"fd00:2021:1111::5:bcfd","preshared_key":"anX2T9RH9mimT5Xd5+HqNGV0bfCodWDHQch1DLiFNls=","local_ice_credentials":{{"username":"resc","password":"rqi3ibvfikfaxj3wgp7muh"}},"remote_ice_credentials":{{"username":"jbi4","password":"a6oeevhlutevykcifd5r2a"}},"ice_role":"controlling","flow_logs_ingest_token":"{token}"}}}}"#
         );

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_authorize_flow() {
-        let token = crate::messages::TEST_INGEST_TOKEN;
+        let token = flow_tracker::TEST_INGEST_TOKEN;
         let json = AUTHORIZE_FLOW.replace(
             r#""flow_id""#,
             &format!(r#""flow_logs_ingest_token":"{token}","flow_id""#),

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -1380,7 +1380,7 @@ fn address_from_destination(
 }
 
 fn test_ingest_token() -> crate::messages::IngestToken {
-    serde_json::from_str(&format!("\"{}\"", crate::messages::TEST_INGEST_TOKEN)).unwrap()
+    serde_json::from_str(&format!("\"{}\"", flow_tracker::TEST_INGEST_TOKEN)).unwrap()
 }
 
 fn make_preshared_key_and_ice(


### PR DESCRIPTION
Extracts the flow tracker out of the tunnel crate into a dedicated flow-tracker crate, as suggested in review on #14028.

The tracker's spool test lived as a unit test inside the tunnel and pulled the flow-log writer in as a dev-dependency of the whole tunnel crate. That coverage is now an integration test of the tracker and writer together: one test guards the emit/writer field contract, and a new one drives the tracker like a Gateway and checks both halves of a flow's report reach the spool.

The ingest token type moves along with the tracker since records carry it. The tunnel re-exports it from its messages module, so the message types and their users are unchanged.

Related: #14028