### PR TITLE
chore(portal): log more info for unknown messages

### DIFF
--- a/elixir/lib/portal_api/client/channel.ex
+++ b/elixir/lib/portal_api/client/channel.ex
@@ -1135,7 +1135,12 @@ defmodule PortalAPI.Client.Channel do
 
   # Catch-all for unknown messages
   def handle_in(message, payload, socket) do
-    Logger.error("Unknown client message", message: message, payload: payload)
+    Logger.error("Unknown client message",
+      message: message,
+      payload: payload,
+      subject: Map.get(socket.assigns, :subject),
+      client: Map.get(socket.assigns, :client)
+    )
 
     {:reply, {:error, %{reason: :unknown_message}}, socket}
   end


### PR DESCRIPTION
After removing the `request_device_access` message we're getting a fair amount of messages inbound for this. It would be good to understand more context about the client(s) sending these.
