### PR TITLE
fix(portal): revoke responder authorizations on member removal

### DIFF
--- a/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
+++ b/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
@@ -26,7 +26,9 @@ defmodule Portal.Changes.Hooks.StaticDevicePoolMembers do
     member = struct_from_params(Portal.StaticDevicePoolMember, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: member}
 
-    Database.delete_responder_authorizations_for_member(member)
+    if member.device_id && member.resource_id do
+      Database.delete_responder_authorizations_for_member(member)
+    end
 
     PubSub.Changes.broadcast(member.account_id, :static_device_pool_members, change)
   end

--- a/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
+++ b/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
@@ -26,11 +26,6 @@ defmodule Portal.Changes.Hooks.StaticDevicePoolMembers do
     member = struct_from_params(Portal.StaticDevicePoolMember, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: member}
 
-    # The removed device is no longer a responder in this pool, so revoke the
-    # authorizations that let peers reach it through the pool resource. Deleting
-    # these rows makes the removed device receive `reject_access` and stops it
-    # re-hydrating the stale authorizations from its `init` on reconnect. The
-    # initiating side is handled separately via the member-delete broadcast.
     Database.delete_responder_authorizations_for_member(member)
 
     PubSub.Changes.broadcast(member.account_id, :static_device_pool_members, change)

--- a/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
+++ b/elixir/lib/portal/changes/hooks/static_device_pool_members.ex
@@ -1,6 +1,7 @@
 defmodule Portal.Changes.Hooks.StaticDevicePoolMembers do
   @behaviour Portal.Changes.Hooks
   alias Portal.{Changes.Change, PubSub}
+  alias __MODULE__.Database
   import Portal.SchemaHelpers
 
   @impl true
@@ -25,6 +26,27 @@ defmodule Portal.Changes.Hooks.StaticDevicePoolMembers do
     member = struct_from_params(Portal.StaticDevicePoolMember, old_data)
     change = %Change{lsn: lsn, op: :delete, old_struct: member}
 
+    # The removed device is no longer a responder in this pool, so revoke the
+    # authorizations that let peers reach it through the pool resource. Deleting
+    # these rows makes the removed device receive `reject_access` and stops it
+    # re-hydrating the stale authorizations from its `init` on reconnect. The
+    # initiating side is handled separately via the member-delete broadcast.
+    Database.delete_responder_authorizations_for_member(member)
+
     PubSub.Changes.broadcast(member.account_id, :static_device_pool_members, change)
+  end
+
+  defmodule Database do
+    import Ecto.Query
+    alias Portal.{Safe, PolicyAuthorization, StaticDevicePoolMember}
+
+    def delete_responder_authorizations_for_member(%StaticDevicePoolMember{} = member) do
+      from(f in PolicyAuthorization, as: :policy_authorizations)
+      |> where([policy_authorizations: f], f.account_id == ^member.account_id)
+      |> where([policy_authorizations: f], f.resource_id == ^member.resource_id)
+      |> where([policy_authorizations: f], f.receiving_device_id == ^member.device_id)
+      |> Safe.unscoped()
+      |> Safe.delete_all()
+    end
   end
 end

--- a/elixir/test/portal/changes/hooks/static_device_pool_members_test.exs
+++ b/elixir/test/portal/changes/hooks/static_device_pool_members_test.exs
@@ -1,0 +1,84 @@
+defmodule Portal.Changes.Hooks.StaticDevicePoolMembersTest do
+  use Portal.DataCase, async: true
+  import Portal.Changes.Hooks.StaticDevicePoolMembers
+  import Portal.AccountFixtures
+  import Portal.ResourceFixtures
+  import Portal.PolicyAuthorizationFixtures
+  alias Portal.Changes.Change
+  alias Portal.PolicyAuthorization
+  alias Portal.PubSub
+  alias Portal.StaticDevicePoolMember
+
+  defp member_data(account, resource, device_id) do
+    %{
+      "id" => Ecto.UUID.generate(),
+      "account_id" => account.id,
+      "resource_id" => resource.id,
+      "device_id" => device_id,
+      "device_type" => "client"
+    }
+  end
+
+  describe "insert/1" do
+    test "broadcasts created member" do
+      account = account_fixture()
+      resource = resource_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id, :static_device_pool_members)
+
+      data = member_data(account, resource, Ecto.UUID.generate())
+
+      assert :ok == on_insert(0, data)
+      assert_receive %Change{op: :insert, struct: %StaticDevicePoolMember{} = member, lsn: 0}
+      assert member.resource_id == resource.id
+    end
+  end
+
+  describe "delete/1" do
+    test "broadcasts deleted member and revokes the member's responder authorizations" do
+      account = account_fixture()
+      resource = resource_fixture(account: account)
+      :ok = PubSub.Changes.subscribe(account.id, :static_device_pool_members)
+
+      # The removed member is the receiving (responder) device for this pool.
+      authorization =
+        policy_authorization_fixture(account: account, resource: resource)
+
+      data = member_data(account, resource, authorization.receiving_device_id)
+
+      assert :ok == on_delete(0, data)
+
+      assert_receive %Change{op: :delete, old_struct: %StaticDevicePoolMember{}, lsn: 0}
+
+      refute Repo.get_by(PolicyAuthorization, id: authorization.id)
+    end
+
+    test "does not revoke authorizations for other resources or devices" do
+      account = account_fixture()
+      resource = resource_fixture(account: account)
+      other_resource = resource_fixture(account: account)
+
+      authorization =
+        policy_authorization_fixture(account: account, resource: resource)
+
+      # Same device, different pool resource: must survive.
+      other_pool_authorization =
+        policy_authorization_fixture(
+          account: account,
+          resource: other_resource,
+          gateway: Repo.get_by(Portal.Device, id: authorization.receiving_device_id)
+        )
+
+      # Same pool resource, different responder device: must survive.
+      other_device_authorization =
+        policy_authorization_fixture(account: account, resource: resource)
+
+      data = member_data(account, resource, authorization.receiving_device_id)
+
+      assert :ok == on_delete(0, data)
+
+      refute Repo.get_by(PolicyAuthorization, id: authorization.id)
+      assert Repo.get_by(PolicyAuthorization, id: other_pool_authorization.id)
+      assert Repo.get_by(PolicyAuthorization, id: other_device_authorization.id)
+    end
+  end
+end

--- a/elixir/test/portal/changes/hooks/static_device_pool_members_test.exs
+++ b/elixir/test/portal/changes/hooks/static_device_pool_members_test.exs
@@ -2,6 +2,7 @@ defmodule Portal.Changes.Hooks.StaticDevicePoolMembersTest do
   use Portal.DataCase, async: true
   import Portal.Changes.Hooks.StaticDevicePoolMembers
   import Portal.AccountFixtures
+  import Portal.DeviceFixtures
   import Portal.ResourceFixtures
   import Portal.PolicyAuthorizationFixtures
   alias Portal.Changes.Change
@@ -37,13 +38,13 @@ defmodule Portal.Changes.Hooks.StaticDevicePoolMembersTest do
     test "broadcasts deleted member and revokes the member's responder authorizations" do
       account = account_fixture()
       resource = resource_fixture(account: account)
+      responder = client_fixture(account: account)
       :ok = PubSub.Changes.subscribe(account.id, :static_device_pool_members)
 
-      # The removed member is the receiving (responder) device for this pool.
       authorization =
-        policy_authorization_fixture(account: account, resource: resource)
+        policy_authorization_fixture(account: account, resource: resource, gateway: responder)
 
-      data = member_data(account, resource, authorization.receiving_device_id)
+      data = member_data(account, resource, responder.id)
 
       assert :ok == on_delete(0, data)
 
@@ -56,23 +57,27 @@ defmodule Portal.Changes.Hooks.StaticDevicePoolMembersTest do
       account = account_fixture()
       resource = resource_fixture(account: account)
       other_resource = resource_fixture(account: account)
+      responder = client_fixture(account: account)
+      other_responder = client_fixture(account: account)
 
       authorization =
-        policy_authorization_fixture(account: account, resource: resource)
+        policy_authorization_fixture(account: account, resource: resource, gateway: responder)
 
-      # Same device, different pool resource: must survive.
       other_pool_authorization =
         policy_authorization_fixture(
           account: account,
           resource: other_resource,
-          gateway: Repo.get_by(Portal.Device, id: authorization.receiving_device_id)
+          gateway: responder
         )
 
-      # Same pool resource, different responder device: must survive.
       other_device_authorization =
-        policy_authorization_fixture(account: account, resource: resource)
+        policy_authorization_fixture(
+          account: account,
+          resource: resource,
+          gateway: other_responder
+        )
 
-      data = member_data(account, resource, authorization.receiving_device_id)
+      data = member_data(account, resource, responder.id)
 
       assert :ok == on_delete(0, data)
 


### PR DESCRIPTION
Removing a device from a static device pool only told the initiating side to stop. The removed device itself kept the authorizations that let peers reach it, honored them until they expired, and re-loaded them from init on reconnect.

Deleting a pool member now also deletes the policy authorizations where the removed device is the responder. The device then receives reject_access and drops the stale access right away.

Related: #11143