### PR TITLE
fix(connlib): validate inbound packets from device pool peers

### DIFF
--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -21,7 +21,7 @@ use tokio::sync::{mpsc, watch};
 use tun::Tun;
 use tunnel::messages::client::{
     Authorization, AuthorizationCreated, AuthorizationCreationFailed, ClientDeviceAccessAuthorized,
-    ClientDeviceAccessDenied, ClientIceCandidates, ClientRejectAccess,
+    ClientDeviceAccessDenied, ClientIceCandidateError, ClientIceCandidates, ClientRejectAccess,
     DevicePoolDomainResolutionFailed, DevicePoolDomainResolved, EgressMessages, FailReason,
     GatewayIceCandidates, IngressMessages, InitClient, ResourceAuthorization,
     ResourceFiltersUpdated,
@@ -701,6 +701,16 @@ impl Eventloop {
                 tunnel
                     .state_mut()
                     .handle_client_device_access_denied(ipv4, ipv6, reason, now);
+            }
+            IngressMessages::ClientIceCandidateError(ClientIceCandidateError {
+                client_id,
+                reason,
+            }) => {
+                tracing::debug!(%client_id, ?reason, "ICE candidates could not be delivered to peer");
+
+                tunnel
+                    .state_mut()
+                    .handle_client_ice_candidate_error(client_id, now);
             }
             IngressMessages::DevicePoolDomainResolved(DevicePoolDomainResolved {
                 resource_id,

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -708,9 +708,19 @@ impl Eventloop {
             }) => {
                 tracing::debug!(%client_id, ?reason, "ICE candidates could not be delivered to peer");
 
-                tunnel
-                    .state_mut()
-                    .handle_client_ice_candidate_error(client_id, now);
+                match reason {
+                    FailReason::Offline => {
+                        tunnel.state_mut().set_device_offline(client_id, now);
+                    }
+                    FailReason::NotFound
+                    | FailReason::VersionMismatch
+                    | FailReason::Forbidden
+                    | FailReason::Disabled
+                    | FailReason::AmbiguousAddress
+                    | FailReason::MissingAddress
+                    | FailReason::InvalidAddress
+                    | FailReason::Unknown => {}
+                }
             }
             IngressMessages::DevicePoolDomainResolved(DevicePoolDomainResolved {
                 resource_id,

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -401,8 +401,8 @@ impl ClientState {
         );
     }
 
-    /// Abandons a pending connection whose ICE candidates the portal could not deliver.
-    pub fn handle_client_ice_candidate_error(&mut self, cid: ClientId, now: Instant) {
+    /// Abandons the pending authorizations and any connection to an offline device.
+    pub fn set_device_offline(&mut self, cid: ClientId, now: Instant) {
         let memberships = self
             .static_device_pools()
             .flat_map(|pool| {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -401,7 +401,7 @@ impl ClientState {
         );
     }
 
-    /// Abandon a pending connection whose ICE candidates the portal could not deliver.
+    /// Abandons a pending connection whose ICE candidates the portal could not deliver.
     pub fn handle_client_ice_candidate_error(&mut self, cid: ClientId, now: Instant) {
         let member_networks = self
             .static_device_pools()

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -403,27 +403,25 @@ impl ClientState {
 
     /// Abandons a pending connection whose ICE candidates the portal could not deliver.
     pub fn handle_client_ice_candidate_error(&mut self, cid: ClientId, now: Instant) {
-        let member_networks = self
+        let memberships = self
             .static_device_pools()
             .flat_map(|pool| {
                 let pool_id = pool.id;
                 pool.devices
                     .iter()
                     .filter(|d| d.id == cid)
-                    .map(move |d| (pool_id, d.ipv4, d.ipv6))
+                    .map(move |d| (pool_id, d.clone()))
             })
             .collect::<Vec<_>>();
 
-        self.pending_authorizations
-            .extract_device_authorizations(|pool, addr| {
-                member_networks.iter().any(|(pool_id, v4, v6)| {
-                    *pool_id == pool
-                        && match addr {
-                            IpAddr::V4(a) => v4.contains(a),
-                            IpAddr::V6(a) => v6.contains(a),
-                        }
-                })
-            });
+        for _ in self
+            .pending_authorizations
+            .remove_device_authorizations(|pool, addr| {
+                memberships
+                    .iter()
+                    .any(|(pool_id, member)| *pool_id == pool && member.contains(addr))
+            })
+        {}
 
         if self.clients.remove(&cid).is_some() {
             self.node
@@ -677,19 +675,13 @@ impl ClientState {
 
         match pid {
             ClientOrGatewayId::Client(cid) => {
-                let Some(local_tun) = self.tun_config.current().map(|c| c.ip) else {
-                    tracing::debug!("Dropping inbound peer packet: no TUN configuration");
-
-                    return Ok(None);
-                };
-
                 let Some(peer) = self.clients.peer_by_id_mut(&cid) else {
                     tracing::error!(%cid, "Couldn't find connection by ID");
 
                     return Ok(None);
                 };
 
-                let packet = match peer.ensure_allowed_inbound(packet, local_tun, now)? {
+                let packet = match peer.ensure_allowed_inbound(packet, now)? {
                     InboundResult::Send(p) => p,
                     InboundResult::Filtered(reply) => {
                         encapsulate_and_queue(
@@ -1111,6 +1103,12 @@ impl ClientState {
     ) -> Result<(), NoTurnServers> {
         tracing::debug!(%cid, "New device access authorized");
 
+        let Some(local_tun) = self.tun_config.current().map(|c| c.ip) else {
+            tracing::debug!("Ignoring device access authorization: no TUN configuration");
+
+            return Ok(());
+        };
+
         self.node.upsert_connection(
             ClientOrGatewayId::Client(cid),
             client_key,
@@ -1132,7 +1130,7 @@ impl ClientState {
         });
 
         let peer = self.clients.upsert(cid, || {
-            ClientOnClient::new(cid, client_tun, client_name.clone())
+            ClientOnClient::new(cid, local_tun, client_tun, client_name.clone())
         });
 
         if peer.remote_name() != client_name {
@@ -2562,8 +2560,10 @@ impl ClientState {
 
         self.pending_authorizations.remove(id);
 
-        self.pending_authorizations
-            .extract_device_authorizations(|pool, _| pool == id);
+        for _ in self
+            .pending_authorizations
+            .remove_device_authorizations(|pool, _| pool == id)
+        {}
 
         for cid in pool_members {
             if self.is_client_in_other_static_device_pool(cid, id) {

--- a/rust/libs/connlib/tunnel/src/client.rs
+++ b/rust/libs/connlib/tunnel/src/client.rs
@@ -309,6 +309,11 @@ impl ClientState {
     }
 
     fn resource_status(&self, resource: &Resource) -> ResourceStatus {
+        // `all()` over an empty site set is vacuously true.
+        if resource.sites().is_empty() {
+            return ResourceStatus::Unknown;
+        }
+
         if resource.sites().iter().any(|s| {
             self.sites_status
                 .get(&s.id)
@@ -394,6 +399,36 @@ impl ClientState {
             p2p_control::goodbye(),
             now,
         );
+    }
+
+    /// Abandon a pending connection whose ICE candidates the portal could not deliver.
+    pub fn handle_client_ice_candidate_error(&mut self, cid: ClientId, now: Instant) {
+        let member_networks = self
+            .static_device_pools()
+            .flat_map(|pool| {
+                let pool_id = pool.id;
+                pool.devices
+                    .iter()
+                    .filter(|d| d.id == cid)
+                    .map(move |d| (pool_id, d.ipv4, d.ipv6))
+            })
+            .collect::<Vec<_>>();
+
+        self.pending_authorizations
+            .extract_device_authorizations(|pool, addr| {
+                member_networks.iter().any(|(pool_id, v4, v6)| {
+                    *pool_id == pool
+                        && match addr {
+                            IpAddr::V4(a) => v4.contains(a),
+                            IpAddr::V6(a) => v6.contains(a),
+                        }
+                })
+            });
+
+        if self.clients.remove(&cid).is_some() {
+            self.node
+                .close_connection(ClientOrGatewayId::Client(cid), p2p_control::goodbye(), now);
+        }
     }
 
     pub fn handle_device_pool_domain_resolved(
@@ -642,13 +677,19 @@ impl ClientState {
 
         match pid {
             ClientOrGatewayId::Client(cid) => {
+                let Some(local_tun) = self.tun_config.current().map(|c| c.ip) else {
+                    tracing::debug!("Dropping inbound peer packet: no TUN configuration");
+
+                    return Ok(None);
+                };
+
                 let Some(peer) = self.clients.peer_by_id_mut(&cid) else {
                     tracing::error!(%cid, "Couldn't find connection by ID");
 
                     return Ok(None);
                 };
 
-                let packet = match peer.ensure_allowed_inbound(packet, now)? {
+                let packet = match peer.ensure_allowed_inbound(packet, local_tun, now)? {
                     InboundResult::Send(p) => p,
                     InboundResult::Filtered(reply) => {
                         encapsulate_and_queue(
@@ -1254,11 +1295,14 @@ impl ClientState {
 
     pub fn on_resource_connection_failed(&mut self, resource: ResourceId, now: Instant) {
         self.pending_authorizations.remove(resource);
-        let Some(AccessPath::Gateway(disconnected_gateway)) =
-            self.authorized_resources.remove(&resource)
-        else {
-            return;
+
+        // A pool's `Direct` authorizations must survive a single member's failure.
+        let disconnected_gateway = match self.authorized_resources.get(&resource) {
+            Some(AccessPath::Gateway(gid)) => *gid,
+            Some(AccessPath::Direct(_)) | None => return,
         };
+
+        self.authorized_resources.remove(&resource);
         self.cleanup_connected_gateway(&disconnected_gateway, now);
     }
 
@@ -2494,6 +2538,14 @@ impl ClientState {
             return;
         };
 
+        let pool_members: Vec<ClientId> = match resource {
+            Resource::StaticDevicePool(p) => p.devices.iter().map(|d| d.id).collect(),
+            Resource::Dns(_)
+            | Resource::Cidr(_)
+            | Resource::Internet(_)
+            | Resource::DynamicDevicePool(_) => Vec::new(),
+        };
+
         match resource {
             Resource::Dns(_) => self.resource_stub_resolver.remove_resource(id),
             Resource::Cidr(_) => {}
@@ -2509,6 +2561,23 @@ impl ClientState {
         tracing::info!(%name, address, sites, "Deactivating resource");
 
         self.pending_authorizations.remove(id);
+
+        self.pending_authorizations
+            .extract_device_authorizations(|pool, _| pool == id);
+
+        for cid in pool_members {
+            if self.is_client_in_other_static_device_pool(cid, id) {
+                continue;
+            }
+
+            if self.clients.remove(&cid).is_some() {
+                self.node.close_connection(
+                    ClientOrGatewayId::Client(cid),
+                    p2p_control::goodbye(),
+                    now,
+                );
+            }
+        }
 
         let Some((_, peer)) =
             gateway_by_resource_mut(&self.authorized_resources, &mut self.gateways, id)

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -24,6 +24,7 @@ use std::time::Instant;
 /// isn't the return traffic of packets that we have sent.
 pub(crate) struct ClientOnClient {
     id: ClientId,
+    local_tun: IpConfig,
     remote_tun: IpConfig,
     remote_name: String,
     /// Inbound resources authorising the remote peer to send packets to us.
@@ -53,9 +54,15 @@ pub(crate) enum InboundResult {
 }
 
 impl ClientOnClient {
-    pub(crate) fn new(id: ClientId, remote_tun: IpConfig, remote_name: String) -> ClientOnClient {
+    pub(crate) fn new(
+        id: ClientId,
+        local_tun: IpConfig,
+        remote_tun: IpConfig,
+        remote_name: String,
+    ) -> ClientOnClient {
         ClientOnClient {
             id,
+            local_tun,
             remote_tun,
             remote_name,
             resources: ExpiringMap::default(),
@@ -221,13 +228,12 @@ impl ClientOnClient {
     pub(crate) fn ensure_allowed_inbound(
         &mut self,
         packet: IpPacket,
-        local_tun: IpConfig,
         now: Instant,
     ) -> Result<InboundResult> {
         let src = packet.source();
         let dst = packet.destination();
         anyhow::ensure!(
-            self.remote_tun.is_ip(src) && local_tun.is_ip(dst),
+            self.remote_tun.is_ip(src) && self.local_tun.is_ip(dst),
             "Dropping spoofed inbound packet from peer (src {src}, dst {dst})"
         );
 
@@ -281,10 +287,7 @@ mod tests {
             &[],
         )
         .unwrap();
-        assert!(
-            peer.ensure_allowed_inbound(spoofed, local_tun(), now)
-                .is_err()
-        );
+        assert!(peer.ensure_allowed_inbound(spoofed, now).is_err());
     }
 
     #[test]
@@ -301,10 +304,7 @@ mod tests {
             &[],
         )
         .unwrap();
-        assert!(
-            peer.ensure_allowed_inbound(spoofed, local_tun(), now)
-                .is_err()
-        );
+        assert!(peer.ensure_allowed_inbound(spoofed, now).is_err());
     }
 
     #[test]
@@ -313,12 +313,10 @@ mod tests {
         let mut peer = peer();
 
         let outbound = make::udp_packet(our_v4(), peer_v4(), 8080, 80, &[]).unwrap();
-        peer.record_outbound(&outbound, now);
+        peer.handle_outbound(&outbound, now);
         let icmp = make::icmp_dest_unreachable_prohibited(&outbound).unwrap();
 
-        assert!(is_send(
-            peer.ensure_allowed_inbound(icmp, local_tun(), now).unwrap()
-        ));
+        assert!(is_send(peer.ensure_allowed_inbound(icmp, now).unwrap()));
     }
 
     #[test]
@@ -329,7 +327,7 @@ mod tests {
         let stray = make::udp_packet(our_v4(), peer_v4(), 8080, 80, &[]).unwrap();
         let icmp = make::icmp_dest_unreachable_prohibited(&stray).unwrap();
 
-        assert!(peer.ensure_allowed_inbound(icmp, local_tun(), now).is_err());
+        assert!(peer.ensure_allowed_inbound(icmp, now).is_err());
     }
 
     #[test]
@@ -340,15 +338,13 @@ mod tests {
         peer.add_resource(rid, udp_port(80), None, now);
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
 
         peer.remove_resource(&rid);
 
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
     }
 
@@ -361,10 +357,7 @@ mod tests {
         peer.handle_outbound(&outbound, now);
 
         let reply = make::udp_packet(peer_v4(), our_v4(), 80, 8080, &[]).unwrap();
-        assert!(is_send(
-            peer.ensure_allowed_inbound(reply, local_tun(), now)
-                .unwrap()
-        ));
+        assert!(is_send(peer.ensure_allowed_inbound(reply, now).unwrap()));
     }
 
     #[test]
@@ -375,8 +368,7 @@ mod tests {
         peer.add_resource(rid, udp_port(80), Some(now + Duration::from_secs(60)), now);
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
         assert_eq!(peer.poll_timeout(), Some(now + Duration::from_secs(60)));
 
@@ -385,8 +377,7 @@ mod tests {
 
         assert_eq!(peer.poll_timeout(), None);
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), later)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), later).unwrap()
         ));
     }
 
@@ -400,23 +391,19 @@ mod tests {
         peer.add_resource(drop, udp_port(90), None, now);
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(90), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(90), now).unwrap()
         ));
 
         peer.retain_authorizations(&BTreeSet::from([keep]));
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(90), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(90), now).unwrap()
         ));
     }
 
@@ -431,13 +418,17 @@ mod tests {
         peer.handle_timeout(now);
 
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
-                .unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
         ));
     }
 
     fn peer() -> ClientOnClient {
-        ClientOnClient::new(ClientId::from_u128(1), peer_tun(), "peer".to_owned())
+        ClientOnClient::new(
+            ClientId::from_u128(1),
+            local_tun(),
+            peer_tun(),
+            "peer".to_owned(),
+        )
     }
 
     fn peer_tun() -> IpConfig {

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -231,14 +231,9 @@ impl ClientOnClient {
             "Dropping spoofed inbound packet from peer (src {src}, dst {dst})"
         );
 
-        if let Ok(Some((failed, _))) = packet.icmp_error() {
+        if packet.icmp_error().is_ok_and(|e| e.is_some()) {
             anyhow::ensure!(
-                self.conn_track.is_known_flow_parts(
-                    failed.src(),
-                    failed.src_proto(),
-                    failed.dst(),
-                    failed.dst_proto(),
-                ),
+                self.conn_track.is_known_flow(&packet),
                 "Dropping ICMP error from peer referencing an unknown flow"
             );
 

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -221,12 +221,27 @@ impl ClientOnClient {
     pub(crate) fn ensure_allowed_inbound(
         &mut self,
         packet: IpPacket,
+        local_tun: IpConfig,
         now: Instant,
     ) -> Result<InboundResult> {
-        // ICMP errors are always allowed through so unreachable / TTL-exceeded
-        // notifications can reach the application even if the inbound filter
-        // would otherwise drop them.
-        if packet.icmp_error().is_ok_and(|e| e.is_some()) {
+        let src = packet.source();
+        let dst = packet.destination();
+        anyhow::ensure!(
+            self.remote_tun.is_ip(src) && local_tun.is_ip(dst),
+            "Dropping spoofed inbound packet from peer (src {src}, dst {dst})"
+        );
+
+        if let Ok(Some((failed, _))) = packet.icmp_error() {
+            anyhow::ensure!(
+                self.conn_track.is_known_flow_parts(
+                    failed.src(),
+                    failed.src_proto(),
+                    failed.dst(),
+                    failed.dst_proto(),
+                ),
+                "Dropping ICMP error from peer referencing an unknown flow"
+            );
+
             return Ok(InboundResult::Send(packet));
         }
 
@@ -258,6 +273,71 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    fn spoofed_source_is_rejected() {
+        let now = Instant::now();
+        let mut peer = peer();
+        peer.add_resource(ResourceId::from_u128(1), vec![], None, now);
+
+        let spoofed = make::udp_packet(
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 99)),
+            our_v4(),
+            40000,
+            80,
+            &[],
+        )
+        .unwrap();
+        assert!(
+            peer.ensure_allowed_inbound(spoofed, local_tun(), now)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn spoofed_destination_is_rejected() {
+        let now = Instant::now();
+        let mut peer = peer();
+        peer.add_resource(ResourceId::from_u128(1), vec![], None, now);
+
+        let spoofed = make::udp_packet(
+            peer_v4(),
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 99)),
+            40000,
+            80,
+            &[],
+        )
+        .unwrap();
+        assert!(
+            peer.ensure_allowed_inbound(spoofed, local_tun(), now)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn icmp_error_for_known_flow_is_forwarded() {
+        let now = Instant::now();
+        let mut peer = peer();
+
+        let outbound = make::udp_packet(our_v4(), peer_v4(), 8080, 80, &[]).unwrap();
+        peer.record_outbound(&outbound, now);
+        let icmp = make::icmp_dest_unreachable_prohibited(&outbound).unwrap();
+
+        assert!(is_send(
+            peer.ensure_allowed_inbound(icmp, local_tun(), now).unwrap()
+        ));
+    }
+
+    #[test]
+    fn icmp_error_for_unknown_flow_is_rejected() {
+        let now = Instant::now();
+        let mut peer = peer();
+
+        let stray = make::udp_packet(our_v4(), peer_v4(), 8080, 80, &[]).unwrap();
+        let icmp = make::icmp_dest_unreachable_prohibited(&stray).unwrap();
+
+        assert!(peer.ensure_allowed_inbound(icmp, local_tun(), now).is_err());
+    }
+
+    #[test]
     fn peer_opened_flow_is_re_filtered_after_revocation() {
         let now = Instant::now();
         let rid = ResourceId::from_u128(1);
@@ -265,13 +345,15 @@ mod tests {
         peer.add_resource(rid, udp_port(80), None, now);
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
+                .unwrap()
         ));
 
         peer.remove_resource(&rid);
 
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
+                .unwrap()
         ));
     }
 
@@ -284,7 +366,10 @@ mod tests {
         peer.handle_outbound(&outbound, now);
 
         let reply = make::udp_packet(peer_v4(), our_v4(), 80, 8080, &[]).unwrap();
-        assert!(is_send(peer.ensure_allowed_inbound(reply, now).unwrap()));
+        assert!(is_send(
+            peer.ensure_allowed_inbound(reply, local_tun(), now)
+                .unwrap()
+        ));
     }
 
     #[test]
@@ -295,7 +380,8 @@ mod tests {
         peer.add_resource(rid, udp_port(80), Some(now + Duration::from_secs(60)), now);
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
+                .unwrap()
         ));
         assert_eq!(peer.poll_timeout(), Some(now + Duration::from_secs(60)));
 
@@ -304,7 +390,8 @@ mod tests {
 
         assert_eq!(peer.poll_timeout(), None);
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(80), later).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), later)
+                .unwrap()
         ));
     }
 
@@ -318,19 +405,23 @@ mod tests {
         peer.add_resource(drop, udp_port(90), None, now);
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
+                .unwrap()
         ));
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(90), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(90), local_tun(), now)
+                .unwrap()
         ));
 
         peer.retain_authorizations(&BTreeSet::from([keep]));
 
         assert!(is_send(
-            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
+                .unwrap()
         ));
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(90), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(90), local_tun(), now)
+                .unwrap()
         ));
     }
 
@@ -345,7 +436,8 @@ mod tests {
         peer.handle_timeout(now);
 
         assert!(is_filtered(
-            peer.ensure_allowed_inbound(udp_to(80), now).unwrap()
+            peer.ensure_allowed_inbound(udp_to(80), local_tun(), now)
+                .unwrap()
         ));
     }
 
@@ -357,6 +449,13 @@ mod tests {
         IpConfig {
             v4: Ipv4Addr::new(100, 64, 0, 2),
             v6: Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 2),
+        }
+    }
+
+    fn local_tun() -> IpConfig {
+        IpConfig {
+            v4: Ipv4Addr::new(100, 64, 0, 1),
+            v6: Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 1),
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -291,6 +291,7 @@ mod tests {
             &[],
         )
         .unwrap();
+
         assert!(peer.ensure_allowed_inbound(spoofed, now).is_err());
     }
 
@@ -308,6 +309,7 @@ mod tests {
             &[],
         )
         .unwrap();
+
         assert!(peer.ensure_allowed_inbound(spoofed, now).is_err());
     }
 

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -233,8 +233,12 @@ impl ClientOnClient {
         let src = packet.source();
         let dst = packet.destination();
         anyhow::ensure!(
-            self.remote_tun.is_ip(src) && self.local_tun.is_ip(dst),
-            "Dropping spoofed inbound packet from peer (src {src}, dst {dst})"
+            self.remote_tun.is_ip(src),
+            "Dropping inbound packet with spoofed source (src {src})"
+        );
+        anyhow::ensure!(
+            self.local_tun.is_ip(dst),
+            "Dropping inbound packet not addressed to us (dst {dst})"
         );
 
         if packet.icmp_error().is_ok_and(|e| e.is_some()) {

--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -81,7 +81,18 @@ impl ConnTrack {
     }
 
     /// Returns `true` if the packet belongs to an existing flow in either direction.
+    ///
+    /// An ICMP error belongs to the flow of the failed packet it references.
     pub(crate) fn is_known_flow(&self, packet: &IpPacket) -> bool {
+        if let Ok(Some((failed, _))) = packet.icmp_error() {
+            return self.contains(Key {
+                local: failed.src_proto(),
+                peer: failed.dst_proto(),
+                local_ip: failed.src(),
+                peer_ip: failed.dst(),
+            });
+        }
+
         let Ok(local) = packet.source_protocol() else {
             return false;
         };
@@ -89,32 +100,15 @@ impl ConnTrack {
             return false;
         };
 
-        let key = Key {
+        self.contains(Key {
             local,
             peer,
             local_ip: packet.source(),
             peer_ip: packet.destination(),
-        };
-
-        self.initiated.contains_key(&key) || self.received.contains_key(&key)
+        })
     }
 
-    /// Returns `true` if a flow with our endpoint `local_ip`/`local` and the peer's
-    /// `peer_ip`/`peer` is known in either direction.
-    pub(crate) fn is_known_flow_parts(
-        &self,
-        local_ip: IpAddr,
-        local: Protocol,
-        peer_ip: IpAddr,
-        peer: Protocol,
-    ) -> bool {
-        let key = Key {
-            local,
-            peer,
-            local_ip,
-            peer_ip,
-        };
-
+    fn contains(&self, key: Key) -> bool {
         self.initiated.contains_key(&key) || self.received.contains_key(&key)
     }
 

--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -99,7 +99,7 @@ impl ConnTrack {
         self.initiated.contains_key(&key) || self.received.contains_key(&key)
     }
 
-    /// Whether a flow with our endpoint `local_ip`/`local` and the peer's
+    /// Returns `true` if a flow with our endpoint `local_ip`/`local` and the peer's
     /// `peer_ip`/`peer` is known in either direction.
     pub(crate) fn is_known_flow_parts(
         &self,

--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -99,6 +99,25 @@ impl ConnTrack {
         self.initiated.contains_key(&key) || self.received.contains_key(&key)
     }
 
+    /// Whether a flow with our endpoint `local_ip`/`local` and the peer's
+    /// `peer_ip`/`peer` is known in either direction.
+    pub(crate) fn is_known_flow_parts(
+        &self,
+        local_ip: IpAddr,
+        local: Protocol,
+        peer_ip: IpAddr,
+        peer: Protocol,
+    ) -> bool {
+        let key = Key {
+            local,
+            peer,
+            local_ip,
+            peer_ip,
+        };
+
+        self.initiated.contains_key(&key) || self.received.contains_key(&key)
+    }
+
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
         for map in [&mut self.initiated, &mut self.received] {
             for _ in map.extract_if(.., |key, last_seen| {

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -270,7 +270,7 @@ pub struct ClientDeviceAccessDenied {
     pub reason: FailReason,
 }
 
-/// Portal's report that our ICE candidates could not be delivered to a target peer.
+/// Sent by the portal when our ICE candidates could not be delivered to a target peer.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClientIceCandidateError {
     pub client_id: ClientId,

--- a/rust/libs/connlib/tunnel/src/messages/client.rs
+++ b/rust/libs/connlib/tunnel/src/messages/client.rs
@@ -270,6 +270,13 @@ pub struct ClientDeviceAccessDenied {
     pub reason: FailReason,
 }
 
+/// Portal's report that our ICE candidates could not be delivered to a target peer.
+#[derive(Debug, Deserialize, Clone)]
+pub struct ClientIceCandidateError {
+    pub client_id: ClientId,
+    pub reason: FailReason,
+}
+
 /// Portal's response when a dynamic device pool domain is resolved.
 #[derive(Debug, Deserialize, Clone)]
 pub struct DevicePoolDomainResolved {
@@ -344,6 +351,7 @@ pub enum IngressMessages {
 
     ClientDeviceAccessAuthorized(ClientDeviceAccessAuthorized),
     ClientDeviceAccessDenied(ClientDeviceAccessDenied),
+    ClientIceCandidateError(ClientIceCandidateError),
 
     DevicePoolDomainResolved(DevicePoolDomainResolved),
     DevicePoolDomainResolutionFailed(DevicePoolDomainResolutionFailed),
@@ -978,6 +986,23 @@ mod tests {
             resolved.ipv6,
             "fd00:2021:1111::42".parse::<Ipv6Addr>().unwrap()
         );
+    }
+
+    #[test]
+    fn can_deserialize_client_ice_candidate_error() {
+        let json = serde_json::json!({
+            "event": "client_ice_candidate_error",
+            "payload": {
+                "client_id": "a3632404-4b03-4468-9fc0-4a4c82415ade",
+                "reason": "offline"
+            }
+        });
+
+        let msg: IngressMessages = serde_json::from_value(json).unwrap();
+        let IngressMessages::ClientIceCandidateError(error) = msg else {
+            panic!("expected ClientIceCandidateError")
+        };
+        assert!(matches!(error.reason, FailReason::Offline));
     }
 
     #[test]


### PR DESCRIPTION
A connected peer device could send us packets with any source or destination address and they were written to the TUN device as long as the port filter passed. ICMP errors skipped all checks entirely, so a peer could forge errors for flows it was never part of. The Gateway path validates both; the peer path validated neither.

Inbound peer packets must now come from the peer's own tunnel IP and be addressed to ours. ICMP errors are only forwarded when they reference a flow we actually have with that peer.

This also tightens initiator-side lifecycle handling: deleting a whole pool closes the connections to its members, one member's failure no longer clears the recorded authorizations of the other members, and the portal's client_ice_candidate_error is handled instead of dropped as an unknown message.

Related: #14060
Related: #11143