### PR TITLE
refactor(portal): rename event_id to log_id

### DIFF
--- a/elixir/lib/portal/api_request_log.ex
+++ b/elixir/lib/portal/api_request_log.ex
@@ -4,7 +4,7 @@ defmodule Portal.APIRequestLog do
 
   @type t :: %__MODULE__{
           account_id: Ecto.UUID.t(),
-          event_id: String.t(),
+          log_id: String.t(),
           actor_id: Ecto.UUID.t(),
           api_token_id: Ecto.UUID.t(),
           method: String.t(),
@@ -25,7 +25,7 @@ defmodule Portal.APIRequestLog do
 
   schema "api_request_logs" do
     belongs_to :account, Portal.Account, primary_key: true
-    field :event_id, Portal.Types.EventId, primary_key: true
+    field :log_id, Portal.Types.LogId, primary_key: true
 
     field :actor_id, :binary_id
     field :api_token_id, :binary_id
@@ -49,7 +49,7 @@ defmodule Portal.APIRequestLog do
     changeset
     |> validate_required([
       :account_id,
-      :event_id,
+      :log_id,
       :actor_id,
       :api_token_id,
       :method,

--- a/elixir/lib/portal/authentication.ex
+++ b/elixir/lib/portal/authentication.ex
@@ -6,7 +6,7 @@ defmodule Portal.Authentication do
   alias Portal.OneTimePasscode
   alias Portal.PortalSession
   alias Portal.SessionLog
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
   alias Portal.Authentication.Context
   alias Portal.Authentication.Credential
   alias Portal.Authentication.Subject
@@ -198,7 +198,7 @@ defmodule Portal.Authentication do
   defp portal_session_log_attrs(session, actor, auth_provider_id, timestamp) do
     %{
       account_id: session.account_id,
-      event_id: EventId.build_session_log(),
+      log_id: LogId.build_session_log(),
       timestamp: timestamp,
       context: :portal,
       subject: %{

--- a/elixir/lib/portal/change_log.ex
+++ b/elixir/lib/portal/change_log.ex
@@ -7,7 +7,7 @@ defmodule Portal.ChangeLog do
 
   schema "change_logs" do
     belongs_to :account, Portal.Account, primary_key: true
-    field :event_id, Portal.Types.EventId, primary_key: true
+    field :log_id, Portal.Types.LogId, primary_key: true
     field :timestamp, :utc_datetime_usec
     field :lsn, :integer
     field :object, :string

--- a/elixir/lib/portal/change_logs/consumer.ex
+++ b/elixir/lib/portal/change_logs/consumer.ex
@@ -9,7 +9,7 @@ defmodule Portal.ChangeLogs.Consumer do
   require Logger
 
   alias __MODULE__.Database
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   # Bump this to signify a change in the audit log schema. Use with care.
   @vsn 0
@@ -60,10 +60,10 @@ defmodule Portal.ChangeLogs.Consumer do
   def on_logical_message(state, _message), do: state
 
   # Handle Begin to reset transaction state. On the first Begin of each poll
-  # batch, seed seq_start from the Postgres clock so every event_id in the
+  # batch, seed seq_start from the Postgres clock so every log_id in the
   # batch shares a single authoritative timestamp. flush/1 drops the seed, so
   # each batch reseeds: batches are serialized by the poller's advisory lock,
-  # which keeps event_ids monotonic even when nodes alternate polling.
+  # which keeps log_ids monotonic even when nodes alternate polling.
   @impl true
   def on_begin(state, %{commit_timestamp: commit_timestamp}) do
     state
@@ -160,7 +160,7 @@ defmodule Portal.ChangeLogs.Consumer do
     offset = Map.get(tenant_offsets, account_id, 0)
 
     entry = %{
-      event_id: EventId.build_change_log(seq_start, offset),
+      log_id: LogId.build_change_log(seq_start, offset),
       timestamp: commit_timestamp,
       lsn: lsn,
       operation: op,
@@ -179,7 +179,7 @@ defmodule Portal.ChangeLogs.Consumer do
     }
   end
 
-  # event_ids are <<type::4, seq_start::52, tenant_offset::40>>, so a stale
+  # log_ids are <<type::4, seq_start::52, tenant_offset::40>>, so a stale
   # seq_start from an earlier batch would sort later entries before earlier
   # ones when another node's fresher seed produced the batch in between.
   defp drop_batch_seed(state) do

--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -9,7 +9,7 @@ defmodule Portal.FlowLog do
 
   @type t :: %__MODULE__{
           account_id: Ecto.UUID.t(),
-          event_id: Portal.Types.EventId.t(),
+          log_id: Portal.Types.LogId.t(),
           device_id: Ecto.UUID.t(),
           role: :initiator | :responder,
           policy_authorization_id: Ecto.UUID.t(),
@@ -56,12 +56,12 @@ defmodule Portal.FlowLog do
   # The primary key is the natural flow identity, tagged primary_key: true
   # field-by-field below: the reporting side (account_id, device_id, role), the
   # inner tunnel 6-tuple (protocol, inner src/dst ip+port), the resource, and
-  # flow_start. event_id is a random public handle, not part of the key.
+  # flow_start. log_id is a random public handle, not part of the key.
   # flow_start is included partly because Postgres requires the
   # partition key in every key on a partitioned table. See the partition migration.
   schema "flow_logs" do
     belongs_to :account, Portal.Account, primary_key: true
-    field :event_id, Portal.Types.EventId
+    field :log_id, Portal.Types.LogId
 
     field :device_id, :binary_id, primary_key: true
     field :role, Ecto.Enum, values: @roles, primary_key: true
@@ -133,7 +133,7 @@ defmodule Portal.FlowLog do
     changeset
     |> validate_required([
       :account_id,
-      :event_id,
+      :log_id,
       :device_id,
       :role,
       :policy_authorization_id,

--- a/elixir/lib/portal/session_log.ex
+++ b/elixir/lib/portal/session_log.ex
@@ -7,7 +7,7 @@ defmodule Portal.SessionLog do
 
   schema "session_logs" do
     belongs_to :account, Portal.Account, primary_key: true
-    field :event_id, Portal.Types.EventId, primary_key: true
+    field :log_id, Portal.Types.LogId, primary_key: true
     field :timestamp, :utc_datetime_usec
     field :context, Ecto.Enum, values: [:client, :gateway, :portal]
 

--- a/elixir/lib/portal/types/log_id.ex
+++ b/elixir/lib/portal/types/log_id.ex
@@ -1,8 +1,8 @@
-defmodule Portal.Types.EventId do
+defmodule Portal.Types.LogId do
   @moduledoc """
-  96-bit public event identifier for the audit log streams.
+  96-bit public log identifier for the audit log streams.
 
-  The high nibble namespaces the event streams, so the stream a given event_id
+  The high nibble namespaces the log streams, so the stream a given log_id
   belongs to can be read off its first hex character:
 
   - `0xC` change_log
@@ -10,17 +10,17 @@ defmodule Portal.Types.EventId do
   - `0xA` api_request_log
   - `0xF` flow_log
 
-  change_log event_ids encode ordering:
+  change_log log_ids encode ordering:
 
       [ 4 bits log_type ][ 52 bits seq_start ][ 40 bits tenant_offset ]
 
   - `seq_start` is the consumer's boot timestamp in Unix microseconds, sourced from
     Postgres `clock_timestamp()` so all consumers share a single authoritative clock.
     Constant for the lifetime of one consumer process; advances on every restart,
-    giving prior events a strictly-lower prefix than anything generated post-restart.
+    giving prior entries a strictly-lower prefix than anything generated post-restart.
   - `tenant_offset` is a per-tenant counter starting at 0 each consumer run.
 
-  session_log, api_request_log, and flow_log event_ids carry no ordering
+  session_log, api_request_log, and flow_log log_ids carry no ordering
   semantics: the 92 bits after the log_type nibble are random, and those
   streams are ordered by their timestamp column instead.
 
@@ -77,7 +77,7 @@ defmodule Portal.Types.EventId do
   def valid?(value), do: match?({:ok, _}, parse(value))
 
   @doc """
-  Build a change_log event_id from seq_start (52 bits) and tenant_offset (40 bits).
+  Build a change_log log_id from seq_start (52 bits) and tenant_offset (40 bits).
 
   Returns the canonical 24-char lowercase hex string. Raises FunctionClauseError
   if either value is out of range; binary construction would silently truncate,
@@ -92,7 +92,7 @@ defmodule Portal.Types.EventId do
   end
 
   @doc """
-  Build a session_log event_id: the `0x5` log_type nibble followed by 92
+  Build a session_log log_id: the `0x5` log_type nibble followed by 92
   random bits. Returns the canonical 24-char lowercase hex string.
   """
   def build_session_log do
@@ -100,7 +100,7 @@ defmodule Portal.Types.EventId do
   end
 
   @doc """
-  Build an api_request_log event_id: the `0xA` log_type nibble followed by 92
+  Build an api_request_log log_id: the `0xA` log_type nibble followed by 92
   random bits. Returns the canonical 24-char lowercase hex string.
   """
   def build_api_request_log do
@@ -108,7 +108,7 @@ defmodule Portal.Types.EventId do
   end
 
   @doc """
-  Build a flow_log event_id: the `0xF` log_type nibble followed by 92 random
+  Build a flow_log log_id: the `0xF` log_type nibble followed by 92 random
   bits. Returns the canonical 24-char lowercase hex string.
   """
   def build_flow_log do

--- a/elixir/lib/portal_api/client/socket.ex
+++ b/elixir/lib/portal_api/client/socket.ex
@@ -2,7 +2,7 @@ defmodule PortalAPI.Client.Socket do
   use Phoenix.Socket
   alias Portal.{Authentication, ClientSession, Device, PG, SessionLog, Version}
   alias Portal.Repo.Batch
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
   alias __MODULE__.Database
   require Logger
   require OpenTelemetry.Tracer
@@ -175,7 +175,7 @@ defmodule PortalAPI.Client.Socket do
   defp session_log_attrs(attrs, %{subject: subject, timestamp: timestamp}) do
     %{
       account_id: attrs.account_id,
-      event_id: EventId.build_session_log(),
+      log_id: LogId.build_session_log(),
       timestamp: timestamp,
       context: :client,
       subject:

--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -19,15 +19,15 @@ defmodule PortalAPI.FlowLogController do
   import Ecto.Changeset
   alias Portal.FlowLog
   alias Portal.FlowLogToken
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
   alias PortalAPI.ProblemDetails
   alias __MODULE__.Database
 
-  # Schema fields we cast/persist. `event_id` is server-assigned per record (a
-  # fresh flow_log event_id is minted here, not trusted from the body); on a
-  # slot conflict the existing row keeps its own event_id. Attribution fields
+  # Schema fields we cast/persist. `log_id` is server-assigned per record (a
+  # fresh flow_log log_id is minted here, not trusted from the body); on a
+  # slot conflict the existing row keeps its own log_id. Attribution fields
   # come from the token; the rest are reported in the body.
-  @cast_fields ~w[account_id event_id device_id role policy_authorization_id policy_id
+  @cast_fields ~w[account_id log_id device_id role policy_authorization_id policy_id
                   auth_provider_id resource_id
                   resource_name resource_address actor_id actor_email actor_name authorized_at
                   authorization_expires_at
@@ -186,7 +186,7 @@ defmodule PortalAPI.FlowLogController do
   end
 
   # The only fields a reporter may supply: the network tuples, flow window, and
-  # counters. Everything else (attribution, event_id, inserted_at) is set from
+  # counters. Everything else (attribution, log_id, inserted_at) is set from
   # the verified token or the server below.
   @body_fields ~w[protocol inner_src_ip inner_dst_ip inner_src_port inner_dst_port domain
                   outer_src_ip outer_dst_ip outer_src_port outer_dst_port
@@ -196,13 +196,13 @@ defmodule PortalAPI.FlowLogController do
   # fields, flow window, and counters come from the body. Taking the body fields
   # as an explicit whitelist means a record can never supply its own attribution
   # (account, device, role, policy, resource, actor) or the server-assigned
-  # event_id, regardless of what keys it sends.
+  # log_id, regardless of what keys it sends.
   defp to_attrs(record, claims, now) do
     record
     |> Map.take(@body_fields)
     |> Map.merge(%{
       "account_id" => claims["account_id"],
-      "event_id" => EventId.build_flow_log(),
+      "log_id" => LogId.build_flow_log(),
       "device_id" => claims["device_id"],
       "role" => claims["role"],
       "policy_authorization_id" => claims["policy_authorization_id"],

--- a/elixir/lib/portal_api/controllers/log_controller.ex
+++ b/elixir/lib/portal_api/controllers/log_controller.ex
@@ -4,7 +4,7 @@ defmodule PortalAPI.LogController do
   alias PortalAPI.Pagination
   alias PortalAPI.Error
   alias PortalAPI.Schemas.ProblemDetails
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
   alias __MODULE__.Database
 
   # Default window when `begin` is omitted from a list request.
@@ -17,7 +17,7 @@ defmodule PortalAPI.LogController do
     "api_request" => :api_request
   }
 
-  # The event_id high nibble (its first hex character) identifies the stream
+  # The log_id high nibble (its first hex character) identifies the stream
   # an entry belongs to, so show requests dispatch on it.
   @nibbles_to_types %{
     "c" => :change,
@@ -153,12 +153,12 @@ defmodule PortalAPI.LogController do
   operation(:show,
     summary: "Show Log",
     description: """
-    Fetches a single Log entry by its `event_id`. The entry's type is
-    determined from the `event_id` itself: its first character identifies
+    Fetches a single Log entry by its `log_id`. The entry's type is
+    determined from the `log_id` itself: its first character identifies
     the log stream (`c` change, `5` session, `f` flow, `a` api_request).
     """,
     parameters: [
-      event_id: [
+      log_id: [
         in: :path,
         description:
           "Identifier of the Log entry. A 24-character lowercase hexadecimal string.",
@@ -174,10 +174,10 @@ defmodule PortalAPI.LogController do
   # coveralls-ignore-stop
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, %{"event_id" => event_id}) do
-    with {:ok, event_id} <- parse_event_id(event_id),
-         {:ok, type} <- type_from_event_id(event_id),
-         {:ok, log} <- Database.fetch_log(type, event_id, conn.assigns.subject) do
+  def show(conn, %{"log_id" => log_id}) do
+    with {:ok, log_id} <- parse_log_id(log_id),
+         {:ok, type} <- type_from_log_id(log_id),
+         {:ok, log} <- Database.fetch_log(type, log_id, conn.assigns.subject) do
       render(conn, :show, log: log)
     else
       error -> Error.handle(conn, error)
@@ -198,14 +198,14 @@ defmodule PortalAPI.LogController do
      reason: "`type` is required and must be one of: change, session, flow, api_request"}
   end
 
-  defp type_from_event_id(<<nibble::binary-size(1), _rest::binary>>)
+  defp type_from_log_id(<<nibble::binary-size(1), _rest::binary>>)
        when is_map_key(@nibbles_to_types, nibble) do
     {:ok, Map.fetch!(@nibbles_to_types, nibble)}
   end
 
-  # A well-formed event_id whose high nibble is not a known log stream cannot
+  # A well-formed log_id whose high nibble is not a known log stream cannot
   # reference anything.
-  defp type_from_event_id(_event_id), do: {:error, :not_found}
+  defp type_from_log_id(_log_id), do: {:error, :not_found}
 
   defp coerce_filters(type, params) do
     now = DateTime.utc_now()
@@ -274,10 +274,10 @@ defmodule PortalAPI.LogController do
     {:error, :bad_request, reason: "`#{name}` must be a string"}
   end
 
-  defp parse_event_id(value) do
-    case EventId.parse(value) do
-      {:ok, event_id} -> {:ok, event_id}
-      :error -> {:error, :bad_request, reason: "`event_id` must be a 24-char hex string"}
+  defp parse_log_id(value) do
+    case LogId.parse(value) do
+      {:ok, log_id} -> {:ok, log_id}
+      :error -> {:error, :bad_request, reason: "`log_id` must be a 24-char hex string"}
     end
   end
 
@@ -324,10 +324,10 @@ defmodule PortalAPI.LogController do
       |> Safe.list(__MODULE__.APIRequest, opts)
     end
 
-    def fetch_log(type, event_id, subject) do
+    def fetch_log(type, log_id, subject) do
       result =
         type
-        |> by_event_id_query(event_id)
+        |> by_log_id_query(log_id)
         |> Safe.scoped(subject, :replica)
         |> Safe.one()
 
@@ -338,28 +338,28 @@ defmodule PortalAPI.LogController do
       end
     end
 
-    defp by_event_id_query(:change, event_id) do
-      from(cl in ChangeLog, as: :logs, where: cl.event_id == ^event_id)
+    defp by_log_id_query(:change, log_id) do
+      from(cl in ChangeLog, as: :logs, where: cl.log_id == ^log_id)
     end
 
-    defp by_event_id_query(:session, event_id) do
-      from(sl in SessionLog, as: :logs, where: sl.event_id == ^event_id)
+    defp by_log_id_query(:session, log_id) do
+      from(sl in SessionLog, as: :logs, where: sl.log_id == ^log_id)
     end
 
-    defp by_event_id_query(:flow, event_id) do
-      from(fl in FlowLog, as: :logs, where: fl.event_id == ^event_id)
+    defp by_log_id_query(:flow, log_id) do
+      from(fl in FlowLog, as: :logs, where: fl.log_id == ^log_id)
     end
 
-    defp by_event_id_query(:api_request, event_id) do
-      from(arl in APIRequestLog, as: :logs, where: arl.event_id == ^event_id)
+    defp by_log_id_query(:api_request, log_id) do
+      from(arl in APIRequestLog, as: :logs, where: arl.log_id == ^log_id)
     end
 
     defmodule Change do
       import Ecto.Query
 
-      # change_log event_ids encode commit order, so they are the cursor.
+      # change_log log_ids encode commit order, so they are the cursor.
       def cursor_fields do
-        [{:logs, :desc, :event_id}]
+        [{:logs, :desc, :log_id}]
       end
 
       def filters do
@@ -400,10 +400,10 @@ defmodule PortalAPI.LogController do
     defmodule Session do
       import Ecto.Query
 
-      # session_log event_ids are random, so order by timestamp with the
-      # event_id as a unique tie-breaker.
+      # session_log log_ids are random, so order by timestamp with the
+      # log_id as a unique tie-breaker.
       def cursor_fields do
-        [{:logs, :desc, :timestamp}, {:logs, :desc, :event_id}]
+        [{:logs, :desc, :timestamp}, {:logs, :desc, :log_id}]
       end
 
       def filters do
@@ -446,10 +446,10 @@ defmodule PortalAPI.LogController do
     defmodule Flow do
       import Ecto.Query
 
-      # flow_log event_ids are random, so order by when the flow started,
-      # with the event_id as a unique tie-breaker.
+      # flow_log log_ids are random, so order by when the flow started,
+      # with the log_id as a unique tie-breaker.
       def cursor_fields do
-        [{:logs, :desc, :flow_start}, {:logs, :desc, :event_id}]
+        [{:logs, :desc, :flow_start}, {:logs, :desc, :log_id}]
       end
 
       def filters do
@@ -516,10 +516,10 @@ defmodule PortalAPI.LogController do
     defmodule APIRequest do
       import Ecto.Query
 
-      # api_request_log event_ids are random, so order by insertion time with
-      # the event_id as a unique tie-breaker.
+      # api_request_log log_ids are random, so order by insertion time with
+      # the log_id as a unique tie-breaker.
       def cursor_fields do
-        [{:logs, :desc, :inserted_at}, {:logs, :desc, :event_id}]
+        [{:logs, :desc, :inserted_at}, {:logs, :desc, :log_id}]
       end
 
       def filters do

--- a/elixir/lib/portal_api/controllers/log_json.ex
+++ b/elixir/lib/portal_api/controllers/log_json.ex
@@ -19,7 +19,7 @@ defmodule PortalAPI.LogJSON do
   defp data(%ChangeLog{} = log) do
     %{
       type: "change",
-      event_id: log.event_id,
+      log_id: log.log_id,
       timestamp: log.timestamp,
       object: log.object,
       operation: log.operation,
@@ -32,7 +32,7 @@ defmodule PortalAPI.LogJSON do
   defp data(%SessionLog{} = log) do
     %{
       type: "session",
-      event_id: log.event_id,
+      log_id: log.log_id,
       timestamp: log.timestamp,
       context: log.context,
       subject: log.subject
@@ -42,7 +42,7 @@ defmodule PortalAPI.LogJSON do
   defp data(%FlowLog{} = log) do
     %{
       type: "flow",
-      event_id: log.event_id,
+      log_id: log.log_id,
       timestamp: log.inserted_at,
       device_id: log.device_id,
       role: log.role,
@@ -76,7 +76,7 @@ defmodule PortalAPI.LogJSON do
   defp data(%APIRequestLog{} = log) do
     %{
       type: "api_request",
-      event_id: log.event_id,
+      log_id: log.log_id,
       timestamp: log.inserted_at,
       actor_id: log.actor_id,
       api_token_id: log.api_token_id,

--- a/elixir/lib/portal_api/gateway/socket.ex
+++ b/elixir/lib/portal_api/gateway/socket.ex
@@ -3,7 +3,7 @@ defmodule PortalAPI.Gateway.Socket do
   alias Portal.Authentication
   alias Portal.{Device, GatewaySession, PG, SessionLog, Version}
   alias Portal.Repo.Batch
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
   alias __MODULE__.Database
   require Logger
   require OpenTelemetry.Tracer
@@ -205,7 +205,7 @@ defmodule PortalAPI.Gateway.Socket do
   defp session_log_attrs(attrs, %{timestamp: timestamp}) do
     %{
       account_id: attrs.account_id,
-      event_id: EventId.build_session_log(),
+      log_id: LogId.build_session_log(),
       timestamp: timestamp,
       context: :gateway,
       subject: %{

--- a/elixir/lib/portal_api/plugs/request_log.ex
+++ b/elixir/lib/portal_api/plugs/request_log.ex
@@ -6,7 +6,7 @@ defmodule PortalAPI.Plugs.RequestLog do
   operation to proceed unlogged.
   """
   alias __MODULE__.Database
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   # Bandit caps the request line well below this; the slice is a guard against
   # the column growing unbounded if that ever changes.
@@ -29,7 +29,7 @@ defmodule PortalAPI.Plugs.RequestLog do
 
     %{
       account_id: subject.account.id,
-      event_id: EventId.build_api_request_log(),
+      log_id: LogId.build_api_request_log(),
       actor_id: subject.actor.id,
       api_token_id: subject.credential.id,
       method: conn.method,
@@ -73,7 +73,7 @@ defmodule PortalAPI.Plugs.RequestLog do
 
     @cast_fields ~w[
       account_id
-      event_id
+      log_id
       actor_id
       api_token_id
       method

--- a/elixir/lib/portal_api/plugs/validate_uuid_params.ex
+++ b/elixir/lib/portal_api/plugs/validate_uuid_params.ex
@@ -1,5 +1,5 @@
 defmodule PortalAPI.Plugs.ValidateUUIDParams do
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   def init(opts), do: opts
 
@@ -23,7 +23,7 @@ defmodule PortalAPI.Plugs.ValidateUUIDParams do
   defp valid_id?(value) when is_binary(value) do
     case Ecto.UUID.cast(value) do
       {:ok, _} -> true
-      :error -> EventId.valid?(value)
+      :error -> LogId.valid?(value)
     end
   end
 

--- a/elixir/lib/portal_api/router.ex
+++ b/elixir/lib/portal_api/router.ex
@@ -64,7 +64,7 @@ defmodule PortalAPI.Router do
     put "/clients/:id/unverify", ClientController, :unverify
 
     get "/logs", LogController, :index
-    get "/logs/:event_id", LogController, :show
+    get "/logs/:log_id", LogController, :show
 
     resources "/resources", ResourceController, except: [:new, :edit]
     resources "/policies", PolicyController, except: [:new, :edit]

--- a/elixir/lib/portal_api/schemas/log_schema.ex
+++ b/elixir/lib/portal_api/schemas/log_schema.ex
@@ -15,7 +15,7 @@ defmodule PortalAPI.Schemas.Log do
       type: :object,
       properties: %{
         type: %Schema{type: :string, enum: ["change"]},
-        event_id: %Schema{
+        log_id: %Schema{
           type: :string,
           description: """
           Opaque identifier for the audit log entry. A 24-character lowercase
@@ -61,10 +61,10 @@ defmodule PortalAPI.Schemas.Log do
         },
         subject: Schemas.Subject
       },
-      required: [:type, :event_id, :timestamp, :object, :operation],
+      required: [:type, :log_id, :timestamp, :object, :operation],
       example: %{
         "type" => "change",
-        "event_id" => "c00060db0c2c8eb400000000",
+        "log_id" => "c00060db0c2c8eb400000000",
         "timestamp" => "2026-05-26T12:34:56.789Z",
         "object" => "actors",
         "operation" => "update",
@@ -90,7 +90,7 @@ defmodule PortalAPI.Schemas.Log do
       type: :object,
       properties: %{
         type: %Schema{type: :string, enum: ["session"]},
-        event_id: %Schema{
+        log_id: %Schema{
           type: :string,
           description: """
           Opaque identifier for the Session Log entry. A 24-character
@@ -110,10 +110,10 @@ defmodule PortalAPI.Schemas.Log do
         },
         subject: Schemas.Subject
       },
-      required: [:type, :event_id, :timestamp, :context, :subject],
+      required: [:type, :log_id, :timestamp, :context, :subject],
       example: %{
         "type" => "session",
-        "event_id" => "500060db0c2c8eb400000000",
+        "log_id" => "500060db0c2c8eb400000000",
         "timestamp" => "2026-05-26T12:34:56.789Z",
         "context" => "client",
         "subject" => %{
@@ -145,7 +145,7 @@ defmodule PortalAPI.Schemas.Log do
       type: :object,
       properties: %{
         type: %Schema{type: :string, enum: ["flow"]},
-        event_id: %Schema{
+        log_id: %Schema{
           type: :string,
           description: """
           Opaque identifier for the Flow Log entry. A 24-character lowercase
@@ -237,7 +237,7 @@ defmodule PortalAPI.Schemas.Log do
       },
       required: [
         :type,
-        :event_id,
+        :log_id,
         :timestamp,
         :device_id,
         :role,
@@ -263,7 +263,7 @@ defmodule PortalAPI.Schemas.Log do
       ],
       example: %{
         "type" => "flow",
-        "event_id" => "f00060db0c2c8eb400000000",
+        "log_id" => "f00060db0c2c8eb400000000",
         "timestamp" => "2026-05-26T12:34:56.789Z",
         "device_id" => "11e7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "role" => "responder",
@@ -304,7 +304,7 @@ defmodule PortalAPI.Schemas.Log do
       type: :object,
       properties: %{
         type: %Schema{type: :string, enum: ["api_request"]},
-        event_id: %Schema{
+        log_id: %Schema{
           type: :string,
           description: """
           Opaque identifier for the API Request Log entry. A 24-character
@@ -339,7 +339,7 @@ defmodule PortalAPI.Schemas.Log do
       },
       required: [
         :type,
-        :event_id,
+        :log_id,
         :timestamp,
         :actor_id,
         :api_token_id,
@@ -350,7 +350,7 @@ defmodule PortalAPI.Schemas.Log do
       ],
       example: %{
         "type" => "api_request",
-        "event_id" => "a00060db0c2c8eb400000000",
+        "log_id" => "a00060db0c2c8eb400000000",
         "timestamp" => "2026-05-26T12:34:56.789Z",
         "actor_id" => "84e7f82f-831a-4a9d-8f17-c66c2bb6e205",
         "api_token_id" => "44e7f82f-831a-4a9d-8f17-c66c2bb6e205",
@@ -377,7 +377,7 @@ defmodule PortalAPI.Schemas.Log do
       description: """
       A single Log entry. The `type` field identifies the log stream the
       entry belongs to, which is also encoded in the first character of its
-      `event_id` (`c` change, `5` session, `f` flow, `a` api_request).
+      `log_id` (`c` change, `5` session, `f` flow, `a` api_request).
       """,
       oneOf: [Log.Change, Log.Session, Log.Flow, Log.APIRequest]
     })
@@ -424,7 +424,7 @@ defmodule PortalAPI.Schemas.Log do
         "data" => [
           %{
             "type" => "change",
-            "event_id" => "c00060db0c2c8eb400000000",
+            "log_id" => "c00060db0c2c8eb400000000",
             "timestamp" => "2026-05-26T12:34:56.789Z",
             "object" => "actors",
             "operation" => "update",

--- a/elixir/lib/portal_web/live/logs/api_request_logs.ex
+++ b/elixir/lib/portal_web/live/logs/api_request_logs.ex
@@ -18,7 +18,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
       |> assign(tz_mode: "utc", display_tz: "Etc/UTC")
       |> assign_live_table(@table_id,
         query_module: Database,
-        sortable_fields: [{:api_request_logs, :inserted_at}, {:api_request_logs, :event_id}],
+        sortable_fields: [{:api_request_logs, :inserted_at}, {:api_request_logs, :log_id}],
         callback: &handle_logs_update!/2
       )
 
@@ -26,7 +26,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
   end
 
   def handle_params(
-        %{"event_id" => event_id} = params,
+        %{"log_id" => log_id} = params,
         uri,
         %{assigns: %{live_action: :show}} = socket
       ) do
@@ -35,7 +35,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
       |> assign_tz(params, @filter_key)
       |> handle_live_tables_params(params, uri)
 
-    case Database.fetch_log(event_id, socket.assigns.subject) do
+    case Database.fetch_log(log_id, socket.assigns.subject) do
       {:ok, row} ->
         {:noreply, assign(socket, selected_log: row)}
 
@@ -113,15 +113,15 @@ defmodule PortalWeb.Logs.APIRequestLogs do
         <.live_table
           id="api_request_logs"
           rows={@api_request_logs}
-          row_id={&"api-request-log-#{&1.log.event_id}"}
+          row_id={&"api-request-log-#{&1.log.log_id}"}
           row_click={
             fn row ->
-              ~p"/#{@account}/logs/api_request_logs/#{row.log.event_id}?#{@query_params}"
+              ~p"/#{@account}/logs/api_request_logs/#{row.log.log_id}?#{@query_params}"
             end
           }
           row_selected={
             fn row ->
-              not is_nil(@selected_log) and row.log.event_id == @selected_log.log.event_id
+              not is_nil(@selected_log) and row.log.log_id == @selected_log.log.log_id
             end
           }
           filters={@filters_by_table_id["api_request_logs"]}
@@ -138,7 +138,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
             class="w-44"
           >
             <.timestamp_cell
-              event_id={row.log.event_id}
+              log_id={row.log.log_id}
               timestamp={row.log.inserted_at}
               tz_mode={@tz_mode}
               display_tz={@display_tz}
@@ -274,7 +274,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
               <.detail_row label="Timestamp">
                 <.timestamp_cell
                   id_prefix="panel-timestamp"
-                  event_id={@selected_log.log.event_id}
+                  log_id={@selected_log.log.log_id}
                   timestamp={@selected_log.log.inserted_at}
                   tz_mode={@tz_mode}
                   display_tz={@display_tz}
@@ -282,7 +282,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
               </.detail_row>
               <.detail_row label="Event ID">
                 <span class="font-mono text-[11px] text-[var(--text-secondary)] break-all">
-                  {@selected_log.log.event_id}
+                  {@selected_log.log.log_id}
                 </span>
               </.detail_row>
             </dl>
@@ -469,7 +469,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
     alias Portal.APIRequestLog
     alias Portal.Actor
     alias Portal.Safe
-    alias Portal.Types.EventId
+    alias Portal.Types.LogId
 
     def list_api_request_logs(subject, opts \\ []) do
       result =
@@ -483,11 +483,11 @@ defmodule PortalWeb.Logs.APIRequestLogs do
       end
     end
 
-    def fetch_log(event_id, subject) do
-      with {:ok, event_id} <- EventId.parse(event_id) do
+    def fetch_log(log_id, subject) do
+      with {:ok, log_id} <- LogId.parse(log_id) do
         result =
           from(arl in APIRequestLog, as: :api_request_logs)
-          |> where([api_request_logs: arl], arl.event_id == ^event_id)
+          |> where([api_request_logs: arl], arl.log_id == ^log_id)
           |> Safe.scoped(subject, :replica)
           |> Safe.one(fallback_to_primary: true)
 
@@ -508,7 +508,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
     end
 
     def cursor_fields,
-      do: [{:api_request_logs, :desc, :inserted_at}, {:api_request_logs, :desc, :event_id}]
+      do: [{:api_request_logs, :desc, :inserted_at}, {:api_request_logs, :desc, :log_id}]
 
     @method_values [
       {"GET", "GET"},
@@ -594,7 +594,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
          [api_request_logs: arl],
          fragment("? ILIKE ?", arl.path, ^pattern) or
            fragment("?::text ILIKE ?", arl.actor_id, ^pattern) or
-           fragment("encode(?, 'hex') ILIKE ?", arl.event_id, ^pattern) or
+           fragment("encode(?, 'hex') ILIKE ?", arl.log_id, ^pattern) or
            fragment("? ILIKE ?", arl.request_id, ^pattern)
        )}
     end

--- a/elixir/lib/portal_web/live/logs/change_logs.ex
+++ b/elixir/lib/portal_web/live/logs/change_logs.ex
@@ -19,7 +19,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
       |> assign(tz_mode: "utc", display_tz: "Etc/UTC")
       |> assign_live_table(@table_id,
         query_module: Database,
-        sortable_fields: [{:change_logs, :timestamp}, {:change_logs, :event_id}],
+        sortable_fields: [{:change_logs, :timestamp}, {:change_logs, :log_id}],
         callback: &handle_change_logs_update!/2
       )
 
@@ -27,7 +27,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
   end
 
   def handle_params(
-        %{"event_id" => event_id} = params,
+        %{"log_id" => log_id} = params,
         uri,
         %{assigns: %{live_action: :show}} = socket
       ) do
@@ -36,7 +36,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
       |> assign_tz(params, @filter_key)
       |> handle_live_tables_params(params, uri)
 
-    case Database.fetch_change_log(event_id, socket.assigns.subject) do
+    case Database.fetch_change_log(log_id, socket.assigns.subject) do
       {:ok, change_log} ->
         {:noreply, assign(socket, selected_change_log: change_log)}
 
@@ -128,16 +128,16 @@ defmodule PortalWeb.Logs.ChangeLogs do
         <.live_table
           id="change_logs"
           rows={@change_logs}
-          row_id={&"change_log-#{&1.change_log.event_id}"}
+          row_id={&"change_log-#{&1.change_log.log_id}"}
           row_click={
             fn row ->
-              ~p"/#{@account}/logs/change_logs/#{row.change_log.event_id}?#{@query_params}"
+              ~p"/#{@account}/logs/change_logs/#{row.change_log.log_id}?#{@query_params}"
             end
           }
           row_selected={
             fn row ->
               not is_nil(@selected_change_log) and
-                row.change_log.event_id == @selected_change_log.event_id
+                row.change_log.log_id == @selected_change_log.log_id
             end
           }
           filters={@filters_by_table_id["change_logs"]}
@@ -149,15 +149,15 @@ defmodule PortalWeb.Logs.ChangeLogs do
         >
           <:col :let={row} field={{:change_logs, :timestamp}} label="Timestamp" class="w-44">
             <.timestamp_cell
-              event_id={row.change_log.event_id}
+              log_id={row.change_log.log_id}
               timestamp={row.change_log.timestamp}
               tz_mode={@tz_mode}
               display_tz={@display_tz}
             />
           </:col>
-          <:col :let={row} field={{:change_logs, :event_id}} label="Event ID" class="w-52">
+          <:col :let={row} field={{:change_logs, :log_id}} label="Event ID" class="w-52">
             <span class="font-mono text-[10px] text-[var(--text-tertiary)] break-all">
-              {row.change_log.event_id}
+              {row.change_log.log_id}
             </span>
           </:col>
           <:col :let={row} label="Object" class="w-44">
@@ -275,7 +275,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
               <.detail_row label="Timestamp">
                 <.timestamp_cell
                   id_prefix="panel-timestamp"
-                  event_id={@selected_change_log.event_id}
+                  log_id={@selected_change_log.log_id}
                   timestamp={@selected_change_log.timestamp}
                   tz_mode={@tz_mode}
                   display_tz={@display_tz}
@@ -283,7 +283,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
               </.detail_row>
               <.detail_row label="Event ID">
                 <span class="font-mono text-[11px] text-[var(--text-secondary)] break-all">
-                  {@selected_change_log.event_id}
+                  {@selected_change_log.log_id}
                 </span>
               </.detail_row>
             </dl>
@@ -388,7 +388,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
 
     alias Portal.ChangeLog
     alias Portal.Safe
-    alias Portal.Types.EventId
+    alias Portal.Types.LogId
 
     def list_change_logs(subject, opts \\ []) do
       from(cl in ChangeLog, as: :change_logs)
@@ -396,14 +396,14 @@ defmodule PortalWeb.Logs.ChangeLogs do
       |> Safe.list_offset(__MODULE__, opts)
     end
 
-    def fetch_change_log(event_id, subject) do
-      # `EventId.parse/1` is the strict 24-char-hex validator; `cast/1` only
+    def fetch_change_log(log_id, subject) do
+      # `LogId.parse/1` is the strict 24-char-hex validator; `cast/1` only
       # checks length and would let a malformed value reach `dump/1`, which
       # then errors on base16 decode and crashes the LiveView.
-      with {:ok, event_id} <- EventId.parse(event_id) do
+      with {:ok, log_id} <- LogId.parse(log_id) do
         result =
           from(cl in ChangeLog, as: :change_logs)
-          |> where([change_logs: cl], cl.event_id == ^event_id)
+          |> where([change_logs: cl], cl.log_id == ^log_id)
           |> Safe.scoped(subject, :replica)
           |> Safe.one(fallback_to_primary: true)
 
@@ -417,7 +417,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
       end
     end
 
-    def cursor_fields, do: [{:change_logs, :desc, :event_id}]
+    def cursor_fields, do: [{:change_logs, :desc, :log_id}]
 
     @object_values [
       {"Accounts", "accounts"},
@@ -507,9 +507,9 @@ defmodule PortalWeb.Logs.ChangeLogs do
       do: dynamic([change_logs: cl], cl.timestamp <= ^to)
 
     # Combined search box matches against actor identity (id, name, email) and
-    # the event_id of the entry itself. event_id is stored as a 12-byte bytea
+    # the log_id of the entry itself. log_id is stored as a 12-byte bytea
     # whose canonical public form is its 24-char lowercase hex encoding, so we
-    # `encode(event_id, 'hex') ILIKE ...` to support prefix searches.
+    # `encode(log_id, 'hex') ILIKE ...` to support prefix searches.
     defp filter_by_actor(queryable, value) do
       pattern = "%" <> value <> "%"
 
@@ -519,7 +519,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
          fragment("?->>'actor_id' ILIKE ?", cl.subject, ^pattern) or
            fragment("?->>'actor_name' ILIKE ?", cl.subject, ^pattern) or
            fragment("?->>'actor_email' ILIKE ?", cl.subject, ^pattern) or
-           fragment("encode(?, 'hex') ILIKE ?", cl.event_id, ^pattern)
+           fragment("encode(?, 'hex') ILIKE ?", cl.log_id, ^pattern)
        )}
     end
 

--- a/elixir/lib/portal_web/live/logs/components.ex
+++ b/elixir/lib/portal_web/live/logs/components.ex
@@ -12,11 +12,11 @@ defmodule PortalWeb.Logs.Components do
   alias PortalWeb.CoreComponents
 
   @doc """
-  Single timestamp table cell. `event_id` keeps the wrapper's id unique so LV's
+  Single timestamp table cell. `log_id` keeps the wrapper's id unique so LV's
   diff can patch it independently. `tz_mode`/`display_tz` flow as explicit
   props so column re-rendering picks up timezone toggles.
   """
-  attr :event_id, :string, required: true
+  attr :log_id, :string, required: true
   attr :timestamp, DateTime, required: true
   attr :tz_mode, :string, required: true
   attr :display_tz, :string, required: true
@@ -25,7 +25,7 @@ defmodule PortalWeb.Logs.Components do
   def timestamp_cell(assigns) do
     ~H"""
     <span
-      id={"#{@id_prefix}-#{@event_id}"}
+      id={"#{@id_prefix}-#{@log_id}"}
       data-tz-mode={@tz_mode}
       title={"#{DateTime.to_iso8601(@timestamp)} (#{@display_tz})"}
       class="text-xs text-[var(--text-primary)] tabular-nums"

--- a/elixir/lib/portal_web/live/logs/session_logs.ex
+++ b/elixir/lib/portal_web/live/logs/session_logs.ex
@@ -19,7 +19,7 @@ defmodule PortalWeb.Logs.SessionLogs do
       |> assign(tz_mode: "utc", display_tz: "Etc/UTC")
       |> assign_live_table(@table_id,
         query_module: Database,
-        sortable_fields: [{:session_logs, :timestamp}, {:session_logs, :event_id}],
+        sortable_fields: [{:session_logs, :timestamp}, {:session_logs, :log_id}],
         callback: &handle_logs_update!/2
       )
 
@@ -27,7 +27,7 @@ defmodule PortalWeb.Logs.SessionLogs do
   end
 
   def handle_params(
-        %{"event_id" => event_id} = params,
+        %{"log_id" => log_id} = params,
         uri,
         %{assigns: %{live_action: :show}} = socket
       ) do
@@ -36,7 +36,7 @@ defmodule PortalWeb.Logs.SessionLogs do
       |> assign_tz(params, @filter_key)
       |> handle_live_tables_params(params, uri)
 
-    case Database.fetch_log(event_id, socket.assigns.subject) do
+    case Database.fetch_log(log_id, socket.assigns.subject) do
       {:ok, log} ->
         {:noreply, assign(socket, selected_log: log)}
 
@@ -114,15 +114,15 @@ defmodule PortalWeb.Logs.SessionLogs do
         <.live_table
           id="session_logs"
           rows={@session_logs}
-          row_id={&"session-log-#{&1.event_id}"}
+          row_id={&"session-log-#{&1.log_id}"}
           row_click={
             fn row ->
-              ~p"/#{@account}/logs/session_logs/#{row.event_id}?#{@query_params}"
+              ~p"/#{@account}/logs/session_logs/#{row.log_id}?#{@query_params}"
             end
           }
           row_selected={
             fn row ->
-              not is_nil(@selected_log) and row.event_id == @selected_log.event_id
+              not is_nil(@selected_log) and row.log_id == @selected_log.log_id
             end
           }
           filters={@filters_by_table_id["session_logs"]}
@@ -134,7 +134,7 @@ defmodule PortalWeb.Logs.SessionLogs do
         >
           <:col :let={row} field={{:session_logs, :timestamp}} label="Timestamp" class="w-44">
             <.timestamp_cell
-              event_id={row.event_id}
+              log_id={row.log_id}
               timestamp={row.timestamp}
               tz_mode={@tz_mode}
               display_tz={@display_tz}
@@ -245,7 +245,7 @@ defmodule PortalWeb.Logs.SessionLogs do
               <.detail_row label="Timestamp">
                 <.timestamp_cell
                   id_prefix="panel-timestamp"
-                  event_id={@selected_log.event_id}
+                  log_id={@selected_log.log_id}
                   timestamp={@selected_log.timestamp}
                   tz_mode={@tz_mode}
                   display_tz={@display_tz}
@@ -253,7 +253,7 @@ defmodule PortalWeb.Logs.SessionLogs do
               </.detail_row>
               <.detail_row label="Event ID">
                 <span class="font-mono text-[11px] text-[var(--text-secondary)] break-all">
-                  {@selected_log.event_id}
+                  {@selected_log.log_id}
                 </span>
               </.detail_row>
             </dl>
@@ -349,7 +349,7 @@ defmodule PortalWeb.Logs.SessionLogs do
 
     alias Portal.SessionLog
     alias Portal.Safe
-    alias Portal.Types.EventId
+    alias Portal.Types.LogId
 
     def list_session_logs(subject, opts \\ []) do
       from(sl in SessionLog, as: :session_logs)
@@ -357,11 +357,11 @@ defmodule PortalWeb.Logs.SessionLogs do
       |> Safe.list_offset(__MODULE__, opts)
     end
 
-    def fetch_log(event_id, subject) do
-      with {:ok, event_id} <- EventId.parse(event_id) do
+    def fetch_log(log_id, subject) do
+      with {:ok, log_id} <- LogId.parse(log_id) do
         result =
           from(sl in SessionLog, as: :session_logs)
-          |> where([session_logs: sl], sl.event_id == ^event_id)
+          |> where([session_logs: sl], sl.log_id == ^log_id)
           |> Safe.scoped(subject, :replica)
           |> Safe.one(fallback_to_primary: true)
 
@@ -376,7 +376,7 @@ defmodule PortalWeb.Logs.SessionLogs do
     end
 
     def cursor_fields,
-      do: [{:session_logs, :desc, :timestamp}, {:session_logs, :desc, :event_id}]
+      do: [{:session_logs, :desc, :timestamp}, {:session_logs, :desc, :log_id}]
 
     @context_values [
       {"Client", "client"},
@@ -429,7 +429,7 @@ defmodule PortalWeb.Logs.SessionLogs do
          [session_logs: sl],
          fragment("?->>'actor_id' ILIKE ?", sl.subject, ^pattern) or
            fragment("?->>'actor_email' ILIKE ?", sl.subject, ^pattern) or
-           fragment("encode(?, 'hex') ILIKE ?", sl.event_id, ^pattern)
+           fragment("encode(?, 'hex') ILIKE ?", sl.log_id, ^pattern)
        )}
     end
 

--- a/elixir/lib/portal_web/router.ex
+++ b/elixir/lib/portal_web/router.ex
@@ -258,12 +258,12 @@ defmodule PortalWeb.Router do
       # Audit
       scope "/logs", Logs do
         live "/change_logs", ChangeLogs
-        live "/change_logs/:event_id", ChangeLogs, :show
+        live "/change_logs/:log_id", ChangeLogs, :show
         live "/session_logs", SessionLogs
-        live "/session_logs/:event_id", SessionLogs, :show
+        live "/session_logs/:log_id", SessionLogs, :show
         live "/flow_logs", FlowLogs
         live "/api_request_logs", APIRequestLogs
-        live "/api_request_logs/:event_id", APIRequestLogs, :show
+        live "/api_request_logs/:log_id", APIRequestLogs, :show
       end
 
       scope "/settings", Settings do

--- a/elixir/priv/repo/manual_migrations/20260710000000_rename_event_id_to_log_id.exs
+++ b/elixir/priv/repo/manual_migrations/20260710000000_rename_event_id_to_log_id.exs
@@ -1,0 +1,91 @@
+defmodule Portal.Repo.Migrations.RenameEventIdToLogId do
+  use Ecto.Migration
+
+  @moduledoc """
+  Renames event_id to log_id on all four log streams. All statements are
+  catalog-only; the flow_logs column rename recurses to its partitions, and
+  the DO block sweeps the auto-named per-partition indexes.
+  """
+
+  def up do
+    execute("ALTER TABLE change_logs RENAME COLUMN event_id TO log_id")
+    execute("ALTER TABLE change_logs RENAME CONSTRAINT event_id_is_12_bytes TO log_id_is_12_bytes")
+
+    execute("ALTER TABLE session_logs RENAME COLUMN event_id TO log_id")
+
+    execute(
+      "ALTER TABLE session_logs RENAME CONSTRAINT event_id_is_12_bytes TO log_id_is_12_bytes"
+    )
+
+    execute("ALTER TABLE api_request_logs RENAME COLUMN event_id TO log_id")
+
+    execute(
+      "ALTER TABLE api_request_logs RENAME CONSTRAINT event_id_is_12_bytes TO log_id_is_12_bytes"
+    )
+
+    execute("ALTER TABLE flow_logs RENAME COLUMN event_id TO log_id")
+
+    execute(
+      "ALTER TABLE flow_logs RENAME CONSTRAINT flow_logs_event_id_must_be_12_bytes " <>
+        "TO flow_logs_log_id_must_be_12_bytes"
+    )
+
+    execute("""
+    DO $$
+    DECLARE r record;
+    BEGIN
+      FOR r IN
+        SELECT schemaname, indexname FROM pg_indexes
+        WHERE indexname LIKE '%event\\_id%' ESCAPE '\\'
+          AND tablename LIKE 'flow\\_logs%' ESCAPE '\\'
+      LOOP
+        EXECUTE format(
+          'ALTER INDEX %I.%I RENAME TO %I',
+          r.schemaname, r.indexname, replace(r.indexname, 'event_id', 'log_id')
+        );
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  def down do
+    execute("""
+    DO $$
+    DECLARE r record;
+    BEGIN
+      FOR r IN
+        SELECT schemaname, indexname FROM pg_indexes
+        WHERE indexname LIKE '%log\\_id%' ESCAPE '\\'
+          AND tablename LIKE 'flow\\_logs%' ESCAPE '\\'
+      LOOP
+        EXECUTE format(
+          'ALTER INDEX %I.%I RENAME TO %I',
+          r.schemaname, r.indexname, replace(r.indexname, 'log_id', 'event_id')
+        );
+      END LOOP;
+    END $$;
+    """)
+
+    execute(
+      "ALTER TABLE flow_logs RENAME CONSTRAINT flow_logs_log_id_must_be_12_bytes " <>
+        "TO flow_logs_event_id_must_be_12_bytes"
+    )
+
+    execute("ALTER TABLE flow_logs RENAME COLUMN log_id TO event_id")
+
+    execute(
+      "ALTER TABLE api_request_logs RENAME CONSTRAINT log_id_is_12_bytes TO event_id_is_12_bytes"
+    )
+
+    execute("ALTER TABLE api_request_logs RENAME COLUMN log_id TO event_id")
+
+    execute(
+      "ALTER TABLE session_logs RENAME CONSTRAINT log_id_is_12_bytes TO event_id_is_12_bytes"
+    )
+
+    execute("ALTER TABLE session_logs RENAME COLUMN log_id TO event_id")
+
+    execute("ALTER TABLE change_logs RENAME CONSTRAINT log_id_is_12_bytes TO event_id_is_12_bytes")
+    execute("ALTER TABLE change_logs RENAME COLUMN log_id TO event_id")
+  end
+end

--- a/elixir/priv/repo/seeds.exs
+++ b/elixir/priv/repo/seeds.exs
@@ -35,7 +35,7 @@ defmodule Portal.Repo.Seeds do
     Userpass
   }
 
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   # User agent strings for seeded clients and gateways.
   # Update these when bumping the connlib version used in dev/test.
@@ -344,7 +344,7 @@ defmodule Portal.Repo.Seeds do
         lsn = :atomics.add_get(seq, 1, 1)
 
         %{
-          event_id: EventId.build_change_log(System.os_time(:microsecond), lsn),
+          log_id: LogId.build_change_log(System.os_time(:microsecond), lsn),
           account_id: account.id,
           timestamp: timestamp,
           lsn: lsn,
@@ -388,7 +388,7 @@ defmodule Portal.Repo.Seeds do
         timestamp = DateTime.add(now, -mins_ago * 60, :second)
 
         %{
-          event_id: EventId.build_session_log(),
+          log_id: LogId.build_session_log(),
           account_id: account.id,
           timestamp: timestamp,
           context: context,
@@ -455,7 +455,7 @@ defmodule Portal.Repo.Seeds do
         secs_ago = trunc(:math.pow(i + 1, 1.7) * 60)
 
         %{
-          event_id: EventId.build_api_request_log(),
+          log_id: LogId.build_api_request_log(),
           account_id: account.id,
           actor_id: api_actor.id,
           api_token_id: api_token_id,

--- a/elixir/test/portal/authentication_test.exs
+++ b/elixir/test/portal/authentication_test.exs
@@ -845,18 +845,18 @@ defmodule Portal.AuthenticationTest do
       account = account_fixture()
       actor = admin_actor_fixture(account: account)
       auth_provider = auth_provider_fixture(account: account)
-      event_id = Portal.Types.EventId.build_session_log()
+      log_id = Portal.Types.LogId.build_session_log()
 
       log_attrs = %{
         account_id: account.id,
-        event_id: event_id,
+        log_id: log_id,
         timestamp: DateTime.utc_now(),
         context: :portal,
         subject: %{}
       }
 
       # Pre-seed the log row so the transaction's log insert collides on the
-      # (account_id, event_id) primary key and fails.
+      # (account_id, log_id) primary key and fails.
       Portal.Repo.insert_all(Portal.SessionLog, [log_attrs])
 
       session = %Portal.PortalSession{
@@ -874,7 +874,7 @@ defmodule Portal.AuthenticationTest do
 
       # Fail closed: the session must not persist without its audit record.
       assert Portal.Repo.all(Portal.PortalSession) == []
-      assert [%Portal.SessionLog{event_id: ^event_id}] = Portal.Repo.all(Portal.SessionLog)
+      assert [%Portal.SessionLog{log_id: ^log_id}] = Portal.Repo.all(Portal.SessionLog)
     end
 
     test "creates a portal session for disabled account" do

--- a/elixir/test/portal/change_logs/consumer_test.exs
+++ b/elixir/test/portal/change_logs/consumer_test.exs
@@ -6,7 +6,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
   alias Portal.ChangeLogs.Consumer
   alias Portal.ChangeLogs.Consumer.Database
   alias Portal.ChangeLog
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   @commit_timestamp ~U[2026-05-26 12:00:00.123000Z]
   @seq_start 1_700_000_000_000_000
@@ -134,7 +134,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       assert attrs.subject == nil
       assert attrs.vsn == 0
       assert attrs.timestamp == @commit_timestamp
-      assert attrs.event_id == EventId.build_change_log(@seq_start, 0)
+      assert attrs.log_id == LogId.build_change_log(@seq_start, 0)
     end
 
     test "adds insert operation to flush buffer for non-account tables", %{
@@ -179,7 +179,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       existing_lsn = 100
 
       existing_item = %{
-        event_id: EventId.build_change_log(@seq_start, 99),
+        log_id: LogId.build_change_log(@seq_start, 99),
         timestamp: @commit_timestamp,
         lsn: existing_lsn,
         object: "other_table",
@@ -461,7 +461,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
     end
   end
 
-  describe "event_id allocation" do
+  describe "log_id allocation" do
     test "every row in a transaction shares the same commit_timestamp", %{
       account: account
     } do
@@ -502,9 +502,9 @@ defmodule Portal.ChangeLogs.ConsumerTest do
         |> Consumer.on_write(302, :insert, "resources", nil, data.())
 
       assert state.tenant_offsets[account.id] == 3
-      assert state.flush_buffer[300].event_id == EventId.build_change_log(@seq_start, 0)
-      assert state.flush_buffer[301].event_id == EventId.build_change_log(@seq_start, 1)
-      assert state.flush_buffer[302].event_id == EventId.build_change_log(@seq_start, 2)
+      assert state.flush_buffer[300].log_id == LogId.build_change_log(@seq_start, 0)
+      assert state.flush_buffer[301].log_id == LogId.build_change_log(@seq_start, 1)
+      assert state.flush_buffer[302].log_id == LogId.build_change_log(@seq_start, 2)
     end
 
     test "interleaved writes for three tenants each get their own dense offset progression",
@@ -543,7 +543,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       assert state.tenant_offsets[b.id] == 3
       assert state.tenant_offsets[c.id] == 3
 
-      # ...and the per-lsn event_ids encode the tenant's own offset progression,
+      # ...and the per-lsn log_ids encode the tenant's own offset progression,
       # not the global write order.
       expected = %{
         1000 => {a, 0},
@@ -559,8 +559,8 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       }
 
       for {lsn, {_account, offset}} <- expected do
-        assert state.flush_buffer[lsn].event_id ==
-                 EventId.build_change_log(@seq_start, offset)
+        assert state.flush_buffer[lsn].log_id ==
+                 LogId.build_change_log(@seq_start, offset)
       end
     end
 
@@ -586,8 +586,8 @@ defmodule Portal.ChangeLogs.ConsumerTest do
 
       assert pre_restart.seq_start == old_seq_start
 
-      assert pre_restart.flush_buffer[500].event_id ==
-               EventId.build_change_log(old_seq_start, 5)
+      assert pre_restart.flush_buffer[500].log_id ==
+               LogId.build_change_log(old_seq_start, 5)
 
       # Post-restart: fresh empty state. on_begin seeds a brand-new seq_start
       # from the Postgres clock, and per-tenant offsets start over at 0.
@@ -608,12 +608,12 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       assert post_restart.seq_start > old_seq_start
       assert post_restart.tenant_offsets[account.id] == 1
 
-      assert post_restart.flush_buffer[600].event_id ==
-               EventId.build_change_log(post_restart.seq_start, 0)
+      assert post_restart.flush_buffer[600].log_id ==
+               LogId.build_change_log(post_restart.seq_start, 0)
 
-      # Crucially, the new event_id sorts strictly after the old one.
-      assert pre_restart.flush_buffer[500].event_id <
-               post_restart.flush_buffer[600].event_id
+      # Crucially, the new log_id sorts strictly after the old one.
+      assert pre_restart.flush_buffer[500].log_id <
+               post_restart.flush_buffer[600].log_id
     end
 
     test "raises FunctionClauseError when a tenant_offset would reach 2^40", %{
@@ -641,7 +641,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
 
       assert state.tenant_offsets[account.id] == max_offset
 
-      # The write after that overflows the EventId.build_change_log guard.
+      # The write after that overflows the LogId.build_change_log guard.
       assert_raise FunctionClauseError, fn ->
         Consumer.on_write(
           state,
@@ -654,7 +654,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       end
     end
 
-    test "persists event_id and timestamp end-to-end through flush", %{
+    test "persists log_id and timestamp end-to-end through flush", %{
       account: account
     } do
       commit_timestamp = ~U[2026-05-26 12:00:00.999000Z]
@@ -679,7 +679,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
 
       change_log = Repo.one(from cl in ChangeLog, where: cl.lsn == 500)
       assert change_log.timestamp == commit_timestamp
-      assert change_log.event_id == EventId.build_change_log(@seq_start, 0)
+      assert change_log.log_id == LogId.build_change_log(@seq_start, 0)
     end
   end
 
@@ -694,7 +694,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       committed_at = ~U[2026-05-26 12:00:00.000000Z]
 
       attrs1 = %{
-        event_id: EventId.build_change_log(@seq_start, 0),
+        log_id: LogId.build_change_log(@seq_start, 0),
         timestamp: committed_at,
         lsn: 100,
         object: "resources",
@@ -707,7 +707,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       }
 
       attrs2 = %{
-        event_id: EventId.build_change_log(@seq_start, 1),
+        log_id: LogId.build_change_log(@seq_start, 1),
         timestamp: committed_at,
         lsn: 101,
         object: "resources",
@@ -748,7 +748,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
 
       attrs_map = %{
         400 => %{
-          event_id: EventId.build_change_log(@seq_start, 0),
+          log_id: LogId.build_change_log(@seq_start, 0),
           timestamp: committed_at,
           lsn: 400,
           object: "resources",
@@ -760,7 +760,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
           subject: nil
         },
         402 => %{
-          event_id: EventId.build_change_log(@seq_start, 1),
+          log_id: LogId.build_change_log(@seq_start, 1),
           timestamp: committed_at,
           lsn: 402,
           object: "resources",
@@ -772,7 +772,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
           subject: nil
         },
         401 => %{
-          event_id: EventId.build_change_log(@seq_start, 2),
+          log_id: LogId.build_change_log(@seq_start, 2),
           timestamp: committed_at,
           lsn: 401,
           object: "resources",
@@ -801,7 +801,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       missing_account_id = Ecto.UUID.generate()
 
       valid_entry = %{
-        event_id: EventId.build_change_log(@seq_start, 0),
+        log_id: LogId.build_change_log(@seq_start, 0),
         timestamp: committed_at,
         lsn: 500,
         object: "resources",
@@ -814,7 +814,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       }
 
       dead_entry = %{
-        event_id: EventId.build_change_log(@seq_start, 1),
+        log_id: LogId.build_change_log(@seq_start, 1),
         timestamp: committed_at,
         lsn: 501,
         object: "resources",
@@ -848,7 +848,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       # must surface as a crash rather than being silently dropped like the
       # missing-account case.
       entry = %{
-        event_id: EventId.build_change_log(@seq_start, 0),
+        log_id: LogId.build_change_log(@seq_start, 0),
         timestamp: committed_at,
         lsn: 600,
         object: "resources",
@@ -862,7 +862,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       assert_raise Postgrex.Error, fn -> Database.bulk_insert([entry]) end
     end
 
-    test "drops the batch seed so the next batch reseeds event_id ordering", %{account: account} do
+    test "drops the batch seed so the next batch reseeds log_id ordering", %{account: account} do
       state =
         %{flush_buffer: %{}, seq_start: @seq_start, tenant_offsets: %{account.id => 5}}
         |> Consumer.flush()
@@ -871,7 +871,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       refute Map.has_key?(state, :tenant_offsets)
 
       # The next batch's first Begin reseeds from the shared Postgres clock,
-      # so its event_ids sort after every previous batch's regardless of
+      # so its log_ids sort after every previous batch's regardless of
       # which node produced them
       state = Consumer.on_begin(state, %{commit_timestamp: @commit_timestamp})
       assert state.seq_start > @seq_start
@@ -882,7 +882,7 @@ defmodule Portal.ChangeLogs.ConsumerTest do
       committed_at = ~U[2026-05-26 12:00:00.000000Z]
 
       entry = %{
-        event_id: EventId.build_change_log(@seq_start, 0),
+        log_id: LogId.build_change_log(@seq_start, 0),
         timestamp: committed_at,
         lsn: 700,
         object: "resources",

--- a/elixir/test/portal/flow_log_test.exs
+++ b/elixir/test/portal/flow_log_test.exs
@@ -8,7 +8,7 @@ defmodule Portal.FlowLogTest do
     Map.merge(
       %{
         account_id: Ecto.UUID.generate(),
-        event_id: Portal.Types.EventId.build_flow_log(),
+        log_id: Portal.Types.LogId.build_flow_log(),
         device_id: Ecto.UUID.generate(),
         role: :initiator,
         policy_authorization_id: Ecto.UUID.generate(),

--- a/elixir/test/portal/types/log_id_test.exs
+++ b/elixir/test/portal/types/log_id_test.exs
@@ -1,11 +1,11 @@
-defmodule Portal.Types.EventIdTest do
+defmodule Portal.Types.LogIdTest do
   use ExUnit.Case, async: true
 
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   describe "build_change_log/2" do
     test "produces a 24-character lowercase hex string" do
-      hex = EventId.build_change_log(1_700_000_000_000_000, 0)
+      hex = LogId.build_change_log(1_700_000_000_000_000, 0)
       assert byte_size(hex) == 24
       assert hex == String.downcase(hex)
       assert hex =~ ~r/^[0-9a-f]{24}$/
@@ -14,16 +14,16 @@ defmodule Portal.Types.EventIdTest do
     test "encodes layout as [4 bits 0xC][52 bits seq_start][40 bits tenant_offset]" do
       seq_start = 1_700_000_000_000_000
       offset = 42
-      hex = EventId.build_change_log(seq_start, offset)
+      hex = LogId.build_change_log(seq_start, offset)
       bin = Base.decode16!(hex, case: :mixed)
       assert <<0xC::4, ^seq_start::52, ^offset::40>> = bin
     end
 
     test "lex order matches integer order of (log_type, seq_start, offset)" do
-      a = EventId.build_change_log(1_000, 0)
-      b = EventId.build_change_log(1_000, 1)
-      c = EventId.build_change_log(1_001, 0)
-      d = EventId.build_change_log(2_000, 0)
+      a = LogId.build_change_log(1_000, 0)
+      b = LogId.build_change_log(1_000, 1)
+      c = LogId.build_change_log(1_001, 0)
+      d = LogId.build_change_log(2_000, 0)
 
       assert a < b
       assert b < c
@@ -33,205 +33,205 @@ defmodule Portal.Types.EventIdTest do
     test "accepts the 52-bit max seq_start and 40-bit max tenant_offset" do
       max_seq = 2 ** 52 - 1
       max_off = 2 ** 40 - 1
-      hex = EventId.build_change_log(max_seq, max_off)
+      hex = LogId.build_change_log(max_seq, max_off)
       bin = Base.decode16!(hex, case: :mixed)
       assert <<0xC::4, ^max_seq::52, ^max_off::40>> = bin
     end
 
     test "raises FunctionClauseError when tenant_offset is 2^40" do
       assert_raise FunctionClauseError, fn ->
-        EventId.build_change_log(0, 2 ** 40)
+        LogId.build_change_log(0, 2 ** 40)
       end
     end
 
     test "raises FunctionClauseError when seq_start is 2^52" do
       assert_raise FunctionClauseError, fn ->
-        EventId.build_change_log(2 ** 52, 0)
+        LogId.build_change_log(2 ** 52, 0)
       end
     end
 
     test "raises FunctionClauseError on negative seq_start" do
       assert_raise FunctionClauseError, fn ->
-        EventId.build_change_log(-1, 0)
+        LogId.build_change_log(-1, 0)
       end
     end
 
     test "raises FunctionClauseError on negative tenant_offset" do
       assert_raise FunctionClauseError, fn ->
-        EventId.build_change_log(0, -1)
+        LogId.build_change_log(0, -1)
       end
     end
   end
 
   describe "build_session_log/0" do
     test "produces a 24-character lowercase hex string" do
-      hex = EventId.build_session_log()
+      hex = LogId.build_session_log()
       assert byte_size(hex) == 24
       assert hex == String.downcase(hex)
       assert hex =~ ~r/^[0-9a-f]{24}$/
     end
 
     test "encodes the 0x5 log_type in the high nibble" do
-      hex = EventId.build_session_log()
+      hex = LogId.build_session_log()
       assert <<0x5::4, _random::92>> = Base.decode16!(hex, case: :mixed)
       assert String.starts_with?(hex, "5")
     end
 
     test "successive calls produce distinct values" do
-      ids = for _ <- 1..100, do: EventId.build_session_log()
+      ids = for _ <- 1..100, do: LogId.build_session_log()
       assert length(Enum.uniq(ids)) == 100
     end
   end
 
   describe "build_api_request_log/0" do
     test "produces a 24-character lowercase hex string" do
-      hex = EventId.build_api_request_log()
+      hex = LogId.build_api_request_log()
       assert byte_size(hex) == 24
       assert hex == String.downcase(hex)
       assert hex =~ ~r/^[0-9a-f]{24}$/
     end
 
     test "encodes the 0xA log_type in the high nibble" do
-      hex = EventId.build_api_request_log()
+      hex = LogId.build_api_request_log()
       assert <<0xA::4, _random::92>> = Base.decode16!(hex, case: :mixed)
       assert String.starts_with?(hex, "a")
     end
 
     test "successive calls produce distinct values" do
-      ids = for _ <- 1..100, do: EventId.build_api_request_log()
+      ids = for _ <- 1..100, do: LogId.build_api_request_log()
       assert length(Enum.uniq(ids)) == 100
     end
 
     test "round-trips through cast, dump, and load" do
-      original = EventId.build_api_request_log()
-      {:ok, cast} = EventId.cast(original)
-      {:ok, dumped} = EventId.dump(cast)
-      {:ok, loaded} = EventId.load(dumped)
+      original = LogId.build_api_request_log()
+      {:ok, cast} = LogId.cast(original)
+      {:ok, dumped} = LogId.dump(cast)
+      {:ok, loaded} = LogId.load(dumped)
       assert loaded == original
     end
   end
 
   describe "cast/1" do
     test "normalizes 24-char hex to lowercase" do
-      assert {:ok, "abc" <> _} = EventId.cast("ABC" <> String.duplicate("0", 21))
+      assert {:ok, "abc" <> _} = LogId.cast("ABC" <> String.duplicate("0", 21))
     end
 
     test "accepts a 12-byte binary and encodes as lowercase hex" do
       bin = <<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
-      assert {:ok, "c00000000000000000000000"} = EventId.cast(bin)
+      assert {:ok, "c00000000000000000000000"} = LogId.cast(bin)
     end
 
     test "rejects integers" do
-      assert :error = EventId.cast(123)
+      assert :error = LogId.cast(123)
     end
 
     test "rejects nil" do
-      assert :error = EventId.cast(nil)
+      assert :error = LogId.cast(nil)
     end
 
     test "rejects binaries of any other length" do
-      assert :error = EventId.cast("")
-      assert :error = EventId.cast("short")
-      assert :error = EventId.cast(String.duplicate("a", 23))
-      assert :error = EventId.cast(String.duplicate("a", 25))
+      assert :error = LogId.cast("")
+      assert :error = LogId.cast("short")
+      assert :error = LogId.cast(String.duplicate("a", 23))
+      assert :error = LogId.cast(String.duplicate("a", 25))
     end
 
     test "rejects atoms and maps" do
-      assert :error = EventId.cast(:foo)
-      assert :error = EventId.cast(%{})
+      assert :error = LogId.cast(:foo)
+      assert :error = LogId.cast(%{})
     end
   end
 
   describe "dump/1" do
     test "converts 24-char hex to a 12-byte binary" do
-      hex = EventId.build_change_log(1_234, 5)
-      assert {:ok, bin} = EventId.dump(hex)
+      hex = LogId.build_change_log(1_234, 5)
+      assert {:ok, bin} = LogId.dump(hex)
       assert byte_size(bin) == 12
     end
 
     test "rejects binaries that are not 24 chars" do
-      assert :error = EventId.dump("short")
-      assert :error = EventId.dump(String.duplicate("a", 23))
-      assert :error = EventId.dump(String.duplicate("a", 25))
+      assert :error = LogId.dump("short")
+      assert :error = LogId.dump(String.duplicate("a", 23))
+      assert :error = LogId.dump(String.duplicate("a", 25))
     end
 
     test "rejects 24-char binaries that are not valid hex" do
-      assert :error = EventId.dump(String.duplicate("z", 24))
+      assert :error = LogId.dump(String.duplicate("z", 24))
     end
 
     test "rejects nil and non-binary inputs" do
-      assert :error = EventId.dump(nil)
-      assert :error = EventId.dump(123)
-      assert :error = EventId.dump(%{})
+      assert :error = LogId.dump(nil)
+      assert :error = LogId.dump(123)
+      assert :error = LogId.dump(%{})
     end
   end
 
   describe "load/1" do
     test "converts 12-byte binary to 24-char lowercase hex" do
       bin = <<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7>>
-      assert {:ok, "c00000000000000000000007"} = EventId.load(bin)
+      assert {:ok, "c00000000000000000000007"} = LogId.load(bin)
     end
 
     test "rejects binaries that are not 12 bytes" do
-      assert :error = EventId.load(<<>>)
-      assert :error = EventId.load(<<0>>)
-      assert :error = EventId.load(:binary.copy(<<0>>, 11))
-      assert :error = EventId.load(:binary.copy(<<0>>, 13))
+      assert :error = LogId.load(<<>>)
+      assert :error = LogId.load(<<0>>)
+      assert :error = LogId.load(:binary.copy(<<0>>, 11))
+      assert :error = LogId.load(:binary.copy(<<0>>, 13))
     end
 
     test "rejects nil and non-binary inputs" do
-      assert :error = EventId.load(nil)
-      assert :error = EventId.load(123)
-      assert :error = EventId.load(%{})
+      assert :error = LogId.load(nil)
+      assert :error = LogId.load(123)
+      assert :error = LogId.load(%{})
     end
   end
 
   describe "parse/1" do
     test "normalizes a valid 24-char hex string to lowercase" do
       assert {:ok, "c00060db0c2c8eb400000000"} =
-               EventId.parse("C00060DB0C2C8EB400000000")
+               LogId.parse("C00060DB0C2C8EB400000000")
     end
 
     test "rejects a 24-char string that is not valid hex" do
-      assert :error = EventId.parse(String.duplicate("z", 24))
+      assert :error = LogId.parse(String.duplicate("z", 24))
     end
 
     test "rejects the 12-byte on-disk binary form" do
       bin = <<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
-      assert :error = EventId.parse(bin)
+      assert :error = LogId.parse(bin)
     end
 
     test "rejects binaries of any other length" do
-      assert :error = EventId.parse("")
-      assert :error = EventId.parse(String.duplicate("a", 23))
-      assert :error = EventId.parse(String.duplicate("a", 25))
+      assert :error = LogId.parse("")
+      assert :error = LogId.parse(String.duplicate("a", 23))
+      assert :error = LogId.parse(String.duplicate("a", 25))
     end
 
     test "rejects nil and non-binary inputs" do
-      assert :error = EventId.parse(nil)
-      assert :error = EventId.parse(123)
-      assert :error = EventId.parse(%{})
+      assert :error = LogId.parse(nil)
+      assert :error = LogId.parse(123)
+      assert :error = LogId.parse(%{})
     end
   end
 
   describe "valid?/1" do
     test "returns true for a valid 24-char hex string" do
-      assert EventId.valid?(EventId.build_change_log(1_234, 5))
-      assert EventId.valid?("C00060DB0C2C8EB400000000")
+      assert LogId.valid?(LogId.build_change_log(1_234, 5))
+      assert LogId.valid?("C00060DB0C2C8EB400000000")
     end
 
     test "returns false for non-hex, wrong-length, and non-binary inputs" do
-      refute EventId.valid?(String.duplicate("z", 24))
-      refute EventId.valid?(String.duplicate("a", 23))
-      refute EventId.valid?(<<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
-      refute EventId.valid?(nil)
-      refute EventId.valid?(123)
+      refute LogId.valid?(String.duplicate("z", 24))
+      refute LogId.valid?(String.duplicate("a", 23))
+      refute LogId.valid?(<<0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
+      refute LogId.valid?(nil)
+      refute LogId.valid?(123)
     end
   end
 
   describe "build_flow_log/0" do
     test "produces a 24-character lowercase hex string in the 0xF namespace" do
-      hex = EventId.build_flow_log()
+      hex = LogId.build_flow_log()
       assert byte_size(hex) == 24
       assert hex == String.downcase(hex)
       assert hex =~ ~r/^f[0-9a-f]{23}$/
@@ -239,21 +239,21 @@ defmodule Portal.Types.EventIdTest do
     end
 
     test "is random: successive calls differ" do
-      refute EventId.build_flow_log() == EventId.build_flow_log()
+      refute LogId.build_flow_log() == LogId.build_flow_log()
     end
 
     test "decodes to a 12-byte value" do
-      {:ok, bin} = EventId.dump(EventId.build_flow_log())
+      {:ok, bin} = LogId.dump(LogId.build_flow_log())
       assert byte_size(bin) == 12
     end
   end
 
   describe "round-trip" do
     test "cast → dump → load is lossless" do
-      original = EventId.build_change_log(987_654_321, 17)
-      {:ok, cast} = EventId.cast(original)
-      {:ok, dumped} = EventId.dump(cast)
-      {:ok, loaded} = EventId.load(dumped)
+      original = LogId.build_change_log(987_654_321, 17)
+      {:ok, cast} = LogId.cast(original)
+      {:ok, dumped} = LogId.dump(cast)
+      {:ok, loaded} = LogId.load(dumped)
       assert loaded == original
     end
   end

--- a/elixir/test/portal/workers/delete_old_api_request_logs_test.exs
+++ b/elixir/test/portal/workers/delete_old_api_request_logs_test.exs
@@ -15,7 +15,7 @@ defmodule Portal.Workers.DeleteOldAPIRequestLogsTest do
 
       assert :ok = perform_job(DeleteOldAPIRequestLogs, %{})
 
-      refute Repo.one(from arl in APIRequestLog, where: arl.event_id == ^old.event_id)
+      refute Repo.one(from arl in APIRequestLog, where: arl.log_id == ^old.log_id)
     end
 
     test "does not delete api_request_logs newer than 90 days" do
@@ -24,7 +24,7 @@ defmodule Portal.Workers.DeleteOldAPIRequestLogsTest do
 
       assert :ok = perform_job(DeleteOldAPIRequestLogs, %{})
 
-      assert Repo.one(from arl in APIRequestLog, where: arl.event_id == ^recent.event_id)
+      assert Repo.one(from arl in APIRequestLog, where: arl.log_id == ^recent.log_id)
     end
 
     test "deletes old api_request_logs across accounts" do
@@ -38,9 +38,9 @@ defmodule Portal.Workers.DeleteOldAPIRequestLogsTest do
 
       assert :ok = perform_job(DeleteOldAPIRequestLogs, %{})
 
-      refute Repo.one(from arl in APIRequestLog, where: arl.event_id == ^old1.event_id)
-      refute Repo.one(from arl in APIRequestLog, where: arl.event_id == ^old2.event_id)
-      assert Repo.one(from arl in APIRequestLog, where: arl.event_id == ^recent.event_id)
+      refute Repo.one(from arl in APIRequestLog, where: arl.log_id == ^old1.log_id)
+      refute Repo.one(from arl in APIRequestLog, where: arl.log_id == ^old2.log_id)
+      assert Repo.one(from arl in APIRequestLog, where: arl.log_id == ^recent.log_id)
     end
   end
 end

--- a/elixir/test/portal/workers/delete_old_session_logs_test.exs
+++ b/elixir/test/portal/workers/delete_old_session_logs_test.exs
@@ -15,7 +15,7 @@ defmodule Portal.Workers.DeleteOldSessionLogsTest do
 
       assert :ok = perform_job(DeleteOldSessionLogs, %{})
 
-      refute Repo.one(from sl in SessionLog, where: sl.event_id == ^old.event_id)
+      refute Repo.one(from sl in SessionLog, where: sl.log_id == ^old.log_id)
     end
 
     test "does not delete session_logs newer than 90 days" do
@@ -23,7 +23,7 @@ defmodule Portal.Workers.DeleteOldSessionLogsTest do
 
       assert :ok = perform_job(DeleteOldSessionLogs, %{})
 
-      assert Repo.one(from sl in SessionLog, where: sl.event_id == ^recent.event_id)
+      assert Repo.one(from sl in SessionLog, where: sl.log_id == ^recent.log_id)
     end
 
     test "deletes old session_logs across accounts" do
@@ -37,9 +37,9 @@ defmodule Portal.Workers.DeleteOldSessionLogsTest do
 
       assert :ok = perform_job(DeleteOldSessionLogs, %{})
 
-      refute Repo.one(from sl in SessionLog, where: sl.event_id == ^old1.event_id)
-      refute Repo.one(from sl in SessionLog, where: sl.event_id == ^old2.event_id)
-      assert Repo.one(from sl in SessionLog, where: sl.event_id == ^recent.event_id)
+      refute Repo.one(from sl in SessionLog, where: sl.log_id == ^old1.log_id)
+      refute Repo.one(from sl in SessionLog, where: sl.log_id == ^old2.log_id)
+      assert Repo.one(from sl in SessionLog, where: sl.log_id == ^recent.log_id)
     end
   end
 end

--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -664,7 +664,7 @@ defmodule PortalAPI.LogControllerTest do
       assert log_id == change_log.log_id
     end
 
-    test "returns 404 for an log_id with an unknown log type nibble", %{
+    test "returns 404 for a log_id with an unknown log type nibble", %{
       conn: conn,
       actor: actor
     } do

--- a/elixir/test/portal_api/controllers/log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/log_controller_test.exs
@@ -60,8 +60,8 @@ defmodule PortalAPI.LogControllerTest do
       assert length(data) == 3
       assert Enum.all?(data, &(&1["type"] == "change"))
 
-      expected = logs |> Enum.map(& &1.event_id) |> Enum.sort(:desc)
-      assert Enum.map(data, & &1["event_id"]) == expected
+      expected = logs |> Enum.map(& &1.log_id) |> Enum.sort(:desc)
+      assert Enum.map(data, & &1["log_id"]) == expected
     end
 
     test "renders change log fields", %{conn: conn, account: account, actor: actor} do
@@ -81,7 +81,7 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=change")
 
       assert %{"data" => [data]} = json_response(conn, 200)
-      assert data["event_id"] == change_log.event_id
+      assert data["log_id"] == change_log.log_id
       assert data["object"] == "actors"
       assert data["operation"] == "update"
       assert data["before"] == %{"name" => "Jane Doe"}
@@ -123,16 +123,16 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=change&actor_id=#{actor_id}")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn1, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn1, 200)
+      assert log_id == matching.log_id
 
       conn2 =
         build_conn()
         |> authorize_conn(actor)
         |> get(~p"/logs?type=change&actor_email=admin@example.com")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn2, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn2, 200)
+      assert log_id == matching.log_id
     end
 
     test "bounds the window with begin and end", %{conn: conn, account: account, actor: actor} do
@@ -144,8 +144,8 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=change&begin=2025-12-01T00:00:00Z&end=2026-02-01T00:00:00Z")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
-      assert event_id == old.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn, 200)
+      assert log_id == old.log_id
     end
 
     test "paginates with limit and page_cursor", %{conn: conn, account: account, actor: actor} do
@@ -170,8 +170,8 @@ defmodule PortalAPI.LogControllerTest do
       assert %{"data" => page2} = json_response(conn2, 200)
       assert length(page2) == 1
       assert MapSet.disjoint?(
-               MapSet.new(page1, & &1["event_id"]),
-               MapSet.new(page2, & &1["event_id"])
+               MapSet.new(page1, & &1["log_id"]),
+               MapSet.new(page2, & &1["log_id"])
              )
     end
 
@@ -198,8 +198,8 @@ defmodule PortalAPI.LogControllerTest do
 
       assert %{"data" => data} = json_response(conn, 200)
 
-      assert Enum.map(data, & &1["event_id"]) ==
-               [newest.event_id, middle.event_id, oldest.event_id]
+      assert Enum.map(data, & &1["log_id"]) ==
+               [newest.log_id, middle.log_id, oldest.log_id]
 
       assert Enum.all?(data, &(&1["type"] == "session"))
     end
@@ -218,7 +218,7 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=session")
 
       assert %{"data" => [data]} = json_response(conn, 200)
-      assert data["event_id"] == session_log.event_id
+      assert data["log_id"] == session_log.log_id
       assert data["context"] == "portal"
 
       assert data["subject"] == session_log.subject
@@ -243,8 +243,8 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=session&actor_id=#{actor_id}")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn, 200)
+      assert log_id == matching.log_id
     end
 
     test "filters by actor_email recorded on the session", %{
@@ -266,8 +266,8 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=session&actor_email=target@example.com")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn, 200)
+      assert log_id == matching.log_id
     end
 
     test "does not return another account's session logs", %{conn: conn, actor: actor} do
@@ -308,7 +308,7 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=flow")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert Enum.map(data, & &1["event_id"]) == [newer.event_id, older.event_id]
+      assert Enum.map(data, & &1["log_id"]) == [newer.log_id, older.log_id]
       assert Enum.all?(data, &(&1["type"] == "flow"))
     end
 
@@ -355,7 +355,7 @@ defmodule PortalAPI.LogControllerTest do
 
       assert %{"data" => data} = json_response(conn, 200)
 
-      assert Enum.map(data, & &1["event_id"]) == [late_report.event_id, long_lived.event_id]
+      assert Enum.map(data, & &1["log_id"]) == [late_report.log_id, long_lived.log_id]
     end
 
     test "renders flow log fields", %{conn: conn, account: account, actor: actor} do
@@ -367,7 +367,7 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=flow")
 
       assert %{"data" => [data]} = json_response(conn, 200)
-      assert data["event_id"] == flow_log.event_id
+      assert data["log_id"] == flow_log.log_id
       assert data["device_id"] == flow_log.device_id
       assert data["role"] == "responder"
       assert data["protocol"] == "tcp"
@@ -398,8 +398,8 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=flow&actor_id=#{actor_id}")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn, 200)
+      assert log_id == matching.log_id
     end
 
     test "filters by actor_email via the email recorded on the flow", %{
@@ -415,8 +415,8 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=flow&actor_email=target@example.com")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn, 200)
+      assert log_id == matching.log_id
     end
   end
 
@@ -441,9 +441,9 @@ defmodule PortalAPI.LogControllerTest do
       assert length(data) == 3
       assert Enum.all?(data, &(&1["type"] == "api_request"))
 
-      event_ids = MapSet.new(data, & &1["event_id"])
-      assert MapSet.member?(event_ids, log1.event_id)
-      assert MapSet.member?(event_ids, log2.event_id)
+      log_ids = MapSet.new(data, & &1["log_id"])
+      assert MapSet.member?(log_ids, log1.log_id)
+      assert MapSet.member?(log_ids, log2.log_id)
     end
 
     test "filters by actor_id", %{conn: conn, account: account, actor: actor} do
@@ -456,8 +456,8 @@ defmodule PortalAPI.LogControllerTest do
         |> authorize_conn(actor)
         |> get(~p"/logs?type=api_request&actor_id=#{actor_id}")
 
-      assert %{"data" => [%{"event_id" => event_id}]} = json_response(conn, 200)
-      assert event_id == matching.event_id
+      assert %{"data" => [%{"log_id" => log_id}]} = json_response(conn, 200)
+      assert log_id == matching.log_id
     end
 
     test "returns 400 when actor_email is combined with type=api_request", %{
@@ -489,7 +489,7 @@ defmodule PortalAPI.LogControllerTest do
         |> get(~p"/logs?type=api_request&actor_id=#{log.actor_id}")
 
       assert %{"data" => [data]} = json_response(conn, 200)
-      assert data["event_id"] == log.event_id
+      assert data["log_id"] == log.log_id
       assert data["actor_id"] == log.actor_id
       assert data["api_token_id"] == log.api_token_id
       assert data["method"] == "POST"
@@ -579,92 +579,92 @@ defmodule PortalAPI.LogControllerTest do
       assert json_response(conn, 401)
     end
 
-    test "fetches a change log by its c-prefixed event_id", %{
+    test "fetches a change log by its c-prefixed log_id", %{
       conn: conn,
       account: account,
       actor: actor
     } do
       change_log = change_log_fixture(account: account)
-      assert String.starts_with?(change_log.event_id, "c")
+      assert String.starts_with?(change_log.log_id, "c")
 
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs/#{change_log.event_id}")
+        |> get(~p"/logs/#{change_log.log_id}")
 
       assert %{"data" => data} = json_response(conn, 200)
       assert data["type"] == "change"
-      assert data["event_id"] == change_log.event_id
+      assert data["log_id"] == change_log.log_id
     end
 
-    test "fetches a session log by its 5-prefixed event_id", %{
+    test "fetches a session log by its 5-prefixed log_id", %{
       conn: conn,
       account: account,
       actor: actor
     } do
       session_log = session_log_fixture(account: account)
-      assert String.starts_with?(session_log.event_id, "5")
+      assert String.starts_with?(session_log.log_id, "5")
 
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs/#{session_log.event_id}")
+        |> get(~p"/logs/#{session_log.log_id}")
 
       assert %{"data" => data} = json_response(conn, 200)
       assert data["type"] == "session"
-      assert data["event_id"] == session_log.event_id
+      assert data["log_id"] == session_log.log_id
       assert data["context"] == "client"
     end
 
-    test "fetches a flow log by its f-prefixed event_id", %{
+    test "fetches a flow log by its f-prefixed log_id", %{
       conn: conn,
       account: account,
       actor: actor
     } do
       flow_log = flow_log_fixture(account: account)
-      assert String.starts_with?(flow_log.event_id, "f")
+      assert String.starts_with?(flow_log.log_id, "f")
 
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs/#{flow_log.event_id}")
+        |> get(~p"/logs/#{flow_log.log_id}")
 
       assert %{"data" => data} = json_response(conn, 200)
       assert data["type"] == "flow"
-      assert data["event_id"] == flow_log.event_id
+      assert data["log_id"] == flow_log.log_id
     end
 
-    test "fetches an api request log by its a-prefixed event_id", %{
+    test "fetches an api request log by its a-prefixed log_id", %{
       conn: conn,
       account: account,
       actor: actor
     } do
       log = api_request_log_fixture(account: account)
-      assert String.starts_with?(log.event_id, "a")
+      assert String.starts_with?(log.log_id, "a")
 
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs/#{log.event_id}")
+        |> get(~p"/logs/#{log.log_id}")
 
       assert %{"data" => data} = json_response(conn, 200)
       assert data["type"] == "api_request"
-      assert data["event_id"] == log.event_id
+      assert data["log_id"] == log.log_id
     end
 
-    test "normalizes uppercase event_ids", %{conn: conn, account: account, actor: actor} do
+    test "normalizes uppercase log_ids", %{conn: conn, account: account, actor: actor} do
       change_log = change_log_fixture(account: account)
 
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs/#{String.upcase(change_log.event_id)}")
+        |> get(~p"/logs/#{String.upcase(change_log.log_id)}")
 
-      assert %{"data" => %{"event_id" => event_id}} = json_response(conn, 200)
-      assert event_id == change_log.event_id
+      assert %{"data" => %{"log_id" => log_id}} = json_response(conn, 200)
+      assert log_id == change_log.log_id
     end
 
-    test "returns 404 for an event_id with an unknown log type nibble", %{
+    test "returns 404 for an log_id with an unknown log type nibble", %{
       conn: conn,
       actor: actor
     } do
@@ -676,7 +676,7 @@ defmodule PortalAPI.LogControllerTest do
       assert json_response(conn, 404)
     end
 
-    test "returns 404 for a valid event_id that does not exist", %{conn: conn, actor: actor} do
+    test "returns 404 for a valid log_id that does not exist", %{conn: conn, actor: actor} do
       conn =
         conn
         |> authorize_conn(actor)
@@ -691,12 +691,12 @@ defmodule PortalAPI.LogControllerTest do
       conn =
         conn
         |> authorize_conn(actor)
-        |> get(~p"/logs/#{other.event_id}")
+        |> get(~p"/logs/#{other.log_id}")
 
       assert json_response(conn, 404)
     end
 
-    test "returns 400 for a malformed event_id", %{conn: conn, actor: actor} do
+    test "returns 400 for a malformed log_id", %{conn: conn, actor: actor} do
       # ValidateUUIDParams rejects malformed identifiers before the controller.
       conn =
         conn
@@ -707,15 +707,15 @@ defmodule PortalAPI.LogControllerTest do
       assert detail =~ "not valid identifiers"
     end
 
-    test "returns 400 for a UUID-shaped event_id", %{conn: conn, actor: actor} do
-      # A UUID passes ValidateUUIDParams but is not a valid event_id.
+    test "returns 400 for a UUID-shaped log_id", %{conn: conn, actor: actor} do
+      # A UUID passes ValidateUUIDParams but is not a valid log_id.
       conn =
         conn
         |> authorize_conn(actor)
         |> get(~p"/logs/#{Ecto.UUID.generate()}")
 
       assert %{"detail" => detail} = json_response(conn, 400)
-      assert detail =~ "`event_id` must be a 24-char hex string"
+      assert detail =~ "`log_id` must be a 24-char hex string"
     end
   end
 

--- a/elixir/test/portal_api/plugs/request_log_test.exs
+++ b/elixir/test/portal_api/plugs/request_log_test.exs
@@ -39,7 +39,7 @@ defmodule PortalAPI.Plugs.RequestLogTest do
       api_token = Repo.one(from t in Portal.APIToken, where: t.actor_id == ^actor.id)
       assert log.api_token_id == api_token.id
 
-      assert String.starts_with?(log.event_id, "a")
+      assert String.starts_with?(log.log_id, "a")
       assert log.method == "GET"
       assert log.path == "/account"
       assert log.content_length == nil

--- a/elixir/test/portal_api/plugs/validate_uuid_params_test.exs
+++ b/elixir/test/portal_api/plugs/validate_uuid_params_test.exs
@@ -7,7 +7,7 @@ defmodule PortalAPI.Plugs.ValidateUUIDParamsTest do
   alias PortalAPI.Plugs.ValidateUUIDParams
 
   @valid_uuid "00000000-0000-0000-0000-000000000000"
-  @valid_event_id "c00060db0c2c8eb400000000"
+  @valid_log_id "c00060db0c2c8eb400000000"
   @opts ValidateUUIDParams.init([])
 
   defp build_conn(path_params) do
@@ -36,8 +36,8 @@ defmodule PortalAPI.Plugs.ValidateUUIDParamsTest do
       refute result.halted
     end
 
-    test "passes through when id param is a valid 24-char hex event_id" do
-      conn = build_conn(%{"id" => @valid_event_id})
+    test "passes through when id param is a valid 24-char hex log_id" do
+      conn = build_conn(%{"id" => @valid_log_id})
       result = ValidateUUIDParams.call(conn, @opts)
       refute result.halted
     end

--- a/elixir/test/portal_web/live/logs/change_logs_test.exs
+++ b/elixir/test/portal_web/live/logs/change_logs_test.exs
@@ -75,9 +75,9 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/logs/change_logs")
 
-      assert html =~ mine.event_id
+      assert html =~ mine.log_id
       assert html =~ "actors"
-      refute html =~ other.event_id
+      refute html =~ other.log_id
     end
 
     test "shows `system` badge when subject is nil", %{
@@ -155,7 +155,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, _lv, index_html} =
         live(conn, ~p"/#{account}/logs/change_logs?change_logs_filter[show_system]=true")
 
-      assert index_html =~ cl.event_id
+      assert index_html =~ cl.log_id
       assert index_html =~ "system"
 
       # Side panel: subject_section with subject={"ip"=>...} renders the IP row
@@ -163,7 +163,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, _lv, show_html} =
         live(
           conn,
-          ~p"/#{account}/logs/change_logs/#{cl.event_id}?change_logs_filter[show_system]=true"
+          ~p"/#{account}/logs/change_logs/#{cl.log_id}?change_logs_filter[show_system]=true"
         )
 
       assert show_html =~ "203.0.113.7"
@@ -184,7 +184,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         conn
         |> authorize_conn(actor)
         |> live(
-          ~p"/#{account}/logs/change_logs/#{cl.event_id}?change_logs_filter[show_system]=true"
+          ~p"/#{account}/logs/change_logs/#{cl.log_id}?change_logs_filter[show_system]=true"
         )
 
       assert html =~ "Deleted actor"
@@ -234,10 +234,10 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         {:ok, _lv, html} =
           live(conn, ~p"/#{account}/logs/change_logs?change_logs_filter[operation]=#{value}")
 
-        assert html =~ want.event_id, "operation=#{value} should show #{want.event_id}"
+        assert html =~ want.log_id, "operation=#{value} should show #{want.log_id}"
 
         for d <- deny do
-          refute html =~ d.event_id, "operation=#{value} should hide #{d.event_id}"
+          refute html =~ d.log_id, "operation=#{value} should hide #{d.log_id}"
         end
       end
     end
@@ -283,9 +283,9 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           ~p"/#{account}/logs/change_logs?change_logs_filter[operation]=update&change_logs_filter[object][]=actors"
         )
 
-      assert html =~ hit.event_id
-      refute html =~ wrong_op.event_id
-      refute html =~ wrong_obj.event_id
+      assert html =~ hit.log_id
+      refute html =~ wrong_op.log_id
+      refute html =~ wrong_obj.log_id
     end
 
     test "filters by object via the object multi-select", %{
@@ -305,9 +305,9 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           ~p"/#{account}/logs/change_logs?change_logs_filter[object][]=actors&change_logs_filter[object][]=policies"
         )
 
-      assert html =~ actor_cl.event_id
-      assert html =~ policy_cl.event_id
-      refute html =~ site_cl.event_id
+      assert html =~ actor_cl.log_id
+      assert html =~ policy_cl.log_id
+      refute html =~ site_cl.log_id
     end
 
     test "reset button clears all filters", %{
@@ -324,16 +324,16 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/logs/change_logs?change_logs_filter[object][]=actors")
 
-      assert render(lv) =~ cl_a.event_id
-      refute render(lv) =~ cl_b.event_id
+      assert render(lv) =~ cl_a.log_id
+      refute render(lv) =~ cl_b.log_id
 
       lv
       |> element("button[phx-click='filter'][title='Clear all filters']")
       |> render_click()
 
       html = render(lv)
-      assert html =~ cl_a.event_id
-      assert html =~ cl_b.event_id
+      assert html =~ cl_a.log_id
+      assert html =~ cl_b.log_id
     end
 
     test "hides system updates by default", %{
@@ -350,8 +350,8 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/logs/change_logs")
 
-      assert html =~ actor_cl.event_id
-      refute html =~ system_cl.event_id
+      assert html =~ actor_cl.log_id
+      refute html =~ system_cl.log_id
     end
 
     test "datetime mode without bounds is treated as no-op", %{
@@ -369,7 +369,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           ~p"/#{account}/logs/change_logs?change_logs_filter[timestamp][mode]=local&change_logs_filter[show_system]=true"
         )
 
-      assert html =~ cl.event_id
+      assert html =~ cl.log_id
       refute html =~ "invalid pagination filter"
     end
 
@@ -387,7 +387,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       # UTC by default
       {:ok, lv, _html} = live(conn, ~p"/#{account}/logs/change_logs")
       assert has_element?(lv, "#change_logs-timestamp-mode-utc[checked]")
-      assert has_element?(lv, "#timestamp-#{cl.event_id}[data-tz-mode='utc']")
+      assert has_element?(lv, "#timestamp-#{cl.log_id}[data-tz-mode='utc']")
 
       # mode=local in URL flips both the radio and the cell's data-tz-mode
       {:ok, lv, _html} =
@@ -395,7 +395,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
 
       assert has_element?(lv, "#change_logs-timestamp-mode-local[checked]")
       refute has_element?(lv, "#change_logs-timestamp-mode-utc[checked]")
-      assert has_element?(lv, "#timestamp-#{cl.event_id}[data-tz-mode='local']")
+      assert has_element?(lv, "#timestamp-#{cl.log_id}[data-tz-mode='local']")
     end
 
     test "toggling mode via form change re-renders the cell text in the browser's TZ", %{
@@ -418,7 +418,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         |> Phoenix.LiveViewTest.put_connect_params(%{"timezone" => "America/New_York"})
         |> live(~p"/#{account}/logs/change_logs")
 
-      initial = lv |> element("#timestamp-#{cl.event_id}") |> render()
+      initial = lv |> element("#timestamp-#{cl.log_id}") |> render()
       assert initial =~ "12:00 PM"
       refute initial =~ "8:00 AM"
 
@@ -426,7 +426,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       |> form("form[phx-change='filter']", change_logs: %{timestamp: %{mode: "local"}})
       |> render_change()
 
-      shifted = lv |> element("#timestamp-#{cl.event_id}") |> render()
+      shifted = lv |> element("#timestamp-#{cl.log_id}") |> render()
       assert shifted =~ "8:00 AM"
       refute shifted =~ "12:00 PM"
     end
@@ -445,11 +445,11 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/logs/change_logs?change_logs_filter[show_system]=true")
 
-      assert html =~ actor_cl.event_id
-      assert html =~ system_cl.event_id
+      assert html =~ actor_cl.log_id
+      assert html =~ system_cl.log_id
     end
 
-    test "actor search matches actor_email, actor_name, actor_id, and event_id hex", %{
+    test "actor search matches actor_email, actor_name, actor_id, and log_id hex", %{
       conn: conn,
       account: account,
       actor: actor
@@ -479,10 +479,10 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
 
       {:ok, lv, _html} = conn |> authorize_conn(actor) |> live(~p"/#{account}/logs/change_logs")
 
-      # Fixture event_ids share their leading bytes (the boot-timestamp prefix is
+      # Fixture log_ids share their leading bytes (the boot-timestamp prefix is
       # the same for fixtures created microseconds apart), so probe the unique
-      # tail of the event_id rather than the head.
-      alice_tail = String.slice(alice.event_id, 16, 8)
+      # tail of the log_id rather than the head.
+      alice_tail = String.slice(alice.log_id, 16, 8)
 
       for query <- ["alice@", "Alice Admin", alice_id, alice_tail] do
         html =
@@ -490,12 +490,12 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           |> form("form[phx-change='filter']", change_logs: %{actor: query})
           |> render_change()
 
-        assert html =~ alice.event_id, "expected alice match for query=#{inspect(query)}"
-        refute html =~ bob.event_id, "expected bob NOT to match for query=#{inspect(query)}"
+        assert html =~ alice.log_id, "expected alice match for query=#{inspect(query)}"
+        refute html =~ bob.log_id, "expected bob NOT to match for query=#{inspect(query)}"
       end
     end
 
-    test "sorts by event_id and timestamp via the sortable column headers", %{
+    test "sorts by log_id and timestamp via the sortable column headers", %{
       conn: conn,
       account: account,
       actor: actor,
@@ -519,13 +519,13 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       base = ~p"/#{account}/logs/change_logs"
 
       # Format: "{assoc}:{dir}:{field}" per LiveTable.parse_order_by.
-      for column <- ["timestamp", "event_id"], dir <- ["desc", "asc"] do
+      for column <- ["timestamp", "log_id"], dir <- ["desc", "asc"] do
         path = "#{base}?change_logs_order_by=change_logs:#{dir}:#{column}"
 
         {:ok, _lv, html} = live(conn, path)
 
-        newer_pos = :binary.match(html, newer.event_id) |> elem(0)
-        older_pos = :binary.match(html, older.event_id) |> elem(0)
+        newer_pos = :binary.match(html, newer.log_id) |> elem(0)
+        older_pos = :binary.match(html, older.log_id) |> elem(0)
 
         case dir do
           "desc" ->
@@ -569,9 +569,9 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           ~p"/#{account}/logs/change_logs?change_logs_filter[timestamp][from]=#{from}&change_logs_filter[timestamp][mode]=utc"
         )
 
-      assert html =~ mid_cl.event_id
-      assert html =~ new_cl.event_id
-      refute html =~ old_cl.event_id
+      assert html =~ mid_cl.log_id
+      assert html =~ new_cl.log_id
+      refute html =~ old_cl.log_id
 
       # to-bound only: includes yesterday + today, excludes tomorrow
       to = "2026-06-02T00:00:00"
@@ -582,9 +582,9 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           ~p"/#{account}/logs/change_logs?change_logs_filter[timestamp][to]=#{to}&change_logs_filter[timestamp][mode]=utc"
         )
 
-      assert html =~ old_cl.event_id
-      assert html =~ mid_cl.event_id
-      refute html =~ new_cl.event_id
+      assert html =~ old_cl.log_id
+      assert html =~ mid_cl.log_id
+      refute html =~ new_cl.log_id
 
       # both bounds: includes only today
       {:ok, _lv, html} =
@@ -593,9 +593,9 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
           ~p"/#{account}/logs/change_logs?change_logs_filter[timestamp][from]=#{from}&change_logs_filter[timestamp][to]=#{to}&change_logs_filter[timestamp][mode]=utc"
         )
 
-      assert html =~ mid_cl.event_id
-      refute html =~ old_cl.event_id
-      refute html =~ new_cl.event_id
+      assert html =~ mid_cl.log_id
+      refute html =~ old_cl.log_id
+      refute html =~ new_cl.log_id
     end
   end
 
@@ -617,13 +617,13 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
       assert has_element?(lv, "#change-log-panel.translate-x-0")
-      # Panel title renders the operation badge + object instead of raw event_id.
+      # Panel title renders the operation badge + object instead of raw log_id.
       assert has_element?(lv, "#change-log-panel", "Update")
       assert has_element?(lv, "#change-log-panel", "actors")
-      assert html =~ cl.event_id
+      assert html =~ cl.log_id
       # Details sidebar
       assert html =~ "Timestamp"
       # Diff is rendered server-side as a tree of <li> elements with the
@@ -649,7 +649,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
       render_click(lv, "close_panel")
       assert_patch(lv, ~p"/#{account}/logs/change_logs")
@@ -667,7 +667,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
       lv
       |> element("#change-log-panel")
@@ -692,7 +692,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
       # The keydown handler's catch-all returns :noreply without patching.
       render_hook(lv, "handle_keydown", %{"key" => "ArrowDown"})
@@ -706,7 +706,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       account: account,
       actor: actor
     } do
-      missing = Portal.Types.EventId.build_change_log(0, 0)
+      missing = Portal.Types.LogId.build_change_log(0, 0)
 
       assert {:error, {:live_redirect, %{to: to}}} =
                conn
@@ -716,7 +716,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       assert to == ~p"/#{account}/logs/change_logs"
     end
 
-    test "redirects when path event_id is the right length but not hex", %{
+    test "redirects when path log_id is the right length but not hex", %{
       conn: conn,
       account: account,
       actor: actor
@@ -748,7 +748,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
       assert html =~ ~r/bg-success-light[^>]*>\s*Insert/
     end
@@ -771,12 +771,12 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, lv, _html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
-      assert has_element?(lv, "#panel-timestamp-#{cl.event_id}[data-tz-mode='utc']")
+      assert has_element?(lv, "#panel-timestamp-#{cl.log_id}[data-tz-mode='utc']")
 
       # Server-rendered text is the absolute short_datetime form, not "X ago".
-      panel_html = lv |> element("#panel-timestamp-#{cl.event_id}") |> render()
+      panel_html = lv |> element("#panel-timestamp-#{cl.log_id}") |> render()
       refute panel_html =~ "ago"
       assert panel_html =~ "5/30/26"
     end
@@ -798,7 +798,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
       {:ok, _lv, html} =
         conn
         |> authorize_conn(actor)
-        |> live(~p"/#{account}/logs/change_logs/#{cl.event_id}")
+        |> live(~p"/#{account}/logs/change_logs/#{cl.log_id}")
 
       assert html =~ ~r/bg-danger-light[^>]*>\s*Delete/
     end

--- a/elixir/test/support/fixtures/api_request_log_fixtures.ex
+++ b/elixir/test/support/fixtures/api_request_log_fixtures.ex
@@ -7,11 +7,11 @@ defmodule Portal.APIRequestLogFixtures do
   import Portal.AccountFixtures
 
   alias Portal.APIRequestLog
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   def valid_api_request_log_attrs do
     %{
-      event_id: EventId.build_api_request_log(),
+      log_id: LogId.build_api_request_log(),
       actor_id: Ecto.UUID.generate(),
       api_token_id: Ecto.UUID.generate(),
       method: "GET",

--- a/elixir/test/support/fixtures/change_log_fixtures.ex
+++ b/elixir/test/support/fixtures/change_log_fixtures.ex
@@ -7,7 +7,7 @@ defmodule Portal.ChangeLogFixtures do
 
   alias Portal.ChangeLog
   alias Portal.Repo
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   def change_log_fixture(attrs \\ %{}) do
     attrs = Enum.into(attrs, %{})
@@ -18,7 +18,7 @@ defmodule Portal.ChangeLogFixtures do
     row =
       attrs
       |> Map.drop([:account])
-      |> Map.put_new(:event_id, EventId.build_change_log(System.os_time(:microsecond), lsn))
+      |> Map.put_new(:log_id, LogId.build_change_log(System.os_time(:microsecond), lsn))
       |> Map.put_new(:account_id, account.id)
       |> Map.put_new(:lsn, lsn)
       |> Map.put_new(:timestamp, DateTime.utc_now())

--- a/elixir/test/support/fixtures/flow_log_fixtures.ex
+++ b/elixir/test/support/fixtures/flow_log_fixtures.ex
@@ -7,7 +7,7 @@ defmodule Portal.FlowLogFixtures do
 
   alias Portal.FlowLog
   alias Portal.Repo
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   @doc """
   Insert a flow_log row directly, with sensible defaults for every NOT NULL
@@ -24,7 +24,7 @@ defmodule Portal.FlowLogFixtures do
       attrs
       |> Map.drop([:account])
       |> Map.put_new(:account_id, account.id)
-      |> Map.put_new(:event_id, EventId.build_flow_log())
+      |> Map.put_new(:log_id, LogId.build_flow_log())
       |> Map.put_new(:device_id, Ecto.UUID.generate())
       |> Map.put_new(:role, :responder)
       |> Map.put_new(:protocol, :tcp)

--- a/elixir/test/support/fixtures/session_log_fixtures.ex
+++ b/elixir/test/support/fixtures/session_log_fixtures.ex
@@ -7,7 +7,7 @@ defmodule Portal.SessionLogFixtures do
 
   alias Portal.Repo
   alias Portal.SessionLog
-  alias Portal.Types.EventId
+  alias Portal.Types.LogId
 
   @subject_keys [:actor_id, :actor_email, :device_id, :token_id]
 
@@ -28,7 +28,7 @@ defmodule Portal.SessionLogFixtures do
     row =
       attrs
       |> Map.drop([:account, :subject])
-      |> Map.put_new(:event_id, EventId.build_session_log())
+      |> Map.put_new(:log_id, LogId.build_session_log())
       |> Map.put_new(:account_id, account.id)
       |> Map.put_new(:timestamp, DateTime.utc_now())
       |> Map.put_new(:context, :client)


### PR DESCRIPTION
Renames event_id to log_id across the four log streams (change, session, flow, api_request), the /logs API, and the database.

The upcoming log sinks feature will deliver flow logs to external destinations (Splunk, Datadog, etc.) as two events: one when the flow opens and one when it closes. Both events share the same id because they describe the same flow log row. `event_id` implied the id is unique per event, and it isn't. `log_id` names what it actually identifies: the log row. Sinks will use (type, log_id, phase) as the delivery idempotency key, e.g. (flow, log_id, start|end).

The column rename is catalog-only but needs a brief exclusive lock on the log tables, so it ships as a manual migration.