### PR TITLE
feat(portal): add seq to log tables

### DIFF
--- a/elixir/lib/portal/api_request_log.ex
+++ b/elixir/lib/portal/api_request_log.ex
@@ -5,6 +5,7 @@ defmodule Portal.APIRequestLog do
   @type t :: %__MODULE__{
           account_id: Ecto.UUID.t(),
           log_id: String.t(),
+          seq: pos_integer(),
           actor_id: Ecto.UUID.t(),
           api_token_id: Ecto.UUID.t(),
           method: String.t(),
@@ -26,6 +27,7 @@ defmodule Portal.APIRequestLog do
   schema "api_request_logs" do
     belongs_to :account, Portal.Account, primary_key: true
     field :log_id, Portal.Types.LogId, primary_key: true
+    field :seq, :integer, read_after_writes: true
 
     field :actor_id, :binary_id
     field :api_token_id, :binary_id

--- a/elixir/lib/portal/change_log.ex
+++ b/elixir/lib/portal/change_log.ex
@@ -8,6 +8,7 @@ defmodule Portal.ChangeLog do
   schema "change_logs" do
     belongs_to :account, Portal.Account, primary_key: true
     field :log_id, Portal.Types.LogId, primary_key: true
+    field :seq, :integer, read_after_writes: true
     field :timestamp, :utc_datetime_usec
     field :lsn, :integer
     field :object, :string

--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -10,6 +10,7 @@ defmodule Portal.FlowLog do
   @type t :: %__MODULE__{
           account_id: Ecto.UUID.t(),
           log_id: Portal.Types.LogId.t(),
+          seq: pos_integer(),
           device_id: Ecto.UUID.t(),
           role: :initiator | :responder,
           policy_authorization_id: Ecto.UUID.t(),
@@ -62,6 +63,7 @@ defmodule Portal.FlowLog do
   schema "flow_logs" do
     belongs_to :account, Portal.Account, primary_key: true
     field :log_id, Portal.Types.LogId
+    field :seq, :integer, read_after_writes: true
 
     field :device_id, :binary_id, primary_key: true
     field :role, Ecto.Enum, values: @roles, primary_key: true

--- a/elixir/lib/portal/session_log.ex
+++ b/elixir/lib/portal/session_log.ex
@@ -8,6 +8,7 @@ defmodule Portal.SessionLog do
   schema "session_logs" do
     belongs_to :account, Portal.Account, primary_key: true
     field :log_id, Portal.Types.LogId, primary_key: true
+    field :seq, :integer, read_after_writes: true
     field :timestamp, :utc_datetime_usec
     field :context, Ecto.Enum, values: [:client, :gateway, :portal]
 

--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -263,9 +263,12 @@ defmodule PortalAPI.FlowLogController do
     # The attribution snapshot, both tunnel tuples, and domain are stable for the
     # life of a flow and are only ever set on insert.
     defp on_conflict_query do
+      # The close takes a fresh seq so cursor-based consumers that already
+      # delivered the open row see it again and deliver the close.
       from(f in FlowLog,
         update: [
           set: [
+            seq: fragment("nextval('flow_logs_seq_seq')"),
             flow_end: fragment("EXCLUDED.flow_end"),
             last_packet: fragment("EXCLUDED.last_packet"),
             rx_packets: fragment("EXCLUDED.rx_packets"),

--- a/elixir/priv/repo/manual_migrations/20260710000001_add_seq_to_log_tables.exs
+++ b/elixir/priv/repo/manual_migrations/20260710000001_add_seq_to_log_tables.exs
@@ -1,0 +1,141 @@
+defmodule Portal.Repo.Migrations.AddSeqToLogTables do
+  @moduledoc """
+  Adds a `seq` bigint to the four log tables, assigned from a per-table
+  sequence on insert. Log sinks page each stream with a cursor over
+  (account_id, seq): unlike the timestamp columns, seq follows arrival order,
+  so rows that arrive late (e.g. flow reports spooled on an offline gateway)
+  can never land behind an already-advanced cursor.
+
+  The column and default are catalog-only changes; existing rows are then
+  backfilled in chronological batches by a temporary procedure that commits
+  per batch, so the migration is resumable and never holds a long
+  transaction. NOT NULL is established through a validated CHECK constraint
+  to avoid a full-table scan under ACCESS EXCLUSIVE. The (account_id, seq)
+  indexes are created last so the backfill updates stay out of them.
+
+  Every statement is idempotent; re-run after a crash and it resumes where it
+  left off.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  @tables [
+    {"change_logs", "account_id, log_id", "lsn"},
+    {"session_logs", "account_id, log_id", ~s("timestamp")},
+    {"api_request_logs", "account_id, log_id", "inserted_at"},
+    # flow_logs' primary key is the 10-column flow identity, so its batch joins
+    # go through the flow_logs_log_id_index secondary instead.
+    {"flow_logs", "account_id, log_id", "flow_start"}
+  ]
+
+  def up do
+    for {table, _key_cols, ord_col} <- @tables do
+      execute("CREATE SEQUENCE IF NOT EXISTS #{table}_seq_seq")
+      execute("ALTER TABLE #{table} ADD COLUMN IF NOT EXISTS seq bigint")
+      execute("ALTER SEQUENCE #{table}_seq_seq OWNED BY #{table}.seq")
+
+      execute(
+        "ALTER TABLE #{table} ALTER COLUMN seq SET DEFAULT nextval('#{table}_seq_seq')"
+      )
+
+      # Partial index so each backfill batch is a cheap ordered index scan
+      # that shrinks as rows are filled in. CONCURRENTLY is not supported on
+      # the partitioned flow_logs, which is small enough not to need it.
+      execute(
+        "CREATE INDEX #{concurrently(table)} IF NOT EXISTS #{table}_seq_backfill_index " <>
+          "ON #{table} (#{ord_col}) WHERE seq IS NULL"
+      )
+    end
+
+    execute("""
+    CREATE OR REPLACE PROCEDURE backfill_log_seq(
+      tbl regclass, key_cols text, ord_col text, seqname text
+    )
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      remaining boolean;
+      batch_count bigint;
+      total bigint := 0;
+      tkeys text := (SELECT string_agg('t.' || trim(c), ', ')
+                     FROM unnest(string_to_array(key_cols, ',')) c);
+      nkeys text := (SELECT string_agg('n.' || trim(c), ', ')
+                     FROM unnest(string_to_array(key_cols, ',')) c);
+    BEGIN
+      LOOP
+        -- nextval must run over the already-sorted subquery: a bare
+        -- UPDATE ... WHERE key IN (ordered subquery) assigns seqs in heap
+        -- scan order, discarding the chronology the subquery established.
+        EXECUTE format(
+          'WITH numbered AS (
+             SELECT %s, nextval(%L) AS s
+             FROM (
+               SELECT %s FROM %s WHERE seq IS NULL ORDER BY %s LIMIT 10000
+             ) b
+           )
+           UPDATE %s t SET seq = n.s FROM numbered n WHERE (%s) = (%s)',
+          key_cols, seqname, key_cols, tbl, ord_col, tbl, tkeys, nkeys
+        );
+        GET DIAGNOSTICS batch_count = ROW_COUNT;
+
+        COMMIT;
+        total := total + batch_count;
+        RAISE NOTICE 'Backfilled % rows of % so far', total, tbl;
+
+        -- Terminate on emptiness rather than batch_count: a concurrent
+        -- update can move selected rows so a batch updates fewer rows than
+        -- it selected while NULL rows still remain.
+        EXECUTE format('SELECT EXISTS (SELECT 1 FROM %s WHERE seq IS NULL)', tbl)
+        INTO remaining;
+
+        EXIT WHEN NOT remaining;
+      END LOOP;
+    END;
+    $$
+    """)
+
+    for {table, key_cols, ord_col} <- @tables do
+      execute("CALL backfill_log_seq('#{table}', '#{key_cols}', '#{escape(ord_col)}', '#{table}_seq_seq')")
+    end
+
+    execute("DROP PROCEDURE backfill_log_seq(regclass, text, text, text)")
+
+    for {table, _key_cols, _ord_col} <- @tables do
+      execute("DROP INDEX #{concurrently(table)} IF EXISTS #{table}_seq_backfill_index")
+
+      # Validated CHECK lets SET NOT NULL skip its full-table scan, so no
+      # statement here takes more than a brief lock.
+      execute("ALTER TABLE #{table} DROP CONSTRAINT IF EXISTS #{table}_seq_not_null")
+
+      execute(
+        "ALTER TABLE #{table} ADD CONSTRAINT #{table}_seq_not_null " <>
+          "CHECK (seq IS NOT NULL) NOT VALID"
+      )
+
+      execute("ALTER TABLE #{table} VALIDATE CONSTRAINT #{table}_seq_not_null")
+      execute("ALTER TABLE #{table} ALTER COLUMN seq SET NOT NULL")
+      execute("ALTER TABLE #{table} DROP CONSTRAINT #{table}_seq_not_null")
+
+      execute(
+        "CREATE INDEX #{concurrently(table)} IF NOT EXISTS #{table}_account_id_seq_index " <>
+          "ON #{table} (account_id, seq)"
+      )
+    end
+  end
+
+  def down do
+    for {table, _key_cols, _ord_col} <- @tables do
+      execute("DROP INDEX #{concurrently(table)} IF EXISTS #{table}_account_id_seq_index")
+      execute("DROP INDEX #{concurrently(table)} IF EXISTS #{table}_seq_backfill_index")
+      execute("ALTER TABLE #{table} DROP CONSTRAINT IF EXISTS #{table}_seq_not_null")
+      execute("ALTER TABLE #{table} DROP COLUMN IF EXISTS seq")
+      execute("DROP SEQUENCE IF EXISTS #{table}_seq_seq")
+    end
+  end
+
+  defp concurrently("flow_logs"), do: ""
+  defp concurrently(_table), do: "CONCURRENTLY"
+
+  defp escape(sql), do: String.replace(sql, "'", "''")
+end

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -412,6 +412,7 @@ defmodule PortalAPI.FlowLogControllerTest do
       [log] = Repo.all(FlowLog)
       assert is_nil(log.flow_end)
       assert log.tx_bytes == 100
+      open_seq = log.seq
 
       close = build_record(%{"flow_end" => "2026-03-20T10:05:00.000000Z", "tx_bytes" => 999})
 
@@ -421,6 +422,7 @@ defmodule PortalAPI.FlowLogControllerTest do
       [log] = Repo.all(FlowLog)
       assert log.flow_end == ~U[2026-03-20 10:05:00.000000Z]
       assert log.tx_bytes == 999
+      assert log.seq > open_seq
     end
 
     test "replaying a closed record is idempotent", %{conn: _conn, account: account} do
@@ -430,9 +432,11 @@ defmodule PortalAPI.FlowLogControllerTest do
       record = build_record()
 
       assert build_conn() |> authorize(account, claims) |> post_logs([record]) |> json_response(200)
+      [%{seq: seq}] = Repo.all(FlowLog)
+
       assert build_conn() |> authorize(account, claims) |> post_logs([record]) |> json_response(200)
 
-      assert length(Repo.all(FlowLog)) == 1
+      assert [%{seq: ^seq}] = Repo.all(FlowLog)
     end
 
     test "a late open does not wipe an existing close", %{conn: _conn, account: account} do


### PR DESCRIPTION
Log sinks need to page through each log stream and remember how far they synced. This adds a `seq` bigint to the four log tables, assigned from a per-table sequence, with an (account_id, seq) index. A sink's cursor is then simply "everything with seq greater than X", the same way for all four streams.

Why not the columns we already have: timestamps break on late arrivals. A gateway can spool flow reports while offline and upload them hours later, so a row can land with a flow_start far in the past. A timestamp cursor has already moved past that point and would skip the row forever. log_id encodes insert order only for change_logs; for the other three streams it's random.

Flow logs are also updated once, when the flow closes. The close now takes a fresh seq, so a cursor that already delivered the open state sees the row again and delivers the close. Flows that close before a sink ever read them are delivered once, with final counters.

Alternatives considered: a timestamp cursor with a safety lag (still misses spooled uploads and can't re-deliver closes) and a per-record delivery journal (one row per log per sink, which multiplies log storage). Existing rows are backfilled in chronological batches; the migration is manual so the backfill runs at a controlled time.

Related: #14065