### PR TITLE
feat(portal): unify audit logs behind a single Logs section

### DIFF
--- a/elixir/assets/js/hooks/datetime_range_filter.js
+++ b/elixir/assets/js/hooks/datetime_range_filter.js
@@ -35,6 +35,10 @@ export const DatetimeRangeFilter = {
     const mode = this.mode();
     for (const { canonical, display } of this.bounds) {
       if (!canonical || !display) continue;
+      // Don't clobber an input the user is actively editing — the hook
+      // still holds the last-committed canonical value and will re-render
+      // when the user is done.
+      if (display === document.activeElement) continue;
       const canonicalValue = canonical.value || "";
       display.value =
         mode === "local"
@@ -47,6 +51,18 @@ export const DatetimeRangeFilter = {
     for (const { canonical, display } of this.bounds) {
       if (!canonical || !display) continue;
       display.addEventListener("change", () => {
+        // Chrome reports an incomplete datetime as empty and fires `change`
+        // on blur. Treat that as "the user isn't done yet" rather than
+        // wiping the last committed value — restore the display from
+        // canonical and stop.
+        if (display.validity.badInput || (!display.value && canonical.value)) {
+          const mode = this.mode();
+          display.value =
+            mode === "local"
+              ? utcNaiveToLocalNaive(canonical.value)
+              : canonical.value || "";
+          return;
+        }
         const next =
           this.mode() === "local"
             ? localNaiveToUtcNaive(display.value)

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -298,6 +298,7 @@ defmodule PortalWeb.NavigationComponents do
             <.sidebar_item
               current_path={@current_path}
               navigate={~p"/#{@account}/logs/change_logs"}
+              match="/#{@account.slug}/logs"
               icon="ri-file-list-3-line"
               badge="NEW"
             >
@@ -365,9 +366,10 @@ defmodule PortalWeb.NavigationComponents do
   slot :inner_block, required: true
   attr :current_path, :string, required: true
   attr :badge, :string, default: nil
+  attr :match, :string, default: nil, doc: "Prefix used for the active-state check; defaults to navigate. Set to a shared parent when one sidebar item covers multiple sibling routes."
 
   def sidebar_item(assigns) do
-    active? = sidebar_item_active?(assigns.current_path, assigns.navigate)
+    active? = sidebar_item_active?(assigns.current_path, assigns.match || assigns.navigate)
     assigns = assign(assigns, :active?, active?)
 
     ~H"""

--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -298,34 +298,10 @@ defmodule PortalWeb.NavigationComponents do
             <.sidebar_item
               current_path={@current_path}
               navigate={~p"/#{@account}/logs/change_logs"}
-              icon="ri-history-line"
+              icon="ri-file-list-3-line"
               badge="NEW"
             >
-              Change Logs
-            </.sidebar_item>
-            <.sidebar_item
-              current_path={@current_path}
-              navigate={~p"/#{@account}/logs/session_logs"}
-              icon="ri-login-circle-line"
-              badge="NEW"
-            >
-              Session Logs
-            </.sidebar_item>
-            <.sidebar_item
-              current_path={@current_path}
-              navigate={~p"/#{@account}/logs/flow_logs"}
-              icon="ri-exchange-line"
-              badge="NEW"
-            >
-              Flow Logs
-            </.sidebar_item>
-            <.sidebar_item
-              current_path={@current_path}
-              navigate={~p"/#{@account}/logs/api_request_logs"}
-              icon="ri-terminal-box-line"
-              badge="NEW"
-            >
-              API Request Logs
+              Logs
             </.sidebar_item>
           </ul>
         </div>
@@ -576,6 +552,101 @@ defmodule PortalWeb.NavigationComponents do
   defp settings_tab_active?(current_path, tab_path) do
     [_, _slug_or_id, current_subpath] = String.split(current_path, "/", parts: 3)
     String.starts_with?(current_subpath, tab_path)
+  end
+
+  @doc """
+  Renders the Logs page header and tab strip.
+  Shared across the four log LiveViews so they read as one destination.
+  """
+  attr :account, :any, required: true
+  attr :current_path, :string, required: true
+
+  def logs_nav(assigns) do
+    ~H"""
+    <div class="flex flex-col bg-surface shrink-0">
+      <div class="relative overflow-hidden px-4 pt-4 pb-3 md:px-6 md:pt-6 md:pb-4 border-b border-border">
+        <div class="absolute inset-x-0 top-0 h-[2px] bg-brand opacity-50"></div>
+        <div class="flex items-start gap-5">
+          <div class="hidden md:block shrink-0 mt-0.5">
+            <.icon name="ri-file-list-3-line" class="w-16 h-16 text-brand" />
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+              <div class="min-w-0">
+                <h1 class="text-base font-semibold text-heading">Logs</h1>
+                <p class="hidden md:block mt-0.5 text-sm text-body">
+                  Structured, immutable records of every configuration change, session, connection, and API call in your account.
+                </p>
+              </div>
+              <div class="shrink-0 flex items-center gap-2">
+                <.docs_action path="/administer/logs" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="flex overflow-x-auto overflow-y-hidden border-b border-border px-6 shrink-0 bg-surface">
+        <.logs_tab
+          current_path={@current_path}
+          navigate={~p"/#{@account}/logs/change_logs"}
+          tab_path="logs/change_logs"
+          icon="ri-history-line"
+        >
+          Change Logs
+        </.logs_tab>
+        <.logs_tab
+          current_path={@current_path}
+          navigate={~p"/#{@account}/logs/session_logs"}
+          tab_path="logs/session_logs"
+          icon="ri-login-circle-line"
+        >
+          Session Logs
+        </.logs_tab>
+        <.logs_tab
+          current_path={@current_path}
+          navigate={~p"/#{@account}/logs/flow_logs"}
+          tab_path="logs/flow_logs"
+          icon="ri-exchange-line"
+        >
+          Flow Logs
+        </.logs_tab>
+        <.logs_tab
+          current_path={@current_path}
+          navigate={~p"/#{@account}/logs/api_request_logs"}
+          tab_path="logs/api_request_logs"
+          icon="ri-terminal-box-line"
+        >
+          API Request Logs
+        </.logs_tab>
+      </div>
+    </div>
+    """
+  end
+
+  attr :navigate, :string, required: true
+  attr :current_path, :string, required: true
+  attr :tab_path, :string, required: true
+  attr :icon, :string, required: true
+  slot :inner_block, required: true
+
+  defp logs_tab(assigns) do
+    active? = settings_tab_active?(assigns.current_path, assigns.tab_path)
+    assigns = assign(assigns, :active?, active?)
+
+    ~H"""
+    <.link
+      navigate={@navigate}
+      class={[
+        "flex items-center gap-2 px-5 py-3 text-sm font-medium border-b-2 -mb-px whitespace-nowrap transition-colors",
+        @active? && "border-brand text-brand",
+        not @active? &&
+          "border-transparent text-body hover:text-heading hover:border-border-strong"
+      ]}
+    >
+      <.icon name={@icon} class="w-4 h-4 shrink-0" />
+      {render_slot(@inner_block)}
+    </.link>
+    """
   end
 
   defp format_member_since(nil), do: "—"

--- a/elixir/lib/portal_web/live/logs/api_request_logs.ex
+++ b/elixir/lib/portal_web/live/logs/api_request_logs.ex
@@ -96,18 +96,7 @@ defmodule PortalWeb.Logs.APIRequestLogs do
   def render(assigns) do
     ~H"""
     <div class="relative flex flex-col h-full overflow-hidden">
-      <.page_header>
-        <:icon>
-          <.icon name="ri-terminal-box-line" class="w-16 h-16 text-[var(--brand)]" />
-        </:icon>
-        <:title>API Request Logs</:title>
-        <:description>
-          Every authenticated REST API call, with full actor and source attribution.
-        </:description>
-        <:action>
-          <.docs_action path="/administer/logs" />
-        </:action>
-      </.page_header>
+      <.logs_nav account={@account} current_path={@current_path} />
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
         <.live_table

--- a/elixir/lib/portal_web/live/logs/change_logs.ex
+++ b/elixir/lib/portal_web/live/logs/change_logs.ex
@@ -111,18 +111,7 @@ defmodule PortalWeb.Logs.ChangeLogs do
   def render(assigns) do
     ~H"""
     <div class="relative flex flex-col h-full overflow-hidden">
-      <.page_header>
-        <:icon>
-          <.icon name="ri-history-line" class="w-16 h-16 text-[var(--brand)]" />
-        </:icon>
-        <:title>Change Logs</:title>
-        <:description>
-          An immutable audit trail of every configuration change in your account.
-        </:description>
-        <:action>
-          <.docs_action path="/administer/logs" />
-        </:action>
-      </.page_header>
+      <.logs_nav account={@account} current_path={@current_path} />
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
         <.live_table

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -8,18 +8,7 @@ defmodule PortalWeb.Logs.FlowLogs do
   def render(assigns) do
     ~H"""
     <div class="flex flex-col h-full">
-      <.page_header>
-        <:icon>
-          <.icon name="ri-exchange-line" class="w-16 h-16 text-[var(--brand)]" />
-        </:icon>
-        <:title>Flow Logs</:title>
-        <:description>
-          Detailed access logs for all Firezone traffic as reported by Clients and Gateways.
-        </:description>
-        <:action>
-          <.docs_action path="/administer/logs" />
-        </:action>
-      </.page_header>
+      <.logs_nav account={@account} current_path={@current_path} />
 
       <div class="flex-1 overflow-y-auto p-6">
         <div class="max-w-2xl mx-auto">

--- a/elixir/lib/portal_web/live/logs/flow_logs.ex
+++ b/elixir/lib/portal_web/live/logs/flow_logs.ex
@@ -7,10 +7,10 @@ defmodule PortalWeb.Logs.FlowLogs do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col h-full">
+    <div class="relative flex flex-col h-full overflow-hidden">
       <.logs_nav account={@account} current_path={@current_path} />
 
-      <div class="flex-1 overflow-y-auto p-6">
+      <div class="flex-1 min-h-0 overflow-y-auto p-6">
         <div class="max-w-2xl mx-auto">
           <div class="rounded-lg border border-[var(--border)] bg-[var(--surface)] overflow-hidden">
             <div class="px-6 py-8 flex flex-col items-center text-center gap-4">

--- a/elixir/lib/portal_web/live/logs/session_logs.ex
+++ b/elixir/lib/portal_web/live/logs/session_logs.ex
@@ -97,18 +97,7 @@ defmodule PortalWeb.Logs.SessionLogs do
   def render(assigns) do
     ~H"""
     <div class="relative flex flex-col h-full overflow-hidden">
-      <.page_header>
-        <:icon>
-          <.icon name="ri-login-circle-line" class="w-16 h-16 text-[var(--brand)]" />
-        </:icon>
-        <:title>Session Logs</:title>
-        <:description>
-          Each time a Client or Gateway connects to the portal, or an admin signs in.
-        </:description>
-        <:action>
-          <.docs_action path="/administer/logs" />
-        </:action>
-      </.page_header>
+      <.logs_nav account={@account} current_path={@current_path} />
 
       <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
         <.live_table

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -165,6 +165,7 @@ defmodule PortalWeb.LiveTable do
         min={@min}
         step="1"
         autocomplete="off"
+        phx-update="ignore"
         class={[
           "bg-input border text-heading text-xs font-medium rounded h-8",
           "px-2 py-1.5 w-56",

--- a/elixir/test/portal_web/live/logs/change_logs_test.exs
+++ b/elixir/test/portal_web/live/logs/change_logs_test.exs
@@ -38,7 +38,7 @@ defmodule PortalWeb.Logs.ChangeLogsTest do
         |> live(~p"/#{account}/logs/change_logs")
 
       assert html =~ "Change Logs"
-      assert html =~ "immutable audit trail of every configuration change"
+      assert html =~ "Structured, immutable records"
     end
 
     test "fresh account shows the unfiltered empty slot, not the filtered one", %{


### PR DESCRIPTION
Collapse the four Audit sidebar items (Change / Session / Flow / API Request Logs) into a single **Logs** entry with a `file-list-3` icon and a `NEW` badge.

The four views become tabs under a shared header — one icon, one title, one description — so they read as one destination. The tab strip owns the per-log navigation and the `docs_action` link.

<img width="1840" height="1191" alt="Screenshot 2026-07-10 at 9 44 56 AM" src="https://github.com/user-attachments/assets/711c457e-deb9-4a98-acea-16616f40ee61" />


Related: #13442