### PR TITLE
chore(rust): bump Rust to 1.97.0 and fix new clippy lints

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783320166,
-        "narHash": "sha256-l7C/OsjcnWDOk2K3ssj+SBduwL67LashjBqis9+t468=",
+        "lastModified": 1783747106,
+        "narHash": "sha256-KlepQu/O5m11lAjcJ4ER5bc6bIzyX2UMPDARzMzQfIw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20ee15370c9256669d66968b89ee20a4b0a4e673",
+        "rev": "e598b37857b895b81020a65a802ef55f5bbed72f",
         "type": "github"
       },
       "original": {

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -62,7 +62,7 @@ COPY ${PACKAGE} .
 FROM runtime AS dev
 
 ARG PACKAGE
-ARG RUST_VERSION="1.96.1" # Keep in sync with `rust-toolchain.toml`
+ARG RUST_VERSION="1.97.0" # Keep in sync with `rust-toolchain.toml`
 
 WORKDIR /app
 

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -182,10 +182,9 @@ impl Candidate {
 
         let candidate = if let Some(tcp) = packet.as_tcp() {
             Self::try_from_tcp(packet, &tcp, ip_hdr_len)?
-        } else if let Some(udp) = packet.as_udp() {
-            Self::from_udp(packet, &udp, ip_hdr_len)
         } else {
-            return None;
+            let udp = packet.as_udp()?;
+            Self::from_udp(packet, &udp, ip_hdr_len)
         };
 
         if candidate.payload_len == 0 {

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -180,11 +180,10 @@ impl Candidate {
     fn from_packet(packet: &IpPacket) -> Option<Self> {
         let ip_hdr_len = ip_layout(packet)?;
 
-        let candidate = if let Some(tcp) = packet.as_tcp() {
-            Self::try_from_tcp(packet, &tcp, ip_hdr_len)?
-        } else {
-            let udp = packet.as_udp()?;
-            Self::from_udp(packet, &udp, ip_hdr_len)
+        let candidate = match (packet.as_tcp(), packet.as_udp()) {
+            (Some(tcp), _) => Self::try_from_tcp(packet, &tcp, ip_hdr_len)?,
+            (_, Some(udp)) => Self::from_udp(packet, &udp, ip_hdr_len),
+            _ => return None,
         };
 
         if candidate.payload_len == 0 {

--- a/rust/libs/connlib/tunnel/src/tests/sut.rs
+++ b/rust/libs/connlib/tunnel/src/tests/sut.rs
@@ -747,7 +747,7 @@ impl TunnelTest {
                 continue;
             }
 
-            for (_, relay) in self.relays.iter_mut() {
+            for relay in self.relays.values_mut() {
                 let Some(message) = relay.exec_mut(|r| r.sut.next_command()) else {
                     continue;
                 };
@@ -832,13 +832,13 @@ impl TunnelTest {
     }
 
     fn drain_transmits(&mut self, buffered_transmits: &mut BufferedTransmits, now: Instant) {
-        for (_, gateway) in self.gateways.iter_mut() {
+        for gateway in self.gateways.values_mut() {
             while let Some(transmit) = gateway.exec_mut(|g| g.sut.poll_transmit()) {
                 buffered_transmits.push_from(transmit, gateway, now);
             }
         }
 
-        for (_, client) in self.clients.iter_mut() {
+        for client in self.clients.values_mut() {
             while let Some(transmit) = client.exec_mut(|g| g.sut.poll_transmit()) {
                 buffered_transmits.push_from(transmit, client, now);
             }
@@ -895,7 +895,7 @@ impl TunnelTest {
         }
 
         // Handle all gateway `Transmit`s and timeouts.
-        for (_, gateway) in self.gateways.iter_mut() {
+        for gateway in self.gateways.values_mut() {
             for transmit in gateway.exec_mut(|g| g.advance_resources(global_dns_records, now)) {
                 buffered_transmits.push_from(transmit, gateway, now);
             }
@@ -913,7 +913,7 @@ impl TunnelTest {
         }
 
         // Handle all relay `Transmit`s and timeouts.
-        for (_, relay) in self.relays.iter_mut() {
+        for relay in self.relays.values_mut() {
             while let Some(transmit) = relay.poll_inbox(now) {
                 let Some(reply) = relay.exec_mut(|r| r.receive(transmit, now)) else {
                     continue;

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.1" # Keep in sync with `Dockerfile`
+channel = "1.97.0" # Keep in sync with `Dockerfile`
 components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.96.1 to 1.97.0 and addresses the new clippy lints (`question_mark` and `for_kv_map`) that the newer compiler surfaces.