### PR TITLE
fix(portal): resync slot and publication upon missing

### DIFF
--- a/elixir/lib/portal/replication/slot_poller.ex
+++ b/elixir/lib/portal/replication/slot_poller.ex
@@ -35,6 +35,12 @@ defmodule Portal.Replication.SlotPoller do
   harmless with naturally-keyed effects (`Portal.ChangeLogs.Consumer` inserts
   are keyed by LSN with `on_conflict: :nothing`) or idempotent side effects
   (`Portal.Changes.Consumer` broadcasts).
+
+  Setup creates the publication and slot when missing and syncs the
+  publication's tables. It re-runs whenever a poll cycle fails because the
+  slot or publication no longer exists (Azure Postgres upgrades drop
+  replication slots), recreating them without a restart; WAL written between
+  the drop and the recreation is lost.
   """
 
   use GenServer
@@ -86,6 +92,7 @@ defmodule Portal.Replication.SlotPoller do
     Process.flag(:trap_exit, true)
 
     send(self(), :setup)
+    Process.send_after(self(), :status_log, config.status_log_interval)
 
     {:ok,
      %{
@@ -107,7 +114,6 @@ defmodule Portal.Replication.SlotPoller do
           publication: state.config.publication_name
         )
 
-        Process.send_after(self(), :status_log, state.config.status_log_interval)
         send(self(), :poll)
         {:noreply, %{state | consumer_state: consumer_state}}
 
@@ -122,17 +128,22 @@ defmodule Portal.Replication.SlotPoller do
   end
 
   def handle_info(:poll, state) do
-    {state, drained?} = poll(state)
+    case poll(state) do
+      {state, :resetup} ->
+        send(self(), :setup)
+        {:noreply, state}
 
-    delay =
-      if drained? do
-        state.config.poll_interval
-      else
-        0
-      end
+      {state, drained?} ->
+        delay =
+          if drained? do
+            state.config.poll_interval
+          else
+            0
+          end
 
-    Process.send_after(self(), :poll, delay)
-    {:noreply, state}
+        Process.send_after(self(), :poll, delay)
+        {:noreply, state}
+    end
   end
 
   def handle_info(:status_log, state) do
@@ -163,14 +174,40 @@ defmodule Portal.Replication.SlotPoller do
 
     {state, drained?}
   rescue
-    error ->
+    error -> handle_poll_error(state, error, __STACKTRACE__)
+  end
+
+  defp handle_poll_error(state, error, stacktrace) do
+    if missing_replication_object?(state.config, error) do
+      Logger.warning(
+        "#{inspect(state.consumer)}: replication slot or publication is missing, re-running setup",
+        reason: inspect(error)
+      )
+
+      {state, :resetup}
+    else
       Logger.error("#{inspect(state.consumer)}: replication poll cycle failed",
         reason: inspect(error),
-        stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+        stacktrace: Exception.format_stacktrace(stacktrace)
       )
 
       {state, true}
+    end
   end
+
+  # A 42704 naming our slot or publication means it was dropped out from
+  # under us (Azure Postgres upgrades drop replication slots); re-run setup
+  # to recreate it instead of peeking a missing slot forever. Consumer
+  # callbacks can raise undefined_object for unrelated database objects,
+  # which must keep the ordinary replay path.
+  defp missing_replication_object?(config, %Postgrex.Error{
+         postgres: %{code: :undefined_object, message: message}
+       }) do
+    String.contains?(message, ~s("#{config.slot_name}")) or
+      String.contains?(message, ~s("#{config.publication_name}"))
+  end
+
+  defp missing_replication_object?(_config, _error), do: false
 
   defp run_cycle(state) do
     now_lsn = current_wal_lsn(state.config)

--- a/elixir/test/portal/replication/slot_poller_test.exs
+++ b/elixir/test/portal/replication/slot_poller_test.exs
@@ -13,7 +13,9 @@ defmodule Portal.Replication.SlotPollerTest do
 
     @impl true
     def init_state(_config) do
-      %{test_pid: Portal.Config.get_env(:portal, :slot_poller_test_pid)}
+      test_pid = Portal.Config.get_env(:portal, :slot_poller_test_pid)
+      send(test_pid, :init_state)
+      %{test_pid: test_pid}
     end
 
     @impl true
@@ -34,6 +36,13 @@ defmodule Portal.Replication.SlotPollerTest do
       end
 
       send(state.test_pid, {:write, lsn, op, table, old_data, data})
+
+      # Simulates a consumer raising undefined_object (42704) for something
+      # that is not the slot or the publication
+      if data && data["val"] == "undefined-object" do
+        Portal.Repo.query!("SELECT NULL::nonexistent_type", [])
+      end
+
       state
     end
 
@@ -208,6 +217,63 @@ defmodule Portal.Replication.SlotPollerTest do
 
       assert confirmed > lsn
     end)
+  end
+
+  test "recreates the slot when it is dropped at runtime", %{
+    aux: aux,
+    slot: slot,
+    table: table
+  } do
+    start_poller!()
+    assert_receive :init_state, 5000
+
+    Postgrex.query!(aux, "INSERT INTO #{table} (id, val) VALUES (6, 'before-drop')", [])
+    assert_receive {:write, _, :insert, ^table, nil, %{"id" => "6"}}, 5000
+
+    # The drop can race an in-flight peek that holds the slot active; retry
+    wait_for(fn ->
+      assert {:ok, _} = Postgrex.query(aux, "SELECT pg_drop_replication_slot($1)", [slot])
+    end)
+
+    # The recreated slot is visible before creation finds its consistent
+    # point, which can take a while under concurrent test transactions; only
+    # rows written after confirmed_flush_lsn is set are decodable
+    wait_for(
+      fn ->
+        %{rows: rows} =
+          Postgrex.query!(
+            aux,
+            "SELECT 1 FROM pg_replication_slots WHERE slot_name = $1 AND confirmed_flush_lsn IS NOT NULL",
+            [slot]
+          )
+
+        assert rows == [[1]]
+      end,
+      30
+    )
+
+    # Recreation went through setup, which re-initialized the consumer
+    assert_receive :init_state, 5000
+
+    Postgrex.query!(aux, "INSERT INTO #{table} (id, val) VALUES (7, 'after-recreate')", [])
+
+    assert_receive {:write, _, :insert, ^table, nil, %{"id" => "7", "val" => "after-recreate"}},
+                   5000
+  end
+
+  test "unrelated undefined_object errors replay instead of re-running setup", %{
+    aux: aux,
+    table: table
+  } do
+    start_poller!()
+    assert_receive :init_state, 5000
+
+    Postgrex.query!(aux, "INSERT INTO #{table} (id, val) VALUES (8, 'undefined-object')", [])
+
+    # The failed cycle replays through the ordinary error path
+    assert_receive {:write, _, :insert, ^table, nil, %{"id" => "8"}}, 5000
+    assert_receive {:write, _, :insert, ^table, nil, %{"id" => "8"}}, 5000
+    refute_receive :init_state, 500
   end
 
   test "resumes from retained WAL after a restart", %{


### PR DESCRIPTION
Fixes an issue where if the publication or slot go missing, we recreate them.

Related: #14045 
