### PR TITLE
refactor(portal): move flow_logs pkey to log_id

### DIFF
--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -53,23 +53,23 @@ defmodule Portal.FlowLog do
   @roles [:initiator, :responder]
   @protocols [:tcp, :udp]
 
-  # The primary key is the natural flow identity, tagged primary_key: true
-  # field-by-field below: the reporting side (account_id, device_id, role), the
-  # inner tunnel 6-tuple (protocol, inner src/dst ip+port), the resource, and
-  # flow_start. log_id is a random public handle, not part of the key.
-  # flow_start is included partly because Postgres requires the
-  # partition key in every key on a partitioned table. See the partition migration.
+  # Keyed by (account_id, log_id) like the other log tables; flow_start rides
+  # along in the primary key only because Postgres requires the partition key
+  # in every key on a partitioned table. The natural flow identity (the
+  # reporting side, the inner tunnel 6-tuple, the resource, and flow_start) is
+  # a unique constraint and the open/close upsert conflict target. See the
+  # move_flow_logs_pkey_to_log_id migration.
   schema "flow_logs" do
     belongs_to :account, Portal.Account, primary_key: true
-    field :log_id, Portal.Types.LogId
+    field :log_id, Portal.Types.LogId, primary_key: true
 
-    field :device_id, :binary_id, primary_key: true
-    field :role, Ecto.Enum, values: @roles, primary_key: true
+    field :device_id, :binary_id
+    field :role, Ecto.Enum, values: @roles
 
     field :policy_authorization_id, :binary_id
     field :policy_id, :binary_id
     field :auth_provider_id, :binary_id
-    field :resource_id, :binary_id, primary_key: true
+    field :resource_id, :binary_id
     field :resource_name, :string
     field :resource_address, :string
     field :actor_id, :binary_id
@@ -86,12 +86,12 @@ defmodule Portal.FlowLog do
     field :device_identifier_for_vendor, :string
     field :device_firebase_installation_id, :string
 
-    field :protocol, Ecto.Enum, values: @protocols, primary_key: true
+    field :protocol, Ecto.Enum, values: @protocols
 
-    field :inner_src_ip, Portal.Types.IP, primary_key: true
-    field :inner_dst_ip, Portal.Types.IP, primary_key: true
-    field :inner_src_port, :integer, primary_key: true
-    field :inner_dst_port, :integer, primary_key: true
+    field :inner_src_ip, Portal.Types.IP
+    field :inner_dst_ip, Portal.Types.IP
+    field :inner_src_port, :integer
+    field :inner_dst_port, :integer
     field :domain, :string
 
     field :outer_src_ip, Portal.Types.IP

--- a/elixir/priv/repo/manual_migrations/20260712000000_move_flow_logs_pkey_to_log_id.exs
+++ b/elixir/priv/repo/manual_migrations/20260712000000_move_flow_logs_pkey_to_log_id.exs
@@ -1,0 +1,47 @@
+defmodule Portal.Repo.Migrations.MoveFlowLogsPkeyToLogId do
+  @moduledoc """
+  Moves the flow_logs primary key to (account_id, log_id, flow_start) so the
+  table is keyed by its public handle like the other log tables; flow_start
+  rides along only because Postgres requires the partition key in every
+  primary key on a partitioned table.
+
+  The natural flow identity that was the primary key becomes a unique
+  constraint. Its column order is preserved: its (account_id, flow_start)
+  prefix serves account-scoped time-range listing, and it remains the
+  open/close upsert conflict target. The standalone log_id index is dropped;
+  point lookups are account-scoped and now use the primary key prefix.
+
+  Runs in one transaction, so the upsert never observes a state without its
+  arbiter index. Index builds take ACCESS EXCLUSIVE on the partitions.
+  """
+  use Ecto.Migration
+
+  @identity_columns "account_id, flow_start, device_id, resource_id, " <>
+                      "inner_dst_ip, inner_dst_port, role, protocol, inner_src_ip, inner_src_port"
+
+  def up do
+    execute(
+      "ALTER TABLE flow_logs ADD CONSTRAINT flow_logs_identity_key UNIQUE (#{@identity_columns})"
+    )
+
+    execute("ALTER TABLE flow_logs DROP CONSTRAINT flow_logs_pkey")
+
+    execute(
+      "ALTER TABLE flow_logs ADD CONSTRAINT flow_logs_pkey " <>
+        "PRIMARY KEY (account_id, log_id, flow_start)"
+    )
+
+    execute("DROP INDEX IF EXISTS flow_logs_log_id_index")
+  end
+
+  def down do
+    execute("CREATE INDEX IF NOT EXISTS flow_logs_log_id_index ON flow_logs (log_id)")
+    execute("ALTER TABLE flow_logs DROP CONSTRAINT flow_logs_pkey")
+
+    execute(
+      "ALTER TABLE flow_logs ADD CONSTRAINT flow_logs_pkey PRIMARY KEY (#{@identity_columns})"
+    )
+
+    execute("ALTER TABLE flow_logs DROP CONSTRAINT flow_logs_identity_key")
+  end
+end


### PR DESCRIPTION
flow_logs was keyed by its 10-column natural flow identity, unlike the other log tables, which are keyed by (account_id, log_id). The upcoming seq backfill (#14066) also needs an unambiguous way to address a flow_logs row by log_id.

The primary key is now (account_id, log_id, flow_start); flow_start is included only because Postgres requires the partition key in every primary key on a partitioned table. The flow identity becomes a unique constraint with its column order preserved, so its (account_id, flow_start) prefix still serves time-range listing and it stays the open/close upsert conflict target. The standalone log_id index is dropped since point lookups are account-scoped and now use the primary key.

Related: #14066