### PR TITLE
fix(portal): extend poller timeout

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -63,10 +63,11 @@ config :portal, Portal.Repo.Replica,
   queue_interval: 1000,
   parameters: [application_name: "replica"]
 
-# Isolated primary connection pools (web/api)
+# Isolated primary connection pools (web/api/poller)
 for {repo, app_name} <- [
       {Portal.Repo.Web, "web"},
-      {Portal.Repo.Api, "api"}
+      {Portal.Repo.Api, "api"},
+      {Portal.Repo.Poller, "poller"}
     ] do
   config :portal, repo,
     hostname: "localhost",
@@ -80,10 +81,11 @@ for {repo, app_name} <- [
     parameters: [application_name: app_name]
 end
 
-# Isolated replica connection pools (web/api)
+# Isolated replica connection pools (web/api/poller)
 for {repo, app_name} <- [
       {Portal.Repo.Replica.Web, "replica-web"},
-      {Portal.Repo.Replica.Api, "replica-api"}
+      {Portal.Repo.Replica.Api, "replica-api"},
+      {Portal.Repo.Replica.Poller, "replica-poller"}
     ] do
   config :portal, repo,
     hostname: "localhost",
@@ -98,7 +100,7 @@ for {repo, app_name} <- [
 end
 
 config :portal, Portal.ChangeLogs.Consumer,
-  repo: Portal.Repo,
+  repo: Portal.Repo.Poller,
   replication_slot_name: "change_logs_slot",
   publication_name: "change_logs_publication",
   region: "",
@@ -147,7 +149,7 @@ config :portal, Portal.ChangeLogs.Consumer,
 config :portal, Portal.Changes.Consumer,
   # Changes only broadcasts, so it reads from the regional replica to keep
   # decoding load off the primary
-  repo: Portal.Repo.Replica,
+  repo: Portal.Repo.Replica.Poller,
   replication_slot_name: "changes_slot",
   publication_name: "changes_publication",
   region: "",

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -31,6 +31,8 @@ config :portal, Portal.Repo.Web, db_opts
 config :portal, Portal.Repo.Api, db_opts
 config :portal, Portal.Repo.Replica.Web, db_opts
 config :portal, Portal.Repo.Replica.Api, db_opts
+config :portal, Portal.Repo.Poller, db_opts
+config :portal, Portal.Repo.Replica.Poller, db_opts
 
 # Poll fast locally so live updates and change logs appear without a wait
 config :portal, Portal.ChangeLogs.Consumer,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -140,6 +140,23 @@ if config_env() == :prod do
            ] ++ replica_pool_base_opts
   end
 
+  # Isolated poller connection pools, sized for the two slot pollers: poll
+  # cycles hold a connection for as long as a cycle runs, which must not
+  # starve the shared pools
+  config :portal,
+         Portal.Repo.Poller,
+         [
+           {:pool_size, 2},
+           {:parameters, Keyword.merge(database_parameters, application_name: "poller")}
+         ] ++ primary_pool_base_opts
+
+  config :portal,
+         Portal.Repo.Replica.Poller,
+         [
+           {:pool_size, 2},
+           {:parameters, Keyword.merge(database_parameters, application_name: "replica-poller")}
+         ] ++ replica_pool_base_opts
+
   config :portal, Portal.ChangeLogs.Consumer,
     enabled: env_var_to_config!(:change_logs_replication_enabled),
     replication_slot_name: env_var_to_config!(:database_change_logs_replication_slot_name),

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -33,7 +33,9 @@ for repo <- [
       Portal.Repo.Web,
       Portal.Repo.Api,
       Portal.Repo.Replica.Web,
-      Portal.Repo.Replica.Api
+      Portal.Repo.Replica.Api,
+      Portal.Repo.Poller,
+      Portal.Repo.Replica.Poller
     ] do
   config :portal, repo,
     database: "firezone_test#{partition_suffix}",

--- a/elixir/lib/portal/application.ex
+++ b/elixir/lib/portal/application.ex
@@ -41,11 +41,13 @@ defmodule Portal.Application do
       # Core services
       Portal.Repo,
       Portal.Repo.Replica,
-      # Isolated connection pools (web/api)
+      # Isolated connection pools (web/api/poller)
       Portal.Repo.Web,
       Portal.Repo.Api,
       Portal.Repo.Replica.Web,
       Portal.Repo.Replica.Api,
+      Portal.Repo.Poller,
+      Portal.Repo.Replica.Poller,
       # Default pg scope for distributed process discovery (used by replication)
       %{id: :pg, start: {:pg, :start_link, []}},
       # Named pg scope for Portal.PG, isolated so a crash here does not affect replication

--- a/elixir/lib/portal/health.ex
+++ b/elixir/lib/portal/health.ex
@@ -50,6 +50,8 @@ defmodule Portal.Health do
     |> File.exists?()
   end
 
+  # Deliberately excludes the poller pools: their cycle-long checkouts would
+  # make the readiness query queue up and fail
   @repos [
     Portal.Repo,
     Portal.Repo.Replica,

--- a/elixir/lib/portal/replication/slot_poller.ex
+++ b/elixir/lib/portal/replication/slot_poller.ex
@@ -557,11 +557,25 @@ defmodule Portal.Replication.SlotPoller do
       :ok
     end
 
+    # Runs in `after`: raising here would mask the error that failed the
+    # cycle, so unexpected outcomes are logged instead. A dead connection
+    # already released the lock server-side.
     defp release_leadership(key) do
       case Safe.unscoped(Portal.Repo.Poller)
            |> Safe.query("SELECT pg_advisory_unlock(hashtext($1))", [key]) do
-        {:ok, %{rows: [[true]]}} -> :ok
-        {:error, %DBConnection.ConnectionError{}} -> :ok
+        {:ok, %{rows: [[true]]}} ->
+          :ok
+
+        {:error, %DBConnection.ConnectionError{}} ->
+          :ok
+
+        other ->
+          Logger.error("Unexpected result releasing replication leadership lock",
+            key: key,
+            result: inspect(other)
+          )
+
+          :ok
       end
     end
   end

--- a/elixir/lib/portal/replication/slot_poller.ex
+++ b/elixir/lib/portal/replication/slot_poller.ex
@@ -53,6 +53,13 @@ defmodule Portal.Replication.SlotPoller do
   @default_poll_interval 500
   @default_batch_size 500
 
+  # Bounds a poll cycle and its decoding queries: peek and advance re-decode
+  # WAL from the slot's restart_lsn, so a backlogged slot needs far longer
+  # than the default 15s query timeout; timing out means the slot never
+  # advances and the backlog only grows. Long by design, it only guards
+  # against a permanently hung connection.
+  @default_processing_timeout :timer.hours(24)
+
   @doc """
   Builds the consumer's initial state during poller setup. May query the
   database; a raise is retried together with the rest of setup.
@@ -165,7 +172,9 @@ defmodule Portal.Replication.SlotPoller do
   # makes racing advances harmless.
   defp poll(state) do
     {state, drained?, ack_lsn} =
-      Database.with_leadership(lock_key(state.config), fn -> run_cycle(state) end) ||
+      Database.with_leadership(lock_key(state.config), state.config.processing_timeout, fn ->
+        run_cycle(state)
+      end) ||
         {state, true, nil}
 
     if ack_lsn do
@@ -380,7 +389,8 @@ defmodule Portal.Replication.SlotPoller do
           'proto_version', '1', 'publication_names', $3, 'messages', 'true'
         )
         """,
-        [config.slot_name, config.batch_size, config.publication_name]
+        [config.slot_name, config.batch_size, config.publication_name],
+        timeout: config.processing_timeout
       )
 
     rows
@@ -407,7 +417,8 @@ defmodule Portal.Replication.SlotPoller do
       FROM pg_replication_slots
       WHERE slot_name = $1 AND confirmed_flush_lsn < '0/0'::pg_lsn + $2
       """,
-      [config.slot_name, lsn]
+      [config.slot_name, lsn],
+      timeout: config.processing_timeout
     )
 
     :ok
@@ -428,6 +439,7 @@ defmodule Portal.Replication.SlotPoller do
       region: Keyword.get(config, :region, ""),
       poll_interval: Keyword.get(config, :poll_interval, @default_poll_interval),
       batch_size: Keyword.get(config, :batch_size, @default_batch_size),
+      processing_timeout: Keyword.get(config, :processing_timeout, @default_processing_timeout),
       warning_threshold: Keyword.fetch!(config, :warning_threshold),
       error_threshold: Keyword.fetch!(config, :error_threshold),
       status_log_interval: Keyword.get(config, :status_log_interval, :timer.minutes(1)),
@@ -442,8 +454,11 @@ defmodule Portal.Replication.SlotPoller do
 
     @doc """
     Runs `fun` while holding the session advisory lock for `key` on a
-    checked-out primary connection, or returns nil without calling it when
-    another session holds the lock.
+    connection checked out from the dedicated `Portal.Repo.Poller` primary
+    pool, or returns nil without calling it when another session holds the
+    lock. Advisory locks are unavailable on standbys, so the lock lives on
+    the primary even when the slot being polled is on a replica; the
+    dedicated pool keeps the cycle-long checkout from starving shared pools.
 
     Deliberately not a transaction: `fun` runs consumer side effects (hooks,
     inserts) whose own inner transactions may roll back, which would poison
@@ -451,26 +466,35 @@ defmodule Portal.Replication.SlotPoller do
     released in `after` on the same pinned connection; if the process dies
     mid-cycle the pool disconnects the connection and the server releases the
     lock with it.
-    """
-    def with_leadership(key, fun) do
-      Safe.unscoped()
-      |> Safe.checkout(fn ->
-        {:ok, %{rows: [[locked?]]}} =
-          Safe.unscoped()
-          |> Safe.query("SELECT pg_try_advisory_lock(hashtext($1))", [key])
 
-        if locked? do
-          try do
-            fun.()
-          after
-            {:ok, %{rows: [[true]]}} =
-              Safe.unscoped()
-              |> Safe.query("SELECT pg_advisory_unlock(hashtext($1))", [key])
+    The checkout deadline is `timeout`, the poller's processing timeout,
+    rather than DBConnection's default 15s: leadership must last exactly as
+    long as the cycle, and a shorter deadline would reclaim the pinned
+    connection mid-cycle, silently releasing the lock and failing every
+    later query on it. When the connection dies anyway, the server has
+    already released the lock with it, so a failed unlock is tolerated
+    instead of masking the error that killed the cycle.
+    """
+    def with_leadership(key, timeout, fun) do
+      Safe.unscoped(Portal.Repo.Poller)
+      |> Safe.checkout(
+        fn ->
+          {:ok, %{rows: [[locked?]]}} =
+            Safe.unscoped(Portal.Repo.Poller)
+            |> Safe.query("SELECT pg_try_advisory_lock(hashtext($1))", [key])
+
+          if locked? do
+            try do
+              fun.()
+            after
+              release_leadership(key)
+            end
+          else
+            nil
           end
-        else
-          nil
-        end
-      end)
+        end,
+        timeout: timeout
+      )
     end
 
     # Publications are DDL, which a read replica cannot execute, so they are
@@ -531,6 +555,14 @@ defmodule Portal.Replication.SlotPoller do
       end
 
       :ok
+    end
+
+    defp release_leadership(key) do
+      case Safe.unscoped(Portal.Repo.Poller)
+           |> Safe.query("SELECT pg_advisory_unlock(hashtext($1))", [key]) do
+        {:ok, %{rows: [[true]]}} -> :ok
+        {:error, %DBConnection.ConnectionError{}} -> :ok
+      end
     end
   end
 end

--- a/elixir/lib/portal/repo/poller.ex
+++ b/elixir/lib/portal/repo/poller.ex
@@ -1,0 +1,14 @@
+defmodule Portal.Repo.Poller do
+  @moduledoc """
+  Isolated primary pool for the replication slot pollers.
+
+  Poll cycles hold a checked-out connection for as long as a cycle runs
+  (leadership advisory locks, WAL decoding), which must not starve the
+  shared pools.
+  """
+
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres,
+    read_only: true
+end

--- a/elixir/lib/portal/repo/replica/poller.ex
+++ b/elixir/lib/portal/repo/replica/poller.ex
@@ -1,0 +1,11 @@
+defmodule Portal.Repo.Replica.Poller do
+  @moduledoc """
+  Isolated replica pool for `Portal.Changes.Consumer` WAL decoding; see
+  `Portal.Repo.Poller`.
+  """
+
+  use Ecto.Repo,
+    otp_app: :portal,
+    adapter: Ecto.Adapters.Postgres,
+    read_only: true
+end

--- a/elixir/lib/portal/safe.ex
+++ b/elixir/lib/portal/safe.ex
@@ -360,16 +360,17 @@ defmodule Portal.Safe do
 
   ## Examples
       Safe.unscoped() |> Safe.query("SELECT * FROM actors WHERE id = $1", [actor_id])
+      Safe.unscoped(Repo.Poller) |> Safe.query("SELECT pg_try_advisory_lock($1)", [key])
   """
   @spec query(Unscoped.t(), String.t(), list()) ::
-          {:ok, Postgrex.Result.t()} | {:error, Postgrex.Error.t()}
+          {:ok, Postgrex.Result.t()} | {:error, Exception.t()}
   # sobelow_skip ["SQL.Query"]
-  def query(%Unscoped{}, sql, params) when is_binary(sql) and is_list(params) do
-    Repo.query(sql, params)
+  def query(%Unscoped{repo: repo}, sql, params) when is_binary(sql) and is_list(params) do
+    repo.query(sql, params)
   end
 
   @spec query(Portal.Repo, String.t(), list()) ::
-          {:ok, Postgrex.Result.t()} | {:error, Postgrex.Error.t()}
+          {:ok, Postgrex.Result.t()} | {:error, Exception.t()}
   # sobelow_skip ["SQL.Query"]
   def query(repo, sql, params) when repo == Repo and is_binary(sql) and is_list(params) do
     Repo.query(sql, params)
@@ -391,16 +392,18 @@ defmodule Portal.Safe do
   end
 
   @doc """
-  Runs a function with a single checked-out primary connection, without
-  wrapping it in a transaction. All primary queries inside `fun` use that
-  connection, which session-scoped state (such as advisory locks) requires.
+  Runs a function with a single connection checked out from the context's
+  repo, without wrapping it in a transaction. All of that repo's queries
+  inside `fun` use that connection, which session-scoped state (such as
+  advisory locks) requires.
 
   ## Examples
       Safe.unscoped() |> Safe.checkout(fn -> ... end)
+      Safe.unscoped(Repo.Poller) |> Safe.checkout(fn -> ... end, timeout: :timer.hours(24))
   """
-  @spec checkout(Unscoped.t(), (-> term())) :: term()
-  def checkout(%Unscoped{}, fun) when is_function(fun, 0) do
-    Repo.checkout(fun)
+  @spec checkout(Unscoped.t(), (-> term()), keyword()) :: term()
+  def checkout(%Unscoped{repo: repo}, fun, opts \\ []) when is_function(fun, 0) do
+    repo.checkout(fun, opts)
   end
 
   @doc """


### PR DESCRIPTION
- Extends processing timeout to 24h from the connection timeout of 15s
- Adds a dedicated pool for Pollers so they don't hang up regular queries