### PR TITLE
chore(ci): don't use cache for runtime image

### DIFF
--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           build-args: ${{ matrix.build-args }}
           target: ${{ matrix.target }}
+          no-cache-filters: runtime
           context: elixir
           cache-from: |
             type=gha,scope=${{ matrix.image_name }}:${{ env.CACHE_TAG }}
@@ -80,6 +81,7 @@ jobs:
         with:
           build-args: ${{ matrix.build-args }}
           target: ${{ matrix.target }}
+          no-cache-filters: runtime
           context: elixir
           cache-from: |
             type=gha,scope=${{ matrix.image_name }}:${{ env.CACHE_TAG }}


### PR DESCRIPTION
Prevents the runtime phase Dockerfile steps from using the cache so that we always upgrade packages in the runtime image when building the release.

---

Fixes https://github.com/firezone/firezone/security/code-scanning/191
