### PR TITLE
fix(connlib): only connect flow sockets for batching pairs

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -368,9 +368,10 @@ impl PerfUdpSocket {
             datagram.ecn,
         )?;
 
-        let pooled = self
-            .pool
-            .get_send_socket(transmit.src_ip, datagram.dst, &self.recv_buffers);
+        let is_batch = transmit.contents.len() > datagram.segment_size;
+        let pooled =
+            self.pool
+                .get_send_socket(transmit.src_ip, datagram.dst, is_batch, &self.recv_buffers);
 
         self.send_transmit(pooled.as_socket(), &transmit).await
     }

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -368,10 +368,10 @@ impl PerfUdpSocket {
             datagram.ecn,
         )?;
 
-        let is_batch = transmit.contents.len() > datagram.segment_size;
+        let datagrams = transmit.contents.len().div_ceil(datagram.segment_size);
         let pooled =
             self.pool
-                .get_send_socket(transmit.src_ip, datagram.dst, is_batch, &self.recv_buffers);
+                .get_send_socket(transmit.src_ip, datagram.dst, datagrams, &self.recv_buffers);
 
         self.send_transmit(pooled.as_socket(), &transmit).await
     }

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -17,22 +17,22 @@
 //! The catch-all remains as the wildcard receiver (ICE peer-reflexive traffic, NAT
 //! rebinds) and as the fallback when connecting fails.
 //!
-//! Only pairs that send batches get a flow socket: a pair must send
-//! [`PROMOTE_BATCHES`] multi-segment transmits within [`PROMOTE_WINDOW`] before we
-//! connect one. Batching is what `sendmsg_x` accelerates, and a batch only forms when
-//! the event loop coalesces several same-destination datagrams in one cycle — i.e.
-//! exactly when traffic is dense enough to benefit. Single-datagram senders —
-//! keepalives, sparse control traffic, interactive traffic — are served correctly by
-//! the catch-all socket and would otherwise thrash the bounded cache. Relay traffic
-//! (sent without a pinned source) connects right away.
+//! Only pairs that send batches get a flow socket: a pair is connected once it sends
+//! its second multi-segment transmit. Batching is what `sendmsg_x` accelerates, and a
+//! batch only forms when the event loop coalesces several same-destination datagrams in
+//! one cycle — i.e. exactly when traffic is dense enough to benefit; waiting for the
+//! second batch avoids connecting for a pair whose traffic has not settled yet.
+//! Single-datagram senders — keepalives, sparse control traffic, interactive traffic —
+//! are served correctly by the catch-all socket and would otherwise thrash the bounded
+//! cache.
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, Waker},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use anyhow::Result;
@@ -49,17 +49,6 @@ use super::{OwnedSocket, Socket, poll_recv_ready};
 /// Apple devices only ever run Clients, so the steady-state working set is tiny:
 /// the data-bearing gateway path(s) and the relays.
 const MAX_FLOW_SOCKETS: usize = 16;
-
-/// Multi-segment transmits a `(source, destination)` pair must send within
-/// [`PROMOTE_WINDOW`] to prove it is worth a flow socket.
-///
-/// Requiring a second batch keeps a one-off coalescence — e.g. a TLS flight of two
-/// packets during a page load — from connecting a socket for an otherwise quiet pair,
-/// while anything genuinely batching hits it within moments.
-const PROMOTE_BATCHES: usize = 2;
-
-/// Window within which [`PROMOTE_BATCHES`] must accumulate.
-const PROMOTE_WINDOW: Duration = Duration::from_secs(10);
 
 /// Bound on the pairs tracked for promotion at any one time.
 const MAX_TRACKED_PAIRS: usize = 64;
@@ -232,15 +221,12 @@ impl SocketPool {
             return None;
         }
 
-        // Relay traffic is sent without a pinned source and connects right away;
-        // everything else must earn its flow socket by sending batches.
-        if src.is_some() {
-            if !is_batch {
-                return None;
-            }
-            if !inner.promote.record_batch(key, Instant::now()) {
-                return None;
-            }
+        if !is_batch {
+            return None;
+        }
+
+        if !inner.promote.record_batch(key) {
+            return None;
         }
 
         if inner.flows.len() >= MAX_FLOW_SOCKETS {
@@ -317,69 +303,30 @@ impl Flow {
     }
 }
 
-/// Tracks batched sends per pair to decide when a pair deserves a flow socket.
+/// Tracks pairs that have sent one batch, pending the second that promotes them.
 #[derive(Default)]
 struct PromoteTracker {
-    windows: BTreeMap<Key, RateWindow>,
-}
-
-struct RateWindow {
-    started_at: Instant,
-    batches: usize,
+    batched_once: BTreeSet<Key>,
 }
 
 impl PromoteTracker {
     /// Records a batched (multi-segment) transmit to `key`.
     ///
-    /// Returns `true` once the key has sent [`PROMOTE_BATCHES`] batches within
-    /// [`PROMOTE_WINDOW`], i.e. proven it benefits from the batching fast path.
-    fn record_batch(&mut self, key: Key, now: Instant) -> bool {
-        if !self.windows.contains_key(&key) && self.windows.len() >= MAX_TRACKED_PAIRS {
-            self.evict(now);
+    /// Returns `true` on the key's second batch, i.e. once the pair has settled as a
+    /// data path. A promoted key starts over: should its flow socket be evicted, it
+    /// earns the next one the same way.
+    fn record_batch(&mut self, key: Key) -> bool {
+        if self.batched_once.remove(&key) {
+            return true;
         }
 
-        let window = self.windows.entry(key).or_insert(RateWindow {
-            started_at: now,
-            batches: 0,
-        });
-
-        if now.duration_since(window.started_at) >= PROMOTE_WINDOW {
-            *window = RateWindow {
-                started_at: now,
-                batches: 0,
-            };
+        if self.batched_once.len() >= MAX_TRACKED_PAIRS {
+            self.batched_once.pop_first();
         }
 
-        window.batches += 1;
+        self.batched_once.insert(key);
 
-        if window.batches < PROMOTE_BATCHES {
-            return false;
-        }
-
-        self.windows.remove(&key);
-
-        true
-    }
-
-    /// Drops all expired windows and - if that freed nothing - the stalest one.
-    fn evict(&mut self, now: Instant) {
-        self.windows
-            .retain(|_, w| now.duration_since(w.started_at) < PROMOTE_WINDOW);
-
-        if self.windows.len() < MAX_TRACKED_PAIRS {
-            return;
-        }
-
-        let Some(stalest) = self
-            .windows
-            .iter()
-            .min_by_key(|(_, w)| w.started_at)
-            .map(|(key, _)| *key)
-        else {
-            return;
-        };
-
-        self.windows.remove(&stalest);
+        false
     }
 }
 
@@ -541,40 +488,35 @@ mod tests {
         )
     }
 
-    /// Traffic dense enough to batch: consecutive event-loop cycles each coalescing
-    /// several datagrams. The second batch promotes.
     #[test]
-    fn consecutive_batches_promote() {
+    fn second_batch_promotes() {
         let mut tracker = PromoteTracker::default();
-        let start = Instant::now();
 
-        assert!(!tracker.record_batch(key(1), start));
-        assert!(tracker.record_batch(key(1), start + Duration::from_millis(1)));
+        assert!(!tracker.record_batch(key(1)));
+        assert!(tracker.record_batch(key(1)));
     }
 
-    /// A one-off coalescence - e.g. a TLS flight of two packets during a page load -
-    /// does not promote an otherwise quiet pair.
+    /// A promoted pair starts over: after eviction of its flow socket it earns the
+    /// next one with two batches again.
     #[test]
-    fn single_batch_per_window_never_promotes() {
+    fn promotion_resets_tracking() {
         let mut tracker = PromoteTracker::default();
-        let start = Instant::now();
 
-        let promoted = (0..10)
-            .map(|i| start + (PROMOTE_WINDOW + Duration::from_millis(100)) * i)
-            .any(|now| tracker.record_batch(key(1), now));
+        assert!(!tracker.record_batch(key(1)));
+        assert!(tracker.record_batch(key(1)));
 
-        assert!(!promoted);
+        assert!(!tracker.record_batch(key(1)));
+        assert!(tracker.record_batch(key(1)));
     }
 
     #[test]
     fn tracked_pairs_are_bounded() {
         let mut tracker = PromoteTracker::default();
-        let now = Instant::now();
 
         for port in 0..(MAX_TRACKED_PAIRS as u16 * 2) {
-            tracker.record_batch(key(port), now);
+            tracker.record_batch(key(port));
         }
 
-        assert!(tracker.windows.len() <= MAX_TRACKED_PAIRS);
+        assert!(tracker.batched_once.len() <= MAX_TRACKED_PAIRS);
     }
 }

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -17,13 +17,18 @@
 //! The catch-all remains as the wildcard receiver (ICE peer-reflexive traffic, NAT
 //! rebinds) and as the fallback when connecting fails.
 //!
-//! Only pairs that send big batches get a flow socket: a pair is connected once a
-//! single transmit carries at least [`PROMOTE_BATCH_SIZE`] datagrams. Batching is what
-//! `sendmsg_x` accelerates, and a batch that large only forms when the event loop
-//! coalesces a queue's worth of same-destination datagrams in one cycle — i.e. exactly
-//! when traffic is dense enough to benefit. Everything else — keepalives, sparse
-//! control traffic, interactive traffic and its incidental small batches — is served
-//! correctly by the catch-all socket and would otherwise thrash the bounded cache.
+//! Only pairs with real traffic get a flow socket, decided by two gates:
+//!
+//! - A single transmit carrying at least [`PROMOTE_BATCH_SIZE`] datagrams. Batching is
+//!   what `sendmsg_x` accelerates, and a batch that large only forms when the event loop
+//!   coalesces a queue's worth of same-destination datagrams in one cycle — i.e. exactly
+//!   when traffic is dense enough to benefit.
+//! - Sustaining [`PROMOTE_PACKETS_PER_SECOND`] across transmits. Paced senders (e.g.
+//!   constant-bitrate media) may never coalesce a batch yet still need the flow
+//!   advisories only a connected socket gets.
+//!
+//! Everything else — probes, keepalives, sparse control traffic — is served correctly by
+//! the catch-all socket and would otherwise thrash the bounded cache.
 
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -31,7 +36,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, Waker},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::Result;
@@ -57,6 +62,18 @@ const MAX_FLOW_SOCKETS: usize = 16;
 /// clears the incidental band and is hit within moments by anything genuinely bulk.
 const PROMOTE_BATCH_SIZE: usize = 16;
 
+/// Datagrams a pair must send within [`RATE_WINDOW`] to earn a flow socket without batching.
+///
+/// This promotes paced senders whose transmits never coalesce, so their congestion shows
+/// up as flow advisories instead of silent AQM drops. Path probing cannot trip it: a
+/// probed pair peaks at ~5 packets within a second (the initial burst) and then idles at
+/// 1 packet per second, a 5x margin to this bound. Real paced traffic clears it easily —
+/// a single VoIP stream alone sends 33-50 packets per second.
+const PROMOTE_PACKETS_PER_SECOND: usize = 25;
+
+/// The window over which [`PROMOTE_PACKETS_PER_SECOND`] is measured.
+const RATE_WINDOW: Duration = Duration::from_secs(1);
+
 type Key = (Option<IpAddr>, SocketAddr);
 
 /// The unconnected catch-all socket plus a cache of connected flow sockets, keyed by
@@ -72,6 +89,8 @@ pub(crate) struct SocketPool {
 
 struct Inner {
     flows: BTreeMap<Key, Flow>,
+    /// Send rates of pairs that have not (yet) earned a flow socket.
+    rates: RateGate,
     /// Latched off the first time connecting a flow socket fails.
     ///
     /// A failure means the environment (e.g. the iOS Network Extension sandbox) doesn't permit
@@ -114,6 +133,7 @@ impl SocketPool {
             local,
             inner: Mutex::new(Inner {
                 flows: BTreeMap::new(),
+                rates: RateGate::default(),
                 flow_sockets_supported: true,
                 buffer_sizes: None,
                 drained: VecDeque::new(),
@@ -221,7 +241,7 @@ impl SocketPool {
             return None;
         }
 
-        if datagrams < PROMOTE_BATCH_SIZE {
+        if datagrams < PROMOTE_BATCH_SIZE && !inner.rates.record(key, datagrams, Instant::now()) {
             return None;
         }
 
@@ -232,6 +252,8 @@ impl SocketPool {
         match connect(self.local, src, dst, inner.buffer_sizes) {
             Ok(socket) => {
                 tracing::debug!(?src, %dst, "Connected new flow socket");
+
+                inner.rates.forget(&key);
 
                 let socket = Arc::new(socket);
                 inner.flows.insert(
@@ -296,6 +318,57 @@ impl Inner {
 impl Flow {
     fn record_received(&self, now: Instant) {
         *self.last_received.lock() = Some(now);
+    }
+}
+
+/// Per-pair datagram counters over a fixed [`RATE_WINDOW`].
+///
+/// A tumbling window rather than a sliding one: counts reset when a window expires. That
+/// can at worst double the time to promotion (traffic split across two windows), which is
+/// fine — the gate only needs to separate sustained senders from probing, not be precise.
+#[derive(Default)]
+struct RateGate {
+    counters: BTreeMap<Key, RateCounter>,
+}
+
+struct RateCounter {
+    window_start: Instant,
+    datagrams: usize,
+}
+
+impl RateGate {
+    /// Records a transmit of `datagrams` for a pair; returns whether the pair crossed
+    /// [`PROMOTE_PACKETS_PER_SECOND`] within the current window and thus earned a flow socket.
+    fn record(&mut self, key: Key, datagrams: usize, now: Instant) -> bool {
+        // Pairs that stop sending (probed dead ends) leave counters behind; prune expired
+        // ones before growing the map so it stays bounded by concurrently-active pairs.
+        if self.counters.len() >= MAX_FLOW_SOCKETS * 4 && !self.counters.contains_key(&key) {
+            self.counters
+                .retain(|_, counter| now.duration_since(counter.window_start) < RATE_WINDOW);
+        }
+
+        let counter = self.counters.entry(key).or_insert(RateCounter {
+            window_start: now,
+            datagrams: 0,
+        });
+
+        if now.duration_since(counter.window_start) >= RATE_WINDOW {
+            counter.window_start = now;
+            counter.datagrams = 0;
+        }
+
+        counter.datagrams += datagrams;
+
+        if counter.datagrams >= PROMOTE_PACKETS_PER_SECOND {
+            self.counters.remove(&key);
+            return true;
+        }
+
+        false
+    }
+
+    fn forget(&mut self, key: &Key) {
+        self.counters.remove(key);
     }
 }
 
@@ -421,7 +494,7 @@ fn connect(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::net::Ipv4Addr;
 
     use super::*;
 
@@ -448,5 +521,66 @@ mod tests {
         let later = earlier + Duration::from_secs(60);
 
         assert!(eviction_rank(Some(earlier), earlier) < eviction_rank(Some(later), earlier));
+    }
+
+    const KEY: Key = (None, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234));
+
+    #[test]
+    fn paced_sender_promotes_within_a_window() {
+        let mut gate = RateGate::default();
+        let start = Instant::now();
+
+        // 20ms pacing, one datagram per transmit: 50 packets/s.
+        let promoted = (0..PROMOTE_PACKETS_PER_SECOND)
+            .any(|i| gate.record(KEY, 1, start + Duration::from_millis(20 * i as u64)));
+
+        assert!(promoted);
+    }
+
+    #[test]
+    fn probe_cadence_never_promotes() {
+        let mut gate = RateGate::default();
+        let start = Instant::now();
+
+        // The initial probe burst: 4 packets within the first second ...
+        for gap in [0, 200, 500, 1000] {
+            assert!(!gate.record(KEY, 1, start + Duration::from_millis(gap)));
+        }
+
+        // ... then one probe per second, forever.
+        for i in 2..120 {
+            assert!(!gate.record(KEY, 1, start + Duration::from_secs(i)));
+        }
+    }
+
+    #[test]
+    fn expired_window_forgets_earlier_transmits() {
+        let mut gate = RateGate::default();
+        let start = Instant::now();
+
+        for _ in 0..PROMOTE_PACKETS_PER_SECOND - 1 {
+            assert!(!gate.record(KEY, 1, start));
+        }
+
+        // Just under the threshold again, but in a fresh window: no promotion.
+        let later = start + RATE_WINDOW;
+        for _ in 0..PROMOTE_PACKETS_PER_SECOND - 1 {
+            assert!(!gate.record(KEY, 1, later));
+        }
+    }
+
+    #[test]
+    fn stale_counters_are_pruned() {
+        let mut gate = RateGate::default();
+        let start = Instant::now();
+
+        for port in 0..MAX_FLOW_SOCKETS as u16 * 4 {
+            let key = (None, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port));
+            gate.record(key, 1, start);
+        }
+
+        gate.record(KEY, 1, start + RATE_WINDOW);
+
+        assert_eq!(gate.counters.len(), 1);
     }
 }

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -17,13 +17,15 @@
 //! The catch-all remains as the wildcard receiver (ICE peer-reflexive traffic, NAT
 //! rebinds) and as the fallback when connecting fails.
 //!
-//! Only pairs that send big batches get a flow socket: a pair is connected once a
-//! single transmit carries at least [`PROMOTE_BATCH_SIZE`] datagrams. Batching is what
-//! `sendmsg_x` accelerates, and a batch that large only forms when the event loop
-//! coalesces a queue's worth of same-destination datagrams in one cycle — i.e. exactly
-//! when traffic is dense enough to benefit. Everything else — keepalives, sparse
-//! control traffic, interactive traffic and its incidental small batches — is served
-//! correctly by the catch-all socket and would otherwise thrash the bounded cache.
+//! Only pairs that carry data get a flow socket: a pair is connected once a single
+//! transmit carries at least [`PROMOTE_BATCH_SIZE`] datagrams. A multi-segment
+//! transmit only forms when the event loop coalesces same-destination datagrams in one
+//! cycle, which any genuine data flow does within its first round-trips — even on a
+//! slow link, where engaging the flow advisories quickly matters most, because without
+//! them the AQM drops silently and TCP inside the tunnel cannot ramp. Probes,
+//! keepalives and handshakes are paced too far apart to ever coalesce, so pure
+//! signalling pairs stay on the catch-all socket instead of thrashing the bounded
+//! cache.
 
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -51,11 +53,12 @@ const MAX_FLOW_SOCKETS: usize = 16;
 
 /// Datagrams a single transmit must carry for its pair to earn a flow socket.
 ///
-/// Production batch-size percentiles inform this bound: incidental coalescence
-/// (interactive traffic, control chatter) keeps p95 below ~12 datagrams per transmit,
-/// while bulk transfers pin p99 at the send path's batch limit of 32. Half that limit
-/// clears the incidental band and is hit within moments by anything genuinely bulk.
-const PROMOTE_BATCH_SIZE: usize = 16;
+/// The bound must stay low: flow advisories are a link-capacity signal, and a congested
+/// slow link keeps TCP's window — and thus our batch sizes — small, so a high bound
+/// would lock exactly the pairs that need backpressure out of it. Two is enough to
+/// separate data from signalling: probes, keepalives and handshakes are paced hundreds
+/// of milliseconds apart and never coalesce.
+const PROMOTE_BATCH_SIZE: usize = 2;
 
 type Key = (Option<IpAddr>, SocketAddr);
 

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -11,11 +11,21 @@
 //!   Unconnected sockets suffer silent head-drops in the AQM instead.
 //! - The route (and thus `so_pktheadroom`) is cached at connect time.
 //!
-//! We therefore connect a socket per `(source, destination)` pair on first send, all bound
-//! to the same local port as the unconnected catch-all socket. The kernel delivers inbound
-//! datagrams with an exact 4-tuple match to the connected socket in preference to the
-//! wildcard one. The catch-all remains as the wildcard receiver (ICE peer-reflexive
-//! traffic, NAT rebinds) and as the fallback when connecting fails.
+//! We therefore connect a socket per `(source, destination)` pair, all bound to the same
+//! local port as the unconnected catch-all socket. The kernel delivers inbound datagrams
+//! with an exact 4-tuple match to the connected socket in preference to the wildcard one.
+//! The catch-all remains as the wildcard receiver (ICE peer-reflexive traffic, NAT
+//! rebinds) and as the fallback when connecting fails.
+//!
+//! Only pairs that send batches get a flow socket: a pair must send
+//! [`PROMOTE_BATCHES`] multi-segment transmits within [`PROMOTE_WINDOW`] before we
+//! connect one. Batching is what `sendmsg_x` accelerates, and a batch only forms when
+//! the event loop coalesces several same-destination datagrams in one cycle — i.e.
+//! exactly when traffic is dense enough to benefit. Single-datagram senders — path-agent
+//! probes fanning out over the candidate mesh (paced too far apart to ever coalesce),
+//! WireGuard keepalives, interactive traffic — are served correctly by the catch-all
+//! socket and would otherwise thrash the bounded cache. Relay traffic (sent without a
+//! pinned source) connects right away.
 
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -23,7 +33,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, Waker},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::Result;
@@ -38,9 +48,24 @@ use super::{OwnedSocket, Socket, poll_recv_ready};
 /// so this is effectively the per-family cap.
 ///
 /// Apple devices only ever run Clients, so the steady-state working set is tiny:
-/// the connected gateway(s) and possibly a relay. The cap mainly bounds the burst
-/// of short-lived sockets during ICE connectivity checks.
-const MAX_FLOW_SOCKETS: usize = if cfg!(target_os = "ios") { 8 } else { 16 };
+/// the data-bearing gateway path(s) and the relays.
+const MAX_FLOW_SOCKETS: usize = 16;
+
+/// Multi-segment transmits a `(source, destination)` pair must send within
+/// [`PROMOTE_WINDOW`] to prove it is worth a flow socket.
+///
+/// Requiring a second batch keeps a one-off coalescence — e.g. a TLS flight of two
+/// packets during a page load — from connecting a socket for an otherwise quiet pair,
+/// while anything genuinely batching hits it within moments. Probing pairs can never
+/// qualify: probes are paced hundreds of milliseconds apart, so the event loop cannot
+/// coalesce them into a batch in the first place.
+const PROMOTE_BATCHES: usize = 2;
+
+/// Window within which [`PROMOTE_BATCHES`] must accumulate.
+const PROMOTE_WINDOW: Duration = Duration::from_secs(10);
+
+/// Bound on the pairs tracked for promotion at any one time.
+const MAX_TRACKED_PAIRS: usize = 64;
 
 type Key = (Option<IpAddr>, SocketAddr);
 
@@ -66,6 +91,8 @@ struct Inner {
     /// sockets already connected keep working. Re-binding the sockets on a network change builds a
     /// fresh [`SocketPool`], giving connecting another chance.
     flow_sockets_supported: bool,
+    /// Send accounting for pairs that have not (yet) proven data-bearing.
+    promote: PromoteTracker,
     buffer_sizes: Option<(usize, usize)>,
     /// Datagrams rescued from an evicted socket's receive buffer just before closing it.
     drained: VecDeque<DatagramSegmentIter>,
@@ -100,6 +127,7 @@ impl SocketPool {
             inner: Mutex::new(Inner {
                 flows: BTreeMap::new(),
                 flow_sockets_supported: true,
+                promote: PromoteTracker::default(),
                 buffer_sizes: None,
                 drained: VecDeque::new(),
                 recv_waker: None,
@@ -108,16 +136,19 @@ impl SocketPool {
         }
     }
 
-    /// Picks the socket to send a datagram for `(src, dst)` on.
+    /// Picks the socket to send a transmit for `(src, dst)` on; `is_batch` says whether
+    /// it carries multiple datagrams.
     ///
-    /// Connects (or reuses) a flow socket; on failure it falls back to the catch-all socket.
+    /// Reuses (or connects) a flow socket; non-batching pairs and connect failures fall
+    /// back to the catch-all socket.
     pub(crate) fn get_send_socket(
         &self,
         src: Option<IpAddr>,
         dst: SocketAddr,
+        is_batch: bool,
         recv_buffers: &RecvBuffers,
     ) -> Arc<OwnedSocket> {
-        self.get_or_connect(src, dst, recv_buffers)
+        self.get_or_connect(src, dst, is_batch, recv_buffers)
             .unwrap_or_else(|| self.wildcard.clone())
     }
 
@@ -181,13 +212,16 @@ impl SocketPool {
         }
     }
 
-    /// Returns the flow socket for the given `(src, dst)` pair, connecting a new one if needed.
+    /// Returns the flow socket for the given `(src, dst)` pair, connecting a new one once
+    /// the pair proves it sends batches.
     ///
-    /// Returns `None` if connecting fails (or has failed before); see `Inner::flow_sockets_supported`.
+    /// Returns `None` for pairs below the promotion threshold and when connecting fails
+    /// (or has failed before); see `Inner::flow_sockets_supported`.
     fn get_or_connect(
         &self,
         src: Option<IpAddr>,
         dst: SocketAddr,
+        is_batch: bool,
         recv_buffers: &RecvBuffers,
     ) -> Option<Arc<OwnedSocket>> {
         let key = (src, dst);
@@ -199,6 +233,17 @@ impl SocketPool {
 
         if !inner.flow_sockets_supported {
             return None;
+        }
+
+        // Relay traffic is sent without a pinned source and connects right away;
+        // everything else must earn its flow socket by sending batches.
+        if src.is_some() {
+            if !is_batch {
+                return None;
+            }
+            if !inner.promote.record_batch(key, Instant::now()) {
+                return None;
+            }
         }
 
         if inner.flows.len() >= MAX_FLOW_SOCKETS {
@@ -272,6 +317,72 @@ impl Inner {
 impl Flow {
     fn record_received(&self, now: Instant) {
         *self.last_received.lock() = Some(now);
+    }
+}
+
+/// Tracks batched sends per pair to decide when a pair deserves a flow socket.
+#[derive(Default)]
+struct PromoteTracker {
+    windows: BTreeMap<Key, RateWindow>,
+}
+
+struct RateWindow {
+    started_at: Instant,
+    batches: usize,
+}
+
+impl PromoteTracker {
+    /// Records a batched (multi-segment) transmit to `key`.
+    ///
+    /// Returns `true` once the key has sent [`PROMOTE_BATCHES`] batches within
+    /// [`PROMOTE_WINDOW`], i.e. proven it benefits from the batching fast path.
+    fn record_batch(&mut self, key: Key, now: Instant) -> bool {
+        if !self.windows.contains_key(&key) && self.windows.len() >= MAX_TRACKED_PAIRS {
+            self.evict(now);
+        }
+
+        let window = self.windows.entry(key).or_insert(RateWindow {
+            started_at: now,
+            batches: 0,
+        });
+
+        if now.duration_since(window.started_at) >= PROMOTE_WINDOW {
+            *window = RateWindow {
+                started_at: now,
+                batches: 0,
+            };
+        }
+
+        window.batches += 1;
+
+        if window.batches < PROMOTE_BATCHES {
+            return false;
+        }
+
+        self.windows.remove(&key);
+
+        true
+    }
+
+    /// Drops all expired windows and - if that freed nothing - the stalest one.
+    fn evict(&mut self, now: Instant) {
+        self.windows
+            .retain(|_, w| now.duration_since(w.started_at) < PROMOTE_WINDOW);
+
+        if self.windows.len() < MAX_TRACKED_PAIRS {
+            return;
+        }
+
+        let Some(stalest) = self
+            .windows
+            .iter()
+            .min_by_key(|(_, w)| w.started_at)
+            .map(|(key, _)| *key)
+        else {
+            return;
+        };
+
+        self.windows.remove(&stalest);
     }
 }
 
@@ -424,5 +535,49 @@ mod tests {
         let later = earlier + Duration::from_secs(60);
 
         assert!(eviction_rank(Some(earlier), earlier) < eviction_rank(Some(later), earlier));
+    }
+
+    fn key(port: u16) -> Key {
+        (
+            Some("10.0.0.1".parse().unwrap()),
+            SocketAddr::new("10.0.0.2".parse().unwrap(), port),
+        )
+    }
+
+    /// Traffic dense enough to batch: consecutive event-loop cycles each coalescing
+    /// several datagrams. The second batch promotes.
+    #[test]
+    fn consecutive_batches_promote() {
+        let mut tracker = PromoteTracker::default();
+        let start = Instant::now();
+
+        assert!(!tracker.record_batch(key(1), start));
+        assert!(tracker.record_batch(key(1), start + Duration::from_millis(1)));
+    }
+
+    /// A one-off coalescence - e.g. a TLS flight of two packets during a page load -
+    /// does not promote an otherwise quiet pair.
+    #[test]
+    fn single_batch_per_window_never_promotes() {
+        let mut tracker = PromoteTracker::default();
+        let start = Instant::now();
+
+        let promoted = (0..10)
+            .map(|i| start + (PROMOTE_WINDOW + Duration::from_millis(100)) * i)
+            .any(|now| tracker.record_batch(key(1), now));
+
+        assert!(!promoted);
+    }
+
+    #[test]
+    fn tracked_pairs_are_bounded() {
+        let mut tracker = PromoteTracker::default();
+        let now = Instant::now();
+
+        for port in 0..(MAX_TRACKED_PAIRS as u16 * 2) {
+            tracker.record_batch(key(port), now);
+        }
+
+        assert!(tracker.windows.len() <= MAX_TRACKED_PAIRS);
     }
 }

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -21,11 +21,10 @@
 //! [`PROMOTE_BATCHES`] multi-segment transmits within [`PROMOTE_WINDOW`] before we
 //! connect one. Batching is what `sendmsg_x` accelerates, and a batch only forms when
 //! the event loop coalesces several same-destination datagrams in one cycle — i.e.
-//! exactly when traffic is dense enough to benefit. Single-datagram senders — path-agent
-//! probes fanning out over the candidate mesh (paced too far apart to ever coalesce),
-//! WireGuard keepalives, interactive traffic — are served correctly by the catch-all
-//! socket and would otherwise thrash the bounded cache. Relay traffic (sent without a
-//! pinned source) connects right away.
+//! exactly when traffic is dense enough to benefit. Single-datagram senders —
+//! keepalives, sparse control traffic, interactive traffic — are served correctly by
+//! the catch-all socket and would otherwise thrash the bounded cache. Relay traffic
+//! (sent without a pinned source) connects right away.
 
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -56,9 +55,7 @@ const MAX_FLOW_SOCKETS: usize = 16;
 ///
 /// Requiring a second batch keeps a one-off coalescence — e.g. a TLS flight of two
 /// packets during a page load — from connecting a socket for an otherwise quiet pair,
-/// while anything genuinely batching hits it within moments. Probing pairs can never
-/// qualify: probes are paced hundreds of milliseconds apart, so the event loop cannot
-/// coalesce them into a batch in the first place.
+/// while anything genuinely batching hits it within moments.
 const PROMOTE_BATCHES: usize = 2;
 
 /// Window within which [`PROMOTE_BATCHES`] must accumulate.

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -17,17 +17,16 @@
 //! The catch-all remains as the wildcard receiver (ICE peer-reflexive traffic, NAT
 //! rebinds) and as the fallback when connecting fails.
 //!
-//! Only pairs that send batches get a flow socket: a pair is connected once it sends
-//! its second multi-segment transmit. Batching is what `sendmsg_x` accelerates, and a
-//! batch only forms when the event loop coalesces several same-destination datagrams in
-//! one cycle — i.e. exactly when traffic is dense enough to benefit; waiting for the
-//! second batch avoids connecting for a pair whose traffic has not settled yet.
-//! Single-datagram senders — keepalives, sparse control traffic, interactive traffic —
-//! are served correctly by the catch-all socket and would otherwise thrash the bounded
-//! cache.
+//! Only pairs that send big batches get a flow socket: a pair is connected once a
+//! single transmit carries at least [`PROMOTE_BATCH_SIZE`] datagrams. Batching is what
+//! `sendmsg_x` accelerates, and a batch that large only forms when the event loop
+//! coalesces a queue's worth of same-destination datagrams in one cycle — i.e. exactly
+//! when traffic is dense enough to benefit. Everything else — keepalives, sparse
+//! control traffic, interactive traffic and its incidental small batches — is served
+//! correctly by the catch-all socket and would otherwise thrash the bounded cache.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
@@ -50,8 +49,13 @@ use super::{OwnedSocket, Socket, poll_recv_ready};
 /// the data-bearing gateway path(s) and the relays.
 const MAX_FLOW_SOCKETS: usize = 16;
 
-/// Bound on the pairs tracked for promotion at any one time.
-const MAX_TRACKED_PAIRS: usize = 64;
+/// Datagrams a single transmit must carry for its pair to earn a flow socket.
+///
+/// Production batch-size percentiles inform this bound: incidental coalescence
+/// (interactive traffic, control chatter) keeps p95 below ~12 datagrams per transmit,
+/// while bulk transfers pin p99 at the send path's batch limit of 32. Half that limit
+/// clears the incidental band and is hit within moments by anything genuinely bulk.
+const PROMOTE_BATCH_SIZE: usize = 16;
 
 type Key = (Option<IpAddr>, SocketAddr);
 
@@ -77,8 +81,6 @@ struct Inner {
     /// sockets already connected keep working. Re-binding the sockets on a network change builds a
     /// fresh [`SocketPool`], giving connecting another chance.
     flow_sockets_supported: bool,
-    /// Send accounting for pairs that have not (yet) proven data-bearing.
-    promote: PromoteTracker,
     buffer_sizes: Option<(usize, usize)>,
     /// Datagrams rescued from an evicted socket's receive buffer just before closing it.
     drained: VecDeque<DatagramSegmentIter>,
@@ -113,7 +115,6 @@ impl SocketPool {
             inner: Mutex::new(Inner {
                 flows: BTreeMap::new(),
                 flow_sockets_supported: true,
-                promote: PromoteTracker::default(),
                 buffer_sizes: None,
                 drained: VecDeque::new(),
                 recv_waker: None,
@@ -122,19 +123,18 @@ impl SocketPool {
         }
     }
 
-    /// Picks the socket to send a transmit for `(src, dst)` on; `is_batch` says whether
-    /// it carries multiple datagrams.
+    /// Picks the socket to send a transmit of `datagrams` datagrams for `(src, dst)` on.
     ///
-    /// Reuses (or connects) a flow socket; non-batching pairs and connect failures fall
-    /// back to the catch-all socket.
+    /// Reuses (or connects) a flow socket; pairs below the promotion threshold and
+    /// connect failures fall back to the catch-all socket.
     pub(crate) fn get_send_socket(
         &self,
         src: Option<IpAddr>,
         dst: SocketAddr,
-        is_batch: bool,
+        datagrams: usize,
         recv_buffers: &RecvBuffers,
     ) -> Arc<OwnedSocket> {
-        self.get_or_connect(src, dst, is_batch, recv_buffers)
+        self.get_or_connect(src, dst, datagrams, recv_buffers)
             .unwrap_or_else(|| self.wildcard.clone())
     }
 
@@ -199,7 +199,7 @@ impl SocketPool {
     }
 
     /// Returns the flow socket for the given `(src, dst)` pair, connecting a new one once
-    /// the pair proves it sends batches.
+    /// the pair proves it sends big batches.
     ///
     /// Returns `None` for pairs below the promotion threshold and when connecting fails
     /// (or has failed before); see `Inner::flow_sockets_supported`.
@@ -207,7 +207,7 @@ impl SocketPool {
         &self,
         src: Option<IpAddr>,
         dst: SocketAddr,
-        is_batch: bool,
+        datagrams: usize,
         recv_buffers: &RecvBuffers,
     ) -> Option<Arc<OwnedSocket>> {
         let key = (src, dst);
@@ -221,11 +221,7 @@ impl SocketPool {
             return None;
         }
 
-        if !is_batch {
-            return None;
-        }
-
-        if !inner.promote.record_batch(key) {
+        if datagrams < PROMOTE_BATCH_SIZE {
             return None;
         }
 
@@ -300,33 +296,6 @@ impl Inner {
 impl Flow {
     fn record_received(&self, now: Instant) {
         *self.last_received.lock() = Some(now);
-    }
-}
-
-/// Tracks pairs that have sent one batch, pending the second that promotes them.
-#[derive(Default)]
-struct PromoteTracker {
-    batched_once: BTreeSet<Key>,
-}
-
-impl PromoteTracker {
-    /// Records a batched (multi-segment) transmit to `key`.
-    ///
-    /// Returns `true` on the key's second batch, i.e. once the pair has settled as a
-    /// data path. A promoted key starts over: should its flow socket be evicted, it
-    /// earns the next one the same way.
-    fn record_batch(&mut self, key: Key) -> bool {
-        if self.batched_once.remove(&key) {
-            return true;
-        }
-
-        if self.batched_once.len() >= MAX_TRACKED_PAIRS {
-            self.batched_once.pop_first();
-        }
-
-        self.batched_once.insert(key);
-
-        false
     }
 }
 
@@ -479,44 +448,5 @@ mod tests {
         let later = earlier + Duration::from_secs(60);
 
         assert!(eviction_rank(Some(earlier), earlier) < eviction_rank(Some(later), earlier));
-    }
-
-    fn key(port: u16) -> Key {
-        (
-            Some("10.0.0.1".parse().unwrap()),
-            SocketAddr::new("10.0.0.2".parse().unwrap(), port),
-        )
-    }
-
-    #[test]
-    fn second_batch_promotes() {
-        let mut tracker = PromoteTracker::default();
-
-        assert!(!tracker.record_batch(key(1)));
-        assert!(tracker.record_batch(key(1)));
-    }
-
-    /// A promoted pair starts over: after eviction of its flow socket it earns the
-    /// next one with two batches again.
-    #[test]
-    fn promotion_resets_tracking() {
-        let mut tracker = PromoteTracker::default();
-
-        assert!(!tracker.record_batch(key(1)));
-        assert!(tracker.record_batch(key(1)));
-
-        assert!(!tracker.record_batch(key(1)));
-        assert!(tracker.record_batch(key(1)));
-    }
-
-    #[test]
-    fn tracked_pairs_are_bounded() {
-        let mut tracker = PromoteTracker::default();
-
-        for port in 0..(MAX_TRACKED_PAIRS as u16 * 2) {
-            tracker.record_batch(key(port));
-        }
-
-        assert!(tracker.batched_once.len() <= MAX_TRACKED_PAIRS);
     }
 }

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -17,15 +17,13 @@
 //! The catch-all remains as the wildcard receiver (ICE peer-reflexive traffic, NAT
 //! rebinds) and as the fallback when connecting fails.
 //!
-//! Only pairs that carry data get a flow socket: a pair is connected once a single
-//! transmit carries at least [`PROMOTE_BATCH_SIZE`] datagrams. A multi-segment
-//! transmit only forms when the event loop coalesces same-destination datagrams in one
-//! cycle, which any genuine data flow does within its first round-trips — even on a
-//! slow link, where engaging the flow advisories quickly matters most, because without
-//! them the AQM drops silently and TCP inside the tunnel cannot ramp. Probes,
-//! keepalives and handshakes are paced too far apart to ever coalesce, so pure
-//! signalling pairs stay on the catch-all socket instead of thrashing the bounded
-//! cache.
+//! Only pairs that send big batches get a flow socket: a pair is connected once a
+//! single transmit carries at least [`PROMOTE_BATCH_SIZE`] datagrams. Batching is what
+//! `sendmsg_x` accelerates, and a batch that large only forms when the event loop
+//! coalesces a queue's worth of same-destination datagrams in one cycle — i.e. exactly
+//! when traffic is dense enough to benefit. Everything else — keepalives, sparse
+//! control traffic, interactive traffic and its incidental small batches — is served
+//! correctly by the catch-all socket and would otherwise thrash the bounded cache.
 
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -53,12 +51,11 @@ const MAX_FLOW_SOCKETS: usize = 16;
 
 /// Datagrams a single transmit must carry for its pair to earn a flow socket.
 ///
-/// The bound must stay low: flow advisories are a link-capacity signal, and a congested
-/// slow link keeps TCP's window — and thus our batch sizes — small, so a high bound
-/// would lock exactly the pairs that need backpressure out of it. Two is enough to
-/// separate data from signalling: probes, keepalives and handshakes are paced hundreds
-/// of milliseconds apart and never coalesce.
-const PROMOTE_BATCH_SIZE: usize = 2;
+/// Production batch-size percentiles inform this bound: incidental coalescence
+/// (interactive traffic, control chatter) keeps p95 below ~12 datagrams per transmit,
+/// while bulk transfers pin p99 at the send path's batch limit of 32. Half that limit
+/// clears the incidental band and is hit within moments by anything genuinely bulk.
+const PROMOTE_BATCH_SIZE: usize = 16;
 
 type Key = (Option<IpAddr>, SocketAddr);
 

--- a/rust/libs/connlib/socket-factory/src/pool/fallback.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/fallback.rs
@@ -31,6 +31,7 @@ impl SocketPool {
         &self,
         _src: Option<IpAddr>,
         _dst: SocketAddr,
+        _is_batch: bool,
         _recv_buffers: &crate::RecvBuffers,
     ) -> Arc<OwnedSocket> {
         self.wildcard.clone()

--- a/rust/libs/connlib/socket-factory/src/pool/fallback.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/fallback.rs
@@ -31,7 +31,7 @@ impl SocketPool {
         &self,
         _src: Option<IpAddr>,
         _dst: SocketAddr,
-        _is_batch: bool,
+        _datagrams: usize,
         _recv_buffers: &crate::RecvBuffers,
     ) -> Arc<OwnedSocket> {
         self.wildcard.clone()

--- a/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
+++ b/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
@@ -9,10 +9,13 @@ use socket_factory::{DatagramOut, udp};
 /// Datagrams sent to a fresh peer round-trip: the peer receives them and the reply is
 /// delivered back through the same [`PerfUdpSocket`](socket_factory::PerfUdpSocket).
 ///
-/// The batched sends promote the pair to a connected flow socket on Apple (see the
-/// assertion below); on every other platform everything uses the single catch-all socket.
+/// The batch is big enough to promote the pair to a connected flow socket on Apple (see
+/// the assertion below); on every other platform everything uses the single catch-all
+/// socket.
 #[tokio::test]
 async fn sends_and_receives_a_datagram() {
+    const DATAGRAMS: usize = 16;
+
     let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let peer_addr = peer.local_addr().unwrap();
 
@@ -23,29 +26,26 @@ async fn sends_and_receives_a_datagram() {
 
     let pool = BufferPool::<BytesMut>::new(2048, "test");
 
-    // Two multi-segment transmits promote the pair to a connected flow socket.
-    for _ in 0..2 {
-        socket
-            .send(DatagramOut {
-                src: None,
-                dst: peer_addr,
-                packet: pool.pull_initialised(b"hellohello"),
-                segment_size: 5,
-                ecn: Ecn::NonEct,
-            })
-            .await
-            .unwrap();
-    }
+    socket
+        .send(DatagramOut {
+            src: None,
+            dst: peer_addr,
+            packet: pool.pull_initialised(&b"hello".repeat(DATAGRAMS)),
+            segment_size: 5,
+            ecn: Ecn::NonEct,
+        })
+        .await
+        .unwrap();
 
-    // On Apple, the second batch must connect a flow socket - not silently fall back to
-    // the catch-all. A count of 0 would mean `connect()` failed (e.g. the catch-all lacked
-    // `SO_REUSEPORT`) and the fast path latched off.
+    // On Apple, a batch of `DATAGRAMS` datagrams must connect a flow socket - not
+    // silently fall back to the catch-all. A count of 0 would mean `connect()` failed
+    // (e.g. the catch-all lacked `SO_REUSEPORT`) and the fast path latched off.
     #[cfg(apple)]
     assert_eq!(socket.flow_socket_count(), 1);
 
     let mut buf = [0u8; 16];
     let mut from = peer_addr;
-    for _ in 0..4 {
+    for _ in 0..DATAGRAMS {
         let (len, sender) = peer.recv_from(&mut buf).await.unwrap();
         assert_eq!(&buf[..len], b"hello");
         from = sender;

--- a/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
+++ b/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
@@ -6,12 +6,11 @@ use gat_lending_iterator::LendingIterator as _;
 use ip_packet::Ecn;
 use socket_factory::{DatagramOut, udp};
 
-/// A datagram sent to a fresh peer round-trips: the peer receives it and the reply is
+/// Datagrams sent to a fresh peer round-trip: the peer receives them and the reply is
 /// delivered back through the same [`PerfUdpSocket`](socket_factory::PerfUdpSocket).
 ///
-/// The datagram carries no pinned source, which marks relay traffic, so on Apple it goes
-/// out over a connected per-destination flow socket right away (see the assertion below);
-/// on every other platform it uses the single catch-all socket.
+/// The batched sends promote the pair to a connected flow socket on Apple (see the
+/// assertion below); on every other platform everything uses the single catch-all socket.
 #[tokio::test]
 async fn sends_and_receives_a_datagram() {
     let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -24,73 +23,11 @@ async fn sends_and_receives_a_datagram() {
 
     let pool = BufferPool::<BytesMut>::new(2048, "test");
 
-    socket
-        .send(DatagramOut {
-            src: None,
-            dst: peer_addr,
-            packet: pool.pull_initialised(b"hello"),
-            segment_size: 5,
-            ecn: Ecn::NonEct,
-        })
-        .await
-        .unwrap();
-
-    // On Apple, the send must go out over a connected flow socket - not silently fall back to
-    // the catch-all. A count of 0 would mean `connect()` failed (e.g. the catch-all lacked
-    // `SO_REUSEPORT`) and the fast path latched off.
-    #[cfg(apple)]
-    assert_eq!(socket.flow_socket_count(), 1);
-
-    let mut buf = [0u8; 16];
-    let (len, from) = peer.recv_from(&mut buf).await.unwrap();
-    assert_eq!(&buf[..len], b"hello");
-
-    // The reply matches the (connected) socket's 4-tuple exactly and must be delivered via it.
-    peer.send_to(b"world", from).await.unwrap();
-
-    let mut iter = socket.recv_from().await.unwrap();
-    let datagram = iter.next().unwrap();
-
-    assert_eq!(datagram.packet, b"world");
-    assert_eq!(datagram.from, peer_addr);
-}
-
-/// A pair with a pinned source only earns a connected flow socket by sending batches:
-/// single-datagram sends stay on the catch-all socket, the second multi-segment transmit
-/// promotes the pair.
-#[tokio::test]
-async fn batched_sends_promote_to_flow_socket() {
-    let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-    let peer_addr = peer.local_addr().unwrap();
-
-    let socket = udp("127.0.0.1:0".parse().unwrap())
-        .unwrap()
-        .into_perf()
-        .unwrap();
-
-    let pool = BufferPool::<BytesMut>::new(2048, "test");
-    let src = Some("127.0.0.1:0".parse().unwrap());
-
-    // A single-datagram send does not connect a flow socket.
-    socket
-        .send(DatagramOut {
-            src,
-            dst: peer_addr,
-            packet: pool.pull_initialised(b"hello"),
-            segment_size: 5,
-            ecn: Ecn::NonEct,
-        })
-        .await
-        .unwrap();
-
-    #[cfg(apple)]
-    assert_eq!(socket.flow_socket_count(), 0);
-
-    // Two multi-segment transmits prove the pair batches and promote it.
+    // Two multi-segment transmits promote the pair to a connected flow socket.
     for _ in 0..2 {
         socket
             .send(DatagramOut {
-                src,
+                src: None,
                 dst: peer_addr,
                 packet: pool.pull_initialised(b"hellohello"),
                 segment_size: 5,
@@ -100,13 +37,26 @@ async fn batched_sends_promote_to_flow_socket() {
             .unwrap();
     }
 
+    // On Apple, the second batch must connect a flow socket - not silently fall back to
+    // the catch-all. A count of 0 would mean `connect()` failed (e.g. the catch-all lacked
+    // `SO_REUSEPORT`) and the fast path latched off.
     #[cfg(apple)]
     assert_eq!(socket.flow_socket_count(), 1);
 
-    // All five datagrams arrive, regardless of which socket carried them.
     let mut buf = [0u8; 16];
-    for _ in 0..5 {
-        let (len, _) = peer.recv_from(&mut buf).await.unwrap();
+    let mut from = peer_addr;
+    for _ in 0..4 {
+        let (len, sender) = peer.recv_from(&mut buf).await.unwrap();
         assert_eq!(&buf[..len], b"hello");
+        from = sender;
     }
+
+    // The reply matches the (connected) socket's 4-tuple exactly and must be delivered via it.
+    peer.send_to(b"world", from).await.unwrap();
+
+    let mut iter = socket.recv_from().await.unwrap();
+    let datagram = iter.next().unwrap();
+
+    assert_eq!(datagram.packet, b"world");
+    assert_eq!(datagram.from, peer_addr);
 }

--- a/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
+++ b/rust/libs/connlib/socket-factory/tests/perf_udp_socket.rs
@@ -9,8 +9,9 @@ use socket_factory::{DatagramOut, udp};
 /// A datagram sent to a fresh peer round-trips: the peer receives it and the reply is
 /// delivered back through the same [`PerfUdpSocket`](socket_factory::PerfUdpSocket).
 ///
-/// On Apple this goes out over a connected per-destination flow socket (see the assertion
-/// below); on every other platform it uses the single catch-all socket.
+/// The datagram carries no pinned source, which marks relay traffic, so on Apple it goes
+/// out over a connected per-destination flow socket right away (see the assertion below);
+/// on every other platform it uses the single catch-all socket.
 #[tokio::test]
 async fn sends_and_receives_a_datagram() {
     let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -52,4 +53,60 @@ async fn sends_and_receives_a_datagram() {
 
     assert_eq!(datagram.packet, b"world");
     assert_eq!(datagram.from, peer_addr);
+}
+
+/// A pair with a pinned source only earns a connected flow socket by sending batches:
+/// single-datagram sends stay on the catch-all socket, the second multi-segment transmit
+/// promotes the pair.
+#[tokio::test]
+async fn batched_sends_promote_to_flow_socket() {
+    let peer = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let peer_addr = peer.local_addr().unwrap();
+
+    let socket = udp("127.0.0.1:0".parse().unwrap())
+        .unwrap()
+        .into_perf()
+        .unwrap();
+
+    let pool = BufferPool::<BytesMut>::new(2048, "test");
+    let src = Some("127.0.0.1:0".parse().unwrap());
+
+    // A single-datagram send does not connect a flow socket.
+    socket
+        .send(DatagramOut {
+            src,
+            dst: peer_addr,
+            packet: pool.pull_initialised(b"hello"),
+            segment_size: 5,
+            ecn: Ecn::NonEct,
+        })
+        .await
+        .unwrap();
+
+    #[cfg(apple)]
+    assert_eq!(socket.flow_socket_count(), 0);
+
+    // Two multi-segment transmits prove the pair batches and promote it.
+    for _ in 0..2 {
+        socket
+            .send(DatagramOut {
+                src,
+                dst: peer_addr,
+                packet: pool.pull_initialised(b"hellohello"),
+                segment_size: 5,
+                ecn: Ecn::NonEct,
+            })
+            .await
+            .unwrap();
+    }
+
+    #[cfg(apple)]
+    assert_eq!(socket.flow_socket_count(), 1);
+
+    // All five datagrams arrive, regardless of which socket carried them.
+    let mut buf = [0u8; 16];
+    for _ in 0..5 {
+        let (len, _) = peer.recv_from(&mut buf).await.unwrap();
+        assert_eq!(&buf[..len], b"hello");
+    }
 }


### PR DESCRIPTION
The Apple socket pool connected a flow socket for every (source, destination) pair on first send. The initial probing during hole-punching sends packets on the full candidate mesh so during discovery the number of probed pairs exceeds the pool cap by 2-3x.

Gate flow sockets on real traffic instead, with two triggers: a single transmit carrying at least 16 datagrams (batching is what the connected fast path accelerates via `sendmsg_x`, and such a batch only forms when a local sender bursts a queue's worth of same-destination packets), or sustaining 25 packets per second (paced senders never coalesce a batch yet still need the flow advisories only a connected socket gets). Probing can trip neither: probes are single datagrams at no more than a handful of packets per second.

The working set now only holds pairs with real traffic, so iOS no longer needs a smaller cap than macOS.