### PR TITLE
fix(connlib): don't emit 0x0 from incremental checksum updates

### DIFF
--- a/rust/libs/incremental-inet-checksum/src/lib.rs
+++ b/rust/libs/incremental-inet-checksum/src/lib.rs
@@ -93,18 +93,20 @@ impl ChecksumUpdate {
     /// `0x0000` where this function returns `0xFFFF`; validators comparing the two must
     /// treat them as equivalent rather than compare for strict equality.
     pub fn into_ip_checksum(self) -> u16 {
-        let checksum = !self.inner;
-
-        if checksum == 0 { 0xFFFF } else { checksum }
+        non_zero_complement(self.inner)
     }
 
     pub fn into_udp_checksum(self) -> u16 {
         // RFC 768, Section 3.1 states that we must invert the final computed checksum if it came
         // out to be zero.
-        let check = !self.inner;
-
-        if check == 0 { 0xFFFF } else { check }
+        non_zero_complement(self.inner)
     }
+}
+
+fn non_zero_complement(inner: u16) -> u16 {
+    let checksum = !inner;
+
+    if checksum == 0 { 0xFFFF } else { checksum }
 }
 
 #[inline(always)]

--- a/rust/libs/incremental-inet-checksum/src/lib.rs
+++ b/rust/libs/incremental-inet-checksum/src/lib.rs
@@ -79,15 +79,20 @@ impl ChecksumUpdate {
         }
     }
 
+    /// Finalizes the update into an IP-style checksum (also used by TCP and ICMP).
+    ///
+    /// A zero checksum is always emitted as `0xFFFF`, never as `0x0000`: one's
+    /// complement has two representations of zero and the running sum can land on
+    /// either one for the same underlying value, e.g. removing a zero-valued field adds
+    /// `!0 = 0xFFFF` and turns +0 into -0. Whether a checksum of `0x0000` verifies
+    /// depends on which zero the covered data actually sums to: for data summing to -0
+    /// it does, for all-zero data (which sums to +0) receivers compute an
+    /// end-around-carry sum of `0x0000` instead of the required `0xFFFF` and drop the
+    /// packet. A checksum of `0xFFFF` verifies in both cases, so it is the only safe
+    /// way to emit "zero". Consequently, a from-scratch computation may arrive at
+    /// `0x0000` where this function returns `0xFFFF`; validators comparing the two must
+    /// treat them as equivalent rather than compare for strict equality.
     pub fn into_ip_checksum(self) -> u16 {
-        // One's complement has two representations of zero: 0x0000 (+0) and 0xFFFF (-0).
-        // The running sum can land on either one for the same underlying value, e.g.
-        // removing a zero-valued field adds !0 = 0xFFFF and turns +0 into -0. Whether a
-        // checksum of 0x0000 verifies depends on which zero the covered data actually
-        // sums to: for data summing to -0 it does, for all-zero data (which sums to +0)
-        // receivers compute an end-around-carry sum of 0x0000 instead of the required
-        // 0xFFFF and drop the packet. A checksum of 0xFFFF verifies in both cases, so it
-        // is the only safe way to emit "zero".
         let checksum = !self.inner;
 
         if checksum == 0 { 0xFFFF } else { checksum }

--- a/rust/libs/incremental-inet-checksum/src/lib.rs
+++ b/rust/libs/incremental-inet-checksum/src/lib.rs
@@ -80,7 +80,17 @@ impl ChecksumUpdate {
     }
 
     pub fn into_ip_checksum(self) -> u16 {
-        !self.inner
+        // One's complement has two representations of zero: 0x0000 (+0) and 0xFFFF (-0).
+        // The running sum can land on either one for the same underlying value, e.g.
+        // removing a zero-valued field adds !0 = 0xFFFF and turns +0 into -0. Whether a
+        // checksum of 0x0000 verifies depends on which zero the covered data actually
+        // sums to: for data summing to -0 it does, for all-zero data (which sums to +0)
+        // receivers compute an end-around-carry sum of 0x0000 instead of the required
+        // 0xFFFF and drop the packet. A checksum of 0xFFFF verifies in both cases, so it
+        // is the only safe way to emit "zero".
+        let checksum = !self.inner;
+
+        if checksum == 0 { 0xFFFF } else { checksum }
     }
 
     pub fn into_udp_checksum(self) -> u16 {
@@ -121,12 +131,27 @@ mod tests {
     #[test]
     fn updates_word_like_rfc1624() {
         // Example from RFC 1624, section 4: checksum 0xdd2f, word 0x5555 becomes 0x3285.
+        // The RFC arrives at 0x0000; we emit the equivalent -0 representation because
+        // 0x0000 does not verify for all-zero data (see `into_ip_checksum`).
         let updated = ChecksumUpdate::new(0xdd2f)
             .remove_u16(0x5555)
             .add_u16(0x3285)
             .into_ip_checksum();
 
-        assert_eq!(updated, 0x0000);
+        assert_eq!(updated, 0xFFFF);
+    }
+
+    #[test]
+    fn removing_zero_from_all_zero_data_keeps_checksum_valid() {
+        // An all-zero ICMP echo message has checksum 0xFFFF (its words sum to +0).
+        // Removing and re-adding a zero-valued field must not flip it to 0x0000,
+        // which would not verify.
+        let updated = ChecksumUpdate::new(0xFFFF)
+            .remove_u16(0x0000)
+            .add_u16(0x0000)
+            .into_ip_checksum();
+
+        assert_eq!(updated, 0xFFFF);
     }
 
     #[test]

--- a/rust/tests/fuzz/fuzz_targets/ip_packet.rs
+++ b/rust/tests/fuzz/fuzz_targets/ip_packet.rs
@@ -66,7 +66,7 @@ fn checksum_errors(packet: &IpPacket) -> Vec<String> {
     if let Some(hdr) = packet.ipv4_header() {
         let expected = hdr.calc_header_checksum();
 
-        if hdr.header_checksum != expected {
+        if !checksum_matches(hdr.header_checksum, expected) {
             errors.push(format!(
                 "IPv4 header checksum: stored {:#06x}, expected {expected:#06x}",
                 hdr.header_checksum
@@ -81,7 +81,7 @@ fn checksum_errors(packet: &IpPacket) -> Vec<String> {
         // Over IPv6 the checksum is mandatory, so zero is always a bug there.
         let ipv4_not_computed = matches!(packet.source(), IpAddr::V4(_)) && stored == 0;
 
-        if !ipv4_not_computed && stored != expected {
+        if !ipv4_not_computed && !checksum_matches(stored, expected) {
             errors.push(format!(
                 "UDP checksum: stored {stored:#06x}, expected {expected:#06x}"
             ));
@@ -91,7 +91,7 @@ fn checksum_errors(packet: &IpPacket) -> Vec<String> {
     if let (Some(tcp), Ok(expected)) = (packet.as_tcp(), packet.calculate_tcp_checksum()) {
         let stored = tcp.checksum();
 
-        if stored != expected {
+        if !checksum_matches(stored, expected) {
             errors.push(format!(
                 "TCP checksum: stored {stored:#06x}, expected {expected:#06x}"
             ));
@@ -102,7 +102,7 @@ fn checksum_errors(packet: &IpPacket) -> Vec<String> {
         let stored = icmp.checksum();
         let expected = icmp.icmp_type().calc_checksum(icmp.payload());
 
-        if stored != expected {
+        if !checksum_matches(stored, expected) {
             errors.push(format!(
                 "ICMPv4 checksum: stored {stored:#06x}, expected {expected:#06x}"
             ));
@@ -117,7 +117,7 @@ fn checksum_errors(packet: &IpPacket) -> Vec<String> {
     {
         let stored = icmp.checksum();
 
-        if stored != expected {
+        if !checksum_matches(stored, expected) {
             errors.push(format!(
                 "ICMPv6 checksum: stored {stored:#06x}, expected {expected:#06x}"
             ));
@@ -125,6 +125,13 @@ fn checksum_errors(packet: &IpPacket) -> Vec<String> {
     }
 
     errors
+}
+
+/// The incremental updates emit 0xFFFF where a from-scratch computation arrives at
+/// 0x0000: both encode zero in one's complement and both verify on the wire, but only
+/// 0xFFFF also verifies for all-zero data (see `ChecksumUpdate::into_ip_checksum`).
+fn checksum_matches(stored: u16, expected: u16) -> bool {
+    stored == expected || (expected == 0x0000 && stored == 0xFFFF)
 }
 
 #[derive(Arbitrary, Debug)]


### PR DESCRIPTION
One's complement has two representations of zero, and the running sum of an incremental checksum update can land on either one for the same value: removing a zero-valued field adds `!0 = 0xFFFF` and silently turns +0 into -0. Finalizing that as a checksum of `0x0000` is invalid for data that sums to +0 (an all-zero ICMP echo, for example): receivers compute an end-around-carry sum of `0x0000` instead of the required `0xFFFF` and drop the packet.

Emit `0xFFFF` instead, which verifies for both representations of a zero sum, and teach the fuzz oracle that `0xFFFF` is an acceptable encoding where a from-scratch computation arrives at `0x0000`.