### PR TITLE
fix(connlib): prefer stable IPv6 source addresses

### DIFF
--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -134,34 +134,32 @@ const STABLE_IPV6_SOURCE_OPTION: (libc::c_int, libc::c_int) =
 ///
 /// Failure is logged and otherwise ignored: without the preference the socket still
 /// works, it merely keeps following the rotating addresses.
+#[cfg(any(apple, target_os = "linux", target_os = "android"))]
 fn prefer_stable_ipv6_source(socket: &socket2::Socket) {
-    #[cfg(any(apple, target_os = "linux", target_os = "android"))]
-    {
-        use std::os::fd::AsRawFd as _;
+    use std::os::fd::AsRawFd as _;
 
-        let (option, value) = STABLE_IPV6_SOURCE_OPTION;
+    let (option, value) = STABLE_IPV6_SOURCE_OPTION;
 
-        // SAFETY: `value` outlives the call and the option length matches its type.
-        let ret = unsafe {
-            libc::setsockopt(
-                socket.as_raw_fd(),
-                libc::IPPROTO_IPV6,
-                option,
-                &value as *const libc::c_int as *const libc::c_void,
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            )
-        };
+    // SAFETY: `value` outlives the call and the option length matches its type.
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            option,
+            &value as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
 
-        if ret != 0 {
-            let error = io::Error::last_os_error();
+    if ret != 0 {
+        let error = io::Error::last_os_error();
 
-            tracing::warn!(%error, "Failed to prefer stable IPv6 source address");
-        }
+        tracing::warn!(%error, "Failed to prefer stable IPv6 source address");
     }
-
-    #[cfg(not(any(apple, target_os = "linux", target_os = "android")))]
-    let _ = socket;
 }
+
+#[cfg(not(any(apple, target_os = "linux", target_os = "android")))]
+fn prefer_stable_ipv6_source(_socket: &socket2::Socket) {}
 
 pub struct TcpSocket {
     inner: tokio::net::TcpSocket,
@@ -1027,38 +1025,6 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV6};
 
     use super::*;
-
-    #[cfg(any(apple, target_os = "linux"))]
-    #[test]
-    fn stable_ipv6_source_preference_sticks() {
-        use std::os::fd::AsRawFd as _;
-
-        let Ok(socket) = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None)
-        else {
-            eprintln!("skipping; environment has no IPv6 support");
-            return;
-        };
-
-        prefer_stable_ipv6_source(&socket);
-
-        let (option, expected) = STABLE_IPV6_SOURCE_OPTION;
-        let mut value: libc::c_int = -1;
-        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
-
-        // SAFETY: `value` and `len` outlive the call and match the option's type.
-        let ret = unsafe {
-            libc::getsockopt(
-                socket.as_raw_fd(),
-                libc::IPPROTO_IPV6,
-                option,
-                &mut value as *mut libc::c_int as *mut libc::c_void,
-                &mut len,
-            )
-        };
-
-        assert_eq!(ret, 0);
-        assert_eq!(value, expected);
-    }
 
     #[derive(derive_more::Deref)]
     struct DummyBuffer(Vec<u8>);

--- a/rust/libs/connlib/socket-factory/src/lib.rs
+++ b/rust/libs/connlib/socket-factory/src/lib.rs
@@ -85,6 +85,7 @@ pub fn udp(std_addr: SocketAddr) -> io::Result<UdpSocket> {
     // Note: for AF_INET sockets IPV6_V6ONLY is not a valid flag
     if addr.is_ipv6() {
         socket.set_only_v6(true)?;
+        prefer_stable_ipv6_source(&socket);
     }
 
     socket.set_nonblocking(true)?;
@@ -107,6 +108,59 @@ pub fn udp(std_addr: SocketAddr) -> io::Result<UdpSocket> {
     let socket = UdpSocket::new(socket)?;
 
     Ok(socket)
+}
+
+/// The socket option to prefer a stable IPv6 source address, with the value that selects it.
+///
+/// On Apple, `IPV6_PREFER_TEMPADDR` (from xnu's `netinet6/in6.h`, not exposed by `libc`)
+/// overrides the system-wide `prefer_tempaddr` sysctl per socket; `0` selects the stable
+/// address. Linux and Android implement RFC 5014 instead.
+#[cfg(apple)]
+const STABLE_IPV6_SOURCE_OPTION: (libc::c_int, libc::c_int) = (63, 0);
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const STABLE_IPV6_SOURCE_OPTION: (libc::c_int, libc::c_int) =
+    (libc::IPV6_ADDR_PREFERENCES, libc::IPV6_PREFER_SRC_PUBLIC);
+
+/// Prefers a stable IPv6 source address over a temporary (RFC 8981) one for this socket.
+///
+/// The kernel selects the source address for every socket that does not pin one: per
+/// `connect` for connected sockets and per datagram for unconnected ones, and it prefers
+/// temporary addresses by default. Temporary addresses rotate periodically, which
+/// silently changes the selected source: connected sockets keep their now-deprecated
+/// address until it is removed and sends fail with `EADDRNOTAVAIL`, and every rotation
+/// changes the host candidate our peers learn, costing us relay allocations and
+/// connectivity re-checks. The stable address lives as long as the network attachment
+/// itself, which is exactly the lifetime of our sockets.
+///
+/// Failure is logged and otherwise ignored: without the preference the socket still
+/// works, it merely keeps following the rotating addresses.
+fn prefer_stable_ipv6_source(socket: &socket2::Socket) {
+    #[cfg(any(apple, target_os = "linux", target_os = "android"))]
+    {
+        use std::os::fd::AsRawFd as _;
+
+        let (option, value) = STABLE_IPV6_SOURCE_OPTION;
+
+        // SAFETY: `value` outlives the call and the option length matches its type.
+        let ret = unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::IPPROTO_IPV6,
+                option,
+                &value as *const libc::c_int as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+
+        if ret != 0 {
+            let error = io::Error::last_os_error();
+
+            tracing::warn!(%error, "Failed to prefer stable IPv6 source address");
+        }
+    }
+
+    #[cfg(not(any(apple, target_os = "linux", target_os = "android")))]
+    let _ = socket;
 }
 
 pub struct TcpSocket {
@@ -973,6 +1027,38 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV6};
 
     use super::*;
+
+    #[cfg(any(apple, target_os = "linux"))]
+    #[test]
+    fn stable_ipv6_source_preference_sticks() {
+        use std::os::fd::AsRawFd as _;
+
+        let Ok(socket) = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None)
+        else {
+            eprintln!("skipping; environment has no IPv6 support");
+            return;
+        };
+
+        prefer_stable_ipv6_source(&socket);
+
+        let (option, expected) = STABLE_IPV6_SOURCE_OPTION;
+        let mut value: libc::c_int = -1;
+        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+        // SAFETY: `value` and `len` outlive the call and match the option's type.
+        let ret = unsafe {
+            libc::getsockopt(
+                socket.as_raw_fd(),
+                libc::IPPROTO_IPV6,
+                option,
+                &mut value as *mut libc::c_int as *mut libc::c_void,
+                &mut len,
+            )
+        };
+
+        assert_eq!(ret, 0);
+        assert_eq!(value, expected);
+    }
 
     #[derive(derive_more::Deref)]
     struct DummyBuffer(Vec<u8>);

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -358,10 +358,15 @@ fn connect(
     dst: SocketAddr,
     buffer_sizes: Option<(usize, usize)>,
 ) -> io::Result<OwnedSocket> {
-    let bind_addr = socket2::SockAddr::from(SocketAddr::new(
-        src.unwrap_or_else(|| local.ip()),
-        local.port(),
-    ));
+    // A pinned source is part of the pair's identity and must bind exactly. Without one,
+    // bind the unspecified address so the kernel runs source selection at `connect` -
+    // that is where the stable-source preference (see `prefer_stable_ipv6_source`)
+    // takes effect.
+    let bind_ip = src.unwrap_or(match dst {
+        SocketAddr::V4(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+        SocketAddr::V6(_) => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+    });
+    let bind_addr = socket2::SockAddr::from(SocketAddr::new(bind_ip, local.port()));
     let dst_addr = socket2::SockAddr::from(dst);
 
     let socket = socket2::Socket::new(dst_addr.domain(), socket2::Type::DGRAM, None)?;

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -368,6 +368,7 @@ fn connect(
 
     if dst.is_ipv6() {
         socket.set_only_v6(true)?;
+        crate::prefer_stable_ipv6_source(&socket);
     }
 
     // Share the local port with the (unconnected) catch-all socket.

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -361,15 +361,10 @@ fn connect(
     dst: SocketAddr,
     buffer_sizes: Option<(usize, usize)>,
 ) -> io::Result<OwnedSocket> {
-    // A pinned source is part of the pair's identity and must bind exactly. Without one,
-    // bind the unspecified address so the kernel runs source selection at `connect` -
-    // that is where the stable-source preference (see `prefer_stable_ipv6_source`)
-    // takes effect.
-    let bind_ip = src.unwrap_or(match dst {
-        SocketAddr::V4(_) => IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
-        SocketAddr::V6(_) => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
-    });
-    let bind_addr = socket2::SockAddr::from(SocketAddr::new(bind_ip, local.port()));
+    let bind_addr = socket2::SockAddr::from(SocketAddr::new(
+        src.unwrap_or_else(|| local.ip()),
+        local.port(),
+    ));
     let dst_addr = socket2::SockAddr::from(dst);
 
     let socket = socket2::Socket::new(dst_addr.domain(), socket2::Type::DGRAM, None)?;


### PR DESCRIPTION
Kernels prefer temporary (RFC 8981) IPv6 addresses when selecting a source for sockets that do not pin one. Temporary addresses rotate periodically, which silently changes the selected source: connected sockets keep their now-deprecated address until sends fail with `EADDRNOTAVAIL`, and every rotation changes the host candidate our peers learn. Each rotation also cascades into relay allocation churn: the relay keys allocations by 5-tuple, answers the new source with 437 Allocation Mismatch, and the re-allocation yields a new relay port, restarting path discovery.

Opt every IPv6 UDP socket into stable source addresses instead, via `IPV6_PREFER_TEMPADDR` on Apple and RFC 5014's `IPV6_ADDR_PREFERENCES` on Linux and Android. The stable address lives as long as the network attachment itself, which is exactly the lifetime of our sockets.