### PR TITLE
ci: notify website repo when PR merges to main

### DIFF
--- a/.github/workflows/notify-website-changelog.yml
+++ b/.github/workflows/notify-website-changelog.yml
@@ -1,16 +1,15 @@
 name: Notify website of merged PR
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 jobs:
   notify-website:
-    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Dispatch changelog evaluation to firezone/website
@@ -18,9 +17,24 @@ jobs:
           # repository_dispatch on firezone/website requires this token to have
           # Contents: write there.
           GH_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+
+          # A push to main is how every merge (squash, merge, or rebase) lands
+          # and, unlike a fork's `pull_request` event, runs in the trusted
+          # base-repo context with access to secrets. Resolve the PR this commit
+          # merged via the commits API; direct pushes with no PR are skipped.
+          pr_number=$(gh api \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+            --jq 'map(select(.merged_at)) | .[0].number // empty')
+
+          if [[ -z "$pr_number" ]]; then
+            echo "No merged PR associated with ${HEAD_SHA}; skipping."
+            exit 0
+          fi
 
           gh api \
             --method POST \
@@ -28,4 +42,4 @@ jobs:
             --header "X-GitHub-Api-Version: 2022-11-28" \
             /repos/firezone/website/dispatches \
             --raw-field "event_type=pr-merged" \
-            --field "client_payload[pr_number]=${PR_NUMBER}"
+            --field "client_payload[pr_number]=${pr_number}"

--- a/.github/workflows/notify-website-changelog.yml
+++ b/.github/workflows/notify-website-changelog.yml
@@ -1,20 +1,5 @@
 name: Notify website of merged PR
 
-# Notifies firezone/website whenever a PR merges here so it can evaluate
-# whether the change warrants a changelog entry. The changelog lives in that
-# repo (src/components/Changelog), which is why the evaluation runs there.
-# Mirrors the publish-release.yml -> repository_dispatch -> website pattern.
-#
-# Uses pull_request_target (not pull_request) so the dispatch also fires for
-# PRs opened from forks, which otherwise run with a read-only token and no
-# access to secrets. This job never checks out or executes PR code — it only
-# reads the PR number from the event and sends a repository_dispatch — so
-# pull_request_target is safe here.
-#
-# Required secret (owned by the firezone-bot account):
-#   RELEASE_PR_BOT_GITHUB_TOKEN — needs Contents: write on firezone/website to
-#     send it a repository_dispatch. Same secret used by publish-release.yml.
-
 on:
   pull_request_target:
     types:

--- a/.github/workflows/notify-website-changelog.yml
+++ b/.github/workflows/notify-website-changelog.yml
@@ -1,0 +1,46 @@
+name: Notify website of merged PR
+
+# Notifies firezone/website whenever a PR merges here so it can evaluate
+# whether the change warrants a changelog entry. The changelog lives in that
+# repo (src/components/Changelog), which is why the evaluation runs there.
+# Mirrors the publish-release.yml -> repository_dispatch -> website pattern.
+#
+# Uses pull_request_target (not pull_request) so the dispatch also fires for
+# PRs opened from forks, which otherwise run with a read-only token and no
+# access to secrets. This job never checks out or executes PR code — it only
+# reads the PR number from the event and sends a repository_dispatch — so
+# pull_request_target is safe here.
+#
+# Required secret (owned by the firezone-bot account):
+#   RELEASE_PR_BOT_GITHUB_TOKEN — needs Contents: write on firezone/website to
+#     send it a repository_dispatch. Same secret used by publish-release.yml.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  notify-website:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dispatch changelog evaluation to firezone/website
+        env:
+          # repository_dispatch on firezone/website requires this token to have
+          # Contents: write there.
+          GH_TOKEN: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          gh api \
+            --method POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/firezone/website/dispatches \
+            --raw-field "event_type=pr-merged" \
+            --field "client_payload[pr_number]=${PR_NUMBER}"


### PR DESCRIPTION
Add a GitHub Actions workflow that dispatches a repository event to the firezone/website repository whenever a PR is merged to main. This enables the website to automatically evaluate and update its changelog based on merged changes.