### PR TITLE
perf(connlib): align Apple TUN batch size to UDP batch size

### DIFF
--- a/rust/libs/connlib/tun/src/lib.rs
+++ b/rust/libs/connlib/tun/src/lib.rs
@@ -21,12 +21,21 @@ pub mod apple;
 /// send / receive (and the associated task wake-up) is paid once per batch
 /// rather than once per packet.
 ///
-/// Mobile platforms are memory-constrained and cannot afford to buffer big
-/// batches of packets, so we use a smaller limit there. The desktop value also
-/// stays below the kernel's `kern.ipc.somaxrecvmsgx` clamp on Apple platforms.
+/// On Apple, sized as a multiple of `quinn_udp::BATCH_SIZE` (32): a TUN batch destined
+/// for a single peer becomes one GSO transmit, and the Apple UDP send path moves 32
+/// datagrams per `sendmsg_x`, so any other size leaves the last syscall of every full
+/// batch underfilled. iOS is memory-constrained and gets exactly one syscall's worth;
+/// macOS gets three. Both are far below the kernel's `sendmsg_x` / `recvmsg_x` clamp
+/// (`kern.ipc.somaxsendmsgx` / `somaxrecvmsgx`, 256 by default).
+///
+/// Elsewhere the batch size has no syscall quantum to align to - Linux and Android
+/// send real GSO super-datagrams of up to 64 segments per syscall regardless of batch
+/// size, and Windows sends a whole transmit in one USO call - so those values only
+/// balance channel amortisation against buffer memory.
 pub const MAX_BATCH_SIZE: usize = cfg_select! {
-    target_os = "ios" => { 25 }
+    target_os = "ios" => { 32 }
     target_os = "android" => { 25 }
+    target_os = "macos" => { 96 }
     _ => { 100 }
 };
 


### PR DESCRIPTION
On Apple, a TUN batch destined for a single peer becomes one GSO transmit, and the UDP send path moves at most 32 datagrams per `sendmsg_x` (quinn-udp's `BATCH_SIZE`). The current TUN batch sizes don't line up with that number: iOS reads 25 packets per tick and thus underfills every send syscall, while macOS reads 100 and pays a fourth, nearly-empty syscall (32+32+32+4) for every full batch under load.

Align them: 32 on iOS (exactly one full syscall, still within the 4 MB channel-memory budget) and 96 on macOS (three full syscalls; 128 would exceed the desktop budget). The kernel-side clamp (`kern.ipc.somaxsendmsgx` / `somaxrecvmsgx`) defaults to 256, so both values have ample headroom.

Other platforms are unchanged on purpose: Linux and Android send real GSO super-datagrams of up to 64 segments per syscall regardless of batch size, and Windows sends a whole transmit in one USO call, so there is no 32-quantum to align to.