### PR TITLE
chore(connlib): count flow-socket evictions

### DIFF
--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -70,10 +70,6 @@ pub fn network_packets_batch_count() -> Histogram<u64> {
 /// Only recorded on Apple, the only platform with per-destination flow sockets. Rebinding
 /// on a network change discards the whole pool and does not count; this measures cache
 /// churn - sockets displaced to make room for another pair.
-///
-/// Recorded with a `socket.received` boolean attribute: `true` means the evicted socket
-/// had received traffic (a live path was displaced - the churn worth alarming on),
-/// `false` means it never received anything and was merely leftover.
 pub fn flow_socket_evictions() -> Counter<u64> {
     meter()
         .u64_counter("connlib.flow_sockets.evicted")

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -65,6 +65,21 @@ pub fn network_packets_batch_count() -> Histogram<u64> {
         .build()
 }
 
+/// How many connected flow sockets were evicted from the socket pool's cache.
+///
+/// Only recorded on Apple, the only platform with per-destination flow sockets. Rebinding
+/// on a network change discards the whole pool and does not count; this measures cache
+/// churn - sockets displaced to make room for another pair.
+pub fn flow_socket_evictions() -> Counter<u64> {
+    meter()
+        .u64_counter("connlib.flow_sockets.evicted")
+        .with_description(
+            "Number of connected flow sockets evicted from the socket pool's cache to make room for another pair.",
+        )
+        .with_unit("{socket}")
+        .build()
+}
+
 /// Number of errors encountered while processing a packet batch.
 pub fn tunnel_errors() -> Counter<u64> {
     meter()

--- a/rust/libs/connlib/otel-instruments/src/lib.rs
+++ b/rust/libs/connlib/otel-instruments/src/lib.rs
@@ -70,6 +70,10 @@ pub fn network_packets_batch_count() -> Histogram<u64> {
 /// Only recorded on Apple, the only platform with per-destination flow sockets. Rebinding
 /// on a network change discards the whole pool and does not count; this measures cache
 /// churn - sockets displaced to make room for another pair.
+///
+/// Recorded with a `socket.received` boolean attribute: `true` means the evicted socket
+/// had received traffic (a live path was displaced - the churn worth alarming on),
+/// `false` means it never received anything and was merely leftover.
 pub fn flow_socket_evictions() -> Counter<u64> {
     meter()
         .u64_counter("connlib.flow_sockets.evicted")

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -85,6 +85,7 @@ pub(crate) struct SocketPool {
     /// The local address flow sockets bind to; they share the wildcard socket's port.
     local: SocketAddr,
     inner: Mutex<Inner>,
+    evictions: opentelemetry::metrics::Counter<u64>,
 }
 
 struct Inner {
@@ -140,6 +141,7 @@ impl SocketPool {
                 recv_waker: None,
                 round_robin: 0,
             }),
+            evictions: otel_instruments::flow_socket_evictions(),
         }
     }
 
@@ -246,7 +248,7 @@ impl SocketPool {
         }
 
         if inner.flows.len() >= MAX_FLOW_SOCKETS {
-            evict_one(&mut inner, self.local.port(), recv_buffers);
+            evict_one(&mut inner, self.local.port(), recv_buffers, &self.evictions);
         }
 
         match connect(self.local, src, dst, inner.buffer_sizes) {
@@ -373,7 +375,12 @@ impl RateGate {
 }
 
 /// Evicts the flow socket that is least likely to still be useful.
-fn evict_one(inner: &mut Inner, port: u16, recv_buffers: &RecvBuffers) {
+fn evict_one(
+    inner: &mut Inner,
+    port: u16,
+    recv_buffers: &RecvBuffers,
+    evictions: &opentelemetry::metrics::Counter<u64>,
+) {
     let Some(key) = inner
         .flows
         .iter()
@@ -390,6 +397,16 @@ fn evict_one(inner: &mut Inner, port: u16, recv_buffers: &RecvBuffers) {
     let Some(victim) = inner.flows.remove(&key) else {
         return;
     };
+
+    // A socket that received traffic served a live path; evicting those under cap
+    // pressure is the churn worth alarming on. Never-received victims are leftovers.
+    evictions.add(
+        1,
+        &[opentelemetry::KeyValue::new(
+            "received",
+            victim.last_received.lock().is_some(),
+        )],
+    );
 
     drain(&victim, port, recv_buffers, &mut inner.drained);
 

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -403,7 +403,7 @@ fn evict_one(
     evictions.add(
         1,
         &[opentelemetry::KeyValue::new(
-            "received",
+            "socket.received",
             victim.last_received.lock().is_some(),
         )],
     );

--- a/rust/libs/connlib/socket-factory/src/pool/apple.rs
+++ b/rust/libs/connlib/socket-factory/src/pool/apple.rs
@@ -398,15 +398,7 @@ fn evict_one(
         return;
     };
 
-    // A socket that received traffic served a live path; evicting those under cap
-    // pressure is the churn worth alarming on. Never-received victims are leftovers.
-    evictions.add(
-        1,
-        &[opentelemetry::KeyValue::new(
-            "socket.received",
-            victim.last_received.lock().is_some(),
-        )],
-    );
+    evictions.add(1, &[]);
 
     drain(&victim, port, recv_buffers, &mut inner.drained);
 


### PR DESCRIPTION
The Apple socket pool silently evicts a connected flow socket when the cache is full and another pair earns one. Sustained eviction means the working set exceeds the cap and connections lose their fast path and flow advisories - the churn #14109 fixed was only visible through log analysis.

Count evictions in a `connlib.flow_sockets.evicted` counter, attributed by whether the evicted socket ever received traffic: displacing a proven, live socket is the churn worth alarming on, while never-received victims are just leftovers being cleaned up.