### PR TITLE
perf(connlib): reuse receive buffers in Apple TUN reads

### DIFF
--- a/rust/libs/connlib/tun/src/apple/bulk.rs
+++ b/rust/libs/connlib/tun/src/apple/bulk.rs
@@ -138,7 +138,7 @@ pub fn recv(
 
                 let mut batch = PacketBatch::default();
 
-                for (buf, len) in bufs.iter_mut().zip(lens).take(n) {
+                for (buf, &len) in bufs.iter_mut().zip(&lens).take(n) {
                     if len == 0 {
                         continue; // Empty or truncated datagram; the slot's buffer is reused.
                     }

--- a/rust/libs/connlib/tun/src/apple/bulk.rs
+++ b/rust/libs/connlib/tun/src/apple/bulk.rs
@@ -105,11 +105,15 @@ pub fn recv(
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, Interest::READABLE)?;
 
-            'recv: loop {
-                let mut bufs: Vec<IpPacketBuf> =
-                    (0..MAX_BATCH_SIZE).map(|_| IpPacketBuf::new()).collect();
-                let mut lens = [0usize; MAX_BATCH_SIZE];
+            // Long-lived receive slots: a syscall reading `n` packets consumes `n` buffers,
+            // which are re-pulled from the pool in place; the remaining slots are reused
+            // as-is, so the cost of preparing a read scales with the packets it returns
+            // rather than with `MAX_BATCH_SIZE`.
+            let mut bufs: Vec<IpPacketBuf> =
+                (0..MAX_BATCH_SIZE).map(|_| IpPacketBuf::new()).collect();
+            let mut lens = [0usize; MAX_BATCH_SIZE];
 
+            'recv: loop {
                 let n = fd
                     .async_io(Interest::READABLE, |fd| {
                         // Safety: The file descriptor is valid within this module.
@@ -134,10 +138,13 @@ pub fn recv(
 
                 let mut batch = PacketBatch::default();
 
-                for (buf, len) in bufs.into_iter().zip(lens).take(n) {
+                for (buf, len) in bufs.iter_mut().zip(lens).take(n) {
                     if len == 0 {
-                        continue; // Empty or truncated datagram.
+                        continue; // Empty or truncated datagram; the slot's buffer is reused.
                     }
+
+                    // `Default` refills the slot with a fresh buffer from the pool.
+                    let buf = std::mem::take(buf);
 
                     match IpPacket::new(buf, len).context("Failed to parse IP packet") {
                         Ok(packet) => {

--- a/rust/libs/connlib/tun/src/apple/bulk.rs
+++ b/rust/libs/connlib/tun/src/apple/bulk.rs
@@ -105,10 +105,6 @@ pub fn recv(
         .block_on(async move {
             let fd = AsyncFd::with_interest(fd, Interest::READABLE)?;
 
-            // Long-lived receive slots: a syscall reading `n` packets consumes `n` buffers,
-            // which are re-pulled from the pool in place; the remaining slots are reused
-            // as-is, so the cost of preparing a read scales with the packets it returns
-            // rather than with `MAX_BATCH_SIZE`.
             let mut bufs: Vec<IpPacketBuf> =
                 (0..MAX_BATCH_SIZE).map(|_| IpPacketBuf::new()).collect();
             let mut lens = [0usize; MAX_BATCH_SIZE];
@@ -140,7 +136,7 @@ pub fn recv(
 
                 for (buf, &len) in bufs.iter_mut().zip(&lens).take(n) {
                     if len == 0 {
-                        continue; // Empty or truncated datagram; the slot's buffer is reused.
+                        continue; // Empty or truncated datagram.
                     }
 
                     // `Default` refills the slot with a fresh buffer from the pool.


### PR DESCRIPTION
Every `recvmsg_x` on the utun fd allocated a fresh `Vec` and pulled `MAX_BATCH_SIZE` buffers from the pool, only to return the unused ones right after the syscall. Application metrics show typical reads of around a dozen packets, so most of that per-syscall work - two pool-queue operations plus refcount traffic per slot, on a queue shared by all packet-processing threads - was wasted. Keep the receive slots alive across reads and refill only the slots whose buffer was consumed by a packet, so the setup cost scales with the packets actually received instead of the batch ceiling.