### PR TITLE
refactor(connlib): track flow direction in conn tracker

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -7,7 +7,7 @@ use hickory_resolver::TokioResolver;
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::proto::rr::RecordType;
 use phoenix_channel::{PhoenixChannel, PublicKeyParam};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::future::{self, Future, poll_fn};
 use std::net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::ops::ControlFlow;
@@ -21,7 +21,7 @@ use tunnel::messages::gateway::{
     Authorization, ClientIceCandidates, ClientsIceCandidates, EgressMessages, IngressMessages,
     InitGateway, RejectAccess,
 };
-use tunnel::messages::{RelaysPresence, SnownetCapabilities};
+use tunnel::messages::{self, RelaysPresence, SnownetCapabilities};
 use tunnel::{
     GatewayEvent, GatewayTunnel, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest, TunnelError,
 };
@@ -417,16 +417,8 @@ impl Eventloop {
                 });
                 tunnel
                     .state_mut()
-                    .retain_authorizations(authorizations.iter().fold(
-                        BTreeMap::new(),
-                        |mut authorizations, next| {
-                            authorizations
-                                .entry(next.client_id)
-                                .or_default()
-                                .insert(next.resource_id);
-
-                            authorizations
-                        },
+                    .retain_authorizations(messages::group_authorizations_by_client(
+                        &authorizations,
                     ));
                 for Authorization {
                     client_id: cid,

--- a/rust/libs/connlib/tunnel/src/client/client_on_client.rs
+++ b/rust/libs/connlib/tunnel/src/client/client_on_client.rs
@@ -145,7 +145,7 @@ impl ClientOnClient {
 
     /// Record an outbound packet so subsequent inbound replies are admitted.
     pub(crate) fn record_outbound(&mut self, packet: &IpPacket, now: Instant) {
-        self.conn_track.record_outbound(packet, now);
+        self.conn_track.handle_outbound(packet, now);
     }
 
     pub(crate) fn handle_timeout(&mut self, now: Instant) {

--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -18,9 +18,9 @@ pub(crate) struct ConnTrack {
 impl ConnTrack {
     /// Handles an outbound packet we sent to a peer.
     ///
-    /// The first packet of a flow records it as one *we* opened. A reply to a
-    /// flow the peer opened records nothing: it must not earn a return-traffic
-    /// exemption, or the peer's flow would outlive its authorization.
+    /// Remembers the packet's flow as one that we opened. Replies to flows
+    /// that the peer opened are ignored: those flows must keep passing the
+    /// inbound filter, so that they stop once their authorization is gone.
     pub(crate) fn handle_outbound(&mut self, packet: &IpPacket, now: Instant) {
         let Ok(local) = packet.source_protocol() else {
             return;

--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -1,18 +1,8 @@
 //! Stateful connection tracker for client-to-client flows.
 //!
-//! Records each flow under a normalised "from this peer's perspective" key
-//! (local IP + protocol, peer IP + protocol). The same key is produced for:
-//!
-//! - An outbound we initiated (`record_outbound`) and the inbound reply
-//!   that comes back (`is_return_traffic`).
-//! - An inbound we received from a peer (`record_inbound`) and the outbound
-//!   reply we may produce (`is_known_flow`).
-//!
-//! That symmetry lets a single map serve both directions: a peer initiates
-//! to us → we record on inbound → our reply outbound is admitted as a known
-//! flow without firing a fresh connection intent. The IP pair is part of
-//! the key so a v4 flow and a v6 flow with identical port pairs don't
-//! collide.
+//! Flows are tracked separately by which side opened them: only flows *we*
+//! opened grant a return-traffic exemption from the inbound filter, so
+//! revoking or expiring an authorization cuts off peer-opened flows.
 
 use ip_packet::{IpPacket, Protocol};
 use std::collections::BTreeMap;
@@ -21,11 +11,14 @@ use std::time::{Duration, Instant};
 
 #[derive(Default, Debug)]
 pub(crate) struct ConnTrack {
-    entries: BTreeMap<Key, Instant>,
+    initiated: BTreeMap<Key, Instant>,
+    received: BTreeMap<Key, Instant>,
 }
 
 impl ConnTrack {
-    /// Record an outbound packet we sent to a peer.
+    /// Record an outbound packet as a flow *we* opened, unless it is a reply
+    /// to a flow the peer opened: that must not earn a return-traffic
+    /// exemption, or a peer-opened flow would outlive its authorization.
     pub(crate) fn record_outbound(&mut self, packet: &IpPacket, now: Instant) {
         let Ok(local) = packet.source_protocol() else {
             return;
@@ -34,18 +27,21 @@ impl ConnTrack {
             return;
         };
 
-        self.entries.insert(
-            Key {
-                local,
-                peer,
-                local_ip: packet.source(),
-                peer_ip: packet.destination(),
-            },
-            now,
-        );
+        let key = Key {
+            local,
+            peer,
+            local_ip: packet.source(),
+            peer_ip: packet.destination(),
+        };
+
+        if self.received.contains_key(&key) && !self.initiated.contains_key(&key) {
+            return;
+        }
+
+        self.initiated.insert(key, now);
     }
 
-    /// Record an inbound packet we received from a peer.
+    /// Record an inbound packet of a flow the *peer* opened to us.
     pub(crate) fn record_inbound(&mut self, packet: &IpPacket, now: Instant) {
         let Ok(local) = packet.destination_protocol() else {
             return;
@@ -54,7 +50,7 @@ impl ConnTrack {
             return;
         };
 
-        self.entries.insert(
+        self.received.insert(
             Key {
                 local,
                 peer,
@@ -65,9 +61,7 @@ impl ConnTrack {
         );
     }
 
-    /// Returns `true` if the inbound packet matches a recorded flow (either
-    /// an outbound we initiated or an inbound we previously received from
-    /// the peer).
+    /// Returns `true` if the inbound packet is the reply to a flow *we* opened.
     pub(crate) fn is_return_traffic(&self, packet: &IpPacket) -> bool {
         let Ok(peer) = packet.source_protocol() else {
             return false;
@@ -76,7 +70,7 @@ impl ConnTrack {
             return false;
         };
 
-        self.entries.contains_key(&Key {
+        self.initiated.contains_key(&Key {
             local,
             peer,
             local_ip: packet.destination(),
@@ -84,9 +78,8 @@ impl ConnTrack {
         })
     }
 
-    /// Returns `true` if the *outbound* packet is part of an existing flow
-    /// (either initiated by us or in reply to inbound traffic from the
-    /// peer).
+    /// Returns `true` if the *outbound* packet belongs to an existing flow in
+    /// either direction.
     pub(crate) fn is_known_flow(&self, packet: &IpPacket) -> bool {
         let Ok(local) = packet.source_protocol() else {
             return false;
@@ -95,18 +88,22 @@ impl ConnTrack {
             return false;
         };
 
-        self.entries.contains_key(&Key {
+        let key = Key {
             local,
             peer,
             local_ip: packet.source(),
             peer_ip: packet.destination(),
-        })
+        };
+
+        self.initiated.contains_key(&key) || self.received.contains_key(&key)
     }
 
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
-        for _ in self.entries.extract_if(.., |key, last_seen| {
-            now.saturating_duration_since(*last_seen) >= ttl(key)
-        }) {}
+        for map in [&mut self.initiated, &mut self.received] {
+            for _ in map.extract_if(.., |key, last_seen| {
+                now.saturating_duration_since(*last_seen) >= ttl(key)
+            }) {}
+        }
     }
 }
 
@@ -168,6 +165,60 @@ mod tests {
         let unrelated = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 9999, 53535, &[])
             .expect("valid packet");
         assert!(!ct.is_return_traffic(&unrelated));
+    }
+
+    #[test]
+    fn peer_opened_flow_is_not_return_traffic() {
+        let mut ct = ConnTrack::default();
+        let now = Instant::now();
+
+        let inbound = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 40000, 80, &[])
+            .expect("valid packet");
+        ct.record_inbound(&inbound, now);
+
+        let next = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 40000, 80, &[1])
+            .expect("valid packet");
+        assert!(!ct.is_return_traffic(&next));
+
+        let reply = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 80, 40000, &[])
+            .expect("valid packet");
+        assert!(ct.is_known_flow(&reply));
+    }
+
+    #[test]
+    fn continued_traffic_keeps_initiated_flow_alive() {
+        let mut ct = ConnTrack::default();
+        let start = Instant::now();
+
+        let outbound = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 53535, 8080, &[])
+            .expect("valid packet");
+        ct.record_outbound(&outbound, start);
+
+        ct.record_outbound(&outbound, start + UDP_TTL - Duration::from_secs(1));
+
+        ct.handle_timeout(start + UDP_TTL + Duration::from_secs(1));
+
+        let reply = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 8080, 53535, &[])
+            .expect("valid packet");
+        assert!(ct.is_return_traffic(&reply));
+    }
+
+    #[test]
+    fn reply_to_peer_opened_flow_does_not_create_exemption() {
+        let mut ct = ConnTrack::default();
+        let now = Instant::now();
+
+        let inbound = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 40000, 80, &[])
+            .expect("valid packet");
+        ct.record_inbound(&inbound, now);
+
+        let reply = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 80, 40000, &[])
+            .expect("valid packet");
+        ct.record_outbound(&reply, now);
+
+        let next = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 40000, 80, &[1])
+            .expect("valid packet");
+        assert!(!ct.is_return_traffic(&next));
     }
 
     #[test]

--- a/rust/libs/connlib/tunnel/src/conn_track.rs
+++ b/rust/libs/connlib/tunnel/src/conn_track.rs
@@ -16,10 +16,12 @@ pub(crate) struct ConnTrack {
 }
 
 impl ConnTrack {
-    /// Record an outbound packet as a flow *we* opened, unless it is a reply
-    /// to a flow the peer opened: that must not earn a return-traffic
-    /// exemption, or a peer-opened flow would outlive its authorization.
-    pub(crate) fn record_outbound(&mut self, packet: &IpPacket, now: Instant) {
+    /// Handles an outbound packet we sent to a peer.
+    ///
+    /// The first packet of a flow records it as one *we* opened. A reply to a
+    /// flow the peer opened records nothing: it must not earn a return-traffic
+    /// exemption, or the peer's flow would outlive its authorization.
+    pub(crate) fn handle_outbound(&mut self, packet: &IpPacket, now: Instant) {
         let Ok(local) = packet.source_protocol() else {
             return;
         };
@@ -61,7 +63,7 @@ impl ConnTrack {
         );
     }
 
-    /// Returns `true` if the inbound packet is the reply to a flow *we* opened.
+    /// Returns `true` if the packet is the reply to a flow *we* opened.
     pub(crate) fn is_return_traffic(&self, packet: &IpPacket) -> bool {
         let Ok(peer) = packet.source_protocol() else {
             return false;
@@ -78,8 +80,7 @@ impl ConnTrack {
         })
     }
 
-    /// Returns `true` if the *outbound* packet belongs to an existing flow in
-    /// either direction.
+    /// Returns `true` if the packet belongs to an existing flow in either direction.
     pub(crate) fn is_known_flow(&self, packet: &IpPacket) -> bool {
         let Ok(local) = packet.source_protocol() else {
             return false;
@@ -145,7 +146,7 @@ mod tests {
 
         let outbound = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 53535, 8080, &[])
             .expect("valid packet");
-        ct.record_outbound(&outbound, now);
+        ct.handle_outbound(&outbound, now);
 
         let reply = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 8080, 53535, &[])
             .expect("valid packet");
@@ -159,7 +160,7 @@ mod tests {
 
         let outbound = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 53535, 8080, &[])
             .expect("valid packet");
-        ct.record_outbound(&outbound, now);
+        ct.handle_outbound(&outbound, now);
 
         // Different source port — not the reply we expected.
         let unrelated = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 9999, 53535, &[])
@@ -192,9 +193,9 @@ mod tests {
 
         let outbound = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 53535, 8080, &[])
             .expect("valid packet");
-        ct.record_outbound(&outbound, start);
+        ct.handle_outbound(&outbound, start);
 
-        ct.record_outbound(&outbound, start + UDP_TTL - Duration::from_secs(1));
+        ct.handle_outbound(&outbound, start + UDP_TTL - Duration::from_secs(1));
 
         ct.handle_timeout(start + UDP_TTL + Duration::from_secs(1));
 
@@ -214,7 +215,7 @@ mod tests {
 
         let reply = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 80, 40000, &[])
             .expect("valid packet");
-        ct.record_outbound(&reply, now);
+        ct.handle_outbound(&reply, now);
 
         let next = make::udp_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 40000, 80, &[1])
             .expect("valid packet");
@@ -228,7 +229,7 @@ mod tests {
 
         let outbound = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 53535, 8080, &[])
             .expect("valid packet");
-        ct.record_outbound(&outbound, start);
+        ct.handle_outbound(&outbound, start);
 
         ct.handle_timeout(start + UDP_TTL + Duration::from_secs(1));
 
@@ -244,7 +245,7 @@ mod tests {
 
         let request =
             make::icmp_request_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 1, 42, &[]).expect("valid");
-        ct.record_outbound(&request, now);
+        ct.handle_outbound(&request, now);
 
         let reply =
             make::icmp_reply_packet(ip(10, 0, 0, 2), ip(10, 0, 0, 1), 1, 42, &[]).expect("valid");
@@ -258,7 +259,7 @@ mod tests {
 
         let v4_outbound = make::udp_packet(ip(10, 0, 0, 1), ip(10, 0, 0, 2), 5353, 5353, &[])
             .expect("valid packet");
-        ct.record_outbound(&v4_outbound, now);
+        ct.handle_outbound(&v4_outbound, now);
 
         // A v6 reply on the same port pair must NOT count as return traffic.
         let v6_reply = make::udp_packet(

--- a/rust/libs/connlib/tunnel/src/expiring_map.rs
+++ b/rust/libs/connlib/tunnel/src/expiring_map.rs
@@ -83,6 +83,15 @@ where
         self.inner.values().map(|e| &e.value)
     }
 
+    /// Set the expiration of an existing entry to `expires_at`. Returns
+    /// `true` if the entry exists.
+    ///
+    /// An `expires_at` in the past collapses to a zero TTL, evicting the
+    /// entry on the next `handle_timeout` call.
+    pub fn update_expiry_at(&mut self, key: &K, expires_at: Instant, now: Instant) -> bool {
+        self.update_expiry(key, now, expires_at.saturating_duration_since(now))
+    }
+
     /// Push back (or move forward) the expiration of an existing entry to
     /// `now + ttl`, re-bucketing it in the expiration index. Returns `true`
     /// if the entry exists.

--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -220,10 +220,7 @@ impl ClientOnGateway {
         new_expiry: Instant,
         now: Instant,
     ) {
-        // A past `new_expiry` collapses to a zero TTL, evicting the
-        // entry on the next `handle_timeout` call.
-        let ttl = new_expiry.saturating_duration_since(now);
-        if !self.resources.update_expiry(&rid, now, ttl) {
+        if !self.resources.update_expiry_at(&rid, new_expiry, now) {
             tracing::debug!(%rid, "Unknown resource");
         }
     }

--- a/rust/libs/connlib/tunnel/src/messages.rs
+++ b/rust/libs/connlib/tunnel/src/messages.rs
@@ -1,11 +1,14 @@
 //! Message types that are used by both the gateway and client.
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc, serde::ts_seconds};
-use connlib_model::RelayId;
+use connlib_model::{ClientId, RelayId, ResourceId};
 use dns_types::{DoHUrl, DomainName};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
+use serde_with::{DurationSeconds, serde_as};
 use std::fmt;
 
 pub mod client;
@@ -14,6 +17,35 @@ mod key;
 
 pub use flow_tracker::IngestToken;
 pub use key::{Key, SecretKey};
+
+/// An active authorization: `client_id` may access `resource_id` until `expires_at`.
+#[serde_as]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct Authorization {
+    pub client_id: ClientId,
+    pub resource_id: ResourceId,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub expires_at: Duration,
+}
+
+/// Group the authorizations of an `init` message by client, for resyncing
+/// against the currently connected peers.
+pub fn group_authorizations_by_client(
+    authorizations: &[Authorization],
+) -> BTreeMap<ClientId, BTreeSet<ResourceId>> {
+    authorizations.iter().fold(
+        BTreeMap::new(),
+        |mut grouped,
+         Authorization {
+             client_id,
+             resource_id,
+             ..
+         }| {
+            grouped.entry(*client_id).or_default().insert(*resource_id);
+            grouped
+        },
+    )
+}
 
 /// Represents a wireguard peer.
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -14,6 +14,8 @@ use std::{
     time::Duration,
 };
 
+pub use crate::messages::Authorization;
+
 /// Description of a resource that maps to a DNS record.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ResourceDescriptionDns {
@@ -99,15 +101,6 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RemoveResource {
     pub id: ResourceId,
-}
-
-#[serde_as]
-#[derive(Debug, Deserialize, Clone)]
-pub struct Authorization {
-    pub client_id: ClientId,
-    pub resource_id: ResourceId,
-    #[serde_as(as = "DurationSeconds<u64>")]
-    pub expires_at: Duration,
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
The client-to-client connection tracker kept all flows in one map, so our replies to a peer-opened flow counted as proof we opened it, and the peer's traffic bypassed the inbound filter for as long as we kept responding.

Flows are now tracked by which side opened them. Only flows we opened grant a return-traffic exemption, and a reply to a peer-opened flow never earns one, so revoking or expiring an authorization actually cuts the peer off.

Related: #11143