### PR TITLE
refactor(connlib): share authorization message bookkeeping

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -7,7 +7,7 @@ use hickory_resolver::TokioResolver;
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::proto::rr::RecordType;
 use phoenix_channel::{PhoenixChannel, PublicKeyParam};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::future::{self, Future, poll_fn};
 use std::net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::ops::ControlFlow;
@@ -21,7 +21,7 @@ use tunnel::messages::gateway::{
     Authorization, ClientIceCandidates, ClientsIceCandidates, EgressMessages, IngressMessages,
     InitGateway, RejectAccess,
 };
-use tunnel::messages::{RelaysPresence, SnownetCapabilities};
+use tunnel::messages::{self, RelaysPresence, SnownetCapabilities};
 use tunnel::{
     GatewayEvent, GatewayTunnel, IPV4_TUNNEL, IPV6_TUNNEL, IpConfig, ResolveDnsRequest, TunnelError,
 };
@@ -417,16 +417,8 @@ impl Eventloop {
                 });
                 tunnel
                     .state_mut()
-                    .retain_authorizations(authorizations.iter().fold(
-                        BTreeMap::new(),
-                        |mut authorizations, next| {
-                            authorizations
-                                .entry(next.client_id)
-                                .or_default()
-                                .insert(next.resource_id);
-
-                            authorizations
-                        },
+                    .retain_authorizations(messages::group_authorizations_by_client(
+                        &authorizations,
                     ));
                 for Authorization {
                     client_id: cid,

--- a/rust/libs/connlib/tunnel/src/expiring_map.rs
+++ b/rust/libs/connlib/tunnel/src/expiring_map.rs
@@ -83,6 +83,15 @@ where
         self.inner.values().map(|e| &e.value)
     }
 
+    /// Set the expiration of an existing entry to `expires_at`. Returns
+    /// `true` if the entry exists.
+    ///
+    /// An `expires_at` in the past collapses to a zero TTL, evicting the
+    /// entry on the next `handle_timeout` call.
+    pub fn update_expiry_at(&mut self, key: &K, expires_at: Instant, now: Instant) -> bool {
+        self.update_expiry(key, now, expires_at.saturating_duration_since(now))
+    }
+
     /// Push back (or move forward) the expiration of an existing entry to
     /// `now + ttl`, re-bucketing it in the expiration index. Returns `true`
     /// if the entry exists.

--- a/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/libs/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -220,10 +220,7 @@ impl ClientOnGateway {
         new_expiry: Instant,
         now: Instant,
     ) {
-        // A past `new_expiry` collapses to a zero TTL, evicting the
-        // entry on the next `handle_timeout` call.
-        let ttl = new_expiry.saturating_duration_since(now);
-        if !self.resources.update_expiry(&rid, now, ttl) {
+        if !self.resources.update_expiry_at(&rid, new_expiry, now) {
             tracing::debug!(%rid, "Unknown resource");
         }
     }

--- a/rust/libs/connlib/tunnel/src/messages.rs
+++ b/rust/libs/connlib/tunnel/src/messages.rs
@@ -1,11 +1,14 @@
 //! Message types that are used by both the gateway and client.
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc, serde::ts_seconds};
-use connlib_model::RelayId;
+use connlib_model::{ClientId, RelayId, ResourceId};
 use dns_types::{DoHUrl, DomainName};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
+use serde_with::{DurationSeconds, serde_as};
 use std::fmt;
 
 pub mod client;
@@ -14,6 +17,35 @@ mod key;
 
 pub use flow_tracker::IngestToken;
 pub use key::{Key, SecretKey};
+
+/// An active authorization: `client_id` may access `resource_id` until `expires_at`.
+#[serde_as]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct Authorization {
+    pub client_id: ClientId,
+    pub resource_id: ResourceId,
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub expires_at: Duration,
+}
+
+/// Group the authorizations of an `init` message by client, for resyncing
+/// against the currently connected peers.
+pub fn group_authorizations_by_client(
+    authorizations: &[Authorization],
+) -> BTreeMap<ClientId, BTreeSet<ResourceId>> {
+    authorizations.iter().fold(
+        BTreeMap::new(),
+        |mut grouped,
+         Authorization {
+             client_id,
+             resource_id,
+             ..
+         }| {
+            grouped.entry(*client_id).or_default().insert(*resource_id);
+            grouped
+        },
+    )
+}
 
 /// Represents a wireguard peer.
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -4,6 +4,8 @@ use crate::messages::{
     Filter, FlowLogsConfig, IceCredentials, IngestToken, Interface, Key, Relay, RelaysPresence,
     SecretKey, SnownetCapabilities,
 };
+
+pub use crate::messages::Authorization;
 use connlib_model::{ClientId, IceCandidate, ResourceId};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
@@ -99,15 +101,6 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RemoveResource {
     pub id: ResourceId,
-}
-
-#[serde_as]
-#[derive(Debug, Deserialize, Clone)]
-pub struct Authorization {
-    pub client_id: ClientId,
-    pub resource_id: ResourceId,
-    #[serde_as(as = "DurationSeconds<u64>")]
-    pub expires_at: Duration,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/rust/libs/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/libs/connlib/tunnel/src/messages/gateway.rs
@@ -4,8 +4,6 @@ use crate::messages::{
     Filter, FlowLogsConfig, IceCredentials, IngestToken, Interface, Key, Relay, RelaysPresence,
     SecretKey, SnownetCapabilities,
 };
-
-pub use crate::messages::Authorization;
 use connlib_model::{ClientId, IceCandidate, ResourceId};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
@@ -15,6 +13,8 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr},
     time::Duration,
 };
+
+pub use crate::messages::Authorization;
 
 /// Description of a resource that maps to a DNS record.
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
The Authorization init payload, the group-by-client fold that consumes it, and the past-expiry-collapses-to-zero-TTL update logic each exist once per role today. Client-to-client resync (#14060) needs all three on the client too, so this moves them to shared code instead of copying them: Authorization lives in the shared messages module, grouping is a helper next to it, and ExpiringMap grows update_expiry_at.

No behavior change; the gateway is converted to the shared pieces.

Related: #14125 #11143