### PR TITLE
perf(connlib): drive wireguard timers on demand

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#268e4c6be799d90f84f75ed581f4d662e1a09251"
+source = "git+https://github.com/firezone/boringtun?branch=master#cf83e8bca2fdd7cd1565ba358ec96c66b7ecac17"
 dependencies = [
  "aead",
  "blake2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.7.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#74acc48217c96653d6d8efdf490d17e14f2a1ace"
+source = "git+https://github.com/firezone/boringtun?branch=master#268e4c6be799d90f84f75ed581f4d662e1a09251"
 dependencies = [
  "aead",
  "blake2",
@@ -1593,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -9943,9 +9943,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-rc.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17b575e04fcdb37e5509a85a14ff08116678a1c9724befb8b571db742dbdbb0"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
  "getrandom 0.4.2",

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -94,8 +94,6 @@ pub struct Node<TId, RId> {
 
     buffered_transmits: TransmitBuffer,
 
-    next_rate_limiter_reset: Option<Instant>,
-
     allocations: Allocations<RId>,
 
     connections: Connections<TId, RId>,
@@ -201,7 +199,6 @@ where
             index,
             rate_limiter: Arc::new(RateLimiter::new_at(public_key, HANDSHAKE_RATE_LIMIT, now)),
             buffered_transmits: TransmitBuffer::default(),
-            next_rate_limiter_reset: None,
             pending_events: VecDeque::default(),
             allocations,
             inflight_stun_requests: Default::default(),
@@ -610,10 +607,6 @@ where
         iter::empty()
             .chain(self.connections.poll_timeout())
             .chain(self.allocations.poll_timeout())
-            .chain(
-                self.next_rate_limiter_reset
-                    .map(|instant| (instant, "rate limiter reset")),
-            )
             .min_by_key(|(instant, _)| *instant)
     }
 
@@ -661,18 +654,6 @@ where
         for (kind, count) in PeerSocket::KINDS.into_iter().zip(connections_by_path) {
             self.connection_count
                 .record(count, &[telemetry::otel::attr::connection_socket(kind)]);
-        }
-
-        if self.connections.all_idle() {
-            // If all connections are idle, there is no point in resetting the rate limiter.
-            self.next_rate_limiter_reset = None;
-        } else {
-            let next_reset = *self.next_rate_limiter_reset.get_or_insert(now);
-
-            if now >= next_reset {
-                self.rate_limiter.reset_count_at(now);
-                self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
-            }
         }
 
         let gc = self.allocations.gc();
@@ -2158,10 +2139,6 @@ where
 
     fn is_failed(&self) -> bool {
         matches!(self.state, ConnectionState::Failed)
-    }
-
-    fn is_idle(&self) -> bool {
-        matches!(self.state, ConnectionState::Idle { .. })
     }
 
     fn migrate_relay<TId>(

--- a/rust/libs/connlib/snownet/src/node.rs
+++ b/rust/libs/connlib/snownet/src/node.rs
@@ -850,7 +850,6 @@ where
             agent,
             index,
             tunnel,
-            next_wg_timer_update: now,
             stats: Default::default(),
             buffer: vec![0; ip_packet::MAX_FZ_PAYLOAD],
             intent_sent_at,
@@ -1337,8 +1336,6 @@ struct Connection<RId> {
     #[debug(skip)]
     tunnel: Tunn,
     remote_pub_key: PublicKey,
-    /// When to next update the [`Tunn`]'s timers.
-    next_wg_timer_update: Instant,
 
     last_proactive_handshake_sent_at: Option<Instant>,
 
@@ -1386,7 +1383,7 @@ where
                     .poll_timeout()
                     .map(|instant| (instant, "ICE agent")),
             )
-            .chain(Some((self.next_wg_timer_update, "boringtun tunnel")))
+            .chain(self.tunnel.next_timer_update())
             .chain(
                 self.candidate_timeout
                     .map(|instant| (instant, "candidate timeout")),
@@ -1446,18 +1443,6 @@ where
         }
 
         self.handle_tunnel_timeout(now, allocations, transmits);
-
-        // If this was a scheduled update, hop to the next interval.
-        if now >= self.next_wg_timer_update {
-            self.next_wg_timer_update = now + Duration::from_secs(1); // TODO: Remove fixed interval in favor of precise `next_timer_update` function in `boringtun`.
-        }
-
-        // If `boringtun` wants to be called earlier than the scheduled interval, move it forward.
-        if let Some(next_update) = self.tunnel.next_timer_update()
-            && next_update < self.next_wg_timer_update
-        {
-            self.next_wg_timer_update = next_update;
-        }
 
         while let Some(event) = self.agent.poll_ice_event() {
             match event {

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -305,10 +305,6 @@ where
         self.established.keys().copied()
     }
 
-    pub(crate) fn all_idle(&self) -> bool {
-        self.established.values().all(|c| c.is_idle())
-    }
-
     pub(crate) fn all_iceless(&self) -> bool {
         !self.established.is_empty() && self.established.values().all(|c| c.agent.is_iceless())
     }

--- a/rust/libs/connlib/snownet/src/node/connections.rs
+++ b/rust/libs/connlib/snownet/src/node/connections.rs
@@ -669,7 +669,6 @@ mod tests {
                 Duration::ZERO,
             ),
             remote_pub_key: PublicKey::from(rand::random::<[u8; 32]>()),
-            next_wg_timer_update: Instant::now(),
             last_proactive_handshake_sent_at: None,
             relay: SelectedRelay { id: relay_id },
             state: crate::node::ConnectionState::Connecting {


### PR DESCRIPTION
boringtun's `next_timer_update` now reports the exact instant of the next required timer action, so the tunnel no longer needs to be polled on a fixed one-second interval. This bumps boringtun to pick that up and queries it on demand when computing the next timeout. The correctness of `next_timer_update` is extensively tested in boringtun.

Related: firezone/boringtun#213