### PR TITLE
fix(portal): pin HEC timestamp format, isolate code 15

### DIFF
--- a/elixir/lib/portal/splunk/sync.ex
+++ b/elixir/lib/portal/splunk/sync.ex
@@ -128,9 +128,12 @@ defmodule Portal.Splunk.Sync do
       {:ok, %Req.Response{status: 413} = response} ->
         handle_rejected_chunk(sink, cursor, chunk, response, :oversized)
 
-      # Code 6 "Invalid data format" rejects the payload, not the config, so a
-      # poison event must be isolated rather than disabling the whole sink.
-      {:ok, %Req.Response{status: 400, body: %{"code" => 6}} = response} ->
+      # Codes 6 (invalid data format), 12/13 (event field required/blank) and
+      # 15 (error in handling indexed fields) reject event content, not the
+      # config, so a poison event must be isolated rather than disabling the
+      # whole sink.
+      {:ok, %Req.Response{status: 400, body: %{"code" => code}} = response}
+      when code in [6, 12, 13, 15] ->
         handle_rejected_chunk(sink, cursor, chunk, response, :malformed)
 
       {:ok, %Req.Response{} = response} ->
@@ -297,7 +300,7 @@ defmodule Portal.Splunk.Sync do
     {time, event} = render(stream, row)
 
     envelope = %{
-      "time" => time,
+      "time" => hec_time(time),
       "source" => "firezone",
       "sourcetype" => "firezone:#{stream}",
       "event" => event
@@ -402,6 +405,13 @@ defmodule Portal.Splunk.Sync do
 
   defp epoch(datetime) do
     DateTime.to_unix(datetime, :millisecond) / 1000
+  end
+
+  # JSON encodes floats in shortest-round-trip form, which turns round
+  # timestamps into scientific notation ("time":1.75248e9); HEC rejects that
+  # with 400 code 15, so pin the sec.ms format.
+  defp hec_time(time) do
+    :erlang.float_to_binary(time, decimals: 3)
   end
 
   defmodule Database do

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -57,7 +57,9 @@ defmodule Portal.Splunk.SyncTest do
       assert event["sourcetype"] == "firezone:session"
       assert event["event"]["type"] == "session"
       assert event["event"]["log_id"] == log.log_id
-      assert_in_delta event["time"], DateTime.to_unix(log.timestamp, :millisecond) / 1000, 0.001
+      assert_in_delta String.to_float(event["time"]),
+                      DateTime.to_unix(log.timestamp, :millisecond) / 1000,
+                      0.001
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.cursor == log.seq
@@ -198,7 +200,7 @@ defmodule Portal.Splunk.SyncTest do
       assert_receive {:hec, _conn, [start_event]}
       assert start_event["event"]["phase"] == "start"
       assert start_event["event"]["log_id"] == flow.log_id
-      assert_in_delta start_event["time"],
+      assert_in_delta String.to_float(start_event["time"]),
                       DateTime.to_unix(flow.flow_start, :millisecond) / 1000,
                       0.001
 
@@ -226,7 +228,9 @@ defmodule Portal.Splunk.SyncTest do
       assert end_event["event"]["phase"] == "end"
       assert end_event["event"]["log_id"] == flow.log_id
       assert end_event["event"]["rx_bytes"] == 1024
-      assert_in_delta end_event["time"], DateTime.to_unix(flow_end, :millisecond) / 1000, 0.001
+      assert_in_delta String.to_float(end_event["time"]),
+                      DateTime.to_unix(flow_end, :millisecond) / 1000,
+                      0.001
     end
 
     test "splits deliveries that exceed the HEC request size limit", %{account: account} do
@@ -345,6 +349,55 @@ defmodule Portal.Splunk.SyncTest do
       assert cursor.cursor >= poison.seq
 
       refute reload_sink(sink).is_disabled
+    end
+
+    test "round timestamps render in fixed sec.ms notation", %{account: account} do
+      sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      # 1752480000.0 JSON-encodes as 1.75248e9, which HEC rejects with
+      # "Error in handling indexed fields (code 15)".
+      session_log_fixture(
+        account: account,
+        timestamp: DateTime.from_unix!(1_752_480_000_000_000, :microsecond)
+      )
+
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      assert_receive {:hec, _conn, [event]}
+      assert event["time"] == "1752480000.000"
+    end
+
+    test "an indexed-fields rejection is isolated, not a sink error", %{account: account} do
+      sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      poison = session_log_fixture(account: account, actor_email: "poison@example.com")
+
+      Req.Test.stub(Splunk.APIClient, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        if body =~ "poison@example.com" do
+          conn
+          |> Plug.Conn.put_status(400)
+          |> Req.Test.json(%{"text" => "Error in handling indexed fields", "code" => 15})
+        else
+          Req.Test.json(conn, %{"text" => "Success", "code" => 0})
+        end
+      end)
+
+      log_output =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+        end)
+
+      assert log_output =~ "Dropping undeliverable log sink event"
+
+      cursor = get_cursor(sink, :session, :live)
+      assert cursor.dropped_count == 1
+      assert cursor.cursor >= poison.seq
+      refute reload_sink(sink).is_disabled
+      refute reload_sink(sink).errored_at
     end
 
     test "capacity warnings on successful deliveries are still successes", %{account: account} do


### PR DESCRIPTION
Staging's Splunk sink disabled itself with "Error in handling indexed fields (code 15)". Root cause: the HEC envelope's `time` was a raw float, and Elixir's JSON encoder prints floats in shortest-round-trip form, so timestamps landing on a round second (millis .000 and epoch seconds ending in two or more zeros) encoded as `"time":1.75248e9`. HEC rejects scientific-notation timestamps with 400 code 15. The time field is now a fixed `sec.ms` string.

Code 15 was also unmapped, so it classified as a client error and disabled the sink; since the cursor never advances past the rejected event, edit-and-save re-disabled it on the same event. Content-level HEC rejections (codes 6, 12, 13, 15) now go through poison isolation: the offending event is bisected out, dropped, and paged via error log while delivery continues.

After deploy, edit and save the staging sink to re-enable it; the wedged events deliver from the existing cursor position.

Related: #14107