### PR TITLE
fix(portal): never skip undeliverable log sink events

### DIFF
--- a/elixir/lib/portal/log_sinks/delivery.ex
+++ b/elixir/lib/portal/log_sinks/delivery.ex
@@ -13,7 +13,9 @@ defmodule Portal.LogSinks.Delivery do
   in a `Portal.LogSinks.Adapter`. Errors follow the directory sync
   convention: an unrecoverable response disables the sink immediately,
   transient failures (408/429/5xx/transport) disable it only after 24 hours
-  of continuous failure. Nothing here can re-enable a disabled sink.
+  of continuous failure. An event the destination rejects outright parks its
+  stream and pages us with no customer-facing state at all: failing to map
+  our own data is our bug to fix, not the admin's. Nothing here can re-enable a disabled sink.
   """
 
   alias __MODULE__.Database
@@ -35,6 +37,7 @@ defmodule Portal.LogSinks.Delivery do
       Enum.reduce_while(Database.list_cursors(sink), :ok, fn cursor, :ok ->
         case sync_cursor(sink, adapter, cursor, @max_batches_per_stream) do
           :ok -> {:cont, :ok}
+          {:error, :undeliverable} -> {:cont, :ok}
           {:error, reason} -> {:halt, {:error, reason}}
         end
       end)
@@ -121,27 +124,26 @@ defmodule Portal.LogSinks.Delivery do
     end
   end
 
-  # A single event the destination cannot accept, ever, is counted as dropped
-  # and the cursor moves past it: malformed events never fix themselves, and
-  # oversized ones only count when they genuinely exceed our own chunk budget.
-  # A too-large rejection for a small event is not a size problem, it is a
-  # server that is not the intake (this happened: Splunk Web answers 413 to
-  # redirected deliveries), so it errors out rather than silently dropping
-  # data. A rejected multi-event chunk is bisected until the offender is
-  # isolated.
+  # A single event the destination rejects is never skipped: the cursor parks
+  # on it and the error pages us with the exact request and response, every
+  # run, until we fix the cause and delivery resumes with nothing lost. The
+  # sink's customer-facing state stays untouched and other streams keep
+  # flowing. A rejected multi-event chunk is bisected until the offender is
+  # isolated, delivering the healthy events along the way.
   defp handle_rejected_chunk(_sink, _adapter, cursor, [{seq, json}] = _chunk, response, reason) do
-    if reason == :malformed or byte_size(json) > max_body_bytes() do
-      Logger.warning("Dropping undeliverable log sink event",
-        log_sink_id: cursor.log_sink_id,
-        stream: cursor.stream,
-        seq: seq,
-        reason: reason
-      )
+    Logger.error("Log sink event cannot be delivered, halting stream",
+      log_sink_id: cursor.log_sink_id,
+      account_id: cursor.account_id,
+      stream: cursor.stream,
+      seq: seq,
+      reason: reason,
+      request_bytes: byte_size(json),
+      request: binary_part(json, 0, min(byte_size(json), 65_536)),
+      response_status: response.status,
+      response_body: response.body
+    )
 
-      advance(cursor, seq, 0, 1)
-    else
-      {:error, {:status, response}}
-    end
+    {:error, :undeliverable}
   end
 
   defp handle_rejected_chunk(sink, adapter, cursor, chunk, _response, _reason) do

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -287,17 +287,18 @@ defmodule Portal.Splunk.SyncTest do
       refute reload_sink(sink).is_disabled
     end
 
-    test "drops an event that exceeds the chunk budget when the server rejects it", %{
+    test "halts on an event that exceeds the chunk budget instead of skipping it", %{
       account: account
     } do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
       assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
 
-      log =
-        session_log_fixture(
-          account: account,
-          subject: %{"blob" => String.duplicate("x", 600_000)}
-        )
+      parked = get_cursor(sink, :session, :live)
+
+      session_log_fixture(
+        account: account,
+        subject: %{"blob" => String.duplicate("x", 600_000)}
+      )
 
       Req.Test.stub(Splunk.APIClient, fn conn ->
         conn
@@ -305,17 +306,25 @@ defmodule Portal.Splunk.SyncTest do
         |> Req.Test.json(%{"text" => "Request too large", "code" => 6})
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      log_output =
+        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+        end)
+
+      assert log_output =~ "Log sink event cannot be delivered, halting stream"
 
       cursor = get_cursor(sink, :session, :live)
-      assert cursor.cursor == log.seq
+      assert cursor.cursor == parked.cursor
       assert cursor.synced_count == 0
-      assert cursor.dropped_count == 1
+      assert cursor.dropped_count == 0
 
-      refute reload_sink(sink).is_disabled
+      sink = reload_sink(sink)
+      refute sink.errored_at
+      refute sink.error_message
+      refute sink.is_disabled
     end
 
-    test "isolates and drops a malformed event without disabling the sink", %{
+    test "parks on a poison event after delivering the healthy prefix", %{
       account: account
     } do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
@@ -341,14 +350,24 @@ defmodule Portal.Splunk.SyncTest do
         end
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      log_output =
+        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+        end)
 
+      assert log_output =~ "Log sink event cannot be delivered, halting stream"
+
+      # The healthy prefix is delivered; the cursor parks just before the
+      # poison event so nothing is ever skipped.
       cursor = get_cursor(sink, :session, :live)
-      assert cursor.synced_count == 2
-      assert cursor.dropped_count == 1
-      assert cursor.cursor >= poison.seq
+      assert cursor.synced_count == 1
+      assert cursor.dropped_count == 0
+      assert cursor.cursor < poison.seq
 
-      refute reload_sink(sink).is_disabled
+      sink = reload_sink(sink)
+      refute sink.errored_at
+      refute sink.error_message
+      refute sink.is_disabled
     end
 
     test "round timestamps render in fixed sec.ms notation", %{account: account} do
@@ -368,7 +387,7 @@ defmodule Portal.Splunk.SyncTest do
       assert event["time"] == "1752480000.000"
     end
 
-    test "an indexed-fields rejection is isolated, not a sink error", %{account: account} do
+    test "an indexed-fields rejection parks the stream and pages us", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
       assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
 
@@ -387,16 +406,56 @@ defmodule Portal.Splunk.SyncTest do
       end)
 
       log_output =
-        ExUnit.CaptureLog.capture_log(fn ->
+        ExUnit.CaptureLog.capture_log([level: :error], fn ->
           assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
         end)
 
-      assert log_output =~ "Dropping undeliverable log sink event"
+      assert log_output =~ "Log sink event cannot be delivered, halting stream"
 
       cursor = get_cursor(sink, :session, :live)
-      assert cursor.dropped_count == 1
-      assert cursor.cursor >= poison.seq
-      refute reload_sink(sink).is_disabled
+      assert cursor.dropped_count == 0
+      assert cursor.cursor < poison.seq
+
+      sink = reload_sink(sink)
+      refute sink.errored_at
+      refute sink.error_message
+      refute sink.is_disabled
+    end
+
+    test "a parked stream does not block other streams", %{account: account} do
+      sink = splunk_log_sink_fixture(account: account, enabled_streams: [:change, :session])
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      poison = change_log_fixture(account: account)
+      log = session_log_fixture(account: account)
+
+      test_pid = self()
+
+      Req.Test.stub(Splunk.APIClient, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        if body =~ "firezone:change" do
+          conn
+          |> Plug.Conn.put_status(400)
+          |> Req.Test.json(%{"text" => "Invalid data format", "code" => 6})
+        else
+          send(test_pid, {:delivered, body})
+          Req.Test.json(conn, %{"text" => "Success", "code" => 0})
+        end
+      end)
+
+      log_output =
+        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+        end)
+
+      assert log_output =~ "Log sink event cannot be delivered, halting stream"
+
+      assert_receive {:delivered, body}
+      assert body =~ log.log_id
+
+      assert get_cursor(sink, :change, :live).cursor < poison.seq
+      assert get_cursor(sink, :session, :live).cursor == log.seq
       refute reload_sink(sink).errored_at
     end
 
@@ -422,7 +481,7 @@ defmodule Portal.Splunk.SyncTest do
       refute sink.errored_at
     end
 
-    test "a 413 for a small event disables the sink instead of dropping data", %{
+    test "a 413 for a small event halts the stream instead of dropping data", %{
       account: account
     } do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:session])
@@ -435,15 +494,21 @@ defmodule Portal.Splunk.SyncTest do
         |> Req.Test.json(%{"text" => "Unexpected request data received", "code" => 6})
       end)
 
-      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+      log_output =
+        ExUnit.CaptureLog.capture_log([level: :error], fn ->
+          assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+        end)
+
+      assert log_output =~ "Log sink event cannot be delivered, halting stream"
 
       cursor = get_cursor(sink, :session, :live)
       assert cursor.synced_count == 0
       assert cursor.dropped_count == 0
 
       sink = reload_sink(sink)
-      assert sink.is_disabled
-      assert sink.error_message =~ "413"
+      refute sink.errored_at
+      refute sink.error_message
+      refute sink.is_disabled
     end
 
     test "a redirect disables the sink with a pointed error", %{account: account} do


### PR DESCRIPTION
Undeliverable events were isolated and dropped with the cursor advancing past them, which silently loses data. An event the destination rejects now parks its stream instead: the cursor stays on the event and an error-level log pages us every sync run with the exact request body and response, so we can see precisely what triggered the rejection and fix it. Delivery resumes from the same position with nothing lost.

Failing to map our own data is our bug, not the admin's, so a parked stream produces no customer-facing signals at all: the sink stays Active, no error state is set, and it is never disabled for this. Other streams on the sink keep delivering past the parked one. Bisection still isolates the offending event, delivering the healthy events around it. Genuine transient errors (408/429/5xx/transport) keep the existing behavior: visible warning state and disable after 24 hours of continuous failure.

Related: #14107