### PR TITLE
fix(connlib): introduce suspend-aware clock

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1260,6 +1260,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow-ext",
  "bootstrap-dns-client",
+ "clock",
  "connlib-model",
  "dns-types",
  "etc-hosts-dns-client",
@@ -1290,6 +1291,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "clock"
+version = "0.1.0"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]
@@ -2327,6 +2335,7 @@ dependencies = [
  "bin-shared",
  "caps",
  "clap",
+ "clock",
  "dns-types",
  "flow-log-upload",
  "flow-log-writer",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "libs/backoff",
     "libs/bin-shared",
     "libs/client-shared",
+    "libs/clock",
     "libs/connlib/bootstrap-dns-client",
     "libs/connlib/bufferpool",
     "libs/connlib/dns-over-tcp",
@@ -85,6 +86,7 @@ caps = "0.5.6"
 chrono = { version = "0.4.44", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
 clap = "4.6.1"
 client-shared = { path = "libs/client-shared" }
+clock = { path = "libs/clock" }
 connlib-model = { path = "libs/connlib/model" }
 crc32fast = "1.5.0"
 crossbeam-queue = "0.3.12"

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = { workspace = true }
 backoff = { workspace = true }
 bin-shared = { workspace = true }
 clap = { workspace = true }
+clock = { workspace = true }
 dns-types = { workspace = true }
 flow-log-upload = { workspace = true }
 flow-log-writer = { workspace = true }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -3,6 +3,7 @@ use bin_shared::{TunDeviceManager, signals};
 use dns_types::DomainName;
 use telemetry::analytics;
 
+use clock::Clock;
 use hickory_resolver::TokioResolver;
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::proto::rr::RecordType;
@@ -34,6 +35,7 @@ pub const PHOENIX_TOPIC: &str = "gateway";
 const DNS_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct Eventloop {
+    clock: Clock,
     // Tunnel is `Option` because we need to take ownership on shutdown.
     tunnel: Option<GatewayTunnel>,
     tun_device_manager: TunDeviceManager,
@@ -67,6 +69,7 @@ enum PortalCommand {
 
 impl Eventloop {
     pub(crate) fn new(
+        clock: Clock,
         tunnel: GatewayTunnel,
         portal: PhoenixChannel<(), EgressMessages, IngressMessages, PublicKeyParam>,
         tun_device_manager: TunDeviceManager,
@@ -86,6 +89,7 @@ impl Eventloop {
         ));
 
         Ok(Self {
+            clock,
             tunnel: Some(tunnel),
             tun_device_manager,
             resolver,
@@ -149,17 +153,13 @@ impl Eventloop {
             )),
             CombinedEvent::Portal(Some(Err(e))) => Err(e).context("Failed to login to portal"),
             CombinedEvent::DomainResolved((result, req)) => {
+                let now = self.clock.now();
                 let Some(tunnel) = self.tunnel.as_mut() else {
                     tracing::debug!("Ignoring DNS resolution result during shutdown");
 
                     return Ok(ControlFlow::Continue(()));
                 };
-
-                if let Err(e) =
-                    tunnel
-                        .state_mut()
-                        .handle_domain_resolved(req, result, Instant::now())
-                {
+                if let Err(e) = tunnel.state_mut().handle_domain_resolved(req, result, now) {
                     tracing::warn!("Failed to set DNS resource NAT: {e:#}");
                 };
 
@@ -190,7 +190,8 @@ impl Eventloop {
             return Poll::Ready(CombinedEvent::DomainResolved((result, trigger)));
         }
 
-        if let Some(Poll::Ready(event)) = self.tunnel.as_mut().map(|t| t.poll_next_event(cx)) {
+        let now = self.clock.now();
+        if let Some(Poll::Ready(event)) = self.tunnel.as_mut().map(|t| t.poll_next_event(cx, now)) {
             return Poll::Ready(CombinedEvent::Tunnel(event));
         }
 
@@ -202,6 +203,7 @@ impl Eventloop {
     }
 
     async fn shut_down_tunnel(&mut self) -> Result<()> {
+        let now = self.clock.now();
         let Some(tunnel) = self.tunnel.take() else {
             tracing::debug!("Tunnel has already been shut down");
 
@@ -209,7 +211,7 @@ impl Eventloop {
         };
 
         tunnel
-            .shut_down()
+            .shut_down(now)
             .await
             .context("Failed to shutdown tunnel")?;
 
@@ -300,12 +302,12 @@ impl Eventloop {
     }
 
     async fn handle_portal_message(&mut self, msg: IngressMessages) -> Result<()> {
+        let now = self.clock.now();
         let Some(tunnel) = self.tunnel.as_mut() else {
             tracing::debug!(?msg, "Ignoring portal message during shutdown");
 
             return Ok(());
         };
-
         match msg {
             IngressMessages::AuthorizeFlow(msg) => {
                 let token = &msg.flow_logs_ingest_token;
@@ -324,7 +326,7 @@ impl Eventloop {
                     msg.expires_at,
                     msg.resource,
                     msg.use_iceless,
-                    Instant::now(),
+                    now,
                     msg.flow_logs_ingest_token,
                 ) {
                     tracing::debug!("Failed to authorise flow: No TURN servers available");
@@ -350,7 +352,7 @@ impl Eventloop {
                 for candidate in candidates {
                     tunnel
                         .state_mut()
-                        .add_ice_candidate(client_id, candidate, Instant::now());
+                        .add_ice_candidate(client_id, candidate, now);
                 }
             }
             IngressMessages::InvalidateIceCandidates(ClientIceCandidates {
@@ -360,7 +362,7 @@ impl Eventloop {
                 for candidate in candidates {
                     tunnel
                         .state_mut()
-                        .remove_ice_candidate(client_id, candidate, Instant::now());
+                        .remove_ice_candidate(client_id, candidate, now);
                 }
             }
             IngressMessages::RejectAccess(RejectAccess {
@@ -369,7 +371,7 @@ impl Eventloop {
             }) => {
                 tunnel
                     .state_mut()
-                    .remove_access(&client_id, &resource_id, Instant::now());
+                    .remove_access(&client_id, &resource_id, now);
             }
             IngressMessages::RelaysPresence(RelaysPresence {
                 disconnected_ids,
@@ -377,7 +379,7 @@ impl Eventloop {
             }) => tunnel.state_mut().update_relays(
                 BTreeSet::from_iter(disconnected_ids),
                 tunnel::turn(&connected),
-                Instant::now(),
+                now,
             ),
             IngressMessages::Init(InitGateway {
                 interface,
@@ -406,11 +408,9 @@ impl Eventloop {
                     tracing::warn!("Failed to persist flow-log upload config: {e:#}");
                 }
 
-                tunnel.state_mut().update_relays(
-                    BTreeSet::default(),
-                    tunnel::turn(&relays),
-                    Instant::now(),
-                );
+                tunnel
+                    .state_mut()
+                    .update_relays(BTreeSet::default(), tunnel::turn(&relays), now);
                 tunnel.state_mut().update_tun_device(IpConfig {
                     v4: interface.ipv4,
                     v6: interface.ipv6,
@@ -434,12 +434,10 @@ impl Eventloop {
                     expires_at,
                 } in authorizations
                 {
-                    if let Err(e) = tunnel.state_mut().update_access_authorization_expiry(
-                        cid,
-                        rid,
-                        expires_at,
-                        Instant::now(),
-                    ) {
+                    if let Err(e) = tunnel
+                        .state_mut()
+                        .update_access_authorization_expiry(cid, rid, expires_at, now)
+                    {
                         tracing::debug!(%cid, %rid, "Failed to update access authorization: {e:#}");
                     }
                 }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -18,6 +18,7 @@ use telemetry::SentryMeterProvider;
 use tokio_util::task::AbortOnDropHandle;
 use tunnel::GatewayTunnel;
 
+use clock::Clock;
 use phoenix_channel::PhoenixChannel;
 use secrecy::{ExposeSecret, SecretString};
 use std::{collections::BTreeSet, fmt};
@@ -201,10 +202,12 @@ async fn try_main(cli: Cli) -> Result<()> {
         .map(|ip| ip.into())
         .collect::<BTreeSet<_>>();
 
+    let mut clock = Clock::new();
     let mut tunnel = GatewayTunnel::new(
         Arc::new(tcp_socket_factory),
         Arc::new(UdpSocketFactory::default()),
         nameservers,
+        clock.now(),
     );
 
     flow_log_upload::spawn(flow_logs_dir.clone(), Arc::new(tcp_socket_factory));
@@ -255,6 +258,7 @@ async fn try_main(cli: Cli) -> Result<()> {
         .context("Failed to build DNS resolver")?;
 
     Eventloop::new(
+        clock,
         tunnel,
         portal,
         tun_device_manager,

--- a/rust/libs/client-shared/Cargo.toml
+++ b/rust/libs/client-shared/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 bootstrap-dns-client = { workspace = true }
+clock = { workspace = true }
 connlib-model = { workspace = true }
 dns-types = { workspace = true }
 etc-hosts-dns-client = { workspace = true }

--- a/rust/libs/client-shared/src/eventloop.rs
+++ b/rust/libs/client-shared/src/eventloop.rs
@@ -1,6 +1,7 @@
 use crate::PHOENIX_TOPIC;
 use anyhow::{Context as _, ErrorExt as _, Result};
 use bootstrap_dns_client::BootstrapDnsClient;
+use clock::Clock;
 use connlib_model::{ClientOrGatewayId, PublicKey, ResourceId, ResourceList};
 use parking_lot::Mutex;
 use phoenix_channel::{PhoenixChannel, PublicKeyParam};
@@ -8,7 +9,7 @@ use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::ops::ControlFlow;
 use std::pin::pin;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::{
     collections::BTreeSet,
     io,
@@ -48,6 +49,7 @@ use tunnel::{ClientEvent, ClientTunnel, DnsResourceRecord, IpConfig, TunConfig, 
 static DNS_RESOURCE_RECORDS_CACHE: Mutex<BTreeSet<DnsResourceRecord>> = Mutex::new(BTreeSet::new());
 
 pub struct Eventloop {
+    clock: Clock,
     tunnel: Option<ClientTunnel>,
 
     resolver_bypass: tunnel_bypass_resolver::Bypass,
@@ -126,12 +128,14 @@ impl Eventloop {
     ) -> Self {
         let (portal_event_tx, portal_event_rx) = mpsc::channel(128);
         let (portal_cmd_tx, portal_cmd_rx) = mpsc::channel(128);
+        let mut clock = Clock::new();
 
         let mut tunnel = ClientTunnel::new(
             tcp_socket_factory.clone(),
             udp_socket_factory.clone(),
             DNS_RESOURCE_RECORDS_CACHE.lock().clone(),
             is_internet_resource_active,
+            clock.now(),
         );
         tunnel.update_system_resolvers(dns_servers.clone());
         let resolver_bypass = tunnel_bypass_resolver::Bypass::with_servers(dns_servers.clone());
@@ -147,6 +151,7 @@ impl Eventloop {
         ));
 
         Self {
+            clock,
             tunnel: Some(tunnel),
             resolver_bypass,
             flow_logs_dir,
@@ -234,13 +239,12 @@ impl Eventloop {
                     .context("Failed to send message to portal")?;
             }
             Command::SetInternetResourceState(active) => {
+                let now = self.clock.now();
                 let Some(tunnel) = self.tunnel.as_mut() else {
                     return Ok(ControlFlow::Continue(()));
                 };
 
-                tunnel
-                    .state_mut()
-                    .set_internet_resource_state(active, Instant::now())
+                tunnel.state_mut().set_internet_resource_state(active, now)
             }
             Command::SetTun(tun) => {
                 let Some(tunnel) = self.tunnel.as_mut() else {
@@ -250,11 +254,12 @@ impl Eventloop {
                 tunnel.set_tun(tun);
             }
             Command::Reset(reason) => {
+                let now = self.clock.now();
                 let Some(tunnel) = self.tunnel.as_mut() else {
                     return Ok(ControlFlow::Continue(()));
                 };
 
-                tunnel.reset(&reason);
+                tunnel.reset(&reason, now);
                 tunnel_bypass_resolver::reset_sockets();
                 telemetry::reset_ingest();
                 self.portal_cmd_tx
@@ -430,6 +435,7 @@ impl Eventloop {
     }
 
     async fn handle_portal_message(&mut self, msg: IngressMessages) -> Result<()> {
+        let now = self.clock.now();
         let Some(tunnel) = self.tunnel.as_mut() else {
             return Ok(());
         };
@@ -445,7 +451,7 @@ impl Eventloop {
                 for candidate in candidates {
                     tunnel
                         .state_mut()
-                        .add_ice_candidate(gateway_id, candidate, Instant::now())
+                        .add_ice_candidate(gateway_id, candidate, now)
                 }
             }
             IngressMessages::ClientIceCandidates(ClientIceCandidates {
@@ -455,7 +461,7 @@ impl Eventloop {
                 for candidate in candidates {
                     tunnel
                         .state_mut()
-                        .add_ice_candidate(client_id, candidate, Instant::now())
+                        .add_ice_candidate(client_id, candidate, now)
                 }
             }
             IngressMessages::Init(InitClient {
@@ -485,14 +491,14 @@ impl Eventloop {
                 let state = tunnel.state_mut();
 
                 state.update_interface_config(interface);
-                state.set_resources(resources, Instant::now());
-                state.update_relays(BTreeSet::default(), tunnel::turn(&relays), Instant::now());
+                state.set_resources(resources, now);
+                state.update_relays(BTreeSet::default(), tunnel::turn(&relays), now);
             }
             IngressMessages::ResourceCreatedOrUpdated(resource) => {
-                tunnel.state_mut().add_resource(resource, Instant::now());
+                tunnel.state_mut().add_resource(resource, now);
             }
             IngressMessages::ResourceDeleted(resource) => {
-                tunnel.state_mut().remove_resource(resource, Instant::now());
+                tunnel.state_mut().remove_resource(resource, now);
             }
             IngressMessages::RelaysPresence(RelaysPresence {
                 disconnected_ids,
@@ -500,7 +506,7 @@ impl Eventloop {
             }) => tunnel.state_mut().update_relays(
                 BTreeSet::from_iter(disconnected_ids),
                 tunnel::turn(&connected),
-                Instant::now(),
+                now,
             ),
             IngressMessages::InvalidateGatewayIceCandidates(GatewayIceCandidates {
                 gateway_id,
@@ -509,7 +515,7 @@ impl Eventloop {
                 for candidate in candidates {
                     tunnel
                         .state_mut()
-                        .remove_ice_candidate(gateway_id, candidate, Instant::now())
+                        .remove_ice_candidate(gateway_id, candidate, now)
                 }
             }
             IngressMessages::InvalidateClientIceCandidates(ClientIceCandidates {
@@ -519,7 +525,7 @@ impl Eventloop {
                 for candidate in candidates {
                     tunnel
                         .state_mut()
-                        .remove_ice_candidate(client_id, candidate, Instant::now())
+                        .remove_ice_candidate(client_id, candidate, now)
                 }
             }
             IngressMessages::FlowCreated(FlowCreated {
@@ -550,7 +556,7 @@ impl Eventloop {
                     client_ice_credentials,
                     gateway_ice_credentials,
                     use_iceless,
-                    Instant::now(),
+                    now,
                 ) {
                     Ok(Ok(())) => {}
                     Ok(Err(e @ snownet::NoTurnServers {})) => {
@@ -575,9 +581,7 @@ impl Eventloop {
 
                 match reason {
                     FailReason::Offline => {
-                        tunnel
-                            .state_mut()
-                            .set_resource_offline(resource_id, Instant::now());
+                        tunnel.state_mut().set_resource_offline(resource_id, now);
 
                         let _ = self
                             .user_notification_sender
@@ -639,7 +643,7 @@ impl Eventloop {
                     use_iceless,
                     client_name,
                     authorization,
-                    Instant::now(),
+                    now,
                 ) {
                     Ok(()) => {}
                     Err(e @ snownet::NoTurnServers {}) => {
@@ -675,12 +679,9 @@ impl Eventloop {
                 ipv6,
                 reason,
             }) => {
-                tunnel.state_mut().handle_client_device_access_denied(
-                    ipv4,
-                    ipv6,
-                    reason,
-                    Instant::now(),
-                );
+                tunnel
+                    .state_mut()
+                    .handle_client_device_access_denied(ipv4, ipv6, reason, now);
             }
             IngressMessages::DevicePoolDomainResolved(DevicePoolDomainResolved {
                 resource_id,
@@ -727,7 +728,8 @@ impl Eventloop {
             return Poll::Ready(CombinedEvent::Portal(event));
         }
 
-        if let Some(Poll::Ready(event)) = self.tunnel.as_mut().map(|t| t.poll_next_event(cx)) {
+        let now = self.clock.now();
+        if let Some(Poll::Ready(event)) = self.tunnel.as_mut().map(|t| t.poll_next_event(cx, now)) {
             return Poll::Ready(CombinedEvent::Tunnel(event));
         }
 
@@ -735,13 +737,14 @@ impl Eventloop {
     }
 
     async fn shut_down_tunnel(&mut self) -> Result<()> {
+        let now = self.clock.now();
         let Some(tunnel) = self.tunnel.take() else {
             tracing::debug!("Tunnel has already been shut down");
             return Ok(());
         };
 
         tunnel
-            .shut_down()
+            .shut_down(now)
             .await
             .context("Failed to shut down tunnel")?;
 

--- a/rust/libs/clock/Cargo.toml
+++ b/rust/libs/clock/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "clock"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/libs/clock/src/lib.rs
+++ b/rust/libs/clock/src/lib.rs
@@ -1,0 +1,168 @@
+use std::time::{Duration, Instant, SystemTime};
+
+/// Differences smaller than this are assumed to be clock resolution, sampling jitter, or clock
+/// slewing rather than time spent suspended.
+const CLOCK_DRIFT_TOLERANCE: Duration = Duration::from_secs(1);
+
+/// A monotonic clock that also advances while the system is suspended.
+///
+/// [`Instant`] does not consistently include time spent suspended across supported platforms.
+/// [`SystemTime`] does, but can move backwards and is therefore unsuitable for state-machine
+/// deadlines. This clock retains [`Instant`] as its clock domain and adds any elapsed time observed
+/// by [`SystemTime`] but not by [`Instant`].
+pub struct Clock {
+    last_monotonic: Instant,
+    last_system: SystemTime,
+    suspend_offset: Duration,
+}
+
+impl Clock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a monotonic timestamp that includes time spent suspended.
+    pub fn now(&mut self) -> Instant {
+        self.sample(Instant::now(), SystemTime::now())
+    }
+
+    fn sample(&mut self, monotonic: Instant, system: SystemTime) -> Instant {
+        let monotonic_elapsed = monotonic.saturating_duration_since(self.last_monotonic);
+        let system_elapsed = system.duration_since(self.last_system).ok();
+
+        self.last_monotonic = monotonic;
+        self.last_system = system;
+
+        let missing = system_elapsed
+            .unwrap_or(monotonic_elapsed)
+            .saturating_sub(monotonic_elapsed);
+
+        if missing >= CLOCK_DRIFT_TOLERANCE {
+            let offset = self.suspend_offset.saturating_add(missing);
+
+            if monotonic.checked_add(offset).is_some() {
+                self.suspend_offset = offset;
+                tracing::debug!(
+                    advanced_by = ?missing,
+                    total_advance = ?self.suspend_offset,
+                    "Advancing suspend-aware clock after system suspend or wall-clock adjustment"
+                );
+            } else {
+                tracing::warn!(
+                    ?missing,
+                    "Unable to advance suspend-aware clock without overflowing"
+                );
+            }
+        }
+
+        monotonic
+            .checked_add(self.suspend_offset)
+            .unwrap_or(monotonic)
+    }
+}
+
+impl Default for Clock {
+    fn default() -> Self {
+        Self {
+            last_monotonic: Instant::now(),
+            last_system: SystemTime::now(),
+            suspend_offset: Duration::ZERO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn follows_monotonic_clock_during_normal_operation() {
+        let monotonic = Instant::now();
+        let system = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let mut clock = clock_at(monotonic, system);
+
+        assert_eq!(
+            clock.sample(
+                monotonic + Duration::from_secs(5),
+                system + Duration::from_secs(5)
+            ),
+            monotonic + Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn adds_time_missing_from_monotonic_clock() {
+        let monotonic = Instant::now();
+        let system = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let mut clock = clock_at(monotonic, system);
+
+        let now = clock.sample(
+            monotonic + Duration::from_secs(1),
+            system + Duration::from_secs(3 * 60 * 60 + 1),
+        );
+
+        assert_eq!(now, monotonic + Duration::from_secs(3 * 60 * 60 + 1));
+
+        // The detected suspend offset remains part of the clock domain without being counted
+        // again on subsequent samples.
+        assert_eq!(
+            clock.sample(
+                monotonic + Duration::from_secs(2),
+                system + Duration::from_secs(3 * 60 * 60 + 2),
+            ),
+            monotonic + Duration::from_secs(3 * 60 * 60 + 2)
+        );
+    }
+
+    #[test]
+    fn ignores_small_clock_differences_without_accumulating_them() {
+        let monotonic = Instant::now();
+        let system = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let mut clock = clock_at(monotonic, system);
+
+        assert_eq!(
+            clock.sample(
+                monotonic + Duration::from_secs(1),
+                system + Duration::from_millis(1_500),
+            ),
+            monotonic + Duration::from_secs(1)
+        );
+        assert_eq!(
+            clock.sample(
+                monotonic + Duration::from_secs(2),
+                system + Duration::from_millis(2_500),
+            ),
+            monotonic + Duration::from_secs(2)
+        );
+    }
+
+    #[test]
+    fn ignores_backward_system_clock_adjustments() {
+        let monotonic = Instant::now();
+        let system = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        let mut clock = clock_at(monotonic, system);
+
+        assert_eq!(
+            clock.sample(
+                monotonic + Duration::from_secs(5),
+                system - Duration::from_secs(60),
+            ),
+            monotonic + Duration::from_secs(5)
+        );
+        assert_eq!(
+            clock.sample(
+                monotonic + Duration::from_secs(6),
+                system - Duration::from_secs(59),
+            ),
+            monotonic + Duration::from_secs(6)
+        );
+    }
+
+    fn clock_at(monotonic: Instant, system: SystemTime) -> Clock {
+        Clock {
+            last_monotonic: monotonic,
+            last_system: system,
+            suspend_offset: Duration::ZERO,
+        }
+    }
+}

--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -75,7 +75,6 @@ struct DnsQueryMetaData {
 /// This structure allows us to batch-process multiple ready sources rather than
 /// handling them one at a time, improving fairness and preventing starvation.
 pub struct Input<D, I> {
-    pub now: Instant,
     pub timeout: bool,
     pub device: Option<D>,
     pub network: Option<I>,
@@ -88,7 +87,6 @@ pub struct Input<D, I> {
 impl<D, I> Input<D, I> {
     fn error(e: impl Into<anyhow::Error>) -> Self {
         Self {
-            now: Instant::now(),
             timeout: false,
             device: None,
             network: None,
@@ -366,7 +364,6 @@ impl Io {
         }
 
         Poll::Ready(Input {
-            now: Instant::now(),
             timeout,
             device: poll_result_to_option(device, &mut error),
             network: poll_to_option(network),
@@ -457,9 +454,16 @@ impl Io {
         }
     }
 
-    pub fn reset_timeout(&mut self, timeout: Instant, reason: &'static str) {
+    pub fn reset_timeout_after(&mut self, wakeup_in: Duration, reason: &'static str) {
+        let now = Instant::now();
+        let Some(timeout) = now.checked_add(wakeup_in) else {
+            tracing::warn!(?wakeup_in, %reason, "Unable to schedule tunnel timeout without overflowing");
+
+            return;
+        };
+
         let wakeup_in = tracing::event_enabled!(Level::TRACE)
-            .then(|| timeout.saturating_duration_since(Instant::now()))
+            .then_some(wakeup_in)
             .map(tracing::field::debug);
 
         if self.timeout.deadline() != timeout {
@@ -470,8 +474,9 @@ impl Io {
     }
 
     /// Schedules a wakeup in case one isn't registered yet.
-    pub fn schedule_timeout(&mut self, now: Instant) {
-        self.timeout.schedule(now + Duration::from_secs(1));
+    pub fn schedule_timeout(&mut self) {
+        self.timeout
+            .schedule(Instant::now() + Duration::from_secs(1));
     }
 
     /// The GSO queue used as the destination buffer when encapsulating packets in place.
@@ -489,14 +494,14 @@ impl Io {
         self.gso_queue.enqueue(src, dst, payload, ecn);
     }
 
-    pub fn send_dns_query(&mut self, query: dns::RecursiveQuery) {
+    pub fn send_dns_query(&mut self, query: dns::RecursiveQuery, now: Instant) {
         let meta = DnsQueryMetaData {
             query: query.message.clone(),
             server: query.server.clone(),
             transport: query.transport,
             local: query.local,
             remote: query.remote,
-            started_at: Instant::now(),
+            started_at: now,
         };
 
         match (query.transport, query.server) {
@@ -606,48 +611,9 @@ fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use futures::task::noop_waker_ref;
     use std::{future::poll_fn, net::Ipv4Addr};
 
     use super::*;
-
-    #[tokio::test]
-    async fn timer_is_reset_after_it_fires() {
-        let mut io = Io::for_test();
-
-        let deadline = Instant::now() + Duration::from_secs(1);
-        io.reset_timeout(deadline, "");
-        let scheduled_deadline = io.timeout.deadline();
-
-        let input = io.next().await;
-
-        assert!(input.timeout);
-        assert!(input.now >= deadline, "timer expire after deadline");
-        assert_eq!(deadline, scheduled_deadline);
-
-        drop(input);
-
-        let poll = io.poll_test();
-
-        assert!(poll.is_pending());
-        assert_eq!(
-            io.timeout.deadline().duration_since(scheduled_deadline),
-            DEFAULT_TIME_ADVANCE
-        );
-    }
-
-    #[tokio::test]
-    async fn emits_now_in_case_timeout_is_in_the_past() {
-        let now = Instant::now();
-        let mut io = Io::for_test();
-
-        io.reset_timeout(now - Duration::from_secs(10), "");
-
-        let input = io.next().await;
-        let timeout = input.now;
-
-        assert!(timeout >= now, "timeout = {timeout:?}, now = {now:?}");
-    }
 
     #[tokio::test]
     async fn bootstrap_doh() {
@@ -660,7 +626,7 @@ mod tests {
         io.update_system_resolvers(vec![IpAddr::from([1, 1, 1, 1])]);
 
         {
-            io.send_dns_query(example_com_recursive_query());
+            io.send_dns_query(example_com_recursive_query(), Instant::now());
 
             let input = io.next().await;
 
@@ -674,7 +640,7 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(2), io.next()).await;
 
         {
-            io.send_dns_query(example_com_recursive_query());
+            io.send_dns_query(example_com_recursive_query(), Instant::now());
 
             let input = io.next().await;
 
@@ -692,13 +658,13 @@ mod tests {
         // The default deadline is DEFAULT_TIME_ADVANCE (10s) from now.
         // schedule_timeout should pull it in to ~1s from now.
         let now = Instant::now();
-        io.schedule_timeout(now);
+        io.schedule_timeout();
 
         let deadline = io.timeout.deadline();
         let wakeup_in = deadline.duration_since(now);
 
         assert!(
-            wakeup_in <= Duration::from_secs(1),
+            wakeup_in <= Duration::from_millis(1_010),
             "expected deadline within 1s, got {wakeup_in:?}"
         );
     }
@@ -708,11 +674,10 @@ mod tests {
         let mut io = Io::for_test();
 
         // Set a deadline that is already sooner than 1s.
-        let now = Instant::now();
-        let close_deadline = now + Duration::from_millis(100);
-        io.reset_timeout(close_deadline, "close deadline");
+        io.reset_timeout_after(Duration::from_millis(100), "close deadline");
+        let close_deadline = io.timeout.deadline();
 
-        io.schedule_timeout(now);
+        io.schedule_timeout();
 
         let deadline = io.timeout.deadline();
 
@@ -781,17 +746,6 @@ mod tests {
         ) -> Input<tun::PacketBatch, impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>>
         {
             poll_fn(|cx| self.poll(cx)).await
-        }
-
-        fn poll_test(
-            &mut self,
-        ) -> Poll<
-            Input<
-                tun::PacketBatch,
-                impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
-            >,
-        > {
-            self.poll(&mut Context::from_waker(noop_waker_ref()))
         }
     }
 

--- a/rust/libs/connlib/tunnel/src/lib.rs
+++ b/rust/libs/connlib/tunnel/src/lib.rs
@@ -124,6 +124,7 @@ impl ClientTunnel {
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         records: BTreeSet<DnsResourceRecord>,
         is_internet_resource_active: bool,
+        now: Instant,
     ) -> Self {
         Self {
             io: Io::new(
@@ -135,7 +136,7 @@ impl ClientTunnel {
                 rand::random(),
                 records,
                 is_internet_resource_active,
-                Instant::now(),
+                now,
                 SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("Should be able to compute UNIX timestamp"),
@@ -148,8 +149,16 @@ impl ClientTunnel {
         self.role_state.public_key()
     }
 
-    pub fn reset(&mut self, reason: &str) {
-        self.role_state.reset(Instant::now(), reason);
+    pub fn reset(&mut self, reason: &str, now: Instant) {
+        if self
+            .role_state
+            .poll_timeout()
+            .is_some_and(|(timeout, _)| timeout <= now)
+        {
+            self.role_state.handle_timeout(now);
+        }
+
+        self.role_state.reset(now, reason);
         self.io.reset();
     }
 
@@ -161,9 +170,9 @@ impl ClientTunnel {
     }
 
     /// Shut down the Client tunnel.
-    pub fn shut_down(mut self) -> BoxFuture<'static, Result<()>> {
+    pub fn shut_down(mut self, now: Instant) -> BoxFuture<'static, Result<()>> {
         // Initiate shutdown.
-        self.role_state.shut_down(Instant::now());
+        self.role_state.shut_down(now);
 
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
@@ -185,10 +194,19 @@ impl ClientTunnel {
         .boxed()
     }
 
-    pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<ClientEvent> {
+    pub fn poll_next_event(&mut self, cx: &mut Context<'_>, now: Instant) -> Poll<ClientEvent> {
         let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "client-tunnel");
 
         while let Some(mut tick) = budget.next() {
+            if self
+                .role_state
+                .poll_timeout()
+                .is_some_and(|(timeout, _)| timeout <= now)
+            {
+                self.role_state.handle_timeout(now);
+                tick.want_continue();
+            }
+
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
             // Pass up existing events.
@@ -223,13 +241,12 @@ impl ClientTunnel {
 
             // Drain all scheduled DNS queries.
             while let Some(query) = self.role_state.poll_dns_queries() {
-                self.io.send_dns_query(query);
+                self.io.send_dns_query(query, now);
                 tick.want_continue();
             }
 
             // Process all IO sources that are ready.
             if let Poll::Ready(io::Input {
-                now,
                 timeout,
                 dns_response,
                 tcp_dns_queries: _,
@@ -241,7 +258,7 @@ impl ClientTunnel {
             {
                 if let Some(response) = dns_response {
                     self.role_state.handle_dns_response(response, now);
-                    self.io.schedule_timeout(now);
+                    self.io.schedule_timeout();
 
                     tick.want_continue();
                 }
@@ -263,7 +280,7 @@ impl ClientTunnel {
                         }
                     }
 
-                    self.io.schedule_timeout(now);
+                    self.io.schedule_timeout();
 
                     // Eagerly flush GSO queue.
                     if let Poll::Ready(Err(e)) = self.io.flush_gso_queue(cx) {
@@ -299,7 +316,7 @@ impl ClientTunnel {
                             Ok(Some(packet)) => self
                                 .io
                                 .queue_tun(packet.with_ecn_from_transport(received.ecn)),
-                            Ok(None) => self.io.schedule_timeout(now),
+                            Ok(None) => self.io.schedule_timeout(),
                             Err(e) => error.push(e),
                         };
                     }
@@ -317,7 +334,8 @@ impl ClientTunnel {
 
         // Reset timer for time-based wakeup before we suspend.
         if let Some((timeout, reason)) = self.role_state.poll_timeout() {
-            self.io.reset_timeout(timeout, reason);
+            self.io
+                .reset_timeout_after(timeout.saturating_duration_since(now), reason);
         }
 
         Poll::Pending
@@ -329,12 +347,13 @@ impl GatewayTunnel {
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         nameservers: BTreeSet<IpAddr>,
+        now: Instant,
     ) -> Self {
         Self {
             io: Io::new(tcp_socket_factory, udp_socket_factory.clone(), nameservers),
             role_state: GatewayState::new(
                 rand::random(),
-                Instant::now(),
+                now,
                 SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("Should be able to compute UNIX timestamp"),
@@ -348,9 +367,9 @@ impl GatewayTunnel {
     }
 
     /// Shut down the Gateway tunnel.
-    pub fn shut_down(mut self) -> BoxFuture<'static, Result<()>> {
+    pub fn shut_down(mut self, now: Instant) -> BoxFuture<'static, Result<()>> {
         // Initiate shutdown.
-        self.role_state.shut_down(Instant::now());
+        self.role_state.shut_down(now);
 
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
@@ -372,10 +391,19 @@ impl GatewayTunnel {
         .boxed()
     }
 
-    pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<GatewayEvent> {
+    pub fn poll_next_event(&mut self, cx: &mut Context<'_>, now: Instant) -> Poll<GatewayEvent> {
         let mut budget = Budget::new(cx.waker(), MAX_EVENTLOOP_ITERS, "gateway-tunnel");
 
         while let Some(mut tick) = budget.next() {
+            if self
+                .role_state
+                .poll_timeout()
+                .is_some_and(|(timeout, _)| timeout <= now)
+            {
+                self.role_state.handle_timeout(now);
+                tick.want_continue();
+            }
+
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
 
             // Pass up existing events.
@@ -393,7 +421,6 @@ impl GatewayTunnel {
 
             // Process all IO sources that are ready.
             if let Poll::Ready(io::Input {
-                now,
                 timeout,
                 dns_response,
                 tcp_dns_queries,
@@ -464,7 +491,7 @@ impl GatewayTunnel {
                         }
                     }
 
-                    self.io.schedule_timeout(now);
+                    self.io.schedule_timeout();
 
                     // Eagerly flush GSO queue.
                     if let Poll::Ready(Err(e)) = self.io.flush_gso_queue(cx) {
@@ -500,7 +527,7 @@ impl GatewayTunnel {
                             Ok(Some(packet)) => self
                                 .io
                                 .queue_tun(packet.with_ecn_from_transport(received.ecn)),
-                            Ok(None) => self.io.schedule_timeout(now),
+                            Ok(None) => self.io.schedule_timeout(),
                             Err(e) => error.push(e),
                         };
                     }
@@ -512,15 +539,18 @@ impl GatewayTunnel {
 
                 for query in udp_dns_queries {
                     if let Some(nameserver) = self.io.fastest_nameserver() {
-                        self.io.send_dns_query(dns::RecursiveQuery {
-                            server: dns::Upstream::Do53 {
-                                server: SocketAddr::new(nameserver, dns::DNS_PORT),
+                        self.io.send_dns_query(
+                            dns::RecursiveQuery {
+                                server: dns::Upstream::Do53 {
+                                    server: SocketAddr::new(nameserver, dns::DNS_PORT),
+                                },
+                                local: query.local,
+                                remote: query.remote,
+                                message: query.message,
+                                transport: dns::Transport::Udp,
                             },
-                            local: query.local,
-                            remote: query.remote,
-                            message: query.message,
-                            transport: dns::Transport::Udp,
-                        });
+                            now,
+                        );
                     } else {
                         tracing::warn!(query = ?query.message, "No nameserver available to handle UDP DNS query");
 
@@ -538,15 +568,18 @@ impl GatewayTunnel {
 
                 for query in tcp_dns_queries {
                     if let Some(nameserver) = self.io.fastest_nameserver() {
-                        self.io.send_dns_query(dns::RecursiveQuery {
-                            server: dns::Upstream::Do53 {
-                                server: SocketAddr::new(nameserver, dns::DNS_PORT),
+                        self.io.send_dns_query(
+                            dns::RecursiveQuery {
+                                server: dns::Upstream::Do53 {
+                                    server: SocketAddr::new(nameserver, dns::DNS_PORT),
+                                },
+                                local: query.local,
+                                remote: query.remote,
+                                message: query.message,
+                                transport: dns::Transport::Tcp,
                             },
-                            local: query.local,
-                            remote: query.remote,
-                            message: query.message,
-                            transport: dns::Transport::Tcp,
-                        });
+                            now,
+                        );
                     } else {
                         tracing::warn!(query = ?query.message, "No nameserver available to handle TCP DNS query");
 
@@ -570,7 +603,8 @@ impl GatewayTunnel {
 
         // Reset timer for time-based wakeup before we suspend.
         if let Some((timeout, reason)) = self.role_state.poll_timeout() {
-            self.io.reset_timeout(timeout, reason);
+            self.io
+                .reset_timeout_after(timeout.saturating_duration_since(now), reason);
         }
 
         Poll::Pending


### PR DESCRIPTION
From the documentation of a Rust `Instant`:

> it is also not specified whether system suspends count as elapsed time or not. The behavior varies across platforms and Rust versions.

This represents a problem for Firezone. With the new ICEless connectivity layer, we keep the WireGuard session alive, even across roaming events. When a client resumes from suspend and its clock has not advanced, the local state assumes the WireGuard session is still valid (less than 180s since the start have passed) and it simply tries to re-key. The other peer however has long de-allocated the connection and therefore the re-key will never succeed.

To fix this, we introduce a suspend-aware `Clock` abstraction. The new `Clock` lives in both the client's and gateway's event-loop to ensure that we pass consistent `Instant`s to all components.