### PR TITLE
feat(portal): canonical timestamp on flow log events

### DIFF
--- a/elixir/lib/portal/log_sinks/delivery.ex
+++ b/elixir/lib/portal/log_sinks/delivery.ex
@@ -302,6 +302,7 @@ defmodule Portal.LogSinks.Delivery do
        type: "flow",
        log_id: log.log_id,
        phase: phase,
+       timestamp: log.flow_end || log.flow_start,
        flow_start: log.flow_start,
        flow_end: log.flow_end,
        last_packet: log.last_packet,

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -200,6 +200,7 @@ defmodule Portal.Splunk.SyncTest do
       assert_receive {:hec, _conn, [start_event]}
       assert start_event["event"]["phase"] == "start"
       assert start_event["event"]["log_id"] == flow.log_id
+      assert start_event["event"]["timestamp"] == DateTime.to_iso8601(flow.flow_start)
       assert_in_delta String.to_float(start_event["time"]),
                       DateTime.to_unix(flow.flow_start, :millisecond) / 1000,
                       0.001
@@ -226,6 +227,7 @@ defmodule Portal.Splunk.SyncTest do
 
       assert_receive {:hec, _conn, [end_event]}
       assert end_event["event"]["phase"] == "end"
+      assert end_event["event"]["timestamp"] == DateTime.to_iso8601(flow_end)
       assert end_event["event"]["log_id"] == flow.log_id
       assert end_event["event"]["rx_bytes"] == 1024
       assert_in_delta String.to_float(end_event["time"]),


### PR DESCRIPTION
Change, session, and api_request events carry a timestamp field in the log sink payload, but flow events did not: consumers had to derive the event time from phase plus flow_start/flow_end. Flow events now carry the same canonical timestamp the providers' native time fields already use: flow_start on start events, flow_end on end events. Additive wire change; the field self-registers in the field-type registry, which already holds timestamp as a string.

Related: #14107