### PR TITLE
feat(portal): closed flows deliver as start and end events

### DIFF
--- a/elixir/lib/portal/flow_log.ex
+++ b/elixir/lib/portal/flow_log.ex
@@ -64,6 +64,7 @@ defmodule Portal.FlowLog do
     belongs_to :account, Portal.Account, primary_key: true
     field :log_id, Portal.Types.LogId
     field :seq, :integer, read_after_writes: true
+    field :start_seq, :integer
 
     field :device_id, :binary_id, primary_key: true
     field :role, Ecto.Enum, values: @roles, primary_key: true

--- a/elixir/lib/portal/log_sinks/delivery.ex
+++ b/elixir/lib/portal/log_sinks/delivery.ex
@@ -80,8 +80,10 @@ defmodule Portal.LogSinks.Delivery do
 
   defp deliver_batch(sink, adapter, cursor, rows, budget) do
     encoded =
-      Enum.map(rows, fn row ->
-        {row.seq, adapter.encode_event(sink, cursor.stream, render_event(cursor.stream, row))}
+      Enum.flat_map(rows, fn row ->
+        for event <- render_event(cursor.stream, row, cursor.cursor) do
+          {row.seq, adapter.encode_event(sink, cursor.stream, event)}
+        end
       end)
 
     case deliver_chunks(sink, adapter, cursor, chunk_by_bytes(encoded, max_body_bytes())) do
@@ -161,24 +163,32 @@ defmodule Portal.LogSinks.Delivery do
     end
   end
 
+  # Same-seq events (a flow's start/end pair) never split across chunks: the
+  # cursor advances past their seq when a chunk lands, so a crash between
+  # chunks could otherwise lose the trailing half of the pair.
   defp chunk_by_bytes(encoded, max_bytes) do
-    Enum.chunk_while(
-      encoded,
+    encoded
+    |> Enum.chunk_by(fn {seq, _json} -> seq end)
+    |> Enum.chunk_while(
       {[], 0},
-      fn {_seq, json} = item, {acc, bytes} ->
-        size = byte_size(json) + 1
+      fn group, {acc, bytes} ->
+        size = group |> Enum.map(fn {_seq, json} -> byte_size(json) + 1 end) |> Enum.sum()
 
         cond do
-          acc == [] -> {:cont, {[item], size}}
-          bytes + size > max_bytes -> {:cont, Enum.reverse(acc), {[item], size}}
-          true -> {:cont, {[item | acc], bytes + size}}
+          acc == [] -> {:cont, {[group], size}}
+          bytes + size > max_bytes -> {:cont, flatten_groups(acc), {[group], size}}
+          true -> {:cont, {[group | acc], bytes + size}}
         end
       end,
       fn
         {[], _bytes} -> {:cont, []}
-        {acc, _bytes} -> {:cont, Enum.reverse(acc), []}
+        {acc, _bytes} -> {:cont, flatten_groups(acc), []}
       end
     )
+  end
+
+  defp flatten_groups(reversed_groups) do
+    reversed_groups |> Enum.reverse() |> List.flatten()
   end
 
   # Clears transient error streaks only. A disabled sink never syncs, so
@@ -247,8 +257,9 @@ defmodule Portal.LogSinks.Delivery do
 
   defp format_error(_adapter, :cursor_conflict), do: "Concurrent sync detected."
 
-  defp render_event(:change, log) do
-    {epoch(log.timestamp),
+  defp render_event(:change, log, _batch_floor) do
+    [
+      {epoch(log.timestamp),
      %{
        type: "change",
        log_id: log.log_id,
@@ -259,10 +270,12 @@ defmodule Portal.LogSinks.Delivery do
        after: log.after,
        subject: log.subject
      }}
+    ]
   end
 
-  defp render_event(:session, log) do
-    {epoch(log.timestamp),
+  defp render_event(:session, log, _batch_floor) do
+    [
+      {epoch(log.timestamp),
      %{
        type: "session",
        log_id: log.log_id,
@@ -270,10 +283,12 @@ defmodule Portal.LogSinks.Delivery do
        context: log.context,
        subject: log.subject
      }}
+    ]
   end
 
-  defp render_event(:api_request, log) do
-    {epoch(log.inserted_at),
+  defp render_event(:api_request, log, _batch_floor) do
+    [
+      {epoch(log.inserted_at),
      %{
        type: "api_request",
        log_id: log.log_id,
@@ -289,22 +304,51 @@ defmodule Portal.LogSinks.Delivery do
        ip_region: log.ip_region,
        ip_city: log.ip_city
      }}
+    ]
   end
 
-  defp render_event(:flow, log) do
-    phase =
-      if is_nil(log.flow_end) do
-        "start"
-      else
-        "end"
-      end
+  # A flow yields two logical events sharing its log_id. The close bumps seq
+  # and replaces the open-state row, so a sink that was not live for the open
+  # phase (backfills, fast-closing flows) would otherwise never see a start
+  # event: a closed row therefore renders as a start/end pair. Sinks that
+  # already delivered the start at open time redeliver it here; (log_id,
+  # phase) stays the dedup key, and destinations with _id semantics collapse
+  # it entirely.
+  defp render_event(:flow, %{flow_end: nil} = log, _batch_floor) do
+    [flow_event(log, "-s", log.flow_start)]
+  end
 
-    {epoch(log.flow_end || log.flow_start),
+  # A closed row is the only version left of the flow, so the start event is
+  # synthesized unless this sink already delivered it: start_seq records the
+  # open-state seq the close replaced, and the frontier can only have swept
+  # that version if it lies at or below where this batch started. Suffixed
+  # log_ids make log_id alone the dedup key everywhere.
+  defp render_event(:flow, log, batch_floor) do
+    end_event = flow_event(log, "-e", log.flow_end)
+
+    if is_nil(log.start_seq) or log.start_seq > batch_floor do
+      open = %{
+        log
+        | flow_end: nil,
+          last_packet: nil,
+          rx_packets: nil,
+          tx_packets: nil,
+          rx_bytes: nil,
+          tx_bytes: nil
+      }
+
+      [flow_event(open, "-s", log.flow_start), end_event]
+    else
+      [end_event]
+    end
+  end
+
+  defp flow_event(log, suffix, time) do
+    {epoch(time),
      %{
        type: "flow",
-       log_id: log.log_id,
-       phase: phase,
-       timestamp: log.flow_end || log.flow_start,
+       log_id: log.log_id <> suffix,
+       timestamp: time,
        flow_start: log.flow_start,
        flow_end: log.flow_end,
        last_packet: log.last_packet,

--- a/elixir/lib/portal_api/controllers/flow_log_controller.ex
+++ b/elixir/lib/portal_api/controllers/flow_log_controller.ex
@@ -264,11 +264,13 @@ defmodule PortalAPI.FlowLogController do
     # life of a flow and are only ever set on insert.
     defp on_conflict_query do
       # The close takes a fresh seq so cursor-based consumers that already
-      # delivered the open row see it again and deliver the close.
+      # delivered the open row see it again and deliver the close; start_seq
+      # records the open-state seq so they can tell whether they did.
       from(f in FlowLog,
         update: [
           set: [
             seq: fragment("nextval('flow_logs_seq_seq')"),
+            start_seq: f.seq,
             flow_end: fragment("EXCLUDED.flow_end"),
             last_packet: fragment("EXCLUDED.last_packet"),
             rx_packets: fragment("EXCLUDED.rx_packets"),

--- a/elixir/priv/repo/migrations/20260715120000_add_start_seq_to_flow_logs.exs
+++ b/elixir/priv/repo/migrations/20260715120000_add_start_seq_to_flow_logs.exs
@@ -1,0 +1,9 @@
+defmodule Portal.Repo.Migrations.AddStartSeqToFlowLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:flow_logs) do
+      add(:start_seq, :bigint)
+    end
+  end
+end

--- a/elixir/test/portal/splunk/sync_test.exs
+++ b/elixir/test/portal/splunk/sync_test.exs
@@ -80,7 +80,7 @@ defmodule Portal.Splunk.SyncTest do
 
       sourcetypes =
         for _batch <- 1..4 do
-          assert_receive {:hec, _conn, [event]}
+          assert_receive {:hec, _conn, [event | _rest]}
           event["sourcetype"]
         end
 
@@ -180,7 +180,7 @@ defmodule Portal.Splunk.SyncTest do
       assert get_cursor(sink, :session, :backfill).completed_at
     end
 
-    test "a closed flow is delivered again as an end event", %{account: account} do
+    test "closing a delivered flow sends only the end event", %{account: account} do
       sink = splunk_log_sink_fixture(account: account, enabled_streams: [:flow])
       assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
 
@@ -198,41 +198,82 @@ defmodule Portal.Splunk.SyncTest do
       assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
 
       assert_receive {:hec, _conn, [start_event]}
-      assert start_event["event"]["phase"] == "start"
-      assert start_event["event"]["log_id"] == flow.log_id
+      assert start_event["event"]["log_id"] == flow.log_id <> "-s"
+      refute Map.has_key?(start_event["event"], "phase")
       assert start_event["event"]["timestamp"] == DateTime.to_iso8601(flow.flow_start)
       assert_in_delta String.to_float(start_event["time"]),
                       DateTime.to_unix(flow.flow_start, :millisecond) / 1000,
                       0.001
 
       flow_end = DateTime.utc_now()
-
-      from(f in FlowLog,
-        where: f.account_id == ^account.id,
-        update: [
-          set: [
-            seq: fragment("nextval('flow_logs_seq_seq')"),
-            flow_end: ^flow_end,
-            last_packet: ^flow_end,
-            rx_packets: 10,
-            tx_packets: 12,
-            rx_bytes: 1024,
-            tx_bytes: 2048
-          ]
-        ]
-      )
-      |> Repo.update_all([])
+      close_flow(account, flow_end)
 
       assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
 
+      # start_seq sits at or below this sink's frontier, so the start is known
+      # to be delivered and only the end event ships: no duplicates.
       assert_receive {:hec, _conn, [end_event]}
-      assert end_event["event"]["phase"] == "end"
+      assert end_event["event"]["log_id"] == flow.log_id <> "-e"
       assert end_event["event"]["timestamp"] == DateTime.to_iso8601(flow_end)
-      assert end_event["event"]["log_id"] == flow.log_id
       assert end_event["event"]["rx_bytes"] == 1024
       assert_in_delta String.to_float(end_event["time"]),
                       DateTime.to_unix(flow_end, :millisecond) / 1000,
                       0.001
+    end
+
+    test "a flow that closes before delivery sends both events", %{account: account} do
+      sink = splunk_log_sink_fixture(account: account, enabled_streams: [:flow])
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      flow =
+        flow_log_fixture(
+          account: account,
+          flow_end: nil,
+          last_packet: nil,
+          rx_packets: nil,
+          tx_packets: nil,
+          rx_bytes: nil,
+          tx_bytes: nil
+        )
+
+      # Closed before any sync swept the open-state row: start_seq is above
+      # the sink's frontier, so the start must be synthesized.
+      close_flow(account, DateTime.utc_now())
+
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      assert_receive {:hec, _conn, [start_event, end_event]}
+      assert start_event["event"]["log_id"] == flow.log_id <> "-s"
+      refute start_event["event"]["rx_bytes"]
+      assert end_event["event"]["log_id"] == flow.log_id <> "-e"
+      assert end_event["event"]["rx_bytes"] == 1024
+    end
+
+    test "a backfilled closed flow delivers both start and end events", %{account: account} do
+      flow = flow_log_fixture(account: account)
+
+      sink =
+        splunk_log_sink_fixture(
+          account: account,
+          retroactive: true,
+          enabled_streams: [:flow]
+        )
+
+      assert :ok = perform_job(Splunk.Sync, %{log_sink_id: sink.id})
+
+      assert_receive {:hec, _conn, [start_event, end_event]}
+      assert start_event["event"]["log_id"] == flow.log_id <> "-s"
+      assert start_event["event"]["timestamp"] == DateTime.to_iso8601(flow.flow_start)
+      refute start_event["event"]["flow_end"]
+      refute start_event["event"]["rx_bytes"]
+
+      assert end_event["event"]["log_id"] == flow.log_id <> "-e"
+      assert end_event["event"]["timestamp"] == DateTime.to_iso8601(flow.flow_end)
+      assert end_event["event"]["rx_bytes"] == flow.rx_bytes
+
+      backfill = get_cursor(sink, :flow, :backfill)
+      assert backfill.synced_count == 2
+      assert backfill.completed_at
     end
 
     test "splits deliveries that exceed the HEC request size limit", %{account: account} do
@@ -649,6 +690,25 @@ defmodule Portal.Splunk.SyncTest do
       refute_enqueued(worker: Splunk.Sync, args: %{log_sink_id: disabled_sink.id})
       refute_enqueued(worker: Splunk.Sync, args: %{log_sink_id: feature_off_sink.id})
     end
+  end
+
+  defp close_flow(account, flow_end) do
+    from(f in FlowLog,
+      where: f.account_id == ^account.id,
+      update: [
+        set: [
+          start_seq: f.seq,
+          seq: fragment("nextval('flow_logs_seq_seq')"),
+          flow_end: ^flow_end,
+          last_packet: ^flow_end,
+          rx_packets: 10,
+          tx_packets: 12,
+          rx_bytes: 1024,
+          tx_bytes: 2048
+        ]
+      ]
+    )
+    |> Repo.update_all([])
   end
 
   defp get_cursor(sink, stream, phase) do

--- a/elixir/test/portal_api/controllers/flow_log_controller_test.exs
+++ b/elixir/test/portal_api/controllers/flow_log_controller_test.exs
@@ -423,6 +423,7 @@ defmodule PortalAPI.FlowLogControllerTest do
       assert log.flow_end == ~U[2026-03-20 10:05:00.000000Z]
       assert log.tx_bytes == 999
       assert log.seq > open_seq
+      assert log.start_seq == open_seq
     end
 
     test "replaying a closed record is idempotent", %{conn: _conn, account: account} do


### PR DESCRIPTION
A flow yields two logical events, but a closed row rendered only the end event: the close bumps seq and replaces the open-state row, so backfills and flows that closed within a sync window never produced a start event on any provider.

A closed row now renders as a start/end pair when needed, and exactly when needed: the close preserves the open-state seq it replaces as start_seq, and a sink synthesizes the start only when that seq lies above the frontier its batch started from, meaning it cannot have delivered the start before. Sinks that already delivered the start at open time send only the end, so the common long-lived flow produces no duplicates at all. Start and end events carry suffixed ids (log_id-s / log_id-e) instead of a phase field, making log_id alone the dedup key on every provider. Same-seq pairs are kept atomic through chunking so a crash between chunks cannot advance the cursor past a half-delivered pair.

Related: #14146
