### PR TITLE
fix(portal): validate Splunk HEC URLs like discovery URIs

### DIFF
--- a/elixir/lib/portal/splunk/log_sink.ex
+++ b/elixir/lib/portal/splunk/log_sink.ex
@@ -1,6 +1,7 @@
 defmodule Portal.Splunk.LogSink do
   use Ecto.Schema
   import Ecto.Changeset
+  import Portal.Changeset
 
   @primary_key false
   @foreign_key_type :binary_id
@@ -71,7 +72,7 @@ defmodule Portal.Splunk.LogSink do
     |> validate_length(:index, max: 255)
     |> validate_length(:enabled_streams, min: 1)
     |> validate_number(:error_email_count, greater_than_or_equal_to: 0)
-    |> validate_collector_url()
+    |> validate_uri(:collector_url, schemes: ~w[https], block_private_ips: true)
     |> assoc_constraint(:account)
     |> assoc_constraint(:log_sink)
     |> unique_constraint(:name,
@@ -91,16 +92,4 @@ defmodule Portal.Splunk.LogSink do
     |> String.trim_trailing("/")
   end
 
-  defp validate_collector_url(changeset) do
-    validate_change(changeset, :collector_url, fn :collector_url, url ->
-      case URI.new(url) do
-        {:ok, %URI{scheme: scheme, host: host}}
-        when scheme in ["http", "https"] and is_binary(host) and host != "" ->
-          []
-
-        _ ->
-          [collector_url: "must be a valid http(s) URL"]
-      end
-    end)
-  end
 end

--- a/elixir/test/portal_web/live/settings/log_sinks_test.exs
+++ b/elixir/test/portal_web/live/settings/log_sinks_test.exs
@@ -330,7 +330,45 @@ defmodule PortalWeb.Settings.LogSinksTest do
         )
         |> render_change()
 
-      assert html =~ "must be a valid http(s) URL"
+      assert html =~ "is invalid"
+      assert Repo.all(Splunk.LogSink) == []
+    end
+
+    test "rejects plaintext and private-address HEC URLs", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/log_sinks/splunk/new")
+
+      html =
+        lv
+        |> form("#log-sink-form",
+          log_sink: %{
+            name: "SOC Splunk",
+            collector_url: "http://splunk.internal.example:8088",
+            hec_token: "test-hec-token"
+          }
+        )
+        |> render_change()
+
+      assert html =~ "only https schemes are supported"
+
+      html =
+        lv
+        |> form("#log-sink-form",
+          log_sink: %{
+            name: "SOC Splunk",
+            collector_url: "https://169.254.169.254:8088",
+            hec_token: "test-hec-token"
+          }
+        )
+        |> render_change()
+
+      assert html =~ "must not be a private or reserved IP address"
       assert Repo.all(Splunk.LogSink) == []
     end
   end


### PR DESCRIPTION
The Splunk collector URL accepted any http(s) URL, letting an admin point deliveries at internal services and read probe results from the surfaced error messages. The URL now goes through the same validate_uri restrictions as the OIDC discovery document URI (private and reserved addresses are blocked, with hostnames resolved) and additionally requires https.

Elastic's endpoint URL gets the same treatment on its open PR; Datadog and New Relic only offer fixed site/region choices and need nothing.

Note: the OIDC discovery document URI itself still permits plain http. Tightening it to https-only may break local development IdPs, so it is left for a separate decision.

Related: #14107