### PR TITLE
fix(portal): require https for OIDC discovery document URIs

### DIFF
--- a/elixir/lib/portal/oidc/auth_provider.ex
+++ b/elixir/lib/portal/oidc/auth_provider.ex
@@ -69,7 +69,7 @@ defmodule Portal.OIDC.AuthProvider do
     |> validate_acceptance(:is_verified)
     |> validate_length(:client_id, min: 1, max: 255)
     |> validate_length(:client_secret, min: 1, max: 255)
-    |> validate_uri(:discovery_document_uri, block_private_ips: true)
+    |> validate_uri(:discovery_document_uri, schemes: ~w[https], block_private_ips: true)
     |> validate_length(:discovery_document_uri, min: 1, max: 2000)
     |> validate_length(:issuer, min: 1, max: 2000)
     |> validate_number(:portal_session_lifetime_secs,

--- a/elixir/lib/portal/okta/auth_provider.ex
+++ b/elixir/lib/portal/okta/auth_provider.ex
@@ -63,7 +63,7 @@ defmodule Portal.Okta.AuthProvider do
     |> validate_acceptance(:is_verified)
     |> put_discovery_document_uri()
     |> validate_required(:discovery_document_uri)
-    |> validate_uri(:discovery_document_uri, block_private_ips: true)
+    |> validate_uri(:discovery_document_uri, schemes: ~w[https], block_private_ips: true)
     |> validate_length(:okta_domain, min: 1, max: 255)
     |> validate_fqdn(:okta_domain)
     |> validate_length(:issuer, min: 1, max: 2_000)


### PR DESCRIPTION
The OIDC and Okta discovery document URIs blocked private addresses but still accepted plain http, so a discovery document (and the token endpoints it names) could be fetched over cleartext. They now require https, matching the restriction just applied to log sink endpoint URLs in #14148.

Existing rows are unaffected until edited; anyone running an http-only IdP will be asked for an https URL on the next save.

Related: #14148