### PR TITLE
test: relax flaky download-rst byte-count assertion

### DIFF
--- a/scripts/tests/download-rst.sh
+++ b/scripts/tests/download-rst.sh
@@ -21,4 +21,8 @@ for flow in "${flows[@]}"; do
     rx_bytes+="$(get_flow_field "$flow" "rx_bytes")"
 done
 
-assert_gteq "$rx_bytes" 2000000
+# A mid-transfer RST should still be accounted with the bytes that made it
+# through before the reset. The exact amount depends on how much of the
+# rate-limited window was spent on connection setup, so assert a floor that
+# proves real data moved rather than the window's theoretical maximum.
+assert_gteq "$rx_bytes" 500000


### PR DESCRIPTION
The `download-rst` integration test rate-limits a download to 1 MB/s and aborts it after 2 s to force a mid-transfer RST, so the theoretical maximum that can transfer is ~2 MB. Asserting `rx_bytes >= 2000000` therefore demanded essentially the whole window with no margin — connection-setup time inside those 2 s regularly pushed the actual bytes below the threshold, making the test flaky (it's the most frequent integration-test failure and the only one in the base suite).

The test exists to verify that a flow torn down by RST is still logged with the bytes accounted so far, not to measure throughput. Lower the floor so it proves real data moved before the reset without pinning the assertion to the window's theoretical maximum.
