### PR TITLE
ci: group is and str0m-proto dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -122,6 +122,10 @@ updates:
         patterns:
           - sentry
           - sentry-*
+      str0m:
+        patterns:
+          - is
+          - str0m-proto
       rust-crypto:
         patterns:
           - aead


### PR DESCRIPTION
Adds a `str0m` Dependabot group so the cargo `is` and `str0m-proto` crates, which move together as part of the ICE/str0m stack in `snownet`, land in a single PR rather than two.