### PR TITLE
ci: install cargo-fuzz via mise instead of install-action

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -197,11 +197,11 @@ jobs:
       - uses: ./.github/actions/setup-rust-nightly
         id: setup-rust
       - uses: ./.github/actions/setup-rust-sccache
-      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: --cd rust
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tool: cargo-fuzz
       - run: rustup run ${{ steps.setup-rust.outputs.nightly_version }} cargo fuzz run --target x86_64-unknown-linux-gnu --fuzz-dir tests/fuzz ${{ matrix.fuzz-target }} -- -max_total_time=120
         env:
           CARGO_PROFILE_RELEASE_LTO: false

--- a/rust/mise.lock
+++ b/rust/mise.lock
@@ -4,6 +4,10 @@
 version = "3.7.0"
 backend = "cargo:cargo-deb"
 
+[[tools."cargo:cargo-fuzz"]]
+version = "0.13.2"
+backend = "cargo:cargo-fuzz"
+
 [[tools."github:Boshen/cargo-shear"]]
 version = "1.12.4"
 backend = "github:Boshen/cargo-shear"

--- a/rust/mise.toml
+++ b/rust/mise.toml
@@ -12,6 +12,7 @@ RUSTFLAGS = "--cfg tokio_unstable"
 [tools]
 "github:aya-rs/bpf-linker" = { version = "0.10.3", os = ["linux"] }
 "cargo:cargo-deb" = { version = "3.7.0", os = ["linux"] }
+"cargo:cargo-fuzz" = { version = "0.13.2", os = ["linux"] }
 "github:taiki-e/cargo-llvm-cov" = "0.6.21"
 "github:tauri-apps/tauri" = { version = "2.11.2", version_prefix = "tauri-cli-v" }
 


### PR DESCRIPTION
Manage `cargo-fuzz` as a pinned mise tool alongside the rest of the Rust tooling instead of pulling it in through a separate `taiki-e/install-action` step in the fuzz job.

This puts its version under source control and brings it under the same supply-chain cooldown and Trivy scanning that already cover our other mise-managed tools.