### PR TITLE
chore: bump Rust to 1.97.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783747106,
-        "narHash": "sha256-KlepQu/O5m11lAjcJ4ER5bc6bIzyX2UMPDARzMzQfIw=",
+        "lastModified": 1784216271,
+        "narHash": "sha256-bvaxxdk7mmMQ88AuXQGTUtk+PcUujHpgxqpryqTWvTU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e598b37857b895b81020a65a802ef55f5bbed72f",
+        "rev": "1f69c7203034a4a974d7a4eac0f19b54af30804d",
         "type": "github"
       },
       "original": {

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -62,7 +62,7 @@ COPY ${PACKAGE} .
 FROM runtime AS dev
 
 ARG PACKAGE
-ARG RUST_VERSION="1.97.0" # Keep in sync with `rust-toolchain.toml`
+ARG RUST_VERSION="1.97.1" # Keep in sync with `rust-toolchain.toml`
 
 WORKDIR /app
 

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.0" # Keep in sync with `Dockerfile`
+channel = "1.97.1" # Keep in sync with `Dockerfile`
 components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.97.0 to 1.97.1.

1.97.1 is a point release that fixes an LLVM miscompilation of enum discriminant handling. A representation change in 1.97.0 assigned `None`-like niche variants a `-1` discriminant, which LLVM turned into a `2^32-1` offset and an out-of-bounds read gigabytes away from the intended location — reliably crashing affected binaries. See [Announcing Rust 1.97.1](https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/) and rust-lang/rust#159035.