### PR TITLE
ci: prefix tauri group PRs with build(deps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ multi-ecosystem-groups:
     target-branch: main
     schedule:
       interval: weekly
+    # Multi-ecosystem groups don't inherit Dependabot's conventional-commit
+    # auto-detection, so set the prefix explicitly to match our other updates.
+    commit-message:
+      prefix: build
+      include: scope
 
 updates:
   # Keep version update jobs on the active codebase while the legacy branch exists.


### PR DESCRIPTION
Multi-ecosystem Dependabot groups don't inherit the conventional-commit prefix that our regular updates get, so the `tauri` group opens PRs titled like `Bump the "tauri" group with 1 update across multiple ecosystems`, with no `build(deps):` prefix. This sets the prefix explicitly on the group so its PRs match the rest of our Dependabot updates.