### PR TITLE
feat(portal): configure Sentry DSN at runtime

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -567,6 +567,9 @@ if config_env() == :prod do
 
   # Sentry
 
+  config :sentry,
+    dsn: env_var_to_config!(:sentry_dsn)
+
   with api_external_url when not is_nil(api_external_url) <-
          env_var_to_config!(:api_external_url),
        api_external_url_host <- URI.parse(api_external_url).host,
@@ -577,8 +580,6 @@ if config_env() == :prod do
             true -> :unknown
           end) do
     config :sentry,
-      environment_name: environment_name,
-      dsn:
-        "https://29f4ab7c6c473c17bc01f8aeffb0ac16@o4507971108339712.ingest.us.sentry.io/4508756715569152"
+      environment_name: environment_name
   end
 end

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -567,9 +567,6 @@ if config_env() == :prod do
 
   # Sentry
 
-  config :sentry,
-    dsn: env_var_to_config!(:sentry_dsn)
-
   with api_external_url when not is_nil(api_external_url) <-
          env_var_to_config!(:api_external_url),
        api_external_url_host <- URI.parse(api_external_url).host,
@@ -580,6 +577,7 @@ if config_env() == :prod do
             true -> :unknown
           end) do
     config :sentry,
-      environment_name: environment_name
+      environment_name: environment_name,
+      dsn: env_var_to_config!(:sentry_dsn)
   end
 end

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -729,6 +729,25 @@ defmodule Portal.Config.Definitions do
   ##############################################
 
   @doc """
+  DSN used to report errors to Sentry.
+
+  Sentry reporting is disabled when this is unset or blank.
+  """
+  defconfig(:sentry_dsn, :string,
+    default: nil,
+    dump: fn
+      dsn when is_binary(dsn) ->
+        case String.trim(dsn) do
+          "" -> nil
+          dsn -> dsn
+        end
+
+      dsn ->
+        dsn
+    end
+  )
+
+  @doc """
   Enable or disable the Firezone telemetry collection.
   """
   defconfig(:instrumentation_client_logs_enabled, :boolean, default: true)

--- a/elixir/test/portal/config_test.exs
+++ b/elixir/test/portal/config_test.exs
@@ -183,6 +183,25 @@ defmodule Portal.ConfigTest do
   end
 
   describe "env_var_to_config!/1" do
+    test "returns nil for a missing or blank Sentry DSN" do
+      assert env_var_to_config!(Portal.Config.Definitions, :sentry_dsn, %{}) == nil
+
+      assert env_var_to_config!(Portal.Config.Definitions, :sentry_dsn, %{"SENTRY_DSN" => ""}) ==
+               nil
+
+      assert env_var_to_config!(Portal.Config.Definitions, :sentry_dsn, %{
+               "SENTRY_DSN" => "  \n"
+             }) == nil
+    end
+
+    test "returns the configured Sentry DSN" do
+      dsn = "https://public-key@example.com/1"
+
+      assert env_var_to_config!(Portal.Config.Definitions, :sentry_dsn, %{
+               "SENTRY_DSN" => dsn
+             }) == dsn
+    end
+
     test "returns config value" do
       assert env_var_to_config!(Test, :optional_generated) ==
                %Postgrex.INET{address: {1, 1, 1, 1}, netmask: nil}


### PR DESCRIPTION
## Summary

- add a SENTRY_DSN-backed runtime option to the existing Firezone-domain-gated Sentry configuration
- disable Sentry reporting when the DSN is missing or blank
- remove the hard-coded production DSN while preserving environment-name inference

## Tests

- mix test test/portal/config_test.exs test/portal/config test/portal/telemetry/sentry_test.exs
- verified that production runtime config applies the DSN for Firezone domains and ignores it for non-Firezone domains
- verified missing and blank DSNs resolve to nil