### PR TITLE
chore(connlib): remove unnecessary tracing-enabled check

### DIFF
--- a/rust/libs/connlib/tunnel/src/io.rs
+++ b/rust/libs/connlib/tunnel/src/io.rs
@@ -27,7 +27,6 @@ use std::{
     task::{Context, Poll, ready},
     time::{Duration, Instant},
 };
-use tracing::Level;
 use tun::Tun;
 
 const DEFAULT_TIME_ADVANCE: Duration = Duration::from_secs(10);
@@ -462,12 +461,8 @@ impl Io {
             return;
         };
 
-        let wakeup_in = tracing::event_enabled!(Level::TRACE)
-            .then_some(wakeup_in)
-            .map(tracing::field::debug);
-
         if self.timeout.deadline() != timeout {
-            tracing::trace!(wakeup_in, %reason);
+            tracing::trace!(?wakeup_in, %reason);
 
             self.timeout.reset(timeout);
         }


### PR DESCRIPTION
Now that we are passing a `Duration` directly to `reset_timeout_after`, having the `tracing::enabled!` check is pointless. We just directly include the value in the macro call.