### PR TITLE
feat(portal): Entra sync via workload identity federation

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -185,9 +185,12 @@ if config_env() == :prod do
     client_id: env_var_to_config!(:entra_oidc_client_id),
     client_secret: env_var_to_config!(:entra_oidc_client_secret)
 
+  # No client secret required: when ENTRA_SYNC_CLIENT_SECRET is unset the app
+  # authenticates with workload identity federation, minting a token-exchange
+  # assertion from the portal's managed identity (Portal.Azure.ManagedIdentity).
+  # The optional secret still flows from config.exs for environments that set it.
   config :portal, Portal.Entra.APIClient,
     client_id: env_var_to_config!(:entra_sync_client_id),
-    client_secret: env_var_to_config!(:entra_sync_client_secret),
     token_base_url: "https://login.microsoftonline.com",
     endpoint: "https://graph.microsoft.com"
 

--- a/elixir/lib/portal/config/definitions.ex
+++ b/elixir/lib/portal/config/definitions.ex
@@ -730,7 +730,6 @@ defmodule Portal.Config.Definitions do
   defconfig(:google_oidc_client_secret, :string, default: nil, sensitive: true)
 
   defconfig(:entra_sync_client_id, :string, default: @entra_sync_client_id)
-  defconfig(:entra_sync_client_secret, :string, default: nil, sensitive: true)
 
   defconfig(:entra_oidc_client_id, :string, default: @entra_oidc_client_id)
   defconfig(:entra_oidc_client_secret, :string, default: nil, sensitive: true)

--- a/elixir/lib/portal/entra/api_client.ex
+++ b/elixir/lib/portal/entra/api_client.ex
@@ -13,31 +13,55 @@ defmodule Portal.Entra.APIClient do
   """
   def get_access_token(tenant_id) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    client_id = config[:client_id]
-    client_secret = config[:client_secret]
-    token_base_url = config[:token_base_url]
-    token_endpoint = "#{token_base_url}/#{tenant_id}/oauth2/v2.0/token"
+    token_endpoint = "#{config[:token_base_url]}/#{tenant_id}/oauth2/v2.0/token"
 
-    # Request access token to read what our app is set up to do (.default scope)
-    scope = "https://graph.microsoft.com/.default"
+    with {:ok, credential} <- client_credential(config) do
+      # Request access token to read what our app is set up to do (.default scope)
+      payload =
+        %{
+          "client_id" => config[:client_id],
+          "scope" => "https://graph.microsoft.com/.default",
+          "grant_type" => "client_credentials"
+        }
+        |> Map.merge(credential)
+        |> URI.encode_query()
 
-    payload =
-      URI.encode_query(%{
-        "client_id" => client_id,
-        "client_secret" => client_secret,
-        "scope" => scope,
-        "grant_type" => "client_credentials"
-      })
+      req_opts = fetch_config(:req_opts) || []
 
-    req_opts = fetch_config(:req_opts) || []
+      Req.post(
+        token_endpoint,
+        [
+          headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
+          body: payload
+        ] ++ req_opts
+      )
+    end
+  end
 
-    Req.post(
-      token_endpoint,
-      [
-        headers: [{"Content-Type", "application/x-www-form-urlencoded"}],
-        body: payload
-      ] ++ req_opts
-    )
+  # Production authenticates the app with workload identity federation: the
+  # portal's managed identity mints a token-exchange assertion, so no secret is
+  # stored. A configured client secret (dev and test, which have no managed
+  # identity) uses the secret directly.
+  defp client_credential(config) do
+    case config[:client_secret] do
+      secret when is_binary(secret) and secret != "" ->
+        {:ok, %{"client_secret" => secret}}
+
+      _ ->
+        federated_credential()
+    end
+  end
+
+  defp federated_credential do
+    assertion = Portal.Azure.ManagedIdentity.access_token!("api://AzureADTokenExchange")
+
+    {:ok,
+     %{
+       "client_assertion_type" => "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+       "client_assertion" => assertion
+     }}
+  rescue
+    exception -> {:error, exception}
   end
 
   @doc """

--- a/elixir/test/portal/entra/api_client_test.exs
+++ b/elixir/test/portal/entra/api_client_test.exs
@@ -50,6 +50,35 @@ defmodule Portal.Entra.APIClientTest do
       assert params["client_secret"] == config[:client_secret]
     end
 
+    test "authenticates with a managed-identity assertion when no secret is set" do
+      test_pid = self()
+      Portal.Config.put_env_override(:portal, APIClient, client_secret: nil)
+
+      Req.Test.stub(Portal.Azure.ManagedIdentity, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => "mi-federation-assertion",
+          "expires_on" => Integer.to_string(System.system_time(:second) + 3600)
+        })
+      end)
+
+      Req.Test.expect(APIClient, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:token_request, body})
+        Req.Test.json(conn, %{"access_token" => "graph_token", "expires_in" => 3600})
+      end)
+
+      assert {:ok, %Req.Response{status: 200}} = APIClient.get_access_token(@test_tenant_id)
+
+      assert_receive {:token_request, request_body}
+      params = URI.decode_query(request_body)
+      assert params["client_assertion"] == "mi-federation-assertion"
+
+      assert params["client_assertion_type"] ==
+               "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+      refute params["client_secret"]
+    end
+
     test "returns error on network failure" do
       Req.Test.expect(APIClient, fn conn ->
         Req.Test.transport_error(conn, :econnrefused)


### PR DESCRIPTION
Moves Entra directory sync off its stored client secret and onto workload identity federation, the same change made for the Sentinel log sink. When no `ENTRA_SYNC_CLIENT_SECRET` is set, the adapter mints a token-exchange assertion from the portal's managed identity and presents it as the client assertion; Entra accepts this for a multitenant app against a customer tenant. Dev and test have no managed identity, so a configured secret still authenticates directly.

This is invisible to customers: it only changes how the portal authenticates as the app, not the app identity or the permissions customers consented to. It also retires the shared secret with the widest blast radius, since that app can read customer directories.

Safe for the live app, deployed in this order:
1. Apply the federated credential (firezone/infra#754).
2. Deploy this.
3. Clear the ENTRA_SYNC_CLIENT_SECRET workspace variable per environment once verified. An Entra app holds both credentials at once, so there is no window where auth breaks.

Related: firezone/infra#754
