### PR TITLE
fix(portal): clearer Sentinel error messages

### DIFF
--- a/elixir/lib/portal/sentinel/api_client.ex
+++ b/elixir/lib/portal/sentinel/api_client.ex
@@ -114,9 +114,12 @@ defmodule Portal.Sentinel.APIClient do
 
   def format_status_error(%Req.Response{status: status, body: body})
       when status in [401, 403] do
-    "Azure Monitor returned HTTP #{status}: #{azure_error_message(body) || "access denied"}. " <>
-      "Grant the Firezone service principal the Monitoring Metrics Publisher role on the " <>
-      "data collection rule; role assignments can take up to 30 minutes to propagate."
+    detail = strip_trailing_period(azure_error_message(body) || "access denied")
+
+    "Azure Monitor returned HTTP #{status}: #{detail}. " <>
+      "Grant the Firezone Sentinel Log Ingestion service principal the Monitoring Metrics " <>
+      "Publisher role on the data collection rule; role assignments can take up to 30 minutes " <>
+      "to propagate."
   end
 
   # Only the customer configuration path reaches here for a 400: our own
@@ -124,12 +127,12 @@ defmodule Portal.Sentinel.APIClient do
   def format_status_error(%Req.Response{status: 400, body: body}) do
     prefix =
       case azure_error_message(body) do
-        nil -> "Azure Monitor returned HTTP 400."
-        message -> "Azure Monitor returned HTTP 400: #{message}."
+        nil -> "Azure Monitor returned HTTP 400"
+        message -> "Azure Monitor returned HTTP 400: #{strip_trailing_period(message)}"
       end
 
     prefix <>
-      " Check that the stream name and DCR immutable ID match your data collection rule, " <>
+      ". Check that the stream name and DCR immutable ID match your data collection rule, " <>
       "and that the stream is declared under the rule's stream declarations."
   end
 
@@ -146,6 +149,12 @@ defmodule Portal.Sentinel.APIClient do
 
   defp azure_error_message(%{"error" => error}) when is_binary(error), do: error
   defp azure_error_message(_body), do: nil
+
+  # Azure error messages usually end in a period; drop it so appending our own
+  # sentence does not leave a double period.
+  defp strip_trailing_period(message) do
+    message |> String.trim() |> String.trim_trailing(".")
+  end
 
   # 400s about the request we construct (an empty body, a wrong api-version).
   # Everything else Azure reports at 400 is DCR or stream configuration, which

--- a/elixir/test/portal/sentinel/sync_test.exs
+++ b/elixir/test/portal/sentinel/sync_test.exs
@@ -119,7 +119,8 @@ defmodule Portal.Sentinel.SyncTest do
       refute sink.is_disabled
       assert sink.errored_at
       assert sink.error_message =~ "Azure Monitor returned HTTP 403"
-      assert sink.error_message =~ "Monitoring Metrics Publisher"
+      assert sink.error_message =~ "Firezone Sentinel Log Ingestion service principal"
+      refute sink.error_message =~ ".."
     end
 
     test "authenticates with a managed-identity assertion when no secret is set", %{
@@ -179,6 +180,7 @@ defmodule Portal.Sentinel.SyncTest do
       assert sink.errored_at
       assert sink.error_message =~ "was not configured in the data collection rule"
       assert sink.error_message =~ "stream name and DCR immutable ID"
+      refute sink.error_message =~ ".."
     end
 
     test "a malformed-request 400 parks the stream without alarming the customer", %{


### PR DESCRIPTION
Fixes two things in the Sentinel ingestion error messages.

The 403 and 400 messages told the admin to grant the role to "the Firezone service principal", but the app shows up in Azure as "Firezone Sentinel Log Ingestion". The messages now use that exact name so it matches what they see.

Azure's error text already ends in a period, and we appended our own sentence after it, which produced a double period ("...operation.. Grant..."). The trailing period is now trimmed before we append.
