### PR TITLE
feat(portal): add SSRF plugin to Req

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -30,6 +30,9 @@ end
 config :portal, ecto_repos: [Portal.Repo]
 config :portal, generators: [binary_id: true]
 
+config :req,
+  default_options: [plugins: [Portal.Req.SSRFProtection]]
+
 config :portal, sql_sandbox: false
 config :portal, replica_repo: Portal.Repo.Replica
 

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -50,7 +50,8 @@ config :portal, outbound_email_adapter_configured?: true
 config :portal, run_manual_migrations: true
 
 config :portal, Portal.ComponentVersions,
-  firezone_releases_url: "http://localhost:3000/api/releases"
+  firezone_releases_url: "http://localhost:3000/api/releases",
+  req_opts: [allow_private_ips: true]
 
 config :portal, Portal.Billing,
   enabled: System.get_env("BILLING_ENABLED", "false") == "true",

--- a/elixir/lib/openid_connect.ex
+++ b/elixir/lib/openid_connect.ex
@@ -198,12 +198,14 @@ defmodule OpenIDConnect do
       %{client_id: config.client_id, client_secret: config.client_secret}
       |> Map.merge(params)
 
+    request =
+      req_opts
+      |> Keyword.merge(form: form_params, retry: retry_option())
+      |> Req.new()
+
     with {:ok, document} <- Document.fetch_document(discovery_document_uri, req_opts),
          {:ok, %{status: status, body: body}} when status in 200..299 <-
-           Req.post(
-             document.token_endpoint,
-             Keyword.merge([form: form_params, retry: retry_option()], req_opts)
-           ) do
+           Req.post(request, url: document.token_endpoint) do
       {:ok, decode_body(body)}
     else
       {:ok, %{status: status, body: body}} -> {:error, {status, decode_body(body)}}
@@ -399,13 +401,15 @@ defmodule OpenIDConnect do
 
     headers = [{"Authorization", "Bearer #{access_token}"}]
 
+    request =
+      req_opts
+      |> Keyword.merge(headers: headers, retry: retry_option())
+      |> Req.new()
+
     with {:ok, document} <- Document.fetch_document(discovery_document_uri, req_opts),
          true <- not is_nil(document.userinfo_endpoint),
          {:ok, %{status: status, body: body}} when status in 200..299 <-
-           Req.get(
-             document.userinfo_endpoint,
-             Keyword.merge([headers: headers, retry: retry_option()], req_opts)
-           ) do
+           Req.get(request, url: document.userinfo_endpoint) do
       {:ok, decode_body(body)}
     else
       {:ok, %{status: status, body: body}} -> {:error, {status, decode_body(body)}}

--- a/elixir/lib/openid_connect/document.ex
+++ b/elixir/lib/openid_connect/document.ex
@@ -92,7 +92,12 @@ defmodule OpenIDConnect.Document do
     collector = body_collector(@document_max_byte_size)
     options = Keyword.merge([into: collector, retry: retry_option()], req_opts)
 
-    case Req.get(uri, options) do
+    result =
+      options
+      |> Req.new()
+      |> Req.get(url: uri)
+
+    case result do
       {:ok, %{body: {:error, :body_too_large}}} ->
         {:error, :discovery_document_is_too_large}
 

--- a/elixir/lib/portal/azure/managed_identity.ex
+++ b/elixir/lib/portal/azure/managed_identity.ex
@@ -90,19 +90,20 @@ defmodule Portal.Azure.ManagedIdentity do
 
   defp fetch_token!(resource) do
     config = Portal.Config.fetch_env!(:portal, __MODULE__)
-    req_opts = config[:req_opts] || []
+    req_opts =
+      (config[:req_opts] || [])
+      |> Keyword.put(:allow_private_ips, true)
+      |> Keyword.put(:headers, [{"Metadata", "true"}])
+      |> Keyword.put(:params, [
+        "api-version": "2018-02-01",
+        resource: resource,
+        client_id: config[:client_id]
+      ])
 
     response =
       Req.get!(
         "#{config[:endpoint]}/metadata/identity/oauth2/token",
-        [
-          headers: [{"Metadata", "true"}],
-          params: [
-            "api-version": "2018-02-01",
-            resource: resource,
-            client_id: config[:client_id]
-          ]
-        ] ++ req_opts
+        req_opts
       )
 
     %Req.Response{status: 200, body: %{"access_token" => token, "expires_on" => expires_on}} =

--- a/elixir/lib/portal/changeset.ex
+++ b/elixir/lib/portal/changeset.ex
@@ -296,6 +296,16 @@ defmodule Portal.Changeset do
 
   def public_host?(_), do: false
 
+  def validate_public_host(%Ecto.Changeset{} = changeset, field) when is_atom(field) do
+    validate_change(changeset, field, fn _current_field, value ->
+      if public_host?(value) do
+        []
+      else
+        [{field, "must not be a private or reserved IP address"}]
+      end
+    end)
+  end
+
   defp private_host?(host) do
     charlist = String.to_charlist(host)
 

--- a/elixir/lib/portal/okta/api_client.ex
+++ b/elixir/lib/portal/okta/api_client.ex
@@ -144,7 +144,8 @@ defmodule Portal.Okta.APIClient do
       [base_url: client.base_url]
       |> Keyword.merge(req_opts())
 
-    Req.new(req_opts)
+    req_opts
+    |> Req.new()
     |> Req.merge(url: "/oauth2/v1/introspect")
     |> Req.Request.put_header("content-type", "application/x-www-form-urlencoded")
     |> Req.post(form: form_data)
@@ -274,7 +275,8 @@ defmodule Portal.Okta.APIClient do
       [base_url: client.base_url]
       |> Keyword.merge(req_opts())
 
-    Req.new(req_opts)
+    req_opts
+    |> Req.new()
     |> ReqDPoP.attach(
       sign_fun: &dpop_sign(&1, client.private_key, client.kid),
       access_token: access_token,

--- a/elixir/lib/portal/okta/directory.ex
+++ b/elixir/lib/portal/okta/directory.ex
@@ -1,6 +1,7 @@
 defmodule Portal.Okta.Directory do
   use Ecto.Schema
   import Ecto.Changeset
+  import Portal.Changeset
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -60,6 +61,8 @@ defmodule Portal.Okta.Directory do
       :is_verified
     ])
     |> validate_length(:okta_domain, min: 1, max: 255)
+    |> validate_fqdn(:okta_domain)
+    |> validate_public_host(:okta_domain)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_number(:error_email_count, greater_than_or_equal_to: 0)
     |> assoc_constraint(:account)

--- a/elixir/lib/portal/req/ssrf_protection.ex
+++ b/elixir/lib/portal/req/ssrf_protection.ex
@@ -1,0 +1,312 @@
+defmodule Portal.Req.SSRFProtection do
+  @moduledoc """
+  A Req plugin for requests to user-configured HTTP endpoints.
+
+  The plugin resolves the request host immediately before the adapter runs,
+  rejects private and special-use addresses, and pins the connection to one of
+  the checked addresses. The original hostname is retained for TLS certificate
+  verification, SNI, and the HTTP `Host` header.
+
+  Keeping this at the adapter boundary means retries and redirects are checked
+  independently instead of relying on validation performed when a database
+  record was created.
+
+  Firezone attaches the plugin to every Req request through Req's global default
+  options. Private addresses are denied by default. A client that intentionally
+  calls an internal service must opt out explicitly:
+
+      Req.get!(url, allow_private_ips: true)
+  """
+
+  @default_pool_max_idle_time :timer.minutes(1)
+  @original_adapter_key :portal_ssrf_protection_original_adapter
+  @resolver_key :portal_ssrf_protection_resolver
+
+  defmodule UnsafeURLError do
+    defexception [:host, :reason]
+
+    @impl true
+    def message(%__MODULE__{host: host, reason: :non_public_address}) do
+      "request to #{inspect(host)} was blocked because it resolves to a private or reserved IP address"
+    end
+
+    def message(%__MODULE__{host: host, reason: :nxdomain}) do
+      "request to #{inspect(host)} failed because the host could not be resolved"
+    end
+
+    def message(%__MODULE__{host: host, reason: :invalid_url}) do
+      "request was blocked because #{inspect(host)} is not a valid HTTP host"
+    end
+  end
+
+  @type resolver :: (:inet.hostname(), :inet | :inet6 ->
+                       {:ok, [:inet.ip_address()]} | {:error, term()})
+
+  @doc false
+  @spec attach(Req.Request.t()) :: Req.Request.t()
+  def attach(%Req.Request{} = request), do: attach(request, [])
+
+  @doc false
+  @spec attach(Req.Request.t(), keyword()) :: Req.Request.t()
+  def attach(%Req.Request{} = request, options) do
+    request = Req.Request.register_options(request, [:allow_private_ips])
+
+    request =
+      case Keyword.fetch(options, :resolver) do
+        {:ok, resolver} -> Req.Request.put_private(request, @resolver_key, resolver)
+        :error -> request
+      end
+
+    if request.adapter == (&run/1) do
+      request
+    else
+      request
+      |> Req.Request.put_private(@original_adapter_key, request.adapter)
+      |> Map.put(:adapter, &run/1)
+    end
+  end
+
+  @doc false
+  @spec resolve_public_address(String.t(), resolver()) ::
+          {:ok, :inet.ip_address()} | {:error, :non_public_address | :nxdomain}
+  def resolve_public_address(host, resolver \\ &:inet.getaddrs/2)
+
+  def resolve_public_address(host, resolver) when is_binary(host) and host != "" do
+    charlist = String.to_charlist(host)
+
+    case :inet.parse_address(charlist) do
+      {:ok, ip} ->
+        validate_addresses([ip])
+
+      {:error, _reason} ->
+        charlist
+        |> resolve_addresses(resolver)
+        |> validate_addresses()
+    end
+  end
+
+  def resolve_public_address(_host, _resolver), do: {:error, :nxdomain}
+
+  defp resolve_addresses(host, resolver) do
+    [:inet, :inet6]
+    |> Enum.flat_map(&resolve_addresses(host, &1, resolver))
+    |> Enum.uniq()
+  end
+
+  defp resolve_addresses(host, family, resolver) do
+    case resolver.(host, family) do
+      {:ok, addresses} -> addresses
+      {:error, _reason} -> []
+    end
+  end
+
+  defp validate_addresses([]), do: {:error, :nxdomain}
+
+  defp validate_addresses(addresses) do
+    if Enum.any?(addresses, &Portal.Changeset.private_ip?/1) do
+      {:error, :non_public_address}
+    else
+      # Prefer IPv4, matching Req's default connection behavior. Because every
+      # returned address was checked, selecting any member is safe.
+      address = Enum.find(addresses, &(tuple_size(&1) == 4)) || List.first(addresses)
+      {:ok, address}
+    end
+  end
+
+  defp run(%Req.Request{} = request) do
+    if request.options[:allow_private_ips] do
+      run_original_adapter(request)
+    else
+      resolver = Req.Request.get_private(request, @resolver_key) || (&:inet.getaddrs/2)
+      run_protected(request, resolver)
+    end
+  end
+
+  defp run_protected(
+         %Req.Request{url: %URI{scheme: scheme, host: host}} = request,
+         resolver
+       )
+       when scheme in ["http", "https"] and is_binary(host) and host != "" do
+    case resolve_public_address(host, resolver) do
+      {:ok, address} ->
+        request
+        |> pin_request(address)
+        |> run_original_adapter(request)
+
+      {:error, reason} ->
+        {request, %UnsafeURLError{host: host, reason: reason}}
+    end
+  end
+
+  defp run_protected(%Req.Request{} = request, _resolver) do
+    {request, %UnsafeURLError{host: request.url.host, reason: :invalid_url}}
+  end
+
+  defp pin_request(%Req.Request{} = request, address) do
+    original_host = request.url.host
+    address_string = address |> :inet.ntoa() |> to_string()
+    connect_options = Keyword.put(request.options[:connect_options] || [], :hostname, original_host)
+    inet6? = tuple_size(address) == 8
+
+    request
+    |> Req.Request.put_header("host", authority(request.url))
+    |> put_in([Access.key(:url), Access.key(:host)], address_string)
+    |> put_in([Access.key(:options), :connect_options], connect_options)
+    |> put_in([Access.key(:options), :inet6], inet6?)
+  end
+
+  defp run_original_adapter(%Req.Request{} = request) do
+    original_adapter = Req.Request.get_private(request, @original_adapter_key)
+    original_adapter.(request)
+  end
+
+  defp run_original_adapter(%Req.Request{} = pinned_request, %Req.Request{} = original_request) do
+    original_adapter = Req.Request.get_private(original_request, @original_adapter_key)
+
+    pinned_request =
+      if original_adapter == (&Req.Steps.run_finch/1) do
+        use_pinned_finch_pool(pinned_request, original_request.url.host)
+      else
+        pinned_request
+      end
+
+    case original_adapter.(pinned_request) do
+      {%Req.Request{}, response_or_error} -> {original_request, response_or_error}
+    end
+  end
+
+  # Req creates a named Finch instance for each distinct set of connection
+  # options. Since the TLS hostname is user-controlled here, doing that would
+  # create atoms dynamically. A tagged pool on Req's existing Finch instance
+  # pins the checked IP without creating atoms.
+  defp use_pinned_finch_pool(%Req.Request{} = request, original_host) do
+    pool_options =
+      request.options
+      |> Req.Finch.pool_options()
+      |> Keyword.update(:conn_opts, [hostname: original_host], fn conn_opts ->
+        Keyword.put(conn_opts, :hostname, original_host)
+      end)
+      |> Keyword.put_new(:pool_max_idle_time, @default_pool_max_idle_time)
+
+    tag = {__MODULE__, original_host, request.options[:connect_options] || []}
+
+    pool = %Finch.Pool{
+      scheme: String.to_existing_atom(request.url.scheme),
+      host: request.url.host,
+      port: request.url.port || URI.default_port(request.url.scheme),
+      tag: tag
+    }
+
+    :ok = Finch.start_pool(Req.Finch, pool, pool_options)
+
+    finch_request = fn req_request, finch_request, finch_name, finch_options ->
+      finch_request = %{finch_request | pool_tag: tag}
+      run_finch_request(req_request, finch_request, finch_name, finch_options)
+    end
+
+    options =
+      request.options
+      |> Map.delete(:connect_options)
+      |> Map.put(:finch, Req.Finch)
+      |> Map.put(:finch_request, finch_request)
+
+    %{request | options: options}
+  end
+
+  defp run_finch_request(
+         %Req.Request{into: nil} = request,
+         finch_request,
+         finch_name,
+         finch_options
+       ) do
+    result =
+      case Finch.request(finch_request, finch_name, finch_options) do
+        {:ok, response} -> Req.Response.new(response)
+        {:error, exception} -> normalize_finch_error(exception)
+      end
+
+    {request, result}
+  end
+
+  defp run_finch_request(
+         %Req.Request{into: into} = request,
+         finch_request,
+         finch_name,
+         finch_options
+       )
+       when is_function(into, 2) do
+    response = Req.Response.new()
+
+    stream = fn
+      {:status, status}, {request, response} ->
+        {:cont, {request, %{response | status: status}}}
+
+      {:headers, headers}, {request, response} ->
+        response =
+          Enum.reduce(headers, response, fn {name, value}, response ->
+            Req.Response.put_header(response, name, value)
+          end)
+
+        {:cont, {request, response}}
+
+      {:data, data}, acc ->
+        into.({:data, data}, acc)
+
+      {:trailers, trailers}, {request, response} ->
+        trailers = fields_to_map(trailers)
+        response = update_in(response.trailers, &Map.merge(&1, trailers))
+        {:cont, {request, response}}
+    end
+
+    case Finch.stream_while(
+           finch_request,
+           finch_name,
+           {request, response},
+           stream,
+           finch_options
+         ) do
+      {:ok, acc} -> acc
+      {:error, exception, _acc} -> {request, normalize_finch_error(exception)}
+    end
+  end
+
+  defp run_finch_request(%Req.Request{} = request, _finch_request, _finch_name, _options) do
+    error =
+      ArgumentError.exception(
+        "Portal.Req.SSRFProtection does not support Req's #{inspect(request.into)} streaming mode"
+      )
+
+    {request, error}
+  end
+
+  defp normalize_finch_error(%Finch.Error{reason: reason}) do
+    %Req.HTTPError{protocol: :http2, reason: reason}
+  end
+
+  defp normalize_finch_error(%Finch.TransportError{reason: reason}) do
+    %Req.TransportError{reason: reason}
+  end
+
+  defp normalize_finch_error(%Finch.HTTPError{module: module, reason: reason}) do
+    protocol = if module == Mint.HTTP2, do: :http2, else: :http1
+    %Req.HTTPError{protocol: protocol, reason: reason}
+  end
+
+  defp normalize_finch_error(error), do: error
+
+  defp fields_to_map(fields) do
+    Enum.reduce(fields, %{}, fn {name, value}, acc ->
+      Map.update(acc, name, [value], &(&1 ++ [value]))
+    end)
+  end
+
+  defp authority(%URI{scheme: scheme, host: host, port: port}) do
+    host = if String.contains?(host, ":"), do: "[#{host}]", else: host
+
+    if port && port != URI.default_port(scheme) do
+      "#{host}:#{port}"
+    else
+      host
+    end
+  end
+end

--- a/elixir/test/portal/okta/directory_test.exs
+++ b/elixir/test/portal/okta/directory_test.exs
@@ -13,6 +13,18 @@ defmodule Portal.Okta.DirectoryTest do
   end
 
   describe "changeset/1 basic validations" do
+    test "rejects private IP addresses used as the Okta API host" do
+      changeset = build_changeset(%{okta_domain: "169.254.169.254"})
+
+      assert "must not be a private or reserved IP address" in errors_on(changeset).okta_domain
+    end
+
+    test "rejects invalid Okta API hosts" do
+      changeset = build_changeset(%{okta_domain: "not a valid host"})
+
+      assert "not a valid host is not a valid FQDN" in errors_on(changeset).okta_domain
+    end
+
     test "inserts okta_domain at maximum length" do
       dir = okta_directory_fixture(okta_domain: String.duplicate("a", 255))
       assert String.length(dir.okta_domain) == 255

--- a/elixir/test/portal/req/ssrf_protection_test.exs
+++ b/elixir/test/portal/req/ssrf_protection_test.exs
@@ -1,0 +1,203 @@
+defmodule Portal.Req.SSRFProtectionTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Req.SSRFProtection
+  alias Portal.Req.SSRFProtection.UnsafeURLError
+
+  test "is configured as a global Req plugin" do
+    assert SSRFProtection in Keyword.fetch!(Req.default_options(), :plugins)
+
+    assert {:error, %UnsafeURLError{reason: :non_public_address}} =
+             Req.get("http://127.0.0.1", retry: false)
+  end
+
+  test "the global allow_private_ips escape hatch reaches an explicit loopback address" do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [:binary, active: false, packet: :raw, reuseaddr: true])
+
+    {:ok, {_address, port}} = :inet.sockname(listen_socket)
+
+    server =
+      Task.async(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen_socket)
+        {:ok, _request} = :gen_tcp.recv(socket, 0, 1_000)
+
+        :ok =
+          :gen_tcp.send(
+            socket,
+            "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+          )
+
+        :gen_tcp.close(socket)
+      end)
+
+    assert {:ok, %Req.Response{status: 204}} =
+             Req.get("http://127.0.0.1:#{port}", allow_private_ips: true, retry: false)
+
+    Task.await(server)
+    :gen_tcp.close(listen_socket)
+  end
+
+  test "blocks literal private and reserved IPv4 and IPv6 addresses before the adapter runs" do
+    urls = [
+      "https://169.254.169.254/latest/meta-data",
+      "http://[::1]/metadata",
+      "http://[::ffff:127.0.0.1]/metadata"
+    ]
+
+    for url <- urls do
+      request = protected_request(url, unreachable_adapter())
+
+      assert {:error, %UnsafeURLError{reason: :non_public_address}} = Req.get(request)
+    end
+  end
+
+  test "allows and pins literal public IPv4 addresses without a DNS lookup" do
+    test_pid = self()
+    resolver = fn _host, _family -> flunk("literal IP addresses must not use DNS") end
+
+    adapter = fn request ->
+      send(test_pid, {:request, request})
+      {request, Req.Response.new(status: 204)}
+    end
+
+    request =
+      protected_request("https://8.8.8.8:8443/events", adapter, resolver: resolver)
+
+    assert {:ok, %Req.Response{status: 204}} = Req.get(request)
+    assert_receive {:request, pinned_request}
+    assert pinned_request.url.host == "8.8.8.8"
+    assert Req.Request.get_header(pinned_request, "host") == ["8.8.8.8:8443"]
+    assert pinned_request.options[:connect_options][:hostname] == "8.8.8.8"
+    refute pinned_request.options[:inet6]
+  end
+
+  test "allows and pins literal public IPv6 addresses with a bracketed Host header" do
+    test_pid = self()
+    resolver = fn _host, _family -> flunk("literal IP addresses must not use DNS") end
+
+    adapter = fn request ->
+      send(test_pid, {:request, request})
+      {request, Req.Response.new(status: 204)}
+    end
+
+    request =
+      protected_request("https://[2606:4700:4700::1111]:8443/events", adapter,
+        resolver: resolver
+      )
+
+    assert {:ok, %Req.Response{status: 204}} = Req.get(request)
+    assert_receive {:request, pinned_request}
+    assert pinned_request.url.host == "2606:4700:4700::1111"
+    assert Req.Request.get_header(pinned_request, "host") == ["[2606:4700:4700::1111]:8443"]
+    assert pinned_request.options[:connect_options][:hostname] == "2606:4700:4700::1111"
+    assert pinned_request.options[:inet6]
+  end
+
+  test "blocks a hostname when any DNS answer is non-public" do
+    resolver = fn
+      ~c"logs.example.com", :inet -> {:ok, [{8, 8, 8, 8}, {10, 0, 0, 1}]}
+      ~c"logs.example.com", :inet6 -> {:error, :nxdomain}
+    end
+
+    request =
+      protected_request("https://logs.example.com", unreachable_adapter(), resolver: resolver)
+
+    assert {:error, %UnsafeURLError{reason: :non_public_address}} = Req.get(request)
+  end
+
+  test "fails closed when a hostname has no DNS answers" do
+    resolver = fn _host, _family -> {:error, :nxdomain} end
+    request = protected_request("https://missing.example.com", unreachable_adapter(), resolver: resolver)
+
+    assert {:error, %UnsafeURLError{reason: :nxdomain}} = Req.get(request)
+  end
+
+  test "pins the connection to a checked address and preserves the HTTP and TLS hostname" do
+    test_pid = self()
+
+    resolver = fn
+      ~c"logs.example.com", :inet -> {:ok, [{8, 8, 8, 8}]}
+      ~c"logs.example.com", :inet6 -> {:error, :nxdomain}
+    end
+
+    adapter = fn request ->
+      send(test_pid, {:request, request})
+      {request, Req.Response.new(status: 204)}
+    end
+
+    request =
+      protected_request("https://logs.example.com:8443/events", adapter, resolver: resolver)
+
+    assert {:ok, %Req.Response{status: 204}} = Req.get(request)
+    assert_receive {:request, pinned_request}
+    assert pinned_request.url.host == "8.8.8.8"
+    assert Req.Request.get_header(pinned_request, "host") == ["logs.example.com:8443"]
+    assert pinned_request.options[:connect_options][:hostname] == "logs.example.com"
+  end
+
+  test "checks the destination of every redirect" do
+    test_pid = self()
+
+    resolver = fn
+      ~c"public.example.com", :inet -> {:ok, [{8, 8, 8, 8}]}
+      ~c"public.example.com", :inet6 -> {:error, :nxdomain}
+      ~c"private.example.com", :inet -> {:ok, [{10, 0, 0, 1}]}
+      ~c"private.example.com", :inet6 -> {:error, :nxdomain}
+    end
+
+    adapter = fn request ->
+      send(test_pid, :adapter_called)
+
+      response =
+        Req.Response.new(
+          status: 302,
+          headers: [{"location", "https://private.example.com/metadata"}]
+        )
+
+      {request, response}
+    end
+
+    request = protected_request("https://public.example.com", adapter, resolver: resolver)
+
+    assert {:error, %UnsafeURLError{reason: :non_public_address}} = Req.get(request)
+    assert_receive :adapter_called
+    refute_receive :adapter_called
+  end
+
+  test "allow_private_ips bypasses protection for literal private IPv4 and IPv6 hosts" do
+    test_pid = self()
+
+    adapter = fn request ->
+      send(test_pid, {:request, request})
+      {request, Req.Response.new(status: 200)}
+    end
+
+    urls = [
+      "http://169.254.169.254/metadata/identity/oauth2/token",
+      "http://[::1]/metadata/identity/oauth2/token"
+    ]
+
+    for url <- urls do
+      request = protected_request(url, adapter, allow_private_ips: true)
+
+      assert {:ok, %Req.Response{status: 200}} = Req.get(request)
+      assert_receive {:request, request}
+      assert request.url.host == URI.parse(url).host
+      assert Req.Request.get_header(request, "host") == []
+      refute request.options[:connect_options][:hostname]
+    end
+  end
+
+  defp protected_request(url, adapter, options \\ []) do
+    {resolver, options} = Keyword.pop(options, :resolver)
+
+    Req.new(url: url, adapter: adapter, retry: false)
+    |> SSRFProtection.attach(resolver: resolver || (&:inet.getaddrs/2))
+    |> Req.merge(options)
+  end
+
+  defp unreachable_adapter do
+    fn _request -> flunk("adapter must not run for an unsafe URL") end
+  end
+end

--- a/elixir/test/portal_web/components/navigation_components_test.exs
+++ b/elixir/test/portal_web/components/navigation_components_test.exs
@@ -53,7 +53,7 @@ defmodule PortalWeb.NavigationComponentsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
-      refute html =~ "Log Sinks"
+      refute html =~ ~s(href="/#{account.slug}/settings/log_sinks")
     end
 
     test "shown when log_sinks feature is enabled", %{
@@ -68,7 +68,7 @@ defmodule PortalWeb.NavigationComponentsTest do
         |> authorize_conn(actor)
         |> live(~p"/#{account}/settings/account")
 
-      assert html =~ "Log Sinks"
+      assert html =~ ~s(href="/#{account.slug}/settings/log_sinks")
     end
   end
 


### PR DESCRIPTION
Adds private and reserved IP checking at resolution time to all HTTPS requests to all user-supplied URLs.

Since we've standardized on Req, this is done via a Req plugin that also exposes an option to allow private IP addresses so things like fetch Entra access tokens internally works.

Related: #14193 
