### PR TITLE
fix(portal): make sync_pricing_plans pass event checks

### DIFF
--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -48,8 +48,13 @@ defmodule Portal.Ops do
     {:ok, subscriptions} = Portal.Billing.list_all_subscriptions()
 
     Enum.each(subscriptions, fn subscription ->
+      # id/created satisfy the ProcessedEvents checks; created=now also makes
+      # stale webhook events delivered after the sync get skipped as :old_event
       %{
+        "id" => "evt_sync_" <> Ecto.UUID.generate(),
         "object" => "event",
+        "created" => System.os_time(:second),
+        "livemode" => Map.get(subscription, "livemode", false),
         "data" => %{
           "object" => subscription
         },

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -13,6 +13,7 @@ defmodule Portal.OpsTest do
   import Portal.TokenFixtures
   import Portal.ObanJobFixtures
 
+  alias Portal.Mocks.Stripe
   alias Portal.Workers.DeleteAccount
 
   describe "count_presences/0" do
@@ -38,6 +39,50 @@ defmodule Portal.OpsTest do
       assert {"presences:test_clients", 2} in result
       assert {"presences:test_gateways", 1} in result
       assert {"presences:test_relays", 1} in result
+    end
+  end
+
+  describe "sync_pricing_plans/0" do
+    test "applies current Stripe product features and limits to accounts" do
+      account =
+        account_fixture(%{
+          metadata: %{stripe: %{customer_id: "cus_sync123"}}
+        })
+
+      refute account.features.log_sinks
+
+      customer =
+        Stripe.build_customer(id: "cus_sync123", metadata: %{"account_id" => account.id})
+
+      product =
+        Stripe.build_product(
+          id: "prod_test_enterprise",
+          name: "Enterprise",
+          metadata: Stripe.enterprise_metadata(%{"log_sinks" => true})
+        )
+
+      price = Stripe.build_price(product: "prod_test_enterprise")
+
+      subscription =
+        Stripe.build_subscription(
+          customer: "cus_sync123",
+          items: [[price: price, quantity: 42]]
+        )
+
+      subscriptions = %{"object" => "list", "has_more" => false, "data" => [subscription]}
+
+      Stripe.stub(
+        [{"GET", "/v1/subscriptions", 200, subscriptions}] ++
+          Stripe.fetch_customer_endpoint(customer) ++
+          Stripe.fetch_product_endpoint(product)
+      )
+
+      assert :ok = sync_pricing_plans()
+
+      account = Repo.get!(Portal.Account, account.id)
+      assert account.features.log_sinks
+      assert account.features.idp_sync
+      assert account.metadata.stripe.product_name == "Enterprise"
     end
   end
 


### PR DESCRIPTION
Portal.Ops.sync_pricing_plans/0 fabricated subscription events without the id and created fields. The event handler's idempotency checks pattern-match on those fields, so every sync crashed with a MatchError before touching any account.

The synthetic events now carry a unique evt_sync_ id and a created timestamp of now. Recording them in processed events also means stale webhook events delivered after a sync get skipped instead of reverting the freshly synced state.