### PR TITLE
fix(portal): log sink form crash when clearing a field

### DIFF
--- a/elixir/lib/portal/datadog/log_sink.ex
+++ b/elixir/lib/portal/datadog/log_sink.ex
@@ -92,6 +92,8 @@ defmodule Portal.Datadog.LogSink do
     )
   end
 
+  defp normalize_tags(nil), do: nil
+
   defp normalize_tags(tags) do
     normalized =
       tags

--- a/elixir/lib/portal/elastic/log_sink.ex
+++ b/elixir/lib/portal/elastic/log_sink.ex
@@ -86,6 +86,8 @@ defmodule Portal.Elastic.LogSink do
     )
   end
 
+  defp normalize_endpoint_url(nil), do: nil
+
   defp normalize_endpoint_url(url) do
     url
     |> String.trim()

--- a/elixir/lib/portal/s3/log_sink.ex
+++ b/elixir/lib/portal/s3/log_sink.ex
@@ -97,6 +97,8 @@ defmodule Portal.S3.LogSink do
     )
   end
 
+  defp normalize_key_prefix(nil), do: nil
+
   defp normalize_key_prefix(prefix) do
     normalized = prefix |> String.trim() |> String.trim("/")
 

--- a/elixir/lib/portal/sentinel/log_sink.ex
+++ b/elixir/lib/portal/sentinel/log_sink.ex
@@ -61,10 +61,10 @@ defmodule Portal.Sentinel.LogSink do
 
   def changeset(%Ecto.Changeset{} = changeset) do
     changeset
-    |> update_change(:tenant_id, &String.trim/1)
+    |> update_change(:tenant_id, &trim_change/1)
     |> update_change(:ingestion_endpoint, &normalize_ingestion_endpoint/1)
-    |> update_change(:dcr_immutable_id, &String.trim/1)
-    |> update_change(:stream_name, &String.trim/1)
+    |> update_change(:dcr_immutable_id, &trim_change/1)
+    |> update_change(:stream_name, &trim_change/1)
     |> validate_required([
       :name,
       :tenant_id,
@@ -98,11 +98,16 @@ defmodule Portal.Sentinel.LogSink do
     )
   end
 
+  defp normalize_ingestion_endpoint(nil), do: nil
+
   defp normalize_ingestion_endpoint(url) do
     url
     |> String.trim()
     |> String.trim_trailing("/")
   end
+
+  defp trim_change(nil), do: nil
+  defp trim_change(value), do: String.trim(value)
 
   # Each delivery mints a bearer token from Firezone's shared Entra credentials
   # scoped to Azure Monitor, so the endpoint must be an Azure Monitor ingestion

--- a/elixir/lib/portal/splunk/log_sink.ex
+++ b/elixir/lib/portal/splunk/log_sink.ex
@@ -83,6 +83,8 @@ defmodule Portal.Splunk.LogSink do
 
   # People paste the full endpoint from the Splunk docs; the client appends
   # the collector path itself, so strip it down to the base URL.
+  defp normalize_collector_url(nil), do: nil
+
   defp normalize_collector_url(url) do
     url
     |> String.trim()

--- a/elixir/test/portal/datadog/log_sink_test.exs
+++ b/elixir/test/portal/datadog/log_sink_test.exs
@@ -1,0 +1,15 @@
+defmodule Portal.Datadog.LogSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Datadog.LogSink
+
+  test "clearing filled tags does not crash the changeset" do
+    changeset =
+      %LogSink{tags: "env:dev"}
+      |> Ecto.Changeset.cast(%{"tags" => ""}, [:tags])
+      |> LogSink.changeset()
+
+    assert %Ecto.Changeset{} = changeset
+    assert Ecto.Changeset.get_field(changeset, :tags) == nil
+  end
+end

--- a/elixir/test/portal/elastic/log_sink_test.exs
+++ b/elixir/test/portal/elastic/log_sink_test.exs
@@ -1,0 +1,15 @@
+defmodule Portal.Elastic.LogSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Elastic.LogSink
+
+  test "clearing a filled endpoint_url does not crash the changeset" do
+    changeset =
+      %LogSink{endpoint_url: "https://cluster.es.example.com"}
+      |> Ecto.Changeset.cast(%{"endpoint_url" => ""}, [:endpoint_url])
+      |> LogSink.changeset()
+
+    assert %Ecto.Changeset{} = changeset
+    refute changeset.valid?
+  end
+end

--- a/elixir/test/portal/s3/log_sink_test.exs
+++ b/elixir/test/portal/s3/log_sink_test.exs
@@ -1,0 +1,15 @@
+defmodule Portal.S3.LogSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.S3.LogSink
+
+  test "clearing a filled key_prefix does not crash the changeset" do
+    changeset =
+      %LogSink{key_prefix: "firezone/logs"}
+      |> Ecto.Changeset.cast(%{"key_prefix" => ""}, [:key_prefix])
+      |> LogSink.changeset()
+
+    assert %Ecto.Changeset{} = changeset
+    assert Ecto.Changeset.get_field(changeset, :key_prefix) == nil
+  end
+end

--- a/elixir/test/portal/sentinel/log_sink_test.exs
+++ b/elixir/test/portal/sentinel/log_sink_test.exs
@@ -1,0 +1,28 @@
+defmodule Portal.Sentinel.LogSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Sentinel.LogSink
+
+  test "clearing filled fields does not crash the changeset" do
+    changeset =
+      %LogSink{
+        tenant_id: "00000000-0000-0000-0000-000000000000",
+        ingestion_endpoint: "https://dce.eastus-1.ingest.monitor.azure.com",
+        dcr_immutable_id: "dcr-0123456789abcdef0123456789abcdef",
+        stream_name: "Custom-FirezoneLogs_CL"
+      }
+      |> Ecto.Changeset.cast(
+        %{
+          "tenant_id" => "",
+          "ingestion_endpoint" => "",
+          "dcr_immutable_id" => "",
+          "stream_name" => ""
+        },
+        [:tenant_id, :ingestion_endpoint, :dcr_immutable_id, :stream_name]
+      )
+      |> LogSink.changeset()
+
+    assert %Ecto.Changeset{} = changeset
+    refute changeset.valid?
+  end
+end

--- a/elixir/test/portal/splunk/log_sink_test.exs
+++ b/elixir/test/portal/splunk/log_sink_test.exs
@@ -1,0 +1,15 @@
+defmodule Portal.Splunk.LogSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Splunk.LogSink
+
+  test "clearing a filled collector_url does not crash the changeset" do
+    changeset =
+      %LogSink{collector_url: "https://http-inputs-acme.splunkcloud.com"}
+      |> Ecto.Changeset.cast(%{"collector_url" => ""}, [:collector_url])
+      |> LogSink.changeset()
+
+    assert %Ecto.Changeset{} = changeset
+    refute changeset.valid?
+  end
+end


### PR DESCRIPTION
Fixes a crash in the log sink settings form: type in a field, then backspace it empty, and the LiveView dies with a FunctionClauseError on String.trim/1.

When a field is cleared, Ecto casts the empty string to nil, and the changeset then ran a trim or normalize on that nil value. The normalizers and trims now accept nil, so clearing a field just clears it (and required fields show the usual "can't be blank").

This covers the five merged providers: Splunk, Datadog, Elastic, Sentinel, and S3. QRadar and HTTP have the same fix on their own PRs (#14194, #14193).
