### PR TITLE
fix(portal/api): use accurate examples for 4xx responses

### DIFF
--- a/elixir/lib/portal_api/schemas/problem_details_schema.ex
+++ b/elixir/lib/portal_api/schemas/problem_details_schema.ex
@@ -9,7 +9,7 @@ defmodule PortalAPI.Schemas.ProblemDetails do
     unauthorized: "Authentication credentials were missing or invalid.",
     forbidden: "You do not have permission to perform this action.",
     not_found: "The requested resource could not be found.",
-    conflict: "An active token already exists for this gateway. Rotate it or delete it first.",
+    conflict: "The request conflicts with the current state of the resource.",
     unprocessable_entity: "The request body failed validation.",
     too_many_requests:
       "Rate limit exceeded. Retry after the time indicated in the Retry-After header."

--- a/elixir/lib/portal_api/schemas/problem_details_schema.ex
+++ b/elixir/lib/portal_api/schemas/problem_details_schema.ex
@@ -4,6 +4,17 @@ defmodule PortalAPI.Schemas.ProblemDetails do
 
   @content_type "application/problem+json"
 
+  @response_details %{
+    bad_request: "The request could not be processed.",
+    unauthorized: "Authentication credentials were missing or invalid.",
+    forbidden: "You do not have permission to perform this action.",
+    not_found: "The requested resource could not be found.",
+    conflict: "An active token already exists for this gateway. Rotate it or delete it first.",
+    unprocessable_entity: "The request body failed validation.",
+    too_many_requests:
+      "Rate limit exceeded. Retry after the time indicated in the Retry-After header."
+  }
+
   OpenApiSpex.schema(%{
     title: "ProblemDetails",
     description: "RFC 9457 (Problem Details for HTTP APIs) error response.",
@@ -81,24 +92,28 @@ defmodule PortalAPI.Schemas.ProblemDetails do
     Enum.map(codes, fn code -> {code, response_for(code)} end)
   end
 
-  defp response_for(:bad_request),
-    do: {"Bad Request", @content_type, __MODULE__}
+  defp response_for(code) do
+    status = Plug.Conn.Status.code(code)
+    title = Plug.Conn.Status.reason_phrase(status)
+    detail = Map.fetch!(@response_details, code)
 
-  defp response_for(:unauthorized),
-    do: {"Unauthorized", @content_type, __MODULE__}
+    example = %{
+      "type" => "about:blank",
+      "title" => title,
+      "status" => status,
+      "detail" => detail
+    }
 
-  defp response_for(:forbidden),
-    do: {"Forbidden", @content_type, __MODULE__}
+    example =
+      if code == :unprocessable_entity do
+        Map.put(example, "validation_errors", %{"name" => ["can't be blank"]})
+      else
+        example
+      end
 
-  defp response_for(:not_found),
-    do: {"Not Found", @content_type, __MODULE__}
+    {title, @content_type, response_schema(code), example: example}
+  end
 
-  defp response_for(:conflict),
-    do: {"Conflict", @content_type, __MODULE__}
-
-  defp response_for(:unprocessable_entity),
-    do: {"Unprocessable Content", @content_type, ValidationError}
-
-  defp response_for(:too_many_requests),
-    do: {"Too Many Requests", @content_type, __MODULE__}
+  defp response_schema(:unprocessable_entity), do: ValidationError
+  defp response_schema(_code), do: __MODULE__
 end

--- a/elixir/test/portal_api/api_spec_test.exs
+++ b/elixir/test/portal_api/api_spec_test.exs
@@ -1,0 +1,31 @@
+defmodule PortalAPI.ApiSpecTest do
+  use ExUnit.Case, async: true
+
+  @content_type "application/problem+json"
+
+  test "problem response examples match their HTTP status" do
+    spec = PortalAPI.ApiSpec.spec() |> OpenApiSpex.OpenApi.to_map()
+
+    responses =
+      for {path, path_item} <- spec["paths"],
+          {method, %{"responses" => operation_responses}} <- path_item,
+          {code, response} <- operation_responses,
+          media = get_in(response, ["content", @content_type]),
+          media != nil do
+        {path, method, code, media["example"]}
+      end
+
+    assert responses != []
+
+    for {path, method, code, example} <- responses do
+      status = String.to_integer(code)
+      operation = "#{String.upcase(method)} #{path}"
+
+      assert is_map(example), "#{operation} #{code} response is missing an example"
+      assert example["status"] == status, "#{operation} #{code} example has the wrong status"
+
+      assert example["title"] == Plug.Conn.Status.reason_phrase(status),
+             "#{operation} #{code} example has the wrong title"
+    end
+  end
+end


### PR DESCRIPTION
Fixes the below issue:

<img width="1840" height="1191" alt="Screenshot 2026-07-18 at 9 55 30 AM" src="https://github.com/user-attachments/assets/b7ae6b80-c660-497c-b87e-a80d582fccc6" />
