### PR TITLE
fix(portal): move log sinks link to table footer

### DIFF
--- a/elixir/lib/portal_web/components/navigation_components.ex
+++ b/elixir/lib/portal_web/components/navigation_components.ex
@@ -587,12 +587,6 @@ defmodule PortalWeb.NavigationComponents do
                 <p class="hidden md:block mt-0.5 text-sm text-body">
                   Structured, immutable records of every configuration change, session, connection, and API call in your account.
                 </p>
-                <p class="hidden md:block mt-1 text-sm text-body">
-                  Stream logs to external destinations using
-                  <.link navigate={~p"/#{@account}/settings/log_sinks"} class={link_style()}>
-                    log sinks <.icon name="ri-arrow-right-line" class="w-3.5 h-3.5 inline" />
-                  </.link>
-                </p>
               </div>
               <div class="shrink-0 flex items-center gap-2">
                 <.docs_action path="/administer/logs" />

--- a/elixir/lib/portal_web/live/logs/api_request_logs.ex
+++ b/elixir/lib/portal_web/live/logs/api_request_logs.ex
@@ -173,6 +173,9 @@ defmodule PortalWeb.Logs.APIRequestLogs do
               </div>
             </div>
           </:empty>
+          <:footer>
+            <.log_sinks_notice account={@account} />
+          </:footer>
         </.live_table>
       </div>
 

--- a/elixir/lib/portal_web/live/logs/change_logs.ex
+++ b/elixir/lib/portal_web/live/logs/change_logs.ex
@@ -176,6 +176,9 @@ defmodule PortalWeb.Logs.ChangeLogs do
               </div>
             </div>
           </:empty>
+          <:footer>
+            <.log_sinks_notice account={@account} />
+          </:footer>
         </.live_table>
       </div>
 

--- a/elixir/lib/portal_web/live/logs/components.ex
+++ b/elixir/lib/portal_web/live/logs/components.ex
@@ -8,6 +8,7 @@ defmodule PortalWeb.Logs.Components do
   block are defined once.
   """
   use Phoenix.Component
+  use PortalWeb, :verified_routes
   alias PortalWeb.Clients
   alias PortalWeb.CoreComponents
 
@@ -367,6 +368,24 @@ defmodule PortalWeb.Logs.Components do
 
     ~H"""
     <CoreComponents.icon name={@icon_name} title={@user_agent || "Client"} class={@class} />
+    """
+  end
+
+  @doc """
+  Centered notice for the paginator bar linking to log sink settings.
+  """
+  attr :account, :any, required: true
+
+  def log_sinks_notice(assigns) do
+    ~H"""
+    <span class="hidden lg:inline-flex items-center gap-1.5 whitespace-nowrap">
+      <CoreComponents.icon name="ri-information-line" class="w-3.5 h-3.5 shrink-0" />
+      <span>
+        Log streaming to SIEMs and other destinations can be configured in
+        <.link navigate={~p"/#{@account}/settings/log_sinks"} class={CoreComponents.link_style()}>
+          log sinks</.link>.
+      </span>
+    </span>
     """
   end
 

--- a/elixir/lib/portal_web/live/logs/session_logs.ex
+++ b/elixir/lib/portal_web/live/logs/session_logs.ex
@@ -159,6 +159,9 @@ defmodule PortalWeb.Logs.SessionLogs do
               </div>
             </div>
           </:empty>
+          <:footer>
+            <.log_sinks_notice account={@account} />
+          </:footer>
         </.live_table>
       </div>
 

--- a/elixir/lib/portal_web/live_table.ex
+++ b/elixir/lib/portal_web/live_table.ex
@@ -49,6 +49,8 @@ defmodule PortalWeb.LiveTable do
     attr :type, :string, doc: "the type of notice: info, warning, danger"
   end
 
+  slot :footer, doc: "content rendered centered in the paginator bar"
+
   def live_table(assigns) do
     ~H"""
     <div class={["flex flex-col", @class]}>
@@ -120,7 +122,7 @@ defmodule PortalWeb.LiveTable do
           </div>
         </div>
       </div>
-      <.paginator id={@id} metadata={@metadata} rows_count={Enum.count(@rows)} />
+      <.paginator id={@id} metadata={@metadata} rows_count={Enum.count(@rows)} footer={@footer} />
     </div>
     """
   end
@@ -594,6 +596,9 @@ defmodule PortalWeb.LiveTable do
     last_row = min(assigns.metadata.offset + assigns.rows_count, assigns.metadata.count)
 
     assigns =
+      assign_new(assigns, :footer, fn -> [] end)
+
+    assigns =
       assign(assigns,
         first_row: first_row,
         last_row: last_row,
@@ -605,9 +610,9 @@ defmodule PortalWeb.LiveTable do
     ~H"""
     <div
       :if={@rows_count > 0}
-      class="shrink-0 flex items-center justify-between px-6 py-2.5 border-t border-border bg-raised text-xs text-subtle"
+      class="shrink-0 flex items-center justify-between gap-4 px-6 py-2.5 border-t border-border bg-raised text-xs text-subtle"
     >
-      <div class="flex items-center gap-4">
+      <div class="flex-1 flex items-center gap-4">
         <.form
           id={"#{@id}-pagination"}
           for={%{}}
@@ -667,7 +672,8 @@ defmodule PortalWeb.LiveTable do
           </button>
         </div>
       </div>
-      <span>
+      {render_slot(@footer)}
+      <span class="flex-1 text-right">
         Showing <span class="font-medium tabular-nums text-heading mx-1">{@first_row}</span>&mdash;<span class="font-medium tabular-nums text-heading mx-1">{@last_row}</span>
         of <span class="font-medium tabular-nums text-heading mx-1">{@metadata.count}</span>
       </span>


### PR DESCRIPTION
Moves the log sink hint text to the table footer.