### PR TITLE
fix(ci): avoid DNS port race in download-concurrent test

### DIFF
--- a/scripts/tests/download-concurrent.sh
+++ b/scripts/tests/download-concurrent.sh
@@ -5,6 +5,8 @@ source "./scripts/tests/lib.sh"
 domains=(download.httpbin alias.httpbin alias2.httpbin)
 sizes=(5000000 7000000 9000000)
 
+client sh -c "apk add --update --no-cache bind-tools" # The compat tests run using the production image which doesn't have `dig`.
+
 # Resolve all domains before restricting the port range: the range also applies to
 # the UDP sockets used for DNS lookups, so concurrent lookups would race for the
 # single available port and the loser fails with "Could not resolve host".

--- a/scripts/tests/download-concurrent.sh
+++ b/scripts/tests/download-concurrent.sh
@@ -5,11 +5,28 @@ source "./scripts/tests/lib.sh"
 domains=(download.httpbin alias.httpbin alias2.httpbin)
 sizes=(5000000 7000000 9000000)
 
+# Resolve all domains before restricting the port range: the range also applies to
+# the UDP sockets used for DNS lookups, so concurrent lookups would race for the
+# single available port and the loser fails with "Could not resolve host".
+# Only the TCP connections need to share a source port to exercise the Gateway's
+# NAT port remapping; `--resolve` below lets curl skip DNS entirely.
+ips=()
+for domain in "${domains[@]}"; do
+    ip="$(client dig +short "$domain" A | head -n 1)"
+
+    if [ -z "$ip" ]; then
+        echo "Failed to resolve $domain"
+        exit 1
+    fi
+
+    ips+=("$ip")
+done
+
 client sh -c 'echo "5555 5555" > /proc/sys/net/ipv4/ip_local_port_range'
 
 pids=()
 for i in "${!domains[@]}"; do
-    client sh -c "curl --fail --max-time 15 --output /tmp/download$i.file http://${domains[$i]}/bytes?num=${sizes[$i]}" &
+    client sh -c "curl --fail --max-time 15 --resolve ${domains[$i]}:80:${ips[$i]} --output /tmp/download$i.file http://${domains[$i]}/bytes?num=${sizes[$i]}" &
     pids+=($!)
 done
 


### PR DESCRIPTION
The download-concurrent test pins `ip_local_port_range` to a single port so all three concurrent TCP connections share a source port, exercising the Gateway NAT's source-port remapping. That sysctl also applies to the UDP sockets musl's resolver uses, so when two of the concurrently launched curls happen to resolve their domain at the same time, the loser fails instantly with "Could not resolve host" and the test fails before any download starts, e.g. in [this run](https://github.com/firezone/firezone/actions/runs/29650927490/job/88097760939).

Resolving the domains sequentially up front and handing curl the proxy IPs via `--resolve` keeps DNS out of the constrained phase while leaving the TCP behaviour under test unchanged. It also stops curl from attempting the unreachable IPv6 proxy addresses first, so happy-eyeballs ghost flows can no longer disturb the flow-log assertions.

Related: #13805