### PR TITLE
fix(ci): use stall detection in download tests

### DIFF
--- a/scripts/tests/download-packet-loss.sh
+++ b/scripts/tests/download-packet-loss.sh
@@ -5,7 +5,10 @@ source "./scripts/tests/lib.sh"
 client apk add --no-cache --update iproute2
 client tc qdisc add dev eth0 root netem loss 20%
 
-client sh -c "curl --fail --output download.file http://download.httpbin/bytes?num=10000000" &
+# Abort only if the transfer stalls, never on a fixed deadline: 20% loss makes
+# the download legitimately slow and bursty. The window is lenient (avg < 10
+# KiB/s for 30s) so deep TCP retransmit backoff isn't mistaken for a hang.
+client sh -c "curl --fail --speed-limit 10240 --speed-time 30 --output download.file http://download.httpbin/bytes?num=10000000" &
 
 DOWNLOAD_PID=$!
 

--- a/scripts/tests/download-packet-loss.sh
+++ b/scripts/tests/download-packet-loss.sh
@@ -5,10 +5,11 @@ source "./scripts/tests/lib.sh"
 client apk add --no-cache --update iproute2
 client tc qdisc add dev eth0 root netem loss 20%
 
-# Abort only if the transfer stalls, never on a fixed deadline: 20% loss makes
-# the download legitimately slow and bursty. The window is lenient (avg < 10
-# KiB/s for 30s) so deep TCP retransmit backoff isn't mistaken for a hang.
-client sh -c "curl --fail --speed-limit 10240 --speed-time 30 --output download.file http://download.httpbin/bytes?num=10000000" &
+# Bound the connect phase, then abort only if the transfer stalls, never on a
+# fixed deadline: 20% loss makes the download legitimately slow and bursty. The
+# window is lenient (speed stays below 10 KiB/s for 30s) so deep TCP retransmit
+# backoff isn't mistaken for a hang.
+client sh -c "curl --fail --connect-timeout 10 --speed-limit 10240 --speed-time 30 --output download.file http://download.httpbin/bytes?num=10000000" &
 
 DOWNLOAD_PID=$!
 

--- a/scripts/tests/download.sh
+++ b/scripts/tests/download.sh
@@ -2,7 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-client sh -c "curl --fail --max-time 5 --output download.file http://download.httpbin/bytes?num=10000000" &
+# Abort only if the transfer stalls (avg < 100 KiB/s for 10s), not on a fixed
+# deadline: a slow-but-progressing download on a busy runner is fine, a hung
+# tunnel is not.
+client sh -c "curl --fail --speed-limit 102400 --speed-time 10 --output download.file http://download.httpbin/bytes?num=10000000" &
 
 DOWNLOAD_PID=$!
 

--- a/scripts/tests/download.sh
+++ b/scripts/tests/download.sh
@@ -2,10 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-# Abort only if the transfer stalls (avg < 100 KiB/s for 10s), not on a fixed
-# deadline: a slow-but-progressing download on a busy runner is fine, a hung
-# tunnel is not.
-client sh -c "curl --fail --speed-limit 102400 --speed-time 10 --output download.file http://download.httpbin/bytes?num=10000000" &
+# Bound the connect phase, then abort only if the transfer stalls (speed stays
+# below 100 KiB/s for 10s) rather than on a fixed deadline: a slow-but-progressing
+# download on a busy runner is fine, a hung tunnel is not.
+client sh -c "curl --fail --connect-timeout 10 --speed-limit 102400 --speed-time 10 --output download.file http://download.httpbin/bytes?num=10000000" &
 
 DOWNLOAD_PID=$!
 


### PR DESCRIPTION
The download tests bounded the whole transfer with curl's `--max-time`, which doubles as an implicit throughput floor. On a busy CI runner a debug build behind double-symmetric-NAT can fall just short of that deadline while still transferring steadily, failing a test that is only meant to check correctness (checksum and flow-log byte counts), e.g. in [this run](https://github.com/firezone/firezone/actions/runs/29628748933/job/88038824699) which timed out having received 9.27 of 10 MB.

Bound the transfer by a sustained-throughput floor instead: curl aborts only when the download actually stalls, so a slow-but-progressing transfer completes while a hung tunnel still fails. `download-packet-loss` had no timeout at all and now fails on a real hang rather than blocking until the job timeout; its window is deliberately lenient so TCP retransmit backoff under 20% loss isn't mistaken for a stall.