### PR TITLE
fix(portal): surface log sink errors from any exception

### DIFF
--- a/elixir/lib/portal/directory_sync/error_handler.ex
+++ b/elixir/lib/portal/directory_sync/error_handler.ex
@@ -61,6 +61,10 @@ defmodule Portal.DirectorySync.ErrorHandler do
     end
   end
 
+  def format_transport_error(exception) when is_exception(exception) do
+    Exception.message(exception)
+  end
+
   # Sentry context building
 
   defp build_sentry_context(

--- a/elixir/test/portal/directory_sync/error_handler_test.exs
+++ b/elixir/test/portal/directory_sync/error_handler_test.exs
@@ -73,6 +73,20 @@ defmodule Portal.DirectorySync.ErrorHandlerTest do
 
       assert result == "Network error: :some_unknown_error"
     end
+
+    test "formats other exceptions with their message" do
+      error = %Portal.Req.SSRFProtection.UnsafeURLError{
+        host: "sts.us-east-1.amazonaws.com",
+        reason: :non_public_address
+      }
+
+      result = ErrorHandler.format_transport_error(error)
+
+      assert result ==
+               "request to \"sts.us-east-1.amazonaws.com\" was blocked because it resolves to a private or reserved IP address"
+
+      assert ErrorHandler.format_transport_error(%RuntimeError{message: "boom"}) == "boom"
+    end
   end
 
   describe "handle_error/1 shared behavior" do


### PR DESCRIPTION
The log sink error formatter only handled `Req.TransportError`. Any other exception, like the SSRF protection error in #14233, crashed the sync job with a `FunctionClauseError` before the error message was saved on the sink. The admin saw nothing in the UI and the real error was buried in traces.

The formatter now falls back to `Exception.message/1` for any other exception, so the actual error shows up on the sink and the normal disable-after-24-hours handling applies.

Related: #14233