### PR TITLE
fix(portal): ignore stale panel tab events

### DIFF
--- a/elixir/lib/portal_web/live/actors.ex
+++ b/elixir/lib/portal_web/live/actors.ex
@@ -549,13 +549,21 @@ defmodule PortalWeb.Actors do
     end
   end
 
-  def handle_event("change_tab", %{"tab" => tab}, socket) do
+  def handle_event(
+        "change_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_actor: %Actor{} = actor}} = socket
+      ) do
     params = Map.put(socket.assigns.query_params, "tab", tab)
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.selected_actor.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/actors/#{actor}?#{params}"
      )}
+  end
+
+  def handle_event("change_tab", _params, %{assigns: %{selected_actor: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("validate_token", params, socket) do

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -309,7 +309,11 @@ defmodule PortalWeb.Clients do
     {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/clients?#{params}")}
   end
 
-  def handle_event("switch_client_tab", %{"tab" => tab}, socket) do
+  def handle_event(
+        "switch_client_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_client: %Device{} = client}} = socket
+      ) do
     params =
       socket.assigns.query_params
       |> Map.put("tab", tab)
@@ -317,8 +321,12 @@ defmodule PortalWeb.Clients do
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/clients/#{socket.assigns.selected_client.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/clients/#{client}?#{params}"
      )}
+  end
+
+  def handle_event("switch_client_tab", _params, %{assigns: %{selected_client: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("change_policy_authorizations_page", %{"page" => page}, socket) do

--- a/elixir/lib/portal_web/live/groups.ex
+++ b/elixir/lib/portal_web/live/groups.ex
@@ -279,13 +279,21 @@ defmodule PortalWeb.Groups do
     {:noreply, socket}
   end
 
-  def handle_event("switch_group_tab", %{"tab" => tab}, socket) do
+  def handle_event(
+        "switch_group_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_group: %Group{} = group}} = socket
+      ) do
     params = Map.put(socket.assigns.query_params, "tab", tab)
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/groups/#{socket.assigns.selected_group.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/groups/#{group}?#{params}"
      )}
+  end
+
+  def handle_event("switch_group_tab", _params, %{assigns: %{selected_group: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("open_grant_resource_form", _params, socket) do

--- a/elixir/lib/portal_web/live/policies.ex
+++ b/elixir/lib/portal_web/live/policies.ex
@@ -475,7 +475,11 @@ defmodule PortalWeb.Policies do
     {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/policies?#{params}")}
   end
 
-  def handle_event("switch_policy_tab", %{"tab" => tab}, socket) do
+  def handle_event(
+        "switch_policy_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_policy: %Policy{} = policy}} = socket
+      ) do
     params =
       socket.assigns.query_params
       |> Map.put("tab", tab)
@@ -483,8 +487,12 @@ defmodule PortalWeb.Policies do
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/policies/#{socket.assigns.selected_policy.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/policies/#{policy}?#{params}"
      )}
+  end
+
+  def handle_event("switch_policy_tab", _params, %{assigns: %{selected_policy: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("change_policy_authorizations_page", %{"page" => page}, socket) do

--- a/elixir/lib/portal_web/live/resources.ex
+++ b/elixir/lib/portal_web/live/resources.ex
@@ -656,7 +656,11 @@ defmodule PortalWeb.Resources do
     {:noreply, push_patch(socket, to: cancel_resource_form_path(socket))}
   end
 
-  def handle_event("switch_resource_tab", %{"tab" => tab}, socket) do
+  def handle_event(
+        "switch_resource_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_resource: %Resource{} = resource}} = socket
+      ) do
     params =
       socket.assigns.query_params
       |> Map.put("tab", tab)
@@ -664,8 +668,16 @@ defmodule PortalWeb.Resources do
 
     {:noreply,
      push_patch(socket,
-       to: ~p"/#{socket.assigns.account}/resources/#{socket.assigns.selected_resource.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/resources/#{resource}?#{params}"
      )}
+  end
+
+  def handle_event(
+        "switch_resource_tab",
+        _params,
+        %{assigns: %{selected_resource: nil}} = socket
+      ) do
+    {:noreply, socket}
   end
 
   def handle_event("change_policy_authorizations_page", %{"page" => page}, socket) do

--- a/elixir/lib/portal_web/live/service_accounts.ex
+++ b/elixir/lib/portal_web/live/service_accounts.ex
@@ -477,14 +477,21 @@ defmodule PortalWeb.ServiceAccounts do
     end
   end
 
-  def handle_event("change_tab", %{"tab" => tab}, socket) do
+  def handle_event(
+        "change_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_actor: %Actor{} = actor}} = socket
+      ) do
     params = Map.put(socket.assigns.query_params, "tab", tab)
 
     {:noreply,
      push_patch(socket,
-       to:
-         ~p"/#{socket.assigns.account}/service_accounts/#{socket.assigns.selected_actor.id}?#{params}"
+       to: ~p"/#{socket.assigns.account}/service_accounts/#{actor}?#{params}"
      )}
+  end
+
+  def handle_event("change_tab", _params, %{assigns: %{selected_actor: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("validate_token", params, socket) do

--- a/elixir/lib/portal_web/live/sites.ex
+++ b/elixir/lib/portal_web/live/sites.ex
@@ -553,11 +553,18 @@ defmodule PortalWeb.Sites do
     {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites?#{params}")}
   end
 
-  def handle_event("switch_panel_tab", %{"tab" => tab}, socket) do
-    site = socket.assigns.selected_site
+  def handle_event(
+        "switch_panel_tab",
+        %{"tab" => tab},
+        %{assigns: %{selected_site: %Portal.Site{} = site}} = socket
+      ) do
     params = Map.put(socket.assigns.query_params, "tab", tab)
 
-    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites/#{site.id}?#{params}")}
+    {:noreply, push_patch(socket, to: ~p"/#{socket.assigns.account}/sites/#{site}?#{params}")}
+  end
+
+  def handle_event("switch_panel_tab", _params, %{assigns: %{selected_site: nil}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_event("handle_keydown", _params, socket)

--- a/elixir/test/portal_web/live/actors_test.exs
+++ b/elixir/test/portal_web/live/actors_test.exs
@@ -344,6 +344,26 @@ defmodule PortalWeb.ActorsTest do
       assert html =~ other_actor.name
     end
 
+    test "ignores a tab change queued while the actor panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      other_actor = actor_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/actors/#{other_actor}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/actors")
+
+      render_click(lv, "change_tab", %{"tab" => "groups"})
+
+      refute has_element?(lv, "#actor-panel > div")
+    end
+
     test "shows identities tab content", %{conn: conn, account: account, actor: actor} do
       other_actor = actor_fixture(account: account)
 

--- a/elixir/test/portal_web/live/clients_test.exs
+++ b/elixir/test/portal_web/live/clients_test.exs
@@ -200,6 +200,26 @@ defmodule PortalWeb.ClientsTest do
       assert_patch(lv, ~p"/#{account}/clients")
     end
 
+    test "ignores a tab switch queued while the client panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      client = client_fixture(account: account, actor: actor)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/clients/#{client.id}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/clients")
+
+      render_click(lv, "switch_client_tab", %{"tab" => "authorizations"})
+
+      refute has_element?(lv, "#client-panel > div")
+    end
+
     test "marks only older client versions as outdated" do
       older_html =
         render_component(&PortalWeb.Clients.Components.version/1,

--- a/elixir/test/portal_web/live/groups_test.exs
+++ b/elixir/test/portal_web/live/groups_test.exs
@@ -150,6 +150,26 @@ defmodule PortalWeb.GroupsTest do
       assert html =~ group.name
     end
 
+    test "ignores a tab switch queued while the group panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/groups/#{group}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/groups")
+
+      render_click(lv, "switch_group_tab", %{"tab" => "resources"})
+
+      refute has_element?(lv, "#group-panel > div")
+    end
+
     test "shows group member list", %{conn: conn, account: account, actor: actor} do
       group = group_fixture(account: account)
       other_actor = actor_fixture(account: account)

--- a/elixir/test/portal_web/live/policies_test.exs
+++ b/elixir/test/portal_web/live/policies_test.exs
@@ -382,6 +382,28 @@ defmodule PortalWeb.PoliciesTest do
       assert_patch(lv, ~p"/#{account}/policies")
     end
 
+    test "ignores a tab switch queued while the policy panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      group = group_fixture(account: account)
+      resource = resource_fixture(account: account)
+      policy = policy_fixture(group: group, resource: resource)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/policies/#{policy.id}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/policies")
+
+      render_click(lv, "switch_policy_tab", %{"tab" => "authorizations"})
+
+      refute has_element?(lv, "#policy-panel > div")
+    end
+
     test "patches to policies index with flash when policy does not exist", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/resources_test.exs
+++ b/elixir/test/portal_web/live/resources_test.exs
@@ -815,6 +815,26 @@ defmodule PortalWeb.ResourcesTest do
       assert_patch(lv, ~p"/#{account}/resources")
     end
 
+    test "ignores a tab switch queued while the resource panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      resource = resource_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/resources/#{resource.id}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/resources")
+
+      render_click(lv, "switch_resource_tab", %{"tab" => "authorizations"})
+
+      refute has_element?(lv, "#resource-panel > div")
+    end
+
     test "patches to resources index with flash when resource does not exist", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/service_accounts_test.exs
+++ b/elixir/test/portal_web/live/service_accounts_test.exs
@@ -328,6 +328,26 @@ defmodule PortalWeb.ServiceAccountsTest do
       assert html =~ service_account.name
     end
 
+    test "ignores a tab change queued while the service account panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      service_account = service_account_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/service_accounts/#{service_account}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/service_accounts")
+
+      render_click(lv, "change_tab", %{"tab" => "groups"})
+
+      refute has_element?(lv, "#actor-panel > div")
+    end
+
     test "redirects to service accounts list when ID not found", %{
       conn: conn,
       account: account,

--- a/elixir/test/portal_web/live/sites_test.exs
+++ b/elixir/test/portal_web/live/sites_test.exs
@@ -158,6 +158,26 @@ defmodule PortalWeb.SitesTest do
       assert_patch(lv, ~p"/#{account}/sites")
     end
 
+    test "ignores a tab switch queued while the site panel is closing", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      site = site_fixture(account: account)
+
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/sites/#{site.id}")
+
+      render_click(lv, "close_panel")
+      assert_patch(lv, ~p"/#{account}/sites")
+
+      render_click(lv, "switch_panel_tab", %{"tab" => "resources"})
+
+      refute has_element?(lv, "#site-panel > div")
+    end
+
     test "switches to resources tab, opens add resource panel, and closes it", %{
       conn: conn,
       account: account,


### PR DESCRIPTION
Ignores stale tab events after entity panels close.

Fixes #14242