### PR TITLE
fix(portal): reject stale Entra verification callbacks

### DIFF
--- a/elixir/lib/portal_web/controllers/verification_controller.ex
+++ b/elixir/lib/portal_web/controllers/verification_controller.ex
@@ -59,11 +59,18 @@ defmodule PortalWeb.VerificationController do
   """
   def entra(conn, %{"state" => state} = params) do
     case PortalWeb.OIDC.verify_verification_state(state) do
-      {:ok, %{type: "entra-auth-provider", lv_pid: lv_pid_string}} ->
-        handle_entra_auth_provider(conn, params, lv_pid_string)
+      {:ok,
+       %{type: "entra-auth-provider", lv_pid: lv_pid_string, verification_ref: verification_ref}}
+      when is_binary(verification_ref) ->
+        handle_entra_auth_provider(conn, params, lv_pid_string, verification_ref)
 
-      {:ok, %{type: "entra-directory-sync", lv_pid: lv_pid_string}} ->
-        handle_entra_directory_sync(conn, params, lv_pid_string)
+      {:ok,
+       %{type: "entra-directory-sync", lv_pid: lv_pid_string, verification_ref: verification_ref}}
+      when is_binary(verification_ref) ->
+        handle_entra_directory_sync(conn, params, lv_pid_string, verification_ref)
+
+      {:ok, _state} ->
+        render(conn, :failure, error: "Invalid or expired verification state. Please try again.")
 
       {:error, _} ->
         render(conn, :failure, error: "Invalid or expired verification state. Please try again.")
@@ -74,36 +81,44 @@ defmodule PortalWeb.VerificationController do
     render(conn, :failure, error: "Invalid verification request. Please try again.")
   end
 
-  defp handle_entra_auth_provider(conn, params, lv_pid_string) do
+  defp handle_entra_auth_provider(conn, params, lv_pid_string, verification_ref) do
     lv_pid = PortalWeb.OIDC.deserialize_pid(lv_pid_string)
 
-    case run_entra_auth_provider_verification(params, lv_pid) do
+    case run_entra_auth_provider_verification(params, lv_pid, verification_ref) do
       :ok ->
         render(conn, :success)
 
       {:error, error_message, notify_lv?} ->
-        if notify_lv? and lv_pid, do: send(lv_pid, {:verification_failed, error_message})
+        if notify_lv? and lv_pid,
+          do: send(lv_pid, {:verification_failed, error_message, verification_ref})
+
         render(conn, :failure, error: error_message)
     end
   end
 
-  defp handle_entra_directory_sync(conn, params, lv_pid_string) do
+  defp handle_entra_directory_sync(conn, params, lv_pid_string, verification_ref) do
     lv_pid = PortalWeb.OIDC.deserialize_pid(lv_pid_string)
 
-    case run_entra_directory_sync_verification(params, lv_pid) do
+    case run_entra_directory_sync_verification(params, lv_pid, verification_ref) do
       :ok ->
         render(conn, :success)
 
       {:error, error_message, notify_lv?} ->
-        if notify_lv? and lv_pid, do: send(lv_pid, {:verification_failed, error_message})
+        if notify_lv? and lv_pid,
+          do: send(lv_pid, {:verification_failed, error_message, verification_ref})
+
         render(conn, :failure, error: error_message)
     end
   end
 
-  defp run_entra_auth_provider_verification(params, lv_pid) do
+  defp run_entra_auth_provider_verification(params, lv_pid, verification_ref) do
     with {:ok, tenant_id} <- extract_tenant_id_for_verification(params),
          issuer = "https://login.microsoftonline.com/#{tenant_id}/v2.0",
-         :ok <- notify_and_await_ack(lv_pid, {:entra_verify_complete, issuer, tenant_id}) do
+         :ok <-
+           notify_and_await_ack(
+             lv_pid,
+             {:entra_verify_complete, issuer, tenant_id, verification_ref}
+           ) do
       :ok
     else
       {:error, reason} when reason in [:ack_timeout, :no_receiver] ->
@@ -114,10 +129,14 @@ defmodule PortalWeb.VerificationController do
     end
   end
 
-  defp run_entra_directory_sync_verification(params, lv_pid) do
+  defp run_entra_directory_sync_verification(params, lv_pid, verification_ref) do
     with {:ok, tenant_id} <- extract_tenant_id_for_verification(params),
          {:ok, :verified} <- verify_directory_access_for_verification(tenant_id),
-         :ok <- notify_and_await_ack(lv_pid, {:entra_directory_sync_complete, tenant_id}) do
+         :ok <-
+           notify_and_await_ack(
+             lv_pid,
+             {:entra_directory_sync_complete, tenant_id, verification_ref}
+           ) do
       :ok
     else
       {:error, reason} when reason in [:ack_timeout, :no_receiver] ->

--- a/elixir/lib/portal_web/live/settings/authentication.ex
+++ b/elixir/lib/portal_web/live/settings/authentication.ex
@@ -174,24 +174,29 @@ defmodule PortalWeb.Settings.Authentication do
 
     with {:ok, %{config: config}} <- PortalWeb.OIDC.setup_verification(type, opts),
          verifier = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false),
+         verification_ref = Ecto.UUID.generate(),
          lv_pid_string = self() |> :erlang.pid_to_list() |> to_string(),
          state_token <-
            PortalWeb.OIDC.sign_verification_state(
              lv_pid_string,
-             PortalWeb.OIDC.verification_state_type(type)
+             PortalWeb.OIDC.verification_state_type(type),
+             %{verification_ref: verification_ref}
            ),
          {:ok, uri} <- PortalWeb.OIDC.build_verification_uri(type, config, verifier, state_token) do
+      verification = %{
+        config: config,
+        verification_ref: verification_ref,
+        verifier: verifier,
+        require_email_verified:
+          type == "oidc" and get_field(changeset, :email_verification_method) == :claim
+      }
+
       socket =
-        assign(socket,
-          active_verification: nil,
-          pending_verification: %{
-            config: config,
-            verification_ref: Ecto.UUID.generate(),
-            verifier: verifier,
-            require_email_verified:
-              type == "oidc" and get_field(changeset, :email_verification_method) == :claim
-          }
-        )
+        if type == "entra" do
+          assign(socket, active_verification: verification, pending_verification: nil)
+        else
+          assign(socket, active_verification: nil, pending_verification: verification)
+        end
 
       {:noreply, push_event(socket, "open_url", %{url: uri})}
     else
@@ -215,7 +220,10 @@ defmodule PortalWeb.Settings.Authentication do
         socket
       )
 
-    {:noreply, assign(socket, verification_error: nil, form: to_form(changeset))}
+    {:noreply,
+     socket
+     |> clear_verification_state()
+     |> assign(verification_error: nil, form: to_form(changeset))}
   end
 
   def handle_event("submit_provider", _params, socket) do
@@ -409,23 +417,41 @@ defmodule PortalWeb.Settings.Authentication do
   end
 
   # Sent directly by the Entra auth_provider verification controller
-  def handle_info({:entra_verify_complete, issuer, _tenant_id, ack_to}, socket) do
-    attrs = %{"is_verified" => true, "issuer" => issuer}
+  def handle_info({:entra_verify_complete, issuer, _tenant_id, verification_ref, ack_to}, socket) do
+    if active_verification?(socket, verification_ref) do
+      attrs = %{"is_verified" => true, "issuer" => issuer}
 
-    changeset =
-      socket.assigns.form.source
-      |> apply_changes()
-      |> changeset(attrs, socket)
+      changeset =
+        socket.assigns.form.source
+        |> apply_changes()
+        |> changeset(attrs, socket)
 
-    maybe_send_verification_ack(ack_to)
-    {:noreply, assign(socket, form: to_form(changeset))}
+      maybe_send_verification_ack(ack_to)
+      {:noreply, assign(socket, active_verification: nil, form: to_form(changeset))}
+    else
+      maybe_send_verification_ack(ack_to)
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info({:entra_verify_complete, issuer, tenant_id, ack_to}, socket) do
+    handle_info({:entra_verify_complete, issuer, tenant_id, nil, ack_to}, socket)
   end
 
   def handle_info({:entra_verify_complete, issuer, _tenant_id}, socket) do
-    handle_info({:entra_verify_complete, issuer, nil, nil}, socket)
+    handle_info({:entra_verify_complete, issuer, nil, nil, nil}, socket)
   end
 
   # Sent directly by the verification controller on any failure
+  def handle_info({:verification_failed, reason, verification_ref}, socket) do
+    if active_verification?(socket, verification_ref) do
+      error = "Verification failed: #{format_verification_error_reason(reason)}"
+      {:noreply, assign(socket, active_verification: nil, verification_error: error)}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_info({:verification_failed, reason}, socket) do
     error = "Verification failed: #{format_verification_error_reason(reason)}"
     {:noreply, assign(socket, verification_error: error)}

--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -80,7 +80,9 @@ defmodule PortalWeb.Settings.DirectorySync do
     changeset = changeset(struct, attrs)
 
     {:noreply,
-     assign(socket,
+     socket
+     |> clear_verification_state()
+     |> assign(
        type: type,
        verification_error: nil,
        verifying: false,
@@ -114,7 +116,9 @@ defmodule PortalWeb.Settings.DirectorySync do
       type == "google" && directory.legacy_service_account_key != nil
 
     {:noreply,
-     assign(socket,
+     socket
+     |> clear_verification_state()
+     |> assign(
        directory: directory,
        directory_name: directory.name,
        verifying: false,
@@ -131,7 +135,7 @@ defmodule PortalWeb.Settings.DirectorySync do
   end
 
   def handle_params(_params, _url, socket) do
-    {:noreply, socket}
+    {:noreply, clear_verification_state(socket)}
   end
 
   def handle_event("close_panel", _params, socket) do
@@ -222,7 +226,10 @@ defmodule PortalWeb.Settings.DirectorySync do
 
     changeset = changeset(base, attrs)
 
-    {:noreply, assign(socket, verification_error: nil, form: to_form(changeset))}
+    {:noreply,
+     socket
+     |> clear_verification_state()
+     |> assign(verification_error: nil, form: to_form(changeset))}
   end
 
   def handle_event("submit_directory", _params, socket) do
@@ -342,27 +349,53 @@ defmodule PortalWeb.Settings.DirectorySync do
   end
 
   # Sent directly by the Entra directory_sync verification controller
+  def handle_info({:entra_directory_sync_complete, tenant_id, verification_ref, ack_to}, socket) do
+    if active_verification?(socket, verification_ref) do
+      # For EDIT: Use .data (original directory) so changes are tracked relative to DB values.
+      # For NEW: Entra has no programmatically set fields, so .data works here too.
+      changeset = socket.assigns.form.source
+
+      attrs =
+        changeset.changes
+        |> Map.put(:is_verified, true)
+        |> Map.put(:tenant_id, tenant_id)
+
+      changeset = changeset(changeset.data, attrs)
+      maybe_send_verification_ack(ack_to)
+
+      {:noreply,
+       assign(socket,
+         active_verification: nil,
+         form: to_form(changeset),
+         verification_error: nil
+       )}
+    else
+      maybe_send_verification_ack(ack_to)
+      {:noreply, socket}
+    end
+  end
+
   def handle_info({:entra_directory_sync_complete, tenant_id, ack_to}, socket) do
-    # For EDIT: Use .data (original directory) so changes are tracked relative to DB values.
-    # For NEW: Entra has no programmatically set fields, so .data works here too.
-    changeset = socket.assigns.form.source
-
-    attrs =
-      changeset.changes
-      |> Map.put(:is_verified, true)
-      |> Map.put(:tenant_id, tenant_id)
-
-    changeset = changeset(changeset.data, attrs)
-    maybe_send_verification_ack(ack_to)
-
-    {:noreply, assign(socket, form: to_form(changeset), verification_error: nil)}
+    handle_info({:entra_directory_sync_complete, tenant_id, nil, ack_to}, socket)
   end
 
   def handle_info({:entra_directory_sync_complete, tenant_id}, socket) do
-    handle_info({:entra_directory_sync_complete, tenant_id, nil}, socket)
+    handle_info({:entra_directory_sync_complete, tenant_id, nil, nil}, socket)
   end
 
   # Sent directly by the verification controller on any failure
+  def handle_info({:verification_failed, reason, verification_ref}, socket) do
+    if active_verification?(socket, verification_ref) do
+      {:noreply,
+       assign(socket,
+         active_verification: nil,
+         verification_error: format_verification_error_reason(reason)
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_info({:verification_failed, reason}, socket) do
     {:noreply, assign(socket, verification_error: format_verification_error_reason(reason))}
   end
@@ -379,6 +412,20 @@ defmodule PortalWeb.Settings.DirectorySync do
   end
 
   defp maybe_send_verification_ack(_), do: :ok
+
+  defp active_verification?(socket, verification_ref) do
+    case socket.assigns[:active_verification] do
+      %{verification_ref: ^verification_ref} when is_binary(verification_ref) ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp clear_verification_state(socket) do
+    assign(socket, active_verification: nil)
+  end
 
   defp format_verification_error_reason(reason) when is_binary(reason), do: reason
   defp format_verification_error_reason(reason), do: inspect(reason)
@@ -1637,11 +1684,13 @@ defmodule PortalWeb.Settings.DirectorySync do
 
   defp start_verification(%{assigns: %{type: "entra"}} = socket) do
     with {:ok, %{config: config}} <- PortalWeb.OIDC.setup_verification("entra_directory_sync", []),
+         verification_ref = Ecto.UUID.generate(),
          lv_pid_string = self() |> :erlang.pid_to_list() |> to_string(),
          state_token <-
            PortalWeb.OIDC.sign_verification_state(
              lv_pid_string,
-             PortalWeb.OIDC.verification_state_type("entra_directory_sync")
+             PortalWeb.OIDC.verification_state_type("entra_directory_sync"),
+             %{verification_ref: verification_ref}
            ),
          {:ok, uri} <-
            PortalWeb.OIDC.build_verification_uri(
@@ -1650,6 +1699,7 @@ defmodule PortalWeb.Settings.DirectorySync do
              "",
              state_token
            ) do
+      socket = assign(socket, active_verification: %{verification_ref: verification_ref})
       {:noreply, push_event(socket, "open_url", %{url: uri})}
     else
       {:error, reason} ->

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -239,14 +239,15 @@ defmodule PortalWeb.OIDC do
   end
 
   @doc """
-  Signs a short-lived token encoding the LV pid and verification type for use as
-  the OAuth state parameter. Verified by the callback with a 5-minute TTL.
+  Signs a short-lived token encoding the LV pid, verification type, and optional
+  flow-specific attributes for use as the OAuth state parameter. Verified by the
+  callback with a 5-minute TTL.
   """
-  def sign_verification_state(lv_pid_string, type_string) do
+  def sign_verification_state(lv_pid_string, type_string, attrs \\ %{}) do
     Phoenix.Token.sign(
       PortalWeb.Endpoint,
       "oidc-verification-state",
-      %{type: type_string, lv_pid: lv_pid_string}
+      Map.merge(%{type: type_string, lv_pid: lv_pid_string}, attrs)
     )
   end
 

--- a/elixir/test/portal_web/controllers/verification_controller_test.exs
+++ b/elixir/test/portal_web/controllers/verification_controller_test.exs
@@ -8,6 +8,17 @@ defmodule PortalWeb.VerificationControllerTest do
     :ok
   end
 
+  defp sign_entra_state(lv_pid_string, type) do
+    verification_ref = Ecto.UUID.generate()
+
+    state =
+      PortalWeb.OIDC.sign_verification_state(lv_pid_string, type, %{
+        verification_ref: verification_ref
+      })
+
+    {state, verification_ref}
+  end
+
   describe "oidc/2" do
     test "with valid success result token, sends message to LV and renders success", %{
       conn: conn
@@ -113,14 +124,18 @@ defmodule PortalWeb.VerificationControllerTest do
       lv_pid =
         spawn(fn ->
           receive do
-            {:entra_verify_complete, issuer, tenant_id, {from, ref}} ->
-              send(parent, {:entra_verify_complete_received, issuer, tenant_id})
+            {:entra_verify_complete, issuer, tenant_id, verification_ref, {from, ref}} ->
+              send(
+                parent,
+                {:entra_verify_complete_received, issuer, tenant_id, verification_ref}
+              )
+
               send(from, {:verification_ack, ref})
           end
         end)
 
       lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
 
       params = %{
         "state" => state,
@@ -134,7 +149,8 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.resp_body =~ "Verification Successful"
 
       assert_received {:entra_verify_complete_received,
-                       "https://login.microsoftonline.com/my-tenant-id/v2.0", "my-tenant-id"}
+                       "https://login.microsoftonline.com/my-tenant-id/v2.0", "my-tenant-id",
+                       ^verification_ref}
     end
 
     test "with invalid state, renders failure", %{conn: conn} do
@@ -151,9 +167,27 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.resp_body =~ "Invalid or expired"
     end
 
-    test "with consent denied (error params), sends failure and renders failure", %{conn: conn} do
+    test "with signed state missing verification_ref, renders failure", %{conn: conn} do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
       state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
+
+      params = %{
+        "state" => state,
+        "admin_consent" => "True",
+        "tenant" => "my-tenant-id"
+      }
+
+      conn = get(conn, ~p"/verification/entra", params)
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Verification Failed"
+      assert conn.resp_body =~ "Invalid or expired"
+      refute_received {:entra_verify_complete, _issuer, _tenant_id, _verification_ref, _ack_to}
+    end
+
+    test "with consent denied (error params), sends failure and renders failure", %{conn: conn} do
+      lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
 
       params = %{
         "state" => state,
@@ -168,14 +202,14 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "The user denied consent"
       refute conn.resp_body =~ "window.close()"
-      assert_received {:verification_failed, "The user denied consent"}
+      assert_received {:verification_failed, "The user denied consent", ^verification_ref}
     end
 
     test "with admin_consent=False and no error params, sends failure and renders failure", %{
       conn: conn
     } do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
 
       params = %{"state" => state, "admin_consent" => "False"}
 
@@ -184,12 +218,12 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Admin consent was not granted"
-      assert_received {:verification_failed, "Admin consent was not granted"}
+      assert_received {:verification_failed, "Admin consent was not granted", ^verification_ref}
     end
 
     test "with missing admin_consent param, sends failure and renders failure", %{conn: conn} do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
 
       params = %{"state" => state, "tenant" => "some-tenant"}
 
@@ -198,7 +232,7 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Missing tenant information"
-      assert_received {:verification_failed, "Missing tenant information"}
+      assert_received {:verification_failed, "Missing tenant information", ^verification_ref}
     end
 
     # Microsoft always sends error_description alongside error in practice, but it is
@@ -207,7 +241,7 @@ defmodule PortalWeb.VerificationControllerTest do
       conn: conn
     } do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-auth-provider")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-auth-provider")
 
       params = %{
         "state" => state,
@@ -220,7 +254,7 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "access_denied"
-      assert_received {:verification_failed, "access_denied"}
+      assert_received {:verification_failed, "access_denied", ^verification_ref}
     end
   end
 
@@ -241,7 +275,7 @@ defmodule PortalWeb.VerificationControllerTest do
 
     test "with consent denied (error params), sends failure and renders failure", %{conn: conn} do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-directory-sync")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
 
       params = %{
         "state" => state,
@@ -254,7 +288,7 @@ defmodule PortalWeb.VerificationControllerTest do
 
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
-      assert_received {:verification_failed, "The user denied consent"}
+      assert_received {:verification_failed, "The user denied consent", ^verification_ref}
     end
 
     test "with successful Entra API verification, sends message and renders success", %{
@@ -265,14 +299,18 @@ defmodule PortalWeb.VerificationControllerTest do
       lv_pid =
         spawn(fn ->
           receive do
-            {:entra_directory_sync_complete, tenant_id, {from, ref}} ->
-              send(parent, {:entra_directory_sync_complete_received, tenant_id})
+            {:entra_directory_sync_complete, tenant_id, verification_ref, {from, ref}} ->
+              send(
+                parent,
+                {:entra_directory_sync_complete_received, tenant_id, verification_ref}
+              )
+
               send(from, {:verification_ack, ref})
           end
         end)
 
       lv_pid_string = lv_pid |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-directory-sync")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
 
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         cond do
@@ -306,14 +344,15 @@ defmodule PortalWeb.VerificationControllerTest do
 
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Successful"
-      assert_received {:entra_directory_sync_complete_received, "my-tenant-id"}
+      assert_received {:entra_directory_sync_complete_received, "my-tenant-id",
+                       ^verification_ref}
     end
 
     test "with Entra API 401 error (nested message body), sends failure and renders failure", %{
       conn: conn
     } do
       # Sign an invalid pid string to cover the deserialize_pid rescue branch
-      state = PortalWeb.OIDC.sign_verification_state("not-a-valid-pid", "entra-directory-sync")
+      {state, _verification_ref} = sign_entra_state("not-a-valid-pid", "entra-directory-sync")
 
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
@@ -342,7 +381,7 @@ defmodule PortalWeb.VerificationControllerTest do
       conn: conn
     } do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-directory-sync")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
 
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
@@ -362,7 +401,7 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Access denied"
       assert conn.resp_body =~ "Access to resource forbidden"
-      assert_received {:verification_failed, message}
+      assert_received {:verification_failed, message, ^verification_ref}
       assert message =~ "Access denied"
     end
 
@@ -370,7 +409,7 @@ defmodule PortalWeb.VerificationControllerTest do
       conn: conn
     } do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-directory-sync")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
 
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         req_conn
@@ -389,13 +428,13 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Verification failed (HTTP 404)"
-      assert_received {:verification_failed, message}
+      assert_received {:verification_failed, message, ^verification_ref}
       assert message =~ "Verification failed (HTTP 404)"
     end
 
     test "with Entra API transport error, sends failure and renders failure", %{conn: conn} do
       lv_pid_string = self() |> :erlang.pid_to_list() |> to_string()
-      state = PortalWeb.OIDC.sign_verification_state(lv_pid_string, "entra-directory-sync")
+      {state, verification_ref} = sign_entra_state(lv_pid_string, "entra-directory-sync")
 
       Req.Test.stub(Portal.Entra.APIClient, fn req_conn ->
         Req.Test.transport_error(req_conn, :econnrefused)
@@ -412,7 +451,7 @@ defmodule PortalWeb.VerificationControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "Verification Failed"
       assert conn.resp_body =~ "Failed to verify directory access"
-      assert_received {:verification_failed, message}
+      assert_received {:verification_failed, message, ^verification_ref}
       assert message =~ "Failed to verify directory access"
     end
   end

--- a/elixir/test/portal_web/live/settings/authentication_test.exs
+++ b/elixir/test/portal_web/live/settings/authentication_test.exs
@@ -65,6 +65,21 @@ defmodule PortalWeb.Settings.AuthenticationTest do
     |> String.trim()
   end
 
+  defp verification_ref_from_open_url(lv) do
+    assert_push_event(lv, "open_url", %{url: url})
+
+    %{"state" => state} =
+      url
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+
+    assert {:ok, %{verification_ref: verification_ref}} =
+             PortalWeb.OIDC.verify_verification_state(state)
+
+    verification_ref
+  end
+
   # =============================================================================
   # Basic Page Rendering Tests
   # =============================================================================
@@ -2671,6 +2686,83 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       assert html =~ "Verified"
     end
 
+    test "accepts only the active entra verification completion", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication/entra/new")
+
+      lv
+      |> form("#auth-provider-form", %{auth_provider: %{name: "Test Entra"}})
+      |> render_change()
+
+      lv |> element("#verify-button") |> render_click()
+      stale_ref = verification_ref_from_open_url(lv)
+
+      lv |> element("#verify-button") |> render_click()
+      current_ref = verification_ref_from_open_url(lv)
+
+      stale_ack_ref = make_ref()
+
+      send(
+        lv.pid,
+        {:entra_verify_complete, "https://login.microsoftonline.com/stale/v2.0", "stale",
+         stale_ref, {self(), stale_ack_ref}}
+      )
+
+      assert_receive {:verification_ack, ^stale_ack_ref}
+      refute render(lv) =~ "Verified"
+
+      current_ack_ref = make_ref()
+
+      send(
+        lv.pid,
+        {:entra_verify_complete, "https://login.microsoftonline.com/current/v2.0", "current",
+         current_ref, {self(), current_ack_ref}}
+      )
+
+      assert_receive {:verification_ack, ^current_ack_ref}
+      assert render(lv) =~ "Verified"
+    end
+
+    test "ignores entra completion after navigating to another provider form", %{
+      account: account,
+      actor: actor,
+      conn: conn
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/authentication/entra/new")
+
+      lv
+      |> form("#auth-provider-form", %{auth_provider: %{name: "Test Entra"}})
+      |> render_change()
+
+      lv |> element("#verify-button") |> render_click()
+      verification_ref = verification_ref_from_open_url(lv)
+
+      render_patch(lv, ~p"/#{account}/settings/authentication/google/new")
+
+      ack_ref = make_ref()
+
+      send(
+        lv.pid,
+        {:entra_verify_complete, "https://login.microsoftonline.com/stale/v2.0", "stale",
+         verification_ref, {self(), ack_ref}}
+      )
+
+      assert_receive {:verification_ack, ^ack_ref}
+
+      html = render(lv)
+      assert html =~ "Add Google Provider"
+      refute html =~ "Verified"
+    end
+
     test "handles entra provider verification setup via bypass", %{
       account: account,
       actor: actor,
@@ -3174,10 +3266,11 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       # Start verification
       lv |> element("#verify-button") |> render_click()
+      verification_ref = verification_ref_from_open_url(lv)
 
       lv_pid = lv.pid
 
-      send(lv_pid, {:verification_failed, "Admin consent error"})
+      send(lv_pid, {:verification_failed, "Admin consent error", verification_ref})
       html = render(lv)
       assert html =~ "Verification failed"
     end
@@ -3616,6 +3709,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
 
       # Start verification
       lv |> element("#verify-button") |> render_click()
+      verification_ref = verification_ref_from_open_url(lv)
 
       # Wait for the verification to be set up
       html = render(lv)
@@ -3626,7 +3720,7 @@ defmodule PortalWeb.Settings.AuthenticationTest do
       send(
         lv_pid,
         {:entra_verify_complete, "https://login.microsoftonline.com/test_tenant/v2.0",
-         "test_tenant"}
+         "test_tenant", verification_ref, nil}
       )
 
       html = render(lv)

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -26,6 +26,21 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
     |> Enum.any?()
   end
 
+  defp verification_ref_from_open_url(lv) do
+    assert_push_event(lv, "open_url", %{url: url})
+
+    %{"state" => state} =
+      url
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+
+    assert {:ok, %{verification_ref: verification_ref}} =
+             PortalWeb.OIDC.verify_verification_state(state)
+
+    verification_ref
+  end
+
   describe "unauthorized" do
     test "redirects to sign-in when not authenticated", %{conn: conn, account: account} do
       path = ~p"/#{account}/settings/directory_sync"
@@ -221,6 +236,80 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
 
       render_click(lv, "close_panel")
       assert_patch(lv, ~p"/#{account}/settings/directory_sync")
+    end
+
+    test "accepts only the active entra directory verification completion", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync/entra/new")
+
+      lv |> element("button[phx-click='start_verification']") |> render_click()
+      stale_ref = verification_ref_from_open_url(lv)
+
+      lv |> element("button[phx-click='start_verification']") |> render_click()
+      current_ref = verification_ref_from_open_url(lv)
+
+      stale_ack_ref = make_ref()
+
+      send(
+        lv.pid,
+        {:entra_directory_sync_complete, "stale-tenant", stale_ref, {self(), stale_ack_ref}}
+      )
+
+      assert_receive {:verification_ack, ^stale_ack_ref}
+
+      html = render(lv)
+      refute html =~ "Verified"
+      refute html =~ "stale-tenant"
+
+      current_ack_ref = make_ref()
+
+      send(
+        lv.pid,
+        {:entra_directory_sync_complete, "current-tenant", current_ref,
+         {self(), current_ack_ref}}
+      )
+
+      assert_receive {:verification_ack, ^current_ack_ref}
+
+      html = render(lv)
+      assert html =~ "Verified"
+      assert html =~ "current-tenant"
+    end
+
+    test "ignores entra directory completion after navigating to another form", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      {:ok, lv, _html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync/entra/new")
+
+      lv |> element("button[phx-click='start_verification']") |> render_click()
+      verification_ref = verification_ref_from_open_url(lv)
+
+      render_patch(lv, ~p"/#{account}/settings/directory_sync/google/new")
+
+      ack_ref = make_ref()
+
+      send(
+        lv.pid,
+        {:entra_directory_sync_complete, "stale-tenant", verification_ref, {self(), ack_ref}}
+      )
+
+      assert_receive {:verification_ack, ^ack_ref}
+
+      html = render(lv)
+      assert html =~ "Add Google Directory"
+      refute html =~ "Verified"
+      refute html =~ "stale-tenant"
     end
   end
 


### PR DESCRIPTION
## Summary

- bind Entra auth-provider and directory-sync callbacks to a signed per-attempt reference
- ignore stale completions after a retry, navigation, or verification reset while still acknowledging callback windows
- reject Entra verification states that are missing an attempt reference and correlate failure messages too

---

Fixes #13246