### PR TITLE
fix(portal): reverify rotated Okta directory keys

### DIFF
--- a/elixir/lib/portal_web/live/settings/directory_sync.ex
+++ b/elixir/lib/portal_web/live/settings/directory_sync.ex
@@ -181,11 +181,17 @@ defmodule PortalWeb.Settings.DirectorySync do
         "private_key_jwk" => keypair.jwk,
         "kid" => keypair.kid
       })
+      |> put_change(:is_verified, false)
 
     # Extract the public key for display
     public_jwk = JWK.extract_public_key_components(keypair.jwk)
 
-    {:noreply, assign(socket, form: to_form(changeset), public_jwk: public_jwk)}
+    {:noreply,
+     assign(socket,
+       form: to_form(changeset),
+       public_jwk: public_jwk,
+       verification_error: nil
+     )}
   end
 
   def handle_event("start_verification", _params, %{assigns: %{type: "entra"}} = socket) do
@@ -1686,7 +1692,7 @@ defmodule PortalWeb.Settings.DirectorySync do
   end
 
   defp clear_verification_if_trigger_fields_changed(changeset) do
-    fields = [:impersonation_email, :okta_domain, :client_id, :tenant_id]
+    fields = [:impersonation_email, :okta_domain, :client_id, :private_key_jwk, :kid, :tenant_id]
 
     if Enum.any?(fields, &get_change(changeset, &1)) do
       put_change(changeset, :is_verified, false)

--- a/elixir/test/portal_web/live/settings/directory_sync_test.exs
+++ b/elixir/test/portal_web/live/settings/directory_sync_test.exs
@@ -263,6 +263,35 @@ defmodule PortalWeb.Settings.DirectorySyncTest do
       refute html =~ "Verification complete"
     end
 
+    test "requires reverification after regenerating an okta keypair", %{
+      conn: conn,
+      account: account,
+      actor: actor
+    } do
+      directory =
+        okta_directory_fixture(%{
+          account: account,
+          name: "Okta Key Rotation",
+          okta_domain: "key-rotation.okta.com",
+          is_verified: true
+        })
+
+      {:ok, lv, html} =
+        conn
+        |> authorize_conn(actor)
+        |> live(~p"/#{account}/settings/directory_sync/okta/#{directory.id}/edit")
+
+      assert html =~ "This directory has been successfully verified."
+      refute html =~ "Verify Now"
+
+      html = render_click(lv, "generate_keypair")
+
+      assert html =~ "Verify Now"
+      assert html =~ "Awaiting verification..."
+      refute html =~ "This directory has been successfully verified."
+      assert has_element?(lv, "button[form='directory-form'][disabled]", "Save")
+    end
+
     test "updates a google directory name", %{conn: conn, account: account, actor: actor} do
       directory =
         google_directory_fixture(%{


### PR DESCRIPTION
## Summary

- clear `is_verified` whenever an Okta directory keypair is regenerated
- treat `private_key_jwk` and `kid` as verification-trigger fields
- clear stale verification errors and require verification before Save is enabled again