### PR TITLE
fix(ci): drop connect-timeout in download-packet-loss test

### DIFF
--- a/scripts/tests/download-packet-loss.sh
+++ b/scripts/tests/download-packet-loss.sh
@@ -5,11 +5,13 @@ source "./scripts/tests/lib.sh"
 client apk add --no-cache --update iproute2
 client tc qdisc add dev eth0 root netem loss 20%
 
-# Bound the connect phase, then abort only if the transfer stalls, never on a
-# fixed deadline: 20% loss makes the download legitimately slow and bursty. The
-# window is lenient (speed stays below 10 KiB/s for 30s) so deep TCP retransmit
-# backoff isn't mistaken for a hang.
-client sh -c "curl --fail --connect-timeout 10 --speed-limit 10240 --speed-time 30 --output download.file http://download.httpbin/bytes?num=10000000" &
+# Abort only if the transfer stalls, never on a fixed deadline: 20% loss makes
+# the download legitimately slow and bursty. Deliberately no --connect-timeout:
+# under 20% loss the tunnel handshake and TCP connect can take well over ten
+# seconds, so a fixed connect deadline flakes (TCP's own retransmit limit still
+# caps a truly-dead tunnel). The stall window is lenient (speed stays below 10
+# KiB/s for 30s) so deep TCP retransmit backoff isn't mistaken for a hang.
+client sh -c "curl --fail --speed-limit 10240 --speed-time 30 --output download.file http://download.httpbin/bytes?num=10000000" &
 
 DOWNLOAD_PID=$!
 


### PR DESCRIPTION
The `--connect-timeout 10` added to the download tests alongside stall detection is wrong for `download-packet-loss`: 20% loss is applied before the download, so the tunnel handshake and TCP connect legitimately take more than ten seconds and curl aborts with `Connection timed out` before any bytes flow, e.g. [here](https://github.com/firezone/firezone/actions/runs/29786309279/job/88499376088) and [here](https://github.com/firezone/firezone/actions/runs/29833338622/job/88644840200). The client logs confirm the tunnel simply hadn't finished establishing yet, so this is legitimate slowness on the degraded link rather than a real connectivity failure.

Rely on stall detection plus TCP's own retransmit limit to cap a truly-dead tunnel, restoring the connect behaviour this test had before stall detection was introduced. `download.sh` keeps its connect bound since it runs on a clean link where connection setup is fast.

Resolves: #14237