### PR TITLE
fix(portal): only suppress hard bounces, enforce before send

### DIFF
--- a/elixir/lib/portal/azure_communication_services.ex
+++ b/elixir/lib/portal/azure_communication_services.ex
@@ -64,6 +64,12 @@ defmodule Portal.AzureCommunicationServices do
   defp extract_details(details) when is_binary(details), do: details
   defp extract_details(_), do: nil
 
+  # Only permanently-invalid recipients are added to the suppression table. Per
+  # https://learn.microsoft.com/en-us/azure/event-grid/communication-services-email-events
+  # that's "Bounced" (hard bounce: address or domain doesn't exist) and
+  # "Suppressed" (recipient previously hard bounced). "Failed", "Quarantined",
+  # and "FilteredSpam" are transient or content-based, not proof the address is
+  # bad, so they're recorded without suppressing future sends.
   defp terminal_status_attrs("Delivered", _details) do
     %{status: :delivered, failure_code: nil, failure_message: nil, suppress?: false}
   end
@@ -81,7 +87,7 @@ defmodule Portal.AzureCommunicationServices do
       status: :quarantined,
       failure_code: "Quarantined",
       failure_message: details,
-      suppress?: true
+      suppress?: false
     }
   end
 
@@ -90,7 +96,7 @@ defmodule Portal.AzureCommunicationServices do
       status: :filtered_spam,
       failure_code: "FilteredSpam",
       failure_message: details,
-      suppress?: true
+      suppress?: false
     }
   end
 
@@ -99,7 +105,7 @@ defmodule Portal.AzureCommunicationServices do
       status: :failed,
       failure_code: to_string(status),
       failure_message: details,
-      suppress?: true
+      suppress?: false
     }
   end
 

--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -46,7 +46,8 @@ defmodule Portal.Mailer do
     opts = Mailer.parse_config(:portal, __MODULE__, [], config)
     metadata = %{email: email, config: config, mailer: __MODULE__}
 
-    deliver_with_mailer_config(email, opts, metadata)
+    {result, _email} = deliver_with_mailer_config(email, opts, metadata)
+    result
   end
 
   @doc """
@@ -55,21 +56,29 @@ defmodule Portal.Mailer do
   so delivery report webhooks can update those messages too.
   """
   def deliver_and_track(email, config \\ []) do
-    # Filter before delivering so the tracked rows only contain recipients the
-    # message was actually sent to.
-    email = email |> drop_blocked_recipients() |> drop_suppressed_recipients()
+    opts = Mailer.parse_config(:portal, __MODULE__, [], config)
+    metadata = %{email: email, config: config, mailer: __MODULE__}
 
-    case deliver(email, config) do
-      {:ok, result} = ok ->
+    case deliver_with_mailer_config(email, opts, metadata) do
+      {{:ok, result} = ok, email} ->
         maybe_insert_tracked(email, result)
         ok
 
-      {:error, _reason} = error ->
+      {{:error, _reason} = error, _email} ->
         error
     end
   end
 
   def deliver_secondary(email, config \\ []) do
+    {result, _email} = deliver_secondary_with_email(email, config)
+    result
+  end
+
+  @doc """
+  Delivers an email through the secondary adapter and returns the filtered email
+  that was submitted to the adapter alongside the delivery result.
+  """
+  def deliver_secondary_with_email(email, config \\ []) do
     opts =
       Portal.Config.fetch_env!(:portal, Portal.Mailer.Secondary)
       |> Keyword.merge(config)
@@ -87,17 +96,17 @@ defmodule Portal.Mailer do
         email = put_adapter_client_options(email, opts)
         metadata = %{metadata | email: email}
 
-        deliver_with_telemetry(email, opts, metadata)
+        {deliver_with_telemetry(email, opts, metadata), email}
       else
         Logger.info("Skipping email because all recipients are undeliverable or suppressed",
           email_subject: inspect(email.subject)
         )
 
-        {:ok, %{}}
+        {{:ok, %{}}, email}
       end
     else
       Logger.info("Emails are not configured", email_subject: inspect(email.subject))
-      {:ok, %{}}
+      {{:ok, %{}}, email}
     end
   end
 

--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -7,8 +7,6 @@ defmodule Portal.Mailer do
   alias __MODULE__.Database
   require Logger
 
-  @recipient_fields [{"to", :to}, {"cc", :cc}, {"bcc", :bcc}]
-
   # Email addresses ending in any of these suffixes are non-deliverable and are
   # dropped from every recipient field before delivery.
   @blocked_suffixes ["@firezone.invalid"]
@@ -57,6 +55,10 @@ defmodule Portal.Mailer do
   so delivery report webhooks can update those messages too.
   """
   def deliver_and_track(email, config \\ []) do
+    # Filter before delivering so the tracked rows only contain recipients the
+    # message was actually sent to.
+    email = email |> drop_blocked_recipients() |> drop_suppressed_recipients()
+
     case deliver(email, config) do
       {:ok, result} = ok ->
         maybe_insert_tracked(email, result)
@@ -79,7 +81,7 @@ defmodule Portal.Mailer do
 
   defp deliver_with_mailer_config(email, opts, metadata) do
     if opts[:adapter] do
-      email = drop_blocked_recipients(email)
+      email = email |> drop_blocked_recipients() |> drop_suppressed_recipients()
 
       if has_recipients?(email) do
         email = put_adapter_client_options(email, opts)
@@ -87,7 +89,7 @@ defmodule Portal.Mailer do
 
         deliver_with_telemetry(email, opts, metadata)
       else
-        Logger.info("Skipping email because all recipients are undeliverable",
+        Logger.info("Skipping email because all recipients are undeliverable or suppressed",
           email_subject: inspect(email.subject)
         )
 
@@ -184,25 +186,24 @@ defmodule Portal.Mailer do
   Enqueues an email for delivery via the secondary ACS adapter.
 
   Checks the suppression table before inserting the Oban job. Returns
-  `{:ok, :suppressed}` if all recipients are suppressed.
+  `{:ok, :suppressed}` if all recipients are suppressed. The suppression
+  table is checked again right before the queued job delivers.
   """
   def enqueue(%Email{} = email) do
     account_id = email.private[:account_id]
-    request = serialize(email)
+    email = email |> drop_blocked_recipients() |> drop_suppressed_recipients()
 
-    case drop_suppressed_recipients(request) do
-      {:ok, filtered_request} ->
-        %{"account_id" => account_id, "request" => filtered_request}
-        |> OutboundEmailWorker.new()
-        |> Oban.insert()
+    if has_recipients?(email) do
+      %{"account_id" => account_id, "request" => serialize(email)}
+      |> OutboundEmailWorker.new()
+      |> Oban.insert()
+    else
+      Logger.info("Skipping queued email because all recipients are suppressed",
+        account_id: account_id,
+        subject: inspect(email.subject)
+      )
 
-      :fully_suppressed ->
-        Logger.info("Skipping queued email because all recipients are suppressed",
-          account_id: account_id,
-          subject: inspect(email.subject)
-        )
-
-        {:ok, :suppressed}
+      {:ok, :suppressed}
     end
   end
 
@@ -276,30 +277,31 @@ defmodule Portal.Mailer do
     |> Enum.uniq_by(fn %{"address" => addr} -> EmailSuppression.normalize_email(addr) end)
   end
 
-  defp drop_suppressed_recipients(request) do
+  defp drop_suppressed_recipients(%Email{} = email) do
     suppressed_emails =
-      request
-      |> recipient_addresses()
+      email
+      |> email_addresses()
       |> Database.suppressed_recipient_addresses()
 
-    filtered_request =
-      Enum.reduce(@recipient_fields, request, fn {field, _kind}, acc ->
-        recipients = Map.get(acc, field, [])
-
-        Map.put(
-          acc,
-          field,
-          Enum.reject(recipients, fn %{"address" => address} ->
-            undeliverable_address?(address) or
-              EmailSuppression.normalize_email(address) in suppressed_emails
-          end)
-        )
-      end)
-
-    case recipient_addresses(filtered_request) do
-      [] -> :fully_suppressed
-      _ -> {:ok, filtered_request}
+    if suppressed_emails == [] do
+      email
+    else
+      %{
+        email
+        | to: reject_suppressed_addresses(email.to, suppressed_emails),
+          cc: reject_suppressed_addresses(email.cc, suppressed_emails),
+          bcc: reject_suppressed_addresses(email.bcc, suppressed_emails)
+      }
     end
+  end
+
+  defp reject_suppressed_addresses(recipients, suppressed_emails) do
+    recipients
+    |> List.wrap()
+    |> Enum.reject(fn
+      {_name, address} -> EmailSuppression.normalize_email(address) in suppressed_emails
+      address when is_binary(address) -> EmailSuppression.normalize_email(address) in suppressed_emails
+    end)
   end
 
   defp drop_blocked_recipients(%Email{} = email) do
@@ -329,12 +331,6 @@ defmodule Portal.Mailer do
   defp undeliverable_address?(address) do
     normalized = EmailSuppression.normalize_email(address)
     Enum.any?(@blocked_suffixes, &String.ends_with?(normalized, &1))
-  end
-
-  defp recipient_addresses(request) do
-    Enum.flat_map(@recipient_fields, fn {field, _kind} ->
-      Enum.map(Map.get(request, field, []), fn %{"address" => address} -> address end)
-    end)
   end
 
   defmodule Database do

--- a/elixir/lib/portal/workers/outbound_email.ex
+++ b/elixir/lib/portal/workers/outbound_email.ex
@@ -15,7 +15,7 @@ defmodule Portal.Workers.OutboundEmail do
       |> deserialize()
       |> put_operation_id(job_id)
 
-    result = Mailer.deliver_secondary(email)
+    {result, email} = Mailer.deliver_secondary_with_email(email)
     persist_delivery_result(result, account_id, email)
   end
 

--- a/elixir/lib/portal/workers/outbound_email.ex
+++ b/elixir/lib/portal/workers/outbound_email.ex
@@ -19,6 +19,13 @@ defmodule Portal.Workers.OutboundEmail do
     persist_delivery_result(result, account_id, email)
   end
 
+  # An empty response means the mailer skipped the send because every recipient
+  # was suppressed (or undeliverable) by the time the job ran; nothing to track.
+  defp persist_delivery_result({:ok, response}, _account_id, _email)
+       when map_size(response) == 0 do
+    :ok
+  end
+
   defp persist_delivery_result({:ok, response}, account_id, email) do
     with message_id when is_binary(message_id) <- response_message_id(response),
          {:ok, _} <-

--- a/elixir/test/portal/azure_communication_services_test.exs
+++ b/elixir/test/portal/azure_communication_services_test.exs
@@ -88,7 +88,7 @@ defmodule Portal.AzureCommunicationServicesTest do
       assert suppressed == 1
     end
 
-    test "marks a recipient quarantined and inserts a suppression" do
+    test "marks a recipient quarantined without inserting a suppression" do
       account = account_fixture()
 
       entry =
@@ -115,10 +115,10 @@ defmodule Portal.AzureCommunicationServicesTest do
         from(s in Portal.EmailSuppression, where: s.email == "quarantined@example.com")
         |> Repo.aggregate(:count, :email)
 
-      assert suppressed == 1
+      assert suppressed == 0
     end
 
-    test "marks a recipient filtered_spam and inserts a suppression" do
+    test "marks a recipient filtered_spam without inserting a suppression" do
       account = account_fixture()
 
       entry =
@@ -145,10 +145,10 @@ defmodule Portal.AzureCommunicationServicesTest do
         from(s in Portal.EmailSuppression, where: s.email == "filtered@example.com")
         |> Repo.aggregate(:count, :email)
 
-      assert suppressed == 1
+      assert suppressed == 0
     end
 
-    test "marks a recipient failed and inserts a suppression for unknown status" do
+    test "marks a recipient failed without inserting a suppression" do
       account = account_fixture()
 
       entry =
@@ -176,7 +176,7 @@ defmodule Portal.AzureCommunicationServicesTest do
         from(s in Portal.EmailSuppression, where: s.email == "failed@example.com")
         |> Repo.aggregate(:count, :email)
 
-      assert suppressed == 1
+      assert suppressed == 0
     end
 
     test "ignores out-of-order delivery events (stale: already terminal)" do

--- a/elixir/test/portal/mailer_test.exs
+++ b/elixir/test/portal/mailer_test.exs
@@ -303,7 +303,7 @@ defmodule Portal.MailerTest do
       assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
     end
 
-    test "bypasses the suppression table" do
+    test "skips sending when all recipients are suppressed" do
       account = account_fixture()
 
       Repo.insert!(%Portal.EmailSuppression{
@@ -314,12 +314,31 @@ defmodule Portal.MailerTest do
         Swoosh.Email.new()
         |> Swoosh.Email.to({"", "recipient@example.com"})
         |> Swoosh.Email.from({"", "sender@example.com"})
-        |> Swoosh.Email.subject("Bypass")
+        |> Swoosh.Email.subject("Suppressed Send")
         |> Swoosh.Email.text_body("body")
         |> with_account_id(account.id)
 
       assert {:ok, %{}} = deliver(email)
-      assert_email_sent(subject: "Bypass")
+      refute_email_sent(subject: "Suppressed Send")
+    end
+
+    test "drops suppressed recipients before sending" do
+      account = account_fixture()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("suppressed@example.com")
+      })
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to([{"", "recipient@example.com"}, {"", " Suppressed@Example.com "}])
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Partial Suppression")
+        |> Swoosh.Email.text_body("body")
+        |> with_account_id(account.id)
+
+      assert {:ok, %{}} = deliver(email)
+      assert_email_sent(subject: "Partial Suppression", to: [{"", "recipient@example.com"}])
     end
 
     test "drops undeliverable firezone.invalid recipients before sending" do
@@ -442,6 +461,43 @@ defmodule Portal.MailerTest do
 
       assert {:ok, %{}} = deliver_and_track(email)
       assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+
+    test "does not send to or track suppressed recipients" do
+      adapter_plugin = replace_req_adapter_plugin(self())
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("suppressed@example.com")
+      })
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-suppressed-msg", "status" => "Running"})
+      end)
+
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.to([{"", "tracked@example.com"}, {"", "suppressed@example.com"}])
+        |> Swoosh.Email.from({"", "sender@example.com"})
+        |> Swoosh.Email.subject("Tracked Suppression")
+        |> Swoosh.Email.text_body("body")
+
+      assert {:ok, %{id: "acs-suppressed-msg"}} =
+               deliver_and_track(email,
+                 adapter: Swoosh.Adapters.AzureCommunicationServices,
+                 endpoint: "https://acs.example.com",
+                 access_key: Base.encode64("acs-secret"),
+                 req_opts: [
+                   plug: {Req.Test, Portal.AzureCommunicationServices},
+                   plugins: [adapter_plugin]
+                 ]
+               )
+
+      entry = Repo.get!(Portal.OutboundEmail, "acs-suppressed-msg")
+      assert entry.recipients == ["tracked@example.com"]
+
+      assert Repo.aggregate(Portal.OutboundEmailDelivery, :count, :message_id) == 1
     end
   end
 

--- a/elixir/test/portal/workers/outbound_email_test.exs
+++ b/elixir/test/portal/workers/outbound_email_test.exs
@@ -52,6 +52,31 @@ defmodule Portal.Workers.OutboundEmailTest do
       assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
     end
 
+    test "tracks only recipients delivered after suppressions change" do
+      account = account_fixture()
+      configure_acs_secondary()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("suppressed@test.com")
+      })
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-partial-send", "status" => "Running"})
+      end)
+
+      args = put_in(queued_args(account.id), ["request", "to"], [
+        %{"name" => "", "address" => "to@test.com"},
+        %{"name" => "", "address" => "suppressed@test.com"}
+      ])
+
+      assert :ok = perform_job(Worker, args)
+
+      db_entry = Repo.get!(Portal.OutboundEmail, "acs-partial-send")
+      assert db_entry.recipients == ["to@test.com"]
+    end
+
     test "returns error on HTTP delivery failures without tracking a row" do
       account = account_fixture()
       configure_acs_secondary()

--- a/elixir/test/portal/workers/outbound_email_test.exs
+++ b/elixir/test/portal/workers/outbound_email_test.exs
@@ -29,6 +29,29 @@ defmodule Portal.Workers.OutboundEmailTest do
       assert db_entry.recipients == ["to@test.com"]
     end
 
+    test "skips delivery when the recipient was suppressed after enqueue" do
+      account = account_fixture()
+      configure_acs_secondary()
+      test_pid = self()
+
+      Repo.insert!(%Portal.EmailSuppression{
+        email: Portal.EmailSuppression.normalize_email("to@test.com")
+      })
+
+      Req.Test.stub(Portal.AzureCommunicationServices, fn conn ->
+        send(test_pid, :acs_request_sent)
+
+        conn
+        |> Plug.Conn.put_status(202)
+        |> Req.Test.json(%{"id" => "acs-should-not-send", "status" => "Running"})
+      end)
+
+      assert :ok = perform_job(Worker, queued_args(account.id))
+
+      refute_received :acs_request_sent
+      assert Repo.aggregate(Portal.OutboundEmail, :count, :message_id) == 0
+    end
+
     test "returns error on HTTP delivery failures without tracking a row" do
       account = account_fixture()
       configure_acs_secondary()


### PR DESCRIPTION
ACS delivery reports currently insert an email suppression for every non-delivered terminal status, while the suppression table is only consulted when queueing background emails — interactive emails (sign-in OTP, sign-up, invites) are sent regardless.

Per the [ACS delivery report docs](https://learn.microsoft.com/en-us/azure/event-grid/communication-services-email-events), only Bounced (hard bounce: address or domain doesn't exist) and Suppressed (recipient previously hard bounced) indicate a permanently invalid recipient; Failed, Quarantined, and FilteredSpam are transient or content-based, and suppressing on them could permanently lock a user out of email sign-in over one spam-filtered or soft-bounced message. Classify suppressions accordingly at the webhook, and drop suppressed recipients right before every send so all delivery paths — including queued jobs whose recipients were suppressed after enqueue — respect the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)