### PR TITLE
fix(portal): deflake openid_connect exp leeway test

### DIFF
--- a/elixir/test/openid_connect_test.exs
+++ b/elixir/test/openid_connect_test.exs
@@ -587,7 +587,7 @@ defmodule OpenIDConnectTest do
 
       claims = %{
         "email" => "brian@example.com",
-        "exp" => DateTime.utc_now() |> DateTime.add(-29, :second) |> DateTime.to_unix(),
+        "exp" => DateTime.utc_now() |> DateTime.add(-10, :second) |> DateTime.to_unix(),
         "aud" => config.client_id
       }
 


### PR DESCRIPTION
The multiple-keys verify test signed a token that expired 29 seconds ago and expected it to pass the verifier's 30-second leeway. That left a 1-second margin, so any slow moment between minting the token and verifying it (which includes an HTTP fetch of the discovery document) made the test fail.

The token is now expired by only 10 seconds, which still exercises the leeway acceptance path with room to spare. The companion test that asserts rejection at 31 seconds is unaffected, since time passing only makes it more expired.