### PR TITLE
feat(portal): add device trust fields to devices

### DIFF
--- a/elixir/lib/portal/dev/account_population.ex
+++ b/elixir/lib/portal/dev/account_population.ex
@@ -824,7 +824,8 @@ defmodule Portal.Dev.AccountPopulation do
           device_uuid: Ecto.UUID.generate(),
           device_serial: "SN#{index}",
           identifier_for_vendor: "ifv-#{index}",
-          verified_at: if(verified?, do: DateTime.utc_now(), else: nil)
+          verified_at: if(verified?, do: DateTime.utc_now(), else: nil),
+          verification_method: if(verified?, do: :manual, else: nil)
         },
         [
           :name,
@@ -832,7 +833,8 @@ defmodule Portal.Dev.AccountPopulation do
           :device_uuid,
           :device_serial,
           :identifier_for_vendor,
-          :verified_at
+          :verified_at,
+          :verification_method
         ]
       )
       |> put_change(:type, :client)

--- a/elixir/lib/portal/device.ex
+++ b/elixir/lib/portal/device.ex
@@ -56,7 +56,13 @@ defmodule Portal.Device do
           identifier_for_vendor: String.t() | nil,
           firebase_installation_id: String.t() | nil,
           hostname: String.t() | nil,
+          attested_device_serial: String.t() | nil,
+          attested_device_uuid: String.t() | nil,
+          attested_mdm_device_id: String.t() | nil,
+          cert_serial: String.t() | nil,
+          cert_fingerprint: String.t() | nil,
           verified_at: DateTime.t() | nil,
+          verification_method: :manual | :client_certificate | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -81,7 +87,16 @@ defmodule Portal.Device do
     field :identifier_for_vendor, :string
     field :firebase_installation_id, :string
     field :hostname, :string
+
+    # Device trust. Enforced client-only today, but gateways may adopt
+    # cert-based verification too, hence no client_ prefix on the cert columns.
+    field :attested_device_serial, :string
+    field :attested_device_uuid, :string
+    field :attested_mdm_device_id, :string
+    field :cert_serial, :string
+    field :cert_fingerprint, :string
     field :verified_at, :utc_datetime_usec
+    field :verification_method, Ecto.Enum, values: [:manual, :client_certificate]
 
     # Gateway-only
     belongs_to :site, Portal.Site
@@ -148,6 +163,12 @@ defmodule Portal.Device do
         |> validate_length(:device_uuid, max: 255)
         |> validate_length(:identifier_for_vendor, max: 255)
         |> validate_length(:firebase_installation_id, max: 255)
+        |> validate_length(:attested_device_serial, max: 255)
+        |> validate_length(:attested_device_uuid, max: 255)
+        |> validate_length(:attested_mdm_device_id, max: 255)
+        |> validate_length(:cert_serial, max: 255)
+        |> validate_length(:cert_fingerprint, max: 255)
+        |> validate_client_verification()
 
       :gateway ->
         changeset
@@ -160,10 +181,31 @@ defmodule Portal.Device do
   end
 
   defp validate_gateway_verification(changeset) do
-    if is_nil(get_field(changeset, :verified_at)) do
-      changeset
-    else
-      add_error(changeset, :verified_at, "can only be set for client devices")
+    ~w[verified_at verification_method]a
+    |> Enum.reduce(changeset, fn field, changeset ->
+      if is_nil(get_field(changeset, field)) do
+        changeset
+      else
+        add_error(changeset, field, "can only be set for client devices")
+      end
+    end)
+  end
+
+  # `verification_method` records how `verified_at` was established, so the two
+  # must be set and cleared together.
+  defp validate_client_verification(changeset) do
+    verified_at = get_field(changeset, :verified_at)
+    verification_method = get_field(changeset, :verification_method)
+
+    cond do
+      is_nil(verified_at) and not is_nil(verification_method) ->
+        add_error(changeset, :verification_method, "can only be set for verified devices")
+
+      not is_nil(verified_at) and is_nil(verification_method) ->
+        add_error(changeset, :verification_method, "must be set for verified devices")
+
+      true ->
+        changeset
     end
   end
 

--- a/elixir/lib/portal_api/controllers/client_controller.ex
+++ b/elixir/lib/portal_api/controllers/client_controller.ex
@@ -149,7 +149,11 @@ defmodule PortalAPI.ClientController do
     subject = conn.assigns.subject
 
     with {:ok, client} <- Database.fetch_client(id, subject),
-         changeset = client |> change() |> put_default_value(:verified_at, DateTime.utc_now()),
+         changeset =
+           client
+           |> change()
+           |> put_default_value(:verified_at, DateTime.utc_now())
+           |> put_default_value(:verification_method, :manual),
          {:ok, client} <- Database.verify_client(changeset, subject) do
       render(conn, :show, client: client)
     else
@@ -180,7 +184,11 @@ defmodule PortalAPI.ClientController do
     subject = conn.assigns.subject
 
     with {:ok, client} <- Database.fetch_client(id, subject),
-         changeset = client |> change() |> put_change(:verified_at, nil),
+         changeset =
+           client
+           |> change()
+           |> put_change(:verified_at, nil)
+           |> put_change(:verification_method, nil),
          {:ok, client} <- Database.remove_client_verification(changeset, subject) do
       render(conn, :show, client: client)
     else

--- a/elixir/lib/portal_web/live/clients.ex
+++ b/elixir/lib/portal_web/live/clients.ex
@@ -470,6 +470,7 @@ defmodule PortalWeb.Clients do
     selected_client = %{
       socket.assigns.selected_client
       | verified_at: updated_client.verified_at,
+        verification_method: updated_client.verification_method,
         updated_at: updated_client.updated_at
     }
 
@@ -678,6 +679,7 @@ defmodule PortalWeb.Clients do
       client
       |> change()
       |> put_default_value(:verified_at, DateTime.utc_now())
+      |> put_default_value(:verification_method, :manual)
       |> update_client(subject)
     end
 
@@ -687,6 +689,7 @@ defmodule PortalWeb.Clients do
       client
       |> change()
       |> put_change(:verified_at, nil)
+      |> put_change(:verification_method, nil)
       |> update_client(subject)
     end
 

--- a/elixir/priv/repo/migrations/20260721120000_add_device_trust_fields.exs
+++ b/elixir/priv/repo/migrations/20260721120000_add_device_trust_fields.exs
@@ -1,0 +1,50 @@
+defmodule Portal.Repo.Migrations.AddDeviceTrustFields do
+  @moduledoc """
+  Adds client-only fields for MDM-certificate device trust.
+
+  The existing `device_serial` / `device_uuid` / `identifier_for_vendor`
+  columns are self-reported by the client and therefore spoofable. The
+  `attested_*` columns hold identifiers proven by answering the portal's
+  challenge-response with an MDM-provisioned client certificate:
+
+    * `attested_device_serial` / `attested_device_uuid` - hardware identifiers
+      (serial, SMBIOS UUID / UDID) asserted in the certificate subject/SAN.
+      On Android 12+ personally-owned work profiles hardware IDs are
+      unavailable to MDMs, so these stay NULL there.
+    * `attested_mdm_device_id` - the MDM's logical device ID asserted in the
+      certificate (e.g. Intune {{DeviceId}}), the stable link to the MDM
+      record on every platform.
+    * `cert_serial` / `cert_fingerprint` - the pinned client
+      certificate used to answer the challenge-response.
+    * `verification_method` - how `verified_at` was established. Existing
+      verified clients were verified by an admin, so they backfill to `manual`.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:devices) do
+      add(:attested_device_serial, :string)
+      add(:attested_device_uuid, :string)
+      add(:attested_mdm_device_id, :string)
+      add(:cert_serial, :string)
+      add(:cert_fingerprint, :string)
+      add(:verification_method, :string)
+    end
+
+    execute("""
+    UPDATE devices SET verification_method = 'manual'
+    WHERE type = 'client' AND verified_at IS NOT NULL
+    """)
+  end
+
+  def down do
+    alter table(:devices) do
+      remove(:attested_device_serial)
+      remove(:attested_device_uuid)
+      remove(:attested_mdm_device_id)
+      remove(:cert_serial)
+      remove(:cert_fingerprint)
+      remove(:verification_method)
+    end
+  end
+end

--- a/elixir/test/support/fixtures/device_fixtures.ex
+++ b/elixir/test/support/fixtures/device_fixtures.ex
@@ -126,6 +126,7 @@ defmodule Portal.DeviceFixtures do
       attrs
       |> Map.drop([:account, :actor, :ipv4_address, :ipv6_address])
       |> valid_client_attrs()
+      |> put_default_verification_method()
 
     {:ok, device} =
       %Portal.Device{}
@@ -137,7 +138,13 @@ defmodule Portal.DeviceFixtures do
         :identifier_for_vendor,
         :firebase_installation_id,
         :hostname,
-        :verified_at
+        :attested_device_serial,
+        :attested_device_uuid,
+        :attested_mdm_device_id,
+        :cert_serial,
+        :cert_fingerprint,
+        :verified_at,
+        :verification_method
       ])
       |> Ecto.Changeset.put_change(:type, :client)
       |> Ecto.Changeset.put_change(:account_id, account.id)
@@ -229,9 +236,18 @@ defmodule Portal.DeviceFixtures do
   """
   def verify_client(client) do
     client
-    |> Ecto.Changeset.change(verified_at: DateTime.utc_now())
+    |> Ecto.Changeset.change(verified_at: DateTime.utc_now(), verification_method: :manual)
     |> Portal.Repo.update!()
   end
+
+  # `verified_at` and `verification_method` must be set together, so fixtures
+  # that only pass `verified_at` default to a manual verification.
+  defp put_default_verification_method(%{verified_at: verified_at} = attrs)
+       when not is_nil(verified_at) do
+    Map.put_new(attrs, :verification_method, :manual)
+  end
+
+  defp put_default_verification_method(attrs), do: attrs
 
   ##############################################################################
   # Gateway devices


### PR DESCRIPTION
Groundwork for MDM-certificate device trust. Clients will prove possession of an MDM-provisioned client certificate via a portal challenge-response, and the portal needs somewhere to persist what such a verification proves. The existing `device_serial` / `device_uuid` / `identifier_for_vendor` columns are self-reported by the client and therefore spoofable, so this adds `attested_*` counterparts holding identifiers proven by the certificate: `attested_device_serial` and `attested_device_uuid` for hardware identifiers asserted in the certificate subject/SAN (unavailable on Android 12+ personally-owned work profiles, where MDMs cannot embed hardware IDs), and `attested_mdm_device_id` for the MDM's logical device ID, the stable link to the MDM record on every platform. It also adds the pinned certificate itself (`cert_serial`, `cert_fingerprint` — no `client_` prefix since gateways may adopt cert-based verification too) and a `verification_method` distinguishing admin-verified clients from certificate-verified ones; existing verified clients backfill to `manual`. The challenge-response protocol and client API changes build on this in a follow-up PR. Related: #14235

🤖 Generated with [Claude Code](https://claude.com/claude-code)