### PR TITLE
ci: bump mise to 2026.7.7

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "mise version to install"
     required: false
-    default: "2026.5.0"
+    default: "2026.7.7"
   install_args:
     description: "Arguments to pass to `mise install`"
     required: false

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -58,8 +58,6 @@ jobs:
 
   global-linter:
     runs-on: ubuntu-24.04
-    env:
-      MISE_EXPERIMENTAL: 1
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -3,9 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  MISE_EXPERIMENTAL: "1"
-
 jobs:
   update-release-draft:
     name: update-release-draft
@@ -81,7 +78,6 @@ jobs:
     runs-on: macos-26
     env:
       XCODE_VERSION: "26.2"
-      MISE_EXPERIMENTAL: "1"
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write # OIDC auth

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -158,7 +158,7 @@ mise run <task>         # Run a task (e.g. mise run build)
 From the repository root:
 
 ```sh
-mise //swift/apple:<task>   # e.g. mise //swift/apple:build
+mise run //swift/apple:<task>   # e.g. mise run //swift/apple:build
 ```
 
 ### Instruments

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -155,8 +155,7 @@ mise tasks              # List all available tasks
 mise run <task>         # Run a task (e.g. mise run build)
 ```
 
-From the repository root (requires `export MISE_EXPERIMENTAL=1` for monorepo
-syntax):
+From the repository root:
 
 ```sh
 mise //swift/apple:<task>   # e.g. mise //swift/apple:build

--- a/swift/apple/mise.toml
+++ b/swift/apple/mise.toml
@@ -3,8 +3,6 @@
 #
 # Tasks are auto-discovered from mise-tasks/ directory.
 # Task names match filenames (e.g., mise-tasks/build.sh -> //swift/apple:build.sh)
-#
-# Requires: MISE_EXPERIMENTAL=1 for monorepo task discovery
 
 [settings]
 auto_install = false

--- a/swift/apple/mise.toml
+++ b/swift/apple/mise.toml
@@ -1,8 +1,8 @@
 # Firezone Apple Client - mise configuration
-# Usage: mise run <task> (from this directory) or mise //swift/apple:<task> (from repo root)
+# Usage: mise run <task> (from this directory) or mise run //swift/apple:<task> (from repo root)
 #
 # Tasks are auto-discovered from mise-tasks/ directory.
-# Task names match filenames (e.g., mise-tasks/build.sh -> //swift/apple:build.sh)
+# Task names are the filenames without extension (e.g., mise-tasks/build.sh -> //swift/apple:build)
 
 [settings]
 auto_install = false


### PR DESCRIPTION
Monorepo task paths (`mise run //path:task`) no longer require `MISE_EXPERIMENTAL` from this version on, so the flag and its mentions go away.