### PR TITLE
feat(portal): federate Entra OIDC client auth

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -181,6 +181,9 @@ if config_env() == :prod do
     client_id: env_var_to_config!(:google_oidc_client_id),
     client_secret: env_var_to_config!(:google_oidc_client_secret)
 
+  # When ENTRA_OIDC_CLIENT_SECRET is unset, authorization-code redemption
+  # authenticates with a token-exchange assertion from the portal's managed
+  # identity. The optional secret supports dev and migration environments.
   config :portal, Portal.Entra.AuthProvider,
     client_id: env_var_to_config!(:entra_oidc_client_id),
     client_secret: env_var_to_config!(:entra_oidc_client_secret)

--- a/elixir/lib/openid_connect.ex
+++ b/elixir/lib/openid_connect.ex
@@ -53,7 +53,7 @@ defmodule OpenIDConnect do
   @type config :: %{
           required(:discovery_document_uri) => discovery_document_uri(),
           required(:client_id) => client_id(),
-          required(:client_secret) => client_secret(),
+          optional(:client_secret) => client_secret(),
           required(:response_type) => response_type(),
           required(:scope) => scope(),
           optional(:leeway) => non_neg_integer(),
@@ -195,7 +195,8 @@ defmodule OpenIDConnect do
     req_opts = Map.get(config, :req_opts, [])
 
     form_params =
-      %{client_id: config.client_id, client_secret: config.client_secret}
+      %{client_id: config.client_id}
+      |> maybe_put_client_secret(config)
       |> Map.merge(params)
 
     request =
@@ -210,6 +211,13 @@ defmodule OpenIDConnect do
     else
       {:ok, %{status: status, body: body}} -> {:error, {status, decode_body(body)}}
       other -> other
+    end
+  end
+
+  defp maybe_put_client_secret(params, config) do
+    case Map.get(config, :client_secret) do
+      secret when is_binary(secret) and secret != "" -> Map.put(params, :client_secret, secret)
+      _ -> params
     end
   end
 

--- a/elixir/lib/portal/azure/managed_identity.ex
+++ b/elixir/lib/portal/azure/managed_identity.ex
@@ -5,10 +5,9 @@ defmodule Portal.Azure.ManagedIdentity do
 
   Azure Database for PostgreSQL accepts an Entra access token as the connection
   password, which is how database connections are authenticated when
-  DATABASE_ENTRA_AUTH is enabled. The GenServer serializes IMDS requests and
-  caches the token until shortly before it expires; tokens are only needed to
-  establish new connections, so a refresh happens at most once per token
-  lifetime (24 hours for managed identity tokens).
+  DATABASE_ENTRA_AUTH is enabled. Other Entra integrations use managed-identity
+  tokens as workload identity federation assertions. The GenServer serializes
+  IMDS requests and caches tokens by resource until shortly before they expire.
   """
   use GenServer
 
@@ -42,49 +41,55 @@ defmodule Portal.Azure.ManagedIdentity do
   release migrations, which connect without starting the supervision tree.
   """
   def database_access_token! do
+    access_token!(@database_resource)
+  end
+
+  @doc """
+  Returns a Microsoft Entra access token for an arbitrary resource audience,
+  fetching a new one from IMDS if the cached one is missing or about to expire.
+
+  This is used for token-exchange assertions for workload identity federation
+  (`api://AzureADTokenExchange`) as well as database authentication. Falls back
+  to fetching directly when the GenServer is not running. Raises on an IMDS
+  error.
+  """
+  def access_token!(resource) when is_binary(resource) do
     case GenServer.whereis(__MODULE__) do
       nil ->
-        %{token: token} = fetch_token!(@database_resource)
+        %{token: token} = fetch_token!(resource)
         token
 
       server ->
-        case GenServer.call(server, :database_access_token, @call_timeout) do
+        case GenServer.call(server, {:access_token, resource}, @call_timeout) do
           {:ok, token} -> token
           {:error, exception} -> raise exception
         end
     end
   end
 
-  @doc """
-  Fetches an uncached Entra token for an arbitrary resource audience, used by
-  callers other than the database connection (e.g. a token-exchange assertion
-  for workload identity federation, `api://AzureADTokenExchange`). Raises on an
-  IMDS error.
-  """
-  def access_token!(resource) when is_binary(resource) do
-    %{token: token} = fetch_token!(resource)
-    token
-  end
-
   @impl true
   def init(nil) do
-    {:ok, %{token: nil, expires_at: 0}}
+    {:ok, %{}}
   end
 
   @impl true
-  def handle_call(:database_access_token, _from, state) do
-    if state.expires_at - @expiry_margin_seconds > System.system_time(:second) do
-      {:reply, {:ok, state.token}, state}
-    else
-      try do
-        state = fetch_token!(@database_resource)
-        {:reply, {:ok, state.token}, state}
-      rescue
-        # Reply with the error instead of crashing so that an IMDS outage
-        # surfaces in the calling connection process (which DBConnection
-        # retries with backoff) without crash-looping this server
-        exception -> {:reply, {:error, exception}, state}
-      end
+  def handle_call({:access_token, resource}, _from, state) do
+    now = System.system_time(:second)
+
+    case Map.get(state, resource) do
+      %{token: token, expires_at: expires_at}
+      when expires_at - @expiry_margin_seconds > now ->
+        {:reply, {:ok, token}, state}
+
+      _ ->
+        try do
+          token = fetch_token!(resource)
+          {:reply, {:ok, token.token}, Map.put(state, resource, token)}
+        rescue
+          # Reply with the error instead of crashing so that an IMDS outage
+          # surfaces in the calling process without crash-looping this server.
+          exception -> {:reply, {:error, exception}, state}
+        end
     end
   end
 

--- a/elixir/lib/portal/azure/managed_identity.ex
+++ b/elixir/lib/portal/azure/managed_identity.ex
@@ -82,15 +82,17 @@ defmodule Portal.Azure.ManagedIdentity do
         {:reply, {:ok, token}, state}
 
       _ ->
-        try do
-          token = fetch_token!(resource)
-          {:reply, {:ok, token.token}, Map.put(state, resource, token)}
-        rescue
-          # Reply with the error instead of crashing so that an IMDS outage
-          # surfaces in the calling process without crash-looping this server.
-          exception -> {:reply, {:error, exception}, state}
-        end
+        fetch_and_cache_token(resource, state)
     end
+  end
+
+  defp fetch_and_cache_token(resource, state) do
+    token = fetch_token!(resource)
+    {:reply, {:ok, token.token}, Map.put(state, resource, token)}
+  rescue
+    # Reply with the error instead of crashing so that an IMDS outage surfaces
+    # in the calling process without crash-looping this server.
+    exception -> {:reply, {:error, exception}, state}
   end
 
   defp fetch_token!(resource) do

--- a/elixir/lib/portal_web/oidc.ex
+++ b/elixir/lib/portal_web/oidc.ex
@@ -10,6 +10,8 @@ defmodule PortalWeb.OIDC do
 
   require Logger
 
+  @client_assertion_type "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
   # Workaround for an OTP `ssl` bug: the TLS 1.3 client aborts the handshake
   # against servers that send their middlebox-compatibility ChangeCipherSpec
   # after the ServerHello on a HelloRetryRequest. Disabling middlebox mode skips
@@ -116,16 +118,47 @@ defmodule PortalWeb.OIDC do
   Returns {:ok, tokens} or {:error, reason}.
   """
   def exchange_code(provider, code, verifier) do
-    with {:ok, config} <- config_for_provider(provider) do
-      params = %{
-        grant_type: "authorization_code",
-        code: code,
-        code_verifier: verifier,
-        redirect_uri: callback_url(provider)
-      }
+    with {:ok, config} <- config_for_provider(provider),
+         {:ok, credential} <- client_credential(provider, config) do
+      params =
+        %{
+          grant_type: "authorization_code",
+          code: code,
+          code_verifier: verifier,
+          redirect_uri: callback_url(provider)
+        }
+        |> Map.merge(credential)
 
       OpenIDConnect.fetch_tokens(config, params)
     end
+  end
+
+  # Production authenticates the Entra app with workload identity federation:
+  # the portal's managed identity mints a token-exchange assertion, so no secret
+  # is stored. A configured client secret (dev and migration environments) uses
+  # the secret already present in the OpenIDConnect config.
+  defp client_credential(%Entra.AuthProvider{}, config) do
+    case config[:client_secret] do
+      secret when is_binary(secret) and secret != "" ->
+        {:ok, %{}}
+
+      _ ->
+        federated_credential()
+    end
+  end
+
+  defp client_credential(_provider, _config), do: {:ok, %{}}
+
+  defp federated_credential do
+    assertion = Portal.Azure.ManagedIdentity.access_token!("api://AzureADTokenExchange")
+
+    {:ok,
+     %{
+       client_assertion_type: @client_assertion_type,
+       client_assertion: assertion
+     }}
+  rescue
+    exception -> {:error, exception}
   end
 
   @doc """

--- a/elixir/test/openid_connect_test.exs
+++ b/elixir/test/openid_connect_test.exs
@@ -316,6 +316,49 @@ defmodule OpenIDConnectTest do
       assert body =~ "redirect_uri=#{URI.encode_www_form(@redirect_uri)}"
     end
 
+    test "allows a client assertion without a client secret" do
+      test_pid = self()
+
+      token_response_attrs = %{
+        "access_token" => "ACCESS_TOKEN",
+        "id_token" => "ID_TOKEN"
+      }
+
+      token_handler = fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:req, URI.decode_query(body)})
+        Req.Test.json(conn, token_response_attrs)
+      end
+
+      {test_name, uri} =
+        start_fixture_with_routes("azure", %{}, %{{"POST", "/token"} => token_handler})
+
+      config = %{
+        @config
+        | client_secret: nil,
+          discovery_document_uri: uri,
+          req_opts: req_test_options(test_name)
+      }
+
+      params = %{
+        grant_type: "authorization_code",
+        redirect_uri: @redirect_uri,
+        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        client_assertion: "managed-identity-assertion"
+      }
+
+      assert fetch_tokens(config, params) == {:ok, token_response_attrs}
+
+      assert_receive {:req, body}
+      assert body["client_id"] == "CLIENT_ID"
+      assert body["client_assertion"] == "managed-identity-assertion"
+
+      assert body["client_assertion_type"] ==
+               "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+      refute body["client_secret"]
+    end
+
     test "allows to use refresh_token grant type" do
       test_pid = self()
 

--- a/elixir/test/portal/azure/managed_identity_test.exs
+++ b/elixir/test/portal/azure/managed_identity_test.exs
@@ -1,5 +1,5 @@
 defmodule Portal.Azure.ManagedIdentityTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Portal.Azure.ManagedIdentity
 
@@ -70,6 +70,28 @@ defmodule Portal.Azure.ManagedIdentityTest do
       assert ManagedIdentity.database_access_token!() == "cached_token"
       # A second IMDS request would exceed the expectation above and raise
       assert ManagedIdentity.database_access_token!() == "cached_token"
+    end
+
+    test "caches tokens independently by resource" do
+      test_pid = self()
+
+      Req.Test.expect(ManagedIdentity, 2, fn conn ->
+        resource = URI.decode_query(conn.query_string)["resource"]
+        send(test_pid, {:imds_request, resource})
+
+        Req.Test.json(conn, %{
+          "access_token" => "token-for-#{resource}",
+          "expires_on" => System.system_time(:second) + 3600
+        })
+      end)
+
+      assert ManagedIdentity.access_token!("resource-a") == "token-for-resource-a"
+      assert ManagedIdentity.access_token!("resource-b") == "token-for-resource-b"
+      assert ManagedIdentity.access_token!("resource-a") == "token-for-resource-a"
+      assert ManagedIdentity.access_token!("resource-b") == "token-for-resource-b"
+
+      assert_received {:imds_request, "resource-a"}
+      assert_received {:imds_request, "resource-b"}
     end
 
     test "fetches a new token when the cached one is about to expire" do

--- a/elixir/test/portal/azure/managed_identity_test.exs
+++ b/elixir/test/portal/azure/managed_identity_test.exs
@@ -1,7 +1,9 @@
 defmodule Portal.Azure.ManagedIdentityTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Portal.Azure.ManagedIdentity
+
+  @database_resource "https://ossrdbms-aad.database.windows.net"
 
   # The GenServer is not started in the test environment (DATABASE_ENTRA_AUTH
   # is disabled), so database_access_token!/0 uses the direct-fetch fallback
@@ -46,9 +48,9 @@ defmodule Portal.Azure.ManagedIdentityTest do
     end
   end
 
-  describe "database_access_token!/0 with the GenServer" do
+  describe "access token cache" do
     setup do
-      server = start_supervised!(ManagedIdentity)
+      server = start_supervised!({ManagedIdentity, name: unique_name()})
 
       # Establish stub ownership before allowing the server process to use it
       Req.Test.stub(ManagedIdentity, fn conn ->
@@ -59,7 +61,7 @@ defmodule Portal.Azure.ManagedIdentityTest do
       %{server: server}
     end
 
-    test "caches the token until it is about to expire" do
+    test "caches the token until it is about to expire", %{server: server} do
       Req.Test.expect(ManagedIdentity, fn conn ->
         Req.Test.json(conn, %{
           "access_token" => "cached_token",
@@ -67,12 +69,12 @@ defmodule Portal.Azure.ManagedIdentityTest do
         })
       end)
 
-      assert ManagedIdentity.database_access_token!() == "cached_token"
+      assert access_token!(server, @database_resource) == "cached_token"
       # A second IMDS request would exceed the expectation above and raise
-      assert ManagedIdentity.database_access_token!() == "cached_token"
+      assert access_token!(server, @database_resource) == "cached_token"
     end
 
-    test "caches tokens independently by resource" do
+    test "caches tokens independently by resource", %{server: server} do
       test_pid = self()
 
       Req.Test.expect(ManagedIdentity, 2, fn conn ->
@@ -85,16 +87,16 @@ defmodule Portal.Azure.ManagedIdentityTest do
         })
       end)
 
-      assert ManagedIdentity.access_token!("resource-a") == "token-for-resource-a"
-      assert ManagedIdentity.access_token!("resource-b") == "token-for-resource-b"
-      assert ManagedIdentity.access_token!("resource-a") == "token-for-resource-a"
-      assert ManagedIdentity.access_token!("resource-b") == "token-for-resource-b"
+      assert access_token!(server, "resource-a") == "token-for-resource-a"
+      assert access_token!(server, "resource-b") == "token-for-resource-b"
+      assert access_token!(server, "resource-a") == "token-for-resource-a"
+      assert access_token!(server, "resource-b") == "token-for-resource-b"
 
       assert_received {:imds_request, "resource-a"}
       assert_received {:imds_request, "resource-b"}
     end
 
-    test "fetches a new token when the cached one is about to expire" do
+    test "fetches a new token when the cached one is about to expire", %{server: server} do
       test_pid = self()
 
       Req.Test.expect(ManagedIdentity, 2, fn conn ->
@@ -107,8 +109,8 @@ defmodule Portal.Azure.ManagedIdentityTest do
       end)
 
       # The token expires within the refresh margin, so each call fetches
-      assert ManagedIdentity.database_access_token!() == "short_lived_token"
-      assert ManagedIdentity.database_access_token!() == "short_lived_token"
+      assert access_token!(server, @database_resource) == "short_lived_token"
+      assert access_token!(server, @database_resource) == "short_lived_token"
 
       assert_received :imds_request
       assert_received :imds_request
@@ -122,7 +124,7 @@ defmodule Portal.Azure.ManagedIdentityTest do
       end)
 
       assert_raise MatchError, fn ->
-        ManagedIdentity.database_access_token!()
+        access_token!(server, @database_resource)
       end
 
       assert Process.alive?(server)
@@ -134,7 +136,7 @@ defmodule Portal.Azure.ManagedIdentityTest do
         })
       end)
 
-      assert ManagedIdentity.database_access_token!() == "recovered_token"
+      assert access_token!(server, @database_resource) == "recovered_token"
     end
   end
 
@@ -153,4 +155,13 @@ defmodule Portal.Azure.ManagedIdentityTest do
       assert opts[:username] == "apps-identity"
     end
   end
+
+  defp access_token!(server, resource) do
+    case GenServer.call(server, {:access_token, resource}) do
+      {:ok, token} -> token
+      {:error, exception} -> raise exception
+    end
+  end
+
+  defp unique_name, do: :"managed_identity_#{inspect(make_ref())}"
 end

--- a/elixir/test/portal_web/oidc_test.exs
+++ b/elixir/test/portal_web/oidc_test.exs
@@ -1,0 +1,88 @@
+defmodule PortalWeb.OIDCTest do
+  use ExUnit.Case, async: true
+
+  alias Portal.Entra
+  alias PortalWeb.Mocks
+  alias PortalWeb.OIDC
+
+  @client_assertion_type "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+  setup do
+    endpoint = Mocks.OIDC.stub_discovery_document()
+
+    config = [
+      client_id: "test-entra-client-id",
+      response_type: "code",
+      scope: "openid email profile",
+      discovery_document_uri: Mocks.OIDC.discovery_document_uri(),
+      req_opts: [retry: false, plug: {Req.Test, PortalWeb.OIDC}]
+    ]
+
+    provider = %Entra.AuthProvider{issuer: "#{endpoint}/"}
+
+    %{config: config, provider: provider}
+  end
+
+  describe "exchange_code/3 for Entra" do
+    test "uses a configured client secret", %{config: config, provider: provider} do
+      Portal.Config.put_env_override(
+        :portal,
+        Entra.AuthProvider,
+        Keyword.put(config, :client_secret, "test-client-secret")
+      )
+
+      assert {:ok, _tokens} = OIDC.exchange_code(provider, "code", "verifier")
+
+      assert_receive {:oidc_request, discovery_path, _conn}
+      assert String.ends_with?(discovery_path, "/.well-known/openid-configuration")
+
+      assert_receive {:oidc_request, jwks_path, _conn}
+      assert String.ends_with?(jwks_path, "/.well-known/jwks.json")
+
+      assert_receive {:oidc_request, token_path, conn}
+      assert String.ends_with?(token_path, "/oauth/token")
+      assert conn.body_params["client_secret"] == "test-client-secret"
+      refute conn.body_params["client_assertion"]
+    end
+
+    test "uses a managed-identity assertion when no secret is configured", %{
+      config: config,
+      provider: provider
+    } do
+      Portal.Config.put_env_override(
+        :portal,
+        Entra.AuthProvider,
+        Keyword.put(config, :client_secret, nil)
+      )
+
+      test_pid = self()
+
+      Req.Test.expect(Portal.Azure.ManagedIdentity, fn conn ->
+        send(test_pid, {:managed_identity_request, conn})
+
+        Req.Test.json(conn, %{
+          "access_token" => "managed-identity-assertion",
+          "expires_on" => System.system_time(:second) + 3600
+        })
+      end)
+
+      assert {:ok, _tokens} = OIDC.exchange_code(provider, "code", "verifier")
+
+      assert_receive {:managed_identity_request, managed_identity_conn}
+      managed_identity_params = URI.decode_query(managed_identity_conn.query_string)
+      assert managed_identity_params["resource"] == "api://AzureADTokenExchange"
+
+      assert_receive {:oidc_request, discovery_path, _conn}
+      assert String.ends_with?(discovery_path, "/.well-known/openid-configuration")
+
+      assert_receive {:oidc_request, jwks_path, _conn}
+      assert String.ends_with?(jwks_path, "/.well-known/jwks.json")
+
+      assert_receive {:oidc_request, token_path, conn}
+      assert String.ends_with?(token_path, "/oauth/token")
+      assert conn.body_params["client_assertion"] == "managed-identity-assertion"
+      assert conn.body_params["client_assertion_type"] == @client_assertion_type
+      refute conn.body_params["client_secret"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- redeem Entra OIDC authorization codes with a managed-identity client assertion when `ENTRA_OIDC_CLIENT_SECRET` is unset
- retain the client-secret path for development and staged migration
- allow the vendored OIDC client to omit `client_secret` when another client authentication method is used
- cache managed-identity tokens by resource until five minutes before expiry, covering database auth, Entra directory sync, Sentinel, and OIDC

## Tests

- `mix test test/openid_connect_test.exs test/portal/azure/managed_identity_test.exs test/portal_web/oidc_test.exs test/portal/entra/api_client_test.exs test/portal/sentinel/sync_test.exs`
- `mix test test/portal_web/controllers/oidc_controller_test.exs`

## Reference

- [Configure an application to trust a managed identity](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity)

## Rollout

Infrastructure credential: [firezone/infra#763](https://github.com/firezone/infra/pull/763)

This is inert while `ENTRA_OIDC_CLIENT_SECRET` remains configured. Apply the infrastructure PR first, deploy this change, then clear the secret in staging and production after login verification.