### PR TITLE
perf(connlib): avoid memcopies in TUN GSO writes

### DIFF
--- a/rust/libs/connlib/ip-packet/src/slices.rs
+++ b/rust/libs/connlib/ip-packet/src/slices.rs
@@ -196,6 +196,7 @@ pub struct TcpSlice<'a> {
 
 impl<'a> TcpSlice<'a> {
     pub const HEADER_MIN_LEN: usize = 20;
+    pub const HEADER_MAX_LEN: usize = 60;
 
     pub(crate) fn from_l4(l4: &'a [u8]) -> Self {
         let (header, _, payload) = ValidTcp::parse(l4).expect(INVARIANT);

--- a/rust/libs/connlib/tun/src/linux.rs
+++ b/rust/libs/connlib/tun/src/linux.rs
@@ -68,6 +68,7 @@ where
             let fd = AsyncFd::with_interest(tun_fd.fd, Interest::WRITABLE)?;
 
             let mut ready = Vec::new();
+            let mut iov = Vec::new();
             // `None` when the kernel does not support GSO writes or rejected one at
             // runtime; packets then pass through 1:1.
             let mut queue = tun_fd.offloads.then(TunGsoQueue::new);
@@ -90,6 +91,7 @@ where
                 let gso_failed = write_all(
                     &fd,
                     &mut ready,
+                    &mut iov,
                     &batch_size_histogram,
                     &dropped_packets_counter,
                 )
@@ -117,6 +119,7 @@ where
 async fn write_all<T>(
     fd: &AsyncFd<T>,
     ready: &mut Vec<Outgoing>,
+    iov: &mut Vec<libc::iovec>,
     batch_size_histogram: &opentelemetry::metrics::Histogram<u64>,
     dropped_packets_counter: &opentelemetry::metrics::Counter<u64>,
 ) -> bool
@@ -128,7 +131,7 @@ where
     for outgoing in ready.drain(..) {
         let num_segments = outgoing.num_segments();
 
-        match write(fd, &outgoing).await {
+        match write(fd, &outgoing, iov).await {
             Ok(_) => {
                 if num_segments > 1 {
                     batch_size_histogram.record(num_segments as u64, &send_metric_attributes());
@@ -149,26 +152,23 @@ where
     gso_failed
 }
 
-/// Writes a single [`Outgoing`] (its `virtio_net_hdr` plus packet bytes) to the TUN device.
-async fn write<T>(fd: &AsyncFd<T>, outgoing: &Outgoing) -> io::Result<usize>
+/// Writes a single [`Outgoing`] to the TUN device, gathering its buffers with `writev`.
+async fn write<T>(
+    fd: &AsyncFd<T>,
+    outgoing: &Outgoing,
+    iov: &mut Vec<libc::iovec>,
+) -> io::Result<usize>
 where
     T: AsRawFd,
 {
-    let [hdr, packet] = outgoing.bufs();
-
-    let iov = [
-        libc::iovec {
-            iov_base: hdr.as_ptr() as *mut _,
-            iov_len: hdr.len(),
-        },
-        libc::iovec {
-            iov_base: packet.as_ptr() as *mut _,
-            iov_len: packet.len(),
-        },
-    ];
+    iov.clear();
+    iov.extend(outgoing.bufs().map(|buf| libc::iovec {
+        iov_base: buf.as_ptr() as *mut _,
+        iov_len: buf.len(),
+    }));
 
     fd.async_io(Interest::WRITABLE, |fd| {
-        // Safety: Both iovecs point at valid memory of the given lengths.
+        // Safety: All iovecs point at valid memory of the given lengths.
         match unsafe { libc::writev(fd.as_raw_fd(), iov.as_ptr(), iov.len() as _) } {
             -1 => Err(io::Error::last_os_error()),
             n => Ok(n as usize),

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -4,12 +4,20 @@
 //! entire batch traverse the kernel's network stack as a single skb, which is where the
 //! bulk of the per-packet cost lives.
 //!
+//! Super packets are not assembled in memory: a batch keeps its packets as they arrived
+//! and only prepares a small prefix, the [`VirtioNetHdr`] plus the fixed-up IP and L4
+//! headers. The vectored write to the TUN device gathers the prefix and the payload of
+//! every segment straight from the original packets, so payload bytes are copied exactly
+//! once, by the kernel.
+//!
 //! Only packets that the kernel's own GRO would merge are combined, everything else is
 //! passed through untouched.
 
-use bufferpool::{Buffer, BufferPool};
+use bufferpool::{Buffer, BufferPool, VecBuf};
 use ip_packet::{IpNumber, IpPacket, IpVersion, Ipv6HeaderSlice, TcpSlice, UdpSlice};
+use std::iter;
 use std::net::IpAddr;
+use std::slice;
 
 use super::checksum;
 use super::virtio::*;
@@ -24,6 +32,11 @@ const MAX_COALESCED_PACKET: usize = u16::MAX as usize;
 /// (`UDP_MAX_SEGMENTS` in `linux/udp.h`).
 const MAX_UDP_SEGMENTS: usize = 128;
 
+/// The longest possible super-packet prefix: a [`VirtioNetHdr`] followed by the largest
+/// coalescable IP header (the fixed IPv6 one; IPv4 options never coalesce) and a
+/// maximally-sized TCP header.
+const MAX_PREFIX_LEN: usize = VNET_HDR_LEN + Ipv6HeaderSlice::LEN + TcpSlice::HEADER_MAX_LEN;
+
 const TCP_FLAG_PSH: u8 = 0x08;
 
 const ZEROED_VNET_HDR: [u8; VNET_HDR_LEN] = [0; VNET_HDR_LEN];
@@ -36,7 +49,7 @@ pub struct TunGsoQueue {
     /// into the most recent item of its connection, so per-flow ordering is preserved
     /// by construction.
     items: Vec<Item>,
-    buffer_pool: BufferPool<Vec<u8>>,
+    segment_pool: BufferPool<VecBuf<IpPacket>>,
 }
 
 impl Default for TunGsoQueue {
@@ -49,7 +62,7 @@ impl TunGsoQueue {
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
-            buffer_pool: BufferPool::new(VNET_HDR_LEN + MAX_COALESCED_PACKET, "tun-gso-queue"),
+            segment_pool: BufferPool::new(crate::MAX_BATCH_SIZE, "tun-gso-queue"),
         }
     }
 
@@ -71,9 +84,13 @@ impl TunGsoQueue {
             Some(Item::Batch(batch))
                 if batch.key == candidate.key && batch.can_append(&candidate, &packet) =>
             {
-                batch.append(&candidate, &packet, &self.buffer_pool)
+                batch.append(&candidate, packet)
             }
-            _ => self.items.push(Item::Batch(Batch::new(candidate, packet))),
+            _ => self.items.push(Item::Batch(Batch::new(
+                candidate,
+                packet,
+                &self.segment_pool,
+            ))),
         }
     }
 
@@ -89,10 +106,13 @@ pub struct Outgoing(Inner);
 enum Inner {
     /// An individual IP packet; written with a zeroed [`VirtioNetHdr`].
     Packet(IpPacket),
-    /// A coalesced batch of packets, including its [`VirtioNetHdr`].
+    /// A super packet, gathered at write time from its segments.
     Batch {
-        buf: Buffer<Vec<u8>>,
-        num_segments: usize,
+        /// The [`VirtioNetHdr`] plus the fixed-up IP and L4 headers of the super packet.
+        prefix: [u8; MAX_PREFIX_LEN],
+        prefix_len: usize,
+        /// The original packets; only their payloads are written.
+        segments: Buffer<VecBuf<IpPacket>>,
     },
 }
 
@@ -101,20 +121,33 @@ impl Outgoing {
     pub fn num_segments(&self) -> usize {
         match &self.0 {
             Inner::Packet(_) => 1,
-            Inner::Batch { num_segments, .. } => *num_segments,
+            Inner::Batch { segments, .. } => segments.len(),
         }
     }
 
-    /// The [`VirtioNetHdr`] and packet bytes of this write, ready for `writev`.
-    pub fn bufs(&self) -> [&[u8]; 2] {
-        match &self.0 {
-            Inner::Packet(packet) => [ZEROED_VNET_HDR.as_slice(), packet.packet()],
-            Inner::Batch { buf, .. } => {
-                let (hdr, packet) = buf.split_at(VNET_HDR_LEN);
+    /// The buffers of this write, in `writev` order.
+    ///
+    /// The first buffer carries the [`VirtioNetHdr`] (for super packets together with
+    /// the shared headers); every further buffer is the L4 payload of one segment.
+    pub fn bufs(&self) -> impl Iterator<Item = &[u8]> + '_ {
+        let (prefix, segments) = match &self.0 {
+            Inner::Packet(packet) => (ZEROED_VNET_HDR.as_slice(), slice::from_ref(packet)),
+            Inner::Batch {
+                prefix,
+                prefix_len,
+                segments,
+            } => (&prefix[..*prefix_len], segments.as_slice()),
+        };
 
-                [hdr, packet]
-            }
-        }
+        // Everything after the `VirtioNetHdr` are packet bytes; whatever the prefix
+        // does not cover is taken from each segment directly.
+        let payload_offset = prefix.len() - VNET_HDR_LEN;
+
+        iter::once(prefix).chain(
+            segments
+                .iter()
+                .map(move |segment| &segment.packet()[payload_offset..]),
+        )
     }
 }
 
@@ -190,8 +223,8 @@ impl Candidate {
             return None;
         }
 
-        // Appending copies `&bytes[ip_hdr_len + l4_hdr_len..]`, so the parsed layout
-        // must cover the buffer exactly.
+        // The write slices each segment's payload as `&bytes[ip_hdr_len + l4_hdr_len..]`,
+        // so the parsed layout must cover the buffer exactly.
         if ip_hdr_len + candidate.l4_hdr_len + candidate.payload_len != packet.packet().len() {
             return None;
         }
@@ -329,7 +362,10 @@ impl FlowKey {
 
 struct Batch {
     key: FlowKey,
-    state: BatchState,
+    /// The packets of the batch, in order.
+    ///
+    /// The first packet's headers serve as the template for the super packet.
+    segments: Buffer<VecBuf<IpPacket>>,
 
     ip_hdr_len: usize,
     l4_hdr_len: usize,
@@ -339,62 +375,35 @@ struct Batch {
     total_len: usize,
     /// The expected sequence number of the next segment (TCP only).
     next_seq: u32,
-    num_segs: usize,
     psh: bool,
 }
 
-enum BatchState {
-    /// A single packet; not copied anywhere yet.
-    Single(IpPacket),
-    /// Two or more segments coalesced into a buffer, prefixed by space for the [`VirtioNetHdr`].
-    Coalesced(Buffer<Vec<u8>>),
-}
-
-impl BatchState {
-    /// The coalescing buffer, converting from [`BatchState::Single`] on first use.
-    fn coalesced(&mut self, pool: &BufferPool<Vec<u8>>) -> &mut Buffer<Vec<u8>> {
-        if let BatchState::Single(first) = &*self {
-            let mut buf = pool.pull();
-            buf.clear();
-            buf.resize(VNET_HDR_LEN, 0);
-            buf.extend_from_slice(first.packet());
-
-            *self = BatchState::Coalesced(buf);
-        }
-
-        match self {
-            BatchState::Coalesced(buf) => buf,
-            BatchState::Single(_) => unreachable!("converted to `Coalesced` above"),
-        }
-    }
-}
-
 impl Batch {
-    fn new(candidate: Candidate, packet: IpPacket) -> Self {
+    fn new(candidate: Candidate, packet: IpPacket, pool: &BufferPool<VecBuf<IpPacket>>) -> Self {
+        let total_len = packet.packet().len();
+
+        let mut segments = pool.pull();
+        segments.push(packet);
+
         Self {
             key: candidate.key,
+            segments,
             ip_hdr_len: candidate.ip_hdr_len,
             l4_hdr_len: candidate.l4_hdr_len,
             seg_size: candidate.payload_len,
-            total_len: packet.packet().len(),
+            total_len,
             next_seq: candidate.seq.wrapping_add(candidate.payload_len as u32),
-            num_segs: 1,
             psh: candidate.psh,
-            state: BatchState::Single(packet),
         }
     }
 
-    /// Appends the packet's payload to this batch.
-    fn append(&mut self, candidate: &Candidate, packet: &IpPacket, pool: &BufferPool<Vec<u8>>) {
-        let bytes = packet.packet();
-        let payload = &bytes[candidate.ip_hdr_len + candidate.l4_hdr_len..];
-
-        self.state.coalesced(pool).extend_from_slice(payload);
-
-        self.total_len += payload.len();
-        self.next_seq = self.next_seq.wrapping_add(payload.len() as u32);
-        self.num_segs += 1;
+    /// Appends a packet to this batch.
+    fn append(&mut self, candidate: &Candidate, packet: IpPacket) {
+        self.total_len += candidate.payload_len;
+        self.next_seq = self.next_seq.wrapping_add(candidate.payload_len as u32);
         self.psh |= candidate.psh;
+
+        self.segments.push(packet);
     }
 
     /// Whether further segments may be appended.
@@ -404,36 +413,49 @@ impl Batch {
     fn is_ongoing(&self) -> bool {
         let payload_len = self.total_len - self.ip_hdr_len - self.l4_hdr_len;
 
-        !self.psh && payload_len == self.num_segs * self.seg_size
+        !self.psh && payload_len == self.segments.len() * self.seg_size
     }
 
-    fn into_outgoing(self) -> Outgoing {
-        let Batch {
-            key,
-            state,
-            ip_hdr_len,
-            l4_hdr_len,
-            seg_size,
-            num_segs,
-            psh,
-            ..
-        } = self;
+    fn into_outgoing(mut self) -> Outgoing {
+        if self.segments.len() == 1 {
+            let packet = self
+                .segments
+                .pop()
+                .expect("batch holds at least one packet");
 
-        match state {
-            BatchState::Single(packet) => Outgoing::from(packet),
-            BatchState::Coalesced(mut buf) => {
-                finalize(&mut buf, &key, ip_hdr_len, l4_hdr_len, seg_size, psh);
-
-                Outgoing(Inner::Batch {
-                    buf,
-                    num_segments: num_segs,
-                })
-            }
+            return Outgoing::from(packet);
         }
+
+        let (prefix, prefix_len) = self.prefix();
+
+        Outgoing(Inner::Batch {
+            prefix,
+            prefix_len,
+            segments: self.segments,
+        })
+    }
+
+    /// Builds the write prefix of the super packet: the [`VirtioNetHdr`] followed by the
+    /// fixed-up IP and L4 headers of the first segment.
+    fn prefix(&self) -> ([u8; MAX_PREFIX_LEN], usize) {
+        let headers_len = self.ip_hdr_len + self.l4_hdr_len;
+        let prefix_len = VNET_HDR_LEN + headers_len;
+
+        let mut prefix = [0u8; MAX_PREFIX_LEN];
+        prefix[VNET_HDR_LEN..prefix_len].copy_from_slice(&self.template()[..headers_len]);
+
+        finalize(&mut prefix[..prefix_len], self);
+
+        (prefix, prefix_len)
     }
 
     fn can_append(&self, candidate: &Candidate, packet: &IpPacket) -> bool {
         if !self.is_ongoing() {
+            return false;
+        }
+
+        // The pooled segments vec must not outgrow the capacity it was allocated with.
+        if self.segments.len() == crate::MAX_BATCH_SIZE {
             return false;
         }
 
@@ -458,7 +480,7 @@ impl Batch {
             return false;
         }
 
-        if candidate.key.protocol == IpNumber::UDP && self.num_segs >= MAX_UDP_SEGMENTS {
+        if candidate.key.protocol == IpNumber::UDP && self.segments.len() >= MAX_UDP_SEGMENTS {
             return false;
         }
 
@@ -482,10 +504,7 @@ impl Batch {
 
     /// The first packet of the batch; all compatibility checks compare against its headers.
     fn template(&self) -> &[u8] {
-        match &self.state {
-            BatchState::Single(packet) => packet.packet(),
-            BatchState::Coalesced(buf) => &buf[VNET_HDR_LEN..],
-        }
+        self.segments[0].packet()
     }
 }
 
@@ -528,17 +547,11 @@ fn tcp_headers_compatible(
     template[start..end] == packet[start..end]
 }
 
-/// Writes the [`VirtioNetHdr`] and fixes up the outer headers of a coalesced super packet.
-fn finalize(
-    buf: &mut [u8],
-    key: &FlowKey,
-    ip_hdr_len: usize,
-    l4_hdr_len: usize,
-    seg_size: usize,
-    psh: bool,
-) {
-    let total_len = buf.len() - VNET_HDR_LEN;
-    let l4_len = total_len - ip_hdr_len;
+/// Writes the [`VirtioNetHdr`] and fixes up the outer headers of a super packet's prefix.
+fn finalize(buf: &mut [u8], batch: &Batch) {
+    let key = &batch.key;
+    let ip_hdr_len = batch.ip_hdr_len;
+    let l4_len = batch.total_len - ip_hdr_len;
 
     let (gso_type, csum_offset) = match (key.protocol, key.version()) {
         (IpNumber::TCP, IpVersion::V4) => (VIRTIO_NET_HDR_GSO_TCPV4, 16),
@@ -550,8 +563,8 @@ fn finalize(
     VirtioNetHdr {
         flags: VIRTIO_NET_HDR_F_NEEDS_CSUM,
         gso_type,
-        hdr_len: (ip_hdr_len + l4_hdr_len) as u16,
-        gso_size: seg_size as u16,
+        hdr_len: (ip_hdr_len + batch.l4_hdr_len) as u16,
+        gso_size: batch.seg_size as u16,
         csum_start: ip_hdr_len as u16,
         csum_offset: csum_offset as u16,
     }
@@ -561,7 +574,7 @@ fn finalize(
 
     match key.version() {
         IpVersion::V4 => {
-            packet[2..4].copy_from_slice(&(total_len as u16).to_be_bytes());
+            packet[2..4].copy_from_slice(&(batch.total_len as u16).to_be_bytes());
 
             packet[10] = 0;
             packet[11] = 0;
@@ -587,7 +600,7 @@ fn finalize(
 
     match key.protocol {
         IpNumber::TCP => {
-            if psh {
+            if batch.psh {
                 l4[13] |= TCP_FLAG_PSH;
             }
 

--- a/rust/libs/connlib/tun/src/linux/coalesce.rs
+++ b/rust/libs/connlib/tun/src/linux/coalesce.rs
@@ -15,6 +15,7 @@
 
 use bufferpool::{Buffer, BufferPool, VecBuf};
 use ip_packet::{IpNumber, IpPacket, IpVersion, Ipv6HeaderSlice, TcpSlice, UdpSlice};
+use smallvec::SmallVec;
 use std::iter;
 use std::net::IpAddr;
 use std::slice;
@@ -34,8 +35,10 @@ const MAX_UDP_SEGMENTS: usize = 128;
 
 /// The longest possible super-packet prefix: a [`VirtioNetHdr`] followed by the largest
 /// coalescable IP header (the fixed IPv6 one; IPv4 options never coalesce) and a
-/// maximally-sized TCP header.
-const MAX_PREFIX_LEN: usize = VNET_HDR_LEN + Ipv6HeaderSlice::LEN + TcpSlice::HEADER_MAX_LEN;
+/// maximally-sized TCP header, rounded up to the next power of two so the prefix
+/// buffer never spills to the heap.
+const MAX_PREFIX_LEN: usize =
+    (VNET_HDR_LEN + Ipv6HeaderSlice::LEN + TcpSlice::HEADER_MAX_LEN).next_power_of_two();
 
 const TCP_FLAG_PSH: u8 = 0x08;
 
@@ -109,8 +112,7 @@ enum Inner {
     /// A super packet, gathered at write time from its segments.
     Batch {
         /// The [`VirtioNetHdr`] plus the fixed-up IP and L4 headers of the super packet.
-        prefix: [u8; MAX_PREFIX_LEN],
-        prefix_len: usize,
+        prefix: SmallVec<[u8; MAX_PREFIX_LEN]>,
         /// The original packets; only their payloads are written.
         segments: Buffer<VecBuf<IpPacket>>,
     },
@@ -132,11 +134,7 @@ impl Outgoing {
     pub fn bufs(&self) -> impl Iterator<Item = &[u8]> + '_ {
         let (prefix, segments) = match &self.0 {
             Inner::Packet(packet) => (ZEROED_VNET_HDR.as_slice(), slice::from_ref(packet)),
-            Inner::Batch {
-                prefix,
-                prefix_len,
-                segments,
-            } => (&prefix[..*prefix_len], segments.as_slice()),
+            Inner::Batch { prefix, segments } => (prefix.as_slice(), segments.as_slice()),
         };
 
         // Everything after the `VirtioNetHdr` are packet bytes; whatever the prefix
@@ -426,27 +424,26 @@ impl Batch {
             return Outgoing::from(packet);
         }
 
-        let (prefix, prefix_len) = self.prefix();
+        let prefix = self.prefix();
 
         Outgoing(Inner::Batch {
             prefix,
-            prefix_len,
             segments: self.segments,
         })
     }
 
     /// Builds the write prefix of the super packet: the [`VirtioNetHdr`] followed by the
     /// fixed-up IP and L4 headers of the first segment.
-    fn prefix(&self) -> ([u8; MAX_PREFIX_LEN], usize) {
+    fn prefix(&self) -> SmallVec<[u8; MAX_PREFIX_LEN]> {
         let headers_len = self.ip_hdr_len + self.l4_hdr_len;
-        let prefix_len = VNET_HDR_LEN + headers_len;
 
-        let mut prefix = [0u8; MAX_PREFIX_LEN];
-        prefix[VNET_HDR_LEN..prefix_len].copy_from_slice(&self.template()[..headers_len]);
+        let mut prefix = SmallVec::new();
+        prefix.resize(VNET_HDR_LEN + headers_len, 0);
+        prefix[VNET_HDR_LEN..].copy_from_slice(&self.template()[..headers_len]);
 
-        finalize(&mut prefix[..prefix_len], self);
+        finalize(&mut prefix, self);
 
-        (prefix, prefix_len)
+        prefix
     }
 
     fn can_append(&self, candidate: &Candidate, packet: &IpPacket) -> bool {

--- a/rust/libs/connlib/tun/src/linux/tests.rs
+++ b/rust/libs/connlib/tun/src/linux/tests.rs
@@ -6,7 +6,7 @@ use ingot::types::{Emit, HeaderLen as _};
 use ingot::udp::Udp;
 use ip_packet::{IpPacket, IpPacketBuf};
 
-use super::coalesce::TunGsoQueue;
+use super::coalesce::{Outgoing, TunGsoQueue};
 use super::split::split;
 use super::virtio::*;
 use super::{checksum, virtio};
@@ -29,7 +29,7 @@ fn coalesces_sequential_tcp_segments() {
     };
     assert_eq!(super_packet.num_segments(), 3);
 
-    let buf = super_packet.bufs().concat();
+    let buf = write_bytes(super_packet);
     let (hdr, packet) = VirtioNetHdr::parse(&buf).unwrap();
 
     assert_eq!(hdr.flags, VIRTIO_NET_HDR_F_NEEDS_CSUM);
@@ -71,13 +71,36 @@ fn coalesced_tcp_packet_splits_back_into_segments() {
         panic!("Expected a single super packet");
     };
 
-    let roundtripped = split(&super_packet.bufs().concat()).unwrap();
+    let roundtripped = split(&write_bytes(super_packet)).unwrap();
 
     assert_eq!(roundtripped.len(), 3);
 
     for (original, roundtripped) in segments.iter().zip(&roundtripped) {
         assert_eq!(original.packet(), roundtripped.packet());
     }
+}
+
+#[test]
+fn super_packet_gathers_payloads_from_original_packets() {
+    let mut queue = TunGsoQueue::new();
+
+    queue.enqueue(tcp4(1000, &[1; 100]));
+    queue.enqueue(tcp4(1100, &[2; 100]));
+
+    let out = queue.drain().collect::<Vec<_>>();
+
+    let [super_packet] = out.as_slice() else {
+        panic!("Expected a single super packet");
+    };
+
+    let bufs = super_packet.bufs().collect::<Vec<_>>();
+
+    let [prefix, first, second] = bufs.as_slice() else {
+        panic!("Expected the header prefix plus one payload buffer per segment");
+    };
+    assert_eq!(prefix.len(), VNET_HDR_LEN + 20 + 20);
+    assert_eq!(*first, [1u8; 100].as_slice());
+    assert_eq!(*second, [2u8; 100].as_slice());
 }
 
 #[test]
@@ -125,7 +148,7 @@ fn psh_closes_the_batch() {
     assert_eq!(super_packet.num_segments(), 2);
     assert_eq!(segment.num_segments(), 1);
 
-    let buf = super_packet.bufs().concat();
+    let buf = write_bytes(super_packet);
     let (_, packet) = VirtioNetHdr::parse(&buf).unwrap();
     assert_eq!(
         packet[33] & 0x08,
@@ -185,7 +208,7 @@ fn coalesces_udp_datagrams() {
     };
     assert_eq!(super_packet.num_segments(), 3);
 
-    let buf = super_packet.bufs().concat();
+    let buf = write_bytes(super_packet);
     let (hdr, _) = VirtioNetHdr::parse(&buf).unwrap();
     assert_eq!(hdr.gso_type, VIRTIO_NET_HDR_GSO_UDP_L4);
     assert_eq!(hdr.gso_size, 100);
@@ -333,4 +356,9 @@ fn packet_from_bytes(bytes: &[u8]) -> IpPacket {
     buf.buf()[..bytes.len()].copy_from_slice(bytes);
 
     IpPacket::new(buf, bytes.len()).unwrap()
+}
+
+/// Concatenates all buffers of an [`Outgoing`] into the byte stream `writev` produces.
+fn write_bytes(outgoing: &Outgoing) -> Vec<u8> {
+    outgoing.bufs().collect::<Vec<_>>().concat()
 }


### PR DESCRIPTION
Coalescing GSO super packets for the TUN device assembled them in memory: the first packet and every following payload were copied into a pooled 64 KiB buffer before each write. Batches now retain the original `IpPacket`s and only prepare a small prefix holding the `virtio_net_hdr` plus the fixed-up IP and L4 headers; `writev` gathers the prefix and each packet's payload straight from the retained packets, so payload bytes are copied exactly once, by the kernel. This also drops the pool of 64 KiB coalescing buffers.