### PR TITLE
fix(portal): stagger ops admin emails

### DIFF
--- a/elixir/lib/portal/mailer.ex
+++ b/elixir/lib/portal/mailer.ex
@@ -196,15 +196,16 @@ defmodule Portal.Mailer do
 
   Checks the suppression table before inserting the Oban job. Returns
   `{:ok, :suppressed}` if all recipients are suppressed. The suppression
-  table is checked again right before the queued job delivers.
+  table is checked again right before the queued job delivers. Accepts Oban job
+  options such as `:scheduled_at` for callers that need delayed delivery.
   """
-  def enqueue(%Email{} = email) do
+  def enqueue(%Email{} = email, job_opts \\ []) when is_list(job_opts) do
     account_id = email.private[:account_id]
     email = email |> drop_blocked_recipients() |> drop_suppressed_recipients()
 
     if has_recipients?(email) do
       %{"account_id" => account_id, "request" => serialize(email)}
-      |> OutboundEmailWorker.new()
+      |> OutboundEmailWorker.new(job_opts)
       |> Oban.insert()
     else
       Logger.info("Skipping queued email because all recipients are suppressed",

--- a/elixir/lib/portal/ops.ex
+++ b/elixir/lib/portal/ops.ex
@@ -4,6 +4,8 @@ defmodule Portal.Ops do
   alias Portal.Workers.DeleteAccount
 
   @max_bcc_per_message 50
+  @max_recipients_per_send_window 100
+  @send_window_seconds 5 * 60
 
   @doc """
   Counts presences grouped by topic prefix.
@@ -149,21 +151,90 @@ defmodule Portal.Ops do
   end
 
   defp enqueue_chunked(emails_by_account, subject, html_body, plaintext_body) do
-    Enum.each(emails_by_account, fn {account_id, admin_emails} ->
-      admin_emails
-      |> Enum.chunk_every(@max_bcc_per_message)
-      |> Enum.each(fn chunk ->
-        Mailer.default_email()
-        |> Swoosh.Email.subject(subject)
-        |> Mailer.bcc_recipients(chunk)
-        |> Swoosh.Email.html_body(html_body)
-        |> Swoosh.Email.text_body(plaintext_body)
-        |> Mailer.with_account_id(account_id)
-        |> Mailer.enqueue()
-      end)
-    end)
+    first_send_at = DateTime.utc_now()
+
+    emails_by_account
+    |> account_send_windows()
+    |> Enum.with_index()
+    |> Enum.each(&enqueue_send_window(&1, first_send_at, subject, html_body, plaintext_body))
 
     :ok
+  end
+
+  defp account_send_windows([]), do: []
+
+  defp account_send_windows(emails_by_account) do
+    {completed_windows, current_window, _recipient_count} =
+      Enum.reduce(emails_by_account, {[], [], 0}, &add_account_to_send_window/2)
+
+    Enum.reverse([Enum.reverse(current_window) | completed_windows])
+  end
+
+  defp add_account_to_send_window(
+         {_account_id, admin_emails} = account,
+         {completed_windows, current_window, recipient_count}
+       ) do
+    account_recipient_count = length(admin_emails)
+
+    # Keep every admin for an account in the same window. An account larger
+    # than the target window size gets a window to itself.
+    if current_window == [] or
+         recipient_count + account_recipient_count <= @max_recipients_per_send_window do
+      {completed_windows, [account | current_window], recipient_count + account_recipient_count}
+    else
+      {[Enum.reverse(current_window) | completed_windows], [account], account_recipient_count}
+    end
+  end
+
+  defp enqueue_send_window(
+         {send_window, window_index},
+         first_send_at,
+         subject,
+         html_body,
+         plaintext_body
+       ) do
+    job_opts = send_window_job_opts(first_send_at, window_index)
+
+    Enum.each(
+      send_window,
+      &enqueue_account_emails(&1, subject, html_body, plaintext_body, job_opts)
+    )
+  end
+
+  defp enqueue_account_emails(
+         {account_id, admin_emails},
+         subject,
+         html_body,
+         plaintext_body,
+         job_opts
+       ) do
+    admin_emails
+    |> Enum.chunk_every(@max_bcc_per_message)
+    |> Enum.each(&enqueue_admin_email(&1, account_id, subject, html_body, plaintext_body, job_opts))
+  end
+
+  defp enqueue_admin_email(
+         recipients,
+         account_id,
+         subject,
+         html_body,
+         plaintext_body,
+         job_opts
+       ) do
+    Mailer.default_email()
+    |> Swoosh.Email.subject(subject)
+    |> Mailer.bcc_recipients(recipients)
+    |> Swoosh.Email.html_body(html_body)
+    |> Swoosh.Email.text_body(plaintext_body)
+    |> Mailer.with_account_id(account_id)
+    |> Mailer.enqueue(job_opts)
+  end
+
+  defp send_window_job_opts(_first_send_at, 0), do: []
+
+  defp send_window_job_opts(first_send_at, window_index) do
+    scheduled_at = DateTime.add(first_send_at, window_index * @send_window_seconds, :second)
+    [scheduled_at: scheduled_at]
   end
 
   defmodule Database do

--- a/elixir/test/portal/ops_test.exs
+++ b/elixir/test/portal/ops_test.exs
@@ -315,14 +315,19 @@ defmodule Portal.OpsTest do
       end)
     end
 
-    test "chunks BCC recipients into groups of 50" do
-      account = account_fixture()
+    test "keeps each account in one send window" do
+      account1 = account_fixture()
+      account2 = account_fixture()
 
-      # Create 75 admin actors
-      Enum.each(1..75, fn i ->
+      Enum.each(1..60, fn i ->
         admin_actor_fixture(
-          account: account,
-          email: "admin-#{String.pad_leading(to_string(i), 3, "0")}@example.com"
+          account: account1,
+          email: "account-1-admin-#{String.pad_leading(to_string(i), 3, "0")}@example.com"
+        )
+
+        admin_actor_fixture(
+          account: account2,
+          email: "account-2-admin-#{String.pad_leading(to_string(i), 3, "0")}@example.com"
         )
       end)
 
@@ -330,21 +335,50 @@ defmodule Portal.OpsTest do
         capture_io("y\n", fn ->
           assert :ok =
                    queue_admin_email(
-                     [account.id],
+                     [account1.id, account2.id],
                      "Chunk Subject",
                      "<p>Chunk HTML</p>",
                      "Chunk Text"
                    )
 
-          queued = collect_queued_emails(account.id)
-          assert length(queued) == 2
+          jobs =
+            [worker: Portal.Workers.OutboundEmail]
+            |> Oban.Job.query()
+            |> Repo.all()
 
-          bcc_counts = Enum.map(queued, fn email -> length(email.bcc) end) |> Enum.sort()
-          assert bcc_counts == [25, 50]
+          assert length(jobs) == 4
+
+          states_by_account =
+            jobs
+            |> Enum.group_by(& &1.args["account_id"])
+            |> Enum.map(fn {_account_id, account_jobs} ->
+              recipient_count =
+                account_jobs
+                |> Enum.map(&length(&1.args["request"]["bcc"]))
+                |> Enum.sum()
+
+              assert recipient_count == 60
+              assert [state] = Enum.uniq(Enum.map(account_jobs, & &1.state))
+              state
+            end)
+
+          assert Enum.sort(states_by_account) == ["available", "scheduled"]
+
+          scheduled_jobs = Enum.filter(jobs, &(&1.state == "scheduled"))
+          assert length(scheduled_jobs) == 2
+          assert length(Enum.uniq(Enum.map(scheduled_jobs, & &1.scheduled_at))) == 1
+
+          assert Enum.all?(scheduled_jobs, fn job ->
+                   DateTime.diff(job.scheduled_at, job.inserted_at, :second) in 299..300
+                 end)
+
+          assert Enum.all?(jobs, fn job ->
+                   length(job.args["request"]["bcc"]) <= 50
+                 end)
         end)
 
-      assert output =~ "75 unique admin(s)"
-      assert output =~ "1 account(s)"
+      assert output =~ "120 unique admin(s)"
+      assert output =~ "2 account(s)"
     end
   end
 end


### PR DESCRIPTION
## Why

Portal.Ops can send the same announcement to many account admins.

Before this change, every email was ready to send at once. A large announcement could go over our email sending limit.

## What changes

We put whole accounts into send groups of about 100 people.

We never split one account between two send times. If an account does not fit in the current group, the whole account waits for the next group 5 minutes later.

For example, imagine two accounts with 60 admins each:

- all 60 admins from the first account can be sent now
- all 60 admins from the second account can be sent 5 minutes later

We do not send to 40 admins from the second account now and make its other 20 admins wait.

All jobs are added to Oban right away. Oban holds the later jobs until their scheduled time.

Each individual email still has at most 50 people in BCC. An account with 60 admins uses two email jobs, but both jobs have the same send time.

This only changes announcements sent through Portal.Ops. Other emails are unchanged.

## Testing

- Verified every admin in one account gets the same send time
- Verified the next account waits 5 minutes when it does not fit
- Verified each email has no more than 50 BCC recipients
- mix credo --strict passes
- 35 focused tests pass

---

Related to #14250